### PR TITLE
Handle legacy preset context_limit during CPR

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -650,14 +650,17 @@ class Agent(BaseAgent):
             "healthy": healthy,
         }
 
-    def _cpr_agent(self, address: str) -> "Agent | None":
+    def _cpr_agent(self, address: str) -> bool | dict | None:
         """Resuscitate a suspended agent by launching it as a detached process.
 
-        Uses the resolved venv Python to run `lingtai-agent run <dir>`.
-        The target must have init.json to boot from.
+        Uses the resolved venv Python to run `lingtai run <dir>`.  Success is
+        reported only after the target writes a fresh heartbeat; quick child
+        exits and startup timeouts are returned as explicit errors.
         """
+        import shlex
         import subprocess
-        from lingtai_kernel.handshake import is_agent, resolve_address
+        import time
+        from lingtai_kernel.handshake import is_agent, is_alive, resolve_address
         from lingtai.venv_resolve import resolve_venv, venv_python
 
         base_dir = self._working_dir.parent
@@ -686,15 +689,53 @@ class Agent(BaseAgent):
         python = venv_python(venv_dir)
         cmd = [python, "-m", "lingtai", "run", str(target)]
 
-        proc = subprocess.Popen(
-            cmd,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
-        self._log("cpr_launched", target=str(target), pid=proc.pid)
-        return True  # non-None signals success to the kernel
+        def _tail_log(limit: int = 4000) -> str:
+            try:
+                data = log_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                return ""
+            return data[-limit:]
+
+        logs_dir = target / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        log_path = logs_dir / "cpr_relaunch.log"
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        quoted_cmd = " ".join(shlex.quote(str(part)) for part in cmd)
+
+        with log_path.open("ab", buffering=0) as log_fh:
+            log_fh.write(f"\n--- CPR launch {timestamp}: {quoted_cmd} ---\n".encode("utf-8"))
+            proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+
+        self._log("cpr_launched", target=str(target), pid=proc.pid, log=str(log_path))
+
+        deadline = time.time() + 10.0
+        while time.time() < deadline:
+            if is_alive(target, threshold=3.0):
+                self._log("cpr_alive", target=str(target), pid=proc.pid)
+                return True
+            code = proc.poll()
+            if code is not None:
+                tail = _tail_log()
+                self._log("cpr_failed", target=str(target), pid=proc.pid, exit_code=code, log=str(log_path))
+                message = f"CPR launch exited before heartbeat (exit code {code}); see {log_path}"
+                if tail.strip():
+                    message += f"\n\nLast log output:\n{tail}"
+                return {"error": True, "message": message, "exit_code": code, "log": str(log_path)}
+            time.sleep(0.2)
+
+        self._log("cpr_timeout", target=str(target), pid=proc.pid, log=str(log_path))
+        return {
+            "error": True,
+            "message": f"CPR launch did not produce a fresh heartbeat within 10s (pid {proc.pid}); see {log_path}",
+            "pid": proc.pid,
+            "log": str(log_path),
+        }
 
     def start(self) -> None:
         super().start()

--- a/src/lingtai_kernel/intrinsics/system/karma.py
+++ b/src/lingtai_kernel/intrinsics/system/karma.py
@@ -133,6 +133,12 @@ def _cpr(agent, args: dict) -> dict:
     resuscitated = agent._cpr_agent(str(resolved))
     if resuscitated is None:
         return {"error": True, "message": "CPR not supported — no _cpr_agent handler"}
+    if isinstance(resuscitated, dict) and resuscitated.get("error"):
+        agent._log("karma_cpr_failed", target=address, message=resuscitated.get("message"))
+        return resuscitated
+    if resuscitated is False:
+        agent._log("karma_cpr_failed", target=address, message="_cpr_agent returned False")
+        return {"error": True, "message": "CPR failed"}
     agent._log("karma_cpr", target=address)
     return {"status": "resuscitated", "address": address}
 

--- a/src/lingtai_kernel/presets.py
+++ b/src/lingtai_kernel/presets.py
@@ -71,6 +71,60 @@ def home_shortened(path: Path | str) -> str:
         return str(path)
 
 
+def _normalize_legacy_manifest_context_limit(
+    manifest: dict,
+    *,
+    preset_name: str,
+    preset_path: Path,
+) -> None:
+    """Accept legacy preset ``manifest.context_limit`` in memory.
+
+    ``context_limit`` is canonical under ``manifest.llm``.  Older saved presets
+    and hand-written files may still carry a root-level value; rejecting those
+    during refresh can leave an otherwise recoverable agent unable to boot.
+    Prefer the canonical ``manifest.llm.context_limit`` when both are present,
+    and remove the legacy root key before the normal validator runs.
+    """
+    if "context_limit" not in manifest:
+        return
+
+    root_ctx = manifest.pop("context_limit")
+    llm = manifest.setdefault("llm", {})
+    if not isinstance(llm, dict):
+        # The caller's existing manifest.llm validation will raise the precise
+        # schema error; keep this helper focused on the legacy root key.
+        return
+
+    llm_ctx = llm.get("context_limit")
+    if llm_ctx is None:
+        llm["context_limit"] = root_ctx
+        log.warning(
+            "preset %r (%s): migrated legacy manifest.context_limit to "
+            "manifest.llm.context_limit in memory",
+            preset_name,
+            preset_path,
+        )
+        return
+
+    if llm_ctx == root_ctx:
+        log.warning(
+            "preset %r (%s): dropped duplicate legacy manifest.context_limit "
+            "matching manifest.llm.context_limit",
+            preset_name,
+            preset_path,
+        )
+        return
+
+    log.warning(
+        "preset %r (%s): ignored conflicting legacy manifest.context_limit=%r; "
+        "using canonical manifest.llm.context_limit=%r",
+        preset_name,
+        preset_path,
+        root_ctx,
+        llm_ctx,
+    )
+
+
 def resolve_preset_name(name: str, working_dir: Path) -> Path:
     """Resolve a preset name (path string) to an absolute Path.
 
@@ -234,6 +288,8 @@ def load_preset(
     if not isinstance(manifest, dict):
         raise ValueError(f"preset {name!r} ({p}): missing or invalid 'manifest' object")
 
+    _normalize_legacy_manifest_context_limit(manifest, preset_name=name, preset_path=p)
+
     llm = manifest.get("llm")
     if not isinstance(llm, dict):
         raise ValueError(f"preset {name!r} ({p}): missing or invalid 'manifest.llm' object")
@@ -241,15 +297,10 @@ def load_preset(
     if not llm.get("provider") or not llm.get("model"):
         raise ValueError(f"preset {name!r} ({p}): manifest.llm requires non-empty 'provider' and 'model'")
 
-    # context_limit lives inside manifest.llm. Migration m001 relocated any
-    # legacy root-level placements; presets that still have it at the root
-    # are ambiguous (migration explicitly skips both-locations) or hand-edited
-    # regressions. Reject either case with a pointed error.
-    if "context_limit" in manifest:
-        raise ValueError(
-            f"preset {name!r} ({p}): context_limit must live inside "
-            f"manifest.llm, not at manifest root — move it under llm and retry"
-        )
+    # context_limit lives inside manifest.llm. The migration layer persists
+    # straightforward root-only legacy files; the in-memory compatibility layer
+    # above also tolerates duplicate/conflicting root keys so refresh/CPR can
+    # recover from old saved presets instead of failing before the agent boots.
     ctx_limit = llm.get("context_limit")
     if ctx_limit is not None and not isinstance(ctx_limit, int):
         raise ValueError(

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -269,14 +269,35 @@ def test_load_preset_relocates_legacy_root_context_limit(tmp_path):
     assert on_disk["manifest"]["llm"]["context_limit"] == 32768
 
 
-def test_load_preset_rejects_context_limit_at_manifest_root(tmp_path):
-    """Ambiguous preset (both locations populated) is skipped by migration
-    and rejected by the validator with a pointer to the canonical location.
-    """
+def test_load_preset_drops_duplicate_legacy_root_context_limit(tmp_path):
+    """Both locations with the same value are accepted in memory."""
     from lingtai_kernel.migrate.migrate import reset_process_cache
     reset_process_cache()
     p = {
         "name": "dup",
+        "description": _DESC,
+        "manifest": {
+            "llm": {"provider": "x", "model": "y", "context_limit": 32768},
+            "capabilities": {},
+            "context_limit": 32768,
+        },
+    }
+    f = tmp_path / "dup.json"
+    f.write_text(json.dumps(p))
+
+    loaded = load_preset(str(f))
+
+    assert preset_context_limit(loaded["manifest"]) == 32768
+    assert "context_limit" not in loaded["manifest"]
+
+
+def test_load_preset_conflicting_legacy_root_context_limit_preserves_llm(tmp_path):
+    """When both locations disagree, canonical manifest.llm wins."""
+    from lingtai_kernel.migrate.migrate import reset_process_cache
+    reset_process_cache()
+    p = {
+        "name": "dup",
+        "description": _DESC,
         "manifest": {
             "llm": {"provider": "x", "model": "y", "context_limit": 16384},
             "capabilities": {},
@@ -285,8 +306,12 @@ def test_load_preset_rejects_context_limit_at_manifest_root(tmp_path):
     }
     f = tmp_path / "dup.json"
     f.write_text(json.dumps(p))
-    with pytest.raises(ValueError, match="manifest.llm"):
-        load_preset(str(f))
+
+    loaded = load_preset(str(f))
+
+    assert preset_context_limit(loaded["manifest"]) == 16384
+    assert loaded["manifest"]["llm"]["context_limit"] == 16384
+    assert "context_limit" not in loaded["manifest"]
 
 
 def test_load_preset_rejects_non_integer_context_limit(tmp_path):

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -816,3 +816,37 @@ def test_presets_action_marks_unreachable_when_probe_fails(tmp_path, monkeypatch
     broken_path = str(plib / "broken.json")
     assert by_name[broken_path]["connectivity"]["status"] == "unreachable"
     assert "DNS fail" in by_name[broken_path]["connectivity"]["error"]
+
+
+# ---------------------------------------------------------------------------
+# CPR failure propagation
+# ---------------------------------------------------------------------------
+
+
+def test_cpr_propagates_launch_failure_instead_of_resuscitated(tmp_path):
+    """A failed CPR launch must not be reported as resuscitated."""
+    from lingtai_kernel.intrinsics.system.karma import _cpr
+
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / ".agent.json").write_text('{"admin": {}}')
+
+    class FakeAgent:
+        _admin = {"karma": True}
+        _working_dir = tmp_path / "self"
+
+        def __init__(self):
+            self.logs = []
+
+        def _cpr_agent(self, address):
+            return {"error": True, "message": "launch failed before heartbeat"}
+
+        def _log(self, event, **kwargs):
+            self.logs.append((event, kwargs))
+
+    agent = FakeAgent()
+    result = _cpr(agent, {"address": str(target)})
+
+    assert result["error"] is True
+    assert "launch failed" in result["message"]
+    assert any(event == "karma_cpr_failed" for event, _ in agent.logs)


### PR DESCRIPTION
## Summary
- tolerate legacy saved-preset `manifest.context_limit` during kernel preset loading by normalizing it into `manifest.llm.context_limit` in memory
- preserve the canonical `manifest.llm.context_limit` value when legacy root and llm values conflict
- make kernel CPR report success only after the relaunched agent writes a fresh heartbeat, with startup output captured in `logs/cpr_relaunch.log`
- propagate CPR launch failures through the system intrinsic instead of returning `resuscitated`

## Why
This addresses the kernel side of Lingtai-AI/lingtai#348. A dead agent could not restart because its active saved preset still had legacy root-level `manifest.context_limit`; then `system.cpr` returned `resuscitated` even though the child exited before producing a heartbeat.

## Tests
- `python -m pytest tests/test_presets.py::test_load_preset_accepts_context_limit_inside_llm_block tests/test_presets.py::test_load_preset_relocates_legacy_root_context_limit tests/test_presets.py::test_load_preset_drops_duplicate_legacy_root_context_limit tests/test_presets.py::test_load_preset_conflicting_legacy_root_context_limit_preserves_llm tests/test_presets.py::test_load_preset_rejects_non_integer_context_limit tests/test_system.py::test_cpr_propagates_launch_failure_instead_of_resuscitated -q`
- `python -m pytest tests/test_presets.py tests/test_system.py -q`
- `python -m pytest -q` (`2199 passed, 2 skipped`)
