### PR TITLE
Index chat history and daemon JSONL in SQLite

### DIFF
--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -294,7 +294,7 @@ def main() -> None:
     log_parser = sub.add_parser("log", help="Inspect the additive SQLite log index")
     log_sub = log_parser.add_subparsers(dest="log_command", required=True)
 
-    log_rebuild = log_sub.add_parser("rebuild", help="Rebuild logs/log.sqlite from logs/events.jsonl")
+    log_rebuild = log_sub.add_parser("rebuild", help="Rebuild logs/log.sqlite from agent events, chat history, and daemon JSONL")
     log_rebuild.add_argument("agent_dir", type=Path, help="Agent working directory")
 
     log_doctor = log_sub.add_parser("doctor", help="Check logs/log.sqlite integrity and counts")

--- a/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query.md
@@ -2,11 +2,12 @@
 
 # SQLite Log Query
 
-LingTai keeps the durable runtime event log in `logs/events.jsonl`. The SQLite
-file at `logs/log.sqlite` is an **additive, rebuildable query index** over that
-JSONL source of truth. Use it to answer questions that are painful with `grep`:
-which event types are hottest, when a failure started, which tool calls emitted
-errors, or whether notification/daemon/context events are storming.
+LingTai keeps durable runtime traces in JSONL files. The SQLite file at
+`logs/log.sqlite` is an **additive, rebuildable query index** over those JSONL
+sources of truth. Use it to answer questions that are painful with `grep`: which
+event types are hottest, what happened inside daemon runs, what chat-history
+turn surrounded a failure, or whether notification/daemon/context events are
+storming.
 
 ## Safety contract
 
@@ -19,12 +20,15 @@ errors, or whether notification/daemon/context events are storming.
   inspection path.
 - **Rebuild is offline.** `log rebuild` requires the agent working-directory lock;
   if the agent is running, stop/sleep/lull/suspend it first as appropriate.
+- **Runtime SQLite is best effort.** New top-level `logs/events.jsonl` rows are
+  indexed live after the JSONL write succeeds. Chat history and daemon JSONL are
+  indexed by explicit offline rebuild so normal turns and daemon runs do not pay
+  recursive scan or live-rewrite costs.
 - **Live queries are snapshots.** Runtime writes use SQLite WAL mode. The query
   path is intentionally non-mutating, so for a complete historical snapshot stop
-  the agent and run `log rebuild` from `events.jsonl` before querying. For the
-  newest live facts, inspect `logs/events.jsonl` directly.
-- **Never paste secrets.** Logs can contain URLs, tokens, prompts, and user data.
-  Redact before sharing.
+  the agent and run `log rebuild` before querying.
+- **Never paste secrets.** Logs and chat history can contain URLs, tokens,
+  prompts, and user data. Redact before sharing.
 
 ## Commands
 
@@ -47,6 +51,14 @@ rebuild **only while the target agent is stopped/offline**:
 lingtai-agent log rebuild "$AGENT_DIR"
 ```
 
+`log rebuild` scans the known JSONL trace surfaces under the target agent:
+
+- `logs/events.jsonl` → `events` (`source_kind='agent_events'`)
+- `history/chat_history.jsonl` → `chat_entries` (`source_kind='agent_chat'`)
+- `history/chat_history_archive.jsonl` → `chat_entries` (`source_kind='agent_chat_archive'`)
+- `daemons/*/logs/events.jsonl` → `events` (`source_kind='daemon_events'`, `run_id=<daemon folder>`)
+- `daemons/*/history/chat_history.jsonl` → `chat_entries` (`source_kind='daemon_chat'`, `run_id=<daemon folder>`)
+
 Run a read-only query:
 
 ```bash
@@ -67,51 +79,94 @@ lingtai-agent log query "$AGENT_DIR" \
 
 ## Schema quick reference
 
-`events` is the main table:
+`events` indexes top-level agent runtime events and daemon run events:
 
 | Column | Meaning |
 |---|---|
 | `id` | SQLite row id, not a stable cross-rebuild event identifier |
-| `ts` | event timestamp as a numeric epoch-like value |
-| `type` | event type string |
+| `ts` | event timestamp as a numeric epoch-like value; ISO strings are parsed when possible |
+| `type` | event `type` field, or daemon `event` field |
 | `agent_address` | event `address` field when present |
 | `agent_name_snapshot` | event `agent_name` field when present |
 | `fields_json` | the remaining event fields as JSON text |
-| `source_file` | JSONL file imported from, usually `logs/events.jsonl` |
+| `source_file` | JSONL file imported from |
 | `source_offset` | byte offset in the JSONL source; unique with `source_file` |
+| `source_line` | 1-based JSONL line number |
+| `source_kind` | `agent_events`, `daemon_events`, or fallback kind |
+| `scope` | `agent`, `daemon`, or `unknown` |
+| `run_id` | daemon run folder name for daemon rows |
+| `inserted_at` | sidecar insertion time |
+
+`chat_entries` indexes agent and daemon chat-history JSONL rows:
+
+| Column | Meaning |
+|---|---|
+| `id` | SQLite row id, not stable across rebuilds |
+| `ts` | parsed numeric timestamp when a row has `ts`/`timestamp`, else `0` |
+| `ts_text` | original timestamp text/value as stored in JSONL |
+| `role` | chat role (`user`, `assistant`, etc.) when present |
+| `kind` | LingTai daemon user-entry kind (`task`, `tool_results`, `followup`) when present |
+| `turn` | daemon turn number when present |
+| `content_text` | best-effort extracted plain text from `text` or content blocks |
+| `entry_json` | full source chat row as JSON text |
+| `source_file`, `source_offset`, `source_line` | source JSONL identity |
+| `source_kind` | `agent_chat`, `agent_chat_archive`, `daemon_chat`, or fallback kind |
+| `scope` | `agent`, `daemon`, or `unknown` |
+| `run_id` | daemon run folder name for daemon rows |
 | `inserted_at` | sidecar insertion time |
 
 Maintenance tables:
 
 - `schema_migrations(version, name, applied_at)` records sidecar schema version.
 - `import_cursors(source_file, byte_offset, line_no, updated_at)` records the last
-  rebuild/import cursor.
+  rebuild/import cursor for each JSONL source.
 
 ## Query recipes
 
 Recent events:
 
 ```sql
-SELECT id, ts, type, substr(fields_json, 1, 300) AS fields
+SELECT id, ts, type, source_kind, run_id, substr(fields_json, 1, 300) AS fields
 FROM events
 ORDER BY ts DESC
 LIMIT 50;
 ```
 
