### PR TITLE
fix: honor OpenAI Responses compact threshold

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -26,7 +26,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **`presets.py`**: compatibility re-export shim (`presets.py:1-21`); implementation lives in `lingtai_kernel.presets` (`load_preset` :175 · `materialize_active_preset` :290 · `expand_inherit` :503 · `discover_presets_in_dirs` :121).
 
-**`init_schema.py`**: `DEPRECATED_TOP_FIELDS` :28 (plain deprecated top-level fields stripped by `strip_deprecated`), `LEGACY_MIGRATED_TOP_FIELDS` :38 (legacy fields removed by version-controlled agent migrations and known only as inactive schema), `validate_init` :98, `TOP_OPTIONAL` :13, `MANIFEST_OPTIONAL` :59.
+**`init_schema.py`**: `DEPRECATED_TOP_FIELDS` :28 (plain deprecated top-level fields stripped by `strip_deprecated`), `LEGACY_MIGRATED_TOP_FIELDS` :38 (legacy fields removed by version-controlled agent migrations and known only as inactive schema), `validate_init` :94, `TOP_OPTIONAL` :13, `MANIFEST_OPTIONAL` :55; `manifest.llm.compact_threshold` is validated as positive int or null in the LLM block.
 
 **`network.py`**: `build_network` :306 · `_discover_agents` :143 · `_build_avatar_edges` :168
 

--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -235,7 +235,16 @@ def validate_init(data: dict) -> list[str]:
         "api_key": (str, type(None)),
         "api_key_env": str,
         "base_url": (str, type(None)),
+        "compact_threshold": (int, type(None)),
     }, prefix="manifest.llm")
+    if "compact_threshold" in llm:
+        compact_threshold = llm["compact_threshold"]
+        if isinstance(compact_threshold, bool):
+            raise ValueError("manifest.llm.compact_threshold: expected int | null, got bool")
+        if isinstance(compact_threshold, int) and compact_threshold <= 0:
+            raise ValueError(
+                "manifest.llm.compact_threshold: expected positive int or null"
+            )
 
     # If api_key_env is set without api_key, env_file must be provided
     if llm.get("api_key_env") and not llm.get("api_key"):

--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -9,16 +9,16 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 20 | Re-exports kernel types (`ChatSession`, `LLMResponse`, `ToolCall`, `FunctionSchema`, `ChatInterface`) + `LLMAdapter` from `base.py`. Triggers `register_all_adapters()` on import. |
-| `_register.py` | 108 | Registers adapter factories for all providers with `LLMService.register_adapter()` |
+| `_register.py` | 117 | Registers adapter factories for all providers with `LLMService.register_adapter()` |
 | `api_gate.py` | 112 | `APICallGate` — RPM rate limiter with deque timestamps, `ThreadPoolExecutor`, daemon gate thread |
 | `base.py` | 150 | `LLMAdapter` ABC (4 abstract methods), `_GatedSession` proxy |
 | `interface_converters.py` | 335 | Bidirectional converters: `to_*` / `from_*` for Anthropic, OpenAI, OpenAI Responses API, Gemini |
-| `service.py` | 313 | `LLMService` concrete class — adapter registry, session management, one-shot generation |
+| `service.py` | 359 | `LLMService` concrete class — adapter registry, session management, one-shot generation |
 
 ## Connections
 
 - **Kernel types** — `__init__.py:3` imports `ChatSession`, `LLMResponse`, `ToolCall`, `FunctionSchema` from `lingtai_kernel.llm.base`; `ChatInterface` from `lingtai_kernel.llm.interface`.
-- **ABC chain** — `LLMAdapter` (`base.py:53`) → abstract `create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`. `LLMService` (`service.py:51`) extends `lingtai_kernel.llm.service.LLMService` ABC.
+- **ABC chain** — `LLMAdapter` (`base.py:53`) → abstract `create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`. `LLMService` (`service.py:97`) extends `lingtai_kernel.llm.service.LLMService` ABC.
 - **Adapter registration** — `_register.py` registers 7 dedicated factories + 6 generic-routed providers (`grok`, `qwen`, `glm`, `zhipu`, `kimi`, `mimo`) via dedicated or `_custom` factories (`_register.py:91-106`).
 - **Interface converters** — imported by adapter session modules (e.g. `openai.adapter` imports `to_openai`, `to_responses_input` from `interface_converters.py:120`).
 - **Rate gating** — `LLMAdapter._setup_gate(max_rpm)` creates `APICallGate`; `_wrap_with_gate()` returns `_GatedSession` proxy for sessions.
