### PR TITLE
Fix repeated tool error hard stop pairing

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -42,6 +42,7 @@ class EmptyLLMResponseError(RuntimeError):
 
 
 _TRANSIENT_AED_RETRY_LIMIT = 3
+_REPEATED_IDENTICAL_ERROR_HARD_STOP_COUNT = 3
 _TRANSIENT_EXC_NAMES = {
     "APIConnectionError",
     "APITimeoutError",
@@ -124,6 +125,18 @@ def _tool_call_summary(tool_calls) -> dict:
         "call_ids": [getattr(call, "id", None) for call in calls],
         "tool_names": [getattr(call, "name", None) for call in calls],
     }
+
+
+def _trailing_identical_count(items: list[str]) -> int:
+    if not items:
+        return 0
+    last = items[-1]
+    count = 0
+    for item in reversed(items):
+        if item != last:
+            break
+        count += 1
+    return count
 
 
 def _pending_tool_call_summary(iface) -> dict:
@@ -1238,16 +1251,25 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
 
         guard.record_calls(len(response.tool_calls))
 
-        # Break on repeated identical errors
-        if (
-            len(collected_errors) >= 2
-            and collected_errors[-1] == collected_errors[-2]
-        ):
+        # Break on repeated identical errors, but only after committing the
+        # current tool results so the assistant tool_calls are not left pending.
+        repeated_error_count = _trailing_identical_count(collected_errors)
+        if repeated_error_count >= _REPEATED_IDENTICAL_ERROR_HARD_STOP_COUNT:
             logger.warning(
                 "[%s] Same error repeated, breaking early: %s",
                 agent.agent_name,
                 collected_errors[-1],
             )
+            agent._log(
+                "repeated_tool_error_hard_stop",
+                ledger_source=ledger_source,
+                repeated_error_count=repeated_error_count,
+                threshold=_REPEATED_IDENTICAL_ERROR_HARD_STOP_COUNT,
+                error=collected_errors[-1],
+            )
+            if tool_results and agent._chat:
+                agent._chat.commit_tool_results(tool_results)
+                agent._save_chat_history(ledger_source=ledger_source)
             break
 
         in_tool_loop = True

--- a/tests/test_tool_result_restore_after_continuation_failure.py
+++ b/tests/test_tool_result_restore_after_continuation_failure.py
@@ -47,12 +47,16 @@ class _FakeChat:
 class _FakeAgent:
     def __init__(self) -> None:
         self._chat = _FakeChat()
+        self.agent_name = "test-agent"
         self._notification_live_holder = None
+        self._intrinsics = {}
         self.saved = 0
+        self.save_sources: list[str | None] = []
         self.logs: list[tuple[str, dict]] = []
 
     def _save_chat_history(self, *, ledger_source: str | None = None) -> None:
         self.saved += 1
+        self.save_sources.append(ledger_source)
 
     def _log(self, event: str, **kwargs) -> None:
         self.logs.append((event, kwargs))
@@ -184,6 +188,25 @@ class _ProcessExecutor:
         return [self.result], False, ""
 
 
+class _RepeatedErrorExecutor:
+    def __init__(self, error: str = "tool failed identically") -> None:
+        self.guard = _FakeGuard()
+        self.error = error
+        self.calls: list[list] = []
+
+    def execute(self, tool_calls, **kwargs):
+        calls = list(tool_calls)
+        self.calls.append(calls)
+        collected_errors = kwargs.get("collected_errors")
+        if collected_errors is not None:
+            collected_errors.append(self.error)
+        results = [
+            ToolResultBlock(id=tc.id or f"call_{idx}", name=tc.name, content=self.error)
+            for idx, tc in enumerate(calls)
+        ]
+        return results, False, ""
+
+
 class _NoopSentTracker:
     pass
 
@@ -195,6 +218,28 @@ class _FailingSession:
     def send(self, content):
         self.sent.append(content)
         raise RuntimeError("provider continuation failed")
