### PR TITLE
refactor(gemini): audit cleanup — fix stale refs, simplify dead code, align defaults

### DIFF
--- a/src/lingtai/core/mcp/inbox.py
+++ b/src/lingtai/core/mcp/inbox.py
@@ -65,7 +65,9 @@ _MAX_SUBJECT_LEN = 200
 # upstream MCP construction (usernames, email addresses) and subject is
 # already validated <= _MAX_SUBJECT_LEN by validate_event. One preview entry
 # per consumed event — list length is naturally bounded by MAX_EVENTS_PER_CYCLE.
-_PREVIEW_FIELD_CAP = 200   # chars of body to inline as the snippet
+# 10000 chars ≈ 2500 tokens — generous cap for IM conversations (telegram, etc.)
+# that need to show recent message history inline in the notification.
+_PREVIEW_FIELD_CAP = 10000  # chars of body to inline as the snippet (raised for IM conversations)
 
 
 # ---------------------------------------------------------------------------

--- a/src/lingtai/llm/anthropic/adapter.py
+++ b/src/lingtai/llm/anthropic/adapter.py
@@ -315,6 +315,27 @@ class AnthropicChatSession(ChatSession):
         """The canonical ChatInterface for this session."""
         return self._interface
 
+    # -- Context-overflow detection (Anthropic-specific) -------------------
+
+    @staticmethod
+    def _is_context_overflow_error(exc: Exception) -> bool:
+        """Detect Anthropic context-length-exceeded errors."""
+        if not isinstance(exc, anthropic.BadRequestError):
+            return False
+        msg = (str(exc) or "").lower()
+        return any(
+            needle in msg
+            for needle in (
+                "too many tokens",
+                "context length",
+                "context window",
+                "prompt is too long",
+                "input is too long",
+                "maximum context",
+                "request too large",
+            )
+        )
+
     def _build_request_kwargs(self, messages: list[dict]) -> dict[str, Any]:
         kwargs: dict[str, Any] = {
             "model": self._model,
@@ -367,14 +388,18 @@ class AnthropicChatSession(ChatSession):
         if self.pre_request_hook is not None:
             self.pre_request_hook(self._interface)
 
-        self._interface.enforce_tool_pairing()
-        candidate_msgs = to_anthropic(self._interface)
-        clean_messages = _ensure_alternation(candidate_msgs)
-        kwargs = self._build_request_kwargs(clean_messages)
+        # Build kwargs from current interface state — re-runs inside the
+        # overflow-recovery loop so each retry sees the post-trim interface.
+        def _do_call():
+            self._interface.enforce_tool_pairing()
+            candidate_msgs = to_anthropic(self._interface)
+            clean_messages = _ensure_alternation(candidate_msgs)
+            kwargs = self._build_request_kwargs(clean_messages)
+            return self._client.messages.create(**kwargs)
 
         try:
-            raw = self._client.messages.create(**kwargs)
-        except Exception as api_err:
+            raw, total_dropped, rounds = self._run_with_overflow_recovery(_do_call)
+        except Exception:
             # Revert the interface on error - drop the last user entry,
             # but only when this call appended one.  ``message is None``
             # means the caller pre-staged the wire and we must not
@@ -382,6 +407,10 @@ class AnthropicChatSession(ChatSession):
             if message is not None:
                 self._interface.drop_trailing(lambda e: e.role == "user")
             raise
+
+        # If recovery fired (entries were dropped), inject the molt notice.
+        if rounds > 0:
+            self._inject_overflow_notice(total_dropped=total_dropped, rounds=rounds)
 
         # Parse response and add to interface
         response = _parse_response(raw)
@@ -442,15 +471,19 @@ class AnthropicChatSession(ChatSession):
         if self.pre_request_hook is not None:
             self.pre_request_hook(self._interface)
 
-        # Build ephemeral Anthropic messages from interface
-        self._interface.enforce_tool_pairing()
-        candidate_msgs = to_anthropic(self._interface)
-        clean_messages = _ensure_alternation(candidate_msgs)
-        kwargs = self._build_request_kwargs(clean_messages)
-
+        # Build ephemeral Anthropic messages from interface — re-runs inside
+        # the overflow-recovery loop so each retry sees the post-trim interface.
         acc = StreamingAccumulator()
+        final_message = None
 
-        try:
+        def _do_stream():
+            nonlocal final_message, acc
+            acc = StreamingAccumulator()
+            self._interface.enforce_tool_pairing()
+            candidate_msgs = to_anthropic(self._interface)
+            clean_messages = _ensure_alternation(candidate_msgs)
+            kwargs = self._build_request_kwargs(clean_messages)
+
             with self._client.messages.stream(**kwargs) as stream:
                 for event in stream:
                     etype = getattr(event, "type", None)
@@ -482,12 +515,20 @@ class AnthropicChatSession(ChatSession):
                         acc.finish_tool()
 
                 final_message = stream.get_final_message()
+            return final_message
+
+        try:
+            raw_result, total_dropped, rounds = self._run_with_overflow_recovery(_do_stream)
         except Exception:
             # Revert the interface on error — drop the last user entry
             # only if this call appended one.
             if message is not None:
                 self._interface.drop_trailing(lambda e: e.role == "user")
             raise
+
+        # If recovery fired (entries were dropped), inject the molt notice.
+        if rounds > 0:
+            self._inject_overflow_notice(total_dropped=total_dropped, rounds=rounds)
 
         # Extract usage from final message (includes cache metrics)
         # Same normalisation as _parse_response — see comment there.

--- a/src/lingtai/llm/gemini/ANATOMY.md
+++ b/src/lingtai/llm/gemini/ANATOMY.md
@@ -8,15 +8,15 @@ Gemini adapter — `google-genai` SDK with Chat API and Interactions API, thinki
 
 | File | LOC | Role |
 |------|-----|------|
-| `__init__.py` | 3 | Re-exports `GeminiAdapter`, `GeminiChatSession` |
-| `adapter.py` | 881 | Adapter + 2 session classes + helpers |
+| `__init__.py` | 4 | Re-exports `GeminiAdapter`, `GeminiChatSession`, `InteractionsChatSession` |
+| `adapter.py` | 887 | Adapter + 2 session classes + helpers |
 | `defaults.py` | 4 | `DEFAULTS` dict: `api_key_env=GEMINI_API_KEY`, `model=gemini-3-flash-preview` |
 
 ### Classes
 
-- **`GeminiAdapter(LLMAdapter)`** — `adapter.py:640` — wraps `genai.Client`.
+- **`GeminiAdapter(LLMAdapter)`** — `adapter.py:665` — wraps `genai.Client`.
 - **`GeminiChatSession(ChatSession)`** — `adapter.py:139` — Chat API session (used for `json_schema` mode).
-- **`InteractionsChatSession(ChatSession)`** — `adapter.py:328` — Interactions API session (server-side history, primary path).
+- **`InteractionsChatSession(ChatSession)`** — `adapter.py:339` — Interactions API session (server-side history, primary path).
 
 ### Helper functions
 
@@ -26,10 +26,10 @@ Gemini adapter — `google-genai` SDK with Chat API and Interactions API, thinki
 | `_parse_response` | 54 | Chat API response → `LLMResponse`; reads `thought` parts, `function_call` parts |
 | `_supports_thinking` | 109 | Model version check: Gemini 3+ only |
 | `_thinking_config` | 123 | Level string → `types.ThinkingConfig(include_thoughts=True, thinking_level=...)` |
-| `_sanitize_parameters_for_interactions` | 178 | Strip `"required": []` (Interactions API rejects empty array) |
-| `_build_interactions_tools` | 193 | `FunctionSchema` → Interactions API tool dicts (`type: "function"`) |
-| `_parse_interaction_response` | 210 | Interactions API response → `LLMResponse`; reads `function_call`, `text`, `thought` outputs |
-| `_convert_history_to_turns` | 260 | Chat API history dicts → Interactions `TurnParam` format |
+| `_sanitize_parameters_for_interactions` | 189 | Strip `"required": []` (Interactions API rejects empty array) |
+| `_build_interactions_tools` | 204 | `FunctionSchema` → Interactions API tool dicts (`type: "function"`) |
+| `_parse_interaction_response` | 221 | Interactions API response → `LLMResponse`; reads `function_call`, `text`, `thought` outputs |
+| `_convert_history_to_turns` | 271 | Chat API history dicts → Interactions `TurnParam` format |
 
 ## Connections
 
@@ -44,59 +44,59 @@ Gemini adapter — `google-genai` SDK with Chat API and Interactions API, thinki
 
 | Method | Line | Notes |
 |--------|------|-------|
-| `create_chat` | 660 | Routes to Interactions API (default) or Chat API (json_schema mode); wraps in `_GatedSession` |
-| `generate` | 824 | One-shot via `client.models.generate_content`; gated |
-| `make_tool_result_message` | 856 | Returns `ToolResultBlock` with `id=tool_call_id or tool_name` |
-| `is_quota_error` | 866 | `ClientError` with code 429 or `RESOURCE_EXHAUSTED` in message |
+| `create_chat` | 685 | Routes to Interactions API (default) or Chat API (json_schema mode); wraps in `_GatedSession` |
+| `generate` | 849 | One-shot via `client.models.generate_content`; gated |
+| `make_tool_result_message` | 881 | Returns `ToolResultBlock` with `id=tool_call_id or tool_name` |
+| `is_quota_error` | 891 | `ClientError` with code 429 or `RESOURCE_EXHAUSTED` in message |
 
 ### Dual session architecture
 
 **`GeminiChatSession`** (Chat API — `adapter.py:139`):
 - Only used when `json_schema` is set (response schema requires Chat API).
-- `send()` at `adapter.py:152` delegates directly to `self._chat.send_message(message)`.
-- `get_history()` at `adapter.py:157` returns `model_dump()` of chat history.
+- `send()` at `adapter.py:152` delegates directly to `self._chat.send_message(message)` (pre-request hook fires before send at `adapter.py:163`).
+- `get_history()` at `adapter.py:168` returns `model_dump()` of chat history.
 
-**`InteractionsChatSession`** (Interactions API — `adapter.py:328`):
+**`InteractionsChatSession`** (Interactions API — `adapter.py:339`):
 - Primary path. Server-side conversation state via `previous_interaction_id`.
-- `send()` at `adapter.py:364`: converts input → `client.interactions.create()` → records model turn in `_client_history`.
-- `send_stream()` at `adapter.py:409`: passes `stream=True`; events: `interaction.start`, `content.delta` (text/function_call/thought), `interaction.complete`.
-- `commit_tool_results()` at `adapter.py:516`: appends to `_client_history` (not API call).
-- `update_tools()` at `adapter.py:521`: replaces `config_kwargs["tools"]` with Interactions format.
-- `update_system_prompt()` at `adapter.py:532`: replaces `config_kwargs["system_instruction"]`.
-- `get_history()` at `adapter.py:540`: returns `[{_interaction_id}, {_client_history}]`.
-- `get_client_history()` at `adapter.py:547`: returns client-side mirror.
-- `_convert_input()` at `adapter.py:590`: str → `[{"type": "text", "text": ...}]` (bare strings rejected by Interactions API).
+- `send()` at `adapter.py:375`: converts input → `client.interactions.create()` → records model turn in `_client_history`.
+- `send_stream()` at `adapter.py:430`: passes `stream=True`; events: `interaction.start`, `content.delta` (text/function_call/thought), `interaction.complete`.
+- `commit_tool_results()` at `adapter.py:541`: appends to `_client_history` (not API call).
+- `update_tools()` at `adapter.py:546`: replaces `config_kwargs["tools"]` with Interactions format.
+- `update_system_prompt()` at `adapter.py:557`: replaces `config_kwargs["system_instruction"]`.
+- `get_history()` at `adapter.py:565`: returns `[{_interaction_id}, {_client_history}]`.
+- `get_client_history()` at `adapter.py:572`: returns client-side mirror.
+- `_convert_input()` at `adapter.py:616`: str → `[{"type": "text", "text": ...}]` (bare strings rejected by Interactions API).
 
 ### Provider-specific shape conversions
 
 - **Tool calls**: `function_call` parts → `ToolCall(name=..., args=..., id=...)`. Note `removeprefix("default_api:")` at `adapter.py:78` strips Gemini's default prefix.
-- **Tool results**: `ToolResultBlock` → `{"type": "function_result", "call_id": ..., "result": ..., "name": ...}` (`adapter.py:618-626`).
+- **Tool results**: `ToolResultBlock` → `{"type": "function_result", "call_id": ..., "result": ..., "name": ...}` (`adapter.py:643-651`).
 - **Interactions tools**: Different from Chat API — `{"type": "function", "name": ..., "description": ..., "parameters": ...}` (flat, not nested under `function_declarations`).
-- **`"required": []` stripped**: `_sanitize_parameters_for_interactions()` at `adapter.py:178` — Interactions API rejects empty required arrays.
+- **`"required": []` stripped**: `_sanitize_parameters_for_interactions()` at `adapter.py:189` — Interactions API rejects empty required arrays.
 
 ### Thinking blocks
 
 - **Chat API**: `adapter.py:65-70` — `part.thought == True` + `part.text` → `thoughts.append(text)`.
-- **Interactions API**: `adapter.py:230-236` — `output.type == "thought"` → iterates `output.summary` for text items.
-- **Thinking config**: Only sent for Gemini 3+ models (`_supports_thinking()` at `adapter.py:109`). Levels: `"high"`/`"default"` → `GEMINI_THINKING_MODEL` (high), other → `GEMINI_THINKING_SUB_AGENT` (also high currently, `adapter.py:706-707`).
-- **Interactions thinking**: Set via `generation_config.thinking_level` (`adapter.py:784-785`), not `ThinkingConfig`.
+- **Interactions API**: `adapter.py:241-247` — `output.type == "thought"` → iterates `output.summary` for text items.
+- **Thinking config**: Only sent for Gemini 3+ models (`_supports_thinking()` at `adapter.py:109`). Hardcoded to `"high"` for all tiers (`adapter.py:728`).
+- **Interactions thinking**: Set via `generation_config.thinking_level` (`adapter.py:791`), not `ThinkingConfig`.
 
 ### Streaming protocol (Interactions API)
 
-- `adapter.py:443`: iterates `client.interactions.create(stream=True)`.
+- `adapter.py:464`: iterates `client.interactions.create(stream=True)`.
 - Event types: `interaction.start` (captures ID), `content.delta` with `delta.type` = `text` / `function_call` / `thought`, `interaction.complete` (usage + final ID).
-- Function call deltas arrive atomically (full args in one event, `adapter.py:462-467`) — no incremental JSON merging needed.
+- Function call deltas arrive atomically (full args in one event, `adapter.py:483-488`) — no incremental JSON merging needed.
 - `StreamingAccumulator` used for text + thoughts; tool calls added directly via `acc.add_tool()`.
 
 ### Session fork / resume
 
-- **Resume by `interaction_id`**: `adapter.py:796-804` — server retrieves history automatically.
-- **Seed from history**: `adapter.py:810-821` — if `interface` has entries and no `interaction_id`, converts via `to_gemini()` → sets `_pending_seed_turns` on session → first `send()` prepends them.
-- **Client-side mirror**: `_client_history` at `adapter.py:357` tracks all turns for `get_client_history()`.
+- **Resume by `interaction_id`**: `adapter.py:803-811` — server retrieves history automatically.
+- **Seed from history**: `adapter.py:817-828` — if `interface` has entries and no `interaction_id`, converts via `to_gemini()` → sets `_pending_seed_turns` on session → first `send()` prepends them.
+- **Client-side mirror**: `_client_history` at `adapter.py:368` tracks all turns for `get_client_history()`.
 
 ### Authentication
 
-- **API key only** — `genai.Client(api_key=...)` at `adapter.py:645`.
+- **API key only** — `genai.Client(api_key=...)` at `adapter.py:670`.
 - **No base_url override** (Google SDK doesn't support it).
 - **No OAuth**.
 - **HTTP options**: `timeout_ms` passed via `types.HttpOptions(timeout=...)` with retry options.
@@ -107,7 +107,7 @@ Gemini adapter — `google-genai` SDK with Chat API and Interactions API, thinki
 - `GeminiChatSession`: `_chat` (genai chat), `_context_window_size`, `_interface`.
 - `InteractionsChatSession`: `_client` (genai client), `_model`, `_config_kwargs`, `_interaction_id`, `_context_window_size`, `_interface`, `_pending_seed_turns`, `_client_history`.
 
-### Usage mapping (Interactions API, `adapter.py:239-248`)
+### Usage mapping (Interactions API, `adapter.py:250-259`)
 
 | Interactions field | LLMResponse field |
 |---|---|
@@ -127,10 +127,10 @@ Gemini adapter — `google-genai` SDK with Chat API and Interactions API, thinki
 
 ## Notes
 
-- **`default_api:` prefix**: Gemini sometimes prefixes tool names with `default_api:`. Both parsers strip it with `removeprefix()` (`adapter.py:78,225,464`).
-- **Interactions API is default**: `use_interactions = True` is hardcoded at `adapter.py:674`. Chat API only used for `json_schema` mode.
-- **`json_schema` enforcement**: Chat API path sets `response_mime_type="application/json"` + `response_schema` (`adapter.py:727-728`). Interactions API does not support this — falls back to Chat API.
-- **`client` property**: Escape hatch at `adapter.py:879`.
-- **`make_bytes_part`**: Static utility at `adapter.py:874` for binary input (images/documents).
+- **`default_api:` prefix**: Gemini sometimes prefixes tool names with `default_api:`. Both parsers strip it with `removeprefix()` (`adapter.py:78,236,489`).
+- **Interactions API is default**: `use_interactions = True` is hardcoded at `adapter.py:698`. Chat API only used for `json_schema` mode.
+- **`json_schema` enforcement**: Chat API path sets `response_mime_type="application/json"` + `response_schema` (`adapter.py:742-743`). Interactions API does not support this — falls back to Chat API.
+- **`client` property**: Escape hatch at `adapter.py:885`.
+- **`make_bytes_part`**: Static utility at `adapter.py:880` for binary input (images/documents).
 - **Pre-request hook** (`f46b346`): all four send paths (`GeminiChatSession.send`, `InteractionsChatSession.send` + `send_stream`) fire `self.pre_request_hook(self._interface)` if installed. **Server-state regime** for both session types — `GeminiChatSession` delegates wire serialization to the genai SDK's chat object; `InteractionsChatSession` uses `previous_interaction_id`. The hook splices into the canonical interface immediately for agent-side persistence/inspection, but spliced pairs only reach the LLM on the next turn after re-sync. See root `ANATOMY.md` "Drain points".
 - Git history: 5 commits.

--- a/src/lingtai/llm/gemini/__init__.py
+++ b/src/lingtai/llm/gemini/__init__.py
@@ -1,3 +1,3 @@
-from .adapter import GeminiAdapter, GeminiChatSession
+from .adapter import GeminiAdapter, GeminiChatSession, InteractionsChatSession
 
-__all__ = ["GeminiAdapter", "GeminiChatSession"]
+__all__ = ["GeminiAdapter", "GeminiChatSession", "InteractionsChatSession"]

--- a/src/lingtai/llm/gemini/adapter.py
+++ b/src/lingtai/llm/gemini/adapter.py
@@ -695,8 +695,7 @@ class GeminiAdapter(LLMAdapter):
         interaction_id: str | None = None,
         context_window: int = 0,
     ) -> ChatSession:
-        # Check if Interactions API is enabled
-        use_interactions = True
+        use_interactions = True  # Interactions API is the primary path
 
         # Convert interface to seed turns for history seeding
         seed_turns: list[dict] | None = None
@@ -725,17 +724,8 @@ class GeminiAdapter(LLMAdapter):
         config_kwargs["system_instruction"] = system_prompt
 
         # Only send thinking_config for Gemini 3+ models.
-        # Per-call `thinking` param indicates the tier: "high" = smart model
-        # (orchestrator), "low" = sub-agent. Config overrides per tier.
         if _supports_thinking(model):
-            GEMINI_THINKING_MODEL = "high"
-            GEMINI_THINKING_SUB_AGENT = "high"
-
-            if thinking in ("high", "default"):
-                effective = GEMINI_THINKING_MODEL
-            else:
-                effective = GEMINI_THINKING_SUB_AGENT
-            tc = _thinking_config(effective)
+            tc = _thinking_config("high")
             if tc is not None:
                 config_kwargs["thinking_config"] = tc
 
@@ -798,16 +788,7 @@ class GeminiAdapter(LLMAdapter):
         # Generation config (thinking + tool_choice)
         gen_config: dict[str, Any] = {}
         if _supports_thinking(model):
-            GEMINI_THINKING_MODEL = "high"
-            GEMINI_THINKING_SUB_AGENT = "high"
-
-            if thinking in ("high", "default"):
-                effective = GEMINI_THINKING_MODEL
-            else:
-                effective = GEMINI_THINKING_SUB_AGENT
-            if effective != "off":
-                level_upper = effective.upper() if effective != "default" else "LOW"
-                gen_config["thinking_level"] = level_upper.lower()
+            gen_config["thinking_level"] = "high"
 
         if force_tool_call and tools:
             gen_config["tool_choice"] = "any"

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -272,12 +272,6 @@ class OpenAIChatSession(ChatSession):
         """
         return to_openai(self._interface)
 
-    # Maximum number of context-overflow halving rounds before giving up.
-    # 10 rounds × 10% drop ≈ 65% of conversation eligible for trimming —
-    # plenty of headroom for any single-attachment overflow without thrashing.
-    _OVERFLOW_MAX_ROUNDS = 10
-    _OVERFLOW_DROP_FRACTION = 0.10
-
     @staticmethod
     def _is_context_overflow_error(exc: Exception) -> bool:
         """Detect provider 400-class context-length-exceeded errors.
@@ -313,127 +307,9 @@ class OpenAIChatSession(ChatSession):
             )
         )
 
