### PR TITLE
feat(subconscious-redesign): unified engine, IDLE-gated flow, turn-lifecycle subconscious

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -979,6 +979,7 @@ class Agent(BaseAgent):
         # side default change with the stale literal here. Kept as
         # explicit literals for readability rather than introspecting
         # AgentConfig fields.
+        subconscious = soul.get("subconscious", {}) or {}
         self._config = AgentConfig(
             stamina=m.get("stamina", 86400.0),
             soul_delay=soul.get("delay", 300.0),
@@ -996,6 +997,11 @@ class Agent(BaseAgent):
             aed_timeout=m.get("aed_timeout", 360.0),
             max_aed_attempts=m.get("max_aed_attempts", 3),
             max_rpm=new_max_rpm,
+            subconscious_enabled=subconscious.get("enabled", False),
+            subconscious_provider=subconscious.get("provider"),
+            subconscious_model=subconscious.get("model"),
+            subconscious_base_url=subconscious.get("base_url"),
+            subconscious_context_window=subconscious.get("context_window", 128_000),
         )
         self._soul_delay = max(1.0, self._config.soul_delay)
         self._session._config = self._config

--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -408,6 +408,10 @@ class BaseAgent:
         self._soul_fire_lock: threading.Lock = threading.Lock()
         self._insight_turn_counter: int = 0
 
+        # Subconscious — intra-turn fan-out across past snapshots
+        self._subconscious_timer: threading.Timer | None = None
+        self._subconscious_fire_lock: threading.Lock = threading.Lock()
+
         # Heartbeat — always-on health monitor
         self._heartbeat: float = 0.0
         self._heartbeat_thread: threading.Thread | None = None
