### PR TITLE
fix(vision): custom-provider fallback honors api_compat + capability kwargs; clearer non-JSON error

### DIFF
--- a/src/lingtai/capabilities/vision/__init__.py
+++ b/src/lingtai/capabilities/vision/__init__.py
@@ -105,30 +105,64 @@ def setup(
             from ...config_resolve import resolve_env
             api_key = resolve_env(api_key, api_key_env)
         if provider not in PROVIDERS["providers"]:
-            # No dedicated VisionService for this provider. If the agent's
-            # main LLM is OpenAI-compatible (custom relay, OpenRouter,
-            # DeepSeek, Kimi, ...), route vision through OpenAIVisionService
-            # using the LLM's own base_url. If the relay or model can't
-            # actually do vision, the call fails at runtime — no pre-check.
-            api_compat = ""
-            defaults = getattr(getattr(agent, "service", None), "_provider_defaults", None)
-            if isinstance(defaults, dict):
-                api_compat = defaults.get("api_compat") or ""
+            # No dedicated VisionService for this provider (custom relay,
+            # OpenRouter, an anthropic-compat local proxy, ...). Route vision
+            # through the OpenAI- or Anthropic-compatible service, picking the
+            # wire protocol and endpoint from, in order:
+            #   1. capability kwargs — explicit init.json override. This lets a
+            #      user point vision at a *different*, vision-capable model
+            #      (e.g. Kimi-K2.6 on a multi-model proxy) while the main LLM
+            #      stays on a text-only model (e.g. GLM-5.1).
+            #   2. the main LLM: api_compat from service._provider_defaults
+            #      (shaped {provider_name: defaults_dict}), base_url/model from
+            #      service._base_url / service._model.
+            # If the relay or model can't actually do vision, the call fails at
+            # runtime — capability registration never pre-checks.
+            api_compat = (kwargs.get("api_compat") or "").lower()
+            if not api_compat:
+                defaults = getattr(getattr(agent, "service", None), "_provider_defaults", None)
+                if isinstance(defaults, dict):
+                    # _provider_defaults is dict[provider_name, defaults_dict];
+                    # read the bucket for *this* provider, not the outer dict.
+                    bucket = defaults.get((provider or "").lower())
+                    if isinstance(bucket, dict):
+                        api_compat = (bucket.get("api_compat") or "").lower()
+
+            cap_model = kwargs.get("model")
+            cap_base_url = kwargs.get("base_url")
+            cap_max_tokens = kwargs.get("max_tokens")
+            llm_base_url = cap_base_url or getattr(agent.service, "_base_url", None)
+            llm_model = cap_model or getattr(agent.service, "_model", None)
+
             if api_compat == "openai":
                 from ...services.vision.openai import OpenAIVisionService
-                llm_base_url = getattr(agent.service, "_base_url", None)
-                llm_model = getattr(agent.service, "_model", None) or "gpt-4o"
-                vision_service = OpenAIVisionService(
-                    api_key=api_key,
-                    model=llm_model,
-                    base_url=llm_base_url,
-                )
+                svc_kwargs: dict = {
+                    "api_key": api_key,
+                    "model": llm_model or "gpt-4o",
+                    "base_url": llm_base_url,
+                }
+                if cap_max_tokens is not None:
+                    svc_kwargs["max_tokens"] = cap_max_tokens
+                vision_service = OpenAIVisionService(**svc_kwargs)
+            elif api_compat == "anthropic":
+                from ...services.vision.anthropic import AnthropicVisionService
+                svc_kwargs = {
+                    "api_key": api_key,
+                    "model": llm_model or "claude-sonnet-4-20250514",
+                    "base_url": llm_base_url,
+                }
+                if cap_max_tokens is not None:
+                    svc_kwargs["max_tokens"] = cap_max_tokens
+                vision_service = AnthropicVisionService(**svc_kwargs)
             else:
                 agent._log(
                     "capability_skipped",
                     capability="vision",
                     requested_provider=provider,
-                    reason=f"no vision support for provider {provider!r}",
+                    reason=(
+                        f"no vision support for provider {provider!r} "
+                        f"(api_compat={api_compat!r})"
+                    ),
                 )
                 return None
         else:

--- a/src/lingtai/services/vision/anthropic.py
+++ b/src/lingtai/services/vision/anthropic.py
@@ -18,11 +18,17 @@ class AnthropicVisionService(VisionService):
         *,
         api_key: str,
         model: str = "claude-sonnet-4-20250514",
+        base_url: str | None = None,
         max_tokens: int = 1024,
     ) -> None:
         import anthropic as _anthropic
 
