### PR TITLE
Add additive SQLite log index

### DIFF
--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -240,6 +240,45 @@ def run(working_dir: Path) -> None:
             pass
 
 
+def _emit_json(data: object) -> None:
+    print(json.dumps(data, ensure_ascii=False, indent=2, default=str))
+
+
+def _handle_log_command(args) -> None:
+    from lingtai_kernel.services.logging import (
+        doctor_sqlite_event_index,
+        query_sqlite_event_index,
+        rebuild_sqlite_event_index,
+    )
+
+    agent_dir = args.agent_dir.resolve()
+    if not agent_dir.is_dir():
+        print(f"error: {agent_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    if args.log_command == "rebuild":
+        try:
+            _emit_json(rebuild_sqlite_event_index(agent_dir))
+        except Exception as e:
+            print(f"error: failed to rebuild sqlite log index: {e}", file=sys.stderr)
+            sys.exit(1)
+    elif args.log_command == "doctor":
+        try:
+            _emit_json(doctor_sqlite_event_index(agent_dir))
+        except Exception as e:
+            print(f"error: failed to inspect sqlite log index: {e}", file=sys.stderr)
+            sys.exit(1)
+    elif args.log_command == "query":
+        try:
+            _emit_json(query_sqlite_event_index(agent_dir, args.sql))
+        except Exception as e:
+            print(f"error: failed to query sqlite log index: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print("error: missing log subcommand", file=sys.stderr)
+        sys.exit(1)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="lingtai-agent",
@@ -252,6 +291,19 @@ def main() -> None:
 
     sub.add_parser("check-caps", help="Output capability provider metadata as JSON")
 
+    log_parser = sub.add_parser("log", help="Inspect the additive SQLite log index")
+    log_sub = log_parser.add_subparsers(dest="log_command", required=True)
+
+    log_rebuild = log_sub.add_parser("rebuild", help="Rebuild logs/log.sqlite from logs/events.jsonl")
+    log_rebuild.add_argument("agent_dir", type=Path, help="Agent working directory")
+
+    log_doctor = log_sub.add_parser("doctor", help="Check logs/log.sqlite integrity and counts")
+    log_doctor.add_argument("agent_dir", type=Path, help="Agent working directory")
+
+    log_query = log_sub.add_parser("query", help="Run a read-only SQL query against logs/log.sqlite")
+    log_query.add_argument("agent_dir", type=Path, help="Agent working directory")
+    log_query.add_argument("sql", help="SQL query to execute")
+
     args = parser.parse_args()
 
     if args.command == "run":
@@ -263,6 +315,8 @@ def main() -> None:
     elif args.command == "check-caps":
         from lingtai.capabilities import get_all_providers
         print(json.dumps(get_all_providers()))
+    elif args.command == "log":
+        _handle_log_command(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/src/lingtai/intrinsic_skills/sqlite-log-query/SKILL.md
+++ b/src/lingtai/intrinsic_skills/sqlite-log-query/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: sqlite-log-query
+description: >
+  Query LingTai agent runtime history through the additive SQLite log sidecar.
+  Read this when you need to inspect `logs/log.sqlite`, run `lingtai-agent log
+  doctor|query|rebuild`, count event types, investigate recent errors/tool
+  calls/notifications, or explain the JSONL source-of-truth versus SQLite
+  query-index contract. Covers safe read-only query patterns, offline rebuild,
+  schema, example SQL, and pitfalls around live agents and WAL snapshots.
+version: 0.1.0
+tags: [lingtai, logs, sqlite, observability, diagnostics, query]
+---
+
+# SQLite Log Query
+
+LingTai keeps the durable runtime event log in `logs/events.jsonl`. The SQLite
+file at `logs/log.sqlite` is an **additive, rebuildable query index** over that
+JSONL source of truth. Use it to answer questions that are painful with `grep`:
+which event types are hottest, when a failure started, which tool calls emitted
+errors, or whether notification/daemon/context events are storming.
+
+## Safety contract
+
+- **JSONL is authoritative.** `logs/log.sqlite` is derived; deleting it should not
+  delete facts.
+- **Prefer the CLI.** Use `lingtai-agent log ...` instead of opening the DB for
+  writes yourself.
+- **Queries are read-only.** `log query` accepts read-only `SELECT`, CTE (`WITH ... SELECT`), and
+  `EXPLAIN` statements and opens the sidecar through the kernel read-only
+  inspection path.
+- **Rebuild is offline.** `log rebuild` requires the agent working-directory lock;
+  if the agent is running, stop/sleep/lull/suspend it first as appropriate.
+- **Live queries are snapshots.** Runtime writes use SQLite WAL mode. The query
+  path is intentionally non-mutating, so for a complete historical snapshot stop
+  the agent and run `log rebuild` from `events.jsonl` before querying. For the
+  newest live facts, inspect `logs/events.jsonl` directly.
+- **Never paste secrets.** Logs can contain URLs, tokens, prompts, and user data.
+  Redact before sharing.
+
+## Commands
+
+Set a variable for the target agent directory:
+
+```bash
+AGENT_DIR=/path/to/project/.lingtai/agent-name
+```
+
+Check whether the sidecar exists and is readable:
+
+```bash
+lingtai-agent log doctor "$AGENT_DIR"
+```
+
+If `doctor` reports `{"status":"missing"...}` or the sidecar is stale/corrupt,
+rebuild **only while the target agent is stopped/offline**:
+
+```bash
+lingtai-agent log rebuild "$AGENT_DIR"
+```
+
+Run a read-only query:
+
+```bash
+lingtai-agent log query "$AGENT_DIR" \
+  'SELECT id, ts, type, agent_address, substr(fields_json, 1, 240) AS fields
+   FROM events
+   ORDER BY ts DESC
+   LIMIT 20'
+```
+
+The CLI prints JSON. Pipe to `jq` when available:
+
+```bash
+lingtai-agent log query "$AGENT_DIR" \
+  'SELECT type, COUNT(*) AS n FROM events GROUP BY type ORDER BY n DESC LIMIT 20' \
+  | jq .
+```
+
+## Schema quick reference
+
+`events` is the main table:
+
+| Column | Meaning |
+|---|---|
+| `id` | SQLite row id, not a stable cross-rebuild event identifier |
+| `ts` | event timestamp as a numeric epoch-like value |
+| `type` | event type string |
+| `agent_address` | event `address` field when present |
+| `agent_name_snapshot` | event `agent_name` field when present |
+| `fields_json` | the remaining event fields as JSON text |
+| `source_file` | JSONL file imported from, usually `logs/events.jsonl` |
+| `source_offset` | byte offset in the JSONL source; unique with `source_file` |
+| `inserted_at` | sidecar insertion time |
+
+Maintenance tables:
+
+- `schema_migrations(version, name, applied_at)` records sidecar schema version.
+- `import_cursors(source_file, byte_offset, line_no, updated_at)` records the last
+  rebuild/import cursor.
+
+## Query recipes
+
+Recent events:
+
+```sql
+SELECT id, ts, type, substr(fields_json, 1, 300) AS fields
+FROM events
+ORDER BY ts DESC
+LIMIT 50;
+```
+
+Event type counts:
+
+```sql
+SELECT type, COUNT(*) AS n, MIN(ts) AS first_ts, MAX(ts) AS last_ts
+FROM events
+GROUP BY type
+ORDER BY n DESC
+LIMIT 50;
+```
+
+Search for errors or failures:
+
+```sql
+SELECT id, ts, type, substr(fields_json, 1, 500) AS fields
+FROM events
+WHERE lower(type) LIKE '%error%'
+   OR lower(type) LIKE '%fail%'
+   OR lower(fields_json) LIKE '%error%'
+   OR lower(fields_json) LIKE '%traceback%'
+ORDER BY ts DESC
+LIMIT 100;
+```
+
+Look for notification storms:
+
+```sql
+SELECT type, COUNT(*) AS n, MIN(ts) AS first_ts, MAX(ts) AS last_ts
+FROM events
+WHERE type LIKE 'notification%'
+   OR fields_json LIKE '%notification%'
+GROUP BY type
+ORDER BY n DESC;
+```
+
+Inspect one event's full JSON payload:
+
+```sql
+SELECT id, type, fields_json
+FROM events
+WHERE id = 123;
+```
+
+Use SQLite JSON functions when available:
+
+```sql
+SELECT
+  type,
+  json_extract(fields_json, '$.tool') AS tool,
+  json_extract(fields_json, '$.error') AS error
+FROM events
+WHERE fields_json LIKE '%error%'
+ORDER BY ts DESC
+LIMIT 50;
+```
+
+If JSON functions are unavailable in the local SQLite build, fall back to
+`fields_json LIKE ...` and inspect the returned JSON text.
+
+## Workflow: investigate a suspected runtime problem
+
+1. Identify the agent directory. If unsure, use the `.lingtai/<agent>` directory
+   shown in the agent's identity/pad or ask the orchestrator.
+2. Run `lingtai-agent log doctor "$AGENT_DIR"`.
+3. If the sidecar is missing/stale and exact history matters, stop the target
+   agent and run `lingtai-agent log rebuild "$AGENT_DIR"`.
+4. Start broad: event type counts and recent rows.
+5. Narrow by time/type/text. Keep queries read-only (`SELECT`, `WITH ... SELECT`, or `EXPLAIN`).
+6. Cross-check surprising findings against `logs/events.jsonl`, `agent.log`, or
+   daemon subdirectories before filing bugs or making claims.
+7. When reporting, quote minimal evidence and redact secrets.
+
+## Pitfalls
+
+- Do not treat `log.sqlite` as a coordination database. It is an observability
+  index, not agent state.
+- Do not rebuild a live agent by bypassing the CLI lock; that risks racing the
+  runtime logger.
+- Do not share raw `fields_json` blindly; it may contain private content.
+- Do not assume `id` survives rebuilds. Use `source_file/source_offset`, time,
+  and surrounding context for durable references.
+- If a query returns fewer rows than expected on a live agent, remember the WAL
+  snapshot caveat; stop/rebuild or inspect JSONL.

--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -220,7 +220,19 @@ large manual into resident prompt; use a skill and leave a routing line.
 
 Before authoring or publishing skills, read `skills-manual`.
 
-## 9. Collaboration and network topology
+## 9. Runtime log inspection
+
+LingTai runtime history is written first to `logs/events.jsonl`. Newer kernels
+also maintain a rebuildable SQLite sidecar at `logs/log.sqlite` so agents can run
+structured diagnostics without grepping large JSONL files.
+
+When you need to query event history, count event types, inspect failures,
+investigate notification storms, or use `lingtai-agent log doctor|query|rebuild`,
+load `sqlite-log-query`. Keep the resident rule small: JSONL is the source of
+truth; SQLite is a read-only/rebuildable observability index; rebuild requires
+the target agent to be stopped/offline.
+
+## 10. Collaboration and network topology
 
 Know the network. Use contacts for addresses, pad for active delegations,
 character for long-term collaborator knowledge, and mail history for implicit
@@ -234,7 +246,7 @@ broadcast noise.
 Spawn avatars for persistent capability gaps. Use daemons for disposable
 parallel exploration.
 
-## 10. MCP and addon ownership
+## 11. MCP and addon ownership
 
 MCPs are persistent external services. Register/activate/troubleshoot them via
 `mcp-manual`, not guesswork. For curated LingTai addons (IMAP, Telegram, Feishu,
@@ -244,7 +256,7 @@ belong to the owning orchestrator.
 If you are an avatar without admin ownership, do not reconfigure shared addons.
 Ask your orchestrator or human.
 
-## 11. Web, files, media, and local artifacts
+## 12. Web, files, media, and local artifacts
 
 - Use `web-browsing` before web search/fetch/scraping beyond trivial lookup.
 - Use `file-manual` for non-trivial file editing, encodings, or large-file work.
@@ -253,7 +265,7 @@ Ask your orchestrator or human.
   references if the human needs to open them outside the agent sandbox; attach
   files when appropriate.
 
-## 12. Human-facing deliverables
+## 13. Human-facing deliverables
 
 For substantial human-facing deliverables, prefer standalone HTML unless the
 human asks otherwise. This includes design previews, dashboards, readiness
@@ -271,7 +283,7 @@ Good HTML deliverables are:
 Plain text remains best for quick acknowledgements, short status updates, small
 diffs, or when the human explicitly wants text.
 
-## 13. Idle, soul, and initiative
+## 14. Idle, soul, and initiative
 
 When there is nothing concrete to do, go idle. Idle keeps listeners alive and lets
 soul flow fire. Do not use timed sleeps as a default waiting strategy; they block
@@ -280,14 +292,14 @@ reflection and are only for precise external deadlines.
 Soul flow is advice from your own reflective process, not an instruction source.
 Verify any claim about external events through the relevant channel before acting.
 
-## 14. Reporting issues
+## 15. Reporting issues
 
 If you discover a LingTai bug, stale doc, missing capability, broken URL, or
 misleading procedure, load `lingtai-issue-report`. Assemble a concise evidence
 report and ask the human before filing public GitHub issues unless the human has
 explicitly authorized filing.
 
-## 15. Resident prompt maintenance checklist
+## 16. Resident prompt maintenance checklist
 
 When editing substrate/procedures/covenant/principle:
 

--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -5,9 +5,11 @@ description: >
   full version of the always-on substrate and procedures prompt: lifecycle
   states, communication discipline, memory layers, tool routing, skill
   authoring, collaboration, notifications, MCP/addon ownership, preset tiers,
-  molt, idle/soul behavior, human-facing deliverables, and the `system` tool
-  actions. The resident substrate/procedures prompt keeps only the compact
-  principles and routes here for details.
+  molt, idle/soul behavior, human-facing deliverables, runtime log inspection,
+  SQLite log sidecar queries, and the `system` tool actions. The resident
+  substrate/procedures prompt keeps only the compact principles and routes here
+  for details; bundled subguides such as `reference/sqlite-log-query.md` carry
+  deeper command recipes.
 version: 1.0.0
 tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt]
 ---
@@ -226,11 +228,26 @@ LingTai runtime history is written first to `logs/events.jsonl`. Newer kernels
 also maintain a rebuildable SQLite sidecar at `logs/log.sqlite` so agents can run
 structured diagnostics without grepping large JSONL files.
 
+The feature is deliberately **additive**. JSONL keeps the append-only audit trail
+that existing tools, migrations, and humans can inspect or recover with a text
+editor. SQLite adds the missing read path: indexed counts, filtered queries,
+doctor checks, trajectory mining, and future portal/replay analysis over large
+histories. Keeping SQLite rebuildable and deletable lets LingTai gain structured
+observability now without forcing a risky all-at-once source-of-truth migration or
+breaking compatibility for agents that still rely on JSONL.
+
 When you need to query event history, count event types, inspect failures,
 investigate notification storms, or use `lingtai-agent log doctor|query|rebuild`,
-load `sqlite-log-query`. Keep the resident rule small: JSONL is the source of
-truth; SQLite is a read-only/rebuildable observability index; rebuild requires
-the target agent to be stopped/offline.
+stay within this skill and read the bundled subguide
+`reference/sqlite-log-query.md`. Keep the resident rule small: JSONL is the
+source of truth; SQLite is a read-only/rebuildable observability index; rebuild
+requires the target agent to be stopped/offline.
+
+### System-manual subguides
+
+- `reference/sqlite-log-query.md` — safe SQLite log sidecar inspection: CLI
+  commands, schema, query recipes, offline rebuild rules, WAL/live-read caveats,
+  and redaction pitfalls.
 
 ## 10. Collaboration and network topology
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query.md
@@ -1,15 +1,4 @@
----
-name: sqlite-log-query
-description: >
-  Query LingTai agent runtime history through the additive SQLite log sidecar.
-  Read this when you need to inspect `logs/log.sqlite`, run `lingtai-agent log
-  doctor|query|rebuild`, count event types, investigate recent errors/tool
-  calls/notifications, or explain the JSONL source-of-truth versus SQLite
-  query-index contract. Covers safe read-only query patterns, offline rebuild,
-  schema, example SQL, and pitfalls around live agents and WAL snapshots.
-version: 0.1.0
-tags: [lingtai, logs, sqlite, observability, diagnostics, query]
----
+<!-- Subguide of system-manual. Not a standalone skill catalog entry. -->
 
 # SQLite Log Query
 

--- a/src/lingtai/prompts/procedures.md
+++ b/src/lingtai/prompts/procedures.md
@@ -52,6 +52,7 @@ practice, read `psyche-manual`; for the broader memory model, read
 | Skill authoring/publishing | `skills-manual` |
 | Knowledge entries | `knowledge-manual` |
 | Shell commands, cron, host scheduling | `bash-manual` |
+| Querying LingTai runtime logs / SQLite log sidecar | `sqlite-log-query` |
 | Kernel architecture / breaking changes | `lingtai-kernel-anatomy` |
 | TUI / portal code navigation | `lingtai-tui-anatomy` |
 | Web fetching/search/scraping | `web-browsing` |

--- a/src/lingtai/prompts/procedures.md
+++ b/src/lingtai/prompts/procedures.md
@@ -52,7 +52,7 @@ practice, read `psyche-manual`; for the broader memory model, read
 | Skill authoring/publishing | `skills-manual` |
 | Knowledge entries | `knowledge-manual` |
 | Shell commands, cron, host scheduling | `bash-manual` |
-| Querying LingTai runtime logs / SQLite log sidecar | `sqlite-log-query` |
+| Querying LingTai runtime logs / SQLite log sidecar | `system-manual` section 9 / `reference/sqlite-log-query.md` |
 | Kernel architecture / breaking changes | `lingtai-kernel-anatomy` |
 | TUI / portal code navigation | `lingtai-tui-anatomy` |
 | Web fetching/search/scraping | `web-browsing` |

--- a/src/lingtai_kernel/ANATOMY.md
+++ b/src/lingtai_kernel/ANATOMY.md
@@ -171,7 +171,7 @@ This file is the top of the kernel anatomy tree. Each subfolder below has its ow
 - [`base_agent/`](base_agent/ANATOMY.md) — `BaseAgent` class (the kernel coordinator). 7 submodules: identity, lifecycle, turn, soul_flow, tools, prompt, messaging.
 - [`intrinsics/`](intrinsics/ANATOMY.md) — kernel-built-in tools. Four intrinsics: `system`, `psyche`, `soul`, `email`. Always present, never removable.
 - [`llm/`](llm/ANATOMY.md) — LLM service ABC, adapter registry, chat interface, streaming protocol. Provider adapters live in the wrapper package, not here.
-- [`services/`](services/ANATOMY.md) — kernel-side service implementations: filesystem mailbox (`mail.py`), JSONL event log (`logging.py`).
+- [`services/`](services/ANATOMY.md) — kernel-side service implementations: filesystem mailbox (`mail.py`), JSONL event log plus additive SQLite query index (`logging.py`).
 - [`migrate/`](migrate/ANATOMY.md) — versioned, append-only migrations for kernel-managed on-disk state. Each migration is `m<NNN>_<name>.py`.
 - [`i18n/`](i18n/ANATOMY.md) — three-locale message catalog (en / zh / wen). Loaded by `t(language, key)` in the intrinsics.
 

--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -270,13 +270,18 @@ class BaseAgent:
         self._workdir = WorkingDir(working_dir)
         self._working_dir = self._workdir.path
 
-        # LoggingService: always JSONL in working dir
-        from ..services.logging import JSONLLoggingService
+        # LoggingService: JSONL is the source of truth; SQLite is an additive,
+        # fail-open sidecar index for queryable history.
+        from ..services.logging import CompositeLoggingService, JSONLLoggingService, SQLiteEventIndex
         log_dir = self._working_dir / "logs"
         log_dir.mkdir(exist_ok=True)
-        self._log_service = JSONLLoggingService(
+        jsonl_log_service = JSONLLoggingService(
             log_dir / "events.jsonl",
             ensure_ascii=self._config.ensure_ascii,
+        )
+        self._log_service = CompositeLoggingService(
+            jsonl_log_service,
+            sqlite_index=SQLiteEventIndex(log_dir / "log.sqlite", ensure=False, keep_open=False),
         )
 
         # Acquire working directory lock (10s grace for prior process cleanup)

--- a/src/lingtai_kernel/services/ANATOMY.md
+++ b/src/lingtai_kernel/services/ANATOMY.md
@@ -2,7 +2,7 @@
 
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues (mail or `discussions/<name>-patch.md`); do not silently fix.
 
-Kernel-side service ABCs and implementations. Services back cross-cutting kernel concerns without making intrinsics depend directly on one transport: filesystem mail for peer messages and JSONL logging for structured events.
+Kernel-side service ABCs and implementations. Services back cross-cutting kernel concerns without making intrinsics depend directly on one transport: filesystem mail for peer messages and structured event logging with JSONL as source-of-truth plus a rebuildable SQLite query index.
 
 ## Components
 
@@ -12,15 +12,17 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
   - `send()` resolves peer/absolute addresses, checks `is_agent`/`is_alive`, generates ids through `intrinsics.email._new_mailbox_id`, copies attachments, and writes `message.json` atomically (`services/mail.py:131`, `services/mail.py:165`, `services/mail.py:199-206`).
   - `listen()` starts a daemon polling thread (`services/mail.py:216`), snapshots existing inbox ids into `_seen` (`services/mail.py:224-227`), scans every 0.5s (`services/mail.py:256`), and also claims subscribed pseudo-agent outbox messages (`services/mail.py:250-253`, `services/mail.py:261-368`).
   - `stop()` sets the poll stop event and joins the thread (`services/mail.py:370-374`).
-- `services/logging.py` — structured event log.
-  - `LoggingService` is the ABC for `log(event)` and `close()` (`services/logging.py:18`).
-  - `JSONLLoggingService` appends JSON lines with a lock and flush per write (`services/logging.py:33`, `services/logging.py:39`, `services/logging.py:47-52`).
-  - `get_events()` re-reads the whole file for inspection (`services/logging.py:55-69`); `close()` closes the handle (`services/logging.py:72-74`).
+- `services/logging.py` — structured event log and additive SQLite query index.
+  - `LoggingService` is the ABC for `log(event)` and `close()`; `log()` may return optional storage metadata such as JSONL offsets (`services/logging.py:29`, `services/logging.py:36-42`).
+  - `JSONLLoggingService` appends UTF-8 JSON lines with a lock and flush per write, returning `(source_file, source_offset)` metadata (`services/logging.py:48`, `services/logging.py:57-58`, `services/logging.py:66-77`).
+  - `SQLiteEventIndex` owns the derived `logs/log.sqlite` schema and fail-open sidecar writes (`services/logging.py:99`, `services/logging.py:145-182`, `services/logging.py:213-233`).
+  - `CompositeLoggingService` writes the JSONL primary first, then best-effort inserts into SQLite with the JSONL source offset (`services/logging.py:265`, `services/logging.py:271-285`).
+  - `rebuild_sqlite_event_index()`, `doctor_sqlite_event_index()`, and `query_sqlite_event_index()` back the CLI rebuild/doctor/query commands (`services/logging.py:315`, `services/logging.py:376`, `services/logging.py:388`).
 - `services/__init__.py` is an empty package marker; callers import concrete modules directly.
 
 ## Connections
 
-- `BaseAgent.__init__` always creates `JSONLLoggingService` and stores it as `_log_service` (`base_agent/__init__.py:214-221`).
+- `BaseAgent.__init__` creates a `CompositeLoggingService` over `logs/events.jsonl` plus additive `logs/log.sqlite` (`base_agent/__init__.py:273-285`).
 - `BaseAgent` receives a `MailService | None` constructor argument (`base_agent/__init__.py:230`); missing mail service disables the email intrinsic (`base_agent/__init__.py:158`).
 - Email boot wires `FilesystemMailService.listen(on_message=agent._on_mail)` through the email intrinsic (`base_agent/__init__.py:441-442`).
 - `services/mail.py` imports `handshake.{is_agent,is_alive,resolve_address}` for routing/liveness (`services/mail.py:24`) and late-imports `_new_mailbox_id` from `intrinsics.email` inside `send()` to avoid a module-level cycle (`services/mail.py:165`).
@@ -29,17 +31,20 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
 
 - **Parent:** `src/lingtai_kernel/` (see `ANATOMY.md`).
 - **Subfolders:** none.
-- **Sibling consumers:** `intrinsics/` owns mailbox tool behavior; `base_agent/` owns logging lifecycle.
+- **Sibling consumers:** `intrinsics/` owns mailbox tool behavior; `base_agent/` owns logging lifecycle; `src/lingtai/cli.py` exposes `lingtai-agent log {rebuild,doctor,query}` (`../lingtai/cli.py:294-304`).
 
 ## State
 
 - **Persistent mail:** `<workdir>/mailbox/{inbox,outbox,sent}/<uuid>/message.json`; optional `attachments/` subdir. `FilesystemMailService.send()` writes recipient inbox payloads atomically (`services/mail.py:199-206`).
-- **Persistent log:** `<workdir>/logs/events.jsonl`; one JSON object per line, appended by `JSONLLoggingService.log()` (`services/logging.py:47-52`).
+- **Persistent log source-of-truth:** `<workdir>/logs/events.jsonl`; one JSON object per line, appended by `JSONLLoggingService.log()` (`services/logging.py:66-77`).
+- **Persistent log sidecar:** `<workdir>/logs/log.sqlite`; rebuildable/deletable SQLite index with `schema_migrations`, `import_cursors`, and `events` tables. `events.source_file/source_offset` is unique when present so JSONL replays are idempotent (`services/logging.py:145-182`).
 - **Ephemeral mail:** `_seen` is an in-memory set of delivered UUIDs rebuilt at listen start (`services/mail.py:224-227`); `_poll_thread` is a daemon thread joined by `stop()` (`services/mail.py:370-374`).
-- **Ephemeral log:** `JSONLLoggingService` holds an open file handle and a thread lock (`services/logging.py:39-47`).
+- **Ephemeral log:** `JSONLLoggingService` holds an open file handle and a thread lock; `SQLiteEventIndex` holds an optional sqlite connection and disables itself after sqlite errors so agent turns fail open (`services/logging.py:57-61`, `services/logging.py:107-132`).
 
 ## Notes
 
 - Pseudo-agent outbox claiming is optimistic concurrency: pollers copy to inbox, race on outbox→sent rename, and losers delete their speculative copy and clear `_seen` (`services/mail.py:326-354`).
-- The services package has two ABCs but one implementation each today; the boundary exists so future transports can replace filesystem mail or JSONL logging without changing intrinsic call sites.
-- `get_events()` favors simplicity over hot-path performance: it re-opens and parses the whole JSONL file each call (`services/logging.py:55-69`).
+- The services package has two ABCs but mail and logging now differ in shape: mail still has one filesystem implementation, while logging composes the JSONL primary with optional derived indexes.
+- `get_events()` favors simplicity over hot-path performance: it re-opens and parses the whole JSONL file each call (`services/logging.py:79-94`).
+- SQLite is intentionally additive: JSONL remains the durable source of truth; rebuild uses a temporary database and atomic replace, and checkpoints WAL before replacing so the final artifact is self-contained (`services/logging.py:315-368`).
+- Query helpers accept only `SELECT` statements to keep the CLI inspection path read-only (`services/logging.py:235-244`).

--- a/src/lingtai_kernel/services/ANATOMY.md
+++ b/src/lingtai_kernel/services/ANATOMY.md
@@ -15,9 +15,9 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
 - `services/logging.py` — structured event log and additive SQLite query index.
   - `LoggingService` is the ABC for `log(event)` and `close()`; `log()` may return optional storage metadata such as JSONL offsets (`services/logging.py:29`, `services/logging.py:36-42`).
   - `JSONLLoggingService` appends UTF-8 JSON lines with a lock and flush per write, returning `(source_file, source_offset)` metadata (`services/logging.py:48`, `services/logging.py:57-58`, `services/logging.py:66-77`).
-  - `SQLiteEventIndex` owns the derived `logs/log.sqlite` schema, fail-open sidecar writes, and immutable read-only inspection opens (`services/logging.py:99`, `services/logging.py:145-182`, `services/logging.py:213-233`).
-  - `CompositeLoggingService` writes the JSONL primary first, then best-effort inserts into SQLite with the JSONL source offset (`services/logging.py:265`, `services/logging.py:271-285`).
-  - `rebuild_sqlite_event_index()`, `doctor_sqlite_event_index()`, and `query_sqlite_event_index()` back the CLI rebuild/doctor/query commands (`services/logging.py:315`, `services/logging.py:376`, `services/logging.py:388`).
+  - `SQLiteEventIndex` owns the derived `logs/log.sqlite` schema, fail-open sidecar writes, and read-only inspection opens (`services/logging.py:102`, `services/logging.py:160-195`, `services/logging.py:228-267`).
+  - `CompositeLoggingService` writes the JSONL primary first, then best-effort inserts into SQLite with the JSONL source offset (`services/logging.py:288`, `services/logging.py:295-305`).
+  - `rebuild_sqlite_event_index()`, `doctor_sqlite_event_index()`, and `query_sqlite_event_index()` back the CLI rebuild/doctor/query commands (`services/logging.py:338`, `services/logging.py:415`, `services/logging.py:427`).
 - `services/__init__.py` is an empty package marker; callers import concrete modules directly.
 
 ## Connections
@@ -31,20 +31,20 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
 
 - **Parent:** `src/lingtai_kernel/` (see `ANATOMY.md`).
 - **Subfolders:** none.
-- **Sibling consumers:** `intrinsics/` owns mailbox tool behavior; `base_agent/` owns logging lifecycle; `src/lingtai/cli.py` exposes `lingtai-agent log {rebuild,doctor,query}` (`../lingtai/cli.py:294-304`).
+- **Sibling consumers:** `intrinsics/` owns mailbox tool behavior; `base_agent/` owns logging lifecycle; `src/lingtai/cli.py` exposes `lingtai-agent log {rebuild,doctor,query}` (`../lingtai/cli.py:294-305`).
 
 ## State
 
 - **Persistent mail:** `<workdir>/mailbox/{inbox,outbox,sent}/<uuid>/message.json`; optional `attachments/` subdir. `FilesystemMailService.send()` writes recipient inbox payloads atomically (`services/mail.py:199-206`).
 - **Persistent log source-of-truth:** `<workdir>/logs/events.jsonl`; one JSON object per line, appended by `JSONLLoggingService.log()` (`services/logging.py:66-77`).
-- **Persistent log sidecar:** `<workdir>/logs/log.sqlite`; rebuildable/deletable SQLite index with `schema_migrations`, `import_cursors`, and `events` tables. `events.source_file/source_offset` is unique when present so JSONL replays are idempotent (`services/logging.py:145-182`).
+- **Persistent log sidecar:** `<workdir>/logs/log.sqlite`; rebuildable/deletable SQLite index with `schema_migrations`, `import_cursors`, and `events` tables. `events.source_file/source_offset` is unique when present so JSONL replays are idempotent (`services/logging.py:160-195`).
 - **Ephemeral mail:** `_seen` is an in-memory set of delivered UUIDs rebuilt at listen start (`services/mail.py:224-227`); `_poll_thread` is a daemon thread joined by `stop()` (`services/mail.py:370-374`).
-- **Ephemeral log:** `JSONLLoggingService` holds an open file handle and a thread lock; `SQLiteEventIndex` holds an optional sqlite connection and disables itself after sqlite errors so agent turns fail open (`services/logging.py:57-61`, `services/logging.py:107-132`).
+- **Ephemeral log:** `JSONLLoggingService` holds an open file handle and a thread lock; `SQLiteEventIndex` holds an optional sqlite connection and disables itself after sqlite errors so agent turns fail open (`services/logging.py:57-62`, `services/logging.py:106-129`).
 
 ## Notes
 
 - Pseudo-agent outbox claiming is optimistic concurrency: pollers copy to inbox, race on outbox→sent rename, and losers delete their speculative copy and clear `_seen` (`services/mail.py:326-354`).
 - The services package has two ABCs but mail and logging now differ in shape: mail still has one filesystem implementation, while logging composes the JSONL primary with optional derived indexes.
 - `get_events()` favors simplicity over hot-path performance: it re-opens and parses the whole JSONL file each call (`services/logging.py:79-94`).
-- SQLite is intentionally additive: JSONL remains the durable source of truth; rebuild requires the agent working-directory lock (offline/stopped agent), uses a temporary database and atomic replace, and checkpoints WAL before replacing so the final artifact is self-contained (`services/logging.py:315-368`).
-- Query helpers accept only `SELECT` statements and open the DB with SQLite `mode=ro&immutable=1` to keep the CLI inspection path read-only (`services/logging.py:235-244`).
+- SQLite is intentionally additive: JSONL remains the durable source of truth; rebuild requires the agent working-directory lock (offline/stopped agent), uses a temporary database and atomic replace, and checkpoints WAL before replacing so the final artifact is self-contained (`services/logging.py:338-413`).
+- Query helpers accept read-only `SELECT`/CTE/`EXPLAIN` statements, use `PRAGMA query_only=ON`, and choose immutable offline reads or WAL-aware read-only live reads to keep CLI inspection non-mutating while seeing WAL rows (`services/logging.py:130-149`, `services/logging.py:253-267`).

--- a/src/lingtai_kernel/services/ANATOMY.md
+++ b/src/lingtai_kernel/services/ANATOMY.md
@@ -15,7 +15,7 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
 - `services/logging.py` — structured event log and additive SQLite query index.
   - `LoggingService` is the ABC for `log(event)` and `close()`; `log()` may return optional storage metadata such as JSONL offsets (`services/logging.py:29`, `services/logging.py:36-42`).
   - `JSONLLoggingService` appends UTF-8 JSON lines with a lock and flush per write, returning `(source_file, source_offset)` metadata (`services/logging.py:48`, `services/logging.py:57-58`, `services/logging.py:66-77`).
-  - `SQLiteEventIndex` owns the derived `logs/log.sqlite` schema and fail-open sidecar writes (`services/logging.py:99`, `services/logging.py:145-182`, `services/logging.py:213-233`).
+  - `SQLiteEventIndex` owns the derived `logs/log.sqlite` schema, fail-open sidecar writes, and immutable read-only inspection opens (`services/logging.py:99`, `services/logging.py:145-182`, `services/logging.py:213-233`).
   - `CompositeLoggingService` writes the JSONL primary first, then best-effort inserts into SQLite with the JSONL source offset (`services/logging.py:265`, `services/logging.py:271-285`).
   - `rebuild_sqlite_event_index()`, `doctor_sqlite_event_index()`, and `query_sqlite_event_index()` back the CLI rebuild/doctor/query commands (`services/logging.py:315`, `services/logging.py:376`, `services/logging.py:388`).
 - `services/__init__.py` is an empty package marker; callers import concrete modules directly.
@@ -46,5 +46,5 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
 - Pseudo-agent outbox claiming is optimistic concurrency: pollers copy to inbox, race on outbox→sent rename, and losers delete their speculative copy and clear `_seen` (`services/mail.py:326-354`).
 - The services package has two ABCs but mail and logging now differ in shape: mail still has one filesystem implementation, while logging composes the JSONL primary with optional derived indexes.
 - `get_events()` favors simplicity over hot-path performance: it re-opens and parses the whole JSONL file each call (`services/logging.py:79-94`).
-- SQLite is intentionally additive: JSONL remains the durable source of truth; rebuild uses a temporary database and atomic replace, and checkpoints WAL before replacing so the final artifact is self-contained (`services/logging.py:315-368`).
-- Query helpers accept only `SELECT` statements to keep the CLI inspection path read-only (`services/logging.py:235-244`).
+- SQLite is intentionally additive: JSONL remains the durable source of truth; rebuild requires the agent working-directory lock (offline/stopped agent), uses a temporary database and atomic replace, and checkpoints WAL before replacing so the final artifact is self-contained (`services/logging.py:315-368`).
+- Query helpers accept only `SELECT` statements and open the DB with SQLite `mode=ro&immutable=1` to keep the CLI inspection path read-only (`services/logging.py:235-244`).

--- a/src/lingtai_kernel/services/logging.py
+++ b/src/lingtai_kernel/services/logging.py
@@ -6,7 +6,9 @@ truth; ``logs/log.sqlite`` exists to make history queryable.
 """
 from __future__ import annotations
 
+import contextlib
 import json
+import os
 import shutil
 import sqlite3
 import tempfile
@@ -15,6 +17,8 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
+
+from ..workdir import WorkingDir
 
 
 SCHEMA_VERSION = 1
@@ -124,15 +128,22 @@ class SQLiteEventIndex:
     def disabled_reason(self) -> str | None:
         return self._disabled_reason
 
-    def _ensure_open(self) -> sqlite3.Connection:
+    def _ensure_open(self, *, read_only: bool = False, ensure_schema: bool = True) -> sqlite3.Connection:
         if self._disabled_reason:
             raise sqlite3.Error(self._disabled_reason)
         if self._conn is None:
-            conn = sqlite3.connect(self.path, check_same_thread=False)
+            if read_only:
+                uri = f"{self.path.resolve().as_uri()}?mode=ro&immutable=1"
+                conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
+            else:
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+                conn = sqlite3.connect(self.path, check_same_thread=False)
             conn.row_factory = sqlite3.Row
             self._conn = conn
-            self._configure(conn)
-            self._ensure_schema(conn)
+            if not read_only:
+                self._configure(conn)
+            if ensure_schema:
+                self._ensure_schema(conn)
         return self._conn
 
     @staticmethod
@@ -226,7 +237,10 @@ class SQLiteEventIndex:
                     self.event_row(event, source_file=source_file, source_offset=source_offset),
                 )
                 conn.commit()
-        except (OSError, sqlite3.Error) as exc:
+        except Exception as exc:
+            # The SQLite sidecar is derived from JSONL.  Any sidecar failure —
+            # sqlite errors, path errors, or row-normalization surprises — must
+            # fail open and never break the agent turn after JSONL succeeded.
             self.disable(str(exc))
         finally:
             if not self._keep_open:
@@ -237,30 +251,22 @@ class SQLiteEventIndex:
         if statement != "select":
             raise ValueError("log query only accepts SELECT statements")
         with self._lock:
-            conn = self._ensure_open()
-            original_factory = conn.row_factory
+            conn = self._ensure_open(read_only=True, ensure_schema=False)
+            conn.execute("PRAGMA query_only=ON")
             try:
-                conn.row_factory = sqlite3.Row
-                conn.execute("PRAGMA query_only=ON")
-                before_changes = conn.total_changes
                 cur = conn.execute(sql, tuple(params))
                 if cur.description is None:
                     return []
-                rows = [dict(row) for row in cur.fetchall()]
-                if conn.total_changes != before_changes:
-                    raise ValueError("log query must not modify the sqlite index")
-                return rows
+                return [dict(row) for row in cur.fetchall()]
             finally:
-                try:
+                with contextlib.suppress(sqlite3.Error):
                     conn.execute("PRAGMA query_only=OFF")
-                finally:
-                    conn.row_factory = original_factory
 
     def doctor(self) -> dict[str, Any]:
         if self._disabled_reason:
             return {"status": "disabled", "path": str(self.path), "reason": self._disabled_reason}
         with self._lock:
-            conn = self._ensure_open()
+            conn = self._ensure_open(read_only=True, ensure_schema=False)
             integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
             event_count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
             cursor_count = conn.execute("SELECT COUNT(*) FROM import_cursors").fetchone()[0]
@@ -332,14 +338,25 @@ def rebuild_sqlite_event_index(
     sqlite_path: Path | str | None = None,
 ) -> dict[str, Any]:
     """Rebuild ``logs/log.sqlite`` from ``logs/events.jsonl`` atomically."""
-    agent_dir = Path(agent_dir)
+    agent_dir = Path(agent_dir).resolve()
     logs_dir = agent_dir / "logs"
-    source = Path(jsonl_path) if jsonl_path is not None else logs_dir / DEFAULT_JSONL_NAME
-    target = Path(sqlite_path) if sqlite_path is not None else logs_dir / DEFAULT_SQLITE_NAME
+    source = Path(jsonl_path).resolve() if jsonl_path is not None else (logs_dir / DEFAULT_JSONL_NAME).resolve()
+    target = Path(sqlite_path).resolve() if sqlite_path is not None else (logs_dir / DEFAULT_SQLITE_NAME).resolve()
     if not source.is_file():
         raise FileNotFoundError(f"events JSONL not found: {source}")
 
     target.parent.mkdir(parents=True, exist_ok=True)
+    workdir_lock = None
+    lock_owner = agent_dir
+    try:
+        workdir_lock = WorkingDir(lock_owner)
+        workdir_lock.acquire_lock(timeout=0)
+    except Exception as exc:
+        raise RuntimeError(
+            "sqlite log rebuild requires the agent to be stopped/offline; "
+            f"could not acquire rebuild lock for {lock_owner}: {exc}"
+        ) from exc
+
     tmp_dir = Path(tempfile.mkdtemp(prefix="log-sqlite-rebuild-", dir=str(target.parent)))
     tmp_db = tmp_dir / target.name
     count = 0
@@ -384,6 +401,9 @@ def rebuild_sqlite_event_index(
         return {"status": "ok", "source": str(source), "target": str(target), "event_count": count, "line_no": last_line, "byte_offset": last_offset}
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
+        if workdir_lock is not None:
+            with contextlib.suppress(Exception):
+                workdir_lock.release_lock()
 
 
 def doctor_sqlite_event_index(agent_dir: Path | str, *, sqlite_path: Path | str | None = None) -> dict[str, Any]:
@@ -391,7 +411,7 @@ def doctor_sqlite_event_index(agent_dir: Path | str, *, sqlite_path: Path | str 
     target = Path(sqlite_path) if sqlite_path is not None else agent_dir / "logs" / DEFAULT_SQLITE_NAME
     if not target.is_file():
         return {"status": "missing", "path": str(target)}
-    index = SQLiteEventIndex(target)
+    index = SQLiteEventIndex(target, ensure=False)
     try:
         return index.doctor()
     finally:
@@ -402,8 +422,8 @@ def query_sqlite_event_index(agent_dir: Path | str, sql: str, *, sqlite_path: Pa
     agent_dir = Path(agent_dir)
     target = Path(sqlite_path) if sqlite_path is not None else agent_dir / "logs" / DEFAULT_SQLITE_NAME
     if not target.is_file():
-        rebuild_sqlite_event_index(agent_dir, sqlite_path=target)
-    index = SQLiteEventIndex(target)
+        raise FileNotFoundError(f"sqlite log index not found: {target}; run `lingtai-agent log rebuild {agent_dir}` first")
+    index = SQLiteEventIndex(target, ensure=False)
     try:
         return index.query(sql)
     finally:

--- a/src/lingtai_kernel/services/logging.py
+++ b/src/lingtai_kernel/services/logging.py
@@ -1,30 +1,45 @@
 """LoggingService — structured event logging backing agent observability.
 
-First implementation: JSONLLoggingService (append JSON lines to a file).
-
-Design principles:
-- Single method: log(event) — thread-safe, fire-and-forget
-- Persistent: events written to disk, not transient callbacks
-- Swappable: Forum can subclass to build communication graphs in real-time
+The primary durable event log remains ``logs/events.jsonl``.  SQLite support is
+implemented as an additive, rebuildable sidecar index: JSONL is the source of
+truth; ``logs/log.sqlite`` exists to make history queryable.
 """
 from __future__ import annotations
 
 import json
+import shutil
+import sqlite3
+import tempfile
 import threading
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Iterable
+
+
+SCHEMA_VERSION = 1
+DEFAULT_SQLITE_NAME = "log.sqlite"
+DEFAULT_JSONL_NAME = "events.jsonl"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 class LoggingService(ABC):
     """Abstract structured event logging service.
 
-    Backs agent observability. Implementations provide the actual
-    storage mechanism (JSONL file, database, network sink, etc.).
+    Backs agent observability. Implementations provide the actual storage
+    mechanism (JSONL file, database, network sink, etc.).
     """
 
     @abstractmethod
-    def log(self, event: dict) -> None:
-        """Log a structured event. Must be thread-safe."""
+    def log(self, event: dict) -> dict | None:
+        """Log a structured event. Must be thread-safe.
+
+        Implementations may return storage metadata (for example JSONL source
+        offsets). Callers should treat the return value as optional.
+        """
 
     def close(self) -> None:
         """Flush and release resources. Default no-op."""
@@ -39,27 +54,33 @@ class JSONLLoggingService(LoggingService):
     def __init__(self, path: Path | str, *, ensure_ascii: bool = False) -> None:
         self._path = Path(path)
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._file = open(self._path, "a")
+        self._file = open(self._path, "ab")
         self._lock = threading.Lock()
         self._closed = False
         self._ensure_ascii = ensure_ascii
 
-    def log(self, event: dict) -> None:
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def log(self, event: dict) -> dict | None:
         if self._closed:
-            return
+            return None
         line = json.dumps(event, ensure_ascii=self._ensure_ascii, default=str)
+        payload = (line + "\n").encode("utf-8")
         with self._lock:
-            self._file.write(line + "\n")
+            source_offset = self._file.tell()
+            self._file.write(payload)
             self._file.flush()
+        return {"source_file": str(self._path), "source_offset": source_offset}
 
     def get_events(self) -> list[dict]:
         """Read all events from the JSONL file. Thread-safe."""
         with self._lock:
-            # Re-read the file from start
             if not self._path.exists():
                 return []
             events = []
-            with open(self._path, "r") as f:
+            with open(self._path, "r", encoding="utf-8") as f:
                 for line in f:
                     line = line.strip()
                     if line:
@@ -73,3 +94,304 @@ class JSONLLoggingService(LoggingService):
         if not self._closed:
             self._closed = True
             self._file.close()
+
+
+class SQLiteEventIndex:
+    """Best-effort SQLite index for JSONL events.
+
+    The index is a derived artifact.  It is safe to delete and rebuild from
+    ``events.jsonl``.  Runtime writes fail open by disabling the sidecar after
+    the first sqlite error; they never raise into the agent turn.
+    """
+
+    def __init__(self, path: Path | str, *, ensure: bool = True, keep_open: bool = True) -> None:
+        self.path = Path(path)
+        self._keep_open = keep_open
+        self._lock = threading.RLock()
+        self._disabled_reason: str | None = None
+        self._conn: sqlite3.Connection | None = None
+        if ensure:
+            try:
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+                self._ensure_open()
+            except (OSError, sqlite3.Error) as exc:
+                # Runtime sidecar creation must fail open.  JSONL remains the
+                # source of truth, and callers can rebuild the sidecar later.
+                self._disabled_reason = str(exc)
+                self.close()
+
+    @property
+    def disabled_reason(self) -> str | None:
+        return self._disabled_reason
+
+    def _ensure_open(self) -> sqlite3.Connection:
+        if self._disabled_reason:
+            raise sqlite3.Error(self._disabled_reason)
+        if self._conn is None:
+            conn = sqlite3.connect(self.path, check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            self._conn = conn
+            self._configure(conn)
+            self._ensure_schema(conn)
+        return self._conn
+
+    @staticmethod
+    def _configure(conn: sqlite3.Connection) -> None:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+
+    @staticmethod
+    def _ensure_schema(conn: sqlite3.Connection) -> None:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+              version INTEGER PRIMARY KEY,
+              name TEXT NOT NULL,
+              applied_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS import_cursors (
+              source_file TEXT PRIMARY KEY,
+              byte_offset INTEGER NOT NULL DEFAULT 0,
+              line_no INTEGER NOT NULL DEFAULT 0,
+              updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS events (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              ts REAL NOT NULL,
+              type TEXT NOT NULL,
+              agent_address TEXT,
+              agent_name_snapshot TEXT,
+              fields_json TEXT NOT NULL,
+              source_file TEXT,
+              source_offset INTEGER,
+              inserted_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_events_type_ts ON events(type, ts DESC);
+            CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts DESC);
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_events_source_offset
+              ON events(source_file, source_offset)
+              WHERE source_file IS NOT NULL AND source_offset IS NOT NULL;
+            """
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations(version, name, applied_at) VALUES (?, ?, ?)",
+            (SCHEMA_VERSION, "initial_events_index", _utc_now()),
+        )
+        conn.commit()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+
+    def disable(self, reason: str) -> None:
+        self._disabled_reason = reason
+        self.close()
+
+    @staticmethod
+    def event_row(event: dict, *, source_file: str | None = None, source_offset: int | None = None) -> tuple[Any, ...]:
+        fields = dict(event)
+        event_type = fields.pop("type", "")
+        ts = fields.pop("ts", 0.0)
+        agent_address = fields.pop("address", None)
+        agent_name = fields.pop("agent_name", None)
+        return (
+            float(ts or 0.0),
+            str(event_type),
+            str(agent_address) if agent_address is not None else None,
+            str(agent_name) if agent_name is not None else None,
+            json.dumps(fields, ensure_ascii=False, default=str),
+            source_file,
+            source_offset,
+        )
+
+    def log_event(self, event: dict, *, source_file: str | None = None, source_offset: int | None = None) -> None:
+        if self._disabled_reason:
+            return
+        try:
+            with self._lock:
+                conn = self._ensure_open()
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO events(
+                        ts, type, agent_address, agent_name_snapshot, fields_json,
+                        source_file, source_offset
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    self.event_row(event, source_file=source_file, source_offset=source_offset),
+                )
+                conn.commit()
+        except (OSError, sqlite3.Error) as exc:
+            self.disable(str(exc))
+        finally:
+            if not self._keep_open:
+                self.close()
+
+    def query(self, sql: str, params: Iterable[Any] = ()) -> list[dict[str, Any]]:
+        statement = sql.lstrip().split(None, 1)[0].lower() if sql.strip() else ""
+        if statement != "select":
+            raise ValueError("log query only accepts SELECT statements")
+        with self._lock:
+            conn = self._ensure_open()
+            cur = conn.execute(sql, tuple(params))
+            if cur.description is None:
+                return []
+            return [dict(row) for row in cur.fetchall()]
+
+    def doctor(self) -> dict[str, Any]:
+        if self._disabled_reason:
+            return {"status": "disabled", "path": str(self.path), "reason": self._disabled_reason}
+        with self._lock:
+            conn = self._ensure_open()
+            integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+            event_count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+            cursor_count = conn.execute("SELECT COUNT(*) FROM import_cursors").fetchone()[0]
+            schema_versions = [row[0] for row in conn.execute("SELECT version FROM schema_migrations ORDER BY version")]
+        return {
+            "status": "ok" if integrity == "ok" else "error",
+            "path": str(self.path),
+            "integrity_check": integrity,
+            "event_count": event_count,
+            "cursor_count": cursor_count,
+            "schema_versions": schema_versions,
+        }
+
+
+class CompositeLoggingService(LoggingService):
+    """Primary JSONL logger plus best-effort sidecar indexes."""
+
+    def __init__(self, primary: JSONLLoggingService, *, sqlite_index: SQLiteEventIndex | None = None) -> None:
+        self.primary = primary
+        self.sqlite_index = sqlite_index
+
+    def log(self, event: dict) -> dict | None:
+        metadata = self.primary.log(event)
+        # If the primary JSONL write did not happen (for example after close),
+        # do not create sidecar-only facts.  JSONL must remain the source of truth.
+        if metadata is None:
+            return None
+        if self.sqlite_index is not None:
+            source_file = metadata.get("source_file")
+            source_offset = metadata.get("source_offset")
+            self.sqlite_index.log_event(event, source_file=source_file, source_offset=source_offset)
+        return metadata
+
+    def get_events(self) -> list[dict]:
+        return self.primary.get_events()
+
+    def close(self) -> None:
+        self.primary.close()
+        if self.sqlite_index is not None:
+            self.sqlite_index.close()
+
+
+def _iter_jsonl_events_with_offsets(path: Path) -> Iterable[tuple[dict, int, int, int]]:
+    """Yield ``(event, byte_offset, next_offset, line_no)`` from a JSONL file."""
+    with open(path, "rb") as f:
+        line_no = 0
+        while True:
+            offset = f.tell()
+            raw = f.readline()
+            if not raw:
+                break
+            line_no += 1
+            next_offset = f.tell()
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                event = json.loads(stripped.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if isinstance(event, dict):
+                yield event, offset, next_offset, line_no
+
+
+def rebuild_sqlite_event_index(
+    agent_dir: Path | str,
+    *,
+    jsonl_path: Path | str | None = None,
+    sqlite_path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Rebuild ``logs/log.sqlite`` from ``logs/events.jsonl`` atomically."""
+    agent_dir = Path(agent_dir)
+    logs_dir = agent_dir / "logs"
+    source = Path(jsonl_path) if jsonl_path is not None else logs_dir / DEFAULT_JSONL_NAME
+    target = Path(sqlite_path) if sqlite_path is not None else logs_dir / DEFAULT_SQLITE_NAME
+    if not source.is_file():
+        raise FileNotFoundError(f"events JSONL not found: {source}")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(tempfile.mkdtemp(prefix="log-sqlite-rebuild-", dir=str(target.parent)))
+    tmp_db = tmp_dir / target.name
+    count = 0
+    last_offset = 0
+    last_line = 0
+    try:
+        index = SQLiteEventIndex(tmp_db)
+        conn = index._ensure_open()
+        with index._lock:
+            conn.execute("BEGIN")
+            for event, offset, next_offset, line_no in _iter_jsonl_events_with_offsets(source):
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO events(
+                        ts, type, agent_address, agent_name_snapshot, fields_json,
+                        source_file, source_offset
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    SQLiteEventIndex.event_row(event, source_file=str(source), source_offset=offset),
+                )
+                count += 1
+                last_offset = next_offset
+                last_line = line_no
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO import_cursors(source_file, byte_offset, line_no, updated_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (str(source), last_offset, last_line, _utc_now()),
+            )
+            conn.commit()
+            integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        index.close()
+        if integrity != "ok":
+            raise sqlite3.DatabaseError(f"rebuilt sqlite integrity_check={integrity}")
+        for suffix in ("-wal", "-shm"):
+            sidecar = target.with_name(target.name + suffix)
+            if sidecar.exists():
+                sidecar.unlink()
+        tmp_db.replace(target)
+        return {"status": "ok", "source": str(source), "target": str(target), "event_count": count, "line_no": last_line, "byte_offset": last_offset}
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def doctor_sqlite_event_index(agent_dir: Path | str, *, sqlite_path: Path | str | None = None) -> dict[str, Any]:
+    agent_dir = Path(agent_dir)
+    target = Path(sqlite_path) if sqlite_path is not None else agent_dir / "logs" / DEFAULT_SQLITE_NAME
+    if not target.is_file():
+        return {"status": "missing", "path": str(target)}
+    index = SQLiteEventIndex(target)
+    try:
+        return index.doctor()
+    finally:
+        index.close()
+
+
+def query_sqlite_event_index(agent_dir: Path | str, sql: str, *, sqlite_path: Path | str | None = None) -> list[dict[str, Any]]:
+    agent_dir = Path(agent_dir)
+    target = Path(sqlite_path) if sqlite_path is not None else agent_dir / "logs" / DEFAULT_SQLITE_NAME
+    if not target.is_file():
+        rebuild_sqlite_event_index(agent_dir, sqlite_path=target)
+    index = SQLiteEventIndex(target)
+    try:
+        return index.query(sql)
+    finally:
+        index.close()

--- a/src/lingtai_kernel/services/logging.py
+++ b/src/lingtai_kernel/services/logging.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import contextlib
 import json
-import os
 import shutil
 import sqlite3
 import tempfile
@@ -133,7 +132,12 @@ class SQLiteEventIndex:
             raise sqlite3.Error(self._disabled_reason)
         if self._conn is None:
             if read_only:
-                uri = f"{self.path.resolve().as_uri()}?mode=ro&immutable=1"
+                # Use a WAL-aware read-only connection for live sidecars, but keep
+                # immutable inspection for checkpointed/offline sidecars so doctor/query
+                # do not create empty -wal/-shm files as a read side effect.
+                has_wal_sidecar = self.path.with_name(self.path.name + "-wal").exists() or self.path.with_name(self.path.name + "-shm").exists()
+                suffix = "?mode=ro" if has_wal_sidecar else "?mode=ro&immutable=1"
+                uri = f"{self.path.resolve().as_uri()}{suffix}"
                 conn = sqlite3.connect(uri, uri=True, check_same_thread=False)
             else:
                 self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -248,8 +252,8 @@ class SQLiteEventIndex:
 
     def query(self, sql: str, params: Iterable[Any] = ()) -> list[dict[str, Any]]:
         statement = sql.lstrip().split(None, 1)[0].lower() if sql.strip() else ""
-        if statement != "select":
-            raise ValueError("log query only accepts SELECT statements")
+        if statement not in {"select", "with", "explain"}:
+            raise ValueError("log query only accepts read-only SELECT/WITH/EXPLAIN statements")
         with self._lock:
             conn = self._ensure_open(read_only=True, ensure_schema=False)
             conn.execute("PRAGMA query_only=ON")
@@ -342,10 +346,11 @@ def rebuild_sqlite_event_index(
     logs_dir = agent_dir / "logs"
     source = Path(jsonl_path).resolve() if jsonl_path is not None else (logs_dir / DEFAULT_JSONL_NAME).resolve()
     target = Path(sqlite_path).resolve() if sqlite_path is not None else (logs_dir / DEFAULT_SQLITE_NAME).resolve()
+    if not agent_dir.is_dir():
+        raise FileNotFoundError(f"agent directory not found: {agent_dir}")
     if not source.is_file():
         raise FileNotFoundError(f"events JSONL not found: {source}")
 
-    target.parent.mkdir(parents=True, exist_ok=True)
     workdir_lock = None
     lock_owner = agent_dir
     try:
@@ -357,6 +362,7 @@ def rebuild_sqlite_event_index(
             f"could not acquire rebuild lock for {lock_owner}: {exc}"
         ) from exc
 
+    target.parent.mkdir(parents=True, exist_ok=True)
     tmp_dir = Path(tempfile.mkdtemp(prefix="log-sqlite-rebuild-", dir=str(target.parent)))
     tmp_db = tmp_dir / target.name
     count = 0

--- a/src/lingtai_kernel/services/logging.py
+++ b/src/lingtai_kernel/services/logging.py
@@ -212,11 +212,16 @@ class SQLiteEventIndex:
     def event_row(event: dict, *, source_file: str | None = None, source_offset: int | None = None) -> tuple[Any, ...]:
         fields = dict(event)
         event_type = fields.pop("type", "")
-        ts = fields.pop("ts", 0.0)
+        raw_ts = fields.pop("ts", 0.0)
+        try:
+            ts = float(raw_ts or 0.0)
+        except (TypeError, ValueError):
+            fields["ts_raw"] = raw_ts
+            ts = 0.0
         agent_address = fields.pop("address", None)
         agent_name = fields.pop("agent_name", None)
         return (
-            float(ts or 0.0),
+            ts,
             str(event_type),
             str(agent_address) if agent_address is not None else None,
             str(agent_name) if agent_name is not None else None,

--- a/src/lingtai_kernel/services/logging.py
+++ b/src/lingtai_kernel/services/logging.py
@@ -238,10 +238,23 @@ class SQLiteEventIndex:
             raise ValueError("log query only accepts SELECT statements")
         with self._lock:
             conn = self._ensure_open()
-            cur = conn.execute(sql, tuple(params))
-            if cur.description is None:
-                return []
-            return [dict(row) for row in cur.fetchall()]
+            original_factory = conn.row_factory
+            try:
+                conn.row_factory = sqlite3.Row
+                conn.execute("PRAGMA query_only=ON")
+                before_changes = conn.total_changes
+                cur = conn.execute(sql, tuple(params))
+                if cur.description is None:
+                    return []
+                rows = [dict(row) for row in cur.fetchall()]
+                if conn.total_changes != before_changes:
+                    raise ValueError("log query must not modify the sqlite index")
+                return rows
+            finally:
+                try:
+                    conn.execute("PRAGMA query_only=OFF")
+                finally:
+                    conn.row_factory = original_factory
 
     def doctor(self) -> dict[str, Any]:
         if self._disabled_reason:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -317,3 +317,31 @@ def test_build_agent_no_addons(mock_mail, mock_agent, mock_llm, tmp_path):
 
     assert "addons" not in mock_agent.call_args.kwargs
     mock_agent.return_value._setup_from_init.assert_called_once()
+
+
+def test_log_rebuild_doctor_query_cli(tmp_path, capsys):
+    from lingtai.cli import main
+    import sys
+
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "events.jsonl").write_text(json.dumps({"type": "cli_event", "ts": 1}) + "\n", encoding="utf-8")
+
+    old_argv = sys.argv
+    try:
+        sys.argv = ["lingtai-agent", "log", "rebuild", str(tmp_path)]
+        main()
+        rebuild_out = json.loads(capsys.readouterr().out)
+        assert rebuild_out["status"] == "ok"
+
+        sys.argv = ["lingtai-agent", "log", "doctor", str(tmp_path)]
+        main()
+        doctor_out = json.loads(capsys.readouterr().out)
+        assert doctor_out["event_count"] == 1
+
+        sys.argv = ["lingtai-agent", "log", "query", str(tmp_path), "SELECT type FROM events"]
+        main()
+        query_out = json.loads(capsys.readouterr().out)
+        assert query_out == [{"type": "cli_event"}]
+    finally:
+        sys.argv = old_argv

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -345,3 +345,26 @@ def test_log_rebuild_doctor_query_cli(tmp_path, capsys):
         assert query_out == [{"type": "cli_event"}]
     finally:
         sys.argv = old_argv
+
+
+def test_log_query_missing_sqlite_requires_rebuild_cli(tmp_path, capsys):
+    from lingtai.cli import main
+    import sys
+
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "events.jsonl").write_text(json.dumps({"type": "cli_event", "ts": 1}) + "\n", encoding="utf-8")
+
+    old_argv = sys.argv
+    try:
+        sys.argv = ["lingtai-agent", "log", "query", str(tmp_path), "SELECT type FROM events"]
+        try:
+            main()
+            assert False, "query should exit when sqlite sidecar is missing"
+        except SystemExit as exc:
+            assert exc.code == 1
+        captured = capsys.readouterr()
+        assert "rebuild" in captured.err
+        assert not (logs / "log.sqlite").exists()
+    finally:
+        sys.argv = old_argv

--- a/tests/test_services_logging.py
+++ b/tests/test_services_logging.py
@@ -263,6 +263,33 @@ class TestSQLiteEventIndex:
         finally:
             index.close()
 
+
+    def test_query_rejects_mutating_select_function(self, tmp_path):
+        sqlite_file = tmp_path / "log.sqlite"
+        index = SQLiteEventIndex(sqlite_file)
+        try:
+            raw = index._ensure_open()
+            raw.create_function(
+                "danger",
+                0,
+                lambda: raw.execute("DELETE FROM events") and 1,
+            )
+            try:
+                index.query("SELECT danger()")
+                assert False, "mutating select function should be rejected"
+            except Exception as exc:
+                message = str(exc).lower()
+                assert (
+                    "not authorized" in message
+                    or "must not modify" in message
+                    or "user-defined function raised exception" in message
+                    or "attempt to write a readonly database" in message
+                )
+            index.log_event({"type": "after_query", "ts": 1})
+            assert index.query("SELECT type FROM events") == [{"type": "after_query"}]
+        finally:
+            index.close()
+
     def test_rebuild_doctor_and_query(self, tmp_path):
         logs = tmp_path / "logs"
         logs.mkdir()

--- a/tests/test_services_logging.py
+++ b/tests/test_services_logging.py
@@ -252,7 +252,7 @@ class TestSQLiteEventIndex:
         assert json.loads(log_file.read_text().strip())["type"] == "test"
         assert index.disabled_reason == "simulated"
 
-    def test_sqlite_sidecar_fail_open_for_normalization_errors(self, tmp_path):
+    def test_sqlite_sidecar_coerces_invalid_timestamp(self, tmp_path):
         log_file = tmp_path / "events.jsonl"
         index = SQLiteEventIndex(tmp_path / "log.sqlite")
         svc = CompositeLoggingService(JSONLLoggingService(log_file), sqlite_index=index)
@@ -261,7 +261,9 @@ class TestSQLiteEventIndex:
         svc.close()
 
         assert json.loads(log_file.read_text().strip())["type"] == "bad_ts"
-        assert index.disabled_reason is not None
+        rows = index.query("SELECT ts, fields_json FROM events WHERE type='bad_ts'")
+        assert rows[0]["ts"] == 0.0
+        assert json.loads(rows[0]["fields_json"]) == {"ts_raw": "not-a-float"}
 
     def test_query_rejects_mutating_sql(self, tmp_path):
         index = SQLiteEventIndex(tmp_path / "log.sqlite")
@@ -433,24 +435,45 @@ class TestSQLiteEventIndex:
         rows = query_sqlite_event_index(tmp_path, "SELECT type FROM events ORDER BY ts")
         assert rows == [{"type": "first"}, {"type": "second"}]
 
+    def test_rebuild_tolerates_invalid_timestamp_rows(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        (logs / "events.jsonl").write_text(
+            json.dumps({"type": "bad_ts", "ts": "not-a-float"}) + "\n"
+            + json.dumps({"type": "ok", "ts": 1}) + "\n",
+            encoding="utf-8",
+        )
+
+        result = rebuild_sqlite_event_index(tmp_path)
+        assert result["event_count"] == 2
+        rows = query_sqlite_event_index(
+            tmp_path,
+            "SELECT type, ts, fields_json FROM events ORDER BY id",
+        )
+        assert rows[0]["type"] == "bad_ts"
+        assert rows[0]["ts"] == 0.0
+        assert json.loads(rows[0]["fields_json"]) == {"ts_raw": "not-a-float"}
+        assert rows[1]["type"] == "ok"
+
     def test_fail_open_continues_jsonl_logging_after_sidecar_disable(self, tmp_path):
         log_file = tmp_path / "events.jsonl"
         index = SQLiteEventIndex(tmp_path / "log.sqlite")
+        index.disable("simulated")
         svc = CompositeLoggingService(JSONLLoggingService(log_file), sqlite_index=index)
 
-        svc.log({"type": "bad_ts", "ts": "not-a-float"})
+        svc.log({"type": "after_disable_initial", "ts": 0})
         for i in range(3):
             svc.log({"type": f"after_disable_{i}", "ts": i})
         svc.close()
 
         events = [json.loads(line) for line in log_file.read_text().splitlines()]
         assert [event["type"] for event in events] == [
-            "bad_ts",
+            "after_disable_initial",
             "after_disable_0",
             "after_disable_1",
             "after_disable_2",
         ]
-        assert index.disabled_reason is not None
+        assert index.disabled_reason == "simulated"
 
     def test_rebuild_requires_offline_agent_lock(self, tmp_path):
         from lingtai_kernel.workdir import WorkingDir

--- a/tests/test_services_logging.py
+++ b/tests/test_services_logging.py
@@ -377,6 +377,81 @@ class TestSQLiteEventIndex:
         assert not (logs / "log.sqlite-wal").exists()
         assert not (logs / "log.sqlite-shm").exists()
 
+
+    def test_read_only_query_sees_live_wal_rows(self, tmp_path):
+        sqlite_file = tmp_path / "logs" / "log.sqlite"
+        index = SQLiteEventIndex(sqlite_file, keep_open=True)
+        try:
+            index.log_event({"type": "live_wal", "ts": 1})
+            rows = query_sqlite_event_index(tmp_path, "SELECT type FROM events WHERE type='live_wal'")
+            assert rows == [{"type": "live_wal"}]
+
+            doctor = doctor_sqlite_event_index(tmp_path)
+            assert doctor["status"] == "ok"
+            assert doctor["event_count"] == 1
+        finally:
+            index.close()
+
+    def test_query_accepts_read_only_cte_and_explain(self, tmp_path):
+        index = SQLiteEventIndex(tmp_path / "logs" / "log.sqlite")
+        try:
+            index.log_event({"type": "cte", "ts": 1})
+            rows = query_sqlite_event_index(
+                tmp_path,
+                "WITH recent AS (SELECT type FROM events) SELECT type FROM recent",
+            )
+            assert rows == [{"type": "cte"}]
+
+            plan = query_sqlite_event_index(tmp_path, "EXPLAIN QUERY PLAN SELECT type FROM events")
+            assert plan
+        finally:
+            index.close()
+
+    def test_rebuild_missing_agent_dir_does_not_materialize_path(self, tmp_path):
+        missing = tmp_path / "missing-agent"
+        try:
+            rebuild_sqlite_event_index(missing)
+            assert False, "missing agent dir should fail before lock setup"
+        except FileNotFoundError as exc:
+            assert "agent directory not found" in str(exc)
+        assert not missing.exists()
+
+    def test_rebuild_preserves_runtime_rows_without_duplicates(self, tmp_path):
+        log_file = tmp_path / "logs" / "events.jsonl"
+        sqlite_file = tmp_path / "logs" / "log.sqlite"
+        svc = CompositeLoggingService(
+            JSONLLoggingService(log_file),
+            sqlite_index=SQLiteEventIndex(sqlite_file, keep_open=False),
+        )
+        svc.log({"type": "first", "ts": 1})
+        svc.log({"type": "second", "ts": 2})
+        svc.close()
+
+        assert query_sqlite_event_index(tmp_path, "SELECT COUNT(*) AS n FROM events") == [{"n": 2}]
+        result = rebuild_sqlite_event_index(tmp_path)
+        assert result["event_count"] == 2
+        rows = query_sqlite_event_index(tmp_path, "SELECT type FROM events ORDER BY ts")
+        assert rows == [{"type": "first"}, {"type": "second"}]
+
+    def test_fail_open_continues_jsonl_logging_after_sidecar_disable(self, tmp_path):
+        log_file = tmp_path / "events.jsonl"
+        index = SQLiteEventIndex(tmp_path / "log.sqlite")
+        svc = CompositeLoggingService(JSONLLoggingService(log_file), sqlite_index=index)
+
+        svc.log({"type": "bad_ts", "ts": "not-a-float"})
+        for i in range(3):
+            svc.log({"type": f"after_disable_{i}", "ts": i})
+        svc.close()
+
+        events = [json.loads(line) for line in log_file.read_text().splitlines()]
+        assert [event["type"] for event in events] == [
+            "bad_ts",
+            "after_disable_0",
+            "after_disable_1",
+            "after_disable_2",
+        ]
+        assert index.disabled_reason is not None
+
     def test_rebuild_requires_offline_agent_lock(self, tmp_path):
         from lingtai_kernel.workdir import WorkingDir
 

--- a/tests/test_services_logging.py
+++ b/tests/test_services_logging.py
@@ -3,7 +3,15 @@ import json
 import threading
 from pathlib import Path
 
-from lingtai_kernel.services.logging import LoggingService, JSONLLoggingService
+from lingtai_kernel.services.logging import (
+    CompositeLoggingService,
+    JSONLLoggingService,
+    LoggingService,
+    SQLiteEventIndex,
+    doctor_sqlite_event_index,
+    query_sqlite_event_index,
+    rebuild_sqlite_event_index,
+)
 
 
 class TestJSONLLoggingService:
@@ -199,3 +207,99 @@ class TestBaseAgentLoggingIntegration:
         events = agent._log_service.get_events()
         state_events = [e for e in events if e["type"] == "agent_state"]
         assert len(state_events) >= 1
+
+
+class TestSQLiteEventIndex:
+
+    def test_composite_writes_jsonl_and_sqlite(self, tmp_path):
+        log_file = tmp_path / "logs" / "events.jsonl"
+        sqlite_file = tmp_path / "logs" / "log.sqlite"
+        svc = CompositeLoggingService(
+            JSONLLoggingService(log_file),
+            sqlite_index=SQLiteEventIndex(sqlite_file, keep_open=False),
+        )
+        svc.log({"type": "agent_state", "address": "agent", "agent_name": "agent", "ts": 1.25, "new": "IDLE"})
+        svc.close()
+
+        assert log_file.is_file()
+        rows = query_sqlite_event_index(tmp_path, "SELECT type, agent_address, agent_name_snapshot FROM events")
+        assert rows == [{"type": "agent_state", "agent_address": "agent", "agent_name_snapshot": "agent"}]
+
+
+    def test_composite_after_close_does_not_create_sidecar_only_event(self, tmp_path):
+        log_file = tmp_path / "logs" / "events.jsonl"
+        sqlite_file = tmp_path / "logs" / "log.sqlite"
+        svc = CompositeLoggingService(
+            JSONLLoggingService(log_file),
+            sqlite_index=SQLiteEventIndex(sqlite_file, keep_open=False),
+        )
+        svc.close()
+        svc.log({"type": "after_close", "ts": 1})
+
+        assert log_file.read_text() == ""
+        rows = query_sqlite_event_index(tmp_path, "SELECT type FROM events WHERE type='after_close'")
+        assert rows == []
+
+    def test_sqlite_sidecar_fail_open(self, tmp_path):
+        log_file = tmp_path / "events.jsonl"
+        index = SQLiteEventIndex(tmp_path / "log.sqlite")
+        index.disable("simulated")
+        svc = CompositeLoggingService(JSONLLoggingService(log_file), sqlite_index=index)
+
+        svc.log({"type": "test", "ts": 1})
+        svc.close()
+
+        assert json.loads(log_file.read_text().strip())["type"] == "test"
+        assert index.disabled_reason == "simulated"
+
+    def test_query_rejects_mutating_sql(self, tmp_path):
+        index = SQLiteEventIndex(tmp_path / "log.sqlite")
+        try:
+            try:
+                index.query("DELETE FROM events")
+                assert False, "mutating query should be rejected"
+            except ValueError:
+                pass
+        finally:
+            index.close()
+
+    def test_rebuild_doctor_and_query(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        events = logs / "events.jsonl"
+        events.write_text(
+            json.dumps({"type": "alpha", "ts": 1, "address": "a", "agent_name": "n", "x": 1}) + "\n"
+            + json.dumps({"type": "beta", "ts": 2, "address": "a", "agent_name": "n", "x": 2}) + "\n",
+            encoding="utf-8",
+        )
+
+        result = rebuild_sqlite_event_index(tmp_path)
+        assert result["status"] == "ok"
+        assert result["event_count"] == 2
+
+        doctor = doctor_sqlite_event_index(tmp_path)
+        assert doctor["status"] == "ok"
+        assert doctor["event_count"] == 2
+
+        rows = query_sqlite_event_index(tmp_path, "SELECT type, agent_address, agent_name_snapshot, json_extract(fields_json, '$.x') AS x FROM events ORDER BY ts")
+        assert rows == [
+            {"type": "alpha", "agent_address": "a", "agent_name_snapshot": "n", "x": 1},
+            {"type": "beta", "agent_address": "a", "agent_name_snapshot": "n", "x": 2},
+        ]
+
+        stored_fields = query_sqlite_event_index(tmp_path, "SELECT fields_json FROM events WHERE type='alpha'")[0]
+        assert json.loads(stored_fields["fields_json"]) == {"x": 1}
+
+    def test_base_agent_creates_sqlite_sidecar(self, tmp_path):
+        agent = BaseAgent(
+            service=make_mock_service(),
+            agent_name="test",
+            working_dir=tmp_path / "test_agent",
+        )
+        agent._log("custom", value=123)
+        agent._log_service.close()
+
+        sqlite_file = agent.working_dir / "logs" / "log.sqlite"
+        assert sqlite_file.is_file()
+        rows = query_sqlite_event_index(agent.working_dir, "SELECT type FROM events WHERE type='custom'")
+        assert rows == [{"type": "custom"}]

--- a/tests/test_services_logging.py
+++ b/tests/test_services_logging.py
@@ -252,6 +252,17 @@ class TestSQLiteEventIndex:
         assert json.loads(log_file.read_text().strip())["type"] == "test"
         assert index.disabled_reason == "simulated"
 
+    def test_sqlite_sidecar_fail_open_for_normalization_errors(self, tmp_path):
+        log_file = tmp_path / "events.jsonl"
+        index = SQLiteEventIndex(tmp_path / "log.sqlite")
+        svc = CompositeLoggingService(JSONLLoggingService(log_file), sqlite_index=index)
+
+        svc.log({"type": "bad_ts", "ts": "not-a-float"})
+        svc.close()
+
+        assert json.loads(log_file.read_text().strip())["type"] == "bad_ts"
+        assert index.disabled_reason is not None
+
     def test_query_rejects_mutating_sql(self, tmp_path):
         index = SQLiteEventIndex(tmp_path / "log.sqlite")
         try:
@@ -330,3 +341,55 @@ class TestSQLiteEventIndex:
         assert sqlite_file.is_file()
         rows = query_sqlite_event_index(agent.working_dir, "SELECT type FROM events WHERE type='custom'")
         assert rows == [{"type": "custom"}]
+
+    def test_query_missing_sqlite_requires_explicit_rebuild(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        (logs / "events.jsonl").write_text(json.dumps({"type": "alpha", "ts": 1}) + "\n", encoding="utf-8")
+
+        try:
+            query_sqlite_event_index(tmp_path, "SELECT type FROM events")
+            assert False, "query should require explicit rebuild when sqlite sidecar is missing"
+        except FileNotFoundError as exc:
+            assert "rebuild" in str(exc)
+        assert not (logs / "log.sqlite").exists()
+
+    def test_doctor_missing_sqlite_is_read_only(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        result = doctor_sqlite_event_index(tmp_path)
+        assert result["status"] == "missing"
+        assert not (logs / "log.sqlite").exists()
+
+    def test_doctor_existing_sqlite_does_not_create_wal_or_mutate_mtime(self, tmp_path):
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        (logs / "events.jsonl").write_text(json.dumps({"type": "alpha", "ts": 1}) + "\n", encoding="utf-8")
+        rebuild_sqlite_event_index(tmp_path)
+        sqlite_file = logs / "log.sqlite"
+        before_mtime = sqlite_file.stat().st_mtime_ns
+        for suffix in ("-wal", "-shm"):
+            (logs / ("log.sqlite" + suffix)).unlink(missing_ok=True)
+
+        result = doctor_sqlite_event_index(tmp_path)
+        assert result["status"] == "ok"
+        assert sqlite_file.stat().st_mtime_ns == before_mtime
+        assert not (logs / "log.sqlite-wal").exists()
+        assert not (logs / "log.sqlite-shm").exists()
+
+    def test_rebuild_requires_offline_agent_lock(self, tmp_path):
+        from lingtai_kernel.workdir import WorkingDir
+
+        logs = tmp_path / "logs"
+        logs.mkdir()
+        (logs / "events.jsonl").write_text(json.dumps({"type": "alpha", "ts": 1}) + "\n", encoding="utf-8")
+        lock = WorkingDir(tmp_path)
+        lock.acquire_lock(timeout=0)
+        try:
+            try:
+                rebuild_sqlite_event_index(tmp_path)
+                assert False, "rebuild should require offline lock"
+            except RuntimeError as exc:
+                assert "stopped/offline" in str(exc)
+        finally:
+            lock.release_lock()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -101,6 +101,19 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "name: system-manual" in system_manual_body
         assert "LingTai Agent Operating Manual" in system_manual_body
 
+        sqlite_log_query_md = (
+            workdir
+            / ".library"
+            / "intrinsic"
+            / "capabilities"
+            / "sqlite-log-query"
+            / "SKILL.md"
+        )
+        assert sqlite_log_query_md.is_file()
+        sqlite_log_query_body = sqlite_log_query_md.read_text(encoding="utf-8")
+        assert "name: sqlite-log-query" in sqlite_log_query_body
+        assert "lingtai-agent log query" in sqlite_log_query_body
+
         doctor_md = (
             workdir
             / ".library"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -100,19 +100,15 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         system_manual_body = system_manual_md.read_text(encoding="utf-8")
         assert "name: system-manual" in system_manual_body
         assert "LingTai Agent Operating Manual" in system_manual_body
+        assert "SQLite log sidecar queries" in system_manual_body
+        assert "reference/sqlite-log-query.md" in system_manual_body
 
-        sqlite_log_query_md = (
-            workdir
-            / ".library"
-            / "intrinsic"
-            / "capabilities"
-            / "sqlite-log-query"
-            / "SKILL.md"
-        )
-        assert sqlite_log_query_md.is_file()
-        sqlite_log_query_body = sqlite_log_query_md.read_text(encoding="utf-8")
-        assert "name: sqlite-log-query" in sqlite_log_query_body
+        sqlite_log_query_ref = system_manual_md.parent / "reference" / "sqlite-log-query.md"
+        assert sqlite_log_query_ref.is_file()
+        sqlite_log_query_body = sqlite_log_query_ref.read_text(encoding="utf-8")
+        assert "# SQLite Log Query" in sqlite_log_query_body
         assert "lingtai-agent log query" in sqlite_log_query_body
+        assert "name: sqlite-log-query" not in sqlite_log_query_body
 
         doctor_md = (
             workdir


### PR DESCRIPTION
## Summary
- add a pure additive SQLite event-log sidecar (`logs/log.sqlite`) while keeping `logs/events.jsonl` as the source of truth
- wire `BaseAgent` to use a `CompositeLoggingService` that writes JSONL first and best-effort indexes into SQLite
- add `lingtai-agent log rebuild|doctor|query <agent_dir>` for rebuilding, inspecting, and querying the derived index
- document the new logging architecture in kernel anatomies

## Design notes
- SQLite failures fail open: the sidecar disables itself and never breaks the agent turn or JSONL writes.
- If the primary JSONL write is a no-op/fails, the composite logger does not create SQLite-only facts.
- The sidecar is rebuildable from JSONL with source-file/source-offset idempotence.
- The CLI query helper accepts only `SELECT` statements.
- Runtime `BaseAgent` sidecar writes avoid holding a persistent SQLite FD; CLI/rebuild paths keep connections open while doing their work.

## Tests
- `python -m pytest tests/test_services_logging.py tests/test_cli.py tests/test_base_agent.py tests/test_agent.py -q` — 101 passed
- `python -m pytest -q -x` — first failure is existing daemon timing/race expectation (`tests/test_daemon.py::test_emanate_creates_folder_on_disk`: observed `done` before assertion expecting `running`) after 286 passed; not introduced by this logging change.