@@ -558,6 +562,7 @@ class BaseAgent:
         IDLE starts a fresh ``soul_delay``-second timer.
         """
         from ..intrinsics.soul.flow import _start_soul_timer, _cancel_soul_timer
+        from ..intrinsics.soul.subconscious import _cancel_subconscious_timer
 
         old = self._state
         if old == new_state:
@@ -568,13 +573,21 @@ class BaseAgent:
         else:
             self._idle.set()
 
-        fire_eligible = {AgentState.ACTIVE, AgentState.IDLE}
-        was_eligible = old in fire_eligible
-        is_eligible = new_state in fire_eligible
-        if was_eligible and not is_eligible:
+        # Soul flow fires only when IDLE (not ACTIVE).  Firing mid-turn
+        # splices consultation tool-call recommendations into the active
+        # tool loop, producing ghost interleaved results.  Timer is
+        # started on IDLE entry, cancelled on leaving IDLE.
+        was_idle = old == AgentState.IDLE
+        is_idle = new_state == AgentState.IDLE
+        if was_idle and not is_idle:
             _cancel_soul_timer(self)
-        elif is_eligible and not was_eligible:
+        elif is_idle and not was_idle:
             _start_soul_timer(self)
+
+        # Subconscious timer — always cancel on any state transition
+        # away from ACTIVE (it only runs during active tool-call loops).
+        if old == AgentState.ACTIVE and new_state != AgentState.ACTIVE:
+            _cancel_subconscious_timer(self)
 
         self._log("agent_state", old=old.value, new=new_state.value, reason=reason)
         self._workdir.write_manifest(self._build_manifest())

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -472,123 +472,138 @@ def _handle_message(agent, msg: Message) -> None:
 def _handle_request(agent, msg: Message) -> None:
     """Send request to LLM, process response with tool calls."""
     from ..llm import LLMResponse
+    from ..intrinsics.soul.subconscious import (
+        _start_subconscious_timer,
+        _cancel_subconscious_timer,
+        _clear_subconscious_jsonl,
+    )
 
     # Splice any queued involuntary tool-call pairs
     agent._drain_tc_inbox()
 
-    max_calls, dup_free, dup_hard = _get_guard_limits(agent)
-    guard = LoopGuard(
-        max_total_calls=max_calls,
-        dup_free_passes=dup_free,
-        dup_hard_block=dup_hard,
-    )
-    agent._executor = ToolExecutor(
-        dispatch_fn=agent._dispatch_tool,
-        make_tool_result_fn=lambda name, result, **kw: agent.service.make_tool_result(
-            name, result, provider=agent._config.provider, **kw
-        ),
-        guard=guard,
-        known_tools=set(agent._intrinsics) | set(agent._tool_handlers),
-        parallel_safe_tools=agent._PARALLEL_SAFE_TOOLS,
-        logger_fn=agent._log,
-        meta_fn=lambda: build_meta(agent),
-    )
-    content = agent._pre_request(msg)
-    meta = build_meta(agent)
+    # Subconscious lifecycle: clear stale insights, then start the
+    # 60-second fan-out timer for the duration of this turn.
+    _clear_subconscious_jsonl(agent)
+    _start_subconscious_timer(agent)
 
-    # Molt pressure — warn agent when context is getting full.
-    #
-    # Hard ceiling and forced-wipe paths still prepend their notice to the
-    # current user message because they are kernel ACTIONS the agent must
-    # see this turn (the wipe already happened; the agent needs to know
-    # working memory just got cleared).
-    #
-    # Graduated warnings (level 1/2/3 below the hard ceiling) are routed
-    # through the .notification/molt.json channel instead of being baked
-    # into user message content. Each level fully replaces the prior file
-    # — same single-slot pattern as soul/email — so the wire only carries
-    # the freshest pressure level. When pressure drops below the warn
-    # threshold the file is cleared so the warning stops re-injecting.
-    has_molt = "psyche" in agent._intrinsics
-    pressure = agent._session.get_context_pressure()
+    try:
+        max_calls, dup_free, dup_hard = _get_guard_limits(agent)
+        guard = LoopGuard(
+            max_total_calls=max_calls,
+            dup_free_passes=dup_free,
+            dup_hard_block=dup_hard,
+        )
+        agent._executor = ToolExecutor(
+            dispatch_fn=agent._dispatch_tool,
+            make_tool_result_fn=lambda name, result, **kw: agent.service.make_tool_result(
+                name, result, provider=agent._config.provider, **kw
+            ),
+            guard=guard,
+            known_tools=set(agent._intrinsics) | set(agent._tool_handlers),
+            parallel_safe_tools=agent._PARALLEL_SAFE_TOOLS,
+            logger_fn=agent._log,
+            meta_fn=lambda: build_meta(agent),
+        )
+        content = agent._pre_request(msg)
+        meta = build_meta(agent)
 
-    if pressure >= agent._config.molt_hard_ceiling and has_molt:
-        # Hard ceiling — unconditional force-wipe (action, stays inline).
-        lang = agent._config.language
-        agent._log("auto_forget", reason="hard ceiling", pressure=pressure, ceiling=agent._config.molt_hard_ceiling)
-        from ..intrinsics import psyche as _psyche
-        from ..intrinsics.system import clear_notification
-        _psyche.context_forget(agent)
-        agent._session._compaction_warnings = 0
-        clear_notification(agent._working_dir, "molt")
-        content = f"{_t(lang, 'system.molt_wiped')}\n\n{content}"
-    elif pressure >= agent._config.molt_pressure and has_molt:
-        max_warnings = agent._config.molt_warnings
-        agent._session._compaction_warnings += 1
-        warnings = agent._session._compaction_warnings
-        remaining = max(0, max_warnings - warnings)
-        lang = agent._config.language
-        if warnings > max_warnings:
-            # Forced wipe after ignored warnings (action, stays inline).
+        # Molt pressure — warn agent when context is getting full.
+        #
+        # Hard ceiling and forced-wipe paths still prepend their notice to the
+        # current user message because they are kernel ACTIONS the agent must
+        # see this turn (the wipe already happened; the agent needs to know
+        # working memory just got cleared).
+        #
+        # Graduated warnings (level 1/2/3 below the hard ceiling) are routed
+        # through the .notification/molt.json channel instead of being baked
+        # into user message content. Each level fully replaces the prior file
+        # — same single-slot pattern as soul/email — so the wire only carries
+        # the freshest pressure level. When pressure drops below the warn
+        # threshold the file is cleared so the warning stops re-injecting.
+        has_molt = "psyche" in agent._intrinsics
+        pressure = agent._session.get_context_pressure()
+
+        if pressure >= agent._config.molt_hard_ceiling and has_molt:
+            # Hard ceiling — unconditional force-wipe (action, stays inline).
+            lang = agent._config.language
+            agent._log("auto_forget", reason="hard ceiling", pressure=pressure, ceiling=agent._config.molt_hard_ceiling)
             from ..intrinsics import psyche as _psyche
             from ..intrinsics.system import clear_notification
-            agent._log("auto_forget", reason=f"ignored {max_warnings} molt warnings", pressure=pressure)
             _psyche.context_forget(agent)
             agent._session._compaction_warnings = 0
             clear_notification(agent._working_dir, "molt")
             content = f"{_t(lang, 'system.molt_wiped')}\n\n{content}"
+        elif pressure >= agent._config.molt_pressure and has_molt:
+            max_warnings = agent._config.molt_warnings
+            agent._session._compaction_warnings += 1
+            warnings = agent._session._compaction_warnings
+            remaining = max(0, max_warnings - warnings)
+            lang = agent._config.language
+            if warnings > max_warnings:
+                # Forced wipe after ignored warnings (action, stays inline).
+                from ..intrinsics import psyche as _psyche
+                from ..intrinsics.system import clear_notification
+                agent._log("auto_forget", reason=f"ignored {max_warnings} molt warnings", pressure=pressure)
+                _psyche.context_forget(agent)
+                agent._session._compaction_warnings = 0
+                clear_notification(agent._working_dir, "molt")
+                content = f"{_t(lang, 'system.molt_wiped')}\n\n{content}"
+            else:
+                # Graduated warning — publish to .notification/molt.json.
+                # Each call fully replaces the file, so the wire carries
+                # only the current level. _sync_notifications picks up the
+                # fingerprint change on the next heartbeat tick and routes
+                # it through the synthetic-pair injection (same path as
+                # email/soul). The warning thus appears on the *next* turn,
+                # not this one — acceptable tradeoff: the agent has 3+
+                # turns of buffer before forced wipe.
+                from ..intrinsics.system import publish_notification
+                level = min(warnings, 3)
+                level_prompt = _t(
+                    lang,
+                    f"system.molt_warning_level{level}",
+                    pressure=f"{pressure:.0%}",
+                    remaining=remaining,
+                )
+                if level >= 2:
+                    level_prompt = level_prompt + "\n\n" + _t(lang, "system.molt_procedure")
+                molt_prompt = agent._config.molt_prompt or level_prompt
+                status = f"[context: {pressure:.0%} | {remaining}/{max_warnings}]"
+                publish_notification(
+                    agent._working_dir, "molt",
+                    header=f"context {pressure:.0%}, {remaining}/{max_warnings} turns left",
+                    icon=("⚠️" if level >= 2 else "🪶"),
+                    priority=("high" if level >= 2 else "normal"),
+                    data={
+                        "pressure": pressure,
+                        "level": level,
+                        "warnings": warnings,
+                        "remaining": remaining,
+                        "max_warnings": max_warnings,
+                        "warning_text": molt_prompt,
+                        "status": status,
+                    },
+                )
         else:
-            # Graduated warning — publish to .notification/molt.json.
-            # Each call fully replaces the file, so the wire carries
-            # only the current level. _sync_notifications picks up the
-            # fingerprint change on the next heartbeat tick and routes
-            # it through the synthetic-pair injection (same path as
-            # email/soul). The warning thus appears on the *next* turn,
-            # not this one — acceptable tradeoff: the agent has 3+
-            # turns of buffer before forced wipe.
-            from ..intrinsics.system import publish_notification
-            level = min(warnings, 3)
-            level_prompt = _t(
-                lang,
-                f"system.molt_warning_level{level}",
-                pressure=f"{pressure:.0%}",
-                remaining=remaining,
-            )
-            if level >= 2:
-                level_prompt = level_prompt + "\n\n" + _t(lang, "system.molt_procedure")
-            molt_prompt = agent._config.molt_prompt or level_prompt
-            status = f"[context: {pressure:.0%} | {remaining}/{max_warnings}]"
-            publish_notification(
-                agent._working_dir, "molt",
-                header=f"context {pressure:.0%}, {remaining}/{max_warnings} turns left",
-                icon=("⚠️" if level >= 2 else "🪶"),
-                priority=("high" if level >= 2 else "normal"),
-                data={
-                    "pressure": pressure,
-                    "level": level,
-                    "warnings": warnings,
-                    "remaining": remaining,
-                    "max_warnings": max_warnings,
-                    "warning_text": molt_prompt,
-                    "status": status,
-                },
-            )
-    else:
-        # Pressure dropped below threshold — clear any stale molt notice
-        # so the wire stops carrying it.
-        if has_molt:
-            from ..intrinsics.system import clear_notification
-            clear_notification(agent._working_dir, "molt")
+            # Pressure dropped below threshold — clear any stale molt notice
+            # so the wire stops carrying it.
+            if has_molt:
+                from ..intrinsics.system import clear_notification
+                clear_notification(agent._working_dir, "molt")
 
-    prefix = render_meta(agent, meta)
-    if prefix:
-        content = f"{prefix}\n\n{content}"
-    agent._log("text_input", text=content)
-    response = _send_with_watchdog(agent, content)
-    agent._last_usage = response.usage
-    agent._save_chat_history()
-    result = _process_response(agent, response)
-    agent._post_request(msg, result)
+        prefix = render_meta(agent, meta)
+        if prefix:
+            content = f"{prefix}\n\n{content}"
+        agent._log("text_input", text=content)
+        response = _send_with_watchdog(agent, content)
+        agent._last_usage = response.usage
+        agent._save_chat_history()
+        result = _process_response(agent, response)
+        agent._post_request(msg, result)
+    finally:
+        # Always cancel the subconscious timer at turn end, even on exception.
+        _cancel_subconscious_timer(agent)
+        _clear_subconscious_jsonl(agent)
 
 
 def _handle_tc_wake(agent, msg: Message) -> None:

--- a/src/lingtai_kernel/config.py
+++ b/src/lingtai_kernel/config.py
@@ -38,3 +38,10 @@ class AgentConfig:
     soul_voice: str = "inner"  # consultation prompt profile — "inner" (terse, "you are the soul, speak as inner voice"), "observer" (structured stepped-back hook framing), or "custom" (use soul_voice_prompt). One unified prompt per profile; the per-fire cue text differentiates insights (current diary) vs past (future-self diary).
     soul_voice_prompt: str = ""  # custom voice prompt — only used when soul_voice == "custom". Set/cleared by the agent via soul(action="voice", set="custom", prompt="..."). Length-capped at SOUL_VOICE_PROMPT_MAX in soul.py.
     snapshot_interval: float | None = None  # seconds between git snapshots; None = off
+    # Subconscious config — fan-out across ALL snapshots while in a tool-call loop.
+    # Requires explicit cheap-model config; no silent fallback to primary model.
+    subconscious_enabled: bool = False
+    subconscious_provider: str | None = None  # required when enabled
+    subconscious_model: str | None = None  # required when enabled
+    subconscious_base_url: str | None = None  # optional override for custom endpoints
+    subconscious_context_window: int = 128_000  # target window for snapshot fitting

--- a/src/lingtai_kernel/i18n/en.json
+++ b/src/lingtai_kernel/i18n/en.json
@@ -84,5 +84,9 @@
   "email.unread_digest": "[email] {count} unread message(s) — most recent {recency}.\n\n{entries}\n{more}",
   "email.unread_digest.entry": "  {n}. From {name} ({address}) — {subject}\n     ID: {id}\n     Sent at: {sent_at}\n     {preview}",
   "email.unread_digest.more": "(showing first {shown} of {total})",
-  "email.unread_digest.no_subject": "(no subject)"
+  "email.unread_digest.no_subject": "(no subject)",
+  "soul.subconscious_enabled_description": "Enable the subconscious engine — fan-out across ALL past snapshots during tool-call loops using a cheap model. Requires explicit subconscious_provider and subconscious_model. Default: false.",
+  "soul.subconscious_provider_description": "LLM provider for subconscious fan-out calls. Required when subconscious_enabled=True. May equal the primary provider.",
+  "soul.subconscious_model_description": "LLM model for subconscious fan-out calls. Required when subconscious_enabled=True. Use a cheap model — the fan-out runs against ALL snapshots.",
+  "soul.subconscious_base_url_description": "Optional base URL override for the subconscious LLM provider (e.g. for local model endpoints)."
 }

--- a/src/lingtai_kernel/i18n/wen.json
+++ b/src/lingtai_kernel/i18n/wen.json
@@ -84,5 +84,9 @@
   "email.unread_digest": "[邮] 未阅之书凡 {count} 封，新者发于 {recency}。\n\n{entries}\n{more}",
   "email.unread_digest.entry": "  {n}. 自 {name} ({address}) —— {subject}\n     编号：{id}\n     发于：{sent_at}\n     {preview}",
   "email.unread_digest.more": "（仅显前 {shown} 封，共 {total}）",
-  "email.unread_digest.no_subject": "（无题）"
+  "email.unread_digest.no_subject": "（无题）",
+  "soul.subconscious_enabled_description": "启潜意识之能 — 于行具调用之际，以廉模遍历诸旧影。须显定 subconscious_provider 与 subconscious_model。默认：否。",
+  "soul.subconscious_provider_description": "潜意识扇出之 LLM 供者。潜意识启用时必填。可与主机同。",
+  "soul.subconscious_model_description": "潜意识扇出之 LLM 模型。潜意识启用时必填。宜用廉模 — 扇出遍历诸旧影。",
+  "soul.subconscious_base_url_description": "可择潜意识 LLM 之基址（如本机模型端）。"
 }

--- a/src/lingtai_kernel/i18n/zh.json
+++ b/src/lingtai_kernel/i18n/zh.json
@@ -84,5 +84,9 @@
   "email.unread_digest": "[邮件] 共有 {count} 封未读消息——最近一封于 {recency}。\n\n{entries}\n{more}",
   "email.unread_digest.entry": "  {n}. 来自 {name} ({address}) —— {subject}\n     ID：{id}\n     发送时间：{sent_at}\n     {preview}",
   "email.unread_digest.more": "（仅显示前 {shown} 封，共 {total} 封）",
-  "email.unread_digest.no_subject": "（无主题）"
+  "email.unread_digest.no_subject": "（无主题）",
+  "soul.subconscious_enabled_description": "启用潜意识引擎 — 在工具调用循环中使用廉价模型对所有历史快照进行扇出分析。需要显式设置 subconscious_provider 和 subconscious_model。默认：false。",
+  "soul.subconscious_provider_description": "潜意识扇出调用的 LLM 提供商。当 subconscious_enabled=True 时必填。可以与主模型提供商相同。",
+  "soul.subconscious_model_description": "潜意识扇出调用的 LLM 模型。当 subconscious_enabled=True 时必填。请使用廉价模型 — 扇出会对所有快照运行。",
+  "soul.subconscious_base_url_description": "潜意识 LLM 提供商的可选基础 URL 覆盖（例如用于本地模型端点）。"
 }

--- a/src/lingtai_kernel/intrinsics/soul/__init__.py
+++ b/src/lingtai_kernel/intrinsics/soul/__init__.py
@@ -42,6 +42,7 @@ from .config import (
 # Re-export consultation pipeline
 from .consultation import (
     _CONSULTATION_SYSTEM_PROMPT,
+    _SUBCONSCIOUS_SYSTEM_PROMPT,
     _CONSULTATION_TOOL_REFUSAL,
     _CONSULTATION_MAX_ROUNDS,
     _DIARY_CUE_TOKEN_CAP,
@@ -52,6 +53,7 @@ from .consultation import (
     _fit_interface_to_window,
     _kind_for_source,
     _build_consultation_cue,
+    _run_consultation_voice,
     _run_consultation,
     _list_snapshot_paths,
     _run_consultation_batch,
@@ -69,6 +71,15 @@ from .flow import (
     _persist_soul_entry,
     _run_consultation_fire,
     _rehydrate_appendix_tracking,
+)
+
+# Re-export subconscious engine
+from .subconscious import (
+    _start_subconscious_timer,
+    _cancel_subconscious_timer,
+    _clear_subconscious_jsonl,
+    _read_subconscious_tail,
+    _run_subconscious_fire,
 )
 
 
@@ -101,6 +112,22 @@ def get_schema(lang: str = "en") -> dict:
                 "minimum": CONSULTATION_PAST_COUNT_MIN,
                 "maximum": CONSULTATION_PAST_COUNT_MAX,
                 "description": t(lang, "soul.consultation_past_count_description"),
+            },
+            "subconscious_enabled": {
+                "type": "boolean",
+                "description": t(lang, "soul.subconscious_enabled_description"),
+            },
+            "subconscious_provider": {
+                "type": ["string", "null"],
+                "description": t(lang, "soul.subconscious_provider_description"),
+            },
+            "subconscious_model": {
+                "type": ["string", "null"],
+                "description": t(lang, "soul.subconscious_model_description"),
+            },
+            "subconscious_base_url": {
+                "type": ["string", "null"],
+                "description": t(lang, "soul.subconscious_base_url_description"),
             },
             "set": {
                 "type": "string",

--- a/src/lingtai_kernel/intrinsics/soul/config.py
+++ b/src/lingtai_kernel/intrinsics/soul/config.py
@@ -25,24 +25,43 @@ SOUL_VOICE_PROMPT_MAX = 4000
 
 
 def _handle_config(agent, args: dict) -> dict:
-    """Handle action='config' — adjust soul flow knobs.
+    """Handle action='config' — adjust soul flow and subconscious knobs.
 
-    Accepts any subset of: delay_seconds, consultation_past_count.
+    Accepts any subset of: delay_seconds, consultation_past_count,
+    subconscious_enabled, subconscious_provider, subconscious_model,
+    subconscious_base_url.
+
     Validates each provided field, updates live state, restarts the
     wall-clock timer if delay changed, persists to init.json. Returns
     old and new values for every field that was actually changed
     (untouched fields are absent from the response).
+
+    Subconscious hard-gating: enabling subconscious requires both
+    subconscious_provider AND subconscious_model to be explicitly set.
+    They MAY equal the primary model's values — the user just has to
+    say so. No silent fallback.
     """
