### PR TITLE
Fix env-file reload on refresh

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -980,8 +980,13 @@ class Agent(BaseAgent):
         from lingtai_kernel.config import AgentConfig
 
         env_file = data.get("env_file")
+        import os
+
+        overwrite_env_file = os.environ.get("LINGTAI_REFRESH_ENV_OVERWRITE") == "1"
         if env_file:
-            load_env_file(env_file)
+            load_env_file(env_file, overwrite=overwrite_env_file)
+        if overwrite_env_file:
+            os.environ.pop("LINGTAI_REFRESH_ENV_OVERWRITE", None)
 
         # Resolve *_file fields for top-level text content.
         # Note: "soul" / "soul_file" were retired in v0.7.6 and are now

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -76,10 +76,16 @@ def build_agent(data: dict, working_dir: Path) -> Agent:
     then delegates all setup to _perform_refresh() which reads init.json.
     This ensures boot and live refresh share one code path.
     """
-    # Load env file if specified (needed for LLM API key resolution)
+    # Load env file if specified (needed for LLM API key resolution).
+    # Refresh relaunches inherit the old process env; a watcher marker lets
+    # the freshly edited env_file replace those stale values once, then is
+    # consumed so later child processes keep normal boot semantics.
     env_file = data.get("env_file")
+    overwrite_env_file = os.environ.get("LINGTAI_REFRESH_ENV_OVERWRITE") == "1"
     if env_file:
-        load_env_file(env_file)
+        load_env_file(env_file, overwrite=overwrite_env_file)
+    if overwrite_env_file:
+        os.environ.pop("LINGTAI_REFRESH_ENV_OVERWRITE", None)
 
     m = data["manifest"]
     llm = m["llm"]

--- a/src/lingtai_kernel/base_agent/lifecycle.py
+++ b/src/lingtai_kernel/base_agent/lifecycle.py
@@ -399,6 +399,7 @@ def _perform_refresh(agent) -> None:
     ``_shutdown`` / ``_cancel_event`` ourselves so the watcher's second
     phase can complete.
     """
+    import os
     import subprocess
     import sys
 
@@ -557,12 +558,14 @@ def _perform_refresh(agent) -> None:
         "        stderr_tail=stderr_tail[-500:])\n"
         "log('refresh_failed_permanent', attempts=MAX_ATTEMPTS)\n"
     )
+    watcher_env = {**os.environ, "LINGTAI_REFRESH_ENV_OVERWRITE": "1"}
     subprocess.Popen(
         [sys.executable, "-c", relaunch_script],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         start_new_session=True,
+        env=watcher_env,
     )
     agent._log("refresh_deferred_relaunch",
                cmd=cmd[0], handshake=handshake_source)

--- a/src/lingtai_kernel/config_resolve.py
+++ b/src/lingtai_kernel/config_resolve.py
@@ -48,8 +48,15 @@ def resolve_env(value: str | None, env_name: str | None) -> str | None:
     return value
 
 
-def load_env_file(path: str | Path) -> None:
-    """Load a .env file into os.environ. Existing vars are not overwritten."""
+def load_env_file(path: str | Path, *, overwrite: bool = False) -> None:
+    """Load a .env file into os.environ.
+
+    By default, existing process environment variables are preserved so a
+    caller's explicit shell environment wins at initial boot. Pass
+    ``overwrite=True`` for deliberate config reloads (notably
+    ``system(action="refresh")``) so edits to the agent's env_file replace
+    stale values inherited by the relaunched process.
+    """
     env_path = Path(path).expanduser()
     if not env_path.is_file():
         return
@@ -62,7 +69,7 @@ def load_env_file(path: str | Path) -> None:
             continue
         key = key.strip()
         val = val.strip().strip("'\"")
-        if key not in os.environ:
+        if overwrite or key not in os.environ:
             os.environ[key] = val
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,10 +119,14 @@ def test_load_env_file(tmp_path):
     assert os.environ["TEST_CLI_KEY"] == "secret123"
     assert os.environ["TEST_CLI_OTHER"] == "quoted"
 
