### PR TITLE
Add opt-in Codex Responses stream trace

### DIFF
--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -9,30 +9,31 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 3 | Re-exports `OpenAIAdapter`, `OpenAIChatSession` |
-| `adapter.py` | 1470 | 5 classes + helpers: `OpenAIChatSession`, `OpenAIResponsesSession`, `OpenAIAdapter`, `CodexResponsesSession`, `CodexOpenAIAdapter` |
+| `adapter.py` | 1597 | 5 classes + helpers: `OpenAIChatSession`, `OpenAIResponsesSession`, `OpenAIAdapter`, `CodexResponsesSession`, `CodexOpenAIAdapter` |
 | `defaults.py` | 7 | `DEFAULTS` dict: `api_compat="openai"`, `use_responses_api=True` |
 
 ### adapter.py class map
 
 | Class | Lines | Role |
 |-------|-------|------|
-| `OpenAIChatSession` | 289–781 | Chat Completions session with context overflow auto-recovery |
-| `OpenAIResponsesSession` | 789–971 | Responses API session with server-side `previous_response_id` chaining |
-| `OpenAIAdapter` | 979–1242 | `LLMAdapter` implementation; dispatches to Completions or Responses path |
-| `CodexResponsesSession` | 1250–1413 | Stateless Responses variant for ChatGPT-OAuth `/backend-api/codex` |
-| `CodexOpenAIAdapter` | 1416–1470 | Adapter variant that builds `CodexResponsesSession` |
+| `OpenAIChatSession` | 399–891 | Chat Completions session with context overflow auto-recovery |
+| `OpenAIResponsesSession` | 899–1081 | Responses API session with server-side `previous_response_id` chaining |
+| `OpenAIAdapter` | 1089–1352 | `LLMAdapter` implementation; dispatches to Completions or Responses path |
+| `CodexResponsesSession` | 1360–1539 | Stateless Responses variant for ChatGPT-OAuth `/backend-api/codex` |
+| `CodexOpenAIAdapter` | 1543–1597 | Adapter variant that builds `CodexResponsesSession` |
 
 ### adapter.py helpers
 
 | Function | Lines | Role |
 |----------|-------|------|
-| `_build_http_timeout()` | 37–51 | `httpx.Timeout` per-phase caps (connect≤30s, read≤60s, pool=10s) |
-| `_build_tools()` | 59–73 | `FunctionSchema` → OpenAI CC tool format (`{type, function: {name, description, parameters}}`) |
-| `_build_responses_tools()` | 83–107 | `FunctionSchema` → Responses API flat format (`{type, name, description, parameters}`); scrubs disallowed top-level JSON-Schema combinators (`allOf`, `oneOf`, etc.) |
-| `_parse_tool_calls()` | 110–127 | Raw SDK `tool_calls` → `list[ToolCall]` |
-| `_parse_response()` | 130–174 | ChatCompletion → `LLMResponse` (extracts reasoning from `reasoning_content` or `reasoning`) |
-| `_handle_responses_reasoning_event()` | 195–236 | Responses stream reasoning-summary event handler; accumulates `summary_text` deltas/done fallback without raw reasoning text |
-| `_parse_responses_api_response()` | 239–281 | Responses API output → `LLMResponse` (handles `message`, `function_call`, `reasoning` output items) |
+| `_codex_responses_trace_path()` / `_codex_responses_trace_record()` | 46–141 | Opt-in Codex Responses stream diagnostic trace helpers; safe metadata only, default off |
+| `_build_http_timeout()` | 143–157 | `httpx.Timeout` per-phase caps (connect≤30s, read≤60s, pool=10s) |
+| `_build_tools()` | 165–179 | `FunctionSchema` → OpenAI CC tool format (`{type, function: {name, description, parameters}}`) |
+| `_build_responses_tools()` | 189–213 | `FunctionSchema` → Responses API flat format (`{type, name, description, parameters}`); scrubs disallowed top-level JSON-Schema combinators (`allOf`, `oneOf`, etc.) |
+| `_parse_tool_calls()` | 216–233 | Raw SDK `tool_calls` → `list[ToolCall]` |
+| `_parse_response()` | 236–280 | ChatCompletion → `LLMResponse` (extracts reasoning from `reasoning_content` or `reasoning`) |
+| `_handle_responses_reasoning_event()` | 303–346 | Responses stream reasoning-summary event handler; accumulates `summary_text` deltas/done fallback without raw reasoning text |
+| `_parse_responses_api_response()` | 349–391 | Responses API output → `LLMResponse` (handles `message`, `function_call`, `reasoning` output items) |
 
 ## Connections
 
