### PR TITLE
Add bash harness subskills for coding CLIs

### DIFF
--- a/reports/bash-harness-skills-explainer.html
+++ b/reports/bash-harness-skills-explainer.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Bash Harness Skills Migration — Kernel</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;margin:0;background:#f7f7fb;color:#172033;line-height:1.55}main{max-width:1100px;margin:0 auto;padding:36px 24px}h1{font-size:34px;margin:0 0 8px}h2{margin-top:28px;border-bottom:1px solid #d9deea;padding-bottom:6px}.card{background:white;border:1px solid #dfe4ee;border-radius:14px;padding:18px;margin:14px 0;box-shadow:0 1px 8px rgba(20,30,60,.06)}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}.pill{display:inline-block;border-radius:999px;padding:3px 10px;font-size:12px;font-weight:700;margin:2px}.done{background:#e7f7ed;color:#146c2e}.candidate{background:#fff5d8;color:#7b4d00}.moved{background:#e8f0ff;color:#1c4ca3}.warn{background:#fdecec;color:#a12626}code{background:#eef2f7;padding:2px 5px;border-radius:5px}table{border-collapse:collapse;width:100%;background:white;border-radius:12px;overflow:hidden}th,td{border:1px solid #dfe4ee;padding:10px;text-align:left;vertical-align:top}th{background:#eef2fb}</style>
+</head>
+<body><main>
+<h1>Bash Harness Skills Migration — Kernel PR</h1>
+<p><span class="pill done">validated</span><span class="pill moved">bash-manual owns CLI subprocess docs</span><span class="pill candidate">candidate harness matrix included</span></p>
+<div class="card"><strong>Summary.</strong> This branch moves coding-agent CLI guidance out of the general Swiss Knife utility router and into <code>bash-manual</code>, where long-running shell subprocess discipline lives. The daemon manual remains focused on daemon API integration and now cross-links to the bash subskills.</div>
+<h2>What changed in kernel</h2>
+<ul>
+<li>Added bash-manual subskills for existing supported CLI agents: Claude Code, OpenAI Codex, OpenCode, Cursor Agent, MiMo Code, Qwen Code, and Oh-My-Pi.</li>
+<li>Added candidate-harness bash subskills for Gemini CLI, Aider, Goose, OpenHands, Charm Crush, and Zed/ACP.</li>
+<li>Updated <code>src/lingtai/core/bash/manual/SKILL.md</code> catalog/router and long-running CLI guidance.</li>
+<li>Updated <code>src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md</code> with a responsibility split: daemon backend contract here, shell subprocess recipes in bash-manual.</li>
+<li>Expanded <code>tests/test_skills.py</code> to ensure all new bash references are copied with intrinsic manuals.</li>
+</ul>
+<h2>Harness matrix</h2>
+<table><thead><tr><th>Harness</th><th>Status</th><th>Why</th></tr></thead><tbody>
+<tr><td>Claude Code</td><td><span class="pill done">supported / moved</span></td><td>Existing CLI workflow; moved from Swiss Knife to <code>bash-claude-code</code>.</td></tr>
+<tr><td>OpenAI Codex</td><td><span class="pill done">supported / moved</span></td><td>Existing CLI workflow; moved to <code>bash-openai-codex</code>.</td></tr>
+<tr><td>OpenCode</td><td><span class="pill done">supported / moved</span></td><td>Existing CLI workflow; moved to <code>bash-opencode</code>.</td></tr>
+<tr><td>Cursor Agent</td><td><span class="pill done">documented</span></td><td>Already represented in daemon backend guidance; now has bash subprocess checklist.</td></tr>
+<tr><td>MiMo Code / Qwen Code / Oh-My-Pi</td><td><span class="pill done">documented</span></td><td>Recent daemon backends now have matching bash harness subskills.</td></tr>
+<tr><td>Gemini CLI</td><td><span class="pill candidate">candidate</span></td><td>Docs indicate non-interactive prompt mode, approval flags, and resume support; promote only after exact command/session parsing tests.</td></tr>
+<tr><td>Aider / Goose / OpenHands / Crush</td><td><span class="pill candidate">candidate docs-first</span></td><td>Each has headless/scriptable signals, but daemon promotion needs exact current command and resume behavior.</td></tr>
+<tr><td>Zed / ACP</td><td><span class="pill candidate">ecosystem bridge</span></td><td>Useful integration layer, not a direct backend unless a headless ACP client command is chosen.</td></tr>
+</tbody></table>
+<h2>Validation</h2>
+<ul>
+<li><code>git diff --check</code> — passed in kernel worktree.</li>
+<li><code>pytest -q tests/test_skills.py</code> — <strong>23 passed</strong>.</li>
+</ul>
+<h2>Review notes</h2>
+<p>No speculative daemon backend was added in this branch. Candidate harnesses are documented as bash subskills first so future backend promotion can be tested against stable command/session contracts.</p>
+</main></body></html>

--- a/src/lingtai/core/bash/manual/SKILL.md
+++ b/src/lingtai/core/bash/manual/SKILL.md
@@ -2,7 +2,8 @@
 name: bash-manual
 description: >
   **Read this before running long-lived agent/coding CLIs (`claude -p`,
-  `codex exec`, `opencode run`, Cursor agent CLI), or before setting up cron,
+  `codex exec`, `opencode run`, Cursor Agent, Gemini CLI, Aider, Goose,
+  OpenHands, Crush, or similar harnesses), or before setting up cron,
   launchd, systemd timers, crontab jobs, or scheduled reminders.** Router for
   Bash-related operational depth beyond the bash tool schema: async + poll
   discipline for long-running child agents, host-scheduler setup, LingTai
