### PR TITLE
poc: add optional Rust file search sidecar

### DIFF
--- a/experimental/lingtai-search-sidecar/Cargo.toml
+++ b/experimental/lingtai-search-sidecar/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "lingtai-search-sidecar"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/experimental/lingtai-search-sidecar/README.md
+++ b/experimental/lingtai-search-sidecar/README.md
@@ -1,0 +1,13 @@
+# lingtai-search-sidecar PoC
+
+Experimental Rust sidecar for LingTai file search. It is not part of the
+package build and is not used by default. Build manually with:
+
+```bash
+cd experimental/lingtai-search-sidecar
+cargo build
+```
+
+The binary accepts one JSON request on stdin and writes one JSON response to
+stdout. The current PoC only implements a literal substring `grep` operation;
+its purpose is to prove the runtime boundary, not to replace the Python backend.

--- a/experimental/lingtai-search-sidecar/src/main.rs
+++ b/experimental/lingtai-search-sidecar/src/main.rs
@@ -1,0 +1,159 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct Request {
+    op: String,
+    root: PathBuf,
+    path: PathBuf,
+    pattern: String,
+    #[serde(default = "default_max_results")]
+    max_results: usize,
+}
+
+fn default_max_results() -> usize {
+    50
+}
+
+#[derive(Debug, Serialize)]
+struct Match {
+    path: String,
+    line_number: usize,
+    line: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    code: String,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Response {
+    ok: bool,
+    backend: &'static str,
+    matches: Vec<Match>,
+    files_searched: usize,
+    truncated: bool,
+    truncated_reason: Option<&'static str>,
+    error: Option<ErrorBody>,
+}
+
+fn main() {
+    let response = run().unwrap_or_else(|message| Response {
+        ok: false,
+        backend: "rust-sidecar-poc",
+        matches: Vec::new(),
+        files_searched: 0,
+        truncated: false,
+        truncated_reason: None,
+        error: Some(ErrorBody {
+            code: "sidecar_error".to_string(),
+            message,
+        }),
+    });
+    println!("{}", serde_json::to_string(&response).expect("serialize response"));
+    if !response.ok {
+        std::process::exit(2);
+    }
+}
+
+fn run() -> Result<Response, String> {
+    let mut input = String::new();
+    io::stdin()
+        .read_to_string(&mut input)
+        .map_err(|err| format!("read stdin: {err}"))?;
+    let request: Request = serde_json::from_str(&input).map_err(|err| format!("parse request: {err}"))?;
+    if request.op != "grep" {
+        return Err(format!("unsupported op: {}", request.op));
+    }
+    let root = canonicalize_existing(&request.root)?;
+    let path = canonicalize_existing(&request.path)?;
+    if !path.starts_with(&root) {
+        return Err("path escapes root".to_string());
+    }
+
+    let mut matches = Vec::new();
+    let mut files_searched = 0usize;
+    walk_grep(
+        &root,
+        &path,
+        &request.pattern,
+        request.max_results,
+        &mut files_searched,
+        &mut matches,
+    );
+    let truncated = matches.len() >= request.max_results;
+    Ok(Response {
+        ok: true,
+        backend: "rust-sidecar-poc",
+        matches,
+        files_searched,
+        truncated,
+        truncated_reason: if truncated { Some("max_results") } else { None },
+        error: None,
+    })
+}
+
+fn canonicalize_existing(path: &Path) -> Result<PathBuf, String> {
+    path.canonicalize()
+        .map_err(|err| format!("canonicalize {}: {err}", path.display()))
+}
+
+fn walk_grep(
+    root: &Path,
+    path: &Path,
+    pattern: &str,
+    max_results: usize,
+    files_searched: &mut usize,
+    matches: &mut Vec<Match>,
+) {
+    if matches.len() >= max_results {
+        return;
+    }
+    if path.is_dir() {
+        let entries = match fs::read_dir(path) {
+            Ok(entries) => entries,
+            Err(_) => return,
+        };
+        for entry in entries.flatten() {
+            let child = entry.path();
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if matches.len() >= max_results {
+                return;
+            }
+            if name == ".git" || name == "node_modules" || name == ".venv" || name == "__pycache__" {
+                continue;
+            }
+            walk_grep(root, &child, pattern, max_results, files_searched, matches);
+        }
+        return;
+    }
+    if !path.is_file() {
+        return;
+    }
+    let Ok(bytes) = fs::read(path) else {
+        return;
+    };
+    if bytes.iter().take(4096).any(|byte| *byte == 0) {
+        return;
+    }
+    *files_searched += 1;
+    let text = String::from_utf8_lossy(&bytes);
+    for (idx, line) in text.lines().enumerate() {
+        if matches.len() >= max_results {
+            return;
+        }
+        if line.contains(pattern) {
+            let rel = path.strip_prefix(root).unwrap_or(path);
+            matches.push(Match {
+                path: rel.to_string_lossy().replace('\\', "/"),
+                line_number: idx + 1,
+                line: line.to_string(),
+            });
+        }
+    }
+}

--- a/src/lingtai/services/file_search_sidecar.py
+++ b/src/lingtai/services/file_search_sidecar.py
@@ -1,0 +1,100 @@
+"""Experimental adapter for an optional Rust file-search sidecar.
+
+This module is intentionally not wired into ``LocalFileIOService`` by default.
+It exists to prove that LingTai's Python runtime can call a native backend while
+keeping the model-facing tool contract and Python fallback untouched.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from lingtai.services.file_io import GrepMatch
+
+
+class FileSearchSidecarError(RuntimeError):
+    """Raised when the experimental sidecar cannot satisfy a request."""
+
+
+@dataclass(frozen=True)
+class SidecarGrepRequest:
+    """Small JSON request understood by the PoC Rust sidecar."""
+
+    root: str
+    path: str
+    pattern: str
+    max_results: int = 50
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "op": "grep",
+            "root": self.root,
+            "path": self.path,
+            "pattern": self.pattern,
+            "max_results": self.max_results,
+        }
+
+
+class RustFileSearchSidecar:
+    """Thin subprocess wrapper around the optional Rust sidecar binary.
+
+    The binary is discovered from ``binary_path`` or the
+    ``LINGTAI_SEARCH_SIDECAR`` environment variable. No production code uses
+    this adapter unless a caller opts in explicitly.
+    """
+
+    def __init__(self, binary_path: str | None = None, *, timeout_s: float = 5.0) -> None:
+        self.binary_path = binary_path or os.environ.get("LINGTAI_SEARCH_SIDECAR")
+        self.timeout_s = timeout_s
+
+    def available(self) -> bool:
+        return bool(self._resolve_binary())
+
+    def grep(self, request: SidecarGrepRequest) -> list[GrepMatch]:
+        binary = self._resolve_binary()
+        if not binary:
+            raise FileSearchSidecarError(
+                "Rust file-search sidecar is not configured; set LINGTAI_SEARCH_SIDECAR"
+            )
+        completed = subprocess.run(
+            [binary],
+            input=json.dumps(request.to_payload()),
+            text=True,
+            capture_output=True,
+            timeout=self.timeout_s,
+            check=False,
+        )
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
+            raise FileSearchSidecarError(f"sidecar failed: {detail}")
+        try:
+            envelope = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise FileSearchSidecarError("sidecar returned invalid JSON") from exc
+        if not envelope.get("ok"):
+            error = envelope.get("error") or {}
+            message = error.get("message") if isinstance(error, dict) else str(error)
+            raise FileSearchSidecarError(message or "sidecar returned an error")
+        matches: list[GrepMatch] = []
+        for item in envelope.get("matches", []):
+            matches.append(
+                GrepMatch(
+                    path=str(item["path"]),
+                    line_number=int(item["line_number"]),
+                    line=str(item["line"]),
+                )
+            )
+        return matches
+
+    def _resolve_binary(self) -> str | None:
+        if not self.binary_path:
+            return None
+        candidate = Path(self.binary_path).expanduser()
+        if candidate.is_file():
+            return str(candidate)
+        return shutil.which(self.binary_path)

--- a/tests/test_file_search_sidecar.py
+++ b/tests/test_file_search_sidecar.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from lingtai.services.file_search_sidecar import (
+    FileSearchSidecarError,
+    RustFileSearchSidecar,
+    SidecarGrepRequest,
+)
+
+
+def test_sidecar_adapter_requires_explicit_configuration(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("LINGTAI_SEARCH_SIDECAR", raising=False)
+    adapter = RustFileSearchSidecar()
+    assert not adapter.available()
+    with pytest.raises(FileSearchSidecarError, match="not configured"):
+        adapter.grep(SidecarGrepRequest(root=str(tmp_path), path=str(tmp_path), pattern="needle"))
+
+
+@pytest.mark.skipif(shutil.which("cargo") is None, reason="Rust toolchain is optional for this PoC")
+def test_rust_sidecar_grep_poc_round_trip(tmp_path: Path) -> None:
+    crate = Path(__file__).resolve().parents[1] / "experimental" / "lingtai-search-sidecar"
+    subprocess.run(["cargo", "build", "--quiet"], cwd=crate, check=True, timeout=120)
+    binary = crate / "target" / "debug" / ("lingtai-search-sidecar.exe" if os.name == "nt" else "lingtai-search-sidecar")
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "a.py").write_text("alpha\nneedle one\n", encoding="utf-8")
+    (tmp_path / "src" / "b.txt").write_text("needle two\n", encoding="utf-8")
+    (tmp_path / "src" / "bin.dat").write_bytes(b"needle\x00hidden")
+
+    adapter = RustFileSearchSidecar(str(binary))
+    matches = adapter.grep(
+        SidecarGrepRequest(
+            root=str(tmp_path),
+            path=str(tmp_path / "src"),
+            pattern="needle",
+            max_results=10,
+        )
+    )
+
+    assert [(match.path, match.line_number, match.line) for match in matches] == [
+        ("src/a.py", 2, "needle one"),
+        ("src/b.txt", 1, "needle two"),
+    ]


### PR DESCRIPTION
## Summary
- adds an experimental Rust sidecar crate for a minimal grep operation over JSON stdin/stdout
- adds a Python adapter that calls the sidecar only when explicitly configured
- keeps `LocalFileIOService` and default Python behavior unchanged
- includes tests that pass without Rust installed and exercise the sidecar when `cargo` is available

## Notes
This is PR B of Jason's requested two-PR PoC. It is intentionally experimental and should not be merged without design review. It does not add Rust to the package build or default install path.

## Validation
- `python -m pytest tests/test_file_search_sidecar.py -q`
- `cd experimental/lingtai-search-sidecar && cargo test --quiet` (when cargo is available)
