### PR TITLE
fix(mcp): clear stale MCP notifications when inbox is empty

### DIFF
--- a/src/lingtai/core/mcp/inbox.py
+++ b/src/lingtai/core/mcp/inbox.py
@@ -363,6 +363,14 @@ def _scan_once(agent: "BaseAgent", inbox_root: Path) -> int:
                     "mcp_inbox: failed to post summary for %s (count=%d): %s",
                     mcp_name, events_this_mcp, e,
                 )
+        else:
+            # No events for this MCP — clear any stale notification so the
+            # agent doesn't keep seeing "1 new event" after it's been handled.
+            try:
+                from lingtai_kernel.notifications import clear as clear_notification
+                clear_notification(agent._working_dir, f"mcp.{mcp_name}")
+            except Exception:
+                pass
 
     return dispatched
 


### PR DESCRIPTION
## Problem

MCP notifications (e.g. ) were published via  when events were found, but never cleared when the inbox was empty. This caused stale '1 new event' notifications to persist indefinitely in .

## Fix

Added an  branch in  that clears the MCP notification file when the sweep finds zero pending events for that MCP. This matches the email notification pattern — publish on unread, clear when empty.

## Changes

- : Added  call when 