@@ -79,7 +80,8 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 - **`OpenAIChatSession._interface`** — canonical `ChatInterface`, single source of truth. Mutated in-place: `add_user_message`, `add_tool_results`, `add_assistant_message`, `drop_trailing`.
 - **`OpenAIChatSession._request_timeout`** — per-request HTTP timeout set by caller before dispatch (line 319). Prevents race between watchdog and SDK.
 - **`OpenAIResponsesSession._response_id`** — server-side session chain pointer. Updated after each `send()` / streamed response.
-- **`CodexResponsesSession._response_id`** — transient debug aid only; never threaded into next request (line 1410).
+- **`CodexResponsesSession._response_id`** — transient debug aid only; never threaded into next request (line 1538).
+- **Codex Responses trace** — opt-in diagnostics write JSONL metadata to `logs/codex_responses_trace.jsonl` when `LINGTAI_CODEX_RESPONSES_TRACE=1` (override path with `LINGTAI_CODEX_RESPONSES_TRACE_PATH`). Default off; stores event/item shapes, lengths/hashes, usage, and accumulator counts, not raw content.
 - **`OpenAIAdapter._client`** — shared `openai.OpenAI` instance. `_client_kwargs` stored for session `reset()`.
 - **`OpenAIAdapter._session_class`** — class var, subclasses override (e.g. DeepSeek injects `reasoning_content` preservation).
 
@@ -109,7 +111,7 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 
 - **CC streaming** (`send_stream`, line 622) — `stream=True, stream_options={include_usage: True}`. Uses `StreamingAccumulator` for text + tool deltas. Reasoning deltas captured from `delta.reasoning` or `delta.reasoning_content` (OpenRouter compatibility, lines 726-733). Overflow recovery wraps the stream open + first chunk (lines 668-690).
 - **Responses streaming** (`send_stream`, line 891) — event types: `response.reasoning_summary_text.delta/done` (summary thoughts only), `response.output_text.delta`, `response.function_call_arguments.delta`, `response.output_item.added/done`, `response.completed`.
-- **Codex streaming** — forces `stream=True` even on `send()` (line 1262). Full interface replay per request; captured summary thoughts are persisted as ThinkingBlocks so `to_responses_input` replays reasoning items before function calls.
+- **Codex streaming** — forces `stream=True` even on `send()` (line 1372). Full interface replay per request; captured summary thoughts are persisted as ThinkingBlocks so `to_responses_input` replays reasoning items before function calls. Optional diagnostics (`LINGTAI_CODEX_RESPONSES_TRACE=1`) append safe per-event metadata to `logs/codex_responses_trace.jsonl` without changing accumulator/persistence behavior.
 
 ### Authentication paths
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -9,8 +9,12 @@ This is the **only** module that imports the ``openai`` package.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
+import time
 import uuid
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -32,6 +36,108 @@ from ..interface_converters import to_openai, to_responses_input
 from lingtai_kernel.llm.streaming import StreamingAccumulator
 
 logger = get_logger()
