### PR TITLE
Fix daemon preset soft capability failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ venv/
 # Internal design docs / session artifacts (private — not for public repo)
 docs/
 MagicMock/
+reports/
 
 # Specific discussion drafts kept local (others under discussions/ are
 # committed by convention; ignore individual files rather than the whole dir)

--- a/src/lingtai/capabilities/vision/__init__.py
+++ b/src/lingtai/capabilities/vision/__init__.py
@@ -92,6 +92,7 @@ def setup(
     vision_service: VisionService | None = None,
     provider: str | None = None,
     api_key: str | None = None,
+    api_key_env: str | None = None,
     **kwargs: Any,
 ) -> VisionManager:
     """Set up the vision capability on an agent.
@@ -100,6 +101,9 @@ def setup(
     Raises ``ValueError`` if neither is provided.
     """
     if vision_service is None and provider is not None:
+        if api_key_env:
+            from ...config_resolve import resolve_env
+            api_key = resolve_env(api_key, api_key_env)
         if provider not in PROVIDERS["providers"]:
             # No dedicated VisionService for this provider. If the agent's
             # main LLM is OpenAI-compatible (custom relay, OpenRouter,

--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -315,10 +315,25 @@ class DaemonManager:
                     for n in tool_names if n in self._agent._tool_handlers}
         return schemas, dispatch
 
+    def _expand_requested_tools(self, requested: list[str]) -> set[str]:
+        """Expand requested daemon tools after group aliases and blacklist."""
+        from ...capabilities import _GROUPS
+
+        tool_names: set[str] = set()
+        for name in requested:
+            if name in EMANATION_BLACKLIST:
+                continue
+            if name in _GROUPS:
+                tool_names.update(_GROUPS[name])
+            else:
+                tool_names.add(name)
+        return tool_names
+
     def _instantiate_preset_capabilities(
         self,
         preset_caps: dict,
         preset_llm: dict,
+        required_tools: set[str] | None = None,
     ) -> tuple[dict, dict]:
         """Instantiate a preset's manifest.capabilities into a sandbox.
 
@@ -329,9 +344,10 @@ class DaemonManager:
         LLM, not the parent's — capabilities follow the body that hosts
         them.
 
-        Raises ``ValueError`` for unknown or broken capabilities. The caller
-        (``_handle_emanate``) converts that into a tool-level error and
-        refuses the whole batch.
+        Raises ``ValueError`` for broken capabilities that are required by
+        the current task. Broken unused capabilities are logged and skipped.
+        The caller (``_handle_emanate``) converts required setup failures into
+        a tool-level error and refuses the whole batch.
         """
         from ...capabilities import setup_capability, _GROUPS, _BUILTIN
         from ...presets import expand_inherit
@@ -359,6 +375,7 @@ class DaemonManager:
                 expanded[name] = kwargs
 
         collector = _ToolCollector(self._agent)
+        required = required_tools
         for name, kwargs in expanded.items():
             if name in EMANATION_BLACKLIST:
                 continue
@@ -380,6 +397,13 @@ class DaemonManager:
             try:
                 setup_capability(collector, name, **kwargs)
             except Exception as e:
+                if required is not None and name not in required:
+                    self._log(
+                        "daemon_preset_capability_skipped",
+                        capability=name,
+                        reason=f"setup failed: {e}",
+                    )
+                    continue
                 raise ValueError(
                     f"preset capability {name!r} failed to set up: {e}"
                 ) from e
@@ -1185,7 +1209,9 @@ class DaemonManager:
             # if unusual configuration.
             try:
                 preset_schemas, preset_handlers = self._instantiate_preset_capabilities(
-                    preset_caps, preset_llm,
+                    preset_caps,
+                    preset_llm,
+                    required_tools=self._expand_requested_tools(spec.get("tools", [])),
                 )
             except ValueError as e:
                 return {"status": "error",

--- a/src/lingtai/services/vision/codex.py
+++ b/src/lingtai/services/vision/codex.py
@@ -28,6 +28,7 @@ class CodexVisionService(VisionService):
         max_output_tokens: int | None = None,
         timeout: float = 120.0,
         token_path: str | None = None,
+        **_ignored: Any,
     ) -> None:
         import openai as _openai
 

