### PR TITLE
Add api_call_id to LLM and tool events

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -1283,6 +1283,7 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
                 in_tool_loop=in_tool_loop,
                 output_tokens=response.usage.output_tokens,
                 thinking_tokens=response.usage.thinking_tokens,
+                api_call_id=getattr(response, "api_call_id", None),
                 **_diag,
             )
             raise EmptyLLMResponseError(
@@ -1344,6 +1345,7 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
         # Delegate to ToolExecutor
         tool_results, intercepted, intercept_text = agent._executor.execute(
             response.tool_calls,
+            api_call_id=getattr(response, "api_call_id", None),
             on_result_hook=agent._on_tool_result_hook,
             cancel_event=agent._cancel_event,
             collected_errors=collected_errors,

--- a/src/lingtai_kernel/llm/base.py
+++ b/src/lingtai_kernel/llm/base.py
@@ -67,6 +67,11 @@ class LLMResponse:
     usage: UsageMetadata = field(default_factory=UsageMetadata)
     thoughts: list[str] = field(default_factory=list)
     raw: Any = None
+    # Stable identifier for this kernel-level LLM API round-trip.
+    # SessionManager assigns it before logging llm_call/llm_response;
+    # BaseAgent/ToolExecutor propagate it to every tool event produced from
+    # the same assistant response so UI/replay code can group tool batches.
+    api_call_id: str | None = None
 
 
 @dataclass

--- a/src/lingtai_kernel/session.py
+++ b/src/lingtai_kernel/session.py
@@ -6,6 +6,7 @@ BaseAgent delegates all session operations here.
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+import uuid
 from typing import Any, Callable, TYPE_CHECKING
 
 from .config import AgentConfig
@@ -217,9 +218,11 @@ class SessionManager:
 
         self._health_check(message)
 
+        api_call_id = f"api_{uuid.uuid4().hex[:12]}"
         self._log(
             "llm_call",
             model=self._config.model or self._llm_service.model or "unknown",
+            api_call_id=api_call_id,
         )
 
         retry_timeout = self._config.retry_timeout
@@ -236,6 +239,7 @@ class SessionManager:
                 logger=logger,
             )
 
+        response.api_call_id = api_call_id
         self._track_usage(response)
         # Preserve interaction ID for session reuse
         if hasattr(self._chat, "interaction_id") and self._chat.interaction_id:
@@ -330,6 +334,7 @@ class SessionManager:
                 usage=usage,
                 thoughts=response.thoughts,
                 raw=response.raw,
+                api_call_id=response.api_call_id,
             )
             fallback = True
             if not self._token_fallback_warned:
@@ -369,6 +374,7 @@ class SessionManager:
                 thinking_tokens=response.usage.thinking_tokens,
                 cached_tokens=response.usage.cached_tokens,
                 estimated=fallback,
+                api_call_id=response.api_call_id,
             )
 
     def get_token_usage(self) -> dict:

--- a/src/lingtai_kernel/tool_executor.py
+++ b/src/lingtai_kernel/tool_executor.py
@@ -50,6 +50,7 @@ class ToolExecutor:
         self._meta_fn = meta_fn or (lambda: {})
         self._working_dir = Path(working_dir) if working_dir is not None else None
         self._max_result_chars = max_result_chars
