### PR TITLE
Validate secondary read targets

### DIFF
--- a/reports/secondary-telegram-args-20260609.html
+++ b/reports/secondary-telegram-args-20260609.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<title>Secondary Telegram args validation PR explainer</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Arial,"Noto Sans SC",sans-serif;line-height:1.55;margin:32px;color:#1f2937}h1{font-size:26px}h2{font-size:19px;margin-top:26px;border-bottom:1px solid #e5e7eb;padding-bottom:6px}.box{background:#f8fafc;border:1px solid #e2e8f0;border-radius:10px;padding:14px 16px}.ok{background:#f0fdf4;border-color:#86efac}.warn{background:#fff7ed;border-color:#fdba74}code{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;background:#f3f4f6;padding:1px 4px;border-radius:4px}pre{background:#0f172a;color:#e2e8f0;border-radius:8px;padding:12px;overflow:auto}table{border-collapse:collapse;width:100%;margin:12px 0}th,td{border:1px solid #e5e7eb;padding:8px;vertical-align:top}th{background:#f9fafb}.small{color:#6b7280;font-size:13px}</style>
+</head>
+<body>
+<h1>Secondary Telegram args validation</h1>
+<p class="small">Repo: <code>Lingtai-AI/lingtai-kernel</code> · Branch: <code>fix/secondary-telegram-args</code> · 2026-06-09</p>
+<div class="box ok">
+<b>结论：</b>这个 PR 针对调查中发现的高频 Telegram secondary 参数畸形问题，在 kernel secondary 层做本地 normalize/validate。当前 <code>origin/main</code> 已经把 secondary 改为 read-only，所以本 PR 不重新允许 nested send/reply，只修 read 路径的目标字段和类型。
+</div>
+<h2>背景</h2>
+<p>dev-1/dev-3 日志里出现大量 secondary Telegram 失败，例如 <code>chat_id:""</code> 或 <code>chat_id:"6859932159"</code> 直接进入 Telegram MCP，最终由 MCP schema 报 <code>'' is not of type 'integer'</code> / <code>'6859932159' is not of type 'integer'</code>。</p>
+<p>根因是 secondary 的 provider-facing schema 是跨工具共享的轻量 schema，runtime 只检查 tool/action/递归，不按目标工具/action 做必填字段和类型校验。</p>
+<h2>变更</h2>
+<table>
+<tr><th>文件</th><th>变更</th></tr>
+<tr><td><code>src/lingtai_kernel/secondary_tools.py</code></td><td>新增 <code>SECONDARY_READ_TARGET_FIELDS</code> 和 <code>normalize_secondary_args()</code>：剔除空字符串与 <code>limit=0</code> 占位；校验 read 目标字段；Telegram digit-string <code>chat_id</code> 转 int；非整数 Telegram chat_id 本地拒绝。</td></tr>
+<tr><td><code>src/lingtai_kernel/tool_executor.py</code></td><td><code>_validate_secondary()</code> 在 action/递归检查后调用 normalize/validate；失败时返回本地 <code>_secondary.status=error</code>，不 dispatch 到 MCP。</td></tr>
+<tr><td><code>tests/test_tool_executor.py</code></td><td>新增回归测试：Telegram digit-string chat_id normalize；空 chat_id 本地拒绝；email.read 空 email_id 本地拒绝。</td></tr>
+</table>
+<h2>行为示例</h2>
+<pre>{"action":"read", "chat_id":"6859932159", "limit":0}
+→ {"action":"read", "chat_id":6859932159}
+
+{"action":"read", "chat_id":""}
+→ _secondary error: secondary telegram.read requires chat_id
+
+{"action":"read", "email_id":""}
+→ _secondary error: secondary email.read requires email_id</pre>
+<h2>验证</h2>
+<div class="box">
+<pre>git diff --check
+PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m pytest -q tests/test_tool_executor.py tests/test_secondary_schema.py
+# 39 passed
+PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m py_compile src/lingtai_kernel/secondary_tools.py src/lingtai_kernel/tool_executor.py</pre>
+</div>
+<h2>风险与边界</h2>
+<ul>
+<li>不影响 top-level Telegram send/reply/read。</li>
+<li>不重新开放 secondary send/reply；current main 的 read-only policy 保持不变。</li>
+<li>对 Telegram 数字字符串 chat_id 做宽容转换；对空目标字段做本地错误，避免 MCP noise。</li>
+<li>Feishu/WhatsApp chat_id 仅要求存在；没有强制 int，因为这些 channel 的 ID 格式可能不是 Telegram 风格。</li>
+</ul>
+</body>
+</html>

