### PR TITLE
Document molt history knowledge entries

### DIFF
--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -13,6 +13,7 @@ This manual is the router for `psyche` operations. Keep routine guidance here; l
 
 | Asset | When to load | What it contains |
 |---|---|---|
+| `assets/session-journal-entry-template.md` (read from this skill directory) | Whenever you write the molt-history record for a session segment before a molt | Frontmatter + section template for a `knowledge/session-journal/<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md` entry |
 | `assets/molt-template.md` (read from this skill directory) | Consequential molt, long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, active background jobs, or any successor briefing that would be risky to improvise | 9-section summary scaffold plus pre-molt verification checklist |
 
 ## 1. Molt Overview
@@ -41,32 +42,35 @@ All five happen *before* the molt call. They are not optional. Without them, the
 
 ## 4. Session Journal
 
-The four stores capture *who you are*, *what you're working on*, *verifiable truths*, and *reusable procedures*. None of them captures the *story* of a session. The session journal is that missing layer.
+The four stores capture *who you are*, *what you're working on*, *verifiable truths*, and *reusable procedures*. None of them captures the *story* of a session. The session journal is that missing layer — it is also your **molt history**: each sub-entry is the record of one session segment that you write *before* you molt, so the chain of entries reconstructs how you got here across many molts.
 
 Write it as a parent/child knowledge structure under `knowledge/session-journal/`:
 
 ```
 knowledge/session-journal/
-├── KNOWLEDGE.md                                       # parent index
-├── 2026-05-13-nudge-service/KNOWLEDGE.md              # one session
-├── 2026-05-13-procedures-to-kernel/KNOWLEDGE.md       # another session
-└── 2026-05-14-wechat-fixes/KNOWLEDGE.md               # ...
+├── KNOWLEDGE.md                                            # parent index
+├── 2026-05-13-molt-7-nudge-service/KNOWLEDGE.md            # one session
+├── 2026-05-13-molt-8-procedures-to-kernel/KNOWLEDGE.md     # another, same day
+└── 2026-05-14-molt-9-wechat-fixes/KNOWLEDGE.md             # ...
 ```
+
+The directory name is `<YYYY-MM-DD>-molt-<molt-count>-<slug>`. Read the molt count from your resident system prompt's identity section — "You have undergone N molts since birth." Use that N: the entry records the pre-molt segment, written *before* you call `psyche(context, molt)`. (The molt tool result afterward reports the next count, N+1; that belongs to the next segment, not this one.) Embedding the count keeps chronology stable when you molt more than once on the same date: the date alone cannot order two same-day entries, but the molt count always can.
 
 **The parent `knowledge/session-journal/KNOWLEDGE.md` is the index** — short, scannable, progressive-disclosure. One line per sub-entry: date, slug, one-sentence hook.
 
-**The sub-entry `<date>-<slug>/KNOWLEDGE.md` is the substance** — write it long. Several thousand tokens is fine. Include:
+**The sub-entry `<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md` is the substance** — write it as the molt-history record of the segment, *before* you molt. Use `assets/session-journal-entry-template.md` from this skill directory for the frontmatter (including the `molt_count` field) and section layout. It is a journal, not a transcript — capture, in roughly this shape:
 
-- **What the session was about** — the original ask, the framing
-- **What you actually did** — the sequence, including pivots and reasons for them
-- **What you learned** — non-obvious facts, surprises, dead ends
-- **Decisions and their reasoning** — the *why*, especially when an alternative was rejected
-- **Open threads** — things noticed but deferred
-- **Pointers** — knowledge entries, skills, commits/PRs/files that anchor the work
+- **What the segment was about** — the original ask, the framing
+- **Accomplishments** — what you completed/moved forward, the outputs, who was told and where
+- **Decisions and their reasoning** — the *why*, especially where an alternative was rejected
+- **Artifacts and paths** — files, reports, branches, PRs, commits, message IDs that anchor the work; reference paths/IDs, never inline secrets or large blobs
+- **Open tasks** — things noticed or started but deferred, each with a next step
+- **Collaborators** — who is involved, their channels, who is waiting on what
+- **Gotchas and lessons** — actionable warnings and failed approaches
 
-Use a date-prefix slug so chronology is visible in `ls`. The kernel `knowledge` mechanic auto-discovers subdirectories containing `KNOWLEDGE.md`. Write files via `write`/`edit` directly.
+Several thousand tokens is fine when the segment was rich; keep it concise when it was small. The `<YYYY-MM-DD>-molt-<molt-count>-<slug>` prefix keeps chronology visible and stable in `ls` even across multiple molts on one day. The kernel `knowledge` mechanic auto-discovers subdirectories containing `KNOWLEDGE.md`. Write files via `write`/`edit` directly.
 
