### PR TITLE
docs: clean up skill manual metadata

### DIFF
--- a/src/lingtai/core/avatar/manual/SKILL.md
+++ b/src/lingtai/core/avatar/manual/SKILL.md
@@ -2,7 +2,7 @@
 name: avatar-manual
 description: |
   Complete operational guide for the avatar tool — spawning, managing, and communicating with 他我 (alter-ego agents). Read this when: you are about to spawn an avatar; an avatar you spawned goes quiet; you need to decide between avatar, daemon, or bash; or you are an avatar and need to know how to escalate to your parent. Covers spawn types, naming rules, discipline, escalation protocol, and the parent_prompt contract.
-version: "1.0"
+version: 1.0.0
 ---
 
 # Avatar Manual

--- a/src/lingtai/core/bash/manual/reference/bash-claude-code/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-claude-code/SKILL.md
@@ -21,7 +21,7 @@ Delegate code work to [Claude Code](https://docs.anthropic.com/en/docs/claude-co
 
 ## Prerequisites
 
-- Claude Code installed: `which claude` → `/Users/huangzesen/.local/bin/claude`
+- Claude Code installed: `which claude` → `${HOME}/.local/bin/claude`
 - Uses the human's **Claude Max subscription** — no additional API costs
 - Rate limit tier: `default_claude_max_20x` (effectively unlimited for typical use)
 
@@ -247,7 +247,7 @@ claude -p "generate a patch for issue #42" \
 |-------|-----|
 | Timeout after 30s | For a genuinely short inline task, set an explicit modest bash timeout (for example 300s). For long/complex work, prefer a daemon or supervised background wrapper instead of blocking the agent turn. |
 | Agent appears stuck while `claude -p` runs | You likely used synchronous CLI for work that should have been daemon-backed or supervised in the background. Inspect/kill the child if needed, then resume with a non-blocking wrapper. |
-| Claude Code not found | Check `which claude` → `/Users/huangzesen/.local/bin/claude` |
+| Claude Code not found | Check `which claude` → `${HOME}/.local/bin/claude` |
 | Permission errors | Always include `--dangerously-skip-permissions` |
 | Output truncated | Check if Claude hit the budget limit |
 | Rate limited | Wait and retry; Max tier has generous limits |

--- a/src/lingtai/core/bash/manual/reference/notification-reminders/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/notification-reminders/SKILL.md
@@ -80,8 +80,8 @@ Fields the agent will care about:
 External scripts should write via `tmp + rename` so the kernel never sees truncated JSON:
 
 ```bash
-export AGENT_DIR="/Users/huangzesen/work/lingtai-dev/.lingtai/codex-gpt5.5"
-export REMINDER_ID="plot-caption-$(date +%Y%m%d-%H%M%S)"
+export AGENT_DIR="/Users/<you>/work/<project>/.lingtai/<agent>"
+export REMINDER_ID="task-followup-$(date +%Y%m%d-%H%M%S)"
 
 /usr/bin/python3 - <<'PY'
 import json, os, pathlib, time
@@ -92,14 +92,14 @@ notif = agent / ".notification"
 notif.mkdir(exist_ok=True)
 now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 payload = {
-    "header": "Cron reminder: check Codex plot run",
+    "header": "Cron reminder: check pending task",
     "icon": "⏰",
     "priority": "normal",
     "published_at": now,
     "data": {
         "source": "cron-reminder",
-        "message": "Codex active. Plot regenerated (362KB, 23:38) — waiting for caption + commit.",
-        "todo": "Check Codex status, inspect caption, commit if ready.",
+        "message": "Background job still running — waiting for output + commit.",
+        "todo": "Check job status, inspect output, commit if ready.",
         "reminder_id": os.environ.get("REMINDER_ID", "cron-reminder"),
         "epoch": int(time.time()),
     },
@@ -117,7 +117,7 @@ For a short local reminder where the machine is expected to stay awake, a detach
 
 ```bash
 DELAY_SECONDS=240
-nohup /bin/bash -lc 'sleep '"$DELAY_SECONDS"'; export AGENT_DIR="/Users/huangzesen/work/lingtai-dev/.lingtai/codex-gpt5.5"; /usr/bin/python3 - <<"PY"
+nohup /bin/bash -lc 'sleep '"$DELAY_SECONDS"'; export AGENT_DIR="/Users/<you>/work/<project>/.lingtai/<agent>"; /usr/bin/python3 - <<"PY"
 import json, os, pathlib, time
 from datetime import datetime, timezone
 notif = pathlib.Path(os.environ["AGENT_DIR"]) / ".notification"

--- a/src/lingtai/core/mcp/manual/SKILL.md
+++ b/src/lingtai/core/mcp/manual/SKILL.md
@@ -3,7 +3,7 @@ name: mcp-manual
 description: >
   Operational guide for the `mcp` capability — register, activate, update,
   deregister, and troubleshoot MCP (Model Context Protocol) servers in your
-  agent. Single source of truth for both generic MCP setup AND the five
+  agent. Single source of truth for both generic MCP setup AND the six
   kernel-curated LingTai addon MCPs (`imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, `cloud_mail`).
 
   Reach for this manual when:

--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -2,7 +2,7 @@
 name: psyche-manual
 description: |
   Router and operational guide for the psyche tool — molt, pad management, session journaling, and post-wipe recovery. Read this when: you are about to molt; you need to tend the four durable stores; you want guidance on writing a good summary or session journal; you wake up after a system-performed wipe with no summary; or you need to understand keep_tool_calls, keep_last, and pad.append. Routes consequential molt handoffs to assets/molt-template.md while keeping routine guidance compact.
-version: "1.1"
+version: 1.1.0
 ---
 
 # Psyche Manual


### PR DESCRIPTION
## Summary

- remove private/local path examples from bash manual skill docs and neutralize a session-specific reminder payload example
- normalize two skill frontmatter versions from quoted short strings to semantic versions
- fix the MCP manual description to say six curated addon MCPs, matching the listed addons

## Why

This is the kernel-side result of Jason's requested systematic skill-file cleanup. The audit found the skill system is generally healthy; the one blocker-level kernel issue was private/local path leakage in shipped docs. This PR keeps the scope intentionally small and mechanical.

The audit also found a `.library/intrinsic/.../system` generated-artifact/orphan design question. I did **not** edit that in this PR because it needs a source/packaging decision rather than an in-place docs tweak.

## Validation

- `git diff --check`
- `python -m pytest -q tests/test_skills.py`
- `grep -rn '/Users/huangzesen' src .library --include=SKILL.md` → empty
- `grep -rn 'codex-gpt5.5' src .library --include=SKILL.md` → empty
- `grep -rn 'version:[[:space:]]*"' src .library --include=SKILL.md` → empty
