### PR TITLE
Fix tool-loop guard non-dispatch recovery

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -143,6 +143,144 @@ def _pending_tool_call_summary(iface) -> dict:
     }
 
 
+def _publish_tool_loop_guard_notification(
+    agent,
+    *,
+    reason: str,
+    detail: str,
+    ledger_source: str,
+    in_tool_loop: bool,
+    tool_call_fields: dict,
+    closed_count: int,
+) -> None:
+    workdir = getattr(agent, "_working_dir", None)
+    try:
+        from pathlib import Path
+        from ..intrinsics.system import publish_notification
+
+        publish_notification(
+            Path(workdir),
+            "tool_loop_guard",
+            header="tool loop guard interrupted work",
+            icon="!",
+            priority="normal",
+            instructions=(
+                "The kernel stopped a tool-call loop before dispatch. The "
+                "matching synthetic tool results are already visible in the "
+                "conversation transcript and say no side effects occurred "
+                "from those blocked calls. Do not re-issue the same blocked "
+                "tool call(s) unchanged. Continue with a different approach, "
+                "summarize the blocked/completed work, or ask the human for "
+                "direction, then dismiss with system(action='dismiss', "
+                "channel='tool_loop_guard', reason='handled')."
+            ),
+            data={
+                "reason": reason,
+                "detail": detail,
+                "ledger_source": ledger_source,
+                "in_tool_loop": in_tool_loop,
+                "closed_tool_result_count": closed_count,
+                **tool_call_fields,
+                "message": (
+                    "Tool loop guard stopped before dispatch. Synthetic tool "
+                    "results were committed to the transcript for the blocked "
+                    "calls; no side effects occurred from those calls. Do not "
+                    "retry the same blocked calls unchanged; switch strategy, "
+                    "summarize blocked/completed work, or ask the human."
+                ),
+            },
+        )
+    except Exception as e:
+        agent._log(
+            "tool_loop_guard_notification_failed",
+            reason=reason,
+            detail=detail,
+            error=(str(e) or repr(e))[:300],
+        )
+        return
+
+    agent._log(
+        "tool_loop_guard_notification_published",
+        reason=reason,
+        detail=detail,
+        closed_tool_result_count=closed_count,
+    )
+
+
+# Design note: this helper deliberately only closes the provider wire
+# (the ChatInterface transcript sent to the LLM) and publishes
+# .notification/tool_loop_guard.json. It does not post MSG_TC_WAKE.
+# After the turn unwinds to IDLE, BaseAgent._sync_notifications detects the
+# notification file, injects the synthetic notification call/result pair,
+# and posts MSG_TC_WAKE. _handle_tc_wake then builds a fresh ToolExecutor and
+# LoopGuard, so the tool-call limit counter resets for the follow-up turn.
+def _handle_guarded_non_dispatch(
+    agent,
+    response_tool_calls,
+    *,
+    reason: str,
+    detail: str,
+    detail_field: str,
+    ledger_source: str,
+    in_tool_loop: bool,
+    collected_text_parts: list[str],
+) -> dict:
+    tool_call_fields = _tool_call_summary(response_tool_calls)
+    agent._log(
+        "tool_calls_not_dispatched",
+        ledger_source=ledger_source,
+        in_tool_loop=in_tool_loop,
+        reason=reason,
+        detail_field=detail_field,
+        **{detail_field: detail},
+        **tool_call_fields,
+    )
+
+    closed_count = 0
+    chat = getattr(agent, "_chat", None)
+    iface = getattr(chat, "interface", None)
+    if iface is not None and iface.has_pending_tool_calls():
+        pending_fields = _pending_tool_call_summary(iface)
+        closed_count = pending_fields["pending_tool_call_count"]
+        iface.close_pending_tool_calls(
+            reason=f"{reason}: {detail}",
+            tool_not_dispatched=True,
+        )
+        agent._save_chat_history(ledger_source=ledger_source)
+        agent._log(
+            "guarded_tool_calls_closed",
+            ledger_source=ledger_source,
+            reason=reason,
+            detail=detail,
+            result_count=closed_count,
+            pending_tool_call_ids=pending_fields["pending_tool_call_ids"],
+            pending_tool_names=pending_fields["pending_tool_names"],
+        )
+    else:
+        agent._log(
+            "guarded_tool_calls_close_skipped",
+            ledger_source=ledger_source,
+            reason=reason,
+            detail=detail,
+            skipped_reason="no_chat_or_tool_calls",
+        )
+
+    _publish_tool_loop_guard_notification(
+        agent,
+        reason=reason,
+        detail=detail,
+        ledger_source=ledger_source,
+        in_tool_loop=in_tool_loop,
+        tool_call_fields=tool_call_fields,
+        closed_count=closed_count,
+    )
+    return {
+        "text": "\n".join(collected_text_parts),
+        "failed": False,
+        "errors": [],
+    }
+
+
 def _prepare_aed_retry_message(agent, err_desc: str) -> Message:
     """Build the system recovery prompt reused by transient and AED retries."""
     ts = now_iso(agent)