-    # Does not overwrite existing
+    # Does not overwrite existing by default
     os.environ["TEST_CLI_KEY"] = "original"
     load_env_file(env_path)
     assert os.environ["TEST_CLI_KEY"] == "original"
+
+    # Explicit refresh reloads may choose to overwrite stale process env.
+    load_env_file(env_path, overwrite=True)
+    assert os.environ["TEST_CLI_KEY"] == "secret123"
 
     # Clean up
     os.environ.pop("TEST_CLI_KEY", None)
@@ -207,6 +211,36 @@ def test_build_agent_env_file_loaded(mock_mail, mock_agent, mock_llm, tmp_path):
     assert llm_kwargs["api_key"] == "from-file"
     assert llm_kwargs["provider"] == "anthropic"
     assert llm_kwargs["model"] == "test-model"
+
+
+@patch("lingtai.cli.LLMService")
+@patch("lingtai.cli.Agent")
+@patch("lingtai.cli.FilesystemMailService")
+def test_build_agent_env_file_overwrites_on_refresh_marker(mock_mail, mock_agent, mock_llm, tmp_path):
+    """Refresh relaunches should let an edited env_file replace stale
+    inherited process environment values before resolving api_key_env.
+    """
+    from lingtai.cli import load_init, build_agent
+
+    env_path = tmp_path / "secrets.env"
+    env_path.write_text("TEST_ENV_FILE_REFRESH_KEY=fresh-from-file\n")
+
+    _write_init(tmp_path)
+    data = load_init(tmp_path)
+    data["env_file"] = str(env_path)
+    data["manifest"]["llm"]["api_key_env"] = "TEST_ENV_FILE_REFRESH_KEY"
+
+    os.environ["TEST_ENV_FILE_REFRESH_KEY"] = "stale-process-value"
+    os.environ["LINGTAI_REFRESH_ENV_OVERWRITE"] = "1"
+    try:
+        build_agent(data, tmp_path)
+    finally:
+        os.environ.pop("TEST_ENV_FILE_REFRESH_KEY", None)
+        os.environ.pop("LINGTAI_REFRESH_ENV_OVERWRITE", None)
+
+    mock_llm.assert_called_once()
+    assert mock_llm.call_args.kwargs["api_key"] == "fresh-from-file"
+    assert "LINGTAI_REFRESH_ENV_OVERWRITE" not in os.environ
 
 
 # --- addons ---

--- a/tests/test_perform_refresh_handshake.py
+++ b/tests/test_perform_refresh_handshake.py
@@ -229,3 +229,18 @@ def test_perform_refresh_logs_handshake_source(tmp_path):
     _, kw = relaunch_events[0]
     assert kw.get("handshake") == "synthesized_direct_call", \
         f"expected synthesized_direct_call, got {kw.get('handshake')!r}"
+
+
+def test_perform_refresh_watcher_marks_env_file_overwrite(tmp_path):
+    """A refresh relaunch inherits the old process environment. Mark the
+    watcher process so the relaunched agent overwrites stale env_file values
+    with freshly edited .env contents.
+    """
+    agent = _make_agent_with_launch_cmd(tmp_path)
+
+    with patch("subprocess.Popen") as mock_popen:
+        agent._perform_refresh()
+
+    assert mock_popen.called
+    _, kwargs = mock_popen.call_args
+    assert kwargs["env"]["LINGTAI_REFRESH_ENV_OVERWRITE"] == "1"


### PR DESCRIPTION
## Summary
- add an explicit overwrite mode to env-file loading while preserving default shell-env precedence
- mark refresh relaunches with a one-shot env overwrite flag so edited `.env` values replace stale inherited process env
- consume the refresh marker after reload so later child processes keep normal boot semantics
- cover the reload behavior with CLI/env and refresh watcher tests

## Tests
- `.venv/bin/python -m pytest -p no:capture tests/test_cli.py tests/test_perform_refresh_handshake.py tests/test_preset_materialization.py tests/test_preset_swap_e2e.py` — 42 passed
