### PR TITLE
fix: pin text reads to utf-8

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -465,7 +465,7 @@ class Agent(BaseAgent):
         legacy_config = self._working_dir / "mcp" / "servers.json"
         if legacy_config.is_file():
             try:
-                servers = json.loads(legacy_config.read_text())
+                servers = json.loads(legacy_config.read_text(encoding="utf-8"))
                 if isinstance(servers, dict):
                     for name, cfg in servers.items():
                         if isinstance(cfg, dict):
@@ -673,7 +673,7 @@ class Agent(BaseAgent):
         # Resolve Python: target's init.json venv_path → global runtime
         try:
             import json as _json
-            target_data = _json.loads(init_path.read_text())
+            target_data = _json.loads(init_path.read_text(encoding="utf-8"))
         except (ValueError, OSError):
             target_data = None
         venv_dir = resolve_venv(target_data)
@@ -1227,7 +1227,7 @@ class Agent(BaseAgent):
         if covenant:
             covenant_file.write_text(covenant)
         elif covenant_file.is_file():
-            covenant = covenant_file.read_text()
+            covenant = covenant_file.read_text(encoding="utf-8")
         if covenant:
             self._prompt_manager.write_section("covenant", covenant, protected=True)
 
@@ -1252,12 +1252,12 @@ class Agent(BaseAgent):
         else:
             try:
                 from importlib.resources import files
-                packaged = files("lingtai.prompts").joinpath("substrate.md").read_text()
+                packaged = files("lingtai.prompts").joinpath("substrate.md").read_text(encoding="utf-8")
                 substrate_file.write_text(packaged)
                 substrate = packaged
             except (FileNotFoundError, ModuleNotFoundError, OSError):
                 if substrate_file.is_file():
-                    substrate = substrate_file.read_text()
+                    substrate = substrate_file.read_text(encoding="utf-8")
                 else:
                     substrate = ""
         if substrate:
@@ -1269,7 +1269,7 @@ class Agent(BaseAgent):
         rules_md = system_dir / "rules.md"
         if rules_md.is_file():
             try:
-                rules_content = rules_md.read_text().strip()
+                rules_content = rules_md.read_text(encoding="utf-8").strip()
                 if rules_content:
                     self._prompt_manager.write_section("rules", rules_content, protected=True)
                 else:
@@ -1283,7 +1283,7 @@ class Agent(BaseAgent):
         pad_file = system_dir / "pad.md"
         loaded_pad = ""
         if pad_file.is_file():
-            loaded_pad = pad_file.read_text()
+            loaded_pad = pad_file.read_text(encoding="utf-8")
         if loaded_pad.strip():
             self._prompt_manager.write_section("pad", loaded_pad)
 
@@ -1293,7 +1293,7 @@ class Agent(BaseAgent):
         if principle:
             principle_file.write_text(principle)
         elif principle_file.is_file():
-            principle = principle_file.read_text()
+            principle = principle_file.read_text(encoding="utf-8")
         if principle:
             self._prompt_manager.write_section("principle", principle, protected=True)
 
@@ -1314,12 +1314,12 @@ class Agent(BaseAgent):
         else:
             try:
                 from importlib.resources import files
-                packaged = files("lingtai.prompts").joinpath("procedures.md").read_text()
+                packaged = files("lingtai.prompts").joinpath("procedures.md").read_text(encoding="utf-8")
                 procedures_file.write_text(packaged)
                 procedures = packaged
             except (FileNotFoundError, ModuleNotFoundError, OSError):
                 if procedures_file.is_file():
-                    procedures = procedures_file.read_text()
+                    procedures = procedures_file.read_text(encoding="utf-8")
                 else:
                     procedures = ""
         if procedures:
@@ -1333,7 +1333,7 @@ class Agent(BaseAgent):
         if brief:
             brief_file.write_text(brief)
         elif brief_file.is_file():
-            brief = brief_file.read_text()
+            brief = brief_file.read_text(encoding="utf-8")
         if brief:
             self._prompt_manager.write_section("brief", brief, protected=True)
         else:

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -129,7 +129,7 @@ def build_agent(data: dict, working_dir: Path) -> Agent:
     prev_manifest = working_dir / ".agent.json"
     if prev_manifest.is_file():
         try:
