### PR TITLE
docs(manuals): document cron notification wakeup reminders

### DIFF
--- a/src/lingtai/core/bash/manual/SKILL.md
+++ b/src/lingtai/core/bash/manual/SKILL.md
@@ -395,6 +395,148 @@ Add a line:
 
 5 fields: `minute hour day-of-month month day-of-week`. The default `PATH` for crontab is even sparser than launchd's — set `PATH=` at the top of the crontab file or use absolute paths everywhere in the script.
 
+
+## One-shot wakeup reminders via `.notification/cron.json`
+
+Sometimes you do **not** want a recurring cron job and you do **not** want to self-send mail. You only need a lightweight alarm for your future self: "something is still pending; wake later and check it." Use a cron notification reminder for that.
+
+Typical example:
+
+```text
+⏺ Codex active. Plot regenerated (362KB, 23:38) — visibly more polished than my crude version. Waiting for caption + commit. Polling at 23:42.
+```
+
+That sentence has the right shape: current state, what changed, what remains, and the next check time. The mechanism is a scheduled script that writes one file:
+
+```text
+<agent-workdir>/.notification/cron.json
+```
+
+The kernel's notification sync reads `.notification/*.json`, injects the `cron` channel into the agent's wire context, and wakes the agent to act. After handling it, clear it with:
+
+```text
+system(action="dismiss", channel="cron")
+```
+
+Use this pattern when:
+
+- you are going to sleep/rest but a daemon, CLI coding agent, CI job, PR, render, download, or external process may need a follow-up;
+- the reminder is for **you**, not for the human;
+- a single check is enough, or the repeated cadence is purely mechanical;
+- self-email would add mailbox latency/state and does not buy anything.
+
+Do **not** use it when:
+
+- the human needs to be notified — use the channel the human used, or an external addon if appropriate;
+- the reminder must survive process death and machine reboot but you only used a detached `sleep`; use launchd/systemd/crontab for persistence;
+- you are tempted to poll every few seconds. Set one sane reminder, then rest.
+
+### Payload shape
+
+A producer that cannot import the kernel helper should still write the full notification envelope, not a bare message. Minimal valid shape:
+
+```json
+{
+  "header": "Cron reminder: check Codex plot run",
+  "icon": "⏰",
+  "priority": "normal",
+  "published_at": "2026-05-18T06:42:00Z",
+  "data": {
+    "source": "cron-reminder",
+    "message": "Codex active. Plot regenerated (362KB, 23:38) — waiting for caption + commit.",
+    "todo": "Check Codex status, inspect caption, commit if ready.",
+    "reminder_id": "plot-caption-2026-05-17T23-42"
+  }
+}
+```
+
+Fields the agent will care about:
+
+- `header` — short visible summary.
+- `priority` — usually `normal`; use `high` only when the check is time-sensitive.
+- `published_at` — UTC ISO timestamp; useful when the agent wakes late.
+- `data.message` — what changed since the agent rested.
+- `data.todo` — the concrete next action.
+- `data.reminder_id` — stable enough to recognize duplicate fires.
+
+### Atomic writer
+
+External scripts should write via `tmp + rename` so the kernel never sees truncated JSON:
+
+```bash
+export AGENT_DIR="/Users/huangzesen/work/lingtai-dev/.lingtai/codex-gpt5.5"
+export REMINDER_ID="plot-caption-$(date +%Y%m%d-%H%M%S)"
+
+/usr/bin/python3 - <<'PY'
+import json, os, pathlib, time
+from datetime import datetime, timezone
+
+agent = pathlib.Path(os.environ["AGENT_DIR"])
+notif = agent / ".notification"
+notif.mkdir(exist_ok=True)
+now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+payload = {
+    "header": "Cron reminder: check Codex plot run",
+    "icon": "⏰",
+    "priority": "normal",
+    "published_at": now,
+    "data": {
+        "source": "cron-reminder",
+        "message": "Codex active. Plot regenerated (362KB, 23:38) — waiting for caption + commit.",
+        "todo": "Check Codex status, inspect caption, commit if ready.",
+        "reminder_id": os.environ.get("REMINDER_ID", "cron-reminder"),
+        "epoch": int(time.time()),
+    },
+}
+target = notif / "cron.json"
+tmp = target.with_suffix(".json.tmp")
+tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+tmp.replace(target)
+PY
+```
+
+### One-shot reminder from the shell
+
+For a short local reminder where the machine is expected to stay awake, a detached sleeper is enough:
+
+```bash
+DELAY_SECONDS=240
+nohup /bin/bash -lc 'sleep '"$DELAY_SECONDS"'; export AGENT_DIR="/Users/huangzesen/work/lingtai-dev/.lingtai/codex-gpt5.5"; /usr/bin/python3 - <<"PY"
+import json, os, pathlib, time
+from datetime import datetime, timezone
+notif = pathlib.Path(os.environ["AGENT_DIR"]) / ".notification"
+notif.mkdir(exist_ok=True)
+payload = {
+  "header": "Cron reminder: check pending daemon",
+  "icon": "⏰",
+  "priority": "normal",
+  "published_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+  "data": {
+    "source": "cron-reminder",
+    "message": "I rested while a daemon/CLI job was still active.",
+    "todo": "Read pad, then run daemon(list) or inspect the named job/PR.",
+    "reminder_id": "daemon-check-" + str(int(time.time())),
+  },
+}
+target = notif / "cron.json"
+tmp = target.with_suffix(".json.tmp")
+tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+tmp.replace(target)
+PY' >/tmp/lingtai-cron-reminder.log 2>&1 &
+```
+
+This is not a replacement for OS scheduling: a detached sleeper can be lost if the shell/process tree is killed or the machine sleeps through the interval. For long delays or repeated checks, put the same writer into launchd/systemd/crontab using the sections above.
+
+### Rest checklist
+
+Before resting with pending work:
+
+1. Update pad with the current state and what the reminder should inspect.
+2. Set one `cron` notification reminder at a sensible check time.
+3. Include a concise state sentence and a concrete `todo`.
+4. Rest (`system(action="sleep")`) or end the turn.
+5. On wake: handle the `cron` reminder, then `system(action="dismiss", channel="cron")`.
+
 ## Debugging cron — when things go silent
 
 When a scheduled job stops working, the failure is almost always in one of these places. Walk the list in order.

