### PR TITLE
fix: overwrite packaged default procedures/substrate on every boot

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -1229,30 +1229,30 @@ class Agent(BaseAgent):
         # the agent's architecture to itself (tool tiers, data-flow
         # topology, life states, channel discipline, attention model).
         #
-        # Resolution precedence:
-        #   1. data["substrate"]          — inline init.json string
-        #   2. system/substrate.md        — agent's own copy (editable)
-        #   3. packaged prompts/substrate.md — kernel default (v1)
+        # Resolution precedence (issue #133 — refresh-time refresh):
+        #   1. data["substrate"]          — inline init.json string (operator override)
+        #   2. packaged prompts/substrate.md — kernel default, always wins on every boot
+        #   3. system/substrate.md        — fallback only if package missing
         #
-        # Every agent gets the section populated by default. To opt out,
-        # set `"substrate": " "` (a single space, written to system/
-        # substrate.md and rendered as effectively blank).
+        # The packaged default overwrites the on-disk file on every boot so
+        # that `pip install -e .` + `system(refresh)` actually propagates
+        # kernel updates. To opt out, set `"substrate": " "` (a single
+        # space, treated as an explicit operator value by step 1).
         substrate = data.get("substrate", "")
         substrate_file = system_dir / "substrate.md"
         if substrate:
             substrate_file.write_text(substrate)
-        elif substrate_file.is_file():
-            substrate = substrate_file.read_text()
         else:
-            # Packaged default — write to system_dir so the agent has its
-            # own editable copy on disk going forward.
             try:
                 from importlib.resources import files
                 packaged = files("lingtai.prompts").joinpath("substrate.md").read_text()
                 substrate_file.write_text(packaged)
                 substrate = packaged
             except (FileNotFoundError, ModuleNotFoundError, OSError):
-                substrate = ""
+                if substrate_file.is_file():
+                    substrate = substrate_file.read_text()
+                else:
+                    substrate = ""
         if substrate:
             self._prompt_manager.write_section("substrate", substrate, protected=True)
         else:
@@ -1291,20 +1291,19 @@ class Agent(BaseAgent):
             self._prompt_manager.write_section("principle", principle, protected=True)
 
         # --- Procedures ---
-        # Resolution precedence (mirrors substrate above):
-        #   1. data["procedures"]          — inline init.json string
-        #   2. system/procedures.md        — agent's own copy (editable)
-        #   3. packaged prompts/procedures.md — kernel default
+        # Resolution precedence (mirrors substrate above; issue #133):
+        #   1. data["procedures"]          — inline init.json string (operator override)
+        #   2. packaged prompts/procedures.md — kernel default, always wins on every boot
+        #   3. system/procedures.md        — fallback only if package missing
         #
-        # Every agent gets the section populated by default. To opt out,
-        # set `"procedures": " "` (a single space, written to system/
-        # procedures.md and rendered as effectively blank).
+        # The packaged default overwrites the on-disk file on every boot so
+        # that `pip install -e .` + `system(refresh)` actually propagates
+        # kernel updates. To opt out, set `"procedures": " "` (a single
+        # space, treated as an explicit operator value by step 1).
         procedures = data.get("procedures", "")
         procedures_file = system_dir / "procedures.md"
         if procedures:
             procedures_file.write_text(procedures)
-        elif procedures_file.is_file():
-            procedures = procedures_file.read_text()
         else:
             try:
                 from importlib.resources import files
@@ -1312,7 +1311,10 @@ class Agent(BaseAgent):
                 procedures_file.write_text(packaged)
                 procedures = packaged
             except (FileNotFoundError, ModuleNotFoundError, OSError):
-                procedures = ""
+                if procedures_file.is_file():
+                    procedures = procedures_file.read_text()
+                else:
+                    procedures = ""
         if procedures:
             self._prompt_manager.write_section("procedures", procedures, protected=True)
         else:


### PR DESCRIPTION
## Problem
When the kernel is updated (e.g. Obtaining file:///Users/huangzesen/work/GitHub/lingtai-kernel
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: httpx>=0.27 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.28.1)
Requirement already satisfied: openai>=1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (2.30.0)
Requirement already satisfied: anthropic>=0.40 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.88.0)
Requirement already satisfied: google-genai>=1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (1.70.0)
Requirement already satisfied: mcp>=1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (1.26.0)
Requirement already satisfied: ddgs>=7.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (9.12.0)
Requirement already satisfied: trafilatura>=2.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (2.0.0)
Requirement already satisfied: filelock>=3.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (3.13.1)
Requirement already satisfied: pyyaml>=6.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (6.0.2)
Requirement already satisfied: lingtai-imap>=0.1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.1.0)
Requirement already satisfied: lingtai-telegram>=0.1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.3.0)
Requirement already satisfied: lingtai-feishu>=0.1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.2.0)
Requirement already satisfied: lingtai-wechat>=0.1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.1.0)
Requirement already satisfied: anyio<5,>=3.5.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (4.12.1)
Requirement already satisfied: distro<2,>=1.7.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (1.9.0)
Requirement already satisfied: docstring-parser<1,>=0.15 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (0.17.0)
Requirement already satisfied: jiter<1,>=0.4.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (0.13.0)
Requirement already satisfied: pydantic<3,>=1.9.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (2.12.5)
Requirement already satisfied: sniffio in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (1.3.0)
Requirement already satisfied: typing-extensions<5,>=4.14 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (4.15.0)
Requirement already satisfied: click>=8.1.8 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from ddgs>=7.0->lingtai==0.10.5) (8.3.1)
Requirement already satisfied: primp>=1.2.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from ddgs>=7.0->lingtai==0.10.5) (1.2.1)
Requirement already satisfied: lxml>=4.9.4 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from ddgs>=7.0->lingtai==0.10.5) (6.0.2)
Requirement already satisfied: google-auth<3.0.0,>=2.48.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (2.49.1)
Requirement already satisfied: requests<3.0.0,>=2.28.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-genai>=1.0->lingtai==0.10.5) (2.32.3)
Requirement already satisfied: tenacity<9.2.0,>=8.2.3 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-genai>=1.0->lingtai==0.10.5) (8.2.3)
Requirement already satisfied: websockets<17.0,>=13.0.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-genai>=1.0->lingtai==0.10.5) (13.1)
Requirement already satisfied: certifi in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from httpx>=0.27->lingtai==0.10.5) (2024.12.14)
Requirement already satisfied: httpcore==1.* in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from httpx>=0.27->lingtai==0.10.5) (1.0.2)
Requirement already satisfied: idna in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from httpx>=0.27->lingtai==0.10.5) (3.7)
Requirement already satisfied: h11<0.15,>=0.13 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from httpcore==1.*->httpx>=0.27->lingtai==0.10.5) (0.14.0)
Requirement already satisfied: lark-oapi>=1.4.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai-feishu>=0.1.0->lingtai==0.10.5) (1.6.0)
Requirement already satisfied: imapclient>=3.0.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai-imap>=0.1.0->lingtai==0.10.5) (3.1.0)
Requirement already satisfied: httpx-sse>=0.4 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (0.4.3)
Requirement already satisfied: jsonschema>=4.20.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (4.23.0)
Requirement already satisfied: pydantic-settings>=2.5.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (2.13.0)
Requirement already satisfied: pyjwt>=2.10.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from pyjwt[crypto]>=2.10.1->mcp>=1.0->lingtai==0.10.5) (2.11.0)
Requirement already satisfied: python-multipart>=0.0.9 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (0.0.22)
Requirement already satisfied: sse-starlette>=1.6.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (3.2.0)
Requirement already satisfied: starlette>=0.27 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (0.52.1)
Requirement already satisfied: typing-inspection>=0.4.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (0.4.2)
Requirement already satisfied: uvicorn>=0.31.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (0.41.0)
Requirement already satisfied: tqdm>4 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from openai>=1.0->lingtai==0.10.5) (4.66.5)
Requirement already satisfied: charset_normalizer>=3.4.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from trafilatura>=2.0->lingtai==0.10.5) (3.4.7)
Requirement already satisfied: courlan>=1.3.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from trafilatura>=2.0->lingtai==0.10.5) (1.3.2)
Requirement already satisfied: htmldate>=1.9.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from trafilatura>=2.0->lingtai==0.10.5) (1.9.4)
Requirement already satisfied: justext>=3.0.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from trafilatura>=2.0->lingtai==0.10.5) (3.0.2)
Requirement already satisfied: urllib3<3,>=1.26 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from trafilatura>=2.0->lingtai==0.10.5) (2.2.3)
Requirement already satisfied: babel>=2.16.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from courlan>=1.3.2->trafilatura>=2.0->lingtai==0.10.5) (2.18.0)
Requirement already satisfied: tld>=0.13 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from courlan>=1.3.2->trafilatura>=2.0->lingtai==0.10.5) (0.13.2)
Requirement already satisfied: pyasn1-modules>=0.2.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-auth<3.0.0,>=2.48.1->google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (0.2.8)
Requirement already satisfied: cryptography>=38.0.3 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-auth<3.0.0,>=2.48.1->google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (43.0.0)
Requirement already satisfied: dateparser>=1.1.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (1.4.0)
Requirement already satisfied: python-dateutil>=2.9.0.post0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (2.9.0.post0)
Requirement already satisfied: attrs>=22.2.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.0->lingtai==0.10.5) (24.2.0)
Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.0->lingtai==0.10.5) (2023.7.1)
Requirement already satisfied: referencing>=0.28.4 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.0->lingtai==0.10.5) (0.30.2)
Requirement already satisfied: rpds-py>=0.7.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.0->lingtai==0.10.5) (0.10.6)
Requirement already satisfied: requests_toolbelt>=0.9 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lark-oapi>=1.4.0->lingtai-feishu>=0.1.0->lingtai==0.10.5) (1.0.0)
Requirement already satisfied: pycryptodome>=3.9 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lark-oapi>=1.4.0->lingtai-feishu>=0.1.0->lingtai==0.10.5) (3.23.0)
Requirement already satisfied: annotated-types>=0.6.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->anthropic>=0.40->lingtai==0.10.5) (0.6.0)
Requirement already satisfied: pydantic-core==2.41.5 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->anthropic>=0.40->lingtai==0.10.5) (2.41.5)
Requirement already satisfied: python-dotenv>=0.21.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from pydantic-settings>=2.5.2->mcp>=1.0->lingtai==0.10.5) (1.0.1)
Requirement already satisfied: cffi>=1.12 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from cryptography>=38.0.3->google-auth<3.0.0,>=2.48.1->google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (2.0.0)
Requirement already satisfied: pytz>=2024.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from dateparser>=1.1.2->htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (2026.1.post1)
Requirement already satisfied: regex>=2024.9.11 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from dateparser>=1.1.2->htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (2024.9.11)
Requirement already satisfied: tzlocal>=0.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from dateparser>=1.1.2->htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (5.3.1)
Requirement already satisfied: lxml_html_clean in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lxml[html_clean]>=4.4.2->justext>=3.0.1->trafilatura>=2.0->lingtai==0.10.5) (0.4.4)
Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from pyasn1-modules>=0.2.1->google-auth<3.0.0,>=2.48.1->google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (0.4.8)
Requirement already satisfied: six>=1.5 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from python-dateutil>=2.9.0.post0->htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (1.16.0)
Requirement already satisfied: pycparser in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from cffi>=1.12->cryptography>=38.0.3->google-auth<3.0.0,>=2.48.1->google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (2.21)
Building wheels for collected packages: lingtai
  Building editable for lingtai (pyproject.toml): started
  Building editable for lingtai (pyproject.toml): finished with status 'done'
  Created wheel for lingtai: filename=lingtai-0.10.5-0.editable-py3-none-any.whl size=4602 sha256=59719fd3a7bc14a2ff63b42baf9bbb0d6d4e8073b8944faff40bb424ad269cd1
  Stored in directory: /private/var/folders/g1/jbj1s_4x7wn1f67ffjt2_thm0000gn/T/pip-ephem-wheel-cache-ty60ubou/wheels/65/59/f6/a4d1f0db3a9470d1671493505915882728886254d16148a491