+
+
+_CODEX_RESPONSES_TRACE_ENV = "LINGTAI_CODEX_RESPONSES_TRACE"
+_CODEX_RESPONSES_TRACE_PATH_ENV = "LINGTAI_CODEX_RESPONSES_TRACE_PATH"
+_CODEX_RESPONSES_TRACE_FILE = "codex_responses_trace.jsonl"
+
+
+def _codex_responses_trace_path() -> Path | None:
+    """Return the opt-in Codex Responses stream trace path, if enabled."""
+    enabled = os.environ.get(_CODEX_RESPONSES_TRACE_ENV, "")
+    if enabled.lower() not in {"1", "true", "yes", "on"}:
+        return None
+
+    explicit_path = os.environ.get(_CODEX_RESPONSES_TRACE_PATH_ENV)
+    if explicit_path:
+        return Path(explicit_path).expanduser()
+
+    base_dir = Path(os.environ.get("LINGTAI_AGENT_DIR", ".")).expanduser()
+    return base_dir / "logs" / _CODEX_RESPONSES_TRACE_FILE
+
+
+def _text_fingerprint(text: str | None) -> dict[str, Any]:
+    """Return safe metadata for text-like stream deltas without storing content."""
+    if text is None:
+        return {"present": False, "length": 0}
+    encoded = text.encode("utf-8", errors="replace")
+    return {
+        "present": True,
+        "length": len(text),
+        "sha256_12": hashlib.sha256(encoded).hexdigest()[:12],
+    }
+
+
+def _codex_responses_trace_record(
+    *,
+    event: Any,
+    accepted_reasoning: bool,
+    thoughts_before: list[str],
+    thoughts_after: list[str],
+    pending_thought_chars_before: int,
+    pending_thought_chars_after: int,
+    trace_path: Path | None,
+) -> None:
+    """Append safe diagnostic metadata for one Codex Responses stream event.
+
+    This intentionally records event/item shapes, text lengths, and hashes only;
+    it must not store prompt text, raw response text, raw reasoning text, tool
+    result content, or API credentials.
+    """
+    if trace_path is None:
+        return
+
+    item = getattr(event, "item", None)
+    response = getattr(event, "response", None)
+    usage = getattr(response, "usage", None) if response is not None else None
+    input_details = getattr(usage, "input_tokens_details", None) if usage is not None else None
+    output_details = getattr(usage, "output_tokens_details", None) if usage is not None else None
+
+    summaries = []
+    for summary in getattr(item, "summary", None) or []:
+        summaries.append({
+            "type": getattr(summary, "type", None),
+            "text": _text_fingerprint(getattr(summary, "text", None)),
+        })
+
+    record = {
+        "ts": time.time(),
+        "event_type": getattr(event, "type", None),
+        "accepted_reasoning": accepted_reasoning,
+        "item": None if item is None else {
+            "type": getattr(item, "type", None),
+            "id": getattr(item, "id", None),
+            "call_id": getattr(item, "call_id", None),
+            "name": getattr(item, "name", None),
+            "summary": summaries,
+        },
+        "item_id": getattr(event, "item_id", None),
+        "delta": _text_fingerprint(getattr(event, "delta", None)),
+        "summary_text": _text_fingerprint(getattr(event, "text", None)),
+        "thoughts": {
+            "before_count": len(thoughts_before),
+            "after_count": len(thoughts_after),
+            "before_lengths": [len(t) for t in thoughts_before],
+            "after_lengths": [len(t) for t in thoughts_after],
+            "pending_chars_before": pending_thought_chars_before,
+            "pending_chars_after": pending_thought_chars_after,
+        },
+    }
+    if usage is not None:
+        record["usage"] = {
+            "input_tokens": getattr(usage, "input_tokens", None),
+            "output_tokens": getattr(usage, "output_tokens", None),
+            "cached_tokens": getattr(input_details, "cached_tokens", None),
+            "reasoning_tokens": getattr(output_details, "reasoning_tokens", None),
+        }
+
+    try:
+        trace_path.parent.mkdir(parents=True, exist_ok=True)
+        with trace_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception as exc:  # pragma: no cover - diagnostics must not break send
+        logger.warning("Codex Responses trace write failed: %s", exc)
 
 
 def _build_http_timeout(request_timeout: float | None):
@@ -1339,10 +1445,27 @@ class CodexResponsesSession(OpenAIResponsesSession):
             response_id = None
             usage = UsageMetadata()
             seen_reasoning_summary_items: set[str] = set()
+            trace_path = _codex_responses_trace_path()
 
             stream = self._client.responses.create(**kwargs)
             for event in stream:
-                if _handle_responses_reasoning_event(event, acc, seen_reasoning_summary_items):
+                thoughts_before = acc.thoughts
+                pending_thought_chars_before = len("".join(acc._thought_parts))
+                accepted_reasoning = _handle_responses_reasoning_event(
+                    event,
+                    acc,
+                    seen_reasoning_summary_items,
+                )
+                _codex_responses_trace_record(
+                    event=event,
+                    accepted_reasoning=accepted_reasoning,
+                    thoughts_before=thoughts_before,
+                    thoughts_after=acc.thoughts,
+                    pending_thought_chars_before=pending_thought_chars_before,
+                    pending_thought_chars_after=len("".join(acc._thought_parts)),
+                    trace_path=trace_path,
+                )
+                if accepted_reasoning:
                     continue
                 if event.type == "response.output_text.delta":
                     acc.add_text(event.delta)

--- a/tests/test_openai_responses_streaming.py
+++ b/tests/test_openai_responses_streaming.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -252,6 +254,74 @@ def test_done_only_summary_is_not_duplicated_by_output_item_done():
         block for block in assistant_entry.content if isinstance(block, ThinkingBlock)
     ]
     assert [block.text for block in thinking_blocks] == ["Done-only summary."]