-Event type counts:
+Event type counts across agent + daemon events:
 
 ```sql
-SELECT type, COUNT(*) AS n, MIN(ts) AS first_ts, MAX(ts) AS last_ts
+SELECT source_kind, type, COUNT(*) AS n, MIN(ts) AS first_ts, MAX(ts) AS last_ts
 FROM events
-GROUP BY type
+GROUP BY source_kind, type
 ORDER BY n DESC
 LIMIT 50;
+```
+
+Recent chat-history entries:
+
+```sql
+SELECT id, source_kind, run_id, role, kind, turn, substr(content_text, 1, 400) AS text
+FROM chat_entries
+ORDER BY id DESC
+LIMIT 50;
+```
+
+Join daemon tool events with daemon chat rows by `run_id`:
+
+```sql
+SELECT e.run_id, e.ts, e.type, json_extract(e.fields_json, '$.name') AS tool,
+       c.role, c.turn, substr(c.content_text, 1, 240) AS chat
+FROM events e
+LEFT JOIN chat_entries c ON c.run_id = e.run_id AND c.turn = json_extract(e.fields_json, '$.turn')
+WHERE e.source_kind = 'daemon_events'
+ORDER BY e.ts DESC
+LIMIT 100;
 ```
 
 Search for errors or failures:
 
 ```sql
-SELECT id, ts, type, substr(fields_json, 1, 500) AS fields
+SELECT id, ts, source_kind, run_id, type, substr(fields_json, 1, 500) AS fields
 FROM events
 WHERE lower(type) LIKE '%error%'
    OR lower(type) LIKE '%fail%'
@@ -130,6 +185,16 @@ WHERE type LIKE 'notification%'
    OR fields_json LIKE '%notification%'
 GROUP BY type
 ORDER BY n DESC;
+```
+
+Search chat-history text:
+
+```sql
+SELECT source_kind, run_id, role, turn, substr(content_text, 1, 500) AS text
+FROM chat_entries
+WHERE lower(content_text) LIKE '%sqlite%'
+ORDER BY id DESC
+LIMIT 100;
 ```
 
 Inspect one event's full JSON payload:
@@ -160,14 +225,16 @@ If JSON functions are unavailable in the local SQLite build, fall back to
 
 1. Identify the agent directory. If unsure, use the `.lingtai/<agent>` directory
    shown in the agent's identity/pad or ask the orchestrator.
-2. Run `lingtai-agent log doctor "$AGENT_DIR"`.
-3. If the sidecar is missing/stale and exact history matters, stop the target
-   agent and run `lingtai-agent log rebuild "$AGENT_DIR"`.
-4. Start broad: event type counts and recent rows.
-5. Narrow by time/type/text. Keep queries read-only (`SELECT`, `WITH ... SELECT`, or `EXPLAIN`).
-6. Cross-check surprising findings against `logs/events.jsonl`, `agent.log`, or
-   daemon subdirectories before filing bugs or making claims.
-7. When reporting, quote minimal evidence and redact secrets.
+2. Stop the target agent if exact complete history matters, then run
+   `lingtai-agent log rebuild "$AGENT_DIR"`. Otherwise begin with `doctor` and
+   live event queries.
+3. Start broad: event/source-kind counts and recent rows.
+4. Narrow by time/type/text. Include `source_kind` and `run_id` in queries when
+   daemon evidence matters.
+5. Cross-check surprising findings against source JSONL (`logs/events.jsonl`,
+   `history/chat_history*.jsonl`, daemon subdirectories) before filing bugs or
+   making claims.
+6. When reporting, quote minimal evidence and redact secrets.
 
 ## Pitfalls
 
@@ -175,8 +242,9 @@ If JSON functions are unavailable in the local SQLite build, fall back to
   index, not agent state.
 - Do not rebuild a live agent by bypassing the CLI lock; that risks racing the
   runtime logger.
-- Do not share raw `fields_json` blindly; it may contain private content.
+- Do not share raw `fields_json` or `entry_json` blindly; they may contain private
+  content.
 - Do not assume `id` survives rebuilds. Use `source_file/source_offset`, time,
-  and surrounding context for durable references.
+  `run_id`, and surrounding context for durable references.
 - If a query returns fewer rows than expected on a live agent, remember the WAL
-  snapshot caveat; stop/rebuild or inspect JSONL.
+  snapshot and explicit-rebuild caveats; stop/rebuild or inspect JSONL.

--- a/src/lingtai_kernel/services/ANATOMY.md
+++ b/src/lingtai_kernel/services/ANATOMY.md
@@ -12,12 +12,12 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
   - `send()` resolves peer/absolute addresses, checks `is_agent`/`is_alive`, generates ids through `intrinsics.email._new_mailbox_id`, copies attachments, and writes `message.json` atomically (`services/mail.py:131`, `services/mail.py:165`, `services/mail.py:199-206`).
   - `listen()` starts a daemon polling thread (`services/mail.py:216`), snapshots existing inbox ids into `_seen` (`services/mail.py:224-227`), scans every 0.5s (`services/mail.py:256`), and also claims subscribed pseudo-agent outbox messages (`services/mail.py:250-253`, `services/mail.py:261-368`).
   - `stop()` sets the poll stop event and joins the thread (`services/mail.py:370-374`).
