### PR TITLE
chore(kernel): bump version to 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.10.11"
+version = "0.11.0"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump kernel package version from `0.10.11` to `0.11.0`
- use a minor release number for the Rust sidecar/backend rewrite release train

## Validation
- PR #182 already removed the stale release-blocking pytest failures and ran full suite: `1969 passed, 2 skipped`
- `uv run --with build python -m build` → passed for `0.11.0`
- built artifacts report `Name: lingtai`, `Version: 0.11.0`

No tag, GitHub Release, or PyPI upload is performed by this PR.