### PR TITLE
fix(kernel): inject notifications into dict-content ToolResultBlocks

### DIFF
--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -1106,18 +1106,15 @@ class BaseAgent:
         return True
 
     def _inject_notification_meta(self, message):
-        """ACTIVE-state: prepend notification JSON to a recent str ToolResultBlock.
+        """ACTIVE-state: prepend notification JSON to a recent ToolResultBlock.
 
         Called from ``SessionManager.send()`` before the API call.  Walks
-        the wire backwards looking for a ``ToolResultBlock`` whose
-        ``.content`` is a string (dict-content blocks come from MCP
-        structured results — those are skipped to avoid corrupting their
-        schema).  Prepends the
-        ``notifications:\\n<json>\\n\\n`` prefix to the most recent
-        string-content result, stripping any stale prefix from older
-        results.
+        the wire backwards looking for the most recent ``ToolResultBlock``.
+        Dict-content blocks are serialized to JSON before prepending.
+        Prepends the ``notifications:\\n<json>\\n\\n`` prefix to the
+        target result, stripping any stale prefix from older results.
 
-        If no string-content ``ToolResultBlock`` exists, leaves
+        If no ``ToolResultBlock`` exists at all, leaves
         ``_pending_notification_meta`` set and the next ``send()``
         retries.
 
@@ -1136,17 +1133,14 @@ class BaseAgent:
         )
 
         # Walk backwards to find the most recent user entry whose content
-        # contains a *string-content* ToolResultBlock.
+        # contains a ToolResultBlock (str or dict content).
         target_entry = None
         target_block = None
         for entry in reversed(iface.entries):
             if entry.role != "user":
                 continue
             for block in entry.content:
-                if (
-                    isinstance(block, ToolResultBlock)
-                    and isinstance(block.content, str)
-                ):
+                if isinstance(block, ToolResultBlock):
                     target_entry = entry
                     target_block = block
                     break
@@ -1154,14 +1148,18 @@ class BaseAgent:
                 break
 
         if target_block is None:
-            # All recent results are dict-typed (or there are none).
-            # Keep the pending meta; the next send() with a string
-            # result will carry it.
+            # No ToolResultBlocks at all.
             self._log(
                 "notification_meta_deferred",
-                reason="no_str_tool_result",
+                reason="no_tool_result",
             )
             return message
+
+        # If the target block has dict content, serialize to JSON string.
+        if isinstance(target_block.content, dict):
+            target_block.content = json.dumps(
+                target_block.content, ensure_ascii=False
+            )
 
         # Strip notification prefix from ALL OTHER user ToolResultBlocks.
         for entry in iface.entries:

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -809,9 +809,9 @@ def test_sync_active_stashes_meta(tmp_path: Path) -> None:
     assert len(agent._chat_stub.interface.entries) == 0
 
 
-def test_inject_notification_meta_skips_dict_content(tmp_path: Path) -> None:
-    """Most recent ToolResultBlock has dict content — meta walks back to
-    the next string-content result."""
+def test_inject_notification_meta_prefers_most_recent_block(tmp_path: Path) -> None:
+    """Most recent ToolResultBlock has dict content — meta is injected
+    there (dict serialized to JSON string), not on the older str block."""
     from lingtai_kernel.base_agent import BaseAgent
     from lingtai_kernel.llm.interface import ToolCallBlock, ToolResultBlock
 
@@ -821,7 +821,7 @@ def test_inject_notification_meta_skips_dict_content(tmp_path: Path) -> None:
     # First pair: string content (older).
     iface.add_assistant_message(content=[ToolCallBlock(id="c1", name="bash", args={})])
     iface.add_tool_results([ToolResultBlock(id="c1", name="bash", content="hello world")])
-    # Second pair: dict content (newer — should be skipped).
+    # Second pair: dict content (newer — should receive the notification).
     iface.add_assistant_message(content=[ToolCallBlock(id="c2", name="mcp", args={})])
     iface.add_tool_results([ToolResultBlock(id="c2", name="mcp", content={"structured": True})])
 
@@ -841,18 +841,70 @@ def test_inject_notification_meta_skips_dict_content(tmp_path: Path) -> None:
     agent = _Agent()
     agent._inject_notification_meta(message=None)
 
