### PR TITLE
fix(codex): replay reasoning summaries

### DIFF
--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -12,7 +12,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 | `_register.py` | 108 | Registers adapter factories for all providers with `LLMService.register_adapter()` |
 | `api_gate.py` | 112 | `APICallGate` — RPM rate limiter with deque timestamps, `ThreadPoolExecutor`, daemon gate thread |
 | `base.py` | 150 | `LLMAdapter` ABC (4 abstract methods), `_GatedSession` proxy |
-| `interface_converters.py` | 322 | Bidirectional converters: `to_*` / `from_*` for Anthropic, OpenAI, OpenAI Responses API, Gemini |
+| `interface_converters.py` | 335 | Bidirectional converters: `to_*` / `from_*` for Anthropic, OpenAI, OpenAI Responses API, Gemini |
 | `service.py` | 313 | `LLMService` concrete class — adapter registry, session management, one-shot generation |
 
 ## Connections
@@ -45,7 +45,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 - **Interface converters** — Four bidirectional pairs:
   - `to_anthropic`/`from_anthropic` — Anthropic Messages format (system excluded, ThinkingBlock with signature round-trip)
   - `to_openai` — Chat Completions format (tool results as `role=tool`, ThinkingBlocks emit as `reasoning_content` for DeepSeek round-trip; other OpenAI-compat providers ignore the field). One-way only — OpenAI history rehydration goes through `content_block_from_dict` on the canonical interface, not a reverse converter.
-  - `to_responses_input` — Responses API input items (`function_call` / `function_call_output` shapes, ThinkingBlocks omitted)
+  - `to_responses_input` — Responses API input items (`function_call` / `function_call_output` shapes; non-empty ThinkingBlocks replay as `reasoning` items with `summary_text`, before assistant text/calls; `interface_converters.py:184-259`)
   - `to_gemini`/`from_gemini` — Interactions TurnParam format (`role=model`, `function_call`/`function_result`, `thought` blocks)
 - **ToolCallBlock shape conversions** — Anthropic: `tool_use` with `input` dict. OpenAI CC: `function_call` with `arguments` JSON string. Responses: `function_call` with `arguments` JSON string and `call_id`. Gemini: `function_call` with `arguments` dict and `id`.
 - **APICallGate mechanics** — Gate thread dequeues items, prunes timestamps >60s old, sleeps if RPM window full, dispatches to pool (`api_gate.py:71-103`). Pool size defaults to `max(2, min(32, max_rpm // 3))`.

--- a/src/lingtai/llm/interface_converters.py
+++ b/src/lingtai/llm/interface_converters.py
@@ -191,6 +191,7 @@ def to_responses_input(iface: ChatInterface) -> list[dict]:
       * user text       -> ``{"role": "user", "content": <str>}``
       * assistant text  -> ``{"role": "assistant", "content": <str>}``
       * assistant call  -> ``{"type": "function_call", "call_id", "name", "arguments": <json-str>}``
+      * assistant thought -> ``{"type": "reasoning", "summary": [{"type": "summary_text", "text": <str>}]}``
       * tool result     -> ``{"type": "function_call_output", "call_id", "output": <str>}``
 
     Used by stateless Responses sessions (e.g. Codex) that must replay the
@@ -224,10 +225,19 @@ def to_responses_input(iface: ChatInterface) -> list[dict]:
                 })
         elif entry.role == "assistant":
             text_parts: list[str] = []
+            reasoning_items: list[dict] = []
             tool_calls: list[dict] = []
             for block in entry.content:
                 if isinstance(block, TextBlock):
                     text_parts.append(block.text)
+                elif isinstance(block, ThinkingBlock):
+                    if block.text:
+                        reasoning_items.append({
+                            "type": "reasoning",
+                            "summary": [
+                                {"type": "summary_text", "text": block.text},
+                            ],
+                        })
                 elif isinstance(block, ToolCallBlock):
                     tool_calls.append({
                         "type": "function_call",
@@ -235,9 +245,12 @@ def to_responses_input(iface: ChatInterface) -> list[dict]:
                         "name": block.name,
                         "arguments": json.dumps(block.args),
                     })
-                # ThinkingBlocks dropped: the Responses API expects encrypted
-                # reasoning items, which we don't carry through the canonical
-                # interface. Stateless replay simply omits past reasoning.
+            # Preserve the model's original output order: reasoning first,
+            # visible assistant text second, tool calls last.  Responses API
+            # output reasoning items may carry encrypted state when replaying
+            # byte-identical API output, but the input schema also accepts
+            # summary_text-only reasoning items for manually managed context.
+            items.extend(reasoning_items)
             if text_parts:
                 joined = "\n".join(text_parts)
                 if joined:

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -91,7 +91,7 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 | `ToolCallBlock` | `{type: "function", id, function: {name, arguments: <json-str>}}` on assistant message `tool_calls` array | `{type: "function_call", call_id, name, arguments: <json-str>}` as top-level output item |
 | `ToolResultBlock` | `{role: "tool", tool_call_id, content}` as separate message | `{type: "function_call_output", call_id, output}` as top-level input item |
 | `TextBlock` | `content` string on assistant message | `{type: "output_text", text}` inside message content |
