### PR TITLE
Capture Responses reasoning summaries in Codex streams

### DIFF
--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -9,18 +9,18 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 3 | Re-exports `OpenAIAdapter`, `OpenAIChatSession` |
-| `adapter.py` | 1398 | 5 classes + helpers: `OpenAIChatSession`, `OpenAIResponsesSession`, `OpenAIAdapter`, `CodexResponsesSession`, `CodexOpenAIAdapter` |
+| `adapter.py` | 1470 | 5 classes + helpers: `OpenAIChatSession`, `OpenAIResponsesSession`, `OpenAIAdapter`, `CodexResponsesSession`, `CodexOpenAIAdapter` |
 | `defaults.py` | 7 | `DEFAULTS` dict: `api_compat="openai"`, `use_responses_api=True` |
 
 ### adapter.py class map
 
 | Class | Lines | Role |
 |-------|-------|------|
-| `OpenAIChatSession` | 227–718 | Chat Completions session with context overflow auto-recovery |
-| `OpenAIResponsesSession` | 727–904 | Responses API session with server-side `previous_response_id` chaining |
-| `OpenAIAdapter` | 914–1175 | `LLMAdapter` implementation; dispatches to Completions or Responses path |
-| `CodexResponsesSession` | 1185–1343 | Stateless Responses variant for ChatGPT-OAuth `/backend-api/codex` |
-| `CodexOpenAIAdapter` | 1344–1398 | Adapter variant that builds `CodexResponsesSession` |
+| `OpenAIChatSession` | 289–781 | Chat Completions session with context overflow auto-recovery |
+| `OpenAIResponsesSession` | 789–971 | Responses API session with server-side `previous_response_id` chaining |
+| `OpenAIAdapter` | 979–1242 | `LLMAdapter` implementation; dispatches to Completions or Responses path |
+| `CodexResponsesSession` | 1250–1413 | Stateless Responses variant for ChatGPT-OAuth `/backend-api/codex` |
+| `CodexOpenAIAdapter` | 1416–1470 | Adapter variant that builds `CodexResponsesSession` |
 
 ### adapter.py helpers
 
@@ -31,42 +31,43 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | `_build_responses_tools()` | 83–107 | `FunctionSchema` → Responses API flat format (`{type, name, description, parameters}`); scrubs disallowed top-level JSON-Schema combinators (`allOf`, `oneOf`, etc.) |
 | `_parse_tool_calls()` | 110–127 | Raw SDK `tool_calls` → `list[ToolCall]` |
 | `_parse_response()` | 130–174 | ChatCompletion → `LLMResponse` (extracts reasoning from `reasoning_content` or `reasoning`) |
-| `_parse_responses_api_response()` | 177–219 | Responses API output → `LLMResponse` (handles `message`, `function_call`, `reasoning` output items) |
+| `_handle_responses_reasoning_event()` | 195–236 | Responses stream reasoning-summary event handler; accumulates `summary_text` deltas/done fallback without raw reasoning text |
+| `_parse_responses_api_response()` | 239–281 | Responses API output → `LLMResponse` (handles `message`, `function_call`, `reasoning` output items) |
 
 ## Connections
 
 - **Base class** — `OpenAIAdapter` extends `LLMAdapter` (`from lingtai.llm.base import LLMAdapter`, line 29).
 - **Kernel types** — imports `ChatSession`, `FunctionSchema`, `LLMResponse`, `ToolCall`, `UsageMetadata` from `lingtai_kernel.llm.base`.
-- **Interface converters** — imports `to_openai` and `to_responses_input` from `lingtai.llm.interface_converters` (line 30).
-- **Streaming** — imports `StreamingAccumulator` from `lingtai_kernel.llm.streaming` (line 31).
+- **Interface converters** — imports `to_openai` and `to_responses_input` from `lingtai.llm.interface_converters` (line 31).
+- **Streaming** — imports `StreamingAccumulator` from `lingtai_kernel.llm.streaming` (line 32).
 - **HTTP client** — imports `httpx` for timeout construction (line 16); `openai` SDK for all API calls (line 17).
