### PR TITLE
feat(vision): add Codex vision provider

### DIFF
--- a/src/lingtai/capabilities/vision/ANATOMY.md
+++ b/src/lingtai/capabilities/vision/ANATOMY.md
@@ -8,10 +8,10 @@ Vision capability — image understanding via pluggable VisionService backends.
 
 | File | LOC | Role |
 |---|---|---|
-| `__init__.py` | 135 | `VisionManager`, `setup()`, provider registry, tool schema |
+| `__init__.py` | 134 | `VisionManager`, `setup()`, provider registry, tool schema |
 
 **Key symbols:**
-- `PROVIDERS` (L27-31) — supported providers: `minimax`, `zhipu`, `mimo`, `gemini`, `anthropic`, `openai`. No default, no fallback.
+- `PROVIDERS` (L27-31) — supported providers: `minimax`, `zhipu`, `mimo`, `gemini`, `anthropic`, `openai`, `codex`. No default, no fallback.
 - `VisionManager` (L53) — handles tool calls; resolves relative image paths via `agent._working_dir` (L73).
 - `setup()` (L90) — entry point called by `capabilities.setup_capability()`. Creates `VisionManager`, registers `"vision"` tool on agent (L134).
 
@@ -35,6 +35,7 @@ Single file. No internal state — `VisionManager` instances hold agent + servic
 
 ## Notes
 
-- Graceful skip (L105-112): if the agent's provider isn't in `PROVIDERS`, setup returns `None` silently (no error). Agent logs `capability_skipped`.
-- Provider-specific kwarg injection (L119-124) is opt-in per provider — prevents `TypeError` from passing unsupported kwargs to heterogeneous service constructors.
+- Unsupported providers (L104-111): if the requested provider is not in `PROVIDERS`, setup logs `capability_skipped` and raises `ValueError` so capability bookkeeping can roll back.
+- Provider-specific kwarg injection (L115-120) is opt-in per provider — prevents `TypeError` from passing unsupported kwargs to heterogeneous service constructors.
+- Codex is exposed through `PROVIDERS` and flows to `create_vision_service("codex", api_key=None)`; the service uses ChatGPT OAuth rather than an API key.
 - Local mlx-vlm provider exists in `services/vision/local.py` but is intentionally hidden from `PROVIDERS` (see docstring L11-14).

--- a/src/lingtai/capabilities/vision/__init__.py
+++ b/src/lingtai/capabilities/vision/__init__.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
 
 PROVIDERS = {
-    "providers": ["minimax", "zhipu", "mimo", "gemini", "anthropic", "openai"],
+    "providers": ["minimax", "zhipu", "mimo", "gemini", "anthropic", "openai", "codex"],
     "default": None,
     "fallback_on_inherit": None,  # no agnostic fallback for vision
 }