+
+
+class _ContinuingSession:
+    def __init__(self, chat: _FakeChat, responses: list[LLMResponse]) -> None:
+        self.chat = chat
+        self.responses = list(responses)
+        self.sent = []
+
+    def send(self, content):
+        self.sent.append(content)
+        self.chat.commit_tool_results(content)
+        response = self.responses.pop(0)
+        blocks = []
+        if response.text:
+            blocks.append(TextBlock(response.text))
+        blocks.extend(
+            ToolCallBlock(id=tc.id or "", name=tc.name, args=tc.args)
+            for tc in response.tool_calls
+        )
+        if blocks:
+            self.chat.interface.add_assistant_message(blocks)
+        return response
 
 
 class _CancelAfterInitialClear:
@@ -241,6 +286,104 @@ def test_process_response_restores_real_results_when_continuation_send_fails():
     assert agent.logs[-1] == (
         "tool_results_restored_after_continuation_failure",
         {"result_count": 1},
+    )
+
+
+def test_process_response_hard_stop_commits_third_identical_tool_error():
+    """After the third identical tool error, stop without leaving pending calls."""
+    agent = _FakeAgent()
+    agent._executor = _RepeatedErrorExecutor(error="same tool error")
+    agent._cancel_event = threading.Event()
+    agent._on_tool_result_hook = None
+    agent._intermediate_text_streamed = True
+    agent._sent_tracker = _NoopSentTracker()
+    agent._working_dir = Path("/nonexistent/lingtai-test-repeated-errors")
+
+    responses = [
+        LLMResponse(
+            text="",
+            tool_calls=[ToolCall(id="call_2", name="bash", args={"command": "fail"})],
+        ),
+        LLMResponse(
+            text="",
+            tool_calls=[ToolCall(id="call_3", name="bash", args={"command": "fail"})],
+        ),
+    ]
+    agent._session = _ContinuingSession(agent._chat, responses)
+
+    response = LLMResponse(
+        text="",
+        tool_calls=[ToolCall(id="call_1", name="bash", args={"command": "fail"})],
+    )
+
+    result = _process_response(agent, response, ledger_source="test")
+
+    assert result == {
+        "text": "",
+        "failed": True,
+        "errors": ["same tool error", "same tool error", "same tool error"],
+    }
+    assert len(agent._session.sent) == 2
+    assert [batch[0].id for batch in agent._chat.committed] == [
+        "call_1",
+        "call_2",
+        "call_3",
+    ]
+    assert not agent._chat.interface.has_pending_tool_calls()
+    assert agent._chat.interface.entries[-1].content[0].id == "call_3"
+    assert agent.saved == 3
+    assert agent.save_sources == ["test", "test", "test"]
+    hard_stop_logs = [
+        fields for event, fields in agent.logs
+        if event == "repeated_tool_error_hard_stop"
+    ]
+    assert hard_stop_logs == [
+        {
+            "ledger_source": "test",
+            "repeated_error_count": 3,
+            "threshold": 3,
+            "error": "same tool error",
+        }
+    ]
+
+
+def test_process_response_second_identical_tool_error_still_continues():
+    """The second identical tool error should still be sent to the model."""
+    agent = _FakeAgent()
+    agent._executor = _RepeatedErrorExecutor(error="same tool error")
+    agent._cancel_event = threading.Event()
+    agent._on_tool_result_hook = None
+    agent._intermediate_text_streamed = True
+    agent._sent_tracker = _NoopSentTracker()
+    agent._working_dir = Path("/nonexistent/lingtai-test-repeated-errors")
+    agent._session = _ContinuingSession(
+        agent._chat,
+        [
+            LLMResponse(
+                text="",
+                tool_calls=[ToolCall(id="call_2", name="bash", args={"command": "fail"})],
+            ),
+            LLMResponse(text="done", tool_calls=[]),
+        ],
+    )
+
+    response = LLMResponse(
+        text="",
+        tool_calls=[ToolCall(id="call_1", name="bash", args={"command": "fail"})],
+    )
+
+    result = _process_response(agent, response, ledger_source="test")
+
+    assert result == {
+        "text": "done",
+        "failed": False,
+        "errors": ["same tool error", "same tool error"],
+    }
+    assert len(agent._session.sent) == 2
+    assert [batch[0].id for batch in agent._chat.committed] == ["call_1", "call_2"]
+    assert not agent._chat.interface.has_pending_tool_calls()
+    assert not any(
+        event == "repeated_tool_error_hard_stop" for event, _ in agent.logs
     )
 
 


### PR DESCRIPTION
## Summary