-- `services/logging.py` — structured event log and additive SQLite query index.
-  - `LoggingService` is the ABC for `log(event)` and `close()`; `log()` may return optional storage metadata such as JSONL offsets (`services/logging.py:29`, `services/logging.py:36-42`).
-  - `JSONLLoggingService` appends UTF-8 JSON lines with a lock and flush per write, returning `(source_file, source_offset)` metadata (`services/logging.py:48`, `services/logging.py:57-58`, `services/logging.py:66-77`).
-  - `SQLiteEventIndex` owns the derived `logs/log.sqlite` schema, fail-open sidecar writes, and read-only inspection opens (`services/logging.py:102`, `services/logging.py:160-195`, `services/logging.py:228-267`).
-  - `CompositeLoggingService` writes the JSONL primary first, then best-effort inserts into SQLite with the JSONL source offset (`services/logging.py:288`, `services/logging.py:295-305`).
-  - `rebuild_sqlite_event_index()`, `doctor_sqlite_event_index()`, and `query_sqlite_event_index()` back the CLI rebuild/doctor/query commands (`services/logging.py:338`, `services/logging.py:415`, `services/logging.py:427`).
+- `services/logging.py` — structured event log and additive SQLite trace query index.
+  - `LoggingService` is the ABC for `log(event)` and `close()`; `log()` may return optional storage metadata such as JSONL offsets (`services/logging.py:76`, `services/logging.py:83-89`).
+  - `JSONLLoggingService` appends UTF-8 JSON lines with a lock and flush per write, returning `(source_file, source_offset)` metadata (`services/logging.py:95`, `services/logging.py:104-111`, `services/logging.py:119-130`).
+  - `SQLiteEventIndex` owns the derived `logs/log.sqlite` schema, fail-open runtime event writes, v1→v2 migration, and read-only inspection opens (`services/logging.py:143`, `services/logging.py:213-300`, `services/logging.py:383-456`).
+  - `CompositeLoggingService` writes the top-level `logs/events.jsonl` primary first, then best-effort inserts that event into SQLite with the JSONL source offset (`services/logging.py:465`, `services/logging.py:472-482`).
+  - `rebuild_sqlite_event_index()`, `doctor_sqlite_event_index()`, and `query_sqlite_event_index()` back the CLI rebuild/doctor/query commands; rebuild scans agent events, chat history/archive, and daemon event/chat JSONL sources into one sidecar (`services/logging.py:629`, `services/logging.py:735`, `services/logging.py:747`).
 - `services/__init__.py` is an empty package marker; callers import concrete modules directly.
 
 ## Connections
@@ -36,15 +36,16 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
 ## State
 
 - **Persistent mail:** `<workdir>/mailbox/{inbox,outbox,sent}/<uuid>/message.json`; optional `attachments/` subdir. `FilesystemMailService.send()` writes recipient inbox payloads atomically (`services/mail.py:199-206`).
-- **Persistent log source-of-truth:** `<workdir>/logs/events.jsonl`; one JSON object per line, appended by `JSONLLoggingService.log()` (`services/logging.py:66-77`).
-- **Persistent log sidecar:** `<workdir>/logs/log.sqlite`; rebuildable/deletable SQLite index with `schema_migrations`, `import_cursors`, and `events` tables. `events.source_file/source_offset` is unique when present so JSONL replays are idempotent (`services/logging.py:160-195`).
+- **Persistent log source-of-truth:** `<workdir>/logs/events.jsonl`; one JSON object per line, appended by `JSONLLoggingService.log()` (`services/logging.py:119-130`). Chat-history and daemon traces remain authoritative in their own JSONL files (`history/chat_history*.jsonl`, `daemons/*/{logs/events.jsonl,history/chat_history.jsonl}`).
+- **Persistent log sidecar:** `<workdir>/logs/log.sqlite`; rebuildable/deletable SQLite trace index with `schema_migrations`, `import_cursors`, `events`, and `chat_entries` tables. `events` and `chat_entries` keep `source_file/source_offset/source_line` provenance so JSONL replays are idempotent and traceable (`services/logging.py:213-300`).
 - **Ephemeral mail:** `_seen` is an in-memory set of delivered UUIDs rebuilt at listen start (`services/mail.py:224-227`); `_poll_thread` is a daemon thread joined by `stop()` (`services/mail.py:370-374`).
-- **Ephemeral log:** `JSONLLoggingService` holds an open file handle and a thread lock; `SQLiteEventIndex` holds an optional sqlite connection and disables itself after sqlite errors so agent turns fail open (`services/logging.py:57-62`, `services/logging.py:106-129`).
+- **Ephemeral log:** `JSONLLoggingService` holds an open file handle and a thread lock; `SQLiteEventIndex` holds an optional sqlite connection and disables itself after sqlite errors so agent turns fail open (`services/logging.py:99-104`, `services/logging.py:154-174`).
 
 ## Notes
 
 - Pseudo-agent outbox claiming is optimistic concurrency: pollers copy to inbox, race on outbox→sent rename, and losers delete their speculative copy and clear `_seen` (`services/mail.py:326-354`).
 - The services package has two ABCs but mail and logging now differ in shape: mail still has one filesystem implementation, while logging composes the JSONL primary with optional derived indexes.
-- `get_events()` favors simplicity over hot-path performance: it re-opens and parses the whole JSONL file each call (`services/logging.py:79-94`).
-- SQLite is intentionally additive: JSONL remains the durable source of truth; rebuild requires the agent working-directory lock (offline/stopped agent), uses a temporary database and atomic replace, and checkpoints WAL before replacing so the final artifact is self-contained (`services/logging.py:338-413`).
-- Query helpers accept read-only `SELECT`/CTE/`EXPLAIN` statements, use `PRAGMA query_only=ON`, and choose immutable offline reads or WAL-aware read-only live reads to keep CLI inspection non-mutating while seeing WAL rows (`services/logging.py:130-149`, `services/logging.py:253-267`).
+- `get_events()` favors simplicity over hot-path performance: it re-opens and parses the whole JSONL file each call (`services/logging.py:133-148`).
+- SQLite is intentionally additive: JSONL remains the durable source of truth; rebuild requires the agent working-directory lock (offline/stopped agent), uses a temporary database and atomic replace, and checkpoints WAL before replacing so the final artifact is self-contained (`services/logging.py:629-732`).
+- Runtime writes only index the top-level `logs/events.jsonl` stream. Chat history, archive, and daemon JSONL are indexed during explicit rebuild, avoiding extra work on every chat-history rewrite or daemon append (`services/logging.py:472-482`, `services/logging.py:542-628`).
+- Query helpers accept read-only `SELECT`/CTE/`EXPLAIN` statements, use `PRAGMA query_only=ON`, and choose immutable offline reads or WAL-aware read-only live reads to keep CLI inspection non-mutating while seeing WAL rows (`services/logging.py:181-201`, `services/logging.py:425-440`).

