### PR TITLE
refactor: split file io service backend interface

### DIFF
--- a/src/lingtai/__init__.py
+++ b/src/lingtai/__init__.py
@@ -19,7 +19,7 @@ from .core.avatar import AvatarManager
 from lingtai_kernel.intrinsics.email import EmailManager
 
 # Services
-from .services.file_io import FileIOService, LocalFileIOService, GrepMatch
+from .services.file_io import FileIOBackend, FileIOService, GrepMatch, LocalFileIOBackend, LocalFileIOService
 from lingtai_kernel.services.mail import MailService, FilesystemMailService
 from lingtai_kernel.services.logging import LoggingService, JSONLLoggingService
 from .services.vision import VisionService, create_vision_service
@@ -43,6 +43,8 @@ __all__ = [
     "EmailManager",
     # Services
     "FileIOService",
+    "FileIOBackend",
+    "LocalFileIOBackend",
     "LocalFileIOService",
     "GrepMatch",
     "MailService",

--- a/src/lingtai/services/ANATOMY.md
+++ b/src/lingtai/services/ANATOMY.md
@@ -9,7 +9,7 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 | File | LOC | Role |
 |---|---|---|
 | `__init__.py` | 1 | Docstring-only package marker |
-| `file_io.py` | 134 | `FileIOService` (ABC) + `LocalFileIOService` — backs read/edit/write/glob/grep |
+| `file_io.py` | 491 | `FileIOService` facade contract + `FileIOBackend`/`LocalFileIOBackend` — backs read/edit/write/glob/grep |
 | `mail.py` | 4 | Re-exports `MailService`, `FilesystemMailService` from `lingtai_kernel.services.mail` |
 | `mcp.py` | 431 | `MCPClient` (stdio) + `HTTPMCPClient` (streamable HTTP) — async-to-sync MCP bridges |
 
@@ -26,13 +26,14 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 
 ## Composition
 
-`file_io.py` is a pure abstraction layer (no external deps beyond stdlib). `mail.py` is a passthrough re-export. `mcp.py` is the heavy module — two parallel client classes sharing the same pattern.
+`file_io.py` is a pure stdlib abstraction layer. `LocalFileIOService` is now the tool-facing facade while `LocalFileIOBackend` owns the default Python local filesystem implementation; future native/Rust or subprocess backends should satisfy the same backend contract without changing tool schemas. `mail.py` is a passthrough re-export. `mcp.py` is the heavy module — two parallel client classes sharing the same pattern.
 
 ## State
 
 - **`MCPClient` / `HTTPMCPClient`**: each instance manages a background daemon thread (L68, 292), an asyncio event loop (`_loop`), a `ClientSession` (`_session`), and a 50-entry activity log (`_activity_log`, L54, 286). Thread-safe via `threading.Lock` and `threading.Event`.
-- **`LocalFileIOService`**: stateless beyond optional `_root` path (L64).
-- **`FileIOService` ABC**: pure interface, no state.
+- **`LocalFileIOService`**: facade over a `_backend`; exposes `last_traversal` from the backend for tool metadata.
+- **`LocalFileIOBackend`**: default Python local filesystem backend; state is optional `_root` plus `last_traversal`.
+- **`FileIOService` / `FileIOBackend` ABCs**: pure interfaces, no state.
 
 ## Notes
 

--- a/src/lingtai/services/file_io.py
+++ b/src/lingtai/services/file_io.py
@@ -1,12 +1,12 @@
 """FileIOService — abstract file access backing read/edit/write/glob/grep intrinsics.
 
-First implementation: LocalFileIOService (local filesystem, text files only).
-Future: RichFileIOService (PDF, images), RemoteFileIOService, SandboxedFileIOService.
+First implementation: LocalFileIOService facade over LocalFileIOBackend (local filesystem, text files only).
+Future: RichFileIOService, RemoteFileIOService, and SandboxedFileIOService can swap backends without changing tool schemas.
 
 Recursive traversal budgets (issue #164)
 ---------------------------------------
 
-``LocalFileIOService.glob`` and ``LocalFileIOService.grep`` enforce defaults
+``LocalFileIOBackend.glob`` and ``LocalFileIOBackend.grep`` enforce defaults
 that keep a single call from wedging the agent for ~17 min on a broad root
 like ``/Users/<name>/work``:
 
@@ -122,11 +122,69 @@ class FileIOService(ABC):
         ...
 
 
-class LocalFileIOService(FileIOService):
-    """Local filesystem implementation — text files only.
+class FileIOBackend(ABC):
+    """Backend protocol for concrete file operations.
 
-    This is the first and simplest implementation. It reads/writes files
-    on the local filesystem using Path operations.
+    ``FileIOService`` is the stable tool-facing contract. Backends own the
+    implementation details for read/write/edit/glob/grep: local Python today,
+    optional rg/fd or Rust/native backends later. This split keeps tool schemas
+    and safety semantics stable while allowing the execution engine underneath
+    to change.
+    """
+
+    last_traversal: TraversalStats
+
+    @abstractmethod
+    def read(self, path: str) -> str:
+        """Read file contents as text."""
+        ...
+
+    @abstractmethod
+    def write(self, path: str, content: str) -> None:
+        """Write content to a file (create or overwrite)."""
+        ...
+
+    @abstractmethod
+    def edit(self, path: str, old_string: str, new_string: str) -> str:
+        """Replace old_string with new_string in the file. Returns updated content."""
+        ...
+
+    @abstractmethod
+    def glob(
+        self,
+        pattern: str,
+        root: str | None = None,
+        *,
+        exclude_dirs: frozenset[str] | set[str] | None = None,
+        walltime_s: float | None = DEFAULT_WALLTIME_S,
+        max_visited: int | None = DEFAULT_MAX_VISITED,
+        max_results: int | None = 2000,
+    ) -> list[str]:
+        """Find files matching a glob pattern."""
+        ...
+
+    @abstractmethod
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        max_results: int = 50,
+        *,
+        exclude_dirs: frozenset[str] | set[str] | None = None,
+        walltime_s: float | None = DEFAULT_WALLTIME_S,
+        max_visited: int | None = DEFAULT_MAX_VISITED,
+        max_file_bytes: int | None = DEFAULT_MAX_FILE_BYTES,
+    ) -> list[GrepMatch]:
+        """Search file contents by regex pattern."""
+        ...
+
+
+class LocalFileIOBackend(FileIOBackend):
+    """Local Python backend — text files only.
+
+    This is the default backend. It preserves the historical LocalFileIOService
+    behavior while making the backend boundary explicit for future Rust/native
+    implementations.
     """
 
     def __init__(self, root: Path | str | None = None):