> **Core invariant fix:** the hard-stop path must add/commit the already-produced
> `tool_results` back into the chat wire before breaking. Otherwise the assistant
> `tool_call` remains unpaired as a pending tool call, even though `events.jsonl`
> contains the real tool result. This PR's main correctness change is preserving
> that tool-call/tool-result pair on the eventual hard stop.


This fixes one upstream producer of stale pending tool calls in the turn loop:
when `_process_response()` hard-stops after repeated identical tool errors, it used
to `break` before sending or committing the current `tool_results`. That could
leave the canonical chat/interface tail as an assistant `tool_call` with no paired
`tool_result`, even though the tool executor had already logged the real result.

The minimal behavior change here is:

- raise the repeated-identical-error hard-stop threshold from 2 to 3 consecutive identical errors;
- let the second identical error continue through the normal `session.send(tool_results)` path so the model gets another chance to adapt;
- on the third identical error, **commit and save the current real `tool_results` before breaking**, so the already-executed tool result is added back to the chat wire and the assistant `tool_call` is not left pending;
- add a structured `repeated_tool_error_hard_stop` event for future diagnosis.

This intentionally does **not** add a new warning-injection/retry mechanism. It is a narrow first patch that both gives the model one more recovery chance and ensures that any eventual hard stop is clean.

## Field evidence / root cause

This came from a real AlphaSeeker incident involving `bash` call
`call_S1GAreSN5djnwrqMy2BLPZTo`.

Local evidence showed:

- the preceding large command `call_zASHhke...` timed out after 30s, then the model continued and split the work;
- the split-down quick inventory command `call_wffQaj...` succeeded in 104 ms;
- the target reference-scan command `call_S1GAre...` also timed out after 30s and **did** have a real event-log `tool_result`:

```json
{
  "type": "tool_result",
  "tool_name": "bash",
  "tool_call_id": "call_S1GAreSN5djnwrqMy2BLPZTo",
  "status": "error",
  "elapsed_ms": 30021,
  "result": {
    "status": "error",
    "message": "Command timed out after 30s",
    "_elapsed_ms": 30021
  }
}
```

Immediately after that timeout, the raw event log records the agent going idle on the next line, with no intervening `llm_call` / `llm_response` continuation:

```json
{"line":141340,"type":"tool_result","tool_call_id":"call_S1GAreSN5djnwrqMy2BLPZTo","status":"error","elapsed_ms":30021}
{"line":141341,"type":"agent_state","old":"active","new":"idle","reason":""}
```

There is no later LLM activity until the human's email arrives about seven minutes later; at that point the event log shows `mail_received` at line 141342 and only then notification heal + `tc_wake_continue` + `llm_call` at lines 141344-141349.

The agent log at the same timestamp contained:

```text
Same error repeated, breaking early: bash: Command timed out after 30s
```

Later, when a new email notification arrived, notification injection found the chat tail still had a pending tool call and healed it:

```json
{"type":"notification_inject_aborted", "ts":1780187665.252129, "reason":"pending_tool_calls", "_tail":" tail_role=assistant tail_blocks=1 tc_ids=['call_S1GAreSN5djnwrq']"}
{"type":"heal_pending_tool_calls", "ts":1780187665.252246, "reason":"idle_inject_blocked"}
{"type":"notification_pair_injected", "ts":1780187665.264971, "sources":["email"]}
```

So `heal:idle_inject_blocked` was the recovery symptom: the real upstream issue was that `_process_response()` had a branch after tool execution but before `session.send(tool_results)` / commit-save that could break **without adding the already-executed tool result back to the canonical chat wire**, leaving a pending assistant `tool_call`.

Operationally, the bash timeout itself was expected: the target command repeated full-repository-ish `find | xargs grep | head -20` scans for seven patterns across about 13.7k files / 697 MB, measured at ~46 seconds for the grep component alone.

## Tests

Ran locally:

```text
uv run pytest -q tests/test_tool_result_restore_after_continuation_failure.py
# 15 passed

uv run pytest -q tests/test_tool_result_restore_after_continuation_failure.py \
  tests/test_chat_interface_invariant.py \
  tests/test_tc_wake_orphan_heal.py \
  tests/test_aed_recovery.py
# 57 passed

git diff --check
# passed
```