--- a/src/lingtai/core/daemon/manual/SKILL.md
+++ b/src/lingtai/core/daemon/manual/SKILL.md
@@ -164,6 +164,28 @@ Because the only progress signal is `last_output_at`, the right cadence on CLI b
 - **Reclaiming on a hunch.** See the stall heuristic. Default to "let it cook."
 - **`check` with `last=1000, truncate=0`.** Dumps the full event log into your context. Use targeted `last=20` and only widen if needed.
 
+
+### Resting while daemon work is pending: set a cron notification reminder
+
+If the daemon is healthy but unfinished and you are about to rest, do **not** keep polling and do **not** rely on memory. Set a lightweight wakeup reminder through the `bash-manual` section **"One-shot wakeup reminders via `.notification/cron.json`"**.
+
+Use this when:
+
+- a Claude Code / Codex backend task is still running but has enough context to finish alone;
+- you opened a PR and want to check CI/mergeability later;
+- a render/download/build/test run is expected to complete after you sleep;
+- the human asked for a later follow-up and the reminder is for you, not for them.
+
+The reminder should say what is pending and what to check, for example:
+
+```text
+⏺ Codex active. Plot regenerated (362KB, 23:38) — waiting for caption + commit. Polling at 23:42.
+```
+
+When the `cron` notification wakes you, read pad first, inspect the relevant daemon/job/PR, act, then dismiss the channel with `system(action="dismiss", channel="cron")`.
+
+This complements the polling rule above: completion is push-notified, stalls are inspected sparingly, and deliberate rest gets one future reminder rather than a busy loop.
+
 ## Worked example: a daemon that's been running 5 minutes
 
 You called `daemon(action="emanate", ...)` for `em-3`, asked it to "scan src/ for security issues", and it's been running 5 minutes. You're nervous.


### PR DESCRIPTION
## Summary

- Add a common `bash-manual` pattern for one-shot self-wakeup reminders that write `.notification/cron.json` directly instead of self-email.
- Document the notification envelope, atomic tmp+rename writer, one-shot detached sleeper example, and `system(action="dismiss", channel="cron")` cleanup.
- Add a `daemon-manual` pointer: when daemon work is healthy but pending and the agent wants to rest, set a cron notification reminder instead of polling or relying on memory.

## Validation

- `git diff --check`
- grep/assertions for the new sections and key strings (`.notification/cron.json`, `tmp.replace(target)`, `system(action="dismiss", channel="cron")`)

Docs-only; no pytest required.