-        self._client = _anthropic.Anthropic(api_key=api_key)
+        client_kwargs: dict = {"api_key": api_key}
+        if base_url:
+            # anthropic-compat local proxies (e.g. JoyCodeProxy) need an explicit
+            # endpoint; the SDK otherwise defaults to api.anthropic.com.
+            client_kwargs["base_url"] = base_url
+        self._client = _anthropic.Anthropic(**client_kwargs)
         self._model = model
         self._max_tokens = max_tokens
 

--- a/src/lingtai/services/vision/openai.py
+++ b/src/lingtai/services/vision/openai.py
@@ -51,6 +51,20 @@ class OpenAIVisionService(VisionService):
             messages=messages,
             max_tokens=self._max_tokens,
         )
+        if not hasattr(raw, "choices"):
+            # The openai SDK returns the raw body (often a str) instead of a
+            # ChatCompletion when the upstream serves non-JSON — an HTML SPA
+            # route, a plain-text gateway error, etc. Accessing raw.choices
+            # then raised the mystifying "'str' object has no attribute
+            # 'choices'". Surface the actual body so the cause is visible.
+            snippet = repr(raw)[:200] if isinstance(raw, str) else f"<{type(raw).__name__}>"
+            raise RuntimeError(
+                "vision upstream did not return a JSON ChatCompletion. "
+                f"Got {type(raw).__name__}: {snippet}. "
+                "Common cause: base_url missing the '/v1' suffix on a local "
+                "proxy, or the proxy returning an HTML dashboard for unknown "
+                "routes."
+            )
         if raw.choices:
             return raw.choices[0].message.content or ""
         return ""

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -661,3 +661,86 @@ def test_preset_tier_returns_none_when_unset():
 
 def test_tier_vocabulary_is_numeric_one_through_five():
     assert TIER_VALUES == ("1", "2", "3", "4", "5")
+
+
+# ---------------------------------------------------------------------------
+# materialize_active_preset — wholesale capability replacement (issue #114, Bug D)
+# ---------------------------------------------------------------------------
+#
+# Bug D in #114 reports that init.json capability edits silently vanish on the
+# next refresh because materialize_active_preset wholesale-replaces
+# manifest.capabilities from the active preset. This is intentional design
+# (presets are an atomic swap; skills.paths is the one carve-out). These tests
+# pin that documented behavior so it stays explicit rather than surprising, and
+# guard the skills.paths carve-out against regressions.
+
+from lingtai.presets import materialize_active_preset
+
+
+def _preset_content(name, llm, capabilities):
+    return {
+        "name": name,
+        "description": {"summary": f"{name} preset", "tier": "3"},
+        "manifest": {"llm": llm, "capabilities": capabilities},
+    }
+
+
+def test_materialize_wholesale_replaces_init_capabilities(tmp_path):
+    """Documented Bug D behavior: a per-agent init.json capability edit is
+    overwritten by the active preset's capabilities on materialize.
+
+    Pinning this makes the wholesale-replace explicit. Users who need a
+    per-agent override must change the preset, not init.json (see PR/issue #114).
+    """
+    preset_path = _write_preset(
+        tmp_path, "GLM5.1",
+        _preset_content(
+            "GLM5.1",
+            llm={"provider": "custom", "api_compat": "anthropic", "model": "GLM-5.1"},
+            capabilities={"vision": {"provider": "inherit"}},
+        ),
+    )
+    data = {
+        "manifest": {
+            "preset": {"active": str(preset_path)},
+            # user hand-edited init.json to point vision at a different model
+            "capabilities": {
+                "vision": {
+                    "provider": "custom",
+                    "api_compat": "openai",
+                    "model": "Kimi-K2.6",
+                    "base_url": "http://127.0.0.1:34891/v1",
+                },
+            },
+        },
+    }
+    materialize_active_preset(data, working_dir=tmp_path)
+
+    # the user's init.json vision override is gone — preset wins wholesale
+    assert data["manifest"]["capabilities"] == {"vision": {"provider": "inherit"}}
+
+
+def test_materialize_preserves_init_skills_paths_carveout(tmp_path):
+    """The documented skills.paths carve-out: init.json extras append to the
+    preset's skill paths (preset defaults first), surviving the wholesale swap.
+    """
+    preset_path = _write_preset(
+        tmp_path, "withskills",
+        _preset_content(
+            "withskills",
+            llm={"provider": "x", "model": "y"},
+            capabilities={"skills": {"paths": ["~/preset-skills"]}},
+        ),
+    )
+    data = {
+        "manifest": {
+            "preset": {"active": str(preset_path)},
+            "capabilities": {"skills": {"paths": ["~/agent-skills"]}},
+        },
+    }
+    materialize_active_preset(data, working_dir=tmp_path)
+
+    assert data["manifest"]["capabilities"]["skills"]["paths"] == [
+        "~/preset-skills",
+        "~/agent-skills",
+    ]

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -161,7 +161,7 @@ def test_vision_setup_unsupported_provider_skips(tmp_path):
         "capability_skipped",
         capability="vision",
         requested_provider="not-real",
