### PR TITLE
perf: prune grep glob filters before file reads

### DIFF
--- a/src/lingtai/core/grep/__init__.py
+++ b/src/lingtai/core/grep/__init__.py
@@ -4,7 +4,6 @@ Usage: Agent(capabilities=["grep"]) or capabilities=["file"]
 """
 from __future__ import annotations
 
-import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -46,22 +45,18 @@ def setup(agent: "BaseAgent") -> None:
         max_matches = args.get("max_matches", 200)
         glob_filter = args.get("glob", "*")
         try:
-            raw_results = agent._file_io.grep(pattern, path=search_path, max_results=max_matches)
-            raw_truncated = len(raw_results) >= max_matches
-            if glob_filter == "*":
-                matches = [{"file": r.path, "line": r.line_number, "text": r.line} for r in raw_results]
-            else:
-                matches = [
-                    {"file": r.path, "line": r.line_number, "text": r.line}
-                    for r in raw_results
-                    if fnmatch.fnmatch(Path(r.path).name, glob_filter)
-                ]
-            # truncated: true when the raw scan hit its cap (there may be
-            # more matching files beyond what was scanned), OR when glob
-            # filtering was active and we got fewer results than the cap
-            # (meaning the glob may have discarded results that masked
-            # additional matches).
-            truncated = raw_truncated
+            # Push the glob filter into the service so excluded files are
+            # pruned *before* stat / read, instead of post-filtering full
+            # results. ``"*"`` is the schema default and means "no filter".
+            service_glob = None if glob_filter in (None, "", "*") else glob_filter
+            raw_results = agent._file_io.grep(
+                pattern,
+                path=search_path,
+                max_results=max_matches,
+                glob_filter=service_glob,
+            )
+            matches = [{"file": r.path, "line": r.line_number, "text": r.line} for r in raw_results]
+            truncated = len(raw_results) >= max_matches
             result: dict[str, Any] = {
                 "matches": matches,
                 "count": len(matches),

--- a/src/lingtai/services/file_io.py
+++ b/src/lingtai/services/file_io.py
@@ -117,8 +117,20 @@ class FileIOService(ABC):
         ...
 
     @abstractmethod
-    def grep(self, pattern: str, path: str | None = None, max_results: int = 50) -> list[GrepMatch]:
-        """Search file contents by regex pattern."""
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        max_results: int = 50,
+        *,
+        glob_filter: str | None = None,
+    ) -> list[GrepMatch]:
+        """Search file contents by regex pattern.
+
+        ``glob_filter`` is an optional fnmatch-style pattern matched
+        against each file's basename — implementations should use it to
+        prune the candidate set *before* opening / reading.
+        """
         ...
 
 
@@ -282,6 +294,7 @@ class LocalFileIOService(FileIOService):
         path: str | None = None,
         max_results: int = 50,
         *,
+        glob_filter: str | None = None,
         exclude_dirs: frozenset[str] | set[str] | None = None,
         walltime_s: float | None = DEFAULT_WALLTIME_S,
         max_visited: int | None = DEFAULT_MAX_VISITED,
@@ -289,15 +302,34 @@ class LocalFileIOService(FileIOService):
     ) -> list[GrepMatch]:
         """Search file contents by regex.
 
