### PR TITLE
test(kernel): align release tests and bump 0.10.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.10.10"
+version = "0.10.11"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_kernel_isolation.py
+++ b/tests/test_kernel_isolation.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
 
 
 def test_kernel_import_is_clean():
@@ -21,7 +22,7 @@ def test_kernel_import_is_clean():
         [sys.executable, "-c", "import lingtai_kernel; print('OK')"],
         capture_output=True,
         text=True,
-        cwd="/Users/huangzesen/Documents/Github/lingtai-kernel",
+        cwd=str(Path(__file__).resolve().parents[1]),
     )
     assert result.returncode == 0, (
         f"lingtai_kernel failed to import.\n"
@@ -87,7 +88,7 @@ def test_kernel_import_does_not_pull_lingtai():
         ],
         capture_output=True,
         text=True,
-        cwd="/Users/huangzesen/Documents/Github/lingtai-kernel",
+        cwd=str(Path(__file__).resolve().parents[1]),
     )
     assert result.returncode == 0, f"Subprocess error:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     assert "CLEAN" in result.stdout, (

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -308,11 +308,21 @@ class TestMissionQualityGate:
         assert "confirm" in sch["properties"]
         assert sch["properties"]["confirm"]["type"] == "boolean"
 
-    def test_description_warns_against_accidental_spawn(self):
-        from lingtai.core.avatar import get_description
+    def test_description_points_to_avatar_manual_after_prompt_compaction(self):
+        """The terse tool description should route safety guidance to the manual.
+
+        Prompt-token compaction moved verbose WARNING copy out of the always-on
+        tool description and into avatar-manual. The safety contract now lives
+        in the schema gates (dry_run/confirm) plus the manual pointer, not in a
+        long description string.
+        """
+        from lingtai.core.avatar import get_description, get_schema
         desc = get_description("en")
-        assert "WARNING" in desc
-        assert "independent process" in desc.lower()
+        schema = get_schema("en")
+        assert "avatar-manual" in desc
+        assert "WARNING" not in desc
+        assert "confirm" in schema["properties"]
+        assert "dry_run" in schema["properties"]
 
 
 class TestSetupAvatar:

--- a/tests/test_soul.py
+++ b/tests/test_soul.py
@@ -372,5 +372,10 @@ def test_consultation_fire_discards_late_result_after_state_change(monkeypatch):
 
     flow._run_consultation_fire(agent)
 
+    # Soul flow no longer enqueues a TC wake directly; filesystem
+    # notification + heartbeat sync owns injection/wake-up. A mid-flight state
+    # change therefore must not touch tc_inbox, and the fire is allowed to
+    # publish/log through the notification path without the old
+    # consultation_discarded_state event.
     agent._tc_inbox.enqueue.assert_not_called()
-    assert any(name == "consultation_discarded_state" for name, _ in agent._logs)
+    assert any(name == "consultation_fire" for name, _ in agent._logs)

--- a/tests/test_soul_consultation.py
+++ b/tests/test_soul_consultation.py
@@ -1151,7 +1151,9 @@ class TestRehydrateAppendixTracking:
              patch.object(agent, "_start_soul_timer") as mock_resched:
             agent._soul_whisper()
         assert mock_fire.call_count == 1
-        assert mock_resched.call_count == 1
+        # Current cadence is one-shot per IDLE transition: _soul_whisper does
+        # not reschedule itself; the next transition to IDLE starts a new timer.
+        assert mock_resched.call_count == 0
 
     def test_soul_whisper_swallows_consultation_fire_error(self, tmp_path):
         """Errors in the consultation fire must not break the cadence —
@@ -1165,7 +1167,8 @@ class TestRehydrateAppendixTracking:
                           side_effect=RuntimeError("boom")), \
              patch.object(agent, "_start_soul_timer") as mock_resched:
             agent._soul_whisper()  # must not raise
-        assert mock_resched.call_count == 1
+        # Errors are swallowed, but cadence is still one-shot; no self-reschedule.
+        assert mock_resched.call_count == 0
 
     def test_tracks_first_match_only(self, tmp_path):
         """Defensive: if somehow the history contains two soul.flow pairs


### PR DESCRIPTION
## Summary
- bump package version from `0.10.10` to `0.10.11` for the next kernel release
- remove host-specific cwd assumptions from kernel isolation tests
- align avatar description and soul-flow tests with current prompt-compaction / notification-sync behavior

## Validation
- `uv run --with pytest pytest tests/test_kernel_isolation.py tests/test_layers_avatar.py::TestMissionQualityGate tests/test_soul.py::test_consultation_fire_discards_late_result_after_state_change tests/test_soul_consultation.py::TestRehydrateAppendixTracking::test_soul_whisper_delegates_to_consultation_fire tests/test_soul_consultation.py::TestRehydrateAppendixTracking::test_soul_whisper_swallows_consultation_fire_error -q` → `20 passed`
- `ulimit -n 8192 || true; uv run --with pytest pytest -q` → `1969 passed, 2 skipped in 255.45s`
- `uv run --with build python -m build` → passed

No tag, GitHub Release, or PyPI publish is performed by this PR.