### PR TITLE
fix(turn): route has_pending_tool_calls through ChatInterface

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -144,7 +144,7 @@ def _restore_tool_results_after_continuation_failure(
     if (
         not tool_results
         or agent._chat is None
-        or not agent._chat.has_pending_tool_calls()
+        or not agent._chat.interface.has_pending_tool_calls()
     ):
         return False
     agent._chat.commit_tool_results(tool_results)

--- a/tests/test_tool_result_restore_after_continuation_failure.py
+++ b/tests/test_tool_result_restore_after_continuation_failure.py
@@ -38,9 +38,6 @@ class _FakeChat:
         )
         self.committed: list[list[ToolResultBlock]] = []
 
-    def has_pending_tool_calls(self) -> bool:
-        return self.interface.has_pending_tool_calls()
-
     def commit_tool_results(self, results: list[ToolResultBlock]) -> None:
         self.committed.append(list(results))
         self.interface.add_tool_results(results)
@@ -72,7 +69,7 @@ def test_restores_real_tool_results_when_adapter_rolled_back_user_entry():
     )
 
     assert restored is True
-    assert not agent._chat.has_pending_tool_calls()
+    assert not agent._chat.interface.has_pending_tool_calls()
     assert agent._chat.committed == [[real_result]]
     assert agent.saved == 1
     assert agent.logs == [("tool_results_restored_after_continuation_failure", {"result_count": 1})]
@@ -112,7 +109,7 @@ def test_restoration_skips_empty_results():
     )
 
     assert restored is False
-    assert agent._chat.has_pending_tool_calls()
+    assert agent._chat.interface.has_pending_tool_calls()
     assert agent.saved == 0
 
 
@@ -175,7 +172,7 @@ def test_process_response_restores_real_results_when_continuation_send_fails():
 
     assert agent._session.sent == [[real_result]]
     assert agent._chat.committed == [[real_result]]
-    assert not agent._chat.has_pending_tool_calls()
+    assert not agent._chat.interface.has_pending_tool_calls()
     assert agent._chat.interface.entries[-1].content == [real_result]
     assert not agent._chat.interface.entries[-1].content[0].synthesized
     assert agent.saved == 1


### PR DESCRIPTION
## Summary

- One-char typo fix at `turn.py:147` — `agent._chat.has_pending_tool_calls()` → `agent._chat.interface.has_pending_tool_calls()`. `has_pending_tool_calls` is defined on `ChatInterface`, not on `ChatSession`. Every other call site in the kernel already goes through `.interface`; this was the lone outlier.
- The existing regression test (`tests/test_tool_result_restore_after_continuation_failure.py`) masked the bug because `_FakeChat` defined its own `has_pending_tool_calls()` method — a fake that duplicated `ChatInterface`'s surface rather than `ChatSession`'s. Removed the fake method so the test matches the real `ChatSession` API. Verified the updated test now fails on the pre-fix code with `AttributeError: '_FakeChat' object has no attribute 'has_pending_tool_calls'`.

## Why this matters

In quiet operation the buggy line is unreachable. But when an upstream LLM call fails mid-tool-result-persist (socket reset, rate limit, or the Bug A failure mode in Lingtai-AI/lingtai#112), AED recovery hits this branch and trips an `AttributeError`. AED then spends its retry budget on bogus errors, ending in `STUCK` or `preset_auto_fallback` for the wrong reason.

## Credit

Reported by @JieKiYu in [Lingtai-AI/lingtai#112](https://github.com/Lingtai-AI/lingtai/issues/112) with a complete forensic trace identifying line 147 as the typo and the four other call sites that correctly use `.interface`.

## Test plan

- [x] `pytest tests/test_tool_result_restore_after_continuation_failure.py` — 4/4 pass
- [x] `pytest tests/test_chat_interface_invariant.py tests/test_aed_recovery.py tests/test_aed_tool_pairing.py tests/test_tool_result_restore_after_continuation_failure.py` — 40/40 pass
- [x] Verified pre-fix code fails the updated test with the expected `AttributeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)