@@ -100,8 +100,6 @@ def setup(
     Raises ``ValueError`` if neither is provided.
     """
     if vision_service is None and provider is not None:
-        # Graceful skip: if the resolved provider isn't supported by vision
-        # and no fallback exists, silently skip registration.
         if provider not in PROVIDERS["providers"]:
             agent._log(
                 "capability_skipped",
@@ -109,7 +107,7 @@ def setup(
                 requested_provider=provider,
                 reason=f"no vision support for provider {provider!r}",
             )
-            return None
+            raise ValueError(f"Unsupported vision provider: {provider!r}")
 
         # Provider-specific kwarg injection. Each branch is opt-in because
         # vision services have heterogeneous constructor signatures —

--- a/src/lingtai/services/vision/ANATOMY.md
+++ b/src/lingtai/services/vision/ANATOMY.md
@@ -8,8 +8,9 @@ Provider-specific image understanding — standalone services that own their own
 
 | File | LOC | Role |
 |------|-----|------|
-| `__init__.py` | 109 | `VisionService` ABC, `_MIME_BY_EXT` map, `_read_image()` helper, `create_vision_service()` factory |
+| `__init__.py` | 112 | `VisionService` ABC, `_MIME_BY_EXT` map, `_read_image()` helper, `create_vision_service()` factory |
 | `anthropic.py` | 61 | `AnthropicVisionService` — base64 inline image via Anthropic Messages API |
+| `codex.py` | 78 | `CodexVisionService` — ChatGPT Codex Responses API vision via OAuth token |
 | `gemini.py` | 53 | `GeminiVisionService` — `genai.Client` + `types.Part.from_bytes` |
 | `local.py` | 72 | `LocalVisionService` — mlx-vlm on Apple Silicon, lazy model load |
 | `mimo.py` | 75 | `MiMoVisionService` — OpenAI SDK to `api.xiaomimimo.com/v1` |
@@ -20,14 +21,14 @@ Provider-specific image understanding — standalone services that own their own
 ## Connections
 
 - **ABC contract** — all providers inherit `VisionService` (`__init__.py:17`); single abstract method `analyze_image(image_path, prompt) -> str`.
-- **Factory** — `create_vision_service(provider, api_key=...)` at `__init__.py:63` dispatches by name with lazy imports. Supported: `anthropic`, `openai`, `gemini`, `minimax`, `zhipu`, `mimo`, `local`.
+- **Factory** — `create_vision_service(provider, api_key=...)` at `__init__.py:63` dispatches by name with lazy imports. Supported: `anthropic`, `openai`, `gemini`, `minimax`, `zhipu`, `mimo`, `codex`, `local`.
 - **MCP dependency** — `minimax.py` and `zhipu.py` import `lingtai.services.mcp.MCPClient` for subprocess-based tool calls.
-- **External SDKs** — `anthropic` (Anthropic SDK), `openai` (OpenAI SDK), `google.genai` (Gemini), `mlx_vlm` (local).
+- **External SDKs** — `anthropic` (Anthropic SDK), `openai` (OpenAI SDK; OpenAI/MiMo/Codex), `google.genai` (Gemini), `mlx_vlm` (local).
 - **Logging** — MCP providers use `lingtai_kernel.logging.get_logger`.
 
 ## Composition
 
-- **Standalone ownership** — each service creates and owns its own SDK client + API key. Fully independent of LLM adapters or agents.
+- **Standalone ownership** — each service creates and owns its own SDK client + credentials. API providers use API keys; Codex uses `CodexTokenManager`/ChatGPT OAuth; all remain independent of LLM adapters or agents.
 - **Shared helper** — `_read_image(image_path) -> (bytes, mime_type)` at `__init__.py:47` used by all API-based providers.
 - **MCP lazy init** — `minimax.py:34` (`_ensure_client`) and `zhipu.py:29` (`_ensure_client`) start MCP subprocesses on first call, with stale-connection recovery. Both expose `close()` for subprocess teardown.
 - **Local lazy load** — `local.py:39` (`_ensure_loaded`) defers `mlx_vlm.load()` to first `analyze_image` call.
@@ -40,10 +41,11 @@ Provider-specific image understanding — standalone services that own their own
 
 ## Notes
 
-- **Image encoding** — Anthropic (`anthropic.py:34`) and OpenAI/MiMo (`openai.py:38`, `mimo.py:57`) use base64 data URLs. Gemini (`gemini.py:37`) uses `types.Part.from_bytes`. Local passes file path directly to mlx-vlm. MCP providers send base64 in tool args (minimax) or file path (zhipu).
-- **Default models** — Anthropic: `claude-sonnet-4-20250514`; Gemini: `gemini-2.5-flash`; OpenAI: `gpt-4o`; MiMo: `mimo-v2.5`; Local: `mlx-community/paligemma2-3b-ft-docci-448-8bit`.
+- **Image encoding** — Anthropic (`anthropic.py:34`) and OpenAI/MiMo/Codex (`openai.py:38`, `mimo.py:57`, `codex.py:45`) use base64 data URLs. Gemini (`gemini.py:37`) uses `types.Part.from_bytes`. Local passes file path directly to mlx-vlm. MCP providers send base64 in tool args (minimax) or file path (zhipu).
+- **Default models** — Anthropic: `claude-sonnet-4-20250514`; Gemini: `gemini-2.5-flash`; OpenAI: `gpt-4o`; MiMo: `mimo-v2.5`; Codex: `gpt-5.5`; Local: `mlx-community/paligemma2-3b-ft-docci-448-8bit`.
 - **MCP tool names** — MiniMax: `understand_image` (`minimax.py:77`); Zhipu: `analyze_image` (`zhipu.py:70`).
 - **MCP launchers** — MiniMax uses `uvx minimax-coding-plan-mcp -y` (`minimax.py:64`); Zhipu uses `npx -y @z_ai/mcp-server` (`zhipu.py:58`).
 - **Zhipu path vs base64** — Zhipu MCP reads the file directly by path (`zhipu.py:70`), unlike other providers that base64-encode.
+- **Codex Responses API** — `codex.py` constructs `OpenAI(base_url="https://chatgpt.com/backend-api/codex")`, passes `instructions`, `stream=True`, `store=False`, `input_text` + `input_image` content blocks, and concatenates `response.output_text.delta` events. It omits `max_output_tokens` by default because the live ChatGPT Codex backend rejected that parameter (`codex.py:25-28`, `codex.py:70-71`).
 - **Gemini thought filtering** — `gemini.py:51` skips `part.text` when `part.thought` is True to exclude reasoning output.
 - **Git history** — 7 commits. Key: MiMo provider addition (`a728864`), zhipu path-based input fix (`2e6d53c`), region-aware ZAI/ZHIPU mode (`bed1c1e`).

--- a/src/lingtai/services/vision/__init__.py
+++ b/src/lingtai/services/vision/__init__.py
@@ -64,8 +64,8 @@ def create_vision_service(provider: str, *, api_key: str | None = None, **kwargs
     """Factory — create a VisionService for the given provider.
 
     Args:
-        provider: Provider name ("anthropic", "openai", "gemini", "minimax", "local").
-        api_key: API key for the provider (not required for "local").
+        provider: Provider name ("anthropic", "openai", "gemini", "minimax", "codex", "local").
+        api_key: API key for the provider (not required for "codex" or "local").
         **kwargs: Additional provider-specific kwargs (e.g., model, base_url).
 
     Returns:
@@ -77,6 +77,9 @@ def create_vision_service(provider: str, *, api_key: str | None = None, **kwargs
     if provider == "local":
         from .local import LocalVisionService
         return LocalVisionService(**kwargs)
+    elif provider == "codex":
+        from .codex import CodexVisionService
+        return CodexVisionService(**kwargs)
 
     if api_key is None:
         raise ValueError(
@@ -105,5 +108,5 @@ def create_vision_service(provider: str, *, api_key: str | None = None, **kwargs
     else:
         raise ValueError(
             f"Unsupported vision provider: {provider!r}. "
-            f"Supported: anthropic, openai, gemini, minimax, zhipu, mimo, local."
+            f"Supported: anthropic, openai, gemini, minimax, zhipu, mimo, codex, local."
         )

--- a/src/lingtai/services/vision/codex.py
+++ b/src/lingtai/services/vision/codex.py
@@ -1,0 +1,78 @@
+"""Codex vision service — image analysis via ChatGPT Codex Responses API."""
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from ...auth.codex import CodexTokenManager
+from . import VisionService, _read_image
+
+
+class CodexVisionService(VisionService):
+    """Image understanding via the ChatGPT Codex backend.
+
+    Codex uses the ChatGPT OAuth token managed by the TUI, not an API key
+    environment variable. The backend requires the Responses API with
+    ``instructions``, ``stream=True``, and ``store=False``.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = "gpt-5.5",
+        base_url: str = "https://chatgpt.com/backend-api/codex",
+        instructions: str = "You are a concise vision assistant.",
+        # Codex's ChatGPT backend rejected max_output_tokens in a live test;
+        # keep the default as None so the parameter is omitted unless a caller
+        # explicitly opts in after revalidating backend support.
+        max_output_tokens: int | None = None,
+        timeout: float = 120.0,
+        token_path: str | None = None,
+    ) -> None:
+        import openai as _openai
+
+        self._openai = _openai
+        self._token_manager = CodexTokenManager(token_path=token_path)
+        self._model = model
+        self._base_url = base_url
+        self._instructions = instructions
+        self._max_output_tokens = max_output_tokens
+        self._timeout = timeout
+
+    def analyze_image(self, image_path: str, prompt: str | None = None) -> str:
+        """Analyze an image using Codex's Responses API image input."""
+        image_bytes, mime_type = _read_image(image_path)
+        question = prompt or "Describe this image."
+
+        b64 = base64.b64encode(image_bytes).decode("utf-8")
+        data_url = f"data:{mime_type};base64,{b64}"
+
+        client = self._openai.OpenAI(
+            api_key=self._token_manager.get_access_token(),
+            base_url=self._base_url,
+            timeout=self._timeout,
+        )
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "instructions": self._instructions,
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": question},
+                        {"type": "input_image", "image_url": data_url},
+                    ],
+                }
+            ],
+            "stream": True,
+            "store": False,
+        }
+        if self._max_output_tokens is not None:
+            kwargs["max_output_tokens"] = self._max_output_tokens
+
+        stream = client.responses.create(**kwargs)
+        chunks: list[str] = []
+        for event in stream:
+            if getattr(event, "type", "") == "response.output_text.delta":
+                chunks.append(getattr(event, "delta", "") or "")
+        return "".join(chunks).strip()

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -1,6 +1,8 @@
 """Tests for vision capability and VisionService."""
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -115,12 +117,94 @@ def test_vision_setup_with_provider_and_key(tmp_path):
         assert isinstance(mgr, VisionManager)
 
 
