### PR TITLE
Improve daemon CLI progress and completion notifications

### DIFF
--- a/src/lingtai/core/daemon/ANATOMY.md
+++ b/src/lingtai/core/daemon/ANATOMY.md
@@ -2,13 +2,15 @@
 
 Daemon capability (分神) — dispatch ephemeral subagents (分神) that operate
 in parallel on the agent's working directory. Each emanation is a disposable
-`ChatSession` with a curated tool surface, not an agent. Results return as
-`[daemon:em-N]` notifications in the parent's inbox.
+`ChatSession` with a curated tool surface, not an agent. Results are
+persisted in per-run daemon folders; terminal completion/failure is surfaced
+as a compact `.notification/system.json` event instead of ordinary parent
+request text.
 
 ## Components
 
-- `daemon/__init__.py` — public capability surface. `get_description` (`daemon/__init__.py:67-68`), `get_schema` (`daemon/__init__.py:71-124`), `setup` (`daemon/__init__.py:880-892`). The core class is `DaemonManager` (`daemon/__init__.py:127-878`) which manages the full emanation lifecycle. Key internals: `_ToolCollector` (`daemon/__init__.py:37-64`) intercepts `add_tool` calls during preset-driven capability setup to build a sandboxed tool surface without mutating the parent's registry. `EMANATION_BLACKLIST` (`daemon/__init__.py:34`) prevents recursion by blocking `daemon`, `avatar`, `psyche`, and `library` tools in subagents.
-- `daemon/run_dir.py` — per-emanation filesystem run directory. `DaemonRunDir` (`daemon/run_dir.py:21-447`) owns every filesystem effect for one run: folder layout, `daemon.json` atomic writes, JSONL appends, heartbeat touches, terminal state markers. The `DaemonManager` calls into a `DaemonRunDir` at every lifecycle hook without itself touching the filesystem.
+- `daemon/__init__.py` — public capability surface. `get_description`, `get_schema`, and `setup`; the core class is `DaemonManager`, which manages the full emanation lifecycle. Key internals: `_ToolCollector` (`daemon/__init__.py:37-64`) intercepts `add_tool` calls during preset-driven capability setup to build a sandboxed tool surface without mutating the parent's registry. `EMANATION_BLACKLIST` (`daemon/__init__.py:34`) prevents recursion by blocking `daemon`, `avatar`, `psyche`, and `library` tools in subagents.
+- `daemon/run_dir.py` — per-emanation filesystem run directory. `DaemonRunDir` owns every filesystem effect for one run: folder layout, `daemon.json` atomic writes, JSONL appends, CLI progress events, heartbeat touches, `result.txt`, and terminal state markers. The `DaemonManager` calls into a `DaemonRunDir` at every lifecycle hook without itself touching the filesystem.
 
 ## Public API
 
@@ -35,18 +37,19 @@ daemon/__init__.py
   ├── _handle_emanate()             — validates presets, creates DaemonRunDir, submits to pool
   ├── _handle_list/check/ask/reclaim — individual action handlers
   ├── _watchdog()                   — timeout enforcement thread
-  ├── _notify_parent()              — sends [daemon:em-N] messages to parent inbox
+  ├── _publish_daemon_notification() — publishes compact system notifications
   └── _drain_followup()             — drains per-emanation follow-up buffer
 
 daemon/run_dir.py
   ├── DaemonRunDir.__init__         — creates folder on disk, writes daemon.json + .prompt
-  ├── Path properties               — run_id, path, daemon_json_path, prompt_path, heartbeat_path, chat_path, events_path, token_ledger_path
+  ├── Path properties               — run_id, path, daemon_json_path, prompt_path, heartbeat_path, chat_path, events_path, token_ledger_path, result_path
   ├── record_user_send()            — appends user-role entry to chat_history.jsonl
   ├── bump_turn()                   — marks end of LLM round (daemon.json + chat_history + heartbeat)
   ├── set_current_tool()            — marks tool dispatch starting (daemon.json + events + heartbeat)
   ├── clear_current_tool()          — marks tool dispatch finished
+  ├── record_cli_output()           — records CLI backend stdout/stderr as cli_output events
   ├── append_tokens()               — dual-ledger token accounting (daemon's + parent's)
