### PR TITLE
Document session journals as sub-knowledge

### DIFF
--- a/src/lingtai/core/knowledge/manual/SKILL.md
+++ b/src/lingtai/core/knowledge/manual/SKILL.md
@@ -3,10 +3,10 @@ name: knowledge-manual
 description: >
   Concise guide to the `knowledge` capability: private agent-owned memory in
   `<agent>/knowledge/<name>/KNOWLEDGE.md`, progressive disclosure through the
-  prompt catalog, nested knowledge folders, and cross-references between
-  entries. Read this when you need to create, organize, or load private
-  knowledge, or when you need to explain how knowledge differs from portable
-  skills.
+  prompt catalog, nested knowledge folders, routing/index entries with
+  sub-knowledge children, and cross-references between entries. Read this when you
+  need to create, organize, or load private knowledge, lay out a routing parent
+  over related entries, or explain how knowledge differs from portable skills.
 version: 1.0.0
 ---
 
@@ -19,30 +19,24 @@ Skills are different: a skill is a reusable procedure meant to travel across age
 
 ## Names you will see
 
-The current private-memory capability is named `knowledge`, and the only tool it registers is:
+The private-memory capability is named `knowledge`, and the only tool it registers is:
 
 ```text
 knowledge({"action": "info"})
 ```
 
-Older documentation and UI surfaces may still say `library` or `codex`. Treat those as historical names for the private durable knowledge store unless the text is clearly talking about skills. In current agent code, `library(...)` and `codex(...)` are not registered compatibility aliases.
-
-Do not confuse this with the `.library/` directory: `.library/` is the on-disk home for **skills** (`SKILL.md` files), not for private `knowledge` entries. The naming is legacy but intentional for compatibility.
+Do not confuse `knowledge` with the `.library/` directory: `.library/` is the on-disk home for **skills** (`SKILL.md` files), not for private `knowledge` entries.
 
 Quick map:
 
-| Term / path | Current meaning |
+| Term / path | Meaning |
 |---|---|
 | `knowledge` tool / capability | Private per-agent durable memory catalog. |
 | `<agent>/knowledge/<name>/KNOWLEDGE.md` | One private knowledge entry. |
 | `.library/intrinsic`, `.library/custom`, `.library_shared` | Skill shelves containing `SKILL.md` files. |
 | `skills` tool / capability | Catalog of reusable portable procedures. |
-| `/skills` in the TUI | Browse the skill catalog for the selected agent. |
-| `/knowledge` in the TUI | Browse private durable knowledge/codex entries. |
-| `/library` or `/codex` in the TUI | Legacy aliases for `/knowledge`; keep only for compatibility. |
-| `recipe.json#library_name` | Legacy schema field naming a recipe-bundled skill library. It appends to `skills.paths`. |
 
-When writing new docs, prefer `knowledge` for private memory and `skills` for reusable procedures. Use `library` only when referring to a literal legacy path or schema field such as `.library/`, `.library_shared`, or `recipe.json#library_name`.
+Prefer `knowledge` for private memory and `skills` for reusable procedures.
 
 ## Layout
 
@@ -88,17 +82,39 @@ to rescan the catalog and refresh the prompt section, then use `read` on the lis
 
 This keeps the prompt small while still making the memory discoverable.
 
-## Nesting
+## Nesting and sub-knowledge
 
