### PR TITLE
Fix stale notification channel dismiss

### DIFF
--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -444,6 +444,9 @@ class BaseAgent:
         #   skeletonized in-place, not deleted).
         # See notifications.py and notification-filesystem-redesign.md.
         self._notification_fp: tuple = ()
+        # Protects read-modify-write updates and guarded clears for the
+        # shared `.notification/system.json` channel.
+        self._system_notification_lock: threading.Lock = threading.Lock()
         # Last ACTIVE-state notification fingerprint that has already emitted
         # ``notification_deferred_active``.  This is intentionally separate
         # from ``_notification_fp``: ACTIVE must keep the delivery fingerprint

--- a/src/lingtai_kernel/base_agent/messaging.py
+++ b/src/lingtai_kernel/base_agent/messaging.py
@@ -130,7 +130,7 @@ def _enqueue_system_notification(agent, *, source: str, ref_id: str, body: str) 
 
     The merge is read-modify-write on the same file, so concurrent
     arrivals (e.g. a burst of bounces) need a per-agent lock to avoid
-    losing writes.  The lock is created lazily on first use; only
+    losing writes.  The lock is initialized by ``BaseAgent``; only
     ``system.json`` needs it because ``email.json`` and ``soul.json``
     recompute full state on every publish (no merge).
 
@@ -146,7 +146,6 @@ def _enqueue_system_notification(agent, *, source: str, ref_id: str, body: str) 
         per-id lifecycle under the new model).
     """
     import secrets
-    import threading
     from datetime import datetime, timezone
     from ..notifications import collect_notifications
     from ..intrinsics.system import publish_notification
@@ -154,13 +153,7 @@ def _enqueue_system_notification(agent, *, source: str, ref_id: str, body: str) 
     event_id = f"evt_{int(time.time()*1000):x}_{secrets.token_hex(2)}"
     received_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    # Lazy per-agent lock for the read-modify-write merge.  Stored as
-    # a plain attribute since BaseAgent doesn't declare it (only
-    # `system.json` needs this; other producers don't merge).
-    lock = getattr(agent, "_system_notification_lock", None)
-    if lock is None:
-        lock = threading.Lock()
-        agent._system_notification_lock = lock
+    lock = agent._system_notification_lock
 
     with lock:
         current = collect_notifications(agent._working_dir).get("system", {})

--- a/src/lingtai_kernel/notifications.py
+++ b/src/lingtai_kernel/notifications.py
@@ -161,6 +161,69 @@ def clear_with_result(workdir: Path, channel: str) -> bool:
     return True
 
 
+def _channel_fingerprint_entry(fp: tuple | None, channel: str) -> tuple | None:
+    """Return one channel's fingerprint entry from a directory fingerprint."""
+    filename = f"{channel}.json"
+    for entry in fp or ():
+        try:
+            if entry[0] == filename:
+                return tuple(entry)
+        except (IndexError, TypeError):
+            continue
+    return None
+
+
+def _safe_version(entry: tuple | None) -> list | None:
+    """Return a JSON/log-safe fingerprint representation."""
+    return list(entry) if entry is not None else None
+
+
+def _stale_channel_refusal(
+    agent,
+    channel: str,
+    *,
+    invoked_by: str,
+    delivered: tuple | None,
+    current: tuple,
+) -> dict:
+    delivered_version = _safe_version(delivered)
+    current_version = _safe_version(current)
+    try:
+        agent._log(
+            "notification_dismiss_refused",
+            reason="stale_channel_version",
+            channel=channel,
+            invoked_by=invoked_by,
+            forced=False,
+            delivered_version=delivered_version,
+            current_version=current_version,
+        )
+        if invoked_by == "system":
+            agent._log(
+                "system_dismiss_refused",
+                reason="stale_channel_version",
+                channel=channel,
+                forced=False,
+                delivered_version=delivered_version,
+                current_version=current_version,
+            )
+    except Exception:
+        pass
+    return {
+        "status": "error",
+        "reason": "stale_channel_version",
+        "channel": channel,
+        "forced": False,
+        "delivered_version": delivered_version,
+        "current_version": current_version,
+        "message": (
+            f"Channel '{channel}' changed after the delivered notification "
+            "version. Read the current notification state before dismissing, "
+            "or pass force=true to knowingly clear it."
+        ),
+    }
+
+
 def dismiss_channel(
     agent,
     channel: str,
@@ -247,64 +310,89 @@ def dismiss_channel(
             ),
         }
 
