### PR TITLE
fix(presets): inherit api_compat in expand_inherit

### DIFF
--- a/src/lingtai_kernel/presets.py
+++ b/src/lingtai_kernel/presets.py
@@ -447,8 +447,12 @@ def expand_inherit(capabilities: dict, main_llm: dict) -> dict:
 
     For each capability whose kwargs has `provider == "inherit"`, replace it
     with the main LLM's provider plus its credentials (api_key, api_key_env,
-    base_url). The `model` field is NOT inherited — capabilities pick their
-    own model independently.
+    base_url) and wire-protocol flag (api_compat). The `model` field is NOT
+    inherited — capabilities pick their own model independently.
+
+    api_compat must inherit too: capability fallbacks (e.g. vision) dispatch
+    between OpenAI / Anthropic / Gemini adapters based on it, and an inheriting
+    capability that drops api_compat silently routes through the wrong adapter.
 
     Mutates `capabilities` in place. Returns the same dict for convenience.
     """
@@ -461,4 +465,5 @@ def expand_inherit(capabilities: dict, main_llm: dict) -> dict:
         kwargs["api_key"]     = main_llm.get("api_key")
         kwargs["api_key_env"] = main_llm.get("api_key_env")
         kwargs["base_url"]    = main_llm.get("base_url")
+        kwargs["api_compat"]  = main_llm.get("api_compat")
     return capabilities

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -363,6 +363,24 @@ def test_expand_inherit_handles_missing_main_llm_creds():
     assert caps["web_search"].get("api_key_env") is None
 
 
+def test_expand_inherit_propagates_api_compat():
+    # Custom anthropic-compat proxy (e.g. local GLM-5.1 via JoyCodeProxy).
+    # Vision capability fallback dispatches on api_compat — if it isn't
+    # inherited, the capability silently routes through the OpenAI adapter
+    # and chokes on the response shape.
+    main_llm = {
+        "provider": "custom",
+        "api_compat": "anthropic",
+        "model": "GLM-5.1",
+        "api_key_env": "CUSTOM_6_API_KEY",
+        "base_url": "http://127.0.0.1:34891",
+    }
+    caps = {"vision": {"provider": "inherit"}}
+    expand_inherit(caps, main_llm)
+    assert caps["vision"]["api_compat"] == "anthropic"
+    assert caps["vision"]["base_url"] == "http://127.0.0.1:34891"
+
+
 # ---------------------------------------------------------------------------
 # resolve_preset_name
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `expand_inherit` resolves `{"provider": "inherit"}` capability configs by copying main_llm's `provider`, `api_key`, `api_key_env`, `base_url`. It did **not** copy `api_compat`. For built-in providers this is harmless (their adapters hardcode their wire protocol), but for `provider: "custom"` with `api_compat: "anthropic"` (e.g. a local GLM proxy speaking the Anthropic Messages API), an inheriting capability silently routes through the OpenAI adapter and explodes on response shape.
- One-line fix: add `kwargs["api_compat"] = main_llm.get("api_compat")` to the inherited fields. Updated docstring to flag the dispatch dependency. Added regression test.

## Credit

Reported by @JieKiYu in [Lingtai-AI/lingtai#114](https://github.com/Lingtai-AI/lingtai/issues/114) as a sibling bug to the vision capability misrouting investigation (Bugs C-1/C-2/C-3 + the broader vision fallback rework).

## Test plan

- [x] `pytest tests/test_presets.py -k expand_inherit` — 5/5 pass (4 existing + 1 new)
- [x] `pytest tests/test_presets.py tests/test_agent_preset_manifest.py tests/test_agent_capabilities.py tests/test_daemon_preset_capabilities.py tests/test_avatar_preset_inheritance.py` — 110/110 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)