### PR TITLE
fix(poll-backoff): detect found-new across all SEND_TOOLS schemas

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -4,6 +4,7 @@ The core message lifecycle: receive → route → LLM → process → persist.
 """
 from __future__ import annotations
 
+import json
 import queue
 import time
 
@@ -804,24 +805,26 @@ def _check_poll_backoff(agent, tool_calls, tool_results=None) -> bool:
             continue
         if action not in CHECK_ACTIONS:
             continue
-        # Check if this read/check actually returned messages.
+        # Check if this read/check actually returned items. Different
+        # providers use different keys: imap→"emails", telegram/wechat→
+        # "messages", feishu→"conversations" (check) or "messages" (read).
         found_new = False
         tr = result_by_tc_id.get(tc.id)
         if tr:
             content = getattr(tr, "content", None)
+            payload = None
             if isinstance(content, dict):
-                messages = content.get("messages")
-                if messages:
-                    found_new = True
-            # Also check for stringified JSON content.
-            elif isinstance(content, str) and '"messages"' in content:
+                payload = content
+            elif isinstance(content, str):
                 try:
-                    import json
-                    parsed = json.loads(content)
-                    if parsed.get("messages"):
-                        found_new = True
+                    payload = json.loads(content)
                 except (json.JSONDecodeError, TypeError):
-                    pass
+                    payload = None
+            if isinstance(payload, dict):
+                for key in ("messages", "emails", "conversations"):
+                    if payload.get(key):
+                        found_new = True
+                        break
         # Record the poll attempt with found_new status.
         tracker.record_poll(tc.name, found_new=found_new)
         if tracker.should_stop_polling(tc.name):


### PR DESCRIPTION
## Summary

Followup to dace352 (which only partially fixed the notification-woken-reads-as-empty-polls bug).

dace352 inspected tool results for a `"messages"` key to set `found_new=True`. This works for telegram and wechat, but misses:

- **imap** — returns `"emails"` (see `lingtai-imap/src/lingtai_imap/manager.py:459`)
- **feishu check** — returns `"conversations"` (see `lingtai-feishu/src/lingtai_feishu/manager.py:835`)

Net effect: an agent woken by a Gmail/IMAP notification, calling `imap(read)` to fetch the message, still increments the empty-poll counter. If 2 prior empty polls had happened, the third (notification-driven read) trips `idle_after_poll_backoff` and the agent commits tool results and idles **before composing a reply**.

This PR generalizes `_check_poll_backoff` to detect any of `{messages, emails, conversations}` in the result payload, and hoists `import json` to module scope.

## Test plan
- [x] `tests/test_sent_message_tracker.py` — 35 pass
- [x] Broader `-k "poll or turn or backoff"` suite — 143 pass
- [ ] Manual: send a Gmail to an agent with prior empty polls, confirm it now composes a reply