### PR TITLE
Document init migration conventions

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -14,19 +14,19 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 | `cli.py` | `lingtai-agent run <dir>` / `lingtai-agent check-caps` entry points |
 | `network.py` | Read-only network topology crawler — avatar/contact/mail edge discovery |
 | `presets.py` | Compatibility shim re-exporting the kernel preset library (`lingtai_kernel.presets`) |
-| `init_schema.py` | `validate_init()` — strict schema for init.json |
+| `init_schema.py` | `validate_init()` plus `strip_deprecated()` — strict schema for active init.json fields, simple deprecated-field cleanup, and known-but-inactive legacy fields migrated by `lingtai_kernel.migrate` |
 | `venv_resolve.py` | Python venv resolution — init.json → global runtime → auto-create |
 | `intrinsic_skills/__init__.py` | Standalone skill bundles (docs-only) copied into `.library/intrinsic/` |
 
 ### Key functions / classes
 
-**`agent.py`** — `Agent(BaseAgent)`: `__init__` :33 (accept `capabilities=` + `disable=`, expand groups, `apply_core_defaults`, decompress addons, setup caps, install manuals, load MCP) · `_setup_capability` :148 · `_persist_llm_config` :123 · `_install_intrinsic_manuals` :170 · `_load_mcp_from_workdir` :372 (also tracks specs in `_mcp_init_specs`) · `_retry_failed_mcps` :520 (re-spawn dead MCPs on `system(refresh)` — issue #34) · `_read_init` :829 (read + materialize preset + validate) · `_setup_from_init` :965 (**full reconstruct** — shared by boot and live refresh; reads `manifest.disable` and re-applies `apply_core_defaults`) · `_activate_preset` :891 (runtime swap, atomic write) · `_reload_prompt_sections` :1205 (writes `covenant`/`substrate`/`rules`/`principle`/`procedures`/`brief`/`comment`; delegates `character` to `_lingtai_load` and `pad` to `_pad_load` — the canonical composers — so boot/refresh/molt are consistent and hook-order-independent) · `connect_mcp` :700 / `connect_mcp_http` :752 · `start` :693 / `stop` :798
+**`agent.py`** — `Agent(BaseAgent)`: `__init__` :33 (accept `capabilities=` + `disable=`, expand groups, `apply_core_defaults`, decompress addons, setup caps, install manuals, load MCP) · `_setup_capability` :148 · `_persist_llm_config` :127 · `_install_intrinsic_manuals` :174 · `_load_mcp_from_workdir` :376 (also tracks specs in `_mcp_init_specs`) · `_retry_failed_mcps` :524 (re-spawn dead MCPs on `system(refresh)` — issue #34) · `_read_init` :833 (runs `lingtai_kernel.migrate.run_agent_migrations()` before reading `init.json`, then materializes preset, strips plain deprecated fields, validates, and resolves paths) · `_setup_from_init` :967 (**full reconstruct** — shared by boot and live refresh; reads `manifest.disable` and re-applies `apply_core_defaults`) · `_activate_preset` :897 (runtime swap, atomic write) · `_reload_prompt_sections` :1342 (writes `covenant`/`substrate`/`rules`/`principle`/`procedures`/`brief`/`comment`; delegates `character` to `_lingtai_load` and `pad` to `_pad_load` — the canonical composers — so boot/refresh/molt are consistent and hook-order-independent) · `connect_mcp` :704 / `connect_mcp_http` :756 · `start` :697 / `stop` :802
 
 **`cli.py`**: `load_init` :21 · `build_agent` :72 · `run` :200 · `main` :246
 
 **`presets.py`**: compatibility re-export shim (`presets.py:1-21`); implementation lives in `lingtai_kernel.presets` (`load_preset` :175 · `materialize_active_preset` :290 · `expand_inherit` :444 · `discover_presets_in_dirs` :121).
 
-**`init_schema.py`**: `validate_init` :85 · `TOP_OPTIONAL` :13 · `MANIFEST_OPTIONAL` :42
+**`init_schema.py`**: `DEPRECATED_TOP_FIELDS` :28 (plain deprecated top-level fields stripped by `strip_deprecated`), `LEGACY_MIGRATED_TOP_FIELDS` :38 (legacy fields removed by version-controlled agent migrations and known only as inactive schema), `validate_init` :98, `TOP_OPTIONAL` :13, `MANIFEST_OPTIONAL` :59.
 
 **`network.py`**: `build_network` :306 · `_discover_agents` :143 · `_build_avatar_edges` :168
 
@@ -38,7 +38,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **Inbound:** `lingtai-tui` calls `cli.run()` to boot agents; imports `load_preset`, `discover_presets_in_dirs` for UI. Kernel's `BaseAgent` is the parent class.
 
-**Outbound — kernel:** `lingtai_kernel.base_agent.BaseAgent`, `.config.AgentConfig`, `.prompt.build_system_prompt`, `.handshake.resolve_address`, `.intrinsics.{email,psyche}`, `.services.mail.FilesystemMailService`, `.migrate.run_migrations`.
+**Outbound — kernel:** `lingtai_kernel.base_agent.BaseAgent`, `.config.AgentConfig`, `.prompt.build_system_prompt`, `.handshake.resolve_address`, `.intrinsics.{email,psyche}`, `.services.mail.FilesystemMailService`, `.migrate.run_migrations` (preset libraries) and `.migrate.run_agent_migrations` (agent workdir/init migrations; see `../lingtai_kernel/migrate/ANATOMY.md`).
 
 **Cross-module:** `agent.py` → `capabilities.setup_capability`, `core.mcp.{decompress_addons,read_registry,MCPInboxPoller}`, `services.mcp.{MCPClient,HTTPMCPClient}`, `llm.service.LLMService`, `presets`, `lingtai_kernel.config_resolve`, `init_schema`. `cli.py` → `agent.Agent`, `lingtai_kernel.config_resolve`, `presets`.
 
@@ -46,7 +46,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **Capability registration:** `setup_capability()` in `capabilities/__init__.py`; the registry is `_BUILTIN` (per-capability module paths) plus `CORE_DEFAULTS` (which boot automatically). Agent calls `apply_core_defaults` + `_setup_capability` (agent.py:148) during `__init__` and `_setup_from_init`. Hosts disable defaults via the `disable=[...]` kwarg or `manifest.disable` in init.json.
 
-**Preset materialization:** `materialize_active_preset` (`lingtai_kernel/presets.py:290`) called by `cli.load_init` (boot) and `Agent._read_init` (refresh). Reads `manifest.preset.active`, loads preset, substitutes `llm`+`capabilities` into manifest before validation.
+**Agent init migration + preset materialization:** `run_agent_migrations` (`lingtai_kernel/migrate/migrate.py:285`) is called by `cli.load_init` (boot) and `Agent._read_init` (refresh) before `init.json` is read/validated. Then `materialize_active_preset` (`lingtai_kernel/presets.py:290`) reads `manifest.preset.active`, loads preset, substitutes `llm`+`capabilities` into manifest before validation.
 
 ## Composition
 
@@ -56,20 +56,21 @@ Parent: `src/lingtai/` under `lingtai-kernel/src/` alongside `lingtai_kernel/` (
 
 | Path | When | What |
 |---|---|---|
-| `<workdir>/init.json` | `_activate_preset` :880, `cli.run` :200 | Preset swap (atomic write); venv_path writeback |
+| `<workdir>/init.json` | `_activate_preset` :969, `cli.run` :200, `_read_init` :833 | Preset swap (atomic write); venv_path writeback; boot/refresh cleanup of deprecated top-level fields and archive-preserving init migrations |
 | `<workdir>/system/llm.json` | `_persist_llm_config` :111 | LLM provider/model/base_url for revive |
-| `<workdir>/system/{covenant,principle,substrate,procedures,brief,rules,pad,lingtai}.md` + `pad_append.json` | `_reload_prompt_sections` :1205 | Prompt sections from init.json + disk. `covenant.md`→`covenant`, `lingtai.md`→`character` (via `_lingtai_load`), `pad.md`+`pad_append.json`→`pad` (via `_pad_load`). `character` is the agent's self-authored identity (灵台), distinct from `covenant` (operator contract) and the mechanical `identity` section. `substrate` is kernel-owned, cross-app stable (issue #39); kept compact and routed to the packaged `system-manual` skill for expanded operating guidance; auto-seeded from packaged `lingtai/prompts/substrate.md` on first boot if neither `data["substrate"]` nor `system/substrate.md` provides content — see `_setup_from_init` :965. |
+| `<workdir>/system/{covenant,principle,substrate,procedures,brief,rules,pad,lingtai}.md` + `pad_append.json` | `_reload_prompt_sections` :1283 | Prompt sections from init.json + disk. `covenant.md`→`covenant`, `lingtai.md`→`character` (via `_lingtai_load`), `pad.md`+`pad_append.json`→`pad` (via `_pad_load`). `character` is the agent's self-authored identity (灵台), distinct from `covenant` (operator contract) and the mechanical `identity` section. `substrate` is kernel-owned, cross-app stable (issue #39); kept compact and routed to the packaged `system-manual` skill for expanded operating guidance; auto-seeded from packaged `lingtai/prompts/substrate.md` on first boot if neither `data["substrate"]` nor `system/substrate.md` provides content — see `_setup_from_init` :1043. |
 | `<workdir>/.library/intrinsic/` | `_install_intrinsic_manuals` :158 | Wipe-and-rewrite every boot |
-| `<workdir>/.agent.json` | `_build_manifest` :246 via `_workdir.write_manifest` | Runtime manifest snapshot. Includes sanitized `llm` (provider/model/base_url) from the live LLMService and `preset` (active/default/allowed) read from `init.json` by `_read_preset_from_init` :284 — see issue #78. |
+| `<workdir>/.agent.json` | `_build_manifest` :250 via `_workdir.write_manifest` | Runtime manifest snapshot. Includes sanitized `llm` (provider/model/base_url) from the live LLMService and `preset` (active/default/allowed) read from `init.json` by `_read_preset_from_init` :288 — see issue #78. |
 | `<workdir>/.mcp_inbox/` | MCPInboxPoller (started at :761) | LICC events from out-of-process MCPs |
 
 ## Notes
 
-- **Boot vs refresh share one code path:** `cli.build_agent` constructs minimal `Agent`, calls `_setup_from_init()` :954. Live refresh re-enters the same method.
-- **`materialize_active_preset` is pure dict mutation** — disk write only in `_activate_preset` :880 (atomic `.tmp` → replace).
+- **Boot vs refresh share one code path:** `cli.build_agent` constructs minimal `Agent`, calls `_setup_from_init()` :1043. Live refresh re-enters the same method.
+- **Migration discipline:** `lingtai_kernel.migrate` is the kernel's version-controlled migration system for both preset-library and agent-workdir domains (`../lingtai_kernel/migrate/ANATOMY.md:5`). If an `init.json` or other workdir-local on-disk shape changes, add an agent-domain migration there and call/keep `run_agent_migrations()` before validation; do not add ad-hoc one-off helpers in `Agent._read_init()`. Use `init_schema.strip_deprecated()` only for simple discard-only fields that do not need archive/event/version tracking (`init_schema.py:82`). Keep migration tests in `tests/test_kernel_migrate.py` plus boot/refresh coverage in `tests/test_deep_refresh.py` / `tests/test_cli.py`, and update anatomy in the same PR.
+- **`materialize_active_preset` is pure dict mutation** — disk write only in `_activate_preset` :969 (atomic `.tmp` → replace).
 - **Preset implementation moved to kernel** — wrapper `presets.py` re-exports `lingtai_kernel.presets`; preset validation normalizes legacy shapes via kernel migrations before type-checking.
-- **Sensitive key stripping (capabilities):** `_build_manifest` :246 strips `api_key`, `api_key_env`, `api_secret`, `token`, `password` (`_SENSITIVE_KEYS`) from capability kwargs before writing `.agent.json`.
-- **LLM / preset safelists (issue #78):** `_build_manifest` :246 also re-applies `_LLM_PUBLIC_KEYS = ("provider", "model", "base_url", "api_compat", "context_limit")` to the kernel-supplied `llm` block as defense-in-depth, and reads `manifest.preset` from init.json via `_read_preset_from_init` :284 filtered to `_PRESET_PUBLIC_KEYS = ("active", "default", "allowed")`. Anything outside the safelists never reaches `.agent.json` or the identity prompt section. This is the central safety claim of #78 — see `tests/test_agent_preset_manifest.py::test_manifest_never_contains_api_key`.
-- **Drift hazard:** `_setup_from_init` :954 manually reconstructs `AgentConfig` with inline defaults that MUST mirror `lingtai_kernel.config.AgentConfig` (inline construction in `_setup_from_init`, nothing enforces).
-- **Addon decompression** runs BEFORE capability setup so `mcp` capability sees populated `mcp_registry.jsonl` on first reconcile (`Agent.__init__` :33, `_setup_from_init` :954).
-- **MCP retry contract (issue #34):** `_load_mcp_from_workdir` :360 records every registered init.json mcp entry into `self._mcp_init_specs` (name → `{cfg, source, client}`). `_retry_failed_mcps` :508 walks this dict, closes any dead client (`is_connected()` False), respawns with the original config, and reports `{retried, recovered, still_failed, healthy}`. `system(action="refresh")` calls it via `intrinsics/system/preset.py:_refresh` before `_perform_refresh` so the documented "fix config → refresh" recovery path works without full process restart.
+- **Sensitive key stripping (capabilities):** `_build_manifest` :250 strips `api_key`, `api_key_env`, `api_secret`, `token`, `password` (`_SENSITIVE_KEYS`) from capability kwargs before writing `.agent.json`.
+- **LLM / preset safelists (issue #78):** `_build_manifest` :250 also re-applies `_LLM_PUBLIC_KEYS = ("provider", "model", "base_url", "api_compat", "context_limit")` to the kernel-supplied `llm` block as defense-in-depth, and reads `manifest.preset` from init.json via `_read_preset_from_init` :288 filtered to `_PRESET_PUBLIC_KEYS = ("active", "default", "allowed")`. Anything outside the safelists never reaches `.agent.json` or the identity prompt section. This is the central safety claim of #78 — see `tests/test_agent_preset_manifest.py::test_manifest_never_contains_api_key`.
+- **Drift hazard:** `_setup_from_init` :1043 manually reconstructs `AgentConfig` with inline defaults that MUST mirror `lingtai_kernel.config.AgentConfig` (inline construction in `_setup_from_init`, nothing enforces).
+- **Addon decompression** runs BEFORE capability setup so `mcp` capability sees populated `mcp_registry.jsonl` on first reconcile (`Agent.__init__` :33, `_setup_from_init` :1043).
+- **MCP retry contract (issue #34):** `_load_mcp_from_workdir` :376 records every registered init.json mcp entry into `self._mcp_init_specs` (name → `{cfg, source, client}`). `_retry_failed_mcps` :524 walks this dict, closes any dead client (`is_connected()` False), respawns with the original config, and reports `{retried, recovered, still_failed, healthy}`. `system(action="refresh")` calls it via `intrinsics/system/preset.py:_refresh` before `_perform_refresh` so the documented "fix config → refresh" recovery path works without full process restart.

--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -840,7 +840,10 @@ class Agent(BaseAgent):
         import json
         from .init_schema import strip_deprecated, validate_init
         from lingtai_kernel.config_resolve import resolve_paths
+        from lingtai_kernel.migrate import run_agent_migrations
         from .presets import expand_inherit, materialize_active_preset
+
+        run_agent_migrations(self._working_dir)
 
         init_path = self._working_dir / "init.json"
         if not init_path.is_file():
@@ -851,8 +854,6 @@ class Agent(BaseAgent):
         except (json.JSONDecodeError, OSError, ValueError):
             self._log("refresh_init_error", error="failed to read init.json")
             return None
-
-        self._migrate_init_procedures_override(data, init_path)
 
         # Materialize active preset, if any, BEFORE validation so the manifest
         # the schema validates is the fully-resolved one the agent will run on.
@@ -893,78 +894,6 @@ class Agent(BaseAgent):
 
         resolve_paths(data, self._working_dir)
         return data
-
-    def _migrate_init_procedures_override(self, data: dict, init_path: Path) -> None:
-        """Archive and remove legacy top-level ``procedures`` overrides.
-
-        ``procedures.md`` is kernel-owned now. A legacy non-empty
-        ``init.json.procedures`` value is preserved under ``system/migrations``
-        but is never used for prompt construction.
-        """
-        if "procedures" not in data:
-            return
-
-        legacy = data.get("procedures")
-        should_archive = isinstance(legacy, str) and legacy != ""
-        archive_rel: str | None = None
-        content_hash: str | None = None
-        byte_length = 0
-        char_length = 0
-
-        if should_archive:
-            import hashlib
-
-            raw = legacy.encode("utf-8")
-            content_hash = hashlib.sha256(raw).hexdigest()
-            byte_length = len(raw)
-            char_length = len(legacy)
-            migrations_dir = self._working_dir / "system" / "migrations"
-            archive_path = migrations_dir / f"init-procedures-{content_hash}.md"
-            try:
-                migrations_dir.mkdir(parents=True, exist_ok=True)
-                archive_path.write_text(legacy, encoding="utf-8")
-                archive_rel = archive_path.relative_to(self._working_dir).as_posix()
-            except OSError as e:
-                self._log(
-                    "init_procedures_override_migration_failed",
-                    reason=str(e),
-                    content_hash=content_hash,
-                    byte_length=byte_length,
-                    char_length=char_length,
-                )
-                return
-
-        data.pop("procedures", None)
-        try:
-            import json
-            import os
-
-            tmp = init_path.with_suffix(".json.tmp")
-            tmp.write_text(
-                json.dumps(data, indent=2, ensure_ascii=False) + "\n",
-                encoding="utf-8",
-            )
-            os.replace(str(tmp), str(init_path))
-        except OSError as e:
-            self._log(
-                "init_procedures_override_migration_failed",
-                reason=str(e),
-                archive_path=archive_rel,
-                content_hash=content_hash,
-                byte_length=byte_length,
-                char_length=char_length,
-            )
-            return
-
-        if should_archive:
-            self._log(
-                "init_procedures_override_migrated",
-                archive_path=archive_rel,
-                content_hash=content_hash,
-                byte_length=byte_length,
-                char_length=char_length,
-                field_removed=True,
-            )
 
     def _activate_preset(self, name: str) -> None:
         """Substitute a preset's llm + capabilities into init.json on disk.

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -29,6 +29,10 @@ def load_init(working_dir: Path) -> dict:
     from lingtai_kernel.config_resolve import resolve_paths
     from lingtai.presets import materialize_active_preset
 
+    from lingtai_kernel.migrate import run_agent_migrations
+
+    run_agent_migrations(working_dir)
+
     init_path = working_dir / "init.json"
     if not init_path.is_file():
         print(f"error: {init_path} not found", file=sys.stderr)

--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -22,9 +22,11 @@ TOP_OPTIONAL: dict[str, type | tuple[type, ...]] = {
     "mcp": dict,
 }
 
-# Top-level fields that were retired in past versions. strip_deprecated()
-# removes them from the data dict (and optionally from disk) so they never
-# reach validate_init().
+# Top-level fields that were retired in past versions and still have simple
+# shape-only cleanup semantics. strip_deprecated() removes them from the data
+# dict (and optionally from disk) so they never reach validate_init(). Fields
+# that need archive/event/version tracking belong in lingtai_kernel.migrate
+# agent-domain migrations instead.
 DEPRECATED_TOP_FIELDS: set[str] = {
     # "soul" / "soul_file" — retired in v0.7.6. The soul-flow voice is
     # now owned by the agent via soul(action='voice') and stored under
@@ -32,14 +34,19 @@ DEPRECATED_TOP_FIELDS: set[str] = {
     "soul", "soul_file",
 }
 
+# Legacy fields removed by version-controlled agent-domain migrations. They are
+# known to validation only so stale/restored init.json files do not look like
+# active supported schema fields and do not get type-checked as prompt sections.
+LEGACY_MIGRATED_TOP_FIELDS: set[str] = {"procedures", "procedures_file"}
+
 TOP_KNOWN: set[str] = {
     "manifest", "env_file", "venv_path", "addons", "mcp",
     "principle", "principle_file", "covenant", "covenant_file",
     "substrate", "substrate_file",
-    "procedures", "procedures_file", "brief", "brief_file",
+    "brief", "brief_file",
     "pad", "pad_file", "prompt", "prompt_file",
     "comment", "comment_file",
-} | DEPRECATED_TOP_FIELDS
+} | DEPRECATED_TOP_FIELDS | LEGACY_MIGRATED_TOP_FIELDS
 
 MANIFEST_REQUIRED: dict[str, type | tuple[type, ...]] = {
     "llm": dict,
@@ -78,15 +85,6 @@ def strip_deprecated(data: dict) -> list[str]:
         if key in data:
             del data[key]
             removed.append(key)
-
-    # Migration: remove procedures_file if it points to the old
-    # ~/.lingtai-tui/procedures/procedures.md path.  The packaged
-    # default is now the sole source; the on-disk file was a stale
-    # leftover that overwrote the packaged default on every boot.
-    pf = data.get("procedures_file")
-    if isinstance(pf, str) and "procedures/procedures.md" in pf:
-        data.pop("procedures_file", None)
-        removed.append("procedures_file")
 
     if removed:
         log.debug("stripped deprecated init.json fields: %s", ", ".join(sorted(removed)))
@@ -127,7 +125,7 @@ def validate_init(data: dict) -> list[str]:
     # attention model). Injected between covenant and tools by the prompt
     # manager. See lingtai issue #39. Opt-in: agents without substrate
     # configured render the same prompt they did before.
-    for key in ("comment", "procedures", "brief", "substrate"):
+    for key in ("comment", "brief", "substrate"):
         file_key = f"{key}_file"
         if key in data and not isinstance(data[key], str):
             raise ValueError(f"{key}: expected str, got {type(data[key]).__name__}")

--- a/src/lingtai_kernel/ANATOMY.md
+++ b/src/lingtai_kernel/ANATOMY.md
@@ -172,7 +172,7 @@ This file is the top of the kernel anatomy tree. Each subfolder below has its ow
 - [`intrinsics/`](intrinsics/ANATOMY.md) — kernel-built-in tools. Four intrinsics: `system`, `psyche`, `soul`, `email`. Always present, never removable.
 - [`llm/`](llm/ANATOMY.md) — LLM service ABC, adapter registry, chat interface, streaming protocol. Provider adapters live in the wrapper package, not here.
 - [`services/`](services/ANATOMY.md) — kernel-side service implementations: filesystem mailbox (`mail.py`), JSONL event log plus additive SQLite query index (`logging.py`).
-- [`migrate/`](migrate/ANATOMY.md) — versioned, append-only migrations for kernel-managed on-disk state. Each migration is `m<NNN>_<name>.py`.
+- [`migrate/`](migrate/ANATOMY.md) — versioned, append-only migrations for kernel-managed on-disk state. Preset-domain migrations are `m<NNN>_<name>.py`; agent-workdir/init migrations are `agent_m<NNN>_<name>.py`.
 - [`i18n/`](i18n/ANATOMY.md) — three-locale message catalog (en / zh / wen). Loaded by `t(language, key)` in the intrinsics.
 
 ## State

--- a/src/lingtai_kernel/migrate/ANATOMY.md
+++ b/src/lingtai_kernel/migrate/ANATOMY.md
@@ -2,30 +2,38 @@
 
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues (mail or `discussions/<name>-patch.md`); do not silently fix.
 
-Versioned, append-only, forward-only migrations for kernel-managed on-disk preset library state. Each migration is a standalone `m<NNN>_<name>.py` file that rewrites preset `.json`/`.jsonc` files in place to normalize legacy shapes. The on-disk version counter lives in `<presets_dir>/_kernel_meta.json`; a process-level cache prevents re-running within a single process.
+Versioned, append-only, forward-only migrations for kernel-managed on-disk state. This folder is the kernel's migration system: when changing an on-disk shape owned by the kernel, look here first and extend the appropriate registry instead of adding an ad-hoc boot-time helper. The runner currently has two domains: **preset library** migrations over preset `.json`/`.jsonc` directories, and **agent workdir** migrations over one agent directory (including `init.json`). Each domain has its own version counter and append-only registry, but both use the same runner/validation/cache machinery.
 
 ## Components
 
-- `__init__.py` — exports `CURRENT_VERSION` and `run_migrations` (`migrate/__init__.py:25`).
-- `migrate.py` — runner, registry, and version tracking.
-  - `_META_FILENAME = "_kernel_meta.json"` — on-disk version file name (`migrate.py:45`).
-  - `_migrated: set[str]` — process-level guard; resolved path keys already migrated this run (`migrate.py:49`).
-  - `_MIGRATIONS` — append-only registry of `(version, name, function)` tuples (`migrate.py:55-58`).
-  - `_validate_registry()` — import-time sanity check: contiguous, strictly-increasing, callable (`migrate.py:61-100`).
-  - `CURRENT_VERSION` — derived from registry; no hand-maintained constant (`migrate.py:103`).
-  - `meta_filename()` — exposes `_META_FILENAME` for callers that must skip it during directory listing (`migrate.py:106-108`).
-  - `_load_version(presets_path)` — reads version from `_kernel_meta.json`, returns 0 on missing/malformed (`migrate.py:111-128`).
-  - `_save_version(presets_path, version)` — atomic write via PID-suffixed tmp + `os.replace` (`migrate.py:131-150`).
-  - `run_migrations(presets_path)` — main entry: reads version, runs all pending migrations, advances counter after each (`migrate.py:153-213`).
-  - `reset_process_cache()` — test-only; clears `_migrated` (`migrate.py:216-223`).
-- `m001_context_limit_relocation.py` — moves `manifest.context_limit` → `manifest.llm.context_limit` (`m001_context_limit_relocation.py:42`). Local `_load_jsonc()` avoids importing from `lingtai` (`m001_context_limit_relocation.py:25-39`).
-- `m002_description_object.py` — promotes string `description` to `{summary, tier?}`; folds `tags:[tier:N]` into `description.tier`; deletes `tags` (`m002_description_object.py:64`). Local `_load_jsonc()` (`m002_description_object.py:37-44`); `_extract_tier()` (`m002_description_object.py:47-61`).
+- `__init__.py` — public migration facade. Exports preset-domain `CURRENT_VERSION` / `run_migrations`, agent-domain `AGENT_CURRENT_VERSION` / `run_agent_migrations`, plus meta helpers (`__init__.py:31-45`).
+- `migrate.py` — shared runner, registries, and version tracking.
+  - `_META_FILENAME = "_kernel_meta.json"` — preset-domain meta file name (`migrate.py:46`).
+  - `_AGENT_META_REL = Path("system") / "migrations" / _META_FILENAME` — agent-domain meta file path relative to the workdir (`migrate.py:52`).
+  - `_migrated: set[str]` — process-level guard keyed by `domain:resolved_path` (`migrate.py:56`).
+  - `_PRESET_MIGRATIONS` — append-only preset registry (`migrate.py:62-65`).
+  - `_AGENT_MIGRATIONS` — append-only agent/workdir registry (`migrate.py:67-69`).
+  - `_MIGRATIONS` — backwards-compatible alias for `_PRESET_MIGRATIONS`, retained for older internal tests/callers (`migrate.py:73`).
+  - `_validate_registry()` — import-time sanity check: contiguous, strictly-increasing, callable (`migrate.py:76-126`).
+  - `CURRENT_VERSION` / `AGENT_CURRENT_VERSION` — derived from the two registries; no hand-maintained constants (`migrate.py:129-130`).
+  - `meta_filename()` / `agent_meta_relative_path()` — expose on-disk meta locations (`migrate.py:133-141`).
+  - `_load_version(meta_path)` — reads a version file, returns 0 on missing/malformed (`migrate.py:144-161`).
+  - `_save_version(meta_path, version, domain=...)` — atomic PID-suffixed tmp + `os.replace`; accepts either a concrete meta file or a preset directory for compatibility (`migrate.py:164-193`).
+  - `_run_versioned_migrations(...)` — shared domain runner: version gate, future-version downgrade guard, failure abort, per-process cache (`migrate.py:196-256`).
+  - `run_migrations(presets_path)` — preset-domain entry point (`migrate.py:259-282`).
+  - `run_agent_migrations(working_dir)` — agent-domain entry point, called before `init.json` read/validation (`migrate.py:285-301`).
+  - `reset_process_cache()` — test-only; clears `_migrated` (`migrate.py:304-310`).
+- `m001_context_limit_relocation.py` — preset m001: moves `manifest.context_limit` → `manifest.llm.context_limit` (`m001_context_limit_relocation.py:42`). Local `_load_jsonc()` avoids importing from `lingtai` (`m001_context_limit_relocation.py:25-39`).
+- `m002_description_object.py` — preset m002: promotes string `description` to `{summary, tier?}`; folds `tags:[tier:N]` into `description.tier`; deletes `tags` (`m002_description_object.py:64`). Local `_load_jsonc()` (`m002_description_object.py:37-44`); `_extract_tier()` (`m002_description_object.py:47-61`).
+- `agent_m001_init_procedures_override.py` — agent m001: archives non-empty `init.json.procedures` to `<workdir>/system/migrations/init-procedures-<sha256>.md`, removes `procedures` and `procedures_file`, and best-effort logs `init_procedures_override_migrated` before the agent object exists (`agent_m001_init_procedures_override.py:66`).
 
 ## Connections
 
-- **Inbound (caller):** `lingtai.presets.discover_presets_in_dirs` calls `run_migrations(p)` before listing presets (`presets.py:144,157`). `lingtai.presets.load_preset` calls `run_migrations(p.parent)` before reading a file (`presets.py:200,224`). Both paths import `meta_filename()` to skip `_kernel_meta.json` during directory scans (`presets.py:145`).
-- **Outbound (this folder):** Migrations rewrite preset files in the target directory — each uses atomic tmp + `os.replace`. No other kernel or lingtai modules are imported; migrations duplicate `_load_jsonc()` locally to keep the import surface minimal.
-- **Boundary contract:** `__init__.py` exposes only `CURRENT_VERSION` and `run_migrations`. `meta_filename()` is a secondary export accessed via `lingtai_kernel.migrate.migrate.meta_filename`.
+- **Inbound — preset domain:** `lingtai.presets.discover_presets_in_dirs` calls `run_migrations(p)` before listing presets (`presets.py:144,157`). `lingtai.presets.load_preset` calls `run_migrations(p.parent)` before reading a file (`presets.py:200,224`). Both paths import `meta_filename()` to skip `_kernel_meta.json` during directory scans (`presets.py:145`).
+- **Inbound — agent domain:** `lingtai.cli.load_init` calls `run_agent_migrations(working_dir)` before it reads `init.json` for process boot (`../lingtai/cli.py:32-39`). `lingtai.Agent._read_init` calls the same entry before live refresh/setup reads `init.json` (`../lingtai/agent.py:845-852`). This keeps boot and refresh on one migration path.
+- **Outbound — preset migrations:** Rewrite preset files in the target directory. Each migration uses atomic tmp + `os.replace` and local JSONC parsing; no imports from the wrapper package.
+- **Outbound — agent migrations:** Rewrite files under one agent workdir, including `init.json` and archive artifacts under `system/migrations/`. Agent migrations may best-effort append events to `logs/events.jsonl` because they run before `Agent` / `BaseAgent._log` may exist.
+- **Boundary contract:** Public imports come from `lingtai_kernel.migrate`: use `run_migrations` only for preset-library directories; use `run_agent_migrations` for per-agent workdirs/init migrations. Do not add one-off init cleanup in `Agent._read_init()` unless it is merely invoking this versioned runner.
 
 ## Composition
 
@@ -34,14 +42,17 @@ Versioned, append-only, forward-only migrations for kernel-managed on-disk prese
 
 ## State
 
-- **On-disk:** `<presets_dir>/_kernel_meta.json` — `{"version": N}`, persisted after each successful migration step (`migrate.py:138-150`). Created only when at least one migration runs.
-- **Process-level:** `_migrated: set[str]` — resolved absolute path strings already migrated this process. Checked at `migrate.py:178`; added at `migrate.py:181,192,196,213`.
-- **Ephemeral:** each migration rewrites preset files in place (atomic tmp + `os.replace`). No rollback artifacts left on success.
+- **Preset on-disk:** `<presets_dir>/_kernel_meta.json` — `{"version": N}`, persisted after each successful preset migration step (`migrate.py:279-282` via `_save_version`). Created only when at least one preset migration runs.
+- **Agent on-disk:** `<workdir>/system/migrations/_kernel_meta.json` — `{"version": N, "domain": "agent"}`, persisted after each successful agent migration step (`migrate.py:298-301` via `_save_version`). The same directory may hold migration artifacts such as `init-procedures-<sha256>.md`.
+- **Process-level:** `_migrated: set[str]` — `domain:resolved_path` keys already migrated this process. Checked in `_run_versioned_migrations` (`migrate.py:206-208`); populated on no-op/future/current/success paths (`migrate.py:212,225,229,256`).
+- **Ephemeral:** migrations rewrite target files in place (atomic tmp + `os.replace`). No rollback artifacts are left on success except intentional archives.
 
 ## Notes
 
-- **Forward-only:** a meta file with version > `CURRENT_VERSION` (e.g. from a newer kernel later downgraded) is honored as-is; no migrations run; a warning is logged (`migrate.py:186-193`).
-- **Contiguity enforced at import:** `_validate_registry` raises `RuntimeError` if the `_MIGRATIONS` tuple has gaps, duplicates, or non-callable entries (`migrate.py:61-100`). This catches programmer errors before any user data is touched.
-- **Concurrency safety:** PID-suffixed tmp files prevent parent + avatar processes sharing a presets dir from clobbering each other's in-flight writes (`migrate.py:139`).
-- **No lingtai imports:** both `m001` and `m002` duplicate a local `_load_jsonc()` helper (`m001_context_limit_relocation.py:25-39`, `m002_description_object.py:37-44`). This keeps the kernel→lingtai dependency strictly one-directional.
-- **Naming convention:** each migration file is `m<NNN>_<name>.py` and exports `migrate_<name>(presets_path: Path) -> None` (`__init__.py:18-19`).
+- **This is the reminder:** if you are about to change an on-disk kernel-owned shape (preset JSON, agent `init.json`, or another durable kernel file), first inspect/extend this migration system. Do not “just add a cleanup helper” in the boot path and call it a migration.
+- **Forward-only:** a meta file with version > current domain version (e.g. from a newer kernel later downgraded) is honored as-is; no migrations run; a warning is logged (`migrate.py:216-226`).
+- **Contiguity enforced per domain:** `_validate_registry` raises `RuntimeError` if a registry has gaps, duplicates, or non-callable entries (`migrate.py:76-126`).
+- **Concurrency safety:** PID-suffixed tmp files prevent parent + avatar processes sharing a target from clobbering each other's in-flight writes (`migrate.py:180`).
+- **Domain separation:** preset migrations should stay generic over preset directories and should not assume an agent workdir. Agent migrations may touch `init.json`, `system/`, `logs/`, and other workdir-local files, but must remain idempotent and version-gated.
+- **Validation ordering:** agent migrations run before `validate_init()` so retired keys can be removed/archived before schema validation; schema should mark migrated legacy keys as known-but-inactive only when stale files might still be observed.
+- **Tests:** runner/domain behavior lives in `tests/test_kernel_migrate.py`; boot/refresh integration behavior lives in `tests/test_deep_refresh.py` and `tests/test_cli.py`.

--- a/src/lingtai_kernel/migrate/__init__.py
+++ b/src/lingtai_kernel/migrate/__init__.py
@@ -1,27 +1,46 @@
-"""Kernel-side preset library migrations.
+"""Kernel-managed on-disk migrations.
 
 Per-machine analogue of `tui/internal/globalmigrate` in the TUI repo:
-versioned, append-only, forward-only migrations applied to a preset
-library directory (typically `~/.lingtai-tui/presets/`, or any directory
-that holds preset *.json files referenced by agents'
-`manifest.preset.allowed` lists).
+versioned, append-only, forward-only migrations applied to kernel-owned
+on-disk shapes.
 
-The version number is tracked in `<presets_dir>/_kernel_meta.json`.
-Migrations run lazily — `lingtai.presets.discover_presets_in_dirs`
-invokes `run_migrations(presets_path)` before listing files, and
-`load_preset` runs them on the file's parent directory before reading.
-Both paths are guarded by a process-level cache so each directory is
-migrated at most once per run.
+Domains:
+- Preset library migrations target a directory of preset `*.json`/`*.jsonc`
+  files (typically `~/.lingtai-tui/presets/`, or a directory referenced by an
+  agent's `manifest.preset.allowed`). The version number is tracked in
+  `<presets_dir>/_kernel_meta.json`. `lingtai.presets.discover_presets_in_dirs`
+  invokes `run_migrations(presets_path)` before listing files, and
+  `load_preset` runs them on the file's parent directory before reading.
+- Agent workdir migrations target one agent working directory and include
+  `init.json` shape migrations. The version number is tracked in
+  `<workdir>/system/migrations/_kernel_meta.json`. `lingtai.cli.load_init` and
+  `Agent._read_init()` invoke `run_agent_migrations(working_dir)` before
+  reading/validating `init.json`.
 
 Conventions:
-- Append-only ordered slice in `migrate.py`.
-- Each migration lives in `m<NNN>_<name>.py` and exports a
-  `migrate_<name>(presets_path: Path) -> None` function.
-- Failures are reported via `logging.warning` and abort the run for
-  that path (no partial advancement of the version counter).
+- Append-only ordered registries in `migrate.py`.
+- Each migration lives in `m<NNN>_<name>.py` for preset-domain migrations or
+  `agent_m<NNN>_<name>.py` for agent-domain migrations, exporting a
+  `migrate_<name>(path: Path) -> None` function.
+- Failures are reported via `logging.warning` and abort the run for that path
+  (no partial advancement of the version counter).
 """
 from __future__ import annotations
 
-from .migrate import CURRENT_VERSION, run_migrations
+from .migrate import (
+    AGENT_CURRENT_VERSION,
+    CURRENT_VERSION,
+    agent_meta_relative_path,
+    meta_filename,
+    run_agent_migrations,
+    run_migrations,
+)
 
-__all__ = ["CURRENT_VERSION", "run_migrations"]
+__all__ = [
+    "AGENT_CURRENT_VERSION",
+    "CURRENT_VERSION",
+    "agent_meta_relative_path",
+    "meta_filename",
+    "run_agent_migrations",
+    "run_migrations",
+]

--- a/src/lingtai_kernel/migrate/agent_m001_init_procedures_override.py
+++ b/src/lingtai_kernel/migrate/agent_m001_init_procedures_override.py
@@ -1,0 +1,132 @@
+"""agent m001 — retire init.json procedures overrides.
+
+``procedures.md`` is kernel-owned. Earlier agents could set
+``init.json.procedures`` (inline prompt text) or ``init.json.procedures_file``
+(file path override). This agent-domain migration preserves non-empty inline
+legacy content under ``<workdir>/system/migrations/`` and removes both fields
+from ``init.json``.
+
+Idempotency is provided by the versioned migration runner: this migration is
+run at most once per agent workdir version. Within the migration itself, missing
+fields are a no-op.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+
+
+def _load_json(path: Path) -> dict | None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else None
+
+
+def _write_json_atomic(path: Path, data: dict) -> None:
+    tmp = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(str(tmp), str(path))
+
+
+def _append_agent_event(working_dir: Path, event_type: str, **fields) -> None:
+    """Best-effort append to the agent JSONL event log before Agent exists.
+
+    BaseAgent._log normally owns this schema. Agent-domain migrations may run
+    during boot/refresh while init.json is being normalized, so they write the
+    same minimal event shape directly.
+    """
+    try:
+        try:
+            init_data = _load_json(working_dir / "init.json") or {}
+        except Exception:
+            init_data = {}
+        manifest = init_data.get("manifest") if isinstance(init_data.get("manifest"), dict) else {}
+        agent_name = manifest.get("agent_name")
+        log_dir = working_dir / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        event = {
+            "type": event_type,
+            "address": working_dir.name,
+            "agent_name": agent_name,
+            "ts": time.time(),
+            **fields,
+        }
+        with (log_dir / "events.jsonl").open("a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False, default=str) + "\n")
+    except OSError:
+        pass
+
+
+def migrate_init_procedures_override(working_dir: Path) -> None:
+    """Archive/remove legacy procedures fields from an agent workdir init.json."""
+    init_path = working_dir / "init.json"
+    if not init_path.is_file():
+        return
+    data = _load_json(init_path)
+    if data is None:
+        raise ValueError(f"{init_path} did not contain a JSON object")
+
+    has_inline = "procedures" in data
+    has_file = "procedures_file" in data
+    if not has_inline and not has_file:
+        return
+
+    legacy = data.get("procedures")
+    should_archive = isinstance(legacy, str) and legacy != ""
+    archive_rel: str | None = None
+    content_hash: str | None = None
+    byte_length = 0
+    char_length = 0
+
+    if should_archive:
+        raw = legacy.encode("utf-8")
+        content_hash = hashlib.sha256(raw).hexdigest()
+        byte_length = len(raw)
+        char_length = len(legacy)
+        migrations_dir = working_dir / "system" / "migrations"
+        archive_path = migrations_dir / f"init-procedures-{content_hash}.md"
+        try:
+            migrations_dir.mkdir(parents=True, exist_ok=True)
+            archive_path.write_text(legacy, encoding="utf-8")
+            archive_rel = archive_path.relative_to(working_dir).as_posix()
+        except OSError as e:
+            _append_agent_event(
+                working_dir,
+                "init_procedures_override_migration_failed",
+                reason=str(e),
+                content_hash=content_hash,
+                byte_length=byte_length,
+                char_length=char_length,
+            )
+            raise
+
+    data.pop("procedures", None)
+    data.pop("procedures_file", None)
+
+    try:
+        _write_json_atomic(init_path, data)
+    except OSError as e:
+        _append_agent_event(
+            working_dir,
+            "init_procedures_override_migration_failed",
+            reason=str(e),
+            archive_path=archive_rel,
+            content_hash=content_hash,
+            byte_length=byte_length,
+            char_length=char_length,
+        )
+        raise
+
+    _append_agent_event(
+        working_dir,
+        "init_procedures_override_migrated",
+        archive_path=archive_rel,
+        content_hash=content_hash,
+        byte_length=byte_length,
+        char_length=char_length,
+        procedures_removed=has_inline,
+        procedures_file_removed=has_file,
+        field_removed=True,
+    )

--- a/src/lingtai_kernel/migrate/migrate.py
+++ b/src/lingtai_kernel/migrate/migrate.py
@@ -1,29 +1,34 @@
-"""Versioned migration runner for the kernel preset library.
+"""Versioned migration runner for kernel-managed on-disk state.
 
 Mirrors `tui/internal/globalmigrate` from the TUI repo. The TUI runs its
-analogue once at process start against `~/.lingtai-tui/`; the kernel runs
-this once per `presets_path` per process, triggered lazily from
-`lingtai.presets.discover_presets`.
+analogue once at process start against `~/.lingtai-tui/`; the kernel owns
+append-only, forward-only migration registries for the on-disk shapes it
+manages.
 
-Append-only registry. Each migration claims a strictly-increasing version
-number. The on-disk version counter (in `<presets_dir>/_kernel_meta.json`)
-records the highest migration that has run successfully against this
-directory. A migration runs at most once per directory; when its version
-number ≤ the on-disk counter, it is skipped.
+Two domains currently share this runner:
+
+- **Preset library migrations** run once per preset directory, triggered
+  lazily from `lingtai.presets.discover_presets` / `load_preset`. Their
+  version counter lives in `<presets_dir>/_kernel_meta.json`.
+- **Agent workdir migrations** run once per agent working directory before
+  `init.json` validation/refresh. Their version counter lives in
+  `<workdir>/system/migrations/_kernel_meta.json`.
+
+Each domain has an append-only registry. Each migration claims a strictly
+increasing version number. A migration runs at most once per target directory;
+when its version number ≤ the on-disk counter, it is skipped.
 
 Best-practice invariants:
-- Versions form a contiguous strictly-increasing sequence (1, 2, 3, ...).
-  The runner asserts this at import time so a typo in the registry fails
-  fast rather than silently mis-ordering migrations.
-- `CURRENT_VERSION` is derived from the registry — there is no
-  hand-maintained constant that can drift out of sync with the migrations
-  that are actually registered.
-- Forward-only: a meta file with a future version (e.g. from a newer
-  kernel that was later downgraded) is honored as-is and never rolled
-  back. A warning is logged so the operator knows.
-- Tmp-file writes use a PID suffix so concurrent processes (parent +
-  avatar) sharing the same presets directory do not clobber each other's
-  in-flight write.
+- Versions form a contiguous strictly-increasing sequence (1, 2, 3, ...)
+  within each domain. The runner asserts this at import time so a typo in a
+  registry fails fast rather than silently mis-ordering migrations.
+- Current versions are derived from registries — there are no hand-maintained
+  constants that can drift out of sync with the migrations actually registered.
+- Forward-only: a meta file with a future version (e.g. from a newer kernel
+  that was later downgraded) is honored as-is and never rolled back. A warning
+  is logged so the operator knows.
+- Tmp-file writes use a PID suffix so concurrent processes (parent + avatar)
+  sharing the same target directory do not clobber each other's in-flight write.
 """
 from __future__ import annotations
 
@@ -33,74 +38,94 @@ import os
 from pathlib import Path
 from typing import Callable
 
+from .agent_m001_init_procedures_override import migrate_init_procedures_override
 from .m001_context_limit_relocation import migrate_context_limit_relocation
 from .m002_description_object import migrate_description_object
 
 log = logging.getLogger(__name__)
 
-# Filename used to track migration state. Lives inside the presets directory
-# itself so each preset library carries its own migration state. The leading
-# underscore signals "internal" to humans browsing the directory;
-# discover_presets_in_dirs explicitly skips this filename.
+# Filename used to track preset-library migration state. Lives inside the
+# presets directory itself so each preset library carries its own migration
+# state. The leading underscore signals "internal" to humans browsing the
+# directory; discover_presets_in_dirs explicitly skips this filename.
 _META_FILENAME = "_kernel_meta.json"
 
-# Per-process guard so we run at most once per (presets_path) per process.
-# Keyed by resolved absolute path string.
+# Agent-workdir migration state lives under system/migrations beside any archive
+# artifacts produced by agent-domain migrations.
+_AGENT_META_REL = Path("system") / "migrations" / _META_FILENAME
+
+# Per-process guard so we run at most once per (domain, target path) per process.
+# Keyed by "<domain>:<resolved absolute path>".
 _migrated: set[str] = set()
 
 
-# Append-only registry. Each entry: (version, name, function).
-# Versions MUST form a strictly-increasing contiguous sequence starting at 1.
-# The validator below catches violations at import time.
-_MIGRATIONS: tuple[tuple[int, str, Callable[[Path], None]], ...] = (
+# Append-only registries. Each entry: (version, name, function).
+# Versions MUST form a strictly-increasing contiguous sequence starting at 1
+# within each registry. The validator below catches violations at import time.
+_PRESET_MIGRATIONS: tuple[tuple[int, str, Callable[[Path], None]], ...] = (
     (1, "context_limit_relocation", migrate_context_limit_relocation),
     (2, "description_object", migrate_description_object),
 )
 
+_AGENT_MIGRATIONS: tuple[tuple[int, str, Callable[[Path], None]], ...] = (
+    (1, "init_procedures_override", migrate_init_procedures_override),
+)
 
-def _validate_registry() -> int:
-    """Sanity-check the registry shape at import time.
+# Backwards-compatible alias for tests and older internal callers that inspect
+# the original preset migration registry directly.
+_MIGRATIONS = _PRESET_MIGRATIONS
 
-    Returns the highest registered version, which becomes CURRENT_VERSION.
-    Raises RuntimeError if the registry violates contiguity, ordering, or
-    uniqueness — these are programmer errors that should fail loudly long
-    before a migration ever runs against user data.
+
+def _validate_registry(
+    migrations: tuple[tuple[int, str, Callable[[Path], None]], ...] | None = None,
+    *,
+    domain: str = "kernel migrate",
+) -> int:
+    """Sanity-check a registry shape at import time.
+
+    Returns the highest registered version, which becomes the domain's current
+    version. Raises RuntimeError if the registry violates contiguity, ordering,
+    or uniqueness — programmer errors that should fail loudly before user data
+    is touched.
+
+    ``migrations`` defaults to ``_MIGRATIONS`` for compatibility with older
+    tests that monkeypatch that name directly.
     """
-    if not _MIGRATIONS:
+    if migrations is None:
+        migrations = _MIGRATIONS
+    if not migrations:
         return 0
     seen: set[int] = set()
     expected = 1
-    for entry in _MIGRATIONS:
+    for entry in migrations:
         if not (isinstance(entry, tuple) and len(entry) == 3):
             raise RuntimeError(
-                f"kernel migrate registry: malformed entry {entry!r} — "
-                f"expected (version, name, function)"
+                f"{domain}: malformed entry {entry!r} — expected (version, name, function)"
             )
         version, name, fn = entry
         if not isinstance(version, int) or version <= 0:
             raise RuntimeError(
-                f"kernel migrate registry: version must be a positive int, got {version!r} "
+                f"{domain}: version must be a positive int, got {version!r} "
                 f"(in {name!r})"
             )
         if version in seen:
-            raise RuntimeError(
-                f"kernel migrate registry: duplicate version {version} (in {name!r})"
-            )
+            raise RuntimeError(f"{domain}: duplicate version {version} (in {name!r})")
         if version != expected:
             raise RuntimeError(
-                f"kernel migrate registry: expected version {expected}, got {version} "
+                f"{domain}: expected version {expected}, got {version} "
                 f"(in {name!r}) — versions must be strictly increasing and contiguous"
             )
         if not callable(fn):
             raise RuntimeError(
-                f"kernel migrate registry: function for version {version} ({name!r}) is not callable"
+                f"{domain}: function for version {version} ({name!r}) is not callable"
             )
         seen.add(version)
         expected += 1
-    return _MIGRATIONS[-1][0]
+    return migrations[-1][0]
 
 
-CURRENT_VERSION: int = _validate_registry()
+CURRENT_VERSION: int = _validate_registry(_PRESET_MIGRATIONS, domain="kernel preset migrate registry")
+AGENT_CURRENT_VERSION: int = _validate_registry(_AGENT_MIGRATIONS, domain="kernel agent migrate registry")
 
 
 def meta_filename() -> str:
@@ -108,9 +133,13 @@ def meta_filename() -> str:
     return _META_FILENAME
 
 
-def _load_version(presets_path: Path) -> int:
-    """Read the on-disk version counter. Returns 0 when missing or unreadable."""
-    meta_path = presets_path / _META_FILENAME
+def agent_meta_relative_path() -> Path:
+    """Relative path of the agent-workdir migration version file."""
+    return _AGENT_META_REL
+
+
+def _load_version(meta_path: Path) -> int:
+    """Read an on-disk version counter. Returns 0 when missing or unreadable."""
     try:
         raw = meta_path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -121,24 +150,39 @@ def _load_version(presets_path: Path) -> int:
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as e:
-        log.warning("kernel migrate: malformed %s: %s — treating as version 0",
-                    meta_path, e)
+        log.warning("kernel migrate: malformed %s: %s — treating as version 0", meta_path, e)
+        return 0
+    if not isinstance(data, dict):
+        log.warning(
+            "kernel migrate: malformed %s: expected object, got %s — treating as version 0",
+            meta_path,
+            type(data).__name__,
+        )
         return 0
     v = data.get("version", 0)
     return v if isinstance(v, int) else 0
 
 
-def _save_version(presets_path: Path, version: int) -> None:
-    """Atomically persist the version counter.
+def _save_version(meta_path: Path, version: int, *, domain: str | None = None) -> None:
+    """Atomically persist a version counter.
 
-    The tmp file uses a PID suffix so concurrent processes sharing this
-    directory cannot clobber each other's in-flight write. os.replace is
-    atomic on POSIX and Windows for same-filesystem renames.
+    Backwards-compatible input: callers may pass either the concrete meta file
+    path or a preset directory. Directory input is normalized to
+    ``<dir>/_kernel_meta.json``.
+
+    The tmp file uses a PID suffix so concurrent processes sharing this target
+    cannot clobber each other's in-flight write. os.replace is atomic on POSIX
+    and Windows for same-filesystem renames.
     """
-    meta_path = presets_path / _META_FILENAME
-    tmp = meta_path.with_name(f"{_META_FILENAME}.{os.getpid()}.tmp")
-    payload = json.dumps({"version": version}, ensure_ascii=False)
+    if meta_path.is_dir():
+        meta_path = meta_path / _META_FILENAME
+    tmp = meta_path.with_name(f"{meta_path.name}.{os.getpid()}.tmp")
+    payload_data: dict[str, object] = {"version": version}
+    if domain is not None:
+        payload_data["domain"] = domain
+    payload = json.dumps(payload_data, ensure_ascii=False)
     try:
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
         tmp.write_text(payload, encoding="utf-8")
         os.replace(str(tmp), str(meta_path))
     except OSError as e:
@@ -150,29 +194,18 @@ def _save_version(presets_path: Path, version: int) -> None:
             pass
 
 
-def run_migrations(presets_path: Path | str) -> None:
-    """Run pending kernel migrations against the given presets directory.
-
-    Idempotent and process-cached: subsequent calls in the same process for
-    the same path are no-ops. Reads the current version from
-    `<presets_path>/_kernel_meta.json` (defaulting to 0), runs all
-    registered migrations whose version is greater than the current value,
-    and persists the new version after each successful step.
-
-    Failures in individual migrations log a warning and abort the run for
-    this path (no partial version advancement past the failed step).
-    Subsequent process starts will retry from the last-successful version.
-
-    A nonexistent presets directory is a no-op — there's nothing to
-    migrate, and we don't want to create the directory implicitly.
-
-    Forward-only: a meta file with a version greater than CURRENT_VERSION
-    (e.g. written by a newer kernel that was later downgraded) is honored
-    as-is. A warning is logged so the operator notices.
-    """
-    p = Path(presets_path)
+def _run_versioned_migrations(
+    target_path: Path | str,
+    *,
+    domain: str,
+    migrations: tuple[tuple[int, str, Callable[[Path], None]], ...],
+    current_version: int,
+    meta_path_for: Callable[[Path], Path],
+) -> None:
+    """Run one migration registry against one target directory."""
+    p = Path(target_path)
     try:
-        resolved_key = str(p.resolve())
+        resolved_key = f"{domain}:{p.resolve()}"
     except OSError:
         return  # path doesn't resolve — nothing to do
     if resolved_key in _migrated:
@@ -181,43 +214,98 @@ def run_migrations(presets_path: Path | str) -> None:
         _migrated.add(resolved_key)
         return
 
-    current = _load_version(p)
+    meta_path = meta_path_for(p)
+    current = _load_version(meta_path)
 
-    if current > CURRENT_VERSION:
+    if current > current_version:
         log.warning(
-            "kernel migrate: %s reports version %d but this kernel only knows up to %d "
+            "kernel %s migrate: %s reports version %d but this kernel only knows up to %d "
             "— honoring on-disk version, running no migrations (likely a downgrade)",
-            p, current, CURRENT_VERSION,
+            domain,
+            p,
+            current,
+            current_version,
         )
         _migrated.add(resolved_key)
         return
 
-    if current == CURRENT_VERSION:
+    if current == current_version:
         _migrated.add(resolved_key)
         return
 
-    for version, name, fn in _MIGRATIONS:
+    for version, name, fn in migrations:
         if version <= current:
             continue
         try:
             fn(p)
         except Exception as e:
             log.warning(
-                "kernel migrate %d (%s) failed for %s: %s — aborting run, will retry next launch",
-                version, name, p, e,
+                "kernel %s migrate %d (%s) failed for %s: %s — aborting run, will retry next launch",
+                domain,
+                version,
+                name,
+                p,
+                e,
             )
             return
         current = version
-        _save_version(p, current)
+        _save_version(meta_path, current, domain=domain if domain != "preset" else None)
 
     _migrated.add(resolved_key)
+
+
+def run_migrations(presets_path: Path | str) -> None:
+    """Run pending kernel migrations against the given presets directory.
+
+    Idempotent and process-cached: subsequent calls in the same process for
+    the same path are no-ops. Reads the current version from
+    `<presets_path>/_kernel_meta.json` (defaulting to 0), runs all registered
+    preset-library migrations whose version is greater than the current value,
+    and persists the new version after each successful step.
+
+    Failures in individual migrations log a warning and abort the run for this
+    path (no partial version advancement past the failed step). Subsequent
+    process starts will retry from the last-successful version.
+
+    A nonexistent presets directory is a no-op — there's nothing to migrate,
+    and we don't want to create the directory implicitly.
+    """
+    _run_versioned_migrations(
+        presets_path,
+        domain="preset",
+        migrations=_PRESET_MIGRATIONS,
+        current_version=CURRENT_VERSION,
+        meta_path_for=lambda p: p / _META_FILENAME,
+    )
+
+
+def run_agent_migrations(working_dir: Path | str) -> None:
+    """Run pending kernel migrations against one agent working directory.
+
+    This is the version-controlled entry point for agent-local on-disk shape
+    changes, including `init.json` migrations. Call it before reading or
+    validating `init.json` so boot and refresh see the migrated shape.
+
+    A directory without ``init.json`` is a no-op. Do not create migration meta
+    for a half-created workdir, or a later first boot would incorrectly skip
+    init migrations.
+    """
+    p = Path(working_dir)
+    if not (p / "init.json").is_file():
+        return
+    _run_versioned_migrations(
+        p,
+        domain="agent",
+        migrations=_AGENT_MIGRATIONS,
+        current_version=AGENT_CURRENT_VERSION,
+        meta_path_for=lambda p: p / _AGENT_META_REL,
+    )
 
 
 def reset_process_cache() -> None:
     """Clear the per-process migration guard.
 
-    Test-only — not part of the public API. Useful when a test needs to
-    re-run migrations against a freshly-built fixture inside the same
-    process.
+    Test-only — not part of the public API. Useful when a test needs to re-run
+    migrations against a freshly-built fixture inside the same process.
     """
     _migrated.clear()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -369,3 +369,37 @@ def test_log_query_missing_sqlite_requires_rebuild_cli(tmp_path, capsys):
         assert not (logs / "log.sqlite").exists()
     finally:
         sys.argv = old_argv
+
+
+def test_load_init_runs_agent_migrations_before_validation(tmp_path):
+    """CLI boot must normalize legacy procedures fields before validating init.json."""
+    import hashlib
+
+    from lingtai.cli import load_init
+
+    legacy = "legacy CLI procedures"
+    init = {
+        "manifest": {
+            "agent_name": "cli-agent",
+            "llm": {"provider": "p", "model": "m"},
+            "capabilities": {},
+        },
+        "principle": "",
+        "covenant": "",
+        "pad": "",
+        "prompt": "",
+        "procedures": legacy,
+        "procedures_file": "old/procedures.md",
+    }
+    (tmp_path / "init.json").write_text(json.dumps(init), encoding="utf-8")
+
+    data = load_init(tmp_path)
+
+    assert "procedures" not in data
+    assert "procedures_file" not in data
+    on_disk = json.loads((tmp_path / "init.json").read_text(encoding="utf-8"))
+    assert "procedures" not in on_disk
+    assert "procedures_file" not in on_disk
+    digest = hashlib.sha256(legacy.encode("utf-8")).hexdigest()
+    archive = tmp_path / "system" / "migrations" / f"init-procedures-{digest}.md"
+    assert archive.read_text(encoding="utf-8") == legacy

--- a/tests/test_deep_refresh.py
+++ b/tests/test_deep_refresh.py
@@ -337,6 +337,25 @@ def test_single_space_procedures_no_longer_opts_out(tmp_path):
     assert archive.read_text(encoding="utf-8") == " "
 
 
+
+def test_custom_procedures_file_is_removed_not_prompted(tmp_path):
+    """Legacy procedures_file overrides are removed even for custom paths."""
+    custom = tmp_path / "custom-procedures.md"
+    custom.write_text("CUSTOM-PROCEDURES-FILE", encoding="utf-8")
+    init = _make_init()
+    init["procedures_file"] = str(custom)
+    agent = _make_agent(tmp_path, init)
+
+    agent._setup_from_init()
+
+    packaged = _packaged_procedures()
+    prompt = agent._prompt_manager.render()
+    assert "CUSTOM-PROCEDURES-FILE" not in prompt
+    assert agent._prompt_manager.read_section("procedures") == packaged
+    data = json.loads((tmp_path / "init.json").read_text(encoding="utf-8"))
+    assert "procedures_file" not in data
+
+
 def test_system_procedures_is_overwritten_by_packaged_default(tmp_path):
     """Manual system/procedures.md edits are replaced by the packaged default."""
     agent = _make_agent(tmp_path, _make_init())

--- a/tests/test_init_schema_procedures.py
+++ b/tests/test_init_schema_procedures.py
@@ -1,0 +1,59 @@
+from lingtai.init_schema import validate_init
+
+
+def _valid_init() -> dict:
+    return {
+        "manifest": {
+            "agent_name": "alice",
+            "language": "en",
+            "llm": {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-20250514",
+            },
+            "capabilities": {},
+        },
+        "principle": "",
+        "covenant": "",
+        "pad": "",
+        "prompt": "",
+    }
+
+
+def test_procedures_no_longer_active_optional_prompt_field():
+    """Inline procedures is migrated-legacy-known, not active schema."""
+    from lingtai.init_schema import LEGACY_MIGRATED_TOP_FIELDS, TOP_KNOWN, TOP_OPTIONAL
+
+    assert "procedures" in LEGACY_MIGRATED_TOP_FIELDS
+    assert "procedures" in TOP_KNOWN
+    assert "procedures" not in TOP_OPTIONAL
+
+    data = _valid_init()
+    data["procedures"] = {"not": "a string"}
+    warnings = validate_init(data)
+
+    assert all("procedures" not in w for w in warnings)
+
+
+def test_procedures_file_no_longer_active_optional_prompt_field():
+    """procedures_file is migrated-legacy-known, not strip_deprecated schema."""
+    from lingtai.init_schema import (
+        DEPRECATED_TOP_FIELDS,
+        LEGACY_MIGRATED_TOP_FIELDS,
+        TOP_KNOWN,
+        TOP_OPTIONAL,
+        strip_deprecated,
+    )
+
+    assert "procedures_file" not in DEPRECATED_TOP_FIELDS
+    assert "procedures_file" in LEGACY_MIGRATED_TOP_FIELDS
+    assert "procedures_file" in TOP_KNOWN
+    assert "procedures_file" not in TOP_OPTIONAL
+
+    data = _valid_init()
+    data["procedures_file"] = 123
+    stripped = strip_deprecated(data)
+    warnings = validate_init(data)
+
+    assert stripped == []
+    assert "procedures_file" in data
+    assert all("procedures_file" not in w for w in warnings)

--- a/tests/test_kernel_migrate.py
+++ b/tests/test_kernel_migrate.py
@@ -11,7 +11,13 @@ from pathlib import Path
 
 import pytest
 
-from lingtai_kernel.migrate import CURRENT_VERSION, run_migrations
+from lingtai_kernel.migrate import (
+    AGENT_CURRENT_VERSION,
+    CURRENT_VERSION,
+    agent_meta_relative_path,
+    run_agent_migrations,
+    run_migrations,
+)
 from lingtai_kernel.migrate.migrate import meta_filename, reset_process_cache
 
 
@@ -239,6 +245,100 @@ def test_run_migrations_persists_across_simulated_process_restart(tmp_path):
     assert "context_limit" not in after_p2["manifest"]["llm"]
     # Meta file untouched (mtime unchanged)
     assert (plib / meta_filename()).stat().st_mtime_ns == first_meta_mtime
+
+
+# ---------------------------------------------------------------------------
+# Agent workdir migration domain
+# ---------------------------------------------------------------------------
+
+def _write_init(workdir: Path, body: dict) -> Path:
+    p = workdir / "init.json"
+    p.write_text(json.dumps(body, indent=2), encoding="utf-8")
+    return p
+
+
+def _minimal_init() -> dict:
+    return {
+        "manifest": {
+            "agent_name": "alice",
+            "llm": {"provider": "p", "model": "m"},
+            "capabilities": {},
+        },
+        "principle": "",
+        "covenant": "",
+        "pad": "",
+        "prompt": "",
+    }
+
+
+def test_run_agent_migrations_archives_and_removes_procedures_fields(tmp_path):
+    init = _minimal_init()
+    init["procedures"] = "legacy procedures text"
+    init["procedures_file"] = "legacy/procedures.md"
+    init_path = _write_init(tmp_path, init)
+
+    run_agent_migrations(tmp_path)
+
+    data = _read(init_path)
+    assert "procedures" not in data
+    assert "procedures_file" not in data
+
+    import hashlib
+    digest = hashlib.sha256(b"legacy procedures text").hexdigest()
+    archive = tmp_path / "system" / "migrations" / f"init-procedures-{digest}.md"
+    assert archive.read_text(encoding="utf-8") == "legacy procedures text"
+
+    meta = _read(tmp_path / agent_meta_relative_path())
+    assert meta == {"version": AGENT_CURRENT_VERSION, "domain": "agent"}
+
+
+def test_run_agent_migrations_version_gate_prevents_rerun_after_restart(tmp_path):
+    init = _minimal_init()
+    init["procedures"] = "first legacy"
+    init_path = _write_init(tmp_path, init)
+
+    run_agent_migrations(tmp_path)
+    assert "procedures" not in _read(init_path)
+
+    restored = _read(init_path)
+    restored["procedures"] = "restored after migration"
+    _write_init(tmp_path, restored)
+    reset_process_cache()
+
+    run_agent_migrations(tmp_path)
+
+    # Version gate is the source of truth: migrations do not rerun for a
+    # workdir already marked current, even if a stale shape is later restored.
+    assert _read(init_path)["procedures"] == "restored after migration"
+
+
+def test_run_agent_migrations_no_op_when_workdir_missing(tmp_path):
+    workdir = tmp_path / "missing"
+    run_agent_migrations(workdir)
+    assert not workdir.exists()
+
+
+def test_run_agent_migrations_no_op_when_init_missing(tmp_path):
+    run_agent_migrations(tmp_path)
+    assert not (tmp_path / agent_meta_relative_path()).exists()
+
+
+def test_run_agent_migrations_treats_non_object_meta_as_zero(tmp_path, caplog):
+    import logging
+
+    init = _minimal_init()
+    init["procedures_file"] = "legacy/procedures.md"
+    init_path = _write_init(tmp_path, init)
+    meta_path = tmp_path / agent_meta_relative_path()
+    meta_path.parent.mkdir(parents=True)
+    meta_path.write_text("null", encoding="utf-8")
+
+    caplog.set_level(logging.WARNING, logger="lingtai_kernel.migrate.migrate")
+    run_agent_migrations(tmp_path)
+
+    assert "procedures_file" not in _read(init_path)
+    assert _read(meta_path) == {"version": AGENT_CURRENT_VERSION, "domain": "agent"}
+    assert any("expected object" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extends the kernel's existing version-controlled migration runner (`lingtai_kernel.migrate`) with an agent-workdir domain instead of keeping the procedures cleanup as an ad-hoc `Agent._read_init()` helper.
- Adds agent migration `agent_m001_init_procedures_override` to archive legacy inline `init.json.procedures`, remove both `procedures` and `procedures_file`, and track agent migration version under `<workdir>/system/migrations/_kernel_meta.json`.
- Calls `run_agent_migrations()` from both CLI boot and live refresh before `init.json` is read/validated.
- Updates anatomy so future agents see that `src/lingtai_kernel/migrate` is the kernel migration system and should be extended for kernel-owned on-disk shape changes.
- Keeps `procedures` / `procedures_file` known-but-inactive in schema so stale/restored init files do not look supported or trigger active prompt-section type checks.
- Fixes final Codex review findings: non-object migration meta now falls back to version 0, stale anatomy references were removed, and CLI boot migration coverage was added.

## Validation
- `PYTHONPATH=src python3 -m py_compile src/lingtai_kernel/migrate/migrate.py src/lingtai_kernel/migrate/agent_m001_init_procedures_override.py src/lingtai_kernel/migrate/__init__.py src/lingtai/agent.py src/lingtai/cli.py src/lingtai/init_schema.py tests/test_kernel_migrate.py tests/test_deep_refresh.py tests/test_init_schema_procedures.py tests/test_cli.py`
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/pytest -q tests/test_kernel_migrate.py tests/test_cli.py tests/test_init_schema.py tests/test_init_schema_procedures.py tests/test_deep_refresh.py tests/test_avatar_preset_inheritance.py` → 125 passed
- `git diff --check`

## Notes
- This replaces the earlier PR version that only documented a separate boot-time init cleanup convention. The updated implementation follows Jason's direction to use the kernel's version-controlled migration system.
