### PR TITLE
Split psyche molt template into an asset

### DIFF
--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: psyche-manual
 description: |
-  Complete operational guide for the psyche tool — molt, pad management, session journaling, and post-wipe recovery. Read this when: you are about to molt; you need to tend the four durable stores; you want guidance on writing a good summary or session journal; you wake up after a system-performed wipe with no summary; or you need to understand keep_tool_calls, keep_last, and pad.append. Covers molt rhythm, the four-store discipline, summary writing, session journals, pad tending, archiving, and post-wipe reconstruction.
-version: "1.0"
+  Router and operational guide for the psyche tool — molt, pad management, session journaling, and post-wipe recovery. Read this when: you are about to molt; you need to tend the four durable stores; you want guidance on writing a good summary or session journal; you wake up after a system-performed wipe with no summary; or you need to understand keep_tool_calls, keep_last, and pad.append. Routes consequential molt handoffs to assets/molt-template.md while keeping routine guidance compact.
+version: "1.1"
 ---
 
 # Psyche Manual
+
+This manual is the router for `psyche` operations. Keep routine guidance here; load the supporting asset only when you need the full consequential-molt scaffold.
+
+## Asset catalog
+
+| Asset | When to load | What it contains |
+|---|---|---|
+| `assets/molt-template.md` (read from this skill directory) | Consequential molt, long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, active background jobs, or any successor briefing that would be risky to improvise | 9-section summary scaffold plus pre-molt verification checklist |
 
 ## 1. Molt Overview
 
@@ -105,52 +113,22 @@ For a routine molt, include:
 - **The session journal sub-entry path** — so the next you can read the full narrative
 - **Anything else worth carrying forward** — insights, gotchas
 
-For a consequential molt — long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, or any handoff the next you could not reconstruct quickly — use this full scaffold. Fill every section; write `None` rather than omitting a section.
+For a consequential molt — long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, or any handoff the next you could not reconstruct quickly — read `assets/molt-template.md` from this skill directory and use the full scaffold there. Fill every section; write `None` rather than omitting a section.
 
-1. **Who I Am**
-   - Name/address and current role.
-   - Standing constraints, authorizations, and things not to do without explicit confirmation.
-   - Parent/peer relationships or topology that affect the task.
-2. **Accomplishments**
-   - Completed tasks and outputs.
-   - Key decisions made and why.
-   - Who has already been told, on which channel.
-3. **Outstanding Tasks**
-   - Incomplete work, status, blocker, and the next concrete step.
-   - Pending reviews, PRs, human approvals, daemon/avatar work, or external replies.
-4. **Action Checklist**
-   - Priority-ordered actions in the form: `[Immediate|Today|Pending|Optional] Action + recipient/channel + exact content/command`.
-   - Every outstanding task must have a matching action item.
-   - `Immediate` means first five minutes after wake; `Pending` means blocked on someone else and includes when/how to follow up.
-5. **Collaborators**
-   - People/agents involved, addresses/channels, roles/capabilities.
-   - Pending replies, deliverables owed by you, deliverables owed to you.
-6. **Durable Memory and Execution Notes**
-   - Pad sections, knowledge entries, skills/manuals, character changes, session-journal entries, or pinned files the next you should load.
-   - Commands, tests, environment assumptions, active daemons/bash jobs/avatars/schedules, or tool states the next you must know.
-   - Use current durable-store terms; avoid old `codex` wording unless documenting historical material.
-7. **Key Paths and Artifacts**
-   - Absolute paths for repos, worktrees, reports, drafts, logs, local deliverables, and test outputs.
-   - Include PR/issue URLs or branch names when relevant.
-8. **Lessons and Gotchas**
-   - Actionable warnings, failed approaches, verification requirements, and authorization limits.
-   - Prefer precise lessons: “run X before Y” beats “be careful”.
-9. **Context Status**
-   - Why you are molting.
-   - Leftover items not yet stored elsewhere.
-   - Unsent drafts, interrupted tool calls, or recent state that should be re-checked.
+Quick routing:
 
-Before you call `psyche(object="context", action="molt", ...)`, verify:
+| Need | Use |
+|---|---|
+| Routine molt | The short bullet list above. |
+| Consequential molt / successor handoff | Read `assets/molt-template.md` from this skill directory; use its full scaffold and checklist. |
+| Unsure whether the handoff is complex | Use the asset; extra structure is cheaper than a bad handoff. |
 