-Updating the parent index at each session is part of the practice — append one line referencing the new sub-entry.
+Updating the parent index at each session is part of the practice — append one line referencing the new sub-entry. Then write the successor summary (§6), which points back at this entry's path.
 
 ## 5. Tending the Pad
 
@@ -125,6 +129,10 @@ Quick routing:
 
 Before you call `psyche(object="context", action="molt", ...)`, always verify at minimum:
 
+- The just-finished session segment is recorded as a session-journal sub-entry
+  (your molt history) under `knowledge/session-journal/`, using
+  `assets/session-journal-entry-template.md` — see §4. Write this *before* the
+  summary; it is the narrative the summary points back to.
 - Durable stores and session journal were updated where needed before writing the summary.
 - Every outstanding task has an explicit next action.
 - Collaborators, channels, approvals, and key paths are named where relevant.

--- a/src/lingtai/intrinsic_skills/psyche-manual/assets/molt-template.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/assets/molt-template.md
@@ -43,6 +43,11 @@ Fill every section. Write `None` rather than omitting a section. This template i
 
 Before you call `psyche(object="context", action="molt", ...)`, verify:
 
+- The just-finished session segment is recorded as a session-journal sub-entry
+  (your molt history) under
+  `knowledge/session-journal/<YYYY-MM-DD>-molt-<molt-count>-<slug>/`, written
+  from `assets/session-journal-entry-template.md`, before the summary — and the
+  summary points at its path.
 - Pad, lingtai/character, knowledge, skills, and session journal were updated where needed before writing the summary.
 - Every outstanding task has an action checklist entry.
 - Every action names who/where and what exact content or command is needed.

--- a/src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
@@ -1,0 +1,53 @@
+# Session-Journal / Molt-History Entry Template
+
+Use this when writing the molt-history record for a session segment, *before* a
+deliberate molt. Write it to
+`knowledge/session-journal/<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md`
+via `write`/`edit` (the kernel `knowledge` mechanic auto-discovers subdirectories
+containing `KNOWLEDGE.md`). Read `<molt-count>` from your resident system
+prompt's identity section — "You have undergone N molts since birth" — and use
+that N: this entry records the pre-molt segment, written *before* you call
+`psyche(context, molt)`. (The tool result afterward reports the next count,
+N+1, which belongs to the next segment.) Including it keeps chronology stable
+when you molt more than once on the same date: the date alone cannot order two
+same-day entries, but the molt count always can.
+
+It is a **journal, not a transcript**: capture what happened and why, point at
+where the substance lives, and stop. Reference paths/PRs/message IDs — never
+inline secrets or full file contents. After writing it, append one line to the
+parent index at `knowledge/session-journal/KNOWLEDGE.md`.
+
+The frontmatter below is the on-disk format; fill every section, writing `None`
+rather than omitting one.
+
+```markdown
+---
+name: <YYYY-MM-DD>-molt-<molt-count>-<slug>
+description: One-sentence hook — what this session segment did. Used in the parent index line.
+date: <YYYY-MM-DD>
+molt_count: <current molt count, before calling psyche(context, molt)>
+---
+
+## What this segment was about
+The original ask and the framing. Why this segment existed.
+
+## Accomplishments
+What you completed or moved forward, and the outputs. Who was told, on which channel.
+
+## Decisions and reasoning
+The choices made and *why* — especially where an alternative was rejected.
+
+## Artifacts and paths
+Files, reports, branches, worktrees, PRs, commits, message IDs that anchor the
+work. Use repository paths / URLs / IDs; do not paste secrets or large blobs.
+
+## Open tasks
+Work noticed or started but not finished, with the next concrete step for each.
+
+## Collaborators
+People/agents involved, their channels, who is waiting on what.
+
+## Gotchas and lessons
+Actionable warnings, failed approaches, verification requirements — "run X
+before Y" beats "be careful".
+```

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -112,41 +112,14 @@ lifecycle.
 
 ## 6. Molt and durable stores
 
-Before context exhaustion:
+**The molt procedure lives in `psyche-manual`, not here.** It owns durable-store
+tending, the session-journal / molt-history record, the successor summary, and
+the consequential-handoff templates. Read it before molting — while context is
+still cheap, not at the last moment.
 
