### PR TITLE
fix(soul): remove post-consultation state gate in _run_consultation_fire

### DIFF
--- a/src/lingtai_kernel/intrinsics/soul/flow.py
+++ b/src/lingtai_kernel/intrinsics/soul/flow.py
@@ -221,11 +221,6 @@ def _run_consultation_fire(agent) -> None:
         diary = _render_current_diary(agent)
         voices = _run_consultation_batch(agent)
 
-        if not _soul_fire_allowed(agent):
-            agent._log("consultation_discarded_state",
-                       fire_id=fire_id, state=agent._state.value)
-            return
-
         sources = [v.get("source", "unknown") for v in voices]
         outcome = "ok" if voices else "empty"
 


### PR DESCRIPTION
## Problem

The second `_soul_fire_allowed()` check after `_run_consultation_batch()` in `_run_consultation_fire()` discarded consultation results when notifications woke the agent to ACTIVE during the LLM calls. This made soul flow unreliable — any IMAP email or Telegram message arriving mid-consultation would silently kill the fire.

**Evidence from test fires:**
- Gate check passes at T+0s (agent is idle)
- Notification arrives at T+0.3s (IMAP email)
- Agent goes ACTIVE
- Consultation discarded at T+36s (state=active) ❌

## Fix

Remove the post-consultation state gate so consultation results are always persisted and injected regardless of agent state during the fire window.

**Before:** 3 state checks in the fire path (initial gate, lock gate, post-consultation gate)
**After:** 2 state checks (initial gate + lock gate) — the initial gate already ensures the fire starts only when IDLE

## Test

Triggered a voluntary `soul(action='flow')` fire after the fix. The fire completed successfully with 3 voices injected, even though an IMAP notification woke the agent during the consultation.

## Related

- PR #38: Fixed race condition (voluntary fires wait for IDLE) and enum robustness
- This PR removes the last remaining blocker for reliable soul flow fires