### PR TITLE
feat: shared overflow recovery + remove force-wipe

### DIFF
--- a/src/lingtai/llm/anthropic/adapter.py
+++ b/src/lingtai/llm/anthropic/adapter.py
@@ -315,6 +315,27 @@ class AnthropicChatSession(ChatSession):
         """The canonical ChatInterface for this session."""
         return self._interface
 
+    # -- Context-overflow detection (Anthropic-specific) -------------------
+
+    @staticmethod
+    def _is_context_overflow_error(exc: Exception) -> bool:
+        """Detect Anthropic context-length-exceeded errors."""
+        if not isinstance(exc, anthropic.BadRequestError):
+            return False
+        msg = (str(exc) or "").lower()
+        return any(
+            needle in msg
+            for needle in (
+                "too many tokens",
+                "context length",
+                "context window",
+                "prompt is too long",
+                "input is too long",
+                "maximum context",
+                "request too large",
+            )
+        )
+
     def _build_request_kwargs(self, messages: list[dict]) -> dict[str, Any]:
         kwargs: dict[str, Any] = {
             "model": self._model,
@@ -367,14 +388,18 @@ class AnthropicChatSession(ChatSession):
         if self.pre_request_hook is not None:
             self.pre_request_hook(self._interface)
 
-        self._interface.enforce_tool_pairing()
-        candidate_msgs = to_anthropic(self._interface)
-        clean_messages = _ensure_alternation(candidate_msgs)
-        kwargs = self._build_request_kwargs(clean_messages)
+        # Build kwargs from current interface state — re-runs inside the
+        # overflow-recovery loop so each retry sees the post-trim interface.
+        def _do_call():
+            self._interface.enforce_tool_pairing()
+            candidate_msgs = to_anthropic(self._interface)
+            clean_messages = _ensure_alternation(candidate_msgs)
+            kwargs = self._build_request_kwargs(clean_messages)
+            return self._client.messages.create(**kwargs)
 
         try:
-            raw = self._client.messages.create(**kwargs)
-        except Exception as api_err:
+            raw, total_dropped, rounds = self._run_with_overflow_recovery(_do_call)
+        except Exception:
             # Revert the interface on error - drop the last user entry,
             # but only when this call appended one.  ``message is None``
             # means the caller pre-staged the wire and we must not
@@ -382,6 +407,10 @@ class AnthropicChatSession(ChatSession):
             if message is not None:
                 self._interface.drop_trailing(lambda e: e.role == "user")
             raise
+
+        # If recovery fired (entries were dropped), inject the molt notice.
+        if rounds > 0:
+            self._inject_overflow_notice(total_dropped=total_dropped, rounds=rounds)
 
         # Parse response and add to interface
         response = _parse_response(raw)
@@ -442,15 +471,19 @@ class AnthropicChatSession(ChatSession):
         if self.pre_request_hook is not None:
             self.pre_request_hook(self._interface)
 
-        # Build ephemeral Anthropic messages from interface
-        self._interface.enforce_tool_pairing()
-        candidate_msgs = to_anthropic(self._interface)
-        clean_messages = _ensure_alternation(candidate_msgs)
-        kwargs = self._build_request_kwargs(clean_messages)
-
+        # Build ephemeral Anthropic messages from interface — re-runs inside
+        # the overflow-recovery loop so each retry sees the post-trim interface.
         acc = StreamingAccumulator()
+        final_message = None
 
-        try:
+        def _do_stream():
+            nonlocal final_message, acc
+            acc = StreamingAccumulator()
+            self._interface.enforce_tool_pairing()
+            candidate_msgs = to_anthropic(self._interface)
+            clean_messages = _ensure_alternation(candidate_msgs)
+            kwargs = self._build_request_kwargs(clean_messages)
+
             with self._client.messages.stream(**kwargs) as stream:
                 for event in stream:
                     etype = getattr(event, "type", None)
@@ -482,12 +515,20 @@ class AnthropicChatSession(ChatSession):
                         acc.finish_tool()
 
                 final_message = stream.get_final_message()
+            return final_message
+
+        try:
+            raw_result, total_dropped, rounds = self._run_with_overflow_recovery(_do_stream)
         except Exception:
             # Revert the interface on error — drop the last user entry
             # only if this call appended one.
             if message is not None:
                 self._interface.drop_trailing(lambda e: e.role == "user")
             raise
+
+        # If recovery fired (entries were dropped), inject the molt notice.
+        if rounds > 0:
+            self._inject_overflow_notice(total_dropped=total_dropped, rounds=rounds)
 
         # Extract usage from final message (includes cache metrics)
         # Same normalisation as _parse_response — see comment there.

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -272,12 +272,6 @@ class OpenAIChatSession(ChatSession):
         """
         return to_openai(self._interface)
 
-    # Maximum number of context-overflow halving rounds before giving up.
-    # 10 rounds × 10% drop ≈ 65% of conversation eligible for trimming —
-    # plenty of headroom for any single-attachment overflow without thrashing.
-    _OVERFLOW_MAX_ROUNDS = 10
-    _OVERFLOW_DROP_FRACTION = 0.10
-
     @staticmethod
     def _is_context_overflow_error(exc: Exception) -> bool:
         """Detect provider 400-class context-length-exceeded errors.
@@ -313,127 +307,9 @@ class OpenAIChatSession(ChatSession):
             )
         )
 
