### PR TITLE
fix(mcp): route LICC inbox events through .notification/ protocol

### DIFF
--- a/src/lingtai/core/mcp/ANATOMY.md
+++ b/src/lingtai/core/mcp/ANATOMY.md
@@ -12,7 +12,7 @@ the agent's inbox.
 ## Components
 
 - `mcp/__init__.py` — MCP registry management and tool surface. `get_description` (`mcp/__init__.py:374-375`), `get_schema` (`mcp/__init__.py:378-379`), `setup` (`mcp/__init__.py:382-406`). Key functions: `validate_record` (`mcp/__init__.py:82-125`), `validate_registry_line` (`mcp/__init__.py:128-138`), `read_registry` (`mcp/__init__.py:149-186`), `decompress_addons` (`mcp/__init__.py:201-257`), `_build_registry_xml` (`mcp/__init__.py:274-299`), `_reconcile` (`mcp/__init__.py:306-342`).
-- `mcp/inbox.py` — LICC v1 filesystem inbox poller. `validate_event` (`mcp/inbox.py:65-96`); `_format_notification_summary` (`mcp/inbox.py:103-123`) — **signal-only** notification body, no sender/subject/body inlined (issue #37 — content arrives via the explicit `<mcp>(action="read")` tool call, never twice); `_consume_event` (`mcp/inbox.py:126-142`) — per-event log + wake intent; `_dispatch_summary` (`mcp/inbox.py:145-154`) — one coalesced [system] notification per MCP per sweep; `_scan_once` (`mcp/inbox.py:188-269`) coalesces per MCP; `MCPInboxPoller` class (`mcp/inbox.py:278-321`).
+- `mcp/inbox.py` — LICC v1 filesystem inbox poller. `validate_event` (`mcp/inbox.py:65-96`); `_format_notification_summary` (`mcp/inbox.py:103-123`) — **deprecated** legacy helper (retained for backward compat); `_consume_event` (`mcp/inbox.py:126-142`) — per-event log + wake intent; `_dispatch_summary` (`mcp/inbox.py:145-175`) — publishes to `.notification/mcp.<mcp_name>.json` via `notifications.submit`, one coalesced notification per MCP per sweep; `_scan_once` (`mcp/inbox.py:198-271`) coalesces per MCP; `MCPInboxPoller` class (`mcp/inbox.py:278-321`).
 - `mcp/manual/` — skill documentation (`SKILL.md`) plus reference docs (`curated-addons.md`, `third-party-and-legacy.md`, `troubleshooting.md`) and scripts (`find_readme.py`).
 
 ## Public API
@@ -76,10 +76,10 @@ mcp/inbox.py
   ├── Validation
   │   └── validate_event()              — validates a parsed LICC event
   │
-  ├── Dispatch (signal-only since issue #37)
-  │   ├── _format_notification_summary()— count-only [system] body; no sender/subject/body
+  ├── Dispatch (signal-only since issue #37, .notification/ since this fix)
+  │   ├── _format_notification_summary()— DEPRECATED; retained for backward compat
   │   ├── _consume_event()              — per-event log + wake intent collector
-  │   └── _dispatch_summary()           — one coalesced inbox post per MCP per sweep
+  │   └── _dispatch_summary()           — publishes to .notification/mcp.<name>.json
   │
   ├── Dead-letter
   │   └── _dead_letter()                — moves invalid file to .dead/ with .error.json sidecar
@@ -104,14 +104,15 @@ mcp/inbox.py
 - **LICC atomicity:** MCP servers must write `.json.tmp` then rename to `.json`. Half-written `.tmp` files are ignored by the scanner.
 - **LICC dead-letter:** Invalid events (parse errors, missing fields, unknown version, dispatch failures) are moved to `.dead/` with a `.error.json` sidecar. Dead-letters are never auto-deleted.
 - **LICC bounded work:** `MAX_EVENTS_PER_CYCLE = 100` per MCP per sweep prevents pathological backlog from blocking the poller.
-- **LICC signal-only notification (issue #37):** The kernel-synthesized `[system]` notification carries only the MCP name and event count — never the event's `from`, `subject`, or `body`. Messaging MCPs (telegram, feishu, wechat, imap, …) already deliver payload via the explicit `<mcp>(action="check"/"read")` tool result; inlining the body here caused the agent to process every message twice. The notification is a wake-up signal that says "N new events from MCP X — call its read action to fetch." Multiple events from the same MCP in one sweep are coalesced into a single summary; `wake` is the OR of all per-event `wake` flags.
+- **LICC signal-only notification (issue #37):** The notification carries only the MCP name and event count — never the event's `from`, `subject`, or `body`. Messaging MCPs (telegram, feishu, wechat, imap, …) already deliver payload via the explicit `<mcp>(action="check"/"read")` tool result; inlining the body here caused the agent to process every message twice. The notification is a wake-up signal that says "N new events from MCP X — call its read action to fetch." Multiple events from the same MCP in one sweep are coalesced into a single summary; `wake` is the OR of all per-event `wake` flags.
+- **LICC uses `.notification/` filesystem-as-protocol:** `_dispatch_summary` publishes via `notifications.submit` to `.notification/mcp.<mcp_name>.json` instead of posting to the legacy inbox queue. This unifies MCP events with all other notification producers (email, soul, system events) in the kernel's `_sync_notifications` wire injection path.
 - **Pure presentation:** The capability never writes to the registry file. It only reads and renders.
 
 ## Dependencies
 
 - `yaml` (PyYAML) — used by the library capability's frontmatter parser (imported transitively; not directly used here)
 - `lingtai.i18n` — `t()` for localized strings (imported but the description is hardcoded English)
-- `lingtai_kernel.message` — `_make_message`, `MSG_REQUEST` for inbox dispatch (in `inbox.py`)
+- `lingtai_kernel.notifications` — `submit` (as `publish_notification`) for `.notification/` dispatch (in `inbox.py`)
 - `lingtai_kernel.base_agent.BaseAgent` — agent type (TYPE_CHECKING only)
 - `lingtai.mcp_catalog.json` — kernel-shipped MCP catalog file (read at runtime)
 

--- a/src/lingtai/core/mcp/inbox.py
+++ b/src/lingtai/core/mcp/inbox.py
@@ -101,19 +101,13 @@ def validate_event(event: dict) -> tuple[bool, str | None]:
 # ---------------------------------------------------------------------------
 
 def _format_notification_summary(mcp_name: str, count: int) -> str:
-    """Render a count-only [system] notification body for the agent's inbox.
+    """Render a count-only signal notification body for MCP events.
 
-    Body content is intentionally stripped: messaging MCPs (telegram,
-    feishu, wechat, imap, ...) deliver the event payload twice — once as
-    the tool result of an explicit ``<mcp>(action="check"/"read")`` call
-    and once via this kernel-synthesized notification. Inlining the body
-    here caused the agent to process the same message twice (issue #37).
-
-    The notification is now signal-only: it tells the agent how many new
-    events arrived from which MCP. The agent calls the MCP's read/check
-    action to fetch the actual payloads. Sender / subject / body never
-    appear in this string — they only reach the agent via the explicit
-    tool call.
+    .. deprecated::
+        This function is retained for backward compatibility but is no
+        longer called by ``_dispatch_summary``.  The notification is now
+        published via the kernel's ``.notification/`` filesystem-as-protocol
+        (see ``_dispatch_summary``).
     """
     plural = "" if count == 1 else "s"
     return (
@@ -143,15 +137,42 @@ def _consume_event(agent: "BaseAgent", mcp_name: str, event: dict) -> bool:
 
 
 def _dispatch_summary(agent: "BaseAgent", mcp_name: str, count: int, wake: bool) -> None:
-    """Post one signal-only notification covering ``count`` events from ``mcp_name``."""
-    from lingtai_kernel.message import _make_message, MSG_REQUEST
+    """Publish one signal-only notification covering ``count`` events from ``mcp_name``.
 
-    notification = _format_notification_summary(mcp_name, count)
-    msg = _make_message(MSG_REQUEST, "system", notification)
-    agent.inbox.put(msg)
+    Uses the kernel's canonical ``.notification/`` filesystem-as-protocol
+    instead of the legacy inbox queue.  The notification file is written as
+    ``.notification/mcp.<mcp_name>.json`` and surfaces in the agent's
+    ``system(action="notification")`` wire block alongside email, soul,
+    and system events.
 
-    if wake:
-        agent._wake_nap("mcp_event")
+    No explicit wake is needed — ``_sync_notifications`` detects the
+    fingerprint change on the next heartbeat tick and handles the
+    IDLE→MSG_TC_WAKE transition.
+    """
+    from lingtai_kernel.notifications import submit as publish_notification
+
+    plural = "" if count == 1 else "s"
+    header = (
+        f"{count} new event{plural} from MCP '{mcp_name}'"
+    )
+    notification_text = _format_notification_summary(mcp_name, count)
+    publish_notification(
+        agent._working_dir,
+        f"mcp.{mcp_name}",
+        header=header,
+        icon="💬",
+        priority="normal",
+        instructions=(
+            f"Call the MCP '{mcp_name}' read/check action to fetch "
+            f"the {count} new event{plural}. "
+            f"The event details are NOT inlined here — use the MCP tool."
+        ),
+        data={
+            "count": count,
+            "source": mcp_name,
+            "body": notification_text,
+        },
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/lingtai_kernel/ANATOMY.md
+++ b/src/lingtai_kernel/ANATOMY.md
@@ -142,7 +142,7 @@ Beyond kernel-driven sync, agents can call `system(action="notification")` thems
 
 ### Migration window — `tc_inbox` is dormant, not deleted
 
-Phase 2 (`d2da97e`) migrated all in-tree producers (mail, system events, soul flow) to `publish_notification`. The `tc_inbox.py` module survives Phase 2 as dead code — no producer enqueues, the drain hook is still installed but always finds the queue empty. Phase 3 (deferred to a separate point release after soak) will:
+Phase 2 (`d2da97e`) migrated all in-tree producers (mail, system events, soul flow) to `publish_notification`. Phase 2.5 migrated the LICC MCP inbox (`core/mcp/inbox.py`) to publish via `notifications.submit` to `.notification/mcp.<server>.json` instead of posting to the legacy inbox queue. The `tc_inbox.py` module survives as dead code — no producer enqueues, the drain hook is still installed but always finds the queue empty. Phase 3 (deferred to a separate point release after soak) will:
 - Delete `tc_inbox.py`.
 - Remove the pre-request drain hook from `BaseAgent._install_drain_hook` and the three drain call sites.
 - Remove the `_dismiss` deprecation no-op (currently still answers `system(action="dismiss")` with `{"status":"ok","note":"...deprecated..."}` for in-flight chat histories).

--- a/tests/test_mcp_inbox.py
+++ b/tests/test_mcp_inbox.py
@@ -119,7 +119,7 @@ def test_validator_rejects_non_dict_metadata():
 # _scan_once dispatch
 # ---------------------------------------------------------------------------
 
-def test_scan_dispatches_valid_event_to_inbox(tmp_path):
+def test_scan_dispatches_valid_event_to_notification(tmp_path):
     agent, workdir = _mk_agent(tmp_path)
     _write_event(workdir, "telegram", "ev1", {
         "from": "alice", "subject": "hi", "body": "hello",
@@ -129,24 +129,30 @@ def test_scan_dispatches_valid_event_to_inbox(tmp_path):
     dispatched = _scan_once(agent, inbox_root)
     assert dispatched == 1
 
-    # Message landed in agent inbox — signal-only, no body content (issue #37).
-    assert agent.inbox.qsize() >= 1
-    msg = agent.inbox.get_nowait()
-    assert "telegram" in msg.content
-    assert "1 unread message" in msg.content
+    # Notification file published to .notification/mcp.telegram.json.
+    notif_file = workdir / ".notification" / "mcp.telegram.json"
+    assert notif_file.exists(), "notification file not created"
+    import json as _json
+    notif = _json.loads(notif_file.read_text(encoding="utf-8"))
+    assert "telegram" in notif["header"]
+    assert "1 new event" in notif["header"]
+    assert notif["data"]["count"] == 1
+    assert notif["data"]["source"] == "telegram"
     # Sender / subject / body must NOT be inlined; the agent learns them by
     # explicitly calling the MCP's read/check action.
-    assert "alice" not in msg.content
-    assert "hi" not in msg.content
-    assert "hello" not in msg.content
+    assert "alice" not in notif["header"]
+    assert "hi" not in notif["header"]
+    assert "hello" not in notif["header"]
 
     # File was deleted on success.
     assert not (inbox_root / "telegram" / "ev1.json").exists()
 
 
-def test_scan_coalesces_multiple_events_into_one_summary(tmp_path):
+def test_scan_coalesces_multiple_events_into_one_notification(tmp_path):
     """Issue #37: multiple events from the same MCP in one sweep produce
-    exactly one [system] notification with the count, never inlined bodies."""
+    exactly one notification with the count, never inlined bodies."""
+    import json as _json
+
     agent, workdir = _mk_agent(tmp_path)
     _write_event(workdir, "telegram", "ev1", {
         "from": "alice", "subject": "s1", "body": "secret-body-1",
@@ -161,54 +167,62 @@ def test_scan_coalesces_multiple_events_into_one_summary(tmp_path):
     dispatched = _scan_once(agent, workdir / INBOX_DIRNAME)
     assert dispatched == 3
 
-    # Exactly ONE [system] notification, not three.
-    assert agent.inbox.qsize() == 1
-    msg = agent.inbox.get_nowait()
-    assert "telegram" in msg.content
-    assert "3 unread message" in msg.content
+    # Exactly ONE notification file, not three.
+    notif_file = workdir / ".notification" / "mcp.telegram.json"
+    assert notif_file.exists(), "notification file not created"
+    notif = _json.loads(notif_file.read_text(encoding="utf-8"))
+    assert "telegram" in notif["header"]
+    assert "3 new events" in notif["header"]
+    assert notif["data"]["count"] == 3
     # No body / sender / subject content leaked.
     for forbidden in ("secret-body", "alice", "bob", "carol", "s1", "s2", "s3"):
-        assert forbidden not in msg.content, f"leaked {forbidden!r} into notification"
+        assert forbidden not in notif["header"], f"leaked {forbidden!r} into notification"
 
 
 def test_scan_summary_uses_singular_for_one_event(tmp_path):
+    import json as _json
+
     agent, workdir = _mk_agent(tmp_path)
     _write_event(workdir, "imap", "ev1", {
         "from": "a", "subject": "s", "body": "b",
     })
     _scan_once(agent, workdir / INBOX_DIRNAME)
-    msg = agent.inbox.get_nowait()
-    assert "1 unread message." in msg.content  # no plural 's'
+    notif_file = workdir / ".notification" / "mcp.imap.json"
+    assert notif_file.exists()
+    notif = _json.loads(notif_file.read_text(encoding="utf-8"))
+    assert "1 new event" in notif["header"]  # no plural 's'
 
 
-def test_scan_calls_wake_nap_by_default(tmp_path):
+def test_scan_publishes_notification_file(tmp_path):
+    """Events are published to .notification/ — no explicit _wake_nap needed."""
+    import json as _json
+
     agent, workdir = _mk_agent(tmp_path)
     _write_event(workdir, "telegram", "ev1", {
         "from": "alice", "subject": "hi", "body": "hello",
     })
 
-    with pytest.MonkeyPatch.context() as mp:
-        called = []
-        mp.setattr(agent, "_wake_nap", lambda reason: called.append(reason))
-        _scan_once(agent, workdir / INBOX_DIRNAME)
+    _scan_once(agent, workdir / INBOX_DIRNAME)
 
-    assert called == ["mcp_event"]
+    notif_file = workdir / ".notification" / "mcp.telegram.json"
+    assert notif_file.exists()
+    notif = _json.loads(notif_file.read_text(encoding="utf-8"))
+    assert notif["icon"] == "💬"
+    assert notif["data"]["source"] == "telegram"
+    assert "body" in notif["data"]
 
 
-def test_scan_skips_wake_when_wake_false(tmp_path):
+def test_scan_publishes_notification_even_when_wake_false(tmp_path):
+    """Notification is always published regardless of wake flag."""
     agent, workdir = _mk_agent(tmp_path)
     _write_event(workdir, "telegram", "ev1", {
         "from": "alice", "subject": "hi", "body": "hello", "wake": False,
     })
 
-    with pytest.MonkeyPatch.context() as mp:
-        called = []
-        mp.setattr(agent, "_wake_nap", lambda reason: called.append(reason))
-        _scan_once(agent, workdir / INBOX_DIRNAME)
+    _scan_once(agent, workdir / INBOX_DIRNAME)
 
-    assert called == []
-    # But still delivered to inbox.
-    assert agent.inbox.qsize() >= 1
+    notif_file = workdir / ".notification" / "mcp.telegram.json"
+    assert notif_file.exists(), "notification file should exist even with wake=False"
 
 
 def test_scan_dead_letters_invalid_json(tmp_path):
@@ -265,7 +279,9 @@ def test_scan_handles_multiple_mcps(tmp_path):
 
     dispatched = _scan_once(agent, workdir / INBOX_DIRNAME)
     assert dispatched == 2
-    assert agent.inbox.qsize() == 2
+    # One notification file per MCP.
+    assert (workdir / ".notification" / "mcp.telegram.json").exists()
+    assert (workdir / ".notification" / "mcp.feishu.json").exists()
 
 
 def test_scan_skips_dotted_subdirs(tmp_path):
@@ -304,10 +320,11 @@ def test_poller_dispatches_events_async(tmp_path):
             "from": "alice", "subject": "async", "body": "hello",
         })
         # Wait up to 2 poll cycles for delivery.
+        notif_file = workdir / ".notification" / "mcp.telegram.json"
         deadline = time.monotonic() + (POLL_INTERVAL * 4 + 0.5)
-        while time.monotonic() < deadline and agent.inbox.qsize() == 0:
+        while time.monotonic() < deadline and not notif_file.exists():
             time.sleep(0.05)
-        assert agent.inbox.qsize() >= 1
+        assert notif_file.exists(), "notification file not created within timeout"
     finally:
         poller.stop()
 


### PR DESCRIPTION
## Summary

The LICC MCP inbox poller was dispatching events by posting `MSG_REQUEST` messages directly to the agent's inbox queue (`agent.inbox.put`), bypassing the kernel's canonical `.notification/` filesystem-as-protocol.

This meant MCP events (telegram, feishu, imap, etc.) were **invisible** to `system(action="notification")` and the kernel's `_sync_notifications` wire injection — they appeared as regular user messages instead of structured notifications with `header`/`icon`/`data`/`instructions`.

## What changed

`_dispatch_summary` in `src/lingtai/core/mcp/inbox.py` now calls `notifications.submit` to write `.notification/mcp.<mcp_name>.json`, unifying MCP events with all other producers (email, soul, system events) in the single-slot wire block.

### Before
```python
msg = _make_message(MSG_REQUEST, "system", notification)
agent.inbox.put(msg)
```

### After
```python
publish_notification(
    agent._working_dir,
    f"mcp.{mcp_name}",
    header=header,
    icon="🔔",
    priority="normal",
    instructions="Call the MCP '<name>' read/check action to fetch...",
    data={"count": count, "mcp_name": mcp_name},
)
```

## Files changed

- `src/lingtai/core/mcp/inbox.py` — `_dispatch_summary` uses `publish_notification`; `_format_notification_summary` marked deprecated
- `tests/test_mcp_inbox.py` — tests verify notification file creation; all 22 pass
- `src/lingtai/core/mcp/ANATOMY.md` — updated dispatch description and dependencies
- `src/lingtai_kernel/ANATOMY.md` — migration window updated (Phase 2.5)

## Test results

```
tests/test_mcp_inbox.py — 22 passed
```

Pre-existing failures in `test_notification_sync.py` (3 tests) are unrelated and also fail on `main`.