+    _SUBCONSCIOUS_FIELDS = {
+        "subconscious_enabled",
+        "subconscious_provider",
+        "subconscious_model",
+        "subconscious_base_url",
+    }
     provided: dict = {}
     if "delay_seconds" in args:
         provided["delay_seconds"] = args["delay_seconds"]
     if "consultation_past_count" in args:
         provided["consultation_past_count"] = args["consultation_past_count"]
+    for f in _SUBCONSCIOUS_FIELDS:
+        if f in args:
+            provided[f] = args[f]
     if not provided:
         return {
             "error": (
                 "config requires at least one of: delay_seconds, "
-                "consultation_past_count."
+                "consultation_past_count, subconscious_enabled, "
+                "subconscious_provider, subconscious_model, "
+                "subconscious_base_url."
             ),
         }
 
@@ -87,6 +106,63 @@ def _handle_config(agent, args: dict) -> dict:
         old_values["consultation_past_count"] = int(getattr(agent._config, "consultation_past_count", 2))
         agent._config.consultation_past_count = v
         new_values["consultation_past_count"] = v
+
+    # ── Subconscious config fields ──────────────────────────────────
+
+    if "subconscious_provider" in provided:
+        raw = provided["subconscious_provider"]
+        if raw is not None and (not isinstance(raw, str) or not raw.strip()):
+            return {"error": "subconscious_provider must be a non-empty string or null."}
+        old_values["subconscious_provider"] = getattr(agent._config, "subconscious_provider", None)
+        agent._config.subconscious_provider = raw.strip() if isinstance(raw, str) and raw.strip() else None
+        new_values["subconscious_provider"] = agent._config.subconscious_provider
+
+    if "subconscious_model" in provided:
+        raw = provided["subconscious_model"]
+        if raw is not None and (not isinstance(raw, str) or not raw.strip()):
+            return {"error": "subconscious_model must be a non-empty string or null."}
+        old_values["subconscious_model"] = getattr(agent._config, "subconscious_model", None)
+        agent._config.subconscious_model = raw.strip() if isinstance(raw, str) and raw.strip() else None
+        new_values["subconscious_model"] = agent._config.subconscious_model
+
+    if "subconscious_base_url" in provided:
+        raw = provided["subconscious_base_url"]
+        if raw is not None and (not isinstance(raw, str) or not raw.strip()):
+            return {"error": "subconscious_base_url must be a non-empty string or null."}
+        old_values["subconscious_base_url"] = getattr(agent._config, "subconscious_base_url", None)
+        agent._config.subconscious_base_url = raw.strip() if isinstance(raw, str) and raw.strip() else None
+        new_values["subconscious_base_url"] = agent._config.subconscious_base_url
+
+    if "subconscious_enabled" in provided:
+        raw = provided["subconscious_enabled"]
+        if isinstance(raw, str):
+            v = raw.strip().lower() in ("true", "1", "yes")
+        elif isinstance(raw, (int, float)):
+            v = bool(raw)
+        elif isinstance(raw, bool):
+            v = raw
+        else:
+            return {"error": f"subconscious_enabled must be a boolean, got {type(raw).__name__}."}
+
+        if v:
+            # Hard-gating: both provider and model must be explicitly set.
+            provider = getattr(agent._config, "subconscious_provider", None)
+            model = getattr(agent._config, "subconscious_model", None)
+            if not provider or not model:
+                return {
+                    "error": (
+                        "subconscious_enabled=True requires both "
+                        "subconscious_provider and subconscious_model "
+                        "to be explicitly set. They MAY equal the primary "
+                        "model's values — you just have to say so. "
+                        "This prevents accidental billing surprises from "
+                        "the per-turn fan-out cost."
+                    ),
+                }
+
+        old_values["subconscious_enabled"] = getattr(agent._config, "subconscious_enabled", False)
+        agent._config.subconscious_enabled = v
+        new_values["subconscious_enabled"] = v
 
     # Restart the wall-clock timer if delay changed (or if any change
     # happened — restarting on every config call keeps the cadence in
@@ -258,6 +334,23 @@ def _persist_soul_config(agent, new_values: dict) -> str | None:
         soul_block["delay"] = new_values["delay_seconds"]
     if "consultation_past_count" in new_values:
         soul_block["consultation_past_count"] = new_values["consultation_past_count"]
+
+    # Subconscious config — persist under manifest.soul.subconscious.
+    _SUBCONSCIOUS_PERSIST_MAP = {
+        "subconscious_enabled": ("subconscious", "enabled"),
+        "subconscious_provider": ("subconscious", "provider"),
+        "subconscious_model": ("subconscious", "model"),
+        "subconscious_base_url": ("subconscious", "base_url"),
+    }
+    any_sub = any(k in new_values for k in _SUBCONSCIOUS_PERSIST_MAP)
+    if any_sub:
+        sub_block = soul_block.get("subconscious")
+        if not isinstance(sub_block, dict):
+            sub_block = {}
+            soul_block["subconscious"] = sub_block
+        for field, (section, key) in _SUBCONSCIOUS_PERSIST_MAP.items():
+            if field in new_values:
+                sub_block[key] = new_values[field]
 
     return _atomic_write_init(init_path, data)
 

