### PR TITLE
fix(agent): handle null capability kwargs and MiniMax config inheritance

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -66,6 +66,8 @@ class Agent(BaseAgent):
                 if name in _GROUPS:
                     for sub in _GROUPS[name]:
                         expanded_dict[sub] = {}
+                elif cap_kwargs is None:
+                    pass
                 else:
                     expanded_dict[name] = cap_kwargs
             capabilities = expanded_dict
@@ -1035,6 +1037,8 @@ class Agent(BaseAgent):
                 if name in _GROUPS:
                     for sub in _GROUPS[name]:
                         expanded[sub] = {}
+                elif cap_kwargs is None:
+                    pass
                 else:
                     expanded[name] = cap_kwargs
             capabilities = expanded

--- a/src/lingtai/capabilities/vision/__init__.py
+++ b/src/lingtai/capabilities/vision/__init__.py
@@ -122,6 +122,9 @@ def setup(
         if provider == "zhipu" and "z_ai_mode" not in kwargs:
             from .._zhipu_mode import resolve_z_ai_mode
             kwargs["z_ai_mode"] = resolve_z_ai_mode(agent)
+        # Filter out base_url — MiniMaxVisionService only accepts api_key and api_host.
+        # base_url may leak in via provider:inherit or LLM-config inheritance.
+        kwargs.pop("base_url", None)
         vision_service = create_vision_service(provider, api_key=api_key, **kwargs)
     elif vision_service is None:
         raise ValueError(

--- a/src/lingtai/services/websearch/__init__.py
+++ b/src/lingtai/services/websearch/__init__.py
@@ -72,6 +72,12 @@ def create_search_service(
 
     def _require_key() -> str:
         if not api_key:
+            # Try MINIMAX_API_KEY from environment as fallback
+            import os as _os
+            if name == "minimax":
+                _fallback_key = _os.environ.get("MINIMAX_API_KEY", "")
+                if _fallback_key:
+                    return _fallback_key
             raise RuntimeError(
                 f"Search provider {provider!r} requires an api_key."
             )


### PR DESCRIPTION
## Problem

Three crash bugs occur when setting up agents with certain capability configurations:

### Bug 1 — vision:null causes TypeError on agent startup
`capabilities = {"vision": null}` crashes with:
```
TypeError: argument after ** must be a mapping, not NoneType
```
cap_kwargs=None is passed into expanded_dict, then unpacked later as **None.

### Bug 2 — provider:inherit in vision capability causes crash
`capabilities = {"vision": {"provider": "inherit"}}` with MiniMax LLM config causes MiniMaxVisionService to receive base_url as a kwarg, which it doesn't accept.

### Bug 3 — minimax web_search fails without explicit api_key
`web_search: {provider: "minimax"}` without explicit api_key crashes because the subprocess doesn't inherit .env and MINIMAX_API_KEY is not checked.

## Fix

### agent.py — skip null capability kwargs (two locations)
```diff
+                elif cap_kwargs is None:
+                    pass
                 else:
                     expanded_dict[name] = cap_kwargs
```

### capabilities/vision/__init__.py — strip base_url before calling create_vision_service
```diff
+        # Filter out base_url — MiniMaxVisionService only accepts api_key and api_host.
+        # base_url may leak in via provider:inherit or LLM-config inheritance.
+        kwargs.pop("base_url", None)
         vision_service = create_vision_service(provider, api_key=api_key, **kwargs)
```

### services/websearch/__init__.py — fallback to MINIMAX_API_KEY env var
```diff
         if not api_key:
+            # Try MINIMAX_API_KEY from environment as fallback
+            import os as _os
+            if name == "minimax":
+                _fallback_key = _os.environ.get("MINIMAX_API_KEY", "")
+                if _fallback_key:
+                    return _fallback_key
             raise RuntimeError(...)
```

## Testing
- Bug 1: `capabilities = {"vision": null}` agent starts without TypeError
- Bug 2: `capabilities = {"vision": {"provider": "inherit"}}` with MiniMax LLM config starts without crash  
- Bug 3: `web_search: {provider: "minimax"}` without explicit api_key uses MINIMAX_API_KEY from environment