### PR TITLE
fix(daemon): strip stale Claude Code OAuth env

### DIFF
--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -131,14 +131,19 @@ def _iter_stdout_with_deadline(
 # Tools emanations can never use (no recursion, no spawning, no identity mutation)
 EMANATION_BLACKLIST = {"daemon", "avatar", "psyche", "skills", "knowledge"}
 
-# Env vars that force Claude Code CLI onto an API-key billing path instead of
-# the user's Claude Code subscription (OAuth). LingTai loads ``.env`` from
-# ``~/.lingtai-tui/`` early, so an ``ANTHROPIC_API_KEY`` meant for the lingtai
-# LLM adapter silently leaks into spawned ``claude`` subprocesses and bills
-# them through API credits — surfacing as "Credit balance is too low" even
-# when the subscription is healthy. We strip these for claude-code spawns
-# only; other backends (codex, lingtai) are unaffected. See GH #107.
-_CLAUDE_CODE_STRIP_ENV = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+# Env vars that override Claude Code's normal first-party OAuth credentials.
+# LingTai loads ``.env`` from ``~/.lingtai-tui/`` early, so auth intended for
+# another LLM adapter can leak into spawned ``claude`` subprocesses.
+# ``ANTHROPIC_*`` keys force API billing (GH #107); a stale
+# ``CLAUDE_CODE_OAUTH_TOKEN`` can also beat a refreshed
+# ``~/.claude/.credentials.json`` and surface as a false weekly-limit error
+# (GH Lingtai-AI/lingtai#189). Strip these for claude-code spawns only; other
+# backends (codex, lingtai, opencode) are unaffected.
+_CLAUDE_CODE_STRIP_ENV = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+)
 
 
 def _claude_code_env() -> dict[str, str]:

--- a/src/lingtai/core/daemon/manual/SKILL.md
+++ b/src/lingtai/core/daemon/manual/SKILL.md
@@ -222,6 +222,14 @@ The `backend` parameter selects the execution engine for emanations. Default is 
 
 **When to use CLI backends:** When the task benefits from a different agent runtime's tool surface (e.g., Claude Code's built-in file editing, Codex's sandboxed execution) rather than the lingtai emanation's curated tool set.
 
+**Claude Code auth environment hygiene.** The `claude-code` backend deliberately starts `claude` with auth override variables stripped from the subprocess environment. This includes `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` (which force API billing; GH #107) and `CLAUDE_CODE_OAUTH_TOKEN` (a stale inherited token can override a refreshed `~/.claude/.credentials.json` and appear as a false "weekly limit"; see Lingtai-AI/lingtai#189). If a manual shell invocation of `claude` reports a quota/weekly-limit error, run a tiny smoke test with the stale env token unset before concluding the account is actually exhausted:
+
+```bash
+env -u CLAUDE_CODE_OAUTH_TOKEN claude -p 'Reply exactly OK' --allowedTools Read -c
+```
+
+Do not print token values while diagnosing; `claude auth status` plus redacted environment variable names are enough.
+
 **CLI backends skip preset resolution** — the external CLI manages its own model, tools, and permissions. The `tools` field in the task spec is ignored for CLI backends.
 
 ### Passing free-form CLI flags via `backend_options`

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1010,14 +1010,18 @@ def test_emanate_without_preset_inherits_parent(tmp_path, monkeypatch):
     assert data.get("preset_name") is None
 
 
-def test_claude_code_env_strips_anthropic_auth(monkeypatch):
-    """Spawned claude-code processes must not inherit ANTHROPIC_API_KEY /
-    ANTHROPIC_AUTH_TOKEN — they force the CLI off the user's Claude Code
-    subscription onto API billing. See GH #107."""
+def test_claude_code_env_strips_auth_overrides(monkeypatch):
+    """Spawned claude-code processes must not inherit auth overrides.
+
+    ANTHROPIC_* force the CLI off the user's Claude Code subscription onto
+    API billing (GH #107); a stale CLAUDE_CODE_OAUTH_TOKEN can override a
+    refreshed credentials.json and look like a false weekly limit (GH #189).
+    """
     from lingtai.core.daemon import _claude_code_env, _CLAUDE_CODE_STRIP_ENV
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-leaked")
     monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "oauth-leaked")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "stale-claude-code-oauth")
     monkeypatch.setenv("PATH", "/usr/bin:/bin")  # sentinel non-stripped var
     monkeypatch.setenv("HOME", "/tmp/home")
 
@@ -1032,7 +1036,7 @@ def test_claude_code_env_strips_anthropic_auth(monkeypatch):
 
 
 def test_claude_code_env_noop_when_unset(monkeypatch):
-    """When no anthropic auth vars are set, the sanitized env equals os.environ."""
+    """When no Claude auth override vars are set, sanitized env equals os.environ."""
     import os
     from lingtai.core.daemon import _claude_code_env, _CLAUDE_CODE_STRIP_ENV
 


### PR DESCRIPTION
## Summary
- strip `CLAUDE_CODE_OAUTH_TOKEN` from `backend="claude-code"` subprocess environments alongside existing Anthropic auth overrides
- document the weekly-limit smoke test in the daemon manual
- extend daemon env tests to cover stale Claude Code OAuth tokens

## Validation
- `uv run --with pytest pytest tests/test_daemon.py tests/test_daemon_backend_options.py -q` → `69 passed in 12.95s`

Fixes Lingtai-AI/lingtai#189