### PR TITLE
Reap dead-parent daemon records on startup

### DIFF
--- a/src/lingtai/core/daemon/ANATOMY.md
+++ b/src/lingtai/core/daemon/ANATOMY.md
@@ -70,6 +70,7 @@ daemon/run_dir.py
 - **No recursion:** `EMANATION_BLACKLIST` prevents emanations from spawning sub-emanations, avatars, psyche, the skill catalog, or deprecated codex.
 - **Tool surface isolation:** `_ToolCollector` ensures preset-driven capability setup does not mutate the parent agent's tool registry.
 - **Filesystem isolation:** Each emanation gets its own `daemons/em-<N>-<YYYYMMDD-HHMMSS>-<hash6>/` directory. `DaemonRunDir` uses atomic `os.replace` for `daemon.json` and single-writer append-only JSONL for events/chat history.
+- **Startup reaps stale parent-owned records:** `DaemonManager.__init__` scans only the current agent working directory's `daemons/*/daemon.json` files and marks `running`/`active` records as `failed` when their recorded `parent_pid` no longer exists. It does not reconstruct in-memory registry entries from disk.
 - **Timeout vs. cancel distinction:** Separate `timeout_event` and `cancel_event` allow the run loop to call `mark_timeout()` vs. `mark_cancelled()` based on which signal fired first.
 - **Capacity control:** `max_emanations` caps concurrent subagents; completed futures are pruned before each new batch.
 - **Preset validation is pre-flight:** Preset connectivity and capability instantiation are checked before any emanation is scheduled. A single failure refuses the whole batch.

--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -362,6 +362,67 @@ class DaemonManager:
             max_workers=max(1, max_emanations),
             thread_name_prefix="daemon-cli-ask",
         )
+        self._reap_dead_parent_daemon_records()
+
+    def _reap_dead_parent_daemon_records(self) -> None:
+        """Mark stale running daemon.json records failed after parent restart."""
+        daemons_dir = self._agent._working_dir / "daemons"
+        if not daemons_dir.is_dir():
+            return
+
+        current_pid = os.getpid()
+        for daemon_json_path in daemons_dir.glob("*/daemon.json"):
+            try:
+                state = json.loads(daemon_json_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(state, dict):
+                continue
+
+            daemon_state = state.get("state")
+            if not isinstance(daemon_state, str):
+                continue
+            if daemon_state.lower() not in {"running", "active"}:
+                continue
+            if state.get("finished_at") not in (None, ""):
+                continue
+
+            parent_pid = state.get("parent_pid")
+            if not isinstance(parent_pid, int) or isinstance(parent_pid, bool):
+                continue
+            if parent_pid == current_pid:
+                continue
+
+            try:
+                os.kill(parent_pid, 0)
+            except ProcessLookupError:
+                pass
+            except (PermissionError, OSError):
+                continue
+            else:
+                continue
+
+            state["state"] = "failed"
+            state["finished_at"] = DaemonRunDir._now_iso()
+            state["current_tool"] = None
+            state["error"] = {
+                "type": "DaemonOrphaned",
+                "message": (
+                    "Reaped running daemon record because recorded parent_pid "
+                    f"{parent_pid} is no longer alive after daemon manager startup."
+                ),
+            }
+            tmp_path = daemon_json_path.with_suffix(
+                daemon_json_path.suffix + ".tmp"
+            )
+            try:
+                tmp_path.write_text(
+                    json.dumps(state, indent=2, ensure_ascii=False),
+                    encoding="utf-8",
+                )
+                os.replace(tmp_path, daemon_json_path)
+            except OSError:
+                continue
 
     def handle(self, args: dict) -> dict:
         action = args.get("action")

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,6 +1,7 @@
 # tests/test_daemon.py
 """Tests for the daemon (神識) capability — subagent system."""
 import json
+import os
 import queue
 import re
 import threading
@@ -45,6 +46,25 @@ def _make_run_dir(agent, em_id="em-test"):
     )
 
 
+def _write_daemon_json(tmp_path, run_id, **overrides):
+    daemon_dir = tmp_path / "daemon-agent" / "daemons" / run_id
+    daemon_dir.mkdir(parents=True)
+    data = {
+        "handle": "em-test",
+        "run_id": run_id,
+        "parent_pid": 12345,
+        "state": "running",
+        "finished_at": None,
+        "current_tool": "read",
+        "error": None,
+        "unrelated": {"preserved": True},
+    }
+    data.update(overrides)
+    daemon_json = daemon_dir / "daemon.json"
+    daemon_json.write_text(json.dumps(data), encoding="utf-8")
+    return daemon_json
+
+
 def test_daemon_registers_tool(tmp_path):
     agent = _make_agent(tmp_path, ["daemon"])
     tool_names = {s.name for s in agent._tool_schemas}
@@ -65,6 +85,87 @@ def test_daemon_max_emanations_override_reaches_manager(tmp_path):
     mgr = agent.get_capability("daemon")
     assert mgr._max_emanations == 30
     assert mgr._handle_list()["max_emanations"] == 30