-  ├── mark_done/failed/cancelled/timeout — terminal state markers
+  ├── mark_done/failed/cancelled/timeout — terminal state markers (result.txt + preview on done)
   └── _atomic_write_json()          — tempfile + os.replace for crash-safe writes
 ```
 
@@ -59,11 +62,13 @@ daemon/run_dir.py
 - **Capacity control:** `max_emanations` caps concurrent subagents; completed futures are pruned before each new batch.
 - **Preset validation is pre-flight:** Preset connectivity and capability instantiation are checked before any emanation is scheduled. A single failure refuses the whole batch.
 - **Dual token ledger:** Token usage is written to both the daemon's own ledger and the parent's ledger with `source=daemon` attribution.
+- **CLI progress stays inspectable, not conversational:** Claude Code/Codex stdout is persisted as `cli_output` events plus `daemon.json.last_output`; completion/failure publishes a bounded `system` notification pointing the parent to `daemon(action="check", id=...)`.
+- **Full results live on disk:** `mark_done()` writes complete terminal output to `result.txt`; `daemon.json.result_preview` and notification bodies stay bounded.
 
 ## Dependencies
 
 - `lingtai_kernel.llm.base.FunctionSchema` — tool schema type
-- `lingtai_kernel.message` — `MSG_REQUEST`, `_make_message` for inbox notifications
+- `BaseAgent._enqueue_system_notification` — compact daemon completion/failure events
 - `lingtai_kernel.token_ledger` — `append_token_entry` for token accounting
 - `lingtai.i18n` — `t()` for localized strings
 - `lingtai.capabilities` — `setup_capability`, `_GROUPS` for preset sandbox instantiation

--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -146,14 +146,13 @@ class DaemonManager:
 
     def __init__(self, agent: "Agent", max_emanations: int = 10,
                  max_turns: int = 200, timeout: float = 3600.0,
-                 notify_threshold: int = 20, max_result_chars: int = 2000):
+                 notify_threshold: int = 20):
         self._agent = agent
         self._max_emanations = max_emanations
         self._max_turns = max_turns
         self._timeout = timeout
         self._default_model = agent.service.model
         self._notify_threshold = notify_threshold
-        self._max_result_chars = max_result_chars
 
         # Emanation registry: em_id → entry dict
         self._emanations: dict[str, dict] = {}
@@ -737,8 +736,9 @@ class DaemonManager:
         ]
         if run_dir is not None:
             parts.append(f"Run directory: {run_dir.path}")
-            if run_dir._state.get("result_path"):
-                parts.append(f"Result file: {run_dir._state['result_path']}")
+            result_path = run_dir.state_snapshot().get("result_path")
+            if result_path:
+                parts.append(f"Result file: {result_path}")
         if preview:
             parts.append(f"Preview:\n{preview}")
         body = "\n".join(parts)
@@ -1321,13 +1321,12 @@ class DaemonManager:
 
 def setup(agent: "Agent", max_emanations: int = 10,
           max_turns: int = 200, timeout: float = 3600.0,
-          notify_threshold: int = 20, max_result_chars: int = 2000) -> DaemonManager:
+          notify_threshold: int = 20) -> DaemonManager:
     """Set up the daemon capability on an agent."""
     lang = agent._config.language
     mgr = DaemonManager(agent, max_emanations=max_emanations,
                         max_turns=max_turns, timeout=timeout,
-                        notify_threshold=notify_threshold,
-                        max_result_chars=max_result_chars)
+                        notify_threshold=notify_threshold)
     schema = get_schema(lang)
     agent.add_tool("daemon", schema=schema, handler=mgr.handle,
                    description=get_description(lang))

--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -3,7 +3,7 @@
 Gives an agent the ability to split its consciousness into focused worker
 fragments that operate in parallel on the same working directory.  Each
 emanation is a disposable ChatSession with a curated tool surface — not an
-agent.  Results return as [daemon:em-N] notifications in the parent's inbox.
+agent.  Results are persisted in daemon run directories; completion is surfaced via a compact system notification.
 
 Usage:
     Agent(capabilities=["daemon"])
@@ -26,8 +26,6 @@ if TYPE_CHECKING:
     from ...agent import Agent
 
 from lingtai_kernel.llm.base import FunctionSchema
-from lingtai_kernel.message import MSG_REQUEST, _make_message
-
 from .run_dir import DaemonRunDir
 
 PROVIDERS = {"providers": [], "default": "builtin"}
@@ -445,9 +443,8 @@ class DaemonManager:
                 if cancel_event.is_set():
                     return _exit_cancelled()
 
-                # Intermediate text → notify parent
-                if response.text:
-                    self._notify_parent(em_id, response.text)
+                # Intermediate text is already persisted in chat_history via
+                # bump_turn(); do not inject daemon progress as parent requests.
 
                 tool_results = []
                 for tc in response.tool_calls:
@@ -537,7 +534,7 @@ class DaemonManager:
         """Run a Claude Code CLI session as the emanation backend.
 
         Spawns ``claude --print --dangerously-skip-permissions --name <em_id> <task>``
-        and streams stdout back via ``_notify_parent()``. After the process
+        and records stdout in the daemon run directory. After the process
         finishes, discovers the session ID from the JSONL files and stores it
         in run_dir's daemon.json as ``claude_session_id``.
         """
@@ -592,7 +589,7 @@ class DaemonManager:
                 output_lines.append(line)
                 stripped = line.rstrip("\n")
                 if stripped:
-                    self._notify_parent(em_id, stripped)
+                    run_dir.record_cli_output(stripped, stream="combined")
 
             proc.wait()
         except Exception as e:
@@ -633,8 +630,8 @@ class DaemonManager:
     ) -> str:
         """Run a Codex CLI session as the emanation backend.
 
-        Spawns ``codex exec <task>`` and streams stdout back via
-        ``_notify_parent()``.  Unlike Claude Code, Codex has no session
+        Spawns ``codex exec <task>`` and records stdout in the daemon run
+        directory. Unlike Claude Code, Codex has no session
         resumption or JSONL session discovery — each invocation is
         one-shot.
         """
@@ -688,7 +685,7 @@ class DaemonManager:
                 output_lines.append(line)
                 stripped = line.rstrip("\n")
                 if stripped:
-                    self._notify_parent(em_id, stripped)
+                    run_dir.record_cli_output(stripped, stream="combined")
 
             proc.wait()
         except Exception as e:
@@ -711,11 +708,53 @@ class DaemonManager:
         run_dir.mark_done(text)
         return text
 
-    def _notify_parent(self, em_id: str, text: str) -> None:
-        """Send a [daemon] notification to parent's inbox."""
-        notification = f"[daemon:{em_id}]\n\n{text}"
-        msg = _make_message(MSG_REQUEST, "daemon", notification)
-        self._agent.inbox.put(msg)
+    _NOTIFICATION_PREVIEW_MAX = 500
+
+    def _publish_daemon_notification(
+        self,
+        em_id: str,
+        *,
+        status: str,
+        text: str,
+        run_dir: DaemonRunDir | None = None,
+    ) -> None:
+        """Publish a compact daemon completion event via .notification/system.json.
+
+        Full daemon output belongs in the run directory and is inspectable via
+        ``daemon(action="check", id=...)``.  The parent notification is only a
+        wake signal with provenance, bounded preview, and the inspection path.
+        It must not arrive as ordinary ``MSG_REQUEST`` text.
+        """
+        preview = text or ""
+        if len(preview) > self._NOTIFICATION_PREVIEW_MAX:
+            preview = (
+                preview[: self._NOTIFICATION_PREVIEW_MAX]
+                + f"...[truncated; {len(preview)} chars total]"
+            )
+        parts = [
+            f"Daemon {em_id} {status}.",
+            f"Inspect with daemon(action=\"check\", id=\"{em_id}\").",
+        ]
+        if run_dir is not None:
+            parts.append(f"Run directory: {run_dir.path}")
+            if run_dir._state.get("result_path"):
+                parts.append(f"Result file: {run_dir._state['result_path']}")
+        if preview:
+            parts.append(f"Preview:\n{preview}")
+        body = "\n".join(parts)
+        try:
+            self._agent._enqueue_system_notification(
+                source="daemon",
+                ref_id=em_id,
+                body=body,
+            )
+        except Exception as e:
+            self._log(
+                "daemon_notification_error",
+                em_id=em_id,
+                status=status,
+                error=str(e)[:200],
+            )
 
     def _drain_followup(self, em_id: str) -> str | None:
         """Drain the follow-up buffer for a specific emanation."""
@@ -943,8 +982,9 @@ class DaemonManager:
         """Dispatch emanations via an external CLI backend (claude-code, codex).
 
         Skips preset resolution — the CLI manages its own tools/model/provider.
-        Creates a DaemonRunDir for tracking and streams output via the parent
-        notification channel.
+        Creates a DaemonRunDir for tracking. CLI output is persisted in the
+        run directory; only terminal completion/failure emits a compact
+        system notification.
         """
         cancel_event = threading.Event()
         timeout_event = threading.Event()
@@ -1118,7 +1158,10 @@ class DaemonManager:
                                f"{(result.stderr or output)[-500:]}"}
 
         if output:
-            self._notify_parent(em_id, output)
+            run_dir.record_cli_output(output, stream="combined")
+            self._publish_daemon_notification(
+                em_id, status="follow-up completed", text=output, run_dir=run_dir
+            )
 
         return {"status": "sent", "id": em_id, "output": output}
 
@@ -1197,10 +1240,18 @@ class DaemonManager:
             "id": em_id,
             "run_id": state.get("run_id"),
             "state": state.get("state"),
+            "backend": state.get("backend"),
+            "path": str(run_dir.path),
             "turn": state.get("turn"),
             "current_tool": state.get("current_tool"),
             "elapsed_s": state.get("elapsed_s"),
+            "finished_at": state.get("finished_at"),
             "tokens": state.get("tokens", {}),
+            "result_preview": state.get("result_preview"),
+            "result_path": state.get("result_path"),
+            "last_output": state.get("last_output"),
+            "last_output_at": state.get("last_output_at"),
+            "error": state.get("error"),
             "events": events,
             "events_total": events_total,
             "events_returned": len(events),
@@ -1223,25 +1274,28 @@ class DaemonManager:
         entry = self._emanations.get(em_id)
         if entry:
             elapsed = time.time() - entry["start_time"]
+        status = "done"
         try:
             text = future.result()
             self._log("daemon_result", em_id=em_id, status="done",
                       text_length=len(text), elapsed_ms=round(elapsed * 1000))
         except Exception as e:
+            status = "failed"
             text = f"Failed: {e}"
             self._log("daemon_error", em_id=em_id,
                       exception=type(e).__name__, exception_message=str(e))
 
-        # Truncate long results
-        if len(text) > self._max_result_chars:
-            text = text[:self._max_result_chars] + f"\n[truncated — {len(text)} chars total]"
-
-        # Suppress notifications for short results to prevent notification storms
-        if len(text) < self._notify_threshold:
+        # Suppress notifications for short successful results to prevent
+        # notification storms. Failures always notify.
+        if status == "done" and len(text) < self._notify_threshold:
             self._log("daemon_result", em_id=em_id, status="suppressed_short",
                       text_length=len(text))
-        else:
-            self._notify_parent(em_id, text)
+            return
+
+        run_dir = entry.get("run_dir") if entry else None
+        self._publish_daemon_notification(
+            em_id, status=status, text=text, run_dir=run_dir
+        )
 
     def _watchdog(self, cancel_event: threading.Event,
                   timeout_event: threading.Event, timeout: float) -> None:

--- a/src/lingtai/core/daemon/manual/SKILL.md
+++ b/src/lingtai/core/daemon/manual/SKILL.md
@@ -53,13 +53,14 @@ This means: when an emanation looks stuck, you can read its actual state instead
 ```
 daemons/em-3-20260427-094215-a1b2c3/
 ├── daemon.json                  ← identity card + live status snapshot