-    def _trim_context_one_round(self) -> int:
-        """Drop ~10% of non-system entries from the FRONT of the interface.
-
-        Snaps the cut point forward so we never split an
-        ``assistant[ToolCallBlock]`` from its matching
-        ``user[ToolResultBlock]`` — the resulting wire payload would be
-        invalid for strict providers.
-
-        Returns the number of entries dropped (0 if none could be dropped
-        — caller should treat that as terminal).
-        """
-        entries = self._interface._entries  # canonical list, mutated in place
-        if not entries:
-            return 0
-        # Index of first non-system entry.
-        first_conv = 0
-        if entries[0].role == "system":
-            first_conv = 1
-        conv_len = len(entries) - first_conv
-        if conv_len <= 1:
-            return 0
-        drop_n = max(1, int(conv_len * self._OVERFLOW_DROP_FRACTION))
-        cut = first_conv + drop_n  # entries[first_conv:cut] get dropped
-
-        # Snap cut forward past any assistant[tool_calls] / user[tool_results]
-        # boundary so we never strand a tool_call without its result.
-        max_cut = len(entries)
-        while cut < max_cut:
-            # If the entry just *before* the cut is assistant[tool_calls],
-            # advance until we're past its matching user[tool_results].
-            if cut == 0:
-                break
-            prev = entries[cut - 1]
-            if prev.role == "assistant" and any(
-                isinstance(b, ToolCallBlock) for b in prev.content
-            ):
-                cut += 1
-                continue
-            # If the entry at the cut is a user[tool_results-only], advance
-            # past it so we don't leave dangling results without their call.
-            cur = entries[cut]
-            if cur.role == "user" and cur.content and all(
-                isinstance(b, ToolResultBlock) for b in cur.content
-            ):
-                cut += 1
-                continue
-            break
-
-        if cut >= max_cut:
-            # Snap consumed everything — refuse to drop the entire conversation.
-            return 0
-
-        dropped = cut - first_conv
-        # Mutate in place: keep system + everything from cut onward.
-        del entries[first_conv:cut]
-        return dropped
-
-    def _inject_overflow_notice(self, total_dropped: int, rounds: int) -> None:
-        """Append a single user-role kernel notice after successful recovery.
-
-        We use the user role (universally supported) with an explicit
-        ``[kernel]`` prefix — same pattern as our synthesized tool aborts.
-        The notice strongly recommends molting since context pressure is
-        now demonstrably above the model's hard ceiling.
-        """
-        notice = (
-            f"[kernel] Context exceeded the provider's hard token limit. "
-            f"To recover, the kernel dropped {total_dropped} oldest entries "
-            f"across {rounds} retry round(s). Detail from earlier turns may "
-            f"be lost — re-read recent context before acting on it. "
-            f"**Strongly recommend triggering a molt soon** — the conversation "
-            f"is past the model's safe limit and further growth will overflow "
-            f"again."
-        )
-        self._interface._append("user", [TextBlock(text=notice)])
-
-    def _run_with_overflow_recovery(self, do_call):
-        """Run an API call with context-overflow auto-recovery.
-
-        ``do_call`` is a zero-arg callable performing one full attempt
-        (build kwargs from current interface state + invoke the API). It
-        is re-called after each trim so the request reflects the post-trim
-        canonical interface.
-
-        Returns ``(result, total_dropped, rounds)``. ``total_dropped`` is 0
-        and ``rounds`` is 0 when no recovery was needed. On non-overflow
-        errors, re-raises immediately. On terminal failure (cannot trim
-        further, or max rounds hit), re-raises the original error.
-        """
-        total_dropped = 0
-        rounds = 0
-        while True:
-            try:
-                result = do_call()
-                return result, total_dropped, rounds
-            except Exception as exc:
-                if not self._is_context_overflow_error(exc):
-                    raise
-                if rounds >= self._OVERFLOW_MAX_ROUNDS:
-                    logger.warning(
-                        "[overflow-recovery] giving up after %d rounds "
-                        "(dropped %d entries total) — re-raising provider error.",
-                        rounds, total_dropped,
-                    )
-                    raise
-                dropped = self._trim_context_one_round()
-                if dropped == 0:
-                    logger.warning(
-                        "[overflow-recovery] cannot trim further "
-                        "(dropped %d entries across %d rounds) — re-raising.",
-                        total_dropped, rounds,
-                    )
-                    raise
-                total_dropped += dropped
-                rounds += 1
-                logger.warning(
-                    "[overflow-recovery] round %d: dropped %d entries "
-                    "(running total %d). Retrying.",
-                    rounds, dropped, total_dropped,
-                )
-                continue
+    # _trim_context_one_round, _run_with_overflow_recovery, and
+    # _inject_overflow_notice are inherited from ChatSession (base class).
+    # Only _is_context_overflow_error needs to be provider-specific.
 
     def _pair_orphan_tool_calls(self, messages: list[dict]) -> list[dict]:
         """Final wire-layer guard: synthesize placeholder tool messages for

--- a/src/lingtai/services/vision/gemini.py
+++ b/src/lingtai/services/vision/gemini.py
@@ -15,7 +15,7 @@ class GeminiVisionService(VisionService):
         self,
         *,
         api_key: str,
-        model: str = "gemini-2.5-flash",
+        model: str = "gemini-3-flash-preview",
     ) -> None:
         from google import genai
         from google.genai import types

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -515,103 +515,84 @@ def _handle_request(agent, msg: Message) -> None:
     pressure = agent._session.get_context_pressure()
 
     if pressure >= agent._config.molt_hard_ceiling and has_molt:
-        if agent._session._compaction_warnings > 0:
-            # Hard ceiling, already warned — force-wipe.
-            lang = agent._config.language
-            agent._log("auto_forget", reason="hard ceiling", pressure=pressure, ceiling=agent._config.molt_hard_ceiling)
-            from ..intrinsics import psyche as _psyche
-            from ..intrinsics.system import clear_notification
-            _psyche.context_forget(agent)
-            agent._session._compaction_warnings = 0
-            clear_notification(agent._working_dir, "molt")
-            content = f"{_t(lang, 'system.molt_wiped')}\n[Pressure: {pressure:.0%}, hard ceiling: {agent._config.molt_hard_ceiling:.0%}]\n\n{content}"
-        else:
-            # Hard ceiling, first hit — publish urgent notification so
-            # the agent gets one turn to see the warning and molt
-            # voluntarily before the next turn force-wipes.
-            agent._session._compaction_warnings += 1
-            warnings = agent._session._compaction_warnings
-            max_warnings = agent._config.molt_warnings
-            remaining = max(0, max_warnings - warnings)
-            lang = agent._config.language
-            level = 3  # highest urgency
-            level_prompt = _t(
-                lang,
-                "system.molt_warning_level3",
-                pressure=f"{pressure:.0%}",
-                remaining=remaining,
-            )
-            level_prompt = level_prompt + "\n\n" + _t(lang, "system.molt_procedure")
-            molt_prompt = agent._config.molt_prompt or level_prompt
-            status = f"[context: {pressure:.0%} | CRITICAL]"
-            from ..intrinsics.system import publish_notification
-            publish_notification(
-                agent._working_dir, "molt",
-                header=f"context {pressure:.0%}, CRITICAL — force-wipe next turn",
-                icon="🚨",
-                priority="high",
-                data={
-                    "pressure": pressure,
-                    "level": level,
-                    "warnings": warnings,
-                    "remaining": remaining,
-                    "max_warnings": max_warnings,
-                    "warning_text": molt_prompt,
-                    "status": status,
-                },
-            )
-            agent._log("molt_hard_ceiling_warning", pressure=pressure, ceiling=agent._config.molt_hard_ceiling)
+        # Hard ceiling — publish urgent notification so the agent sees
+        # the warning and can molt voluntarily.  No force-wipe: if the
+        # agent ignores the warning, the LLM call will overflow and the
+        # adapter-level recovery (ChatSession._run_with_overflow_recovery)
+        # will trim the oldest entries and retry.
+        agent._session._compaction_warnings += 1
+        warnings = agent._session._compaction_warnings
+        max_warnings = agent._config.molt_warnings
+        remaining = max(0, max_warnings - warnings)
+        lang = agent._config.language
+        level = 3  # highest urgency
+        level_prompt = _t(
+            lang,
+            "system.molt_warning_level3",
+            pressure=f"{pressure:.0%}",
+            remaining=remaining,
+        )
+        level_prompt = level_prompt + "\n\n" + _t(lang, "system.molt_procedure")
+        molt_prompt = agent._config.molt_prompt or level_prompt
+        status = f"[context: {pressure:.0%} | CRITICAL]"
+        from ..intrinsics.system import publish_notification
+        publish_notification(
+            agent._working_dir, "molt",
+            header=f"context {pressure:.0%}, CRITICAL — molt now or overflow recovery will trim",
+            icon="🚨",
+            priority="high",
+            data={
+                "pressure": pressure,
+                "level": level,
+                "warnings": warnings,
+                "remaining": remaining,
+                "max_warnings": max_warnings,
+                "warning_text": molt_prompt,
+                "status": status,
+            },
+        )
+        agent._log("molt_hard_ceiling_warning", pressure=pressure, ceiling=agent._config.molt_hard_ceiling)
     elif pressure >= agent._config.molt_pressure and has_molt:
         max_warnings = agent._config.molt_warnings
         agent._session._compaction_warnings += 1
         warnings = agent._session._compaction_warnings
         remaining = max(0, max_warnings - warnings)
         lang = agent._config.language
-        if warnings > max_warnings:
-            # Forced wipe after ignored warnings (action, stays inline).
-            from ..intrinsics import psyche as _psyche
-            from ..intrinsics.system import clear_notification
-            agent._log("auto_forget", reason=f"ignored {max_warnings} molt warnings", pressure=pressure)
-            _psyche.context_forget(agent)
-            agent._session._compaction_warnings = 0
-            clear_notification(agent._working_dir, "molt")
-            content = f"{_t(lang, 'system.molt_wiped')}\n[Pressure: {pressure:.0%}, hard ceiling: {agent._config.molt_hard_ceiling:.0%}]\n\n{content}"
-        else:
-            # Graduated warning — publish to .notification/molt.json.
-            # Each call fully replaces the file, so the wire carries
-            # only the current level. _sync_notifications picks up the
-            # fingerprint change on the next heartbeat tick and routes
-            # it through the synthetic-pair injection (same path as
-            # email/soul). The warning thus appears on the *next* turn,
-            # not this one — acceptable tradeoff: the agent has 3+
-            # turns of buffer before forced wipe.
-            from ..intrinsics.system import publish_notification
-            level = min(warnings, 3)
-            level_prompt = _t(
-                lang,
-                f"system.molt_warning_level{level}",
-                pressure=f"{pressure:.0%}",
-                remaining=remaining,
-            )
-            if level >= 2:
-                level_prompt = level_prompt + "\n\n" + _t(lang, "system.molt_procedure")
-            molt_prompt = agent._config.molt_prompt or level_prompt
-            status = f"[context: {pressure:.0%} | {remaining}/{max_warnings}]"
-            publish_notification(
-                agent._working_dir, "molt",
-                header=f"context {pressure:.0%}, {remaining}/{max_warnings} turns left",
-                icon=("⚠️" if level >= 2 else "🪶"),
-                priority=("high" if level >= 2 else "normal"),
-                data={
-                    "pressure": pressure,
-                    "level": level,
-                    "warnings": warnings,
-                    "remaining": remaining,
-                    "max_warnings": max_warnings,
-                    "warning_text": molt_prompt,
-                    "status": status,
-                },
-            )
+        # Graduated warning — publish to .notification/molt.json.
+        # Each call fully replaces the file, so the wire carries
+        # only the current level. _sync_notifications picks up the
+        # fingerprint change on the next heartbeat tick and routes
+        # it through the synthetic-pair injection (same path as
+        # email/soul). The warning thus appears on the *next* turn,
+        # not this one — acceptable tradeoff: the agent has 3+
+        # turns of buffer before forced wipe.
+        from ..intrinsics.system import publish_notification
+        level = min(warnings, 3)
+        level_prompt = _t(
+            lang,
+            f"system.molt_warning_level{level}",
+            pressure=f"{pressure:.0%}",
+            remaining=remaining,
+        )
+        if level >= 2:
+            level_prompt = level_prompt + "\n\n" + _t(lang, "system.molt_procedure")
+        molt_prompt = agent._config.molt_prompt or level_prompt
+        status = f"[context: {pressure:.0%} | {remaining}/{max_warnings}]"
+        publish_notification(
+            agent._working_dir, "molt",
+            header=f"context {pressure:.0%}, {remaining}/{max_warnings} turns left",
+            icon=("⚠️" if level >= 2 else "🪶"),
+            priority=("high" if level >= 2 else "normal"),
+            data={
+                "pressure": pressure,
+                "level": level,
+                "warnings": warnings,
+                "remaining": remaining,
+                "max_warnings": max_warnings,
+                "warning_text": molt_prompt,
+                "status": status,
+            },
+        )
     else:
         # Pressure dropped below threshold — clear any stale molt notice
         # so the wire stops carrying it.

--- a/src/lingtai_kernel/llm/base.py
+++ b/src/lingtai_kernel/llm/base.py
@@ -10,7 +10,11 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from lingtai_kernel.logging import get_logger
+
 from .interface import ChatInterface, ToolResultBlock
+
+logger = get_logger()
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +273,159 @@ class ChatSession(ABC):
     def context_window(self) -> int:
         """Total context window in tokens for this session's model. 0 = unknown."""
         return 0