-- **Subclass hooks** — `_session_class` (line 922) for Completions path; `_adapter_extra_body()` (line 1108) for provider-specific `extra_body`.
+- **Subclass hooks** — `_session_class` (line 987) for Completions path; `_adapter_extra_body()` (line 1173) for provider-specific `extra_body`.
 
 ## Composition
 
 ### Two session paths
 
-The adapter forks at `create_chat()` (line 950):
-1. **Responses API** (`_create_responses_session`, line 990) — when `use_responses=True` AND (`base_url` is None OR `force_responses=True`). Builds `OpenAIResponsesSession`.
-2. **Chat Completions** (`_create_completions_session`, line 1050) — fallback for compatible providers. Builds `self._session_class` (subclass-overridable).
+The adapter forks at `create_chat()` (line 1015):
+1. **Responses API** (`_create_responses_session`, line 1055) — when `use_responses=True` AND (`base_url` is None OR `force_responses=True`). Builds `OpenAIResponsesSession`.
+2. **Chat Completions** (`_create_completions_session`, line 1115) — fallback for compatible providers. Builds `self._session_class` (subclass-overridable).
 
 Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 
-### Chat Completions session flow (`OpenAIChatSession.send`, line 376)
+### Chat Completions session flow (`OpenAIChatSession.send`, line 438)
 
 1. Record user input into `ChatInterface` (str → `add_user_message`; list → `add_tool_results`)
 2. `_build_kwargs()`: enforce tool pairing → serialize via `_build_messages()` → `_pair_orphan_tool_calls()` wire guard
 3. `_run_with_overflow_recovery(_do_call)` — retries with context trimming on 400 context-length errors
 4. On success: record assistant response into interface via `_record_assistant_response()`
 
-### Responses API session flow (`OpenAIResponsesSession.send`, line 791)
+### Responses API session flow (`OpenAIResponsesSession.send`, line 853)
 
 1. `_convert_input(message)` → Responses API input items
 2. Chain `previous_response_id` if available
 3. Call `client.responses.create(**kwargs)`
 4. Store `response_id` for next turn
 
-### Codex stateless flow (`CodexResponsesSession.send_stream`, line 1201)
+### Codex stateless flow (`CodexResponsesSession.send_stream`, line 1266)
 
 1. Record message into canonical `ChatInterface`
 2. `to_responses_input(interface)` — replay full conversation as input items
@@ -76,9 +77,9 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 ## State
 
 - **`OpenAIChatSession._interface`** — canonical `ChatInterface`, single source of truth. Mutated in-place: `add_user_message`, `add_tool_results`, `add_assistant_message`, `drop_trailing`.
-- **`OpenAIChatSession._request_timeout`** — per-request HTTP timeout set by caller before dispatch (line 257). Prevents race between watchdog and SDK.
-- **`OpenAIResponsesSession._response_id`** — server-side session chain pointer. Updated after each `send()`.
-- **`CodexResponsesSession._response_id`** — transient debug aid only; never threaded into next request (line 1338).
+- **`OpenAIChatSession._request_timeout`** — per-request HTTP timeout set by caller before dispatch (line 319). Prevents race between watchdog and SDK.
+- **`OpenAIResponsesSession._response_id`** — server-side session chain pointer. Updated after each `send()` / streamed response.
+- **`CodexResponsesSession._response_id`** — transient debug aid only; never threaded into next request (line 1410).
 - **`OpenAIAdapter._client`** — shared `openai.OpenAI` instance. `_client_kwargs` stored for session `reset()`.
 - **`OpenAIAdapter._session_class`** — class var, subclasses override (e.g. DeepSeek injects `reasoning_content` preservation).
 
