### PR TITLE
fix(turn): dedup warning crashes continuation when tool result is dict

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -744,13 +744,23 @@ def _check_external_send(agent, tool_calls, tool_results=None) -> None:
                         recipient=recipient,
                     )
                     if tool_results:
+                        warning = (
+                            "Recently sent similar message to this recipient."
+                            " Skipping duplicate."
+                        )
                         for tr in tool_results:
                             if tr.id == tc.id:
-                                tr.content = (
-                                    (tr.content or "")
-                                    + "\n⚠️ Recently sent similar message"
-                                    " to this recipient. Skipping duplicate."
-                                )
+                                if isinstance(tr.content, dict):
+                                    # ToolResultBlock.content is Any (str or dict);
+                                    # dict + str raises TypeError. Attach as a
+                                    # structured field instead — adapters render
+                                    # the whole dict to the LLM as JSON.
+                                    tr.content["_duplicate_warning"] = warning
+                                else:
+                                    tr.content = (
+                                        (tr.content or "")
+                                        + f"\n⚠️ {warning}"
+                                    )
                                 break
                     continue
                 tracker.record_sent(content, recipient, tc.name)

--- a/tests/test_sent_message_tracker.py
+++ b/tests/test_sent_message_tracker.py
@@ -238,6 +238,45 @@ class TestCheckExternalSend:
         # Only the first send was recorded (dedup skips recording)
         assert len(agent._sent_tracker._entries) == 1
 
+    def test_dedup_warns_when_tool_result_content_is_dict(self):
+        """Regression for lingtai#117: dict content must not raise TypeError.
+
+        ToolResultBlock.content is Any (str or dict). The dedup-warning
+        path previously did `(content or "") + "..."` which crashed with
+        `unsupported operand type(s) for +: 'dict' and 'str'` whenever an
+        MCP tool (e.g. telegram) returned a structured result and the
+        send happened to match a recent one.
+        """
+        from lingtai_kernel.base_agent.turn import _check_external_send
+        agent = self._make_agent()
+        tc1 = self._make_tc("telegram", {
+            "action": "send",
+            "message": "hello human",
+            "chat_id": "12345",
+        })
+        _check_external_send(agent, [tc1])
+
+        tc2 = self._make_tc("telegram", {
+            "action": "send",
+            "message": "hello human",
+            "chat_id": "12345",
+        })
+        tc2.id = "call_dedup_dict"
+
+        tr = MagicMock()
+        tr.id = "call_dedup_dict"
+        tr.content = {"status": "sent", "message_id": "tg:1:42"}
+        tool_results = [tr]
+
+        _check_external_send(agent, [tc2], tool_results)
+        assert isinstance(tr.content, dict)
+        assert tr.content.get("_duplicate_warning", "").startswith(
+            "Recently sent similar message"
+        )
+        # Original fields preserved
+        assert tr.content["status"] == "sent"
+        assert tr.content["message_id"] == "tg:1:42"
+
     def test_dedup_without_tool_results(self):
         """Dedup still skips recording when tool_results not passed."""
         from lingtai_kernel.base_agent.turn import _check_external_send


### PR DESCRIPTION
## Summary
- Fixes `Lingtai-AI/lingtai#117` — `telegram(send)` (and any MCP send returning a dict) crashes LLM continuation with `TypeError: unsupported operand type(s) for +: 'dict' and 'str'` whenever the kernel's send-dedup path triggers.
- Root cause: `_check_external_send` in `base_agent/turn.py` appends a warning by string concatenation, but `ToolResultBlock.content` is `Any (str or dict)`.
- Fix: branch on `isinstance(tr.content, dict)`; attach a structured `_duplicate_warning` field for dict content (same convention used for blocked-duplicate results in `tool_executor.py`), keep the legible `\n⚠️` prefix for string content.

## Test plan
- [x] New regression test `test_dedup_warns_when_tool_result_content_is_dict` reproduces the crash on `main` and passes on this branch
- [x] Existing string-content dedup test (`test_dedup_warns_via_tool_result`) still passes
- [x] `tests/test_sent_message_tracker.py` — 35/35 pass
- [x] Full suite — 1040 pass (the single failure `tests/test_pad.py::test_psyche_in_all_intrinsics` reproduces on `main` and is unrelated, a follow-on from #114's allOf removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)