### PR TITLE
fix(#126): serialize synthesized flag, save after poll_backoff, add diagnostic logging

### DIFF
--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -1070,9 +1070,20 @@ class BaseAgent:
         # If the wire has unanswered tool_calls, appending a user-role
         # result entry would violate the alternation invariant.  Defer.
         if iface.has_pending_tool_calls():
+            # Issue #126 diagnostic: log the tail shape so we can trace
+            # why tool results were not detected as committed.
+            tail_info = ""
+            if iface._entries:
+                last = iface._entries[-1]
+                tail_info = f" tail_role={last.role} tail_blocks={len(last.content)}"
+                if last.role == "assistant":
+                    tc_ids = [b.id[:20] for b in last.content
+                              if hasattr(b, 'id') and hasattr(b, 'name')]
+                    tail_info += f" tc_ids={tc_ids}"
             self._log("notification_inject_aborted",
                       reason="pending_tool_calls",
-                      sources=list(notifications.keys()))
+                      sources=list(notifications.keys()),
+                      _tail=tail_info)
             return False
 
         call_id = f"notif_{int(time.time()*1000):x}_{secrets.token_hex(2)}"

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -972,6 +972,12 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
         if _check_poll_backoff(agent, response.tool_calls, tool_results):
             if tool_results and agent._chat:
                 agent._chat.commit_tool_results(tool_results)
+                # Issue #126: save immediately so the in-memory and on-disk
+                # interface agree that tool results are committed. Without
+                # this, a notification heartbeat tick between the return
+                # and the post-turn save in _run_loop can see a stale wire
+                # and heal the (already-committed) tool calls.
+                agent._save_chat_history(ledger_source=ledger_source)
             agent._log("idle_after_poll_backoff",
                        reason="poll_retries_exhausted")
             return {

--- a/src/lingtai_kernel/llm/interface.py
+++ b/src/lingtai_kernel/llm/interface.py
@@ -60,7 +60,10 @@ class ToolResultBlock:
     synthesized: bool = False
 
     def to_dict(self) -> dict:
-        return {"type": "tool_result", "id": self.id, "name": self.name, "content": self.content}
+        d: dict = {"type": "tool_result", "id": self.id, "name": self.name, "content": self.content}
+        if self.synthesized:
+            d["synthesized"] = True
+        return d
 
 
 def _tool_call_context(tool_call: "ToolCallBlock | None") -> str:
@@ -178,7 +181,12 @@ def content_block_from_dict(d: dict) -> ContentBlock:
     elif btype == "tool_call":
         return ToolCallBlock(id=d["id"], name=d["name"], args=d["args"])
     elif btype == "tool_result":
-        return ToolResultBlock(id=d["id"], name=d["name"], content=d["content"])
+        return ToolResultBlock(
+            id=d["id"],
+            name=d["name"],
+            content=d["content"],
+            synthesized=d.get("synthesized", False),
+        )
     elif btype == "thinking":
         return ThinkingBlock(text=d["text"], provider_data=d.get("provider_data", {}))
     else:


### PR DESCRIPTION
## What
Clean cherry-pick of the 3 relevant fixes from PR #128 (which has a stale branch with many unrelated changes).

## Changes (3 files, +28/-3)
1. **interface.py** — serialize synthesized flag in ToolResultBlock.to_dict() and restore in content_block_from_dict()
2. **turn.py** — _save_chat_history() immediately after commit_tool_results() in poll_backoff path
3. **__init__.py** — diagnostic logging in notification_inject_aborted with tail shape info

## Why
PR 128 branch fix-126-imap-result-orphan is forked from old main and would revert YAML catalog refactor, refresh watcher improvements, etc. This PR cherry-picks only the relevant changes.

## Testing
- 54/54 tests pass (notification_sync, tc_wake_orphan_heal, tool_result_restore)
- Smoke-tested synthesized flag roundtrip

Closes #126
Supersedes #128