@@ -26,8 +26,8 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 ## Composition
 
 - **Factory pattern** — `LLMService._adapter_registry` (class-level dict) maps provider name → `Callable[..., LLMAdapter]`. Each factory receives `(model, defaults, **kw)` and lazy-imports the adapter module.
-- **Adapter caching** — `LLMService._adapters` keyed by `(provider, base_url)` tuple (`service.py:95`). Double-checked locking via `_adapter_lock` (`service.py:153`).
-- **Session tracking** — `LLMService._sessions` dict maps `st_<12-hex>` session IDs to `ChatSession` instances (`service.py:100`). Untracked sessions get `session_id=""`.
+- **Adapter caching** — `LLMService._adapters` keyed by `(provider, base_url)` tuple (`service.py:141`). Double-checked locking via `_adapter_lock` (`service.py:142`).
+- **Session tracking** — `LLMService._sessions` dict maps `st_<12-hex>` session IDs to `ChatSession` instances (`service.py:144`). Untracked sessions get `session_id=""`.
 - **Gated sessions** — `_GatedSession` (`base.py:19`) proxies `send()` and `send_stream()` through `APICallGate.submit()`. Attribute writes land on the proxy; reads fall through to inner session via `__getattr__`.
 - **Codex factory** — `_register.py:54` builds `CodexOpenAIAdapter`, monkey-patches `create_chat` and `generate` to refresh OAuth tokens before each call via `CodexTokenManager.get_access_token()`.
 
@@ -35,7 +35,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 
 - **Class-level** — `LLMService._adapter_registry` (shared across all instances); `LLMAdapter._gate` (per-adapter instance).
 - **Instance-level** — `LLMService._adapters` cache; `LLMService._sessions` registry; `APICallGate._timestamps` deque for RPM window.
-- **Provider defaults** — `LLMService._provider_defaults` dict injected at construction (`service.py:96`). Drives model, base_url, max_rpm, api_compat settings. Build it from `manifest.llm` via `build_provider_defaults_from_manifest_llm()` (`service.py:50`) — opt-in safelist (`_PROVIDER_DEFAULTS_PASS_THROUGH_KEYS`) ensures fields adapter factories consult (notably `api_compat` for the custom-provider dispatch) are propagated. Both `cli.py:_load_init` and `agent.py:_setup_from_init` use this helper to stay in sync.
+- **Provider defaults** — `LLMService._provider_defaults` dict injected at construction (`service.py:140`). Drives model, base_url, max_rpm, api_compat, and OpenAI Responses `compact_threshold` settings. Build it from `manifest.llm` via `build_provider_defaults_from_manifest_llm()` (`service.py:66`) — opt-in safelists ensure adapter-consulted fields propagate: `_PROVIDER_DEFAULTS_PASS_THROUGH_KEYS` skips `None` values such as `api_compat`, while `_PROVIDER_DEFAULTS_PRESERVE_NONE_KEYS` preserves explicit `None` for settings like `compact_threshold` where `null` means “disable”. Both `cli.py:_load_init` and `agent.py:_setup_from_init` use this helper to stay in sync.
 - **Key resolution** — `LLMService._key_resolver` callable (`service.py:94`); defaults to `os.environ.get(f"{PROVIDER}_API_KEY")`.
 
 ## Notes

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -26,7 +26,14 @@ def register_all_adapters() -> None:
     def _openai(*, model=None, defaults=None, **kw):
         from .openai.adapter import OpenAIAdapter
         kw.pop("model", None)
