### PR TITLE
Migrate legacy init procedures overrides

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -852,6 +852,8 @@ class Agent(BaseAgent):
             self._log("refresh_init_error", error="failed to read init.json")
             return None
 
+        self._migrate_init_procedures_override(data, init_path)
+
         # Materialize active preset, if any, BEFORE validation so the manifest
         # the schema validates is the fully-resolved one the agent will run on.
         try:
@@ -891,6 +893,78 @@ class Agent(BaseAgent):
 
         resolve_paths(data, self._working_dir)
         return data
+
+    def _migrate_init_procedures_override(self, data: dict, init_path: Path) -> None:
+        """Archive and remove legacy top-level ``procedures`` overrides.
+
+        ``procedures.md`` is kernel-owned now. A legacy non-empty
+        ``init.json.procedures`` value is preserved under ``system/migrations``
+        but is never used for prompt construction.
+        """
+        if "procedures" not in data:
+            return
+
+        legacy = data.get("procedures")
+        should_archive = isinstance(legacy, str) and legacy != ""
+        archive_rel: str | None = None
+        content_hash: str | None = None
+        byte_length = 0
+        char_length = 0
+
+        if should_archive:
+            import hashlib
+
+            raw = legacy.encode("utf-8")
+            content_hash = hashlib.sha256(raw).hexdigest()
+            byte_length = len(raw)
+            char_length = len(legacy)
+            migrations_dir = self._working_dir / "system" / "migrations"
+            archive_path = migrations_dir / f"init-procedures-{content_hash}.md"
+            try:
+                migrations_dir.mkdir(parents=True, exist_ok=True)
+                archive_path.write_text(legacy, encoding="utf-8")
+                archive_rel = archive_path.relative_to(self._working_dir).as_posix()
+            except OSError as e:
+                self._log(
+                    "init_procedures_override_migration_failed",
+                    reason=str(e),
+                    content_hash=content_hash,
+                    byte_length=byte_length,
+                    char_length=char_length,
+                )
+                return
+
+        data.pop("procedures", None)
+        try:
+            import json
+            import os
+
+            tmp = init_path.with_suffix(".json.tmp")
+            tmp.write_text(
+                json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            os.replace(str(tmp), str(init_path))
+        except OSError as e:
+            self._log(
+                "init_procedures_override_migration_failed",
+                reason=str(e),
+                archive_path=archive_rel,
+                content_hash=content_hash,
+                byte_length=byte_length,
+                char_length=char_length,
+            )
+            return
+
+        if should_archive:
+            self._log(
+                "init_procedures_override_migrated",
+                archive_path=archive_rel,
+                content_hash=content_hash,
+                byte_length=byte_length,
+                char_length=char_length,
+                field_removed=True,
+            )
 
     def _activate_preset(self, name: str) -> None:
         """Substitute a preset's llm + capabilities into init.json on disk.
@@ -995,7 +1069,7 @@ class Agent(BaseAgent):
         # Resolve *_file fields for top-level text content.
         # Note: "soul" / "soul_file" were retired in v0.7.6 and are now
         # stripped by strip_deprecated() before we get here.
-        for key in ("covenant", "principle", "substrate", "procedures",
+        for key in ("covenant", "principle", "substrate",
                     "brief", "pad", "prompt", "comment"):
             file_key = f"{key}_file"
             if file_key in data:
@@ -1219,7 +1293,7 @@ class Agent(BaseAgent):
                 return
             # Resolve *_file fields (brief_file, covenant_file, etc.)
             from lingtai_kernel.config_resolve import resolve_file
-            for key in ("covenant", "principle", "substrate", "procedures",
+            for key in ("covenant", "principle", "substrate",
                         "brief", "pad", "comment"):
                 file_key = f"{key}_file"
                 if file_key in data:
@@ -1312,30 +1386,23 @@ class Agent(BaseAgent):
             self._prompt_manager.write_section("principle", principle, protected=True)
 
         # --- Procedures ---
-        # Resolution precedence (mirrors substrate above; issue #133):
-        #   1. data["procedures"]          — inline init.json string (operator override)
-        #   2. packaged prompts/procedures.md — kernel default, always wins on every boot
-        #   3. system/procedures.md        — fallback only if package missing
-        #
-        # The packaged default overwrites the on-disk file on every boot so
-        # that `pip install -e .` + `system(refresh)` actually propagates
-        # kernel updates. To opt out, set `"procedures": " "` (a single
-        # space, treated as an explicit operator value by step 1).
-        procedures = data.get("procedures", "")
+        # Kernel-owned resident procedures. Legacy init.json procedures values
+        # are migrated by _read_init() and ignored here; the packaged default
+        # wins on every boot/refresh. system/procedures.md is only a packaged
+        # mirror/debug artifact, and is read as fallback if the package
+        # resource is unavailable.
+        procedures = ""
         procedures_file = system_dir / "procedures.md"
-        if procedures:
-            procedures_file.write_text(procedures)
-        else:
-            try:
-                from importlib.resources import files
-                packaged = files("lingtai.prompts").joinpath("procedures.md").read_text(encoding="utf-8")
-                procedures_file.write_text(packaged)
-                procedures = packaged
-            except (FileNotFoundError, ModuleNotFoundError, OSError):
-                if procedures_file.is_file():
-                    procedures = procedures_file.read_text(encoding="utf-8")
-                else:
-                    procedures = ""
+        try:
+            from importlib.resources import files
+            packaged = files("lingtai.prompts").joinpath("procedures.md").read_text(encoding="utf-8")
+            procedures_file.write_text(packaged)
+            procedures = packaged
+        except (FileNotFoundError, ModuleNotFoundError, OSError):
+            if procedures_file.is_file():
+                procedures = procedures_file.read_text(encoding="utf-8")
+            else:
+                procedures = ""
         if procedures:
             self._prompt_manager.write_section("procedures", procedures, protected=True)
         else:

--- a/src/lingtai/core/avatar/__init__.py
+++ b/src/lingtai/core/avatar/__init__.py
@@ -319,7 +319,7 @@ class AvatarManager:
 
         # Resolve relative file paths to absolute so avatar can find them
         for key in ("env_file", "covenant_file", "principle_file",
-                    "substrate_file", "procedures_file", "comment_file"):
+                    "substrate_file", "comment_file"):
             val = parent_init.get(key)
             if val and not os.path.isabs(val):
                 resolved = parent._working_dir / val
@@ -503,6 +503,9 @@ class AvatarManager:
         # Brief is not inherited — avatars don't need life context
         init.pop("brief", None)
         init.pop("brief_file", None)
+        # Procedures are kernel-owned; legacy parent overrides are not inherited.
+        init.pop("procedures", None)
+        init.pop("procedures_file", None)
         # Addons (IMAP, Telegram) are not inherited — each agent must be
         # explicitly configured to avoid multiple agents polling the same account
         init.pop("addons", None)

--- a/tests/test_avatar_preset_inheritance.py
+++ b/tests/test_avatar_preset_inheritance.py
@@ -181,3 +181,16 @@ def test_avatar_strips_materialized_when_active_equals_default(tmp_path):
     assert avatar_preset["active"] == "deepseek"
     assert "llm" not in avatar_init["manifest"]
     assert "capabilities" not in avatar_init["manifest"]
+
+
+def test_avatar_init_drops_legacy_procedures_override(tmp_path):
+    """Avatar init construction must not copy retired procedures overrides."""
+    parent_init = _baseline_parent_init()
+    parent_init["procedures"] = "legacy parent procedures"
+    parent_init["procedures_file"] = "relative/procedures.md"
+
+    from lingtai.core.avatar import AvatarManager
+    avatar_init = AvatarManager._make_avatar_init(parent_init, "child")
+
+    assert "procedures" not in avatar_init
+    assert "procedures_file" not in avatar_init

--- a/tests/test_deep_refresh.py
+++ b/tests/test_deep_refresh.py
@@ -2,6 +2,7 @@
 """Tests for deep refresh (full agent reconstruct from init.json)."""
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -88,6 +89,28 @@ def _make_agent(tmp_path: Path, init_data: dict | None = None):
         config=AgentConfig(),
     )
     return agent
+
+
+def _packaged_procedures() -> str:
+    from importlib.resources import files
+
+    return files("lingtai.prompts").joinpath("procedures.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def _events(tmp_path: Path, event_type: str) -> list[dict]:
+    log_path = tmp_path / "logs" / "events.jsonl"
+    if not log_path.is_file():
+        return []
+    events = []
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        event = json.loads(line)
+        if event.get("type") == event_type:
+            events.append(event)
+    return events
 
 
 def test_deep_refresh_loads_new_capability(tmp_path):
@@ -258,6 +281,89 @@ def test_deep_refresh_reseals(tmp_path):
     agent._setup_from_init()
 
     assert agent._sealed is True
+
+
+def test_init_procedures_override_is_migrated_not_prompted(tmp_path):
+    """Legacy init.json procedures content is archived, removed, and ignored."""
+    legacy = "LEGACY-PROCEDURES-OVERRIDE"
+    init = _make_init()
+    init["procedures"] = legacy
+    agent = _make_agent(tmp_path, init)
+
+    agent._setup_from_init()
+
+    packaged = _packaged_procedures()
+    prompt = agent._prompt_manager.render()
+    assert legacy not in prompt
+    assert packaged in prompt
+    data = json.loads((tmp_path / "init.json").read_text(encoding="utf-8"))
+    assert "procedures" not in data
+
+    digest = hashlib.sha256(legacy.encode("utf-8")).hexdigest()
+    archive = tmp_path / "system" / "migrations" / f"init-procedures-{digest}.md"
+    assert archive.read_text(encoding="utf-8") == legacy
+
+    events = _events(tmp_path, "init_procedures_override_migrated")
+    assert len(events) == 1
+    event = events[0]
+    assert event["archive_path"] == f"system/migrations/init-procedures-{digest}.md"
+    assert event["content_hash"] == digest
+    assert event["byte_length"] == len(legacy.encode("utf-8"))
+    assert event["char_length"] == len(legacy)
+    assert event["field_removed"] is True
+
+    agent._setup_from_init()
+    archives = list((tmp_path / "system" / "migrations").glob("init-procedures-*.md"))
+    assert archives == [archive]
+    assert len(_events(tmp_path, "init_procedures_override_migrated")) == 1
+
+
+def test_single_space_procedures_no_longer_opts_out(tmp_path):
+    """A single-space legacy procedures value is migrated, not treated as opt-out."""
+    init = _make_init()
+    init["procedures"] = " "
+    agent = _make_agent(tmp_path, init)
+
+    agent._setup_from_init()
+
+    packaged = _packaged_procedures()
+    procedures = agent._prompt_manager.read_section("procedures") or ""
+    assert procedures == packaged
+    data = json.loads((tmp_path / "init.json").read_text(encoding="utf-8"))
+    assert "procedures" not in data
+
+    digest = hashlib.sha256(b" ").hexdigest()
+    archive = tmp_path / "system" / "migrations" / f"init-procedures-{digest}.md"
+    assert archive.read_text(encoding="utf-8") == " "
+
+
+def test_system_procedures_is_overwritten_by_packaged_default(tmp_path):
+    """Manual system/procedures.md edits are replaced by the packaged default."""
+    agent = _make_agent(tmp_path, _make_init())
+    system_dir = tmp_path / "system"
+    system_dir.mkdir(exist_ok=True)
+    (system_dir / "procedures.md").write_text("MANUAL-PROCEDURES-EDIT", encoding="utf-8")
+
+    agent._setup_from_init()
+
+    packaged = _packaged_procedures()
+    assert (system_dir / "procedures.md").read_text(encoding="utf-8") == packaged
+    assert agent._prompt_manager.read_section("procedures") == packaged
+
+
+def test_procedures_falls_back_to_system_file_when_packaged_missing(tmp_path):
+    """If the packaged default cannot be read, system/procedures.md is fallback."""
+    fallback = "FALLBACK-PROCEDURES"
+    agent = _make_agent(tmp_path, _make_init())
+    system_dir = tmp_path / "system"
+    system_dir.mkdir(exist_ok=True)
+    (system_dir / "procedures.md").write_text(fallback, encoding="utf-8")
+
+    with patch("importlib.resources.files", side_effect=FileNotFoundError):
+        agent._setup_from_init()
+
+    assert agent._prompt_manager.read_section("procedures") == fallback
+    assert (system_dir / "procedures.md").read_text(encoding="utf-8") == fallback
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- migrate legacy non-empty `init.json.procedures` values into `system/migrations/init-procedures-<sha256>.md`
- remove the legacy `procedures` field from `init.json` during migration and keep packaged `lingtai.prompts/procedures.md` as the prompt source
- stop avatar init construction from carrying `procedures` / `procedures_file` into child agents
- add regression coverage for archive/log/key removal, single-space opt-out removal, packaged overwrite, fallback, and avatar inheritance

Fixes #210.

## Validation
- `PYTHONPATH=src python3 -m py_compile src/lingtai/agent.py src/lingtai/core/avatar/__init__.py tests/test_deep_refresh.py tests/test_avatar_preset_inheritance.py`
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/pytest -q tests/test_deep_refresh.py tests/test_avatar_preset_inheritance.py` → 26 passed
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/pytest -q tests/test_init_schema.py tests/test_avatar_rules.py` → 85 passed
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/pytest -q tests/test_agent_preset_manifest.py tests/test_activate_preset.py` → 26 passed
- `git diff --check`

## Notes
- Codex implemented the patch after an initial read-only sandbox attempt; full transcripts are in `reports/codex-implementation-issue210.txt` and `reports/codex-implementation-issue210-retry.txt` in the local worktree.