--- a/tests/test_daemon_preset_capabilities.py
+++ b/tests/test_daemon_preset_capabilities.py
@@ -209,6 +209,56 @@ def test_instantiate_still_raises_on_broken_known_capability(tmp_path, monkeypat
         raise AssertionError("expected ValueError for broken known capability")
 
 
+def test_instantiate_skips_broken_unused_known_capability(tmp_path, monkeypatch):
+    """A known capability that fails setup is skipped when this task did not
+    request any tool it provides."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    original_setup = __import__(
+        "lingtai.capabilities", fromlist=["setup_capability"]
+    ).setup_capability
+
+    def boom_for_vision(target, name, **kwargs):
+        if name == "vision":
+            raise ValueError("simulated broken vision")
+        return original_setup(target, name, **kwargs)
+
+    monkeypatch.setattr("lingtai.capabilities.setup_capability", boom_for_vision)
+
+    schemas, handlers = mgr._instantiate_preset_capabilities(
+        {"file": {}, "vision": {"provider": "codex", "api_key_env": "IGNORED"}},
+        {"provider": "mock", "model": "mock"},
+        required_tools={"read", "write", "edit", "glob", "grep"},
+    )
+
+    assert "read" in schemas
+    assert "vision" not in schemas
+
+
+def test_instantiate_raises_for_broken_required_known_capability(tmp_path, monkeypatch):
+    """A known capability that fails setup is still hard when requested."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    def boom(target, name, **kwargs):
+        raise ValueError("simulated broken vision")
+
+    monkeypatch.setattr("lingtai.capabilities.setup_capability", boom)
+
+    try:
+        mgr._instantiate_preset_capabilities(
+            {"vision": {"provider": "codex", "api_key_env": "IGNORED"}},
+            {"provider": "mock", "model": "mock"},
+            required_tools={"vision"},
+        )
+    except ValueError as e:
+        assert "vision" in str(e)
+        assert "simulated broken vision" in str(e)
+    else:
+        raise AssertionError("expected ValueError for broken required capability")
+
+
 def test_instantiate_skips_blacklisted_capabilities(tmp_path):
     """daemon/avatar/psyche/skills/knowledge/library/codex in preset capabilities are skipped
     (not instantiated, no error)."""
@@ -434,3 +484,81 @@ def test_emanate_preset_does_not_pollute_parent_tool_registry(tmp_path,
     # Parent unchanged
     assert set(agent._tool_handlers.keys()) == pre_handlers
     assert {s.name for s in agent._tool_schemas} == pre_schemas
+
+
+def test_emanate_preset_broken_unused_vision_dispatches(tmp_path, monkeypatch):
+    """File-only daemon dispatch is not blocked by broken unused vision."""
+    import lingtai.preset_connectivity as preset_connectivity
+    import lingtai.capabilities as capabilities
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+
+    original_setup = capabilities.setup_capability
+
+    def boom_for_vision(target, name, **kwargs):
+        if name == "vision":
+            raise ValueError("simulated broken vision")
+        return original_setup(target, name, **kwargs)
+
+    monkeypatch.setattr(capabilities, "setup_capability", boom_for_vision)
+
+    presets_dir = tmp_path / "presets"
+    presets_dir.mkdir()
+    _write_preset(
+        presets_dir,
+        "file_plus_broken_vision",
+        capabilities={
+            "file": {},
+            "vision": {"provider": "codex", "api_key_env": "IGNORED"},
+        },
+    )
+
+    agent = _make_agent(tmp_path, ["daemon"], presets_dir=presets_dir)
+    agent.inbox = queue.Queue()
+    mgr = agent.get_capability("daemon")
+
+    preset_path = str(presets_dir / "file_plus_broken_vision.json")
+    with patch.object(preset_connectivity, "_probe_host", return_value=12.5):
+        result = mgr.handle({"action": "emanate", "tasks": [
+            {"task": "scan files", "tools": ["file"], "preset": preset_path},
+        ]})
+
+    assert result["status"] == "dispatched", result.get("message")
+    assert result["count"] == 1
+
+
+def test_emanate_preset_broken_requested_vision_fails(tmp_path, monkeypatch):
+    """Requested capability setup failures remain hard errors."""
+    import lingtai.preset_connectivity as preset_connectivity
+    import lingtai.capabilities as capabilities
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+
+    original_setup = capabilities.setup_capability
+
+    def boom_for_vision(target, name, **kwargs):
+        if name == "vision":
+            raise ValueError("simulated broken vision")
+        return original_setup(target, name, **kwargs)
+
+    monkeypatch.setattr(capabilities, "setup_capability", boom_for_vision)
+
+    presets_dir = tmp_path / "presets"
+    presets_dir.mkdir()
+    _write_preset(
+        presets_dir,
+        "broken_vision",
+        capabilities={"vision": {"provider": "codex", "api_key_env": "IGNORED"}},
+    )
+
+    agent = _make_agent(tmp_path, ["daemon"], presets_dir=presets_dir)
+    agent.inbox = queue.Queue()
+    mgr = agent.get_capability("daemon")
+
+    preset_path = str(presets_dir / "broken_vision.json")
+    with patch.object(preset_connectivity, "_probe_host", return_value=12.5):
+        result = mgr.handle({"action": "emanate", "tasks": [
+            {"task": "inspect image", "tools": ["vision"], "preset": preset_path},
+        ]})
+
+    assert result["status"] == "error"
+    assert "preset capability 'vision' failed to set up" in result["message"]
+    assert "simulated broken vision" in result["message"]

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -117,6 +117,22 @@ def test_vision_setup_with_provider_and_key(tmp_path):
         assert isinstance(mgr, VisionManager)
 
 
+def test_vision_setup_resolves_api_key_env(tmp_path, monkeypatch):
+    """setup() should resolve api_key_env before constructing provider services."""
+    monkeypatch.setenv("VISION_TEST_API_KEY", "sk-from-env")
+    with patch("lingtai.capabilities.vision.create_vision_service") as mock_factory:
+        mock_svc = MagicMock(spec=VisionService)
+        mock_factory.return_value = mock_svc
+
+        agent = make_mock_agent(tmp_path)
+        mgr = setup(agent, provider="zhipu", api_key_env="VISION_TEST_API_KEY")
+
+        mock_factory.assert_called_once()
+        assert mock_factory.call_args.args == ("zhipu",)
+        assert mock_factory.call_args.kwargs["api_key"] == "sk-from-env"
+        assert isinstance(mgr, VisionManager)
+
+
 def test_vision_setup_with_codex_provider_without_api_key(tmp_path):
     """Codex vision uses ChatGPT OAuth, so setup should not require api_key."""
     with patch("lingtai.capabilities.vision.create_vision_service") as mock_factory:
@@ -163,6 +179,24 @@ def test_create_vision_service_codex_without_api_key(monkeypatch):
 
     with patch("lingtai.services.vision.codex.CodexTokenManager") as mock_mgr:
         svc = create_vision_service("codex")
+
+    from lingtai.services.vision.codex import CodexVisionService
+
+    assert isinstance(svc, CodexVisionService)
+    mock_mgr.assert_called_once_with(token_path=None)
+
+
+def test_create_vision_service_codex_ignores_extra_preset_kwargs(monkeypatch):
+    """Codex vision should tolerate irrelevant preset kwargs like api_key_env."""
+    fake_openai = SimpleNamespace(OpenAI=MagicMock())
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+
+    with patch("lingtai.services.vision.codex.CodexTokenManager") as mock_mgr:
+        svc = create_vision_service(
+            "codex",
+            api_key_env="IGNORED",
+            provider_note="from preset",
+        )
 
     from lingtai.services.vision.codex import CodexVisionService
 


### PR DESCRIPTION
## Summary
- Soft-skip preset capability setup failures when the current daemon task did not request that capability's tools, while preserving hard failures for requested tools.
- Resolve vision api_key_env values before creating provider vision services, and let Codex vision ignore irrelevant preset kwargs.
- Ignore generated reports/ artifacts without staging existing local report files.

## Tests
- .venv/bin/python -m pytest -p no:capture tests/test_daemon_preset_capabilities.py tests/test_vision_capability.py
- .venv/bin/python -m pytest -p no:capture tests/test_daemon.py tests/test_daemon_check.py tests/test_daemon_run_dir.py tests/test_daemon_per_batch_limits.py

Note: plain pytest currently segfaults during pytest capture initialization in this environment; disabling the capture plugin avoids the environment crash.