### PR TITLE
feat: expose kernel LICC client interface

### DIFF
--- a/reports/licc-kernel-interface-explainer.html
+++ b/reports/licc-kernel-interface-explainer.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>LICC kernel interface PR explainer</title>
+  <style>
+    :root { --bg:#0b1020; --panel:#121a33; --panel2:#172040; --text:#e8eefc; --muted:#a8b3cf; --accent:#7dd3fc; --ok:#86efac; --warn:#fde68a; --line:#2a355e; --red:#fca5a5; }
+    * { box-sizing: border-box; }
+    body { margin:0; font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; background:linear-gradient(180deg,#0b1020,#111827); color:var(--text); }
+    .wrap { max-width:1100px; margin:0 auto; padding:36px 20px 60px; }
+    h1 { margin:0 0 8px; font-size:32px; letter-spacing:-.02em; }
+    h2 { margin:28px 0 12px; font-size:21px; }
+    h3 { margin:18px 0 8px; font-size:16px; color:var(--accent); }
+    p { margin:8px 0; }
+    code { background:#0a0f1f; border:1px solid var(--line); border-radius:5px; padding:1px 5px; color:#dbeafe; }
+    pre { background:#0a0f1f; border:1px solid var(--line); border-radius:12px; padding:14px; overflow:auto; color:#dbeafe; }
+    .meta { color:var(--muted); margin-bottom:20px; }
+    .panel { background:rgba(18,26,51,.92); border:1px solid var(--line); border-radius:16px; padding:18px; margin:16px 0; box-shadow:0 8px 30px rgba(0,0,0,.22); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:14px; }
+    .card { background:var(--panel2); border:1px solid var(--line); border-radius:14px; padding:14px; }
+    .badge { display:inline-block; border:1px solid var(--line); border-radius:999px; padding:3px 9px; margin:2px 4px 2px 0; color:var(--muted); background:#0a0f1f; }
+    .ok { color:var(--ok); } .warn { color:var(--warn); } .red { color:var(--red); }
+    table { width:100%; border-collapse:collapse; margin:8px 0; }
+    th,td { border-bottom:1px solid var(--line); padding:9px 8px; text-align:left; vertical-align:top; }
+    th { color:var(--accent); font-weight:600; }
+    ul { margin-top:8px; }
+    .small { color:var(--muted); font-size:13px; }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <h1>LICC kernel interface cleanup</h1>
+    <div class="meta">Branch: <code>feature/licc-kernel-interface</code> · Worktree: <code>/Users/huangzesen/work/GitHub/lingtai-kernel/.worktrees/licc-kernel-interface</code> · 2026-06-05</div>
+
+    <section class="panel">
+      <h2>Conclusion</h2>
+      <p><strong class="ok">Ready for PR.</strong> GLM review returned with no blockers, and useful low-severity suggestions were incorporated. This patch implements Jason’s clarified item 2 scope: LICC is a kernel-intrinsic protocol, so the kernel now exposes a clear client-side interface module while the existing <code>inbox.py</code> remains the receiver/consumer.</p>
+      <p>It does <strong>not</strong> create a standalone package, modify addon repositories, add addon dependencies, or migrate existing addon helpers.</p>
+      <div>
+        <span class="badge ok">kernel-only</span>
+        <span class="badge ok">producer + consumer documented</span>
+        <span class="badge ok">48 focused tests pass</span>
+        <span class="badge ok">no addon changes</span>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="card">
+        <h3>New producer</h3>
+        <p><code>src/lingtai/core/mcp/licc.py</code></p>
+        <p>Canonical client-side helper: <code>push_inbox_event(...)</code>.</p>
+      </div>
+      <div class="card">
+        <h3>Existing consumer</h3>
+        <p><code>src/lingtai/core/mcp/inbox.py</code></p>
+        <p>Poller/validator/dispatcher remains unchanged.</p>
+      </div>
+      <div class="card">
+        <h3>New tests</h3>
+        <p><code>tests/test_mcp_licc_client.py</code></p>
+        <p>Producer schema, atomicity, safety, and receiver compatibility.</p>
+      </div>
+      <div class="card">
+        <h3>Docs/anatomy</h3>
+        <p><code>src/lingtai/core/mcp/ANATOMY.md</code></p>
+        <p>Defines LICC producer/consumer split inside kernel MCP capability.</p>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>What the new interface does</h2>
+      <pre>from lingtai.core.mcp.licc import push_inbox_event
+
+push_inbox_event(
+    "alice",
+    "new DM",
+    "hey, are you around?",
+    metadata={"platform": "telegram"},
+)</pre>
+      <ul>
+        <li>Defaults target from <code>LINGTAI_AGENT_DIR</code> and <code>LINGTAI_MCP_NAME</code>, the env vars the kernel already injects into spawned MCPs.</li>
+        <li>Supports explicit <code>agent_dir</code> / <code>mcp_name</code> for tests and advanced integrations.</li>
+        <li>Writes <code>&lt;agent_dir&gt;/.mcp_inbox/&lt;mcp_name&gt;/&lt;event_id&gt;.json</code>.</li>
+        <li>Uses <code>inbox.validate_event</code> before writing, so the canonical producer only emits receiver-valid LICC v1 events.</li>
+      </ul>
+    </section>
+
+    <section class="panel">
+      <h2>Contract alignment</h2>
+      <table>
+        <tr><th>Concern</th><th>Implementation</th></tr>
+        <tr><td>Producer/consumer drift</td><td><code>licc.py</code> re-exports <code>LICC_VERSION</code>, <code>INBOX_DIRNAME</code>, <code>TMP_SUFFIX</code>, and <code>EVENT_SUFFIX</code> from <code>inbox.py</code>.</td></tr>
+        <tr><td>Atomicity</td><td>Writes <code>.json.tmp</code>, flushes + fsyncs, then <code>os.replace()</code> to final <code>.json</code>. The poller ignores tmp files.</td></tr>
+        <tr><td>Listener safety</td><td>Missing env, invalid path components, invalid payload fields, filesystem failures, and JSON serialization failures return <code>False</code>; they do not raise into listener callbacks.</td></tr>
+        <tr><td>Secret hygiene</td><td>Failure logs do not echo body, subject, or metadata.</td></tr>
+        <tr><td>Scope</td><td>No addon repo changes, no dependency changes, no standalone package.</td></tr>
+      </table>
+    </section>
+
+    <section class="panel">
+      <h2>Validation so far</h2>
+      <pre>python -m pytest tests/test_mcp_licc_client.py tests/test_mcp_inbox.py -q
+# 48 passed in 1.16s
+
+python -m pytest tests/test_mcp_licc_client.py tests/test_mcp_inbox.py tests/test_mcp_capability.py -q
+# 71 passed in 1.39s
+
+python -m pytest tests/test_mcp_closed_resource_restart.py tests/test_tc_inbox.py tests/test_tc_inbox_mid_turn_drain.py tests/test_tc_inbox_remove_by_notif_id.py -q
+# 43 passed in 0.50s
+
+python -m compileall src/lingtai/core/mcp/licc.py src/lingtai/core/mcp/inbox.py
+# OK
+
+git diff --check
+# OK
+
+PYTHONPATH=src python - <<'PY'
+from lingtai.core.mcp.licc import push_inbox_event, LICC_VERSION, INBOX_DIRNAME, TMP_SUFFIX
+print(push_inbox_event.__name__, LICC_VERSION, INBOX_DIRNAME, TMP_SUFFIX)
+PY
+# push_inbox_event 1 .mcp_inbox .json.tmp</pre>
+    </section>
+
+    <section class="panel">
+      <h2>Review status</h2>
+      <ul>
+        <li><strong>Claude Code xhigh/opus</strong>: main implementation author; wrote the initial module/tests/anatomy and ran focused tests.</li>
+        <li><strong>Codex</strong>: reviewed and hardened the patch; added path-safety, pre-write validation, producer→consumer integration, and serialization-failure coverage; expanded validation to adjacent MCP/inbox tests.</li>
+        <li><strong>GLM</strong>: formal review completed with no blockers; low-severity suggestions accepted where useful (lightweight import guard comment, producer→consumer integration test).</li>
+      </ul>
+      <p class="small">Review artifacts: <code>reports/licc-kernel-interface-claude-implementation.md</code>, <code>reports/licc-kernel-interface-codex-review.md</code>, pending <code>reports/licc-kernel-interface-glm-review.md</code>.</p>
+    </section>
+
+    <section class="panel">
+      <h2>Non-goals explicitly preserved</h2>
+      <ul>
+        <li>No <code>Lingtai-AI/lingtai-licc</code> repository.</li>
+        <li>No PyPI standalone LICC package.</li>
+        <li>No edits to <code>lingtai-imap</code>, <code>lingtai-telegram</code>, <code>lingtai-feishu</code>, <code>lingtai-wechat</code>, <code>lingtai-whatsapp</code>, or other addon repos.</li>
+        <li>No addon dependency changes.</li>
+        <li>No PR merge without explicit Jason authorization.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/src/lingtai/core/mcp/ANATOMY.md
+++ b/src/lingtai/core/mcp/ANATOMY.md
@@ -12,7 +12,8 @@ the agent's inbox.
 ## Components
 
 - `mcp/__init__.py` — MCP registry management and tool surface. `get_description` (`mcp/__init__.py:374-375`), `get_schema` (`mcp/__init__.py:378-379`), `setup` (`mcp/__init__.py:382-406`). Key functions: `validate_record` (`mcp/__init__.py:82-125`), `validate_registry_line` (`mcp/__init__.py:128-138`), `read_registry` (`mcp/__init__.py:149-186`), `decompress_addons` (`mcp/__init__.py:201-257`), `_build_registry_xml` (`mcp/__init__.py:274-299`), `_reconcile` (`mcp/__init__.py:306-342`).
-- `mcp/inbox.py` — LICC v1 filesystem inbox poller. `validate_event` validates required `from`/`subject`/`body` fields; `_format_notification_summary` is **deprecated** legacy helper (retained for backward compat); `_extract_preview_meta` pulls optional IM/chat scalars (`conversation_ref`, `message_ref`, `platform`) out of `event["metadata"]` when present as non-empty strings, each capped at `_PREVIEW_META_FIELD_CAP` (200 chars); `_consume_event` returns `(wake, preview)` where `preview = {"from": sender, "subject": subject, "preview": body[:_PREVIEW_FIELD_CAP], **extracted_meta}` — only the body snippet gets capped (sender/subject are bounded by upstream construction); `_dispatch_summary` publishes to `.notification/mcp.<mcp_name>.json` via `notifications.submit`, embedding `data.previews` and rendering them (with any IM metadata) inline in `instructions`; `_scan_once` coalesces per MCP, threading the preview list through; `MCPInboxPoller` class drives the poll loop. Body snippet cap is `_PREVIEW_FIELD_CAP = 10000`.
+- `mcp/inbox.py` — LICC v1 filesystem inbox poller (the **consumer** half). `validate_event` validates required `from`/`subject`/`body` fields; `_format_notification_summary` is **deprecated** legacy helper (retained for backward compat); `_extract_preview_meta` pulls optional IM/chat scalars (`conversation_ref`, `message_ref`, `platform`) out of `event["metadata"]` when present as non-empty strings, each capped at `_PREVIEW_META_FIELD_CAP` (200 chars); `_consume_event` returns `(wake, preview)` where `preview = {"from": sender, "subject": subject, "preview": body[:_PREVIEW_FIELD_CAP], **extracted_meta}` — only the body snippet gets capped (sender/subject are bounded by upstream construction); `_dispatch_summary` publishes to `.notification/mcp.<mcp_name>.json` via `notifications.submit`, embedding `data.previews` and rendering them (with any IM metadata) inline in `instructions`; `_scan_once` coalesces per MCP, threading the preview list through; `MCPInboxPoller` class drives the poll loop. Body snippet cap is `_PREVIEW_FIELD_CAP = 10000`. Defines the shared contract constants `LICC_VERSION` / `INBOX_DIRNAME` / `DEAD_DIRNAME` / `TMP_SUFFIX` / `EVENT_SUFFIX`.
+- `mcp/licc.py` — LICC v1 client (the **producer** half). One public function, `push_inbox_event(sender, subject, body, *, metadata=None, wake=True, received_at=None, agent_dir=None, mcp_name=None, event_id=None) -> bool`, that an out-of-process MCP imports to drop one event into `<agent_dir>/.mcp_inbox/<mcp_name>/<event_id>.json`. Lightweight by design — importing it starts no threads and re-exports the contract constants (`LICC_VERSION`, `INBOX_DIRNAME`, `TMP_SUFFIX`, `EVENT_SUFFIX`) straight from `inbox.py` so producer and consumer never drift. `agent_dir`/`mcp_name` default to env vars `LINGTAI_AGENT_DIR`/`LINGTAI_MCP_NAME` (kernel-injected per MCP); explicit params override for tests/advanced callers. Writes atomically: serialize → `<event_id>.json.tmp` → `flush`+`os.fsync` → `os.replace` onto the final `.json` (the poller ignores `.tmp`, so half-writes are never observed). `event_id` defaults to a fresh `uuid4().hex` (guarantees per-call uniqueness); explicit `mcp_name`/`event_id` path components are validated before use. The payload is checked with `validate_event` before writing, so the canonical producer does not intentionally emit dead-letterable events. Best-effort/silent: missing/invalid target, unsafe path component, invalid payload, or filesystem/serialization error → `False` (never raises into the MCP), with a terse, content-free log that never echoes `body`/`subject`/`metadata`.
 - `mcp/manual/` — skill documentation (`SKILL.md`) plus reference docs (`curated-addons.md`, `third-party-and-legacy.md`, `troubleshooting.md`) and scripts (`find_readme.py`).
 
 ## Public API
@@ -25,9 +26,19 @@ The `mcp` tool exposes one action:
 
 ### LICC v1 Inbox Protocol
 
+Two halves share one wire format:
+
+- **Producer** (`licc.py`) — an out-of-process MCP calls `push_inbox_event(...)` to atomically drop an event into the inbox. This is the canonical client-side entry point; MCPs should import it rather than hand-rolling the atomic write.
+- **Consumer** (`inbox.py`) — `MCPInboxPoller` sweeps the inbox at `POLL_INTERVAL`, validates each event with `validate_event`, coalesces a `.notification/mcp.<name>.json`, and deletes the file.
+
 MCP servers push events via filesystem writes:
 ```
 <agent_working_dir>/.mcp_inbox/<mcp_name>/<event_id>.json
+```
+
+```python
+from lingtai.core.mcp.licc import push_inbox_event
+push_inbox_event("alice", "new DM", "hey, are you around?")  # agent_dir/mcp_name from env
 ```
 
 Schema (v1):
@@ -43,7 +54,7 @@ Schema (v1):
 }
 ```
 
-Atomic write: write to `<event_id>.json.tmp`, fsync, then rename.
+Atomic write: write to `<event_id>.json.tmp`, fsync, then rename. `push_inbox_event` does exactly this (`os.replace`) so the poller never observes a half-written file.
 
 ## Internal Module Layout
 
@@ -92,6 +103,11 @@ mcp/inbox.py
       └── MCPInboxPoller                — daemon thread that polls at POLL_INTERVAL (0.5s)
           ├── start()                   — creates root dir, starts poll thread
           └── stop()                    — signals stop, joins thread
+
+mcp/licc.py  (client-side producer; mirrors inbox.py's consumer)
+  ├── Re-exports                        — LICC_VERSION / INBOX_DIRNAME / TMP_SUFFIX / EVENT_SUFFIX (from inbox.py)
+  └── push_inbox_event()                — resolve agent_dir/mcp_name (args or env) → build v1 payload
+                                          → atomic .tmp + fsync + os.replace → True / False (no-op or OSError)
 ```
 
 ## Key Invariants
@@ -101,7 +117,8 @@ mcp/inbox.py
 - **Transport validation:** `stdio` requires `command` + `args`; `http` requires `url`.
 - **Addons decompression is idempotent:** Running `decompress_addons()` multiple times produces the same registry. Existing records are never modified.
 - **`{python}` substitution:** Catalog entries support `{python}` placeholder in command args, resolved to `sys.executable` at decompression time.
-- **LICC atomicity:** MCP servers must write `.json.tmp` then rename to `.json`. Half-written `.tmp` files are ignored by the scanner.
+- **LICC atomicity:** Events must be written to `.json.tmp` then renamed to `.json`. Half-written `.tmp` files are ignored by the scanner. `licc.push_inbox_event` is the canonical producer that performs this (`flush` + `os.fsync` + `os.replace`); MCPs should call it rather than re-implement the dance.
+- **LICC client is best-effort, path-safe, and receiver-validating:** `push_inbox_event` never raises into the calling MCP. Missing agent dir / mcp name (neither arg nor env var set), invalid MCP names, unsafe explicit event IDs, or payload fields rejected by `validate_event` → `False` no-op; filesystem/serialization errors → `False`. Failure logs are terse and never echo `body`/`subject`/`metadata` (which may carry user content or secrets). Producer and consumer share the contract constants and validation because `licc.py` imports them from `inbox.py` — they cannot drift.
 - **LICC dead-letter:** Invalid events (parse errors, missing fields, unknown version, dispatch failures) are moved to `.dead/` with a `.error.json` sidecar. Dead-letters are never auto-deleted.
 - **LICC bounded work:** `MAX_EVENTS_PER_CYCLE = 100` per MCP per sweep prevents pathological backlog from blocking the poller.
 - **LICC notification shape (post-#37 + previews):** The coalesced notification carries the MCP name, event count, plus a `previews` list — one entry per consumed event with `{"from": <sender>, "subject": <subject>, "preview": <body[:_PREVIEW_FIELD_CAP]>}` and, **when the event opts in via `metadata`**, optional IM/chat scalars `conversation_ref`, `message_ref`, `platform` (each capped at `_PREVIEW_META_FIELD_CAP = 200` chars). Only well-formed non-empty string metadata values are copied; non-string/empty/unknown keys are silently ignored, so legacy events without metadata produce the identical preview shape as before. The body snippet is hard-truncated at `_PREVIEW_FIELD_CAP` (10000 chars); `from` and `subject` pass through uncapped (sender bounded by upstream construction; subject already validated `<= 200` chars by `validate_event`). Full message **bodies** are still NOT inlined — those stay behind the `<mcp>(action="check"/"read")` tool result. The original issue #37 invariant (no body duplication → no agent re-processing loop) is preserved; previews exist purely to let the agent triage which MCPs/messages deserve a read call. Multiple events from the same MCP in one sweep are coalesced into a single summary; `wake` is the OR of all per-event `wake` flags. Preview list length is naturally bounded by `MAX_EVENTS_PER_CYCLE` (100).
@@ -115,6 +132,8 @@ mcp/inbox.py
 - `lingtai_kernel.notifications` — `submit` (as `publish_notification`) for `.notification/` dispatch (in `inbox.py`)
 - `lingtai_kernel.base_agent.BaseAgent` — agent type (TYPE_CHECKING only)
 - `lingtai.mcp_catalog.json` — kernel-shipped MCP catalog file (read at runtime)
+- `lingtai.core.mcp.inbox` — `licc.py` imports the contract constants (`LICC_VERSION`, `INBOX_DIRNAME`, `TMP_SUFFIX`, `EVENT_SUFFIX`) from it; stdlib only otherwise (`json`, `os`, `uuid`, `datetime`, `pathlib`, `logging`)
+- env: `LINGTAI_AGENT_DIR` / `LINGTAI_MCP_NAME` — kernel-injected per spawned MCP (see `lingtai.agent`); the default source for `push_inbox_event`'s target
 
 ## Composition
 

--- a/src/lingtai/core/mcp/inbox.py
+++ b/src/lingtai/core/mcp/inbox.py
@@ -47,6 +47,10 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# Keep these contract constants and validate_event() lightweight at module
+# import time: the client-side producer (licc.py) imports/re-exports them so
+# out-of-process MCP servers can share the receiver's source of truth without
+# starting the poller or pulling in heavy runtime machinery.
 INBOX_DIRNAME = ".mcp_inbox"
 DEAD_DIRNAME = ".dead"
 TMP_SUFFIX = ".json.tmp"

--- a/src/lingtai/core/mcp/licc.py
+++ b/src/lingtai/core/mcp/licc.py
@@ -1,0 +1,178 @@
+"""LICC v1 client — the producer half of the LingTai Inbox Callback Contract.
+
+``inbox.py`` is the kernel-side *consumer*: it polls ``.mcp_inbox/<mcp>/``,
+validates each event, dispatches it to the agent, and deletes the file. This
+module is the *producer*: the single function an out-of-process MCP server
+calls to drop one event into that inbox.
+
+It is deliberately tiny and dependency-free so an MCP subprocess can::
+
+    from lingtai.core.mcp.licc import push_inbox_event
+    push_inbox_event("alice", "new DM", "hey, are you around?")
+
+without importing the agent runtime, the poller, or any provider SDK.
+Importing this module starts no threads and touches no filesystem.
+
+Where it writes
+---------------
+``<agent_dir>/.mcp_inbox/<mcp_name>/<event_id>.json``
+
+``agent_dir`` and ``mcp_name`` default to the two environment variables the
+kernel injects into every MCP it spawns (see ``lingtai.agent``)::
+
+    LINGTAI_AGENT_DIR  — absolute path of the agent's working directory
+    LINGTAI_MCP_NAME   — this MCP's registry name
+
+Callers (tests, advanced integrations) may pass ``agent_dir`` / ``mcp_name``
+explicitly to override the environment.
+
+How it writes
+-------------
+Atomically, matching the contract the poller relies on: serialize to
+``<event_id>.json.tmp``, ``fsync`` the file, then ``os.replace`` it onto the
+final ``<event_id>.json``. The poller ignores ``*.json.tmp`` files, so a
+half-written event is never observed. The payload conforms to the LICC v1
+schema validated by :func:`lingtai.core.mcp.inbox.validate_event`.
+
+Failure policy
+--------------
+Best-effort and silent: any missing configuration (no agent dir / no mcp
+name) or filesystem error returns ``False`` and writes nothing — it never
+raises into the calling MCP. Failure logs are intentionally terse and never
+include the event ``body``/``subject``/``metadata``, which may carry user
+content or secrets.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Re-export the contract constants from the kernel-side module so producer and
+# consumer share one source of truth — they must never drift apart.
+from .inbox import EVENT_SUFFIX, INBOX_DIRNAME, LICC_VERSION, TMP_SUFFIX, validate_event
+
+__all__ = [
+    "push_inbox_event",
+    "LICC_VERSION",
+    "INBOX_DIRNAME",
+    "TMP_SUFFIX",
+    "EVENT_SUFFIX",
+]
+
+log = logging.getLogger(__name__)
+
+_ENV_AGENT_DIR = "LINGTAI_AGENT_DIR"
+_ENV_MCP_NAME = "LINGTAI_MCP_NAME"
+_MCP_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,30}$")
+_EVENT_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{1,128}$")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def push_inbox_event(
+    sender: str,
+    subject: str,
+    body: str,
+    *,
+    metadata: dict[str, Any] | None = None,
+    wake: bool = True,
+    received_at: str | None = None,
+    agent_dir: str | os.PathLike[str] | None = None,
+    mcp_name: str | None = None,
+    event_id: str | None = None,
+) -> bool:
+    """Atomically push one LICC v1 event into the agent's MCP inbox.
+
+    Args:
+        sender: Human-readable sender (required, non-empty). Written to the
+            ``"from"`` JSON key.
+        subject: One-line summary (required, non-empty, <= 200 chars to pass
+            the kernel validator).
+        body: Full message body (required string; may be empty).
+        metadata: Optional dict of extra fields. The kernel surfaces the
+            scalar keys ``conversation_ref`` / ``message_ref`` / ``platform``
+            in the notification preview. Defaults to ``{}``.
+        wake: Whether delivery should wake a napping agent. Default ``True``.
+        received_at: ISO 8601 timestamp. Defaults to the current UTC time.
+        agent_dir: Agent working directory. Defaults to ``$LINGTAI_AGENT_DIR``.
+        mcp_name: This MCP's registry name. Defaults to ``$LINGTAI_MCP_NAME``.
+        event_id: Filename stem for the event. Defaults to a fresh UUID4,
+            which also guarantees uniqueness across repeated pushes. Explicit
+            values must be a single safe filename segment.
+
+    Returns:
+        ``True`` if the event file was written and atomically renamed into
+        place; ``False`` on missing configuration, invalid LICC payload fields,
+        unsafe path components, or write/serialization failure. Never raises.
+
+    ``mcp_name`` and ``event_id`` are path components. Explicit/env values
+    that do not match the kernel MCP name convention or safe event-id
+    filename convention are rejected with ``False`` rather than being used
+    in a path.
+    """
+    resolved_dir = agent_dir if agent_dir is not None else os.environ.get(_ENV_AGENT_DIR)
+    resolved_mcp = mcp_name if mcp_name is not None else os.environ.get(_ENV_MCP_NAME)
+
+    # No agent dir or no MCP name → we don't know where to write. No-op.
+    if not resolved_dir or not resolved_mcp:
+        return False
+    if not isinstance(resolved_mcp, str) or not _MCP_NAME_RE.fullmatch(resolved_mcp):
+        return False
+
+    stem = event_id if event_id is not None else uuid.uuid4().hex
+    if not isinstance(stem, str) or not _EVENT_ID_RE.fullmatch(stem):
+        return False
+
+    event = {
+        "licc_version": LICC_VERSION,
+        "from": sender,
+        "subject": subject,
+        "body": body,
+        "metadata": metadata if metadata is not None else {},
+        "wake": wake,
+        "received_at": received_at if received_at is not None else _now_iso(),
+    }
+
+    valid, _err = validate_event(event)
+    if not valid:
+        return False
+
+    tmp_path: Path | None = None
+
+    try:
+        mcp_dir = Path(resolved_dir) / INBOX_DIRNAME / resolved_mcp
+        tmp_path = mcp_dir / f"{stem}{TMP_SUFFIX}"
+        final_path = mcp_dir / f"{stem}{EVENT_SUFFIX}"
+        mcp_dir.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(event, ensure_ascii=False)
+        # Write + flush + fsync so the bytes are durable before the rename
+        # makes the event visible to the poller.
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        # Atomic publish: the poller only ever sees a complete file.
+        os.replace(tmp_path, final_path)
+        return True
+    except (OSError, TypeError, ValueError) as e:
+        # Terse, content-free log: never echo body/subject/metadata, which may
+        # carry user content or secrets. Errno + class is enough to triage.
+        log.warning(
+            "licc: failed to push event for mcp %r: %s", resolved_mcp, type(e).__name__
+        )
+        # Best-effort cleanup of a stray .tmp so it can't linger. The poller
+        # ignores .tmp files anyway, but leaving litter is untidy.
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+        return False

--- a/tests/test_mcp_licc_client.py
+++ b/tests/test_mcp_licc_client.py
@@ -1,0 +1,381 @@
+"""Tests for the client-side LICC writer (``lingtai.core.mcp.licc``).
+
+``inbox.py`` is the kernel-side *consumer* of LICC v1 — it polls
+``.mcp_inbox/<mcp>/*.json``, validates, dispatches, and deletes. This
+module tests the *producer* half: the lightweight ``push_inbox_event``
+helper an out-of-process MCP imports to atomically drop an event into the
+agent's inbox.
+
+The two halves must agree on the wire format, so several tests round-trip a
+pushed event back through ``inbox.validate_event`` to prove compatibility.
+
+Coverage:
+- missing env / missing args → ``False`` no-op (no file written)
+- default schema + defaults (licc_version, wake, received_at)
+- explicit ``agent_dir`` / ``mcp_name`` parameters
+- env-var defaults (``LINGTAI_AGENT_DIR`` / ``LINGTAI_MCP_NAME``)
+- atomicity: only the final ``.json`` remains, no leftover ``.tmp``
+- unicode bodies/subjects round-trip
+- repeated pushes produce distinct event files (uniqueness)
+- invalid path components / serialization or filesystem errors → ``False``
+- pushed events pass ``inbox.validate_event``
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lingtai.agent import Agent
+from lingtai.core.mcp import licc
+from lingtai.core.mcp.inbox import (
+    EVENT_SUFFIX,
+    INBOX_DIRNAME,
+    LICC_VERSION,
+    TMP_SUFFIX,
+    _scan_once,
+    validate_event,
+)
+
+
+# ---------------------------------------------------------------------------
+# Re-exported constants must match the kernel-side contract exactly.
+# ---------------------------------------------------------------------------
+
+def test_constants_match_inbox():
+    assert licc.LICC_VERSION == LICC_VERSION == 1
+    assert licc.INBOX_DIRNAME == INBOX_DIRNAME == ".mcp_inbox"
+    assert licc.TMP_SUFFIX == TMP_SUFFIX
+
+
+def _events_in(agent_dir: Path, mcp_name: str) -> list[Path]:
+    d = agent_dir / INBOX_DIRNAME / mcp_name
+    if not d.is_dir():
+        return []
+    return sorted(p for p in d.iterdir() if p.name.endswith(EVENT_SUFFIX)
+                  and not p.name.endswith(TMP_SUFFIX))
+
+
+def _read_event(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def make_mock_service():
+    svc = MagicMock()
+    svc.get_adapter.return_value = MagicMock()
+    svc.provider = "gemini"
+    svc.model = "gemini-test"
+    return svc
+
+
+def _mk_agent(tmp_path: Path):
+    workdir = tmp_path / "agent"
+    return Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=workdir,
+        capabilities={"mcp": {}},
+    ), workdir
+
+
+# ---------------------------------------------------------------------------
+# Missing-config no-op
+# ---------------------------------------------------------------------------
+
+def test_missing_env_and_args_is_noop(monkeypatch, tmp_path):
+    """No agent dir and no mcp name anywhere → return False, write nothing."""
+    monkeypatch.delenv("LINGTAI_AGENT_DIR", raising=False)
+    monkeypatch.delenv("LINGTAI_MCP_NAME", raising=False)
+
+    ok = licc.push_inbox_event("alice", "hi", "hello")
+    assert ok is False
+    # Nothing should have been created anywhere under tmp_path.
+    assert not any(tmp_path.rglob("*.json"))
+
+
+def test_missing_mcp_name_is_noop(monkeypatch, tmp_path):
+    """Agent dir present but no mcp name → no-op (we don't know where to write)."""
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path))
+    monkeypatch.delenv("LINGTAI_MCP_NAME", raising=False)
+
+    ok = licc.push_inbox_event("alice", "hi", "hello")
+    assert ok is False
+    assert not (tmp_path / INBOX_DIRNAME).exists()
+
+
+def test_missing_agent_dir_is_noop(monkeypatch, tmp_path):
+    """MCP name present but no agent dir → no-op."""
+    monkeypatch.delenv("LINGTAI_AGENT_DIR", raising=False)
+    monkeypatch.setenv("LINGTAI_MCP_NAME", "telegram")
+
+    ok = licc.push_inbox_event("alice", "hi", "hello")
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Happy path: schema + defaults
+# ---------------------------------------------------------------------------
+
+def test_push_writes_event_with_defaults(tmp_path):
+    ok = licc.push_inbox_event(
+        "alice", "hi", "hello",
+        agent_dir=tmp_path, mcp_name="telegram",
+    )
+    assert ok is True
+
+    events = _events_in(tmp_path, "telegram")
+    assert len(events) == 1
+    event = _read_event(events[0])
+
+    assert event["licc_version"] == LICC_VERSION
+    assert event["from"] == "alice"
+    assert event["subject"] == "hi"
+    assert event["body"] == "hello"
+    # Defaults: wake True, metadata empty dict, received_at populated (ISO-ish).
+    assert event["wake"] is True
+    assert event["metadata"] == {}
+    assert isinstance(event["received_at"], str) and event["received_at"]
+
+
+def test_push_respects_explicit_fields(tmp_path):
+    ok = licc.push_inbox_event(
+        "bob", "subj", "body text",
+        metadata={"conversation_ref": "tg:chat:1"},
+        wake=False,
+        received_at="2026-01-01T00:00:00+00:00",
+        agent_dir=tmp_path, mcp_name="feishu",
+    )
+    assert ok is True
+    event = _read_event(_events_in(tmp_path, "feishu")[0])
+    assert event["from"] == "bob"
+    assert event["wake"] is False
+    assert event["metadata"] == {"conversation_ref": "tg:chat:1"}
+    assert event["received_at"] == "2026-01-01T00:00:00+00:00"
+
+
+def test_push_uses_env_defaults(monkeypatch, tmp_path):
+    """With no explicit args, agent dir + mcp name come from env."""
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path))
+    monkeypatch.setenv("LINGTAI_MCP_NAME", "imap")
+
+    ok = licc.push_inbox_event("carol", "s", "b")
+    assert ok is True
+    events = _events_in(tmp_path, "imap")
+    assert len(events) == 1
+    assert _read_event(events[0])["from"] == "carol"
+
+
+def test_explicit_args_override_env(monkeypatch, tmp_path):
+    """Explicit agent_dir / mcp_name win over env vars."""
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path / "wrong"))
+    monkeypatch.setenv("LINGTAI_MCP_NAME", "wrong-mcp")
+
+    right = tmp_path / "right"
+    ok = licc.push_inbox_event(
+        "dave", "s", "b", agent_dir=right, mcp_name="right-mcp",
+    )
+    assert ok is True
+    assert _events_in(right, "right-mcp")
+    assert not (tmp_path / "wrong").exists()
+
+
+# ---------------------------------------------------------------------------
+# Atomicity
+# ---------------------------------------------------------------------------
+
+def test_push_leaves_no_tmp_file(tmp_path):
+    """After a successful push only the final .json exists — the .tmp is gone."""
+    ok = licc.push_inbox_event(
+        "alice", "hi", "hello", agent_dir=tmp_path, mcp_name="telegram",
+    )
+    assert ok is True
+    mcp_dir = tmp_path / INBOX_DIRNAME / "telegram"
+    tmps = [p for p in mcp_dir.iterdir() if p.name.endswith(TMP_SUFFIX)]
+    finals = [p for p in mcp_dir.iterdir() if p.name.endswith(EVENT_SUFFIX)
+              and not p.name.endswith(TMP_SUFFIX)]
+    assert tmps == []
+    assert len(finals) == 1
+
+
+def test_event_filename_is_json_not_tmp(tmp_path):
+    licc.push_inbox_event(
+        "alice", "hi", "hello", agent_dir=tmp_path, mcp_name="telegram",
+        event_id="fixed-id",
+    )
+    final = tmp_path / INBOX_DIRNAME / "telegram" / "fixed-id.json"
+    assert final.is_file()
+    assert not (tmp_path / INBOX_DIRNAME / "telegram" / f"fixed-id{TMP_SUFFIX}").exists()
+
+
+# ---------------------------------------------------------------------------
+# Schema and path-component safety
+# ---------------------------------------------------------------------------
+
+def test_invalid_payload_is_noop(tmp_path):
+    """The canonical producer should not intentionally write dead-letterable events."""
+    ok = licc.push_inbox_event(
+        "alice", "", "hello", agent_dir=tmp_path, mcp_name="telegram",
+    )
+    assert ok is False
+    assert not any(tmp_path.rglob("*.json"))
+
+
+def test_invalid_mcp_name_is_noop(tmp_path):
+    ok = licc.push_inbox_event(
+        "alice", "hi", "hello", agent_dir=tmp_path, mcp_name="../escape",
+    )
+    assert ok is False
+    assert not any(tmp_path.rglob("*.json"))
+
+
+def test_invalid_event_id_is_noop(tmp_path):
+    ok = licc.push_inbox_event(
+        "alice", "hi", "hello", agent_dir=tmp_path, mcp_name="telegram",
+        event_id="../escape",
+    )
+    assert ok is False
+    assert not any(tmp_path.rglob("*.json"))
+
+
+# ---------------------------------------------------------------------------
+# Unicode
+# ---------------------------------------------------------------------------
+
+def test_push_handles_unicode(tmp_path):
+    ok = licc.push_inbox_event(
+        "爱丽丝", "主题 — émoji 🚀", "正文 with 中文 and 🌟 and ✨",
+        agent_dir=tmp_path, mcp_name="telegram",
+    )
+    assert ok is True
+    event = _read_event(_events_in(tmp_path, "telegram")[0])
+    assert event["from"] == "爱丽丝"
+    assert event["subject"] == "主题 — émoji 🚀"
+    assert event["body"] == "正文 with 中文 and 🌟 and ✨"
+
+
+# ---------------------------------------------------------------------------
+# Uniqueness
+# ---------------------------------------------------------------------------
+
+def test_repeated_pushes_are_distinct_files(tmp_path):
+    for i in range(5):
+        assert licc.push_inbox_event(
+            "alice", f"subj {i}", f"body {i}",
+            agent_dir=tmp_path, mcp_name="telegram",
+        ) is True
+    events = _events_in(tmp_path, "telegram")
+    assert len(events) == 5
+    # Each file has a unique name (no collisions / overwrites).
+    assert len({p.name for p in events}) == 5
+    # And each carries a distinct subject (no clobbering).
+    subjects = {_read_event(p)["subject"] for p in events}
+    assert subjects == {f"subj {i}" for i in range(5)}
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+def test_non_json_metadata_returns_false(tmp_path):
+    """Serialization failures are swallowed → False, never raises."""
+    ok = licc.push_inbox_event(
+        "alice", "hi", "hello", metadata={"bad": object()},
+        agent_dir=tmp_path, mcp_name="telegram",
+    )
+    assert ok is False
+
+
+def test_invalid_agent_dir_returns_false():
+    """Invalid explicit agent_dir values are swallowed → False, never raises."""
+    ok = licc.push_inbox_event(
+        "alice", "hi", "hello", agent_dir=object(), mcp_name="telegram",
+    )
+    assert ok is False
+
+
+def test_oserror_returns_false(tmp_path, monkeypatch):
+    """A filesystem failure during write is swallowed → False, never raises."""
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    # Make the atomic os.replace fail; push must catch and return False.
+    monkeypatch.setattr(licc.os, "replace", boom)
+    ok = licc.push_inbox_event(
+        "alice", "hi", "hello", agent_dir=tmp_path, mcp_name="telegram",
+    )
+    assert ok is False
+
+
+def test_mkdir_oserror_returns_false(tmp_path, monkeypatch):
+    """If the inbox dir cannot be created, push returns False without raising."""
+    def boom(*a, **k):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", boom)
+    ok = licc.push_inbox_event(
+        "alice", "hi", "hello", agent_dir=tmp_path, mcp_name="telegram",
+    )
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Round-trip compatibility with the kernel-side validator
+# ---------------------------------------------------------------------------
+
+def test_pushed_event_passes_inbox_validator(tmp_path):
+    """The producer's output must validate as a legal LICC event."""
+    licc.push_inbox_event(
+        "alice", "hi", "hello",
+        metadata={"platform": "telegram"},
+        agent_dir=tmp_path, mcp_name="telegram",
+    )
+    event = _read_event(_events_in(tmp_path, "telegram")[0])
+    ok, err = validate_event(event)
+    assert ok, err
+
+
+def test_pushed_event_with_all_fields_passes_validator(tmp_path):
+    licc.push_inbox_event(
+        "alice", "s" * 200, "long body " * 100,
+        metadata={"conversation_ref": "c", "message_ref": "m", "platform": "p"},
+        wake=False,
+        agent_dir=tmp_path, mcp_name="telegram",
+    )
+    event = _read_event(_events_in(tmp_path, "telegram")[0])
+    ok, err = validate_event(event)
+    assert ok, err
+
+
+# ---------------------------------------------------------------------------
+# Producer → consumer integration
+# ---------------------------------------------------------------------------
+
+def test_pushed_event_is_consumed_by_scan_once(tmp_path):
+    """The canonical producer's output should drive the real consumer path."""
+    agent, workdir = _mk_agent(tmp_path)
+
+    assert licc.push_inbox_event(
+        "alice", "new DM", "hello from producer",
+        metadata={"platform": "telegram", "conversation_ref": "chat-1"},
+        agent_dir=workdir,
+        mcp_name="telegram",
+    ) is True
+
+    event_files = _events_in(workdir, "telegram")
+    assert len(event_files) == 1
+
+    dispatched = _scan_once(agent, workdir / INBOX_DIRNAME)
+    assert dispatched == 1
+    assert not event_files[0].exists(), "consumer should delete the consumed event"
+
+    notif_file = workdir / ".notification" / "mcp.telegram.json"
+    assert notif_file.exists()
+    notif = json.loads(notif_file.read_text(encoding="utf-8"))
+    preview = notif["data"]["previews"][0]
+    assert preview["from"] == "alice"
+    assert preview["subject"] == "new DM"
+    assert preview["preview"] == "hello from producer"
+    assert preview["platform"] == "telegram"
+    assert preview["conversation_ref"] == "chat-1"


### PR DESCRIPTION
## Summary

This PR implements the clarified item 2 scope from the LingTai cleanup discussion: LICC remains a kernel-intrinsic protocol, and the kernel now exposes a canonical client-side producer interface alongside the existing receiver.

Adds:
- `lingtai.core.mcp.licc` with `push_inbox_event(...)` as the official LICC v1 producer/client helper.
- Shared contract constants imported from `inbox.py` so producer and consumer do not drift.
- Atomic `.json.tmp` → fsync → `os.replace()` writes into `.mcp_inbox/<mcp_name>/`.
- Producer-side receiver validation via `validate_event` before writing.
- Path-component safety for `mcp_name` / explicit `event_id` and best-effort `False` returns for invalid input, missing env, serialization errors, or filesystem errors.
- A producer→consumer integration test proving events written by `push_inbox_event` are consumed by `_scan_once` and produce notification previews.
- MCP anatomy/docs update framing LICC as producer (`licc.py`) + consumer (`inbox.py`).
- Standalone HTML explainer: `reports/licc-kernel-interface-explainer.html`.

Non-goals preserved:
- No standalone `lingtai-licc` package/repo.
- No addon repo changes.
- No addon dependency changes or migration.

## Validation

```text
python -m pytest tests/test_mcp_licc_client.py tests/test_mcp_inbox.py -q
# 48 passed in 1.16s

python -m pytest tests/test_mcp_licc_client.py tests/test_mcp_inbox.py tests/test_mcp_capability.py -q
# 71 passed in 1.39s

python -m pytest tests/test_mcp_closed_resource_restart.py tests/test_tc_inbox.py tests/test_tc_inbox_mid_turn_drain.py tests/test_tc_inbox_remove_by_notif_id.py -q
# 43 passed in 0.50s

python -m compileall src/lingtai/core/mcp/licc.py src/lingtai/core/mcp/inbox.py
# OK

git diff --check
# OK

PYTHONPATH=src python - <<'PY'
from lingtai.core.mcp.licc import push_inbox_event, LICC_VERSION, INBOX_DIRNAME, TMP_SUFFIX
print(push_inbox_event.__name__, LICC_VERSION, INBOX_DIRNAME, TMP_SUFFIX)
PY
# push_inbox_event 1 .mcp_inbox .json.tmp
```

## Reviews

- Claude Code xhigh/opus was the main implementation author.
- Codex review hardened path safety, pre-write validation, error behavior, and added expanded tests.
- GLM review returned no blockers; useful low-severity suggestions were incorporated (lightweight import guard comment, producer→consumer integration test).
