### PR TITLE
docs: update MCP inbox preview docstrings

### DIFF
--- a/reports/mcp-inbox-preview-docstrings-20260610.html
+++ b/reports/mcp-inbox-preview-docstrings-20260610.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<title>MCP inbox preview docstring cleanup</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.55;max-width:920px;margin:40px auto;padding:0 24px;color:#18212f;background:#f8fafc}main{background:white;border:1px solid #e2e8f0;border-radius:18px;padding:28px;box-shadow:0 10px 28px rgba(15,23,42,.06)}h1{margin-top:0}code{background:#f1f5f9;border-radius:6px;padding:.1em .35em}.ok{color:#047857;font-weight:700}.box{border-left:4px solid #2563eb;background:#eff6ff;padding:12px 16px;border-radius:10px;margin:16px 0}ul{padding-left:1.4rem}</style>
+</head>
+<body><main>
+<h1>MCP inbox preview docstring cleanup</h1>
+<p class="ok">结论：只清理过期注释/文档字符串，不改变运行时行为。</p>
+<div class="box">
+<p>背景：PR #251 合并后，Claude Code final review 指出 <code>src/lingtai/core/mcp/inbox.py</code> 中相关 docstring 仍描述旧行为：100-char snippet、body 不进入 preview。实际行为已经是 body preview 进入 <code>data.previews[*].preview</code>，且不会复制到顶层 <code>instructions</code>。</p>
+</div>
+<h2>改动</h2>
+<ul>
+<li>更新 <code>_consume_event()</code> docstring：说明 preview 包含 sender、subject、bounded body preview；<code>preview</code> 由 <code>_PREVIEW_FIELD_CAP</code> 截断。</li>
+<li>明确 body preview 只保留在结构化 <code>data.previews[*].preview</code> 中，不再复制到 coalesced notification 的顶层 <code>instructions</code>。</li>
+<li>更新 <code>_dispatch_summary()</code> docstring：说明 <code>instructions</code> 只保留 read/check guidance、sender/subject 和 lightweight routing metadata。</li>
+<li>更新 <code>_scan_once()</code> docstring：去掉旧的 “只包含 count / body-sender-subject never inlined / _format_notification_summary” 描述，改成当前 coalesced notification + structured previews 的描述。</li>
+</ul>
+<h2>验证计划</h2>
+<ul>
+<li><code>git diff --check</code></li>
+<li><code>PYTHONPATH=src python -m py_compile src/lingtai/core/mcp/inbox.py</code></li>
+<li><code>PYTHONPATH=src python -m pytest -q tests/test_mcp_inbox.py tests/test_mcp_licc_client.py tests/test_notification_sync.py</code></li>
+</ul>
+<h2>风险</h2>
+<p>低。改动只涉及 docstring 文本，不触碰逻辑、测试断言或通知 payload 结构。</p>
+</main></body></html>

--- a/src/lingtai/core/mcp/inbox.py
+++ b/src/lingtai/core/mcp/inbox.py
@@ -176,16 +176,17 @@ def _extract_preview_meta(event: dict) -> dict:
 def _consume_event(agent: "BaseAgent", mcp_name: str, event: dict) -> tuple[bool, dict]:
     """Record the per-event log entry; return (wake, preview).
 
-    The preview surfaces sender + subject + a 100-char snippet of the body
-    so the agent can triage what arrived without calling read() on every
-    event. ``from`` and ``subject`` pass through uncapped — both are bounded
-    by upstream MCP construction (subject is also validated <= 200 chars).
-    Only ``preview`` is truncated, since bodies can be arbitrarily large
-    (multi-paragraph emails, OCR text, voice transcripts).
+    The preview surfaces sender, subject, and a bounded body preview so the
+    agent can triage what arrived without calling read() on every event.
+    ``from`` and ``subject`` pass through as supplied by the upstream MCP
+    event construction; ``preview`` is truncated at ``_PREVIEW_FIELD_CAP``
+    because bodies can be arbitrarily large (multi-paragraph emails, OCR
+    text, voice transcripts, chat conversation digests).
 
-    The full body is NOT included — it stays behind the MCP's read action
-    so the agent has one source of truth and avoids the re-processing loop
-    that issue #37 fixed.
+    The preview body is included once in structured notification data
+    (``data.previews[*].preview``) and is not duplicated into the coalesced
+    notification's top-level ``instructions`` text. The MCP's read action
+    remains the source of truth for exact/full message content.
 
     Optional IM/chat metadata fields (``conversation_ref``, ``message_ref``,
     ``platform``) from ``event["metadata"]`` are copied into the preview
@@ -226,9 +227,11 @@ def _dispatch_summary(
 ) -> None:
     """Publish one coalesced notification covering ``count`` events from ``mcp_name``.
 
-    Each preview entry has ``{"from": <sender>, "subject": <subject>}`` with
-    both fields capped at ``_PREVIEW_FIELD_CAP`` chars. Full message bodies
-    are NOT included — those stay behind the MCP's read action (issue #37).
+    Each preview entry carries the sender, subject, a bounded body preview,
+    and optional lightweight routing metadata. Body preview text is kept in
+    structured ``data.previews[*].preview`` only; top-level ``instructions``
+    contains read/check guidance plus sender/subject/metadata context, not a
+    second copy of the body preview.
 
     Uses the kernel's canonical ``.notification/`` filesystem-as-protocol
     instead of the legacy inbox queue.  The notification file is written as
@@ -314,9 +317,10 @@ def _scan_once(agent: "BaseAgent", inbox_root: Path) -> int:
     """One sweep through .mcp_inbox/<mcp_name>/*.json. Returns count dispatched.
 
     Per MCP per sweep: consume up to ``MAX_EVENTS_PER_CYCLE`` valid events
-    (logging each individually), then post a single coalesced [system]
-    notification carrying only the count. Body / sender / subject are
-    intentionally never inlined — see ``_format_notification_summary``.
+    (logging each individually), then post a single coalesced notification.
+    The notification includes lightweight instructions plus structured
+    preview entries; body preview text stays in ``data.previews[*].preview``
+    rather than being duplicated into the top-level ``instructions`` string.
     """
     if not inbox_root.is_dir():
         return 0


### PR DESCRIPTION
## Summary
- update stale MCP inbox docstrings after #251
- describe the current preview contract: body preview lives once in `data.previews[*].preview`
- clarify that top-level `instructions` carries read/check guidance and lightweight routing context, not duplicated body preview text
- add a small HTML explainer report

## Validation
- `git diff --check`
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m py_compile src/lingtai/core/mcp/inbox.py`
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m pytest -q tests/test_mcp_inbox.py tests/test_mcp_licc_client.py tests/test_notification_sync.py` → 96 passed

Report: `reports/mcp-inbox-preview-docstrings-20260610.html`