### PR TITLE
fix(email): clarify stale ID semantics in notification digest

### DIFF
--- a/src/lingtai_kernel/base_agent/messaging.py
+++ b/src/lingtai_kernel/base_agent/messaging.py
@@ -87,7 +87,14 @@ def _rerender_unread_digest(agent) -> str | None:
             "the IDs you have handled. Both 'read' and 'dismiss' accept "
             "a list, so process multiple mails in one call. Until you "
             "read or dismiss a mail, this notification will keep "
-            "reminding you about it."
+            "reminding you about it. "
+            "Note: this digest is a live mirror of current unread mail, "
+            "not a fixed arrival log. IDs can become stale if you "
+            "already read, dismissed, or archived a message through "
+            "another path (e.g. email.check → email.read). If read or "
+            "dismiss returns 'not_found', the mail was likely already "
+            "handled — call email(action=\"check\", unread_only=true) "
+            "to see what is still pending."
         ),
         data={
             "count": count,

--- a/src/lingtai_kernel/intrinsics/email/manager.py
+++ b/src/lingtai_kernel/intrinsics/email/manager.py
@@ -809,6 +809,11 @@ class EmailManager:
         result = {"status": "ok", "emails": results}
         if errors:
             result["not_found"] = errors
+            result["hint"] = ("not_found IDs were likely already read, dismissed, "
+                              "or archived via another path — this is normal when "
+                              "using stale digest IDs. Call "
+                              "email(action=\"check\", unread_only=true) to see "
+                              "current pending mail.")
 
         return result
 
@@ -847,6 +852,11 @@ class EmailManager:
         result: dict = {"status": "ok", "dismissed": dismissed}
         if not_found:
             result["not_found"] = not_found
+            result["hint"] = ("not_found IDs were likely already read, dismissed, "
+                              "or archived via another path — this is normal when "
+                              "using stale digest IDs. Call "
+                              "email(action=\"check\", unread_only=true) to see "
+                              "current pending mail.")
         return result
 
     def _lookup(self, email_id: str) -> dict | None:
@@ -991,6 +1001,9 @@ class EmailManager:
         result: dict = {"status": "ok", "archived": archived}
         if not_found:
             result["not_found"] = not_found
+            result["hint"] = ("not_found IDs were likely already read, dismissed, "
+                              "or archived via another path — this is normal when "
+                              "using stale digest IDs.")
         return result
 
     def _delete(self, args: dict) -> dict:
@@ -1029,6 +1042,9 @@ class EmailManager:
         result: dict = {"status": "ok", "deleted": deleted}
         if not_found:
             result["not_found"] = not_found
+            result["hint"] = ("not_found IDs were likely already read, dismissed, "
+                              "or deleted via another path — this is normal when "
+                              "using stale digest IDs.")
         return result
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Closes #84

## Summary
Email notification digest IDs can become stale when mail is already handled via another path (e.g. email.check → email.read). The old notification instructions didn't explain this, making normal race conditions look like failures.

## Changes
1. **Notification instructions** (messaging.py): Added paragraph explaining that digest is a live mirror of current unread mail, not a fixed arrival log. IDs can become stale. Recommends `email(action="check", unread_only=true)` to verify.

2. **Friendly hints** (manager.py): Added `hint` field to `not_found` responses in read, dismiss, archive, and delete actions. Explains that stale IDs are normal and suggests checking current pending mail.

## Testing
- All 16 email tests pass
- All 1677 kernel tests pass