--- a/src/lingtai_kernel/secondary_tools.py
+++ b/src/lingtai_kernel/secondary_tools.py
@@ -28,6 +28,14 @@ SECONDARY_ALLOWED_ACTIONS: dict[str, set[str]] = {
     "whatsapp": {"read"},
 }
 
+SECONDARY_READ_TARGET_FIELDS: dict[str, str] = {
+    "email": "email_id",
+    "telegram": "chat_id",
+    "wechat": "user_id",
+    "feishu": "chat_id",
+    "whatsapp": "chat_id",
+}
+
 # Maximum serialized size of a ``read`` result body forwarded under
 # ``_secondary.result``. The full read response stays in the producer's own
 # storage; this is just a preview-into-the-primary slice so the agent does
@@ -45,7 +53,9 @@ _SECONDARY_ARGS_PROPERTIES: dict[str, Any] = {
         ),
     },
     "email_id": {"description": "Internal email id/list to read (used by email read)."},
-    "chat_id": {"description": "Telegram/feishu chat id to read."},
+    "chat_id": {
+        "description": "Telegram/Feishu/WhatsApp chat id to read. Telegram chat_id should be an integer; digit strings are normalized at runtime."
+    },
     "user_id": {"type": "string", "description": "WeChat user id to read."},
     "limit": {
         "type": "integer",
@@ -110,3 +120,46 @@ def is_secondary_primary_eligible(tool_name: str) -> bool:
 def secondary_schema_property() -> dict[str, Any]:
     """Return a fresh copy of the JSON-schema property for ``secondary``."""
     return copy.deepcopy(SECONDARY_SCHEMA_PROPERTY)
+
+
+def normalize_secondary_args(tool_name: str, args: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    """Return normalized secondary args and an optional validation error.
+
+    The provider-facing secondary schema is intentionally small and shared
+    across communication tools, so runtime validation must still enforce the
+    target tool/action contract before dispatching to MCP handlers. This keeps
+    obviously malformed model output (empty target ids, string Telegram
+    ``chat_id`` values, ``limit=0`` placeholders) from surfacing as noisy MCP
+    schema errors.
+    """
+
+    normalized: dict[str, Any] = {}
+    for key, value in args.items():
+        if value is None:
+            continue
+        if isinstance(value, str) and value == "":
+            continue
+        # Models often emit optional numeric placeholders as zero; for read
+        # limits, omission is safer because channel tools apply their defaults.
+        if key == "limit" and value == 0:
+            continue
+        normalized[key] = value
+
+    action = normalized.get("action")
+    if action != "read":
+        # The caller already reports disallowed actions. Keep this helper
+        # focused on the read contract.
+        return normalized, None
+
+    required_field = SECONDARY_READ_TARGET_FIELDS.get(tool_name)
+    if required_field and required_field not in normalized:
+        return normalized, f"secondary {tool_name}.read requires {required_field}"
+
+    if tool_name == "telegram":
+        chat_id = normalized.get("chat_id")
+        if isinstance(chat_id, str) and chat_id.isdigit():
+            normalized["chat_id"] = int(chat_id)
+        elif not isinstance(chat_id, int):
+            return normalized, "secondary telegram.read requires integer chat_id"
+
+    return normalized, None

--- a/src/lingtai_kernel/tool_executor.py
+++ b/src/lingtai_kernel/tool_executor.py
@@ -15,6 +15,7 @@ from .secondary_tools import (
     SECONDARY_ALLOWED_TOOLS,
     SECONDARY_EXCLUDED_PRIMARY_TOOLS,
     SECONDARY_READ_RESULT_MAX_BYTES,
+    normalize_secondary_args,
 )
 from .tool_result_artifacts import (
     PREVENTIVE_MAX_CHARS as _DEFAULT_MAX_RESULT_CHARS,
@@ -245,6 +246,14 @@ class ToolExecutor:
                 action=action,
                 status="error",
                 message="recursive secondary calls are forbidden",
+            )
+        sanitized_args, validation_error = normalize_secondary_args(tool_name, sanitized_args)
+        if validation_error is not None:
+            return tool_name, sanitized_args, _secondary_summary(
+                tool=tool_name,
+                action=action,
+                status="error",
+                message=validation_error,
             )
         return tool_name, sanitized_args, None
 

--- a/tests/test_tool_executor.py
+++ b/tests/test_tool_executor.py
@@ -233,6 +233,94 @@ def test_secondary_executes_before_primary_and_is_stripped():
     assert payload["_secondary"]["action"] == "read"
 
 
+
+def test_secondary_telegram_digit_string_chat_id_is_normalized():
+    seen = []
+
+    def dispatch(tc):
+        seen.append((tc.name, dict(tc.args)))
+        if tc.name == "telegram":
+            return {"status": "ok", "messages": []}
+        return {"status": "ok"}
+
+    executor = make_executor(dispatch_fn=dispatch, known_tools={"read", "telegram"})
+    calls = [ToolCall(
+        name="read",
+        args={
+            "secondary": {
+                "tool": "telegram",
+                "args": {"action": "read", "chat_id": "6859932159", "limit": 0},
+            },
+        },
+        id="tc1",
+    )]
+
+    results, intercepted, _ = executor.execute(calls)
+
+    assert not intercepted
+    assert seen[0] == ("telegram", {"action": "read", "chat_id": 6859932159})
+    assert results[0]["result"]["_secondary"]["status"] == "success"
+
+
+def test_secondary_telegram_empty_chat_id_is_rejected_before_dispatch():
+    seen = []
+
+    def dispatch(tc):
+        seen.append(tc.name)
+        return {"status": "ok"}
+
+    executor = make_executor(dispatch_fn=dispatch, known_tools={"read", "telegram"})
+    calls = [ToolCall(
+        name="read",
+        args={
+            "secondary": {
+                "tool": "telegram",
+                "args": {"action": "read", "chat_id": "", "limit": 0},
+            },
+        },
+        id="tc1",
+    )]
+
+    results, intercepted, _ = executor.execute(calls)
+
+    assert not intercepted
+    assert seen == ["read"]
+    payload = results[0]["result"]
+    assert payload["_secondary"]["status"] == "error"
+    assert payload["_secondary"]["tool"] == "telegram"
+    assert payload["_secondary"]["action"] == "read"
+    assert "chat_id" in payload["_secondary"]["message"]
+
+
+def test_secondary_email_read_requires_email_id_before_dispatch():
+    seen = []
+
+    def dispatch(tc):
+        seen.append(tc.name)
+        return {"status": "ok"}
+
+    executor = make_executor(dispatch_fn=dispatch, known_tools={"read", "email"})
+    calls = [ToolCall(
+        name="read",
+        args={
+            "secondary": {
+                "tool": "email",
+                "args": {"action": "read", "email_id": ""},
+            },
+        },
+        id="tc1",
+    )]
+
+    results, intercepted, _ = executor.execute(calls)
+
+    assert not intercepted
+    assert seen == ["read"]
+    payload = results[0]["result"]
+    assert payload["_secondary"]["status"] == "error"
+    assert payload["_secondary"]["tool"] == "email"
+    assert payload["_secondary"]["action"] == "read"
+    assert "email_id" in payload["_secondary"]["message"]
+
 def test_secondary_send_action_is_rejected():
     """The secondary channel is read-only — send must be rejected at runtime
     without blocking the primary."""


### PR DESCRIPTION
## Summary\n- normalize secondary read args before dispatching to communication MCPs\n- reject empty secondary read targets locally instead of forwarding malformed args to MCP validators\n- coerce Telegram digit-string chat_id values to integers and add regression tests\n- include HTML explainer at reports/secondary-telegram-args-20260609.html\n\n## Context\nJason asked to investigate frequent Telegram send/read failures across dev bots. Current main has already made secondary read-only; this PR preserves that policy and fixes the remaining read-path argument validation/noise.\n\n## Validation\n- git diff --check\n- PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m pytest -q tests/test_tool_executor.py tests/test_secondary_schema.py\n- PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m py_compile src/lingtai_kernel/secondary_tools.py src/lingtai_kernel/tool_executor.py