### PR TITLE
Clarify bash sandbox and recovery notices

### DIFF
--- a/src/lingtai/core/bash/ANATOMY.md
+++ b/src/lingtai/core/bash/ANATOMY.md
@@ -7,7 +7,7 @@ be explicitly opted into.
 
 ## Components
 
-- `bash/__init__.py` — the entire capability in a single file. `get_description` (`bash/__init__.py:28-29`), `get_schema` (`bash/__init__.py:32-51`), `setup` (`bash/__init__.py:217-255`). Two core classes: `BashPolicy` (`bash/__init__.py:55-143`) for command filtering, `BashManager` (`bash/__init__.py:146-214`) for execution.
+- `bash/__init__.py` — the entire capability in a single file. `get_description` (`bash/__init__.py:32-33`), `get_schema` (`bash/__init__.py:36-70`), `setup` (`bash/__init__.py:505-539`). Two core classes: `BashPolicy` (`bash/__init__.py:74-162`) for command filtering, `BashManager` (`bash/__init__.py:165-503`) for execution.
 - `bash/bash_policy.json` — default denylist policy shipped with the kernel. Denies destructive (`rm`, `rmdir`, `shred`, `dd`), privilege escalation (`sudo`, `su`, `doas`), permission changes (`chmod`, `chown`, `chgrp`), disk management (`mount`, `umount`, `mkfs`, `fdisk`), package managers (`apt`, `apt-get`, `yum`, `dnf`, `brew`), process control (`kill`, `killall`, `pkill`, `shutdown`, `reboot`, `systemctl`), network (`nc`, `ncat`), and code execution (`eval`, `exec`).
 
 ## Public API

--- a/src/lingtai/core/bash/__init__.py
+++ b/src/lingtai/core/bash/__init__.py
@@ -191,8 +191,12 @@ class BashManager:
             if not (resolved == sandbox or resolved.startswith(sandbox + "/")):
                 return {
                     "status": "error",
-                    "message": f"working_dir must be under agent working directory: "
-                    f"{self._working_dir}",
+                    "message": (
+                        f"working_dir must be under agent working directory: "
+                        f"{self._working_dir}. To operate on an external path, "
+                        f"use an allowed working_dir and put `cd {resolved} && ...` "
+                        f"inside the command."
+                    ),
                 }
         except (ValueError, OSError):
             return {"status": "error", "message": "Invalid working_dir path"}

--- a/src/lingtai/i18n/en.json
+++ b/src/lingtai/i18n/en.json
@@ -23,7 +23,7 @@
   "bash.action": "Action to perform: 'run' (default) executes a command, 'poll' checks async job status, 'cancel' kills an async job",
   "bash.command": "The shell command to execute",
   "bash.timeout": "Timeout in seconds (default: 30, only for sync execution)",
-  "bash.working_dir": "Working directory for the command (optional)",
+  "bash.working_dir": "Working directory for the command (optional). Must be inside the agent working directory sandbox; paths outside it are rejected. For external repos/paths, keep working_dir at the agent dir and put an explicit cd in command, e.g. cd /absolute/path && ...",
   "bash.async": "Run command in background and return immediately with a job_id (default: false, only for action='run')",
   "bash.job_id": "Job ID for poll/cancel actions (returned by async run)",
   "codex.description": "Your durable journal across molts — what you've learned, decided, and discovered. Each entry's id + title + summary is visible in your system prompt; content and supplementary load on demand via view. Use progressive disclosure: keep summaries concise and scannable (1-3 sentences); put detailed explanations in content; raw data, citations, and long-form reference in supplementary. This layered approach keeps your prompt efficient while preserving depth. Slots are limited — consolidate related entries when you fill up. submit to add. view to read. consolidate to merge. delete to remove.",

--- a/src/lingtai/i18n/wen.json
+++ b/src/lingtai/i18n/wen.json
@@ -23,7 +23,7 @@
   "bash.action": "所行之事：'run'（默认）执行指令，'poll' 查异步任务之状，'cancel' 斩异步任务",
   "bash.command": "欲执行之指令",
   "bash.timeout": "超时秒数（默认：30，唯同步执行时生效）",