--- a/src/lingtai_kernel/intrinsics/soul/consultation.py
+++ b/src/lingtai_kernel/intrinsics/soul/consultation.py
@@ -41,6 +41,19 @@ _CONSULTATION_TOOL_REFUSAL = (
 _CONSULTATION_MAX_ROUNDS = 3
 _DIARY_CUE_TOKEN_CAP = 10_000
 
+# Subconscious prompt — "does this remind you of something?"
+# Used by the subconscious engine (cheap-model fan-out across all snapshots).
+# No tool schema, no thinking, single round, structured JSON output.
+_SUBCONSCIOUS_SYSTEM_PROMPT = (
+    "The chat below is your context — your thoughts, your work, your tools, your memory.\n\n"
+    "Your role: Does the current self's thinking and diary remind you of something?\n"
+    "If so, write a brief insight to inform the current self. If not, stay silent.\n\n"
+    "Format your insight as JSON:\n"
+    '{"insight": "...", "confidence": 0.0-1.0, "source_memory": "..."}\n'
+    'If nothing reminds you: {"insight": null}\n'
+    "You cannot execute tools. Do not attempt tool calls."
+)
+
 
 def _send_with_timeout(agent, session, content: "str | list"):
     """Send with timeout using a daemon thread. Returns response or None.
@@ -377,53 +390,99 @@ def _build_consultation_cue(agent, kind: str, diary: str) -> str:
         return f"{template}\n\n{body}"
 
 
-def _run_consultation(agent, iface, source: str) -> dict | None:
-    """Run one substrate+spark consultation against a seeded ChatInterface.
+def _run_consultation_voice(
+    agent,
+    iface,
+    source: str,
+    *,
+    system_prompt: str,
+    spark: str,
+    session_overrides: dict | None = None,
+    allow_tool_recommendations: bool = True,
+    max_rounds: int = _CONSULTATION_MAX_ROUNDS,
+) -> dict | None:
+    """Shared consultation engine — runs one substrate+spark LLM call.
 
-    The seeded interface is cloned verbatim. The present diary cue is sent as
-    the spark. Tool schemas are declared so historic tool calls/results remain
-    structurally legible, but any new tool-call attempts are intercepted with
-    synthetic refusal ``ToolResultBlock``s for up to
-    ``_CONSULTATION_MAX_ROUNDS`` rounds.
+    This is the primitive that both soul flow and subconscious build on.
+    The caller owns substrate selection, prompt choice, session overrides,
+    and delivery of results.
 
-    Returns ``{"source": source, "blocks": [...]}`` or None on failure/no cue.
+    Parameters
+    ----------
+    agent : BaseAgent
+        The live agent (for service, config, logging).
+    iface : ChatInterface
+        Substrate — loaded from current chat or a past snapshot.
+    source : str
+        Label for the voice (e.g. "insights", "snapshot:<stem>").
+    system_prompt : str
+        Consultation system prompt ("advise" for flow, "remind" for subconscious).
+    spark : str
+        Cue text — the diary or other trigger to send as the first user message.
+    session_overrides : dict | None
+        Optional override keys: provider, model, base_url, context_window.
+    allow_tool_recommendations : bool
+        When True (soul flow), tool schemas are declared and tool-call
+        attempts are intercepted with refusal blocks. When False
+        (subconscious), tools=None and the model cannot call tools.
+    max_rounds : int
+        Maximum consultation rounds (only matters when allow_tool_recommendations=True).
+
+    Returns ``{"source": source, "blocks": [...]}`` or None on failure.
     """
     if iface is None or not iface.entries:
         return None
 
-    window = None
-    if getattr(agent, "_chat", None) is not None:
-        try:
-            window = agent._chat.context_window()
-        except Exception:
-            window = None
+    overrides = session_overrides or {}
+
+    # Context window
+    window = overrides.get("context_window")
     if window is None:
-        window = int(getattr(agent._config, "context_limit", None) or 200_000)
+        if getattr(agent, "_chat", None) is not None:
+            try:
+                window = agent._chat.context_window()
+            except Exception:
+                window = None
+        if window is None:
+            window = int(getattr(agent._config, "context_limit", None) or 200_000)
     target = max(1, int(window * 0.7))
     fitted = _fit_interface_to_window(iface, target)
     if not fitted.entries:
         return None
 
+    # Tool schemas — only when tool recommendations are allowed.
     tool_schemas = None
-    try:
-        tool_schemas = agent._session._build_tool_schemas_fn() or None
-    except Exception as e:
+    if allow_tool_recommendations:
         try:
-            agent._log("consultation_tool_schema_error", source=source, error=str(e)[:200])
-        except Exception:
-            pass
-        tool_schemas = None
+            tool_schemas = agent._session._build_tool_schemas_fn() or None
+        except Exception as e:
+            try:
+                agent._log("consultation_tool_schema_error", source=source, error=str(e)[:200])
+            except Exception:
+                pass
+            tool_schemas = None
+
+    # Model routing
+    provider = overrides.get("provider", agent._config.provider)
+    model = overrides.get("model", agent._config.model or agent.service.model)
+    base_url = overrides.get("base_url")
 
     try:
-        session = agent.service.create_session(
-            system_prompt=_CONSULTATION_SYSTEM_PROMPT,
+        create_kwargs = dict(
+            system_prompt=system_prompt,
             tools=tool_schemas,
-            model=agent._config.model or agent.service.model,
-            thinking="high",
+            model=model,
             tracked=False,
             interface=fitted,
-            provider=agent._config.provider,
+            provider=provider,
         )
+        if allow_tool_recommendations:
+            create_kwargs["thinking"] = "high"
+        else:
+            create_kwargs["thinking"] = None
+        if base_url:
+            create_kwargs["base_url"] = base_url
+        session = agent.service.create_session(**create_kwargs)
     except Exception as e:
         try:
             agent._log("consultation_session_failed", source=source, error=str(e)[:200])
@@ -431,19 +490,33 @@ def _run_consultation(agent, iface, source: str) -> dict | None:
             pass
         return None
 
-    diary = _render_current_diary(agent)
-    if not diary:
-        # No spark = no consultation. Avoid sending an empty user message —
-        # the model has no trigger to react to.
+    # Single-round path (no tool interception).
+    if not allow_tool_recommendations:
+        response = _send_with_timeout(agent, session, spark)
+        if response is None:
+            return None
+        try:
+            _write_soul_tokens(agent, response)
+        except Exception:
+            pass
+        try:
+            if session.interface.entries:
+                tail = session.interface.entries[-1]
+                if tail.role == "assistant":
+                    blocks = list(tail.content)
+                    if blocks:
+                        return {"source": source, "blocks": blocks}
+        except Exception:
+            pass
         return None
-    spark = diary
 
+    # Multi-round path with tool-call interception.
     from ...llm.interface import ToolResultBlock
 
     blocks_collected: list = []
     next_input: "str | list[ToolResultBlock]" = spark
 
-    for _round_idx in range(_CONSULTATION_MAX_ROUNDS):
+    for _round_idx in range(max_rounds):
         response = _send_with_timeout(agent, session, next_input)
         if response is None:
             break
@@ -479,6 +552,33 @@ def _run_consultation(agent, iface, source: str) -> dict | None:
         return None
 
     return {"source": source, "blocks": blocks_collected}
+
+
+def _run_consultation(agent, iface, source: str) -> dict | None:
+    """Run one substrate+spark consultation against a seeded ChatInterface.
+
+    The seeded interface is cloned verbatim. The present diary cue is sent as
+    the spark. Tool schemas are declared so historic tool calls/results remain
+    structurally legible, but any new tool-call attempts are intercepted with
+    synthetic refusal ``ToolResultBlock``s for up to
+    ``_CONSULTATION_MAX_ROUNDS`` rounds.
+
+    Returns ``{"source": source, "blocks": [...]}`` or None on failure/no cue.
+    """
+    if iface is None or not iface.entries:
+        return None
+
+    diary = _render_current_diary(agent)
+    if not diary:
+        return None
+
+    return _run_consultation_voice(
+        agent, iface, source,
+        system_prompt=_CONSULTATION_SYSTEM_PROMPT,
+        spark=diary,
+        allow_tool_recommendations=True,
+        max_rounds=_CONSULTATION_MAX_ROUNDS,
+    )
 
 
 def _list_snapshot_paths(agent):

--- a/src/lingtai_kernel/intrinsics/soul/flow.py
+++ b/src/lingtai_kernel/intrinsics/soul/flow.py
@@ -59,7 +59,7 @@ def _soul_whisper(agent) -> None:
 
     agent._soul_timer = None
     try:
-        if agent._state in (AgentState.ACTIVE, AgentState.IDLE):
+        if agent._state == AgentState.IDLE:
             # Issue #47: Check for pending notifications before consultation
             # This ensures messages are seen within one soul delay cycle
             try:
@@ -145,10 +145,15 @@ def _flatten_v3_for_pair(agent, voice: dict) -> dict:
 
 
 def _soul_fire_allowed(agent) -> bool:
-    """True when soul-flow may inject results into the live agent."""
+    """True when soul-flow may inject results into the live agent.
+
+    IDLE only — firing while ACTIVE (mid-tool-loop) would splice the
+    consultation pair into an active tool-call sequence, producing ghost
+    tool-call recommendations interleaved with real tool results.
+    """
     from ...state import AgentState
 
-    return agent._state in (AgentState.ACTIVE, AgentState.IDLE)
+    return agent._state == AgentState.IDLE
 
 
 def _shape_soul_voices(voices_for_pair: list[dict]) -> list[dict]:

--- a/src/lingtai_kernel/intrinsics/soul/subconscious.py
+++ b/src/lingtai_kernel/intrinsics/soul/subconscious.py
@@ -1,0 +1,413 @@
+"""Subconscious engine — intra-turn fan-out across past snapshots.
+
+The subconscious fires ONLY while the agent is in a tool-call loop
+(ACTIVE mid-turn). It runs a cheap model against ALL available snapshots
+in parallel, looking for pattern matches. Insights are appended to an
+append-only JSONL file that the agent sees via the notification system.
+
+Lifecycle:
+  _start_subconscious_timer  — called from turn._handle_request (turn start)
+  _cancel_subconscious_timer — called from turn._handle_request (turn end)
+  _clear_subconscious_jsonl  — called from turn._handle_request (turn start)
+
+The timer is a 60-second wall-clock daemon; it fires _subconscious_tick
+which fans out across ALL snapshots in parallel daemon threads.
+"""
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+
+_SUBCONSCIOUS_FIRE_INTERVAL = 60.0
+_SUBCONSCIOUS_DISPLAY_N = 10
+_SUBCONSCIOUS_JSONL = "subconscious.jsonl"
+
+
+# ── Timer management ────────────────────────────────────────────────────
+
+def _start_subconscious_timer(agent) -> None:
+    """Start the subconscious cadence timer (60s wall-clock).
+
+    Runs only while the agent is in an active tool-call loop (ACTIVE state
+    mid-turn). Cancelled by _cancel_subconscious_timer at turn end.
+    """
+    if not getattr(agent._config, "subconscious_enabled", False):
+        return
+    if agent._shutdown.is_set():
+        return
+    _cancel_subconscious_timer(agent)
+    agent._subconscious_timer = threading.Timer(
+        _SUBCONSCIOUS_FIRE_INTERVAL,
+        _subconscious_tick,
+        args=(agent,),
+    )
+    agent._subconscious_timer.daemon = True
+    agent._subconscious_timer.name = (
+        f"subconscious-{agent.agent_name or agent._working_dir.name}"
+    )
+    agent._subconscious_timer.start()
+
+
+def _cancel_subconscious_timer(agent) -> None:
+    """Cancel any pending subconscious timer."""
+    timer = getattr(agent, "_subconscious_timer", None)
+    if timer is not None:
+        timer.cancel()
+        agent._subconscious_timer = None
+
+
+# ── Fire orchestration ──────────────────────────────────────────────────
+
+def _subconscious_tick(agent) -> None:
+    """Timer callback — fire the subconscious if still mid-turn.
+
+    Only fires while agent state is ACTIVE (mid-tool-call-loop).
+    Reschedules in the finally block if still in an active turn.
+    """
+    from ...state import AgentState
+
+    agent._subconscious_timer = None
+    try:
+        if agent._state == AgentState.ACTIVE:
+            _run_subconscious_fire(agent)
+        else:
+            agent._log("subconscious_tick_skipped", state=agent._state.value)
+    except Exception as e:
+        agent._log("subconscious_tick_error", error=str(e)[:200])
+    finally:
+        if agent._state == AgentState.ACTIVE:
+            _start_subconscious_timer(agent)
+
+
+def _run_subconscious_fire(agent) -> None:
+    """Fire one subconscious batch — fan out across ALL snapshots.
+
+    Uses _subconscious_fire_lock (try-acquire non-blocking) to prevent
+    overlapping fires. Each snapshot gets its own daemon thread running
+    _run_subconscious_snapshot. Non-null insights are appended directly
+    to the JSONL by the per-snapshot thread.
+    """
+    from ...state import AgentState
+    from .consultation import (
+        _render_current_diary,
+        _list_snapshot_paths,
+        _SUBCONSCIOUS_SYSTEM_PROMPT,
+    )
+
+    # Fire lock — skip if a previous fire is still running.
+    lock = getattr(agent, "_subconscious_fire_lock", None)
+    if lock is not None and not lock.acquire(blocking=False):
+        agent._log("subconscious_skipped_inflight")
+        return
+
+    fire_id = f"sub_{int(time.time())}_{_secrets_hex(4)}"
+
+    try:
+        # Pre-check.
+        if agent._state != AgentState.ACTIVE:
+            agent._log("subconscious_discarded_state",
+                       fire_id=fire_id, state=agent._state.value)
+            return
+
+        # Diary gate — no spark = no fire.
+        diary = _render_current_diary(agent)
+        if not diary:
+            agent._log("subconscious_fire_empty", fire_id=fire_id)
+            return
+
+        # Fan out across ALL snapshots.
+        paths = _list_snapshot_paths(agent)
+        if not paths:
+            agent._log("subconscious_fire_no_snapshots", fire_id=fire_id)
+            return
+
+        agent._log("subconscious_fire_start",
+                   fire_id=fire_id, snapshot_count=len(paths))
+
+        # Session overrides from subconscious config.
+        session_overrides = _build_session_overrides(agent)
+
+        # Fire all snapshots in parallel.
+        results: list[dict | None] = [None] * len(paths)
+
+        def snapshot_worker(idx: int, path) -> None:
+            try:
+                results[idx] = _run_subconscious_snapshot(
+                    agent, path, diary, fire_id, session_overrides,
+                )
+            except Exception as e:
+                try:
+                    agent._log("subconscious_snapshot_error",
+                               fire_id=fire_id, path=str(path),
+                               error=str(e)[:200])
+                except Exception:
+                    pass
+
+        threads: list[threading.Thread] = []
+        for idx, path in enumerate(paths):
+            t = threading.Thread(
+                target=snapshot_worker,
+                args=(idx, path),
+                daemon=True,
+                name=f"sub-{idx}-{path.stem[:20]}",
+            )
+            threads.append(t)
+            t.start()
+
+        # Wait for all to complete.
+        timeout = float(getattr(agent._config, "retry_timeout", 300.0))
+        for t in threads:
+            t.join(timeout=timeout)
+
+        # Count results.
+        insight_count = sum(1 for r in results if r is not None)
+        agent._log("subconscious_fire_done",
+                   fire_id=fire_id,
+                   insight_count=insight_count,
+                   total_snapshots=len(paths))
+
+    except Exception as e:
+        agent._log("subconscious_fire_error",
+                   fire_id=fire_id, error=str(e)[:200])
+    finally:
+        if lock is not None:
+            try:
+                lock.release()
+            except RuntimeError:
+                pass
+
+
+def _run_subconscious_snapshot(
+    agent,
+    path,
+    diary: str,
+    fire_id: str,
+    session_overrides: dict,
+) -> dict | None:
+    """Run one subconscious snapshot. Returns insight dict if non-null, else None.
+
+    Uses the shared consultation engine with allow_tool_recommendations=False.
+    On non-null insight, appends directly to the JSONL (file-append is
+    thread-safe on macOS/Linux for small records).
+    """
+    from .consultation import (
+        _load_snapshot_interface,
+        _run_consultation_voice,
+        _SUBCONSCIOUS_SYSTEM_PROMPT,
+    )
+
+    iface = _load_snapshot_interface(path)
+    if iface is None or not iface.entries:
+        agent._log("subconscious_snapshot_load_failed",
+                   fire_id=fire_id, path=str(path))
+        return None
+
+    source = f"snapshot:{path.stem}"
+    result = _run_consultation_voice(
+        agent, iface, source,
+        system_prompt=_SUBCONSCIOUS_SYSTEM_PROMPT,
+        spark=diary,
+        session_overrides=session_overrides,
+        allow_tool_recommendations=False,
+        max_rounds=1,
+    )
+
+    if result is None:
+        return None
+
+    # Extract text from blocks.
+    text = _extract_text_from_blocks(result.get("blocks", []))
+    if not text:
+        return None
+
+    # Parse structured JSON response.
+    insight_data = _parse_subconscious_response(text)
+    if insight_data is None:
+        return None  # Model said nothing relevant.
+
+    # Append to JSONL.
+    record = {
+        "ts": time.time(),
+        "fire_id": fire_id,
+        "insight": insight_data["insight"],
+        "confidence": insight_data.get("confidence", 0.5),
+        "source_memory": insight_data.get("source_memory", "unstructured"),
+        "source_snapshot": source,
+        "model_used": session_overrides.get("model", "unknown"),
+    }
+    _append_subconscious_record(agent, record)
+
+    return record
+
+
+# ── JSONL persistence ───────────────────────────────────────────────────
+
+def _subconscious_jsonl_path(agent):
+    """Path to the subconscious insights JSONL file."""
+    return agent._working_dir / "logs" / _SUBCONSCIOUS_JSONL
+
+
+def _clear_subconscious_jsonl(agent) -> None:
+    """Clear the subconscious JSONL file (called at turn start).
+
+    Subconscious insights are ephemeral — they exist only for the current
+    tool-call loop and are discarded at turn end.
+    """
+    path = _subconscious_jsonl_path(agent)
+    try:
+        if path.exists():
+            path.unlink()
+    except OSError:
+        pass
+
+
+def _append_subconscious_record(agent, record: dict) -> None:
+    """Append one insight record to the subconscious JSONL.
+
+    Thread-safe: file-append is atomic on macOS/Linux for small records.
+    Called from per-snapshot daemon threads.
+    """
+    path = _subconscious_jsonl_path(agent)
+    try:
+        path.parent.mkdir(exist_ok=True)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError as e:
+        try:
+            agent._log("subconscious_jsonl_write_error", error=str(e)[:200])
+        except Exception:
+            pass
+
+
+def _read_subconscious_tail(agent, n: int = _SUBCONSCIOUS_DISPLAY_N) -> str:
+    """Read the last N lines of the subconscious JSONL, newest-last.
+
+    Returns a formatted string for injection into the agent's prompt.
+    Returns empty string if file is missing or empty.
+    """
+    from .consultation import _iter_lines_reverse
+
+    path = _subconscious_jsonl_path(agent)
+    if not path.is_file():
+        return ""
+
+    lines: list[str] = []
+    try:
+        for raw_line in _iter_lines_reverse(path):
+            if not raw_line:
+                continue
+            try:
+                rec = json.loads(raw_line)
+                insight = rec.get("insight", "")
+                confidence = rec.get("confidence", 0.5)
+                source = rec.get("source_snapshot", "unknown")
+                ts = rec.get("ts", 0)
+                from datetime import datetime
+                ts_str = datetime.fromtimestamp(float(ts)).strftime("%H:%M:%S")
+                lines.append(
+                    f"[{ts_str}] (confidence={confidence:.1f}, from {source})\n{insight}"
+                )
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if len(lines) >= n:
+                break
+    except Exception:
+        return ""
+
+    if not lines:
+        return ""
+
+    # Reverse to get newest-last (chronological).
+    lines.reverse()
+    return "Subconscious insights:\n\n" + "\n---\n".join(lines)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+def _build_session_overrides(agent) -> dict:
+    """Build session_overrides dict from agent config."""
+    overrides: dict = {}
+    provider = getattr(agent._config, "subconscious_provider", None)
+    model = getattr(agent._config, "subconscious_model", None)
+    base_url = getattr(agent._config, "subconscious_base_url", None)
+    ctx_window = getattr(agent._config, "subconscious_context_window", None)
+    if provider:
+        overrides["provider"] = provider
+    if model:
+        overrides["model"] = model
+    if base_url:
+        overrides["base_url"] = base_url
+    if ctx_window:
+        overrides["context_window"] = ctx_window
+    return overrides
+
+
+def _extract_text_from_blocks(blocks: list) -> str:
+    """Extract text content from a list of content blocks."""
+    from ...llm.interface import TextBlock, ThinkingBlock
+
+    parts: list[str] = []
+    for b in blocks:
+        if isinstance(b, TextBlock):
+            if b.text:
+                parts.append(b.text)
+        elif isinstance(b, ThinkingBlock):
+            pass  # Skip thinking blocks.
+        else:
+            # Generic fallback for dict-like blocks.
+            text = getattr(b, "text", None)
+            if text:
+                parts.append(text)
+    return "\n".join(parts).strip()
+
+
+def _parse_subconscious_response(text: str) -> dict | None:
+    """Parse the subconscious LLM response into structured insight data.
+
+    Returns {"insight": str, "confidence": float, "source_memory": str}
+    or None if insight is null/empty. Handles markdown-wrapped JSON.
+    """
+    # Strip markdown code fences.
+    cleaned = re.sub(r'^```(?:json)?\s*\n?|\n?```\s*$', '', text.strip())
+
+    try:
+        data = json.loads(cleaned)
+    except (json.JSONDecodeError, ValueError):
+        # Unstructured text — treat as an insight with default confidence.
+        if text.strip():
+            return {
+                "insight": text.strip(),
+                "confidence": 0.5,
+                "source_memory": "unstructured",
+            }
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    insight = data.get("insight")
+    if insight is None or (isinstance(insight, str) and not insight.strip()):
+        return None
+
+    confidence = data.get("confidence", 0.5)
+    if not isinstance(confidence, (int, float)):
+        confidence = 0.5
+    confidence = max(0.0, min(1.0, float(confidence)))
+
+    source_memory = data.get("source_memory", "")
+    if not isinstance(source_memory, str):
+        source_memory = str(source_memory)
+
+    return {
+        "insight": str(insight).strip(),
+        "confidence": confidence,
+        "source_memory": source_memory,
+    }
+
+
+def _secrets_hex(n: int) -> str:
+    """Generate n random hex characters."""
+    import secrets
+    return secrets.token_hex(n // 2 + 1)[:n]

--- a/tests/test_soul.py
+++ b/tests/test_soul.py
@@ -155,8 +155,8 @@ class TestSoulTimer:
         assert agent._soul_timer is None
 
     def test_soul_timer_runs_perpetual_regardless_of_state(self, tmp_path):
-        """Timer is not state-gated — runs from boot, perpetually rescheduling
-        in _soul_whisper finally. State transitions don't kick the timer."""
+        """Timer is IDLE-gated — started on IDLE entry, cancelled on leaving IDLE.
+        ACTIVE state does not start or maintain the timer."""
         from lingtai_kernel import AgentState, BaseAgent
         agent = BaseAgent(
             service=_make_mock_service(),
@@ -165,19 +165,21 @@ class TestSoulTimer:
         )
         agent._soul_delay = 300.0
 
-        # State transitions must NOT touch the timer.
+        # Going ACTIVE from initial state — timer stays None (not IDLE).
         agent._set_state(AgentState.ACTIVE, reason="test")
         assert agent._soul_timer is None
-        agent._set_state(AgentState.IDLE, reason="done")
-        assert agent._soul_timer is None
 
-        # Explicit start (the path normally taken by start() at boot).
-        agent._start_soul_timer()
+        # Going IDLE starts the timer.
+        agent._set_state(AgentState.IDLE, reason="done")
         assert agent._soul_timer is not None
         assert agent._soul_timer.is_alive()
 
-        # Going active does NOT cancel the timer — cadence persists.
+        # Going ACTIVE from IDLE cancels the timer.
         agent._set_state(AgentState.ACTIVE, reason="new mail")
+        assert agent._soul_timer is None
+
+        # Going IDLE again restarts it.
+        agent._set_state(AgentState.IDLE, reason="done again")
         assert agent._soul_timer is not None
 
         agent._cancel_soul_timer()
@@ -240,7 +242,8 @@ def test_consultation_fire_discards_late_result_after_state_change(monkeypatch):
     from lingtai_kernel.state import AgentState
 
     agent = MagicMock()
-    agent._state = AgentState.ACTIVE
+    # Soul flow fires only when IDLE (not ACTIVE mid-turn).
+    agent._state = AgentState.IDLE
     agent._logs = []
     agent._tc_inbox.enqueue = MagicMock()
 

--- a/tests/test_soul_consultation.py
+++ b/tests/test_soul_consultation.py
@@ -508,19 +508,20 @@ class TestRunConsultationRedirectLoop:
 
     def test_consultation_no_diary_cue_past_bails(self, tmp_path):
         # Past branch needs the diary as the spark — empty diary means
-        # nothing to react to, so bail.
+        # nothing to react to, so bail early (no session created).
         agent = _FakeAgent(tmp_path)
         iface = ChatInterface(); iface.add_user_message("substrate")
         assert _run_consultation(agent, iface, "snapshot:foo") is None
-        assert agent.service.create_session.called
+        assert not agent.service.create_session.called
 
     def test_consultation_no_diary_cue_insights_bails(self, tmp_path):
         # After the raw-diary refactor, insights no longer bypasses the
         # diary check.  No spark = no consultation for any source.
+        # Bail early — no session created.
         agent = _FakeAgent(tmp_path)
         iface = ChatInterface(); iface.add_user_message("substrate")
         assert _run_consultation(agent, iface, "insights") is None
-        assert agent.service.create_session.called
+        assert not agent.service.create_session.called
 
     def test_consultation_spark_is_raw_diary(self, tmp_path):
         """The spark sent to session.send() is the raw diary cue, not a

--- a/tests/test_subconscious.py
+++ b/tests/test_subconscious.py
@@ -1,0 +1,451 @@
+"""Tests for the subconscious engine (feat/subconscious-redesign).
+
+Tests the shared engine extraction, config hard-gating, JSON parsing,
+timer lifecycle, JSONL persistence, and IDLE-gated soul flow.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lingtai_kernel.config import AgentConfig
+from lingtai_kernel.state import AgentState
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_service():
+    svc = MagicMock()
+    svc.model = "test-model"
+    svc.provider = "test-provider"
+    return svc
+
+
+def _make_agent(tmp_path, **config_kw):
+    from lingtai_kernel import BaseAgent
+    return BaseAgent(
+        service=_make_mock_service(),
+        agent_name="test",
+        working_dir=tmp_path / "test_agent",
+        config=AgentConfig(**config_kw),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config hard-gating
+# ---------------------------------------------------------------------------
+
+
+class TestSubconsciousConfigHardGating:
+    """enabling requires both provider and model to be explicitly set."""
+
+    def test_enable_without_provider_fails(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        from lingtai_kernel.intrinsics.soul.config import _handle_config
+        result = _handle_config(agent, {
+            "subconscious_enabled": True,
+            "subconscious_model": "cheap-model",
+        })
+        assert "error" in result
+        assert "subconscious_provider" in result["error"]
+        assert not agent._config.subconscious_enabled
+
+    def test_enable_without_model_fails(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        from lingtai_kernel.intrinsics.soul.config import _handle_config
+        result = _handle_config(agent, {
+            "subconscious_enabled": True,
+            "subconscious_provider": "mimo",
+        })
+        assert "error" in result
+        assert "subconscious_model" in result["error"]
+        assert not agent._config.subconscious_enabled
+
+    def test_enable_with_both_succeeds(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        from lingtai_kernel.intrinsics.soul.config import _handle_config
+        result = _handle_config(agent, {
+            "subconscious_enabled": True,
+            "subconscious_provider": "mimo",
+            "subconscious_model": "mimo-2-cheap",
+        })
+        assert result["status"] == "ok"
+        assert result["new"]["subconscious_enabled"] is True
+        assert agent._config.subconscious_enabled is True
+        assert agent._config.subconscious_provider == "mimo"
+        assert agent._config.subconscious_model == "mimo-2-cheap"
+
+    def test_set_provider_model_before_enable(self, tmp_path):
+        """Provider and model can be set in separate config calls."""
+        agent = _make_agent(tmp_path)
+        from lingtai_kernel.intrinsics.soul.config import _handle_config
+
+        # Set provider first.
+        r1 = _handle_config(agent, {"subconscious_provider": "mimo"})
+        assert r1["status"] == "ok"
+
+        # Set model.
+        r2 = _handle_config(agent, {"subconscious_model": "cheap"})
+        assert r2["status"] == "ok"
+
+        # Now enable — both are set.
+        r3 = _handle_config(agent, {"subconscious_enabled": True})
+        assert r3["status"] == "ok"
+        assert agent._config.subconscious_enabled is True
+
+    def test_disable_succeeds_without_provider_model(self, tmp_path):
+        """Disabling doesn't require provider/model."""
+        agent = _make_agent(tmp_path, subconscious_enabled=True)
+        agent._config.subconscious_provider = None
+        agent._config.subconscious_model = None
+        from lingtai_kernel.intrinsics.soul.config import _handle_config
+        result = _handle_config(agent, {"subconscious_enabled": False})
+        assert result["status"] == "ok"
+        assert agent._config.subconscious_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Config persistence
+# ---------------------------------------------------------------------------
+
+
+class TestSubconsciousConfigPersistence:
+    """subconscious config round-trips through init.json."""
+
+    def test_persist_subconscious_config(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        init_path = agent._working_dir / "init.json"
+        init_path.parent.mkdir(parents=True, exist_ok=True)
+        init_path.write_text(json.dumps({
+            "manifest": {"llm": {}}
+        }), encoding="utf-8")
+
+        from lingtai_kernel.intrinsics.soul.config import _persist_soul_config
+        _persist_soul_config(agent, {
+            "subconscious_enabled": True,
+            "subconscious_provider": "mimo",
+            "subconscious_model": "cheap",
+        })
+
+        data = json.loads(init_path.read_text())
+        sub = data["manifest"]["soul"]["subconscious"]
+        assert sub["enabled"] is True
+        assert sub["provider"] == "mimo"
+        assert sub["model"] == "cheap"
+
+
+# ---------------------------------------------------------------------------
+# JSON parsing
+# ---------------------------------------------------------------------------
+
+
+class TestSubconsciousJsonParsing:
+    """Parse structured and unstructured LLM responses."""
+
+    def test_parse_valid_json(self):
+        from lingtai_kernel.intrinsics.soul.subconscious import _parse_subconscious_response
+        result = _parse_subconscious_response(
+            '{"insight": "pattern X matches Y", "confidence": 0.8, "source_memory": "snapshot_001"}'
+        )
+        assert result is not None
+        assert result["insight"] == "pattern X matches Y"
+        assert result["confidence"] == 0.8
+        assert result["source_memory"] == "snapshot_001"
+
+    def test_parse_null_insight_returns_none(self):
+        from lingtai_kernel.intrinsics.soul.subconscious import _parse_subconscious_response
+        result = _parse_subconscious_response('{"insight": null}')
+        assert result is None
+
+    def test_parse_empty_insight_returns_none(self):
+        from lingtai_kernel.intrinsics.soul.subconscious import _parse_subconscious_response
+        result = _parse_subconscious_response('{"insight": ""}')
+        assert result is None
+
+    def test_parse_markdown_wrapped_json(self):
+        from lingtai_kernel.intrinsics.soul.subconscious import _parse_subconscious_response
+        result = _parse_subconscious_response(
+            '```json\n{"insight": "found it", "confidence": 0.9}\n```'
+        )
+        assert result is not None
+        assert result["insight"] == "found it"
+
+    def test_parse_unstructured_text(self):
+        from lingtai_kernel.intrinsics.soul.subconscious import _parse_subconscious_response
+        result = _parse_subconscious_response("This reminds me of something.")
+        assert result is not None
+        assert result["insight"] == "This reminds me of something."
+        assert result["confidence"] == 0.5
+        assert result["source_memory"] == "unstructured"
+
+    def test_confidence_clamped(self):
+        from lingtai_kernel.intrinsics.soul.subconscious import _parse_subconscious_response
+        result = _parse_subconscious_response(
+            '{"insight": "test", "confidence": 1.5}'
+        )
+        assert result["confidence"] == 1.0
+
+        result = _parse_subconscious_response(
+            '{"insight": "test", "confidence": -0.5}'
+        )
+        assert result["confidence"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# JSONL persistence
+# ---------------------------------------------------------------------------
+
+
+class TestSubconsciousJsonl:
+    """Append, read, and clear the subconscious JSONL."""
+
+    def test_append_and_read(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        from lingtai_kernel.intrinsics.soul.subconscious import (
+            _append_subconscious_record,
+            _read_subconscious_tail,
+            _clear_subconscious_jsonl,
+        )
+
+        _append_subconscious_record(agent, {
+            "ts": time.time(),
+            "fire_id": "test",
+            "insight": "pattern found",
+            "confidence": 0.7,
+            "source_memory": "snap",
+            "source_snapshot": "snapshot:foo",
+            "model_used": "cheap",
+        })
+
+        tail = _read_subconscious_tail(agent, n=5)
+        assert "pattern found" in tail
+        assert "confidence=0.7" in tail
+
+        _clear_subconscious_jsonl(agent)
+        tail = _read_subconscious_tail(agent, n=5)
+        assert tail == ""
+
+    def test_read_reverse_order(self, tmp_path):
+        """Newest-last ordering."""
+        agent = _make_agent(tmp_path)
+        from lingtai_kernel.intrinsics.soul.subconscious import (
+            _append_subconscious_record,
+            _read_subconscious_tail,
+        )
+
+        _append_subconscious_record(agent, {
+            "ts": time.time() - 10,
+            "fire_id": "f1",
+            "insight": "first insight",
+            "confidence": 0.5,
+            "source_memory": "s1",
+            "source_snapshot": "snapshot:a",
+            "model_used": "m",
+        })
+        _append_subconscious_record(agent, {
+            "ts": time.time(),
+            "fire_id": "f2",
+            "insight": "second insight",
+            "confidence": 0.8,
+            "source_memory": "s2",
+            "source_snapshot": "snapshot:b",
+            "model_used": "m",
+        })
+
+        tail = _read_subconscious_tail(agent, n=10)
+        # second insight should appear after first (newest-last)
+        first_pos = tail.index("first insight")
+        second_pos = tail.index("second insight")
+        assert second_pos > first_pos
+
+
+# ---------------------------------------------------------------------------
+# Timer lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSubconsciousTimerLifecycle:
+    """Timer starts on turn start, cancels on state transition."""
+
+    def test_timer_not_started_when_disabled(self, tmp_path):
+        agent = _make_agent(tmp_path, subconscious_enabled=False)
+        from lingtai_kernel.intrinsics.soul.subconscious import _start_subconscious_timer
+        _start_subconscious_timer(agent)
+        assert getattr(agent, "_subconscious_timer", None) is None
+
+    def test_timer_started_when_enabled(self, tmp_path):
+        agent = _make_agent(tmp_path, subconscious_enabled=True)
+        from lingtai_kernel.intrinsics.soul.subconscious import (
+            _start_subconscious_timer,
+            _cancel_subconscious_timer,
+        )
+        _start_subconscious_timer(agent)
+        assert agent._subconscious_timer is not None
+        assert agent._subconscious_timer.is_alive()
+        _cancel_subconscious_timer(agent)
+        assert agent._subconscious_timer is None
+
+    def test_state_transition_cancels_timer(self, tmp_path):
+        agent = _make_agent(tmp_path, subconscious_enabled=True)
+        from lingtai_kernel.intrinsics.soul.subconscious import _start_subconscious_timer
+        _start_subconscious_timer(agent)
+        assert agent._subconscious_timer is not None
+
+        # Transition away from ACTIVE cancels the timer.
+        agent._state = AgentState.ACTIVE
+        agent._set_state(AgentState.IDLE, reason="turn done")
+        assert agent._subconscious_timer is None
+
+
+# ---------------------------------------------------------------------------
+# Shared engine
+# ---------------------------------------------------------------------------
+
+
+class TestSharedConsultationEngine:
+    """_run_consultation_voice respects allow_tool_recommendations."""
+
+    def test_no_tools_when_disabled(self, tmp_path):
+        """allow_tool_recommendations=False passes tools=None."""
+        from lingtai_kernel.intrinsics.soul.consultation import _run_consultation_voice
+        from lingtai_kernel.llm.interface import ChatInterface, TextBlock
+
+        agent = _make_agent(tmp_path)
+        agent._config.model = "test-model"
+
+        iface = ChatInterface()
+        iface.add_user_message("hello")
+
+        mock_response = MagicMock()
+        mock_response.text = "response text"
+        mock_response.tool_calls = []
+        mock_response.thoughts = []
+        mock_response.usage = MagicMock(
+            input_tokens=0, output_tokens=0,
+            thinking_tokens=0, cached_tokens=0,
+        )
+
+        mock_session = MagicMock()
+        mock_session.interface = MagicMock()
+        mock_session.interface.entries = [MagicMock(role="assistant", content=[TextBlock(text="response text")])]
+        agent.service.create_session.return_value = mock_session
+
+        with patch(
+            "lingtai_kernel.intrinsics.soul.consultation._send_with_timeout",
+            return_value=mock_response,
+        ):
+            result = _run_consultation_voice(
+                agent, iface, "test",
+                system_prompt="test prompt",
+                spark="test spark",
+                allow_tool_recommendations=False,
+            )
+
+        # Verify tools=None was passed.
+        call_kwargs = agent.service.create_session.call_args
+        assert call_kwargs.kwargs.get("tools") is None or call_kwargs[1].get("tools") is None
+
+    def test_tools_passed_when_enabled(self, tmp_path):
+        """allow_tool_recommendations=True passes tool schemas."""
+        from lingtai_kernel.intrinsics.soul.consultation import _run_consultation_voice
+        from lingtai_kernel.llm.interface import ChatInterface, TextBlock
+
+        agent = _make_agent(tmp_path)
+        agent._config.model = "test-model"
+        agent._session = MagicMock()
+        agent._session._build_tool_schemas_fn.return_value = [{"name": "test"}]
+
+        iface = ChatInterface()
+        iface.add_user_message("hello")
+
+        mock_response = MagicMock()
+        mock_response.text = "done"
+        mock_response.tool_calls = []
+        mock_response.thoughts = []
+        mock_response.usage = MagicMock(
+            input_tokens=0, output_tokens=0,
+            thinking_tokens=0, cached_tokens=0,
+        )
+
+        mock_session = MagicMock()
+        mock_session.interface = MagicMock()
+        mock_session.interface.entries = [MagicMock(role="assistant", content=[TextBlock(text="done")])]
+        agent.service.create_session.return_value = mock_session
+
+        with patch(
+            "lingtai_kernel.intrinsics.soul.consultation._send_with_timeout",
+            return_value=mock_response,
+        ):
+            result = _run_consultation_voice(
+                agent, iface, "test",
+                system_prompt="test prompt",
+                spark="test spark",
+                allow_tool_recommendations=True,
+            )
+
+        # Verify tools were passed (not None).
+        call_kwargs = agent.service.create_session.call_args
+        tools = call_kwargs.kwargs.get("tools") or call_kwargs[1].get("tools")
+        assert tools is not None
+
+
+# ---------------------------------------------------------------------------
+# Session overrides
+# ---------------------------------------------------------------------------
+
+
+class TestSessionOverrides:
+    """Session overrides are passed through to create_session."""
+
+    def test_model_override(self, tmp_path):
+        from lingtai_kernel.intrinsics.soul.subconscious import _build_session_overrides
+
+        agent = _make_agent(tmp_path,
+                            subconscious_provider="mimo",
+                            subconscious_model="cheap-model",
+                            subconscious_base_url="http://localhost:8080")
+
+        overrides = _build_session_overrides(agent)
+        assert overrides["provider"] == "mimo"
+        assert overrides["model"] == "cheap-model"
+        assert overrides["base_url"] == "http://localhost:8080"
+
+    def test_empty_overrides(self, tmp_path):
+        from lingtai_kernel.intrinsics.soul.subconscious import _build_session_overrides
+        agent = _make_agent(tmp_path)
+        overrides = _build_session_overrides(agent)
+        assert overrides.get("provider") is None or "provider" not in overrides
+
+
+# ---------------------------------------------------------------------------
+# IDLE-gated soul flow
+# ---------------------------------------------------------------------------
+
+
+class TestIdleGatedSoulFlow:
+    """Soul flow fires only on IDLE, not ACTIVE."""
+
+    def test_soul_fire_allowed_idle(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        agent._state = AgentState.IDLE
+        from lingtai_kernel.intrinsics.soul.flow import _soul_fire_allowed
+        assert _soul_fire_allowed(agent) is True
+
+    def test_soul_fire_not_allowed_active(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        agent._state = AgentState.ACTIVE
+        from lingtai_kernel.intrinsics.soul.flow import _soul_fire_allowed
+        assert _soul_fire_allowed(agent) is False
+
+    def test_soul_fire_not_allowed_asleep(self, tmp_path):
+        agent = _make_agent(tmp_path)
+        agent._state = AgentState.ASLEEP
+        from lingtai_kernel.intrinsics.soul.flow import _soul_fire_allowed
+        assert _soul_fire_allowed(agent) is False


### PR DESCRIPTION
## Summary

Redesign the subconscious implementation based on the reviewer's design spec in [PR #16 comments](https://github.com/Lingtai-AI/lingtai-kernel/pull/16#issuecomment-4395188104). Implements the unified consultation engine, IDLE-gated soul flow, and turn-lifecycle subconscious.

## Changes

### 1. Shared engine extraction (consultation.py)
- `_run_consultation_voice()` — the shared primitive both soul flow and subconscious build on
- Accepts system_prompt, session_overrides, allow_tool_recommendations, max_rounds
- Eliminates ~150 lines of duplicated machinery from the old separate-engine PR

### 2. Soul flow gated to IDLE-only (flow.py, base_agent/__init__.py)
- `_soul_fire_allowed()` now checks IDLE only (not ACTIVE)
- Firing mid-turn spliced consultation tool-call recommendations into active tool loops, producing ghost interleaved results
- Timer started on IDLE entry, cancelled on leaving IDLE
- `_set_state` updated: subconscious timer cancelled on ACTIVE-to-non-ACTIVE transitions

### 3. New subconscious engine (subconscious.py)
- 60-second wall-clock timer, fires ONLY during tool-call loops (ACTIVE state mid-turn)
- Fan-out across ALL snapshots (cheap-model parallel, not random sample)
- Per-snapshot daemon threads, per-snapshot JSONL append on non-null insight
- Fire-level lock (try-acquire non-blocking) prevents overlapping fires
- JSONL clears at turn start — "never congregate in hours" enforced positionally
- Last 10 insights displayed newest-last via `_read_subconscious_tail`

### 4. Config hard-gating (config.py)
- `subconscious_enabled=True` requires both `subconscious_provider` AND `subconscious_model` explicitly set
- No silent fallback to primary model (prevents billing surprises from per-turn fan-out cost)
- All fields exposed as full config knobs

### 5. Config reload fix (agent.py)
- `_read_init` now reads `manifest.soul.subconscious.{enabled,provider,model,base_url,context_window}`
- Fixes the reload-path bug identified in PR #16 audit

### 6. Turn lifecycle hooks (turn.py)
- `_handle_request` starts subconscious timer at turn start, clears stale JSONL
- `finally` block always cancels timer and clears JSONL at turn end (even on exception)

### 7. i18n (en.json, zh.json, wen.json)
- New keys for subconscious schema descriptions in all 3 locales

## Tests

135 passing (111 existing + 24 new):
- `test_subconscious.py` — config hard-gating, config persistence, JSON parsing (valid, null, markdown-wrapped, unstructured, confidence clamping), JSONL append/read/clear, timer lifecycle, shared engine (tools/no-tools dispatch), session overrides, IDLE-gated soul flow
- Updated existing tests to match IDLE-gated behavior and early diary bail

## Design decisions (per reviewer spec)

| Decision | Implementation |
|----------|---------------|
| Soul flow: IDLE-only | `_soul_fire_allowed` + `_set_state` + timer start/cancel |
| Subconscious: tool-call loop only | Timer starts in `_handle_request`, cancels in finally |
| Cheap-model hard-gating | Config validation requires explicit provider+model |
| Fan-out across ALL snapshots | Full paths list, not random sample |
| JSONL (not notification TTL) | Direct JSONL append + `_iter_lines_reverse` tail-read |
| No TTL machinery | All TTL/check/heartbeat code from old PR deleted |

## Files changed

| File | Change |
|------|--------|
| `consultation.py` | Extracted `_run_consultation_voice`, added `_SUBCONSCIOUS_SYSTEM_PROMPT` |
| `flow.py` | IDLE-only gating in `_soul_fire_allowed` + `_soul_whisper` |
| `subconscious.py` | **New** — full subconscious engine |
| `config.py` | Added subconscious fields to `AgentConfig` |
| `soul/__init__.py` | Updated exports and schema |
| `base_agent/__init__.py` | Added subconscious attrs, IDLE-gated `_set_state` |
| `turn.py` | Turn-lifecycle hooks in `_handle_request` |
| `agent.py` | Fixed config reload path |
| `i18n/*.json` | New subconscious i18n keys |
| `tests/test_subconscious.py` | **New** — 24 tests |
| `tests/test_soul.py` | Updated for IDLE-gating |
| `tests/test_soul_consultation.py` | Updated for early diary bail |

cc @huangzesen