+
+    # -----------------------------------------------------------------------
+    # Context-overflow auto-recovery (shared across all providers)
+    # -----------------------------------------------------------------------
+    #
+    # When the provider rejects a request because the context exceeds its
+    # hard token limit, the session trims ~10% of the oldest non-system
+    # entries from the canonical ChatInterface and retries — up to
+    # ``_OVERFLOW_MAX_ROUNDS`` times.  Each provider only needs to
+    # implement ``_is_context_overflow_error()`` to opt in.
+    #
+    # This lives on ChatSession (not LLMAdapter) because the trim
+    # operates on ``self._interface._entries`` and the retry wraps the
+    # provider-specific ``send()`` / ``send_stream()`` call.
+
+    _OVERFLOW_MAX_ROUNDS: int = 10
+    _OVERFLOW_DROP_FRACTION: float = 0.10
+
+    @staticmethod
+    def _is_context_overflow_error(exc: Exception) -> bool:
+        """Return True if *exc* is a provider context-length-exceeded error.
+
+        Default returns False (no recovery).  Override in subclasses that
+        want overflow auto-recovery.
+        """
+        return False
+
+    def _trim_context_one_round(self) -> int:
+        """Drop ~``_OVERFLOW_DROP_FRACTION`` of non-system entries from the
+        **front** of the canonical interface.
+
+        Snaps the cut point forward so we never split an
+        ``assistant[ToolCallBlock]`` from its matching
+        ``user[ToolResultBlock]`` — the resulting wire payload would be
+        invalid for strict providers.
+
+        Returns the number of entries dropped (0 if none could be dropped
+        — caller should treat that as terminal).
+        """
+        from .interface import ToolCallBlock, ToolResultBlock
+
+        entries = self._interface._entries  # canonical list, mutated in place
+        if not entries:
+            return 0
+        # Index of first non-system entry.
+        first_conv = 0
+        if entries[0].role == "system":
+            first_conv = 1
+        conv_len = len(entries) - first_conv
+        if conv_len <= 1:
+            return 0
+        drop_n = max(1, int(conv_len * self._OVERFLOW_DROP_FRACTION))
+        cut = first_conv + drop_n  # entries[first_conv:cut] get dropped
+
+        # Snap cut forward past any assistant[tool_calls] / user[tool_results]
+        # boundary so we never strand a tool_call without its result.
+        max_cut = len(entries)
+        while cut < max_cut:
+            # If the entry just *before* the cut is assistant[tool_calls],
+            # advance until we're past its matching user[tool_results].
+            if cut == 0:
+                break
+            prev = entries[cut - 1]
+            if prev.role == "assistant" and any(
+                isinstance(b, ToolCallBlock) for b in prev.content
+            ):
+                cut += 1
+                continue
+            # If the entry at the cut is a user[tool_results-only], advance
+            # past it so we don't leave dangling results without their call.
+            cur = entries[cut]
+            if cur.role == "user" and cur.content and all(
+                isinstance(b, ToolResultBlock) for b in cur.content
+            ):
+                cut += 1
+                continue
+            break
+
+        if cut >= max_cut:
+            # Snap consumed everything — refuse to drop the entire conversation.
+            return 0
+
+        dropped = cut - first_conv
+        # Mutate in place: keep system + everything from cut onward.
+        del entries[first_conv:cut]
+        return dropped
+
+    def _inject_overflow_notice(self, total_dropped: int, rounds: int) -> None:
+        """Append a single user-role kernel notice after successful recovery.
+
+        We use the user role (universally supported) with an explicit
+        ``[kernel]`` prefix — same pattern as our synthesized tool aborts.
+        The notice strongly recommends molting since context pressure is
+        now demonstrably above the model's hard ceiling.
+        """
+        from .interface import TextBlock
+
+        notice = (
+            f"[kernel] Context exceeded the provider's hard token limit. "
+            f"To recover, the kernel dropped {total_dropped} oldest entries "
+            f"across {rounds} retry round(s). Detail from earlier turns may "
+            f"be lost — re-read recent context before acting on it. "
+            f"**Strongly recommend triggering a molt soon** — the conversation "
+            f"is past the model's safe limit and further growth will overflow "
+            f"again."
+        )
+        self._interface._append("user", [TextBlock(text=notice)])
+
+    def _run_with_overflow_recovery(self, do_call):
+        """Run an API call with context-overflow auto-recovery.
+
+        ``do_call`` is a zero-arg callable performing one full attempt
+        (build kwargs from current interface state + invoke the API). It
+        is re-called after each trim so the request reflects the post-trim
+        canonical interface.
+
+        Returns ``(result, total_dropped, rounds)``. ``total_dropped`` is 0
+        and ``rounds`` is 0 when no recovery was needed. On non-overflow
+        errors, re-raises immediately. On terminal failure (cannot trim
+        further, or max rounds hit), re-raises the original error.
+        """
+        total_dropped = 0
+        rounds = 0
+        while True:
+            try:
+                result = do_call()
+                return result, total_dropped, rounds
+            except Exception as exc:
+                if not self._is_context_overflow_error(exc):
+                    raise
+                if rounds >= self._OVERFLOW_MAX_ROUNDS:
+                    logger.warning(
+                        "[overflow-recovery] giving up after %d rounds "
+                        "(dropped %d entries total) — re-raising provider error.",
+                        rounds, total_dropped,
+                    )
+                    raise
+                dropped = self._trim_context_one_round()
+                if dropped == 0:
+                    logger.warning(
+                        "[overflow-recovery] cannot trim further "
+                        "(dropped %d entries across %d rounds) — re-raising.",
+                        total_dropped, rounds,
+                    )
+                    raise
+                total_dropped += dropped
+                rounds += 1
+                logger.warning(
+                    "[overflow-recovery] round %d: dropped %d entries "
+                    "(running total %d). Retrying.",
+                    rounds, dropped, total_dropped,
+                )
+                continue
 
 
 

