### PR TITLE
fix: recover overflow from empty OpenAI-compatible responses

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -38,6 +38,34 @@ from lingtai_kernel.llm.streaming import StreamingAccumulator
 logger = get_logger()
 
 
+class _ContextOverflowEmptyResponseError(RuntimeError):
+    """Provider returned an empty 200 response for an over-window prompt.
+
+    Some OpenAI-compatible gateways do not surface context overflow as a
+    400-class error.  They return a structurally valid ChatCompletion with
+    no text, no tool calls, zero output tokens, and prompt_tokens already past
+    the configured context window.  Treat that as the same recoverable
+    overflow signal as a canonical context_length_exceeded error so the
+    adapter trims and retries before committing an empty assistant turn.
+    """
+
+    def __init__(
+        self,
+        *,
+        input_tokens: int,
+        context_window: int,
+        raw: Any,
+    ):
+        self.input_tokens = input_tokens
+        self.context_window = context_window
+        self.raw = raw
+        super().__init__(
+            "context window exceeded: provider returned empty completion "
+            f"with {input_tokens} input tokens over configured context window "
+            f"{context_window}"
+        )
+
+
 _CODEX_RESPONSES_TRACE_ENV = "LINGTAI_CODEX_RESPONSES_TRACE"
 _CODEX_RESPONSES_TRACE_PATH_ENV = "LINGTAI_CODEX_RESPONSES_TRACE_PATH"
 _CODEX_RESPONSES_TRACE_FILE = "codex_responses_trace.jsonl"
@@ -303,6 +331,31 @@ def _parse_tool_calls(raw_tool_calls) -> list[ToolCall]:
     return result
 
 
+def _chat_completion_is_empty(raw) -> bool:
+    """Return True when a ChatCompletion has no usable assistant payload."""
+    choices = getattr(raw, "choices", None) or []
+    if not choices:
+        return True
+    message = getattr(choices[0], "message", None)
+    if message is None:
+        return True
+    reasoning = (
+        getattr(message, "reasoning_content", None)
+        or getattr(message, "reasoning", None)
+    )
+    return (
+        not getattr(message, "content", None)
+        and not getattr(message, "tool_calls", None)
+        and not reasoning
+    )
+
+
+def _prompt_tokens(raw) -> int:
+    usage = getattr(raw, "usage", None)
+    value = getattr(usage, "prompt_tokens", 0) if usage is not None else 0
+    return value or 0
+
+
 def _parse_response(raw) -> LLMResponse:
     """Parse a raw OpenAI ChatCompletion into a provider-agnostic LLMResponse."""
     if not raw.choices:
@@ -522,6 +575,8 @@ class OpenAIChatSession(ChatSession):
         loose string-match heuristics used by compatible vendors (DeepSeek,
         Together, Groq, etc.) that often only signal via the message body.
         """
+        if isinstance(exc, _ContextOverflowEmptyResponseError):
+            return True
         if not isinstance(exc, openai.BadRequestError):
             return False
         # Canonical OpenAI code on the body's error object.
@@ -552,6 +607,29 @@ class OpenAIChatSession(ChatSession):
     # _trim_context_one_round, _run_with_overflow_recovery, and
     # _inject_overflow_notice are inherited from ChatSession (base class).
     # Only _is_context_overflow_error needs to be provider-specific.
+
+    def _raise_for_empty_context_overflow(self, raw) -> None:
+        """Treat empty 200 responses past the configured window as overflow.
+
+        This is intentionally narrow.  A zero-token empty completion can mean
+        many things, so we only convert it to context-overflow recovery when
+        the provider's own usage says the prompt has exceeded the model window
+        supplied by the preset/config.  The check runs before assistant
+        history is recorded; if recovery succeeds, no empty assistant turn is
+        ever committed.
+        """
+        if self._context_window <= 0:
+            return
+        input_tokens = _prompt_tokens(raw)
+        if input_tokens <= self._context_window:
+            return
+        if not _chat_completion_is_empty(raw):
+            return
+        raise _ContextOverflowEmptyResponseError(
+            input_tokens=input_tokens,
+            context_window=self._context_window,
+            raw=raw,
+        )
 
     def _pair_orphan_tool_calls(self, messages: list[dict]) -> list[dict]:
         """Final wire-layer guard: synthesize placeholder tool messages for
@@ -676,7 +754,9 @@ class OpenAIChatSession(ChatSession):
         # 3. Make the API call (with auto-recovery on context overflow);
         #    revert interface on any other error.
         def _do_call():
-            return self._client.chat.completions.create(**_build_kwargs())
+            raw = self._client.chat.completions.create(**_build_kwargs())
+            self._raise_for_empty_context_overflow(raw)
+            return raw
 
         try:
             raw, total_dropped, rounds = self._run_with_overflow_recovery(_do_call)

--- a/tests/test_openai_overflow_recovery.py
+++ b/tests/test_openai_overflow_recovery.py
@@ -21,14 +21,14 @@ from lingtai_kernel.llm.interface import (
 )
 
 
