### PR TITLE
fix(system): confirm runtime preset swaps

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -22,7 +22,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 ### Key functions / classes
 
-**`agent.py`** — `Agent(BaseAgent)`: `__init__` :33 (expand groups, decompress addons, setup caps, install manuals, load MCP) · `_setup_capability` :136 · `_persist_llm_config` :111 · `_install_intrinsic_manuals` :158 · `_load_mcp_from_workdir` :284 (also tracks specs in `_mcp_init_specs`) · `_retry_failed_mcps` :432 (re-spawn dead MCPs on `system(refresh)` — issue #34) · `_read_init` :742 (read + materialize preset + validate) · `_setup_from_init` :878 (**full reconstruct** — shared by boot and live refresh) · `_activate_preset` :804 (runtime swap, atomic write) · `_reload_prompt_sections` :1091 · `connect_mcp` :613 / `connect_mcp_http` :665 · `start` :606 / `stop` :711
+**`agent.py`** — `Agent(BaseAgent)`: `__init__` :33 (expand groups, decompress addons, setup caps, install manuals, load MCP) · `_setup_capability` :136 · `_persist_llm_config` :111 · `_install_intrinsic_manuals` :158 · `_load_mcp_from_workdir` :284 (also tracks specs in `_mcp_init_specs`) · `_retry_failed_mcps` :432 (re-spawn dead MCPs on `system(refresh)` — issue #34) · `_read_init` :742 (read + materialize preset + validate) · `_setup_from_init` :878 (**full reconstruct** — shared by boot and live refresh; clears confirmed `.preset.pending`) · `_activate_preset` :804 (runtime swap, atomic write) · `_confirm_preset_pending` :1092 · `_reload_prompt_sections` :1171 · `connect_mcp` :613 / `connect_mcp_http` :665 · `start` :606 / `stop` :711
 
 **`cli.py`**: `load_init` :21 · `build_agent` :72 · `run` :200 · `main` :246
 
@@ -50,7 +50,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **Capability registration:** `setup_capability()` in `capabilities/__init__.py`; `@register_capability` decorator. Agent calls `_setup_capability` (agent.py:136) during `__init__` and `_setup_from_init`.
 
-**Preset materialization:** `materialize_active_preset` (`lingtai_kernel/presets.py:290`) called by `cli.load_init` (boot) and `Agent._read_init` (refresh). Reads `manifest.preset.active`, loads preset, substitutes `llm`+`capabilities` into manifest before validation.
+**Preset materialization:** `materialize_active_preset` (`lingtai_kernel/presets.py:290`) called by `cli.load_init` (boot) and `Agent._read_init` (refresh). Reads `manifest.preset.active`, loads preset, substitutes `llm`+`capabilities` into manifest before validation. Runtime swaps use `.preset.pending` as a separate confirmation marker so `system(action="presets")` can distinguish “file says active” from “relaunched process confirmed.”
 
 ## Composition
 
@@ -61,8 +61,9 @@ Parent: `src/lingtai/` under `lingtai-kernel/src/` alongside `lingtai_kernel/` (
 | Path | When | What |
 |---|---|---|
 | `<workdir>/init.json` | `_activate_preset` :804, `cli.run` :200 | Preset swap (atomic write); venv_path writeback |
+| `<workdir>/.preset.pending` | `system/preset.py:_refresh`, `_confirm_preset_pending` :1092 | Runtime preset swap handshake marker; written before relaunch and cleared only after the relaunched process confirms active preset |
 | `<workdir>/system/llm.json` | `_persist_llm_config` :111 | LLM provider/model/base_url for revive |
-| `<workdir>/system/{covenant,principle,substrate,procedures,brief,rules,pad}.md` | `_reload_prompt_sections` :1091 | Prompt sections from init.json. `substrate` is kernel-owned, cross-app stable (issue #39); auto-seeded from packaged `lingtai/prompts/substrate.md` (v1) on first boot if neither `data["substrate"]` nor `system/substrate.md` provides content — see `_setup_from_init` :878. |
+| `<workdir>/system/{covenant,principle,substrate,procedures,brief,rules,pad}.md` | `_reload_prompt_sections` :1171 | Prompt sections from init.json. `substrate` is kernel-owned, cross-app stable (issue #39); auto-seeded from packaged `lingtai/prompts/substrate.md` (v1) on first boot if neither `data["substrate"]` nor `system/substrate.md` provides content — see `_setup_from_init` :878. |
 | `<workdir>/.library/intrinsic/` | `_install_intrinsic_manuals` :156 | Wipe-and-rewrite every boot |
 | `<workdir>/.agent.json` | `_build_manifest` :233 via `_workdir.write_manifest` | Runtime manifest snapshot |
 | `<workdir>/.mcp_inbox/` | MCPInboxPoller (started at :452) | LICC events from out-of-process MCPs |

--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -1087,6 +1087,86 @@ class Agent(BaseAgent):
             capabilities=[name for name, _ in self._capabilities],
             tools=list(self._tool_handlers.keys()),
         )
+        self._confirm_preset_pending()
+
+    def _confirm_preset_pending(self) -> None:
+        """Confirm or report drift on a pending preset swap.
+
+        `system(action="refresh", preset=...)` drops `.preset.pending`
+        before relaunch. The relaunched process is the only actor that can
+        clear it, so clearing the marker after setup proves a real round trip
+        instead of merely re-reading the `init.json` written by the old
+        process.
+        """
+        import json
+
+        pending_path = self._working_dir / ".preset.pending"
+        if not pending_path.is_file():
+            return
+
+        try:
+            pending = json.loads(pending_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            self._log("preset_pending_unreadable", error=str(e))
+            try:
+                pending_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return
+        if not isinstance(pending, dict):
+            self._log("preset_pending_unreadable", error="marker is not an object")
+            try:
+                pending_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return
+
+        requested = pending.get("requested")
+        active = None
+        try:
+            init = json.loads(
+                (self._working_dir / "init.json").read_text(encoding="utf-8"))
+            preset = init.get("manifest", {}).get("preset") or {}
+            if isinstance(preset, dict):
+                active = preset.get("active")
+        except (OSError, json.JSONDecodeError) as e:
+            self._log("preset_pending_active_read_failed", error=str(e))
+
+        if isinstance(requested, str) and active == requested:
+            prior_active = pending.get("prior_active")
+            self._log(
+                "preset_swap_completed",
+                preset=requested,
+                prior_active=prior_active,
+                requested_at=pending.get("requested_at"),
+                revert=bool(pending.get("revert")),
+            )
+            try:
+                self._enqueue_system_notification(
+                    source="preset",
+                    ref_id=requested,
+                    body=(
+                        f"Preset switch completed: {prior_active or '(none)'} "
+                        f"→ {requested}"
+                    ),
+                )
+            except Exception as e:
+                self._log("preset_swap_notification_failed", error=str(e))
+            try:
+                pending_path.unlink(missing_ok=True)
+            except OSError as e:
+                self._log("preset_pending_clear_failed", error=str(e))
+            return
+
+        self._log(
+            "preset_swap_drifted",
+            requested=requested,
+            active=active,
+            prior_active=pending.get("prior_active"),
+            requested_at=pending.get("requested_at"),
+        )
+        # Leave `.preset.pending` in place so system(action="presets") and
+        # operators can see that the swap has not been confirmed.
 
     def _reload_prompt_sections(self, data: dict | None = None) -> None:
         """Re-read all prompt sections from init.json and disk.

--- a/src/lingtai_kernel/intrinsics/system/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/system/ANATOMY.md
@@ -15,9 +15,9 @@ System intrinsic — runtime, lifecycle, and synchronization. Provides the agent
 
 - `preset.py` — Preset management and refresh.
   - `_preset_ref_in()` (`preset.py:13-33`) — normalized membership test for preset path strings (~/foo vs absolute).
-  - `_check_context_fits()` (`preset.py:36-64`) — verify agent's current context fits within target preset's context_limit.
-  - `_refresh()` (`preset.py:79-186`) — stop, reload config + MCP servers, restart. Handles preset swap (named or revert) with authorization gate and context-limit guard. **MCP retry hook (issue #34):** before calling `agent._perform_refresh()`, invokes `agent._retry_failed_mcps()` if the Agent subclass defines it. Failures are logged and swallowed so a flaky MCP cannot block refresh itself. Lets the documented "fix config → refresh" recovery path work in-process.
-  - `_presets()` (`preset.py:189-270`) — list available presets with LLM connectivity probing.
+  - `_check_context_fits()` (`preset.py:39-76`) — verify agent's current context fits within target preset's context_limit.
+  - `_refresh()` (`preset.py:131-249`) — stop, reload config + MCP servers, restart. Handles preset swap (named or revert) with authorization gate and context-limit guard, snapshots prior active preset, and writes `.preset.pending` before relaunch so the new process must confirm the swap. **MCP retry hook (issue #34):** before calling `agent._perform_refresh()`, invokes `agent._retry_failed_mcps()` if the Agent subclass defines it. Failures are logged and swallowed so a flaky MCP cannot block refresh itself. Lets the documented "fix config → refresh" recovery path work in-process.
+  - `_presets()` (`preset.py:253-330`) — list available presets with LLM connectivity probing and any unconfirmed `.preset.pending` marker.
 
 - `karma.py` — Karma-gated lifecycle actions.
   - `_KARMA_ACTIONS` / `_NIRVANA_ACTIONS` (`karma.py:13-14`) — gate mapping sets.
@@ -42,7 +42,7 @@ System intrinsic — runtime, lifecycle, and synchronization. Provides the agent
 - **Inbound:** `handle()` is called by the tool dispatcher (via `base_agent._dispatch_tool`).
 - **Inbound (cross-module):** `publish_notification` is imported by `base_agent/messaging.py` (both `_rerender_unread_digest` and `_enqueue_system_notification`) and by `intrinsics/soul/flow.py:_run_consultation_fire`. `clear_notification` is imported by the same call sites for the empty-state path. `_dismiss` is no longer called from `email/manager.py` — email arrivals use the single-slot unread-digest pattern, and dismiss is a no-op shim regardless.
 - **Outbound:** Depends on `...notifications` (canonical `submit`/`clear`/`collect_notifications`), `...i18n` (translations), `...handshake` (`resolve_address`, `is_agent`, `is_alive`), `...state` (`AgentState`), `lingtai.presets` (preset loading), `lingtai.preset_connectivity` (connectivity probing).
-- **Data flow:** Karma actions write signal files (`.sleep`, `.suspend`, `.interrupt`, `.clear`) into target agent working directories. Preset swap reads/writes `init.json` manifest. The `notification` action reads `.notification/*.json` (read-only); `publish_notification` re-export writes them via `tmp + rename`.
+- **Data flow:** Karma actions write signal files (`.sleep`, `.suspend`, `.interrupt`, `.clear`) into target agent working directories. Preset swap reads/writes `init.json` manifest and, for runtime swaps, writes `.preset.pending` until the relaunched `Agent._setup_from_init` confirms or reports drift. The `notification` action reads `.notification/*.json` (read-only); `publish_notification` re-export writes them via `tmp + rename`.
 
 ## Key invariants
 
@@ -50,5 +50,5 @@ System intrinsic — runtime, lifecycle, and synchronization. Provides the agent
 - The `notification` action is now agent-callable: it returns the bare `collect_notifications(workdir)` dict (no `_synthesized` envelope, since the call wasn't synthesized). Kernel-synthesized notification reads happen via the wire-injection path in `BaseAgent._inject_notification_pair` and carry `_synthesized: true` in their JSON body.
 - Karma gate checks resolve addresses through `_check_karma_gate()` which validates admin flags before any filesystem mutation.
 - `_dismiss` is a channel-level generic clear: guarded producer channels (currently email) refuse unless `force=true`; legacy `ids=` calls are ignored and logged for one release.
-- Preset swap has two guards: authorization (allowed list) and context-fit (current tokens ≤ target context_limit).
+- Preset swap has two guards: authorization (allowed list) and context-fit (current tokens ≤ target context_limit). A swap is only fully confirmed after `.preset.pending` is cleared by the relaunched process; until then `_presets()` surfaces the marker as `pending`.
 - Producer notification writes (`publish_notification`) are atomic (`tmp + rename` inside `notifications.publish`) — readers never see a half-written file.

--- a/src/lingtai_kernel/intrinsics/system/preset.py
+++ b/src/lingtai_kernel/intrinsics/system/preset.py
@@ -76,6 +76,58 @@ def _check_context_fits(agent, preset_name: str) -> tuple:
     return True, None, None
 
 
+def _read_active_preset(agent) -> str | None:
+    """Return manifest.preset.active from init.json, or None if absent."""
+    import json as _json
+
+    try:
+        data = _json.loads(
+            (agent._working_dir / "init.json").read_text(encoding="utf-8"))
+    except (OSError, _json.JSONDecodeError):
+        return None
+    preset_block = data.get("manifest", {}).get("preset") or {}
+    if not isinstance(preset_block, dict):
+        return None
+    active = preset_block.get("active")
+    return active if isinstance(active, str) else None
+
+
+def _write_preset_pending(agent, *, requested: str, prior_active: str | None,
+                          reason: str, revert: bool) -> None:
+    """Drop a durable marker for the relaunched process to confirm."""
+    import json as _json
+    import time as _time
+
+    pending = {
+        "requested": requested,
+        "prior_active": prior_active,
+        "requested_at": _time.time(),
+        "reason": reason,
+        "revert": bool(revert),
+    }
+    pending_path = agent._working_dir / ".preset.pending"
+    tmp = pending_path.with_suffix(".pending.tmp")
+    tmp.write_text(
+        _json.dumps(pending, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(pending_path)
+
+
+def _read_preset_pending(agent) -> dict | None:
+    """Read `.preset.pending` for `_presets`; return None when absent."""
+    import json as _json
+
+    pending_path = agent._working_dir / ".preset.pending"
+    if not pending_path.is_file():
+        return None
+    try:
+        pending = _json.loads(pending_path.read_text(encoding="utf-8"))
+    except (OSError, _json.JSONDecodeError):
+        return {"unreadable": True}
+    return pending if isinstance(pending, dict) else {"unreadable": True}
+
+
 def _refresh(agent, args: dict) -> dict:
     from ...i18n import t
     reason = args.get("reason", "")
@@ -143,6 +195,7 @@ def _refresh(agent, args: dict) -> dict:
             agent._log("preset_swap_refused_oversize", **log_extra)
             return {"status": "error", "message": refuse_msg}
 
+        prior_active = _read_active_preset(agent)
         try:
             if revert_preset:
                 agent._activate_default_preset()
@@ -162,6 +215,17 @@ def _refresh(agent, args: dict) -> dict:
                     "message": f"failed to activate preset {preset_name!r}: {e}"}
         agent._log("preset_swap_started",
                    preset=preset_name, reason=reason, revert=revert_preset)
+        try:
+            _write_preset_pending(
+                agent,
+                requested=preset_name,
+                prior_active=prior_active,
+                reason=reason,
+                revert=bool(revert_preset),
+            )
+        except OSError as e:
+            # Best effort: refresh can still proceed; logs retain the failure.
+            agent._log("preset_pending_write_failed", error=str(e))
 
     agent._log("refresh_requested", reason=reason)
 
@@ -265,5 +329,6 @@ def _presets(agent, args: dict) -> dict:
     return {
         "status": "ok",
         "active": active,
+        "pending": _read_preset_pending(agent),
         "available": available,
     }

--- a/tests/unit/test_preset_pending_confirmation.py
+++ b/tests/unit/test_preset_pending_confirmation.py
@@ -1,0 +1,153 @@
+import json
+from pathlib import Path
+
+from lingtai.agent import Agent
+from lingtai_kernel.intrinsics.system.preset import _presets, _refresh
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def make_preset(path: Path, provider: str, model: str) -> None:
+    write_json(path, {
+        "name": path.stem,
+        "description": {"summary": path.stem},
+        "manifest": {
+            "llm": {"provider": provider, "model": model},
+            "capabilities": {},
+        },
+    })
+
+
+def make_init(workdir: Path, active: str, default: str, allowed: list[str]) -> None:
+    write_json(workdir / "init.json", {
+        "name": "tester",
+        "manifest": {
+            "llm": {"provider": "openai", "model": "old"},
+            "capabilities": {},
+            "preset": {
+                "active": active,
+                "default": default,
+                "allowed": allowed,
+            },
+        },
+    })
+
+
+class RefreshAgent:
+    def __init__(self, workdir: Path):
+        self._working_dir = workdir
+        self._config = type("Config", (), {"language": "en"})()
+        self.events = []
+        self.refreshed = False
+
+    def _log(self, event_type, **fields):
+        self.events.append((event_type, fields))
+
+    def _activate_preset(self, name):
+        Agent._activate_preset(self, name)
+
+    def _activate_default_preset(self):
+        Agent._activate_default_preset(self)
+
+    def _perform_refresh(self):
+        self.refreshed = True
+
+    def get_token_usage(self):
+        return {"ctx_total_tokens": 0}
+
+
+class ConfirmAgent:
+    def __init__(self, workdir: Path):
+        self._working_dir = workdir
+        self.events = []
+        self.notifications = []
+
+    def _log(self, event_type, **fields):
+        self.events.append((event_type, fields))
+
+    def _enqueue_system_notification(self, **kwargs):
+        self.notifications.append(kwargs)
+        return "evt_test"
+
+
+def test_refresh_writes_pending_marker_before_relaunch(tmp_path):
+    old = str(tmp_path / "old.json")
+    new = str(tmp_path / "new.json")
+    make_preset(Path(old), "openai", "old")
+    make_preset(Path(new), "openai", "new")
+    make_init(tmp_path, active=old, default=old, allowed=[old, new])
+
+    agent = RefreshAgent(tmp_path)
+    result = _refresh(agent, {"preset": new, "reason": "test swap"})
+
+    assert result["status"] == "ok"
+    assert agent.refreshed is True
+    pending = json.loads((tmp_path / ".preset.pending").read_text(encoding="utf-8"))
+    assert pending["requested"] == new
+    assert pending["prior_active"] == old
+    assert pending["reason"] == "test swap"
+    assert pending["revert"] is False
+    init = json.loads((tmp_path / "init.json").read_text(encoding="utf-8"))
+    assert init["manifest"]["preset"]["active"] == new
+
+
+def test_presets_surfaces_pending_marker(tmp_path, monkeypatch):
+    preset = str(tmp_path / "active.json")
+    make_preset(Path(preset), "openai", "model")
+    make_init(tmp_path, active=preset, default=preset, allowed=[preset])
+    write_json(tmp_path / ".preset.pending", {"requested": preset})
+
+    monkeypatch.setattr(
+        "lingtai_kernel.preset_connectivity.check_many",
+        lambda specs: [{"ok": True} for _ in specs],
+    )
+    agent = RefreshAgent(tmp_path)
+    result = _presets(agent, {})
+
+    assert result["status"] == "ok"
+    assert result["active"] == preset
+    assert result["pending"] == {"requested": preset}
+
+
+def test_confirm_preset_pending_clears_marker_on_match(tmp_path):
+    active = str(tmp_path / "active.json")
+    make_init(tmp_path, active=active, default=active, allowed=[active])
+    write_json(tmp_path / ".preset.pending", {
+        "requested": active,
+        "prior_active": "old",
+        "requested_at": 123.0,
+        "revert": False,
+    })
+    agent = ConfirmAgent(tmp_path)
+
+    Agent._confirm_preset_pending(agent)
+
+    assert not (tmp_path / ".preset.pending").exists()
+    assert any(event == "preset_swap_completed" for event, _ in agent.events)
+    assert agent.notifications
+    assert agent.notifications[0]["source"] == "preset"
+    assert agent.notifications[0]["ref_id"] == active
+
+
+def test_confirm_preset_pending_leaves_marker_on_drift(tmp_path):
+    requested = str(tmp_path / "requested.json")
+    active = str(tmp_path / "active.json")
+    make_init(tmp_path, active=active, default=active, allowed=[active, requested])
+    write_json(tmp_path / ".preset.pending", {
+        "requested": requested,
+        "prior_active": "old",
+        "requested_at": 123.0,
+    })
+    agent = ConfirmAgent(tmp_path)
+
+    Agent._confirm_preset_pending(agent)
+
+    assert (tmp_path / ".preset.pending").exists()
+    drift = [fields for event, fields in agent.events if event == "preset_swap_drifted"]
+    assert drift
+    assert drift[0]["requested"] == requested
+    assert drift[0]["active"] == active
+    assert not agent.notifications


### PR DESCRIPTION
## Summary
- Add a `.preset.pending` handshake marker for explicit runtime preset swaps before refresh/relaunch.
- Surface the marker through `system(action="presets")` as `pending` until a relaunched agent confirms the active preset.
- Confirm and clear the marker in `Agent._setup_from_init`, logging completion or drift and enqueueing a system notification on success.
- Add focused tests and update the relevant ANATOMY docs.

Closes #73.

## Validation
- `PYTHONPATH=src pytest -q tests/unit/test_preset_pending_confirmation.py` (`4 passed`)
- `python -m py_compile src/lingtai_kernel/intrinsics/system/preset.py src/lingtai/agent.py`
- `git diff --check`
- Independent avatar validation: syntax/import/focused tests passed, semantic harness confirmed marker-before-refresh, `pending` visibility, clear-on-match, retain-on-drift, expected logs, and notification enqueue.

## Notes
- Scope is explicit `system(refresh, preset=...)` and `revert_preset` runtime swaps. AED auto-fallback still calls `_activate_default_preset()` + `_perform_refresh()` directly and can be covered in a follow-up if we want the broader invariant that every relaunching active-preset mutation uses the same marker.
- A full `pytest -q` run was attempted earlier and hit broad unrelated failures plus `OSError: [Errno 24] Too many open files` during pytest temp cleanup, so focused validation is the relevant signal for this change.