+        self._current_api_call_id: str | None = None
 
     def _tool_trace_id(self, tc: ToolCall) -> str:
         """Return the stable trace id for one top-level tool-call execution.
@@ -305,6 +306,8 @@ class ToolExecutor:
         self._guard = value
 
     def _log(self, event_type: str, **fields) -> None:
+        if self._current_api_call_id and "api_call_id" not in fields:
+            fields["api_call_id"] = self._current_api_call_id
         if self._logger_fn:
             self._logger_fn(event_type, **fields)
 
@@ -315,11 +318,37 @@ class ToolExecutor:
         on_result_hook: Callable | None = None,
         cancel_event: Any | None = None,
         collected_errors: list[str] | None = None,
+        api_call_id: str | None = None,
     ) -> tuple[list, bool, str]:
-        """Execute tool calls. Returns (results, intercepted, intercept_text)."""
+        """Execute tool calls. Returns (results, intercepted, intercept_text).
+
+        ``api_call_id`` identifies the LLM API response that produced this
+        batch. When present it is stamped onto every tool lifecycle/result
+        event for UI grouping and trace reconstruction.
+        """
         if collected_errors is None:
             collected_errors = []
 
+        previous_api_call_id = self._current_api_call_id
+        self._current_api_call_id = api_call_id
+        try:
+            return self._execute_with_current_api_call_id(
+                tool_calls,
+                collected_errors,
+                on_result_hook=on_result_hook,
+                cancel_event=cancel_event,
+            )
+        finally:
+            self._current_api_call_id = previous_api_call_id
+
+    def _execute_with_current_api_call_id(
+        self,
+        tool_calls: list[ToolCall],
+        collected_errors: list[str],
+        *,
+        on_result_hook: Callable | None = None,
+        cancel_event: Any | None = None,
+    ) -> tuple[list, bool, str]:
         all_parallel_safe = (
             len(tool_calls) > 1
             and self._parallel_safe_tools

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -119,14 +119,24 @@ def test_send_preserves_interaction_id():
     assert sm.interaction_id == "new-id"
 
 
-def test_send_logs_llm_call():
+def test_send_logs_llm_call_with_api_call_id():
     events = []
+
     def log_fn(event_type, **fields):
-        events.append(event_type)
-    sm, _, _ = make_session_manager(logger_fn=log_fn)
+        events.append((event_type, fields))
+
+    sm, _, response = make_session_manager(logger_fn=log_fn)
     sm.send("hello")
-    assert "llm_call" in events
-    assert "llm_response" in events
+
+    event_types = [event for event, _ in events]
+    assert "llm_call" in event_types
+    assert "llm_response" in event_types
+
+    llm_call = next(fields for event, fields in events if event == "llm_call")
+    llm_response = next(fields for event, fields in events if event == "llm_response")
+    assert llm_call["api_call_id"].startswith("api_")
+    assert llm_response["api_call_id"] == llm_call["api_call_id"]
+    assert response.send.return_value.api_call_id == llm_call["api_call_id"]
 
 
 # ------------------------------------------------------------------

--- a/tests/test_tool_executor.py
+++ b/tests/test_tool_executor.py
@@ -104,6 +104,27 @@ def test_lifecycle_trace_events_for_sequential_success():
     assert model_visible["spilled"] is False
 
 
+def test_api_call_id_is_stamped_on_tool_events():
+    logs = []
+    executor = make_executor(
+        known_tools={"read"},
+        logger_fn=lambda event_type, **fields: logs.append((event_type, fields)),
+    )
+
+    executor.execute(
+        [ToolCall(name="read", args={"path": "/tmp"}, id="tc-api")],
+        api_call_id="api_test123",
+    )
+
+    for event_type, fields in logs:
+        assert fields.get("api_call_id") == "api_test123", event_type
+
+    # The temporary execution context must not leak to later calls.
+    logs.clear()
+    executor.execute([ToolCall(name="read", args={"path": "/tmp"}, id="tc-next")])
+    assert all("api_call_id" not in fields for _, fields in logs)
+
+
 def test_lifecycle_trace_events_for_parallel_success_preserve_result_order():
     logs = []
 


### PR DESCRIPTION
## Summary\n- assign a stable api_call_id for each SessionManager LLM API round-trip\n- include the id on llm_call/llm_response events and propagate it through BaseAgent to ToolExecutor\n- stamp tool lifecycle/result events from the same assistant response with the same id for UI/replay grouping\n\n## Validation\n- git diff --check\n- python -m compileall -q src\n- python -m pytest -q tests/test_session.py tests/test_tool_executor.py tests/test_aed_recovery.py tests/test_active_stuck_watchdog.py\n\nTUI consumer PR will use this field to insert visual separators between tool batches.