@@ -91,7 +92,7 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 | `ToolCallBlock` | `{type: "function", id, function: {name, arguments: <json-str>}}` on assistant message `tool_calls` array | `{type: "function_call", call_id, name, arguments: <json-str>}` as top-level output item |
 | `ToolResultBlock` | `{role: "tool", tool_call_id, content}` as separate message | `{type: "function_call_output", call_id, output}` as top-level input item |
 | `TextBlock` | `content` string on assistant message | `{type: "output_text", text}` inside message content |
-| `ThinkingBlock` | Emitted as `reasoning_content` on assistant message (DeepSeek thinking-mode round-trip; other CC providers ignore the field). Captured back from `message.reasoning_content` / `message.reasoning` into a ThinkingBlock by `_record_assistant_response` (non-streaming) and the streaming finalize path. | Replayed as a top-level `{type: "reasoning", summary: [{type: "summary_text", text: ...}]}` item before assistant text/calls by `to_responses_input` (`../interface_converters.py:233-258`) so stateless Codex can retain summarized reasoning context. |
+| `ThinkingBlock` | Emitted as `reasoning_content` on assistant message (DeepSeek thinking-mode round-trip; other CC providers ignore the field). Captured back from `message.reasoning_content` / `message.reasoning` into a ThinkingBlock by `_record_assistant_response` (non-streaming) and the streaming finalize path. | Replayed as a top-level `{type: "reasoning", summary: [{type: "summary_text", text: ...}]}` item before assistant text/calls by `to_responses_input` (`../interface_converters.py:233-258`) so stateless Codex can retain summarized reasoning context. Responses streaming captures `response.reasoning_summary_text.*` into thoughts and Codex persists those thoughts as ThinkingBlocks before tool calls. |
 
 ### Context overflow auto-recovery
 
@@ -102,17 +103,17 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 
 ### Wire-layer orphan guard
 
-`_pair_orphan_tool_calls()` (line 314) scans the serialized message list for `assistant.tool_calls` without matching `role=tool` messages. Synthesizes placeholder tool results with `[synthesized placeholder — real result was not in context at send time]`. Logs warnings for investigation. Does NOT mutate canonical interface.
+`_pair_orphan_tool_calls()` (line 376) scans the serialized message list for `assistant.tool_calls` without matching `role=tool` messages. Synthesizes placeholder tool results with `[synthesized placeholder — real result was not in context at send time]`. Logs warnings for investigation. Does NOT mutate canonical interface.
 
 ### Streaming
 
-- **CC streaming** (`send_stream`, line 560) — `stream=True, stream_options={include_usage: True}`. Uses `StreamingAccumulator` for text + tool deltas. Reasoning deltas captured from `delta.reasoning` or `delta.reasoning_content` (OpenRouter compatibility, lines 664-671). Overflow recovery wraps the stream open + first chunk (lines 606-625).
-- **Responses streaming** (`send_stream`, line 829) — event types: `response.output_text.delta`, `response.function_call_arguments.delta`, `response.output_item.added/done`, `response.completed`.
-- **Codex streaming** — forces `stream=True` even on `send()` (line 1197). Full interface replay per request.
+- **CC streaming** (`send_stream`, line 622) — `stream=True, stream_options={include_usage: True}`. Uses `StreamingAccumulator` for text + tool deltas. Reasoning deltas captured from `delta.reasoning` or `delta.reasoning_content` (OpenRouter compatibility, lines 726-733). Overflow recovery wraps the stream open + first chunk (lines 668-690).
+- **Responses streaming** (`send_stream`, line 891) — event types: `response.reasoning_summary_text.delta/done` (summary thoughts only), `response.output_text.delta`, `response.function_call_arguments.delta`, `response.output_item.added/done`, `response.completed`.
+- **Codex streaming** — forces `stream=True` even on `send()` (line 1262). Full interface replay per request; captured summary thoughts are persisted as ThinkingBlocks so `to_responses_input` replays reasoning items before function calls.
 
 ### Authentication paths
 