-    def _trim_context_one_round(self) -> int:
-        """Drop ~10% of non-system entries from the FRONT of the interface.
-
-        Snaps the cut point forward so we never split an
-        ``assistant[ToolCallBlock]`` from its matching
-        ``user[ToolResultBlock]`` — the resulting wire payload would be
-        invalid for strict providers.
-
-        Returns the number of entries dropped (0 if none could be dropped
-        — caller should treat that as terminal).
-        """
-        entries = self._interface._entries  # canonical list, mutated in place
-        if not entries:
-            return 0
-        # Index of first non-system entry.
-        first_conv = 0
-        if entries[0].role == "system":
-            first_conv = 1
-        conv_len = len(entries) - first_conv
-        if conv_len <= 1:
-            return 0
-        drop_n = max(1, int(conv_len * self._OVERFLOW_DROP_FRACTION))
-        cut = first_conv + drop_n  # entries[first_conv:cut] get dropped
-
-        # Snap cut forward past any assistant[tool_calls] / user[tool_results]
-        # boundary so we never strand a tool_call without its result.
-        max_cut = len(entries)
-        while cut < max_cut:
-            # If the entry just *before* the cut is assistant[tool_calls],
-            # advance until we're past its matching user[tool_results].
-            if cut == 0:
-                break
-            prev = entries[cut - 1]
-            if prev.role == "assistant" and any(
-                isinstance(b, ToolCallBlock) for b in prev.content
-            ):
-                cut += 1
-                continue
-            # If the entry at the cut is a user[tool_results-only], advance
-            # past it so we don't leave dangling results without their call.
-            cur = entries[cut]
-            if cur.role == "user" and cur.content and all(
-                isinstance(b, ToolResultBlock) for b in cur.content
-            ):
-                cut += 1
-                continue
-            break
-
-        if cut >= max_cut:
-            # Snap consumed everything — refuse to drop the entire conversation.
-            return 0
-
-        dropped = cut - first_conv
-        # Mutate in place: keep system + everything from cut onward.
-        del entries[first_conv:cut]
-        return dropped
-
-    def _inject_overflow_notice(self, total_dropped: int, rounds: int) -> None:
-        """Append a single user-role kernel notice after successful recovery.
-
-        We use the user role (universally supported) with an explicit
-        ``[kernel]`` prefix — same pattern as our synthesized tool aborts.
-        The notice strongly recommends molting since context pressure is
-        now demonstrably above the model's hard ceiling.
-        """
-        notice = (
-            f"[kernel] Context exceeded the provider's hard token limit. "
-            f"To recover, the kernel dropped {total_dropped} oldest entries "
-            f"across {rounds} retry round(s). Detail from earlier turns may "
-            f"be lost — re-read recent context before acting on it. "
-            f"**Strongly recommend triggering a molt soon** — the conversation "
-            f"is past the model's safe limit and further growth will overflow "
-            f"again."
-        )
-        self._interface._append("user", [TextBlock(text=notice)])
-
-    def _run_with_overflow_recovery(self, do_call):
-        """Run an API call with context-overflow auto-recovery.
-
-        ``do_call`` is a zero-arg callable performing one full attempt
-        (build kwargs from current interface state + invoke the API). It
-        is re-called after each trim so the request reflects the post-trim
-        canonical interface.
-
-        Returns ``(result, total_dropped, rounds)``. ``total_dropped`` is 0
-        and ``rounds`` is 0 when no recovery was needed. On non-overflow
-        errors, re-raises immediately. On terminal failure (cannot trim
-        further, or max rounds hit), re-raises the original error.
-        """
-        total_dropped = 0
-        rounds = 0
-        while True:
-            try:
-                result = do_call()
-                return result, total_dropped, rounds
-            except Exception as exc:
-                if not self._is_context_overflow_error(exc):
-                    raise
-                if rounds >= self._OVERFLOW_MAX_ROUNDS:
-                    logger.warning(
-                        "[overflow-recovery] giving up after %d rounds "
-                        "(dropped %d entries total) — re-raising provider error.",
-                        rounds, total_dropped,
-                    )
-                    raise
-                dropped = self._trim_context_one_round()
-                if dropped == 0:
-                    logger.warning(
-                        "[overflow-recovery] cannot trim further "
-                        "(dropped %d entries across %d rounds) — re-raising.",
-                        total_dropped, rounds,
-                    )
-                    raise
-                total_dropped += dropped
-                rounds += 1
-                logger.warning(
-                    "[overflow-recovery] round %d: dropped %d entries "
-                    "(running total %d). Retrying.",
-                    rounds, dropped, total_dropped,
-                )
-                continue
+    # _trim_context_one_round, _run_with_overflow_recovery, and
+    # _inject_overflow_notice are inherited from ChatSession (base class).
+    # Only _is_context_overflow_error needs to be provider-specific.
 
     def _pair_orphan_tool_calls(self, messages: list[dict]) -> list[dict]:
         """Final wire-layer guard: synthesize placeholder tool messages for

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -515,103 +515,84 @@ def _handle_request(agent, msg: Message) -> None:
     pressure = agent._session.get_context_pressure()
 
     if pressure >= agent._config.molt_hard_ceiling and has_molt:
-        if agent._session._compaction_warnings > 0:
-            # Hard ceiling, already warned — force-wipe.
-            lang = agent._config.language
-            agent._log("auto_forget", reason="hard ceiling", pressure=pressure, ceiling=agent._config.molt_hard_ceiling)
-            from ..intrinsics import psyche as _psyche
-            from ..intrinsics.system import clear_notification
-            _psyche.context_forget(agent)
-            agent._session._compaction_warnings = 0
-            clear_notification(agent._working_dir, "molt")
-            content = f"{_t(lang, 'system.molt_wiped')}\n[Pressure: {pressure:.0%}, hard ceiling: {agent._config.molt_hard_ceiling:.0%}]\n\n{content}"
-        else:
-            # Hard ceiling, first hit — publish urgent notification so
-            # the agent gets one turn to see the warning and molt
-            # voluntarily before the next turn force-wipes.
-            agent._session._compaction_warnings += 1
-            warnings = agent._session._compaction_warnings
-            max_warnings = agent._config.molt_warnings
-            remaining = max(0, max_warnings - warnings)
-            lang = agent._config.language
-            level = 3  # highest urgency
-            level_prompt = _t(
-                lang,
-                "system.molt_warning_level3",
-                pressure=f"{pressure:.0%}",
-                remaining=remaining,
-            )
-            level_prompt = level_prompt + "\n\n" + _t(lang, "system.molt_procedure")
-            molt_prompt = agent._config.molt_prompt or level_prompt
-            status = f"[context: {pressure:.0%} | CRITICAL]"
-            from ..intrinsics.system import publish_notification
-            publish_notification(
-                agent._working_dir, "molt",
-                header=f"context {pressure:.0%}, CRITICAL — force-wipe next turn",
-                icon="🚨",
-                priority="high",
-                data={
-                    "pressure": pressure,
-                    "level": level,
-                    "warnings": warnings,
-                    "remaining": remaining,
-                    "max_warnings": max_warnings,
-                    "warning_text": molt_prompt,
-                    "status": status,
-                },
-            )
-            agent._log("molt_hard_ceiling_warning", pressure=pressure, ceiling=agent._config.molt_hard_ceiling)
+        # Hard ceiling — publish urgent notification so the agent sees
+        # the warning and can molt voluntarily.  No force-wipe: if the
+        # agent ignores the warning, the LLM call will overflow and the
+        # adapter-level recovery (ChatSession._run_with_overflow_recovery)
+        # will trim the oldest entries and retry.
+        agent._session._compaction_warnings += 1
+        warnings = agent._session._compaction_warnings
+        max_warnings = agent._config.molt_warnings
+        remaining = max(0, max_warnings - warnings)
+        lang = agent._config.language
+        level = 3  # highest urgency
+        level_prompt = _t(
+            lang,
+            "system.molt_warning_level3",
+            pressure=f"{pressure:.0%}",
+            remaining=remaining,
+        )
+        level_prompt = level_prompt + "\n\n" + _t(lang, "system.molt_procedure")
+        molt_prompt = agent._config.molt_prompt or level_prompt
+        status = f"[context: {pressure:.0%} | CRITICAL]"
+        from ..intrinsics.system import publish_notification
+        publish_notification(
+            agent._working_dir, "molt",
+            header=f"context {pressure:.0%}, CRITICAL — molt now or overflow recovery will trim",
+            icon="🚨",
+            priority="high",
+            data={
+                "pressure": pressure,
+                "level": level,
+                "warnings": warnings,
+                "remaining": remaining,
+                "max_warnings": max_warnings,
+                "warning_text": molt_prompt,
+                "status": status,
+            },
+        )
+        agent._log("molt_hard_ceiling_warning", pressure=pressure, ceiling=agent._config.molt_hard_ceiling)
     elif pressure >= agent._config.molt_pressure and has_molt:
         max_warnings = agent._config.molt_warnings
         agent._session._compaction_warnings += 1
         warnings = agent._session._compaction_warnings
         remaining = max(0, max_warnings - warnings)
         lang = agent._config.language
-        if warnings > max_warnings:
-            # Forced wipe after ignored warnings (action, stays inline).
-            from ..intrinsics import psyche as _psyche
-            from ..intrinsics.system import clear_notification
-            agent._log("auto_forget", reason=f"ignored {max_warnings} molt warnings", pressure=pressure)
-            _psyche.context_forget(agent)
-            agent._session._compaction_warnings = 0
-            clear_notification(agent._working_dir, "molt")
-            content = f"{_t(lang, 'system.molt_wiped')}\n[Pressure: {pressure:.0%}, hard ceiling: {agent._config.molt_hard_ceiling:.0%}]\n\n{content}"
-        else:
-            # Graduated warning — publish to .notification/molt.json.
-            # Each call fully replaces the file, so the wire carries
-            # only the current level. _sync_notifications picks up the
-            # fingerprint change on the next heartbeat tick and routes
-            # it through the synthetic-pair injection (same path as
-            # email/soul). The warning thus appears on the *next* turn,
-            # not this one — acceptable tradeoff: the agent has 3+
-            # turns of buffer before forced wipe.
-            from ..intrinsics.system import publish_notification
-            level = min(warnings, 3)
-            level_prompt = _t(
-                lang,
-                f"system.molt_warning_level{level}",
-                pressure=f"{pressure:.0%}",
-                remaining=remaining,
-            )
-            if level >= 2:
-                level_prompt = level_prompt + "\n\n" + _t(lang, "system.molt_procedure")
-            molt_prompt = agent._config.molt_prompt or level_prompt
-            status = f"[context: {pressure:.0%} | {remaining}/{max_warnings}]"
-            publish_notification(
-                agent._working_dir, "molt",
-                header=f"context {pressure:.0%}, {remaining}/{max_warnings} turns left",
-                icon=("⚠️" if level >= 2 else "🪶"),
-                priority=("high" if level >= 2 else "normal"),
-                data={
-                    "pressure": pressure,
-                    "level": level,
-                    "warnings": warnings,
-                    "remaining": remaining,
-                    "max_warnings": max_warnings,
-                    "warning_text": molt_prompt,
-                    "status": status,
-                },
-            )
+        # Graduated warning — publish to .notification/molt.json.
+        # Each call fully replaces the file, so the wire carries
+        # only the current level. _sync_notifications picks up the
+        # fingerprint change on the next heartbeat tick and routes
+        # it through the synthetic-pair injection (same path as
+        # email/soul). The warning thus appears on the *next* turn,
+        # not this one — acceptable tradeoff: the agent has 3+
+        # turns of buffer before forced wipe.
+        from ..intrinsics.system import publish_notification
+        level = min(warnings, 3)
+        level_prompt = _t(
+            lang,
+            f"system.molt_warning_level{level}",
+            pressure=f"{pressure:.0%}",
+            remaining=remaining,
+        )
+        if level >= 2:
+            level_prompt = level_prompt + "\n\n" + _t(lang, "system.molt_procedure")
+        molt_prompt = agent._config.molt_prompt or level_prompt
+        status = f"[context: {pressure:.0%} | {remaining}/{max_warnings}]"
+        publish_notification(
+            agent._working_dir, "molt",
+            header=f"context {pressure:.0%}, {remaining}/{max_warnings} turns left",
+            icon=("⚠️" if level >= 2 else "🪶"),
+            priority=("high" if level >= 2 else "normal"),
+            data={
+                "pressure": pressure,
+                "level": level,
+                "warnings": warnings,
+                "remaining": remaining,
+                "max_warnings": max_warnings,
+                "warning_text": molt_prompt,
+                "status": status,
+            },
+        )
     else:
         # Pressure dropped below threshold — clear any stale molt notice
         # so the wire stops carrying it.

--- a/src/lingtai_kernel/llm/base.py
+++ b/src/lingtai_kernel/llm/base.py
@@ -10,7 +10,11 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from lingtai_kernel.logging import get_logger
+
 from .interface import ChatInterface, ToolResultBlock
+
+logger = get_logger()
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +273,159 @@ class ChatSession(ABC):
     def context_window(self) -> int:
         """Total context window in tokens for this session's model. 0 = unknown."""
         return 0
