### PR TITLE
Document async bash for agent CLIs

### DIFF
--- a/reports/bash-async-agent-cli-20260609.html
+++ b/reports/bash-async-agent-cli-20260609.html
@@ -1,0 +1,38 @@
+<!doctype html><html lang="zh-CN"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Bash manual — async rule for long-running agent CLIs</title><style>body{font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Arial,"Noto Sans CJK SC",sans-serif;margin:0;background:#f7f8fb;color:#1f2937}main{max-width:980px;margin:32px auto;padding:0 20px 72px}.card{background:white;border:1px solid #e5e7eb;border-radius:16px;padding:24px;box-shadow:0 12px 30px rgba(15,23,42,.06)}h1{margin-top:0;color:#111827;line-height:1.15}h2{margin-top:30px;border-top:1px solid #e5e7eb;padding-top:20px}code{background:#f3f4f6;border:1px solid #e5e7eb;border-radius:5px;padding:.1rem .28rem}pre{background:#111827;color:#f9fafb;border-radius:12px;padding:16px;overflow:auto}.ok{display:inline-block;background:#dcfce7;color:#166534;border-radius:999px;padding:4px 10px;font-weight:700}.warn{display:inline-block;background:#fef3c7;color:#92400e;border-radius:999px;padding:4px 10px;font-weight:700}li{margin:.35rem 0}</style></head><body><main><div class="card">
+<h1>Bash manual — async rule for long-running agent CLIs</h1>
+<p><span class="ok">Ready for review</span> <span class="warn">Scope: docs only</span></p>
+<h2>Summary</h2>
+<p>Documents a normative rule in the bash manual: a long-running agent/coding CLI session (<code>claude -p</code>, <code>codex exec</code>, <code>opencode run</code>, the Cursor agent CLI, or any sub-agent that may think and run tools for minutes) must <strong>never</strong> be run as a synchronous <code>bash</code> call. Synchronous <code>bash</code> is reserved for short, deterministic commands; long-running child CLIs use <code>bash(async=true)</code> and poll the returned <code>job_id</code>.</p>
+<h2>Problem</h2>
+<p>An audit of LingTai trajectories found agents blocking themselves by running long-lived child agent CLIs (e.g. <code>claude -p</code>) as synchronous <code>bash</code> calls. A synchronous call holds the turn until the child exits — which can be minutes — so the parent stays <code>ACTIVE</code> and stops seeing channel notifications (mail, refresh, interrupts) for the whole duration. The bash tool already supports <code>async=true</code> + <code>action="poll"</code>; the manual just never told agents to use it for this case. The old text said ordinary one-off commands can use bash directly and only routed scheduled work, leaving the long-running-CLI case unaddressed.</p>
+<h2>What changed</h2>
+<p>One file edited: <code>src/lingtai/core/bash/manual/SKILL.md</code> (top-level router; version bumped <code>1.2.0 → 1.3.0</code>). Changes are additive — no existing guidance removed.</p>
+<ul>
+<li>Router intro now distinguishes <em>short, deterministic</em> synchronous commands from long-running agent CLIs.</li>
+<li>New router-table row pointing the long-running-CLI case at the resident rule (<code>bash(async=true)</code> + poll).</li>
+<li>Quick decision tree gains an explicit step: long-running agent/coding CLI ⇒ never synchronous, use async + poll. Subsequent steps renumbered.</li>
+<li>New first entry under "Core rules to keep resident": the normative rule plus a <code>text</code> example showing start (<code>async=true</code> → <code>job_id</code>), poll, and cancel, and why this keeps the agent responsive and avoids ACTIVE blockage.</li>
+</ul>
+<h2>Non-goals</h2>
+<ul>
+<li>No code changes — the async/poll/cancel bash surface already exists (<code>BashManager</code> in <code>src/lingtai/core/bash/__init__.py</code>).</li>
+<li>No new nested reference file; the rule belongs in the resident top-level router, kept short.</li>
+<li>No changes to scheduled-work / notification / debugging references.</li>
+<li>No mutation of historical reports.</li>
+</ul>
+<h2>Validation</h2>
+<pre><code>git diff --check
+# clean
+
+python3 src/lingtai/core/skills/manual/scripts/validate.py src/lingtai/core/bash/manual/
+# [PASS] Frontmatter / [PASS] Directory structure / ALL CHECKS PASSED
+
+PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m pytest -q \
+  tests/test_skills.py tests/test_validate_skill.py
+# 42 passed in 0.92s</code></pre>
+<p>The snapshot test in <code>tests/test_skills.py</code> asserts substrings that this PR preserves (<code>name: bash-manual</code>, <code>Nested reference catalog</code>, and the three <code>reference/*/SKILL.md</code> paths), so no test or snapshot updates were required.</p>
+<h2>Risk</h2>
+<p><span class="ok">Low.</span> Docs-only, additive, in a single skill file. The validator and skill tests pass. Worst case is a wording tweak in review. No runtime behavior changes.</p>
+<h2>Reviewer notes</h2>
+<p>The rule lives in the top-level router rather than a nested reference deliberately: it is a "keep resident" guardrail agents should internalize, not a drill-down recipe, and the manual's maintenance note asks the router to stay short. The example uses <code>text</code> fencing because the calls are tool-invocation pseudo-syntax, not shell.</p>
+</div></main></body></html>

--- a/src/lingtai/core/bash/manual/SKILL.md
+++ b/src/lingtai/core/bash/manual/SKILL.md
@@ -7,7 +7,7 @@ description: >
   hygiene, one-shot `.notification/cron.json` reminders, debugging silent jobs,
   and safe cleanup. Start here for any time-driven recurring work ("every hour",
   "weekdays at 9", "remind me later") or when a scheduled job misbehaves.
-version: 1.2.0
+version: 1.3.0
 ---
 
 # Bash Manual — Router
@@ -16,8 +16,10 @@ The `bash` tool schema covers one-off command execution. This manual routes to
 operational depth that is too long for the schema: host scheduling, mailbox-drop
 wakeups, reminder files, debugging, and cleanup.
 
-For ordinary one-off shell commands, use the tool schema. For anything involving
-time, recurring work, external schedulers, or a silent scheduled job, start here.
+For ordinary short, deterministic one-off shell commands, use the tool schema
+synchronously. For anything involving time, recurring work, external schedulers,
+a silent scheduled job, or a **long-running agent/coding CLI** (see the resident
+rule below), start here.
 
 ## Nested reference catalog
 
@@ -50,21 +52,50 @@ files, not standalone top-level skills.
 
 | Need / keywords | Read |
 |---|---|
+| Running a long-running agent/coding CLI as a sub-process: `claude -p`, `codex exec`, `opencode run`, Cursor agent CLI; "run an agent in the background"; avoid blocking the turn | "Core rules to keep resident" below (use `bash(async=true)` + poll) |
 | Human asks for time-driven recurring work: "every hour", "daily", "weekdays at 9", "write/check/send on a schedule"; choose cron vs event watcher; create launchd/systemd/crontab wiring; understand wake-by-mailbox-drop; write scheduler prompt/script hygiene | `reference/scheduled-work/SKILL.md` |
 | Need a one-shot reminder or wakeup nudge while work is pending; `.notification/cron.json`; atomic reminder writer; rest checklist | `reference/notification-reminders/SKILL.md` |
 | Scheduled job is silent, fires twice, exits immediately, gets killed by launchd, fails to deliver mail, or must be retired/cleaned up | `reference/debugging-cleanup/SKILL.md` |
 
 ## Quick decision tree
 
-1. **One-off deterministic host work?** Use `bash` directly; this manual is not
-   needed unless the command is risky, scheduled, or failing mysteriously.
-2. **Time itself is the trigger?** Read `reference/scheduled-work/SKILL.md`.
-3. **You only need a single future nudge?** Read
+1. **Short deterministic host work** (finishes in seconds: `ls`, `git status`,
+   `grep`, a quick build)? Use `bash` synchronously; this manual is not needed
+   unless the command is risky, scheduled, or failing mysteriously.
+2. **Long-running agent/coding CLI** (`claude -p`, `codex exec`, `opencode run`,
+   Cursor agent CLI, or any sub-agent that may think/run tools for minutes)?
+   **Never run it synchronously.** Use `bash(async=true)` and poll — see the
+   resident rule below.
+3. **Time itself is the trigger?** Read `reference/scheduled-work/SKILL.md`.
+4. **You only need a single future nudge?** Read
    `reference/notification-reminders/SKILL.md`.
-4. **A scheduled job already exists and is misbehaving?** Read
+5. **A scheduled job already exists and is misbehaving?** Read
    `reference/debugging-cleanup/SKILL.md` before editing blindly.
 
 ## Core rules to keep resident
+
+- **Synchronous `bash` is only for short, deterministic commands.** A long-running
+  agent/coding CLI session — `claude -p`, `codex exec`, `opencode run`, the Cursor
+  agent CLI, or any sub-agent that may think and run tools for minutes — must
+  **never** be a synchronous `bash` call. Run it with `bash(async=true)` and poll
+  the returned `job_id`. A synchronous call blocks the whole turn until the child
+  exits: you stay `ACTIVE` and stop seeing channel notifications (mail, refresh,
+  interrupts) for the entire duration. Async + poll keeps you responsive and
+  prevents ACTIVE blockage while the child CLI works.
+
+  ```text
+  # Start the child agent in the background — returns immediately with a job_id:
+  bash(async=true, command="claude -p 'refactor the auth module' --output-format json")
+  # → {"status": "ok", "job_id": "ab12…", "pid": 4321}
+
+  # Later turns: poll until done (handle mail/other work between polls):
+  bash(action="poll", job_id="ab12…")
+  # → {"status": "running", …}   then eventually
+  # → {"status": "done", "exit_code": 0, "stdout": "…", "stderr": "…"}
+
+  # Abandon it if needed:
+  bash(action="cancel", job_id="ab12…")
+  ```
 
 - LingTai has no built-in recurring scheduler. Host schedulers wake agents by
   producing channel input, usually a mailbox-drop or notification file.

--- a/src/lingtai/core/bash/manual/SKILL.md
+++ b/src/lingtai/core/bash/manual/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: bash-manual
 description: >
-  **Read this before setting up cron, launchd, systemd timers, crontab jobs, or
-  scheduled reminders.** Router for Bash-related operational depth beyond the
-  bash tool schema: host-scheduler setup, LingTai wake-by-mailbox-drop, script
-  hygiene, one-shot `.notification/cron.json` reminders, debugging silent jobs,
-  and safe cleanup. Start here for any time-driven recurring work ("every hour",
-  "weekdays at 9", "remind me later") or when a scheduled job misbehaves.
+  **Read this before running long-lived agent/coding CLIs (`claude -p`,
+  `codex exec`, `opencode run`, Cursor agent CLI), or before setting up cron,
+  launchd, systemd timers, crontab jobs, or scheduled reminders.** Router for
+  Bash-related operational depth beyond the bash tool schema: async + poll
+  discipline for long-running child agents, host-scheduler setup, LingTai
+  wake-by-mailbox-drop, script hygiene, one-shot `.notification/cron.json`
+  reminders, debugging silent jobs, and safe cleanup. Start here for any
+  long-running agent CLI, time-driven recurring work ("every hour", "weekdays at
+  9", "remind me later"), or when a scheduled job misbehaves.
 version: 1.3.0
 ---
 


### PR DESCRIPTION
## Summary
- adds a resident bash-manual rule forbidding synchronous `bash` runs for long-running agent/coding CLIs
- explicitly covers `claude -p`, `codex exec`, `opencode run`, Cursor agent CLI, and similar sub-agent commands
- documents the `bash(async=true)` → `poll` → optional `cancel` pattern and why it keeps agents responsive to notifications
- broadens the manual frontmatter description so agents route to this manual for long-running agent CLI work
- includes a self-contained HTML explainer at `reports/bash-async-agent-cli-20260609.html`

## Review
- GLM independent review: NON-BLOCKING; suggested broadening the frontmatter description, now addressed

## Validation
- `git diff --check`
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m pytest -q tests/test_skills.py tests/test_validate_skill.py` → 42 passed
