### PR TITLE
fix(email): preserve abs return route on reply across .lingtai/ networks

### DIFF
--- a/src/lingtai_kernel/intrinsics/email/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/email/ANATOMY.md
@@ -25,6 +25,7 @@ Filesystem-based email system — mailbox I/O, composition, search, contacts, re
   - Schedules: `_handle_schedule` (`manager.py:214-224`), `_schedule_create` / `_cancel` / `_reactivate` / `_list` (`manager.py:226-363`), schedule helpers (`manager.py:368-442`), `_scheduler_loop` / `_scheduler_tick` (`manager.py:444-543`).
   - Send: `_send` (`manager.py:548-650`). Dispatches via `_mailman` daemon threads.
   - CRUD: `_check` (`manager.py:657-699`), `_read`, `_dismiss`, `_reply`, `_reply_all`, `_search`, `_archive`, `_delete`. `_dismiss` is the lightweight cousin of `_read` — same effect on read state and notification but returns no email bodies; intended for the "I already saw it in the digest" path. All four read-state mutators (`_read`, `_dismiss`, `_archive`, `_delete`) call `EmailManager._rerender_unread_digest()` after the mutation so `.notification/email.json` mirrors the new state.
+  - Reply routing: `_resolve_reply_target` picks ``(address, mode)`` for `_reply` / `_reply_all`. Preference order is (1) inbound `_return_route` (embedded by abs sends), (2) absolute-path `from`, (3) bare `from` in peer mode. An ambiguity guard refuses to send when a peer-mode bare `from` would resolve to the responder's own workdir while the original message's `identity.agent_id` differs from the responder's own agent id — the live failure mode from issue #145 where two `.lingtai/` networks both host an agent with the same short name (e.g. both have "mimo-1").
   - Notification refresh: `_rerender_unread_digest` (method on `EmailManager`) — lazy-imports the kernel-side helper from `base_agent/messaging.py` and runs it. Centralised here so all read-state mutators share one call site.
   - Contacts: `_contacts_path` / `_load_contacts` / `_save_contacts` / `_contacts` / `_add_contact` / `_remove_contact` / `_edit_contact` (`manager.py:947-1082`).
 
@@ -40,6 +41,7 @@ Filesystem-based email system — mailbox I/O, composition, search, contacts, re
 
 ## Key invariants
 
