### PR TITLE
fix(psyche): remove strict-incompatible schema allOf

### DIFF
--- a/src/lingtai_kernel/intrinsics/psyche/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/psyche/ANATOMY.md
@@ -7,10 +7,10 @@ Agent identity, working notes, and context lifecycle — the "bare essentials of
 ## Components
 
 - `__init__.py` — Package surface. Re-exports all public API for backward compatibility. Contains:
-  - `get_description` / `get_schema` (`__init__.py:41-93`) — tool registration.
-  - `_VALID_ACTIONS` / `_DISPATCH` (`__init__.py:97-112`) — action→handler dispatch table replacing the former `globals().get()` pattern.
-  - `handle()` (`__init__.py:114-140`) — main dispatcher.
-  - `boot()` (`__init__.py:142-151`) — boot-time hook: loads lingtai + pad, registers post-molt reload callback.
+  - `get_description` / `get_schema` (`__init__.py:41-84`) — tool registration; schema intentionally avoids top-level JSON Schema combinators for strict-mode provider compatibility.
+  - `_VALID_ACTIONS` / `_DISPATCH` (`__init__.py:91-105`) — action→handler dispatch table replacing the former `globals().get()` pattern; preserves per-object action validation that is not encoded with schema combinators.
+  - `handle()` (`__init__.py:108-128`) — main dispatcher.
+  - `boot()` (`__init__.py:136-145`) — boot-time hook: loads lingtai + pad, registers post-molt reload callback.
 
 - `_snapshots.py` — Snapshot and summary persistence for the molt machinery.
   - `SNAPSHOT_SCHEMA_VERSION` (`_snapshots.py:16`) — schema version tag for snapshots.

--- a/src/lingtai_kernel/intrinsics/psyche/__init__.py
+++ b/src/lingtai_kernel/intrinsics/psyche/__init__.py
@@ -81,16 +81,6 @@ def get_schema(lang: str = "en") -> dict:
             },
         },
         "required": ["object", "action"],
-        "allOf": [
-            {"if": {"properties": {"object": {"const": "lingtai"}}},
-             "then": {"properties": {"action": {"enum": ["update", "load"]}}}},
-            {"if": {"properties": {"object": {"const": "pad"}}},
-             "then": {"properties": {"action": {"enum": ["edit", "load", "append"]}}}},
-            {"if": {"properties": {"object": {"const": "context"}}},
-             "then": {"properties": {"action": {"enum": ["molt"]}}}},
-            {"if": {"properties": {"object": {"const": "name"}}},
-             "then": {"properties": {"action": {"enum": ["set", "nickname"]}}}},
-        ],
     }
 
 

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -180,18 +180,26 @@ def test_psyche_molt_rejects_missing_summary(tmp_path):
 
 
 def test_eigen_schema_has_context_molt(tmp_path):
-    """Schema exposes context/molt/summary for agent-callable molt."""
+    """Schema exposes context/summary without strict-incompatible combinators."""
     from lingtai_kernel.intrinsics.psyche import get_schema
     s = get_schema("en")
     assert "context" in s["properties"]["object"]["enum"]
-    # action enum is per-object via allOf, not a flat enum
-    context_actions = next(
-        rule["then"]["properties"]["action"]["enum"]
-        for rule in s["allOf"]
-        if rule["if"]["properties"]["object"]["const"] == "context"
-    )
-    assert "molt" in context_actions
     assert "summary" in s["properties"]
+    assert {"object", "action"}.issubset(set(s["required"]))
+    for keyword in ("allOf", "oneOf", "anyOf", "not"):
+        assert keyword not in s
+
+
+def test_psyche_rejects_invalid_object_action_pair(tmp_path):
+    """Runtime validation still enforces per-object actions without schema allOf."""
+    agent = BaseAgent(
+        service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test",
+    )
+    result = agent._intrinsics["psyche"]({"object": "context", "action": "load"})
+    assert "error" in result
+    assert "Invalid action" in result["error"]
+    assert "molt" in result["error"]
+    agent.stop(timeout=1.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove the top-level `allOf`/`if`/`then` constraints from the `psyche` tool schema so strict-mode OpenAI-compatible providers do not reject tool registration
- keep per-object action validation in runtime `_VALID_ACTIONS` / `handle()`
- update the psyche anatomy citations and add regression coverage for strict-compatible schema plus runtime invalid-pair rejection

Fixes #113.

## Validation
- `python3 -m compileall -q src tests`
- `pytest tests/test_eigen.py -q`
- `PYTHONPATH=src python3 - <<'PY' ... get_schema('en') has no allOf/oneOf/anyOf/not ... PY`
- `git diff --check`