-- **Standard** — `api_key` passed to `openai.OpenAI(api_key=...)` at construction (line 944).
+- **Standard** — `api_key` passed to `openai.OpenAI(api_key=...)` at construction (line 1009).
 - **Codex OAuth** — `CodexOpenAIAdapter` built by `../_register.py:54` with `CodexTokenManager.get_access_token()`. Token refreshed by monkey-patching `create_chat` and `generate` to update `adapter._client.api_key` in-place before each call.
 
 ### Tool schema conversion
@@ -123,14 +124,14 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 ### Reasoning extraction
 
 - **CC non-streaming** (`_parse_response`, line 130) — checks `message.reasoning_content` (OpenAI native) then `message.reasoning` (OpenRouter).
-- **CC streaming** — `delta.reasoning` or `delta.reasoning_content` accumulated via `acc.add_thought()` (line 671).
-- **Responses non-streaming** — `reasoning` output items with `summary_text` blocks (lines 193-197).
-- **Responses streaming** — reasoning events not currently handled (Responses API reasoning is encrypted).
+- **CC streaming** — `delta.reasoning` or `delta.reasoning_content` accumulated via `acc.add_thought()` (line 733).
+- **Responses non-streaming** — `reasoning` output items with `summary_text` blocks (lines 256-259).
+- **Responses streaming** — `response.reasoning_summary_text.delta/done` and reasoning output-item summaries are captured as summary thoughts; raw `response.reasoning_text.*` is intentionally not persisted by default.
 
 ### Subclass hooks
 
-- `_session_class` (line 922) — override to inject provider-specific session behavior on the CC path.
-- `_adapter_extra_body()` (line 1108) — override to add `extra_body` JSON fields (e.g. OpenRouter `reasoning: {include: true}`).
+- `_session_class` (line 987) — override to inject provider-specific session behavior on the CC path.
+- `_adapter_extra_body()` (line 1173) — override to add `extra_body` JSON fields (e.g. OpenRouter `reasoning: {include: true}`).
 
 ### `send(None)` contract — continue from wire
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -174,6 +174,68 @@ def _parse_response(raw) -> LLMResponse:
     )
 
 
+def _add_responses_reasoning_done_text(
+    acc: StreamingAccumulator,
+    reasoning_item_id: str | None,
+    seen_reasoning_delta_items: set[str],
+    text: str | None,
+) -> None:
+    """Add final reasoning-summary text only when no delta was seen.
+
+    Responses ``*.done`` events carry the complete text.  When the stream
+    already delivered ``*.delta`` chunks for the same reasoning item, adding
+    ``done.text`` would duplicate the thought.  If a provider emits only the
+    done event, use it as a lossless fallback.
+    """
+    if text and (not reasoning_item_id or reasoning_item_id not in seen_reasoning_delta_items):
+        acc.add_thought(text)
+    acc.finish_thought()
+
+
+def _handle_responses_reasoning_event(
+    event: Any,
+    acc: StreamingAccumulator,
+    seen_reasoning_delta_items: set[str],
+) -> bool:
+    """Feed safe Responses reasoning-summary events into ``acc``.
+
+    We persist summary text, not raw ``response.reasoning_text.*`` events, so
+    stateless Codex replay can include documented ``summary_text`` reasoning
+    items without storing hidden chain-of-thought.
+    """
+    event_type = getattr(event, "type", None)
+    if event_type == "response.reasoning_summary_text.delta":
+        delta = getattr(event, "delta", None)
+        if delta:
+            acc.add_thought(delta)
+            item_id = getattr(event, "item_id", None)
+            if item_id:
+                seen_reasoning_delta_items.add(item_id)
+        return True
+    if event_type == "response.reasoning_summary_text.done":
+        _add_responses_reasoning_done_text(
+            acc,
+            getattr(event, "item_id", None),
+            seen_reasoning_delta_items,
+            getattr(event, "text", None),
+        )
+        return True
+    if event_type == "response.output_item.done" and getattr(event.item, "type", None) == "reasoning":
+        summaries = getattr(event.item, "summary", None) or []
+        added_fallback = False
+        for summary in summaries:
+            if getattr(summary, "type", None) == "summary_text":
+                item_id = getattr(event.item, "id", None)
+                text = getattr(summary, "text", None)
+                if text and (not item_id or item_id not in seen_reasoning_delta_items):
+                    acc.add_thought(text)
+                    added_fallback = True
+        if added_fallback or acc.thoughts:
+            acc.finish_thought()
+        return True
+    return False
+
+
 def _parse_responses_api_response(raw) -> LLMResponse:
     """Parse a raw OpenAI Responses API response into a provider-agnostic LLMResponse."""
     text_parts = []