-    # Older str-content block now carries the prefix.
+    # Older str-content block is untouched.
     str_block = iface.entries[1].content[0]
-    assert isinstance(str_block.content, str)
-    assert str_block.content.startswith("notifications:\n")
-    assert "hello world" in str_block.content
+    assert str_block.content == "hello world"
 
-    # Newer dict-content block is untouched.
+    # Newer dict-content block was serialized and now carries the prefix.
     dict_block = iface.entries[3].content[0]
-    assert dict_block.content == {"structured": True}
+    assert isinstance(dict_block.content, str)
+    assert dict_block.content.startswith("notifications:\n")
+    assert '"structured": true' in dict_block.content
 
     # Pending meta cleared.
     assert agent._pending_notification_meta is None
+
+
+def test_inject_notification_meta_dict_only(tmp_path: Path) -> None:
+    """When ALL ToolResultBlocks have dict content, the notification is
+    still injected (dict serialized to JSON string) instead of being
+    deferred indefinitely.  Regression test for 79% deferral rate bug."""
+    from lingtai_kernel.base_agent import BaseAgent
+    from lingtai_kernel.llm.interface import ToolCallBlock, ToolResultBlock
+
+    chat = _make_chat_stub()
+    iface = chat.interface
+
+    # Only dict-content blocks — the old code would defer here.
+    iface.add_assistant_message(content=[ToolCallBlock(id="c1", name="psyche", args={})])
+    iface.add_tool_results([ToolResultBlock(id="c1", name="psyche", content={"status": "ok", "identity": "test"})])
+    iface.add_assistant_message(content=[ToolCallBlock(id="c2", name="soul", args={})])
+    iface.add_tool_results([ToolResultBlock(id="c2", name="soul", content={"voices": []})])
+
+    class _Agent(BaseAgent):
+        def __init__(self):
+            self._chat_stub = chat
+            self._pending_notification_meta = '{"_synthesized": true, "notifications": {"molt": {"pressure": 0.9}}}'
+            self._logs = []
+
+        @property
+        def _chat(self):
+            return self._chat_stub
+
+        def _log(self, evt, **fields):
+            self._logs.append((evt, fields))
+
+    agent = _Agent()
+    agent._inject_notification_meta(message=None)
+
+    # Most recent block (soul) should carry the notification prefix.
+    target = iface.entries[3].content[0]
+    assert isinstance(target.content, str)
+    assert target.content.startswith("notifications:\n")
+    assert '"voices": []' in target.content
+    assert "molt" in target.content
+
+    # Older dict block untouched (already serialized would only happen
+    # if it had been a previous target — it wasn't, so still dict).
+    older = iface.entries[1].content[0]
+    assert older.content == {"status": "ok", "identity": "test"}
+
+    # Pending meta cleared — not deferred.
+    assert agent._pending_notification_meta is None
+    # Logged as injected, not deferred.
+    events = [e for e, _ in agent._logs]
+    assert "notification_meta_injected" in events
+    assert "notification_meta_deferred" not in events
 
 
 def test_inject_notification_meta_strips_old_prefix(tmp_path: Path) -> None:


### PR DESCRIPTION
## Bug

The notification injection system ( in ) only handled s with string content. Most tools (psyche, soul, system, email, codex, bash, etc.) return dict-content blocks, so 79% of notifications were deferred with  and never injected.

**Impact**: Molt warnings were written to  but never appeared in the agent's context. The agent never saw warnings and never molted.

## Root Cause

Lines 1148-1154 checked , which excluded all dict-content blocks from being injection targets.

## Fix (minimal, 2 changes)

1. **Removed the  filter** — any  is now a valid injection target
2. **Added dict-to-JSON serialization** — when the target block has dict content,  converts it to a string before prepending the notification prefix

## Tests

- Updated  →  (verifies notification lands on most recent block, even if dict)
- Added  — the actual bug scenario where ALL blocks have dict content; verifies injection succeeds instead of deferring
- All 40 notification tests pass, 1476/1476 other tests pass (3 pre-existing failures unrelated to this change)