-- Pad, lingtai/character, knowledge, skills, and session journal were updated where needed before writing the summary.
-- Every outstanding task has an action checklist entry.
-- Every action names who/where and what exact content or command is needed.
-- Every collaborator has a usable address/channel and pending-reply state.
-- Every key path is absolute and still useful.
+Before you call `psyche(object="context", action="molt", ...)`, always verify at minimum:
+
+- Durable stores and session journal were updated where needed before writing the summary.
+- Every outstanding task has an explicit next action.
+- Collaborators, channels, approvals, and key paths are named where relevant.
 - Active background work is listed or explicitly absent.
-- Authorization limits, external-side-effect approvals, and secret/privacy constraints are explicit.
-- Every lesson/gotcha is actionable.
-- Pending human/peer contacts have been acknowledged if the molt will delay them.
 - The first five minutes after wake are obvious.
 
 **`keep_tool_calls`** — optional list of tool-call IDs to preserve across molt. Each named pair (tool_use + tool_result) is replayed into the fresh session right after the summary, in the order you list them. If any ID is not found, the molt is refused. Keep this list short — the durable stores are the primary persistence.

--- a/src/lingtai/intrinsic_skills/psyche-manual/assets/molt-template.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/assets/molt-template.md
@@ -1,0 +1,55 @@
+# Consequential Molt Summary Template
+
+Use this asset when a molt is more than routine: long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, active background jobs, or any handoff the next you could not reconstruct quickly.
+
+Fill every section. Write `None` rather than omitting a section. This template is for the `summary=` argument to `psyche(object="context", action="molt", ...)`; tend durable stores before writing it.
+
+## Summary scaffold
+
+1. **Who I Am**
+   - Name/address and current role.
+   - Standing constraints, authorizations, and things not to do without explicit confirmation.
+   - Parent/peer relationships or topology that affect the task.
+2. **Accomplishments**
+   - Completed tasks and outputs.
+   - Key decisions made and why.
+   - Who has already been told, on which channel.
+3. **Outstanding Tasks**
+   - Incomplete work, status, blocker, and the next concrete step.
+   - Pending reviews, PRs, human approvals, daemon/avatar work, or external replies.
+4. **Action Checklist**
+   - Priority-ordered actions in the form: `[Immediate|Today|Pending|Optional] Action + recipient/channel + exact content/command`.
+   - Every outstanding task must have a matching action item.
+   - `Immediate` means first five minutes after wake; `Pending` means blocked on someone else and includes when/how to follow up.
+5. **Collaborators**
+   - People/agents involved, addresses/channels, roles/capabilities.
+   - Pending replies, deliverables owed by you, deliverables owed to you.
+6. **Durable Memory and Execution Notes**
+   - Pad sections, knowledge entries, skills/manuals, character changes, session-journal entries, or pinned files the next you should load.
+   - Commands, tests, environment assumptions, active daemons/bash jobs/avatars/schedules, or tool states the next you must know.
+   - Use current durable-store terms; avoid old `codex` wording unless documenting historical material.
+7. **Key Paths and Artifacts**
+   - Absolute paths for repos, worktrees, reports, drafts, logs, local deliverables, and test outputs.
+   - Include PR/issue URLs or branch names when relevant.
+8. **Lessons and Gotchas**
+   - Actionable warnings, failed approaches, verification requirements, and authorization limits.
+   - Prefer precise lessons: “run X before Y” beats “be careful”.
+9. **Context Status**
+   - Why you are molting.
+   - Leftover items not yet stored elsewhere.
+   - Unsent drafts, interrupted tool calls, or recent state that should be re-checked.
+
+## Pre-molt verification checklist
+
+Before you call `psyche(object="context", action="molt", ...)`, verify:
+
+- Pad, lingtai/character, knowledge, skills, and session journal were updated where needed before writing the summary.
+- Every outstanding task has an action checklist entry.
+- Every action names who/where and what exact content or command is needed.
+- Every collaborator has a usable address/channel and pending-reply state.
+- Every key path is absolute and still useful.
+- Active background work is listed or explicitly absent.
+- Authorization limits, external-side-effect approvals, and secret/privacy constraints are explicit.
+- Every lesson/gotcha is actionable.
+- Pending human/peer contacts have been acknowledged if the molt will delay them.
+- The first five minutes after wake are obvious.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -124,11 +124,12 @@ A good molt summary is not a transcript. It is an operational briefing for the
 next self: what to do first, what is done, what remains, what is forbidden
 without authorization, who is waiting, and where the durable state lives.
 