-    try:
-        existed = clear_with_result(agent._working_dir, channel)
-    except OSError as e:
+    def _clear_current_channel() -> dict:
+        if not force:
+            fp = notification_fingerprint(agent._working_dir)
+            current = _channel_fingerprint_entry(fp, channel)
+            if current is not None:
+                delivered = _channel_fingerprint_entry(
+                    getattr(agent, "_notification_fp", ()),
+                    channel,
+                )
+                if delivered != current:
+                    return _stale_channel_refusal(
+                        agent,
+                        channel,
+                        invoked_by=invoked_by,
+                        delivered=delivered,
+                        current=current,
+                    )
+
+        try:
+            existed = clear_with_result(agent._working_dir, channel)
+        except OSError as e:
+            try:
+                agent._log(
+                    "notification_dismiss_error",
+                    channel=channel,
+                    invoked_by=invoked_by,
+                    forced=bool(force),
+                    error=str(e)[:200],
+                )
+            except Exception:
+                pass
+            return {
+                "status": "error",
+                "reason": "clear_failed",
+                "channel": channel,
+                "message": str(e),
+            }
+
+        # Any pending ACTIVE-state payload may contain the dismissed channel.
+        # Invalidate after a successful clear attempt; stale refusals above
+        # leave newer notification state intact for later delivery.
+        if hasattr(agent, "_pending_notification_meta"):
+            agent._pending_notification_meta = None
+        if hasattr(agent, "_pending_notification_fp"):
+            agent._pending_notification_fp = None
+
         try:
             agent._log(
-                "notification_dismiss_error",
+                "notification_dismiss",
                 channel=channel,
                 invoked_by=invoked_by,
-                forced=bool(force),
-                error=str(e)[:200],
-            )
-        except Exception:
-            pass
-        return {
-            "status": "error",
-            "reason": "clear_failed",
-            "channel": channel,
-            "message": str(e),
-        }
-
-    # Any pending ACTIVE-state payload may contain the dismissed channel.
-    # Invalidate unconditionally; the next sync rebuilds from disk.
-    if hasattr(agent, "_pending_notification_meta"):
-        agent._pending_notification_meta = None
-    if hasattr(agent, "_pending_notification_fp"):
-        agent._pending_notification_fp = None
-
-    try:
-        agent._log(
-            "notification_dismiss",
-            channel=channel,
-            invoked_by=invoked_by,
-            existed=existed,
-            forced=bool(force),
-            reason=ack_reason or None,
-        )
-        if invoked_by == "system":
-            agent._log(
-                "system_dismiss",
-                channel=channel,
                 existed=existed,
                 forced=bool(force),
                 reason=ack_reason or None,
             )
-        elif invoked_by == "soul":
-            agent._log("soul_dismiss")
-    except Exception:
-        pass
+            if invoked_by == "system":
+                agent._log(
+                    "system_dismiss",
+                    channel=channel,
+                    existed=existed,
+                    forced=bool(force),
+                    reason=ack_reason or None,
+                )
+            elif invoked_by == "soul":
+                agent._log("soul_dismiss")
+        except Exception:
+            pass
 
