### PR TITLE
fix: honor daemon max emanations config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ CustomAgent(Agent) — host's wrapper (subclass with domain logic)
 | `draw` | `capabilities=["draw"]` | Text-to-image via MiniMax MCP |
 | `video` | `capabilities=["video"]` or `{"video": {"provider": "minimax"}}` | Video generation via MiniMax MCP. Text-to-video and image-to-video (via `first_frame_image`). Director models support camera movement instructions in prompts. Output: MP4 saved to media/videos/. |
 | `listen` | `capabilities=["listen"]` | Speech transcription + music analysis |
-| `daemon` | `capabilities=["daemon"]` or `{"daemon": {"max_emanations": 10}}` | Subagent system (分神). Dispatch ephemeral LLM sessions as parallel workers in the same working dir. Actions: emanate (分, dispatch batch), list (观, status), ask (问, follow-up), reclaim (收, kill all). Results return as `[daemon:em-N]` notifications. MCP tools auto-inherited. Blacklist: daemon, avatar, psyche, skills, knowledge. |
+| `daemon` | `capabilities=["daemon"]` or `{"daemon": {"max_emanations": 100}}` | Subagent system (分神). Dispatch ephemeral LLM sessions as parallel workers in the same working dir. Actions: emanate (分, dispatch batch), list (观, status), ask (问, follow-up), reclaim (收, kill all). Results return as `[daemon:em-N]` notifications. MCP tools auto-inherited. Blacklist: daemon, avatar, psyche, skills, knowledge. |
 
 ### Extension Pattern
 

