### PR TITLE
fix: restart stale MCP stdio sessions

### DIFF
--- a/reports/pr-issue104-mcp-closed-resource-restart-explainer.html
+++ b/reports/pr-issue104-mcp-closed-resource-restart-explainer.html
@@ -1,0 +1,275 @@
+<!doctype html>
+<html lang="zh-Hans">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>MCP 陈旧连接自愈补丁说明：当 stdio 流悄悄断开之后</title>
+<style>
+  :root {
+    --bg: #fafafa;
+    --fg: #1a1a1a;
+    --muted: #555;
+    --line: #e0e0e0;
+    --line-soft: #efefef;
+    --card-bg: #ffffff;
+    --code-bg: #f4f4f5;
+    --code-fg: #1f2328;
+    --accent: #2c5fbf;
+    --green: #1f7a3a;
+    --green-bg: #e6f4ea;
+    --green-line: #b6dfc1;
+    --orange: #a85a00;
+    --orange-bg: #fdf3e6;
+    --orange-line: #e9c89a;
+    --red: #a72020;
+    --red-bg: #fbe9e9;
+    --red-line: #e7b4b4;
+    --blue: #1e4d8c;
+    --blue-bg: #e8f0fc;
+    --blue-line: #b3cdee;
+    --gray-bg: #f0f1f2;
+  }
+  * { box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: -apple-system, "Helvetica Neue", "PingFang SC",
+      "Hiragino Sans GB", "Microsoft YaHei", "Source Han Sans SC",
+      "Noto Sans CJK SC", sans-serif;
+    font-size: 15px;
+    line-height: 1.7;
+    margin: 0;
+    padding: 32px 24px 80px;
+  }
+  main { max-width: 880px; margin: 0 auto; }
+  h1 { font-size: 1.7em; margin: 0 0 4px; line-height: 1.3; }
+  h2 {
+    font-size: 1.18em; margin: 36px 0 10px; padding-bottom: 6px;
+    border-bottom: 1px solid var(--line);
+  }
+  h3 { font-size: 1.02em; margin: 22px 0 6px; }
+  p { margin: 10px 0; }
+  .sub { color: var(--muted); margin: 0 0 18px; font-size: 0.95em; }
+  .meta {
+    display: flex; flex-wrap: wrap; gap: 8px 18px;
+    font-size: 0.85em; color: var(--muted);
+    margin: 0 0 24px; padding-bottom: 18px; border-bottom: 1px solid var(--line);
+  }
+  .meta code { background: var(--code-bg); padding: 1px 6px; border-radius: 4px; }
+  code, pre {
+    font-family: "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    font-size: 0.86em;
+  }
+  p code, li code, td code {
+    background: var(--code-bg); color: var(--code-fg);
+    padding: 1px 6px; border-radius: 4px;
+  }
+  pre {
+    background: var(--code-bg); color: var(--code-fg);
+    padding: 14px 16px; border-radius: 8px; overflow-x: auto;
+    border: 1px solid var(--line); line-height: 1.55;
+  }
+  .card {
+    background: var(--card-bg); border: 1px solid var(--line);
+    border-radius: 10px; padding: 4px 20px 16px; margin: 16px 0;
+  }
+  .callout {
+    border-left: 4px solid var(--accent); border-radius: 0 8px 8px 0;
+    padding: 12px 16px; margin: 16px 0; background: var(--blue-bg);
+  }
+  .callout.bad { border-color: var(--red); background: var(--red-bg); }
+  .callout.good { border-color: var(--green); background: var(--green-bg); }
+  .callout.warn { border-color: var(--orange); background: var(--orange-bg); }
+  .callout .t { font-weight: 600; margin-bottom: 2px; }
+  .callout.bad .t { color: var(--red); }
+  .callout.good .t { color: var(--green); }
+  .callout.warn .t { color: var(--orange); }
+  table { border-collapse: collapse; width: 100%; margin: 14px 0; font-size: 0.92em; }
+  th, td { border: 1px solid var(--line); padding: 8px 12px; text-align: left; vertical-align: top; }
+  th { background: var(--gray-bg); font-weight: 600; }
+  .flow { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 14px 0; }
+  .flow .step {
+    background: var(--card-bg); border: 1px solid var(--line);
+    border-radius: 8px; padding: 8px 12px; font-size: 0.88em;
+  }
+  .flow .step.bad { background: var(--red-bg); border-color: var(--red-line); }
+  .flow .step.good { background: var(--green-bg); border-color: var(--green-line); }
+  .flow .arrow { color: var(--muted); font-weight: 600; }
+  ul, ol { margin: 8px 0; padding-left: 24px; }
+  li { margin: 4px 0; }
+  .files li { font-family: "SF Mono", Menlo, monospace; font-size: 0.86em; }
+  footer { margin-top: 48px; padding-top: 18px; border-top: 1px solid var(--line);
+    color: var(--muted); font-size: 0.85em; }
+  .tag {
+    display: inline-block; font-size: 0.78em; padding: 1px 8px; border-radius: 999px;
+    background: var(--blue-bg); color: var(--blue); border: 1px solid var(--blue-line);
+  }
+</style>
+</head>
+<body>
+<main>
+
+  <h1>MCP 陈旧连接自愈补丁</h1>
+  <p class="sub">当 stdio 流悄悄断开之后 —— 让工具调用不再返回空错误，并能自我重连重试一次。</p>
+
+  <div class="meta">
+    <span>Issue <code>Lingtai-AI/lingtai#104</code></span>
+    <span>分支 <code>fix/mcp-closed-resource-restart</code></span>
+    <span>核心文件 <code>src/lingtai/services/mcp.py</code></span>
+    <span class="tag">stdio MCPClient</span>
+  </div>
+
+  <h2>一、症状</h2>
+  <p>
+    一个被唤醒 / 恢复（revive / cpr）的智能体仍然挂着 Telegram 的 MCP 工具，但每一次工具调用都返回：
+  </p>
+  <pre>{"status": "error", "message": ""}</pre>
+  <p>事件日志里能看到异常类是 <code>ClosedResourceError</code>，消息为空，<code>elapsed_ms=0</code>。</p>
+  <ul>
+    <li>直接用 Telegram 包 / API 测试是好的 —— 说明配置与凭据都健康。</li>
+    <li><code>system(clear)</code> / <code>refresh</code> 修不好这个“看起来还活着、其实流已经断了”的桥。</li>
+    <li>只有 <code>suspend</code> → 等进程停 → <code>cpr</code> 重启子进程才能恢复。</li>
+  </ul>
+
+  <h2>二、三个根因</h2>
+
+  <div class="card">
+    <h3>1. 空错误（blank error）</h3>
+    <p>
+      <code>call_tool</code> 里的 <code>future.result()</code> 没有任何 try/except。
+      anyio 的 <code>ClosedResourceError</code> 的 <code>str(e)</code> 恰好是空字符串，
+      于是它要么裸抛、要么被上层渲染成空 <code>message</code>。启动路径同理：
+      <code>_run_loop</code> 用 <code>self._error = str(e)</code>，类名丢失，
+      <code>start()</code> 抛出的就是 <code>"MCP server failed to start: "</code>。
+    </p>
+  </div>
+
+  <div class="card">
+    <h3>2. 不会重连（no restart on stale）</h3>
+    <p>
+      <code>call_tool</code> 从不识别 <code>ClosedResourceError</code>。会话对象还在、
+      <code>_loop.is_running()</code> 还是 <code>True</code>，于是 <code>is_connected()</code>
+      返回 <code>True</code> —— 尽管底层 stdio 流早已死掉。这正是
+      <code>refresh</code> / <code>clear</code> 救不回来的原因：它们看到的是一座“还亮着灯的空房子”。
+    </p>
+  </div>
+
+  <div class="card">
+    <h3>3. <code>start()</code> 会撒谎（start lies after restart）</h3>
+    <p>
+      <code>start()</code> 在 <code>is_connected()</code> 时直接早返回，而且从不清理已锁存的启动状态：
+      <code>_ready</code> 事件一旦 set 就不再清，<code>_error</code> 留着旧值，
+      <code>close()</code> 之后 <code>_closed=True</code> 永久挡住重启。
+      即便不 close，陈旧的 <code>_ready</code> / <code>_error</code> 也会让新的 <code>start()</code>
+      立刻返回 —— 根本没有真正重连，却“声称”自己连上了。
+    </p>
+  </div>
+
+  <h2>三、修复</h2>
+
+  <h3>两个静态助手</h3>
+  <pre>@staticmethod
+def _format_exception(exc) -> str:
+    cls = type(exc).__name__
+    msg = str(exc).strip()
+    return f"{cls}: {msg}" if msg else cls   # 空消息 → 仅类名，永不空白
+
+@staticmethod
+def _is_stale_resource_error(exc) -> bool:
+    if type(exc).__name__ == "ClosedResourceError":   # 按类名匹配，无需 import anyio
+        return True
+    text = str(exc).lower()
+    return any(m in text for m in
+               ("closed", "broken pipe", "stream", "transport"))</pre>
+
+  <h3>真正的重连：<code>restart()</code></h3>
+  <p>把所有锁存的启动 / 会话状态清干净，让随后的 <code>start()</code> 不可能再撒谎：</p>
+  <pre>def restart(self) -> None:
+    self.close()
+    self._ready.clear()        # 否则 start() 会以为自己已就绪
+    self._error = None         # 否则 start() 会拿旧错误重新抛
+    self._closed = False       # 解除 close() 留下的永久封锁
+    self._session = None
+    self._read_stream = self._write_stream = None
+    self._loop = None
+    self._thread = None
+    self._stdio_cm = self._session_cm = None
+    self.start()               # 真正重新拉起子进程</pre>
+
+  <h3><code>call_tool</code>：陈旧即重启，重试一次</h3>
+  <div class="flow">
+    <span class="step">调用工具</span>
+    <span class="arrow">→</span>
+    <span class="step bad">抛出 ClosedResourceError</span>
+    <span class="arrow">→</span>
+    <span class="step">是陈旧资源？</span>
+    <span class="arrow">→</span>
+    <span class="step">restart()</span>
+    <span class="arrow">→</span>
+    <span class="step good">重试一次</span>
+  </div>
+
+  <table>
+    <tr><th>情形</th><th>返回</th></tr>
+    <tr><td>正常成功</td><td>原样返回工具结果（happy path 完全不变）</td></tr>
+    <tr><td>陈旧错误 + 重试成功</td><td>返回重试得到的正常结果</td></tr>
+    <tr><td>陈旧错误 + 重试仍失败</td>
+        <td><code>{status:"error", message:"ClosedResourceError: MCP session closed; restarted once but retry failed"}</code></td></tr>
+    <tr><td>非陈旧错误（不重启）</td>
+        <td><code>{status:"error", message:"&lt;ClassName&gt;: &lt;msg&gt;"}</code> —— 永不空白</td></tr>
+  </table>
+
+  <div class="callout good">
+    <div class="t">关键不变量</div>
+    最多重启一次、重试一次。成功路径零开销、零行为变化；失败路径永远带类名，不再有空 <code>message</code>。
+  </div>
+
+  <h2>四、范围与取舍</h2>
+  <ul>
+    <li><b>stdio 是上报的传输方式</b>，因此 <code>MCPClient</code> 拿到完整的“识别 → 重启 → 重试”闭环。</li>
+    <li><code>HTTPMCPClient</code> 仅复用 <code>_format_exception</code> 修掉连接期的空错误 ——
+        不加陈旧重启，避免在未复现的传输上过度改动（遵循 issue 的“don't overreach”）。</li>
+    <li>按<b>类名</b>而非 <code>isinstance</code> 识别 <code>ClosedResourceError</code>，
+        因此无需把 anyio 变成硬依赖。</li>
+  </ul>
+
+  <h2>五、测试</h2>
+  <p>全部使用 fake / monkeypatch —— 不需要真实的 Telegram 凭据或 MCP 子进程：</p>
+  <ul class="files">
+    <li>tests/test_mcp_closed_resource_restart.py</li>
+  </ul>
+  <table>
+    <tr><th>测试</th><th>验证</th></tr>
+    <tr><td>format_exception_empty_message</td><td>空 <code>str()</code> → 仅类名</td></tr>
+    <tr><td>format_exception_with_message</td><td><code>ValueError: boom</code></td></tr>
+    <tr><td>is_stale_resource_error_*</td><td>按类名 / 子串识别陈旧，其它错误不误判</td></tr>
+    <tr><td>restart_resets_startup_state</td><td>清空 <code>_ready/_error/_closed/session/loop/thread/cm</code></td></tr>
+    <tr><td>restarts_and_retries_once</td><td>陈旧 → 恰好 1 次重启 + 1 次重试 → 成功结果</td></tr>
+    <tr><td>failed_retry_returns_helpful_error</td><td>重试仍败 → 含类名、含 “retry”，非空白</td></tr>
+    <tr><td>non_stale_empty_error_surfaces_class</td><td>非陈旧空错误 → 类名，<b>且不重启</b></td></tr>
+    <tr><td>success_passes_through_unchanged</td><td>happy path 不重启、原样返回</td></tr>
+  </table>
+
+  <div class="callout">
+    <div class="t">验证结果</div>
+    新增 10 个测试全部通过；既有 MCP 测试（<code>test_mcp_capability.py</code>、
+    <code>test_mcp_inbox.py</code>，49 项）保持绿色；全量套件 2023 通过 / 3 跳过，
+    仅有 2 个与本改动无关的既有失败（沙箱 <code>/tmp/</code> 路径触发的 file_io / daemon 断言，
+    在未应用本补丁时同样失败）。
+  </div>
+
+  <h2>六、改动文件</h2>
+  <ul class="files">
+    <li>src/lingtai/services/mcp.py　　— 助手 + restart() + call_tool 重试 + 启动错误格式化</li>
+    <li>src/lingtai/services/ANATOMY.md　— 同提交更新结构说明（仓库纪律）</li>
+    <li>tests/test_mcp_closed_resource_restart.py — 新增聚焦测试</li>
+    <li>reports/pr-issue104-mcp-closed-resource-restart-explainer.html — 本文</li>
+  </ul>
+
+  <footer>
+    灵台 · MCP 陈旧连接自愈补丁 · Issue #104 · 仅修 stdio，HTTP 仅修空错误。
+  </footer>
+
+</main>
+</body>
+</html>