-    result = {
-        "status": "ok",
-        "channel": channel,
-        "cleared": existed,
-        "forced": bool(force),
-    }
-    if ack_reason:
-        result["reason"] = ack_reason
-    return result
+        result = {
+            "status": "ok",
+            "channel": channel,
+            "cleared": existed,
+            "forced": bool(force),
+        }
+        if ack_reason:
+            result["reason"] = ack_reason
+        return result
+
+    if channel == "system":
+        with agent._system_notification_lock:
+            return _clear_current_channel()
+
+    return _clear_current_channel()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -222,6 +222,7 @@ class _ProducerStubAgent:
     write to .notification/."""
     _working_dir: Path = None
     _logs: list[tuple[str, dict]] = field(default_factory=list)
+    _system_notification_lock: threading.Lock = field(default_factory=threading.Lock)
 
     def _log(self, evt: str, **fields: Any) -> None:
         self._logs.append((evt, fields))

--- a/tests/test_system_dismiss.py
+++ b/tests/test_system_dismiss.py
@@ -7,6 +7,7 @@ accepted for one release cycle so old chat-history tails do not crash.
 from __future__ import annotations
 
 import json
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,6 +19,7 @@ from lingtai_kernel.intrinsics import system as sys_intrinsic
 from lingtai_kernel.notifications import (
     collect_notifications,
     is_generic_dismiss_guarded,
+    notification_fingerprint,
     publish,
 )
 
@@ -26,20 +28,39 @@ from lingtai_kernel.notifications import (
 class _StubAgent:
     _working_dir: Path
     _logs: list[tuple[str, dict]] = field(default_factory=list)
+    _notification_fp: tuple = ()
     _pending_notification_meta: str | None = "stale"
     _pending_notification_fp: tuple | None = (("soul.json", 1, 2),)
+    _system_notification_lock: threading.Lock = field(default_factory=threading.Lock)
 
     def _log(self, event_type: str, **fields: Any) -> None:
         self._logs.append((event_type, fields))
+
+
+class _RecordingLock:
+    def __init__(self) -> None:
+        self.entered = False
+
+    def __enter__(self):
+        self.entered = True
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        return None
 
 
 def _events(agent: _StubAgent, name: str) -> list[dict]:
     return [fields for event, fields in agent._logs if event == name]
 
 
+def _mark_delivered(agent: _StubAgent) -> None:
+    agent._notification_fp = notification_fingerprint(agent._working_dir)
+
+
 def test_dismiss_channel_clears_existing_file(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
     publish(tmp_path, "soul", {"header": "soul flow"})
+    _mark_delivered(agent)
 
     res = sys_intrinsic._dismiss(agent, {"channel": "soul"})
 
@@ -66,6 +87,7 @@ def test_dismiss_channel_is_idempotent_when_absent(tmp_path: Path) -> None:
 def test_dismiss_mcp_dotted_channel(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
     publish(tmp_path, "mcp.telegram", {"header": "telegram event"})
+    _mark_delivered(agent)
 
     res = sys_intrinsic.handle(agent, {"action": "dismiss", "channel": "mcp.telegram"})
 
@@ -166,6 +188,7 @@ def test_soul_dismiss_alias_uses_shared_helper(tmp_path: Path) -> None:
 
     agent = _StubAgent(tmp_path)
     publish(tmp_path, "soul", {"header": "soul flow"})
+    _mark_delivered(agent)
 
     res = soul.handle(agent, {"action": "dismiss"})
 
@@ -180,6 +203,7 @@ def test_dismiss_one_channel_preserves_other_channels(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
     publish(tmp_path, "email", {"header": "1 unread"})
     publish(tmp_path, "soul", {"header": "soul flow"})
+    _mark_delivered(agent)
 
     res = sys_intrinsic._dismiss(agent, {"channel": "soul"})
 
@@ -203,6 +227,7 @@ def test_post_molt_dismiss_requires_ack_reason(tmp_path: Path) -> None:
 def test_post_molt_dismiss_records_ack_reason(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
     publish(tmp_path, "post-molt", {"header": "resume work"})
+    _mark_delivered(agent)
 
     res = sys_intrinsic._dismiss(agent, {
         "channel": "post-molt",
@@ -221,3 +246,99 @@ def test_post_molt_dismiss_records_ack_reason(tmp_path: Path) -> None:
         "continue: resumed the preserved task"
     assert _events(agent, "system_dismiss")[0]["reason"] == \
         "continue: resumed the preserved task"
+
+
+def test_stale_system_dismiss_refuses_and_preserves_newer_file(tmp_path: Path) -> None:
+    agent = _StubAgent(tmp_path)
+    publish(tmp_path, "system", {"header": "one", "data": {"events": ["old"]}})
+    _mark_delivered(agent)
+    delivered_fp = agent._notification_fp
+    publish(
+        tmp_path,
+        "system",
+        {"header": "two", "data": {"events": ["old", "new"], "extra": "changed"}},
+    )
+
+    res = sys_intrinsic._dismiss(agent, {"channel": "system"})
+
+    assert res["status"] == "error"
+    assert res["reason"] == "stale_channel_version"
+    assert res["channel"] == "system"
+    assert res["forced"] is False
+    assert res["delivered_version"] != res["current_version"]
+    assert collect_notifications(tmp_path)["system"]["header"] == "two"
+    assert agent._pending_notification_meta == "stale"
+    assert agent._pending_notification_fp == (("soul.json", 1, 2),)
+    assert agent._notification_fp == delivered_fp
+    refusal = _events(agent, "notification_dismiss_refused")[0]
+    assert refusal["reason"] == "stale_channel_version"
+    assert refusal["invoked_by"] == "system"
+
+
+def test_force_bypasses_stale_version_guard(tmp_path: Path) -> None:
+    agent = _StubAgent(tmp_path)
+    publish(tmp_path, "system", {"header": "one", "data": {"events": ["old"]}})
+    _mark_delivered(agent)
+    publish(
+        tmp_path,
+        "system",
+        {"header": "two", "data": {"events": ["old", "new"], "extra": "changed"}},
+    )
+
+    res = sys_intrinsic._dismiss(agent, {"channel": "system", "force": True})
+
+    assert res["status"] == "ok"
+    assert res["cleared"] is True
+    assert res["forced"] is True
+    assert "system" not in collect_notifications(tmp_path)
+    assert agent._pending_notification_meta is None
+    assert agent._pending_notification_fp is None
+
+
+def test_stale_other_channel_does_not_block_delivered_channel(tmp_path: Path) -> None:
+    agent = _StubAgent(tmp_path)
+    publish(tmp_path, "soul", {"header": "soul flow"})
+    publish(tmp_path, "system", {"header": "one", "data": {"events": ["old"]}})
+    _mark_delivered(agent)
+    publish(
+        tmp_path,
+        "system",
+        {"header": "two", "data": {"events": ["old", "new"], "extra": "changed"}},
+    )
+
+    res = sys_intrinsic._dismiss(agent, {"channel": "soul"})
+
+    assert res["status"] == "ok"
+    assert res["cleared"] is True
+    out = collect_notifications(tmp_path)
+    assert set(out) == {"system"}
+    assert out["system"]["header"] == "two"
+
+
+def test_never_delivered_current_channel_refuses_without_force(tmp_path: Path) -> None:
+    agent = _StubAgent(tmp_path)
+    publish(tmp_path, "nudge", {"header": "new nudge"})
+
+    res = sys_intrinsic._dismiss(agent, {"channel": "nudge"})
+
+    assert res["status"] == "error"
+    assert res["reason"] == "stale_channel_version"
+    assert res["delivered_version"] is None
+    assert res["current_version"][0] == "nudge.json"
+    assert "nudge" in collect_notifications(tmp_path)
+    assert agent._pending_notification_meta == "stale"
+    assert agent._pending_notification_fp == (("soul.json", 1, 2),)
+
+
+def test_system_compare_and_clear_uses_system_notification_lock(tmp_path: Path) -> None:
+    agent = _StubAgent(tmp_path)
+    lock = _RecordingLock()
+    agent._system_notification_lock = lock
+    publish(tmp_path, "system", {"header": "system event"})
+    _mark_delivered(agent)
+
+    res = sys_intrinsic._dismiss(agent, {"channel": "system"})
+
+    assert res["status"] == "ok"
+    assert lock.entered is True
+    assert "system" not in collect_notifications(tmp_path)


### PR DESCRIPTION
## Summary

Closes #230.

This PR adds a minimal channel-version guard for generic notification dismiss. Before `system(action="dismiss", channel=...)` unlinks `.notification/<channel>.json`, the kernel now verifies that the current channel file is still the same version that was delivered to the model in `agent._notification_fp`.

If the current channel file exists but changed after delivery, or exists even though that channel was never delivered, non-forced dismiss now refuses with `reason="stale_channel_version"` and leaves the file on disk. The refusal is model-visible through the dismiss tool result, and the newer notification remains available for later notification sync.

For the shared `system` channel, the compare-and-clear path now runs under the same `_system_notification_lock` used by system notification enqueue, preventing a publish-between-check-and-unlink race.

## Behavior

- Generic dismiss checks the requested channel's current fingerprint entry against the delivered entry in `agent._notification_fp`.
- Stale or never-delivered current channel files return `status="error", reason="stale_channel_version"` unless `force=True`.
- Missing current files remain idempotent no-ops.
- `force=True` bypasses only the new version guard; existing validation, guarded-producer behavior, and `post-molt` acknowledgement requirements remain intact.
- `system` compare+clear uses `_system_notification_lock`; the lock is initialized in `BaseAgent.__init__`, and `_enqueue_system_notification` uses that pre-existing lock.
- Stale refusals do not clear pending notification metadata, so newer notification state is preserved for later delivery.

## Tests

- `uv run --with pytest pytest tests/test_system_dismiss.py tests/test_notification_sync.py tests/test_meta_block.py tests/test_karma.py -q` — 120 passed
- `uv run --with pytest pytest -q` — 2042 passed, 3 skipped
- `git diff --check`