-  "bash.working_dir": "指令之工作目录（可选）",
+  "bash.working_dir": "指令之工作目录（可选）。须在 agent 工作目录沙箱之内；沙箱外路径会被拒。若需操作外部仓库/路径，请令 working_dir 保持为 agent 目录，并在 command 中显式 cd，如 cd /absolute/path && ...",
   "bash.async": "后台运行指令，即返 job_id（默认：false，唯 action='run' 时生效）",
   "bash.job_id": "异步任务之号，用于 poll/cancel（由异步 run 所返）",
   "codex.description": "汝跨凝蜕长存之自我记忆——所习、所断、所悟之日记。每经卷之 id + 题 + 摘要恒见于汝之系统提示（上方典之目录块）；正文与扩展之材按需以 view 取之。经卷数有上限——珍惜每一条目。将满时合经。submit 录入。view 展阅其文。consolidate 合经。delete 焚经。",

--- a/src/lingtai/i18n/zh.json
+++ b/src/lingtai/i18n/zh.json
@@ -23,7 +23,7 @@
   "bash.action": "执行动作：'run'（默认）执行命令，'poll' 查询异步任务状态，'cancel' 终止异步任务",
   "bash.command": "要执行的 shell 命令",
   "bash.timeout": "超时秒数（默认：30，仅同步执行时生效）",
-  "bash.working_dir": "命令的工作目录（可选）",
+  "bash.working_dir": "命令的工作目录（可选）。必须位于 agent 工作目录沙箱内；沙箱外路径会被拒绝。若要操作外部仓库/路径，请将 working_dir 保持为 agent 目录，并在 command 中显式 cd，例如 cd /absolute/path && ...",
   "bash.async": "后台运行命令并立即返回 job_id（默认：false，仅 action='run' 时生效）",
   "bash.job_id": "异步任务 ID，用于 poll/cancel（由异步 run 返回）",
   "codex.description": "你的跨凝蜕长存自我之记忆——记录所学、所断、所悟之日记。每条之 id + 标题 + 摘要始终于系统提示中可见；正文与扩展材料按需以 view 取之。条目有上限——珍惜每一条。将满时合经。submit 录入。view 展阅。consolidate 合经。delete 焚经。",