@@ -856,9 +918,12 @@ class OpenAIResponsesSession(ChatSession):
         acc = StreamingAccumulator()
         response_id = None
         usage = UsageMetadata()
+        seen_reasoning_delta_items: set[str] = set()
 
         stream = self._client.responses.create(**kwargs)
         for event in stream:
+            if _handle_responses_reasoning_event(event, acc, seen_reasoning_delta_items):
+                continue
             if event.type == "response.output_text.delta":
                 acc.add_text(event.delta)
                 if on_chunk:
@@ -1269,9 +1334,12 @@ class CodexResponsesSession(OpenAIResponsesSession):
             acc = StreamingAccumulator()
             response_id = None
             usage = UsageMetadata()
+            seen_reasoning_delta_items: set[str] = set()
 
             stream = self._client.responses.create(**kwargs)
             for event in stream:
+                if _handle_responses_reasoning_event(event, acc, seen_reasoning_delta_items):
+                    continue
                 if event.type == "response.output_text.delta":
                     acc.add_text(event.delta)
                     if on_chunk:
@@ -1317,6 +1385,10 @@ class CodexResponsesSession(OpenAIResponsesSession):
         # the next request. Without this, the stateless backend would never
         # see the assistant's own prior turns.
         blocks: list = []
+        if result.thoughts:
+            joined = "\n".join(t for t in result.thoughts if t)
+            if joined:
+                blocks.append(ThinkingBlock(text=joined))
         if result.text:
             blocks.append(TextBlock(text=result.text))
         for tc in result.tool_calls:

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -177,25 +177,27 @@ def _parse_response(raw) -> LLMResponse:
 def _add_responses_reasoning_done_text(
     acc: StreamingAccumulator,
     reasoning_item_id: str | None,
-    seen_reasoning_delta_items: set[str],
+    seen_reasoning_summary_items: set[str],
     text: str | None,
 ) -> None:
     """Add final reasoning-summary text only when no delta was seen.
 
     Responses ``*.done`` events carry the complete text.  When the stream
-    already delivered ``*.delta`` chunks for the same reasoning item, adding
-    ``done.text`` would duplicate the thought.  If a provider emits only the
-    done event, use it as a lossless fallback.
+    already accepted summary text for the same reasoning item from deltas or a
+    done fallback, adding ``done.text`` would duplicate the thought.  If a
+    provider emits only the done event, use it as a lossless fallback.
     """
-    if text and (not reasoning_item_id or reasoning_item_id not in seen_reasoning_delta_items):
+    if text and (not reasoning_item_id or reasoning_item_id not in seen_reasoning_summary_items):
         acc.add_thought(text)
