### PR TITLE
fix(llm): propagate api_compat from manifest.llm to provider_defaults

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -14,7 +14,7 @@ from typing import Any
 from pathlib import Path
 
 from lingtai_kernel.base_agent import BaseAgent
-from lingtai.llm.service import LLMService
+from lingtai.llm.service import LLMService, build_provider_defaults_from_manifest_llm
 from lingtai_kernel.prompt import build_system_prompt
 
 
@@ -1039,24 +1039,19 @@ class Agent(BaseAgent):
         # init.json predates this field cooperatively share the network-wide
         # 60 RPM cap by default. Set to 0 in init.json to disable gating.
         new_max_rpm = m.get("max_rpm", 60)
-        new_provider_key = new_provider.lower()
-        new_per_provider: dict = {}
-        if new_max_rpm > 0:
-            new_per_provider["max_rpm"] = new_max_rpm
-        new_user_headers = llm.get("default_headers")
-        if isinstance(new_user_headers, dict) and new_user_headers:
-            new_per_provider["default_headers"] = dict(new_user_headers)
-        new_provider_defaults: dict | None = (
-            {new_provider_key: new_per_provider} if new_per_provider else None
+        new_provider_defaults = build_provider_defaults_from_manifest_llm(
+            llm, max_rpm=new_max_rpm
         )
 
+        cur_provider_defaults_bucket = getattr(
+            self.service, "_provider_defaults", {}
+        ).get(new_provider.lower(), {})
         if (
             new_provider != self.service.provider
             or new_model != self.service.model
             or new_base_url != getattr(self.service, "_base_url", None)
-            or new_max_rpm != getattr(self.service, "_provider_defaults", {}).get(
-                new_provider.lower(), {}
-            ).get("max_rpm", 0)
+            or new_max_rpm != cur_provider_defaults_bucket.get("max_rpm", 0)
+            or llm.get("api_compat") != cur_provider_defaults_bucket.get("api_compat")
         ):
             self.service = LLMService(
                 provider=new_provider, model=new_model,

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -13,7 +13,7 @@ from lingtai.config_resolve import (
     load_env_file,
 )
 from lingtai.init_schema import validate_init
-from lingtai.llm.service import LLMService
+from lingtai.llm.service import LLMService, build_provider_defaults_from_manifest_llm
 from lingtai.agent import Agent
 from lingtai_kernel.services.mail import FilesystemMailService
 
@@ -90,18 +90,9 @@ def build_agent(data: dict, working_dir: Path) -> Agent:
     # predates this field cooperatively share the network-wide 60 RPM cap
     # by default. Set to 0 in init.json to disable gating.
     max_rpm = m.get("max_rpm", 60)
-    provider_key = llm["provider"].lower()
-    per_provider: dict = {}
-    if max_rpm > 0:
-        per_provider["max_rpm"] = max_rpm
-    user_headers = llm.get("default_headers")
-    if isinstance(user_headers, dict) and user_headers:
-        # Pass-through; LLMService._default_headers_for honors caller-supplied
-        # headers and fills only the gaps with provider policy.
-        per_provider["default_headers"] = dict(user_headers)
-    # provider_defaults is dict[provider_name, defaults_dict]; scope to
-    # the agent's configured provider so other providers stay unaffected.
-    provider_defaults: dict | None = {provider_key: per_provider} if per_provider else None
+    provider_defaults = build_provider_defaults_from_manifest_llm(
+        llm, max_rpm=max_rpm
+    )
     service = LLMService(
         provider=llm["provider"],
         model=llm["model"],

--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -35,7 +35,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 
 - **Class-level** — `LLMService._adapter_registry` (shared across all instances); `LLMAdapter._gate` (per-adapter instance).
 - **Instance-level** — `LLMService._adapters` cache; `LLMService._sessions` registry; `APICallGate._timestamps` deque for RPM window.
-- **Provider defaults** — `LLMService._provider_defaults` dict injected at construction (`service.py:96`). Drives model, base_url, max_rpm, api_compat settings.
+- **Provider defaults** — `LLMService._provider_defaults` dict injected at construction (`service.py:96`). Drives model, base_url, max_rpm, api_compat settings. Build it from `manifest.llm` via `build_provider_defaults_from_manifest_llm()` (`service.py:50`) — opt-in safelist (`_PROVIDER_DEFAULTS_PASS_THROUGH_KEYS`) ensures fields adapter factories consult (notably `api_compat` for the custom-provider dispatch) are propagated. Both `cli.py:_load_init` and `agent.py:_setup_from_init` use this helper to stay in sync.
 - **Key resolution** — `LLMService._key_resolver` callable (`service.py:94`); defaults to `os.environ.get(f"{PROVIDER}_API_KEY")`.
 
 ## Notes

--- a/src/lingtai/llm/service.py
+++ b/src/lingtai/llm/service.py
@@ -48,6 +48,48 @@ def _generate_tool_call_id() -> str:
     return f"tc_{int(time.time())}_{uuid.uuid4().hex[:4]}"
 
 
+# Fields from manifest.llm that adapter factories may consult via
+# LLMService._provider_defaults. Keep this list opt-in (rather than
+# splatting the whole manifest.llm dict) so the surface area between
+# init.json and adapter construction stays auditable.
+#
+# api_compat in particular MUST propagate: the custom-provider factory
+# (lingtai/llm/_register.py:_custom) dispatches between OpenAI/Anthropic/
+# Gemini wire protocols based on it. Dropping it silently routes
+# api_compat="anthropic" custom providers (e.g. local GLM proxies) to
+# OpenAIAdapter, which then explodes on raw.choices access. See
+# Lingtai-AI/lingtai#112 for the full failure trace.
+_PROVIDER_DEFAULTS_PASS_THROUGH_KEYS = ("api_compat",)
+
+
+def build_provider_defaults_from_manifest_llm(
+    llm: dict,
+    *,
+    max_rpm: int,
+) -> dict | None:
+    """Convert a manifest.llm block into LLMService.provider_defaults.
+
+    Returns ``{provider_name: defaults_dict}`` (scoped to the agent's
+    configured provider so other providers stay unaffected), or ``None``
+    when no fields are set — preserving the historical behavior where
+    callers passed ``provider_defaults=None`` for the unconfigured case.
+    """
+    provider_key = llm["provider"].lower()
+    per_provider: dict = {}
+    if max_rpm > 0:
+        per_provider["max_rpm"] = max_rpm
+    user_headers = llm.get("default_headers")
+    if isinstance(user_headers, dict) and user_headers:
+        # Pass-through; LLMService._default_headers_for honors caller-supplied
+        # headers and fills only the gaps with provider policy.
+        per_provider["default_headers"] = dict(user_headers)
+    for key in _PROVIDER_DEFAULTS_PASS_THROUGH_KEYS:
+        value = llm.get(key)
+        if value is not None:
+            per_provider[key] = value
+    return {provider_key: per_provider} if per_provider else None
+
+
 class LLMService(LLMServiceABC):
     """Concrete LLM service — adapter registry, session management, generation.
 

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -41,3 +41,65 @@ def test_no_get_context_limit():
     assert not hasattr(mod, "get_context_limit")
     assert not hasattr(mod, "CONTEXT_WINDOWS")
     assert not hasattr(mod, "DEFAULT_CONTEXT_WINDOW")
+
+
+# ---------------------------------------------------------------------------
+# build_provider_defaults_from_manifest_llm
+#
+# Regression: Lingtai-AI/lingtai#112 Bug A — cli.py and agent.py constructed
+# `per_provider` inline and silently dropped `api_compat`, causing custom
+# anthropic-compat proxies to be routed through OpenAIAdapter and crash on
+# raw.choices access. The helper exists so the two call sites stay in sync.
+# ---------------------------------------------------------------------------
+
+from lingtai.llm.service import build_provider_defaults_from_manifest_llm
+
+
+def test_build_provider_defaults_propagates_api_compat():
+    """The whole point: api_compat from manifest.llm reaches the bucket."""
+    out = build_provider_defaults_from_manifest_llm(
+        {"provider": "custom", "api_compat": "anthropic", "model": "GLM-5.1"},
+        max_rpm=60,
+    )
+    assert out == {"custom": {"max_rpm": 60, "api_compat": "anthropic"}}
+
+
+def test_build_provider_defaults_returns_none_when_nothing_set():
+    """Preserve historical: empty defaults pass through as None, not {}."""
+    out = build_provider_defaults_from_manifest_llm(
+        {"provider": "openai", "model": "gpt-5"},
+        max_rpm=0,
+    )
+    assert out is None
+
+
+def test_build_provider_defaults_includes_default_headers():
+    out = build_provider_defaults_from_manifest_llm(
+        {
+            "provider": "openai",
+            "model": "gpt-5",
+            "default_headers": {"X-Foo": "bar"},
+        },
+        max_rpm=60,
+    )
+    assert out == {
+        "openai": {"max_rpm": 60, "default_headers": {"X-Foo": "bar"}},
+    }
+
+
+def test_build_provider_defaults_lowercases_provider_key():
+    """Bucket key must match the lowercased lookup used by the adapter factory."""
+    out = build_provider_defaults_from_manifest_llm(
+        {"provider": "Custom", "api_compat": "anthropic", "model": "GLM-5.1"},
+        max_rpm=0,
+    )
+    assert out == {"custom": {"api_compat": "anthropic"}}
+
+
+def test_build_provider_defaults_skips_none_api_compat():
+    """Don't pollute the bucket with explicit Nones."""
+    out = build_provider_defaults_from_manifest_llm(
+        {"provider": "openai", "model": "gpt-5", "api_compat": None},
+        max_rpm=60,
+    )
+    assert out == {"openai": {"max_rpm": 60}}


### PR DESCRIPTION
## Summary

Fixes the root cause of @JieKiYu's "preset swap silently reverts" report ([Lingtai-AI/lingtai#112](https://github.com/Lingtai-AI/lingtai/issues/112) Bug A).

The two bridges between init.json's `manifest.llm` and the `LLMService` constructor — `cli.py:_load_init` and `agent.py:_setup_from_init` — each built a `per_provider` dict inline, copying `max_rpm` and `default_headers` but silently dropping `api_compat`. For built-in providers this is harmless (their adapter factories hardcode the wire protocol), but for `provider="custom"` with `api_compat="anthropic"` (e.g. a local GLM proxy speaking the Anthropic Messages API), the custom-provider factory falls back to `"openai"` and the OpenAI adapter crashes on the Anthropic-shaped response with `'str' object has no attribute 'choices'`. AED retries three times, `preset_auto_fallback` reverts the preset — making the swap look like it didn't stick.

## Changes

- **Extract `build_provider_defaults_from_manifest_llm` helper** in `lingtai/llm/service.py` with an explicit safelist (`_PROVIDER_DEFAULTS_PASS_THROUGH_KEYS`) of `manifest.llm` keys that flow through to `provider_defaults`. `api_compat` is the only current member; future pass-through fields go in one place rather than two.
- **Rewire `cli.py` and `agent.py`** to use the helper. The two sites had drifted out of sync historically per JieKiYu's report; centralizing prevents future drift.
- **Extend `agent.py`'s "did anything change?" check** to include `api_compat`. A preset that only changes `api_compat` (same provider/model/base_url) would otherwise silently skip the `LLMService` rebuild and keep the wrong adapter cached.
- Update `lingtai/llm/ANATOMY.md` to document the helper as the canonical bridge.

## Credit

Reported by @JieKiYu in [Lingtai-AI/lingtai#112](https://github.com/Lingtai-AI/lingtai/issues/112) with a complete forensic trace including event-log excerpts, root-cause walk, and a validated patch. This PR also addresses the report's suggested follow-up #1 (extract shared helper) and #3 (opt-in safelist for manifest.llm → provider_defaults).

## Companion PRs

- #115 — turn.py:147 `.interface` typo (Bug B)
- #116 — `expand_inherit` propagates `api_compat` (lingtai#114 sibling)

## Test plan

- [x] `pytest tests/test_llm_service.py` — 10/10 pass (5 existing + 5 new for the helper)
- [x] `pytest tests/test_cli.py tests/test_cli_integration.py tests/test_agent.py tests/test_activate_preset.py tests/test_agent_preset_manifest.py tests/test_deep_refresh.py tests/test_presets.py` — 172/172 pass, stable across 3 runs
- [x] Verified `tests/test_molt_notification_persistence.py` flakiness reproduces on `origin/main` (independent issue, not caused by this PR)
- [x] Helper functional check: `api_compat` propagates, lowercase normalization preserved, `None` returned when no fields set, explicit `None` values skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)