@@ -331,3 +389,103 @@ class LocalFileIOService(FileIOService):
                         )
                         return results
         return results
+
+class LocalFileIOService(FileIOService):
+    """Tool-facing file I/O service facade using a pluggable backend.
+
+    Existing agents continue to instantiate ``LocalFileIOService(root=...)`` and
+    see the same behavior. The implementation is delegated to
+    ``LocalFileIOBackend`` by default, so future Rust/native backends can be
+    introduced behind the same read/write/edit/glob/grep contract.
+    """
+
+    def __init__(
+        self,
+        root: Path | str | None = None,
+        *,
+        backend: FileIOBackend | None = None,
+    ):
+        self._backend = backend or LocalFileIOBackend(root=root)
+
+    @property
+    def last_traversal(self) -> TraversalStats:
+        return self._backend.last_traversal
+
+    @last_traversal.setter
+    def last_traversal(self, value: TraversalStats) -> None:
+        self._backend.last_traversal = value
+
+    def _resolve(self, path: str) -> Path:
+        """Compatibility shim for callers that reached into the old local service."""
+        resolver = getattr(self._backend, "_resolve", None)
+        if resolver is None:
+            raise AttributeError("configured file I/O backend does not expose _resolve")
+        return resolver(path)
+
+    def _walk_files(
+        self,
+        root: Path,
+        *,
+        exclude_dirs: frozenset[str] | set[str] | None,
+        walltime_s: float | None,
+        max_visited: int | None,
+    ) -> Iterable[Path]:
+        """Compatibility shim for callers that reached into the old local service."""
+        walker = getattr(self._backend, "_walk_files", None)
+        if walker is None:
+            raise AttributeError("configured file I/O backend does not expose _walk_files")
+        return walker(
+            root,
+            exclude_dirs=exclude_dirs,
+            walltime_s=walltime_s,
+            max_visited=max_visited,
+        )
+
+    def read(self, path: str) -> str:
+        return self._backend.read(path)
+
+    def write(self, path: str, content: str) -> None:
+        self._backend.write(path, content)
+
+    def edit(self, path: str, old_string: str, new_string: str) -> str:
+        return self._backend.edit(path, old_string, new_string)
+
+    def glob(
+        self,
+        pattern: str,
+        root: str | None = None,
+        *,
+        exclude_dirs: frozenset[str] | set[str] | None = None,
+        walltime_s: float | None = DEFAULT_WALLTIME_S,
+        max_visited: int | None = DEFAULT_MAX_VISITED,
+        max_results: int | None = 2000,
+    ) -> list[str]:
+        return self._backend.glob(
+            pattern,
+            root=root,
+            exclude_dirs=exclude_dirs,
+            walltime_s=walltime_s,
+            max_visited=max_visited,
+            max_results=max_results,
+        )
+
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        max_results: int = 50,
+        *,
+        exclude_dirs: frozenset[str] | set[str] | None = None,
+        walltime_s: float | None = DEFAULT_WALLTIME_S,
+        max_visited: int | None = DEFAULT_MAX_VISITED,
+        max_file_bytes: int | None = DEFAULT_MAX_FILE_BYTES,
+    ) -> list[GrepMatch]:
+        return self._backend.grep(
+            pattern,
+            path=path,
+            max_results=max_results,
+            exclude_dirs=exclude_dirs,
+            walltime_s=walltime_s,
+            max_visited=max_visited,
+            max_file_bytes=max_file_bytes,
+        )