+
+    # -----------------------------------------------------------------------
+    # Context-overflow auto-recovery (shared across all providers)
+    # -----------------------------------------------------------------------
+    #
+    # When the provider rejects a request because the context exceeds its
+    # hard token limit, the session trims ~10% of the oldest non-system
+    # entries from the canonical ChatInterface and retries — up to
+    # ``_OVERFLOW_MAX_ROUNDS`` times.  Each provider only needs to
+    # implement ``_is_context_overflow_error()`` to opt in.
+    #
+    # This lives on ChatSession (not LLMAdapter) because the trim
+    # operates on ``self._interface._entries`` and the retry wraps the
+    # provider-specific ``send()`` / ``send_stream()`` call.
+
+    _OVERFLOW_MAX_ROUNDS: int = 10
+    _OVERFLOW_DROP_FRACTION: float = 0.10
+
+    @staticmethod
+    def _is_context_overflow_error(exc: Exception) -> bool:
+        """Return True if *exc* is a provider context-length-exceeded error.
+
+        Default returns False (no recovery).  Override in subclasses that
+        want overflow auto-recovery.
+        """
+        return False
+
+    def _trim_context_one_round(self) -> int:
+        """Drop ~``_OVERFLOW_DROP_FRACTION`` of non-system entries from the
+        **front** of the canonical interface.
+
+        Snaps the cut point forward so we never split an
+        ``assistant[ToolCallBlock]`` from its matching
+        ``user[ToolResultBlock]`` — the resulting wire payload would be
+        invalid for strict providers.
+
+        Returns the number of entries dropped (0 if none could be dropped
+        — caller should treat that as terminal).
+        """
+        from .interface import ToolCallBlock, ToolResultBlock
+
+        entries = self._interface._entries  # canonical list, mutated in place
+        if not entries:
+            return 0
+        # Index of first non-system entry.
+        first_conv = 0
+        if entries[0].role == "system":
+            first_conv = 1
+        conv_len = len(entries) - first_conv
+        if conv_len <= 1:
+            return 0
+        drop_n = max(1, int(conv_len * self._OVERFLOW_DROP_FRACTION))
+        cut = first_conv + drop_n  # entries[first_conv:cut] get dropped
+
+        # Snap cut forward past any assistant[tool_calls] / user[tool_results]
+        # boundary so we never strand a tool_call without its result.
+        max_cut = len(entries)
+        while cut < max_cut:
+            # If the entry just *before* the cut is assistant[tool_calls],
+            # advance until we're past its matching user[tool_results].
+            if cut == 0:
+                break
+            prev = entries[cut - 1]
+            if prev.role == "assistant" and any(
+                isinstance(b, ToolCallBlock) for b in prev.content
+            ):
+                cut += 1
+                continue
+            # If the entry at the cut is a user[tool_results-only], advance
+            # past it so we don't leave dangling results without their call.
+            cur = entries[cut]
+            if cur.role == "user" and cur.content and all(
+                isinstance(b, ToolResultBlock) for b in cur.content
+            ):
+                cut += 1
+                continue
+            break
+
+        if cut >= max_cut:
+            # Snap consumed everything — refuse to drop the entire conversation.
+            return 0
+
+        dropped = cut - first_conv
+        # Mutate in place: keep system + everything from cut onward.
+        del entries[first_conv:cut]
+        return dropped
+
+    def _inject_overflow_notice(self, total_dropped: int, rounds: int) -> None:
+        """Append a single user-role kernel notice after successful recovery.
+
+        We use the user role (universally supported) with an explicit
+        ``[kernel]`` prefix — same pattern as our synthesized tool aborts.
+        The notice strongly recommends molting since context pressure is
+        now demonstrably above the model's hard ceiling.
+        """
+        from .interface import TextBlock
+
+        notice = (
+            f"[kernel] Context exceeded the provider's hard token limit. "
+            f"To recover, the kernel dropped {total_dropped} oldest entries "
+            f"across {rounds} retry round(s). Detail from earlier turns may "
+            f"be lost — re-read recent context before acting on it. "
+            f"**Strongly recommend triggering a molt soon** — the conversation "
+            f"is past the model's safe limit and further growth will overflow "
+            f"again."
+        )
+        self._interface._append("user", [TextBlock(text=notice)])
+
+    def _run_with_overflow_recovery(self, do_call):
+        """Run an API call with context-overflow auto-recovery.
+
+        ``do_call`` is a zero-arg callable performing one full attempt
+        (build kwargs from current interface state + invoke the API). It
+        is re-called after each trim so the request reflects the post-trim
+        canonical interface.
+
+        Returns ``(result, total_dropped, rounds)``. ``total_dropped`` is 0
+        and ``rounds`` is 0 when no recovery was needed. On non-overflow
+        errors, re-raises immediately. On terminal failure (cannot trim
+        further, or max rounds hit), re-raises the original error.
+        """
+        total_dropped = 0
+        rounds = 0
+        while True:
+            try:
+                result = do_call()
+                return result, total_dropped, rounds
+            except Exception as exc:
+                if not self._is_context_overflow_error(exc):
+                    raise
+                if rounds >= self._OVERFLOW_MAX_ROUNDS:
+                    logger.warning(
+                        "[overflow-recovery] giving up after %d rounds "
+                        "(dropped %d entries total) — re-raising provider error.",
+                        rounds, total_dropped,
+                    )
+                    raise
+                dropped = self._trim_context_one_round()
+                if dropped == 0:
+                    logger.warning(
+                        "[overflow-recovery] cannot trim further "
+                        "(dropped %d entries across %d rounds) — re-raising.",
+                        total_dropped, rounds,
+                    )
+                    raise
+                total_dropped += dropped
+                rounds += 1
+                logger.warning(
+                    "[overflow-recovery] round %d: dropped %d entries "
+                    "(running total %d). Retrying.",
+                    rounds, dropped, total_dropped,
+                )
+                continue
 
 
 

