### PR TITLE
docs: add cleanup footprint contract to tool manuals

### DIFF
--- a/src/lingtai/core/avatar/manual/SKILL.md
+++ b/src/lingtai/core/avatar/manual/SKILL.md
@@ -130,3 +130,34 @@ Example:
 Always report findings via email.
 Do not spawn more than 3 avatars.
 ```
+
+## Cleanup / Footprint
+
+Avatars leave independent agent directories under the `.lingtai/` network plus
+parent-side delegation records such as `delegates/ledger.jsonl`. These are lives,
+not cache files. Do not delete an avatar directory directly unless the user has
+explicitly approved retiring that avatar and you have captured any handoff,
+knowledge, or files worth preserving. Prefer lifecycle tools (`lull`, `suspend`,
+`nirvana` when appropriate and authorized) over filesystem deletion.
+
+Footprint check (read-only, records the audit from the parent agent directory):
+
+```bash
+python3 - <<'PY'
+import json, time
+from pathlib import Path
+agent = Path.cwd(); network = agent.parent if agent.parent.name == ".lingtai" else agent / ".lingtai"
+avatars = [p for p in network.iterdir() if p.is_dir() and (p / ".agent.json").exists()] if network.is_dir() else []
+def size(p): return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+rows = [(p, size(p)) for p in avatars]
+total = sum(s for _, s in rows)
+print(f"agent dirs: {len(rows)}; bytes: {total}")
+for p, s in sorted(rows, key=lambda r: r[1], reverse=True): print(f"{s:>12}  {p.name}")
+log = agent / "logs" / "cleanup.jsonl"; log.parent.mkdir(parents=True, exist_ok=True)
+log.open("a", encoding="utf-8").write(json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "tool": "avatar", "dry_run": True, "candidates": len(rows), "bytes": total, "human_approved": False, "summary": "avatar network footprint audit"}) + "\n")
+PY
+```
+
+Recommended cadence: after spawning new specialists, before pruning a network,
+and monthly for busy orchestrators. Any destructive cleanup requires explicit
+user consent after a dry-run list of avatars and sizes.

--- a/src/lingtai/core/bash/manual/SKILL.md
+++ b/src/lingtai/core/bash/manual/SKILL.md
@@ -620,3 +620,35 @@ Don't delete the script first — if the unit is still loaded and tries to fire 
 # Other bash topics
 
 This section is empty. As more operational knowledge accumulates (debugging pipelines, working with binary data, locale handling), it gets added here.
+
+## Cleanup / Footprint for bash work
+
+`bash` can create anything the command creates: scripts, logs, downloads,
+virtualenvs, cron/launchd/systemd units, and arbitrary build artifacts. Because
+ownership is command-specific, every non-trivial bash workflow should document
+its own cleanup path near the script it creates. Never run a destructive shell
+cleanup from a manual without first showing a dry-run and getting explicit user
+consent.
+
+Generic footprint check (read-only, records the audit from the agent directory):
+
+```bash
+python3 - <<'PY'
+import json, time
+from pathlib import Path
+agent = Path.cwd()
+roots = [p for p in [agent / "tmp", agent / "logs", agent / "scripts"] if p.exists()]
+def size(p): return p.stat().st_size if p.is_file() else sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+rows = [(p, size(p)) for p in roots]
+total = sum(s for _, s in rows)
+print(f"bash-adjacent roots: {len(rows)}; bytes: {total}")
+for p, s in rows: print(f"{s:>12}  {p}")
+log = agent / "logs" / "cleanup.jsonl"; log.parent.mkdir(parents=True, exist_ok=True)
+log.open("a", encoding="utf-8").write(json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "tool": "bash", "dry_run": True, "candidates": len(rows), "bytes": total, "human_approved": False, "summary": "bash-adjacent footprint audit"}) + "\n")
+PY
+```
+
+Recommended cadence: when retiring cron jobs, after large downloads/builds, and
+whenever a shell workflow writes outside a short-lived temp directory. Cleanup
+records belong in `logs/cleanup.jsonl`; cron/launchd/systemd retirement should
+also record the scheduler unit name that was unloaded.

--- a/src/lingtai/core/daemon/manual/SKILL.md
+++ b/src/lingtai/core/daemon/manual/SKILL.md
@@ -347,3 +347,37 @@ After the emanation completes, verify:
 - Provider routing / LLM presets — deferred to a separate spec.
 - Cross-process recovery — if your kernel restarted mid-daemon, the folder may show `state=running` indefinitely. Compare `now()` vs `.heartbeat` mtime to detect orphans.
 - Folder cleanup — there is none. Molts wipe the working dir. For non-molting agents, you may eventually want to `rm -rf daemons/em-*-2026-04-*` manually.
+
+## Cleanup / Footprint
+
+Daemon runs are intentionally persistent forensic records. Each emanation leaves
+`daemons/em-*` under the parent agent, including `daemon.json`, events,
+transcript/history, result files, and token ledgers. Do not delete an active
+run, and do not delete a run you still need for a report, review, or cost audit.
+
+Footprint check (read-only, records the audit):
+
+```bash
+python3 - <<'PY'
+import json, time
+from pathlib import Path
+agent = Path.cwd()
+daemons = agent / "daemons"
+items = [p for p in daemons.glob("em-*") if p.is_dir()] if daemons.is_dir() else []
+def size(p):
+    return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+rows = [(p, size(p)) for p in items]
+total = sum(s for _, s in rows)
+print(f"daemon runs: {len(rows)}; bytes: {total}")
+for p, s in sorted(rows, key=lambda r: r[1], reverse=True)[:20]:
+    print(f"{s:>12}  {p}")
+log = agent / "logs" / "cleanup.jsonl"; log.parent.mkdir(parents=True, exist_ok=True)
+log.open("a", encoding="utf-8").write(json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "tool": "daemon", "dry_run": True, "candidates": len(rows), "bytes": total, "human_approved": False, "summary": "daemon footprint audit"}) + "\n")
+PY
+```
+
+Recommended cadence: after daemon-heavy debugging sessions, before molt if a
+large review generated many runs, and monthly for always-on orchestrators.
+Cleanup is optional. Before deleting old completed `daemons/em-*` folders, show
+the dry-run output to the user and get explicit consent; then append an `apply`
+record to `logs/cleanup.jsonl` with the deleted paths/bytes.

--- a/src/lingtai/core/email/manual/SKILL.md
+++ b/src/lingtai/core/email/manual/SKILL.md
@@ -250,3 +250,36 @@ email(action="add_contact", address="mimo-1", name="MiMo (vision)",
 
 ---
 > **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.
+
+## Cleanup / Footprint
+
+Internal email persists under the agent mailbox: inbox/archive/sent message
+files, attachments, contacts, and schedule metadata. Mail is also memory: do not
+blindly delete it. Prefer `email(archive)`, `email(delete)`, or schedule cancel
+verbs over `rm`, and never delete mail that is the only copy of a decision,
+handoff, or attachment the human may expect you to retain.
+
+Footprint check (read-only, records the audit):
+
+```bash
+python3 - <<'PY'
+import json, time
+from pathlib import Path
+agent = Path.cwd()
+roots = [p for p in [agent / "mailbox", agent / "mail", agent / "email"] if p.exists()]
+def size(p):
+    return p.stat().st_size if p.is_file() else sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+rows = [(p, size(p)) for r in roots for p in ([r] if r.is_file() else r.iterdir())]
+total = sum(s for _, s in rows)
+print(f"internal email roots: {[str(r) for r in roots]}")
+print(f"top-level entries: {len(rows)}; bytes: {total}")
+for p, s in sorted(rows, key=lambda r: r[1], reverse=True)[:20]: print(f"{s:>12}  {p}")
+log = agent / "logs" / "cleanup.jsonl"; log.parent.mkdir(parents=True, exist_ok=True)
+log.open("a", encoding="utf-8").write(json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "tool": "email", "dry_run": True, "candidates": len(rows), "bytes": total, "human_approved": False, "summary": "internal email footprint audit"}) + "\n")
+PY
+```
+
+Recommended cadence: when large attachments are exchanged, before exporting or
+archiving a project, and quarterly for long-lived agents. Cleanup requires a
+dry-run report plus explicit user consent; after deletion/archive, append an
+`apply` record to `logs/cleanup.jsonl`.

--- a/src/lingtai/core/knowledge/manual/SKILL.md
+++ b/src/lingtai/core/knowledge/manual/SKILL.md
@@ -128,3 +128,34 @@ Create or update a knowledge entry when the information is useful beyond the cur
 - conclusions from research that are specific to this agent's work.
 
 If the content is a reusable how-to that another agent should be able to apply without your private context, write a skill instead.
+
+## Cleanup / Footprint
+
+Knowledge entries live under `knowledge/<name>/KNOWLEDGE.md` plus supporting
+files. They are durable memory, not cache. Cleanup usually means consolidation,
+renaming, or archiving stale entries after review; never delete knowledge just to
+save space unless the user explicitly agrees after a dry-run report and the content is backed up or no
+longer useful.
+
+Footprint check (read-only, records the audit):
+
+```bash
+python3 - <<'PY'
+import json, time
+from pathlib import Path
+agent = Path.cwd(); root = agent / "knowledge"
+entries = [p for p in root.iterdir() if p.is_dir()] if root.is_dir() else []
+def size(p): return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+rows = [(p, size(p)) for p in entries]
+total = sum(s for _, s in rows)
+print(f"knowledge entries: {len(rows)}; bytes: {total}")
+for p, s in sorted(rows, key=lambda r: r[1], reverse=True)[:30]: print(f"{s:>12}  {p.name}")
+log = agent / "logs" / "cleanup.jsonl"; log.parent.mkdir(parents=True, exist_ok=True)
+log.open("a", encoding="utf-8").write(json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "tool": "knowledge", "dry_run": True, "candidates": len(rows), "bytes": total, "human_approved": False, "summary": "knowledge footprint audit"}) + "\n")
+PY
+```
+
+Recommended cadence: before molt if knowledge sprawl is confusing, after major
+projects, and monthly for long-lived agents. If cleanup is approved with explicit user consent, record the
+entries consolidated/removed in `logs/cleanup.jsonl` and update the catalog with
+`knowledge(action="info")`.

--- a/src/lingtai/core/mcp/manual/SKILL.md
+++ b/src/lingtai/core/mcp/manual/SKILL.md
@@ -126,3 +126,35 @@ All registry mutations happen via `write` / `edit` / `bash`. The `mcp` capabilit
 
 - **Canonical spec**: `lingtai-kernel-anatomy reference/mcp-protocol.md` — full three-layer model, env injection, validator schema, **LICC v1** inbox callback contract, reference implementations.
 - **File formats**: `lingtai-kernel-anatomy reference/file-formats.md` §2.7 (init.json `addons` + `mcp` fields), §6 (`mcp/servers.json` legacy direct mounts), §6.5 (`mcp_registry.jsonl`), §6.6 (`.mcp_inbox/<name>/<id>.json` LICC events).
+
+## Cleanup / Footprint
+
+MCP itself owns registry/configuration state (`mcp_registry.jsonl`, optional
+`mcp/servers.json`, and `.mcp_inbox/<name>/...` LICC event files). Curated addon
+packages such as Telegram/Feishu/WeChat/IMAP also maintain their own data
+stores; their README/manual is responsible for declaring addon-specific cleanup
+such as downloaded voice/audio attachments. Do not delete credentials or active
+registry entries as a cleanup shortcut.
+
+Footprint check (read-only, records the audit):
+
+```bash
+python3 - <<'PY'
+import json, time
+from pathlib import Path
+agent = Path.cwd()
+roots = [p for p in [agent / "mcp_registry.jsonl", agent / "mcp", agent / ".mcp_inbox"] if p.exists()]
+def size(p): return p.stat().st_size if p.is_file() else sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+rows = [(p, size(p)) for p in roots]
+total = sum(s for _, s in rows)
+print(f"mcp roots: {len(rows)}; bytes: {total}")
+for p, s in rows: print(f"{s:>12}  {p}")
+log = agent / "logs" / "cleanup.jsonl"; log.parent.mkdir(parents=True, exist_ok=True)
+log.open("a", encoding="utf-8").write(json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "tool": "mcp", "dry_run": True, "candidates": len(rows), "bytes": total, "human_approved": False, "summary": "mcp footprint audit"}) + "\n")
+PY
+```
+
+Recommended cadence: after adding/removing MCP servers, when `.mcp_inbox` grows,
+and before sharing a project. Cleanup requires explicit user consent after the
+dry-run report, and the audit/apply step must be recorded in `logs/cleanup.jsonl`. Prefer deregistering/updating registry files followed by
+`system(action="refresh")` over deleting registry state by hand.

--- a/src/lingtai/core/skills/manual/SKILL.md
+++ b/src/lingtai/core/skills/manual/SKILL.md
@@ -103,6 +103,23 @@ Example: `tags: [python, physics, mhd, solver]`. Tags are best-effort metadata, 
 
 After writing, call `system({"action": "refresh"})` so the skills capability rescans and re-injects the catalog.
 
+
+### Cleanup / Footprint contract for tool manuals
+
+Every tool/capability manual that owns persistent state must include a `Cleanup / Footprint` section. This is a contract, not a janitor: the section teaches agents what the tool leaves behind and how to audit it safely.
+
+Minimum requirements:
+
+- list concrete files/directories/caches/logs the tool creates;
+- say what must never be deleted blindly;
+- provide a read-only footprint check script or command;
+- recommend an audit/cleanup cadence;
+- require a dry-run report plus explicit user consent before destructive cleanup;
+- append a cleanup/audit record to `logs/cleanup.jsonl` after the script runs;
+- guide agents who read the manual for setup/troubleshooting/long-running work to self-audit the footprint.
+
+The full template and consent rule live in `reference/cleanup-footprint-contract.md`.
+
 ### Starting from the template
 
 If you'd rather not start from a blank file, copy the bundled template:
@@ -255,3 +272,33 @@ If a custom skill is worth sharing outside the network — with humans, external
 Do NOT `git init` inside `.library/custom/` directly — it is a subtree of your agent working directory and you would entangle two repos. Always copy out first.
 
 Once published, agents elsewhere can install it with `git clone` into their `.library/custom/` and call `system({"action": "refresh"})`.
+
+## Cleanup / Footprint
+
+Skills live under `.library/intrinsic/`, `.library/custom/`, network shared
+skill paths, and any extra paths configured in `init.json`. Intrinsic skills are
+runtime-owned; do not delete them. Custom/shared skills are portable procedure
+memory: cleanup should usually mean validation, renaming, consolidation, or git
+removal through a reviewed PR, not ad-hoc `rm`.
+
+Footprint check (read-only, records the audit):
+
+```bash
+python3 - <<'PY'
+import json, time
+from pathlib import Path
+agent = Path.cwd()
+roots = [p for p in [agent / ".library" / "custom", agent / ".library" / "intrinsic", agent.parent / ".library_shared"] if p.exists()]
+def size(p): return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+rows = [(p, size(p)) for p in roots]
+total = sum(s for _, s in rows)
+print(f"skill roots: {len(rows)}; bytes: {total}")
+for p, s in rows: print(f"{s:>12}  {p}")
+log = agent / "logs" / "cleanup.jsonl"; log.parent.mkdir(parents=True, exist_ok=True)
+log.open("a", encoding="utf-8").write(json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "tool": "skills", "dry_run": True, "candidates": len(rows), "bytes": total, "human_approved": False, "summary": "skills footprint audit"}) + "\n")
+PY
+```
+
+Recommended cadence: after authoring/publishing skills, before recipe export,
+and monthly for shared libraries. Destructive cleanup requires a dry-run report,
+explicit user consent, and a git commit/PR when the skill root is tracked.

--- a/src/lingtai/core/skills/manual/reference/cleanup-footprint-contract.md
+++ b/src/lingtai/core/skills/manual/reference/cleanup-footprint-contract.md
@@ -1,0 +1,70 @@
+# Cleanup / Footprint Contract for Tool Manuals
+
+Every tool/capability manual that owns persistent files MUST include a section named
+`Cleanup / Footprint`. The point is not to force cleanup. The point is to make each
+tool responsible for declaring its own footprint and safe cleanup ritual.
+
+## Required fields
+
+A compliant `Cleanup / Footprint` section MUST state:
+
+1. **What this tool leaves behind** — concrete files/directories, caches, logs,
+   external scheduler entries, downloaded attachments, subprocess run folders,
+   or registry records.
+2. **What must never be deleted blindly** — secrets, message records,
+   knowledge/skills/system state, active subprocess state, or anything needed
+   for recovery/audit.
+3. **Footprint check script** — a copy/pasteable command or script that reports
+   count and size without deleting anything. The default mode MUST be read-only.
+4. **Recommended audit cadence** — when agents should run the footprint check
+   (for example after a daemon-heavy session, weekly for chat addons, or before
+   retiring a cron job).
+5. **Cleanup protocol** — a safe procedure for deleting or archiving artifacts.
+   Destructive cleanup MUST require explicit user consent after a dry-run report.
+6. **Cleanup record** — every cleanup/audit script run SHOULD append a JSONL
+   record to `logs/cleanup.jsonl` under the relevant agent/workdir, including at
+   minimum: timestamp, tool/manual name, dry-run vs apply, candidate count,
+   bytes, paths or glob summary, and whether human approval was obtained.
+
+## Consent rule
+
+Cleanup is never mandatory and never implicit. A tool manual may recommend a
+cleanup, but before deletion the agent must:
+
+1. run/show the read-only footprint report,
+2. explain what would be removed and what would be kept,
+3. ask the user for explicit consent, and
+4. only then run the destructive step.
+
+If the user is unavailable, stop after the dry-run report.
+
+## Self-audit rule
+
+When an agent reads a tool manual for setup, troubleshooting, long-running
+operation, or anything involving disk/privacy footprint, it should run (or at
+least consider running) that manual's footprint check. If the footprint is
+large, stale, or privacy-sensitive, report it and ask whether to clean.
+
+## Standard cleanup record snippet
+
+Manuals may adapt this snippet in their own footprint scripts:
+
+```python
+import json, time
+from pathlib import Path
+
+def append_cleanup_record(agent_dir: Path, *, tool: str, dry_run: bool,
+                          candidates: int, bytes_total: int,
+                          human_approved: bool, summary: str) -> None:
+    log = agent_dir / "logs" / "cleanup.jsonl"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.open("a", encoding="utf-8").write(json.dumps({
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "tool": tool,
+        "dry_run": dry_run,
+        "candidates": candidates,
+        "bytes": bytes_total,
+        "human_approved": human_approved,
+        "summary": summary,
+    }, ensure_ascii=False) + "\n")
+```


### PR DESCRIPTION
## Summary
- define a reusable `Cleanup / Footprint` contract for tool/capability manuals
- require each manual to document footprint, read-only audit script, recommended cadence, cleanup record, and explicit user consent before destructive cleanup
- add concrete cleanup/footprint sections to the existing core manuals: avatar, bash, daemon, email, knowledge, mcp, skills
- add `reference/cleanup-footprint-contract.md` with the full template and consent/self-audit rules

## Validation
- Python sanity check: every core manual has a `Cleanup / Footprint` section, cleanup record language, and explicit consent language
- `git diff --check`

## Notes
This follows Jason's design direction: cleanup is not a global forced janitor or a separate clean skill. Each tool manual defines how to audit and clean its own footprint, and destructive cleanup requires a dry-run report plus explicit user consent.