@@ -10,7 +11,7 @@ description: >
   reminders, debugging silent jobs, and safe cleanup. Start here for any
   long-running agent CLI, time-driven recurring work ("every hour", "weekdays at
   9", "remind me later"), or when a scheduled job misbehaves.
-version: 1.4.0
+version: 1.5.0
 ---
 
 # Bash Manual — Router
@@ -49,13 +50,76 @@ files, not standalone top-level skills.
     Debugging and cleanup for scheduled jobs: scheduler fired, script ran, work
     landed, agent saw mail, worked launchd diagnosis, retiring cron jobs, and
     bash work footprint hygiene.
+- name: bash-claude-code
+  location: reference/bash-claude-code/SKILL.md
+  description: |
+    Claude Code CLI as a long-running bash subprocess: explicit model selection,
+    async/poll discipline, allowed tools, JSON output, and stuck-run recovery.
+- name: bash-openai-codex
+  location: reference/bash-openai-codex/SKILL.md
+  description: |
+    OpenAI Codex CLI (`codex exec`) subprocess usage: sandbox/approval flags,
+    model selection, async handling, and automation caveats.
+- name: bash-opencode
+  location: reference/bash-opencode/SKILL.md
+  description: |
+    OpenCode CLI (`opencode run` / `opencode serve`) subprocess usage, provider
+    configuration, JSON output, session caveats, and daemon-harness notes.
+- name: bash-cursor-agent
+  location: reference/bash-cursor-agent/SKILL.md
+  description: |
+    Cursor Agent CLI subprocess usage and daemon-harness checks.
+- name: bash-mimocode
+  location: reference/bash-mimocode/SKILL.md
+  description: |
+    MiMo Code CLI subprocess usage; provider discovery stays with swiss-knife,
+    while shell execution hygiene lives here.
+- name: bash-qwen-code
+  location: reference/bash-qwen-code/SKILL.md
+  description: |
+    Qwen Code CLI subprocess usage and daemon-harness checks.
+- name: bash-oh-my-pi
+  location: reference/bash-oh-my-pi/SKILL.md
+  description: |
+    Oh-My-Pi / Pi Coding Agent (`omp`) subprocess usage, JSON mode, approval
+    mode, and session-resume caveats.
+- name: bash-gemini-cli
+  location: reference/bash-gemini-cli/SKILL.md
+  description: |
+    Gemini CLI as a candidate coding harness: non-interactive prompt mode,
+    approval flags, resume questions, and promotion checklist.
+- name: bash-aider
+  location: reference/bash-aider/SKILL.md
+  description: |
+    Aider as a scriptable coding harness: `--message` mode, git behavior,
+    one-shot automation, and daemon suitability caveats.
+- name: bash-goose
+  location: reference/bash-goose/SKILL.md
+  description: |
+    Goose CLI as a candidate coding harness: session/no-session modes and
+    daemon promotion checklist.
+- name: bash-openhands
+  location: reference/bash-openhands/SKILL.md
+  description: |
+    OpenHands CLI headless mode as a candidate harness: `--task`/`--file`, JSONL,
+    dependency footprint, and daemon promotion checklist.
+- name: bash-crush
+  location: reference/bash-crush/SKILL.md
+  description: |
+    Charm Crush CLI as a candidate harness: `crush run`, permission/session
+    questions, and daemon promotion checklist.
+- name: bash-zed-acp
+  location: reference/bash-zed-acp/SKILL.md
+  description: |
+    Zed/ACP external-agent bridge notes: ecosystem integration, not a direct
+    daemon backend unless a headless ACP client command is available.
 ```
 
 ## Router table
 
 | Need / keywords | Read |
 |---|---|
-| Running a long-running agent/coding CLI as a sub-process: `claude -p`, `codex exec`, `opencode run`, Cursor agent CLI; "run an agent in the background"; avoid blocking the turn | "Core rules to keep resident" below (use `bash(async=true)` + poll) |
+| Running a long-running agent/coding CLI as a sub-process: `claude -p`, `codex exec`, `opencode run`, Cursor Agent, MiMo Code, Qwen Code, Oh-My-Pi, Gemini CLI, Aider, Goose, OpenHands, Crush; "run an agent in the background"; avoid blocking the turn | `reference/bash-claude-code/SKILL.md`, `reference/bash-openai-codex/SKILL.md`, `reference/bash-opencode/SKILL.md`, or the matching `reference/bash-*/SKILL.md`; keep the core async/poll rules below resident |
 | Human asks for time-driven recurring work: "every hour", "daily", "weekdays at 9", "write/check/send on a schedule"; choose cron vs event watcher; create launchd/systemd/crontab wiring; understand wake-by-mailbox-drop; write scheduler prompt/script hygiene | `reference/scheduled-work/SKILL.md` |
 | Need a one-shot reminder or wakeup nudge while work is pending; `.notification/cron.json`; atomic reminder writer; rest checklist | `reference/notification-reminders/SKILL.md` |
 | Scheduled job is silent, fires twice, exits immediately, gets killed by launchd, fails to deliver mail, or must be retired/cleaned up | `reference/debugging-cleanup/SKILL.md` |
@@ -66,7 +130,8 @@ files, not standalone top-level skills.
    `grep`, a quick build)? Use `bash` synchronously; this manual is not needed
    unless the command is risky, scheduled, or failing mysteriously.
 2. **Long-running agent/coding CLI** (`claude -p`, `codex exec`, `opencode run`,
-   Cursor agent CLI, or any sub-agent that may think/run tools for minutes)?
+   Cursor Agent, MiMo Code, Qwen Code, Oh-My-Pi, Gemini CLI, Aider, Goose,
+   OpenHands, Crush, or any sub-agent that may think/run tools for minutes)?
    **Never run it synchronously.** Use `bash(async=true)` and poll — see the
    resident rule below.
 3. **Time itself is the trigger?** Read `reference/scheduled-work/SKILL.md`.

--- a/src/lingtai/core/bash/manual/reference/bash-aider/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-aider/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash-aider
+description: >
+  Nested bash-manual reference for Aider CLI. Read this when you need to run,
+  validate, or document `aider` as a long-running shell subprocess or LingTai
+  daemon harness candidate.
+version: 0.1.0
+---
+
+# Aider CLI
+
+Nested bash-manual reference. This page owns **shell execution hygiene** for
+`aider`: command shape, async/poll discipline, approval flags, session/resume
+caveats, and whether the CLI is ready for a LingTai daemon backend.
+
+## Status
+
+Candidate harness. Official scripting docs support `--message`; it is strong for one-shot code edits but resume semantics differ from daemon ask.
+
+## Command shape
+
+```bash
+aider --message "<prompt>"
+```
+
+Before relying on the command in production, run the current CLI's `--help` and
+prefer `bash(async=true)` for work that can think, edit files, or run tools for
+minutes. Do not run long coding CLIs synchronously from the parent turn.
+
+## LingTai daemon notes
+
+- A daemon backend needs a deterministic non-interactive start command.
+- `ask`/resume needs a stable session id and a tested resume command.
+- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
+  tests pin the output contract.
+- If any of those are missing, keep the CLI as a documented bash harness rather
+  than adding a speculative daemon backend.
+
+## Validation checklist
+
+1. `command -v aider` or documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
+   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/bash/manual/reference/bash-claude-code/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-claude-code/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: bash-claude-code
+description: >
+  Nested bash-manual reference for Claude Code CLI. Delegate code implementation, patch writing, documentation, and refactoring to
+  Claude Code CLI (Anthropic's coding agent). Runs non-interactively from bash,
+  uses the human's Claude Max subscription (no additional API costs), and supports
+  quality/effort/budget controls. Use this when you need to write code, generate
+  patches, refactor files, create documentation, or do any multi-file code work
+  that would be faster delegated than done manually.
+version: 1.0.2
+tags: [cli, code, delegation, claude, implementation]
+---
+
+# Claude Code CLI — Code Delegation
+
+> Ownership: this CLI-agent reference now lives under `bash-manual`
+> because the workflow is executed as a long-running shell subprocess.
+> It was moved from `swiss-knife` during the bash harness migration.
+
+Delegate code work to [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — Anthropic's coding agent — running non-interactively from bash.
+
+## Prerequisites
+
+- Claude Code installed: `which claude` → `/Users/huangzesen/.local/bin/claude`
+- Uses the human's **Claude Max subscription** — no additional API costs
+- Rate limit tier: `default_claude_max_20x` (effectively unlimited for typical use)
+
+## Quick Usage
+
+```bash
+env \
+  -u CLAUDE_CODE_OAUTH_TOKEN \
+  -u ANTHROPIC_API_KEY \
+  -u ANTHROPIC_AUTH_TOKEN \
+  -u ANTHROPIC_BASE_URL \
+  -u ANTHROPIC_MODEL \
+  -u ANTHROPIC_SMALL_FAST_MODEL \
+  claude -p "your prompt here" --dangerously-skip-permissions
+```
+
+This runs Claude Code in non-interactive mode (`-p` = print and exit), skipping permission checks for automation.
+
+> **Agent responsiveness rule:** long synchronous `claude -p` jobs in an agent's main turn are **strongly discouraged**. The Claude CLI itself is synchronous: `claude -p` starts a subprocess, waits until the work is done, prints stdout, and exits. If you run that subprocess through a normal blocking bash tool call, the whole agent is blocked until it returns: the agent cannot answer new human messages, cannot checkpoint progress, and appears "stuck" even though the process is alive. Use inline `claude -p` only for short, bounded jobs where waiting inline is acceptable. For PR-sized, multi-file, exploratory, or 15+ minute work, prefer the LingTai daemon Claude-Code backend; if you must use the CLI, wrap it in an explicitly supervised background/async job with logs, timeout, and recovery instructions.
+
+### Weekly-limit smoke test
+
+If `claude` reports `You've hit your weekly limit` from inside LingTai but the human recently refreshed Claude Code OAuth credentials, first rule out a stale inherited env token before concluding the subscription is truly exhausted:
+
+```bash
+# Do not print token values. This only removes the stale override for the child.
+env -u CLAUDE_CODE_OAUTH_TOKEN claude -p 'Reply exactly OK' --allowedTools Read -c
+```
+
+If this succeeds while plain `claude -p ...` fails, use the sanitized `env -u ...` wrapper above (and prefer the daemon `claude-code` backend, which strips the override automatically).
+
+> **Why the `env -u …` prefix?** If `ANTHROPIC_API_KEY` (or related `ANTHROPIC_*` variables) is set in the agent environment, the `claude` CLI **prefers the API-key billing path over the Claude Max subscription/OAuth token**. That path can fail with `Credit balance is too low` and bills the API key instead of using the subscription. Separately, a stale inherited `CLAUDE_CODE_OAUTH_TOKEN` can override a refreshed `~/.claude/.credentials.json` and make Claude Code falsely report `You've hit your weekly limit`. Unsetting these variables for the child process forces Claude Code onto the current first-party OAuth/subscription credentials. If you've confirmed your environment has no auth overrides, you can drop the `env -u …` prefix; when in doubt, keep it. **Never echo the variable values while diagnosing — they are secrets.**
+
+### Find and remove the stale-token source
+
+The smoke test above proves a child process can work when the bad override is removed. To make the fix durable, find where the variable is being exported and remove or comment out that source. Common places are shell startup files (`~/.zshrc`, `~/.zprofile`, `~/.bashrc`, `~/.bash_profile`) or launch-service environment configuration.
+
+Safe diagnostic commands:
+
+```bash
+# 1. Check whether macOS launchd is injecting it. Do not print token values.
+if launchctl getenv CLAUDE_CODE_OAUTH_TOKEN >/dev/null 2>&1; then
+  echo "launchctl may define CLAUDE_CODE_OAUTH_TOKEN"
+fi
+
+# 2. Search shell startup files for the variable name, not the value.
+grep -n 'CLAUDE_CODE_OAUTH_TOKEN\|ANTHROPIC_API_KEY\|ANTHROPIC_AUTH_TOKEN' \
+  ~/.zshenv ~/.zprofile ~/.zshrc ~/.bash_profile ~/.bashrc ~/.profile 2>/dev/null
+
+# 3. Verify a clean future shell does not recreate the variable.
+env -u CLAUDE_CODE_OAUTH_TOKEN /bin/zsh -lc \
+  'test -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" && echo NOT_SET || echo STILL_SET'
+```
+
+If the variable is hard-coded in a shell startup file, comment out only that export line and keep a backup. A plain `claude` process can then use Claude Code's own refreshed local OAuth credentials instead of a stale environment override. Already-running LingTai agents may still have inherited the old environment until they are refreshed or restarted; for those current processes, keep using the `env -u ...` child-process wrapper.
+
+## CLI vs Daemon — Which to Use
+
+LingTai exposes Claude Code in two forms. They are **not interchangeable** — pick the one whose shape matches the work.
+
+### CLI (`claude -p ...` via bash)
+
+A single synchronous subprocess. You wait for it to finish, you get one transcript, the conversation ends when the bash call returns.
+
+**Use the CLI when:**
+- The task is **one-off** and you want the result inline — a typo fix, a single-file refactor, generating a snippet
+- You want the output **threaded back into your current reasoning** (you'll read the diff and decide next steps yourself)
+- The task is **quick** (under a few minutes), budget-bounded, and has an explicit bash timeout
+- You only need **one** of these running at a time
+
+**Synchronous CLI is strongly discouraged when:**
+- The work is PR-sized, branch-producing, exploratory, or likely to run 15+ minutes
+- The human is waiting for responsiveness or may send follow-up instructions
+- A stalled subprocess would make the parent agent look dead
+- You need progress checkpoints, retries, or the ability to inspect/interrupt work independently
+
+`claude -p` does not provide its own async/job protocol. "Async" means a LingTai or OS wrapper around the CLI (for example bash `async=true`, a supervised background job, or an independent daemon/backend), and that wrapper must own logs, timeout, cancellation, and recovery notes.
+
+**Examples:**
+```bash
+# Fix a typo
+claude -p "fix the typo in line 42 of README.md" --dangerously-skip-permissions
+
+# Generate a small patch you'll review immediately
+claude -p "add a --verbose flag to the build script" --dangerously-skip-permissions
+
+# Quick documentation pass on one file
+claude -p "add docstrings to utils/parser.py" --dangerously-skip-permissions
+```
+
+### Daemon (LingTai `daemon` capability with `backend="claude-code"`)
+
+A persistent agent spawned by the LingTai kernel. Runs in its **own worktree**, with its **own context window**, on its **own branch**. You dispatch it, it works asynchronously, you come back and review the diff.
+
+**Use the daemon when:**
+- You need to run **multiple tasks in parallel** — three disjoint refactors at once, batch validation across N files
+- The task is **complex or multi-step** — designing then implementing, exploring then refactoring — and you want a fresh context window dedicated to it (not competing with your conversation history)
+- You need **context isolation** — the daemon shouldn't see (and shouldn't pollute) your current session's context
+- The work runs **long enough** that a synchronous bash call would be awkward — large refactors, multi-file feature implementations, PR composition
+- You're acting as an **orchestrator** — planning and reviewing, not hand-coding (see the LingTai contributing guide's orchestrator-and-daemons discipline)
+
+**Examples of daemon-shaped work:**
+- "Implement the caching layer in `feat/cache` branch, with tests, and open a PR" — long, multi-step, deserves its own worktree
+- Three parallel skill rewrites that don't share files — dispatch three daemons, review three diffs
+- An exploratory refactor where you don't want intermediate steps cluttering your conversation
+- A "fire-and-check-back-later" task
+
+### Quick decision rule
+
+| Signal | Pick |
+|--------|------|
+| "I want the answer in this conversation, now" | **CLI** |
+| "I want to do three of these at once" | **Daemon** (one per task) |
+| "I'll review a diff afterward, not the transcript" | **Daemon** |
+| "The output is a small string/snippet I'll paste somewhere" | **CLI** |
+| "This might block my main turn while a human waits" | **Daemon** or supervised background wrapper |
+| "This will take 15+ minutes and produce a branch" | **Daemon** |
+| "I'm the orchestrator; the daemon is the worker" | **Daemon** |
+
+When in doubt for non-trivial work: daemon. The orchestrator/daemon split is the project's default discipline — see `utilities/lingtai-dev-guide/reference/contributing/SKILL.md` for the full convention.
+
+## Key Flags
+
+| Flag | Purpose |
+|------|---------|
+| `-p` / `--print` | Non-interactive mode — run, print result, exit |
+| `--dangerously-skip-permissions` | Skip permission prompts (required for automation) |
+| `--effort max` | Maximum reasoning effort for complex tasks |
+| `--model opus` | Use Opus model for highest quality |
+| `--model sonnet` | Use Sonnet model for speed (default) |
+| `--max-budget-usd N` | Spending limit per call |
+| `--allowedTools "Bash Edit Read Write"` | Restrict which tools Claude can use |
+| `--system-prompt "..."` | Custom system prompt |
+| `--add-dir /path/to/dir` | Grant access to additional directories |
+| `-d /path/to/repo` | Set working directory |
+
+## Recommended Patterns
+
+### Simple task (default quality)
+```bash
+claude -p "fix the typo in README.md" --dangerously-skip-permissions
+```
+
+### Bounded implementation (max quality, still short)
+
+Use this shape only when you expect the task to finish quickly enough that blocking the current turn is acceptable. If it is PR-sized or exploratory, prefer a daemon; if you must use CLI anyway, run it through a supervised background wrapper rather than a blocking main-turn bash call.
+
+```bash
+# Run inside a bash tool call with an explicit timeout, e.g. timeout=300.
+claude -p "implement the small caching helper described in DESIGN.md" \
+  --dangerously-skip-permissions \
+  --effort max \
+  --model opus
+```
+
+### With budget control
+```bash
+claude -p "refactor the auth module" \
+  --dangerously-skip-permissions \
+  --effort max \
+  --model opus \
+  --max-budget-usd 5.0
+```
+
+### Working in a specific repo
+```bash
+claude -p "add unit tests for the parser module" \
+  --dangerously-skip-permissions \
+  -d /path/to/repo
+```
+
+### Restricted tools (safer)
+```bash
+claude -p "generate a patch for issue #42" \
+  --dangerously-skip-permissions \
+  --allowedTools "Bash Edit Read Write"
+```
+
+## Best Practices
+
+1. **Keep synchronous calls short and explicitly timed**: Claude Code has no built-in timeout; the bash tool's timeout controls it. For inline `claude -p`, set a short explicit timeout (for example 300 seconds). Solving a long task by raising the synchronous timeout to 15+ minutes while the main agent waits is strongly discouraged.
+
+2. **Prefer daemon or supervised background execution for long or PR-sized work**: If the task is complex, multi-file, branch-producing, or exploratory, dispatch it to the LingTai daemon Claude-Code backend or another independently inspectable supervised wrapper. The parent agent should stay responsive and able to report progress. Remember: the wrapper is asynchronous; `claude -p` itself is not.
+
+3. **Checkpoint before delegation**: For any task that might outlive the current turn, write the worktree, branch, goal, and recovery instructions to pad or a journal before dispatching.
+
+4. **Use `--effort max` for complex work**: This tells Claude to think harder. Worth it for architecture, refactoring, and multi-file changes — but complexity is also a signal to avoid synchronous `claude -p` in the main turn.
+
+5. **Use `--model opus` for quality**: Opus produces better code for complex logic. Use Sonnet (default) for simple tasks.
+
+6. **Split large tasks**: Multiple smaller, bounded `claude -p` calls are safer than one monolithic prompt. If the steps still take long or need a branch, prefer a daemon or supervised background wrapper.
+
+7. **Write clear prompts**: Claude Code reads the repo context itself. Give it the goal, constraints, and acceptance criteria — don't dump the entire codebase into the prompt.
+
+8. **Set budget for unknown tasks**: Use `--max-budget-usd` to prevent runaway spending on ambiguous tasks.
+
+## Workflow for Patch/PR Creation
+
+1. **Design**: Write a clear spec (what to change, why, constraints)
+2. **Choose execution shape**: quick, bounded patch → `claude -p` with an explicit short bash timeout; PR-sized or long-running work → LingTai daemon Claude-Code backend or a supervised background wrapper, not a blocking main-turn subprocess
+3. **Delegate**: run the chosen workflow with clear constraints and a recovery checkpoint
+4. **Review**: Check the output, run tests
+5. **Push**: Create branch, commit, push as PR
+
+## What to Delegate
+
+- **Code implementation**: New features, bug fixes, refactoring
+- **Patch generation**: Multi-file changes, API migrations
+- **Documentation**: READMEs, docstrings, API docs
+- **Test writing**: Unit tests, integration tests
+- **Code review**: Ask Claude to review a PR or diff
+
+## What NOT to Delegate
+
+- **Simple one-line edits**: Use the `edit` tool directly
+- **File reading/searching**: Use `read`/`grep`/`glob` directly
+- **Shell commands**: Use `bash` directly for non-code tasks
+- **Tasks requiring your full context**: Claude Code doesn't share your conversation history
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| Timeout after 30s | For a genuinely short inline task, set an explicit modest bash timeout (for example 300s). For long/complex work, prefer a daemon or supervised background wrapper instead of blocking the agent turn. |
+| Agent appears stuck while `claude -p` runs | You likely used synchronous CLI for work that should have been daemon-backed or supervised in the background. Inspect/kill the child if needed, then resume with a non-blocking wrapper. |
+| Claude Code not found | Check `which claude` → `/Users/huangzesen/.local/bin/claude` |
+| Permission errors | Always include `--dangerously-skip-permissions` |
+| Output truncated | Check if Claude hit the budget limit |
+| Rate limited | Wait and retry; Max tier has generous limits |
+| `Credit balance is too low` despite Claude Code subscription/OAuth being authenticated | `ANTHROPIC_API_KEY` (or another `ANTHROPIC_*` variable) is set and is overriding the OAuth/subscription path. Wrap the call with `env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_BASE_URL -u ANTHROPIC_MODEL -u ANTHROPIC_SMALL_FAST_MODEL claude …` so the child process uses the OAuth/subscription path. Do **not** print the variable values while diagnosing — only their presence/length. |
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/src/lingtai/core/bash/manual/reference/bash-crush/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-crush/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash-crush
+description: >
+  Nested bash-manual reference for Charm Crush CLI. Read this when you need to run,
+  validate, or document `crush` as a long-running shell subprocess or LingTai
+  daemon harness candidate.
+version: 0.1.0
+---
+
+# Charm Crush CLI
+
+Nested bash-manual reference. This page owns **shell execution hygiene** for
+`crush`: command shape, async/poll discipline, approval flags, session/resume
+caveats, and whether the CLI is ready for a LingTai daemon backend.
+
+## Status
+
+Candidate harness. Docs describe non-interactive `crush run`; verify permission/session flags before daemon integration.
+
+## Command shape
+
+```bash
+crush run "<prompt>"
+```
+
+Before relying on the command in production, run the current CLI's `--help` and
+prefer `bash(async=true)` for work that can think, edit files, or run tools for
+minutes. Do not run long coding CLIs synchronously from the parent turn.
+
+## LingTai daemon notes
+
+- A daemon backend needs a deterministic non-interactive start command.
+- `ask`/resume needs a stable session id and a tested resume command.
+- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
+  tests pin the output contract.
+- If any of those are missing, keep the CLI as a documented bash harness rather
+  than adding a speculative daemon backend.
+
+## Validation checklist
+
+1. `command -v crush` or documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
+   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/bash/manual/reference/bash-cursor-agent/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-cursor-agent/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash-cursor-agent
+description: >
+  Nested bash-manual reference for Cursor Agent CLI. Read this when you need to run,
+  validate, or document `cursor-agent` as a long-running shell subprocess or LingTai
+  daemon harness candidate.
+version: 0.1.0
+---
+
+# Cursor Agent CLI
+
+Nested bash-manual reference. This page owns **shell execution hygiene** for
+`cursor-agent`: command shape, async/poll discipline, approval flags, session/resume
+caveats, and whether the CLI is ready for a LingTai daemon backend.
+
+## Status
+
+Use for Cursor Agent CLI subprocesses and daemon backend checks. Prefer async bash; verify `cursor-agent --help` because CLI flags vary.
+
+## Command shape
+
+```bash
+cursor-agent --print <prompt>
+```
+
+Before relying on the command in production, run the current CLI's `--help` and
+prefer `bash(async=true)` for work that can think, edit files, or run tools for
+minutes. Do not run long coding CLIs synchronously from the parent turn.
+
+## LingTai daemon notes
+
+- A daemon backend needs a deterministic non-interactive start command.
+- `ask`/resume needs a stable session id and a tested resume command.
+- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
+  tests pin the output contract.
+- If any of those are missing, keep the CLI as a documented bash harness rather
+  than adding a speculative daemon backend.
+
+## Validation checklist
+
+1. `command -v cursor-agent` or documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
+   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/bash/manual/reference/bash-gemini-cli/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-gemini-cli/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash-gemini-cli
+description: >
+  Nested bash-manual reference for Gemini CLI. Read this when you need to run,
+  validate, or document `gemini` as a long-running shell subprocess or LingTai
+  daemon harness candidate.
+version: 0.1.0
+---
+
+# Gemini CLI
+
+Nested bash-manual reference. This page owns **shell execution hygiene** for
+`gemini`: command shape, async/poll discipline, approval flags, session/resume
+caveats, and whether the CLI is ready for a LingTai daemon backend.
+
+## Status
+
+Candidate harness. Public docs indicate non-interactive prompt mode, YOLO approval, and resume support; add daemon backend only after exact command/session parsing is verified.
+
+## Command shape
+
+```bash
+gemini -p "<prompt>" / gemini --prompt "<prompt>"
+```
+
+Before relying on the command in production, run the current CLI's `--help` and
+prefer `bash(async=true)` for work that can think, edit files, or run tools for
+minutes. Do not run long coding CLIs synchronously from the parent turn.
+
+## LingTai daemon notes
+
+- A daemon backend needs a deterministic non-interactive start command.
+- `ask`/resume needs a stable session id and a tested resume command.
+- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
+  tests pin the output contract.
+- If any of those are missing, keep the CLI as a documented bash harness rather
+  than adding a speculative daemon backend.
+
+## Validation checklist
+
+1. `command -v gemini` or documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
+   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/bash/manual/reference/bash-goose/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-goose/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash-goose
+description: >
+  Nested bash-manual reference for Goose CLI. Read this when you need to run,
+  validate, or document `goose` as a long-running shell subprocess or LingTai
+  daemon harness candidate.
+version: 0.1.0
+---
+
+# Goose CLI
+
+Nested bash-manual reference. This page owns **shell execution hygiene** for
+`goose`: command shape, async/poll discipline, approval flags, session/resume
+caveats, and whether the CLI is ready for a LingTai daemon backend.
+
+## Status
+
+Candidate harness. Docs mention start/resume sessions and `--no-session`; exact headless command should be verified before backend implementation.
+
+## Command shape
+
+```bash
+goose run/session commands (verify current `goose --help`)
+```
+
+Before relying on the command in production, run the current CLI's `--help` and
+prefer `bash(async=true)` for work that can think, edit files, or run tools for
+minutes. Do not run long coding CLIs synchronously from the parent turn.
+
+## LingTai daemon notes
+
+- A daemon backend needs a deterministic non-interactive start command.
+- `ask`/resume needs a stable session id and a tested resume command.
+- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
+  tests pin the output contract.
+- If any of those are missing, keep the CLI as a documented bash harness rather
+  than adding a speculative daemon backend.
+
+## Validation checklist
+
+1. `command -v goose` or documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
+   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/bash/manual/reference/bash-mimocode/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-mimocode/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash-mimocode
+description: >
+  Nested bash-manual reference for MiMo Code CLI. Read this when you need to run,
+  validate, or document `mimocode / mimo` as a long-running shell subprocess or LingTai
+  daemon harness candidate.
+version: 0.1.0
+---
+
+# MiMo Code CLI
+
+Nested bash-manual reference. This page owns **shell execution hygiene** for
+`mimocode / mimo`: command shape, async/poll discipline, approval flags, session/resume
+caveats, and whether the CLI is ready for a LingTai daemon backend.
+
+## Status
+
+Use for Xiaomi MiMo Code subprocesses. Keep provider/model credential discovery in `swiss-knife` xiaomi-mimo; this page only owns shell execution hygiene.
+
+## Command shape
+
+```bash
+mimocode <prompt> (daemon backend uses the tested command shape in daemon docs)
+```
+
+Before relying on the command in production, run the current CLI's `--help` and
+prefer `bash(async=true)` for work that can think, edit files, or run tools for
+minutes. Do not run long coding CLIs synchronously from the parent turn.
+
+## LingTai daemon notes
+
+- A daemon backend needs a deterministic non-interactive start command.
+- `ask`/resume needs a stable session id and a tested resume command.
+- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
+  tests pin the output contract.
+- If any of those are missing, keep the CLI as a documented bash harness rather
+  than adding a speculative daemon backend.
+
+## Validation checklist
+
+1. `command -v mimocode` or documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
+   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/bash/manual/reference/bash-oh-my-pi/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-oh-my-pi/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash-oh-my-pi
+description: >
+  Nested bash-manual reference for Oh-My-Pi CLI. Read this when you need to run,
+  validate, or document `omp` as a long-running shell subprocess or LingTai
+  daemon harness candidate.
+version: 0.1.0
+---
+
+# Oh-My-Pi CLI
+
+Nested bash-manual reference. This page owns **shell execution hygiene** for
+`omp`: command shape, async/poll discipline, approval flags, session/resume
+caveats, and whether the CLI is ready for a LingTai daemon backend.
+
+## Status
+
+Use for Pi Coding Agent / Oh-My-Pi subprocesses. Daemon ask/resume uses `--session <id>` once the runner has captured the first session id.
+
+## Command shape
+
+```bash
+omp --mode json --approval-mode yolo <prompt>
+```
+
+Before relying on the command in production, run the current CLI's `--help` and
+prefer `bash(async=true)` for work that can think, edit files, or run tools for
+minutes. Do not run long coding CLIs synchronously from the parent turn.
+
+## LingTai daemon notes
+
+- A daemon backend needs a deterministic non-interactive start command.
+- `ask`/resume needs a stable session id and a tested resume command.
+- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
+  tests pin the output contract.
+- If any of those are missing, keep the CLI as a documented bash harness rather
+  than adding a speculative daemon backend.
+
+## Validation checklist
+
+1. `command -v omp` or documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
+   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/bash/manual/reference/bash-openai-codex/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-openai-codex/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: bash-openai-codex
+description: >
+  Nested bash-manual reference for OpenAI Codex CLI. Manual (not a tool) for OpenAI Codex CLI — OpenAI's coding agent that runs
+  locally from your terminal. Built in Rust for speed and efficiency. Supports
+  headless remote control, Vim editing, plugin management, hooks, and Chrome
+  browser integration. Read this when the human asks to use OpenAI Codex CLI,
+  wants to compare it with Claude Code, or needs help with installation and
+  configuration.
+version: 1.0.1
+---
+
+# OpenAI Codex CLI
+
+> Ownership: this CLI-agent reference now lives under `bash-manual`
+> because the workflow is executed as a long-running shell subprocess.
+> It was moved from `swiss-knife` during the bash harness migration.
+
+> **OpenAI's coding agent — run locally from your terminal.**
+> Built in Rust for speed. Open source. ~4 million weekly active users (as of April 2026).
+
+## CLI vs Daemon — Which to Use
+
+LingTai exposes Codex in two forms. They are **not interchangeable** — pick the one whose shape matches the work.
+
+### CLI (`codex exec ...` via bash)
+
+A single synchronous subprocess. You wait for it to finish, you get one transcript back, the conversation ends when the bash call returns.
+
+> **Agent responsiveness rule:** long synchronous `codex exec` jobs in an agent's main turn are **strongly discouraged**. The Codex CLI command is a blocking subprocess from the parent agent's point of view: if you run it through a normal blocking bash tool call, the whole agent is blocked until it returns. The agent cannot answer new human messages, cannot checkpoint progress, and appears "stuck" even though the process is alive. Use inline `codex exec` only for short, bounded jobs where waiting inline is acceptable. For PR-sized, multi-file, exploratory, or 15+ minute work, prefer the LingTai daemon Codex backend; if you must use the CLI, wrap it in an explicitly supervised background/async job with logs, timeout, and recovery instructions.
+
+**Use the CLI when:**
+- The task is **one-off** and you want the result inline — a tightly-scoped edit, a single deterministic refactor, a quick mechanical pass
+- You want the output **threaded back into your current reasoning** (you'll read it and decide next steps yourself)
+- The task is **quick**, well-bounded, and has an explicit bash timeout
+- You only need **one** of these running at a time
+
+**Synchronous CLI is strongly discouraged when:**
+- The work is PR-sized, branch-producing, exploratory, or likely to run 15+ minutes
+- The human is waiting for responsiveness or may send follow-up instructions
+- A stalled subprocess would make the parent agent look dead
+- You need progress checkpoints, retries, or the ability to inspect/interrupt work independently
+
+`codex exec` does not provide a LingTai job protocol by itself. "Async" means a LingTai or OS wrapper around the CLI (for example bash `async=true`, a supervised background job, or an independent daemon/backend), and that wrapper must own logs, timeout, cancellation, and recovery notes.
+
+**Examples:**
+```bash
+# Rename a symbol across a small file
+codex exec "rename the function foo() to fooBar() in utils/helpers.py"
+
+# Mechanical lint-style pass
+codex exec --model gpt-5.5 "remove unused imports from src/main.py"
+
+# Quick scoped fix
+codex exec --dir /path/to/project "fix the off-by-one in parse_range()"
+```
+
+### Daemon (LingTai `daemon` capability with `backend="codex"`)
+
+A persistent agent spawned by the LingTai kernel. Runs in its **own worktree**, with its **own context window**, on its **own branch**. You dispatch it, it works asynchronously, you come back and review the diff.
+
+**Use the daemon when:**
+- You need to run **multiple tasks in parallel** — several disjoint deterministic refactors at once, a batch validation sweep
+- The task is **complex or multi-step** enough to deserve a fresh context window dedicated to it (not competing with your conversation history)
+- You need **context isolation** — the daemon shouldn't see (and shouldn't pollute) your current session's context
+- The work runs **long enough** that a synchronous bash call would be awkward — wide mechanical refactors, multi-file deterministic diffs, validation passes that touch the whole tree
+- You're acting as an **orchestrator** — planning and reviewing, not hand-coding (see the LingTai contributing guide's orchestrator-and-daemons discipline)
+
+Per the LingTai dev guide, Codex daemons are particularly good for **tightly-scoped diffs, deterministic refactors, and mechanical validation passes** — they're more conservative than Claude Code daemons and are the right choice when the change is well-specified and the scope is clear.
+
+**Examples of daemon-shaped work:**
+- "Apply this codemod across `src/**/*.ts` and open a PR" — wide, mechanical, deserves its own worktree
+- Three parallel deterministic refactors that don't share files — dispatch three daemons, review three diffs
+- A validation sweep over the repo that produces a report and (optionally) fixes
+- A "fire-and-check-back-later" task
+
+### Quick decision rule
+
+| Signal | Pick |
+|--------|------|
+| "I want the answer in this conversation, now" | **CLI** |
+| "I want to do three of these at once" | **Daemon** (one per task) |
+| "I'll review a diff afterward, not the transcript" | **Daemon** |
+| "The output is a small string/snippet I'll paste somewhere" | **CLI** |
+| "This might block my main turn while a human waits" | **Daemon** or supervised background wrapper |
+| "This will take 15+ minutes and produce a branch" | **Daemon** |
+| "I'm the orchestrator; the daemon is the worker" | **Daemon** |
+
+### Codex vs Claude Code (same axis)
+
+Both backends are available as CLI and daemon. The CLI-vs-daemon choice is about **shape of work** (one-shot vs parallel/long/isolated). The Codex-vs-Claude-Code choice is about **style of work**:
+
+- **Codex daemons** — tightly-scoped diffs, deterministic refactors, mechanical validation
+- **Claude Code daemons** — exploratory code reading, multi-file edits, skill/doc work, PR composition
+
+When in doubt for non-trivial work: daemon. See `utilities/lingtai-dev-guide/reference/contributing/SKILL.md` for the full orchestrator/daemon convention.
+
+## Agent Responsiveness Practices
+
+1. **Keep synchronous calls short and explicitly timed**: For inline `codex exec`, set a short explicit bash timeout appropriate to the scoped task. Solving a long task by raising the synchronous timeout to 15+ minutes while the main agent waits is strongly discouraged.
+
+2. **Prefer daemon or supervised background execution for long or PR-sized work**: If the task is complex, multi-file, branch-producing, exploratory, or a wide validation sweep, dispatch it to the LingTai daemon Codex backend or another independently inspectable supervised wrapper. The parent agent should stay responsive and able to report progress. Remember: the wrapper is asynchronous; the CLI subprocess itself is not a LingTai job.
+
+3. **Checkpoint before delegation**: For any task that might outlive the current turn, write the worktree, branch, goal, and recovery instructions to pad or a journal before dispatching.
+
+4. **Split large tasks**: Multiple smaller, bounded `codex exec` calls are safer than one monolithic prompt. If the steps still take long or need a branch, prefer a daemon or supervised background wrapper.
+
+
+## Installation
+
+```bash
+npm install -g @openai/codex@0.130.0
+```
+
+Update existing installation:
+```bash
+codex update
+# or
+npm i -g @openai/codex@latest
+```
+
+## Configuration
+
+### API Key
+Set your OpenAI API key:
+```bash
+export OPENAI_API_KEY="your-api-key"
+```
+
+Or configure in `~/.codex/config.toml`:
+```toml
+[api]
+key = "your-api-key"
+```
+
+### Models
+Codex CLI supports multiple models:
+- GPT-5.5 (latest, recommended)
+- GPT-5.4
+- GPT-5.3-Codex (specialized for coding)
+
+Configure in `config.toml`:
+```toml
+[model]
+default = "gpt-5.5"
+```
+
+### Bedrock Auth
+For AWS Bedrock, use console-login credentials:
+```bash
+aws login
+codex exec "your prompt"
+```
+
+## Key Features
+
+### 1. Remote Control
+New in 0.130.0 — headless, remotely controllable app-server:
+```bash
+codex remote-control
+```
+- Start a headless app-server
+- Control Codex remotely
+- Page large threads with different view modes (unloaded/summary/full)
+
+### 2. Vim Editing
+Full Vim modal editing in the TUI:
+```bash
+codex exec "your prompt"
+# In TUI:
+/vim                    # Toggle Vim mode
+:set default-mode=insert  # Set default mode
+```
+
+### 3. Plugin Management
+Workspace sharing and marketplace:
+```bash
+codex plugins list      # List installed plugins
+codex plugins install   # Install from marketplace
+codex plugins share     # Share with workspace
+```
+
+Features:
+- Workspace sharing with access controls
+- Source filtering and local share path tracking
+- Marketplace removal/upgrades
+- Remote bundle sync
+- Admin-disabled status handling
+
+### 4. Hooks
+Browseable and toggleable hooks:
+```bash
+codex hooks list        # List available hooks
+codex hooks toggle      # Toggle hook on/off
+```
+
+Capabilities:
+- Before/after compaction support
+- PreToolUse context injection
+- Codex Apps auth integration
+- MCP elicitations through TUI/Guardian flows
+
+### 5. Chrome Extension
+Browser integration without takeover:
+- Works in parallel across tabs
+- Background operation
+- User controls which websites Codex can use
+- Install from Chrome Web Store
+
+### 6. App-Server
+Thread management and pagination:
+```bash
+codex exec "your prompt"
+# In TUI:
+# - Resume/fork picker
+# - Raw scrollback mode
+# - /ide context injection
+# - /diff workspace-aware diffing
+```
+
+## Usage Examples
+
+### Basic Usage
+```bash
+# Start interactive session
+codex exec "Create a Python script that reads CSV files"
+
+# With specific model
+codex exec --model gpt-5.5 "Refactor this function"
+
+# In specific directory
+codex exec --dir /path/to/project "Fix the bug in main.py"
+```
+
+### Remote Control
+```bash
+# Start headless server
+codex remote-control
+
+# Connect from another terminal
+codex connect localhost:8080
+```
+
+### Plugin Management
+```bash
+# List plugins
+codex plugins list
+
+# Install plugin
+codex plugins install @openai/plugin-name
+
+# Share with workspace
+codex plugins share ./my-plugin
+```
+
+### Hooks
+```bash
+# List hooks
+codex hooks list
+
+# Toggle hook
+codex hooks toggle my-hook
+
+# Run with hooks
+codex exec --hooks my-hook "your prompt"
+```
+
+## Integration with LingTai
+
+### Workflow Integration
+Codex CLI can be used alongside Claude Code for different tasks:
+
+| Task | Claude Code | OpenAI Codex |
+|------|-------------|--------------|
+| Complex reasoning | ✅ Excellent | ✅ Good |
+| Local file operations | ✅ Good | ✅ Excellent |
+| Browser integration | ❌ No | ✅ Chrome extension |
+| Remote control | ❌ No | ✅ Yes |
+| Plugin ecosystem | ❌ Limited | ✅ Rich marketplace |
+
+### When to Use Codex CLI
+- **Browser automation**: Use Chrome extension for web tasks
+- **Remote development**: Use remote-control for headless operation
+- **Plugin ecosystem**: Leverage marketplace for specialized tools
+- **Vim users**: Native Vim editing support
+
+### When to Use Claude Code
+- **Complex reasoning**: Deep analysis and multi-step problem solving
+- **LingTai integration**: Native integration with LingTai kernel
+- **Cost efficiency**: Uses Claude Max subscription
+
+## Comparison with Claude Code
+
+| Feature | OpenAI Codex CLI | Claude Code |
+|---------|------------------|-------------|
+| Language | Rust | TypeScript |
+| Open Source | ✅ Yes | ❌ No |
+| Vim Support | ✅ Native | ❌ No |
+| Browser Extension | ✅ Chrome | ❌ No |
+| Remote Control | ✅ Yes | ❌ No |
+| Plugin Marketplace | ✅ Rich | ❌ Limited |
+| LingTai Integration | ❌ No | ✅ Native |
+| Cost | API usage | Claude Max subscription |
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Installation fails**
+   ```bash
+   # Clear npm cache
+   npm cache clean --force
+   # Reinstall
+   npm install -g @openai/codex@0.130.0
+   ```
+
+2. **API key not found**
+   ```bash
+   # Check environment variable
+   echo $OPENAI_API_KEY
+   # Or check config file
+   cat ~/.codex/config.toml
+   ```
+
+3. **Plugin installation fails**
+   ```bash
+   # Check marketplace connectivity
+   codex plugins search
+   # Clear plugin cache
+   rm -rf ~/.codex/plugins/cache
+   ```
+
+4. **Agent appears stuck while `codex exec` runs**
+   - You likely used synchronous CLI for work that should have been daemon-backed or supervised in the background.
+   - Inspect the child process and worktree. If needed, kill the child so the blocking bash call returns.
+   - Resume with the LingTai daemon Codex backend or a supervised background wrapper that records logs, timeout, cancellation path, and recovery notes.
+
+## Resources
+
+- **GitHub**: https://github.com/openai/codex
+- **Documentation**: https://developers.openai.com/codex
+- **Changelog**: https://developers.openai.com/codex/changelog
+- **Chrome Extension**: Available on Chrome Web Store
+
+## Version History
+
+- **0.130.0** (May 8, 2026): Remote control, plugin hooks, Bedrock auth
+- **0.129.0** (May 7, 2026): Vim editing, Chrome extension, plugin management
+- **0.128.0** (May 5, 2026): /goal command, Ralph loop
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/src/lingtai/core/bash/manual/reference/bash-openai-codex/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-openai-codex/SKILL.md
@@ -8,6 +8,7 @@ description: >
   wants to compare it with Claude Code, or needs help with installation and
   configuration.
 version: 1.0.1
