### PR TITLE
fix: correlate poll results by tool result id

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -949,11 +949,13 @@ def _check_poll_backoff(agent, tool_calls, tool_results=None) -> bool:
     arrive via the notification system, or when a check/read action
     actually returns messages (found_new=True).
     """
-    # Build a lookup from tool_call_id to result for found-new detection.
+    # Build a lookup from tool-call id to result for found-new detection.
+    # ToolResultBlock stores the correlated tool-call id on `.id` (the same
+    # field name as ToolCallBlock), not on a separate `.tool_call_id`.
     result_by_tc_id: dict = {}
     if tool_results:
         for tr in tool_results:
-            tc_id = getattr(tr, "tool_call_id", None)
+            tc_id = getattr(tr, "id", None)
             if tc_id:
                 result_by_tc_id[tc_id] = tr
 

--- a/tests/test_sent_message_tracker.py
+++ b/tests/test_sent_message_tracker.py
@@ -170,8 +170,9 @@ class TestCheckExternalSend:
         agent._log = MagicMock()
         return agent
 
-    def _make_tc(self, name, args):
+    def _make_tc(self, name, args, id="tc-1"):
         tc = MagicMock()
+        tc.id = id
         tc.name = name
         tc.args = args
         return tc
@@ -337,8 +338,9 @@ class TestCheckPollBackoff:
         agent._log = MagicMock()
         return agent
 
-    def _make_tc(self, name, args):
+    def _make_tc(self, name, args, id="tc-1"):
         tc = MagicMock()
+        tc.id = id
         tc.name = name
         tc.args = args
         return tc
@@ -370,6 +372,41 @@ class TestCheckPollBackoff:
         _check_poll_backoff(agent, [tc_check])  # 2
         _check_poll_backoff(agent, [tc_send])   # send resets
         assert not _check_poll_backoff(agent, [tc_check])  # 1 again
+
+    def test_read_result_with_messages_resets_backoff(self):
+        from lingtai_kernel.base_agent.turn import _check_poll_backoff
+        from lingtai_kernel.llm.interface import ToolResultBlock
+
+        agent = self._make_agent()
+        tc = self._make_tc("telegram", {"action": "read"}, id="tc-read")
+
+        _check_poll_backoff(agent, [tc])
+        _check_poll_backoff(agent, [tc])
+        result = ToolResultBlock(
+            id="tc-read",
+            name="telegram",
+            content={"messages": [{"id": "msg-1", "text": "hello"}]},
+        )
+
+        assert not _check_poll_backoff(agent, [tc], [result])
+        assert agent._sent_tracker._poll_counts.get("telegram", 0) == 0
+
+    def test_check_result_with_emails_or_conversations_resets_backoff(self):
+        from lingtai_kernel.base_agent.turn import _check_poll_backoff
+        from lingtai_kernel.llm.interface import ToolResultBlock
+
+        for tool_name, content in (
+            ("imap", '{"emails": [{"subject": "hi"}]}'),
+            ("feishu", {"conversations": [{"chat_id": "oc_1"}]}),
+        ):
+            agent = self._make_agent()
+            tc = self._make_tc(tool_name, {"action": "check"}, id=f"{tool_name}-check")
+            _check_poll_backoff(agent, [tc])
+            _check_poll_backoff(agent, [tc])
+            result = ToolResultBlock(id=tc.id, name=tool_name, content=content)
+
+            assert not _check_poll_backoff(agent, [tc], [result])
+            assert agent._sent_tracker._poll_counts.get(tool_name, 0) == 0
 
     def test_non_external_tool_ignored(self):
         from lingtai_kernel.base_agent.turn import _check_poll_backoff


### PR DESCRIPTION
## Summary
- fix `_check_poll_backoff` to correlate tool results by `ToolResultBlock.id` instead of nonexistent `tool_call_id`
- add regression coverage proving non-empty `messages`, `emails`, and `conversations` results reset poll backoff

Fixes #141.

## Validation
- `python -m pytest tests/test_sent_message_tracker.py -q` — 37 passed
- `python -m pytest tests/test_notification_sync.py tests/test_sent_message_tracker.py -q` — 82 passed
- `python -m py_compile src/lingtai_kernel/base_agent/turn.py`
- `git diff --check`

## Review
- Claude Code reviewed current diff: no blockers, correct/minimal.
- Zhipu daemon independently confirmed the root cause (`ToolResultBlock` has `.id`, no `.tool_call_id`); no contrary blocker surfaced.
