### PR TITLE
feat(daemon): add Codex CLI backend (backend='codex')

### DIFF
--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -1052,8 +1052,11 @@ class DaemonManager:
             return {"status": "error", "message": f"Unknown emanation: {em_id}"}
 
         # Claude Code backend: resume the session with --resume <session-id>
-        if entry.get("backend") in ("claude-code", "codex"):
+        if entry.get("backend") == "claude-code":
             return self._handle_ask_cli(em_id, entry, message)
+        if entry.get("backend") == "codex":
+            return {"status": "error",
+                    "message": "ask is not supported for codex backends (one-shot execution)"}
 
         if entry["future"].done():
             return {"status": "error", "message": "not running"}

--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -618,6 +618,94 @@ class DaemonManager:
         run_dir.mark_done(text)
         return text
 
+    def _run_codex_emanation(
+        self,
+        em_id: str,
+        run_dir: DaemonRunDir,
+        task: str,
+        cancel_event: threading.Event,
+        timeout_event: threading.Event | None = None,
+    ) -> str:
+        """Run a Codex CLI session as the emanation backend.
+
+        Spawns ``codex exec <task>`` and streams stdout back via
+        ``_notify_parent()``.  Unlike Claude Code, Codex has no session
+        resumption or JSONL session discovery — each invocation is
+        one-shot.
+        """
+        def _exit_cancelled() -> str:
+            if timeout_event is not None and timeout_event.is_set():
+                run_dir.mark_timeout()
+            else:
+                run_dir.mark_cancelled()
+            return "[cancelled]"
+
+        if cancel_event.is_set():
+            return _exit_cancelled()
+
+        cmd = [
+            "codex",
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--ephemeral",
+            task,
+        ]
+        self._log("daemon_codex_start", em_id=em_id, cmd=" ".join(cmd))
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                cwd=str(self._agent._working_dir),
+            )
+        except FileNotFoundError:
+            exc = RuntimeError("'codex' CLI not found on PATH")
+            run_dir.mark_failed(exc)
+            raise exc
+        except OSError as e:
+            exc = RuntimeError(f"Failed to start codex CLI: {e}")
+            run_dir.mark_failed(exc)
+            raise exc
+
+        output_lines: list[str] = []
+        try:
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                if cancel_event.is_set():
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+                    return _exit_cancelled()
+                output_lines.append(line)
+                stripped = line.rstrip("\n")
+                if stripped:
+                    self._notify_parent(em_id, stripped)
+
+            proc.wait()
+        except Exception as e:
+            proc.kill()
+            proc.wait()
+            run_dir.mark_failed(e)
+            raise
+
+        full_output = "".join(output_lines)
+
+        if proc.returncode != 0:
+            exc = RuntimeError(
+                f"codex CLI exited with code {proc.returncode}: "
+                f"{full_output[-500:]}"
+            )
+            run_dir.mark_failed(exc)
+            raise exc
+
+        text = full_output.strip() or "[no output]"
+        run_dir.mark_done(text)
+        return text
+
     def _notify_parent(self, em_id: str, text: str) -> None:
         """Send a [daemon] notification to parent's inbox."""
         notification = f"[daemon:{em_id}]\n\n{text}"
@@ -887,8 +975,12 @@ class DaemonManager:
                 return {"status": "error",
                         "message": f"Failed to create daemon folder: {e}"}
 
+            if backend == "codex":
+                run_fn = self._run_codex_emanation
+            else:
+                run_fn = self._run_claude_code_emanation
             future = pool.submit(
-                self._run_claude_code_emanation,
+                run_fn,
                 em_id, run_dir, spec["task"],
                 cancel_event, timeout_event,
             )

--- a/src/lingtai/core/daemon/manual/SKILL.md
+++ b/src/lingtai/core/daemon/manual/SKILL.md
@@ -124,6 +124,22 @@ That's a healthy pattern: the LLM is between tool calls, has good progress narra
 
 `list` reports only currently-active emanations (in-memory registry). It includes `run_id` and `path` so you know where to read on disk. Historical (completed/failed/cancelled) emanations don't appear in `list` — find them with `bash("ls daemons/")` instead.
 
+## CLI backends
+
+The `backend` parameter selects the execution engine for emanations. Default is `lingtai` (the built-in ChatSession loop). Two external CLI backends are also available:
+
+| Backend | CLI command | Session resume | Notes |
+|---------|------------|----------------|-------|
+| `lingtai` | (built-in) | N/A — in-process `ask` | Default. Uses preset resolution, tool surface curation, model routing. |
+| `claude-code` | `claude --print --dangerously-skip-permissions --name <em_id> <task>` | `claude --resume <session-id>` via `ask` | Discovers session ID from JSONL files after run. `ask` resumes that session. |
+| `codex` | `codex exec <task>` | Not supported | One-shot execution. No session ID, no `--resume`. `ask` is not available for codex emanations. |
+
+**When to use CLI backends:** When the task benefits from a different agent runtime's tool surface (e.g., Claude Code's built-in file editing, Codex's sandboxed execution) rather than the lingtai emanation's curated tool set.
+
+**CLI backends skip preset resolution** — the external CLI manages its own model, tools, and permissions. The `tools` field in the task spec is ignored for CLI backends.
+
+**Working directory:** Both CLI backends run in the parent agent's working directory (`_working_dir`), not in the emanation's `daemons/em-N-*/` folder. The `daemons/` folder is used only for tracking state (`daemon.json`, logs).
+
 ## What the manual does NOT cover
 
 - Provider routing / LLM presets — deferred to a separate spec.


### PR DESCRIPTION
## Summary
Add a proper Codex CLI backend to the daemon tool. Previously, `backend='codex'` was in the schema enum but incorrectly routed to `_run_claude_code_emanation`. Now it has its own implementation.

### Changes
- **`_run_codex_emanation()`**: New method following the Claude Code pattern
  - Command: `codex exec --dangerously-bypass-approvals-and-sandbox --ephemeral <task>`
  - Streams stdout via `_notify_parent()` (same as Claude Code)
  - Error handling: FileNotFoundError for missing binary, OSError for spawn failure
  - No session discovery needed (Codex is one-shot, no JSONL sessions)
- **`_dispatch_cli_emanation()`**: Routes by backend field
  - `backend == "codex"` → `_run_codex_emanation`
  - `backend == "claude-code"` → `_run_claude_code_emanation`

### What was already there
The schema enum already listed `"codex"` as a backend option, and the `_dispatch_cli_emanation` docstring mentioned it. The only missing piece was the actual implementation — it was hardcoded to call `_run_claude_code_emanation` for both backends.