-| `ThinkingBlock` | Emitted as `reasoning_content` on assistant message (DeepSeek thinking-mode round-trip; other CC providers ignore the field). Captured back from `message.reasoning_content` / `message.reasoning` into a ThinkingBlock by `_record_assistant_response` (non-streaming) and the streaming finalize path. | Dropped (reasoning items are encrypted) |
+| `ThinkingBlock` | Emitted as `reasoning_content` on assistant message (DeepSeek thinking-mode round-trip; other CC providers ignore the field). Captured back from `message.reasoning_content` / `message.reasoning` into a ThinkingBlock by `_record_assistant_response` (non-streaming) and the streaming finalize path. | Replayed as a top-level `{type: "reasoning", summary: [{type: "summary_text", text: ...}]}` item before assistant text/calls by `to_responses_input` (`../interface_converters.py:233-258`) so stateless Codex can retain summarized reasoning context. |
 
 ### Context overflow auto-recovery
 

--- a/tests/test_responses_converter.py
+++ b/tests/test_responses_converter.py
@@ -1,0 +1,64 @@
+"""Tests for OpenAI Responses API input conversion."""
+
+from __future__ import annotations
+
+from lingtai.llm.interface_converters import to_responses_input
+from lingtai_kernel.llm.interface import (
+    ChatInterface,
+    TextBlock,
+    ThinkingBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+)
+
+
+def test_responses_input_replays_thinking_block_as_reasoning_summary():
+    iface = ChatInterface()
+    iface.add_user_message("What should we do?")
+    iface.add_assistant_message([
+        ThinkingBlock(text="Need to inspect the inbox before answering."),
+        TextBlock(text="I'll check first."),
+        ToolCallBlock(id="call_123", name="email", args={"action": "check"}),
+    ])
+    iface.add_tool_results([
+        ToolResultBlock(id="call_123", name="email", content={"count": 0}),
+    ])
+
+    items = to_responses_input(iface)
+
+    assert items == [
+        {"role": "user", "content": "What should we do?"},
+        {
+            "type": "reasoning",
+            "summary": [
+                {
+                    "type": "summary_text",
+                    "text": "Need to inspect the inbox before answering.",
+                }
+            ],
+        },
+        {"role": "assistant", "content": "I'll check first."},
+        {
+            "type": "function_call",
+            "call_id": "call_123",
+            "name": "email",
+            "arguments": '{"action": "check"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_123",
+            "output": '{"count": 0}',
+        },
+    ]
+
+
+def test_responses_input_omits_empty_thinking_blocks():
+    iface = ChatInterface()
+    iface.add_assistant_message([
+        ThinkingBlock(text=""),
+        TextBlock(text="visible"),
+    ])
+
+    assert to_responses_input(iface) == [
+        {"role": "assistant", "content": "visible"},
+    ]


### PR DESCRIPTION
## Summary

- Replays non-empty canonical `ThinkingBlock`s through `to_responses_input()` as top-level Responses API `reasoning` items with `summary_text`.
- Preserves assistant-turn output ordering for stateless Codex replay: reasoning first, visible assistant text second, function calls last.
- Adds focused converter tests and updates LLM/OpenAI ANATOMY docs.

## Review notes

- The OpenAI SDK schema includes `ResponseReasoningItemParam` in `ResponseInputItemParam` and documents it as context to include when manually managing conversation state.
- I also live-checked the ChatGPT Codex Responses backend with a bare `{type: "reasoning", summary: [{type: "summary_text", text: "..."}]}` input item plus a user message. The request completed and returned `ok`; the local Python process then segfaulted during shutdown (known-looking SDK/native cleanup issue), but the API accepted and completed the request before that.
- The prior comment that Responses replay requires encrypted reasoning is too strict for this stateless replay case: encrypted items are needed to preserve hidden reasoning tokens byte/state-identically, but summary-only reasoning items are accepted as manual context.

## Validation

- `PYTHONPATH=src python -m pytest tests/test_responses_converter.py tests/test_notification_sync.py::test_responses_convert_input_none_yields_empty_list tests/test_deepseek_adapter.py tests/test_mimo_adapter.py -q` → 19 passed.
- `python -m compileall -q src/lingtai/llm/interface_converters.py tests/test_responses_converter.py` passed.
- `git diff --check` passed.
