### PR TITLE
feat(capabilities): boot core capabilities by default

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -22,7 +22,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 ### Key functions / classes
 
-**`agent.py`** — `Agent(BaseAgent)`: `__init__` :33 (expand groups, decompress addons, setup caps, install manuals, load MCP) · `_setup_capability` :136 · `_persist_llm_config` :111 · `_install_intrinsic_manuals` :158 · `_load_mcp_from_workdir` :360 (also tracks specs in `_mcp_init_specs`) · `_retry_failed_mcps` :508 (re-spawn dead MCPs on `system(refresh)` — issue #34) · `_read_init` :818 (read + materialize preset + validate) · `_setup_from_init` :954 (**full reconstruct** — shared by boot and live refresh) · `_activate_preset` :880 (runtime swap, atomic write) · `_reload_prompt_sections` :1167 · `connect_mcp` :689 / `connect_mcp_http` :741 · `start` :682 / `stop` :787
+**`agent.py`** — `Agent(BaseAgent)`: `__init__` :33 (accept `capabilities=` + `disable=`, expand groups, `apply_core_defaults`, decompress addons, setup caps, install manuals, load MCP) · `_setup_capability` :148 · `_persist_llm_config` :123 · `_install_intrinsic_manuals` :170 · `_load_mcp_from_workdir` :372 (also tracks specs in `_mcp_init_specs`) · `_retry_failed_mcps` :520 (re-spawn dead MCPs on `system(refresh)` — issue #34) · `_read_init` :829 (read + materialize preset + validate) · `_setup_from_init` :965 (**full reconstruct** — shared by boot and live refresh; reads `manifest.disable` and re-applies `apply_core_defaults`) · `_activate_preset` :891 (runtime swap, atomic write) · `_reload_prompt_sections` :1200 · `connect_mcp` :700 / `connect_mcp_http` :752 · `start` :693 / `stop` :798
 
 **`cli.py`**: `load_init` :21 · `build_agent` :72 · `run` :200 · `main` :246
 
@@ -48,7 +48,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **Agent → BaseAgent:** Three-layer hierarchy: `BaseAgent` (kernel) → `Agent` (capabilities) → `CustomAgent` (domain). Agent adds capability registration, MCP auto-loading, preset swap, full init.json reconstruct.
 
-**Capability registration:** `setup_capability()` in `capabilities/__init__.py`; `@register_capability` decorator. Agent calls `_setup_capability` (agent.py:136) during `__init__` and `_setup_from_init`.
+**Capability registration:** `setup_capability()` in `capabilities/__init__.py`; the registry is `_BUILTIN` (per-capability module paths) plus `CORE_DEFAULTS` (which boot automatically). Agent calls `apply_core_defaults` + `_setup_capability` (agent.py:148) during `__init__` and `_setup_from_init`. Hosts disable defaults via the `disable=[...]` kwarg or `manifest.disable` in init.json.
 
 **Preset materialization:** `materialize_active_preset` (`lingtai_kernel/presets.py:290`) called by `cli.load_init` (boot) and `Agent._read_init` (refresh). Reads `manifest.preset.active`, loads preset, substitutes `llm`+`capabilities` into manifest before validation.
 

--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -36,6 +36,7 @@ class Agent(BaseAgent):
         capabilities: list[str] | dict[str, dict] | None = None,
         addons: list[str] | None = None,
         combo_name: str | None = None,
+        disable: list[str] | None = None,
         **kwargs: Any,
     ):
         # Default karma authority for the primary agent (本我)
@@ -67,11 +68,22 @@ class Agent(BaseAgent):
                     for sub in _GROUPS[name]:
                         expanded_dict[sub] = {}
                 elif cap_kwargs is None:
-                    expanded_dict[name] = {}
+                    expanded_dict[name] = None  # propagate disable-sentinel
                 else:
                     expanded_dict[name] = cap_kwargs
-            capabilities = normalize_capabilities(expanded_dict)
+            capabilities = normalize_capabilities(
+                {n: (v if v is not None else {}) for n, v in expanded_dict.items()}
+            )
+            # Preserve null sentinels for apply_core_defaults to interpret as opt-out.
+            for n, v in expanded_dict.items():
+                if v is None:
+                    capabilities[n] = None  # type: ignore[assignment]
 
+        # Apply core defaults — the `lingtai.core.*` floor boots on every agent
+        # unless explicitly disabled via `disable=[...]` or `"name": null` in
+        # the capabilities dict. init.json kwargs override default kwargs.
+        from .capabilities import apply_core_defaults
+        capabilities = apply_core_defaults(capabilities, disable=disable)
 
         # Track for avatar replay
         self._capabilities: list[tuple[str, dict]] = []
@@ -1111,20 +1123,42 @@ class Agent(BaseAgent):
             except Exception as e:
                 self._log("mcp_decompress_failed", reason=str(e))
 
-        # Re-run capability setup
-        capabilities = _resolve_capabilities(m.get("capabilities", {}))
+        # Re-run capability setup. init.json declares overrides/opt-ins;
+        # `apply_core_defaults` ensures the `lingtai.core.*` floor boots even
+        # when the manifest omits it. `manifest.disable` and `"name": null`
+        # entries are the opt-out channels.
+        raw_caps = m.get("capabilities", {}) or {}
+        resolved = _resolve_capabilities(raw_caps)
+        # Preserve null sentinels through env-resolution (it converts None to {}).
+        null_outs = {n for n, v in raw_caps.items() if v is None}
+
+        from .capabilities import (
+            _GROUPS,
+            apply_core_defaults,
+            normalize_capabilities,
+        )
+        expanded: dict[str, Any] = {}
+        for name, cap_kwargs in resolved.items():
+            if name in _GROUPS:
+                for sub in _GROUPS[name]:
+                    expanded[sub] = {}
+            elif name in null_outs:
+                expanded[name] = None
+            elif cap_kwargs is None:
+                expanded[name] = None
+            else:
+                expanded[name] = cap_kwargs
+        normalized = normalize_capabilities(
+            {n: (v if v is not None else {}) for n, v in expanded.items()}
+        )
+        for n, v in expanded.items():
+            if v is None:
+                normalized[n] = None  # type: ignore[assignment]
+
+        disable_list = m.get("disable") or []
+        capabilities = apply_core_defaults(normalized, disable=disable_list)
+
         if capabilities:
-            from .capabilities import _GROUPS, normalize_capabilities
-            expanded: dict[str, dict] = {}
-            for name, cap_kwargs in capabilities.items():
-                if name in _GROUPS:
-                    for sub in _GROUPS[name]:
-                        expanded[sub] = {}
-                elif cap_kwargs is None:
-                    expanded[name] = {}
-                else:
-                    expanded[name] = cap_kwargs
-            capabilities = normalize_capabilities(expanded)
             for name, cap_kwargs in capabilities.items():
                 try:
                     self._setup_capability(name, **cap_kwargs)

--- a/src/lingtai/capabilities/ANATOMY.md
+++ b/src/lingtai/capabilities/ANATOMY.md
@@ -8,7 +8,7 @@ Root capabilities package — registry, capability normalization, and setup disp
 
 | File | Role |
 |---|---|
-| `__init__.py` | Static registry (`_BUILTIN`, `_GROUPS`), normalization helper (`normalize_capabilities`), `setup_capability()`, and `get_all_providers()` |
+| `__init__.py` | Static registry (`_BUILTIN`, `_GROUPS`, `CORE_DEFAULTS`), normalization (`normalize_capabilities`, `apply_core_defaults`), `setup_capability()`, and `get_all_providers()` |
 | `_media_host.py` | `resolve_media_host()` — extracts origin from the agent LLM `base_url` |
 | `_zhipu_mode.py` | `resolve_z_ai_mode()` — returns `"ZHIPU"` (bigmodel.cn) or `"ZAI"` (international) |
 
@@ -27,13 +27,15 @@ Root capabilities package — registry, capability normalization, and setup disp
 
 ## State
 
-- `_BUILTIN` is static capability name → module path (`__init__.py:15-34`). `knowledge` resolves to `lingtai.core.knowledge`; former durable-memory names `library` and `codex` are not registered.
-- `_GROUPS` is static group name → list of capabilities; currently only `"file"` expands to `[read, write, edit, glob, grep]` (`__init__.py:36-39`).
+- `_BUILTIN` is static capability name → module path. `knowledge` resolves to `lingtai.core.knowledge`; former durable-memory names `library` and `codex` are not registered.
+- `_GROUPS` is static group name → list of capabilities; currently only `"file"` expands to `[read, write, edit, glob, grep]`.
+- `CORE_DEFAULTS` is the static set of capability-name → default-kwargs pairs that boot automatically on every `Agent`: `knowledge`, `skills`, `bash` (`{yolo: true}`), `avatar`, `daemon`, `mcp`, and the file group (`read`/`write`/`edit`/`glob`/`grep`). `vision` and `web_search` are NOT in this set — they require provider config / API keys and stay opt-in.
 - `normalize_capabilities()` is intentionally small after the breaking rename: it does not map former `library`/`codex` names, and only preserves deterministic merges such as duplicate `skills.paths`.
 - No mutable runtime state is held by this package.
 
 ## Notes
 
-- `setup_capability()` imports the target module and calls its `setup()` (`__init__.py:122-143`). Unknown names raise `ValueError` with available capabilities and groups.
+- `setup_capability()` imports the target module and calls its `setup()`. Unknown names raise `ValueError` with available capabilities and groups.
+- `apply_core_defaults(capabilities, disable)` overlays `CORE_DEFAULTS` with user-supplied kwargs (init.json wins on merge), then strips names listed in `disable`. A `"name": None` entry in `capabilities` is an inline opt-out equivalent to including the name in `disable`. The function is the single seam where init.json's `manifest.capabilities` becomes the effective set; called from `Agent.__init__` and `Agent._setup_from_init`.
 - `get_all_providers()` returns user-facing capability/provider metadata for `lingtai-agent check-caps`; it intentionally lists canonical `knowledge` and `skills`, not former `library`/`codex` durable-memory names.
 - `knowledge`/`skills` is a flat tool namespace split, not a nested taxonomy: private durable memory is `knowledge`; portable procedures are `skills`.

--- a/src/lingtai/capabilities/__init__.py
+++ b/src/lingtai/capabilities/__init__.py
@@ -35,6 +35,63 @@ _GROUPS: dict[str, list[str]] = {
     "file": ["read", "write", "edit", "glob", "grep"],
 }
 
+# Capabilities that boot by default on every Agent — the `lingtai.core.*` floor.
+# init.json's `manifest.capabilities` only needs to declare overrides (kwargs)
+# or opt-ins beyond this set; `manifest.disable` is the opt-out channel.
+#
+# `bash` defaults to {"yolo": True} (unsandboxed). Hosts that want a sandbox
+# pass {"policy_file": "..."} in init.json, which overrides the default kwargs.
+# `vision` and `web_search` are NOT in this set — they require provider config
+# and API keys, so they stay explicit opt-in.
+CORE_DEFAULTS: dict[str, dict] = {
+    "knowledge": {},
+    "skills": {},
+    "bash": {"yolo": True},
+    "avatar": {},
+    "daemon": {},
+    "mcp": {},
+    "read": {},
+    "write": {},
+    "edit": {},
+    "glob": {},
+    "grep": {},
+}
+
+
+def apply_core_defaults(
+    capabilities: dict[str, dict] | None,
+    disable: list[str] | None = None,
+) -> dict[str, dict]:
+    """Merge `CORE_DEFAULTS` with user-supplied capabilities and remove disabled ones.
+
+    Resolution order (per capability name):
+    1. Start with `CORE_DEFAULTS`.
+    2. Overlay `capabilities` from init.json — init.json kwargs win on conflict.
+       Entries with name not in `CORE_DEFAULTS` (e.g. `vision`, `web_search`)
+       pass through unchanged.
+    3. Drop any name listed in `disable`.
+
+    Returns a fresh dict; does not mutate inputs.
+    """
+    out: dict[str, dict] = {name: dict(kwargs) for name, kwargs in CORE_DEFAULTS.items()}
+    if capabilities:
+        for name, kwargs in capabilities.items():
+            if kwargs is None:
+                # Explicit `"name": null` from JSON — disable without needing the
+                # `disable` list. Useful for one-off opt-outs in init.json.
+                out.pop(name, None)
+                continue
+            if name in out and isinstance(out[name], dict) and isinstance(kwargs, dict):
+                merged = dict(out[name])
+                merged.update(kwargs)
+                out[name] = merged
+            else:
+                out[name] = kwargs
+    if disable:
+        for name in disable:
+            out.pop(name, None)
+    return out
+
 
 def normalize_capabilities(capabilities: dict[str, dict]) -> dict[str, dict]:
     """Normalize capability configuration.

--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -49,6 +49,7 @@ MANIFEST_OPTIONAL: dict[str, type | tuple[type, ...]] = {
     "agent_name": (str, type(None)),
     "language": str,
     "capabilities": dict,
+    "disable": list,
     "soul": dict,
     "stamina": (int, float),
     "context_limit": (int, type(None)),

--- a/tests/test_agent_capabilities.py
+++ b/tests/test_agent_capabilities.py
@@ -26,28 +26,71 @@ class FakeSearchService(SearchService):
         return [SearchResult(title="t", url="u", snippet="s")]
 
 
-def test_agent_no_capabilities(tmp_path):
-    """Agent with no capabilities works like BaseAgent."""
+def test_agent_no_capabilities_boots_core_floor(tmp_path):
+    """Agent with no explicit capabilities still boots the `lingtai.core.*` floor.
+
+    The default-on set covers knowledge/skills/bash/avatar/daemon/mcp + file caps.
+    Opt-in capabilities (vision, web_search) stay off until requested.
+    """
+    from lingtai.capabilities import CORE_DEFAULTS
     agent = Agent(service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test")
-    assert agent._capabilities == []
-    assert agent._capability_managers == {}
+    registered = {name for name, _ in agent._capabilities}
+    assert registered == set(CORE_DEFAULTS), (
+        f"expected exactly the core defaults, got {registered - set(CORE_DEFAULTS)} extra / "
+        f"{set(CORE_DEFAULTS) - registered} missing"
+    )
+    assert "vision" not in registered
+    assert "web_search" not in registered
+    agent.stop(timeout=1.0)
+
+
+def test_agent_disable_strips_core_capability(tmp_path):
+    """`disable=[...]` opt-out drops a default-on capability."""
+    agent = Agent(
+        service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test",
+        disable=["bash", "avatar"],
+    )
+    registered = {name for name, _ in agent._capabilities}
+    assert "bash" not in registered
+    assert "avatar" not in registered
+    assert "knowledge" in registered  # other defaults still on
+    agent.stop(timeout=1.0)
+
+
+def test_agent_capabilities_dict_kwarg_overrides_default(tmp_path):
+    """Passing kwargs for a default-on capability merges over the defaults.
+
+    `bash` defaults to {"yolo": True}; passing `policy_file` keeps yolo (since
+    the override is a merge, not a replace) — hosts wanting strict sandbox
+    should set `{"yolo": False, "policy_file": "..."}`.
+    """
+    agent = Agent(
+        service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test",
+        capabilities={"bash": {"yolo": False}},
+    )
+    bash_entry = [(n, k) for n, k in agent._capabilities if n == "bash"]
+    assert bash_entry and bash_entry[0][1].get("yolo") is False
     agent.stop(timeout=1.0)
 
 
 def test_agent_capabilities_list(tmp_path):
-    """capabilities= as list of strings registers capabilities (using file caps that need no key)."""
+    """capabilities= as list of strings is honored alongside the core defaults."""
     agent = Agent(
         service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test",
         capabilities=["read", "write"],
     )
-    assert len(agent._capabilities) == 2
-    assert ("read", {}) in agent._capabilities
-    assert ("write", {}) in agent._capabilities
+    registered = {name for name, _ in agent._capabilities}
+    assert "read" in registered
+    assert "write" in registered
     agent.stop(timeout=1.0)
 
 
 def test_agent_capabilities_dict(tmp_path):
-    """capabilities= as dict registers capabilities with kwargs."""
+    """capabilities= as dict registers user-supplied capabilities with kwargs.
+
+    Core defaults still register alongside; the assertion focuses on the
+    opt-in tools getting their handler wired.
+    """
     agent = Agent(
         service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test",
         capabilities={
@@ -55,7 +98,9 @@ def test_agent_capabilities_dict(tmp_path):
             "web_search": {"search_service": FakeSearchService()},
         },
     )
-    assert len(agent._capabilities) == 2
+    registered = {name for name, _ in agent._capabilities}
+    assert "vision" in registered
+    assert "web_search" in registered
     assert "vision" in agent._tool_handlers
     assert "web_search" in agent._tool_handlers
     agent.stop(timeout=1.0)

--- a/tests/test_deep_refresh.py
+++ b/tests/test_deep_refresh.py
@@ -186,8 +186,14 @@ def test_deep_refresh_invalid_init_keeps_old_config(tmp_path):
 
 
 def test_deep_refresh_removes_old_capabilities(tmp_path):
-    """Capabilities removed from init.json are gone after refresh."""
-    init = _make_init(capabilities={"read": {}, "write": {}})
+    """Capabilities removed from init.json are gone after refresh.
+
+    Tested against opt-in (non-core) capabilities so the assertion is about
+    the refresh path, not about the core-defaults floor. Core capabilities
+    persist across refresh regardless of init.json — that is by design;
+    `manifest.disable` is the opt-out channel for those.
+    """
+    init = _make_init(capabilities={"web_search": {"provider": "duckduckgo"}})
     agent = _make_agent(tmp_path, init)
     agent._setup_from_init()  # initial setup
 
@@ -197,17 +203,17 @@ def test_deep_refresh_removes_old_capabilities(tmp_path):
     mock_session.chat.interface = MagicMock()
     agent._session = mock_session
 
-    assert len(agent._capabilities) == 2
+    cap_names_before = {name for name, _ in agent._capabilities}
+    assert "web_search" in cap_names_before
 
-    # Remove "write" from init.json
-    new_init = _make_init(capabilities={"read": {}})
+    # Drop web_search from init.json
+    new_init = _make_init(capabilities={})
     (tmp_path / "init.json").write_text(json.dumps(new_init))
 
     agent._setup_from_init()
 
-    cap_names = [name for name, _ in agent._capabilities]
-    assert "read" in cap_names
-    assert "write" not in cap_names
+    cap_names_after = {name for name, _ in agent._capabilities}
+    assert "web_search" not in cap_names_after
 
 
 def test_deep_refresh_preserves_chat_history(tmp_path):

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -57,7 +57,13 @@ def test_knowledge_setup_registers_only_knowledge_tool(tmp_path):
         agent.stop(timeout=1.0)
 
 
-def test_former_alias_capabilities_do_not_register_knowledge(tmp_path):
+def test_former_alias_capabilities_are_not_tools(tmp_path):
+    """Legacy `library` / `codex` capability names must not register as tools.
+
+    `knowledge` itself is now default-on, so it WILL be available — but the
+    breaking-rename guarantee is still that the legacy names produce no
+    `library(...)` / `codex(...)` tool handler.
+    """
     for cap in ("library", "codex"):
         agent = Agent(
             service=make_mock_service(),
@@ -66,8 +72,6 @@ def test_former_alias_capabilities_do_not_register_knowledge(tmp_path):
             capabilities=[cap],
         )
         try:
-            assert agent.get_capability("knowledge") is None
-            assert "knowledge" not in agent._tool_handlers
             assert cap not in agent._tool_handlers
         finally:
             agent.stop(timeout=1.0)

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -352,10 +352,16 @@ class TestAddCapability:
         assert isinstance(avatar_mgr, AvatarManager)
 
     def test_capabilities_log(self, tmp_path):
-        """Agent should record (name, kwargs) in _capabilities."""
+        """Agent should record (name, kwargs) in _capabilities.
+
+        Core defaults are recorded too — the assertions here verify that
+        explicit caller-supplied kwargs land in `_capabilities` with the
+        expected merged shape.
+        """
         from lingtai.agent import Agent
         agent = Agent(service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test",
                            capabilities={"bash": {"yolo": True}, "avatar": {}})
-        assert len(agent._capabilities) == 2
-        assert agent._capabilities[0] == ("bash", {"yolo": True})
-        assert agent._capabilities[1] == ("avatar", {})
+        caps_by_name = {name: kwargs for name, kwargs in agent._capabilities}
+        # `bash` default is {"yolo": True}; explicit override merges → still yolo
+        assert caps_by_name.get("bash") == {"yolo": True}
+        assert caps_by_name.get("avatar") == {}

--- a/tests/test_layers_file.py
+++ b/tests/test_layers_file.py
@@ -40,10 +40,14 @@ def test_file_sugar_dict_form(tmp_path):
 
 
 def test_individual_file_capability(tmp_path):
-    """Each file capability can be loaded individually."""
+    """Each file capability can be disabled individually via `disable=[...]`.
+
+    The `lingtai.core.*` file caps are default-on; `disable` is the opt-out
+    channel for hosts that want a narrower surface.
+    """
     agent = Agent(
         service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test",
-        capabilities=["read", "write"],
+        disable=["edit", "glob", "grep"],
     )
     assert "read" in agent._tool_handlers
     assert "write" in agent._tool_handlers

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -316,9 +316,15 @@ def test_custom_skills_appear_in_catalog(tmp_path):
 
 
 
-def test_former_library_config_no_longer_normalizes_to_skills(tmp_path):
-    workdir = tmp_path / "agent"
+# NOTE: `knowledge` and `skills` are now default-on (the `lingtai.core.*` floor
+# boots on every Agent). The tests below preserve the breaking-rename guarantee
+# at its remaining surface: legacy `library` / `codex` capability NAMES must not
+# themselves produce tool handlers. Whether `knowledge`/`skills` are present is
+# governed by core defaults, not by alias normalization.
 
+
+def test_former_library_config_does_not_register_library_tool(tmp_path):
+    workdir = tmp_path / "agent"
     agent = Agent(
         service=make_mock_service(),
         agent_name="test",
@@ -326,16 +332,13 @@ def test_former_library_config_no_longer_normalizes_to_skills(tmp_path):
         capabilities={"library": {}},
     )
     try:
-        assert "skills" not in agent._tool_handlers
-        assert "knowledge" not in agent._tool_handlers
         assert "library" not in agent._tool_handlers
     finally:
         agent.stop(timeout=1.0)
 
 
-def test_former_library_list_config_no_longer_normalizes_to_skills(tmp_path):
+def test_former_library_list_config_does_not_register_library_tool(tmp_path):
     workdir = tmp_path / "agent"
-
     agent = Agent(
         service=make_mock_service(),
         agent_name="test",
@@ -343,14 +346,13 @@ def test_former_library_list_config_no_longer_normalizes_to_skills(tmp_path):
         capabilities=["library"],
     )
     try:
-        assert "skills" not in agent._tool_handlers
-        assert "knowledge" not in agent._tool_handlers
         assert "library" not in agent._tool_handlers
     finally:
         agent.stop(timeout=1.0)
 
 
-def test_former_library_paths_config_no_longer_normalizes_to_skills(tmp_path):
+def test_former_library_paths_do_not_leak_into_skills_catalog(tmp_path):
+    """Skills extra paths must come from the `skills` cap, not `library` alias."""
     extra = tmp_path / "extra"
     _write_skill(extra / "old-shared", "old-shared")
     workdir = tmp_path / "agent"
@@ -362,14 +364,14 @@ def test_former_library_paths_config_no_longer_normalizes_to_skills(tmp_path):
         capabilities={"library": {"paths": [str(extra)]}},
     )
     try:
-        assert "skills" not in agent._tool_handlers
-        assert "knowledge" not in agent._tool_handlers
+        # `skills` is default-on, but the legacy `library.paths` must not be
+        # picked up as an extra skill path by alias normalization.
         assert "old-shared" not in (agent._prompt_manager.read_section("skills") or "")
     finally:
         agent.stop(timeout=1.0)
 
 
-def test_former_codex_library_pair_does_not_register_knowledge_or_skills(tmp_path):
+def test_former_codex_library_pair_does_not_register_legacy_tools(tmp_path):
     extra = tmp_path / "extra"
     _write_skill(extra / "paired-shared", "paired-shared")
     workdir = tmp_path / "agent"
@@ -381,8 +383,6 @@ def test_former_codex_library_pair_does_not_register_knowledge_or_skills(tmp_pat
         capabilities={"codex": {}, "library": {"paths": [str(extra)]}},
     )
     try:
-        assert "knowledge" not in agent._tool_handlers
-        assert "skills" not in agent._tool_handlers
         assert "codex" not in agent._tool_handlers
         assert "library" not in agent._tool_handlers
     finally:


### PR DESCRIPTION
## Summary

- Adds `CORE_DEFAULTS` and `apply_core_defaults()` in `src/lingtai/capabilities/__init__.py`. Every `Agent` now boots the `lingtai.core.*` floor (knowledge, skills, bash, avatar, daemon, mcp, read/write/edit/glob/grep) without needing init.json to enumerate it.
- `init.json`'s `manifest.capabilities` is now opt-out (top-level `disable: [...]` or inline `"name": null`) plus override (kwargs merge on top of defaults). Opt-in still applies to `vision` and `web_search` (need provider config / API keys).
- New `disable=[...]` kwarg on `Agent.__init__`; `manifest.disable` honored in `_setup_from_init` so live refresh respects opt-outs too.

## Why

Fixes [lingtai#105](https://github.com/Lingtai-AI/lingtai/issues/105). The kernel rename `library → knowledge` (durable memory) left the TUI's init.jsonc template still emitting `"library": {...}`, which `setup_capability()` rejected with ``Unknown capability `library` `` → silently logged as `capability_skipped` → agent boots with no durable-memory tool, yet the covenant + skill catalog (`knowledge-manual`) instruct it to use one. Defaults-on closes the contract gap from the kernel side: `knowledge` is wired regardless of what init.json says about `library`.

## What changes

- `src/lingtai/capabilities/__init__.py` — `CORE_DEFAULTS` dict, `apply_core_defaults(capabilities, disable)` helper.
- `src/lingtai/agent.py` — `__init__` and `_setup_from_init` both call `apply_core_defaults` after group/null normalization; new `disable=` kwarg; null-sentinels in init.json's `capabilities` (`"name": null`) treated as opt-out.
- `src/lingtai/init_schema.py` — adds `disable: list` to `MANIFEST_OPTIONAL`.
- 9 stale-contract tests refactored, 3 new tests covering defaults-on / disable / kwarg-override.
- `src/lingtai/ANATOMY.md` and `src/lingtai/capabilities/ANATOMY.md` updated.

## Test plan

- [x] \`PYTHONPATH=src python -m pytest tests/ --timeout=60\` → 1668 passed, 4 failed (all 4 verified pre-existing on main: soul-consultation timer reschedule + molt-notification flake).
- [x] \`PYTHONPATH=src python -c \"import lingtai.agent; import lingtai.capabilities; from lingtai.init_schema import validate_init\"\` — smoke imports clean.
- [ ] Reviewer: verify the kernel boots a real agent from a stripped init.json (no \`capabilities\` block at all) and tool inventory includes \`knowledge\`/\`skills\`/\`bash\`/file tools.

## Coordination

Pairs with TUI PR [Lingtai-AI/lingtai#TBD](https://github.com/Lingtai-AI/lingtai) that strips the redundant default-on entries from init.jsonc and the provider presets. The TUI PR is safe to merge only after this PR ships to PyPI — until then, new agents created from the stripped templates would boot without durable memory (kernel doesn't know about defaults-on yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)