+- `_send(mode="abs")` embeds an explicit `_return_route` dict (`{"mode": "abs", "address": <sender abs workdir>, "sender_agent_id": <sender id>}`) into every dispatched payload AND the local `sent/{id}/message.json` record. This is the only safe return route across `.lingtai/` networks where short addresses can collide (issue #145). Recipients without the field — older messages — keep working through the existing absolute-`from` fallback in `_resolve_reply_target`.
 - `_mailman` runs as a daemon thread per recipient. It waits until `deliver_at`, then dispatches. The outbox entry is written synchronously before the thread starts.
 - `_mailman` with `skip_sent=True` (used by `_send`) deletes the outbox entry instead of moving it to `sent/`, because `_send` writes the `sent/` entry itself.
 - Schedule status lifecycle: `active` → `inactive` (cancel) or `completed` (all sent). On startup, `_reconcile_schedules_on_startup` flips `active` → `inactive` so schedules don't fire until explicitly reactivated.

--- a/src/lingtai_kernel/intrinsics/email/manager.py
+++ b/src/lingtai_kernel/intrinsics/email/manager.py
@@ -667,12 +667,27 @@ class EmailManager:
         # so the recipient can reply to the correct address.
         abs_sender = str(self._agent._working_dir) if mode == "abs" else None
 
+        # When delivering across .lingtai/ network boundaries, also embed
+        # an explicit return route so the recipient's later ``reply``
+        # cannot collapse to an ambiguous bare alias (issue #145). The
+        # bare ``from`` alone is unsafe when two networks each host an
+        # agent with the same short name (e.g. both have "mimo-1").
+        return_route = None
+        if mode == "abs":
+            return_route = {
+                "mode": "abs",
+                "address": str(self._agent._working_dir),
+                "sender_agent_id": getattr(self._agent, "_agent_id", ""),
+            }
+
         for addr in all_recipients:
             dispatch_payload = dict(base_payload)
             dispatch_payload["_dispatch_to"] = addr
             dispatch_payload["_mode"] = mode
             if abs_sender is not None:
                 dispatch_payload["from"] = abs_sender
+            if return_route is not None:
+                dispatch_payload["_return_route"] = return_route
             msg_id = _persist_to_outbox(self._agent, dispatch_payload, deliver_at)
             tt = threading.Thread(
                 target=_mailman,
@@ -689,6 +704,8 @@ class EmailManager:
         sent_payload = dict(base_payload)
         if abs_sender is not None:
             sent_payload["from"] = abs_sender
+        if return_route is not None:
+            sent_payload["_return_route"] = return_route
         sent_record = {
             **sent_payload,
             "_mailbox_id": sent_id,
@@ -908,6 +925,74 @@ class EmailManager:
             orig_subject = body_first[:30] if body_first else "(no subject)"
         return orig_subject if orig_subject.startswith("Re: ") else f"Re: {orig_subject}"
 
+    def _resolve_reply_target(self, original: dict) -> tuple[str, str] | dict:
+        """Pick the concrete address+mode to reply to.
+
+        Returns ``(address, mode)`` on success, or ``{"error": ...}`` on
+        an ambiguous self-route — the live failure mode of issue #145
+        where two ``.lingtai/`` networks both host an agent with the
+        same bare name.
+
+        Resolution order:
+
+        1. Inbound ``_return_route`` (embedded by abs sends) wins.
+        2. Else, an absolute-path ``from`` is treated as an abs route
+           (graceful upgrade for messages from older senders).
+        3. Else, the bare ``from`` is used in peer mode.
+
+        Ambiguity guard: in branches 2 & 3, if the resolved peer-mode
+        target points at the responder's own working directory while
+        ``identity.agent_id`` differs from the responder's own agent
+        id, refuse rather than silently self-deliver.
+        """
+        rr = original.get("_return_route")
+        if isinstance(rr, dict) and rr.get("mode") == "abs" and rr.get("address"):
+            return (str(rr["address"]), "abs")
+
+        from_field = original.get("from") or ""
+        from_str = str(from_field)
+        if from_str:
+            try:
+                p = Path(from_str)
+            except (TypeError, ValueError):
+                p = None
+            if p is not None and p.is_absolute():
+                return (from_str, "abs")
+
+        # Bare alias / peer mode. Apply ambiguity guard.
+        own_workdir = self._agent._working_dir
+        own_addr = (self._agent._mail_service.address
+                    if self._agent._mail_service is not None
+                    and self._agent._mail_service.address
+                    else own_workdir.name)
+        own_id = getattr(self._agent, "_agent_id", "") or ""
+        identity = original.get("identity") or {}
+        sender_id = ""
+        if isinstance(identity, dict):
+            sender_id = identity.get("agent_id", "") or ""
+        # The bare from would resolve to self when it equals our own
+        # short alias OR equals our workdir name. In that situation,
+        # if the original carries a sender_agent_id different from
+        # ours, the reply would silently land in our own inbox — the
+        # exact misroute reported in #145.
+        if from_str and sender_id and sender_id != own_id and (
+            from_str == own_addr or from_str == own_workdir.name
+        ):
+            return {
+                "error": (
+                    "Reply target is ambiguous: the original message's "
+                    f"from={from_str!r} resolves to this agent's own "
+                    f"address, but identity.agent_id={sender_id!r} differs "
+                    f"from our own agent_id={own_id!r}. The original "
+                    "sender likely lives in a different .lingtai/ network "
+                    "that shares the same bare address. Resend with "
+                    "email(action='send', mode='abs', address='<absolute "
+                    "path of the original sender>') instead."
+                )
+            }
+
+        return (from_str, "peer")
+
     def _reply(self, args: dict) -> dict:
         email_id = args.get("email_id", "")
         if isinstance(email_id, list):
@@ -922,8 +1007,14 @@ class EmailManager:
         if original is None:
             return {"error": f"Email not found: {email_id}"}
 
+        resolved = self._resolve_reply_target(original)
+        if isinstance(resolved, dict):
+            return resolved
+        address, mode = resolved
+
         return self._send({
-            "address": original["from"],
+            "address": address,
+            "mode": mode,
             "subject": self._reply_subject(original, args.get("subject")),
             "message": message_text,
             "cc": args.get("cc") or [],
@@ -944,20 +1035,31 @@ class EmailManager:
         if original is None:
             return {"error": f"Email not found: {email_id}"}
 
+        resolved = self._resolve_reply_target(original)
+        if isinstance(resolved, dict):
+            return resolved
+        reply_to, mode = resolved
+
         my_address = (
             self._agent._mail_service.address
             if self._agent._mail_service
             else str(self._agent._working_dir)
         )
 
-        reply_to = original["from"]
         orig_to = original.get("to") or []
         if isinstance(orig_to, str):
             orig_to = [orig_to]
         orig_cc = original.get("cc") or []
+        # Exclude our own address(es) and the primary reply target from
+        # the CC fan-out, comparing against both the bare ``from`` of
+        # the original and the resolved abs/peer address we'll actually
+        # dispatch to.
+        bare_from = original.get("from", "")
         other_recipients = [
             addr for addr in orig_to + orig_cc
-            if addr != my_address and addr != reply_to
+            if addr != my_address
+            and addr != reply_to
+            and addr != bare_from
         ]
 
         extra_cc = args.get("cc") or []
@@ -965,6 +1067,7 @@ class EmailManager:
 
         return self._send({
             "address": reply_to,
+            "mode": mode,
             "subject": self._reply_subject(original, args.get("subject")),
             "message": message_text,
             "cc": other_recipients + extra_cc,

--- a/tests/test_email_abs_reply_route.py
+++ b/tests/test_email_abs_reply_route.py
@@ -1,0 +1,443 @@
+"""Regression tests for issue #145 — internal email reply route preservation.
+
+When two `.lingtai/` networks both contain an agent named ``mimo-1``,
+``email(action="send", mode="abs", address=...)`` from A to B followed by
+``email(action="reply", ...)`` on the receiving side must route back to the
+original sender's absolute path — not collapse to the ambiguous bare name and
+self-deliver inside the responder's own network.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from lingtai.agent import Agent
+
+
+def make_mock_service():
+    svc = MagicMock()
+    svc.get_adapter.return_value = MagicMock()
+    svc.provider = "gemini"
+    svc.model = "gemini-test"
+    return svc
+
+
+def _seed_agent_dir(path: Path, *, agent_name: str = "mimo-1") -> None:
+    """Materialize the .agent.json + heartbeat that FilesystemMailService needs."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".agent.json").write_text(json.dumps({"agent_name": agent_name, "admin": {}}))
+    (path / ".agent.heartbeat").write_text(str(time.time()))
+    (path / "mailbox" / "inbox").mkdir(parents=True, exist_ok=True)
+
+
+def _make_inbox_email(working_dir: Path, *, sender: str, subject: str = "hello",
+                       message: str = "body", identity: dict | None = None,
+                       return_route: dict | None = None,
+                       to: list[str] | None = None) -> str:
+    """Write a fake inbound message into working_dir/mailbox/inbox/{uuid}/."""
+    eid = str(uuid4())
+    msg_dir = working_dir / "mailbox" / "inbox" / eid
+    msg_dir.mkdir(parents=True, exist_ok=True)
+    data: dict = {
+        "_mailbox_id": eid,
+        "from": sender,
+        "to": to or ["mimo-1"],
+        "subject": subject,
+        "message": message,
+        "received_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    if identity is not None:
+        data["identity"] = identity
+    if return_route is not None:
+        data["_return_route"] = return_route
+    (msg_dir / "message.json").write_text(json.dumps(data, indent=2))
+    return eid
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_abs_send_embeds_return_route_in_dispatched_payload(tmp_path):
+    """``_send(mode="abs")`` must persist a concrete return route so the
+    recipient's later ``reply`` can address the original sender exactly,
+    even when ``from`` is later trimmed/normalized."""
+    sender_dir = tmp_path / "dev-1" / ".lingtai" / "mimo-1"
+    sender_dir.mkdir(parents=True)
+    agent = Agent(service=make_mock_service(), agent_name="mimo-1",
+                  working_dir=sender_dir)
+    mock_svc = MagicMock()
+    mock_svc.address = "mimo-1"
+    mock_svc.send.return_value = None
+    agent._mail_service = mock_svc
+
+    recipient_path = str(tmp_path / "dev-2" / ".lingtai" / "mimo-1")
+    result = agent._email_manager.handle({
+        "action": "send",
+        "mode": "abs",
+        "address": recipient_path,
+        "subject": "hi",
+        "message": "ping",
+    })
+    assert result["status"] == "sent"
+
+    # Wait briefly for the daemon dispatch thread to run mail_service.send.
+    deadline = time.time() + 2.0
+    while time.time() < deadline and not mock_svc.send.called:
+        time.sleep(0.05)
+    assert mock_svc.send.called, "mail service was never invoked"
+
+    dispatched = mock_svc.send.call_args[0][1]
+    rr = dispatched.get("_return_route")
+    assert rr is not None, "abs send must embed _return_route"
+    assert rr.get("mode") == "abs"
+    assert rr.get("address") == str(sender_dir)
+    # sender_agent_id is mandatory for the ambiguity guard on reply.
+    assert rr.get("sender_agent_id") == agent._agent_id
+
+    agent.stop(timeout=1.0)
+
+
+def test_peer_send_does_not_embed_return_route(tmp_path):
+    """Peer-mode (intra-network) sends keep the lean payload — no route needed."""
+    sender_dir = tmp_path / "dev-1" / ".lingtai" / "mimo-1"
+    sender_dir.mkdir(parents=True)
+    agent = Agent(service=make_mock_service(), agent_name="mimo-1",
+                  working_dir=sender_dir)
+    mock_svc = MagicMock()
+    mock_svc.address = "mimo-1"
+    mock_svc.send.return_value = None
+    agent._mail_service = mock_svc
+
+    agent._email_manager.handle({
+        "action": "send",
+        "address": "peer-2",
+        "subject": "hi",
+        "message": "ping",
+    })
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and not mock_svc.send.called:
+        time.sleep(0.05)
+    assert mock_svc.send.called
+
+    dispatched = mock_svc.send.call_args[0][1]
+    assert dispatched.get("_return_route") in (None,)
+
+    agent.stop(timeout=1.0)
+
+
+def test_reply_uses_return_route_address_in_abs_mode(tmp_path):
+    """When an inbound message carries ``_return_route`` (mode=abs), the
+    reply must be dispatched in abs mode to the route's address — not to
+    the bare ``from`` alias."""
+    # dev-2 side: where we live and reply *from*.
+    responder_dir = tmp_path / "dev-2" / ".lingtai" / "mimo-1"
+    responder_dir.mkdir(parents=True)
+    agent = Agent(service=make_mock_service(), agent_name="mimo-1",
+                  working_dir=responder_dir)
+    mock_svc = MagicMock()
+    mock_svc.address = "mimo-1"
+    mock_svc.send.return_value = None
+    agent._mail_service = mock_svc
+
+    original_sender_abs = str(tmp_path / "dev-1" / ".lingtai" / "mimo-1")
+    eid = _make_inbox_email(
+        responder_dir,
+        sender="mimo-1",  # bare; this is what made the original bug bite
+        subject="please reply",
+        message="original",
+        identity={"agent_name": "mimo-1", "agent_id": "AGENT-DEV-1",
+                  "admin": {}},
+        return_route={"mode": "abs", "address": original_sender_abs,
+                      "sender_agent_id": "AGENT-DEV-1"},
+    )
+    result = agent._email_manager.handle({
+        "action": "reply",
+        "email_id": [eid],
+        "message": "reply body",
+    })
+    assert result["status"] == "sent"
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and not mock_svc.send.called:
+        time.sleep(0.05)
+    assert mock_svc.send.called, "reply was never dispatched"
+
+    call = mock_svc.send.call_args
+    address_arg = call[0][0]
+    kwargs = call[1]
+    assert address_arg == original_sender_abs, (
+        f"reply went to {address_arg!r} not the abs return route"
+    )
+    assert kwargs.get("mode") == "abs"
+
+    agent.stop(timeout=1.0)
+
+
+def test_reply_falls_back_to_abs_when_from_is_absolute_path(tmp_path):
+    """Older messages without ``_return_route`` but with an absolute ``from``
+    should still be replied to via abs mode — graceful upgrade path."""
+    responder_dir = tmp_path / "dev-2" / ".lingtai" / "mimo-1"
+    responder_dir.mkdir(parents=True)
+    agent = Agent(service=make_mock_service(), agent_name="mimo-1",
+                  working_dir=responder_dir)
+    mock_svc = MagicMock()
+    mock_svc.address = "mimo-1"
+    mock_svc.send.return_value = None
+    agent._mail_service = mock_svc
+
+    original_sender_abs = str(tmp_path / "dev-1" / ".lingtai" / "mimo-1")
+    eid = _make_inbox_email(
+        responder_dir,
+        sender=original_sender_abs,
+        subject="please reply",
+        message="original",
+        identity={"agent_name": "mimo-1", "agent_id": "AGENT-DEV-1",
+                  "admin": {}},
+    )
+    agent._email_manager.handle({
+        "action": "reply",
+        "email_id": [eid],
+        "message": "reply body",
+    })
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and not mock_svc.send.called:
+        time.sleep(0.05)
+    assert mock_svc.send.called
+
+    address_arg = mock_svc.send.call_args[0][0]
+    kwargs = mock_svc.send.call_args[1]
+    assert address_arg == original_sender_abs
+    assert kwargs.get("mode") == "abs"
+
+    agent.stop(timeout=1.0)
+
+
+def test_reply_to_same_network_bare_address_still_uses_peer_mode(tmp_path):
+    """Same-network replies must not be perturbed: bare ``from`` →
+    peer-mode dispatch to the same bare address."""
+    responder_dir = tmp_path / "dev-2" / ".lingtai" / "mimo-1"
+    responder_dir.mkdir(parents=True)
+    agent = Agent(service=make_mock_service(), agent_name="mimo-1",
+                  working_dir=responder_dir)
+    mock_svc = MagicMock()
+    mock_svc.address = "mimo-1"
+    mock_svc.send.return_value = None
+    agent._mail_service = mock_svc
+
+    eid = _make_inbox_email(
+        responder_dir,
+        sender="peer-7",
+        subject="hey",
+        message="howdy",
+        identity={"agent_name": "peer-7", "agent_id": "AGENT-PEER-7",
+                  "admin": {}},
+    )
+    agent._email_manager.handle({
+        "action": "reply",
+        "email_id": [eid],
+        "message": "back at you",
+    })
+
+    deadline = time.time() + 2.0
+    while time.time() < deadline and not mock_svc.send.called:
+        time.sleep(0.05)
+    assert mock_svc.send.called
+
+    address_arg = mock_svc.send.call_args[0][0]
+    kwargs = mock_svc.send.call_args[1]
+    assert address_arg == "peer-7"
+    # Peer is the default; allow either explicit "peer" or absent.
+    assert kwargs.get("mode", "peer") == "peer"
+
+    agent.stop(timeout=1.0)
+
+
+def test_reply_self_route_with_different_agent_id_is_refused(tmp_path):
+    """Ambiguity guard: if the reply would target the responder's own
+    workdir while ``sender_agent_id`` says the original came from a
+    different agent, the reply must fail loudly rather than silently
+    self-deliver (the exact bug observed in issue #145)."""
+    responder_dir = tmp_path / "dev-2" / ".lingtai" / "mimo-1"
+    responder_dir.mkdir(parents=True)
+    agent = Agent(service=make_mock_service(), agent_name="mimo-1",
+                  working_dir=responder_dir)
+    mock_svc = MagicMock()
+    mock_svc.address = "mimo-1"
+    mock_svc.send.return_value = None
+    agent._mail_service = mock_svc
+
+    # No ``_return_route`` and bare ``from`` that resolves to self under
+    # the peer-resolution rule; identity says the sender is a different
+    # agent. This is the exact shape of the dev-1→dev-2 reply that bit
+    # us live.
+    eid = _make_inbox_email(
+        responder_dir,
+        sender="mimo-1",
+        subject="cross-project ping",
+        message="please reply",
+        identity={"agent_name": "mimo-1", "agent_id": "AGENT-DEV-1",
+                  "admin": {}},
+    )
+    result = agent._email_manager.handle({
+        "action": "reply",
+        "email_id": [eid],
+        "message": "should be refused",
+    })
+    assert "error" in result, f"expected ambiguity error, got {result!r}"
+    err = result["error"].lower()
+    assert "ambig" in err or "abs" in err or "self" in err, (
+        f"error should explain the ambiguity, got: {result['error']!r}"
+    )
+    # No outbound dispatch.
+    time.sleep(0.3)
+    assert not mock_svc.send.called
+
+    agent.stop(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: two real .lingtai/ roots, both with an agent named "mimo-1".
+# ---------------------------------------------------------------------------
+
+
+def test_abs_reply_lands_in_original_sender_inbox_not_self(tmp_path):
+    """Full integration: dev-1 and dev-2 both run an agent named ``mimo-1``.
+    The live regression from #145 surfaces on the *second* reply: dev-2
+    sends abs to dev-1, dev-1 replies (this hop works because peer-mode
+    resolution still honours the abs ``from`` address), then dev-2 replies
+    to dev-1's reply. That third hop is where the bare-alias ``from`` made
+    the message self-deliver inside dev-2's own network.
+    """
+    from lingtai_kernel.services.mail import FilesystemMailService
+
+    stop = threading.Event()
+
+    # Two .lingtai/ roots, each with an agent dir named "mimo-1".
+    dev1_dir = tmp_path / "dev-1" / ".lingtai" / "mimo-1"
+    dev2_dir = tmp_path / "dev-2" / ".lingtai" / "mimo-1"
+    _seed_agent_dir(dev1_dir)
+    _seed_agent_dir(dev2_dir)
+
+    # Keep heartbeats fresh on both dirs (FilesystemMailService refuses
+    # delivery when heartbeat is stale).
+    def _hb(target: Path) -> None:
+        while not stop.is_set():
+            try:
+                (target / ".agent.heartbeat").write_text(str(time.time()))
+            except OSError:
+                pass
+            stop.wait(0.3)
+    threading.Thread(target=_hb, args=(dev1_dir,), daemon=True).start()
+    threading.Thread(target=_hb, args=(dev2_dir,), daemon=True).start()
+
+    dev1_received: list[dict] = []
+    dev2_received: list[dict] = []
+    dev1_ev = threading.Event()
+    dev2_ev = threading.Event()
+
+    dev1_svc = FilesystemMailService(working_dir=dev1_dir)
+    dev2_svc = FilesystemMailService(working_dir=dev2_dir)
+    dev1_svc.listen(on_message=lambda m: (dev1_received.append(m), dev1_ev.set()))
+    dev2_svc.listen(on_message=lambda m: (dev2_received.append(m), dev2_ev.set()))
+
+    try:
+        # Two Agents — one per network root, each backed by its own
+        # FilesystemMailService.
+        dev1 = Agent(
+            service=make_mock_service(), agent_name="mimo-1",
+            working_dir=dev1_dir, mail_service=dev1_svc,
+        )
+        dev2 = Agent(
+            service=make_mock_service(), agent_name="mimo-1",
+            working_dir=dev2_dir, mail_service=dev2_svc,
+        )
+
+        # Hop 1: dev-2 sends abs to dev-1.
+        send_result = dev2._email_manager.handle({
+            "action": "send",
+            "mode": "abs",
+            "address": str(dev1_dir),
+            "subject": "ping from dev-2",
+            "message": "are you there?",
+        })
+        assert send_result["status"] == "sent"
+        assert dev1_ev.wait(timeout=5.0), "dev-1 never received dev-2's mail"
+
+        # Hop 2: dev-1 replies to dev-2.
+        check_dev1 = dev1._email_manager.handle({"action": "check"})
+        hop1_candidates = [e for e in check_dev1["emails"]
+                           if "are you there" in (e.get("preview") or "")]
+        assert hop1_candidates, f"dev-1 inbox unexpected shape: {check_dev1}"
+        hop1_eid = hop1_candidates[0]["id"]
+        dev2_ev.clear()
+        reply1 = dev1._email_manager.handle({
+            "action": "reply",
+            "email_id": [hop1_eid],
+            "message": "yes, hi back",
+        })
+        assert reply1.get("status") == "sent", f"reply1 failed: {reply1!r}"
+        assert dev2_ev.wait(timeout=5.0), "dev-2 never received dev-1's reply"
+
+        # Hop 3: dev-2 replies to dev-1's reply. This is the hop that
+        # silently self-delivered in #145.
+        check_dev2 = dev2._email_manager.handle({"action": "check"})
+        hop2_candidates = [e for e in check_dev2["emails"]
+                           if (e.get("subject") or "").startswith("Re: ping from dev-2")]
+        assert hop2_candidates, f"dev-2 inbox unexpected shape: {check_dev2}"
+        hop2_eid = hop2_candidates[0]["id"]
+
+        dev1_ev.clear()
+        before_dev2_inbox = len(dev2._email_manager.handle({"action": "check"})["emails"])
+        reply2 = dev2._email_manager.handle({
+            "action": "reply",
+            "email_id": [hop2_eid],
+            "message": "round 3, dev-2 → dev-1",
+        })
+        assert reply2.get("status") == "sent", (
+            f"reply2 did not dispatch: {reply2!r}"
+        )
+        assert dev1_ev.wait(timeout=5.0), (
+            "dev-1 never received dev-2's second-hop reply — likely "
+            "self-delivered inside dev-2's own network, which is exactly "
+            "bug #145."
+        )
+
+        # dev-2 must NOT have received its own reply back.
+        time.sleep(0.5)
+        after_dev2_inbox = dev2._email_manager.handle({"action": "check"})["emails"]
+        # The only delta should be from genuine arrivals — not the
+        # second-hop reply self-bouncing into dev-2's inbox.
+        new_in_dev2 = [
+            e for e in after_dev2_inbox
+            if "round 3" in (e.get("preview") or "")
+        ]
+        assert not new_in_dev2, (
+            "dev-2 self-received its own reply — this is exactly the "
+            "misroute described in issue #145.\n"
+            f"dev-2 inbox (count {before_dev2_inbox} → {len(after_dev2_inbox)}): "
+            f"{after_dev2_inbox}"
+        )
+
+        # dev-1 must have the second-hop reply.
+        dev1_msgs = [m.get("message", "") for m in dev1_received]
+        assert any("round 3" in m for m in dev1_msgs), (
+            f"dev-1 missed the second-hop reply: {dev1_msgs}"
+        )
+
+        dev1.stop(timeout=1.0)
+        dev2.stop(timeout=1.0)
+    finally:
+        dev1_svc.stop()
+        dev2_svc.stop()
+        stop.set()


### PR DESCRIPTION
## Summary

- `email.reply` now resolves the concrete return route of the inbound message instead of blindly using the bare `from` alias. Cross-`.lingtai/` replies survive the same-short-name collision that bit us live (e.g. both networks host `mimo-1`).
- `_send(mode="abs")` embeds `_return_route` (mode + sender abs workdir + sender_agent_id) in the dispatched payload AND the local `sent/` record. Recipients without the field — older messages — keep working through the existing absolute-`from` fallback.
- Loud ambiguity guard: if a peer-mode reply target would resolve to the responder's own workdir while the original's `identity.agent_id` differs from the responder's own id, the reply is refused with an actionable error pointing at `mode="abs"`. No more silent self-delivery.

Fixes #145

## Why

dev-2 (`/Users/.../dev-2/.lingtai/mimo-1`) replied to a dev-1 message and the reply silently landed back in dev-2's own inbox: `_reply` used `original["from"] == "mimo-1"`, and dev-2's `FilesystemMailService` resolved that against its own `.lingtai/` directory → self. The lossy hop was on the *second* reply: dev-1's reply payload carried `from = "mimo-1"` because `_send(mode="peer")` (the default) overwrites `from` with the bare mail-service address, dropping the abs path that would have made the route unambiguous.

## Test plan
- [x] New regression tests in `tests/test_email_abs_reply_route.py`:
  - `_send(mode="abs")` embeds `_return_route` in dispatched payload + sent/.
  - Peer-mode sends do NOT add `_return_route` (no overhead on the happy path).
  - `_reply` prefers `_return_route` (abs mode) over `from`.
  - `_reply` falls back to abs mode when `from` is itself an absolute path.
  - Same-network bare-address reply still uses peer mode (no regression).
  - Ambiguity guard refuses self-resolving peer replies when `sender_agent_id` differs.
  - Full integration test: two `.lingtai/` roots both with `mimo-1`, three hops (A→B abs, B→A reply, A→B reply). The third hop is the exact misroute from #145 — it now lands in B's inbox, NOT A's own inbox.
- [x] All 266 existing email/mail/messaging tests still pass (`pytest -k "email or mail or messag or intrinsics_comm"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)