+        ``glob_filter`` (optional) — fnmatch-style pattern matched against
+        the file's *basename*. When supplied, non-matching files are
+        skipped before ``stat`` / ``open``. This lets callers (e.g. the
+        ``grep`` tool's ``glob`` argument) prune the candidate set
+        cheaply instead of post-filtering full match results. The
+        pattern ``"*"`` (or ``None``) is treated as "no filter".
+
         Per-file: skipped (counted) when larger than ``max_file_bytes``
-        or when ``read_text(utf-8)`` raises ``UnicodeDecodeError`` /
-        ``PermissionError`` / ``OSError`` (binary, unreadable). Across
-        files: bounded by ``walltime_s`` and ``max_visited``. See module
-        docstring for default values.
+        or when the file cannot be read as utf-8 / is unreadable
+        (``UnicodeDecodeError`` / ``PermissionError`` / ``OSError``).
+        Files are streamed line-by-line — we never load the whole file
+        into memory, and undecodable bytes inside an otherwise textual
+        file are skipped via ``errors="replace"`` instead of aborting
+        the entire file. Across files: bounded by ``walltime_s`` and
+        ``max_visited``. See module docstring for default values.
         """
+        import fnmatch
+        import io
         import re
 
         regex = re.compile(pattern)
+        # Pre-translate the glob to a regex once instead of letting
+        # fnmatch translate-and-cache per call. Translating ourselves
+        # also lets us cheaply detect the no-op "*" filter.
+        compiled_glob: re.Pattern[str] | None = None
+        if glob_filter and glob_filter != "*":
+            compiled_glob = re.compile(fnmatch.translate(glob_filter))
+
         self.last_traversal = TraversalStats()
         search_path = Path(path) if path else (self._root or Path("."))
         results: list[GrepMatch] = []
@@ -308,6 +340,10 @@ class LocalFileIOService(FileIOService):
             walltime_s=walltime_s,
             max_visited=max_visited,
         ):
+            # Cheapest filter first: glob match on basename. This runs
+            # before stat/open so excluded files contribute zero I/O.
+            if compiled_glob is not None and not compiled_glob.match(f.name):
+                continue
             if not f.is_file():
                 continue
             try:
@@ -317,17 +353,36 @@ class LocalFileIOService(FileIOService):
             if max_file_bytes is not None and size > max_file_bytes:
                 self.last_traversal.files_skipped_size += 1
                 continue
+            # Stream line-by-line. A cheap NUL-byte prefix sniff keeps
+            # obvious binary files out of the text decoder (mirroring
+            # ripgrep's binary detection), while ``errors="replace"``
+            # keeps mostly-text files searchable even when a few bytes are
+            # garbage. Use one binary open + TextIOWrapper so we do not
+            # load the whole file and do not open matched files twice.
             try:
-                text = f.read_text(encoding="utf-8")
+                with open(f, "rb") as raw:
+                    prefix = raw.read(4096)
+                    if b"\x00" in prefix:
+                        self.last_traversal.files_skipped_binary += 1
+                        continue
+                    raw.seek(0)
+                    text_stream = io.TextIOWrapper(raw, encoding="utf-8", errors="replace")
+                    for i, line in enumerate(text_stream, 1):
+                        # Match against the line without its trailing
+                        # newline so ``$``-anchored patterns behave as
+                        # callers expect.
+                        if line.endswith("\n"):
+                            line = line[:-1]
+                            if line.endswith("\r"):
+                                line = line[:-1]
+                        if regex.search(line):
+                            results.append(GrepMatch(path=str(f), line_number=i, line=line))
+                            if len(results) >= max_results:
+                                self.last_traversal.truncated_reason = (
+                                    self.last_traversal.truncated_reason or "max_results"
+                                )
+                                return results
             except (UnicodeDecodeError, PermissionError, OSError):
                 self.last_traversal.files_skipped_binary += 1
                 continue
-            for i, line in enumerate(text.splitlines(), 1):
-                if regex.search(line):
-                    results.append(GrepMatch(path=str(f), line_number=i, line=line))
-                    if len(results) >= max_results:
-                        self.last_traversal.truncated_reason = (
-                            self.last_traversal.truncated_reason or "max_results"
-                        )
-                        return results
         return results

--- a/tests/test_services_file_io.py
+++ b/tests/test_services_file_io.py
@@ -205,3 +205,161 @@ class TestTraversalBudgets:
         svc.write(".git/HEAD", "ref")
         results = svc.glob("**/*", exclude_dirs=set())
         assert any(".git" in r for r in results)
+
+
+class TestGrepGlobFilter:
+    """``glob_filter`` should prune the candidate set *before* stat/read.
+
+    Pre-filtering matters because the previous tool wrapper post-filtered
+    full ``GrepMatch`` results — every file under the search root still
+    got opened and scanned even when callers narrowed by ``glob`` (e.g.
+    ``glob="*.py"`` over a 50k-file repo). The contract these tests pin:
+
+    1. Non-matching files are not opened (no ``open`` / ``read_text``
+       calls).
+    2. Matching files still yield the same results as an unfiltered run.
+    3. ``glob_filter=None`` / ``"*"`` is a no-op (back-compat).
+    """
+
+    def test_glob_filter_skips_non_matching_files_before_open(
+        self, svc, tmp_dir, monkeypatch
+    ):
+        # Layout: one .py file that matches the regex, one .log file that
+        # would also match — but the glob filter should hide the .log.
+        svc.write("good.py", "needle here\n")
+        svc.write("noisy.log", "needle here\n")
+
+        opened: list[str] = []
+        real_open = file_io.open if hasattr(file_io, "open") else open
+        import builtins
+
+        real_builtin_open = builtins.open
+
+        def tracking_open(path, *a, **kw):
+            opened.append(str(path))
+            return real_builtin_open(path, *a, **kw)
+
+        # Patch the name resolved inside file_io.py so we observe only
+        # the grep code's opens, not those from the test harness.
+        monkeypatch.setattr(file_io, "open", tracking_open, raising=False)
+        # ``open`` isn't a module-level name in file_io.py — patch the
+        # builtin so the ``open(f, ...)`` call inside grep is intercepted.
+        monkeypatch.setattr("builtins.open", tracking_open)
+
+        results = svc.grep("needle", glob_filter="*.py")
+
+        # Only the .py file's match comes back.
+        assert len(results) == 1
+        assert results[0].path.endswith("/good.py")
+        # And the .log was never opened by grep — pre-filter pruned it.
+        opened_by_grep = [p for p in opened if p.endswith(".log")]
+        assert opened_by_grep == [], f"unexpected reads of excluded files: {opened_by_grep}"
+
+    def test_glob_filter_none_matches_all(self, svc, tmp_dir):
+        svc.write("a.py", "needle\n")
+        svc.write("b.txt", "needle\n")
+        results = svc.grep("needle", glob_filter=None)
+        files = {r.path for r in results}
+        assert any(p.endswith("/a.py") for p in files)
+        assert any(p.endswith("/b.txt") for p in files)
+
+    def test_glob_filter_star_matches_all(self, svc, tmp_dir):
+        # "*" is the schema default for the grep tool; treat it as no-op.
+        svc.write("a.py", "needle\n")
+        svc.write("b.txt", "needle\n")
+        results = svc.grep("needle", glob_filter="*")
+        assert len(results) == 2
+
+    def test_glob_filter_works_with_nested_layout(self, svc, tmp_dir):
+        svc.write("src/main.py", "needle\n")
+        svc.write("src/data.json", "needle\n")
+        svc.write("tests/test_main.py", "needle\n")
+        results = svc.grep("needle", glob_filter="*.py")
+        files = {r.path for r in results}
+        assert any(p.endswith("/src/main.py") for p in files)
+        assert any(p.endswith("/tests/test_main.py") for p in files)
+        assert not any(p.endswith(".json") for p in files)
+
+
+class TestGrepLineStreaming:
+    """Grep streams files line-by-line instead of slurping into memory.
+
+    Two invariants the tests pin:
+
+    1. A genuinely undecodable file is still skipped (no crash) and
+       counted in ``files_skipped_binary``.
+    2. A *mostly* utf-8 file with a few bad bytes mid-stream is still
+       searchable — we use ``errors="replace"`` so one rogue byte does
+       not blank the whole file the way ``read_text`` did.
+    """
+
+    def test_grep_handles_mixed_utf8_with_bad_bytes(self, svc, tmp_dir):
+        # File with a valid utf-8 needle line, plus a line containing an
+        # invalid utf-8 continuation byte. ``read_text(utf-8)`` would
+        # raise UnicodeDecodeError on the whole file; the streamed
+        # ``errors="replace"`` path keeps the good lines searchable.
+        path = tmp_dir / "mixed.txt"
+        path.write_bytes(b"needle here\n\xff\xfe garbage\nanother needle\n")
+
+        results = svc.grep("needle")
+        files = {r.path for r in results}
+        assert any(p.endswith("/mixed.txt") for p in files)
+        # Both clean ``needle`` lines should match — the garbage line in
+        # the middle does not abort the file.
+        needle_matches = [r for r in results if r.path.endswith("/mixed.txt")]
+        assert len(needle_matches) == 2
+        assert needle_matches[0].line_number == 1
+        assert needle_matches[1].line_number == 3
+
+
+    def test_grep_skips_nul_binary_files(self, svc, tmp_dir):
+        # NUL-byte prefix sniff mirrors ripgrep-style binary detection: an
+        # obvious binary file should be skipped even if it contains bytes
+        # that would otherwise decode via errors="replace".
+        path = tmp_dir / "binary.bin"
+        path.write_bytes(b"\x00needle\x00\xff\xfe\x00")
+
+        results = svc.grep("needle")
+
+        assert not any(r.path.endswith("/binary.bin") for r in results)
+        assert svc.last_traversal.files_skipped_binary >= 1
+
+    def test_grep_skips_unreadable_files_without_crashing(
+        self, svc, tmp_dir, monkeypatch
+    ):
+        svc.write("ok.txt", "needle\n")
+        svc.write("locked.txt", "needle\n")
+
+        import builtins
+        real_open = builtins.open
+
+        def selective_open(path, *a, **kw):
+            if str(path).endswith("/locked.txt"):
+                raise PermissionError("nope")
+            return real_open(path, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", selective_open)
+
+        results = svc.grep("needle")
+        files = {r.path for r in results}
+        assert any(p.endswith("/ok.txt") for p in files)
+        assert not any(p.endswith("/locked.txt") for p in files)
+        assert svc.last_traversal.files_skipped_binary >= 1
+
+    def test_grep_does_not_load_whole_file_into_memory(self, svc, tmp_dir, monkeypatch):
+        # Pin the streaming contract: ``read_text`` (whole-file read)
+        # must not be called by grep. Anyone reintroducing it would
+        # regress memory behavior on large logs / jsonl.
+        svc.write("a.txt", "needle\n")
+
+        original = Path.read_text
+        calls: list[str] = []
+
+        def spy(self, *a, **kw):
+            calls.append(str(self))
+            return original(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "read_text", spy)
+        results = svc.grep("needle")
+        assert len(results) >= 1
+        assert calls == [], f"grep should stream, not call read_text: {calls}"


### PR DESCRIPTION
## Summary

Low-risk first pass at improving the built-in `grep` file tool, inspired by oh-my-pi's search harness design but staying pure Python / dependency-free:

- push the `grep` tool's `glob` filter down into `LocalFileIOService.grep()` so non-matching files are skipped before `stat()` / `open()`
- stream grep inputs line-by-line instead of loading whole files with `Path.read_text()`
- add a cheap NUL-byte prefix sniff to skip obvious binary files before text decoding
- keep malformed-but-mostly-text UTF-8 files searchable via `errors="replace"`
- add regression tests for pre-open glob pruning, streaming behavior, mixed UTF-8, binary skip, and backward-compatible `None` / `*` filters

## Why

Before this PR, `grep(pattern, glob="*.py")` still scanned every file under the search root, then discarded matches whose basenames did not match `*.py`. In large repos this wastes I/O on logs, JSON, JS bundles, etc. The service now prunes those files before opening them.

The old grep path also read every candidate file into memory before splitting lines. Streaming keeps memory bounded by line length rather than file size.

## Validation

```bash
python -m pytest tests/test_services_file_io.py tests/test_layers_file.py tests/test_agent_capabilities.py -q
# 56 passed in 1.50s

git diff --check
```

Claude Code initial validation before the final NUL-byte test also ran the broader related set:

```text
tests/test_services_file_io.py: 29 passed
notification_sync + layers_email + eigen + daemon_preset_capabilities + agent related tests: 237 passed
```

## Notes / follow-up

This intentionally does **not** change glob result ordering, add `.gitignore` parsing, add output modes, or introduce a native/ripgrep backend. Those are better split into follow-up PRs after the behavior/API surface is discussed.
