### PR TITLE
test(psyche): align schema tests with flat schema (no allOf)

### DIFF
--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -31,20 +31,14 @@ def test_psyche_in_all_intrinsics():
     info = ALL_INTRINSICS["psyche"]
     mod = info["module"]
     schema = mod.get_schema()
-    # Schema uses allOf per-object action constraints, not a flat action.enum.
-    pad_actions = next(
-        rule["then"]["properties"]["action"]["enum"]
-        for rule in schema["allOf"]
-        if rule["if"]["properties"]["object"]["const"] == "pad"
-    )
-    context_actions = next(
-        rule["then"]["properties"]["action"]["enum"]
-        for rule in schema["allOf"]
-        if rule["if"]["properties"]["object"]["const"] == "context"
-    )
-    assert "edit" in pad_actions
-    assert "load" in pad_actions
-    assert "molt" in context_actions
+    # Schema is intentionally flat (no allOf) for strict-mode provider
+    # compatibility — see #114. Per-(object, action) constraints live in
+    # the runtime _VALID_ACTIONS table instead.
+    assert "allOf" not in schema
+    assert schema["properties"]["object"]["enum"] == ["pad", "context", "name", "lingtai"]
+    valid = mod._VALID_ACTIONS
+    assert {"edit", "load"} <= valid["pad"]
+    assert "molt" in valid["context"]
 
 
 def test_psyche_wired_in_agent(tmp_path):

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -309,15 +309,14 @@ def test_psyche_schema_has_correct_objects():
 
 
 def test_psyche_schema_has_correct_actions():
-    from lingtai_kernel.intrinsics.psyche import get_schema
+    # Schema is intentionally flat (no allOf) for strict-mode provider
+    # compatibility — see #114. Per-(object, action) constraints live in
+    # the runtime _VALID_ACTIONS table.
+    from lingtai_kernel.intrinsics.psyche import _VALID_ACTIONS, get_schema
     SCHEMA = get_schema("en")
     assert "enum" not in SCHEMA["properties"]["action"]
-    action_sets = {}
-    for rule in SCHEMA["allOf"]:
-        obj = rule["if"]["properties"]["object"]["const"]
-        acts = set(rule["then"]["properties"]["action"]["enum"])
-        action_sets[obj] = acts
-    assert action_sets == {
+    assert "allOf" not in SCHEMA
+    assert _VALID_ACTIONS == {
         "lingtai": {"update", "load"},
         "pad": {"edit", "load", "append"},
         "context": {"molt"},


### PR DESCRIPTION
## Summary
- Two psyche schema tests still indexed into `SCHEMA[\"allOf\"]` and failed with `KeyError: 'allOf'` after PR #114 flattened the schema (the `allOf` combinator was removed for strict-mode provider compatibility — action constraints moved to the runtime `_VALID_ACTIONS` table).
- Rewrite `tests/test_pad.py::test_psyche_in_all_intrinsics` and `tests/test_psyche.py::test_psyche_schema_has_correct_actions` to assert the new shape: `allOf` absent, `_VALID_ACTIONS` as the source of truth.

## Test plan
- [x] `tests/test_pad.py` — 13/13 pass (was 1 failing)
- [x] `tests/test_psyche.py` — pass (was 1 failing)
- [x] Failures reproduce on `main` and disappear on this branch

Three pre-existing soul-test failures (`test_consultation_fire_discards_late_result_after_state_change`, `TestRehydrateAppendixTracking`) are unrelated to this PR — they reproduce on `main` and involve `_soul_whisper` / `_start_soul_timer` plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)