### PR TITLE
fix: strip deprecated procedures_file in migration

### DIFF
--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -78,6 +78,16 @@ def strip_deprecated(data: dict) -> list[str]:
         if key in data:
             del data[key]
             removed.append(key)
+
+    # Migration: remove procedures_file if it points to the old
+    # ~/.lingtai-tui/procedures/procedures.md path.  The packaged
+    # default is now the sole source; the on-disk file was a stale
+    # leftover that overwrote the packaged default on every boot.
+    pf = data.get("procedures_file")
+    if isinstance(pf, str) and "procedures/procedures.md" in pf:
+        data.pop("procedures_file", None)
+        removed.append("procedures_file")
+
     if removed:
         log.debug("stripped deprecated init.json fields: %s", ", ".join(sorted(removed)))
     return removed


### PR DESCRIPTION
## Problem
init.json could carry a stale `procedures_file` key pointing to `~/.lingtai-tui/procedures/procedures.md`. The `resolve_file` loop read this old file into `data["procedures"]`, causing the packaged default to be overwritten on every boot.

## Root Cause
The old on-disk file was a leftover from an earlier design. `resolve_file` resolved it into `data["procedures"]`, making the `if procedures:` branch write stale content back to `system/procedures.md` — defeating the packaged default.

## Fix
Add a migration in `strip_deprecated()` that removes `procedures_file` from init.json if it points to `~/.lingtai-tui/procedures/procedures.md`. This runs on every agent boot (via `_read_init()` → `strip_deprecated()`), so all agents get migrated automatically.

## Testing
- Verified that after migration, the packaged default is used on refresh
- Old file deleted from disk