### PR TITLE
feat(kernel): turn-loop observability diagnostics (current-main rework of #143)

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -117,6 +117,32 @@ def _is_transient_provider_error(exc: Exception) -> bool:
     return any(fragment in msg for fragment in _TRANSIENT_MSG_FRAGMENTS)
 
 
+def _tool_call_summary(tool_calls) -> dict:
+    calls = list(tool_calls or [])
+    return {
+        "call_count": len(calls),
+        "call_ids": [getattr(call, "id", None) for call in calls],
+        "tool_names": [getattr(call, "name", None) for call in calls],
+    }
+
+
+def _pending_tool_call_summary(iface) -> dict:
+    entries = getattr(iface, "entries", None) or []
+    tail = entries[-1] if entries else None
+    calls = []
+    if getattr(tail, "role", None) == "assistant":
+        calls = [
+            block
+            for block in getattr(tail, "content", []) or []
+            if hasattr(block, "id") and hasattr(block, "name") and hasattr(block, "args")
+        ]
+    return {
+        "pending_tool_call_count": len(calls),
+        "pending_tool_call_ids": [getattr(call, "id", None) for call in calls],
+        "pending_tool_names": [getattr(call, "name", None) for call in calls],
+    }
+
+
 def _prepare_aed_retry_message(agent, err_desc: str) -> Message:
     """Build the system recovery prompt reused by transient and AED retries."""
     ts = now_iso(agent)
@@ -271,7 +297,18 @@ def _restore_tool_results_after_continuation_failure(
     ):
         return False
     agent._chat.commit_tool_results(tool_results)
-    agent._save_chat_history(ledger_source=ledger_source)
+    try:
+        agent._save_chat_history(ledger_source=ledger_source)
+    except Exception as e:
+        agent._log(
+            "tool_results_restored_after_continuation_failure",
+            result_count=len(tool_results),
+            ledger_source=ledger_source,
+            failed_at="save_chat_history",
+            save_error=(str(e) or repr(e))[:300],
+            side_effect="memory_state_may_be_ahead_of_disk",
+        )
+        raise
     agent._log(
         "tool_results_restored_after_continuation_failure",
         result_count=len(tool_results),
@@ -301,18 +338,23 @@ def _run_loop(agent) -> None:
                     agent._chat is not None
                     and agent._chat.interface.has_pending_tool_calls()
                 ):
+                    phase = "close_pending_tool_calls"
                     try:
                         agent._chat.interface.close_pending_tool_calls(
                             reason="heal:going_asleep"
                         )
-                        agent._log("heal_pending_tool_calls", reason="going_asleep")
+                        phase = "save_chat_history"
                         agent._save_chat_history(ledger_source="heal")
+                        agent._log("heal_pending_tool_calls", reason="going_asleep")
                     except Exception as e:
-                        agent._log(
-                            "heal_pending_tool_calls_failed",
-                            reason="going_asleep",
-                            error=str(e)[:200],
-                        )
+                        fields = {
+                            "reason": "going_asleep",
+                            "failed_at": phase,
+                            "error": (str(e) or repr(e))[:200],
+                        }
+                        if phase == "save_chat_history":
+                            fields["side_effect"] = "memory_state_may_be_ahead_of_disk"
+                        agent._log("heal_pending_tool_calls_failed", **fields)
                 agent._log("sleep")
 
                 # Block until a message arrives or shutdown
@@ -763,7 +805,11 @@ def _handle_tc_wake(agent, msg: Message) -> None:
     if iface.has_pending_tool_calls():
         for item in items:
             agent._tc_inbox.enqueue(item)
-        agent._log("tc_wake_noop", reason="pending_tool_calls")
+        agent._log(
+            "tc_wake_noop",
+            reason="pending_tool_calls",
+            **_pending_tool_call_summary(iface),
+        )
         return
 
     agent._executor = ToolExecutor(
@@ -1083,16 +1129,40 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
         if not response.tool_calls:
             break
 
+        tool_call_fields = _tool_call_summary(response.tool_calls)
         if agent._cancel_event.is_set():
             agent._cancel_event.clear()
+            agent._log(
+                "tool_calls_not_dispatched",
+                ledger_source=ledger_source,
+                in_tool_loop=in_tool_loop,
+                reason="cancel_event",
+                **tool_call_fields,
+            )
             return {"text": "", "failed": False, "errors": []}
 
         stop_reason = guard.check_limit(len(response.tool_calls))
         if stop_reason:
+            agent._log(
+                "tool_calls_not_dispatched",
+                ledger_source=ledger_source,
+                in_tool_loop=in_tool_loop,
+                reason="tool_loop_limit",
+                stop_reason=stop_reason,
+                **tool_call_fields,
+            )
             break
 
         invalid_reason = guard.check_invalid_tool_limit()
         if invalid_reason:
+            agent._log(
+                "tool_calls_not_dispatched",
+                ledger_source=ledger_source,
+                in_tool_loop=in_tool_loop,
+                reason="invalid_tool_limit",
+                invalid_reason=invalid_reason,
+                **tool_call_fields,
+            )
             break
 
         # Delegate to ToolExecutor

--- a/tests/test_tc_wake_chat_not_ready.py
+++ b/tests/test_tc_wake_chat_not_ready.py
@@ -21,8 +21,10 @@ from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import MagicMock
 
+from lingtai_kernel.base_agent.turn import _handle_tc_wake
 from lingtai_kernel.llm.interface import (
     ChatInterface,
+    TextBlock,
     ToolCallBlock,
     ToolResultBlock,
 )
@@ -199,6 +201,34 @@ def test_ensure_session_failure_re_enqueues_and_logs():
     _, fields = err_logs[0]
     assert fields["reason"] == "ensure_session_failed"
     assert "provider unreachable" in fields["error"]
+
+
+def test_pending_tool_calls_logs_diagnostic_with_pending_ids():
+    iface = ChatInterface()
+    iface.add_system("system")
+    iface.add_user_message("run pending tool")
+    iface.add_assistant_message(
+        [
+            TextBlock("calling"),
+            ToolCallBlock(id="call_pending", name="bash", args={"command": "sleep"}),
+        ]
+    )
+    chat = _StubChatHolder(iface)
+    session = _StubSession(chat=chat, _chat_after_ensure=chat)
+    agent = _StubAgent(_session=session)
+    agent._tc_inbox.enqueue(_make_notification_item(call_id="notif_call"))
+
+    _handle_tc_wake(agent, MagicMock())
+
+    assert len(agent._tc_inbox) == 1
+    names = [event for event, _ in agent._logs]
+    assert names == ["tc_wake_noop"]
+    assert agent._logs[0][1] == {
+        "reason": "pending_tool_calls",
+        "pending_tool_call_count": 1,
+        "pending_tool_call_ids": ["call_pending"],
+        "pending_tool_names": ["bash"],
+    }
 
 
 def test_empty_queue_short_circuits_before_ensure_session():

--- a/tests/test_tool_result_restore_after_continuation_failure.py
+++ b/tests/test_tool_result_restore_after_continuation_failure.py
@@ -58,6 +58,11 @@ class _FakeAgent:
         self.logs.append((event, kwargs))
 
 
+class _HistorySaveFailingAgent(_FakeAgent):
+    def _save_chat_history(self, *, ledger_source: str | None = None) -> None:
+        raise RuntimeError("history disk full")
+
+
 def test_restores_real_tool_results_when_adapter_rolled_back_user_entry():
     """If send(tool_results) fails after local execution, restore real results."""
     agent = _FakeAgent()
@@ -114,23 +119,68 @@ def test_restoration_skips_empty_results():
     assert agent.saved == 0
 
 
+def test_restore_logs_save_failure_on_existing_recovery_event():
+    """If _save_chat_history fails after the real results are committed, the
+    existing recovery event is tagged with failed_at + side_effect and the
+    error is re-raised (no behavior change beyond the extra log)."""
+    agent = _HistorySaveFailingAgent()
+    real_result = ToolResultBlock(id="call_1", name="bash", content="exit_code=0")
+
+    with pytest.raises(RuntimeError, match="history disk full"):
+        _restore_tool_results_after_continuation_failure(
+            agent,
+            [real_result],
+            ledger_source="test",
+        )
+
+    assert agent._chat.committed == [[real_result]]
+    assert agent.logs == [
+        (
+            "tool_results_restored_after_continuation_failure",
+            {
+                "result_count": 1,
+                "ledger_source": "test",
+                "failed_at": "save_chat_history",
+                "save_error": "history disk full",
+                "side_effect": "memory_state_may_be_ahead_of_disk",
+            },
+        )
+    ]
+
+
 class _FakeGuard:
+    def __init__(
+        self,
+        *,
+        stop_reason: str | None = None,
+        invalid_reason: str | None = None,
+    ) -> None:
+        self.stop_reason = stop_reason
+        self.invalid_reason = invalid_reason
+
     def check_limit(self, count: int) -> str | None:
-        return None
+        return self.stop_reason
 
     def check_invalid_tool_limit(self) -> str | None:
-        return None
+        return self.invalid_reason
 
     def record_calls(self, count: int) -> None:
         pass
 
 
 class _ProcessExecutor:
-    def __init__(self, result: ToolResultBlock) -> None:
-        self.guard = _FakeGuard()
+    def __init__(
+        self,
+        result: ToolResultBlock,
+        *,
+        guard: _FakeGuard | None = None,
+    ) -> None:
+        self.guard = guard or _FakeGuard()
         self.result = result
+        self.calls: list[list] = []
 
     def execute(self, tool_calls, **kwargs):
+        self.calls.append(list(tool_calls))
         return [self.result], False, ""
 
 
@@ -145,6 +195,17 @@ class _FailingSession:
     def send(self, content):
         self.sent.append(content)
         raise RuntimeError("provider continuation failed")
+
+
+class _CancelAfterInitialClear:
+    def __init__(self) -> None:
+        self.clear_count = 0
+
+    def clear(self) -> None:
+        self.clear_count += 1
+
+    def is_set(self) -> bool:
+        return self.clear_count == 1
 
 
 def test_process_response_restores_real_results_when_continuation_send_fails():
@@ -181,6 +242,95 @@ def test_process_response_restores_real_results_when_continuation_send_fails():
         "tool_results_restored_after_continuation_failure",
         {"result_count": 1},
     )
+
+
+def test_process_response_logs_cancel_before_tool_dispatch():
+    agent = _FakeAgent()
+    real_result = ToolResultBlock(
+        id="call_1",
+        name="bash",
+        content="should not execute",
+    )
+    agent._executor = _ProcessExecutor(real_result)
+    agent._cancel_event = _CancelAfterInitialClear()
+    agent._on_tool_result_hook = None
+    agent._intermediate_text_streamed = True
+    agent._sent_tracker = _NoopSentTracker()
+
+    response = LLMResponse(
+        text="",
+        tool_calls=[ToolCall(id="call_1", name="bash", args={"command": "echo ok"})],
+    )
+
+    result = _process_response(agent, response, ledger_source="test")
+
+    assert result == {"text": "", "failed": False, "errors": []}
+    assert agent._executor.calls == []
+
+    names = [name for name, _ in agent.logs]
+    assert names == ["tool_calls_not_dispatched"]
+    aborted = agent.logs[0][1]
+    assert aborted == {
+        "ledger_source": "test",
+        "in_tool_loop": False,
+        "reason": "cancel_event",
+        "call_count": 1,
+        "call_ids": ["call_1"],
+        "tool_names": ["bash"],
+    }
+
+
+@pytest.mark.parametrize(
+    ("guard", "reason", "extra"),
+    [
+        (
+            _FakeGuard(stop_reason="max tool calls reached"),
+            "tool_loop_limit",
+            {"stop_reason": "max tool calls reached"},
+        ),
+        (
+            _FakeGuard(invalid_reason="too many invalid tools"),
+            "invalid_tool_limit",
+            {"invalid_reason": "too many invalid tools"},
+        ),
+    ],
+)
+def test_process_response_logs_guarded_tool_calls_not_dispatched(guard, reason, extra):
+    agent = _FakeAgent()
+    real_result = ToolResultBlock(
+        id="call_1",
+        name="bash",
+        content="should not execute",
+    )
+    agent._executor = _ProcessExecutor(real_result, guard=guard)
+    agent._cancel_event = threading.Event()
+    agent._on_tool_result_hook = None
+    agent._intermediate_text_streamed = True
+    agent._sent_tracker = _NoopSentTracker()
+
+    response = LLMResponse(
+        text="",
+        tool_calls=[ToolCall(id="call_1", name="bash", args={"command": "echo ok"})],
+    )
+
+    result = _process_response(agent, response, ledger_source="test")
+
+    assert result == {"text": "", "failed": False, "errors": []}
+    assert agent._executor.calls == []
+    assert agent.logs == [
+        (
+            "tool_calls_not_dispatched",
+            {
+                "ledger_source": "test",
+                "in_tool_loop": False,
+                "reason": reason,
+                "call_count": 1,
+                "call_ids": ["call_1"],
+                "tool_names": ["bash"],
+                **extra,
+            },
+        )
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Current-main rework of the stale PR #143. This adds **turn-loop logging/diagnostics only** so future stuck or orphaned tool-call incidents leave enough evidence to trace where execution stopped. It branches from current `origin/main` and re-applies #143's intent verbatim against today's code — it does **not** merge stale PR #143, and #143 stays open.

**Diagnostics-only — no behavior changes outside logging.**

### Changes
- Helpers in `turn.py` to summarize tool calls and pending assistant tool calls safely (count / ids / names), tolerant of missing attributes:
  - `_tool_call_summary(tool_calls)`
  - `_pending_tool_call_summary(iface)`
- Enrich `tc_wake_noop reason="pending_tool_calls"` with pending count / ids / names.
- New `tool_calls_not_dispatched` event: fired when `_process_response()` sees `response.tool_calls` but exits **before** `ToolExecutor.execute` due to `cancel_event`, `tool_loop_limit`, or `invalid_tool_limit`. Carries `ledger_source`, `in_tool_loop`, `reason`, the relevant `stop_reason` / `invalid_reason`, and call count / ids / names.
- Asleep heal + restore diagnostics: tag `heal_pending_tool_calls_failed` with `failed_at` and `side_effect` on save failure, and emit a save-failure variant of `tool_results_restored_after_continuation_failure` (with `failed_at` / `side_effect`) before re-raising.

`ToolExecutor` remains the source of truth for actual executed-tool observability (`tool_call` / `tool_result`); this PR does **not** fake tool results for calls that were never dispatched.

## Relation to #143
This is the current-main rework of #143 (which was opened against an older base). The diagnostics applied cleanly against current `origin/main`. **PR #143 is intentionally left open and not merged** — this PR supersedes it on current main.

## Tests
Focused tests adapted from #143, compatible with current main, added to existing files:
- `tests/test_tc_wake_chat_not_ready.py` — pending-tool-calls diagnostic with ids/names
- `tests/test_tool_result_restore_after_continuation_failure.py` — save-failure recovery log + `tool_calls_not_dispatched` for cancel / tool-loop-limit / invalid-tool-limit

```text
uv run --with pytest pytest tests/test_tc_wake_chat_not_ready.py tests/test_tool_result_restore_after_continuation_failure.py
16 passed

# extra safety (referenced by #143):
uv run --with pytest pytest tests/test_aed_recovery.py tests/test_tc_wake_orphan_heal.py
20 passed

git diff --check   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)