--- a/reports/pr-daemon-max-emanations-config-explainer.html
+++ b/reports/pr-daemon-max-emanations-config-explainer.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Daemon 并发上限与 init.json 覆盖修复</title>
+  <style>
+    :root { color-scheme: light; --bg:#f7f8fb; --card:#fff; --ink:#1f2937; --muted:#6b7280; --line:#e5e7eb; --good:#047857; --warn:#b45309; --blue:#1d4ed8; }
+    body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; background:var(--bg); color:var(--ink); line-height:1.6; }
+    main { max-width:960px; margin:0 auto; padding:32px 20px 56px; }
+    header { margin-bottom:24px; }
+    h1 { font-size:30px; margin:0 0 8px; }
+    h2 { margin-top:28px; font-size:20px; }
+    .subtitle { color:var(--muted); margin:0; }
+    .card { background:var(--card); border:1px solid var(--line); border-radius:16px; padding:20px; margin:16px 0; box-shadow:0 1px 2px rgba(0,0,0,.04); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px; }
+    .pill { display:inline-block; padding:2px 10px; border-radius:999px; font-size:13px; border:1px solid var(--line); background:#f9fafb; }
+    .good { color:var(--good); font-weight:700; }
+    .warn { color:var(--warn); font-weight:700; }
+    code { background:#f3f4f6; padding:2px 5px; border-radius:5px; font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.92em; }
+    pre { background:#111827; color:#e5e7eb; padding:14px; border-radius:12px; overflow:auto; }
+    ul { padding-left:22px; }
+    table { width:100%; border-collapse:collapse; margin-top:8px; }
+    th,td { border-bottom:1px solid var(--line); padding:10px; text-align:left; vertical-align:top; }
+    th { color:#374151; background:#f9fafb; }
+    .small { color:var(--muted); font-size:14px; }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>Daemon 并发上限与 init.json 覆盖修复</h1>
+    <p class="subtitle">目标：默认 daemon 并发上限从 10 提到 100，并确保 <code>manifest.capabilities.daemon.max_emanations</code> 能通过 <code>init.json</code> 覆盖默认值。</p>
+  </header>
+
+  <section class="card">
+    <h2>结论</h2>
+    <p><span class="good">已修复两个问题。</span> 原因不是单纯默认值低，而是 active preset materialization 会把 agent 自己写在 <code>init.json</code> 里的 core capability kwargs 覆盖掉；因此即使写了 <code>daemon.max_emanations=30/50</code>，refresh 后仍回到默认。</p>
+    <div class="grid">
+      <div><span class="pill">默认值</span><br/>Daemon 默认 <code>max_emanations</code>：<strong>10 → 100</strong></div>
+      <div><span class="pill">可配置</span><br/><code>init.json</code> 的 daemon override 在 preset refresh 后会保留</div>
+      <div><span class="pill">兼容性</span><br/>非 core 的可选 capability 仍由 preset 决定，不被 init-only 项污染</div>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2>Root cause</h2>
+    <ol>
+      <li><code>DaemonManager</code> 和 <code>daemon.setup()</code> 的默认参数写死为 <code>10</code>。</li>
+      <li>更隐蔽的问题：<code>materialize_active_preset()</code> 会把 <code>manifest.capabilities</code> 换成 active preset 的 capabilities。Codex preset 不显式列 <code>daemon</code>，但 <code>daemon</code> 是 core default；后续 <code>apply_core_defaults()</code> 重新加回 <code>daemon={}</code>，于是 init.json 的 <code>max_emanations</code> 丢失。</li>
+    </ol>
+  </section>
+
+  <section class="card">
+    <h2>修复设计</h2>
+    <table>
+      <tr><th>场景</th><th>新行为</th></tr>
+      <tr><td>Preset 也启用了同名 capability</td><td>按 key 合并，preset 提供默认，<code>init.json</code> kwargs 优先。</td></tr>
+      <tr><td>Preset 没列出 core default capability（如 daemon）</td><td>保留 <code>init.json</code> 对 core default capability 的 kwargs，因为这些 capability 本来就会启动。</td></tr>
+      <tr><td>Preset 没列出非 core 可选 capability（如 vision/web_search）</td><td>仍然丢弃 init-only 可选 capability，保持“切换 preset = 切换能力集合”的语义。</td></tr>
+      <tr><td><code>skills.paths</code></td><td>保留原有特殊规则：preset paths 在前，init.json paths append + 去重。</td></tr>
+    </table>
+  </section>
+
+  <section class="card">
+    <h2>主要改动文件</h2>
+    <ul>
+      <li><code>src/lingtai/core/daemon/__init__.py</code>：默认 <code>max_emanations</code> 改为 100。</li>
+      <li><code>src/lingtai_kernel/presets.py</code>：preset materialization 支持 core default capability kwargs carry-forward。</li>
+      <li><code>src/lingtai/agent.py</code> / <code>src/lingtai/cli.py</code>：调用 materialization 时注入 <code>CORE_DEFAULTS</code>，避免 kernel 包反向依赖 wrapper。</li>
+      <li><code>tests/test_preset_materialization.py</code>、<code>tests/test_daemon.py</code>、<code>tests/test_presets.py</code>：新增/更新回归测试。</li>
+      <li><code>src/lingtai/ANATOMY.md</code>、<code>CLAUDE.md</code>：同步说明。</li>
+    </ul>
+  </section>
+
+  <section class="card">
+    <h2>验证</h2>
+    <pre>PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m pytest \
+  tests/test_preset_materialization.py \
+  tests/test_presets.py \
+  tests/test_daemon.py::test_daemon_default_max_emanations_is_100 \
+  tests/test_daemon.py::test_daemon_max_emanations_override_reaches_manager \
+  tests/test_cli.py -q
+
+# 100 passed
+
+git diff --check
+# pass</pre>
+    <p class="small">备注：更宽的 daemon suite 里有一个已确认 baseline 也失败的 pre-existing timing/flaky case：<code>tests/test_daemon.py::test_emanate_creates_folder_on_disk</code> 会因 mock daemon 结束太快而看到 <code>done</code> 而不是 <code>running</code>；本 PR 未触碰该逻辑。</p>
+  </section>
+</main>
+</body>
+</html>

--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -24,7 +24,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **`cli.py`**: `load_init` :21 · `build_agent` :72 · `run` :200 · `main` :246
 
-**`presets.py`**: compatibility re-export shim (`presets.py:1-21`); implementation lives in `lingtai_kernel.presets` (`load_preset` :175 · `materialize_active_preset` :290 · `expand_inherit` :444 · `discover_presets_in_dirs` :121).
+**`presets.py`**: compatibility re-export shim (`presets.py:1-21`); implementation lives in `lingtai_kernel.presets` (`load_preset` :175 · `materialize_active_preset` :290 · `expand_inherit` :503 · `discover_presets_in_dirs` :121).
 
 **`init_schema.py`**: `DEPRECATED_TOP_FIELDS` :28 (plain deprecated top-level fields stripped by `strip_deprecated`), `LEGACY_MIGRATED_TOP_FIELDS` :38 (legacy fields removed by version-controlled agent migrations and known only as inactive schema), `validate_init` :98, `TOP_OPTIONAL` :13, `MANIFEST_OPTIONAL` :59.
 
@@ -46,7 +46,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **Capability registration:** `setup_capability()` in `capabilities/__init__.py`; the registry is `_BUILTIN` (per-capability module paths) plus `CORE_DEFAULTS` (which boot automatically). Agent calls `apply_core_defaults` + `_setup_capability` (agent.py:148) during `__init__` and `_setup_from_init`. Hosts disable defaults via the `disable=[...]` kwarg or `manifest.disable` in init.json.
 
-**Agent init migration + preset materialization:** `run_agent_migrations` (`lingtai_kernel/migrate/migrate.py:285`) is called by `cli.load_init` (boot) and `Agent._read_init` (refresh) before `init.json` is read/validated. Then `materialize_active_preset` (`lingtai_kernel/presets.py:290`) reads `manifest.preset.active`, loads preset, substitutes `llm`+`capabilities` into manifest before validation.
+**Agent init migration + preset materialization:** `run_agent_migrations` (`lingtai_kernel/migrate/migrate.py:285`) is called by `cli.load_init` (boot) and `Agent._read_init` (refresh) before `init.json` is read/validated. Then `materialize_active_preset` (`lingtai_kernel/presets.py:290`) reads `manifest.preset.active`, loads preset, substitutes `llm`+`capabilities` into manifest before validation. The preset owns explicit opt-in capabilities, but per-agent init.json kwargs survive in two ways: (1) for capabilities the preset *also* enables, init.json wins key-by-key; (2) for always-on `CORE_DEFAULTS` capabilities the preset *omits* (daemon, bash, knowledge, …), init.json kwargs are carried forward so `apply_core_defaults` doesn't re-add an empty entry and lose e.g. `daemon.max_emanations`. Non-core optional caps the preset omits are dropped (the swap). `CORE_DEFAULTS` lives in `lingtai.capabilities` and is injected via the `core_defaults=` arg by both callers (`agent._read_init` :861, `cli.load_init` :48) — the kernel does not import the wrapper. `skills.paths` additionally append-merges (preset defaults first).
 
 ## Composition
 

--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -842,6 +842,7 @@ class Agent(BaseAgent):
         from lingtai_kernel.config_resolve import resolve_paths
         from lingtai_kernel.migrate import run_agent_migrations
         from .presets import expand_inherit, materialize_active_preset
+        from .capabilities import CORE_DEFAULTS
 
         run_agent_migrations(self._working_dir)
 
@@ -858,7 +859,8 @@ class Agent(BaseAgent):
         # Materialize active preset, if any, BEFORE validation so the manifest
         # the schema validates is the fully-resolved one the agent will run on.
         try:
-            materialize_active_preset(data, self._working_dir)
+            materialize_active_preset(data, self._working_dir,
+                                      core_defaults=CORE_DEFAULTS)
         except (KeyError, ValueError) as e:
             self._log("refresh_init_error",
                       error=f"preset materialization failed: {e}")

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -28,6 +28,7 @@ def load_init(working_dir: Path) -> dict:
     """
     from lingtai_kernel.config_resolve import resolve_paths
     from lingtai.presets import materialize_active_preset
+    from lingtai.capabilities import CORE_DEFAULTS
 
     from lingtai_kernel.migrate import run_agent_migrations
 
@@ -45,7 +46,7 @@ def load_init(working_dir: Path) -> dict:
         sys.exit(1)
 
     try:
-        materialize_active_preset(data, working_dir)
+        materialize_active_preset(data, working_dir, core_defaults=CORE_DEFAULTS)
     except (KeyError, ValueError) as e:
         print(f"error: failed to materialize active preset: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -7,7 +7,7 @@ agent.  Results are persisted in daemon run directories; completion is surfaced 
 
 Usage:
     Agent(capabilities=["daemon"])
-    Agent(capabilities={"daemon": {"max_emanations": 10}})
+    Agent(capabilities={"daemon": {"max_emanations": 100}})
 """
 from __future__ import annotations
 
@@ -334,7 +334,7 @@ class DaemonManager:
     # Short results (e.g. "[cancelled]") are suppressed to avoid notification storms.
     _NOTIFY_MIN_LEN = 20
 
-    def __init__(self, agent: "Agent", max_emanations: int = 10,
+    def __init__(self, agent: "Agent", max_emanations: int = 100,
                  max_turns: int = 200, timeout: float = 3600.0,
                  notify_threshold: int = 20):
         self._agent = agent
@@ -3257,7 +3257,7 @@ class DaemonManager:
             self._agent._log(event_type, **fields)
 
 
-def setup(agent: "Agent", max_emanations: int = 10,
+def setup(agent: "Agent", max_emanations: int = 100,
           max_turns: int = 200, timeout: float = 3600.0,
           notify_threshold: int = 20) -> DaemonManager:
     """Set up the daemon capability on an agent."""

--- a/src/lingtai_kernel/presets.py
+++ b/src/lingtai_kernel/presets.py
@@ -286,18 +286,47 @@ def load_preset(
     return data
 
 
-def materialize_active_preset(data: dict, working_dir: Path) -> None:
+def materialize_active_preset(
+    data: dict,
+    working_dir: Path,
+    core_defaults: dict | set | list | None = None,
+) -> None:
     """Substitute the active preset's llm + capabilities into init.json data.
 
     If ``manifest.preset.active`` is set, load that preset and copy its
     ``manifest.llm`` and ``manifest.capabilities`` into ``data["manifest"]``
     so downstream validators and consumers see a fully-resolved manifest.
 
-    Capabilities are wholesale-replaced by the preset (atomic swap is the
-    whole point of presets) with one carve-out: ``skills.paths`` from
-    init.json appends to the preset's skills paths, deduped, preset defaults
-    first. Skill paths are project-truth (where this agent's extra skills
-    live) — swapping presets should not erase them.
+    The active preset owns explicit opt-in capability/tier choices (atomic
+    swap is the whole point of presets), but it must not silently discard
+    per-agent capability kwargs declared in init.json. Two layers preserve
+    those:
+
+    - **Per-key override** (any capability the preset *also* enables):
+      init.json's kwargs win key-by-key over the preset's — e.g. init.json's
+      ``daemon.max_emanations`` survives a preset that also enables daemon
+      with a different ceiling.
+    - **Core-default carry-forward** (capabilities the preset *omits*): for
+      capability names in ``core_defaults`` — the always-on floor
+      (``knowledge``/``skills``/``bash``/``avatar``/``daemon``/``mcp``/
+      ``read``/``write``/``edit``/``glob``/``grep``) — init.json's kwargs are
+      carried into the materialized manifest even when the preset never
+      mentions the capability. Without this, a preset that omits ``daemon``
+      drops init.json's ``daemon.max_emanations``, and ``apply_core_defaults``
+      later re-adds ``daemon={}`` (losing the override). Non-core optional
+      capabilities (``vision``/``web_search``/...) the preset omits are NOT
+      carried — that omission is the swap.
+
+    ``core_defaults`` is the set/dict/list of always-on capability names; pass
+    ``lingtai.capabilities.CORE_DEFAULTS`` from the wrapper. It lives in
+    ``lingtai`` (not the kernel), so it is injected rather than imported —
+    the kernel must not depend on the wrapper. When ``None`` (legacy callers
+    and the no-core tests), only the per-key override layer runs.
+
+    The ``skills.paths`` carve-out (init.json extras append to the preset's
+    skills paths, deduped, preset defaults first) layers on top of both —
+    ``skills`` is excluded from the generic merge so this append-dedup logic
+    stays in charge.
 
     Mutates ``data`` in place. No-op when ``manifest.preset.active`` is unset
     or when the manifest already has a literal ``llm`` and no preset block.
@@ -352,14 +381,24 @@ def materialize_active_preset(data: dict, working_dir: Path) -> None:
     preset_ctx = preset_llm.pop("context_limit", None)
     manifest["llm"] = preset_llm
 
-    # Capabilities are wholesale-replaced by the preset (atomic swap is the
-    # whole point of presets). One carve-out preserves project-truth across
-    # preset switches:
-    #   - skills.paths: extras declared in init.json append to the preset's
-    #     defaults. Skill paths are project-truth (where this agent's extra
-    #     skills live), not runtime-tier choices, so swapping presets should
-    #     not erase them.
+    # The preset chooses *which* opt-in capabilities run (atomic swap is the
+    # whole point of presets), but it must not clobber per-agent capability
+    # kwargs declared in init.json. Two layers preserve those (see docstring):
+    #   1. Per-key override — for capabilities the preset ALSO enables,
+    #      init.json's kwargs win key-by-key.
+    #   2. Core-default carry-forward — for always-on capabilities (in
+    #      `core_defaults`) the preset OMITS, init.json's kwargs are carried in
+    #      anyway, since those capabilities boot regardless of the preset.
+    # `skills` is excluded from both generic passes; its dedicated append-dedup
+    # block below owns it (and skills is itself a core default).
     # If you need to add another carve-out, do it here — keep the list short.
+    if isinstance(core_defaults, dict):
+        core_names: set[str] = set(core_defaults.keys())
+    elif core_defaults is not None:
+        core_names = set(core_defaults)
+    else:
+        core_names = set()
+
     init_caps = manifest.get("capabilities", {}) if isinstance(
         manifest.get("capabilities"), dict) else {}
     init_skill_paths: list[str] = []
@@ -370,6 +409,25 @@ def materialize_active_preset(data: dict, working_dir: Path) -> None:
                 init_skill_paths.append(path)
 
     new_caps = preset_manifest.get("capabilities", init_caps)
+    if isinstance(new_caps, dict) and isinstance(init_caps, dict):
+        merged_caps = dict(new_caps)
+        # 1. Per-key override for capabilities the preset also enables.
+        for cap_name, preset_kwargs in new_caps.items():
+            if cap_name == "skills":
+                continue
+            init_kwargs = init_caps.get(cap_name)
+            if isinstance(preset_kwargs, dict) and isinstance(init_kwargs, dict):
+                merged_caps[cap_name] = {**preset_kwargs, **init_kwargs}
+        # 2. Carry forward init kwargs for always-on capabilities the preset
+        #    omits — these boot via apply_core_defaults regardless, so their
+        #    per-agent kwargs must not be lost. `skills` stays with its block.
+        for cap_name in core_names:
+            if cap_name == "skills" or cap_name in new_caps:
+                continue
+            init_kwargs = init_caps.get(cap_name)
+            if isinstance(init_kwargs, dict):
+                merged_caps[cap_name] = dict(init_kwargs)
+        new_caps = merged_caps
     if isinstance(new_caps, dict) and init_skill_paths:
         # Make sure we have a skills entry to merge into. If the preset didn't
         # enable skills, init.json's paths alone are enough to enable it.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -51,6 +51,22 @@ def test_daemon_registers_tool(tmp_path):
     assert "daemon" in tool_names
 
 
+def test_daemon_default_max_emanations_is_100(tmp_path):
+    """Default concurrency ceiling is 100 when init.json gives no override."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+    assert mgr._max_emanations == 100
+    assert mgr._handle_list()["max_emanations"] == 100
+
+
+def test_daemon_max_emanations_override_reaches_manager(tmp_path):
+    """A kwargs override on the daemon capability reaches DaemonManager."""
+    agent = _make_agent(tmp_path, {"daemon": {"max_emanations": 30}})
+    mgr = agent.get_capability("daemon")
+    assert mgr._max_emanations == 30
+    assert mgr._handle_list()["max_emanations"] == 30
+
+
 def test_build_tool_surface_expands_groups(tmp_path):
     """'file' group expands to read/write/edit/glob/grep."""
     agent = _make_agent(tmp_path, ["file", "daemon"])

--- a/tests/test_preset_materialization.py
+++ b/tests/test_preset_materialization.py
@@ -327,6 +327,227 @@ def test_materialize_picks_up_context_limit_from_llm_block(tmp_path, monkeypatch
     assert "context_limit" not in data["manifest"]["llm"]
 
 
+def test_materialize_preserves_init_capability_overrides(tmp_path, monkeypatch):
+    """Per-agent capability kwargs in init.json survive preset materialization.
+
+    A preset enabling daemon must not clobber init.json's
+    manifest.capabilities.daemon.max_emanations — the preset decides *which*
+    capabilities run, but per-agent overrides win key-by-key. Regression for
+    daemon(list) reporting the default ceiling instead of the configured one.
+    """
+    plib = _make_preset_lib(tmp_path, {
+        "smart": {
+            "name": "smart",
+            "description": {"summary": "smart preset with daemon"},
+            "manifest": {
+                "llm": {"provider": "gemini", "model": "gemini-2.5-pro",
+                        "api_key": None, "api_key_env": "GEMINI_API_KEY"},
+                # Preset enables daemon with its own (default-ish) ceiling.
+                "capabilities": {"file": {}, "daemon": {"max_emanations": 10}},
+            },
+        },
+    })
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-test")
+    # init.json declares daemon with a per-agent override of 30.
+    wd = _make_workdir(
+        tmp_path, active_preset=str(plib / "smart.json"),
+        manifest_extra={"capabilities": {"daemon": {"max_emanations": 30}}},
+    )
+    a = _make_probe_agent(wd)
+    data = a._read_init()
+    caps = data["manifest"]["capabilities"]
+    # Preset still chose the capability set (file is present from the preset)...
+    assert "file" in caps
+    assert "daemon" in caps
+    # ...but the init.json override wins for the key it specified.
+    assert caps["daemon"]["max_emanations"] == 30
+
+
+def test_materialize_preset_only_capability_kwargs_kept(tmp_path, monkeypatch):
+    """Preset kwargs survive for capabilities init.json does NOT override.
+
+    The merge must not erase preset-supplied kwargs for capabilities the agent
+    never mentions — only same-key overrides win.
+    """
+    plib = _make_preset_lib(tmp_path, {
+        "smart": {
+            "name": "smart",
+            "description": {"summary": "smart preset"},
+            "manifest": {
+                "llm": {"provider": "gemini", "model": "gemini-2.5-pro",
+                        "api_key": None, "api_key_env": "GEMINI_API_KEY"},
+                "capabilities": {"daemon": {"max_emanations": 50, "max_turns": 99}},
+            },
+        },
+    })
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-test")
+    # init.json overrides only max_emanations; max_turns must come from preset.
+    wd = _make_workdir(
+        tmp_path, active_preset=str(plib / "smart.json"),
+        manifest_extra={"capabilities": {"daemon": {"max_emanations": 30}}},
+    )
+    a = _make_probe_agent(wd)
+    data = a._read_init()
+    daemon_kw = data["manifest"]["capabilities"]["daemon"]
+    assert daemon_kw["max_emanations"] == 30   # init override wins
+    assert daemon_kw["max_turns"] == 99        # preset kwarg preserved
+
+
+def test_materialize_preserves_core_default_override_when_preset_omits_it(tmp_path, monkeypatch):
+    """A CORE_DEFAULTS capability's init.json kwargs survive even when the
+    active preset OMITS that capability entirely.
+
+    Jason's real case: the codex preset enables file/web tools but never
+    mentions daemon. daemon is always-on (CORE_DEFAULTS), so init.json's
+    daemon.max_emanations=30 must be carried into the materialized manifest;
+    otherwise apply_core_defaults later re-adds daemon={} and the override is
+    lost. Non-core capabilities the preset omits are still dropped (the swap).
+    """
+    plib = _make_preset_lib(tmp_path, {
+        "codex": {
+            "name": "codex",
+            "description": {"summary": "codex preset — no daemon entry"},
+            "manifest": {
+                "llm": {"provider": "gemini", "model": "gemini-2.5-pro",
+                        "api_key": None, "api_key_env": "GEMINI_API_KEY"},
+                # Note: NO daemon key. Has a non-core optional cap instead.
+                "capabilities": {"file": {}, "web_search": {"provider": "inherit"}},
+            },
+        },
+    })
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-test")
+    wd = _make_workdir(
+        tmp_path, active_preset=str(plib / "codex.json"),
+        manifest_extra={"capabilities": {
+            "daemon": {"max_emanations": 30},   # core default — must survive
+            "vision": {"provider": "custom"},   # non-core, preset omits — must drop
+        }},
+    )
+    a = _make_probe_agent(wd)
+    data = a._read_init()
+    caps = data["manifest"]["capabilities"]
+    # Core-default daemon override carried forward despite preset omitting it.
+    assert "daemon" in caps
+    assert caps["daemon"]["max_emanations"] == 30
+    # Preset still owns the explicit opt-in set.
+    assert "web_search" in caps
+    # Non-core optional capability that the preset omits is NOT carried over.
+    assert "vision" not in caps
+
+
+def test_materialize_core_default_no_init_override_left_to_apply_core_defaults(tmp_path, monkeypatch):
+    """When init.json has no kwargs for a core-default cap and the preset omits
+    it too, materialize leaves it absent — apply_core_defaults adds the floor
+    later. Materialize must not invent empty core entries."""
+    plib = _make_preset_lib(tmp_path, {
+        "codex": {
+            "name": "codex",
+            "description": {"summary": "codex preset"},
+            "manifest": {
+                "llm": {"provider": "gemini", "model": "gemini-2.5-pro",
+                        "api_key": None, "api_key_env": "GEMINI_API_KEY"},
+                "capabilities": {"file": {}},
+            },
+        },
+    })
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-test")
+    # init.json declares only file (no daemon kwargs).
+    wd = _make_workdir(
+        tmp_path, active_preset=str(plib / "codex.json"),
+        manifest_extra={"capabilities": {"file": {}}},
+    )
+    a = _make_probe_agent(wd)
+    data = a._read_init()
+    caps = data["manifest"]["capabilities"]
+    # No daemon entry invented by materialize — apply_core_defaults owns the floor.
+    assert "daemon" not in caps
+
+
+def test_refresh_preset_omitting_daemon_keeps_override_in_manager(tmp_path, monkeypatch):
+    """End-to-end refresh for Jason's case: active preset omits daemon, init.json
+    sets daemon.max_emanations=30 → live DaemonManager ceiling is 30."""
+    from unittest.mock import MagicMock
+    from lingtai.agent import Agent
+    from lingtai_kernel.config import AgentConfig
+
+    plib = _make_preset_lib(tmp_path, {
+        "codex": {
+            "name": "codex",
+            "description": {"summary": "codex preset, no daemon"},
+            "manifest": {
+                "llm": {"provider": "deepseek", "model": "deepseek-v4-flash",
+                        "api_key": None, "api_key_env": "DEEPSEEK_API_KEY"},
+                "capabilities": {"file": {}},   # no daemon entry
+            },
+        },
+    })
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+    wd = _make_workdir(
+        tmp_path, active_preset=str(plib / "codex.json"),
+        manifest_extra={"capabilities": {"daemon": {"max_emanations": 30}}},
+    )
+
+    svc = MagicMock()
+    svc.provider = "mock"
+    svc.model = "mock-model"
+    svc.create_session = MagicMock()
+    svc.make_tool_result = MagicMock()
+    agent = Agent(svc, working_dir=wd, capabilities=["daemon"],
+                  config=AgentConfig())
+    agent._setup_from_init()
+
+    mgr = agent.get_capability("daemon")
+    assert mgr is not None
+    assert mgr._max_emanations == 30
+    assert mgr._handle_list()["max_emanations"] == 30
+
+
+def test_refresh_preset_keeps_daemon_override_in_manager(tmp_path, monkeypatch):
+    """End-to-end refresh: a real Agent with an active preset that enables
+    daemon at 10 plus an init.json daemon override of 30 ends up with a live
+    DaemonManager whose ceiling is 30 (and daemon(list) reports 30).
+
+    This exercises the full path the bug report described: materialize active
+    preset → _setup_from_init → _setup_capability("daemon", ...) → DaemonManager.
+    """
+    from unittest.mock import MagicMock
+    from lingtai.agent import Agent
+    from lingtai_kernel.config import AgentConfig
+
+    plib = _make_preset_lib(tmp_path, {
+        "smart": {
+            "name": "smart",
+            "description": {"summary": "smart preset enabling daemon"},
+            "manifest": {
+                "llm": {"provider": "deepseek", "model": "deepseek-v4-flash",
+                        "api_key": None, "api_key_env": "DEEPSEEK_API_KEY"},
+                "capabilities": {"daemon": {"max_emanations": 10}},
+            },
+        },
+    })
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
+    wd = _make_workdir(
+        tmp_path, active_preset=str(plib / "smart.json"),
+        manifest_extra={"capabilities": {"daemon": {"max_emanations": 30}}},
+    )
+
+    svc = MagicMock()
+    svc.provider = "mock"
+    svc.model = "mock-model"
+    svc.create_session = MagicMock()
+    svc.make_tool_result = MagicMock()
+    agent = Agent(svc, working_dir=wd, capabilities=["daemon"],
+                  config=AgentConfig())
+
+    # Drive the documented "fix config → refresh" reconstruct path.
+    agent._setup_from_init()
+
+    mgr = agent.get_capability("daemon")
+    assert mgr is not None
+    assert mgr._max_emanations == 30
+    assert mgr._handle_list()["max_emanations"] == 30
+
+
 def test_materialize_inherit_expansion_runs(tmp_path, monkeypatch):
     """Capabilities with provider:inherit get the main LLM's provider after materialization."""
     plib = _make_preset_lib(tmp_path, {

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -685,12 +685,14 @@ def _preset_content(name, llm, capabilities):
     }
 
 
-def test_materialize_wholesale_replaces_init_capabilities(tmp_path):
-    """Documented Bug D behavior: a per-agent init.json capability edit is
-    overwritten by the active preset's capabilities on materialize.
+def test_materialize_init_capability_overrides_win_per_key(tmp_path):
+    """Per-agent init.json capability kwargs win key-by-key over preset kwargs.
 
-    Pinning this makes the wholesale-replace explicit. Users who need a
-    per-agent override must change the preset, not init.json (see PR/issue #114).
+    The preset still owns the capability *set* (atomic swap), but for a
+    capability the preset enables that init.json also configures, init.json's
+    kwargs override the preset's per key. A user who hand-edits init.json's
+    vision config keeps that override across preset materialization rather than
+    having it silently clobbered (the previous "Bug D" wholesale-replace).
     """
     preset_path = _write_preset(
         tmp_path, "GLM5.1",
@@ -716,8 +718,16 @@ def test_materialize_wholesale_replaces_init_capabilities(tmp_path):
     }
     materialize_active_preset(data, working_dir=tmp_path)
 
-    # the user's init.json vision override is gone — preset wins wholesale
-    assert data["manifest"]["capabilities"] == {"vision": {"provider": "inherit"}}
+    # init.json's per-key overrides win — vision keeps the user's model/base_url
+    # and overrides the preset's provider:"inherit" with provider:"custom".
+    assert data["manifest"]["capabilities"] == {
+        "vision": {
+            "provider": "custom",
+            "api_compat": "openai",
+            "model": "Kimi-K2.6",
+            "base_url": "http://127.0.0.1:34891/v1",
+        },
+    }
 
 
 def test_materialize_preserves_init_skills_paths_carveout(tmp_path):


### PR DESCRIPTION
## Summary
- raise daemon `max_emanations` default from 10 to 100
- preserve per-agent `init.json` overrides for core default capabilities during active preset materialization, so `manifest.capabilities.daemon.max_emanations` survives refresh even when the active preset omits `daemon`
- keep preset-owned optional capability swaps intact: non-core init-only capabilities still drop if the preset omits them, while `skills.paths` keeps its append/dedupe carve-out

## Why
Jason hit `daemon(action=list)` reporting `max_emanations: 10` even after adding `manifest.capabilities.daemon.max_emanations` to init.json. Root cause: preset materialization replaced capabilities before `apply_core_defaults`, losing daemon kwargs because daemon is an always-on core default rather than always explicit in presets.

## Validation
```bash
PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m pytest   tests/test_preset_materialization.py   tests/test_presets.py   tests/test_daemon.py::test_daemon_default_max_emanations_is_100   tests/test_daemon.py::test_daemon_max_emanations_override_reaches_manager   tests/test_cli.py -q
# 100 passed

git diff --check
# pass
```

Broader daemon/preset sweep has one known pre-existing timing failure in `tests/test_daemon.py::test_emanate_creates_folder_on_disk` (mock emanation can finish before the assertion and write `done` instead of `running`); it reproduces on baseline and is not touched here.

## Report
`reports/pr-daemon-max-emanations-config-explainer.html`