--- a/src/lingtai/services/ANATOMY.md
+++ b/src/lingtai/services/ANATOMY.md
@@ -12,7 +12,7 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 | `file_io.py` | 491 | `FileIOService` facade contract + `FileIOBackend`/`LocalFileIOBackend` — backs read/edit/write/glob/grep |
 | `file_io_sidecar.py` | 619 | Rust-backed grep/glob: `RustFileIOBackend`, `SidecarAdapter`, `SidecarError`, plus the `resolve_sidecar_binary` resolver and the `default_file_io_service` factory used by `Agent.__init__` |
 | `mail.py` | 4 | Re-exports `MailService`, `FilesystemMailService` from `lingtai_kernel.services.mail` |
-| `mcp.py` | 431 | `MCPClient` (stdio) + `HTTPMCPClient` (streamable HTTP) — async-to-sync MCP bridges |
+| `mcp.py` | 510 | `MCPClient` (stdio) + `HTTPMCPClient` (streamable HTTP) — async-to-sync MCP bridges |
 
 **Sub-packages (not covered here):** `vision/` (7 provider files), `websearch/` (6 provider files).
 **Sibling crates:** `experimental/lingtai-search-sidecar/` (Rust) — opt-in binary that backs `RustFileIOBackend`. Not required for install/tests.