-        return OpenAIAdapter(**{k: v for k, v in kw.items() if v is not None})
+        # Honor a host-configured Responses-API compaction threshold. Absent
+        # from defaults -> let OpenAIAdapter's 100k constructor default stand;
+        # explicit None -> disable Responses context_management.
+        adapter_kw = {k: v for k, v in kw.items() if v is not None}
+        if defaults and "compact_threshold" in defaults:
+            # Preserve explicit None after the general None-pruning pass above.
+            adapter_kw["compact_threshold"] = defaults["compact_threshold"]
+        return OpenAIAdapter(**adapter_kw)
 
     def _minimax(*, model=None, defaults=None, **kw):
         from .minimax.adapter import MiniMaxAdapter

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -9,25 +9,26 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 3 | Re-exports `OpenAIAdapter`, `OpenAIChatSession` |
-| `adapter.py` | 1597 | 5 classes + helpers: `OpenAIChatSession`, `OpenAIResponsesSession`, `OpenAIAdapter`, `CodexResponsesSession`, `CodexOpenAIAdapter` |
+| `adapter.py` | 1666 | 5 classes + helpers: `OpenAIChatSession`, `OpenAIResponsesSession`, `OpenAIAdapter`, `CodexResponsesSession`, `CodexOpenAIAdapter` |
 | `defaults.py` | 7 | `DEFAULTS` dict: `api_compat="openai"`, `use_responses_api=True` |
 
 ### adapter.py class map
 
 | Class | Lines | Role |
 |-------|-------|------|
-| `OpenAIChatSession` | 399–891 | Chat Completions session with context overflow auto-recovery |
-| `OpenAIResponsesSession` | 899–1081 | Responses API session with server-side `previous_response_id` chaining |
-| `OpenAIAdapter` | 1089–1352 | `LLMAdapter` implementation; dispatches to Completions or Responses path |
-| `CodexResponsesSession` | 1360–1539 | Stateless Responses variant for ChatGPT-OAuth `/backend-api/codex` |
-| `CodexOpenAIAdapter` | 1543–1597 | Adapter variant that builds `CodexResponsesSession` |
+| `OpenAIChatSession` | 469–961 | Chat Completions session with context overflow auto-recovery |
+| `OpenAIResponsesSession` | 969–1151 | Responses API session with server-side `previous_response_id` chaining and optional `context_management` compaction |
+| `OpenAIAdapter` | 1159–1421 | `LLMAdapter` implementation; dispatches to Completions or Responses path; receives injected `compact_threshold` for Responses sessions |
+| `CodexResponsesSession` | 1429–1608 | Stateless Responses variant for ChatGPT-OAuth `/backend-api/codex` |
+| `CodexOpenAIAdapter` | 1612–1666 | Adapter variant that builds `CodexResponsesSession` |
 
 ### adapter.py helpers
 
 | Function | Lines | Role |
 |----------|-------|------|
-| `_codex_responses_trace_path()` / `_codex_responses_trace_record()` | 46–141 | Opt-in Codex Responses stream diagnostic trace helpers; safe metadata only, default off |
-| `_build_http_timeout()` | 143–157 | `httpx.Timeout` per-phase caps (connect≤30s, read≤60s, pool=10s) |
+| `_validate_compact_threshold()` | 46–60 | Validates/normalizes OpenAI Responses auto-compaction threshold; positive `int` or explicit `None` (disable) only |
+| `_codex_responses_trace_path()` / `_codex_responses_trace_record()` | 63–157 | Opt-in Codex Responses stream diagnostic trace helpers; safe metadata only, default off |
+| `_build_http_timeout()` | 159–173 | `httpx.Timeout` per-phase caps (connect≤30s, read≤60s, pool=10s) |
 | `_build_tools()` | 165–179 | `FunctionSchema` → OpenAI CC tool format (`{type, function: {name, description, parameters}}`) |
 | `_build_responses_tools()` | 189–213 | `FunctionSchema` → Responses API flat format (`{type, name, description, parameters}`); scrubs disallowed top-level JSON-Schema combinators (`allOf`, `oneOf`, etc.) |
 | `_parse_tool_calls()` | 216–233 | Raw SDK `tool_calls` → `list[ToolCall]` |

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -43,6 +43,22 @@ _CODEX_RESPONSES_TRACE_PATH_ENV = "LINGTAI_CODEX_RESPONSES_TRACE_PATH"
 _CODEX_RESPONSES_TRACE_FILE = "codex_responses_trace.jsonl"
 
 