-        reason="no vision support for provider 'not-real'",
+        reason="no vision support for provider 'not-real' (api_compat='')",
     )
 
 
@@ -273,6 +273,109 @@ def test_vision_setup_no_provider_raises(tmp_path):
     agent = make_mock_agent(tmp_path)
     with pytest.raises(ValueError, match="vision capability requires"):
         setup(agent)
+
+
+def make_custom_agent(tmp_path, *, api_compat=None, base_url=None, model=None):
+    """Agent whose main LLM is a `provider='custom'` relay.
+
+    `_provider_defaults` is the real shape: ``{provider_name: defaults_dict}``,
+    so the fallback must peek into the per-provider bucket to read api_compat.
+    """
+    svc = MagicMock()
+    svc.provider = "custom"
+    svc._model = model
+    svc._base_url = base_url
+    svc._provider_defaults = {"custom": {"api_compat": api_compat}} if api_compat else {"custom": {}}
+    return make_mock_agent(tmp_path, svc=svc)
+
+
+# ---------------------------------------------------------------------------
+# Issue #114 — vision fallback for provider='custom'
+# ---------------------------------------------------------------------------
+
+def test_vision_fallback_reads_api_compat_from_provider_bucket(tmp_path):
+    """C-1: api_compat is read from _provider_defaults[provider], not the outer dict.
+
+    `_provider_defaults` is shaped {provider_name: defaults_dict}. The old code
+    called defaults.get("api_compat") on the OUTER dict, which always returned
+    None, so the OpenAI fallback never engaged for custom providers.
+    """
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_cls:
+        agent = make_custom_agent(
+            tmp_path, api_compat="openai", base_url="http://127.0.0.1:34891/v1", model="GLM-5.1"
+        )
+        mgr = setup(agent, provider="custom", api_key="sk-test")
+
+        mock_cls.assert_called_once()
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["base_url"] == "http://127.0.0.1:34891/v1"
+        assert kwargs["model"] == "GLM-5.1"
+        assert isinstance(mgr, VisionManager)
+
+
+def test_vision_fallback_anthropic_compat_routes_to_anthropic_service(tmp_path):
+    """C-2: api_compat='anthropic' routes vision through AnthropicVisionService.
+
+    Previously only the openai branch existed; anthropic-compat custom proxies
+    fell through to capability_skipped even though AnthropicVisionService exists.
+    """
+    with patch("lingtai.services.vision.anthropic.AnthropicVisionService") as mock_cls:
+        agent = make_custom_agent(
+            tmp_path, api_compat="anthropic", base_url="http://127.0.0.1:34891", model="GLM-5.1"
+        )
+        mgr = setup(agent, provider="custom", api_key="sk-test")
+
+        mock_cls.assert_called_once()
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["base_url"] == "http://127.0.0.1:34891"
+        assert kwargs["model"] == "GLM-5.1"
+        assert isinstance(mgr, VisionManager)
+
+
+def test_vision_fallback_honors_capability_kwargs_over_service(tmp_path):
+    """C-3: explicit capability model/base_url/api_compat override the main LLM.
+
+    The whole point of explicit kwargs in init.json is to route vision through a
+    different (vision-capable) model than the text-only main LLM. The fallback
+    must consult kwargs first and only fall back to service._model/._base_url.
+    """
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_cls:
+        # main LLM is GLM-5.1 (text-only) on an anthropic-compat proxy
+        agent = make_custom_agent(
+            tmp_path, api_compat="anthropic", base_url="http://127.0.0.1:34891", model="GLM-5.1"
+        )
+        # capability explicitly overrides: openai-compat vision model on the /v1 route
+        mgr = setup(
+            agent,
+            provider="custom",
+            api_key="sk-test",
+            api_compat="openai",
+            model="Kimi-K2.6",
+            base_url="http://127.0.0.1:34891/v1",
+            max_tokens=2048,
+        )
+
+        mock_cls.assert_called_once()
+        kwargs = mock_cls.call_args.kwargs
+        assert kwargs["model"] == "Kimi-K2.6"
+        assert kwargs["base_url"] == "http://127.0.0.1:34891/v1"
+        assert kwargs["max_tokens"] == 2048
+        assert isinstance(mgr, VisionManager)
+
+
+def test_vision_fallback_unknown_api_compat_skips_with_diagnostic(tmp_path):
+    """Fallback with an unhandled api_compat skips and names api_compat in the reason."""
+    agent = make_custom_agent(tmp_path, api_compat="gemini")
+    result = setup(agent, provider="custom", api_key="sk-test")
+    assert result is None
+    agent.add_tool.assert_not_called()
+    log_kwargs = agent._log.call_args.kwargs
+    assert log_kwargs["capability"] == "vision"
+    assert log_kwargs["requested_provider"] == "custom"
+    assert "gemini" in log_kwargs["reason"]
+    assert "api_compat" in log_kwargs["reason"]
 
 
 def test_minimax_vision_setup_filters_inherited_api_compat(tmp_path):