+def test_vision_setup_with_codex_provider_without_api_key(tmp_path):
+    """Codex vision uses ChatGPT OAuth, so setup should not require api_key."""
+    with patch("lingtai.capabilities.vision.create_vision_service") as mock_factory:
+        mock_svc = MagicMock(spec=VisionService)
+        mock_factory.return_value = mock_svc
+
+        agent = make_mock_agent(tmp_path)
+        mgr = setup(agent, provider="codex")
+
+        mock_factory.assert_called_once_with("codex", api_key=None)
+        assert isinstance(mgr, VisionManager)
+
+
+def test_vision_setup_unsupported_provider_raises(tmp_path):
+    """Unsupported providers should raise so agent capability bookkeeping rolls back."""
+    agent = make_mock_agent(tmp_path)
+    with pytest.raises(ValueError, match="Unsupported vision provider"):
+        setup(agent, provider="not-real")
+    agent._log.assert_called_with(
+        "capability_skipped",
+        capability="vision",
+        requested_provider="not-real",
+        reason="no vision support for provider 'not-real'",
+    )
+
+
 def test_vision_setup_requires_provider_or_service(tmp_path):
     """setup() without provider or service raises ValueError."""
     agent = make_mock_agent(tmp_path)
     with pytest.raises(ValueError, match="vision capability requires"):
         setup(agent)
 