+
+
+def test_daemon_setup_reaps_dead_parent_running_record(tmp_path, monkeypatch):
+    """Startup marks stale running daemon.json records failed."""
+    from lingtai.core import daemon as daemon_mod
+
+    stale_pid = 987654
+    daemon_json = _write_daemon_json(
+        tmp_path,
+        "em-dead-20260101-000000-abcdef",
+        parent_pid=stale_pid,
+    )
+
+    calls = []
+
+    def fake_kill(pid, sig):
+        calls.append((pid, sig))
+        if pid == stale_pid:
+            raise ProcessLookupError
+
+    monkeypatch.setattr(daemon_mod.os, "kill", fake_kill)
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    data = json.loads(daemon_json.read_text(encoding="utf-8"))
+    assert data["state"] == "failed"
+    assert data["finished_at"]
+    assert data["current_tool"] is None
+    assert data["error"] == {
+        "type": "DaemonOrphaned",
+        "message": (
+            "Reaped running daemon record because recorded parent_pid "
+            f"{stale_pid} is no longer alive after daemon manager startup."
+        ),
+    }
+    assert data["unrelated"] == {"preserved": True}
+    assert (stale_pid, 0) in calls
+    assert mgr._emanations == {}
+
+
+def test_daemon_setup_keeps_current_and_live_parent_records(tmp_path, monkeypatch):
+    """Startup skips current PID and records whose parent PID is still alive."""
+    from lingtai.core import daemon as daemon_mod
+
+    current_pid = os.getpid()
+    live_pid = current_pid + 100000
+    current_json = _write_daemon_json(
+        tmp_path,
+        "em-current-20260101-000000-abcdef",
+        parent_pid=current_pid,
+        state="active",
+    )
+    live_json = _write_daemon_json(
+        tmp_path,
+        "em-live-20260101-000000-abcdef",
+        parent_pid=live_pid,
+    )
+
+    calls = []
+
+    def fake_kill(pid, sig):
+        calls.append((pid, sig))
+        return None
+
+    monkeypatch.setattr(daemon_mod.os, "kill", fake_kill)
+
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    current_data = json.loads(current_json.read_text(encoding="utf-8"))
+    live_data = json.loads(live_json.read_text(encoding="utf-8"))
+    assert current_data["state"] == "active"
+    assert current_data["current_tool"] == "read"
+    assert current_data["error"] is None
+    assert live_data["state"] == "running"
+    assert live_data["current_tool"] == "read"
+    assert live_data["error"] is None
+    assert (current_pid, 0) not in calls
+    assert (live_pid, 0) in calls
+    assert mgr._emanations == {}
 
 
 def test_build_tool_surface_expands_groups(tmp_path):


### PR DESCRIPTION
## Summary

- add a daemon-manager startup scan for stale `daemon.json` records whose recorded parent process is definitely dead
- convert only those impossible-to-supervise `running`/`active` records into the existing terminal state `failed`
- add focused setup tests for dead-parent reaping and current/live-parent skip behavior
- document the daemon lifecycle invariant in `src/lingtai/core/daemon/ANATOMY.md`

## Why this is the minimal reasonable fix

The reproduced failure is a mismatch between durable disk state and the new manager's actual supervision state after restart/refresh:

1. A previous daemon wrapper wrote `daemon.json` with `state="running"`, `finished_at=null`, and a `parent_pid` from the old agent process.
2. The agent then restarted/refreshed/crashed before that wrapper could write a terminal state.
3. The new `DaemonManager` starts with an empty in-memory registry, so it cannot manage or finish that old run.
4. TUI activity reads disk and counts `running`/`active` records with empty `finished_at`, so the stale record remains visible as `daemon-active`.

The smallest place to repair this is therefore daemon capability setup, where the new manager first becomes responsible for its working directory. At that point the kernel can compare the durable record against a fact it can verify locally: the recorded parent PID no longer exists. If that parent process is dead, no current manager can write the missing terminal state, so marking the record `failed` is the narrowest honest repair.

The patch intentionally uses the existing `failed` terminal state because the run's outcome is unknown after supervisor loss. It does not claim user cancellation or timeout, and it avoids adding a new state that downstream readers would need to learn.

## Scope

The first PR only handles records that are definitely orphaned:

```text
state in {running, active}
finished_at is empty
parent_pid is an int
parent_pid != os.getpid()
os.kill(parent_pid, 0) raises ProcessLookupError
```

Everything else is left untouched. That conservative boundary is what keeps the fix safe: if the parent PID is current, still alive, missing, invalid, or not provably dead, the record is skipped rather than guessed about. Broader recovery cases such as PID reuse, heartbeat staleness, historical `daemon(check)` rediscovery, or completed external CLI artifacts after supervisor loss remain follow-up territory for `Lingtai-AI/lingtai#118`.

Closes Lingtai-AI/lingtai-kernel#232.
Partially addresses Lingtai-AI/lingtai#118 by reaping stale running daemon records on daemon capability setup.

## Tests

- `uv run --with pytest pytest tests/test_daemon.py tests/test_daemon_run_dir.py tests/test_daemon_check.py` — 112 passed
- `uv run --with pytest pytest` — 2039 passed, 3 skipped
- `git diff --check`
