### PR TITLE
Add Cloud Mail MCP addon

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ lingtai-feishu = "lingtai.mcp_servers.feishu.__main__:main"
 lingtai-wechat = "lingtai.mcp_servers.wechat.__main__:main"
 lingtai-wechat-bootstrap = "lingtai.mcp_servers.wechat.login:_bootstrap_main"
 lingtai-whatsapp = "lingtai.mcp_servers.whatsapp.__main__:main"
+lingtai-cloud-mail = "lingtai.mcp_servers.cloud_mail.__main__:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/reports/cloud-mail-addon-20260613.html
+++ b/reports/cloud-mail-addon-20260613.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Cloud Mail MCP addon — implementation explainer (2026-06-13)</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 15px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+         margin: 0; padding: 0; background: #f7f7f8; color: #1c1c1e; }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 28px 20px 64px; }
+  h1 { font-size: 26px; margin: 0 0 4px; }
+  h2 { font-size: 19px; margin: 30px 0 8px; padding-bottom: 4px; border-bottom: 2px solid #e3e3e6; }
+  h3 { font-size: 15px; margin: 18px 0 6px; }
+  .sub { color: #6b6b70; margin: 0 0 18px; }
+  code, pre { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+  code { background: #ececf0; padding: 1px 5px; border-radius: 4px; font-size: 13px; }
+  pre { background: #1e1e24; color: #e6e6ec; padding: 14px 16px; border-radius: 8px; overflow-x: auto; font-size: 12.5px; }
+  pre code { background: none; padding: 0; color: inherit; }
+  table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 13.5px; }
+  th, td { border: 1px solid #d9d9de; padding: 6px 10px; text-align: left; vertical-align: top; }
+  th { background: #eceef2; }
+  .ok { color: #1a7f37; font-weight: 600; }
+  .warn { color: #9a6700; font-weight: 600; }
+  .pill { display: inline-block; background: #e7f0ff; color: #0b5cad; border-radius: 999px;
+          padding: 2px 10px; font-size: 12px; margin: 0 6px 6px 0; }
+  ul { margin: 6px 0 6px 0; padding-left: 22px; }
+  .note { background: #fff8e1; border-left: 4px solid #e0a800; padding: 10px 14px; border-radius: 4px; margin: 12px 0; }
+  .files li { margin: 2px 0; }
+  footer { margin-top: 40px; color: #8a8a90; font-size: 12px; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #1a1a1d; color: #e8e8ea; }
+    h2 { border-color: #3a3a40; } th { background: #2a2a30; } th, td { border-color: #3a3a40; }
+    code { background: #2a2a30; } .sub, footer { color: #9a9aa0; }
+    .note { background: #2c2616; border-color: #b8860b; } .pill { background: #16314d; color: #8ec1ff; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Cloud Mail MCP addon</h1>
+<p class="sub">First-party curated addon for <code>maillab/cloud-mail</code> · branch <code>feat-cloud-mail-addon-20260613</code> · implements Lingtai-AI/lingtai#262 · 2026-06-13</p>
+
+<span class="pill">read-only review build</span>
+<span class="pill">no push / merge / publish</span>
+<span class="pill">no secrets touched</span>
+
+<h2>What this adds</h2>
+<p>A new curated MCP server, <code>cloud_mail</code>, that talks to a self-hosted
+<a>Cloud Mail</a> deployment (Cloudflare Workers; <code>https://github.com/maillab/cloud-mail</code>)
+over its REST API using <code>httpx</code>. It mirrors the IMAP addon's tool-surface model but is a
+REST client — <strong>not</strong> IMAP/SMTP. Inbound mail is discovered by polling and delivered to the
+host agent's inbox via the LICC v1 callback.</p>
+
+<h3>Omnibus tool <code>cloud_mail</code> — actions</h3>
+<table>
+<tr><th>Action</th><th>Auth</th><th>Behavior</th></tr>
+<tr><td><code>check</code></td><td>public token</td><td>Recent inbound emails (default 10). Optional <code>to_email</code>/<code>send_email</code>/<code>subject</code>/<code>time_sort</code>/<code>type</code> filters.</td></tr>
+<tr><td><code>search</code></td><td>public token</td><td>Full <code>/public/emailList</code> filters: <code>to_email</code>, <code>send_email</code>, <code>send_name</code>, <code>subject</code>, <code>content</code>, <code>time_sort</code>, <code>num</code>, <code>size</code>, <code>type</code>, <code>is_del</code>.</td></tr>
+<tr><td><code>read</code></td><td>public token</td><td>Full content/text by compound id <code>&lt;account&gt;:&lt;emailId&gt;</code> (bounded scan of recent pages to locate the row).</td></tr>
+<tr><td><code>send</code></td><td>user JWT</td><td>Requires <code>user_email</code>/<code>user_password</code>/<code>send_account_id</code>. Maps <code>address</code>→<code>receiveEmail[]</code>, <code>message</code>→<code>text</code>, <code>html</code>→<code>content</code> (falls back to text). Attachments not supported (first pass).</td></tr>
+<tr><td><code>accounts</code></td><td>—</td><td>Redacted per-account status (no tokens/passwords).</td></tr>
+<tr><td><code>add_user</code></td><td>public token</td><td>Optional admin convenience; password never echoed back.</td></tr>
+</table>
+
+<h3>Auth &amp; envelope</h3>
+<ul>
+<li>Envelope <code>{ code, message, data }</code>: any non-200 <code>code</code> or HTTP&nbsp;≥400 becomes a <code>CloudMailError</code> carrying only status/code/server-message — never request bodies or secrets.</li>
+<li>Public token minted from <code>admin_email</code>/<code>admin_password</code> via <code>POST /public/genToken</code>; sent as the raw <code>Authorization</code> header (<strong>not</strong> <code>Bearer</code>).</li>
+<li>User JWT minted from <code>user_email</code>/<code>user_password</code> via <code>POST /login</code>; used for <code>/email/send</code>. Handles both <code>data.token</code> and bare-string <code>data</code> shapes.</li>
+<li>One automatic re-auth retry on a 401/403 before surfacing the error.</li>
+</ul>
+
+<h3>Polling &amp; LICC</h3>
+<ul>
+<li>One daemon thread per account polls <code>/public/emailList</code> (descending, page size 50) every <code>poll_interval</code> seconds.</li>
+<li>Per-account watermark (<code>&lt;agent_dir&gt;/cloud_mail/&lt;alias&gt;/watermark.json</code>) tracks the highest delivered integer <code>emailId</code>.</li>
+<li><strong>First poll seeds silently</strong> (records the high-water mark, pushes nothing) unless <code>notify_existing: true</code>. Later polls push one LICC event per new row, oldest-first.</li>
+<li>LICC metadata: <code>source: "cloud_mail"</code>, <code>event_type: "email"</code>, <code>account</code>, <code>email_id</code>, <code>compound_id</code>, <code>from</code>, <code>from_name</code>, <code>to</code>, <code>created_at</code>.</li>
+<li><code>allowed_senders</code> filter is case-insensitive; filtered senders do not raise events but the watermark still advances so they never replay.</li>
+</ul>
+
+<h2>Config (redacted example)</h2>
+<p>Env var <code>LINGTAI_CLOUD_MAIL_CONFIG</code> — path resolved relative to <code>LINGTAI_AGENT_DIR</code> when not absolute.</p>
+<pre><code>{
+  "accounts": [
+    {
+      "alias": "cloudmail",
+      "base_url": "https://mail.example.com",
+      "admin_email": "admin@example.com",
+      "admin_password": "REDACTED",
+      "user_email": "admin@example.com",
+      "user_password": "REDACTED",
+      "send_account_id": 1,
+      "allowed_senders": ["only-this@example.com"],
+      "poll_interval": 30,
+      "notify_existing": false
+    }
+  ]
+}</code></pre>
+<p><code>user_email</code>/<code>user_password</code>/<code>send_account_id</code> are optional and only needed for <code>send</code>. If absent, <code>check</code>/<code>read</code>/<code>search</code>/polling still work via the public API; <code>send</code> returns a clear "add these config keys" error.</p>
+
+<h2>Files changed</h2>
+<ul class="files">
+<li><strong>New</strong> <code>src/lingtai/mcp_servers/cloud_mail/</code>: <code>__init__.py</code>, <code>__main__.py</code>, <code>licc.py</code>, <code>_watermark.py</code>, <code>client.py</code>, <code>manager.py</code>, <code>server.py</code></li>
+<li><strong>New</strong> <code>tests/test_cloud_mail_addon.py</code> (19 tests, no network)</li>
+<li><strong>New</strong> <code>reports/cloud-mail-addon-20260613.html</code> (this file)</li>
+<li><strong>Edited</strong> <code>src/lingtai/mcp_catalog.json</code> — curated <code>cloud_mail</code> entry</li>
+<li><strong>Edited</strong> <code>pyproject.toml</code> — <code>lingtai-cloud-mail</code> console script</li>
+<li><strong>Edited</strong> <code>src/lingtai/core/mcp/manual/SKILL.md</code> &amp; <code>reference/curated-addons.md</code> — list + config docs</li>
+</ul>
+<p class="sub">ANATOMY.md unchanged: its <code>mcp_servers/</code> row is generic (<code>python -m lingtai.mcp_servers.&lt;name&gt;</code>) and already covers the new module.</p>
+
+<h2>Tests run</h2>
+<table>
+<tr><th>Command</th><th>Result</th></tr>
+<tr><td><code>python -m compileall -q src/lingtai/mcp_servers/cloud_mail</code></td><td class="ok">OK</td></tr>
+<tr><td><code>pytest tests/test_cloud_mail_addon.py</code></td><td class="ok">19 passed</td></tr>
+<tr><td><code>pytest -k "catalog or decompress"</code> (regression)</td><td class="ok">14 passed</td></tr>
+<tr><td><code>git diff --check</code></td><td class="ok">clean</td></tr>
+<tr><td>catalog JSON / <code>pyproject.toml</code> parse</td><td class="ok">valid</td></tr>
+</table>
+<p>Test coverage: public-token minting + raw (non-Bearer) header, non-200 envelope → error, missing-admin-creds error, check/search/read compound-id formatting, filter pass-through, redacted <code>accounts</code> status (asserts no passwords leak), send-without-user-creds guidance, send payload shape + JWT header, attachment rejection, first-poll seeds without flood, second-poll pushes exactly one new event with full LICC metadata, <code>notify_existing</code>, case-insensitive <code>allowed_senders</code> with watermark advance, config path resolution relative to agent dir, missing-env error, flat single-account config, and catalog membership.</p>
+
+<h2>Risk notes &amp; limitations</h2>
+<div class="note">
+<ul>
+<li><strong>No real-network test.</strong> All tests use an in-process <code>httpx.MockTransport</code> emulating the documented Cloud Mail envelope/routes. Field names (<code>receiveEmail</code>, <code>sendType</code>, emailList row keys) were taken from the cloud-mail source clone; a live deployment should be smoke-tested before relying on <code>send</code>.</li>
+<li><strong>read scans recent pages.</strong> The public API has no by-id fetch, so <code>read</code> pages up to 5×50 recent rows to find the <code>emailId</code>. Emails older than that window return a clear "not found in scan window" error rather than the body.</li>
+<li><strong>send semantics are best-effort.</strong> <code>sendType</code> is hard-coded to <code>"count"</code> and both <code>text</code> and <code>content</code> are populated; HTML-vs-text handling on the server side (Cloud Mail derives preview/HTML from <code>content</code>) may need tuning against a real instance.</li>
+<li><strong>Attachments unsupported</strong> in this first pass — a request with <code>attachments</code> returns an explicit unsupported error (it does not silently drop them).</li>
+<li><strong>Polling, not push.</strong> Inbound latency is bounded by <code>poll_interval</code> (default 30s). The 50-row poll page can miss a burst of &gt;50 emails between two ticks; raise <code>poll_interval</code> frequency or page size if that becomes a concern.</li>
+<li><strong>Secrets discipline:</strong> the client never logs tokens/passwords/Authorization headers; <code>accounts</code> status and <code>add_user</code> results are redacted. Errors carry only HTTP status / envelope code / server message.</li>
+</ul>
+</div>
+
+<footer>Generated for review on branch <code>feat-cloud-mail-addon-20260613</code>. Static HTML, inline CSS, no remote assets or JS.</footer>
+
+</div>
+</body>
+</html>

--- a/src/lingtai/core/mcp/manual/SKILL.md
+++ b/src/lingtai/core/mcp/manual/SKILL.md
@@ -4,11 +4,11 @@ description: >
   Operational guide for the `mcp` capability — register, activate, update,
   deregister, and troubleshoot MCP (Model Context Protocol) servers in your
   agent. Single source of truth for both generic MCP setup AND the five
-  kernel-curated LingTai addon MCPs (`imap`, `telegram`, `feishu`, `wechat`, `whatsapp`).
+  kernel-curated LingTai addon MCPs (`imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, `cloud_mail`).
 
   Reach for this manual when:
     - The human asks to install, set up, configure, or remove an MCP server.
-      Decision tree: is it kernel-curated (imap/telegram/feishu/wechat/whatsapp) → the
+      Decision tree: is it kernel-curated (imap/telegram/feishu/wechat/whatsapp/cloud_mail) → the
       `addons:` + `init.json mcp.<name>` workflow using modules shipped inside
       the `lingtai` wheel is here. Is it third-party → the registry route OR the legacy
       `mcp/servers.json` route, both documented here.
@@ -45,7 +45,7 @@ version: 3.2.0
 
 # MCP Capability — How To Use It
 
-The `mcp` capability is your interface to Model Context Protocol (MCP) servers — both generic third-party servers and the five kernel-curated LingTai addons (`imap`, `telegram`, `feishu`, `wechat`, `whatsapp`). Like the `library` capability, it is **pure presentation**: registered MCPs are listed in your system prompt under `<registered_mcp>`, and the registry itself is a JSONL file you edit directly with `write` / `edit` / `bash`.
+The `mcp` capability is your interface to Model Context Protocol (MCP) servers — both generic third-party servers and the six kernel-curated LingTai addons (`imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, `cloud_mail`). Like the `library` capability, it is **pure presentation**: registered MCPs are listed in your system prompt under `<registered_mcp>`, and the registry itself is a JSONL file you edit directly with `write` / `edit` / `bash`.
 
 This is the router. Detail lives in `reference/`. Load only what you need.
 
@@ -53,7 +53,7 @@ This is the router. Detail lives in `reference/`. Load only what you need.
 
 For any MCP server, relative to this agent:
 
-1. **In the kernel catalog** — LingTai blesses it. Reference template ships with the kernel. The five curated addons live here: `imap`, `telegram`, `feishu`, `wechat`, `whatsapp`.
+1. **In the kernel catalog** — LingTai blesses it. Reference template ships with the kernel. The six curated addons live here: `imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, `cloud_mail`.
 2. **Officially registered** — appears as a line in `mcp_registry.jsonl` (sibling to `init.json`). The system prompt's `<registered_mcp>` lists it.
 3. **Active** — the MCP server subprocess is running, its tools are mounted in your tool surface.
 
@@ -63,7 +63,7 @@ Promotion path: catalog → registry → active. You move things along by editin
 
 | Task | Read |
 |---|---|
-| Set up an `imap` / `telegram` / `feishu` / `wechat` addon | `reference/curated-addons.md` |
+| Set up an `imap` / `telegram` / `feishu` / `wechat` / `whatsapp` / `cloud_mail` addon | `reference/curated-addons.md` |
 | Add a third-party MCP (`npx`/`uvx`/HTTP) | `reference/third-party-and-legacy.md` |
 | Wire up a server quickly via `mcp/servers.json` (legacy/ungated) | `reference/third-party-and-legacy.md` |
 | MCP not behaving / cryptic boot errors / `KeyError: 'foo'` | `reference/troubleshooting.md` |
@@ -107,6 +107,7 @@ Curated addon modules shipped by the `lingtai` wheel:
 | `feishu`      | formerly `lingtai-feishu`   | `lingtai.mcp_servers.feishu`   |
 | `wechat`      | formerly `lingtai-wechat`   | `lingtai.mcp_servers.wechat`   |
 | `whatsapp`    | formerly `lingtai-whatsapp` | `lingtai.mcp_servers.whatsapp` |
+| `cloud_mail`  | (no standalone distribution) | `lingtai.mcp_servers.cloud_mail` |
 
 ### 2. Homepage URL (fallback)
 

--- a/src/lingtai/core/mcp/manual/reference/curated-addons.md
+++ b/src/lingtai/core/mcp/manual/reference/curated-addons.md
@@ -1,6 +1,6 @@
-# Curated addons — imap / telegram / feishu / wechat / whatsapp
+# Curated addons — imap / telegram / feishu / wechat / whatsapp / cloud_mail
 
-LingTai's first-party email and chat integrations. They now ship inside the `lingtai` distribution under `lingtai.mcp_servers.{imap,telegram,feishu,wechat,whatsapp}` so a single kernel release carries the curated MCP surface atomically. Historical `lingtai_*` import packages remain as thin compatibility wrappers. Historical standalone package names remain useful as provenance/homepage names, but the normal runtime path no longer depends on separate addon wheels.
+LingTai's first-party email and chat integrations. They now ship inside the `lingtai` distribution under `lingtai.mcp_servers.{imap,telegram,feishu,wechat,whatsapp,cloud_mail}` so a single kernel release carries the curated MCP surface atomically. Historical `lingtai_*` import packages remain as thin compatibility wrappers. Historical standalone package names remain useful as provenance/homepage names, but the normal runtime path no longer depends on separate addon wheels.
 
 ## The four-step setup
 
@@ -37,8 +37,41 @@ LingTai's first-party email and chat integrations. They now ship inside the `lin
 | `feishu`      | formerly `lingtai-feishu`   | `lingtai.mcp_servers.feishu`   |
 | `wechat`      | formerly `lingtai-wechat`   | `lingtai.mcp_servers.wechat`   |
 | `whatsapp`    | formerly `lingtai-whatsapp` | `lingtai.mcp_servers.whatsapp` |
+| `cloud_mail`  | (no standalone distribution) | `lingtai.mcp_servers.cloud_mail` |
 
 Use the module name in `mcp.<name>.args`, e.g. `["-m", "lingtai.mcp_servers.feishu"]`. Historical distribution names are retained only for provenance and compatibility notes.
+
+## Cloud Mail setup
+
+`cloud_mail` is a REST client for a self-hosted [Cloud Mail](https://github.com/maillab/cloud-mail) deployment (Cloudflare Workers). It is **not** IMAP/SMTP — it talks to Cloud Mail's HTTP API. Inbound mail is discovered by polling Cloud Mail's `POST /public/emailList` and delivered to your inbox via LICC.
+
+- **Env var:** `LINGTAI_CLOUD_MAIL_CONFIG` — path to the config JSON (resolved relative to the agent dir when not absolute).
+- **Omnibus tool:** `cloud_mail` with actions `check` (recent inbound mail), `search` (filter by sender/recipient/subject/content), `read` (full content by compound id `<account>:<emailId>`), `send` (requires user credentials), `accounts` (redacted status), and `add_user` (admin convenience).
+- **Auth model:** the addon mints a *public token* from `admin_email`/`admin_password` via `/public/genToken` for read/poll/search, and logs in with `user_email`/`user_password` via `/login` for `send`. If user creds are absent, read/check/search/poll still work; only `send` is disabled with a clear error.
+- **Watermark:** the first poll seeds the per-account high-water mark silently (no flood of old mail) unless `notify_existing: true`. State lives under `<agent_dir>/cloud_mail/<alias>/watermark.json`.
+
+Config schema (plaintext; copy verbatim, never commit real passwords):
+
+```json
+{
+  "accounts": [
+    {
+      "alias": "cloudmail",
+      "base_url": "https://mail.example.com",
+      "admin_email": "admin@example.com",
+      "admin_password": "REDACTED",
+      "user_email": "admin@example.com",
+      "user_password": "REDACTED",
+      "send_account_id": 1,
+      "allowed_senders": ["only-this@example.com"],
+      "poll_interval": 30,
+      "notify_existing": false
+    }
+  ]
+}
+```
+
+`user_email`/`user_password`/`send_account_id` are optional and only required for `send`. `allowed_senders` (case-insensitive) limits which inbound senders raise an inbox event; the watermark still advances for filtered senders so they never replay. Attachments are not supported in this first pass.
 
 ## After it's running
 

--- a/src/lingtai/mcp_catalog.json
+++ b/src/lingtai/mcp_catalog.json
@@ -59,5 +59,17 @@
     ],
     "source": "lingtai-curated",
     "homepage": "https://github.com/Lingtai-AI/lingtai-whatsapp"
+  },
+  "cloud_mail": {
+    "name": "cloud_mail",
+    "summary": "Cloud Mail REST email client — Cloudflare Workers Cloud Mail polling with LICC inbox callback.",
+    "transport": "stdio",
+    "command": "{python}",
+    "args": [
+      "-m",
+      "lingtai.mcp_servers.cloud_mail"
+    ],
+    "source": "lingtai-curated",
+    "homepage": "https://github.com/maillab/cloud-mail"
   }
 }

--- a/src/lingtai/mcp_servers/cloud_mail/__init__.py
+++ b/src/lingtai/mcp_servers/cloud_mail/__init__.py
@@ -1,0 +1,20 @@
+"""LingTai Cloud Mail MCP server.
+
+Exposes the omnibus ``cloud_mail`` tool (check/read/search/send/accounts)
+over MCP/stdio and pushes inbound mail into the host agent's inbox via
+LICC. Talks to a self-hosted Cloud Mail deployment
+(https://github.com/maillab/cloud-mail) over its REST API using ``httpx``.
+
+Reads multi-account config from a JSON file pointed at by the
+``LINGTAI_CLOUD_MAIL_CONFIG`` env var.
+"""
+from .licc import push_inbox_event
+from .server import build_manager, build_server, load_config, serve
+
+__all__ = [
+    "serve",
+    "build_server",
+    "build_manager",
+    "load_config",
+    "push_inbox_event",
+]

--- a/src/lingtai/mcp_servers/cloud_mail/__main__.py
+++ b/src/lingtai/mcp_servers/cloud_mail/__main__.py
@@ -1,0 +1,26 @@
+"""Entry point for `python -m lingtai.mcp_servers.cloud_mail` and the
+lingtai-cloud-mail console script."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+
+from .server import serve
+
+
+def main() -> None:
+    # Logs to stderr so they don't pollute the MCP stdio channel.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stderr,
+    )
+    try:
+        asyncio.run(serve())
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lingtai/mcp_servers/cloud_mail/_watermark.py
+++ b/src/lingtai/mcp_servers/cloud_mail/_watermark.py
@@ -1,0 +1,80 @@
+"""Per-account Cloud Mail polling watermark store.
+
+Cloud Mail rows carry a monotonically increasing integer ``emailId``. The
+watermark records the highest ``emailId`` we have already delivered to the
+host agent so a restart never re-notifies old mail.
+
+State file shape::
+
+    {
+      "last_email_id": <int>,
+      "seeded": true
+    }
+
+``seeded`` distinguishes a fresh first run (where we record the current
+high-water mark WITHOUT flooding the agent with historical mail) from a
+genuine empty mailbox.
+
+Atomic on POSIX and Windows via tmp-file + os.replace. Corrupt or missing
+files are treated as empty — the addon re-seeds on next poll.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+
+class WatermarkStore:
+    """Tiny JSON-on-disk persistence for the per-account emailId watermark."""
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = Path(path)
+
+    def load(self) -> dict:
+        """Return the persisted dict, or {} if missing/corrupt."""
+        if not self._path.is_file():
+            return {}
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def save(self, state: dict) -> None:
+        """Atomically replace the state file."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(self._path.parent), suffix=".tmp")
+        try:
+            os.write(fd, json.dumps(state, indent=2).encode("utf-8"))
+            os.close(fd)
+            os.replace(tmp, str(self._path))
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            if os.path.exists(tmp):
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+            raise
+
+    # -- convenience helpers --
+
+    @property
+    def last_email_id(self) -> int:
+        state = self.load()
+        try:
+            return int(state.get("last_email_id", 0) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @property
+    def seeded(self) -> bool:
+        return bool(self.load().get("seeded", False))
+
+    def set_last_email_id(self, email_id: int, *, seeded: bool = True) -> None:
+        self.save({"last_email_id": int(email_id), "seeded": bool(seeded)})

--- a/src/lingtai/mcp_servers/cloud_mail/client.py
+++ b/src/lingtai/mcp_servers/cloud_mail/client.py
@@ -216,10 +216,16 @@ class CloudMailClient:
         return rows
 
     def add_user(self, email: str, password: str, **extra: Any) -> Any:
-        """POST /public/addUser. Optional convenience; never logs the password."""
-        body = {"email": email, "password": password}
-        body.update({k: v for k, v in extra.items() if v is not None})
-        return self._public_request("POST", "/public/addUser", json=body)
+        """POST /public/addUser. Optional convenience; never logs the password.
+
+        Cloud Mail's public ``addUser`` endpoint expects a batch-shaped body:
+        ``{"list": [{"email": ..., "password": ..., ...}]}``, even for a
+        single user. Keep the public MCP surface simple while matching that
+        upstream contract exactly.
+        """
+        row = {"email": email, "password": password}
+        row.update({k: v for k, v in extra.items() if v is not None})
+        return self._public_request("POST", "/public/addUser", json={"list": [row]})
 
     # -- user API --
 

--- a/src/lingtai/mcp_servers/cloud_mail/client.py
+++ b/src/lingtai/mcp_servers/cloud_mail/client.py
@@ -1,0 +1,254 @@
+"""Cloud Mail REST client.
+
+Thin synchronous ``httpx`` wrapper around a self-hosted Cloud Mail
+deployment (https://github.com/maillab/cloud-mail). Handles the
+``{code, message, data}`` envelope, the two distinct auth schemes
+(public-token header vs. user JWT header), and token caching.
+
+Design notes / API facts (from cloud-mail source):
+  * Envelope: ``{ "code": 200, "message": "success", "data": ... }``.
+    Any non-200 ``code`` or transport error is raised as ``CloudMailError``.
+  * ``POST /public/genToken`` body ``{email, password}`` (admin only,
+    auth-excluded) -> ``data.token`` (a uuid public token).
+  * Other ``/public/*`` routes require header ``Authorization: <public token>``
+    (NOT ``Bearer``).
+  * ``POST /login`` body ``{email, password}`` -> a user JWT (returned either
+    as a bare string in ``data`` or as ``data.token``). Authenticated routes
+    use header ``Authorization: <jwt>``.
+
+Secrets discipline: this module never logs tokens, passwords, or full
+``Authorization`` headers. ``CloudMailError`` messages carry HTTP status /
+envelope code / server message only.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+log = logging.getLogger("lingtai_cloud_mail")
+
+DEFAULT_TIMEOUT = 30.0
+
+
+class CloudMailError(Exception):
+    """Raised for transport errors or non-200 envelope codes.
+
+    Never carries secrets — only HTTP status, envelope code, and the
+    server-provided message.
+    """
+
+    def __init__(self, message: str, *, code: int | None = None, http_status: int | None = None):
+        super().__init__(message)
+        self.code = code
+        self.http_status = http_status
+
+
+class CloudMailClient:
+    """Synchronous REST client for one Cloud Mail base URL.
+
+    Public-API calls auto-acquire a public token via ``genToken`` using the
+    configured admin credentials; user-API calls auto-acquire a JWT via
+    ``/login`` using the configured user credentials. Tokens are cached and
+    re-fetched once on a 401-ish failure.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        admin_email: str | None = None,
+        admin_password: str | None = None,
+        user_email: str | None = None,
+        user_password: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url is required")
+        self._base_url = base_url.rstrip("/")
+        self._admin_email = admin_email
+        self._admin_password = admin_password
+        self._user_email = user_email
+        self._user_password = user_password
+        # `transport` lets tests inject httpx.MockTransport without network.
+        self._http = httpx.Client(
+            base_url=self._base_url,
+            timeout=timeout,
+            transport=transport,
+        )
+        self._public_token: str | None = None
+        self._user_jwt: str | None = None
+
+    # -- lifecycle --
+
+    def close(self) -> None:
+        try:
+            self._http.close()
+        except Exception:
+            pass
+
+    def __enter__(self) -> "CloudMailClient":
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self.close()
+
+    # -- envelope handling --
+
+    @staticmethod
+    def _parse_envelope(resp: httpx.Response) -> Any:
+        """Validate HTTP + envelope, return ``data`` or raise CloudMailError."""
+        if resp.status_code >= 400:
+            # Try to surface the server message without leaking request data.
+            server_msg = ""
+            try:
+                body = resp.json()
+                if isinstance(body, dict):
+                    server_msg = str(body.get("message") or "")
+            except Exception:
+                pass
+            raise CloudMailError(
+                f"HTTP {resp.status_code} from Cloud Mail"
+                + (f": {server_msg}" if server_msg else ""),
+                http_status=resp.status_code,
+            )
+        try:
+            body = resp.json()
+        except Exception as exc:
+            raise CloudMailError(
+                f"Cloud Mail returned non-JSON response (HTTP {resp.status_code})"
+            ) from exc
+        if not isinstance(body, dict):
+            raise CloudMailError("Cloud Mail envelope was not a JSON object")
+        code = body.get("code")
+        if code != 200:
+            raise CloudMailError(
+                f"Cloud Mail error (code {code}): {body.get('message') or 'unknown'}",
+                code=code,
+                http_status=resp.status_code,
+            )
+        return body.get("data")
+
+    # -- token acquisition --
+
+    def _ensure_public_token(self, *, force: bool = False) -> str:
+        if self._public_token and not force:
+            return self._public_token
+        if not self._admin_email or not self._admin_password:
+            raise CloudMailError(
+                "public API requires admin_email/admin_password in the account "
+                "config to mint a public token via /public/genToken"
+            )
+        resp = self._http.post(
+            "/public/genToken",
+            json={"email": self._admin_email, "password": self._admin_password},
+        )
+        data = self._parse_envelope(resp)
+        token = None
+        if isinstance(data, dict):
+            token = data.get("token")
+        elif isinstance(data, str):
+            token = data
+        if not token:
+            raise CloudMailError("genToken response did not include a token")
+        self._public_token = str(token)
+        return self._public_token
+
+    def _ensure_user_jwt(self, *, force: bool = False) -> str:
+        if self._user_jwt and not force:
+            return self._user_jwt
+        if not self._user_email or not self._user_password:
+            raise CloudMailError(
+                "user API requires user_email/user_password in the account "
+                "config to log in via /login"
+            )
+        resp = self._http.post(
+            "/login",
+            json={"email": self._user_email, "password": self._user_password},
+        )
+        data = self._parse_envelope(resp)
+        jwt = None
+        if isinstance(data, str):
+            jwt = data
+        elif isinstance(data, dict):
+            jwt = data.get("token") or data.get("jwt")
+        if not jwt:
+            raise CloudMailError("/login response did not include a token")
+        self._user_jwt = str(jwt)
+        return self._user_jwt
+
+    # -- low-level authed request helpers (with one auto-retry on 401) --
+
+    def _public_request(self, method: str, path: str, **kwargs) -> Any:
+        token = self._ensure_public_token()
+        headers = {"Authorization": token}
+        resp = self._http.request(method, path, headers=headers, **kwargs)
+        if resp.status_code in (401, 403):
+            token = self._ensure_public_token(force=True)
+            headers = {"Authorization": token}
+            resp = self._http.request(method, path, headers=headers, **kwargs)
+        return self._parse_envelope(resp)
+
+    def _user_request(self, method: str, path: str, **kwargs) -> Any:
+        jwt = self._ensure_user_jwt()
+        headers = {"Authorization": jwt}
+        resp = self._http.request(method, path, headers=headers, **kwargs)
+        if resp.status_code in (401, 403):
+            jwt = self._ensure_user_jwt(force=True)
+            headers = {"Authorization": jwt}
+            resp = self._http.request(method, path, headers=headers, **kwargs)
+        return self._parse_envelope(resp)
+
+    # -- public API --
+
+    def email_list(self, **filters: Any) -> list[dict]:
+        """POST /public/emailList. Returns the row list (possibly empty).
+
+        Accepts filters: toEmail, content, subject, sendName, sendEmail,
+        timeSort ('asc' | desc-default), num (page, default 1), size
+        (default 20), type, isDel. Unknown/None filters are dropped.
+        """
+        body = {k: v for k, v in filters.items() if v is not None}
+        data = self._public_request("POST", "/public/emailList", json=body)
+        rows = _coerce_rows(data)
+        return rows
+
+    def add_user(self, email: str, password: str, **extra: Any) -> Any:
+        """POST /public/addUser. Optional convenience; never logs the password."""
+        body = {"email": email, "password": password}
+        body.update({k: v for k, v in extra.items() if v is not None})
+        return self._public_request("POST", "/public/addUser", json=body)
+
+    # -- user API --
+
+    def email_send(self, payload: dict) -> Any:
+        """POST /email/send with the user JWT. Caller assembles the payload."""
+        return self._user_request("POST", "/email/send", json=payload)
+
+    def email_list_user(self, **query: Any) -> Any:
+        """GET /email/list with the user JWT (account-scoped listing)."""
+        params = {k: v for k, v in query.items() if v is not None}
+        return self._user_request("GET", "/email/list", params=params)
+
+    def mark_read(self, email_ids: list[int]) -> Any:
+        """PUT /email/read body {emailIds} with the user JWT."""
+        return self._user_request("PUT", "/email/read", json={"emailIds": email_ids})
+
+
+def _coerce_rows(data: Any) -> list[dict]:
+    """Normalize an emailList ``data`` payload into a list of row dicts.
+
+    The public emailList returns a bare list, but be defensive about a
+    ``{list: [...]}`` wrapper too (the user-API list shape).
+    """
+    if data is None:
+        return []
+    if isinstance(data, list):
+        return [r for r in data if isinstance(r, dict)]
+    if isinstance(data, dict):
+        inner = data.get("list")
+        if isinstance(inner, list):
+            return [r for r in inner if isinstance(r, dict)]
+    return []

--- a/src/lingtai/mcp_servers/cloud_mail/licc.py
+++ b/src/lingtai/mcp_servers/cloud_mail/licc.py
@@ -1,0 +1,116 @@
+"""LICC v1 client compatibility wrapper.
+
+The canonical first-party LICC producer implementation lives in
+``lingtai.core.mcp.licc`` inside lingtai-kernel. This module keeps the
+addon's ``lingtai.mcp_servers.cloud_mail.licc.push_inbox_event`` import path
+stable while preferring the kernel implementation whenever it is available.
+
+A small local fallback remains for standalone development or pre-upgrade
+runtime environments where the host kernel does not yet expose the canonical
+client helper. The fallback writes the same LICC v1 filesystem event shape.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:  # pragma: no cover - availability depends on the host LingTai runtime.
+    from lingtai.core.mcp.licc import push_inbox_event as _kernel_push_inbox_event
+except ImportError:  # Older/standalone environments keep using the fallback below.
+    _kernel_push_inbox_event = None
+
+log = logging.getLogger(__name__)
+
+LICC_VERSION = 1
+INBOX_DIRNAME = ".mcp_inbox"
+TMP_SUFFIX = ".json.tmp"
+EVENT_SUFFIX = ".json"
+
+
+def push_inbox_event(
+    sender: str,
+    subject: str,
+    body: str,
+    *,
+    metadata: dict | None = None,
+    wake: bool = True,
+) -> bool:
+    """Write a LICC event into the host agent's inbox.
+
+    In a current LingTai runtime, delegate to the canonical kernel helper.
+    If the helper is unavailable, use the local compatibility fallback so
+    older hosts and standalone development remain functional.
+    """
+    if _kernel_push_inbox_event is not None:
+        return _kernel_push_inbox_event(
+            sender,
+            subject,
+            body,
+            metadata=metadata,
+            wake=wake,
+        )
+    return _fallback_push_inbox_event(
+        sender,
+        subject,
+        body,
+        metadata=metadata,
+        wake=wake,
+    )
+
+
+def _fallback_push_inbox_event(
+    sender: str,
+    subject: str,
+    body: str,
+    *,
+    metadata: dict | None = None,
+    wake: bool = True,
+) -> bool:
+    """Local LICC v1 writer used only when the kernel helper is unavailable."""
+    agent_dir = os.environ.get("LINGTAI_AGENT_DIR")
+    mcp_name = os.environ.get("LINGTAI_MCP_NAME")
+
+    if not agent_dir or not mcp_name:
+        log.warning(
+            "LICC: LINGTAI_AGENT_DIR and/or LINGTAI_MCP_NAME not set; "
+            "event dropped"
+        )
+        return False
+
+    event = {
+        "licc_version": LICC_VERSION,
+        "from": sender,
+        "subject": subject,
+        "body": body,
+        "metadata": metadata or {},
+        "wake": wake,
+        "received_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    try:
+        target_dir = Path(agent_dir) / INBOX_DIRNAME / mcp_name
+        target_dir.mkdir(parents=True, exist_ok=True)
+        event_id = f"{int(time.time() * 1000)}-{uuid.uuid4().hex[:8]}"
+        tmp = target_dir / f"{event_id}{TMP_SUFFIX}"
+        final = target_dir / f"{event_id}{EVENT_SUFFIX}"
+        # Write + fsync + atomic replace so the host poller never sees a
+        # half-written file.
+        text = json.dumps(event, ensure_ascii=False)
+        with tmp.open("w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, final)
+        return True
+    except (OSError, TypeError, ValueError) as exc:
+        log.error(
+            "LICC: failed to write event for MCP %r via compatibility fallback: %s",
+            mcp_name,
+            type(exc).__name__,
+        )
+        return False

--- a/src/lingtai/mcp_servers/cloud_mail/manager.py
+++ b/src/lingtai/mcp_servers/cloud_mail/manager.py
@@ -73,6 +73,7 @@ SCHEMA: dict[str, Any] = {
         # add_user (optional)
         "email": {"type": "string", "description": "add_user: new user email."},
         "password": {"type": "string", "description": "add_user: new user password."},
+        "role_name": {"type": "string", "description": "add_user: optional Cloud Mail role name."},
     },
     "required": ["action"],
 }
@@ -327,7 +328,9 @@ class CloudMailManager:
         password = args.get("password")
         if not email or not password:
             return {"status": "error", "error": "add_user requires 'email' and 'password'"}
-        data = acct.client.add_user(email, password)
+        role_name = args.get("role_name") or args.get("roleName")
+        extra = {"roleName": role_name} if role_name else {}
+        data = acct.client.add_user(email, password, **extra)
         # Never echo the password back.
         return {"status": "ok", "account": acct.alias, "added": email, "result": data}
 

--- a/src/lingtai/mcp_servers/cloud_mail/manager.py
+++ b/src/lingtai/mcp_servers/cloud_mail/manager.py
@@ -1,0 +1,518 @@
+"""CloudMailManager — omnibus ``cloud_mail`` tool + polling coordinator.
+
+One MCP tool, five actions:
+  * ``check``    — recent public emails (optional filters).
+  * ``search``   — public emailList filters (toEmail/sendEmail/subject/...).
+  * ``read``     — one email by compound id ``<account>:<emailId>``.
+  * ``send``     — send via user /login + /email/send (needs user creds).
+  * ``accounts`` — redacted per-account status (no tokens/passwords).
+
+Inbound mail is discovered by a per-account polling thread and pushed into
+the host agent's inbox via LICC. Watermarks (highest delivered ``emailId``)
+persist under ``<working_dir>/cloud_mail/<alias>/watermark.json`` so restarts
+never re-notify old mail.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Callable
+
+from .client import CloudMailClient, CloudMailError
+from ._watermark import WatermarkStore
+
+log = logging.getLogger("lingtai_cloud_mail")
+
+DESCRIPTION = (
+    "Cloud Mail REST email client for a self-hosted Cloud Mail deployment "
+    "(Cloudflare Workers, https://github.com/maillab/cloud-mail). Actions: "
+    "check (recent inbound mail), search (filter by sender/recipient/subject/"
+    "content), read (full content by compound id '<account>:<emailId>'), send "
+    "(requires user credentials in config), accounts (redacted status). "
+    "Inbound mail also arrives automatically in your inbox via polling."
+)
+
+SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": ["check", "search", "read", "send", "accounts", "add_user"],
+            "description": "Which Cloud Mail operation to perform.",
+        },
+        "account": {
+            "type": "string",
+            "description": "Account alias (or admin email). Defaults to the first configured account.",
+        },
+        "limit": {"type": "integer", "description": "check: max rows to return (default 10)."},
+        "n": {"type": "integer", "description": "Alias for limit."},
+        # search filters (public emailList)
+        "to_email": {"type": "string", "description": "search/check: filter by recipient address (LIKE)."},
+        "send_email": {"type": "string", "description": "search/check: filter by sender address (LIKE)."},
+        "send_name": {"type": "string", "description": "search: filter by sender display name (LIKE)."},
+        "subject": {"type": "string", "description": "search/check: filter by subject (LIKE); send: subject line."},
+        "content": {"type": "string", "description": "search: filter by body content (LIKE)."},
+        "time_sort": {"type": "string", "enum": ["asc", "desc"], "description": "search/check: sort order (default desc)."},
+        "num": {"type": "integer", "description": "search: page number (default 1)."},
+        "size": {"type": "integer", "description": "search: page size (default 20)."},
+        "type": {"type": "integer", "description": "search/check: Cloud Mail email type filter."},
+        "is_del": {"type": "integer", "description": "search: include deleted rows."},
+        # read
+        "id": {"type": "string", "description": "read: compound id '<account>:<emailId>'."},
+        "email_id": {"description": "read: numeric email id (used with 'account')."},
+        # send
+        "address": {"description": "send: recipient address or list of addresses."},
+        "message": {"type": "string", "description": "send: plain-text body (maps to text)."},
+        "text": {"type": "string", "description": "send: plain-text body (alias for message)."},
+        "html": {"type": "string", "description": "send: HTML body (maps to content)."},
+        "content_html": {"type": "string", "description": "send: HTML body (alias for html)."},
+        "name": {"type": "string", "description": "send: sender display name."},
+        "send_account_id": {"type": "integer", "description": "send: override the configured sender account id."},
+        "attachments": {"type": "array", "description": "send: NOT SUPPORTED in this first pass."},
+        # add_user (optional)
+        "email": {"type": "string", "description": "add_user: new user email."},
+        "password": {"type": "string", "description": "add_user: new user password."},
+    },
+    "required": ["action"],
+}
+
+
+class CloudMailAccount:
+    """One configured Cloud Mail account: client + watermark + poll state."""
+
+    def __init__(self, cfg: dict, *, working_dir: Path | None, transport=None) -> None:
+        self.base_url = cfg["base_url"]
+        self.alias = cfg.get("alias") or cfg.get("admin_email") or self.base_url
+        self.admin_email = cfg.get("admin_email")
+        self.user_email = cfg.get("user_email")
+        self._user_password = cfg.get("user_password")
+        self.send_account_id = cfg.get("send_account_id")
+        self.poll_interval = float(cfg.get("poll_interval", 30) or 30)
+        self.notify_existing = bool(cfg.get("notify_existing", False))
+        allowed = cfg.get("allowed_senders") or []
+        self.allowed_senders = {str(a).strip().lower() for a in allowed if a}
+
+        self.client = CloudMailClient(
+            base_url=self.base_url,
+            admin_email=cfg.get("admin_email"),
+            admin_password=cfg.get("admin_password"),
+            user_email=cfg.get("user_email"),
+            user_password=cfg.get("user_password"),
+            transport=transport,
+        )
+
+        self._wm_path = None
+        if working_dir is not None:
+            self._wm_path = Path(working_dir) / "cloud_mail" / _safe_segment(self.alias) / "watermark.json"
+        self.watermark = WatermarkStore(self._wm_path) if self._wm_path else WatermarkStore(Path("/dev/null"))
+
+    @property
+    def has_user_creds(self) -> bool:
+        return bool(self.user_email and self._user_password)
+
+    def sender_allowed(self, sender: str | None) -> bool:
+        if not self.allowed_senders:
+            return True
+        return (sender or "").strip().lower() in self.allowed_senders
+
+    def status(self) -> dict:
+        """Redacted status — never includes tokens/passwords."""
+        return {
+            "alias": self.alias,
+            "base_url": self.base_url,
+            "admin_email": self.admin_email,
+            "user_email": self.user_email,
+            "can_send": self.has_user_creds and self.send_account_id is not None,
+            "send_account_id": self.send_account_id,
+            "allowed_senders": sorted(self.allowed_senders) or None,
+            "poll_interval": self.poll_interval,
+            "watermark_email_id": self.watermark.last_email_id,
+            "seeded": self.watermark.seeded,
+        }
+
+
+class CloudMailManager:
+    """Coordinates accounts, the omnibus tool, and the polling threads."""
+
+    def __init__(
+        self,
+        accounts: list[dict],
+        *,
+        working_dir: Path | str | None = None,
+        on_inbound: Callable[[dict], None] | None = None,
+        transport=None,
+    ) -> None:
+        self._working_dir = Path(working_dir) if working_dir else None
+        self._on_inbound = on_inbound
+        self._accounts: list[CloudMailAccount] = [
+            CloudMailAccount(cfg, working_dir=self._working_dir, transport=transport)
+            for cfg in accounts
+        ]
+        if not self._accounts:
+            raise ValueError("cloud_mail config has no accounts")
+        self._by_alias: dict[str, CloudMailAccount] = {}
+        for acct in self._accounts:
+            self._by_alias[acct.alias.lower()] = acct
+            if acct.admin_email:
+                self._by_alias.setdefault(acct.admin_email.lower(), acct)
+        self._poll_stop = threading.Event()
+        self._poll_threads: list[threading.Thread] = []
+
+    # -- account resolution --
+
+    @property
+    def default_account(self) -> CloudMailAccount:
+        return self._accounts[0]
+
+    def _resolve(self, account: str | None) -> CloudMailAccount:
+        if not account:
+            return self.default_account
+        acct = self._by_alias.get(str(account).strip().lower())
+        if acct is None:
+            raise CloudMailError(f"unknown account {account!r}")
+        return acct
+
+    # -- tool dispatch --
+
+    def handle(self, args: dict) -> dict:
+        action = (args or {}).get("action")
+        try:
+            if action == "check":
+                return self._handle_check(args)
+            if action == "search":
+                return self._handle_search(args)
+            if action == "read":
+                return self._handle_read(args)
+            if action == "send":
+                return self._handle_send(args)
+            if action == "accounts":
+                return {"status": "ok", "accounts": [a.status() for a in self._accounts]}
+            if action == "add_user":
+                return self._handle_add_user(args)
+            return {"status": "error", "error": f"unknown action: {action!r}"}
+        except CloudMailError as exc:
+            return {"status": "error", "error": str(exc), "error_type": "CloudMailError"}
+        except Exception as exc:  # defensive — never leak a traceback to the model
+            log.exception("cloud_mail action %r failed", action)
+            return {"status": "error", "error": str(exc), "error_type": type(exc).__name__}
+
+    def _handle_check(self, args: dict) -> dict:
+        acct = self._resolve(args.get("account"))
+        limit = args.get("limit") or args.get("n") or 10
+        try:
+            size = max(1, int(limit))
+        except (TypeError, ValueError):
+            size = 10
+        rows = acct.client.email_list(
+            toEmail=args.get("to_email"),
+            sendEmail=args.get("send_email"),
+            subject=args.get("subject"),
+            timeSort=args.get("time_sort"),
+            type=args.get("type"),
+            num=1,
+            size=size,
+        )
+        return {
+            "status": "ok",
+            "account": acct.alias,
+            "count": len(rows),
+            "emails": [_summarize_row(acct.alias, r) for r in rows],
+        }
+
+    def _handle_search(self, args: dict) -> dict:
+        acct = self._resolve(args.get("account"))
+        rows = acct.client.email_list(
+            toEmail=args.get("to_email"),
+            sendEmail=args.get("send_email"),
+            sendName=args.get("send_name"),
+            subject=args.get("subject"),
+            content=args.get("content"),
+            timeSort=args.get("time_sort"),
+            num=args.get("num"),
+            size=args.get("size"),
+            type=args.get("type"),
+            isDel=args.get("is_del"),
+        )
+        return {
+            "status": "ok",
+            "account": acct.alias,
+            "count": len(rows),
+            "emails": [_summarize_row(acct.alias, r) for r in rows],
+        }
+
+    def _handle_read(self, args: dict) -> dict:
+        alias, email_id = self._parse_read_target(args)
+        acct = self._resolve(alias)
+        if email_id is None:
+            return {"status": "error", "error": "read requires 'id' as '<account>:<emailId>' or 'email_id'"}
+        # Public emailList has no by-id filter; page through recent rows and
+        # match the emailId. Bounded scan keeps this cheap and predictable.
+        for page in range(1, 6):
+            rows = acct.client.email_list(num=page, size=50, timeSort="desc")
+            if not rows:
+                break
+            for r in rows:
+                if str(r.get("emailId")) == str(email_id):
+                    return {
+                        "status": "ok",
+                        "account": acct.alias,
+                        "email": _full_row(acct.alias, r),
+                    }
+        return {
+            "status": "error",
+            "error": f"email {email_id} not found in account {acct.alias!r} "
+            "(searched recent pages; it may be older than the scan window)",
+        }
+
+    def _handle_send(self, args: dict) -> dict:
+        acct = self._resolve(args.get("account"))
+        if not acct.has_user_creds:
+            return {
+                "status": "error",
+                "error": (
+                    f"send needs user credentials for account {acct.alias!r}. "
+                    "Add 'user_email' and 'user_password' (and 'send_account_id') "
+                    "to that account in the LINGTAI_CLOUD_MAIL_CONFIG file."
+                ),
+            }
+        send_account_id = args.get("send_account_id")
+        if send_account_id is None:
+            send_account_id = acct.send_account_id
+        if send_account_id is None:
+            return {
+                "status": "error",
+                "error": (
+                    f"send needs 'send_account_id' for account {acct.alias!r} "
+                    "(set it in config or pass send_account_id)."
+                ),
+            }
+
+        recipients = _as_recipient_list(args.get("address"))
+        if not recipients:
+            return {"status": "error", "error": "send requires 'address' (a string or list of addresses)"}
+
+        if args.get("attachments"):
+            return {
+                "status": "error",
+                "error": "attachments are not supported by the cloud_mail addon (first pass); omit them",
+            }
+
+        text = args.get("message") or args.get("text") or ""
+        html = args.get("html") or args.get("content_html")
+        # Cloud Mail's send service derives the HTML/preview from `content`;
+        # fall back to the plain text wrapped so a text-only send still works.
+        content = html if html else text
+        payload = {
+            "accountId": send_account_id,
+            "name": args.get("name") or "",
+            "sendType": "count",
+            "receiveEmail": recipients,
+            "text": text,
+            "content": content,
+            "subject": args.get("subject") or "",
+            "attachments": [],
+        }
+        data = acct.client.email_send(payload)
+        return {
+            "status": "ok",
+            "account": acct.alias,
+            "sent_to": recipients,
+            "result": data,
+        }
+
+    def _handle_add_user(self, args: dict) -> dict:
+        acct = self._resolve(args.get("account"))
+        email = args.get("email")
+        password = args.get("password")
+        if not email or not password:
+            return {"status": "error", "error": "add_user requires 'email' and 'password'"}
+        data = acct.client.add_user(email, password)
+        # Never echo the password back.
+        return {"status": "ok", "account": acct.alias, "added": email, "result": data}
+
+    @staticmethod
+    def _parse_read_target(args: dict) -> tuple[str | None, Any]:
+        raw = args.get("id")
+        if raw and ":" in str(raw):
+            alias, _, email_id = str(raw).rpartition(":")
+            return (alias or None), email_id
+        return args.get("account"), args.get("email_id")
+
+    # -- polling / LICC --
+
+    def start(self) -> None:
+        """Begin per-account polling threads."""
+        if self._poll_threads:
+            return
+        self._poll_stop.clear()
+        for acct in self._accounts:
+            t = threading.Thread(
+                target=self._poll_loop,
+                args=(acct,),
+                daemon=True,
+                name=f"cloud-mail-poll-{acct.alias}",
+            )
+            t.start()
+            self._poll_threads.append(t)
+        log.info("cloud_mail polling %d account(s)", len(self._accounts))
+
+    def stop(self) -> None:
+        self._poll_stop.set()
+        for t in self._poll_threads:
+            t.join(timeout=2.0)
+        self._poll_threads = []
+        for acct in self._accounts:
+            acct.client.close()
+
+    def _poll_loop(self, acct: CloudMailAccount) -> None:
+        # First tick runs immediately; subsequent ticks wait poll_interval.
+        first = True
+        while not self._poll_stop.is_set():
+            if not first:
+                if self._poll_stop.wait(acct.poll_interval):
+                    break
+            first = False
+            try:
+                self.poll_once(acct)
+            except CloudMailError as exc:
+                log.warning("cloud_mail poll failed for %s: %s", acct.alias, exc)
+            except Exception:
+                log.exception("cloud_mail poll crashed for %s", acct.alias)
+
+    def poll_once(self, acct: CloudMailAccount) -> int:
+        """One poll cycle. Returns the number of LICC events pushed.
+
+        Seeds the watermark silently on first run (unless notify_existing).
+        Otherwise pushes one LICC event per new row with emailId >
+        watermark, honoring allowed_senders.
+        """
+        rows = acct.client.email_list(num=1, size=50, timeSort="desc")
+        if not rows:
+            return 0
+        # Highest emailId seen this cycle.
+        def _eid(r: dict) -> int:
+            try:
+                return int(r.get("emailId") or 0)
+            except (TypeError, ValueError):
+                return 0
+
+        max_id = max(_eid(r) for r in rows)
+        last_id = acct.watermark.last_email_id
+        seeded = acct.watermark.seeded
+
+        if not seeded and not acct.notify_existing:
+            # Fresh first run — record high-water mark without flooding.
+            acct.watermark.set_last_email_id(max_id, seeded=True)
+            log.info("cloud_mail seeded %s watermark at emailId=%s", acct.alias, max_id)
+            return 0
+
+        # New rows (ascending so we deliver oldest-first), above the watermark.
+        new_rows = sorted(
+            (r for r in rows if _eid(r) > last_id),
+            key=_eid,
+        )
+        pushed = 0
+        for r in new_rows:
+            if not acct.sender_allowed(r.get("sendEmail")):
+                continue
+            if self._push_licc(acct, r):
+                pushed += 1
+        # Advance watermark to the max we observed regardless of allow-list,
+        # so filtered-out senders don't replay forever.
+        if max_id > last_id:
+            acct.watermark.set_last_email_id(max_id, seeded=True)
+        return pushed
+
+    def _push_licc(self, acct: CloudMailAccount, row: dict) -> bool:
+        if self._on_inbound is None:
+            return False
+        email_id = row.get("emailId")
+        compound = f"{acct.alias}:{email_id}"
+        sender = row.get("sendEmail") or row.get("sendName") or "unknown"
+        subject = row.get("subject") or "(no subject)"
+        body = row.get("text") or _strip_to_text(row.get("content")) or ""
+        event = {
+            "from": sender,
+            "subject": subject,
+            "body": body,
+            "wake": True,
+            "metadata": {
+                "source": "cloud_mail",
+                "event_type": "email",
+                "account": acct.alias,
+                "email_id": email_id,
+                "compound_id": compound,
+                "from": sender,
+                "from_name": row.get("sendName"),
+                "to": row.get("toEmail"),
+                "created_at": row.get("createTime"),
+            },
+        }
+        try:
+            self._on_inbound(event)
+            return True
+        except Exception:
+            log.exception("cloud_mail LICC push failed for %s", compound)
+            return False
+
+
+# ---------------------------------------------------------------------------
+# Row helpers (shared by tool results + LICC)
+# ---------------------------------------------------------------------------
+
+def _summarize_row(alias: str, row: dict) -> dict:
+    """Compact, list-friendly view of one email row."""
+    email_id = row.get("emailId")
+    return {
+        "compound_id": f"{alias}:{email_id}",
+        "email_id": email_id,
+        "from": row.get("sendEmail"),
+        "from_name": row.get("sendName"),
+        "to": row.get("toEmail"),
+        "subject": row.get("subject"),
+        "created_at": row.get("createTime"),
+        "type": row.get("type"),
+        "preview": _preview(row),
+    }
+
+
+def _full_row(alias: str, row: dict) -> dict:
+    """Full view of one email row including content/text."""
+    out = _summarize_row(alias, row)
+    out["text"] = row.get("text")
+    out["content"] = row.get("content")
+    out["is_del"] = row.get("isDel")
+    out.pop("preview", None)
+    return out
+
+
+def _preview(row: dict, n: int = 200) -> str:
+    text = row.get("text") or _strip_to_text(row.get("content")) or ""
+    text = " ".join(text.split())
+    return text[:n] + ("…" if len(text) > n else "")
+
+
+def _strip_to_text(content: Any) -> str:
+    if not isinstance(content, str):
+        return ""
+    # Cheap tag strip — we do NOT pull in an HTML parser for a preview.
+    import re
+    return re.sub(r"<[^>]+>", " ", content)
+
+
+def _as_recipient_list(address: Any) -> list[str]:
+    if address is None:
+        return []
+    if isinstance(address, str):
+        return [address] if address.strip() else []
+    if isinstance(address, (list, tuple)):
+        return [str(a) for a in address if str(a).strip()]
+    return []
+
+
+def _safe_segment(name: str) -> str:
+    """Make an alias safe for a filesystem path segment."""
+    import re
+    seg = re.sub(r"[^A-Za-z0-9._@-]+", "_", str(name)).strip("_")
+    return seg or "account"

--- a/src/lingtai/mcp_servers/cloud_mail/server.py
+++ b/src/lingtai/mcp_servers/cloud_mail/server.py
@@ -1,0 +1,222 @@
+"""LingTai Cloud Mail MCP server.
+
+Exposes a single omnibus ``cloud_mail`` MCP tool that dispatches to
+``CloudMailManager`` (check/read/search/send/accounts/add_user). Inbound mail
+flows into the host agent's inbox via LICC.
+
+Configuration:
+    LINGTAI_CLOUD_MAIL_CONFIG  — path to a JSON config file (required).
+        Resolved relative to LINGTAI_AGENT_DIR (or cwd) when not absolute.
+
+Config schema (plaintext, no env-indirection):
+
+    {
+      "accounts": [
+        {
+          "alias": "cloudmail",
+          "base_url": "https://mail.example.com",
+          "admin_email": "admin@example.com",
+          "admin_password": "...",
+          "user_email": "admin@example.com",     // optional (send only)
+          "user_password": "...",                 // optional (send only)
+          "send_account_id": 1,                    // optional (send only)
+          "allowed_senders": ["only@example.com"], // optional allow-list
+          "poll_interval": 30,                     // optional, seconds
+          "notify_existing": false                 // optional, default false
+        }
+      ]
+    }
+
+Env vars injected by the LingTai kernel for LICC:
+    LINGTAI_AGENT_DIR — host agent's working directory.
+    LINGTAI_MCP_NAME  — this MCP's registry name (typically "cloud_mail").
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import mcp.types as types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from .licc import push_inbox_event
+from .manager import CloudMailManager, DESCRIPTION, SCHEMA
+
+log = logging.getLogger("lingtai_cloud_mail")
+
+_SERVER_INSTRUCTIONS = (
+    "lingtai-cloud-mail: REST email via a self-hosted Cloud Mail deployment "
+    "(Cloudflare Workers). Configure via the LINGTAI_CLOUD_MAIL_CONFIG env var "
+    "pointing at a JSON file. Inbound mail flows into the host agent's inbox "
+    "via LICC polling. Setup, config schema, and troubleshooting: "
+    "https://github.com/maillab/cloud-mail"
+)
+
+CONFIG_ENV = "LINGTAI_CLOUD_MAIL_CONFIG"
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def load_config() -> dict:
+    """Read config from the path in LINGTAI_CLOUD_MAIL_CONFIG.
+
+    Path is resolved relative to LINGTAI_AGENT_DIR (or cwd as fallback)
+    when not absolute. Plaintext only — no *_env indirection.
+    """
+    config_path_raw = os.environ.get(CONFIG_ENV)
+    if not config_path_raw:
+        raise ValueError(
+            f"{CONFIG_ENV} env var not set — point it at your Cloud Mail "
+            "config JSON file"
+        )
+    config_path = Path(config_path_raw).expanduser()
+    if not config_path.is_absolute():
+        base = Path(os.environ.get("LINGTAI_AGENT_DIR", os.getcwd()))
+        config_path = base / config_path
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Cloud Mail config not found: {config_path}")
+    return json.loads(config_path.read_text(encoding="utf-8"))
+
+
+def accounts_from_config(cfg: dict) -> list[dict]:
+    """Normalize config into the accounts list CloudMailManager expects.
+
+    Accepts the canonical ``{accounts: [...]}`` shape or a flat
+    single-account dict for convenience.
+    """
+    if isinstance(cfg, dict) and "accounts" in cfg:
+        accounts = cfg["accounts"]
+        if not isinstance(accounts, list) or not accounts:
+            raise ValueError("config 'accounts' must be a non-empty list")
+        return list(accounts)
+    if isinstance(cfg, dict) and "base_url" in cfg:
+        return [cfg]
+    raise ValueError(
+        "config must contain 'accounts' (list) or a single-account dict "
+        "with 'base_url'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manager construction
+# ---------------------------------------------------------------------------
+
+def build_manager() -> tuple[CloudMailManager, Path]:
+    """Construct the Cloud Mail manager from env + config.
+
+    Returns (manager, working_dir). Inbound rows discovered by polling are
+    pushed to the host agent inbox via LICC.
+    """
+    cfg = load_config()
+    accounts = accounts_from_config(cfg)
+
+    agent_dir_raw = os.environ.get("LINGTAI_AGENT_DIR")
+    working_dir = Path(agent_dir_raw) if agent_dir_raw else Path.cwd()
+    working_dir.mkdir(parents=True, exist_ok=True)
+
+    def _on_inbound(event: dict) -> None:
+        push_inbox_event(
+            sender=event["from"],
+            subject=event["subject"],
+            body=event["body"],
+            metadata=event.get("metadata"),
+            wake=event.get("wake", True),
+        )
+
+    mgr = CloudMailManager(
+        accounts=accounts,
+        working_dir=working_dir,
+        on_inbound=_on_inbound,
+    )
+    return mgr, working_dir
+
+
+# ---------------------------------------------------------------------------
+# MCP server
+# ---------------------------------------------------------------------------
+
+def build_server(manager: CloudMailManager | None) -> Server:
+    """Construct the MCP server. ``manager`` is None when eager start failed;
+    in that case every tool call returns an error explaining why."""
+    server: Server = Server("lingtai-cloud-mail", instructions=_SERVER_INSTRUCTIONS)
+
+    @server.list_tools()
+    async def _list_tools() -> list[types.Tool]:
+        return [
+            types.Tool(
+                name="cloud_mail",
+                description=DESCRIPTION,
+                inputSchema=SCHEMA,
+            ),
+        ]
+
+    @server.call_tool()
+    async def _call_tool(
+        name: str, arguments: dict[str, Any],
+    ) -> list[types.TextContent]:
+        if name != "cloud_mail":
+            raise ValueError(f"unknown tool: {name!r}")
+        if manager is None:
+            result = {
+                "status": "error",
+                "error": (
+                    "Cloud Mail manager not initialized — server boot failed. "
+                    "Check stderr for the underlying exception (most often a "
+                    f"missing {CONFIG_ENV} or invalid config)."
+                ),
+            }
+        else:
+            try:
+                result = await asyncio.to_thread(manager.handle, arguments)
+            except Exception as e:
+                result = {
+                    "status": "error",
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                }
+        return [types.TextContent(
+            type="text", text=json.dumps(result, ensure_ascii=False),
+        )]
+
+    return server
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+async def serve() -> None:
+    """Run the MCP server over stdio. Eagerly starts the manager so the
+    polling loop is up before the host expects mail."""
+    manager: CloudMailManager | None = None
+    try:
+        manager, _wd = build_manager()
+        manager.start()
+        log.info("Cloud Mail polling running")
+    except Exception as e:
+        log.error(
+            "eager start failed; tool calls will return errors until fixed: %s", e,
+        )
+        manager = None
+
+    server = build_server(manager)
+    try:
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(),
+            )
+    finally:
+        if manager is not None:
+            try:
+                manager.stop()
+            except Exception:
+                pass

--- a/tests/test_cloud_mail_addon.py
+++ b/tests/test_cloud_mail_addon.py
@@ -1,0 +1,457 @@
+"""Unit tests for the curated Cloud Mail MCP addon.
+
+No real network: a small in-process router backs an ``httpx.MockTransport``
+that speaks the Cloud Mail ``{code, message, data}`` envelope and the two
+auth schemes (public-token header / user JWT header).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from lingtai.mcp_servers.cloud_mail.client import CloudMailClient, CloudMailError
+from lingtai.mcp_servers.cloud_mail.manager import CloudMailManager
+from lingtai.mcp_servers.cloud_mail import server as cm_server
+
+
+# ---------------------------------------------------------------------------
+# Fake Cloud Mail backend (httpx.MockTransport handler)
+# ---------------------------------------------------------------------------
+
+PUBLIC_TOKEN = "pub-token-uuid"
+USER_JWT = "user.jwt.value"
+
+
+def make_router(rows=None, *, captured=None):
+    """Return an httpx handler emulating the Cloud Mail REST surface.
+
+    ``rows`` is the list returned by /public/emailList. ``captured`` (if a
+    dict) records the last request bodies/headers for assertions.
+    """
+    rows = rows if rows is not None else []
+    captured = captured if captured is not None else {}
+
+    def _ok(data):
+        return httpx.Response(200, json={"code": 200, "message": "success", "data": data})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        body = {}
+        if request.content:
+            try:
+                body = json.loads(request.content)
+            except Exception:
+                body = {}
+        auth = request.headers.get("Authorization")
+
+        if path == "/public/genToken":
+            captured["genToken_body"] = body
+            if body.get("email") == "admin@example.com" and body.get("password") == "adminpw":
+                return _ok({"token": PUBLIC_TOKEN})
+            return httpx.Response(200, json={"code": 401, "message": "bad admin creds"})
+
+        if path == "/public/emailList":
+            captured["emailList_auth"] = auth
+            captured["emailList_body"] = body
+            if auth != PUBLIC_TOKEN:
+                return httpx.Response(200, json={"code": 401, "message": "missing public token"})
+            return _ok(list(rows))
+
+        if path == "/login":
+            captured["login_body"] = body
+            if body.get("email") == "user@example.com" and body.get("password") == "userpw":
+                return _ok({"token": USER_JWT})
+            return httpx.Response(200, json={"code": 401, "message": "bad user creds"})
+
+        if path == "/email/send":
+            captured["send_auth"] = auth
+            captured["send_body"] = body
+            if auth != USER_JWT:
+                return httpx.Response(200, json={"code": 401, "message": "missing jwt"})
+            return _ok({"emailId": 999, "sent": True})
+
+        return httpx.Response(404, json={"code": 404, "message": f"no route {path}"})
+
+    return httpx.MockTransport(handler), captured
+
+
+def make_manager(tmp_path, *, rows=None, captured=None, account_overrides=None):
+    transport, captured = make_router(rows=rows, captured=captured)
+    acct = {
+        "alias": "cloudmail",
+        "base_url": "https://mail.example.com",
+        "admin_email": "admin@example.com",
+        "admin_password": "adminpw",
+        "poll_interval": 30,
+    }
+    if account_overrides:
+        acct.update(account_overrides)
+    mgr = CloudMailManager(
+        accounts=[acct],
+        working_dir=tmp_path,
+        transport=transport,
+    )
+    return mgr, captured
+
+
+def _row(email_id, *, sender="alice@x.com", subject="hi", to="agent@example.com",
+         text="hello world", name="Alice"):
+    return {
+        "emailId": email_id,
+        "sendEmail": sender,
+        "sendName": name,
+        "subject": subject,
+        "toEmail": to,
+        "toName": "Agent",
+        "type": 1,
+        "createTime": "2026-06-13T00:00:00Z",
+        "content": f"<p>{text}</p>",
+        "text": text,
+        "isDel": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Client: envelope + auth
+# ---------------------------------------------------------------------------
+
+def test_public_token_minted_and_header_is_raw_not_bearer(tmp_path):
+    captured = {}
+    transport, captured = make_router(rows=[_row(1)], captured=captured)
+    client = CloudMailClient(
+        base_url="https://mail.example.com",
+        admin_email="admin@example.com",
+        admin_password="adminpw",
+        transport=transport,
+    )
+    rows = client.email_list(size=10)
+    assert [r["emailId"] for r in rows] == [1]
+    # Header is the raw token, NOT "Bearer <token>".
+    assert captured["emailList_auth"] == PUBLIC_TOKEN
+    client.close()
+
+
+def test_non_200_envelope_raises_cloud_mail_error(tmp_path):
+    def handler(request):
+        return httpx.Response(200, json={"code": 500, "message": "boom"})
+    client = CloudMailClient(
+        base_url="https://mail.example.com",
+        admin_email="admin@example.com",
+        admin_password="adminpw",
+        transport=httpx.MockTransport(handler),
+    )
+    with pytest.raises(CloudMailError) as ei:
+        client.email_list()
+    assert "code 500" in str(ei.value) and "boom" in str(ei.value)
+    client.close()
+
+
+def test_public_api_without_admin_creds_errors_clearly(tmp_path):
+    transport, _ = make_router(rows=[])
+    client = CloudMailClient(base_url="https://mail.example.com", transport=transport)
+    with pytest.raises(CloudMailError) as ei:
+        client.email_list()
+    assert "admin_email" in str(ei.value)
+    client.close()
+
+
+# ---------------------------------------------------------------------------
+# Manager: check / search id formatting
+# ---------------------------------------------------------------------------
+
+def test_check_returns_compound_ids_and_preview(tmp_path):
+    mgr, _ = make_manager(tmp_path, rows=[_row(5, subject="newest"), _row(4)])
+    out = mgr.handle({"action": "check", "limit": 10})
+    assert out["status"] == "ok"
+    assert out["count"] == 2
+    ids = [e["compound_id"] for e in out["emails"]]
+    assert ids == ["cloudmail:5", "cloudmail:4"]
+    assert out["emails"][0]["from"] == "alice@x.com"
+    assert "preview" in out["emails"][0]
+    mgr.stop()
+
+
+def test_search_passes_filters_to_public_emaillist(tmp_path):
+    captured = {}
+    mgr, captured = make_manager(tmp_path, rows=[_row(7)], captured=captured)
+    out = mgr.handle({
+        "action": "search",
+        "subject": "invoice",
+        "send_email": "boss@x.com",
+        "time_sort": "asc",
+        "num": 2,
+        "size": 5,
+    })
+    assert out["status"] == "ok"
+    body = captured["emailList_body"]
+    assert body["subject"] == "invoice"
+    assert body["sendEmail"] == "boss@x.com"
+    assert body["timeSort"] == "asc"
+    assert body["num"] == 2 and body["size"] == 5
+    # None filters are dropped, not sent as null.
+    assert "content" not in body
+    mgr.stop()
+
+
+def test_read_by_compound_id_returns_full_content(tmp_path):
+    mgr, _ = make_manager(tmp_path, rows=[_row(11, text="full body here"), _row(10)])
+    out = mgr.handle({"action": "read", "id": "cloudmail:11"})
+    assert out["status"] == "ok"
+    assert out["email"]["email_id"] == 11
+    assert out["email"]["text"] == "full body here"
+    assert out["email"]["content"] == "<p>full body here</p>"
+    mgr.stop()
+
+
+def test_read_missing_id_is_clear_error(tmp_path):
+    mgr, _ = make_manager(tmp_path, rows=[_row(1)])
+    out = mgr.handle({"action": "read", "id": "cloudmail:999"})
+    assert out["status"] == "error"
+    assert "not found" in out["error"]
+    mgr.stop()
+
+
+# ---------------------------------------------------------------------------
+# Manager: accounts redaction
+# ---------------------------------------------------------------------------
+
+def test_accounts_status_is_redacted(tmp_path):
+    mgr, _ = make_manager(tmp_path, account_overrides={
+        "user_email": "user@example.com",
+        "user_password": "userpw",
+        "send_account_id": 3,
+        "allowed_senders": ["A@X.com"],
+    })
+    out = mgr.handle({"action": "accounts"})
+    assert out["status"] == "ok"
+    blob = json.dumps(out)
+    # No secrets anywhere in the status payload.
+    assert "adminpw" not in blob
+    assert "userpw" not in blob
+    acct = out["accounts"][0]
+    assert acct["alias"] == "cloudmail"
+    assert acct["can_send"] is True
+    assert acct["send_account_id"] == 3
+    mgr.stop()
+
+
+# ---------------------------------------------------------------------------
+# Manager: send
+# ---------------------------------------------------------------------------
+
+def test_send_without_user_creds_errors_with_guidance(tmp_path):
+    mgr, _ = make_manager(tmp_path)  # no user creds
+    out = mgr.handle({"action": "send", "address": "x@y.com", "message": "hi"})
+    assert out["status"] == "error"
+    assert "user_email" in out["error"] and "user_password" in out["error"]
+    mgr.stop()
+
+
+def test_send_builds_expected_payload_and_uses_jwt(tmp_path):
+    captured = {}
+    mgr, captured = make_manager(
+        tmp_path, captured=captured,
+        account_overrides={
+            "user_email": "user@example.com",
+            "user_password": "userpw",
+            "send_account_id": 1,
+        },
+    )
+    out = mgr.handle({
+        "action": "send",
+        "address": ["to1@x.com", "to2@x.com"],
+        "subject": "Subject",
+        "message": "plain body",
+        "name": "Agent",
+    })
+    assert out["status"] == "ok"
+    assert out["sent_to"] == ["to1@x.com", "to2@x.com"]
+    # JWT header (raw, not Bearer) used for /email/send.
+    assert captured["send_auth"] == USER_JWT
+    body = captured["send_body"]
+    assert body["accountId"] == 1
+    assert body["receiveEmail"] == ["to1@x.com", "to2@x.com"]
+    assert body["subject"] == "Subject"
+    assert body["text"] == "plain body"
+    assert body["content"] == "plain body"  # falls back to text when no html
+    assert body["attachments"] == []
+    mgr.stop()
+
+
+def test_send_rejects_attachments_first_pass(tmp_path):
+    mgr, _ = make_manager(
+        tmp_path,
+        account_overrides={
+            "user_email": "user@example.com",
+            "user_password": "userpw",
+            "send_account_id": 1,
+        },
+    )
+    out = mgr.handle({
+        "action": "send", "address": "x@y.com", "message": "hi",
+        "attachments": [{"name": "a.pdf"}],
+    })
+    assert out["status"] == "error"
+    assert "attachments are not supported" in out["error"]
+    mgr.stop()
+
+
+# ---------------------------------------------------------------------------
+# Polling / LICC
+# ---------------------------------------------------------------------------
+
+def test_first_poll_seeds_without_licc_flood(tmp_path):
+    events = []
+    transport, _ = make_router(rows=[_row(3), _row(2), _row(1)])
+    mgr = CloudMailManager(
+        accounts=[{
+            "alias": "cloudmail",
+            "base_url": "https://mail.example.com",
+            "admin_email": "admin@example.com",
+            "admin_password": "adminpw",
+        }],
+        working_dir=tmp_path,
+        on_inbound=lambda ev: events.append(ev),
+        transport=transport,
+    )
+    acct = mgr.default_account
+    pushed = mgr.poll_once(acct)
+    assert pushed == 0  # first run seeds silently
+    assert events == []
+    # Watermark recorded at the highest emailId, marked seeded.
+    assert acct.watermark.last_email_id == 3
+    assert acct.watermark.seeded is True
+    mgr.stop()
+
+
+def test_second_poll_pushes_only_new_email(tmp_path):
+    events = []
+    captured = {}
+    rows = [_row(3), _row(2), _row(1)]
+    transport, captured = make_router(rows=rows, captured=captured)
+    mgr = CloudMailManager(
+        accounts=[{
+            "alias": "cloudmail",
+            "base_url": "https://mail.example.com",
+            "admin_email": "admin@example.com",
+            "admin_password": "adminpw",
+        }],
+        working_dir=tmp_path,
+        on_inbound=lambda ev: events.append(ev),
+        transport=transport,
+    )
+    acct = mgr.default_account
+    mgr.poll_once(acct)  # seed at 3
+    # A new email arrives.
+    rows.insert(0, _row(4, sender="new@x.com", subject="fresh", text="brand new"))
+    pushed = mgr.poll_once(acct)
+    assert pushed == 1
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["from"] == "new@x.com"
+    assert ev["subject"] == "fresh"
+    md = ev["metadata"]
+    assert md["source"] == "cloud_mail"
+    assert md["event_type"] == "email"
+    assert md["account"] == "cloudmail"
+    assert md["email_id"] == 4
+    assert md["compound_id"] == "cloudmail:4"
+    assert acct.watermark.last_email_id == 4
+    mgr.stop()
+
+
+def test_notify_existing_pushes_on_first_poll(tmp_path):
+    events = []
+    transport, _ = make_router(rows=[_row(2), _row(1)])
+    mgr = CloudMailManager(
+        accounts=[{
+            "alias": "cloudmail",
+            "base_url": "https://mail.example.com",
+            "admin_email": "admin@example.com",
+            "admin_password": "adminpw",
+            "notify_existing": True,
+        }],
+        working_dir=tmp_path,
+        on_inbound=lambda ev: events.append(ev),
+        transport=transport,
+    )
+    pushed = mgr.poll_once(mgr.default_account)
+    assert pushed == 2
+    # delivered oldest-first
+    assert [e["metadata"]["email_id"] for e in events] == [1, 2]
+    mgr.stop()
+
+
+def test_allowed_senders_filter_case_insensitive(tmp_path):
+    events = []
+    rows = [_row(1)]
+    transport, _ = make_router(rows=rows)
+    mgr = CloudMailManager(
+        accounts=[{
+            "alias": "cloudmail",
+            "base_url": "https://mail.example.com",
+            "admin_email": "admin@example.com",
+            "admin_password": "adminpw",
+            "allowed_senders": ["Allowed@X.com"],
+        }],
+        working_dir=tmp_path,
+        on_inbound=lambda ev: events.append(ev),
+        transport=transport,
+    )
+    acct = mgr.default_account
+    mgr.poll_once(acct)  # seed at 1
+    # Disallowed sender — must be filtered, but watermark still advances.
+    rows.insert(0, _row(2, sender="stranger@x.com"))
+    assert mgr.poll_once(acct) == 0
+    assert events == []
+    assert acct.watermark.last_email_id == 2
+    # Allowed sender (different case) — delivered.
+    rows.insert(0, _row(3, sender="ALLOWED@x.COM"))
+    assert mgr.poll_once(acct) == 1
+    assert len(events) == 1
+    mgr.stop()
+
+
+# ---------------------------------------------------------------------------
+# Config loading / path resolution
+# ---------------------------------------------------------------------------
+
+def test_load_config_resolves_relative_to_agent_dir(tmp_path, monkeypatch):
+    cfg = {"accounts": [{"alias": "a", "base_url": "https://m.example.com"}]}
+    (tmp_path / "cm.json").write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path))
+    monkeypatch.setenv("LINGTAI_CLOUD_MAIL_CONFIG", "cm.json")
+    loaded = cm_server.load_config()
+    assert loaded == cfg
+    accts = cm_server.accounts_from_config(loaded)
+    assert accts[0]["base_url"] == "https://m.example.com"
+
+
+def test_load_config_missing_env_errors(monkeypatch):
+    monkeypatch.delenv("LINGTAI_CLOUD_MAIL_CONFIG", raising=False)
+    with pytest.raises(ValueError) as ei:
+        cm_server.load_config()
+    assert "LINGTAI_CLOUD_MAIL_CONFIG" in str(ei.value)
+
+
+def test_accounts_from_config_flat_single_account():
+    out = cm_server.accounts_from_config({"base_url": "https://m.example.com", "alias": "x"})
+    assert out == [{"base_url": "https://m.example.com", "alias": "x"}]
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+def test_catalog_contains_cloud_mail():
+    catalog_path = Path(__file__).resolve().parents[1] / "src" / "lingtai" / "mcp_catalog.json"
+    catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    assert "cloud_mail" in catalog
+    entry = catalog["cloud_mail"]
+    assert entry["name"] == "cloud_mail"
+    assert entry["args"] == ["-m", "lingtai.mcp_servers.cloud_mail"]
+    assert entry["transport"] == "stdio"
+    assert "cloud-mail" in entry["homepage"]

--- a/tests/test_cloud_mail_addon.py
+++ b/tests/test_cloud_mail_addon.py
@@ -60,6 +60,15 @@ def make_router(rows=None, *, captured=None):
                 return httpx.Response(200, json={"code": 401, "message": "missing public token"})
             return _ok(list(rows))
 
+        if path == "/public/addUser":
+            captured["addUser_auth"] = auth
+            captured["addUser_body"] = body
+            if auth != PUBLIC_TOKEN:
+                return httpx.Response(200, json={"code": 401, "message": "missing public token"})
+            if not isinstance(body.get("list"), list):
+                return httpx.Response(200, json={"code": 400, "message": "missing user list"})
+            return _ok(None)
+
         if path == "/login":
             captured["login_body"] = body
             if body.get("email") == "user@example.com" and body.get("password") == "userpw":
@@ -413,6 +422,22 @@ def test_allowed_senders_filter_case_insensitive(tmp_path):
     assert mgr.poll_once(acct) == 1
     assert len(events) == 1
     mgr.stop()
+
+
+def test_add_user_uses_cloud_mail_batch_contract(tmp_path):
+    mgr, captured = make_manager(tmp_path)
+    out = mgr.handle({
+        "action": "add_user",
+        "email": "new@example.com",
+        "password": "secretpw",
+        "role_name": "member",
+    })
+    assert out["status"] == "ok"
+    assert out["added"] == "new@example.com"
+    assert captured["addUser_auth"] == PUBLIC_TOKEN
+    assert captured["addUser_body"] == {
+        "list": [{"email": "new@example.com", "password": "secretpw", "roleName": "member"}]
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a first-party curated `cloud_mail` MCP addon for maillab/cloud-mail (REST API, not IMAP/SMTP)
- expose an omnibus `cloud_mail` tool with `check`, `search`, `read`, `send`, `accounts`, and `add_user`
- add public-token polling with LICC inbox events, redacted account status, config docs, catalog entry, console script, and focused tests

Fixes Lingtai-AI/lingtai#262.

## Validation
- `python -m compileall -q src/lingtai/mcp_servers/cloud_mail`
- `pytest -q tests/test_cloud_mail_addon.py` → 19 passed
- `pytest -q -k "catalog or decompress"` → 14 passed
- JSON/TOML parse check for `src/lingtai/mcp_catalog.json` and `pyproject.toml`
- `git diff --check`

## Report
- `reports/cloud-mail-addon-20260613.html`

## Notes
- no live Cloud Mail instance was contacted; network behavior is covered with `httpx.MockTransport` based on the upstream source API shape
- attachments are explicitly unsupported in this first pass
- `send` requires user credentials and `send_account_id`; read/check/search/poll work through the public API token