--- a/src/lingtai_kernel/services/logging.py
+++ b/src/lingtai_kernel/services/logging.py
@@ -20,13 +20,57 @@ from typing import Any, Iterable
 from ..workdir import WorkingDir
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 DEFAULT_SQLITE_NAME = "log.sqlite"
 DEFAULT_JSONL_NAME = "events.jsonl"
 
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _coerce_ts(raw_ts: Any) -> tuple[float, bool]:
+    """Return ``(numeric_ts, ok)`` for epoch-ish numbers or ISO strings."""
+    if raw_ts is None or raw_ts == "":
+        return 0.0, True
+    try:
+        return float(raw_ts), True
+    except (TypeError, ValueError):
+        pass
+    if isinstance(raw_ts, str):
+        try:
+            parsed = datetime.fromisoformat(raw_ts.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.timestamp(), True
+        except ValueError:
+            pass
+    return 0.0, False
+
+
+def _extract_content_text(value: Any) -> str | None:
+    """Best-effort plain-text extraction from chat-history content shapes."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            text = _extract_content_text(item)
+            if text:
+                parts.append(text)
+        return "\n".join(parts) if parts else None
+    if isinstance(value, dict):
+        if isinstance(value.get("text"), str):
+            return value["text"]
+        if isinstance(value.get("content"), str):
+            return value["content"]
+        nested = _extract_content_text(value.get("content"))
+        if nested:
+            return nested
+        return None
+    return str(value)
 
 
 class LoggingService(ABC):
@@ -58,15 +102,16 @@ class JSONLLoggingService(LoggingService):
         self._path = Path(path)
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._file = open(self._path, "ab")
-        self._lock = threading.Lock()
-        self._closed = False
+        self._lock = threading.RLock()
         self._ensure_ascii = ensure_ascii
+        self._closed = False
 
     @property
     def path(self) -> Path:
         return self._path
 
     def log(self, event: dict) -> dict | None:
+        """Append event as one JSON line and return JSONL source metadata."""
         if self._closed:
             return None
         line = json.dumps(event, ensure_ascii=self._ensure_ascii, default=str)
@@ -100,10 +145,10 @@ class JSONLLoggingService(LoggingService):
 
 
 class SQLiteEventIndex:
-    """Best-effort SQLite index for JSONL events.
+    """Best-effort SQLite index for JSONL traces.
 
     The index is a derived artifact.  It is safe to delete and rebuild from
-    ``events.jsonl``.  Runtime writes fail open by disabling the sidecar after
+    JSONL sources.  Runtime writes fail open by disabling the sidecar after
     the first sqlite error; they never raise into the agent turn.
     """
 
@@ -157,7 +202,19 @@ class SQLiteEventIndex:
         conn.execute("PRAGMA foreign_keys=ON")
 
     @staticmethod
-    def _ensure_schema(conn: sqlite3.Connection) -> None:
+    def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+        try:
+            return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+        except sqlite3.Error:
+            return set()
+
+    @classmethod
+    def _ensure_column(cls, conn: sqlite3.Connection, table: str, name: str, definition: str) -> None:
+        if name not in cls._table_columns(conn, table):
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {definition}")
+
+    @classmethod
+    def _ensure_schema(cls, conn: sqlite3.Connection) -> None:
         conn.executescript(
             """
             CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -182,19 +239,64 @@ class SQLiteEventIndex:
               fields_json TEXT NOT NULL,
               source_file TEXT,
               source_offset INTEGER,
+              source_line INTEGER,
+              source_kind TEXT,
+              scope TEXT,
+              run_id TEXT,
+              inserted_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            );
+            """
+        )
+        # Existing v1 sidecars predate these trace-classification columns.
+        for name, definition in (
+            ("source_line", "INTEGER"),
+            ("source_kind", "TEXT"),
+            ("scope", "TEXT"),
+            ("run_id", "TEXT"),
+        ):
+            cls._ensure_column(conn, "events", name, definition)
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS chat_entries (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              ts REAL NOT NULL DEFAULT 0,
+              ts_text TEXT,
+              role TEXT,
+              kind TEXT,
+              turn INTEGER,
+              content_text TEXT,
+              entry_json TEXT NOT NULL,
+              source_file TEXT NOT NULL,
+              source_offset INTEGER NOT NULL,
+              source_line INTEGER,
+              source_kind TEXT,
+              scope TEXT,
+              run_id TEXT,
               inserted_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
             );
 
             CREATE INDEX IF NOT EXISTS idx_events_type_ts ON events(type, ts DESC);
             CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts DESC);
+            CREATE INDEX IF NOT EXISTS idx_events_source_kind_ts ON events(source_kind, ts DESC);
+            CREATE INDEX IF NOT EXISTS idx_events_run_id_ts ON events(run_id, ts DESC);
             CREATE UNIQUE INDEX IF NOT EXISTS idx_events_source_offset
               ON events(source_file, source_offset)
               WHERE source_file IS NOT NULL AND source_offset IS NOT NULL;
