### PR TITLE
docs(skills): codify nested reference router pattern

### DIFF
--- a/src/lingtai/core/skills/manual/SKILL.md
+++ b/src/lingtai/core/skills/manual/SKILL.md
@@ -203,17 +203,34 @@ way to hide unrelated reusable skills.
 Key rule: a nested `reference/<topic>/SKILL.md` is **not automatically promoted**
 to the global skills catalog. The catalog scanner treats a directory that already
 has `SKILL.md` as a skill boundary and does not descend into that folder for
-additional catalog entries. Therefore the parent `SKILL.md` must advertise the
-children explicitly, usually with a small YAML block such as:
+additional catalog entries. Therefore the parent `SKILL.md` must inject the
+children's routing metadata explicitly and keep the heavy procedural content in
+the children.
+
+Every parent-owned nested-reference router should contain **both**:
+
+1. a `## Nested reference catalog` section with a fenced YAML list containing one
+   item per child (`name`, `location`, `description`); and
+2. a human-readable `## Routing table` (or equivalent decision table) that maps
+   user/agent needs to the same child `location`s.
+
+Preferred catalog shape:
 
 ```yaml
-Nested reference catalog:
-  - name: topic-a
-    location: reference/topic-a/SKILL.md
-    description: >
-      Nested <parent-skill> reference for ... Read this after loading
-      <parent-skill> when ...
+- name: parent-topic-a
+  location: reference/topic-a/SKILL.md
+  description: |
+    Nested <parent-skill> reference for ... Read this after loading
+    <parent-skill> when ...
+- name: parent-topic-b
+  location: reference/topic-b/SKILL.md
+  description: |
+    Nested <parent-skill> reference for ...
 ```
+
+The YAML catalog is not just decoration: it is the machine-readable routing table
+for the second layer. Keep it in sync with child frontmatter and with the human
+routing table. Do not leave the parent as only a prose list of links.
 
 Use nested references when all of these are true:
 
@@ -230,27 +247,33 @@ find directly from the top-level catalog. Those should be normal skills under
 
 Nested child conventions:
 
-- `name` should be unique within the parent and descriptive (`sqlite-log-query`,
-  `procedures-manual`), even though it is not globally cataloged.
-- `description` should start with the fact that it is nested, name the parent,
-  and give the trigger condition: `Nested system-manual reference for ...`.
-- `location` in the parent catalog should be relative to the parent folder so it
-  survives copy/install moves; agents reading the parent can resolve it next to
+- Each child `reference/<topic>/SKILL.md` must have normal skill frontmatter:
+  `name` and `description` required; `version`/`tags` optional. `name` should be
+  unique within the parent and descriptive (`system-manual-sqlite-log-query`,
+  `daily-reflection-data-collection`), even though it is not globally cataloged.
+- The child `description` and the parent catalog `description` should start with
+  the fact that it is nested, name the parent, and give the trigger condition:
+  `Nested system-manual reference for ...`.
+- `location` in the parent YAML catalog should be relative to the parent folder so
+  it survives copy/install moves; agents reading the parent can resolve it next to
   the parent `SKILL.md`.
 - The parent should remain the routing hub. Resident prompts and sibling skills
   should route to the parent first, then to the nested reference; do not bypass
   the parent unless the caller already has the parent context loaded.
-- Tests should verify both levels: the parent catalog/body mentions every nested
-  child, and the installed/copied skill tree contains each child `SKILL.md` with
-  valid frontmatter and key content.
+- Tests should verify both levels: the parent body contains the YAML catalog,
+  every child `name` and `location`, and the human routing table; the
+  installed/copied skill tree contains each child `SKILL.md` with valid
+  frontmatter and key content.
 - The bundled validator checks one skill folder at a time. For nested children,
   validate the parent and then validate each nested child folder directly, e.g.
   `python3 .../validate.py reference/topic-a/` from the parent skill folder.
 
-Reference implementation: `system-manual` is a top-level router with nested
+Reference implementations: `system-manual` is a top-level router with nested
 `reference/substrate-manual/SKILL.md`, `reference/procedures-manual/SKILL.md`,
 and `reference/sqlite-log-query/SKILL.md`, advertised through a `Nested reference
-catalog` in the parent.
+catalog` in the parent. Utility routers such as `swiss-knife`, `web-browsing`,
+and `daily-reflection` use the same two-part shape: YAML child metadata first,
+human routing table second.
 
 ### SKILL.md vs README.md
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -72,6 +72,10 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert "name: skills-manual" in body
         assert "Nested skill/reference pattern for umbrella manuals" in body
         assert "Nested reference catalog" in body
+        assert "## Routing table" in body
+        assert "children's routing metadata explicitly" in body
+        assert "machine-readable routing table" in body
+        assert "Do not leave the parent as only a prose list of links" in body
         assert "reference/substrate-manual/SKILL.md" in body
         assert "The catalog scanner treats a directory that already" in body
         assert "validate.py reference/topic-a/" in body


### PR DESCRIPTION
## Summary

Codify the parent-owned nested-reference router pattern in `skills-manual` so future routing-table skills do not rely on precedent/memory alone.

The updated guidance now says a parent-owned nested-reference router should include both:

1. a `## Nested reference catalog` section with a fenced YAML list containing each child `name`, `location`, and `description`; and
2. a human-readable `## Routing table` (or equivalent decision table) pointing to the same child locations.

It also clarifies that:

- nested `reference/<topic>/SKILL.md` files are not automatically promoted to the global skills catalog;
- the parent router must inject child routing metadata explicitly;
- heavy procedural content belongs in leaf references, keeping the router lightweight;
- child references still need normal skill frontmatter (`name`, `description`, optional `version`/`tags`);
- tests should verify both the parent YAML catalog/routing table and copied child `SKILL.md` files.

## Context

This consolidates the pattern already used by routing-table skills such as `system-manual`, `swiss-knife`, `web-browsing`, and `daily-reflection`, and aligns with the TUI follow-up fixes in PRs:

- Lingtai-AI/lingtai#233
- Lingtai-AI/lingtai#234

## Validation

- `python3 src/lingtai/core/skills/manual/scripts/validate.py src/lingtai/core/skills/manual` PASS
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_skills.py::test_skills_setup_hard_copies_intrinsics tests/test_validate_skill.py` PASS (`20 passed`)
- `git diff --check` PASS
