### PR TITLE
docs: fold molt template into procedures guidance

### DIFF
--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -93,7 +93,9 @@ Pad is your **living index** of what you're working on right now. It is not a sk
 psyche(object="context", action="molt", summary=<your charge to the next you>, ...)
 ```
 
-The `summary` is the only *conversation-layer* thing the next you will see. Aim for ~10,000 tokens — be thorough. Include:
+The `summary` is the only *conversation-layer* thing the next you will see. Aim for ~10,000 tokens — be thorough when state is complex. The summary is not a recap of conversation. It is your charge to the self that comes after you — anchored in the four stores, which are already waiting in the fresh session.
+
+For a routine molt, include:
 
 - **What you are working on** — current task, current state, the next concrete step
 - **What you have accomplished** — completed pieces, key decisions made
@@ -103,7 +105,53 @@ The `summary` is the only *conversation-layer* thing the next you will see. Aim 
 - **The session journal sub-entry path** — so the next you can read the full narrative
 - **Anything else worth carrying forward** — insights, gotchas
 
-The summary is not a recap of conversation. It is your charge to the self that comes after you — anchored in the four stores, which are already waiting in the fresh session.
+For a consequential molt — long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, or any handoff the next you could not reconstruct quickly — use this full scaffold. Fill every section; write `None` rather than omitting a section.
+
+1. **Who I Am**
+   - Name/address and current role.
+   - Standing constraints, authorizations, and things not to do without explicit confirmation.
+   - Parent/peer relationships or topology that affect the task.
+2. **Accomplishments**
+   - Completed tasks and outputs.
+   - Key decisions made and why.
+   - Who has already been told, on which channel.
+3. **Outstanding Tasks**
+   - Incomplete work, status, blocker, and the next concrete step.
+   - Pending reviews, PRs, human approvals, daemon/avatar work, or external replies.
+4. **Action Checklist**
+   - Priority-ordered actions in the form: `[Immediate|Today|Pending|Optional] Action + recipient/channel + exact content/command`.
+   - Every outstanding task must have a matching action item.
+   - `Immediate` means first five minutes after wake; `Pending` means blocked on someone else and includes when/how to follow up.
+5. **Collaborators**
+   - People/agents involved, addresses/channels, roles/capabilities.
+   - Pending replies, deliverables owed by you, deliverables owed to you.
+6. **Durable Memory and Execution Notes**
+   - Pad sections, knowledge entries, skills/manuals, character changes, session-journal entries, or pinned files the next you should load.
+   - Commands, tests, environment assumptions, active daemons/bash jobs/avatars/schedules, or tool states the next you must know.
+   - Use current durable-store terms; avoid old `codex` wording unless documenting historical material.
+7. **Key Paths and Artifacts**
+   - Absolute paths for repos, worktrees, reports, drafts, logs, local deliverables, and test outputs.
+   - Include PR/issue URLs or branch names when relevant.
+8. **Lessons and Gotchas**
+   - Actionable warnings, failed approaches, verification requirements, and authorization limits.
+   - Prefer precise lessons: “run X before Y” beats “be careful”.
+9. **Context Status**
+   - Why you are molting.
+   - Leftover items not yet stored elsewhere.
+   - Unsent drafts, interrupted tool calls, or recent state that should be re-checked.
+
+Before you call `psyche(object="context", action="molt", ...)`, verify:
+
+- Pad, lingtai/character, knowledge, skills, and session journal were updated where needed before writing the summary.
+- Every outstanding task has an action checklist entry.
+- Every action names who/where and what exact content or command is needed.
+- Every collaborator has a usable address/channel and pending-reply state.
+- Every key path is absolute and still useful.
+- Active background work is listed or explicitly absent.
+- Authorization limits, external-side-effect approvals, and secret/privacy constraints are explicit.
+- Every lesson/gotcha is actionable.
+- Pending human/peer contacts have been acknowledged if the molt will delay them.
+- The first five minutes after wake are obvious.
 
 **`keep_tool_calls`** — optional list of tool-call IDs to preserve across molt. Each named pair (tool_use + tool_result) is replayed into the fresh session right after the summary, in the order you list them. If any ID is not found, the molt is refused. Keep this list short — the durable stores are the primary persistence.
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -120,10 +120,30 @@ Before context exhaustion:
 5. Write a molt summary as a successor briefing.
 6. Molt deliberately.
 
-A good molt summary is not a transcript. It states: who you are, what just
-happened, what remains, what not to do without authorization, where artifacts
-live, which chats/mail to check, and which knowledge/skills matter. For detailed
-mechanics, read `psyche-manual`.
+A good molt summary is not a transcript. It is an operational briefing for the
+next self: what to do first, what is done, what remains, what is forbidden
+without authorization, who is waiting, and where the durable state lives.
+
+Use the full consequential scaffold in `psyche-manual` when a long task is
+mid-stream, multiple collaborators are active, human commitments are pending, or
+the next self would otherwise need to reconstruct state from logs. Resident
+`procedures.md` only carries the compact cue; `psyche-manual` is the canonical
+place for the full summary template and pre-molt verification checklist.
+
+Minimum handoff checks:
+
+- Durable stores are tended before the summary is written.
+- Routine molts stay compact; consequential molts get the full scaffold.
+- Every outstanding task has a concrete action item with owner/recipient,
+  channel, and exact next action/content.
+- Collaborators, pending replies, authorization limits, and next human-facing
+  reports are explicit.
+- Active background work (daemons, bash jobs, avatars, schedules) is listed or
+  explicitly absent.
+- Key artifact paths are absolute and still useful.
+- Safety constraints are explicit: approvals required, secrets not shared, and
+  external side effects not implied.
+- The first five minutes after wake are obvious from the summary.
 
 ## 7. Skill routing
 

--- a/src/lingtai/prompts/procedures.md
+++ b/src/lingtai/prompts/procedures.md
@@ -35,10 +35,23 @@ operations, preset swaps, notification handling, and karma actions.
 
 ### Molt and Durable Stores
 
+**If you are about to molt, first read `psyche-manual` for the summary template
+and verification checklist.** Do this while context is still cheap; do not wait
+until the last moment.
+
 Before context exhaustion, update pad, knowledge, character, and skills as
-needed, then molt deliberately with a useful briefing. For detailed molt/pad
-practice, read `psyche-manual`; for the broader memory model, read
-`system-manual`.
+needed, then molt deliberately with a successor briefing — not a transcript.
+For routine molts, include current task/state/next step, accomplishments,
+remaining blockers, contacts, important durable-memory paths, and gotchas.
+
+For consequential molts — long task in flight, multiple collaborators, pending
+human commitments, active background work, or non-trivial artifacts — make the
+briefing operational: role/context, accomplishments, outstanding tasks,
+prioritized action checklist with recipient/channel + exact next action/content,
+collaborators/pending replies, durable memory/execution notes to load, key
+paths, risks/lessons, and context status. Verify every outstanding task has a
+concrete action, durable stores were tended first, and the first five minutes
+after wake are obvious. For the broader memory model, read `system-manual`.
 
 ### Skill Routing — When to Load What
 


### PR DESCRIPTION
## Summary
- fold the old `lingtai-molt-template` guidance into kernel-owned procedures/psyche guidance instead of adding a standalone kernel skill
- add a prominent resident `procedures.md` pointer: if you are about to molt, first read `psyche-manual` for the summary template and verification checklist
- keep resident `procedures.md` compact: routine vs consequential molt cue, stores-first discipline, and action-checklist minimums
- keep `psyche-manual` as the canonical home for the full consequential-molt scaffold and verification checklist
- align `system-manual/reference/procedures-manual` as the middle-layer routing/checklist, not a duplicate source of truth

## Rationale / peer check
Jason pointed out the TUI utility is part of procedures, and clarified that keeping the full template in `psyche-manual` is fine; the missing piece is a top-level resident pointer that is obvious when an agent is about to molt.

I also asked participating bots for opinions before finalizing the shape:
- dev-2 `mimo-1`: approve with small concerns; resident prompt should stay compact; full template should live in `psyche-manual`; replace old `Codex Cheat Sheet` wording with durable-memory terminology; TUI should pointerize/deprecate before deletion.
- yuanjiang `mimo-2-5-pro`: approve with minor concerns; same guidance: single source of truth, compact resident procedures, durable-store/execution-notes naming, active background work and safety constraints, TUI transition pointer.
- dev-1 had not replied by the time I opened this PR.

This PR follows that consensus. Follow-up TUI PR should pointerize/deprecate `lingtai-molt-template` rather than deleting it immediately, to avoid a release-window gap.

## Validation
- `git diff --check` PASS
- no control characters in changed files
- stale wording guard: no `Codex Cheat Sheet` / `codex(...)` in changed files
- focused packaged-procedures tests PASS:
  - `/Users/huangzesen/anaconda3/bin/python -m pytest -q tests/test_deep_refresh.py` → `19 passed`
- full suite attempted earlier on this docs-only branch:
  - first run with default `ulimit -n 256` failed from environment `OSError: [Errno 24] Too many open files`
  - rerun with `ulimit -n 8192`: `2052 passed, 2 skipped, 1 failed`
  - remaining failure is pre-existing/unrelated daemon race in `tests/test_daemon.py::test_emanate_creates_folder_on_disk` asserting `state == "running"`, but daemon finishes as `done`; reproduced as single-test failure on this docs-only branch.