@@ -1166,27 +1304,29 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
 
         stop_reason = guard.check_limit(len(response.tool_calls))
         if stop_reason:
-            agent._log(
-                "tool_calls_not_dispatched",
+            return _handle_guarded_non_dispatch(
+                agent,
+                response.tool_calls,
                 ledger_source=ledger_source,
                 in_tool_loop=in_tool_loop,
                 reason="tool_loop_limit",
-                stop_reason=stop_reason,
-                **tool_call_fields,
+                detail=stop_reason,
+                detail_field="stop_reason",
+                collected_text_parts=collected_text_parts,
             )
-            break
 
         invalid_reason = guard.check_invalid_tool_limit()
         if invalid_reason:
-            agent._log(
-                "tool_calls_not_dispatched",
+            return _handle_guarded_non_dispatch(
+                agent,
+                response.tool_calls,
                 ledger_source=ledger_source,
                 in_tool_loop=in_tool_loop,
                 reason="invalid_tool_limit",
-                invalid_reason=invalid_reason,
-                **tool_call_fields,
+                detail=invalid_reason,
+                detail_field="invalid_reason",
+                collected_text_parts=collected_text_parts,
             )
-            break
 
         # Delegate to ToolExecutor
         tool_results, intercepted, intercept_text = agent._executor.execute(

--- a/src/lingtai_kernel/llm/interface.py
+++ b/src/lingtai_kernel/llm/interface.py
@@ -101,6 +101,7 @@ def _synthesized_abort_message(
     reason: str,
     *,
     tool_completed: bool = False,
+    tool_not_dispatched: bool = False,
     tool_call: "ToolCallBlock | None" = None,
 ) -> str:
     """Content for a heal-path placeholder ToolResultBlock.
@@ -117,9 +118,36 @@ def _synthesized_abort_message(
     executed and the real failure was the LLM continuation *after* the
     tool result.  In that case the message says so honestly instead of
     implying the tool itself failed.
+
+    ``tool_completed`` and ``tool_not_dispatched`` are mutually exclusive:
+    one says side effects likely happened, the other says dispatch never
+    happened.
     """
+    if tool_completed and tool_not_dispatched:
+        raise ValueError(
+            "tool_completed and tool_not_dispatched are mutually exclusive"
+        )
     context = _tool_call_context(tool_call)
     context_block = f"\n\nRecovery metadata:\n{context}" if context else ""
+    if tool_not_dispatched:
+        return (
+            f"[kernel notice — tool call NOT dispatched]\n"
+            f"\n"
+            f"A prior assistant call to `{tool_name}` was NOT dispatched. "
+            f"The kernel stopped the tool loop before invoking the tool "
+            f"handler.\n"
+            f"\n"
+            f"No side effects occurred from this tool call. It did not write "
+            f"files, send messages, start processes, or mutate agent state.\n"
+            f"\n"
+            f"This synthetic tool result is now visible in the conversation "
+            f"transcript. Do not retry the same blocked call unchanged. "
+            f"Summarize the blocked/completed work and either switch strategy "
+            f"or ask the human for direction.\n"
+            f"\n"
+            f"Reason recorded by the kernel: {reason}"
+            f"{context_block}"
+        )
     if tool_completed:
         return (
             f"[kernel notice — tool call completed but LLM continuation failed]\n"
@@ -411,7 +439,11 @@ class ChatInterface:
         return any(isinstance(b, ToolCallBlock) for b in last.content)
 
     def close_pending_tool_calls(
-        self, reason: str, *, tool_completed: bool = False,
+        self,
+        reason: str,
+        *,
+        tool_completed: bool = False,
+        tool_not_dispatched: bool = False,
     ) -> None:
         """Synthesize placeholder ToolResultBlocks for any unanswered tool_calls
         on the tail assistant entry. No-op if the tail has no pending calls.
@@ -428,6 +460,10 @@ class ChatInterface:
         message will say so honestly, guiding the agent to verify side
         effects rather than blindly retrying.
 
+        When ``tool_not_dispatched`` is True, the caller knows execution was
+        blocked before dispatch, so the synthesized message says no side
+        effects occurred instead of using the generic uncertain heal text.
+
         Idempotent: after one call, has_pending_tool_calls() returns False,
         and a second call no-ops.
         """
@@ -443,6 +479,7 @@ class ChatInterface:
                     b.name,
                     reason,
                     tool_completed=tool_completed,
+                    tool_not_dispatched=tool_not_dispatched,
                     tool_call=b,
                 ),
                 synthesized=True,

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -526,7 +526,7 @@ def _make_chat_stub():
 
 
 def test_sync_idle_posts_wake_message(tmp_path: Path) -> None:
-    """IDLE: fingerprint change → MSG_TC_WAKE goes to the inbox.
+    """IDLE: fingerprint change -> MSG_TC_WAKE goes to the inbox.
 
     The synthesized ``(ToolCallBlock, ToolResultBlock)`` pair has
     already been spliced by ``_inject_notification_pair`` —

--- a/tests/test_tool_result_restore_after_continuation_failure.py
+++ b/tests/test_tool_result_restore_after_continuation_failure.py
@@ -7,6 +7,7 @@ that loses the result payload.
 """
 from __future__ import annotations
 
+import json
 import threading
 from pathlib import Path
 
@@ -45,9 +46,12 @@ class _FakeChat:
 
 
 class _FakeAgent:
-    def __init__(self) -> None:
+    def __init__(self, *, working_dir: Path | None = None) -> None:
         self._chat = _FakeChat()
         self._notification_live_holder = None
+        self._working_dir = working_dir or Path(
+            "/nonexistent/lingtai-test-tool-result-restore"
+        )
         self.saved = 0
         self.logs: list[tuple[str, dict]] = []
 
@@ -295,8 +299,10 @@ def test_process_response_logs_cancel_before_tool_dispatch():
         ),
     ],
 )
-def test_process_response_logs_guarded_tool_calls_not_dispatched(guard, reason, extra):
-    agent = _FakeAgent()
+def test_process_response_closes_and_notifies_guarded_tool_calls_not_dispatched(
+    tmp_path, guard, reason, extra,
+):
+    agent = _FakeAgent(working_dir=tmp_path)
     real_result = ToolResultBlock(
         id="call_1",
         name="bash",
@@ -317,20 +323,60 @@ def test_process_response_logs_guarded_tool_calls_not_dispatched(guard, reason, 
 
     assert result == {"text": "", "failed": False, "errors": []}
     assert agent._executor.calls == []
-    assert agent.logs == [
-        (
-            "tool_calls_not_dispatched",
-            {
-                "ledger_source": "test",
-                "in_tool_loop": False,
-                "reason": reason,
-                "call_count": 1,
-                "call_ids": ["call_1"],
-                "tool_names": ["bash"],
-                **extra,
-            },
-        )
+    tail = agent._chat.interface.entries[-1]
+    assert tail.role == "user"
+    assert len(tail.content) == 1
+    synthetic = tail.content[0]
+    assert synthetic.id == "call_1"
+    assert synthetic.name == "bash"
+    assert synthetic.synthesized is True
+    assert synthetic.content.startswith("[kernel notice — tool call NOT dispatched]")
+    assert "NOT dispatched" in synthetic.content
+    assert f"Reason recorded by the kernel: {reason}" in synthetic.content
+    assert "No side effects occurred from this tool call" in synthetic.content
+    assert "visible in the conversation transcript" in synthetic.content
+    assert "Do not retry the same blocked call unchanged" in synthetic.content
+    assert "MAY OR MAY NOT" not in synthetic.content
+    assert not agent._chat.interface.has_pending_tool_calls()
+    assert agent.saved == 1
+
+    log_names = [name for name, _ in agent.logs]
+    assert log_names == [
+        "tool_calls_not_dispatched",
+        "guarded_tool_calls_closed",
+        "tool_loop_guard_notification_published",
     ]
+    assert agent.logs[0] == (
+        "tool_calls_not_dispatched",
+        {
+            "ledger_source": "test",
+            "in_tool_loop": False,
+            "reason": reason,
+            "detail_field": next(iter(extra.keys())),
+            "call_count": 1,
+            "call_ids": ["call_1"],
+            "tool_names": ["bash"],
+            **extra,
+        },
+    )
+    notification_path = tmp_path / ".notification" / "tool_loop_guard.json"
+    notification = json.loads(notification_path.read_text(encoding="utf-8"))
+    assert notification["header"] == "tool loop guard interrupted work"
+    assert notification["priority"] == "normal"
+    instructions = notification["instructions"]
+    assert "already visible in the conversation transcript" in instructions
+    assert "Do not re-issue the same blocked tool call(s) unchanged" in instructions
+    data = notification["data"]
+    assert data["reason"] == reason
+    assert data["detail"] == next(iter(extra.values()))
+    assert data["ledger_source"] == "test"
+    assert data["in_tool_loop"] is False
+    assert data["closed_tool_result_count"] == 1
+    assert data["call_ids"] == ["call_1"]
+    assert data["tool_names"] == ["bash"]
+    assert "Synthetic tool results were committed to the transcript" in data["message"]
+    assert "no side effects occurred" in data["message"]
+    assert "retry the same blocked calls unchanged" in data["message"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause / incident

An affected agent hit the tool-loop guard after a long tool-call chain. The model produced one more `bash` tool call, but `_process_response()` refused to dispatch it because `LoopGuard.check_limit()` had reached the total-call cap.

The bug was what happened next: the guard branch only logged `tool_calls_not_dispatched` and then broke out of the tool loop as a clean/successful turn. That left the assistant tail containing an unanswered `tool_call` with no matching `tool_result` on the provider wire/chat history, and the agent transitioned to IDLE.

Later, when a notification/email tried to inject into the conversation, the notification path discovered the dangling pending tool call and performed a generic `idle_inject_blocked` heal. That later heal was a symptom, not the cause: the original guard stop should have closed the pending tool call explicitly and told the agent what happened.

## Raw log evidence

Sanitized event chain from the affected run:

```json
{"type":"tool_calls_not_dispatched","reason":"tool_loop_limit","stop_reason":"total call limit (100) reached after 100 calls","call_ids":["<blocked_call_id>"],"tool_names":["bash"],"ledger_source":"tc_wake","in_tool_loop":true}
{"type":"agent_state","old":"active","new":"idle","reason":""}
{"type":"heal_pending_tool_calls","reason":"idle_inject_blocked"}
{"type":"agent_state","old":"idle","new":"active","reason":"received tc_wake"}
```

Interpretation:

1. `tool_calls_not_dispatched reason=tool_loop_limit` shows the generated tool call was blocked before dispatch.
2. The immediate `active -> idle` transition shows the guard stop returned as a non-failing clean turn.
3. The later `heal_pending_tool_calls reason=idle_inject_blocked` shows notification injection found the unresolved pending tool-call wire state.
4. The later `received tc_wake` was notification recovery after the symptom, not an explicit recovery for the guard stop.

## Why this approach

This is not routed through AED because this is a deterministic guardrail stop, not an exception/transient provider failure. AED also uses uncertain side-effect wording, while here the kernel knows the blocked call was **not dispatched** and therefore had no side effects.

This also does not add a direct continuation bridge. Existing notification sync already provides the recovery path: when the guard notification is published and the turn returns to IDLE, notification sync injects the notification pair and posts `MSG_TC_WAKE`; `_handle_tc_wake()` creates a fresh `ToolExecutor` / `LoopGuard`, so the continuation gets a fresh guard budget.

## What changed

- When `tool_loop_limit` / `invalid_tool_limit` prevents dispatch, close the pending assistant tool calls with synthetic NOT-dispatched tool results.
- The synthetic result tells the model that the blocked call was not dispatched, no side effects occurred, and it should not retry the same blocked call unchanged.
- Publish a normal-priority `tool_loop_guard` notification so the agent sees an explicit recovery signal instead of silently idling.
- Keep the guard path return contract minimal (`text`, `failed`, `errors`) and rely on the existing notification wake path for continuation.

## Tests

- `.venv/bin/python -m pytest tests/test_tool_result_restore_after_continuation_failure.py tests/test_loop_guard.py tests/test_chat_interface_invariant.py tests/test_notification_sync.py -q`
  - `95 passed in 0.88s`
- `git diff --check`