+
+            CREATE INDEX IF NOT EXISTS idx_chat_entries_role_ts ON chat_entries(role, ts DESC);
+            CREATE INDEX IF NOT EXISTS idx_chat_entries_source_kind_ts ON chat_entries(source_kind, ts DESC);
+            CREATE INDEX IF NOT EXISTS idx_chat_entries_run_id_turn ON chat_entries(run_id, turn);
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_entries_source_offset
+              ON chat_entries(source_file, source_offset);
             """
         )
         conn.execute(
             "INSERT OR IGNORE INTO schema_migrations(version, name, applied_at) VALUES (?, ?, ?)",
-            (SCHEMA_VERSION, "initial_events_index", _utc_now()),
+            (1, "initial_events_index", _utc_now()),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations(version, name, applied_at) VALUES (?, ?, ?)",
+            (2, "trace_chat_and_daemon_index", _utc_now()),
         )
         conn.commit()
 
@@ -209,15 +311,24 @@ class SQLiteEventIndex:
         self.close()
 
     @staticmethod
-    def event_row(event: dict, *, source_file: str | None = None, source_offset: int | None = None) -> tuple[Any, ...]:
+    def event_row(
+        event: dict,
+        *,
+        source_file: str | None = None,
+        source_offset: int | None = None,
+        source_line: int | None = None,
+        source_kind: str | None = None,
+        scope: str | None = None,
+        run_id: str | None = None,
+    ) -> tuple[Any, ...]:
         fields = dict(event)
-        event_type = fields.pop("type", "")
+        event_type = fields.pop("type", None)
+        if event_type is None:
+            event_type = fields.pop("event", "")
         raw_ts = fields.pop("ts", 0.0)
-        try:
-            ts = float(raw_ts or 0.0)
-        except (TypeError, ValueError):
+        ts, ok = _coerce_ts(raw_ts)
+        if not ok:
             fields["ts_raw"] = raw_ts
-            ts = 0.0
         agent_address = fields.pop("address", None)
         agent_name = fields.pop("agent_name", None)
         return (
@@ -228,9 +339,62 @@ class SQLiteEventIndex:
             json.dumps(fields, ensure_ascii=False, default=str),
             source_file,
             source_offset,
+            source_line,
+            source_kind,
+            scope,
+            run_id,
         )
 
-    def log_event(self, event: dict, *, source_file: str | None = None, source_offset: int | None = None) -> None:
+    @staticmethod
+    def chat_entry_row(
+        entry: dict,
+        *,
+        source_file: str,
+        source_offset: int,
+        source_line: int,
+        source_kind: str,
+        scope: str,
+        run_id: str | None,
+    ) -> tuple[Any, ...]:
+        role = entry.get("role")
+        kind = entry.get("kind")
+        turn_raw = entry.get("turn")
+        try:
+            turn = int(turn_raw) if turn_raw is not None else None
+        except (TypeError, ValueError):
+            turn = None
+        raw_ts = entry.get("ts") or entry.get("timestamp")
+        ts, _ = _coerce_ts(raw_ts)
+        content_text = _extract_content_text(entry.get("text"))
+        if content_text is None:
+            content_text = _extract_content_text(entry.get("content"))
+        return (
+            ts,
+            str(raw_ts) if raw_ts is not None else None,
+            str(role) if role is not None else None,
+            str(kind) if kind is not None else None,
+            turn,
+            content_text,
+            json.dumps(entry, ensure_ascii=False, default=str),
+            source_file,
+            source_offset,
+            source_line,
+            source_kind,
+            scope,
+            run_id,
+        )
+
+    def log_event(
+        self,
+        event: dict,
+        *,
+        source_file: str | None = None,
+        source_offset: int | None = None,
+        source_line: int | None = None,
+        source_kind: str | None = "agent_events",
+        scope: str | None = "agent",
+        run_id: str | None = None,
+    ) -> None:
         if self._disabled_reason:
             return
         try:
@@ -240,10 +404,18 @@ class SQLiteEventIndex:
                     """
                     INSERT OR IGNORE INTO events(
                         ts, type, agent_address, agent_name_snapshot, fields_json,
-                        source_file, source_offset
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                        source_file, source_offset, source_line, source_kind, scope, run_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
-                    self.event_row(event, source_file=source_file, source_offset=source_offset),
+                    self.event_row(
+                        event,
+                        source_file=source_file,
+                        source_offset=source_offset,
+                        source_line=source_line,
+                        source_kind=source_kind,
+                        scope=scope,
+                        run_id=run_id,
+                    ),
                 )
                 conn.commit()
         except Exception as exc:
@@ -277,16 +449,20 @@ class SQLiteEventIndex:
         with self._lock:
             conn = self._ensure_open(read_only=True, ensure_schema=False)
             integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
-            event_count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
-            cursor_count = conn.execute("SELECT COUNT(*) FROM import_cursors").fetchone()[0]
-            schema_versions = [row[0] for row in conn.execute("SELECT version FROM schema_migrations ORDER BY version")]
+            tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+            event_count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] if "events" in tables else 0
+            chat_entry_count = conn.execute("SELECT COUNT(*) FROM chat_entries").fetchone()[0] if "chat_entries" in tables else 0
+            cursor_count = conn.execute("SELECT COUNT(*) FROM import_cursors").fetchone()[0] if "import_cursors" in tables else 0
+            schema_versions = [row[0] for row in conn.execute("SELECT version FROM schema_migrations ORDER BY version")] if "schema_migrations" in tables else []
         return {
             "status": "ok" if integrity == "ok" else "error",
             "path": str(self.path),
             "integrity_check": integrity,
             "event_count": event_count,
+            "chat_entry_count": chat_entry_count,
             "cursor_count": cursor_count,
             "schema_versions": schema_versions,
+            "schema_current": SCHEMA_VERSION in schema_versions,
         }
 
 
@@ -318,8 +494,8 @@ class CompositeLoggingService(LoggingService):
             self.sqlite_index.close()
 
 
-def _iter_jsonl_events_with_offsets(path: Path) -> Iterable[tuple[dict, int, int, int]]:
-    """Yield ``(event, byte_offset, next_offset, line_no)`` from a JSONL file."""
+def _iter_jsonl_records_with_offsets(path: Path) -> Iterable[tuple[dict, int, int, int]]:
+    """Yield ``(record, byte_offset, next_offset, line_no)`` from a JSONL file."""
     with open(path, "rb") as f:
         line_no = 0
         while True:
@@ -333,11 +509,125 @@ def _iter_jsonl_events_with_offsets(path: Path) -> Iterable[tuple[dict, int, int
             if not stripped:
                 continue
             try:
-                event = json.loads(stripped.decode("utf-8"))
+                record = json.loads(stripped.decode("utf-8"))
             except (json.JSONDecodeError, UnicodeDecodeError):
                 continue
-            if isinstance(event, dict):
-                yield event, offset, next_offset, line_no
+            if isinstance(record, dict):
+                yield record, offset, next_offset, line_no
+
+
+# Backward-compatible name used by older callers/tests.
+_iter_jsonl_events_with_offsets = _iter_jsonl_records_with_offsets
+
+
+def _classify_trace_source(agent_dir: Path, source: Path) -> tuple[str, str, str | None]:
+    try:
+        rel = source.resolve().relative_to(agent_dir.resolve())
+        parts = rel.parts
+    except ValueError:
+        parts = source.parts
+    if parts == ("logs", DEFAULT_JSONL_NAME):
+        return "agent_events", "agent", None
+    if parts == ("history", "chat_history.jsonl"):
+        return "agent_chat", "agent", None
+    if parts == ("history", "chat_history_archive.jsonl"):
+        return "agent_chat_archive", "agent", None
+    if len(parts) >= 4 and parts[0] == "daemons":
+        run_id = parts[1]
+        if parts[-2:] == ("logs", DEFAULT_JSONL_NAME):
+            return "daemon_events", "daemon", run_id
+        if parts[-2:] == ("history", "chat_history.jsonl"):
+            return "daemon_chat", "daemon", run_id
+    if source.name in {DEFAULT_JSONL_NAME, "event.jsonl"}:
+        return "events", "unknown", None
+    return "chat", "unknown", None
+
+
+def _discover_trace_sources(agent_dir: Path, jsonl_path: Path | None = None) -> list[Path]:
+    if jsonl_path is not None:
+        if not jsonl_path.is_file():
+            raise FileNotFoundError(f"events JSONL not found: {jsonl_path}")
+        return [jsonl_path]
+    candidates = [
+        agent_dir / "logs" / DEFAULT_JSONL_NAME,
+        agent_dir / "history" / "chat_history.jsonl",
+        agent_dir / "history" / "chat_history_archive.jsonl",
+    ]
+    daemons_dir = agent_dir / "daemons"
+    if daemons_dir.is_dir():
+        candidates.extend(sorted(daemons_dir.glob("*/logs/events.jsonl")))
+        candidates.extend(sorted(daemons_dir.glob("*/history/chat_history.jsonl")))
+    return [path.resolve() for path in candidates if path.is_file()]
+
+
+def _import_events_source(
+    conn: sqlite3.Connection,
+    source: Path,
+    *,
+    source_kind: str,
+    scope: str,
+    run_id: str | None,
+) -> tuple[int, int, int]:
+    count = 0
+    last_offset = 0
+    last_line = 0
+    for event, offset, next_offset, line_no in _iter_jsonl_records_with_offsets(source):
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO events(
+                ts, type, agent_address, agent_name_snapshot, fields_json,
+                source_file, source_offset, source_line, source_kind, scope, run_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            SQLiteEventIndex.event_row(
+                event,
+                source_file=str(source),
+                source_offset=offset,
+                source_line=line_no,
+                source_kind=source_kind,
+                scope=scope,
+                run_id=run_id,
+            ),
+        )
+        count += 1
+        last_offset = next_offset
+        last_line = line_no
+    return count, last_offset, last_line
+
+
+def _import_chat_source(
+    conn: sqlite3.Connection,
+    source: Path,
+    *,
+    source_kind: str,
+    scope: str,
+    run_id: str | None,
+) -> tuple[int, int, int]:
+    count = 0
+    last_offset = 0
+    last_line = 0
+    for entry, offset, next_offset, line_no in _iter_jsonl_records_with_offsets(source):
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO chat_entries(
+                ts, ts_text, role, kind, turn, content_text, entry_json,
+                source_file, source_offset, source_line, source_kind, scope, run_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            SQLiteEventIndex.chat_entry_row(
+                entry,
+                source_file=str(source),
+                source_offset=offset,
+                source_line=line_no,
+                source_kind=source_kind,
+                scope=scope,
+                run_id=run_id,
+            ),
+        )
+        count += 1
+        last_offset = next_offset
+        last_line = line_no
+    return count, last_offset, last_line
 
 
 def rebuild_sqlite_event_index(
@@ -346,15 +636,16 @@ def rebuild_sqlite_event_index(
     jsonl_path: Path | str | None = None,
     sqlite_path: Path | str | None = None,
 ) -> dict[str, Any]:
-    """Rebuild ``logs/log.sqlite`` from ``logs/events.jsonl`` atomically."""
+    """Rebuild ``logs/log.sqlite`` from agent trace JSONL sources atomically."""
     agent_dir = Path(agent_dir).resolve()
     logs_dir = agent_dir / "logs"
-    source = Path(jsonl_path).resolve() if jsonl_path is not None else (logs_dir / DEFAULT_JSONL_NAME).resolve()
+    explicit_source = Path(jsonl_path).resolve() if jsonl_path is not None else None
     target = Path(sqlite_path).resolve() if sqlite_path is not None else (logs_dir / DEFAULT_SQLITE_NAME).resolve()
     if not agent_dir.is_dir():
         raise FileNotFoundError(f"agent directory not found: {agent_dir}")
-    if not source.is_file():
-        raise FileNotFoundError(f"events JSONL not found: {source}")
+    sources = _discover_trace_sources(agent_dir, explicit_source)
+    if not sources:
+        raise FileNotFoundError(f"no trace JSONL sources found under: {agent_dir}")
 
     workdir_lock = None
     lock_owner = agent_dir
@@ -370,7 +661,12 @@ def rebuild_sqlite_event_index(
     target.parent.mkdir(parents=True, exist_ok=True)
     tmp_dir = Path(tempfile.mkdtemp(prefix="log-sqlite-rebuild-", dir=str(target.parent)))
     tmp_db = tmp_dir / target.name
-    count = 0
+    event_count = 0
+    chat_entry_count = 0
+    cursor_count = 0
+    primary_source = explicit_source or (logs_dir / DEFAULT_JSONL_NAME).resolve()
+    primary_offset = 0
+    primary_line = 0
     last_offset = 0
     last_line = 0
     try:
@@ -378,26 +674,39 @@ def rebuild_sqlite_event_index(
         conn = index._ensure_open()
         with index._lock:
             conn.execute("BEGIN")
-            for event, offset, next_offset, line_no in _iter_jsonl_events_with_offsets(source):
+            for source in sources:
+                source_kind, scope, run_id = _classify_trace_source(agent_dir, source)
+                if source_kind.endswith("events") or source_kind == "events":
+                    count, offset, line = _import_events_source(
+                        conn,
+                        source,
+                        source_kind=source_kind,
+                        scope=scope,
+                        run_id=run_id,
+                    )
+                    event_count += count
+                else:
+                    count, offset, line = _import_chat_source(
+                        conn,
+                        source,
+                        source_kind=source_kind,
+                        scope=scope,
+                        run_id=run_id,
+                    )
+                    chat_entry_count += count
+                last_offset = offset
+                last_line = line
+                if source == primary_source:
+                    primary_offset = offset
+                    primary_line = line
                 conn.execute(
                     """
-                    INSERT OR IGNORE INTO events(
-                        ts, type, agent_address, agent_name_snapshot, fields_json,
-                        source_file, source_offset
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    INSERT OR REPLACE INTO import_cursors(source_file, byte_offset, line_no, updated_at)
+                    VALUES (?, ?, ?, ?)
                     """,
-                    SQLiteEventIndex.event_row(event, source_file=str(source), source_offset=offset),
+                    (str(source), offset, line, _utc_now()),
                 )
-                count += 1
-                last_offset = next_offset
-                last_line = line_no
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO import_cursors(source_file, byte_offset, line_no, updated_at)
-                VALUES (?, ?, ?, ?)
-                """,
-                (str(source), last_offset, last_line, _utc_now()),
-            )
+                cursor_count += 1
             conn.commit()
             integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
             conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
@@ -409,7 +718,17 @@ def rebuild_sqlite_event_index(
             if sidecar.exists():
                 sidecar.unlink()
         tmp_db.replace(target)
-        return {"status": "ok", "source": str(source), "target": str(target), "event_count": count, "line_no": last_line, "byte_offset": last_offset}
+        return {
+            "status": "ok",
+            "source": str(primary_source if primary_source.is_file() else sources[0]),
+            "target": str(target),
+            "event_count": event_count,
+            "chat_entry_count": chat_entry_count,
+            "source_count": len(sources),
+            "cursor_count": cursor_count,
+            "line_no": primary_line or last_line,
+            "byte_offset": primary_offset or last_offset,
+        }
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
         if workdir_lock is not None:

--- a/src/lingtai_kernel/services/logging.py
+++ b/src/lingtai_kernel/services/logging.py
@@ -62,14 +62,29 @@ def _extract_content_text(value: Any) -> str | None:
                 parts.append(text)
         return "\n".join(parts) if parts else None
     if isinstance(value, dict):
-        if isinstance(value.get("text"), str):
-            return value["text"]
-        if isinstance(value.get("content"), str):
-            return value["content"]
-        nested = _extract_content_text(value.get("content"))
-        if nested:
-            return nested
-        return None
+        block_type = value.get("type")
+        if block_type == "tool_call":
+            parts = ["tool_call"]
+            if value.get("name") is not None:
+                parts.append(str(value["name"]))
+            if value.get("args") is not None:
+                parts.append(json.dumps(value["args"], ensure_ascii=False, default=str))
+            return " ".join(parts)
+        if block_type == "tool_result":
+            parts = ["tool_result"]
+            if value.get("name") is not None:
+                parts.append(str(value["name"]))
+            nested = _extract_content_text(value.get("content"))
+            if nested:
+                parts.append(nested)
+            return " ".join(parts)
+
+        parts: list[str] = []
+        for key in ("text", "content", "system"):
+            nested = _extract_content_text(value.get(key))
+            if nested:
+                parts.append(nested)
+        return "\n".join(parts) if parts else None
     return str(value)
 
 
@@ -363,11 +378,16 @@ class SQLiteEventIndex:
             turn = int(turn_raw) if turn_raw is not None else None
         except (TypeError, ValueError):
             turn = None
-        raw_ts = entry.get("ts") or entry.get("timestamp")
+        if "ts" in entry:
+            raw_ts = entry.get("ts")
+        else:
+            raw_ts = entry.get("timestamp")
         ts, _ = _coerce_ts(raw_ts)
         content_text = _extract_content_text(entry.get("text"))
-        if content_text is None:
+        if not content_text:
             content_text = _extract_content_text(entry.get("content"))
+        if not content_text:
+            content_text = _extract_content_text(entry.get("system"))
         return (
             ts,
             str(raw_ts) if raw_ts is not None else None,
@@ -572,7 +592,7 @@ def _import_events_source(
     last_offset = 0
     last_line = 0
     for event, offset, next_offset, line_no in _iter_jsonl_records_with_offsets(source):
-        conn.execute(
+        cur = conn.execute(
             """
             INSERT OR IGNORE INTO events(
                 ts, type, agent_address, agent_name_snapshot, fields_json,
@@ -589,7 +609,7 @@ def _import_events_source(
                 run_id=run_id,
             ),
         )
-        count += 1
+        count += max(cur.rowcount, 0)
         last_offset = next_offset
         last_line = line_no
     return count, last_offset, last_line
@@ -607,7 +627,7 @@ def _import_chat_source(
     last_offset = 0
     last_line = 0
     for entry, offset, next_offset, line_no in _iter_jsonl_records_with_offsets(source):
-        conn.execute(
+        cur = conn.execute(
             """
             INSERT OR IGNORE INTO chat_entries(
                 ts, ts_text, role, kind, turn, content_text, entry_json,
@@ -624,7 +644,7 @@ def _import_chat_source(
                 run_id=run_id,
             ),
         )
-        count += 1
+        count += max(cur.rowcount, 0)
         last_offset = next_offset
         last_line = line_no
     return count, last_offset, last_line

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -338,6 +338,7 @@ def test_log_rebuild_doctor_query_cli(tmp_path, capsys):
         main()
         doctor_out = json.loads(capsys.readouterr().out)
         assert doctor_out["event_count"] == 1
+        assert doctor_out["chat_entry_count"] == 0
 
         sys.argv = ["lingtai-agent", "log", "query", str(tmp_path), "SELECT type FROM events"]
         main()

--- a/tests/test_services_logging.py
+++ b/tests/test_services_logging.py
@@ -1,5 +1,6 @@
 """Tests for lingtai.services.logging."""
 import json
+import sqlite3
 import threading
 from pathlib import Path
 
@@ -320,6 +321,9 @@ class TestSQLiteEventIndex:
         doctor = doctor_sqlite_event_index(tmp_path)
         assert doctor["status"] == "ok"
         assert doctor["event_count"] == 2
+        assert doctor["chat_entry_count"] == 0
+        assert doctor["schema_current"] is True
+        assert 2 in doctor["schema_versions"]
 
         rows = query_sqlite_event_index(tmp_path, "SELECT type, agent_address, agent_name_snapshot, json_extract(fields_json, '$.x') AS x FROM events ORDER BY ts")
         assert rows == [
@@ -417,6 +421,86 @@ class TestSQLiteEventIndex:
         except FileNotFoundError as exc:
             assert "agent directory not found" in str(exc)
         assert not missing.exists()
+
+    def test_rebuild_indexes_chat_history_and_daemon_jsonl_sources(self, tmp_path):
+        logs = tmp_path / "logs"
+        history = tmp_path / "history"
+        daemon_logs = tmp_path / "daemons" / "em-1-20260531-030000-abcdef" / "logs"
+        daemon_history = tmp_path / "daemons" / "em-1-20260531-030000-abcdef" / "history"
+        logs.mkdir(parents=True)
+        history.mkdir()
+        daemon_logs.mkdir(parents=True)
+        daemon_history.mkdir()
+        (logs / "events.jsonl").write_text(json.dumps({"type": "agent_event", "ts": 1}) + "\n", encoding="utf-8")
+        (history / "chat_history.jsonl").write_text(
+            json.dumps({"role": "user", "content": [{"type": "text", "text": "hello agent"}], "ts": "2026-05-31T03:00:00Z"}) + "\n",
+            encoding="utf-8",
+        )
+        (history / "chat_history_archive.jsonl").write_text(
+            json.dumps({"role": "assistant", "text": "archived reply", "ts": "2026-05-31T03:01:00Z"}) + "\n",
+            encoding="utf-8",
+        )
+        (daemon_logs / "events.jsonl").write_text(json.dumps({"event": "tool_call", "name": "bash", "ts": "2026-05-31T03:02:00Z"}) + "\n", encoding="utf-8")
+        (daemon_history / "chat_history.jsonl").write_text(
+            json.dumps({"role": "assistant", "text": "daemon answer", "turn": 1, "ts": "2026-05-31T03:03:00Z"}) + "\n",
+            encoding="utf-8",
+        )
+
+        result = rebuild_sqlite_event_index(tmp_path)
+        assert result["event_count"] == 2
+        assert result["chat_entry_count"] == 3
+        assert result["source_count"] == 5
+
+        event_rows = query_sqlite_event_index(tmp_path, "SELECT type, source_kind, scope, run_id FROM events ORDER BY id")
+        assert event_rows == [
+            {"type": "agent_event", "source_kind": "agent_events", "scope": "agent", "run_id": None},
+            {"type": "tool_call", "source_kind": "daemon_events", "scope": "daemon", "run_id": "em-1-20260531-030000-abcdef"},
+        ]
+        chat_rows = query_sqlite_event_index(
+            tmp_path,
+            "SELECT role, kind, turn, content_text, source_kind, scope, run_id FROM chat_entries ORDER BY id",
+        )
+        assert chat_rows == [
+            {"role": "user", "kind": None, "turn": None, "content_text": "hello agent", "source_kind": "agent_chat", "scope": "agent", "run_id": None},
+            {"role": "assistant", "kind": None, "turn": None, "content_text": "archived reply", "source_kind": "agent_chat_archive", "scope": "agent", "run_id": None},
+            {"role": "assistant", "kind": None, "turn": 1, "content_text": "daemon answer", "source_kind": "daemon_chat", "scope": "daemon", "run_id": "em-1-20260531-030000-abcdef"},
+        ]
+
+    def test_existing_v1_sidecar_migrates_to_trace_schema(self, tmp_path):
+        sqlite_file = tmp_path / "logs" / "log.sqlite"
+        sqlite_file.parent.mkdir()
+        conn = sqlite3.connect(sqlite_file)
+        conn.executescript(
+            """
+            CREATE TABLE schema_migrations(version INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at TEXT NOT NULL);
+            CREATE TABLE import_cursors(source_file TEXT PRIMARY KEY, byte_offset INTEGER NOT NULL DEFAULT 0, line_no INTEGER NOT NULL DEFAULT 0, updated_at TEXT NOT NULL);
+            CREATE TABLE events(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              ts REAL NOT NULL,
+              type TEXT NOT NULL,
+              agent_address TEXT,
+              agent_name_snapshot TEXT,
+              fields_json TEXT NOT NULL,
+              source_file TEXT,
+              source_offset INTEGER,
+              inserted_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            );
+            INSERT INTO schema_migrations(version, name, applied_at) VALUES (1, 'initial_events_index', 'now');
+            INSERT INTO events(ts, type, fields_json) VALUES (1, 'old', '{}');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        index = SQLiteEventIndex(sqlite_file)
+        index.close()
+
+        doctor = doctor_sqlite_event_index(tmp_path)
+        assert doctor["schema_current"] is True
+        assert 2 in doctor["schema_versions"]
+        rows = query_sqlite_event_index(tmp_path, "SELECT type, source_kind FROM events")
+        assert rows == [{"type": "old", "source_kind": None}]
+        assert query_sqlite_event_index(tmp_path, "SELECT COUNT(*) AS n FROM chat_entries") == [{"n": 0}]
 
     def test_rebuild_preserves_runtime_rows_without_duplicates(self, tmp_path):
         log_file = tmp_path / "logs" / "events.jsonl"

--- a/tests/test_services_logging.py
+++ b/tests/test_services_logging.py
@@ -466,6 +466,47 @@ class TestSQLiteEventIndex:
             {"role": "assistant", "kind": None, "turn": 1, "content_text": "daemon answer", "source_kind": "daemon_chat", "scope": "daemon", "run_id": "em-1-20260531-030000-abcdef"},
         ]
 
+    def test_rebuild_indexes_canonical_chat_history_shapes(self, tmp_path):
+        history = tmp_path / "history"
+        history.mkdir()
+        rows = [
+            {"role": "system", "system": "system prompt text", "timestamp": 0},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_call", "id": "tc-1", "name": "bash", "args": {"command": "echo hi"}},
+                    {"type": "tool_result", "id": "tc-1", "name": "bash", "content": {"stdout": "hi"}},
+                ],
+                "timestamp": 0,
+            },
+        ]
+        (history / "chat_history.jsonl").write_text(
+            "".join(json.dumps(row) + "\n" for row in rows),
+            encoding="utf-8",
+        )
+
+        result = rebuild_sqlite_event_index(tmp_path)
+        assert result["event_count"] == 0
+        assert result["chat_entry_count"] == 2
+
+        chat_rows = query_sqlite_event_index(
+            tmp_path,
+            "SELECT role, ts, ts_text, content_text FROM chat_entries ORDER BY id",
+        )
+        assert chat_rows[0] == {
+            "role": "system",
+            "ts": 0.0,
+            "ts_text": "0",
+            "content_text": "system prompt text",
+        }
+        assert chat_rows[1]["role"] == "assistant"
+        assert chat_rows[1]["ts"] == 0.0
+        assert chat_rows[1]["ts_text"] == "0"
+        assert "tool_call bash" in chat_rows[1]["content_text"]
+        assert "echo hi" in chat_rows[1]["content_text"]
+        assert "tool_result bash" in chat_rows[1]["content_text"]
+        assert "hi" in chat_rows[1]["content_text"]
+
     def test_existing_v1_sidecar_migrates_to_trace_schema(self, tmp_path):
         sqlite_file = tmp_path / "logs" / "log.sqlite"
         sqlite_file.parent.mkdir()


### PR DESCRIPTION
## Summary
- extend the additive SQLite sidecar to schema v2 with trace provenance columns and a new chat_entries table
- make offline log rebuild scan agent chat history/archive plus daemon events and daemon chat JSONL into logs/log.sqlite
- document the expanded trace schema/query recipes and update services anatomy

## Tests
- python -m pytest tests/test_services_logging.py tests/test_cli.py tests/test_daemon_run_dir.py tests/test_skills.py tests/test_base_agent.py tests/test_agent.py -q
- git diff --check