### PR TITLE
fix(email): stop leaked schedulers before re-boot

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -1102,8 +1102,10 @@ class Agent(BaseAgent):
         _psyche.boot(self)
 
         # Re-boot email so a fresh EmailManager + scheduler thread are wired.
-        # The previous manager's scheduler thread is daemon and was abandoned
-        # by the _intrinsics.clear() above; this starts a clean one.
+        # ``email.boot`` stops the previous manager's scheduler before
+        # starting a new one — without that, the prior daemon thread keeps
+        # polling ``mailbox/schedules/*/schedule.json`` and races the new
+        # thread, double-sending the same due tick (issue #154).
         from lingtai_kernel.intrinsics import email as _email
         _email.boot(self)
 

--- a/src/lingtai_kernel/intrinsics/email/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/email/ANATOMY.md
@@ -6,7 +6,7 @@ Filesystem-based email system — mailbox I/O, composition, search, contacts, re
 
 ## Components
 
-- `__init__.py` — Package surface. Re-exports the full public API of the former monolithic `email.py` for backward compatibility: all primitives, schema functions, and `EmailManager`. Registers the `email` generic-dismiss guard at import (`__init__.py:27-32`) because `.notification/email.json` mirrors durable unread state. Contains the module-level `handle()` dispatcher (`__init__.py:74-85`) and `boot()` hook (`__init__.py:88-101`). External callers import `handle`, `boot`, `get_schema`, `get_description`, `EmailManager`, `_new_mailbox_id`, `mode_field` from this package.
+- `__init__.py` — Package surface. Re-exports the full public API of the former monolithic `email.py` for backward compatibility: all primitives, schema functions, and `EmailManager`. Registers the `email` generic-dismiss guard at import (`__init__.py:27-32`) because `.notification/email.json` mirrors durable unread state. Contains the module-level `handle()` dispatcher (`__init__.py:80-93`) and idempotent `boot()` hook (`__init__.py:96-122`); `boot()` stops any prior manager's scheduler before wiring the fresh manager. External callers import `handle`, `boot`, `get_schema`, `get_description`, `EmailManager`, `_new_mailbox_id`, `mode_field` from this package.
 
 - `primitives.py` — Mailbox I/O and display helpers. Module-level functions operating on the agent's `mailbox/` directory tree.
   - ID and path helpers: `_new_mailbox_id` (`primitives.py:22-26`), `mode_field` (`primitives.py:29-34`), `_mailbox_dir` / `_inbox_dir` / `_outbox_dir` / `_sent_dir` (`primitives.py:37-50`).

--- a/src/lingtai_kernel/intrinsics/email/__init__.py
+++ b/src/lingtai_kernel/intrinsics/email/__init__.py
@@ -100,7 +100,20 @@ def boot(agent) -> None:
     done by _wire_intrinsics + ALL_INTRINSICS — this hook does the runtime
     setup that the registry can't: create the manager, wire it into the
     agent so module-level handle() can find it, and kick the scheduler.