--- a/tests/test_services_file_io.py
+++ b/tests/test_services_file_io.py
@@ -6,7 +6,14 @@ from pathlib import Path
 import pytest
 
 import lingtai.services.file_io as file_io
-from lingtai.services.file_io import LocalFileIOService, GrepMatch
+from lingtai.services.file_io import (
+    DEFAULT_MAX_FILE_BYTES,
+    DEFAULT_MAX_VISITED,
+    DEFAULT_WALLTIME_S,
+    GrepMatch,
+    LocalFileIOService,
+    TraversalStats,
+)
 
 
 @pytest.fixture
@@ -205,3 +212,68 @@ class TestTraversalBudgets:
         svc.write(".git/HEAD", "ref")
         results = svc.glob("**/*", exclude_dirs=set())
         assert any(".git" in r for r in results)
+
+
+
+class RecordingBackend:
+    """Small backend double proving LocalFileIOService is now a facade."""
+
+    def __init__(self):
+        self.last_traversal = TraversalStats(truncated_reason="backend")
+        self.calls = []
+
+    def read(self, path: str) -> str:
+        self.calls.append(("read", path))
+        return "read-result"
+
+    def write(self, path: str, content: str) -> None:
+        self.calls.append(("write", path, content))
+
+    def edit(self, path: str, old_string: str, new_string: str) -> str:
+        self.calls.append(("edit", path, old_string, new_string))
+        return "edited"
+
+    def glob(self, pattern: str, root: str | None = None, **kwargs):
+        self.calls.append(("glob", pattern, root, kwargs))
+        return ["one.py"]
+
+    def grep(self, pattern: str, path: str | None = None, max_results: int = 50, **kwargs):
+        self.calls.append(("grep", pattern, path, max_results, kwargs))
+        return [GrepMatch("one.py", 1, "needle")]
+
+
+def test_local_file_io_service_delegates_all_operations_to_backend():
+    backend = RecordingBackend()
+    svc = LocalFileIOService(backend=backend)
+
+    assert svc.read("a.txt") == "read-result"
+    svc.write("a.txt", "body")
+    assert svc.edit("a.txt", "old", "new") == "edited"
+    assert svc.glob("*.py", root="src", max_results=7) == ["one.py"]
+    assert svc.glob("*.py", root="src") == ["one.py"]
+    assert svc.grep("needle", path="src", max_results=3) == [GrepMatch("one.py", 1, "needle")]
+    assert svc.last_traversal.truncated_reason == "backend"
+
+    assert backend.calls == [
+        ("read", "a.txt"),
+        ("write", "a.txt", "body"),
+        ("edit", "a.txt", "old", "new"),
+        ("glob", "*.py", "src", {
+            "exclude_dirs": None,
+            "walltime_s": DEFAULT_WALLTIME_S,
+            "max_visited": DEFAULT_MAX_VISITED,
+            "max_results": 7,
+        }),
+        ("glob", "*.py", "src", {
+            "exclude_dirs": None,
+            "walltime_s": DEFAULT_WALLTIME_S,
+            "max_visited": DEFAULT_MAX_VISITED,
+            "max_results": 2000,
+        }),
+        ("grep", "needle", "src", 3, {
+            "exclude_dirs": None,
+            "walltime_s": DEFAULT_WALLTIME_S,
+            "max_visited": DEFAULT_MAX_VISITED,
+            "max_file_bytes": DEFAULT_MAX_FILE_BYTES,
+        }),
+    ]


### PR DESCRIPTION
## Summary
- splits the file tool service into a stable `FileIOService` facade and a pluggable `FileIOBackend` contract
- moves the existing local Python implementation behind `LocalFileIOBackend`
- covers `read`, `write`, `edit`, `glob`, and `grep`, not just search operations
- preserves the existing `LocalFileIOService(root=...)` constructor, tool schema, default behavior, and `last_traversal` metadata surface

## Context
Jason asked to cut the whole file tool surface (`read/write/edit/glob/grep`) into interface + backend “一劳永逸”, while keeping the current Python implementation as the default. This PR is the mechanical boundary split; Rust/native or rg/fd backends can later implement the backend contract without touching the tool layer.

## Validation
- `python -m pytest tests/test_services_file_io.py tests/test_layers_file.py tests/test_agent_capabilities.py -q` → 49 passed
- `git diff --check`

## Notes
Do not merge without review/approval. This intentionally avoids changing runtime behavior; it only introduces the backend seam.