-Use the full consequential scaffold in `psyche-manual` when a long task is
-mid-stream, multiple collaborators are active, human commitments are pending, or
-the next self would otherwise need to reconstruct state from logs. Resident
-`procedures.md` only carries the compact cue; `psyche-manual` is the canonical
-place for the full summary template and pre-molt verification checklist.
+Use `psyche-manual` when a long task is mid-stream, multiple collaborators are
+active, human commitments are pending, or the next self would otherwise need to
+reconstruct state from logs. Resident `procedures.md` only carries the compact
+cue; `psyche-manual` routes consequential handoffs to its
+`assets/molt-template.md` file, which holds the full summary template and
+pre-molt verification checklist.
 
 Minimum handoff checks:
 

--- a/src/lingtai/prompts/procedures.md
+++ b/src/lingtai/prompts/procedures.md
@@ -35,9 +35,9 @@ operations, preset swaps, notification handling, and karma actions.
 
 ### Molt and Durable Stores
 
-**If you are about to molt, first read `psyche-manual` for the summary template
-and verification checklist.** Do this while context is still cheap; do not wait
-until the last moment.
+**If you are about to molt, first read `psyche-manual`; for consequential
+handoffs it routes to the molt-template asset and verification checklist.** Do
+this while context is still cheap; do not wait until the last moment.
 
 Before context exhaustion, update pad, knowledge, character, and skills as
 needed, then molt deliberately with a successor briefing — not a transcript.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -187,6 +187,41 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "external side effects" in procedures_body
         assert "Resident procedures maintenance" in procedures_body
 
+        psyche_md = (
+            workdir
+            / ".library"
+            / "intrinsic"
+            / "capabilities"
+            / "psyche-manual"
+            / "SKILL.md"
+        )
+        assert psyche_md.is_file()
+        psyche_body = psyche_md.read_text(encoding="utf-8")
+        assert "name: psyche-manual" in psyche_body
+        assert "## Asset catalog" in psyche_body
+        assert "assets/molt-template.md" in psyche_body
+        assert "9-section summary scaffold" in psyche_body
+        assert "9. **Context Status**" not in psyche_body
+
+        molt_template_asset = psyche_md.parent / "assets" / "molt-template.md"
+        assert molt_template_asset.is_file()
+        molt_template_body = molt_template_asset.read_text(encoding="utf-8")
+        assert "# Consequential Molt Summary Template" in molt_template_body
+        assert "## Summary scaffold" in molt_template_body
+        for section in (
+            "1. **Who I Am**",
+            "2. **Accomplishments**",
+            "3. **Outstanding Tasks**",
+            "4. **Action Checklist**",
+            "5. **Collaborators**",
+            "6. **Durable Memory and Execution Notes**",
+            "7. **Key Paths and Artifacts**",
+            "8. **Lessons and Gotchas**",
+            "9. **Context Status**",
+        ):
+            assert section in molt_template_body
+        assert "## Pre-molt verification checklist" in molt_template_body
+
         sqlite_log_query_ref = system_manual_md.parent / "reference" / "sqlite-log-query" / "SKILL.md"
         assert sqlite_log_query_ref.is_file()
         sqlite_log_query_body = sqlite_log_query_ref.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- turn `psyche-manual` into a lighter router for molt guidance
- move the long consequential-molt scaffold/checklist into `psyche-manual/assets/molt-template.md`
- update resident/procedures routing language and package-test the new asset

## Validation
- `git diff --check origin/main...HEAD`
- `/Users/huangzesen/anaconda3/bin/python src/lingtai/core/skills/manual/scripts/validate.py src/lingtai/intrinsic_skills/psyche-manual`
- `/Users/huangzesen/anaconda3/bin/python -m pytest -q tests/test_skills.py tests/test_deep_refresh.py tests/test_validate_skill.py` (`61 passed`)

## Review notes
- Claude Code implementation-plan daemon recommended the asset/router split and no packaging changes.
- GLM review: APPROVE; version/path clarity nits applied.
- DeepSeek replacement review (MiMo preset auth failed): APPROVE; trigger-phrasing and section-level test nits applied.

Do not merge until Jason confirms.