@@ -42,7 +42,8 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 ## Notes
 
 - `MCPClient` uses `stdio_client` transport (subprocess); `HTTPMCPClient` uses `streamablehttp_client` (remote HTTP/SSE). Both expose identical `call_tool()` / `list_tools()` / `close()` API.
-- Lazy start: both clients auto-connect on first `call_tool()` (L119, 321).
+- Lazy start: both clients auto-connect on first `call_tool()`.
+- **Stale-resource recovery (issue #104):** `MCPClient` detects a dead stdio transport in `call_tool` and recovers. `_format_exception` renders `ClassName: message` (class-only when `str(e)` is empty) so an empty `ClosedResourceError` never surfaces as a blank `{"status":"error","message":""}`. `_is_stale_resource_error` flags closed/broken transports by class name + message substrings. On a stale error `call_tool` calls `restart()` (which `close()`s, clears `_ready`/`_error`, resets `_closed`/`_session`/`_loop`/`_thread`/`*_cm` so `start()` cannot lie) and retries **once**; a failed retry returns a helpful error naming the class and the retry failure. Non-stale errors surface the class name without churning the subprocess. `HTTPMCPClient` reuses `MCPClient._format_exception` for its connect error only — it has no stale-resource restart (stdio is the reported transport). Tests: `tests/test_mcp_closed_resource_restart.py`.
 - `mcp.py` has significant code duplication between the two classes — same `call_tool()`, `list_tools()`, `_run_loop()`, `_async_cleanup()` pattern.
 - `mail.py` is a thin shim — the real implementation lives in `lingtai_kernel.services.mail`.
 - `file_io_sidecar.py` is the **default native backend** for `Agent`-created file-I/O services. `default_file_io_service` is the factory that `Agent.__init__` calls; it consults `LINGTAI_FILE_IO_BACKEND` (`auto` / `rust` / `python`, default `auto`) and `resolve_sidecar_binary` to pick between Rust and the pure-Python `LocalFileIOBackend`. Resolver priority: explicit `binary_path=` > `LINGTAI_FILE_IO_SIDECAR` env > `LINGTAI_SEARCH_SIDECAR` (legacy) env > packaged `lingtai/bin/` binary (shipped in platform-specific wheels by `setup.py`) > dev-tree `experimental/lingtai-search-sidecar/target/{release,debug}/`. The strict `SidecarAdapter()` constructor still ignores packaged / dev-tree sources — opt-in callers see `not_configured` rather than picking up a stale binary. Defaults (`DEFAULT_*` constants) are imported from `file_io.py` so both backends stay in lock-step. Cargo is **not** required for install or the normal test suite — tests use a Python-script "sidecar"; only `test_rust_sidecar_integration_grep_and_glob` is cargo-gated.

--- a/src/lingtai/services/mcp.py
+++ b/src/lingtai/services/mcp.py
@@ -55,6 +55,39 @@ class MCPClient:
         self._activity_lock = threading.Lock()
 
     # ------------------------------------------------------------------
+    # Exception helpers — never surface a blank error (issue #104)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_exception(exc: BaseException) -> str:
+        """Render an exception as ``ClassName: message``.
+
+        Some MCP/anyio exceptions (notably ``ClosedResourceError``) have an
+        empty ``str()``. Falling through to that empty string is what produced
+        the blank ``{"status": "error", "message": ""}`` in issue #104. When the
+        message is empty we fall back to the class name alone.
+        """
+        cls = type(exc).__name__
+        msg = str(exc).strip()
+        return f"{cls}: {msg}" if msg else cls
+
+    @staticmethod
+    def _is_stale_resource_error(exc: BaseException) -> bool:
+        """Detect a dead/closed MCP transport that warrants a restart.
+
+        Primary signal is the exception class name ``ClosedResourceError``
+        (anyio) — matched by name so we need not import anyio. As a secondary
+        signal we look for closed-stream substrings in the message.
+        """
+        if type(exc).__name__ == "ClosedResourceError":
+            return True
+        text = str(exc).lower()
+        return any(
+            marker in text
+            for marker in ("closed", "broken pipe", "stream", "transport")
+        )
+
+    # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
@@ -80,6 +113,29 @@ class MCPClient:
             self._loop.call_soon_threadsafe(self._loop.stop)
         if self._thread:
             self._thread.join(timeout=5)
+
+    def restart(self) -> None:
+        """Tear down a (possibly stale) session and reconnect from scratch.
+
+        ``start()`` early-returns when it believes it is connected and never
+        clears latched startup state, so a stale ``_ready``/``_error`` or a
+        ``_closed`` flag from a prior ``close()`` would make a fresh ``start()``
+        lie (return immediately, or raise on the *old* error). This resets all
+        startup/session fields so the subsequent ``start()`` is a real reconnect.
+        Used by ``call_tool`` to recover from a closed stdio resource (issue #104).
+        """
+        self.close()
+        self._ready.clear()
+        self._error = None
+        self._closed = False
+        self._session = None
+        self._read_stream = None
+        self._write_stream = None
+        self._loop = None
+        self._thread = None
+        self._stdio_cm = None
+        self._session_cm = None
+        self.start()
 
     def is_connected(self) -> bool:
         """Check if the client has an active session."""
@@ -122,30 +178,69 @@ class MCPClient:
         if self._session is None or self._loop is None:
             raise RuntimeError("MCP client not connected")
 
-        async def _call():
-            result = await self._session.call_tool(
-                name=name,
-                arguments=args,
-                read_timeout_seconds=timedelta(seconds=timeout),
-            )
-            if result.isError:
-                error_text = (
-                    result.content[0].text if result.content else "Unknown MCP error"
+        def _attempt() -> dict:
+            async def _call():
+                result = await self._session.call_tool(
+                    name=name,
+                    arguments=args,
+                    read_timeout_seconds=timedelta(seconds=timeout),
                 )
-                return {"status": "error", "message": error_text}
+                if result.isError:
+                    error_text = (
+                        result.content[0].text
+                        if result.content
+                        else "Unknown MCP error"
+                    )
+                    return {"status": "error", "message": error_text}
 
-            if result.content:
-                for block in result.content:
-                    if hasattr(block, "text"):
-                        try:
-                            return json.loads(block.text)
-                        except (json.JSONDecodeError, TypeError):
-                            return {"status": "success", "text": block.text}
+                if result.content:
+                    for block in result.content:
+                        if hasattr(block, "text"):
+                            try:
+                                return json.loads(block.text)
+                            except (json.JSONDecodeError, TypeError):
+                                return {"status": "success", "text": block.text}
 
-            return {"status": "success", "text": ""}
+                return {"status": "success", "text": ""}
 
-        future = asyncio.run_coroutine_threadsafe(_call(), self._loop)
-        result = future.result(timeout=timeout)
+            future = asyncio.run_coroutine_threadsafe(_call(), self._loop)
+            return future.result(timeout=timeout)
+
+        try:
+            result = _attempt()
+        except Exception as exc:
+            formatted = self._format_exception(exc)
+            if not self._is_stale_resource_error(exc):
+                # Non-stale failure: surface the class name so the error is
+                # never blank (issue #104), but don't churn the subprocess.
+                result = {"status": "error", "message": formatted}
+            else:
+                # Stale/closed resource: tear down and reconnect, retry once.
+                logger.warning(
+                    "MCP tool %s hit stale resource (%s); restarting and "
+                    "retrying once", name, formatted,
+                )
+                try:
+                    self.restart()
+                except Exception as restart_exc:
+                    result = {
+                        "status": "error",
+                        "message": (
+                            f"{formatted}: MCP session closed; restart failed: "
+                            f"{self._format_exception(restart_exc)}"
+                        ),
+                    }
+                else:
+                    try:
+                        result = _attempt()
+                    except Exception as retry_exc:
+                        result = {
+                            "status": "error",
+                            "message": (
+                                f"{self._format_exception(retry_exc)}: MCP "
+                                "session closed; restarted once but retry failed"
+                            ),
+                        }
 
         # Log activity
         with self._activity_lock:
@@ -210,7 +305,9 @@ class MCPClient:
             loop.run_until_complete(self._async_connect())
             loop.run_forever()
         except Exception as e:
-            self._error = str(e)
+            # Preserve the class name so a blank str(e) (e.g. ClosedResourceError)
+            # does not produce "MCP server failed to start: " (issue #104).
+            self._error = self._format_exception(e)
             self._ready.set()
         finally:
             try:
@@ -393,7 +490,9 @@ class HTTPMCPClient:
             loop.run_until_complete(self._async_connect())
             loop.run_forever()
         except Exception as e:
-            self._error = str(e)
+            # Preserve the class name so a blank str(e) is not surfaced as an
+            # empty connect error (issue #104).
+            self._error = MCPClient._format_exception(e)
             self._ready.set()
         finally:
             try:

--- a/tests/test_mcp_closed_resource_restart.py
+++ b/tests/test_mcp_closed_resource_restart.py
@@ -1,0 +1,240 @@
+"""Stale-resource recovery for stdio MCPClient — regression for Lingtai-AI/lingtai#104.
+
+A revived agent kept a Telegram MCP tool registered, but every call returned
+``{"status": "error", "message": ""}``. The underlying exception was anyio's
+``ClosedResourceError`` (empty ``str(e)``) raised against a dead stdio stream
+whose session object still looked "connected". ``refresh``/``clear`` could not
+repair it because ``call_tool`` never tore down and re-spawned the subprocess.
+
+These tests use fakes/monkeypatching only — no real MCP subprocess, no Telegram
+credentials. They exercise:
+  - empty-message exceptions surface the class name (no blank errors)
+  - a stale ``ClosedResourceError`` triggers exactly one restart + retry
+  - a successful retry returns the normal tool result
+  - a failed retry returns a helpful error mentioning the class and that
+    restart/retry failed (never blank)
+  - non-stale exceptions surface a useful error, no restart attempted
+  - ``restart()`` resets startup state so ``start()`` cannot lie
+"""
+from __future__ import annotations
+
+import pytest
+
+from lingtai.services.mcp import MCPClient
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class ClosedResourceError(Exception):
+    """Stand-in for anyio.ClosedResourceError — same class name, empty str()."""
+
+
+class _FakeFuture:
+    """Mimics concurrent.futures.Future enough for call_tool: result() either
+    returns a value or raises the staged exception."""
+
+    def __init__(self, value=None, exc=None):
+        self._value = value
+        self._exc = exc
+
+    def result(self, timeout=None):
+        if self._exc is not None:
+            raise self._exc
+        return self._value
+
+
+def _install_fake_loop(client: MCPClient):
+    """Make the client look connected without a real subprocess/event loop."""
+    client._session = object()
+
+    class _Loop:
+        def is_running(self):
+            return True
+
+    client._loop = _Loop()
+    client._closed = False
+
+
+# ---------------------------------------------------------------------------
+# Exception formatting
+# ---------------------------------------------------------------------------
+
+def test_format_exception_empty_message_uses_class_name():
+    """An exception whose str() is empty must surface its class name."""
+    msg = MCPClient._format_exception(ClosedResourceError())
+    assert msg == "ClosedResourceError"
+    assert msg.strip() != ""
+
+
+def test_format_exception_with_message_includes_class_and_message():
+    msg = MCPClient._format_exception(ValueError("boom"))
+    assert msg == "ValueError: boom"
+
+
+# ---------------------------------------------------------------------------
+# Stale-resource detection
+# ---------------------------------------------------------------------------
+
+def test_is_stale_resource_error_detects_closed_resource_by_class_name():
+    assert MCPClient._is_stale_resource_error(ClosedResourceError()) is True
+
+
+def test_is_stale_resource_error_detects_closed_substrings():
+    assert MCPClient._is_stale_resource_error(
+        RuntimeError("the stream was closed")) is True
+
+
+def test_is_stale_resource_error_false_for_unrelated_errors():
+    assert MCPClient._is_stale_resource_error(ValueError("bad arg")) is False
+
+
+# ---------------------------------------------------------------------------
+# restart() resets startup state
+# ---------------------------------------------------------------------------
+
+def test_restart_resets_startup_state_so_start_cannot_lie(monkeypatch):
+    """After a first start, _ready is set and _error may linger. restart()
+    must clear _ready/_error, reset _closed, drop stale session/loop/thread/cm
+    so the next start() actually reconnects instead of early-returning."""
+    client = MCPClient(command="/bin/true")
+
+    # Simulate a prior (now-dead) start: ready latched, error latched, closed.
+    client._ready.set()
+    client._error = "old startup error"
+    client._closed = True
+    client._session = object()
+    client._stdio_cm = object()
+    client._session_cm = object()
+
+    closed = {"n": 0}
+    started = {"n": 0}
+
+    def fake_close():
+        closed["n"] += 1
+
+    def fake_start():
+        started["n"] += 1
+
+    monkeypatch.setattr(client, "close", fake_close)
+    monkeypatch.setattr(client, "start", fake_start)
+
+    client.restart()
+
+    assert closed["n"] == 1
+    assert started["n"] == 1
+    # State reset so a real start() would not early-return or raise on stale error.
+    assert not client._ready.is_set()
+    assert client._error is None
+    assert client._closed is False
+    assert client._session is None
+    assert client._stdio_cm is None
+    assert client._session_cm is None
+
+
+# ---------------------------------------------------------------------------
+# call_tool: stale ClosedResourceError → restart + retry once
+# ---------------------------------------------------------------------------
+
+def test_call_tool_restarts_and_retries_once_on_stale_error(monkeypatch):
+    """First attempt raises stale ClosedResourceError → client restarts and
+    retries exactly once → retry succeeds → normal result returned."""
+    client = MCPClient(command="/bin/true")
+    _install_fake_loop(client)
+
+    attempts = {"n": 0}
+    restarts = {"n": 0}
+
+    def fake_run(coro, loop):
+        # The coroutine is created but never awaited in this fake; close it to
+        # avoid "coroutine was never awaited" warnings.
+        coro.close()
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            return _FakeFuture(exc=ClosedResourceError())
+        return _FakeFuture(value={"status": "success", "text": "pong"})
+
+    monkeypatch.setattr(
+        "asyncio.run_coroutine_threadsafe", fake_run)
+
+    def fake_restart():
+        restarts["n"] += 1
+        _install_fake_loop(client)
+
+    monkeypatch.setattr(client, "restart", fake_restart)
+
+    result = client.call_tool("send_message", {"text": "hi"})
+
+    assert attempts["n"] == 2          # original + one retry
+    assert restarts["n"] == 1          # restarted exactly once
+    assert result == {"status": "success", "text": "pong"}
+
+
+def test_call_tool_failed_retry_returns_helpful_error_not_blank(monkeypatch):
+    """If the retry also fails, return a helpful error mentioning the class
+    name and that restart/retry failed — never a blank message."""
+    client = MCPClient(command="/bin/true")
+    _install_fake_loop(client)
+
+    def fake_run(coro, loop):
+        coro.close()
+        return _FakeFuture(exc=ClosedResourceError())  # always stale
+
+    monkeypatch.setattr("asyncio.run_coroutine_threadsafe", fake_run)
+    monkeypatch.setattr(client, "restart", lambda: _install_fake_loop(client))
+
+    result = client.call_tool("send_message", {"text": "hi"})
+
+    assert result["status"] == "error"
+    assert result["message"]                       # not blank
+    assert "ClosedResourceError" in result["message"]
+    assert "retry" in result["message"].lower()
+
+
+def test_call_tool_non_stale_empty_error_surfaces_class_name(monkeypatch):
+    """A non-stale exception with an empty str() must surface the class name,
+    not a blank message, and must NOT trigger a restart."""
+    client = MCPClient(command="/bin/true")
+    _install_fake_loop(client)
+
+    class WeirdEmptyError(Exception):
+        pass
+
+    restarts = {"n": 0}
+
+    def fake_run(coro, loop):
+        coro.close()
+        return _FakeFuture(exc=WeirdEmptyError())
+
+    monkeypatch.setattr("asyncio.run_coroutine_threadsafe", fake_run)
+    monkeypatch.setattr(
+        client, "restart", lambda: restarts.__setitem__("n", restarts["n"] + 1))
+
+    result = client.call_tool("send_message", {"text": "hi"})
+
+    assert result["status"] == "error"
+    assert "WeirdEmptyError" in result["message"]
+    assert restarts["n"] == 0           # non-stale → no restart
+
+
+def test_call_tool_success_passes_through_unchanged(monkeypatch):
+    """The happy path is untouched: a successful call returns its result and
+    never restarts."""
+    client = MCPClient(command="/bin/true")
+    _install_fake_loop(client)
+
+    restarts = {"n": 0}
+
+    def fake_run(coro, loop):
+        coro.close()
+        return _FakeFuture(value={"status": "success", "text": "ok"})
+
+    monkeypatch.setattr("asyncio.run_coroutine_threadsafe", fake_run)
+    monkeypatch.setattr(
+        client, "restart", lambda: restarts.__setitem__("n", restarts["n"] + 1))
+
+    result = client.call_tool("send_message", {"text": "hi"})
+
+    assert result == {"status": "success", "text": "ok"}
+    assert restarts["n"] == 0


### PR DESCRIPTION
## Summary
- surface MCP bridge exceptions with class names when `str(exc)` is empty, so failures like `ClosedResourceError` no longer become `{"status":"error","message":""}`
- detect stale/closed stdio MCP resources, restart the MCP client/session, and retry the tool call once
- reset latched MCP client startup/session state during restart so `_ready`, `_error`, and `_closed` do not make reconnects lie
- document the recovery behavior in `src/lingtai/services/ANATOMY.md`
- add focused fake-session tests plus the required HTML explainer at `reports/pr-issue104-mcp-closed-resource-restart-explainer.html`

Addresses Lingtai-AI/lingtai#104

## Testing
- `python -m py_compile src/lingtai/services/mcp.py tests/test_mcp_closed_resource_restart.py`
- `pytest tests/test_mcp_closed_resource_restart.py tests/test_mcp_capability.py tests/test_mcp_inbox.py -q` → 59 passed
- `git diff --check`

## Notes
Claude Code also ran the broader suite and found two unrelated environment-dependent failures in this sandbox (`/tmp/` path assertions in file I/O/daemon tests); the focused MCP coverage and existing MCP capability/inbox tests pass.
