### PR TITLE
Preserve executed tool results after continuation send failure

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -127,6 +127,35 @@ def _prepare_aed_retry_message(agent, err_desc: str) -> Message:
     return _make_message(MSG_REQUEST, "system", aed_msg)
 
 
+def _restore_tool_results_after_continuation_failure(
+    agent,
+    tool_results,
+    *,
+    ledger_source: str,
+) -> bool:
+    """Persist real tool results after post-tool LLM continuation failure.
+
+    The tools already executed locally before the continuation send. If an
+    adapter rolled back the attempted user tool-result entry on provider error,
+    the canonical interface tail still has pending assistant tool_calls. Restore
+    the real results before AED / notification heal can synthesize a placeholder
+    that lacks the actual result payload.
+    """
+    if (
+        not tool_results
+        or agent._chat is None
+        or not agent._chat.has_pending_tool_calls()
+    ):
+        return False
+    agent._chat.commit_tool_results(tool_results)
+    agent._save_chat_history(ledger_source=ledger_source)
+    agent._log(
+        "tool_results_restored_after_continuation_failure",
+        result_count=len(tool_results),
+    )
+    return True
+
+
 def _run_loop(agent) -> None:
     """Wait for messages, process them. Agent persists between messages."""
     from ..state import AgentState
@@ -916,7 +945,21 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
             break
 
         in_tool_loop = True
-        response = agent._session.send(tool_results)
+        try:
+            response = agent._session.send(tool_results)
+        except Exception:
+            # The local tools have already executed and returned results; only
+            # the post-tool LLM continuation failed. Some adapters append tool
+            # results as part of send(tool_results) and roll that user entry
+            # back on provider error. If AED / notification heal sees the tail
+            # assistant tool_calls as unanswered, it can only synthesize a
+            # completion notice and the real result payload is lost. Restore the
+            # real results before re-raising so recovery paths preserve truthful
+            # tool completion state.
+            _restore_tool_results_after_continuation_failure(
+                agent, tool_results, ledger_source=ledger_source,
+            )
+            raise
         agent._last_usage = response.usage
         agent._save_chat_history(ledger_source=ledger_source)
 