+        if reasoning_item_id:
+            seen_reasoning_summary_items.add(reasoning_item_id)
     acc.finish_thought()
 
 
 def _handle_responses_reasoning_event(
     event: Any,
     acc: StreamingAccumulator,
-    seen_reasoning_delta_items: set[str],
+    seen_reasoning_summary_items: set[str],
 ) -> bool:
     """Feed safe Responses reasoning-summary events into ``acc``.
 
@@ -210,13 +212,13 @@ def _handle_responses_reasoning_event(
             acc.add_thought(delta)
             item_id = getattr(event, "item_id", None)
             if item_id:
-                seen_reasoning_delta_items.add(item_id)
+                seen_reasoning_summary_items.add(item_id)
         return True
     if event_type == "response.reasoning_summary_text.done":
         _add_responses_reasoning_done_text(
             acc,
             getattr(event, "item_id", None),
-            seen_reasoning_delta_items,
+            seen_reasoning_summary_items,
             getattr(event, "text", None),
         )
         return True
@@ -227,8 +229,10 @@ def _handle_responses_reasoning_event(
             if getattr(summary, "type", None) == "summary_text":
                 item_id = getattr(event.item, "id", None)
                 text = getattr(summary, "text", None)
-                if text and (not item_id or item_id not in seen_reasoning_delta_items):
+                if text and (not item_id or item_id not in seen_reasoning_summary_items):
                     acc.add_thought(text)
+                    if item_id:
+                        seen_reasoning_summary_items.add(item_id)
                     added_fallback = True
         if added_fallback or acc.thoughts:
             acc.finish_thought()
@@ -918,11 +922,11 @@ class OpenAIResponsesSession(ChatSession):
         acc = StreamingAccumulator()
         response_id = None
         usage = UsageMetadata()
-        seen_reasoning_delta_items: set[str] = set()
+        seen_reasoning_summary_items: set[str] = set()
 
         stream = self._client.responses.create(**kwargs)
         for event in stream:
-            if _handle_responses_reasoning_event(event, acc, seen_reasoning_delta_items):
+            if _handle_responses_reasoning_event(event, acc, seen_reasoning_summary_items):
                 continue
             if event.type == "response.output_text.delta":
                 acc.add_text(event.delta)
@@ -1334,11 +1338,11 @@ class CodexResponsesSession(OpenAIResponsesSession):
             acc = StreamingAccumulator()
             response_id = None
             usage = UsageMetadata()
-            seen_reasoning_delta_items: set[str] = set()
+            seen_reasoning_summary_items: set[str] = set()
 
             stream = self._client.responses.create(**kwargs)
             for event in stream:
-                if _handle_responses_reasoning_event(event, acc, seen_reasoning_delta_items):
+                if _handle_responses_reasoning_event(event, acc, seen_reasoning_summary_items):
                     continue
                 if event.type == "response.output_text.delta":
                     acc.add_text(event.delta)

--- a/tests/test_openai_responses_streaming.py
+++ b/tests/test_openai_responses_streaming.py
@@ -1,0 +1,234 @@
+"""Tests for OpenAI Responses API streaming reasoning capture."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+from lingtai.llm.interface_converters import to_responses_input
+from lingtai.llm.openai.adapter import (
+    CodexOpenAIAdapter,
+    OpenAIResponsesSession,
+)
+from lingtai_kernel.llm.base import FunctionSchema
+from lingtai_kernel.llm.interface import TextBlock, ThinkingBlock, ToolCallBlock
+
+
+@dataclass
+class Event:
+    type: str
+    delta: str | None = None
+    item: object | None = None
+    response: object | None = None
+    item_id: str | None = None
+    text: str | None = None
+
+
+class FakeResponses:
+    def __init__(self, events: list[Event]):
+        self.events = events
+        self.kwargs: list[dict] = []
+
+    def create(self, **kwargs):
+        self.kwargs.append(kwargs)
+        yield from self.events
+
+
+class FakeClient:
+    def __init__(self, events: list[Event]):
+        self.responses = FakeResponses(events)
+
+
+def _usage(*, reasoning_tokens: int = 7) -> SimpleNamespace:
+    return SimpleNamespace(
+        input_tokens=10,
+        output_tokens=20,
+        input_tokens_details=SimpleNamespace(cached_tokens=0),
+        output_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens),
+    )
+
+
+def _completed() -> Event:
+    return Event(
+        "response.completed",
+        response=SimpleNamespace(id="resp_fake", usage=_usage()),
+    )
+
+
+def _function_schema() -> FunctionSchema:
+    return FunctionSchema(
+        name="report_answer",
+        description="Report answer",
+        parameters={
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+        },
+    )
+
+
+def _function_call_events() -> list[Event]:
+    return [
+        Event(
+            "response.output_item.added",
+            item=SimpleNamespace(
+                type="function_call",
+                call_id="call_fake123",
+                name="report_answer",
+            ),
+        ),
+        Event("response.function_call_arguments.delta", delta='{"answer"'),
+        Event("response.function_call_arguments.delta", delta=':"42"}'),
+        Event(
+            "response.output_item.done",
+            item=SimpleNamespace(
+                type="function_call",
+                call_id="call_fake123",
+                name="report_answer",
+                arguments='{"answer":"42"}',
+            ),
+        ),
+    ]
+
+
+def _reasoning_events() -> list[Event]:
+    return [
+        Event(
+            "response.output_item.added",
+            item=SimpleNamespace(type="reasoning", id="rs_fake"),
+        ),
+        Event(
+            "response.reasoning_summary_text.delta",
+            delta="I should call ",
+            item_id="rs_fake",
+        ),
+        Event(
+            "response.reasoning_summary_text.delta",
+            delta="the report tool.",
+            item_id="rs_fake",
+        ),
+        Event(
+            "response.reasoning_summary_text.done",
+            item_id="rs_fake",
+            text="I should call the report tool.",
+        ),
+        Event(
+            "response.output_item.done",
+            item=SimpleNamespace(
+                type="reasoning",
+                id="rs_fake",
+                summary=[
+                    SimpleNamespace(
+                        type="summary_text",
+                        text="I should call the report tool.",
+                    )
+                ],
+            ),
+        ),
+    ]
+
+
+def _create_codex_session(events: list[Event]):
+    adapter = CodexOpenAIAdapter(
+        api_key="fake",
+        base_url="http://fake",
+        use_responses=True,
+        force_responses=True,
+    )
+    adapter._client = FakeClient(events)
+    return adapter.create_chat(
+        "gpt-5.5",
+        "system prompt",
+        tools=[_function_schema()],
+        force_tool_call=True,
+        thinking="high",
+    )
+
+
+def test_codex_stream_captures_reasoning_and_persists_thinking_block():
+    session = _create_codex_session(_reasoning_events() + _function_call_events() + [_completed()])
+
+    result = session.send("please answer via tool")
+
+    assert result.thoughts == ["I should call the report tool."]
+    assert result.tool_calls[0].name == "report_answer"
+
+    assistant_entry = session.interface.entries[-1]
+    assert isinstance(assistant_entry.content[0], ThinkingBlock)
+    assert assistant_entry.content[0].text == "I should call the report tool."
+    assert isinstance(assistant_entry.content[1], ToolCallBlock)
+    assert not any(
+        isinstance(block, TextBlock) and block.text == ""
+        for block in assistant_entry.content
+    )
+
+
+def test_codex_replay_includes_reasoning_before_function_call():
+    session = _create_codex_session(_reasoning_events() + _function_call_events() + [_completed()])
+
+    session.send("please answer via tool")
+
+    items = to_responses_input(session.interface)
+    reasoning_index = next(
+        idx for idx, item in enumerate(items) if item.get("type") == "reasoning"
+    )
+    call_index = next(
+        idx for idx, item in enumerate(items) if item.get("type") == "function_call"
+    )
+    assert reasoning_index < call_index
+    assert items[reasoning_index] == {
+        "type": "reasoning",
+        "summary": [
+            {"type": "summary_text", "text": "I should call the report tool."}
+        ],
+    }
+
+
+def test_reasoning_done_text_is_not_duplicated_after_delta():
+    session = _create_codex_session(_reasoning_events() + [_completed()])
+
+    result = session.send("think only")
+
+    assert result.thoughts == ["I should call the report tool."]
+    assistant_entry = session.interface.entries[-1]
+    thinking_blocks = [
+        block for block in assistant_entry.content if isinstance(block, ThinkingBlock)
+    ]
+    assert [block.text for block in thinking_blocks] == [
+        "I should call the report tool."
+    ]
+
+
+def test_reasoning_done_text_is_used_as_fallback_without_delta():
+    session = _create_codex_session(
+        [
+            Event(
+                "response.reasoning_summary_text.done",
+                item_id="rs_done_only",
+                text="Done-only summary.",
+            ),
+            _completed(),
+        ]
+    )
+
+    result = session.send("think only")
+
+    assert result.thoughts == ["Done-only summary."]
+    assistant_entry = session.interface.entries[-1]
+    assert isinstance(assistant_entry.content[0], ThinkingBlock)
+    assert assistant_entry.content[0].text == "Done-only summary."
+
+
+def test_openai_responses_stream_captures_summary_thoughts():
+    session = OpenAIResponsesSession(
+        client=FakeClient(_reasoning_events() + [_completed()]),
+        model="gpt-5.5",
+        instructions="system prompt",
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+    )
+
+    result = session.send_stream("think")
+
+    assert result.thoughts == ["I should call the report tool."]

