### PR TITLE
Add WhatsApp MCP runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "lingtai-telegram>=0.1.0",
     "lingtai-feishu>=0.1.0",
     "lingtai-wechat>=0.1.0",
+    "lingtai-whatsapp>=0.1.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add `lingtai-whatsapp>=0.1.0` to the kernel runtime dependencies now that the WhatsApp MCP package has been published to PyPI
- completes the dependency step after the curated WhatsApp MCP catalog/manual registration landed in #188

## Validation
- `pip index versions lingtai-whatsapp` reports `0.1.0`
- temp venv install: `pip install 'lingtai-whatsapp>=0.1.0'` and `import lingtai_whatsapp`
- `uv run python -m pytest tests/test_mcp_capability.py tests/test_secondary_schema.py tests/test_sent_message_tracker.py -q`