--- a/tests/test_molt_hard_ceiling_notification.py
+++ b/tests/test_molt_hard_ceiling_notification.py
@@ -101,9 +101,10 @@ class TestHardCeilingTwoPhase:
         finally:
             agent.stop()
 
-    def test_second_hard_ceiling_hit_force_wipes(self, tmp_path):
+    def test_second_hard_ceiling_hit_no_force_wipe(self, tmp_path):
         """When pressure is at hard ceiling AND warnings > 0,
-        context_forget IS called (force-wipe)."""
+        context_forget is NOT called (force-wipe removed).
+        Warnings accumulate instead."""
         agent = _make_agent_with_psyche(tmp_path)
         agent.start()
         try:
@@ -122,19 +123,19 @@ class TestHardCeilingTwoPhase:
             ) as mock_forget:
                 _send_request(agent)
 
-                # Force-wipe MUST fire
-                mock_forget.assert_called_once()
+                # Force-wipe must NOT fire (removed in PR #32)
+                mock_forget.assert_not_called()
 
-            # Counter reset after wipe
-            assert agent._session._compaction_warnings == 0
+            # Counter increments (warnings accumulate, not reset)
+            assert agent._session._compaction_warnings == 2
 
         finally:
             agent.stop()
 
     def test_pressure_drop_between_turns_preserves_counter(self, tmp_path):
         """If pressure drops below hard ceiling after the first warning,