+def _validate_compact_threshold(value: int | None) -> int | None:
+    """Normalize the OpenAI Responses auto-compaction threshold.
+
+    ``None`` intentionally disables Responses ``context_management``.  Any
+    concrete value must be a positive integer; reject bool explicitly because
+    it is an ``int`` subclass in Python but not a valid token threshold.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("compact_threshold must be a positive int or None")
+    if value <= 0:
+        raise ValueError("compact_threshold must be > 0 or None")
+    return value
+
+
 def _codex_responses_trace_path() -> Path | None:
     """Return the opt-in Codex Responses stream trace path, if enabled."""
     enabled = os.environ.get(_CODEX_RESPONSES_TRACE_ENV, "")
@@ -972,7 +988,7 @@ class OpenAIResponsesSession(ChatSession):
         self._tool_choice = tool_choice
         self._extra_kwargs = extra_kwargs
         self._response_id: str | None = previous_response_id
-        self._compact_threshold = compact_threshold
+        self._compact_threshold = _validate_compact_threshold(compact_threshold)
         self._interface = interface or ChatInterface()
 
     @property
@@ -1160,10 +1176,18 @@ class OpenAIAdapter(LLMAdapter):
         force_responses: bool = False,
         max_rpm: int = 0,
         default_headers: dict | None = None,
+        compact_threshold: int | None = 100_000,
     ):
         self.base_url = base_url
         self._use_responses = use_responses
         self._force_responses = force_responses
+        # Responses-API auto-compaction threshold (input tokens). The host
+        # injects its resolved config value via the adapter factory
+        # (lingtai/llm/_register.py:_openai reads provider defaults); when
+        # unset we fall back to the intended 100k default. ``None`` disables
+        # compaction entirely. Config is injected at construction here, never
+        # read from a global module — see lingtai_kernel.config's contract.
+        self._compact_threshold = _validate_compact_threshold(compact_threshold)
         kwargs: dict[str, Any] = {"api_key": api_key}
         if base_url:
             kwargs["base_url"] = base_url
@@ -1255,15 +1279,6 @@ class OpenAIAdapter(LLMAdapter):
             # endpoint and 400s on Codex's `/backend-api/codex/responses`.
             extra_kwargs["reasoning"] = {"effort": "high" if thinking == "high" else "low"}
 
-        # Get compact threshold from config
-        compact_threshold = None
-        try:
-            from config import get as config_get
-
-            compact_threshold = config_get("providers.openai.compact_threshold", 100000)
-        except ImportError:
-            pass
-
         return OpenAIResponsesSession(
             client=self._client,
             model=model,
@@ -1272,7 +1287,7 @@ class OpenAIAdapter(LLMAdapter):
             tool_choice=tool_choice,
             extra_kwargs=extra_kwargs,
             previous_response_id=None,
-            compact_threshold=compact_threshold,
+            compact_threshold=self._compact_threshold,
             interface=interface,
         )
 

--- a/src/lingtai/llm/service.py
+++ b/src/lingtai/llm/service.py
@@ -60,6 +60,7 @@ def _generate_tool_call_id() -> str:
 # OpenAIAdapter, which then explodes on raw.choices access. See
 # Lingtai-AI/lingtai#112 for the full failure trace.
 _PROVIDER_DEFAULTS_PASS_THROUGH_KEYS = ("api_compat",)
+_PROVIDER_DEFAULTS_PRESERVE_NONE_KEYS = ("compact_threshold",)
 
 
 def build_provider_defaults_from_manifest_llm(
@@ -87,6 +88,9 @@ def build_provider_defaults_from_manifest_llm(
         value = llm.get(key)
         if value is not None:
             per_provider[key] = value
+    for key in _PROVIDER_DEFAULTS_PRESERVE_NONE_KEYS:
+        if key in llm:
+            per_provider[key] = llm[key]
     return {provider_key: per_provider} if per_provider else None
 
 

--- a/tests/test_openai_compact_threshold.py
+++ b/tests/test_openai_compact_threshold.py
@@ -1,0 +1,226 @@
+"""Tests that the OpenAI Responses adapter honors the configured
+``compact_threshold`` end to end.
+
+Regression coverage for the bug where ``_create_responses_session`` read the
+threshold via ``from config import get`` against a non-existent top-level
+``config`` module, swallowed the resulting ``ImportError``, and therefore left
+``compact_threshold`` permanently ``None`` — silently disabling Responses-API
+auto-compaction regardless of configuration.
+
+No network: the Responses client is a fake that records the kwargs it receives.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from lingtai.init_schema import validate_init
+from lingtai.llm.openai.adapter import OpenAIAdapter
+from lingtai.llm.service import (
+    LLMService,
+    build_provider_defaults_from_manifest_llm,
+)
+from lingtai.llm._register import register_all_adapters
+
+
+@dataclass
+class _Event:
+    type: str
+    response: object | None = None
+
+
+def _completed() -> _Event:
+    return _Event(
+        "response.completed",
+        response=SimpleNamespace(
+            id="resp_fake",
+            usage=SimpleNamespace(
+                input_tokens=1,
+                output_tokens=1,
+                input_tokens_details=SimpleNamespace(cached_tokens=0),
+                output_tokens_details=SimpleNamespace(reasoning_tokens=0),
+            ),
+        ),
+    )
+
+
+class _FakeResponses:
+    def __init__(self) -> None:
+        self.kwargs: list[dict] = []
+
+    def create(self, **kwargs):
+        self.kwargs.append(kwargs)
+        if kwargs.get("stream"):
+            return iter([_completed()])
+        return SimpleNamespace(id="resp_fake", output=[], usage=None)
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.responses = _FakeResponses()
+
+
+# -- Default behavior is preserved (100000) --------------------------------
+
+
+def test_responses_session_default_compact_threshold_is_100000():
+    adapter = OpenAIAdapter(api_key="fake", use_responses=True)
+    session = adapter._create_responses_session("gpt-5.5", "sys")
+    assert session._compact_threshold == 100000
+
+
+# -- A configured value propagates into the session ------------------------
+
+
+def test_responses_session_honors_configured_compact_threshold():
+    adapter = OpenAIAdapter(api_key="fake", use_responses=True, compact_threshold=12345)
+    session = adapter._create_responses_session("gpt-5.5", "sys")
+    assert session._compact_threshold == 12345
+
+
+def test_configured_compact_threshold_can_be_disabled_with_none():
+    adapter = OpenAIAdapter(api_key="fake", use_responses=True, compact_threshold=None)
+    session = adapter._create_responses_session("gpt-5.5", "sys")
+    assert session._compact_threshold is None
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, True, False, "100000"])
+def test_invalid_compact_threshold_values_are_rejected(bad_value):
+    with pytest.raises(ValueError, match="compact_threshold"):
+        OpenAIAdapter(api_key="fake", use_responses=True, compact_threshold=bad_value)
+
+
+# -- The threshold actually reaches the Responses wire ---------------------
+
+
+def test_compact_threshold_reaches_responses_wire():
+    adapter = OpenAIAdapter(api_key="fake", use_responses=True, compact_threshold=777)
+    adapter._client = _FakeClient()
+    session = adapter._create_responses_session("gpt-5.5", "sys")
+
+    session.send_stream("hello")
+
+    sent = adapter._client.responses.kwargs[-1]
+    assert sent["context_management"] == [
+        {"type": "compaction", "compact_threshold": 777}
+    ]
+
+
+def test_compact_threshold_reaches_non_streaming_responses_wire():
+    adapter = OpenAIAdapter(api_key="fake", use_responses=True, compact_threshold=888)
+    adapter._client = _FakeClient()
+    session = adapter._create_responses_session("gpt-5.5", "sys")
+
+    session.send("hello")
+
+    sent = adapter._client.responses.kwargs[-1]
+    assert sent["context_management"] == [
+        {"type": "compaction", "compact_threshold": 888}
+    ]
+
+
+def test_no_context_management_when_threshold_disabled():
+    adapter = OpenAIAdapter(api_key="fake", use_responses=True, compact_threshold=None)
+    adapter._client = _FakeClient()
+    session = adapter._create_responses_session("gpt-5.5", "sys")
+
+    session.send_stream("hello")
+
+    sent = adapter._client.responses.kwargs[-1]
+    assert "context_management" not in sent
+
+
+# -- Config flows from the injected provider defaults (host config path) ---
+
+
+def test_openai_factory_passes_compact_threshold_from_defaults():
+    register_all_adapters()
+    factory = LLMService._adapter_registry["openai"]
+    adapter = factory(
+        model="gpt-5.5",
+        defaults={"compact_threshold": 250},
+        api_key="fake",
+    )
+    assert adapter._compact_threshold == 250
+
+
+def test_openai_factory_defaults_to_100000_without_config():
+    register_all_adapters()
+    factory = LLMService._adapter_registry["openai"]
+    adapter = factory(model="gpt-5.5", defaults={}, api_key="fake")
+    assert adapter._compact_threshold == 100000
+
+
+def test_openai_factory_preserves_explicit_none_disable():
+    register_all_adapters()
+    factory = LLMService._adapter_registry["openai"]
+    adapter = factory(
+        model="gpt-5.5",
+        defaults={"compact_threshold": None},
+        api_key="fake",
+    )
+    assert adapter._compact_threshold is None
+
+
+def test_llm_service_threads_compact_threshold_via_provider_defaults():
+    register_all_adapters()
+    service = LLMService(
+        provider="openai",
+        model="gpt-5.5",
+        api_key="fake",
+        provider_defaults={"openai": {"compact_threshold": 4321}},
+    )
+    adapter = service.get_adapter("openai")
+    assert adapter._compact_threshold == 4321
+
+
+# -- Manifest llm block propagates the value into provider defaults --------
+
+
+def test_manifest_llm_compact_threshold_propagates_to_provider_defaults():
+    defaults = build_provider_defaults_from_manifest_llm(
+        {"provider": "openai", "compact_threshold": 250},
+        max_rpm=0,
+    )
+    assert defaults == {"openai": {"compact_threshold": 250}}
+
+
+def test_manifest_llm_explicit_none_compact_threshold_is_preserved():
+    defaults = build_provider_defaults_from_manifest_llm(
+        {"provider": "openai", "compact_threshold": None},
+        max_rpm=0,
+    )
+    assert defaults == {"openai": {"compact_threshold": None}}
+
+# -- init.json schema validation for manifest.llm.compact_threshold --------
+
+
+def _minimal_init_with_compact_threshold(value):
+    return {
+        "manifest": {
+            "llm": {
+                "provider": "openai",
+                "model": "gpt-5.5",
+                "compact_threshold": value,
+            },
+        },
+        "principle": "",
+        "covenant": "",
+        "pad": "",
+        "prompt": "",
+    }
+
+
+@pytest.mark.parametrize("value", [1, 100000, None])
+def test_init_schema_accepts_valid_compact_threshold(value):
+    validate_init(_minimal_init_with_compact_threshold(value))
+
+
+@pytest.mark.parametrize("value", [0, -1, True, False, "100000"])
+def test_init_schema_rejects_invalid_compact_threshold(value):
+    with pytest.raises(ValueError, match="manifest.llm.compact_threshold"):
+        validate_init(_minimal_init_with_compact_threshold(value))
+