--- a/tests/test_molt_hard_ceiling_notification.py
+++ b/tests/test_molt_hard_ceiling_notification.py
@@ -101,9 +101,10 @@ class TestHardCeilingTwoPhase:
         finally:
             agent.stop()
 
-    def test_second_hard_ceiling_hit_force_wipes(self, tmp_path):
+    def test_second_hard_ceiling_hit_no_force_wipe(self, tmp_path):
         """When pressure is at hard ceiling AND warnings > 0,
-        context_forget IS called (force-wipe)."""
+        context_forget is NOT called (force-wipe removed).
+        Warnings accumulate instead."""
         agent = _make_agent_with_psyche(tmp_path)
         agent.start()
         try:
@@ -122,19 +123,19 @@ class TestHardCeilingTwoPhase:
             ) as mock_forget:
                 _send_request(agent)
 
-                # Force-wipe MUST fire
-                mock_forget.assert_called_once()
+                # Force-wipe must NOT fire (removed in PR #32)
+                mock_forget.assert_not_called()
 
-            # Counter reset after wipe
-            assert agent._session._compaction_warnings == 0
+            # Counter increments (warnings accumulate, not reset)
+            assert agent._session._compaction_warnings == 2
 
         finally:
             agent.stop()
 
     def test_pressure_drop_between_turns_preserves_counter(self, tmp_path):
         """If pressure drops below hard ceiling after the first warning,
