### PR TITLE
fix(vision): drop inherited api_compat before service setup

### DIFF
--- a/src/lingtai/capabilities/vision/__init__.py
+++ b/src/lingtai/capabilities/vision/__init__.py
@@ -139,6 +139,11 @@ def setup(
             if provider == "zhipu" and "z_ai_mode" not in kwargs:
                 from .._zhipu_mode import resolve_z_ai_mode
                 kwargs["z_ai_mode"] = resolve_z_ai_mode(agent)
+            # Dedicated vision services do not consume the LLM adapter's
+            # transport selector. ``expand_inherit`` copies it for capability
+            # routing, but forwarding it into service constructors breaks
+            # providers such as MiniMax that only accept provider-native args.
+            kwargs.pop("api_compat", None)
             kwargs.pop("base_url", None)
             vision_service = create_vision_service(provider, api_key=api_key, **kwargs)
     elif vision_service is None:

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -239,3 +239,33 @@ def test_vision_setup_no_provider_raises(tmp_path):
     agent = make_mock_agent(tmp_path)
     with pytest.raises(ValueError, match="vision capability requires"):
         setup(agent)
+
+
+def test_minimax_vision_setup_filters_inherited_api_compat(tmp_path):
+    """MiniMax vision should ignore LLM transport kwargs inherited from presets.
+
+    Regression: presets.expand_inherit copies api_compat from the main LLM into
+    `vision: {provider: inherit}`. MiniMaxVisionService accepts api_host, not
+    api_compat, so setup must filter provider-specific kwargs before factory
+    construction.
+    """
+    with patch("lingtai.capabilities.vision.create_vision_service") as mock_factory:
+        mock_svc = MagicMock(spec=VisionService)
+        mock_factory.return_value = mock_svc
+
+        agent = make_mock_agent(tmp_path)
+        agent.service._base_url = "https://api.minimaxi.com/anthropic"
+        mgr = setup(
+            agent,
+            provider="minimax",
+            api_key="sk-test",
+            api_compat="anthropic",
+            base_url="https://api.minimaxi.com/anthropic",
+        )
+
+        mock_factory.assert_called_once_with(
+            "minimax",
+            api_key="sk-test",
+            api_host="https://api.minimaxi.com",
+        )
+        assert isinstance(mgr, VisionManager)


### PR DESCRIPTION
## Summary
- drop inherited `api_compat` before constructing dedicated vision services
- keep the existing `base_url` drop behavior for dedicated providers
- add a regression test for MiniMax inherited vision with `api_compat` present

## Why
`presets.expand_inherit()` copies the main LLM's `api_compat` into inherited capabilities. For MiniMax, `vision: {provider: inherit}` resolved to `provider=minimax` plus `api_compat=anthropic`, then vision setup forwarded that transport selector into `MiniMaxVisionService`, whose constructor only accepts `api_key` and `api_host`.

This PR keeps the fix narrow: `api_compat` is only needed for capability/provider routing and OpenAI-compatible fallback decisions; once a dedicated vision provider has been selected, it should not be passed into the provider-native service constructor.

## Tests
- `uv run --with pytest pytest tests/test_vision_capability.py tests/test_inherit_fallback.py tests/test_presets.py::test_expand_inherit_resolves_to_main_llm tests/test_preset_swap_e2e.py::test_e2e_inherit_resolves_after_swap -q`