--- a/src/lingtai_kernel/ANATOMY.md
+++ b/src/lingtai_kernel/ANATOMY.md
@@ -150,7 +150,7 @@ Phase 2 (`d2da97e`) migrated all in-tree producers (mail, system events, soul fl
 
 ### Adjacent: healing mid-pair tails
 
-Distinct primitive (and unrelated to notifications) — `interface.close_pending_tool_calls(reason)` (`llm/interface.py:344`) synthesizes `tool_result` placeholders for orphan tool_calls when the wire chat itself ends mid-pair (process killed mid-turn, snapshot saved mid-turn). Marks them `synthesized=True`; if a real result arrives later for the same id, `add_tool_results` overwrites the placeholder so the wire stays honest. Used in `base_agent/turn.py:317-321, 418-422, 450-454, 891-895` after sleep/retry/continuation exceptions, and at snapshot save time in `intrinsics/psyche/_snapshots.py`. The notification path repurposes the same `synthesized=True` flag, but the two systems don't share code.
+Distinct primitive (and unrelated to notifications) — `interface.close_pending_tool_calls(reason)` (`llm/interface.py:405`) synthesizes `tool_result` placeholders for orphan tool_calls when the wire chat itself ends mid-pair (process killed mid-turn, snapshot saved mid-turn). Marks them `synthesized=True`; if a real result arrives later for the same id, `add_tool_results` overwrites the placeholder so the wire stays honest. Used in `base_agent/turn.py:317-321, 419-423, 451-455, 889-893` after sleep/retry/continuation exceptions, and at snapshot save time in `intrinsics/psyche/_snapshots.py`. The notification path repurposes the same `synthesized=True` flag, but the two systems don't share code.
 
 ### Historical note: retired ACTIVE meta-prefix injection
 

--- a/src/lingtai_kernel/llm/ANATOMY.md
+++ b/src/lingtai_kernel/llm/ANATOMY.md
@@ -13,9 +13,9 @@ Provider-agnostic LLM protocol layer. This folder defines the canonical chat log
   - **`send()` signature contract** — adapters accept three message shapes: `str` (new user text → `add_user_message`), `list[ToolResultBlock]` (tool returns → `add_tool_results`), and `None` (the "continue from wire" signal — caller has already pre-staged the canonical interface, e.g. via `_inject_notification_pair`; the adapter must skip the input-append step and send the wire as-is). On API error the error-path `drop_trailing` must be guarded so a `None` send does not corrupt the pre-staged wire. See `lingtai/llm/openai/ANATOMY.md` and `lingtai/llm/anthropic/ANATOMY.md` for adapter-side details, and `base_agent/turn.py:_handle_tc_wake` for the call site that drives a turn off the existing wire.
   - **`pre_request_hook`** (`llm/base.py:121-148`) — optional callable adapters fire after committing the message to the canonical `ChatInterface` but before the API call. Historically the kernel installed `BaseAgent._drain_tc_inbox_for_hook` here to drain the involuntary tool-call inbox mid-turn. Post-`.notification/`-redesign (`fadbabf` / `d2da97e`) the hook is still installed but the queue is always empty in production — ACTIVE notifications now defer to the post-turn IDLE synthetic-pair path instead of a send-time prefix hook. Default `None` — adapters that don't install treat the call as a no-op. Phase 3 will remove the hook. See root `ANATOMY.md` "Notifications" for the full picture, including the canonical-vs-server-state regime distinction.
 - `llm/interface.py` — canonical conversation representation.
-  - Content blocks: `TextBlock`, `ToolCallBlock`, `ToolResultBlock`, `ThinkingBlock`; `ContentBlock` union and `content_block_from_dict()` (`llm/interface.py:35-138`).
-  - `InterfaceEntry` is one role+content row with id, role, timestamp, provider metadata, model/provider, usage, and optional tool snapshot (`llm/interface.py:159-198`).
-  - `ChatInterface` is the append-only source of truth for history (`llm/interface.py:225-257`). It appends system/user/assistant/tool-result entries (`llm/interface.py:410-502`), enforces/repairs tool-call pairing (`llm/interface.py:271-370`), removes strict synthetic pairs (`llm/interface.py:550-654`), prunes history (`llm/interface.py:744-765`), estimates tokens (`llm/interface.py:819-865`), and supports compaction summaries (`llm/interface.py:868-942`).
+  - Content blocks: `TextBlock`, `ToolCallBlock`, `ToolResultBlock`, `ThinkingBlock`; `ContentBlock` union and `content_block_from_dict()` (`llm/interface.py:35-181`).
+  - `InterfaceEntry` is one role+content row with id, role, timestamp, provider metadata, model/provider, usage, and optional tool snapshot (`llm/interface.py:194-253`).
+  - `ChatInterface` is the append-only source of truth for history (`llm/interface.py:260-292`). It appends system/user/assistant/tool-result entries (`llm/interface.py:448-586`), enforces/repairs tool-call pairing (`llm/interface.py:306-445`), removes strict synthetic pairs (`llm/interface.py:588-689`), prunes history (`llm/interface.py:782-831`), estimates tokens (`llm/interface.py:857-904`), and supports compaction summaries (`llm/interface.py:906-979`).
 - `llm/service.py` — `LLMService` ABC: `model`, `provider`, `create_session()`, `generate()`, and `make_tool_result()` (`llm/service.py:16-70`).
 - `llm/streaming.py` — `StreamingAccumulator`, which gathers streaming text/thought/tool-call deltas and finalizes to `LLMResponse` (`llm/streaming.py:16-69`, `llm/streaming.py:145-170`). It supports sequential tool-call assembly (`llm/streaming.py:71-84`), index-keyed deltas (`llm/streaming.py:88-117`), atomic tool calls (`llm/streaming.py:121-126`), and `_finalize_tool()` (`llm/streaming.py:173-180`).
 
@@ -25,7 +25,7 @@ Provider-agnostic LLM protocol layer. This folder defines the canonical chat log
 - `session.py` imports `ChatSession`, `FunctionSchema`, `LLMResponse`, and `LLMService` to own session lifecycle and token/context bookkeeping (`session.py:12-17`).
 - `tool_executor.py` consumes `ToolCall` (`tool_executor.py:8`); `tc_inbox.py` (legacy, dormant — preserved for back-compat until Phase 3) consumes `ToolCallBlock`/`ToolResultBlock` for synthetic pairs (`tc_inbox.py:33`). The same canonical block types are now used by `BaseAgent._inject_notification_pair` to splice synthesized `system(action="notification")` `(call, result)` pairs into the wire, replacing the legacy queue path.
 - `intrinsics/psyche.py` and `intrinsics/soul/` use canonical blocks/interfaces for molt replay and soul-flow consultation (`intrinsics/psyche/_molt.py:13`, `intrinsics/soul/inquiry.py:15`, `intrinsics/soul/consultation.py:196`, `intrinsics/soul/consultation.py:347`, `intrinsics/soul/consultation.py:498`).
-- Outbound from this folder is minimal: `ChatInterface.estimate_context_tokens()` lazy-imports `token_counter.count_tokens` (`llm/interface.py:825`).
+- Outbound from this folder is minimal: `ChatInterface.estimate_context_tokens()` lazy-imports `token_counter.count_tokens` (`llm/interface.py:868`).
 - Wrapper boundary: `src/lingtai/llm/service.py` provides the concrete `LLMService` subclass (`src/lingtai/llm/service.py:25`); wrapper adapters import kernel types, but the kernel does not import the wrapper.
 
 ## Composition
@@ -36,12 +36,12 @@ Provider-agnostic LLM protocol layer. This folder defines the canonical chat log
 
 ## State
 
-- **Ephemeral:** `ChatInterface._entries`, `_next_id`, current system/tools, and `_pending_system` live in memory for one session (`llm/interface.py:234-243`).
+- **Ephemeral:** `ChatInterface._entries`, `_next_id`, current system/tools, and `_pending_system` live in memory for one session (`llm/interface.py:269-278`).
 - **Ephemeral:** `StreamingAccumulator` stores partial text, tool args, thoughts, and usage until `finalize()` (`llm/streaming.py:39-69`).
 - **Persistent writes:** none in this folder. `session.py` writes `history/chat_history.jsonl`; token/state persistence happens in sibling modules that consume these types.
 
 ## Notes
 
-- `add_system()` defers system/tool updates while the tail has unanswered tool calls so strict providers do not see a system entry between assistant tool calls and user tool results (`llm/interface.py:410-458`).
-- `close_pending_tool_calls()` synthesizes abort `ToolResultBlock`s with guidance to verify side effects before retrying (`llm/interface.py:370-407`, `llm/interface.py:66-121`).
+- `add_system()` defers system/tool updates while the tail has unanswered tool calls so strict providers do not see a system entry between assistant tool calls and user tool results (`llm/interface.py:448-496`).
+- `close_pending_tool_calls()` synthesizes abort `ToolResultBlock`s with guidance and short recovery metadata to verify side effects before retrying (`llm/interface.py:405-445`, `llm/interface.py:66-155`).
 - `StreamingAccumulator` intentionally supports three provider styles in one place: sequential, index-keyed, and atomic tool calls (`llm/streaming.py:71-126`).

--- a/src/lingtai_kernel/llm/interface.py
+++ b/src/lingtai_kernel/llm/interface.py
@@ -63,11 +63,42 @@ class ToolResultBlock:
         return {"type": "tool_result", "id": self.id, "name": self.name, "content": self.content}
 
 
+def _tool_call_context(tool_call: "ToolCallBlock | None") -> str:
+    """Short, safe context for a synthesized tool-result recovery notice."""
+    if tool_call is None:
+        return ""
+    lines = [f"Tool call id: {tool_call.id}"]
+    args = tool_call.args if isinstance(tool_call.args, dict) else {}
+    if tool_call.name == "bash":
+        action = args.get("action", "run")
+        lines.append(f"bash action: {action}")
+        if "working_dir" in args:
+            lines.append(f"bash working_dir: {args.get('working_dir')}")
+        if "timeout" in args:
+            lines.append(f"bash timeout: {args.get('timeout')}")
+        if "async" in args:
+            lines.append(f"bash async: {args.get('async')}")
+        if "job_id" in args:
+            lines.append(f"bash job_id: {args.get('job_id')}")
+        command = args.get("command")
+        if isinstance(command, str) and command:
+            preview = command.replace("\n", "\\n")
+            if len(preview) > 240:
+                preview = preview[:240] + "..."
+            lines.append(f"bash command preview: {preview}")
+    elif args:
+        keys = ", ".join(sorted(str(k) for k in args.keys())[:12])
+        if keys:
+            lines.append(f"tool args present: {keys}")
+    return "\n".join(lines)
+
+
 def _synthesized_abort_message(
     tool_name: str,
     reason: str,
     *,
     tool_completed: bool = False,
+    tool_call: "ToolCallBlock | None" = None,
 ) -> str:
     """Content for a heal-path placeholder ToolResultBlock.
 
@@ -84,6 +115,8 @@ def _synthesized_abort_message(
     tool result.  In that case the message says so honestly instead of
     implying the tool itself failed.
     """
+    context = _tool_call_context(tool_call)
+    context_block = f"\n\nRecovery metadata:\n{context}" if context else ""
     if tool_completed:
         return (
             f"[kernel notice — tool call completed but LLM continuation failed]\n"
@@ -101,6 +134,7 @@ def _synthesized_abort_message(
             f"left off without re-executing the tool.\n"
             f"\n"
             f"Reason recorded by the kernel: {reason}"
+            f"{context_block}"
         )
     return (
         f"[kernel notice — tool call did not complete]\n"
@@ -117,6 +151,7 @@ def _synthesized_abort_message(
         f"Only retry the call if you've confirmed it didn't take effect.\n"
         f"\n"
         f"Reason recorded by the kernel: {reason}"
+        f"{context_block}"
     )
 
 
@@ -397,7 +432,10 @@ class ChatInterface:
                 id=b.id,
                 name=b.name,
                 content=_synthesized_abort_message(
-                    b.name, reason, tool_completed=tool_completed,
+                    b.name,
+                    reason,
+                    tool_completed=tool_completed,
+                    tool_call=b,
                 ),
                 synthesized=True,
             )

--- a/tests/test_chat_interface_invariant.py
+++ b/tests/test_chat_interface_invariant.py
@@ -242,6 +242,34 @@ class TestRestoreDanglingToolCalls:
         assert tail.content[0].id == "call_X"
         assert "restored from disk" in tail.content[0].content
 
+    def test_bash_heal_notice_includes_recovery_metadata(self):
+        iface = ChatInterface()
+        iface.add_system("prompt")
+        iface.add_user_message("run")
+        iface.add_assistant_message([
+            ToolCallBlock(
+                id="call_bash_1",
+                name="bash",
+                args={
+                    "command": "cd /repo && git status --short",
+                    "working_dir": "/agent",
+                    "timeout": 30,
+                },
+            )
+        ])
+
+        iface.close_pending_tool_calls("heal:idle_inject_blocked")
+
+        content = iface.entries[-1].content[0].content
+        assert "tool call did not complete" in content
+        assert "Reason recorded by the kernel: heal:idle_inject_blocked" in content
+        assert "Recovery metadata:" in content
+        assert "Tool call id: call_bash_1" in content
+        assert "bash action: run" in content
+        assert "bash working_dir: /agent" in content
+        assert "bash timeout: 30" in content
+        assert "bash command preview: cd /repo && git status --short" in content
+
 
 # ---------------------------------------------------------------------------
 # Real result arriving after a heal — replace-in-place behavior

--- a/tests/test_layers_bash.py
+++ b/tests/test_layers_bash.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from unittest.mock import MagicMock
 
-from lingtai.core.bash import BashManager, BashPolicy, setup as setup_bash
+from lingtai.core.bash import BashManager, BashPolicy, get_schema, setup as setup_bash
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +135,27 @@ class TestBashManager:
         result = mgr.handle({"command": "pwd"})
         assert result["status"] == "ok"
         assert str(tmp_path) in result["stdout"]
+
+    def test_working_dir_outside_sandbox_error_suggests_cd_workaround(self, tmp_path):
+        sandbox = tmp_path / "agent"
+        external = tmp_path / "external"
+        sandbox.mkdir()
+        external.mkdir()
+        mgr = BashManager(policy=BashPolicy.yolo(), working_dir=str(sandbox))
+
+        result = mgr.handle({"command": "pwd", "working_dir": str(external)})
+
+        assert result["status"] == "error"
+        assert "under agent working directory" in result["message"]
+        assert "cd " in result["message"]
+        assert str(external.resolve()) in result["message"]
+
+    def test_schema_documents_working_dir_sandbox_and_cd_workaround(self):
+        desc = get_schema("en")["properties"]["working_dir"]["description"]
+
+        assert "agent working directory sandbox" in desc
+        assert "paths outside" in desc
+        assert "cd /absolute/path &&" in desc
 
     def test_output_truncation(self):
         mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp", max_output=20)


### PR DESCRIPTION
## Summary
- document the bash `working_dir` sandbox in the tool schema and runtime rejection message, including the external-path `cd /absolute/path && ...` workaround
- add recovery metadata to synthesized pending-tool-call heal notices so lost bash results include the call id, action, working_dir, timeout/async/job id, and a short command preview
- update focused tests and anatomy citations for the bash and LLM interface changes

Fixes #93.

## Validation
- `pytest tests/test_layers_bash.py tests/test_bash_async.py tests/test_chat_interface_invariant.py` — 66 passed
- `ruff check src/lingtai/core/bash/__init__.py src/lingtai_kernel/llm/interface.py tests/test_layers_bash.py tests/test_chat_interface_invariant.py`
- `python -m json.tool src/lingtai/i18n/en.json >/dev/null`
- `python -m json.tool src/lingtai/i18n/zh.json >/dev/null`
- `python -m json.tool src/lingtai/i18n/wen.json >/dev/null`
- `git diff --check`

## Notes
- This improves clarity/traceability; it does not attempt to recover stdout/stderr/exit code after a result-commit failure.
- The unrelated untracked `src/lingtai/intrinsic_skills/lingtai-repo-watch/` directory remains untouched locally.