+
+def test_create_vision_service_codex_without_api_key(monkeypatch):
+    """Codex factory should not require api_key and should use OAuth manager."""
+    fake_openai = SimpleNamespace(OpenAI=MagicMock())
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+    with patch("lingtai.services.vision.codex.CodexTokenManager") as mock_mgr:
+        svc = create_vision_service("codex")
+
+    from lingtai.services.vision.codex import CodexVisionService
+
+    assert isinstance(svc, CodexVisionService)
+    mock_mgr.assert_called_once_with(token_path=None)
+
+
+def test_codex_vision_service_streams_responses_api(monkeypatch, tmp_path):
+    """CodexVisionService should parse streaming output_text deltas without network calls."""
+    img_path = tmp_path / "chart.png"
+    img_path.write_bytes(b"fake png bytes")
+
+    events = [
+        SimpleNamespace(type="response.created"),
+        SimpleNamespace(type="response.output_text.delta", delta="A chart"),
+        SimpleNamespace(type="response.output_text.delta", delta=" with candles"),
+        SimpleNamespace(type="response.completed"),
+    ]
+    responses = MagicMock()
+    responses.create.return_value = events
+    client = SimpleNamespace(responses=responses)
+    openai_cls = MagicMock(return_value=client)
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=openai_cls))
+
+    with patch("lingtai.services.vision.codex.CodexTokenManager") as mock_mgr_cls:
+        mock_mgr_cls.return_value.get_access_token.return_value = "oauth-token"
+        from lingtai.services.vision.codex import CodexVisionService
+
+        svc = CodexVisionService(timeout=9.5)
+        result = svc.analyze_image(str(img_path), prompt="What is shown?")
+
+    assert result == "A chart with candles"
+    openai_cls.assert_called_once_with(
+        api_key="oauth-token",
+        base_url="https://chatgpt.com/backend-api/codex",
+        timeout=9.5,
+    )
+    responses.create.assert_called_once()
+    kwargs = responses.create.call_args.kwargs
+    assert kwargs["model"] == "gpt-5.5"
+    assert kwargs["instructions"]
+    assert kwargs["stream"] is True
+    assert kwargs["store"] is False
+    assert "max_output_tokens" not in kwargs
+    content = kwargs["input"][0]["content"]
+    assert content[0] == {"type": "input_text", "text": "What is shown?"}
+    assert content[1]["type"] == "input_image"
+    assert content[1]["image_url"].startswith("data:image/png;base64,")
 
 def test_create_vision_service_unknown_provider():
     """create_vision_service should raise ValueError for unknown providers."""


### PR DESCRIPTION
## Summary
- add `CodexVisionService` for image understanding through the ChatGPT Codex Responses API
- expose `codex` as a supported vision provider and wire it through `create_vision_service()`
- cover Codex vision setup and streaming response parsing in `tests/test_vision_capability.py`

## Validation
- `~/.local/bin/uv run pytest tests/test_vision_capability.py -q` → `16 passed`
- manual Codex vision smoke test succeeded on a local PNG image