-def _make_raw_response(content="ok"):
+def _make_raw_response(content="ok", *, prompt_tokens=10, completion_tokens=5):
     msg = SimpleNamespace(content=content, tool_calls=[])
     choice = SimpleNamespace(message=msg)
     return SimpleNamespace(
         choices=[choice],
         usage=SimpleNamespace(
-            prompt_tokens=10,
-            completion_tokens=5,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
             completion_tokens_details=None,
             prompt_tokens_details=None,
         ),
@@ -43,7 +43,7 @@ def _make_overflow_error(msg="This model's maximum context length is 128000 toke
     return openai.BadRequestError(message=msg, response=response, body=body)
 
 
-def _make_session(client, interface=None):
+def _make_session(client, interface=None, *, context_window=0):
     if interface is None:
         interface = ChatInterface()
         interface.add_system("you are helpful")
@@ -55,6 +55,7 @@ def _make_session(client, interface=None):
         tool_choice=None,
         extra_kwargs={},
         client_kwargs={},
+        context_window=context_window,
     )
 
 
@@ -291,6 +292,58 @@ def test_send_recovers_and_injects_kernel_notice():
                 found = True
                 break
     assert found, "expected a [kernel] molt-recommendation notice in interface"
+
+
+def test_send_recovers_from_empty_200_when_usage_exceeds_context_window():
+    """Some OpenAI-compatible gateways return an empty successful completion
+    instead of a 400 context_length_exceeded error. When their usage metadata
+    shows the prompt already exceeded the configured window, treat it as the
+    same overflow signal and retry before recording any assistant turn."""
+    iface = ChatInterface()
+    iface.add_system("sys")
+    _seed_history(iface, n_pairs=20)
+
+    client = MagicMock()
+    client.chat.completions.create.side_effect = [
+        _make_raw_response(
+            content="",
+            prompt_tokens=250_000,
+            completion_tokens=0,
+        ),
+        _make_raw_response(content="ok", prompt_tokens=180_000),
+    ]
+    session = _make_session(client=client, interface=iface, context_window=200_000)
+
+    response = session.send("a brand new question")
+    assert response.text == "ok"
+    assert client.chat.completions.create.call_count == 2
+
+    empty_assistant_turns = [
+        entry for entry in iface._entries
+        if entry.role == "assistant"
+        and len(entry.content) == 1
+        and isinstance(entry.content[0], TextBlock)
+        and entry.content[0].text == ""
+    ]
+    assert empty_assistant_turns == []
+
+
+def test_send_does_not_treat_empty_200_within_context_window_as_overflow():
+    iface = ChatInterface()
+    iface.add_system("sys")
+    _seed_history(iface, n_pairs=3)
+
+    client = MagicMock()
+    client.chat.completions.create.return_value = _make_raw_response(
+        content="",
+        prompt_tokens=50_000,
+        completion_tokens=0,
+    )
+    session = _make_session(client=client, interface=iface, context_window=200_000)
+
+    response = session.send("hi")
+    assert response.text == ""
+    assert client.chat.completions.create.call_count == 1
 
 
 def test_send_passes_through_when_no_overflow():


### PR DESCRIPTION
## Summary
- detect empty successful OpenAI-compatible chat completions before recording assistant history
- treat the response as context overflow only when `usage.prompt_tokens` exceeds the configured `context_window`
- route that narrow empty-200 over-window case through the existing overflow recovery path, so history is trimmed and retried instead of AED retrying the same oversized prompt
- keep empty successful responses within the configured window unchanged
- add focused regression coverage for both the recovery and non-recovery cases

## Why
Some OpenAI-compatible gateways do not report over-window prompts as a `400 context_length_exceeded` error. Instead, they can return a structurally successful chat completion with no assistant text, no tool calls, no reasoning payload, and zero completion tokens while `usage.prompt_tokens` is already above the configured context window.

The old adapter only entered overflow recovery for provider errors. A successful empty response was therefore treated as a transient empty LLM output, so AED retried without trimming history. The next request stayed over-window and could repeat the same failure mode.

## Safety
The new conversion is intentionally narrow:

- `context_window` must be configured and positive
- provider usage must report `prompt_tokens > context_window`
- the response must have no content, no tool calls, and no reasoning payload

The check runs before `_record_assistant_response(raw)`, so successful recovery does not commit an empty assistant turn to chat history. Empty responses that are still within the configured window continue through the existing empty-response behavior.

## Tests
```bash
/Volumes/Data/miniconda3/bin/python3 -m pytest tests/test_openai_overflow_recovery.py
# 16 passed

/Volumes/Data/miniconda3/bin/python3 -m pytest tests/test_deepseek_adapter.py tests/test_mimo_adapter.py
# 22 passed

git diff --check
# pass
```

Pytest emitted a `.pytest_cache` write warning in this sandbox; test results were unaffected.