-            prev = json.loads(prev_manifest.read_text())
+            prev = json.loads(prev_manifest.read_text(encoding="utf-8"))
             agent._molt_count = prev.get("molt_count", 0)
         except (json.JSONDecodeError, OSError):
             pass

--- a/src/lingtai/core/avatar/__init__.py
+++ b/src/lingtai/core/avatar/__init__.py
@@ -260,7 +260,7 @@ class AvatarManager:
             return {"error": "parent has no init.json — cannot spawn avatar"}
 
         try:
-            parent_init = json.loads(parent_init_path.read_text())
+            parent_init = json.loads(parent_init_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as e:
             return {"error": f"failed to read parent init.json: {e}"}
 
@@ -409,7 +409,7 @@ class AvatarManager:
         parent_rules_md = parent._working_dir / "system" / "rules.md"
         if parent_rules_md.is_file():
             try:
-                rules_content = parent_rules_md.read_text()
+                rules_content = parent_rules_md.read_text(encoding="utf-8")
             except OSError:
                 rules_content = ""
             if rules_content.strip():
@@ -624,7 +624,7 @@ class AvatarManager:
         init_data = None
         if init_path.is_file():
             try:
-                init_data = json.loads(init_path.read_text())
+                init_data = json.loads(init_path.read_text(encoding="utf-8"))
             except (ValueError, OSError):
                 pass
         venv_dir = resolve_venv(init_data)
@@ -660,7 +660,7 @@ class AvatarManager:
         if not self._ledger_path.is_file():
             return []
         records = []
-        for line in self._ledger_path.read_text().splitlines():
+        for line in self._ledger_path.read_text(encoding="utf-8").splitlines():
             if line.strip():
                 try:
                     records.append(json.loads(line))
@@ -728,7 +728,7 @@ class AvatarManager:
             if not ledger_path.is_file():
                 continue
             try:
-                lines = ledger_path.read_text().splitlines()
+                lines = ledger_path.read_text(encoding="utf-8").splitlines()
             except OSError:
                 continue
             # Siblings of `current` live in current.parent

--- a/src/lingtai/core/bash/__init__.py
+++ b/src/lingtai/core/bash/__init__.py
@@ -93,7 +93,7 @@ class BashPolicy:
         p = Path(path)
         if not p.is_file():
             raise FileNotFoundError(f"Policy file not found: {path}")
-        data = json.loads(p.read_text())
+        data = json.loads(p.read_text(encoding="utf-8"))
         return cls(allow=data.get("allow"), deny=data.get("deny"))
 
     @classmethod
@@ -290,8 +290,8 @@ class BashManager:
         (job_dir / "command").write_text(command)
         (job_dir / "status").write_text("running")
 
-        stdout_f = open(job_dir / "stdout.log", "w")
-        stderr_f = open(job_dir / "stderr.log", "w")
+        stdout_f = open(job_dir / "stdout.log", "w", encoding="utf-8")
+        stderr_f = open(job_dir / "stderr.log", "w", encoding="utf-8")
 
         try:
             proc = subprocess.Popen(
@@ -353,7 +353,7 @@ class BashManager:
         # Read stdout preview
         stdout_preview = ""
         try:
-            stdout_text = (job_dir / "stdout.log").read_text()
+            stdout_text = (job_dir / "stdout.log").read_text(encoding="utf-8", errors="replace")
             stdout_preview = stdout_text[:200]
         except Exception:
             pass
@@ -396,11 +396,11 @@ class BashManager:
         if not job_dir.is_dir():
             return {"status": "error", "message": f"Job not found: {job_id}"}
 
-        status = (job_dir / "status").read_text().strip()
+        status = (job_dir / "status").read_text(encoding="utf-8").strip()
         if status != "running":
             return {"status": "error", "message": f"Job already finished ({status})"}
 
-        pid = int((job_dir / "pid").read_text().strip())
+        pid = int((job_dir / "pid").read_text(encoding="utf-8").strip())
 
         # Use Popen.poll() if we have the handle (same process), else os.waitpid
         handles = getattr(self, "_open_handles", {})
@@ -427,8 +427,8 @@ class BashManager:
         # Process finished — close file handles, read output
         self._close_handles(job_id)
 
-        stdout = (job_dir / "stdout.log").read_text()
-        stderr = (job_dir / "stderr.log").read_text()
+        stdout = (job_dir / "stdout.log").read_text(encoding="utf-8", errors="replace")
+        stderr = (job_dir / "stderr.log").read_text(encoding="utf-8", errors="replace")
 
         if len(stdout) > self._max_output:
             stdout = stdout[: self._max_output] + f"\n... (truncated, {len(stdout)} chars total)"
@@ -458,11 +458,11 @@ class BashManager:
         if not job_dir.is_dir():
             return {"status": "error", "message": f"Job not found: {job_id}"}
 
-        status = (job_dir / "status").read_text().strip()
+        status = (job_dir / "status").read_text(encoding="utf-8").strip()
         if status != "running":
             return {"status": "error", "message": f"Job already finished ({status})"}
 
-        pid = int((job_dir / "pid").read_text().strip())
+        pid = int((job_dir / "pid").read_text(encoding="utf-8").strip())
 
         # Kill the entire process group (start_new_session=True makes pid the pgid)
         try:

--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -286,13 +286,13 @@ class BaseAgent:
         if covenant:
             covenant_file.write_text(covenant)
         elif covenant_file.is_file():
-            covenant = covenant_file.read_text()
+            covenant = covenant_file.read_text(encoding="utf-8")
 
         # Principle: constructor value wins, then fall back to file on disk
         if principle:
             principle_file.write_text(principle)
         elif principle_file.is_file():
-            principle = principle_file.read_text()
+            principle = principle_file.read_text(encoding="utf-8")
 
         # Substrate: same pattern as covenant/principle. Opt-in (issue
         # #39): kernel-owned, cross-app-stable system prompt section that
@@ -301,19 +301,19 @@ class BaseAgent:
         if substrate:
             substrate_file.write_text(substrate)
         elif substrate_file.is_file():
-            substrate = substrate_file.read_text()
+            substrate = substrate_file.read_text(encoding="utf-8")
 
         # Procedures: same pattern as covenant/principle
         if procedures:
             procedures_file.write_text(procedures)
         elif procedures_file.is_file():
-            procedures = procedures_file.read_text()
+            procedures = procedures_file.read_text(encoding="utf-8")
 
         # Brief: externally-maintained context (written by secretary agent).
         if brief and not brief_file.is_file():
             brief_file.write_text(brief)
         elif brief_file.is_file():
-            brief = brief_file.read_text()
+            brief = brief_file.read_text(encoding="utf-8")
 
         # Pad: constructor value seeds the file if it doesn't exist
         if pad and not pad_file.is_file():
@@ -322,7 +322,7 @@ class BaseAgent:
         # Auto-load pad from file into prompt manager
         loaded_pad = ""
         if pad_file.is_file():
-            loaded_pad = pad_file.read_text()
+            loaded_pad = pad_file.read_text(encoding="utf-8")
 
         # System prompt manager
         self._prompt_manager = SystemPromptManager()
@@ -340,7 +340,7 @@ class BaseAgent:
         rules_md = system_dir / "rules.md"
         if rules_md.is_file():
             try:
-                rules_content = rules_md.read_text().strip()
+                rules_content = rules_md.read_text(encoding="utf-8").strip()
                 if rules_content:
                     self._prompt_manager.write_section("rules", rules_content, protected=True)
             except OSError:

--- a/src/lingtai_kernel/base_agent/lifecycle.py
+++ b/src/lingtai_kernel/base_agent/lifecycle.py
@@ -40,7 +40,7 @@ def _start(agent) -> None:
         try:
             messages = [
                 json.loads(line)
-                for line in chat_history_file.read_text().splitlines()
+                for line in chat_history_file.read_text(encoding="utf-8").splitlines()
                 if line.strip()
             ]
             agent.restore_chat({"messages": messages})
@@ -238,7 +238,7 @@ def _heartbeat_loop(agent) -> None:
         prompt_file = agent._working_dir / ".prompt"
         if prompt_file.is_file():
             try:
-                content = prompt_file.read_text().strip()
+                content = prompt_file.read_text(encoding="utf-8").strip()
             except OSError:
                 content = ""
             try:
@@ -253,7 +253,7 @@ def _heartbeat_loop(agent) -> None:
         clear_file = agent._working_dir / ".clear"
         if clear_file.is_file():
             try:
-                source = clear_file.read_text().strip() or "admin"
+                source = clear_file.read_text(encoding="utf-8").strip() or "admin"
             except OSError:
                 source = "admin"
             try:
@@ -280,7 +280,7 @@ def _heartbeat_loop(agent) -> None:
                 pass
             else:
                 try:
-                    content = taken_file.read_text().strip()
+                    content = taken_file.read_text(encoding="utf-8").strip()
                 except OSError:
                     content = ""
                 if content:
@@ -611,7 +611,7 @@ def _check_rules_file(agent) -> None:
     if not rules_file.is_file():
         return
     try:
-        content = rules_file.read_text().strip()
+        content = rules_file.read_text(encoding="utf-8").strip()
     except OSError:
         return
     # Always consume the signal file
@@ -626,7 +626,7 @@ def _check_rules_file(agent) -> None:
     existing = ""
     if canonical.is_file():
         try:
-            existing = canonical.read_text().strip()
+            existing = canonical.read_text(encoding="utf-8").strip()
         except OSError:
             pass
     if content == existing:

--- a/src/lingtai_kernel/config_resolve.py
+++ b/src/lingtai_kernel/config_resolve.py
@@ -60,7 +60,7 @@ def load_env_file(path: str | Path, *, overwrite: bool = False) -> None:
     env_path = Path(path).expanduser()
     if not env_path.is_file():
         return
-    for line in env_path.read_text().splitlines():
+    for line in env_path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue

--- a/src/lingtai_kernel/handshake.py
+++ b/src/lingtai_kernel/handshake.py
@@ -66,4 +66,4 @@ def manifest(path: str | Path) -> dict:
     agent_json = Path(path) / ".agent.json"
     if not agent_json.is_file():
         raise FileNotFoundError(f"No .agent.json at {path}")
-    return json.loads(agent_json.read_text())
+    return json.loads(agent_json.read_text(encoding="utf-8"))

--- a/src/lingtai_kernel/intrinsics/email/manager.py
+++ b/src/lingtai_kernel/intrinsics/email/manager.py
@@ -97,7 +97,7 @@ class EmailManager:
         path = self._mailbox_path / "sent" / email_id / "message.json"
         if path.is_file():
             try:
-                data = json.loads(path.read_text())
+                data = json.loads(path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 return None
             data["_folder"] = "sent"
@@ -106,7 +106,7 @@ class EmailManager:
         path = self._mailbox_path / "archive" / email_id / "message.json"
         if path.is_file():
             try:
-                data = json.loads(path.read_text())
+                data = json.loads(path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 return None
             data["_folder"] = "archive"
@@ -130,7 +130,7 @@ class EmailManager:
             msg_file = msg_dir / "message.json"
             if msg_dir.is_dir() and msg_file.is_file():
                 try:
-                    data = json.loads(msg_file.read_text())
+                    data = json.loads(msg_file.read_text(encoding="utf-8"))
                     data["_folder"] = folder
                     data.setdefault("_mailbox_id", msg_dir.name)
                     emails.append(data)
@@ -320,7 +320,7 @@ class EmailManager:
                 if not sched_file.is_file():
                     continue
                 try:
-                    record = json.loads(sched_file.read_text())
+                    record = json.loads(sched_file.read_text(encoding="utf-8"))
                 except (json.JSONDecodeError, OSError):
                     continue
                 status = record.get("status", "active")
@@ -383,7 +383,7 @@ class EmailManager:
             if not sched_file.is_file():
                 continue
             try:
-                record = json.loads(sched_file.read_text())
+                record = json.loads(sched_file.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 continue
 
@@ -435,7 +435,7 @@ class EmailManager:
         if not path.is_file():
             return None
         try:
-            return json.loads(path.read_text())
+            return json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             return None
 
@@ -460,7 +460,7 @@ class EmailManager:
             if not sched_file.is_file():
                 continue
             try:
-                record = json.loads(sched_file.read_text())
+                record = json.loads(sched_file.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 continue
             status = record.get("status", "active")
@@ -500,7 +500,7 @@ class EmailManager:
                 continue
 
             try:
-                record = json.loads(sched_file.read_text())
+                record = json.loads(sched_file.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 continue
 
@@ -801,7 +801,7 @@ class EmailManager:
                 path = self._mailbox_path / folder / eid / "message.json"
                 if path.is_file():
                     try:
-                        data = json.loads(path.read_text())
+                        data = json.loads(path.read_text(encoding="utf-8"))
                         data["_folder"] = folder
                         data.setdefault("_mailbox_id", eid)
                     except (json.JSONDecodeError, OSError):
@@ -1192,7 +1192,7 @@ class EmailManager:
     def _load_contacts(self) -> list[dict]:
         if self._contacts_path.is_file():
             try:
-                return json.loads(self._contacts_path.read_text())
+                return json.loads(self._contacts_path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 return []
         return []

--- a/src/lingtai_kernel/intrinsics/email/primitives.py
+++ b/src/lingtai_kernel/intrinsics/email/primitives.py
@@ -64,7 +64,7 @@ def _load_message(agent, msg_id: str) -> dict | None:
     if not msg_file.is_file():
         return None
     try:
-        return json.loads(msg_file.read_text())
+        return json.loads(msg_file.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
 
@@ -82,7 +82,7 @@ def _list_inbox(agent) -> list[dict]:
         if not msg_file.is_file():
             continue
         try:
-            msg = json.loads(msg_file.read_text())
+            msg = json.loads(msg_file.read_text(encoding="utf-8"))
             msg["_mailbox_id"] = msg_dir.name
             messages.append(msg)
         except (json.JSONDecodeError, OSError):
@@ -105,7 +105,7 @@ def _read_ids(agent) -> set[str]:
     if not path.is_file():
         return set()
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         return set(data) if isinstance(data, list) else set()
     except (json.JSONDecodeError, OSError):
         return set()
@@ -234,7 +234,7 @@ def _move_to_sent(agent, msg_id: str, sent_at: str, status: str) -> None:
     msg_file = src / "message.json"
     if msg_file.is_file():
         try:
-            data = json.loads(msg_file.read_text())
+            data = json.loads(msg_file.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             data = {}
         data["sent_at"] = sent_at

--- a/src/lingtai_kernel/intrinsics/psyche/_lingtai.py
+++ b/src/lingtai_kernel/intrinsics/psyche/_lingtai.py
@@ -22,8 +22,8 @@ def _lingtai_load(agent, _args: dict) -> dict:
     covenant_path = system_dir / "covenant.md"
     lingtai_path = system_dir / "lingtai.md"
 
-    covenant = covenant_path.read_text() if covenant_path.is_file() else ""
-    character = lingtai_path.read_text() if lingtai_path.is_file() else ""
+    covenant = covenant_path.read_text(encoding="utf-8") if covenant_path.is_file() else ""
+    character = lingtai_path.read_text(encoding="utf-8") if lingtai_path.is_file() else ""
 
     parts = [p for p in [covenant, character] if p.strip()]
     combined = "\n\n".join(parts)

--- a/src/lingtai_kernel/intrinsics/psyche/_molt.py
+++ b/src/lingtai_kernel/intrinsics/psyche/_molt.py
@@ -317,7 +317,7 @@ def _context_molt(agent, args: dict) -> dict:
     try:
         if current_path.is_file():
             with open(archive_path, "a") as archive:
-                archive.write(current_path.read_text())
+                archive.write(current_path.read_text(encoding="utf-8"))
             current_path.unlink()
     except OSError:
         pass
@@ -551,7 +551,7 @@ def context_forget(agent, *, source: str = "warning_ladder", attempts: int = 0,
     try:
         if current_path.is_file():
             with open(archive_path, "a") as archive:
-                archive.write(current_path.read_text())
+                archive.write(current_path.read_text(encoding="utf-8"))
             current_path.unlink()
     except OSError:
         pass

--- a/src/lingtai_kernel/intrinsics/psyche/_pad.py
+++ b/src/lingtai_kernel/intrinsics/psyche/_pad.py
@@ -24,7 +24,7 @@ def _load_append_list(agent) -> list[str]:
     if not path.is_file():
         return []
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         if isinstance(data, list):
             return [str(p) for p in data]
     except (json.JSONDecodeError, OSError):
@@ -54,7 +54,7 @@ def _read_append_content(agent, files: list[str]) -> tuple[str, list[str]]:
         if not resolved.is_file():
             not_found.append(fpath)
             continue
-        parts.append(f"[append: {fpath}]\n{resolved.read_text()}")
+        parts.append(f"[append: {fpath}]\n{resolved.read_text(encoding='utf-8')}")
     return "\n\n".join(parts), not_found
 
 
@@ -102,7 +102,7 @@ def _pad_edit(agent, args: dict) -> dict:
         if not resolved.is_file():
             not_found.append(fpath)
             continue
-        file_content = resolved.read_text()
+        file_content = resolved.read_text(encoding='utf-8')
         parts.append(f"[file-{i}]\n{file_content}")
 
     if not_found:
@@ -130,7 +130,7 @@ def _pad_load(agent, args: dict) -> dict:
     if not pad_path.is_file():
         pad_path.write_text("")
 
-    content = pad_path.read_text()
+    content = pad_path.read_text(encoding="utf-8")
     size_bytes = len(content.encode("utf-8"))
 
     if content.strip():

--- a/src/lingtai_kernel/services/mail.py
+++ b/src/lingtai_kernel/services/mail.py
@@ -241,7 +241,7 @@ class FilesystemMailService(MailService):
                             msg_file = entry / "message.json"
                             if msg_file.is_file():
                                 try:
-                                    payload = json.loads(msg_file.read_text())
+                                    payload = json.loads(msg_file.read_text(encoding="utf-8"))
                                     on_message(payload)
                                 except (json.JSONDecodeError, OSError):
                                     pass
@@ -297,7 +297,7 @@ class FilesystemMailService(MailService):
             if not msg_file.is_file():
                 continue
             try:
-                payload = json.loads(msg_file.read_text())
+                payload = json.loads(msg_file.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 continue
 

--- a/src/lingtai_kernel/token_ledger.py
+++ b/src/lingtai_kernel/token_ledger.py
@@ -82,7 +82,7 @@ def count_main_api_calls(path: Path | str) -> int:
     if not path.is_file():
         return 0
     n = 0
-    for line in path.read_text().splitlines():
+    for line in path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
             continue
@@ -113,7 +113,7 @@ def sum_token_ledger(path: Path | str) -> dict:
     }
     if not path.is_file():
         return totals
-    for line in path.read_text().splitlines():
+    for line in path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
             continue

--- a/src/lingtai_kernel/workdir.py
+++ b/src/lingtai_kernel/workdir.py
@@ -154,7 +154,7 @@ class WorkingDir:
                 )
                 if status_result.stdout.strip():
                     file_path = self._path / rel_path
-                    diff_text = f"(new/untracked file)\n{file_path.read_text()}"
+                    diff_text = f"(new/untracked file)\n{file_path.read_text(encoding='utf-8')}"
         except (FileNotFoundError, subprocess.CalledProcessError):
             diff_text = ""
         return diff_text
@@ -263,7 +263,7 @@ class WorkingDir:
         if not path.is_file():
             return ""
         try:
-            data = json.loads(path.read_text())
+            data = json.loads(path.read_text(encoding="utf-8"))
             return data.get("covenant", "")
         except (json.JSONDecodeError, OSError):
             corrupt = self._path / ".agent.json.corrupt"
@@ -279,7 +279,7 @@ class WorkingDir:
         if not path.is_file():
             return {}
         try:
-            return json.loads(path.read_text())
+            return json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             return {}
 

--- a/tests/test_utf8_read_text.py
+++ b/tests/test_utf8_read_text.py
@@ -1,0 +1,42 @@
+import ast
+from pathlib import Path
+
+
+def test_source_read_text_calls_pin_utf8_encoding() -> None:
+    """Production code must not depend on the host locale when reading text."""
+    root = Path(__file__).resolve().parents[1]
+    offenders: list[str] = []
+    for path in sorted((root / "src").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "read_text"
+            ):
+                continue
+            if any(kw.arg == "encoding" for kw in node.keywords):
+                continue
+            # importlib.metadata.Distribution.read_text is not pathlib.Path.read_text:
+            # it has no encoding parameter and decodes dist metadata per Python's
+            # importlib.metadata contract. The Windows-locale crash class is caused
+            # by filesystem/importlib.resources text reads that inherit the process
+            # locale, not by Distribution metadata reads.
+            if isinstance(node.func.value, ast.Name) and node.func.value.id == "dist":
+                continue
+            rel = path.relative_to(root)
+            offenders.append(f"{rel}:{node.lineno}: {lines[node.lineno - 1].strip()}")
+
+    assert offenders == []
+
+
+def test_source_parses_as_python311() -> None:
+    """Keep syntax compatible with the package's declared Python 3.11 floor."""
+    root = Path(__file__).resolve().parents[1]
+    for path in sorted((root / "src").rglob("*.py")):
+        ast.parse(
+            path.read_text(encoding="utf-8"),
+            filename=str(path),
+            feature_version=(3, 11),
+        )


### PR DESCRIPTION
## Summary
- pin production `.read_text()` calls to `encoding="utf-8"` so agent startup and prompt/system-file loading do not inherit a non-UTF-8 Windows locale
- make bash async stdout/stderr logs explicit on both sides (`encoding="utf-8"` on write, `encoding="utf-8", errors="replace"` on read) so invalid child-process bytes do not break polling
- add a static regression test that fails if production source reintroduces locale-default `Path.read_text()` calls, and also parses `src/` with Python 3.11 grammar to protect the declared Python floor

Fixes #160.

## Validation
- `python -m pytest tests/test_utf8_read_text.py -q` — passed
- `python -m py_compile $(find src -name '*.py' | sort | tr '\n' ' ')` — passed
- `python3.11 -m py_compile $(find src -name '*.py' | sort | tr '\n' ' ')` — passed
- `python -m pytest tests/test_utf8_read_text.py tests/test_bash_async.py tests/test_workdir.py tests/test_psyche.py -q` — 52 passed
- earlier targeted regression subset (`tests/test_utf8_read_text.py tests/test_agent.py tests/test_base_agent.py tests/test_avatar_rules.py tests/test_avatar_preset_inheritance.py tests/test_bash_async.py tests/test_filesystem_mail.py tests/test_services_mail.py tests/test_email_identity.py tests/test_mcp_capability.py tests/test_psyche.py tests/test_token_ledger.py tests/test_workdir.py -q`) — 244 passed before the final bash hardening; the final focused run covers the subsequently changed files
- `git diff --check`

## Review follow-up
Codex daemon review found a real blocker in the first pushed revision: two f-string expressions used Python 3.12-only relaxed quote grammar while the project supports Python 3.11. This revision fixes those expressions and adds the Python-3.11 parse guard.

Codex also noted that child process output may contain non-UTF-8 bytes even when parent-side files are opened as UTF-8. This revision reads async bash stdout/stderr with `errors="replace"` so polling/preview remains robust for invalid bytes.

## Notes
I also attempted the full suite:
- with the default `ulimit -n=256`, it failed with many `OSError: [Errno 24] Too many open files` setup errors
- retrying with `ulimit -n 4096` reached `1833 passed, 2 skipped, 7 failed`; spot checks showed at least one failure (`test_filesystem_mail.py::TestListen::test_listen_detects_multiple_messages`) passes in isolation, and the remaining failures appear unrelated to this UTF-8 patch (hard-coded cwd `/Users/huangzesen/Documents/Github/lingtai-kernel`, avatar description expectation, soul timer expectation)