+
+    Idempotent on re-boot: if a previous EmailManager was already wired
+    onto ``agent`` (the molt / refresh / cpr path goes through
+    ``_setup_from_init`` which re-runs ``boot``), stop its scheduler
+    thread first. Otherwise the abandoned daemon keeps polling the same
+    ``mailbox/schedules/*/schedule.json`` and races the new thread on
+    read-modify-write — issue #154.
     """
+    prev = getattr(agent, "_email_manager", None)
+    if prev is not None:
+        try:
+            prev.stop_scheduler()
+        except Exception:
+            pass
     mgr = EmailManager(agent)
     agent._email_manager = mgr
     agent._mailbox_name = "email box"

--- a/src/lingtai_kernel/intrinsics/email/manager.py
+++ b/src/lingtai_kernel/intrinsics/email/manager.py
@@ -526,8 +526,21 @@ class EmailManager:
                 if now < due_at:
                     continue
 
+            # Claim this tick BEFORE the slow ``_send``: stamp
+            # ``last_sent_at = now`` and persist atomically. Without this,
+            # a second scheduler thread (one leaked across refresh — see
+            # issue #154 — or a future duplicate manager) that reads
+            # ``schedule.json`` while we're inside ``_send`` would see the
+            # previous tick's stale ``last_sent_at`` and decide "still
+            # due", firing the same tick twice. Semantic shift:
+            # ``last_sent_at`` now means "tick we *claimed*", not "tick
+            # we *finished sending*" — but the error / blocked branch
+            # below already writes ``now`` here anyway, so this is
+            # consistent with how the field is already used.
             seq = sent + 1
+            now_stamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
             record["sent"] = seq
+            record["last_sent_at"] = now_stamp
             self._write_schedule(sched_file, record)
 
             send_payload = record.get("send_payload", {})
@@ -541,15 +554,15 @@ class EmailManager:
                 "seq": seq,
                 "total": count,
                 "interval": interval,
-                "scheduled_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "scheduled_at": now_stamp,
                 "estimated_finish": estimated_finish,
             }
             send_args = {**send_payload, "_schedule": schedule_meta}
             result = self._send(send_args)
 
             if result.get("error") or result.get("status") == "blocked":
-                record["last_sent_at"] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-                self._write_schedule(sched_file, record)
+                # ``last_sent_at`` was already claimed above; nothing to
+                # update here.
                 continue
 
             to_label = send_payload.get("address", "")
@@ -580,10 +593,11 @@ class EmailManager:
             msg = _make_message(MSG_REQUEST, "system", note)
             self._agent.inbox.put(msg)
 
-            record["last_sent_at"] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+            # ``last_sent_at`` was already stamped before _send; only
+            # flip status if the schedule is now complete.
             if seq >= count:
                 record["status"] = "completed"
-            self._write_schedule(sched_file, record)
+                self._write_schedule(sched_file, record)
 
     # ------------------------------------------------------------------
     # Send — deliver + save to sent/

--- a/tests/test_layers_email.py
+++ b/tests/test_layers_email.py
@@ -1947,3 +1947,126 @@ def test_email_archive_rerenders_notification(tmp_path):
 
     mgr.handle({"action": "archive", "email_id": [eid]})
     assert not notif_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Regression: issue #154 — refresh leaks scheduler threads, ticks double-send
+# ---------------------------------------------------------------------------
+
+def test_email_boot_stops_previous_scheduler(tmp_path):
+    """Re-running email.boot on the same agent must stop the prior
+    EmailManager's scheduler thread; otherwise two daemon threads
+    race on schedule.json (issue #154).
+    """
+    from lingtai_kernel.intrinsics import email as _email
+
+    agent = Agent(service=make_mock_service(), agent_name="test",
+                  working_dir=tmp_path / "test")
+    first_mgr = agent._email_manager
+    first_thread = first_mgr._scheduler_thread
+    assert first_thread is not None
+    assert first_thread.is_alive()
+
+    # Simulate the molt/refresh path that re-boots email on a live agent.
+    _email.boot(agent)
+
+    # The previous scheduler MUST have been stopped.
+    first_thread.join(timeout=5.0)
+    assert not first_thread.is_alive(), (
+        "Old EmailManager scheduler thread still running after refresh — "
+        "two threads will race on schedule.json (issue #154)."
+    )
+    assert agent._email_manager is not first_mgr
+
+
+def test_scheduler_tick_is_idempotent_under_concurrent_threads(tmp_path):
+    """Two scheduler ticks for the same due window must produce exactly
+    one extra send (sent advances by 1, not 2). Regression for the
+    intra-process race between leaked scheduler threads in issue #154.
+
+    Reproduces the exact interleaving from the bug: thread A reads the
+    schedule, claims seq=N by writing sent=N (but ``last_sent_at`` is
+    still the previous tick's old stamp), then enters ``_send``. While
+    A is inside ``_send``, thread B reads the schedule — sees stale
+    ``last_sent_at`` and not-yet-finalised state, decides "still due",
+    fires seq=N+1. After fix #2 (claim ``last_sent_at`` before
+    ``_send``), B's read sees a fresh stamp and skips.
+    """
+    agent = Agent(service=make_mock_service(), agent_name="test",
+                  working_dir=tmp_path / "test")
+    mail_svc = MagicMock()
+    mail_svc.address = "me"
+    mail_svc.send.return_value = None
+    agent._mail_service = mail_svc
+
+    mgr = agent._email_manager
+    # Drive _scheduler_tick by hand — stop the background loop so it
+    # doesn't fire its own ticks concurrently.
+    mgr.stop_scheduler()
+
+    result = mgr.handle({
+        "address": "me",
+        "subject": "tick",
+        "message": "x",
+        "schedule": {"action": "create", "interval": 1, "count": 5},
+    })
+    sid = result["schedule_id"]
+    sched_path = (agent.working_dir / "mailbox" / "schedules"
+                  / sid / "schedule.json")
+
+    # Force "due now" with last_sent_at well in the past.
+    rec = json.loads(sched_path.read_text())
+    rec["sent"] = 1
+    rec["last_sent_at"] = "2020-01-01T00:00:00Z"
+    sched_path.write_text(json.dumps(rec))
+
+    # Force the exact race interleaving: pause thread A inside _send so
+    # thread B can observe the in-flight state (sent advanced but
+    # last_sent_at not yet updated by the post-send write at line 583).
+    in_send = threading.Event()
+    release_send = threading.Event()
+    original_send = mgr._send
+    send_call_count = {"n": 0}
+
+    def slow_send(args):
+        send_call_count["n"] += 1
+        # Only block on the first _send so thread B can race in.
+        if send_call_count["n"] == 1:
+            in_send.set()
+            release_send.wait(timeout=5.0)
+        return original_send(args)
+
+    mgr._send = slow_send
+
+    errors: list[BaseException] = []
+
+    def worker():
+        try:
+            mgr._scheduler_tick()
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    t1 = threading.Thread(target=worker, name="tick-A")
+    t1.start()
+    assert in_send.wait(timeout=5.0), "thread A never entered _send"
+
+    t2 = threading.Thread(target=worker, name="tick-B")
+    t2.start()
+    # Give B time to run _scheduler_tick to completion — without fix #2,
+    # B sees stale last_sent_at and fires; with fix #2, B sees the
+    # tentative claim and skips.
+    t2.join(timeout=10.0)
+
+    release_send.set()
+    t1.join(timeout=10.0)
+
+    assert not errors, f"worker errors: {errors!r}"
+    # The bug: thread B saw the stale ``last_sent_at`` (the post-_send
+    # finalize hadn't happened yet) and fired a second ``_send`` for
+    # the same due window. After fix #2 (claim ``last_sent_at`` before
+    # _send), B's pre-tick read sees the fresh stamp and skips, so
+    # ``_send`` is called exactly once.
+    assert send_call_count["n"] == 1, (
+        f"_send was called {send_call_count['n']} times for one due "
+        f"tick — concurrent scheduler ticks double-fired (issue #154)"
+    )


### PR DESCRIPTION
## Summary
- stop the previous `EmailManager` scheduler thread before re-booting email during refresh/molt
- claim each due schedule tick by stamping `last_sent_at` before `_send`, closing the same-tick race window
- add issue #154 regressions for re-boot lifecycle and concurrent scheduler ticks
- update `intrinsics/email/ANATOMY.md` citation for the boot lifecycle change

Fixes Lingtai-AI/lingtai#154.

## Tests
- `python -m pytest tests/test_layers_email.py::test_email_boot_stops_previous_scheduler tests/test_layers_email.py::test_scheduler_tick_is_idempotent_under_concurrent_threads -q`
- `python -m pytest tests/test_layers_email.py -q`
- Claude daemon also ran related email/refresh suites successfully; full suite has unrelated pre-existing path/soul/avatar failures in this worktree, documented in local report context.