+
+
+
+def test_codex_responses_trace_disabled_by_default(tmp_path, monkeypatch):
+    trace_path = tmp_path / "codex_responses_trace.jsonl"
+    monkeypatch.delenv("LINGTAI_CODEX_RESPONSES_TRACE", raising=False)
+    monkeypatch.setenv("LINGTAI_CODEX_RESPONSES_TRACE_PATH", str(trace_path))
+    session = _create_codex_session(_reasoning_events() + _function_call_events() + [_completed()])
+
+    result = session.send("please answer via tool")
+
+    assert result.thoughts == ["I should call the report tool."]
+    assert result.tool_calls[0].name == "report_answer"
+    assert not trace_path.exists()
+
+
+def test_codex_responses_trace_records_safe_metadata_when_enabled(tmp_path, monkeypatch):
+    trace_path = tmp_path / "codex_responses_trace.jsonl"
+    monkeypatch.setenv("LINGTAI_CODEX_RESPONSES_TRACE", "1")
+    monkeypatch.setenv("LINGTAI_CODEX_RESPONSES_TRACE_PATH", str(trace_path))
+    session = _create_codex_session(_reasoning_events() + _function_call_events() + [_completed()])
+
+    result = session.send("please answer via tool")
+
+    assert result.thoughts == ["I should call the report tool."]
+    assert result.text == ""
+    assert result.tool_calls[0].name == "report_answer"
+    assistant_entry = session.interface.entries[-1]
+    assert isinstance(assistant_entry.content[0], ThinkingBlock)
+    assert isinstance(assistant_entry.content[1], ToolCallBlock)
+
+    records = [json.loads(line) for line in trace_path.read_text().splitlines()]
+    event_types = [record["event_type"] for record in records]
+    assert "response.reasoning_summary_text.delta" in event_types
+    assert "response.output_item.added" in event_types
+    assert "response.function_call_arguments.delta" in event_types
+    assert "response.completed" in event_types
+
+    reasoning_delta = next(
+        record
+        for record in records
+        if record["event_type"] == "response.reasoning_summary_text.delta"
+    )
+    assert reasoning_delta["accepted_reasoning"] is True
+    assert reasoning_delta["item_id"] == "rs_fake"
+    assert reasoning_delta["delta"]["length"] == len("I should call ")
+    assert "sha256_12" in reasoning_delta["delta"]
+    assert "I should call" not in json.dumps(reasoning_delta)
+
+    function_arg_delta = next(
+        record
+        for record in records
+        if record["event_type"] == "response.function_call_arguments.delta"
+    )
+    assert function_arg_delta["accepted_reasoning"] is False
+    assert function_arg_delta["delta"]["length"] == len('{"answer"')
+    assert "answer" not in json.dumps(function_arg_delta)
+
+    completed = next(
+        record for record in records if record["event_type"] == "response.completed"
+    )
+    assert completed["usage"] == {
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "cached_tokens": 0,
+        "reasoning_tokens": 7,
+    }
+    assert completed["thoughts"]["after_count"] == 1
 
 
 def test_openai_responses_stream_captures_summary_thoughts():


### PR DESCRIPTION
## Summary
- add opt-in `LINGTAI_CODEX_RESPONSES_TRACE=1` diagnostics for Codex Responses streaming
- trace safe per-event metadata (event/item shapes, delta lengths/hashes, usage, reasoning-handler acceptance, accumulator thought counts) to JSONL without raw content by default
- cover default-off, enabled trace metadata, and behavior-preservation cases with fake-stream tests

## Trace usage
After installing this branch/merge and refreshing the target agent, enable tracing in the agent process environment:

```bash
export LINGTAI_CODEX_RESPONSES_TRACE=1
# Optional but recommended so the destination is explicit:
export LINGTAI_CODEX_RESPONSES_TRACE_PATH=/path/to/agent/logs/codex_responses_trace.jsonl
```

If `LINGTAI_CODEX_RESPONSES_TRACE_PATH` is unset, the trace writes to `$LINGTAI_AGENT_DIR/logs/codex_responses_trace.jsonl` when `LINGTAI_AGENT_DIR` exists, otherwise `./logs/codex_responses_trace.jsonl` relative to the process working directory.

The trace is diagnostic metadata only: no prompts, raw deltas, raw reasoning text, tool result content, or secrets are recorded by default.

## Tests
- `python3 -m pytest tests/test_responses_converter.py tests/test_streaming.py tests/test_openai_responses_streaming.py -q` → 31 passed
- `python3 -m ruff check src/lingtai/llm/openai/adapter.py tests/test_openai_responses_streaming.py` → passed
- `git diff --check` → clean