### PR TITLE
docs: describe guided goal setup

### DIFF
--- a/reports/goal-manual-guided-setup-20260610.html
+++ b/reports/goal-manual-guided-setup-20260610.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<title>goal-manual guided setup update — 2026-06-10</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.6; margin: 32px auto; max-width: 920px; color: #1f2937; }
+  h1, h2 { color: #111827; }
+  code { background: #f3f4f6; padding: 0.12rem 0.28rem; border-radius: 4px; }
+  pre { background: #111827; color: #f9fafb; padding: 16px; border-radius: 10px; overflow: auto; }
+  .summary { background: #eff6ff; border: 1px solid #3b82f6; border-radius: 12px; padding: 16px 20px; }
+  li { margin: 0.25rem 0; }
+</style>
+</head>
+<body>
+<h1>goal-manual guided setup update</h1>
+<div class="summary">
+  <strong>结论：</strong>本 docs PR 扩写 <code>goal-manual</code>，补上 TUI <code>/goal</code> 触发的
+  <code>goal.request</code> guided setup 流程：agent 收到 system event 后应读 manual、解释机制、询问目标字段、说明取消语义，
+  并只在 human 确认后写入 <code>.notification/goal.json</code>。
+</div>
+
+<h2>新增内容</h2>
+<ul>
+<li><code>/goal</code> 不直接写 <code>goal.json</code>，只向 <code>.notification/system.json</code> 追加 <code>source="goal.request"</code> event。</li>
+<li>Agent 收到请求后应询问 objective、criteria、id/status、<code>reminder_delay_seconds</code>、constraints。</li>
+<li>写入前必须解释：dismiss <code>goal.reminder</code> 只隐藏提醒，不取消 goal。</li>
+<li>取消 goal 需要删除 <code>.notification/goal.json</code>，或把 <code>data.status</code> 标为 inactive/cancelled/canceled。</li>
+<li>完成/替换 goal 需要标记 done/complete/completed/superseded，或删除/替换文件。</li>
+<li>处理完请求后用 <code>system(action="dismiss", channel="system", ref_id="goal.request:&lt;timestamp&gt;")</code> 精确清理该 system event。</li>
+</ul>
+
+<h2>验证</h2>
+<ul>
+<li><code>git diff --check</code> — pass</li>
+<li>Docs-only change; no runtime code modified.</li>
+</ul>
+</body>
+</html>

--- a/src/lingtai/intrinsic_skills/system-manual/reference/goal-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/goal-manual/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Goal notification manual: `.notification/goal.json` source-of-truth, fields,
   instructions, idle reminders, protected dismiss behavior, and cancellation or
   completion semantics.
-version: 0.1.0
+version: 0.2.0
 tags: [lingtai, goal, notifications, reminders]
 ---
 
@@ -13,6 +13,59 @@ tags: [lingtai, goal, notifications, reminders]
 A goal is represented by `.notification/goal.json`. This file is the protected
 source of truth for the agent's current active goal. The short reminder event only
 points the agent back to this file; it does not contain the goal details.
+
+
+## Guided setup via `/goal`
+
+`/goal` is the TUI entry point for human-guided goal creation. It does **not**
+write `.notification/goal.json` directly. Instead, the TUI appends a system event
+to `.notification/system.json` so the running agent can guide the human before
+creating or changing the goal file:
+
+```json
+{
+  "source": "goal.request",
+  "ref_id": "goal.request:<timestamp>",
+  "body": "Human wants to set or revise an active goal..."
+}
+```
+
+When you receive a `source="goal.request"` event:
+
+1. **Read this manual first.** The event is a request to guide goal creation, not
+   permission to invent goal details.
+2. **Explain the mechanism briefly to the human.** Tell them that an active goal
+   lives in `.notification/goal.json`, idle reminders are short
+   `goal.reminder` system events, and dismissing a reminder only hides the
+   reminder.
+3. **Ask for the missing goal fields.** At minimum, clarify:
+   - objective: what should be accomplished;
+   - criteria: how the human and agent will know it is done;
+   - status/id: a stable `data.id` and active status if the goal should start
+     now;
+   - reminder cadence: optional `data.reminder_delay_seconds`;
+   - constraints: deadlines, channels to report on, what not to do, or approval
+     gates.
+4. **Explain cancellation and completion before writing.** Canceling the goal
+   means deleting `.notification/goal.json` or marking `data.status`
+   `inactive`/`cancelled`/`canceled`. Completing or superseding it means marking
+   status `done`/`complete`/`completed`/`superseded`, or deleting/replacing the
+   file. Dismissing a `goal.reminder` does **not** cancel the goal.
+5. **Write `.notification/goal.json` only after confirmation.** If the human gave
+   a complete inline draft with `/goal <text>`, restate the structured goal and
+   ask for confirmation unless the instruction explicitly and unambiguously says
+   to create it now.
+6. **Dismiss the request after handling it.** Use the event `ref_id` so other
+   system events survive:
+
+```text
+system(action="dismiss", channel="system", ref_id="goal.request:<timestamp>")
+```
+
+If the human changes their mind during setup, dismiss the `goal.request` event
+without creating `goal.json`. If a previous active goal exists, do not overwrite
+it silently; explain the existing goal and ask whether to complete, cancel, or
+replace it.
 
 ## Minimal goal file
 


### PR DESCRIPTION
## Summary
- expand `goal-manual` with a guided setup section for TUI `/goal`
- document the `source="goal.request"` system event flow
- spell out agent responsibilities: read manual, explain mechanism, ask for objective/criteria/reminder/cancel semantics, write `.notification/goal.json` only after confirmation
- document precise request dismissal via `system(action="dismiss", channel="system", ref_id="goal.request:<timestamp>")`

## Linked PR
- TUI `/goal` command: https://github.com/Lingtai-AI/lingtai/pull/287

Report: `/Users/huangzesen/work/GitHub/lingtai-kernel/reports/goal-manual-guided-setup-20260610.html`

## Tests
- `git diff --check`
- docs-only change; no runtime code modified
