### PR TITLE
docs: add intrinsic file manual skill

### DIFF
--- a/src/lingtai/i18n/en.json
+++ b/src/lingtai/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "read.description": "Read the contents of a text file. Returns numbered lines. Text files only — cannot read binary, images, or audio. Use offset/limit to read specific sections of large files.",
+  "read.description": "Read the contents of a text file. Returns numbered lines. Text files only — cannot read binary, images, or audio. Use offset/limit to read specific sections of large files. If the file problem is non-UTF-8, unusually large, or needs careful search/edit workflow, read the file-manual skill first.",
   "read.file_path": "Absolute path to the file to read",
   "read.offset": "Line number to start from (1-based)",
   "read.limit": "Max lines to read",

--- a/src/lingtai/i18n/en.json
+++ b/src/lingtai/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "read.description": "Read the contents of a text file. Returns numbered lines. Text files only — cannot read binary, images, or audio. Use offset/limit to read specific sections of large files. If the file problem is non-UTF-8, unusually large, or needs careful search/edit workflow, read the file-manual skill first.",
+  "read.description": "Read the contents of a text file. Returns numbered lines. Text files only — cannot read binary, images, or audio. Use offset/limit to read specific sections of large files. If the file is non-UTF-8, unusually large, or needs a careful search/edit workflow, read the file-manual skill first.",
   "read.file_path": "Absolute path to the file to read",
   "read.offset": "Line number to start from (1-based)",
   "read.limit": "Max lines to read",

