### PR TITLE
fix(skills,knowledge): render catalog as readable blocks instead of escape-soup

### DIFF
--- a/src/lingtai/core/knowledge/__init__.py
+++ b/src/lingtai/core/knowledge/__init__.py
@@ -329,30 +329,44 @@ def _migrate_legacy_json(working_dir: Path, knowledge_dir: Path) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 def _escape_xml(s: str) -> str:
+    """Escape only the characters XML actually requires in element text.
+
+    `"` and `'` only need escaping inside attribute values; escaping them in
+    element bodies just adds `&quot;`/`&apos;` noise to the rendered prompt
+    without making the catalog any more parseable.
+    """
     return (
         s.replace("&", "&amp;")
         .replace("<", "&lt;")
         .replace(">", "&gt;")
-        .replace('"', "&quot;")
-        .replace("'", "&apos;")
     )
+
+
+def _indent_block(text: str, indent: str) -> str:
+    """Indent every line of ``text`` by ``indent``. Empty input → empty string."""
+    if not text:
+        return ""
+    return "\n".join(indent + line for line in text.splitlines())
 
 
 def _build_catalog_xml(entries: list[dict], lang: str) -> str:
     if not entries:
         return ""
 
-    lines = [
+    lines: list[str] = [
         t(lang, "knowledge.preamble"),
         "",
         "<knowledge>",
     ]
     for e in entries:
+        lines.append("")
         lines.append("  <entry>")
-        lines.append(f"    <name>{_escape_xml(e['name'])}</name>")
-        lines.append(f"    <description>{_escape_xml(e['description'])}</description>")
-        lines.append(f"    <location>{_escape_xml(e['path'])}</location>")
+        lines.append(f"    name: {_escape_xml(e['name'])}")
+        lines.append(f"    location: {_escape_xml(e['path'])}")
+        lines.append("    description:")
+        lines.append(_indent_block(_escape_xml(e["description"]), "      "))
         lines.append("  </entry>")
+    lines.append("")
     lines.append("</knowledge>")
     return "\n".join(lines)
 

--- a/src/lingtai/core/skills/__init__.py
+++ b/src/lingtai/core/skills/__init__.py
@@ -170,30 +170,44 @@ def _scan(directory: Path) -> tuple[list[dict], list[dict]]:
 # ---------------------------------------------------------------------------
 
 def _escape_xml(s: str) -> str:
+    """Escape only the characters XML actually requires in element text.
+
+    `"` and `'` only need escaping inside attribute values; escaping them in
+    element bodies just adds `&quot;`/`&apos;` noise to the rendered prompt
+    without making the catalog any more parseable.
+    """
     return (
         s.replace("&", "&amp;")
         .replace("<", "&lt;")
         .replace(">", "&gt;")
-        .replace('"', "&quot;")
-        .replace("'", "&apos;")
     )
+
+
+def _indent_block(text: str, indent: str) -> str:
+    """Indent every line of ``text`` by ``indent``. Empty input → empty string."""
+    if not text:
+        return ""
+    return "\n".join(indent + line for line in text.splitlines())
 
 
 def _build_catalog_xml(skills: list[dict], lang: str) -> str:
     if not skills:
         return ""
 
-    lines = [
+    lines: list[str] = [
         t(lang, "skills.preamble"),
         "",
         "<available_skills>",
     ]
     for sk in skills:
+        lines.append("")
         lines.append("  <skill>")
-        lines.append(f"    <name>{_escape_xml(sk['name'])}</name>")
-        lines.append(f"    <description>{_escape_xml(sk['description'])}</description>")
-        lines.append(f"    <location>{_escape_xml(sk['path'])}</location>")
+        lines.append(f"    name: {_escape_xml(sk['name'])}")
+        lines.append(f"    location: {_escape_xml(sk['path'])}")
+        lines.append("    description:")
+        lines.append(_indent_block(_escape_xml(sk["description"]), "      "))
         lines.append("  </skill>")
+    lines.append("")
     lines.append("</available_skills>")
     return "\n".join(lines)
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -262,6 +262,41 @@ def test_catalog_injected_into_skills_section(tmp_path):
         agent.stop(timeout=1.0)
 
 
+def test_catalog_rendering_is_readable_without_xml_quote_noise(tmp_path):
+    # The catalog goes straight into the system prompt; humans (and the model)
+    # have complained that the prior shape was XML-escape soup. Pin the new
+    # shape: per-skill block with indented `description:` body, no `&quot;` /
+    # `&apos;` noise from over-escaping element text.
+    workdir = tmp_path / "agent"
+    _write_skill(
+        workdir / ".library" / "custom" / "fancy-tool",
+        "fancy-tool",
+        'Handles "quoted" args and \'apostrophes\' — keep them raw.',
+    )
+
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=workdir,
+        capabilities={"skills": {}},
+    )
+    try:
+        prompt = agent._prompt_manager.read_section("skills") or ""
+        # No spurious escape entities for `"` and `'` in element text.
+        assert "&quot;" not in prompt
+        assert "&apos;" not in prompt
+        # The new shape uses indented `description:` blocks.
+        assert "    description:" in prompt
+        assert "      Handles \"quoted\" args" in prompt
+        # The outer wrapper still exists (consumers grep for it).
+        assert "<available_skills>" in prompt
+        assert "</available_skills>" in prompt
+        # The skill block keeps clean field labels rather than inline tags.
+        assert "    name: fancy-tool" in prompt
+    finally:
+        agent.stop(timeout=1.0)
+
+
 def test_custom_skills_appear_in_catalog(tmp_path):
     workdir = tmp_path / "agent"
     _write_skill(workdir / ".library" / "custom" / "my-tool", "my-tool", "my desc")


### PR DESCRIPTION
## Summary

- The `<available_skills>` / `<knowledge>` blocks injected into the system prompt previously over-escaped element text (`&quot;`, `&apos;`) and jammed every field onto a single inline-tag line, producing a chaotic, machine-looking shape.
- `_escape_xml` now only escapes the three characters XML actually requires in element text (`&`, `<`, `>`). The `"` / `'` escaping was unnecessary noise.
- `_build_catalog_xml` (both `skills` and `knowledge`) renders each entry as a clearly indented block with `name:`, `location:`, and a multi-line `description:` body. Outer `<available_skills>`/`<knowledge>` wrappers preserved.
- Information richness is preserved — descriptions are not truncated. Grouping was considered but skipped (per feedback: not the core problem).

## Before / After

**Before**
```
<available_skills>
  <skill>
    <name>feature-dev</name>
    <description>Guided feature development with codebase understanding and architecture focus. Use when the user asks to plan a feature or wants &quot;opinionated&quot; design help.</description>
    <location>/Users/x/.lingtai-tui/utilities/feature-dev/SKILL.md</location>
  </skill>
</available_skills>
```

**After**
```
<available_skills>

  <skill>
    name: feature-dev
    location: /Users/x/.lingtai-tui/utilities/feature-dev/SKILL.md
    description:
      Guided feature development with codebase understanding and architecture focus. Use when the user asks to plan a feature or wants "opinionated" design help.
  </skill>

</available_skills>
```

## Test plan

- [x] `pytest tests/test_skills.py tests/test_knowledge.py -q` — 39 passed
- [x] Full kernel suite (`pytest -q`) — 1667 passed, 4 pre-existing failures in `test_soul*`/`test_molt_notification_persistence` confirmed on `origin/main`, unrelated to this change.
- [x] New test `test_catalog_rendering_is_readable_without_xml_quote_noise` pins absence of `&quot;`/`&apos;` and the new field-block shape.

## Risk / compatibility

- Outer `<available_skills>` / `<knowledge>` wrapper tags and skill `name`s are preserved, so anything that greps for them (tests, docs, prompt scanners) continues to work.
- The change is presentation-only; skill discovery, scanning, and the `info` tool surface are untouched.
- If a downstream parser tried to extract values via inline `<name>…</name>` regex matching, it would need to switch to the `name:` / `location:` / `description:` field form. No such parser exists in either repo (verified via grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)