-Knowledge may be nested for organization. The scanner descends through folders until it finds `KNOWLEDGE.md` files, so these are valid:
+Knowledge and skills are **isomorphic in layout and progressive disclosure**:
+each top-level entry is a folder with a marker file (`KNOWLEDGE.md` here,
+`SKILL.md` there), the prompt carries only the catalog, and a top-level entry may
+act as a **routing/index parent** with nested children that hold the substance —
+exactly the nested-reference pattern documented in the skills manual.
+
+The only real difference is *audience*: knowledge is **private, local, and
+non-portable** by default (it may reference agent-local paths, mail IDs, and
+logs); skills are **reusable, shareable, and portable**.
+
+So for the routing/index parent pattern — when to use it, how the parent stays a
+short scannable index, how children carry the detail, relative child paths,
+keeping the catalog in sync — **read the skills manual's nested reference
+section** (`.library/intrinsic/capabilities/skills/SKILL.md`, "Nested
+skill/reference pattern for umbrella manuals") and apply the same shape with
+`KNOWLEDGE.md` in place of `SKILL.md`.
+
+Compact example of a routing parent with sub-knowledge children — a project's
+incident log:
 
 ```text
-knowledge/project-a/architecture/KNOWLEDGE.md
-knowledge/project-a/incidents/2026-05-cache-bug/KNOWLEDGE.md
-knowledge/people/reviewers/KNOWLEDGE.md
+knowledge/project-x-incidents/
+├── KNOWLEDGE.md                                   # routing/index ONLY
+├── 2026-05-13-cache-stampede/KNOWLEDGE.md         # child — the detail
+└── 2026-05-21-token-leak/KNOWLEDGE.md             # child
 ```
 
-Keep names filesystem-safe and descriptive. Use nesting to group related entries, not to hide information.
+The parent `KNOWLEDGE.md` is a short index: one line per child with a hook and the
+child's relative path; each child holds the full write-up. Keep names
+filesystem-safe and descriptive, point at children by relative path, and use
+nesting to group related entries, not to hide information.
 
 ## Cross-references
 

--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -44,19 +44,34 @@ All five happen *before* the molt call. They are not optional. Without them, the
 
 The four stores capture *who you are*, *what you're working on*, *verifiable truths*, and *reusable procedures*. None of them captures the *story* of a session. The session journal is that missing layer — it is also your **molt history**: each sub-entry is the record of one session segment that you write *before* you molt, so the chain of entries reconstructs how you got here across many molts.
 
-Write it as a parent/child knowledge structure under `knowledge/session-journal/`:
+Write it as a **routing parent with sub-knowledge children** under
+`knowledge/session-journal/` — the routing/index shape from the knowledge manual's
+"Nesting and sub-knowledge" section. Do **not** create each session as its own
+top-level knowledge entry; that floods the catalog. The parent is routing-only;
+the children carry the substance:
 
 ```
 knowledge/session-journal/
-├── KNOWLEDGE.md                                            # parent index
-├── 2026-05-13-molt-7-nudge-service/KNOWLEDGE.md            # one session
-├── 2026-05-13-molt-8-procedures-to-kernel/KNOWLEDGE.md     # another, same day
-└── 2026-05-14-molt-9-wechat-fixes/KNOWLEDGE.md             # ...
+├── KNOWLEDGE.md                                            # top-level routing/index ONLY
+├── 2026-05-13-molt-7-nudge-service/KNOWLEDGE.md            # sub-knowledge — one session
+├── 2026-05-13-molt-8-procedures-to-kernel/KNOWLEDGE.md     # sub-knowledge — same day
+└── 2026-05-14-molt-9-wechat-fixes/KNOWLEDGE.md             # sub-knowledge — ...
 ```
+
+Because `session-journal/` has its own `KNOWLEDGE.md`, the knowledge scanner
+treats it as a single entry and does **not** descend into the children — they are
+reachable only through the parent index. That is why the parent must list every
+child explicitly. See the knowledge manual's "Nesting and sub-knowledge" section
+(`.library/intrinsic/capabilities/knowledge/SKILL.md`) for the structural rule.
 
 The directory name is `<YYYY-MM-DD>-molt-<molt-count>-<slug>`. Read the molt count from your resident system prompt's identity section — "You have undergone N molts since birth." Use that N: the entry records the pre-molt segment, written *before* you call `psyche(context, molt)`. (The molt tool result afterward reports the next count, N+1; that belongs to the next segment, not this one.) Embedding the count keeps chronology stable when you molt more than once on the same date: the date alone cannot order two same-day entries, but the molt count always can.
 
-**The parent `knowledge/session-journal/KNOWLEDGE.md` is the index** — short, scannable, progressive-disclosure. One line per sub-entry: date, slug, one-sentence hook.
+**The parent `knowledge/session-journal/KNOWLEDGE.md` is routing-only** — short,
+scannable, progressive-disclosure. It is a table of contents, not a journal. One
+line per sub-entry: date, slug, one-sentence hook, and the child's *relative* path
+(`2026-05-13-molt-7-nudge-service/KNOWLEDGE.md`), never an absolute local path.
+Never let narrative leak into the parent — if a line grows past its hook, the
+detail belongs in the child.
 
 **The sub-entry `<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md` is the substance** — write it as the molt-history record of the segment, *before* you molt. Use `assets/session-journal-entry-template.md` from this skill directory for the frontmatter (including the `molt_count` field) and section layout. It is a journal, not a transcript — capture, in roughly this shape:
 
@@ -68,7 +83,7 @@ The directory name is `<YYYY-MM-DD>-molt-<molt-count>-<slug>`. Read the molt cou
 - **Collaborators** — who is involved, their channels, who is waiting on what
 - **Gotchas and lessons** — actionable warnings and failed approaches
 
-Several thousand tokens is fine when the segment was rich; keep it concise when it was small. The `<YYYY-MM-DD>-molt-<molt-count>-<slug>` prefix keeps chronology visible and stable in `ls` even across multiple molts on one day. The kernel `knowledge` mechanic auto-discovers subdirectories containing `KNOWLEDGE.md`. Write files via `write`/`edit` directly.
+Several thousand tokens is fine when the segment was rich; keep it concise when it was small. The `<YYYY-MM-DD>-molt-<molt-count>-<slug>` prefix keeps chronology visible and stable in `ls` even across multiple molts on one day. Each child is sub-knowledge under the routing parent — the scanner does not catalog it separately, so it is reachable only via the parent index; that is why you append the index line below. Write files via `write`/`edit` directly.
 
 Updating the parent index at each session is part of the practice — append one line referencing the new sub-entry. Then write the successor summary (§6), which points back at this entry's path.
 

--- a/src/lingtai/intrinsic_skills/psyche-manual/assets/molt-template.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/assets/molt-template.md
@@ -43,11 +43,13 @@ Fill every section. Write `None` rather than omitting a section. This template i
 
 Before you call `psyche(object="context", action="molt", ...)`, verify:
 
-- The just-finished session segment is recorded as a session-journal sub-entry
-  (your molt history) under
+- The just-finished session segment is recorded as a session-journal child
+  (your molt history) — sub-knowledge under the routing parent
+  `knowledge/session-journal/KNOWLEDGE.md`, at
   `knowledge/session-journal/<YYYY-MM-DD>-molt-<molt-count>-<slug>/`, written
-  from `assets/session-journal-entry-template.md`, before the summary — and the
-  summary points at its path.
+  from `assets/session-journal-entry-template.md`, before the summary. It is NOT
+  a top-level knowledge entry. The parent index has a new one-line, relative-path
+  hook for it, and the summary points at the child's path.
 - Pad, lingtai/character, knowledge, skills, and session journal were updated where needed before writing the summary.
 - Every outstanding task has an action checklist entry.
 - Every action names who/where and what exact content or command is needed.


### PR DESCRIPTION
## Summary
- keep `knowledge-manual` short and router-like while clarifying that knowledge and skills share the same progressive-disclosure / nested-reference shape
- document the key difference: knowledge is private/local/non-portable by default, while skills are reusable/shareable/portable
- keep session/molt journal policy in `psyche-manual`: `knowledge/session-journal/KNOWLEDGE.md` is a routing-only parent, and each journal is a child sub-knowledge entry under it
- align the consequential molt checklist with the session-journal child-entry pattern

## Validation
- `git diff --check`
- `python -m pytest tests/test_skills.py tests/test_knowledge.py` (41 passed)

## Notes
Jason requested no legacy-care wording in `knowledge-manual`, and asked that session-journal-specific policy live in `psyche-manual` rather than `knowledge-manual`.