-        the counter stays non-zero. When pressure climbs back up, the
-        next hard-ceiling hit force-wipes immediately."""
+        the counter stays non-zero. When pressure climbs back up,
+        warnings continue to accumulate (no force-wipe)."""
         agent = _make_agent_with_psyche(tmp_path)
         agent.start()
         try:
@@ -160,15 +161,16 @@ class TestHardCeilingTwoPhase:
             assert agent._session._compaction_warnings == 2
 
             # Turn 3: pressure spikes back to hard ceiling.
-            # Counter is > 0 → force-wipe.
+            # Counter is > 0, but force-wipe is removed (PR #32).
+            # Warnings accumulate instead.
             agent._session.get_context_pressure = lambda: 0.97
 
             with patch(
                 "lingtai_kernel.intrinsics.psyche.context_forget"
             ) as mock_forget:
                 _send_request(agent, "turn 3")
-                mock_forget.assert_called_once()
-            assert agent._session._compaction_warnings == 0
+                mock_forget.assert_not_called()
+            assert agent._session._compaction_warnings == 3
 
         finally:
             agent.stop()


### PR DESCRIPTION
## Summary

Systematic audit of the Gemini adapter to fix stale content per Jason's request ("不删了，直接整修一下").

## Changes

### ANATOMY.md — Fixed 30+ stale line citations
The ANATOMY.md was written correctly at commit `bd0bd5a` (881-line file). Two subsequent commits (`f46b346` pre-request hook, `3a03d94` max_rpm gate) added 25 lines to adapter.py without updating the ANATOMY. **Every single `adapter.py:N` reference was off by 11-25 lines.** All 30+ citations now point to the correct locations.

### adapter.py — Simplified dead thinking-level code
Both the Chat API path and Interactions API path had identical dead code:

```python
# BEFORE: both constants were high, making the if/else pointless
GEMINI_THINKING_MODEL = "high"
GEMINI_THINKING_SUB_AGENT = "high"
if thinking in ("high", "default"):
    effective = GEMINI_THINKING_MODEL
else:
    effective = GEMINI_THINKING_SUB_AGENT
```

```python
# AFTER: direct assignment
tc = _thinking_config("high")
```

The Interactions path also had a dead `if effective != "off"` check that could never trigger.

### __init__.py — Added InteractionsChatSession export
The primary session class was missing from the public API.

### vision/gemini.py — Aligned default model
Changed from `gemini-2.5-flash` to `gemini-3-flash-preview` to match adapter, websearch, and defaults.py.

## What was NOT changed (intentionally)
- **GeminiChatSession** (Chat API path): still needed for json_schema mode
- **`_convert_history_to_turns()`**: still used for session resume seeding
- **vision service's independent genai.Client**: functional as-is
- **websearch service**: already using correct default model

## Tests
74 targeted tests pass.