### PR TITLE
Fix #126: IMAP check/read tool result orphaning

### DIFF
--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -1070,9 +1070,20 @@ class BaseAgent:
         # If the wire has unanswered tool_calls, appending a user-role
         # result entry would violate the alternation invariant.  Defer.
         if iface.has_pending_tool_calls():
+            # Issue #126 diagnostic: log the tail shape so we can trace
+            # why tool results were not detected as committed.
+            tail_info = ""
+            if iface._entries:
+                last = iface._entries[-1]
+                tail_info = f" tail_role={last.role} tail_blocks={len(last.content)}"
+                if last.role == "assistant":
+                    tc_ids = [b.id[:20] for b in last.content
+                              if hasattr(b, 'id') and hasattr(b, 'name')]
+                    tail_info += f" tc_ids={tc_ids}"
             self._log("notification_inject_aborted",
                       reason="pending_tool_calls",
-                      sources=list(notifications.keys()))
+                      sources=list(notifications.keys()),
+                      _tail=tail_info)
             return False
 
         call_id = f"notif_{int(time.time()*1000):x}_{secrets.token_hex(2)}"

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -969,6 +969,12 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
         if _check_poll_backoff(agent, response.tool_calls, tool_results):
             if tool_results and agent._chat:
                 agent._chat.commit_tool_results(tool_results)
+                # Issue #126: save immediately so the in-memory and on-disk
+                # interface agree that tool results are committed. Without
+                # this, a notification heartbeat tick between the return
+                # and the post-turn save in _run_loop can see a stale wire
+                # and heal the (already-committed) tool calls.
+                agent._save_chat_history(ledger_source=ledger_source)
             agent._log("idle_after_poll_backoff",
                        reason="poll_retries_exhausted")
             return {

--- a/src/lingtai_kernel/llm/interface.py
+++ b/src/lingtai_kernel/llm/interface.py
@@ -60,7 +60,10 @@ class ToolResultBlock:
     synthesized: bool = False
 
     def to_dict(self) -> dict:
-        return {"type": "tool_result", "id": self.id, "name": self.name, "content": self.content}
+        d: dict = {"type": "tool_result", "id": self.id, "name": self.name, "content": self.content}
+        if self.synthesized:
+            d["synthesized"] = True
+        return d
 
 
 def _tool_call_context(tool_call: "ToolCallBlock | None") -> str:
@@ -178,7 +181,12 @@ def content_block_from_dict(d: dict) -> ContentBlock:
     elif btype == "tool_call":
         return ToolCallBlock(id=d["id"], name=d["name"], args=d["args"])
     elif btype == "tool_result":
-        return ToolResultBlock(id=d["id"], name=d["name"], content=d["content"])
+        return ToolResultBlock(
+            id=d["id"],
+            name=d["name"],
+            content=d["content"],
+            synthesized=d.get("synthesized", False),
+        )
     elif btype == "thinking":
         return ThinkingBlock(text=d["text"], provider_data=d.get("provider_data", {}))
     else:


### PR DESCRIPTION
## Summary

Fixes #126 where IMAP `check`/`read` tool results were orphaned (replaced by `heal:idle_inject_blocked` placeholders) during live email workflows.

## Root Cause

After `poll_backoff` commits tool results via `commit_tool_results()` and the agent goes IDLE, a later notification heartbeat tick still saw `has_pending_tool_calls()` returning True. This triggered `_heal_pending_tool_calls()` which replaced the real results with synthesized abort placeholders — the agent then received "[kernel notice — tool call did not complete]" instead of the actual IMAP data.

The investigation identified two contributing bugs:

1. **Missing `synthesized` flag serialization**: `ToolResultBlock.to_dict()` did not include the `synthesized` field, so it was lost on save/reload. This caused `add_tool_results()` to create duplicate entries instead of replacing synthesized placeholders in-place.

2. **Unsaved state window in poll_backoff path**: `commit_tool_results()` updated the in-memory interface but the save happened later in `_run_loop`. A heartbeat notification sync between the return and the save could see stale wire state.

## Changes

1. **`interface.py`**: Serialize `synthesized` flag in `ToolResultBlock.to_dict()` (only when True, to minimize noise) and restore it in `content_block_from_dict()`.

2. **`turn.py`**: Add `_save_chat_history()` call immediately after `commit_tool_results()` in the poll_backoff path, closing the window where in-memory and on-disk state could diverge.

3. **`__init__.py`**: Add diagnostic logging to `notification_inject_aborted` that captures the interface tail shape (role, block count, tool_call IDs) so the exact wire state can be traced if the issue recurs.

## Testing

- 285 existing tests pass (1 pre-existing failure unrelated to this change — `test_daemon_check_returns_error` fails due to temp file cleanup issue).
- Manual verification: `add_tool_results` correctly replaces synthesized placeholders when the flag survives serialization roundtrip.
- The diagnostic logging will capture the exact tail state if the issue recurs in production.

## Linked Issue

Closes #126