-1. Update pad with current work, open branches, reports, and next steps.
-2. Update knowledge with durable facts/journal entries.
-3. Update character if identity, capability, or stable collaborator topology
-   changed.
-4. Create/update skills for reusable procedures.
-5. Write a molt summary as a successor briefing.
-6. Molt deliberately.
-
-A good molt summary is not a transcript. It is an operational briefing for the
-next self: what to do first, what is done, what remains, what is forbidden
-without authorization, who is waiting, and where the durable state lives.
-
-Use `psyche-manual` when a long task is mid-stream, multiple collaborators are
-active, human commitments are pending, or the next self would otherwise need to
-reconstruct state from logs. Resident `procedures.md` only carries the compact
-cue; `psyche-manual` routes consequential handoffs to its
-`assets/molt-template.md` file, which holds the full summary template and
-pre-molt verification checklist.
-
-Minimum handoff checks:
-
-- Durable stores are tended before the summary is written.
-- Routine molts stay compact; consequential molts get the full scaffold.
-- Every outstanding task has a concrete action item with owner/recipient,
-  channel, and exact next action/content.
-- Collaborators, pending replies, authorization limits, and next human-facing
-  reports are explicit.
-- Active background work (daemons, bash jobs, avatars, schedules) is listed or
-  explicitly absent.
-- Key artifact paths are absolute and still useful.
-- Safety constraints are explicit: approvals required, secrets not shared, and
-  external side effects not implied.
-- The first five minutes after wake are obvious from the summary.
+The invariant in this procedures reference is routing: do not reconstruct molt
+mechanics here. For the checklist, templates, and summary rules, go to
+`psyche-manual`.
 
 ## 7. Skill routing
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -166,10 +166,10 @@ Flow knowledge outward:
 4. Reusable procedures become skills.
 5. Identity/relationship changes update character.
 
-When context pressure rises, tend durable stores before molting. The molt summary
-is a briefing to the next self, not a transcript. It should say what changed,
-what remains, who to contact, which paths/knowledge/skills matter, and what must
-not be done without authorization.
+When context pressure rises, tend durable stores before molting. The detailed
+molt procedure, session-journal / molt-history record, and successor briefing
+rules live in `psyche-manual`; this substrate reference only describes the
+memory model.
 
 ## 6. Runtime logs and trace inspection
 

--- a/src/lingtai/prompts/procedures.md
+++ b/src/lingtai/prompts/procedures.md
@@ -35,23 +35,11 @@ operations, preset swaps, notification handling, and karma actions.
 
 ### Molt and Durable Stores
 
-**If you are about to molt, first read `psyche-manual`; for consequential
-handoffs it routes to the molt-template asset and verification checklist.** Do
-this while context is still cheap; do not wait until the last moment.
-
-Before context exhaustion, update pad, knowledge, character, and skills as
-needed, then molt deliberately with a successor briefing — not a transcript.
-For routine molts, include current task/state/next step, accomplishments,
-remaining blockers, contacts, important durable-memory paths, and gotchas.
-
-For consequential molts — long task in flight, multiple collaborators, pending
-human commitments, active background work, or non-trivial artifacts — make the
-briefing operational: role/context, accomplishments, outstanding tasks,
-prioritized action checklist with recipient/channel + exact next action/content,
-collaborators/pending replies, durable memory/execution notes to load, key
-paths, risks/lessons, and context status. Verify every outstanding task has a
-concrete action, durable stores were tended first, and the first five minutes
-after wake are obvious. For the broader memory model, read `system-manual`.
+**If you are about to molt, first read `psyche-manual`.** It owns the molt
+procedure — tending the durable stores, writing the session-journal / molt-history
+record, and routing consequential handoffs to the molt-template and entry
+templates. Read it while context is still cheap; do not wait until the last
+moment. For the broader memory model, read `system-manual`.
 
 ### Skill Routing — When to Load What
 


### PR DESCRIPTION
## Summary
- make the resident molt procedure explicitly tell agents to record the just-finished session segment as a private `knowledge/session-journal/` molt-history entry before deliberate molt
- align the expanded procedures manual, psyche-manual, and consequential molt template/checklist with the same requirement
- clarify that the entry should be concise (journal, not transcript), include accomplishments/decisions/artifacts/open tasks/collaborators/pointers, avoid secrets, and complement the successor briefing

## Validation
- `git diff --check`
- `python -m pytest tests/test_validate_skill.py tests/test_prompt.py -q` → 25 passed
- `python -m pytest tests/test_init_schema_procedures.py -q` → 2 passed

## Notes
- Documentation/procedure-only change; no runtime behavior changed.
- Uses the existing `knowledge/session-journal/<YYYY-MM-DD>-<slug>/` convention rather than introducing a new fixed storage path.