+tags: [cli, code, delegation, openai, codex]
 ---
 
 # OpenAI Codex CLI
@@ -299,7 +300,7 @@ Codex CLI can be used alongside Claude Code for different tasks:
 | Browser Extension | ✅ Chrome | ❌ No |
 | Remote Control | ✅ Yes | ❌ No |
 | Plugin Marketplace | ✅ Rich | ❌ Limited |
-| LingTai Integration | ❌ No | ✅ Native |
+| LingTai Integration | ✅ Daemon backend + bash subskill | ✅ Daemon backend + bash subskill |
 | Cost | API usage | Claude Max subscription |
 
 ## Troubleshooting

--- a/src/lingtai/core/bash/manual/reference/bash-opencode/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-opencode/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: bash-opencode
+description: >
+  Nested bash-manual reference for OpenCode CLI. Manual (not a tool) for OpenCode CLI — an open-source terminal coding agent
+  that runs locally, supports 75+ LLM providers through Models.dev, and can be
+  scripted with `opencode run` or served through a reusable headless backend.
+  Read this when the human asks to use OpenCode as a CLI tool, compare it with
+  Claude Code or Codex, configure providers/agents/MCPs, or run non-interactive
+  coding tasks from bash.
+version: 1.0.0
+tags: [cli, code, delegation, opencode, automation]
+---
+
+# OpenCode CLI — Local Coding Agent
+
+> Ownership: this CLI-agent reference now lives under `bash-manual`
+> because the workflow is executed as a long-running shell subprocess.
+> It was moved from `swiss-knife` during the bash harness migration.
+
+OpenCode is an open-source coding agent with a terminal UI plus scriptable CLI commands. Use it when you want a provider-flexible local coding agent that can run one-off prompts, reuse a headless server to avoid cold starts, or work with custom OpenCode agents and MCP servers.
+
+Official docs: <https://opencode.ai/docs/cli/>
+
+## Prerequisites
+
+```bash
+# Official install script
+curl -fsSL https://opencode.ai/install | bash
+
+# Or install with a Node.js package manager
+npm install -g opencode-ai      # also works with bun/pnpm/yarn
+
+# Confirm it is on PATH
+opencode --version
+```
+
+Authenticate at least one provider before relying on it for work:
+
+```bash
+opencode auth login          # interactive provider selection
+opencode auth login -p openai
+opencode auth list           # or: opencode auth ls
+```
+
+OpenCode stores provider credentials in `~/.local/share/opencode/auth.json`. It also loads provider keys from the environment and from a project `.env` file.
+
+## CLI vs Long-Running Work
+
+This sub-skill is about using OpenCode directly from the shell. For longer work, first check whether your active LingTai daemon schema explicitly supports an OpenCode backend; otherwise supervise OpenCode through bash/worktrees.
+
+### CLI (`opencode run ...` via bash)
+
+A single synchronous subprocess. You wait for it to finish, review its transcript/diff, and decide the next step in your own context.
+
+**Use the CLI when:**
+- The task is **one-off** and bounded: a small edit, quick code review, narrow documentation pass, or a question about a repo.
+- You want the result **threaded back into your current reasoning** instead of launching a background worker.
+- You need a specific OpenCode flag, provider/model, agent, attached file, or headless-server attachment.
+- You only need **one** OpenCode run at a time.
+
+**Examples:**
+
+```bash
+# Quick answer without opening the TUI
+opencode run "Explain how this parser is structured"
+
+# Run in a specific repository
+opencode run --dir /path/to/repo "Fix the typo in README.md"
+
+# Pick a provider/model explicitly (format: provider/model)
+opencode run --model openai/gpt-5.5 "Review the auth module for race conditions"
+
+# Ask for raw JSON events, useful for scripts
+opencode run --format json "Summarize the public API changes"
+```
+
+### Long-running work from the CLI
+
+This sub-skill documents OpenCode as a direct CLI. Some LingTai installations may also expose external coding CLIs through `daemon` backends, but do not assume an OpenCode daemon is available unless the active `daemon` tool schema explicitly lists `backend="opencode"`.
+
+If `backend="opencode"` is available, use the daemon for parallel or long-running worker tasks that should be tracked outside your current context. If it is not available, keep OpenCode CLI work supervised from bash:
+
+- create a disposable git worktree;
+- run `opencode run --dir /path/to/worktree ...` with a generous bash timeout or async bash job;
+- periodically inspect `git diff`, captured stdout/stderr, and test output yourself;
+- commit only after review.
+
+**Quick decision rule:**
+
+| Signal | Pick |
+|--------|------|
+| “I need the answer inline now” | **CLI** |
+| “Use this exact OpenCode model/agent/flag” | **CLI** |
+| “I want to attach to a warm OpenCode server” | **CLI** |
+| “Run three disjoint coding tasks at once” | **Daemon only if `backend="opencode"` is present; otherwise separate supervised worktrees/async bash jobs** |
+| “This may take 15+ minutes and produce a branch/diff” | **Daemon if supported; otherwise supervised CLI in a worktree** |
+
+## Key Commands
+
+| Command | Purpose |
+|---------|---------|
+| `opencode` or `opencode [project]` | Start the terminal UI in the current/project directory |
+| `opencode run [message...]` | Run non-interactively and exit |
+| `opencode serve` | Start a headless HTTP server for API/attached runs |
+| `opencode attach [url]` | Attach a terminal to an existing backend server |
+| `opencode auth login/list/logout` | Manage provider credentials |
+| `opencode agent create/list` | Manage custom OpenCode agents |
+| `opencode mcp add/list/auth/logout/debug` | Manage MCP servers |
+| `opencode models` / `opencode models --refresh` | List or refresh provider/model cache |
+| `opencode github install/run` | Install or run the GitHub agent workflow |
+
+## Important `opencode run` Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--dir DIR` | Run in a directory (or remote path when using `--attach`) |
+| `--model PROVIDER/MODEL` / `-m` | Choose model, e.g. `openai/gpt-5.5`, `anthropic/claude-sonnet-4-5` |
+| `--variant VALUE` | Provider-specific reasoning effort / model variant |
+| `--agent NAME` | Use a named OpenCode agent |
+| `--file PATH` / `-f` | Attach file(s) to the message |
+| `--format json` | Emit raw JSON events for scripts |
+| `--continue` / `-c` | Continue the last session |
+| `--session ID` / `-s` | Continue a specific session |
+| `--fork` | Fork when continuing a session |
+| `--share` | Share the session |
+| `--title TITLE` | Set session title |
+| `--attach URL` | Attach the run to an existing `opencode serve` backend |
+| `--thinking` | Show thinking blocks if the provider exposes them |
+| `--dangerously-skip-permissions` | Auto-approve permissions not explicitly denied. Dangerous; only use in an externally sandboxed worktree. |
+
+Run `opencode run --help` before depending on flags in automation; OpenCode is moving quickly.
+
+## Recommended Patterns
+
+### 1. Safe one-off read/review
+
+```bash
+cd /path/to/repo
+opencode run "Review the uncommitted diff for correctness. Do not modify files. Return actionable findings only."
+```
+
+### 2. Small automated edit in a worktree
+
+```bash
+git worktree add -b fix/readme-typo /tmp/fix-readme origin/main
+cd /tmp/fix-readme
+opencode run --dangerously-skip-permissions \
+  "Fix the README typo, run relevant formatting checks, and summarize the diff."
+```
+
+Review the diff yourself before committing.
+
+### 3. Warm server for repeated calls
+
+Starting a fresh OpenCode run can cold-boot MCP servers. For many short calls, keep a server warm:
+
+```bash
+# Terminal/session 1: save the generated password where another shell can read it
+pwfile=/tmp/opencode-server-password
+openssl rand -hex 16 > "$pwfile"
+chmod 600 "$pwfile"
+OPENCODE_SERVER_PASSWORD="$(cat "$pwfile")" opencode serve --port 4096
+
+# Terminal/session 2: read the same password
+opencode run --attach http://localhost:4096 \
+  --password "$(cat /tmp/opencode-server-password)" \
+  --dir /path/to/repo \
+  "Explain async/await in this codebase"
+```
+
+### 4. Continue or fork a session
+
+```bash
+# Continue the last session
+opencode run --continue "Now add tests for the change"
+
+# Continue a specific session
+opencode run --session <session-id> "Apply the simpler approach we discussed"
+
+# Fork instead of mutating the prior session
+opencode run --session <session-id> --fork "Try an alternative implementation"
+```
+
+### 5. Custom agent with constrained permissions
+
+```bash
+mkdir -p .opencode/agent
+opencode agent create \
+  --path .opencode/agent/reviewer.md \
+  --description "Read-only reviewer for docs and code diffs" \
+  --mode primary \
+  --permissions read,grep,glob
+
+opencode run --agent reviewer "Review this diff; do not edit files."
+```
+
+`opencode agent create` denies any omitted permission in the generated agent frontmatter. Available permissions include `bash`, `read`, `edit`, `glob`, `grep`, `webfetch`, `task`, `todowrite`, `websearch`, `lsp`, and `skill`.
+
+## Best Practices
+
+1. **Use a clean worktree.** OpenCode can edit files. Isolate risky runs in `/tmp/...` worktrees so you can inspect or discard changes safely.
+2. **Prefer read-only prompts for review.** Say “Do not modify files” when you only want findings.
+3. **Set `--dir` explicitly.** Avoid running against the wrong repository when the bash working directory is ambiguous.
+4. **Use `--format json` for scripts.** Parse events rather than scraping terminal formatting.
+5. **Use `opencode serve` for batches.** A warm server avoids repeated MCP startup costs for many small calls.
+6. **Treat `--dangerously-skip-permissions` like `rm -rf` privileges.** Only use it inside an externally sandboxed repo/worktree, and still review the diff.
+7. **Refresh models when a provider changes.** `opencode models --refresh` updates the local cache from Models.dev.
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `opencode: command not found` | Install with `npm install -g opencode-ai`, then confirm `$(npm prefix -g)/bin` is on PATH (or use your package manager's global-bin command). |
+| No provider/model available | Run `opencode auth login`, check environment variables / project `.env`, then `opencode models --refresh`. |
+| Wrong repository edited | Stop, inspect `git diff`, and rerun with explicit `--dir /path/to/repo` in a disposable worktree. |
+| Permission prompts hang automation | Prefer a custom agent with explicit permissions; if externally sandboxed, use `--dangerously-skip-permissions`. |
+| Slow repeated calls | Use `opencode serve` and `opencode run --attach http://localhost:4096 ...`. |
+| Session continuation goes to wrong thread | Use `--session <id>` instead of `--continue`; add `--fork` for experiments. |
+
+---
+> **Found a bug or issue?** If you encounter any problems with this skill, load the `lingtai-issue-report` skill and follow its instructions to report it.

--- a/src/lingtai/core/bash/manual/reference/bash-openhands/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-openhands/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash-openhands
+description: >
+  Nested bash-manual reference for OpenHands CLI. Read this when you need to run,
+  validate, or document `openhands` as a long-running shell subprocess or LingTai
+  daemon harness candidate.
+version: 0.1.0
+---
+
+# OpenHands CLI
+
+Nested bash-manual reference. This page owns **shell execution hygiene** for
+`openhands`: command shape, async/poll discipline, approval flags, session/resume
+caveats, and whether the CLI is ready for a LingTai daemon backend.
+
+## Status
+
+Candidate harness. Docs mention headless mode with `--task`/`--file` and JSONL; dependency footprint is heavier, so document first unless tests can mock it safely.
+
+## Command shape
+
+```bash
+openhands --task "<prompt>" --json
+```
+
+Before relying on the command in production, run the current CLI's `--help` and
+prefer `bash(async=true)` for work that can think, edit files, or run tools for
+minutes. Do not run long coding CLIs synchronously from the parent turn.
+
+## LingTai daemon notes
+
+- A daemon backend needs a deterministic non-interactive start command.
+- `ask`/resume needs a stable session id and a tested resume command.
+- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
+  tests pin the output contract.
+- If any of those are missing, keep the CLI as a documented bash harness rather
+  than adding a speculative daemon backend.
+
+## Validation checklist
+
+1. `command -v openhands` or documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
+   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/bash/manual/reference/bash-qwen-code/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-qwen-code/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash-qwen-code
+description: >
+  Nested bash-manual reference for Qwen Code CLI. Read this when you need to run,
+  validate, or document `qwen-code / qwen` as a long-running shell subprocess or LingTai
+  daemon harness candidate.
+version: 0.1.0
+---
+
+# Qwen Code CLI
+
+Nested bash-manual reference. This page owns **shell execution hygiene** for
+`qwen-code / qwen`: command shape, async/poll discipline, approval flags, session/resume
+caveats, and whether the CLI is ready for a LingTai daemon backend.
+
+## Status
+
+Use for Qwen Code subprocesses. Verify installed CLI help before passing backend_options; do not confuse provider setup with shell execution.
+
+## Command shape
+
+```bash
+qwen-code <prompt> (daemon backend uses the tested command shape in daemon docs)
+```
+
+Before relying on the command in production, run the current CLI's `--help` and
+prefer `bash(async=true)` for work that can think, edit files, or run tools for
+minutes. Do not run long coding CLIs synchronously from the parent turn.
+
+## LingTai daemon notes
+
+- A daemon backend needs a deterministic non-interactive start command.
+- `ask`/resume needs a stable session id and a tested resume command.
+- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
+  tests pin the output contract.
+- If any of those are missing, keep the CLI as a documented bash harness rather
+  than adding a speculative daemon backend.
+
+## Validation checklist
+
+1. `command -v qwen-code` or documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
+   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/bash/manual/reference/bash-zed-acp/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-zed-acp/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash-zed-acp
+description: >
+  Nested bash-manual reference for Zed / ACP agent bridge. Read this when you need to run,
+  validate, or document `ACP servers` as a long-running shell subprocess or LingTai
+  daemon harness candidate.
+version: 0.1.0
+---
+
+# Zed / ACP agent bridge
+
+Nested bash-manual reference. This page owns **shell execution hygiene** for
+`ACP servers`: command shape, async/poll discipline, approval flags, session/resume
+caveats, and whether the CLI is ready for a LingTai daemon backend.
+
+## Status
+
+Ecosystem bridge rather than a daemon backend by itself. Document only unless there is a direct headless ACP client command to wrap.
+
+## Command shape
+
+```bash
+agent-specific ACP command
+```
+
+Before relying on the command in production, run the current CLI's `--help` and
+prefer `bash(async=true)` for work that can think, edit files, or run tools for
+minutes. Do not run long coding CLIs synchronously from the parent turn.
+
+## LingTai daemon notes
+
+- A daemon backend needs a deterministic non-interactive start command.
+- `ask`/resume needs a stable session id and a tested resume command.
+- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
+  tests pin the output contract.
+- If any of those are missing, keep the CLI as a documented bash harness rather
+  than adding a speculative daemon backend.
+
+## Validation checklist
+
+1. `command -v ACP` or documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
+   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/bash/manual/reference/bash-zed-acp/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-zed-acp/SKILL.md
@@ -38,8 +38,8 @@ minutes. Do not run long coding CLIs synchronously from the parent turn.
 
 ## Validation checklist
 
-1. `command -v ACP` or documented installation path exists.
-2. `--help` confirms the non-interactive command and approval flags.
+1. Identify the specific ACP-compatible client or server command you intend to wrap; ACP is a protocol, not a standalone `ACP` binary.
+2. Run that command's `--help` (or documented equivalent) to confirm non-interactive mode and approval flags.
 3. A dry-run in a disposable worktree exits non-interactively.
 4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
    session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -20,6 +20,32 @@ inspecting `daemon(action="list")`, or passing CLI flags through `backend_option
 (completed/failed/cancelled) emanations don't appear in `list` — find them by
 inspecting the agent's `daemons/` folder.
 
+
+## Bash harness subskills
+
+Daemon backend integration and user-facing shell execution guidance now split by
+ownership:
+
+- This page owns the daemon API contract: backend names, `daemon(...)` behavior,
+  `backend_options`, result/session capture, `ask`/resume, and backend-specific
+  parser caveats.
+- `bash-manual` owns the shell subprocess recipes for the underlying CLIs. Before
+  launching or troubleshooting a long-running coding CLI directly from bash,
+  read the matching nested bash reference:
+  - Claude Code: `bash-manual` → `reference/bash-claude-code/SKILL.md`
+  - OpenAI Codex: `bash-manual` → `reference/bash-openai-codex/SKILL.md`
+  - OpenCode: `bash-manual` → `reference/bash-opencode/SKILL.md`
+  - Cursor Agent: `bash-manual` → `reference/bash-cursor-agent/SKILL.md`
+  - MiMo Code: `bash-manual` → `reference/bash-mimocode/SKILL.md`
+  - Qwen Code: `bash-manual` → `reference/bash-qwen-code/SKILL.md`
+  - Oh-My-Pi / Pi Coding Agent: `bash-manual` →
+    `reference/bash-oh-my-pi/SKILL.md`
+
+Candidate harnesses that are not daemon backends yet (Gemini CLI, Aider, Goose,
+OpenHands, Crush, and Zed/ACP bridges) are tracked under `bash-manual` as
+`reference/bash-*/SKILL.md` pages until their command/session contracts are
+stable enough for backend promotion.
+
 ## CLI backends
 
 The `backend` parameter selects the execution engine for emanations. Default is

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -90,9 +90,42 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert "reference/scheduled-work/SKILL.md" in bash_body
         assert "reference/notification-reminders/SKILL.md" in bash_body
         assert "reference/debugging-cleanup/SKILL.md" in bash_body
+        for moved_reference in (
+            "reference/bash-claude-code/SKILL.md",
+            "reference/bash-openai-codex/SKILL.md",
+            "reference/bash-opencode/SKILL.md",
+            "reference/bash-cursor-agent/SKILL.md",
+            "reference/bash-mimocode/SKILL.md",
+            "reference/bash-qwen-code/SKILL.md",
+            "reference/bash-oh-my-pi/SKILL.md",
+            "reference/bash-gemini-cli/SKILL.md",
+            "reference/bash-aider/SKILL.md",
+            "reference/bash-goose/SKILL.md",
+            "reference/bash-openhands/SKILL.md",
+            "reference/bash-crush/SKILL.md",
+            "reference/bash-zed-acp/SKILL.md",
+        ):
+            assert moved_reference in bash_body
 
         bash_reference_dir = bash_md.parent / "reference"
-        for reference_name in ("scheduled-work", "notification-reminders", "debugging-cleanup"):
+        for reference_name in (
+            "scheduled-work",
+            "notification-reminders",
+            "debugging-cleanup",
+            "bash-claude-code",
+            "bash-openai-codex",
+            "bash-opencode",
+            "bash-cursor-agent",
+            "bash-mimocode",
+            "bash-qwen-code",
+            "bash-oh-my-pi",
+            "bash-gemini-cli",
+            "bash-aider",
+            "bash-goose",
+            "bash-openhands",
+            "bash-crush",
+            "bash-zed-acp",
+        ):
             bash_reference = bash_reference_dir / reference_name / "SKILL.md"
             assert bash_reference.is_file()
         assert "Nested bash-manual reference" in (


### PR DESCRIPTION
## Summary
- move coding-agent CLI subprocess guidance into `bash-manual` nested references
- add bash harness subskills for supported CLIs: Claude Code, Codex, OpenCode, Cursor Agent, MiMo Code, Qwen Code, and Oh-My-Pi
- add docs-first candidate harness pages for Gemini CLI, Aider, Goose, OpenHands, Crush, and Zed/ACP
- keep daemon-manual focused on daemon backend integration and cross-link to bash harness subskills
- add a self-contained explainer at `reports/bash-harness-skills-explainer.html`

## Validation
- `git diff --check`
- `pytest -q tests/test_skills.py` → 23 passed

## Companion PR
Companion TUI PR: https://github.com/Lingtai-AI/lingtai/pull/335