--- a/src/lingtai/i18n/wen.json
+++ b/src/lingtai/i18n/wen.json
@@ -1,5 +1,5 @@
 {
-  "read.description": "阅卷之器。返带行号之文。仅读文卷——不可读二进制、图像或音声。大卷可以 offset/limit 指定区段而阅。",
+  "read.description": "阅卷之器。返带行号之文。仅读文卷——不可读二进制、图像或音声。大卷可以 offset/limit 指定区段而阅。 若遇非 UTF-8、巨卷、繁搜或慎改之难题，先读 file-manual 一技。",
   "read.file_path": "文卷之绝对路径",
   "read.offset": "起始行号（自一起算）",
   "read.limit": "至多读取之行数",

--- a/src/lingtai/i18n/wen.json
+++ b/src/lingtai/i18n/wen.json
@@ -1,5 +1,5 @@
 {
-  "read.description": "阅卷之器。返带行号之文。仅读文卷——不可读二进制、图像或音声。大卷可以 offset/limit 指定区段而阅。 若遇非 UTF-8、巨卷、繁搜或慎改之难题，先读 file-manual 一技。",
+  "read.description": "阅卷之器。返带行号之文。仅读文卷——不可读二进制、图像或音声。大卷可以 offset/limit 指定区段而阅。若遇非 UTF-8、巨卷、繁搜或慎改之难题，先读 file-manual 一技。",
   "read.file_path": "文卷之绝对路径",
   "read.offset": "起始行号（自一起算）",
   "read.limit": "至多读取之行数",

--- a/src/lingtai/i18n/zh.json
+++ b/src/lingtai/i18n/zh.json
@@ -1,5 +1,5 @@
 {
-  "read.description": "读取文本文件的内容。返回带行号的文本。仅支持文本文件——无法读取二进制文件、图片或音频。对大文件可使用 offset/limit 读取指定区段。",
+  "read.description": "读取文本文件的内容。返回带行号的文本。仅支持文本文件——无法读取二进制文件、图片或音频。对大文件可使用 offset/limit 读取指定区段。 如果遇到非 UTF-8、超大文件或复杂搜索/编辑等不好处理的文件问题，请先阅读 file-manual skill。",
   "read.file_path": "文件的绝对路径",
   "read.offset": "起始行号（从 1 开始）",
   "read.limit": "最大读取行数",

--- a/src/lingtai/i18n/zh.json
+++ b/src/lingtai/i18n/zh.json
@@ -1,5 +1,5 @@
 {
-  "read.description": "读取文本文件的内容。返回带行号的文本。仅支持文本文件——无法读取二进制文件、图片或音频。对大文件可使用 offset/limit 读取指定区段。 如果遇到非 UTF-8、超大文件或复杂搜索/编辑等不好处理的文件问题，请先阅读 file-manual skill。",
+  "read.description": "读取文本文件的内容。返回带行号的文本。仅支持文本文件——无法读取二进制文件、图片或音频。对大文件可使用 offset/limit 读取指定区段。如果遇到非 UTF-8、超大文件或复杂搜索/编辑等不好处理的文件问题，请先阅读 file-manual skill。",
   "read.file_path": "文件的绝对路径",
   "read.offset": "起始行号（从 1 开始）",
   "read.limit": "最大读取行数",

--- a/src/lingtai/intrinsic_skills/file-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/file-manual/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: file-manual
+description: "Operational guide for LingTai's built-in file tools: read, write, edit, glob, and grep. Use when working with local text files, deciding whether to use file tools versus bash, handling large files, avoiding binary/image misuse, or reading non-UTF-8 text via explicit bash/Python/iconv instead of complicating the core read tool. Covers UTF-8 policy, safe write/edit discipline, search workflows, and examples for GBK/Shift-JIS/Latin-1 conversion."
+version: 0.1.0
+tags: [files, read, write, edit, grep, glob, encoding, utf-8]
+---
+
+# File Manual
+
+This skill is the working guide for LingTai's built-in file tools:
+
+- `read` — read a text file with line numbers.
+- `write` — create or fully overwrite a text file.
+- `edit` — perform exact string replacement inside an existing text file.
+- `glob` — find files by path pattern.
+- `grep` — search file contents by regex.
+
+Use these tools for ordinary project text: source code, Markdown, JSON/YAML/TOML, logs, prompts, skills, and notes.
+
+Do **not** use these tools for binary/image/audio/video content. For images, use the `vision` skill/tool. For arbitrary binary inspection or transcoding, use `bash` with explicit commands.
+
+## Encoding policy
+
+LingTai's own text assets should be UTF-8:
+
+- source code;
+- prompts and system notes;
+- skills and knowledge entries;
+- JSON/YAML/TOML/Markdown config and documentation.
+
+Do not rely on the host locale. In particular, Windows Chinese/Japanese/Korean locales may default Python text I/O to GBK/CP936/Shift-JIS-like encodings. Internal LingTai assets should not be decoded by guessing the locale; they should be read and written as UTF-8.
+
+For external or user-provided non-UTF-8 files, keep the core `read` tool simple. Use `bash` with an explicit encoding instead.
+
+### Read a GBK file with Python
+
+```bash
+python - <<'PY'
+from pathlib import Path
+print(Path('file.txt').read_text(encoding='gbk'))
+PY
+```
+
+If the goal is to inspect imperfect text without crashing on bad bytes:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+print(Path('file.txt').read_text(encoding='gbk', errors='replace'))
+PY
+```
+
+For Shift-JIS or Latin-1, change the encoding:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+print(Path('file.txt').read_text(encoding='shift_jis', errors='replace'))
+print(Path('latin1.txt').read_text(encoding='latin-1'))
+PY
+```
+
+### Convert a file to UTF-8
+
+With Python:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+src = Path('legacy-gbk.txt')
+dst = Path('legacy-gbk.utf8.txt')
+dst.write_text(src.read_text(encoding='gbk'), encoding='utf-8')
+print(dst)
+PY
+```
+
+With `iconv` when available:
+
+```bash
+iconv -f gbk -t utf-8 legacy-gbk.txt > legacy-gbk.utf8.txt
+iconv -f shift_jis -t utf-8 legacy-sjis.txt > legacy-sjis.utf8.txt
+```
+
+Recommended rule: if a file will become part of the project, convert it to UTF-8 before committing or storing it as a durable LingTai asset.
+
+## Choosing the right tool
+
+| Need | Tool |
+|---|---|
+| Read a known text file | `read` |
+| Read a large file section | `read` with `offset` / `limit` |
+| Create a new text file or replace a whole file | `write` |
+| Make a small exact change | `edit` |
+| Find files by name/path | `glob` |
+| Search text across files | `grep` |
+| Decode non-UTF-8 text | `bash` + Python or `iconv` |
+| Inspect binary format, archive, media | `bash` or a domain skill/tool |
+| Analyze image content | `vision` |
+
+## Reading files safely
+
+Prefer `read` for known text files. It returns line numbers, which makes later edits and citations easier.
+
+For large files, avoid loading everything at once:
+
+```python
+read({"file_path": "/abs/path/to/file.log", "offset": 1, "limit": 120})
+read({"file_path": "/abs/path/to/file.log", "offset": 500, "limit": 120})
+```
+
+If a file may be generated, minified, huge, or noisy, search before reading:
+
+```python
+grep({"pattern": "class Agent|def handle", "path": "/abs/path/src", "glob": "*.py", "max_matches": 50})
+```
+
+Then read only the relevant region.
+
+## Writing files safely
+
+`write` is a full-file operation. Use it when:
+
+- creating a new file;
+- replacing a generated artifact;
+- deliberately rewriting a small file you already understand.
+
+Before overwriting an important existing file, read it first unless the human explicitly asked for a blind overwrite.
+
+Avoid using `write` for tiny modifications to large files. Use `edit` instead.
+
+## Editing files safely
+
+`edit` replaces an exact string. It fails when the old string is absent or ambiguous, which is a feature: it prevents accidental broad changes.
+
+Good pattern:
+
+1. `read` the relevant lines.
+2. Copy an exact old-string region with enough surrounding context to be unique.
+3. Call `edit` once.
+4. Re-read the changed region or run tests.
+
+Use `replace_all=true` only when every occurrence is supposed to change and you have checked the match set with `grep` first.
+
+## Search workflow
+
+Start broad with `glob`, then narrow with `grep`, then inspect with `read`.
+
+Examples:
+
+```python
+glob({"pattern": "**/*.py", "path": "/abs/path/project"})
+grep({"pattern": "read_text\\(", "path": "/abs/path/project/src", "glob": "*.py", "max_matches": 100})
+read({"file_path": "/abs/path/project/src/module.py", "offset": 40, "limit": 80})
+```
+
+Use `grep` for text content. Use `glob` for file names.
+
+## File paths and privacy
+
+Use absolute paths with file tools. Paths inside your working directory may be private to this agent. Do not send local private paths to other agents or humans unless they are useful and safe for that recipient.
+
+When sharing file content, quote the relevant content or attach/export a file through the appropriate communication channel. Do not assume another agent can dereference your local path.
+
+## Quick checklist
+
+Before using file tools:
+
+- Is this text, not binary/media?
+- Is it expected to be UTF-8? If not, use bash with explicit encoding.
+- Is the file large? If yes, search or read a slice.
+- Am I about to overwrite? If yes, read first or confirm intent.
+- Am I about to replace many occurrences? If yes, grep first.

--- a/tests/test_agent_capabilities.py
+++ b/tests/test_agent_capabilities.py
@@ -85,6 +85,22 @@ def test_agent_capabilities_list(tmp_path):
     agent.stop(timeout=1.0)
 
 
+def test_read_tool_description_points_to_file_manual(tmp_path):
+    """The read tool should route hard file cases to the intrinsic file manual."""
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=tmp_path / "test",
+        capabilities=["read"],
+    )
+    try:
+        read_schema = next(schema for schema in agent._tool_schemas if schema.name == "read")
+        assert "file-manual" in read_schema.description
+        assert "non-UTF-8" in read_schema.description
+    finally:
+        agent.stop(timeout=1.0)
+
+
 def test_agent_capabilities_dict(tmp_path):
     """capabilities= as dict registers user-supplied capabilities with kwargs.
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -69,6 +69,28 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         agent.stop(timeout=1.0)
 
 
+def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
+    # Standalone always-included skills live in lingtai.intrinsic_skills and are
+    # copied next to capability manuals under .library/intrinsic/capabilities/.
+    agent, workdir = _mk_agent(tmp_path)
+    try:
+        skill_md = (
+            workdir
+            / ".library"
+            / "intrinsic"
+            / "capabilities"
+            / "file-manual"
+            / "SKILL.md"
+        )
+        assert skill_md.is_file()
+        body = skill_md.read_text(encoding="utf-8")
+        assert "name: file-manual" in body
+        assert "encoding='gbk'" in body
+        assert "iconv -f gbk -t utf-8" in body
+    finally:
+        agent.stop(timeout=1.0)
+
+
 def test_skills_setup_overwrites_stale_intrinsic(tmp_path):
     # The Agent initializer wipes-and-rewrites intrinsic/ on construction.
     # A stale entry from a previous kernel version must be replaced.
@@ -256,6 +278,7 @@ def test_catalog_injected_into_skills_section(tmp_path):
     try:
         prompt = agent._prompt_manager.read_section("skills") or ""
         assert "- name: skills-manual" in prompt
+        assert "- name: file-manual" in prompt
         assert "- name: shared-thing" in prompt
     finally:
         agent.stop(timeout=1.0)


### PR DESCRIPTION
## Summary
- add a packaged intrinsic `file-manual` skill for built-in file tools (`read`, `write`, `edit`, `glob`, `grep`)
- document UTF-8 policy for LingTai-owned text assets and explicit bash/Python/iconv workflows for non-UTF-8 user files
- point the `read` tool description at `file-manual` for non-UTF-8, unusually large, or careful search/edit file cases
- assert standalone intrinsic skills are installed and injected into the skills catalog, and that `read` routes hard file cases to the manual

## Tests
- `python -m pytest tests/test_agent_capabilities.py tests/test_skills.py tests/test_utf8_read_text.py -q`
- `git diff --check`