### PR TITLE
docs: add system preset workflow reference

### DIFF
--- a/.library/intrinsic/capabilities/system/SKILL.md
+++ b/.library/intrinsic/capabilities/system/SKILL.md
@@ -29,6 +29,21 @@ version: 0.1.0
 
 The `system` tool's schema description lists each action in one line. This manual is the deeper reference: what each action actually does, when to reach for it, and the gotchas that don't fit in a schema string.
 
+## Nested reference catalog
+
+`system-manual` owns these nested references. They are parent-owned drill-down
+files, not standalone top-level skills.
+
+```yaml
+- name: system-preset-workflow
+  location: reference/preset-workflow/SKILL.md
+  description: |
+    Saved preset authorization and switching workflow: create/edit a saved
+    preset, add it to an agent's `manifest.preset.allowed[]`, refresh or swap,
+    verify with `system(action='presets')`, revert safely, and avoid changing
+    another agent's active preset when a daemon/avatar with the preset is enough.
+```
+
 ## refresh — rebuild from init.json
 
 `system(action='refresh')` is the **only way to reload your runtime**. There is no lighter alternative.
@@ -74,6 +89,12 @@ Pass `revert_preset=true` to swap back to your default preset (reads `manifest.p
 - **connectivity** field: `ok` (responsive, includes latency_ms), `no_credentials` (api_key_env is unset), or `unreachable` (network probe failed)
 
 Use this to decide what to swap into via `refresh(preset='<name>')`.
+
+### Saved preset authorization workflow
+
+For the full workflow, read `reference/preset-workflow/SKILL.md`. Keep the top
+level rule in mind: a saved preset file is not usable by an agent until that
+agent authorizes the preset path in `manifest.preset.allowed[]`, then refreshes.
 
 **Tier ladder** (from the `tier:*` tag):
 | Tier | Use for |

--- a/.library/intrinsic/capabilities/system/reference/preset-workflow/SKILL.md
+++ b/.library/intrinsic/capabilities/system/reference/preset-workflow/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: system-preset-workflow
+description: >
+  Nested system-manual reference — saved preset authorization and switching
+  workflow for LingTai agents. Read this when adding a new saved preset, making
+  it visible to an agent, swapping
+  an agent to that preset, verifying `system(action="presets")`, reverting, or
+  deciding whether to use a daemon/avatar instead of changing another agent's
+  active preset.
+version: 0.1.0
+tags: [system, presets, refresh, init-json, runtime, authorization]
+---
+
+# Saved preset authorization workflow
+
+Nested system-manual reference. Open this when the top-level `system-manual`
+routes you to the saved-preset authorization workflow. Preset files and runtime
+authorization are separate.
+
+A saved preset file can exist on disk (for example
+`~/.lingtai-tui/presets/saved/glm-5.2.json`) without being usable by a given
+agent. `system(action='presets')` only lists presets authorized for **this
+agent** in `init.json` under `manifest.preset.allowed[]`.
+
+This is deliberate: dropping a JSON file into the saved-preset shelf does not
+grant every agent permission to run it.
+
+## When to use this workflow
+
+Use this reference when a human asks you to:
+
+- add a new model/provider preset,
+- make a saved preset visible to an agent,
+- switch yourself or another agent to a preset,
+- test a preset briefly and then revert,
+- explain why `system(action='presets')` does not show a saved preset file, or
+- choose between changing an agent's active preset and using a daemon/avatar with
+  the desired preset.
+
+## 1. Create or edit the saved preset file
+
+Create the saved preset JSON file under the user's saved-preset shelf, commonly:
+
+```text
+~/.lingtai-tui/presets/saved/<name>.json
+```
+
+A typical saved preset contains:
+
+- `name`
+- `description.summary`
+- `manifest.llm` (`provider`, `model`, `base_url`, `api_key_env`, etc.)
+- `manifest.capabilities` (tools and capability config enabled by the preset)
+
+Example shape:
+
+```json
+{
+  "name": "glm-5.2",
+  "description": {
+    "summary": "Zhipu GLM 5.2 Coding Plan — OpenAI-compatible"
+  },
+  "manifest": {
+    "capabilities": {
+      "bash": { "yolo": true },
+      "daemon": {},
+      "email": {},
+      "file": {},
+      "skills": {
+        "paths": ["../.library_shared", "~/.lingtai-tui/utilities"]
+      }
+    },
+    "llm": {
+      "api_compat": "openai",
+      "api_key": null,
+      "api_key_env": "ZHIPU_API_KEY",
+      "base_url": "https://open.bigmodel.cn/api/coding/paas/v4",
+      "model": "GLM-5.2",
+      "provider": "zhipu"
+    }
+  }
+}
+```
+
+Prefer `api_key_env` over embedding secrets in the preset file.
+
+## 2. Authorize the preset for the target agent
+
+Edit the target agent's `init.json` and add the saved preset path to:
+
+```text
+manifest.preset.allowed[]
+```
+
+Example:
+
+```json
+{
+  "manifest": {
+    "preset": {
+      "allowed": [
+        "~/.lingtai-tui/presets/saved/codex.json",
+        "~/.lingtai-tui/presets/saved/glm-5.2.json"
+      ]
+    }
+  }
+}
+```
+
+Do **not** remove existing allowed presets just because you add a new one.
+
+## 3. Switch or refresh
+
+After the preset is allowed, choose one of these paths:
+
+### Switch in the refresh call
+
+```python
+system(action='refresh', preset='~/.lingtai-tui/presets/saved/glm-5.2.json')
+```
+
+### Or set active in `init.json`, then refresh
+
+Set:
+
+```text
+manifest.preset.active = "~/.lingtai-tui/presets/saved/glm-5.2.json"
+```
+
+Then call:
+
+```python
+system(action='refresh')
+```
+
+## 4. Verify
+
+After refresh, call:
+
+```python
+system(action='presets')
+```
+
+The preset should appear with provider/model, capabilities, and connectivity
+status.
+
+If `system(action='refresh', preset='...')` says the preset is not in the allowed
+list, do not keep retrying. Add the path to `manifest.preset.allowed[]`, then
+refresh or retry the swap.
+
+## 5. Revert
+
+To return to the default preset:
+
+```python
+system(action='refresh', revert_preset=true)
+```
+
+Or set `manifest.preset.active` back to the previous/default preset and refresh.
+
+## Safety notes
+
+- Do not overwrite another agent's active preset unless the human explicitly
+  asked for that target agent to switch.
+- If the task only needs a temporary model, prefer a daemon/avatar with that
+  preset rather than changing an agent's active preset.
+- Keep secrets out of preset files when possible; use `api_key_env` and the
+  agent/TUI environment file.
+- If current context exceeds the target preset's `context_limit`, refresh may be
+  refused with a "molt first" instruction. Molt, then retry.


### PR DESCRIPTION
## What changed

Refactors the saved-preset workflow into `system-manual`'s progressive-disclosure structure.

Top-level `system-manual` now only:

- adds a nested reference catalog entry for `system-preset-workflow`
- keeps a short pointer under the `presets` section

The full workflow lives in:

- `.library/intrinsic/capabilities/system/reference/preset-workflow/SKILL.md`

That nested reference documents:

- saved preset files vs per-agent runtime authorization
- `manifest.preset.allowed[]` as the reason a preset may not appear in `system(action='presets')`
- adding a saved preset path to an agent's `init.json`
- switching with `system(action='refresh', preset=...)` or `manifest.preset.active` + refresh
- verifying with `system(action='presets')`
- reverting with `revert_preset=true` or by restoring the previous active preset
- safety notes: don't change another agent's active preset unless explicitly asked; prefer daemon/avatar for temporary model use; keep secrets in env vars

## GLM 5.2 review

Jason requested GLM review. GLM 5.2 verdict: **NO BLOCKERS**.

I incorporated the two cosmetic suggestions:

- mark the nested file as a "Nested system-manual reference" in frontmatter/body
- set nested reference `version: 0.1.0` to match the parent manual's maturity band

## Validation

- `git diff --check`
- Python assertion check:
  - root system manual has the nested reference catalog and pointer
  - root no longer contains the long workflow section
  - nested reference contains `manifest.preset.allowed[]`, `system(action='presets')`, `revert_preset=true`, and daemon/avatar safety guidance

No merge without Jason approval.