--- a/tests/test_tool_result_restore_after_continuation_failure.py
+++ b/tests/test_tool_result_restore_after_continuation_failure.py
@@ -1,0 +1,185 @@
+"""Regression tests for preserving real tool results when continuation fails.
+
+The turn engine executes tools locally before asking the LLM to continue from
+those tool results. If the provider call fails after the tool result exists,
+recovery must not replace the real result with a synthetic completion notice
+that loses the result payload.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from lingtai_kernel.base_agent.turn import (
+    _process_response,
+    _restore_tool_results_after_continuation_failure,
+)
+from lingtai_kernel.llm.base import LLMResponse, ToolCall
+from lingtai_kernel.llm.interface import (
+    ChatInterface,
+    TextBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+)
+
+
+class _FakeChat:
+    def __init__(self) -> None:
+        self.interface = ChatInterface()
+        self.interface.add_system("system")
+        self.interface.add_user_message("run tool")
+        self.interface.add_assistant_message(
+            [
+                TextBlock("calling"),
+                ToolCallBlock(id="call_1", name="bash", args={"command": "echo ok"}),
+            ]
+        )
+        self.committed: list[list[ToolResultBlock]] = []
+
+    def has_pending_tool_calls(self) -> bool:
+        return self.interface.has_pending_tool_calls()
+
+    def commit_tool_results(self, results: list[ToolResultBlock]) -> None:
+        self.committed.append(list(results))
+        self.interface.add_tool_results(results)
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self._chat = _FakeChat()
+        self._notification_live_holder = None
+        self.saved = 0
+        self.logs: list[tuple[str, dict]] = []
+
+    def _save_chat_history(self, *, ledger_source: str | None = None) -> None:
+        self.saved += 1
+
+    def _log(self, event: str, **kwargs) -> None:
+        self.logs.append((event, kwargs))
+
+
+def test_restores_real_tool_results_when_adapter_rolled_back_user_entry():
+    """If send(tool_results) fails after local execution, restore real results."""
+    agent = _FakeAgent()
+    real_result = ToolResultBlock(id="call_1", name="bash", content="exit_code=0\nstdout=ok")
+
+    restored = _restore_tool_results_after_continuation_failure(
+        agent,
+        [real_result],
+        ledger_source="test",
+    )
+
+    assert restored is True
+    assert not agent._chat.has_pending_tool_calls()
+    assert agent._chat.committed == [[real_result]]
+    assert agent.saved == 1
+    assert agent.logs == [("tool_results_restored_after_continuation_failure", {"result_count": 1})]
+
+    tail = agent._chat.interface.entries[-1]
+    assert tail.role == "user"
+    assert tail.content == [real_result]
+    assert not tail.content[0].synthesized
+
+
+def test_restoration_skips_when_adapter_already_left_result():
+    """Do not append duplicate results if the adapter did not roll back."""
+    agent = _FakeAgent()
+    real_result = ToolResultBlock(id="call_1", name="bash", content="exit_code=0")
+    agent._chat.commit_tool_results([real_result])
+    agent._chat.committed.clear()
+
+    restored = _restore_tool_results_after_continuation_failure(
+        agent,
+        [real_result],
+        ledger_source="test",
+    )
+
+    assert restored is False
+    assert agent._chat.committed == []
+    assert agent.saved == 0
+    assert agent._chat.interface.entries[-1].content == [real_result]
+
+
+def test_restoration_skips_empty_results():
+    agent = _FakeAgent()
+
+    restored = _restore_tool_results_after_continuation_failure(
+        agent,
+        [],
+        ledger_source="test",
+    )
+
+    assert restored is False
+    assert agent._chat.has_pending_tool_calls()
+    assert agent.saved == 0
+
+
+class _FakeGuard:
+    def check_limit(self, count: int) -> str | None:
+        return None
+
+    def check_invalid_tool_limit(self) -> str | None:
+        return None
+
+    def record_calls(self, count: int) -> None:
+        pass
+
+
+class _ProcessExecutor:
+    def __init__(self, result: ToolResultBlock) -> None:
+        self.guard = _FakeGuard()
+        self.result = result
+
+    def execute(self, tool_calls, **kwargs):
+        return [self.result], False, ""
+
+
+class _NoopSentTracker:
+    pass
+
+
+class _FailingSession:
+    def __init__(self) -> None:
+        self.sent = []
+
+    def send(self, content):
+        self.sent.append(content)
+        raise RuntimeError("provider continuation failed")
+
+
+def test_process_response_restores_real_results_when_continuation_send_fails():
+    """Regression: _process_response preserves tool output before AED heal runs."""
+    agent = _FakeAgent()
+    real_result = ToolResultBlock(
+        id="call_1",
+        name="bash",
+        content="exit_code=0\nstdout=ok",
+    )
+    agent._executor = _ProcessExecutor(real_result)
+    agent._session = _FailingSession()
+    agent._cancel_event = threading.Event()
+    agent._on_tool_result_hook = None
+    agent._intermediate_text_streamed = True
+    agent._sent_tracker = _NoopSentTracker()
+    agent._working_dir = Path("/nonexistent/lingtai-test-tool-result-restore")
+
+    response = LLMResponse(
+        text="",
+        tool_calls=[ToolCall(id="call_1", name="bash", args={"command": "echo ok"})],
+    )
+
+    with pytest.raises(RuntimeError, match="provider continuation failed"):
+        _process_response(agent, response, ledger_source="test")
+
+    assert agent._session.sent == [[real_result]]
+    assert agent._chat.committed == [[real_result]]
+    assert not agent._chat.has_pending_tool_calls()
+    assert agent._chat.interface.entries[-1].content == [real_result]
+    assert not agent._chat.interface.entries[-1].content[0].synthesized
+    assert agent.saved == 1
+    assert agent.logs[-1] == (
+        "tool_results_restored_after_continuation_failure",
+        {"result_count": 1},
+    )


### PR DESCRIPTION
## Summary

Fixes a recovery edge case where a tool has already executed locally and returned a real result, but the subsequent post-tool LLM continuation fails. Some provider adapters append the `user[ToolResultBlock]` entry before provider I/O and roll it back on API/provider error. That can leave the canonical chat tail as `assistant[tool_calls]` even though the tool completed, allowing AED/notification heal paths to synthesize a misleading `[kernel notice — tool call did not complete]` placeholder and lose the real output.

This PR preserves the real tool result before generic recovery runs.

## Changes

- Add `_restore_tool_results_after_continuation_failure(...)` in `src/lingtai_kernel/base_agent/turn.py`.
- Wrap the normal `_process_response` post-tool continuation send (`_send_with_watchdog(agent, tool_results)`) in `try/except`.
- If continuation send raises and pending tool calls remain, commit the already-produced real tool results, save chat history, log `tool_results_restored_after_continuation_failure`, then re-raise the original exception so existing AED/retry semantics remain unchanged.
- Add focused regression tests in `tests/test_tool_result_restore_after_continuation_failure.py`, including helper-level coverage and an `_process_response`-level fake executor/session regression.

## Tests

Focused tests and lint from `/Users/tianzhezheng/Documents/lingtai-dev/lingtai-kernel`:

```bash
.venv/bin/python -m pytest -q \
  tests/test_tool_result_restore_after_continuation_failure.py \
  tests/test_chat_interface_invariant.py \
  tests/test_worker_still_running_recovery.py
# 47 passed in 0.29s

.venv/bin/ruff check \
  src/lingtai_kernel/base_agent/turn.py \
  tests/test_tool_result_restore_after_continuation_failure.py
# All checks passed
```

Local full-suite note: this environment currently is not a clean full-suite signal; a prior full `uv run pytest` run hit many unrelated existing failures and eventually aborted inside `ddgs/http_client.py` threads. This PR therefore submits the minimal required code/test changes with focused coverage; CI should provide the authoritative full-suite result.

## Risk / follow-up

Risk is limited to the path where local tool execution already returned results and the subsequent LLM continuation raises. If the adapter already kept the tool-result entry, the helper no-ops to avoid duplicates.

A cleaner future design would decouple tool-result durability from continuation success entirely: commit tool results before provider continuation and continue from the staged wire (`send(None)`), with provider-level tests.
