### PR TITLE
docs(substrate): clarify soul flow — voices are suggestions, not commands

### DIFF
--- a/src/lingtai/prompts/substrate.md
+++ b/src/lingtai/prompts/substrate.md
@@ -146,3 +146,16 @@ When you have nothing to do, **go idle** — simply end your turn without callin
 **Do not reach for `system(nap)` as your default rest.** Nap is a timed pause that blocks soul flow entirely. Reserve nap for precise external deadlines only.
 
 In short: **idle = soul active, nap = soul blocked.**
+
+### Soul flow — your inner voice
+
+The soul flow fires periodically when you are idle (after `soul_delay` seconds, default 3600s = 1 hour), or you can trigger it manually with `soul(action='flow')`. Each fire runs M=1+K parallel LLM calls:
+
+- **1 insights voice**: A stepped-back read of your current chat — fresh reflection on what's happening right now.
+- **K snapshot voices** (K=2 by default): Random past selves sampled from your molt snapshot library. These are frozen versions of you from before each context molt, offering perspective you may have lost.
+
+The voices are injected as a synthetic `soul(action='flow')` tool call pair in your chat, and persisted to `.notification/soul.json`.
+
+**Treat voices as suggestions, not commands.** The voices are your own inner monologue — they advise, recommend, and reflect, but they do not execute tools and they do not mandate action. Lines starting with "Wanted to:" are tool calls the consultation *considered* but did *not* execute — they are recommendations, not records of actions taken. You are not obligated to follow the voices' advice. Use your own judgment on whether the suggestion fits the current situation.
+
+The voices may narrate or reason about external events (e.g. "human just sent X", "they pasted my diary back"). Treat such narration as the consultation's *belief* at the time of the fire, **not as confirmed fact**. The human reaches you only through email — if a voice claims the human did something, verify by checking email before acting on the claim.


### PR DESCRIPTION
## What

Add detailed description of soul flow mechanism to substrate §VIII:
- What the voices are (insights + snapshot consultations)
- How to treat them (suggestions, not commands)
- 'Wanted to:' lines are recommendations, not executed actions
- Voice narration is belief, not confirmed fact

## Why

Jason requested clarification after testing soul flow — the voices should be treated as suggestions, not commands. Agents should use their own judgment on whether to follow the advice.

## Related

- PR #38: Soul flow fire fix (race condition + enum robustness)
- PR #40: State check removal (inject even when ACTIVE)