--- a/tests/test_openai_responses_streaming.py
+++ b/tests/test_openai_responses_streaming.py
@@ -219,6 +219,41 @@ def test_reasoning_done_text_is_used_as_fallback_without_delta():
     assert assistant_entry.content[0].text == "Done-only summary."
 
 
+def test_done_only_summary_is_not_duplicated_by_output_item_done():
+    session = _create_codex_session(
+        [
+            Event(
+                "response.reasoning_summary_text.done",
+                item_id="rs_done_only",
+                text="Done-only summary.",
+            ),
+            Event(
+                "response.output_item.done",
+                item=SimpleNamespace(
+                    type="reasoning",
+                    id="rs_done_only",
+                    summary=[
+                        SimpleNamespace(
+                            type="summary_text",
+                            text="Done-only summary.",
+                        )
+                    ],
+                ),
+            ),
+            _completed(),
+        ]
+    )
+
+    result = session.send("think only")
+
+    assert result.thoughts == ["Done-only summary."]
+    assistant_entry = session.interface.entries[-1]
+    thinking_blocks = [
+        block for block in assistant_entry.content if isinstance(block, ThinkingBlock)
+    ]
+    assert [block.text for block in thinking_blocks] == ["Done-only summary."]
+
+
 def test_openai_responses_stream_captures_summary_thoughts():
     session = OpenAIResponsesSession(
         client=FakeClient(_reasoning_events() + [_completed()]),


### PR DESCRIPTION
## Summary

Fixes the structural reasoning-replay gap behind #87 for stateless Codex Responses streaming.

- Capture Responses API `response.reasoning_summary_text.delta/done` events into the streaming accumulator.
- Use reasoning output-item summaries as a fallback when a provider emits only done/item-summary text.
- Do **not** persist raw `response.reasoning_text.*` events by default; this PR stores only summary text.
- Persist captured Codex stream thoughts as `ThinkingBlock`s before text/tool-call blocks so `to_responses_input()` replays a `type="reasoning"` item before later function calls.
- Add deterministic no-network regression tests for Codex stream capture, replay ordering, and delta+done de-duplication.
- Update `src/lingtai/llm/openai/ANATOMY.md` to reflect the changed Responses streaming behavior and shifted citations.

## Tests

- `python3 -m pytest tests/test_responses_converter.py tests/test_streaming.py tests/test_openai_responses_streaming.py -q`
  - `28 passed`
- `python3 -m pytest tests/test_notification_sync.py tests/test_deepseek_adapter.py tests/test_responses_converter.py tests/test_openai_responses_streaming.py -q`
  - `61 passed`
- `python3 -m ruff check src/lingtai/llm/openai/adapter.py tests/test_openai_responses_streaming.py`
  - `All checks passed!`

## Scope notes

This PR intentionally leaves the visible `tc_wake` retry UX from #87 untouched. It focuses on the narrower structural adapter bug: stateless Codex replay could previously persist tool-call turns without Responses reasoning summary items because streaming reasoning events were ignored.

Closes #87 only if maintainers consider the structural capture/replay fix sufficient; otherwise it addresses the root-cause portion and leaves retry UX as follow-up.