-        the counter stays non-zero. When pressure climbs back up, the
-        next hard-ceiling hit force-wipes immediately."""
+        the counter stays non-zero. When pressure climbs back up,
+        warnings continue to accumulate (no force-wipe)."""
         agent = _make_agent_with_psyche(tmp_path)
         agent.start()
         try:
@@ -160,15 +161,16 @@ class TestHardCeilingTwoPhase:
             assert agent._session._compaction_warnings == 2
 
             # Turn 3: pressure spikes back to hard ceiling.
-            # Counter is > 0 → force-wipe.
+            # Counter is > 0, but force-wipe is removed (PR #32).
+            # Warnings accumulate instead.
             agent._session.get_context_pressure = lambda: 0.97
 
             with patch(
                 "lingtai_kernel.intrinsics.psyche.context_forget"
             ) as mock_forget:
                 _send_request(agent, "turn 3")
-                mock_forget.assert_called_once()
-            assert agent._session._compaction_warnings == 0
+                mock_forget.assert_not_called()
+            assert agent._session._compaction_warnings == 3
 
         finally:
             agent.stop()


### PR DESCRIPTION
## Summary

Moves context-overflow recovery from OpenAI-only to a shared base-class mechanism, and removes the kernel force-wipe that was wiping agent context without consent.

### Changes

**ChatSession base class** ():
-  — abstract, returns False by default; providers override
-  — drops ~10% of oldest non-system entries, snapping past tool-call/result boundaries
-  — retry loop (up to 10 rounds × 10% trim)
-  — post-recovery user message recommending molt

**Anthropic adapter** ():
- Implements  for 
-  and  now use 

**OpenAI adapter** ():
- Removed duplicate , , 
- Kept only  (OpenAI-specific)

**turn.py** ():
- Removed force-wipe () on hard ceiling
- Agent gets warnings and can molt voluntarily
- If agent ignores warnings, the API call will overflow and the adapter-level recovery trims + retries

### Inheritance coverage
- DeepSeek, OpenRouter → inherit from OpenAI (already covered)
- MiniMax → inherits from Anthropic (already covered)
- Custom → delegates to the above (already covered)
- Gemini → not yet implemented (server-side state management is more complex)

### Why
Jason's direction: move the 10% trim to an upper layer abstraction, remove the force-wipe that destroys agent memory without consent.