+├── result.txt                   ← full terminal result when available
 ├── .prompt                      ← system prompt as built (forensic)
 ├── .heartbeat                   ← mtime touched on every write
 ├── history/
 │   └── chat_history.jsonl       ← full LLM transcript
 └── logs/
     ├── token_ledger.jsonl       ← per-call token usage
-    └── events.jsonl             ← daemon_start, tool_call, tool_result, daemon_done/...
+    └── events.jsonl             ← daemon_start, tool_call, tool_result, cli_output, daemon_done/...
 ```
 
 ## Inspection patterns
@@ -73,6 +74,8 @@ Read `daemon.json` once. The fields you want:
 - `turn` — which LLM round the emanation is on
 - `tool_call_count` — how many tool dispatches it has done
 - `tokens` — running totals
+- `last_output` / `last_output_at` — recent stdout/stderr from CLI backends
+- `result_preview` / `result_path` — bounded terminal preview and full `result.txt` path after completion
 - `elapsed_s` — wall clock since start
 
 If `current_tool` is null AND `tool_call_count` hasn't changed for a while, the LLM is thinking — wait. If `current_tool` is set and stays set, that tool is slow (e.g., a big file read or a long bash command).
@@ -138,7 +141,9 @@ The `backend` parameter selects the execution engine for emanations. Default is 
 
 **CLI backends skip preset resolution** — the external CLI manages its own model, tools, and permissions. The `tools` field in the task spec is ignored for CLI backends.
 
-**Working directory:** Both CLI backends run in the parent agent's working directory (`_working_dir`), not in the emanation's `daemons/em-N-*/` folder. The `daemons/` folder is used only for tracking state (`daemon.json`, logs).
+**Working directory:** Both CLI backends run in the parent agent's working directory (`_working_dir`), not in the emanation's `daemons/em-N-*/` folder. The `daemons/` folder is used for tracking state (`daemon.json`, logs) and terminal output (`result.txt`).
+
+**Progress delivery:** CLI stdout/stderr is persisted to the run directory as `cli_output` events and `daemon.json.last_output`; it is not injected into the parent as ordinary `[daemon:em-N]` request text. Completion/failure publishes one compact `system` notification telling the parent which daemon finished and to inspect it with `daemon(action="check", id="em-N")`.
 
 ## What the manual does NOT cover
 

--- a/src/lingtai/core/daemon/run_dir.py
+++ b/src/lingtai/core/daemon/run_dir.py
@@ -29,7 +29,7 @@ class DaemonRunDir:
             history/chat_history.jsonl   # session transcript
             logs/token_ledger.jsonl      # per-call tokens, daemon-scoped
             logs/events.jsonl            # tool_call, tool_result, cli_output, daemon_*
-            result.txt                 # full terminal result when available
+            result.txt                   # full terminal result when available
     """
 
     def __init__(
@@ -152,6 +152,10 @@ class DaemonRunDir:
     @property
     def result_path(self) -> Path:
         return self._path / "result.txt"
+
+    def state_snapshot(self) -> dict:
+        """Return a shallow copy of the current daemon.json state."""
+        return dict(self._state)
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/lingtai/core/daemon/run_dir.py
+++ b/src/lingtai/core/daemon/run_dir.py
@@ -28,7 +28,8 @@ class DaemonRunDir:
             .heartbeat                   # mtime-touched on activity
             history/chat_history.jsonl   # session transcript
             logs/token_ledger.jsonl      # per-call tokens, daemon-scoped
-            logs/events.jsonl            # tool_call, tool_result, daemon_*
+            logs/events.jsonl            # tool_call, tool_result, cli_output, daemon_*
+            result.txt                 # full terminal result when available
     """
 
     def __init__(
@@ -91,6 +92,9 @@ class DaemonRunDir:
             "tool_call_count": 0,
             "tokens": {"input": 0, "output": 0, "thinking": 0, "cached": 0},
             "result_preview": None,
+            "result_path": None,
+            "last_output": None,
+            "last_output_at": None,
             "error": None,
             "preset_name": preset_name,
             "preset_provider": preset_provider,
@@ -144,6 +148,10 @@ class DaemonRunDir:
     @property
     def token_ledger_path(self) -> Path:
         return self._path / "logs" / "token_ledger.jsonl"
+
+    @property
+    def result_path(self) -> Path:
+        return self._path / "result.txt"
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -294,6 +302,57 @@ class DaemonRunDir:
             )
         self._safe("clear_current_tool", _write)
 
+
+    # ------------------------------------------------------------------
+    # External CLI backend hooks
+    # ------------------------------------------------------------------
+
+    _CLI_OUTPUT_EVENT_MAX = 4000
+    _LAST_OUTPUT_MAX = 1000
+
+    def record_cli_output(self, text: str, *, stream: str = "stdout") -> None:
+        """Record one stdout/stderr progress line from an external CLI backend.
+
+        CLI backends (Claude Code / Codex) do not run through the LingTai
+        ChatSession tool loop, so ``turn`` and ``current_tool`` stay mostly
+        static while the child process works.  This hook makes their progress
+        visible to ``daemon(check)`` by appending bounded ``cli_output`` events,
+        updating a small ``last_output`` field in daemon.json, and touching the
+        heartbeat.  The final full output is still captured by ``mark_done``.
+        """
+        text = text.rstrip("\n")
+        if not text:
+            return
+        if stream not in ("stdout", "stderr", "combined"):
+            stream = "stdout"
+        event_text = text
+        truncated = False
+        if len(event_text) > self._CLI_OUTPUT_EVENT_MAX:
+            event_text = event_text[:self._CLI_OUTPUT_EVENT_MAX] + "...[truncated]"
+            truncated = True
+        last_output = text
+        if len(last_output) > self._LAST_OUTPUT_MAX:
+            last_output = last_output[-self._LAST_OUTPUT_MAX:]
+
+        def _write():
+            ts = self._now_iso()
+            self._state["elapsed_s"] = self._now_secs()
+            self._state["last_output"] = last_output
+            self._state["last_output_at"] = ts
+            self._atomic_write_json(self.daemon_json_path, self._state)
+            entry = {
+                "event": "cli_output",
+                "stream": stream,
+                "text": event_text,
+                "elapsed_s": self._state["elapsed_s"],
+                "ts": ts,
+            }
+            if truncated:
+                entry["truncated"] = True
+            self._append_jsonl(self.events_path, entry)
+            self.heartbeat_path.touch()
+        self._safe("record_cli_output", _write)
+
     # ------------------------------------------------------------------
     # Token accounting — dual ledger writes
     # ------------------------------------------------------------------
@@ -369,25 +428,52 @@ class DaemonRunDir:
     _RESULT_PREVIEW_MAX = 200
 
     def mark_done(self, text: str) -> None:
-        """Normal completion. Sets state=done, finished_at, result_preview."""
+        """Normal completion. Sets state=done, finished_at, result_preview.
+
+        The complete terminal text is written to ``result.txt`` for deliberate
+        inspection; daemon.json keeps only a bounded preview so list/check stay
+        compact.  A failure to write result.txt must not prevent the terminal
+        state transition.
+        """
+        text = text or ""
+
         def _write():
+            result_path = None
+            try:
+                self.result_path.write_text(text, encoding="utf-8")
+                result_path = str(self.result_path)
+            except OSError as e:
+                if self._log_callback is not None:
+                    try:
+                        self._log_callback(
+                            "daemon_fs_error",
+                            em_id=self._handle,
+                            run_id=self._run_id,
+                            op="mark_done.result",
+                            error=str(e),
+                        )
+                    except Exception:
+                        pass
             self._state["state"] = "done"
             self._state["finished_at"] = self._now_iso()
             self._state["elapsed_s"] = self._now_secs()
             self._state["current_tool"] = None
-            preview = text or ""
+            preview = text
             if len(preview) > self._RESULT_PREVIEW_MAX:
                 preview = preview[:self._RESULT_PREVIEW_MAX]
             self._state["result_preview"] = preview
+            self._state["result_path"] = result_path
             self._atomic_write_json(self.daemon_json_path, self._state)
             self._append_jsonl(
                 self.events_path,
                 {
                     "event": "daemon_done",
                     "elapsed_s": self._state["elapsed_s"],
+                    "result_path": result_path,
                     "ts": self._now_iso(),
                 },
             )
+            self.heartbeat_path.touch()
         self._safe("mark_done", _write)
 
     def mark_failed(self, exc: BaseException) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -235,6 +235,7 @@ def test_handle_emanate_dispatches_and_returns_ids(tmp_path):
     assert len(events) == 2
     assert {e["source"] for e in events} == {"daemon"}
     assert {e["ref_id"] for e in events} == {"em-1", "em-2"}
+    assert all("[daemon:em-" not in e["body"] for e in events)
 
 
 def test_handle_emanate_allows_concurrent(tmp_path):
@@ -405,6 +406,7 @@ def test_end_to_end_emanate_list_ask_reclaim(tmp_path):
     assert any(e["source"] == "daemon" and e["ref_id"] == "em-1" for e in events)
     assert any("Task done" in e["body"] for e in events)
     assert any("daemon(action=\"check\", id=\"em-1\")" in e["body"] for e in events)
+    assert all("[daemon:em-" not in e["body"] for e in events)
 
     reclaim_result = mgr._handle_reclaim()
     assert reclaim_result["status"] == "reclaimed"
@@ -440,6 +442,7 @@ def test_on_emanation_done_publishes_system_notification_not_request(tmp_path):
     assert "Daemon em-9 done" in event["body"]
     assert "daemon(action=\"check\", id=\"em-9\")" in event["body"]
     assert "final report" in event["body"]
+    assert "[daemon:em-" not in event["body"]
 
 
 def test_on_emanation_done_failure_always_notifies(tmp_path):
@@ -468,6 +471,7 @@ def test_on_emanation_done_failure_always_notifies(tmp_path):
     assert events[0]["ref_id"] == "em-fail"
     assert "failed" in events[0]["body"]
     assert "boom" in events[0]["body"]
+    assert "[daemon:em-" not in events[0]["body"]
 
 
 def test_on_emanation_done_short_success_still_suppressed(tmp_path):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -228,10 +228,13 @@ def test_handle_emanate_dispatches_and_returns_ids(tmp_path):
 
     time.sleep(1)
 
-    messages = []
-    while not agent.inbox.empty():
-        messages.append(agent.inbox.get_nowait())
-    assert len(messages) == 2
+    from lingtai_kernel.notifications import collect_notifications
+
+    assert agent.inbox.empty()
+    events = collect_notifications(agent._working_dir)["system"]["data"]["events"]
+    assert len(events) == 2
+    assert {e["source"] for e in events} == {"daemon"}
+    assert {e["ref_id"] for e in events} == {"em-1", "em-2"}
 
 
 def test_handle_emanate_allows_concurrent(tmp_path):
@@ -395,15 +398,99 @@ def test_end_to_end_emanate_list_ask_reclaim(tmp_path):
     statuses = {e["id"]: e["status"] for e in list_result["emanations"]}
     assert statuses.get("em-1") == "done"
 
-    messages = []
-    while not agent.inbox.empty():
-        messages.append(agent.inbox.get_nowait())
-    assert len(messages) >= 1
-    texts = [m.content for m in messages]
-    assert any("Task done" in t for t in texts)
+    from lingtai_kernel.notifications import collect_notifications
+
+    assert agent.inbox.empty()
+    events = collect_notifications(agent._working_dir)["system"]["data"]["events"]
+    assert any(e["source"] == "daemon" and e["ref_id"] == "em-1" for e in events)
+    assert any("Task done" in e["body"] for e in events)
+    assert any("daemon(action=\"check\", id=\"em-1\")" in e["body"] for e in events)
 
     reclaim_result = mgr._handle_reclaim()
     assert reclaim_result["status"] == "reclaimed"
+
+
+
+def test_on_emanation_done_publishes_system_notification_not_request(tmp_path):
+    from lingtai_kernel.notifications import collect_notifications
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    agent.inbox = queue.Queue()
+    mgr = agent.get_capability("daemon")
+    rd = _make_run_dir(agent, em_id="em-9")
+
+    future = MagicMock()
+    future.result.return_value = "final report long enough to notify"
+    mgr._emanations["em-9"] = {
+        "future": future,
+        "task": "test task",
+        "start_time": time.time(),
+        "run_dir": rd,
+    }
+
+    mgr._on_emanation_done("em-9", "test task", future)
+
+    assert agent.inbox.empty()
+    notifications = collect_notifications(agent._working_dir)
+    events = notifications["system"]["data"]["events"]
+    assert len(events) == 1
+    event = events[0]
+    assert event["source"] == "daemon"
+    assert event["ref_id"] == "em-9"
+    assert "Daemon em-9 done" in event["body"]
+    assert "daemon(action=\"check\", id=\"em-9\")" in event["body"]
+    assert "final report" in event["body"]
+
+
+def test_on_emanation_done_failure_always_notifies(tmp_path):
+    from lingtai_kernel.notifications import collect_notifications
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    agent.inbox = queue.Queue()
+    mgr = agent.get_capability("daemon")
+    rd = _make_run_dir(agent, em_id="em-fail")
+
+    future = MagicMock()
+    future.result.side_effect = RuntimeError("boom")
+    mgr._emanations["em-fail"] = {
+        "future": future,
+        "task": "test task",
+        "start_time": time.time(),
+        "run_dir": rd,
+    }
+
+    mgr._on_emanation_done("em-fail", "test task", future)
+
+    assert agent.inbox.empty()
+    events = collect_notifications(agent._working_dir)["system"]["data"]["events"]
+    assert len(events) == 1
+    assert events[0]["source"] == "daemon"
+    assert events[0]["ref_id"] == "em-fail"
+    assert "failed" in events[0]["body"]
+    assert "boom" in events[0]["body"]
+
+
+def test_on_emanation_done_short_success_still_suppressed(tmp_path):
+    from lingtai_kernel.notifications import collect_notifications
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    agent.inbox = queue.Queue()
+    mgr = agent.get_capability("daemon")
+    rd = _make_run_dir(agent, em_id="em-short")
+
+    future = MagicMock()
+    future.result.return_value = "ok"
+    mgr._emanations["em-short"] = {
+        "future": future,
+        "task": "test task",
+        "start_time": time.time(),
+        "run_dir": rd,
+    }
+
+    mgr._on_emanation_done("em-short", "test task", future)
+
+    assert agent.inbox.empty()
+    assert collect_notifications(agent._working_dir) == {}
 
 
 def test_sequential_emanate_increments_ids(tmp_path):
@@ -764,12 +851,9 @@ def _make_agent_with_presets(tmp_path, presets_dir):
 def test_emanate_with_preset_validates_preset_exists(tmp_path, monkeypatch):
     """If a per-task preset is specified but doesn't exist in the library,
     refuse THE WHOLE BATCH (no partial emanations)."""
-    from unittest.mock import patch
-    import lingtai_kernel.preset_connectivity as preset_connectivity
-
     presets_dir = tmp_path / "presets"
     presets_dir.mkdir()
-    preset_file = _write_preset_file(presets_dir, "deepseek")
+    _write_preset_file(presets_dir, "deepseek")
 
     agent = _make_agent_with_presets(tmp_path, presets_dir)
     agent.inbox = queue.Queue()
@@ -795,7 +879,7 @@ def test_emanate_with_preset_unreachable_refuses(tmp_path, monkeypatch):
 
     presets_dir = tmp_path / "presets"
     presets_dir.mkdir()
-    preset_file = _write_preset_file(presets_dir, "deepseek", api_key_env="DEEPSEEK_API_KEY")
+    _write_preset_file(presets_dir, "deepseek", api_key_env="DEEPSEEK_API_KEY")
 
     monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
 
@@ -862,7 +946,6 @@ def test_emanate_with_preset_passes_through(tmp_path, monkeypatch):
     mock_session.send = MagicMock(return_value=mock_resp)
 
     # The preset's LLMService will call create_session — mock at the class level
-    from lingtai.llm.service import LLMService as ConcreteLLMService
     preset_svc = MagicMock()
     preset_svc.create_session = MagicMock(return_value=mock_session)
     preset_svc.make_tool_result = MagicMock(return_value="mock_result")

--- a/tests/test_daemon_check.py
+++ b/tests/test_daemon_check.py
@@ -1,5 +1,4 @@
 """Tests for daemon(action='check') — read-only event-tail surface."""
-import json
 import threading
 from unittest.mock import MagicMock
 
@@ -147,9 +146,49 @@ def test_check_includes_terminal_event_for_done_emanation(tmp_path):
 
     out = mgr.handle({"action": "check", "id": "em-5"})
     assert out["state"] == "done"
+    assert out["backend"] == "lingtai"
+    assert out["path"] == str(rd.path)
+    assert out["finished_at"] is not None
+    assert out["result_preview"] == "final report text"
+    assert out["result_path"] == str(rd.result_path)
+    assert out["error"] is None
     event_types = {e.get("event") for e in out["events"]}
     assert "daemon_done" in event_types
 
+
+
+def test_check_includes_cli_progress_fields(tmp_path):
+    agent = _make_agent(tmp_path)
+    mgr = agent.get_capability("daemon")
+    rd = _make_run_dir(agent, "em-cli")
+    rd._state["backend"] = "codex"
+    rd._atomic_write_json(rd.daemon_json_path, rd._state)
+    _register(mgr, "em-cli", rd)
+
+    rd.record_cli_output("phase 1 complete", stream="combined")
+
+    out = mgr.handle({"action": "check", "id": "em-cli"})
+    assert out["backend"] == "codex"
+    assert out["last_output"] == "phase 1 complete"
+    assert out["last_output_at"] is not None
+    cli_events = [e for e in out["events"] if e.get("event") == "cli_output"]
+    assert cli_events
+    assert cli_events[-1]["text"] == "phase 1 complete"
+
+
+def test_check_includes_failure_error(tmp_path):
+    agent = _make_agent(tmp_path)
+    mgr = agent.get_capability("daemon")
+    rd = _make_run_dir(agent, "em-fail")
+    _register(mgr, "em-fail", rd, future=MagicMock(done=MagicMock(return_value=True)))
+
+    rd.mark_failed(RuntimeError("boom"))
+
+    out = mgr.handle({"action": "check", "id": "em-fail"})
+    assert out["state"] == "failed"
+    assert out["error"]["type"] == "RuntimeError"
+    assert out["error"]["message"] == "boom"
+    assert out["finished_at"] is not None
 
 def test_check_default_last_is_20(tmp_path):
     agent = _make_agent(tmp_path)

--- a/tests/test_daemon_run_dir.py
+++ b/tests/test_daemon_run_dir.py
@@ -248,6 +248,42 @@ def test_multiple_tool_dispatches_increment_count(tmp_path):
     assert data["tool_call_count"] == 2
 
 
+
+def test_record_cli_output_updates_state_and_event(tmp_path):
+    rd = _make_run_dir(tmp_path, backend="codex")
+    initial_mtime = rd.heartbeat_path.stat().st_mtime
+    time.sleep(0.05)
+
+    rd.record_cli_output("working on step 1", stream="combined")
+
+    data = json.loads(rd.daemon_json_path.read_text())
+    assert data["last_output"] == "working on step 1"
+    assert data["last_output_at"] is not None
+    assert data["elapsed_s"] >= 0.0
+    assert rd.heartbeat_path.stat().st_mtime > initial_mtime
+
+    last = json.loads(rd.events_path.read_text().splitlines()[-1])
+    assert last["event"] == "cli_output"
+    assert last["stream"] == "combined"
+    assert last["text"] == "working on step 1"
+    assert "elapsed_s" in last
+
+
+def test_record_cli_output_bounds_large_event_and_last_output(tmp_path):
+    rd = _make_run_dir(tmp_path)
+    big = "x" * 5000
+
+    rd.record_cli_output(big, stream="stderr")
+
+    data = json.loads(rd.daemon_json_path.read_text())
+    assert len(data["last_output"]) == rd._LAST_OUTPUT_MAX
+
+    last = json.loads(rd.events_path.read_text().splitlines()[-1])
+    assert last["event"] == "cli_output"
+    assert last["stream"] == "stderr"
+    assert last["truncated"] is True
+    assert len(last["text"]) <= rd._CLI_OUTPUT_EVENT_MAX + len("...[truncated]")
+
 def test_append_tokens_writes_daemon_ledger(tmp_path):
     rd = _make_run_dir(tmp_path)
     rd.append_tokens(input=100, output=20, thinking=5, cached=10)
@@ -316,6 +352,8 @@ def test_mark_done_writes_terminal_state(tmp_path):
     assert data["state"] == "done"
     assert data["finished_at"] is not None
     assert data["result_preview"] == "Task done. Found 3 TODOs."
+    assert data["result_path"] == str(rd.result_path)
+    assert rd.result_path.read_text() == "Task done. Found 3 TODOs."
     assert data["error"] is None
 
 
@@ -325,6 +363,7 @@ def test_mark_done_truncates_result_preview(tmp_path):
     rd.mark_done(long_text)
     data = json.loads(rd.daemon_json_path.read_text())
     assert len(data["result_preview"]) <= 200
+    assert rd.result_path.read_text() == long_text
 
 
 def test_mark_done_logs_event(tmp_path):
@@ -333,6 +372,7 @@ def test_mark_done_logs_event(tmp_path):
     lines = rd.events_path.read_text().splitlines()
     last = json.loads(lines[-1])
     assert last["event"] == "daemon_done"
+    assert last["result_path"] == str(rd.result_path)
     assert "elapsed_s" in last
 
 


### PR DESCRIPTION
## Summary

Fixes #80 and #81 by moving daemon CLI progress/result delivery out of ordinary parent request text and into inspectable daemon run directories plus compact system notifications.

- persist Claude Code/Codex CLI stdout as `cli_output` events and `daemon.json.last_output`
- write full terminal output to `result.txt`, while keeping `result_preview` bounded
- enrich `daemon(action="check")` with backend/path/finished_at/result/error/output fields
- replace `[daemon:em-N]` `MSG_REQUEST` completion delivery with compact `.notification/system.json` events pointing to `daemon(check)`
- update daemon anatomy/manual docs and regression tests

## Tests

- `python3 -m ruff check src/lingtai/core/daemon tests/test_daemon.py tests/test_daemon_check.py tests/test_daemon_run_dir.py`
- `python3 -m pytest tests/test_daemon_run_dir.py tests/test_daemon_check.py tests/test_daemon.py -q` (96 passed)

## Notes

The unrelated untracked directory `src/lingtai/intrinsic_skills/lingtai-repo-watch/` was preserved and not included.