### PR DESCRIPTION
## Summary
- remove the broken `from config import get` lookup from the OpenAI Responses session path
- inject `compact_threshold` through manifest/provider defaults into `OpenAIAdapter`
- support `manifest.llm.compact_threshold: null` as an explicit disable path while defaulting absent config to `100_000`
- validate the config value and add focused regression tests for constructor, factory, service, schema, and wire payload behavior
- update anatomy docs for the changed LLM/OpenAI plumbing

## Reviews
- Claude Code xhigh authored the implementation.
- Codex independently reviewed and found a blocking explicit-`null` disable gap; fixed in this branch.
- GLM/Zhipu independently reviewed and found no blockers; requested additional schema/Codex/wire-path coverage, addressed where relevant.

## Tests
- `PYTHONPATH=src python -m pytest tests/test_openai_compact_threshold.py -q` → 25 passed
- `PYTHONPATH=src python -m pytest tests/test_openai_compact_threshold.py tests/test_llm_service.py tests/test_init_schema.py tests/test_openai_responses_streaming.py tests/test_openai_overflow_recovery.py tests/test_adapter_registry.py tests/test_max_rpm_plumbing.py -q` → 118 passed
- `PYTHONPATH=src python -m pytest tests/ -q -k 'openai or responses or codex or adapter or llm_service or max_rpm or init_schema'` → 195 passed, 1870 deselected
- `python -m py_compile src/lingtai/llm/openai/adapter.py src/lingtai/llm/_register.py src/lingtai/llm/service.py src/lingtai/init_schema.py tests/test_openai_compact_threshold.py` → pass

## Local explainer
`/Users/huangzesen/work/GitHub/lingtai-kernel/.worktrees/openai-compact-threshold/reports/pr227-openai-compact-threshold-explainer.html`