--- a/tests/test_vision_services.py
+++ b/tests/test_vision_services.py
@@ -1,0 +1,92 @@
+"""Tests for provider-specific VisionService response handling (issue #114, Bug G)."""
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_openai_service(monkeypatch, raw_response):
+    """Build an OpenAIVisionService whose client returns `raw_response`."""
+    completions = MagicMock()
+    completions.create.return_value = raw_response
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    openai_cls = MagicMock(return_value=client)
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=openai_cls))
+
+    from lingtai.services.vision.openai import OpenAIVisionService
+
+    return OpenAIVisionService(api_key="sk-test", model="gpt-4o", base_url="http://127.0.0.1:34891")
+
+
+def test_openai_vision_raises_clear_error_on_string_response(monkeypatch, tmp_path):
+    """Bug G: a raw `str` body (proxy served HTML/non-JSON) raises a clear RuntimeError.
+
+    Previously `raw.choices` on a str raised the mystifying
+    `'str' object has no attribute 'choices'`.
+    """
+    img = tmp_path / "chart.png"
+    img.write_bytes(b"\x89PNG fake")
+
+    html_body = "<!DOCTYPE html><html><body>404 Not Found dashboard</body></html>"
+    svc = _make_openai_service(monkeypatch, html_body)
+
+    with pytest.raises(RuntimeError) as exc:
+        svc.analyze_image(str(img), prompt="what is this?")
+
+    msg = str(exc.value)
+    assert "ChatCompletion" in msg or "JSON" in msg
+    assert "str" in msg
+    # surfaces a snippet of the actual body so the user can diagnose
+    assert "404 Not Found dashboard" in msg
+    # no misleading AttributeError leaked through
+    assert "object has no attribute" not in msg
+
+
+def test_openai_vision_raises_on_non_completion_object(monkeypatch, tmp_path):
+    """A non-str object without `.choices` also raises a clear RuntimeError, not AttributeError."""
+    img = tmp_path / "chart.png"
+    img.write_bytes(b"\x89PNG fake")
+
+    svc = _make_openai_service(monkeypatch, {"unexpected": "dict"})
+
+    with pytest.raises(RuntimeError) as exc:
+        svc.analyze_image(str(img))
+    assert "object has no attribute" not in str(exc.value)
+
+
+def test_openai_vision_returns_content_on_valid_response(monkeypatch, tmp_path):
+    """A well-formed ChatCompletion still returns its message content."""
+    img = tmp_path / "chart.png"
+    img.write_bytes(b"\x89PNG fake")
+
+    message = SimpleNamespace(content="a candlestick chart")
+    choice = SimpleNamespace(message=message)
+    raw = SimpleNamespace(choices=[choice])
+    svc = _make_openai_service(monkeypatch, raw)
+
+    assert svc.analyze_image(str(img)) == "a candlestick chart"
+
+
+def test_anthropic_vision_service_accepts_base_url(monkeypatch):
+    """C-2 sibling: AnthropicVisionService accepts base_url for local proxies."""
+    anthropic_cls = MagicMock()
+    monkeypatch.setitem(sys.modules, "anthropic", SimpleNamespace(Anthropic=anthropic_cls))
+
+    from lingtai.services.vision.anthropic import AnthropicVisionService
+
+    AnthropicVisionService(api_key="sk-test", model="GLM-5.1", base_url="http://127.0.0.1:34891")
+    anthropic_cls.assert_called_once_with(api_key="sk-test", base_url="http://127.0.0.1:34891")
+
+
+def test_anthropic_vision_service_omits_base_url_when_unset(monkeypatch):
+    """No base_url → default Anthropic endpoint (no base_url kwarg passed)."""
+    anthropic_cls = MagicMock()
+    monkeypatch.setitem(sys.modules, "anthropic", SimpleNamespace(Anthropic=anthropic_cls))
+
+    from lingtai.services.vision.anthropic import AnthropicVisionService
+
+    AnthropicVisionService(api_key="sk-test")
+    anthropic_cls.assert_called_once_with(api_key="sk-test")


