### PR TITLE
fix(soul): stop consultation prompt teaching removed codex() tool

### DIFF
--- a/src/lingtai_kernel/intrinsics/soul/consultation.py
+++ b/src/lingtai_kernel/intrinsics/soul/consultation.py
@@ -25,7 +25,7 @@ _CONSULTATION_SYSTEM_PROMPT = (
     "You cannot execute tools from here — but you can probe with them. Any tool call you "
     "emit is intercepted and forwarded to present-self as a recommendation. Use tool calls "
     "as exploratory gestures: `search(...)` something tangential, `pad(read, ...)` "
-    "something they haven't reopened in a while, `codex(...)` a half-remembered note. "
+    "something they haven't reopened in a while, `knowledge(...)` a half-remembered note. "
     "The call name, arguments, and your adjacent reasoning all reach them — let the why "
     "show. Tool-probes are a cheap way to point present-self at corners they haven't "
     "looked into.\n\n"

--- a/tests/test_soul_consultation.py
+++ b/tests/test_soul_consultation.py
@@ -1924,3 +1924,27 @@ class TestSoulNotificationInstructions:
         assert "email" in text
         # Tells the agent to verify before acting on narrated events.
         assert "verify" in text.lower() or "belief" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Regression: the consultation prompt must not teach removed tools.
+# ---------------------------------------------------------------------------
+
+
+def test_consultation_prompt_has_no_removed_codex_tool_call():
+    """The consultation system prompt (and its refusal echo) must not suggest
+    a `codex(...)` tool call. The `codex` durable-memory capability was removed;
+    its replacement is `knowledge`. Guards against silently reintroducing a
+    dead-tool example into a prompt sent to the detached consultation voice.
+    """
+    from lingtai_kernel.intrinsics.soul.consultation import (
+        _CONSULTATION_SYSTEM_PROMPT,
+        _CONSULTATION_TOOL_REFUSAL,
+    )
+
+    # No `codex(` anywhere as a suggested tool-probe.
+    assert "codex(" not in _CONSULTATION_SYSTEM_PROMPT
+    # The refusal text re-grounds with the full system prompt, so check it too.
+    assert "codex(" not in _CONSULTATION_TOOL_REFUSAL
+    # The durable-memory probe example points at the current tool.
+    assert "knowledge(" in _CONSULTATION_SYSTEM_PROMPT


### PR DESCRIPTION
## Summary

The soul **consultation** system prompt (`src/lingtai_kernel/intrinsics/soul/consultation.py`) listed `codex(...)` as a tool-probe example for the detached consultation voice:

> Use tool calls as exploratory gestures: `search(...)` something tangential, `pad(read, ...)` something they haven't reopened in a while, **`codex(...)`** a half-remembered note.

But the `codex` durable-memory capability was removed — the current durable-memory tool is **`knowledge`** (per CLAUDE.md: *"Former durable-memory names `library` and `codex` are removed."*). A consultation voice that emits `codex(...)` produces a dead tool-call recommendation forwarded to present-self.

This PR swaps the single example to `knowledge(...)`, preserving the exact prose intent (probe a half-remembered durable note), and adds a focused regression test so the prompt text can't silently reintroduce `codex(` as a suggested tool call.

This was finding **F5** from the systematic stale/dead-code audit.

## Changes

- `src/lingtai_kernel/intrinsics/soul/consultation.py` — one-word change in `_CONSULTATION_SYSTEM_PROMPT`: `` `codex(...)` `` → `` `knowledge(...)` ``. (The tool-refusal text `_CONSULTATION_TOOL_REFUSAL` re-grounds with this same prompt, so it is fixed transitively.)
- `tests/test_soul_consultation.py` — added `test_consultation_prompt_has_no_removed_codex_tool_call`: asserts neither the system prompt nor the refusal echo contains `codex(`, and that the durable-memory probe example now points at `knowledge(`. Intentionally minimal — it checks tool-name presence/absence, not large prose, to avoid brittle over-testing.

No behavior change beyond prompt text; no public API change. ANATOMY unchanged (the soul/psyche anatomy does not cite this example line, so no citation rot).

## Validation

```
$ git diff --check
OK: no whitespace errors

$ pytest tests/test_soul_consultation.py::test_consultation_prompt_has_no_removed_codex_tool_call -q
1 passed

$ pytest tests/test_soul_consultation.py tests/test_soul.py -q \
    --deselect <3 pre-existing failures, see note>
117 passed, 3 deselected
```

**Pre-existing failures (NOT caused by this PR):** three soul tests fail identically on clean `main` (verified at both `dc67451` and this PR's base `59d588e` with the change stashed out):
- `tests/test_soul.py::test_consultation_fire_discards_late_result_after_state_change`
- `tests/test_soul_consultation.py::TestRehydrateAppendixTracking::test_soul_whisper_delegates_to_consultation_fire`
- `tests/test_soul_consultation.py::TestRehydrateAppendixTracking::test_soul_whisper_swallows_consultation_fire_error`

They concern consultation-fire state-change / whisper delegation logic, unrelated to prompt text. Out of scope for this PR; flagged for separate triage.

## Non-scope (explicit)

This PR is deliberately tiny and touches **only** the consultation prompt's `codex(` example + its regression test. It does **not** include any other audit findings: no `lingtai.preset_connectivity` / `config_resolve` shim cleanup, no `tc_inbox` work, no `codex_oauth`, no other stale-code removals. Those remain separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)