Successfully built lingtai
Installing collected packages: lingtai
  Attempting uninstall: lingtai
    Found existing installation: lingtai 0.9.2
    Uninstalling lingtai-0.9.2:
      Successfully uninstalled lingtai-0.9.2
Successfully installed lingtai-0.10.5) and the agent refreshes, the kernel-owned prompt files (, ) are NOT overwritten with the latest packaged defaults. This means updates like the skill routing guide (PR #134) are never visible to existing agents.

## Root Cause
In , the resolution precedence was:
1. init.json inline string
2. Existing  file (read from disk)
3. Packaged default (only used if file doesn't exist)

So on subsequent boots (including refresh), the stale on-disk file was always read instead of the latest packaged default.

## Fix
Changed the resolution precedence to:
1. init.json inline string (operator override) — wins
2. Packaged prompts/ default — always written on every boot
3. Existing  file — fallback only if package missing

This ensures Obtaining file:///Users/huangzesen/work/GitHub/lingtai-kernel
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: httpx>=0.27 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.28.1)
Requirement already satisfied: openai>=1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (2.30.0)
Requirement already satisfied: anthropic>=0.40 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.88.0)
Requirement already satisfied: google-genai>=1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (1.70.0)
Requirement already satisfied: mcp>=1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (1.26.0)
Requirement already satisfied: ddgs>=7.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (9.12.0)
Requirement already satisfied: trafilatura>=2.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (2.0.0)
Requirement already satisfied: filelock>=3.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (3.13.1)
Requirement already satisfied: pyyaml>=6.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (6.0.2)
Requirement already satisfied: lingtai-imap>=0.1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.1.0)
Requirement already satisfied: lingtai-telegram>=0.1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.3.0)
Requirement already satisfied: lingtai-feishu>=0.1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.2.0)
Requirement already satisfied: lingtai-wechat>=0.1.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai==0.10.5) (0.1.0)
Requirement already satisfied: anyio<5,>=3.5.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (4.12.1)
Requirement already satisfied: distro<2,>=1.7.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (1.9.0)
Requirement already satisfied: docstring-parser<1,>=0.15 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (0.17.0)
Requirement already satisfied: jiter<1,>=0.4.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (0.13.0)
Requirement already satisfied: pydantic<3,>=1.9.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (2.12.5)
Requirement already satisfied: sniffio in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (1.3.0)
Requirement already satisfied: typing-extensions<5,>=4.14 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from anthropic>=0.40->lingtai==0.10.5) (4.15.0)
Requirement already satisfied: click>=8.1.8 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from ddgs>=7.0->lingtai==0.10.5) (8.3.1)
Requirement already satisfied: primp>=1.2.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from ddgs>=7.0->lingtai==0.10.5) (1.2.1)
Requirement already satisfied: lxml>=4.9.4 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from ddgs>=7.0->lingtai==0.10.5) (6.0.2)
Requirement already satisfied: google-auth<3.0.0,>=2.48.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (2.49.1)
Requirement already satisfied: requests<3.0.0,>=2.28.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-genai>=1.0->lingtai==0.10.5) (2.32.3)
Requirement already satisfied: tenacity<9.2.0,>=8.2.3 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-genai>=1.0->lingtai==0.10.5) (8.2.3)
Requirement already satisfied: websockets<17.0,>=13.0.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-genai>=1.0->lingtai==0.10.5) (13.1)
Requirement already satisfied: certifi in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from httpx>=0.27->lingtai==0.10.5) (2024.12.14)
Requirement already satisfied: httpcore==1.* in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from httpx>=0.27->lingtai==0.10.5) (1.0.2)
Requirement already satisfied: idna in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from httpx>=0.27->lingtai==0.10.5) (3.7)
Requirement already satisfied: h11<0.15,>=0.13 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from httpcore==1.*->httpx>=0.27->lingtai==0.10.5) (0.14.0)
Requirement already satisfied: lark-oapi>=1.4.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai-feishu>=0.1.0->lingtai==0.10.5) (1.6.0)
Requirement already satisfied: imapclient>=3.0.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lingtai-imap>=0.1.0->lingtai==0.10.5) (3.1.0)
Requirement already satisfied: httpx-sse>=0.4 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (0.4.3)
Requirement already satisfied: jsonschema>=4.20.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (4.23.0)
Requirement already satisfied: pydantic-settings>=2.5.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (2.13.0)
Requirement already satisfied: pyjwt>=2.10.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from pyjwt[crypto]>=2.10.1->mcp>=1.0->lingtai==0.10.5) (2.11.0)
Requirement already satisfied: python-multipart>=0.0.9 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (0.0.22)
Requirement already satisfied: sse-starlette>=1.6.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (3.2.0)
Requirement already satisfied: starlette>=0.27 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (0.52.1)
Requirement already satisfied: typing-inspection>=0.4.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (0.4.2)
Requirement already satisfied: uvicorn>=0.31.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from mcp>=1.0->lingtai==0.10.5) (0.41.0)
Requirement already satisfied: tqdm>4 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from openai>=1.0->lingtai==0.10.5) (4.66.5)
Requirement already satisfied: charset_normalizer>=3.4.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from trafilatura>=2.0->lingtai==0.10.5) (3.4.7)
Requirement already satisfied: courlan>=1.3.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from trafilatura>=2.0->lingtai==0.10.5) (1.3.2)
Requirement already satisfied: htmldate>=1.9.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from trafilatura>=2.0->lingtai==0.10.5) (1.9.4)
Requirement already satisfied: justext>=3.0.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from trafilatura>=2.0->lingtai==0.10.5) (3.0.2)
Requirement already satisfied: urllib3<3,>=1.26 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from trafilatura>=2.0->lingtai==0.10.5) (2.2.3)
Requirement already satisfied: babel>=2.16.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from courlan>=1.3.2->trafilatura>=2.0->lingtai==0.10.5) (2.18.0)
Requirement already satisfied: tld>=0.13 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from courlan>=1.3.2->trafilatura>=2.0->lingtai==0.10.5) (0.13.2)
Requirement already satisfied: pyasn1-modules>=0.2.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-auth<3.0.0,>=2.48.1->google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (0.2.8)
Requirement already satisfied: cryptography>=38.0.3 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from google-auth<3.0.0,>=2.48.1->google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (43.0.0)
Requirement already satisfied: dateparser>=1.1.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (1.4.0)
Requirement already satisfied: python-dateutil>=2.9.0.post0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (2.9.0.post0)
Requirement already satisfied: attrs>=22.2.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.0->lingtai==0.10.5) (24.2.0)
Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.0->lingtai==0.10.5) (2023.7.1)
Requirement already satisfied: referencing>=0.28.4 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.0->lingtai==0.10.5) (0.30.2)
Requirement already satisfied: rpds-py>=0.7.1 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from jsonschema>=4.20.0->mcp>=1.0->lingtai==0.10.5) (0.10.6)
Requirement already satisfied: requests_toolbelt>=0.9 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lark-oapi>=1.4.0->lingtai-feishu>=0.1.0->lingtai==0.10.5) (1.0.0)
Requirement already satisfied: pycryptodome>=3.9 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lark-oapi>=1.4.0->lingtai-feishu>=0.1.0->lingtai==0.10.5) (3.23.0)
Requirement already satisfied: annotated-types>=0.6.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->anthropic>=0.40->lingtai==0.10.5) (0.6.0)
Requirement already satisfied: pydantic-core==2.41.5 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->anthropic>=0.40->lingtai==0.10.5) (2.41.5)
Requirement already satisfied: python-dotenv>=0.21.0 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from pydantic-settings>=2.5.2->mcp>=1.0->lingtai==0.10.5) (1.0.1)
Requirement already satisfied: cffi>=1.12 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from cryptography>=38.0.3->google-auth<3.0.0,>=2.48.1->google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (2.0.0)
Requirement already satisfied: pytz>=2024.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from dateparser>=1.1.2->htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (2026.1.post1)
Requirement already satisfied: regex>=2024.9.11 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from dateparser>=1.1.2->htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (2024.9.11)
Requirement already satisfied: tzlocal>=0.2 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from dateparser>=1.1.2->htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (5.3.1)
Requirement already satisfied: lxml_html_clean in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from lxml[html_clean]>=4.4.2->justext>=3.0.1->trafilatura>=2.0->lingtai==0.10.5) (0.4.4)
Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from pyasn1-modules>=0.2.1->google-auth<3.0.0,>=2.48.1->google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (0.4.8)
Requirement already satisfied: six>=1.5 in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from python-dateutil>=2.9.0.post0->htmldate>=1.9.2->trafilatura>=2.0->lingtai==0.10.5) (1.16.0)
Requirement already satisfied: pycparser in /Users/huangzesen/anaconda3/lib/python3.12/site-packages (from cffi>=1.12->cryptography>=38.0.3->google-auth<3.0.0,>=2.48.1->google-auth[requests]<3.0.0,>=2.48.1->google-genai>=1.0->lingtai==0.10.5) (2.21)
Building wheels for collected packages: lingtai
  Building editable for lingtai (pyproject.toml): started
  Building editable for lingtai (pyproject.toml): finished with status 'done'
  Created wheel for lingtai: filename=lingtai-0.10.5-0.editable-py3-none-any.whl size=4602 sha256=13d2861b07c8ba59df0c2dd9094a6e1de710adbbff901594cce3854662b8a4d3
  Stored in directory: /private/var/folders/g1/jbj1s_4x7wn1f67ffjt2_thm0000gn/T/pip-ephem-wheel-cache-dspv0fxu/wheels/65/59/f6/a4d1f0db3a9470d1671493505915882728886254d16148a491
Successfully built lingtai
Installing collected packages: lingtai
  Attempting uninstall: lingtai
    Found existing installation: lingtai 0.10.5
    Uninstalling lingtai-0.10.5:
      Successfully uninstalled lingtai-0.10.5
Successfully installed lingtai-0.10.5 +  actually propagates kernel updates to existing agents.

## Affected Files
-  — kernel-owned architecture description
-  — kernel-owned operational procedures

## Notes
-  and  use a simpler pattern without packaged defaults — they may need the same treatment if they have kernel-owned defaults.
- To opt out of the packaged default, set  (a single space) in init.json.