### PR DESCRIPTION
Fixes the still-unfixed core of **Lingtai-AI/lingtai#114** (vision capability fallback for `provider="custom"` + clearer error surfacing). Scoped to the four concrete bugs; preset architecture is intentionally left as-is.

## Behavior changes

**`src/lingtai/capabilities/vision/__init__.py` — `setup()` fallback (provider not in `PROVIDERS`)**
- **C-1** — Read `api_compat` from `service._provider_defaults[provider]`. `_provider_defaults` is shaped `{provider_name: defaults_dict}`; the old code called `defaults.get("api_compat")` on the *outer* dict, which always returned `None`, so the fallback never engaged for custom providers. Now mirrors the canonical pattern in `base_agent/identity.py:_provider_default_from_service`.
- **C-2** — Added an `api_compat == "anthropic"` fallback branch (routes through `AnthropicVisionService`) alongside the existing openai branch. Failure now happens at the API call, not at capability registration.
- **C-3** — Honor explicit capability kwargs (`api_compat` / `model` / `base_url` / `max_tokens`) over the main LLM's `service._model` / `_base_url`. This lets vision target a different, vision-capable model (e.g. Kimi-K2.6 on a multi-model proxy) while the main LLM stays on a text-only model (e.g. GLM-5.1).
- Enriched the `capability_skipped` reason with `(api_compat=...)` so the failure is diagnosable.

**`src/lingtai/services/vision/anthropic.py`** — `AnthropicVisionService.__init__` now accepts `base_url` (mirrors `OpenAIVisionService`), so anthropic-compat local proxies route correctly instead of defaulting to `api.anthropic.com`. Omitted when unset.

**`src/lingtai/services/vision/openai.py`** — **Bug G**: `analyze_image` raises a clear `RuntimeError` with a body snippet when the upstream returns a non-`ChatCompletion` (e.g. the openai SDK silently returns a `str` for an HTML SPA route), instead of the misleading `'str' object has no attribute 'choices'`.

## Preset materialization (Bug D / Footgun D)
Left **unchanged** by design — `materialize_active_preset` wholesale-replacing `manifest.capabilities` is the intended atomic-swap behavior, and the `expand_inherit` `api_compat` propagation the issue requested is already present on `main`. Per the issue's "minimum" option, the behavior is now pinned by explicit regression tests (`test_materialize_wholesale_replaces_init_capabilities`, `test_materialize_preserves_init_skills_paths_carveout`) so it's documented rather than surprising. No capability-override semantics were broadened.

## Tests
- `tests/test_vision_capability.py` — regression tests for C-1, C-2, C-3, the enriched skip reason; updated `test_vision_setup_unsupported_provider_skips` for the new reason string.
- `tests/test_vision_services.py` (new) — Bug G (`str`/non-`ChatCompletion` → clear `RuntimeError`, valid response still returns content) and `AnthropicVisionService` `base_url` handling.
- `tests/test_presets.py` — wholesale-replace + skills.paths carve-out pinning.

### Validation
Run with `PYTHONPATH=src` against this branch:
- `test_vision_capability.py test_vision_services.py test_presets.py test_llm_service.py` → **97 passed**
- broader: `+ test_agent_capabilities.py test_preset_materialization.py test_daemon_preset_capabilities.py` → **141 passed**
- related (`test_agent_preset_manifest test_max_rpm_plumbing test_services_integration`) → **75 passed, 2 skipped**

## Caveats
- The anthropic fallback's usefulness depends on the upstream proxy actually speaking the Anthropic Messages API and supporting vision; registration no longer pre-checks (by design), so a non-vision model fails at the API call.
- Cross-repo: the HTML-on-`/chat/completions` root cause (Bug G trigger) is a separate JoyCodeProxy issue; this PR only fixes lingtai-kernel's error surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)