### PR TITLE
Add tc_wake diagnostic attribution

### DIFF
--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -47,6 +47,46 @@ from ..trace_redaction import redact_for_trajectory
 logger = get_logger()
 
 
+def _block_type_name(block: object) -> str:
+    """Return a compact, safe block type label for diagnostics."""
+    try:
+        data = block.to_dict()  # type: ignore[attr-defined]
+        btype = data.get("type") if isinstance(data, dict) else None
+        if isinstance(btype, str) and btype:
+            return btype
+    except Exception:
+        pass
+    name = type(block).__name__
+    if name.endswith("Block"):
+        name = name[:-5]
+    return name[:80]
+
+
+def _pending_tool_call_diagnostics(iface, *, tail_limit: int = 3) -> dict:
+    """Bounded, argument-free diagnostics for a pending tool-call tail."""
+    entries = list(getattr(iface, "entries", None) or [])
+    tail_entries = entries[-tail_limit:]
+    tail = entries[-1] if entries else None
+    pending_calls = []
+    if getattr(tail, "role", None) == "assistant":
+        pending_calls = [
+            block
+            for block in getattr(tail, "content", []) or []
+            if hasattr(block, "id") and hasattr(block, "name") and hasattr(block, "args")
+        ]
+
+    return {
+        "pending_tool_call_count": len(pending_calls),
+        "pending_tool_call_ids": [getattr(call, "id", None) for call in pending_calls],
+        "pending_tool_names": [getattr(call, "name", None) for call in pending_calls],
+        "pending_tail_roles": [getattr(entry, "role", None) for entry in tail_entries],
+        "pending_tail_block_types": [
+            [_block_type_name(block) for block in (getattr(entry, "content", []) or [])]
+            for entry in tail_entries
+        ],
+    }
+
+
 # Issue #164 — event types that count as "the agent made forward
 # progress." Bumping ``_last_progress_at`` on these gives the ACTIVE-
 # without-progress watchdog a single, robust signal that survives
@@ -1312,12 +1352,18 @@ class BaseAgent:
             pass
         if not iface.has_pending_tool_calls():
             return False
+        diagnostics = _pending_tool_call_diagnostics(iface)
         try:
             iface.close_pending_tool_calls(reason=f"heal:{reason}")
         except Exception as e:
-            self._log("heal_pending_tool_calls_failed", reason=reason, error=str(e)[:200])
+            self._log(
+                "heal_pending_tool_calls_failed",
+                reason=reason,
+                error=str(e)[:200],
+                **diagnostics,
+            )
             return False
-        self._log("heal_pending_tool_calls", reason=reason)
+        self._log("heal_pending_tool_calls", reason=reason, **diagnostics)
         try:
             self._save_chat_history(ledger_source="heal")
         except Exception:

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -40,14 +40,37 @@ class EmptyLLMResponseError(RuntimeError):
     transitioning to IDLE and abandoning the in-progress task.
     """
 
-    def __init__(self, *, ledger_source: str, in_tool_loop: bool):
+    def __init__(
+        self,
+        *,
+        ledger_source: str,
+        in_tool_loop: bool,
+        response_id: str | None = None,
+        response_model: str | None = None,
+        finish_reason: str | None = None,
+        api_call_id: str | None = None,
+    ):
         self.ledger_source = ledger_source
         self.in_tool_loop = in_tool_loop
+        self.response_id = response_id
+        self.response_model = response_model
+        self.finish_reason = finish_reason
+        self.api_call_id = api_call_id
         where = "after tool results" if in_tool_loop else "on initial send"
         super().__init__(
             f"LLM returned empty response (no text, no tool_calls, no thoughts) "
             f"{where}; ledger={ledger_source}"
         )
+
+    def diagnostic_fields(self) -> dict:
+        return {
+            "ledger_source": self.ledger_source,
+            "in_tool_loop": self.in_tool_loop,
+            "response_id": self.response_id,
+            "response_model": self.response_model,
+            "finish_reason": self.finish_reason,
+            "api_call_id": self.api_call_id,
+        }
 
 
 _TRANSIENT_AED_RETRY_LIMIT = 3
@@ -1208,7 +1231,10 @@ def _handle_tc_wake(agent, msg: Message) -> None:
                 tool_completed=True,
             )
             agent._save_chat_history()
-        agent._log("tc_wake_error", error=str(e)[:300])
+        fields = {"error": str(e)[:300]}
+        if isinstance(e, EmptyLLMResponseError):
+            fields.update(e.diagnostic_fields())
+        agent._log("tc_wake_error", **fields)
         raise
 
 
@@ -1426,6 +1452,10 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
             raise EmptyLLMResponseError(
                 ledger_source=ledger_source,
                 in_tool_loop=in_tool_loop,
+                response_id=_diag.get("response_id"),
+                response_model=_diag.get("response_model"),
+                finish_reason=_diag.get("finish_reason"),
+                api_call_id=getattr(response, "api_call_id", None),
             )
 
         if response.text:

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -18,6 +18,8 @@ from types import SimpleNamespace
 import pytest
 
 from lingtai_kernel.base_agent import turn
+from lingtai_kernel.llm import LLMResponse
+from lingtai_kernel.llm.base import UsageMetadata
 from lingtai_kernel.llm_utils import WorkerStillRunningError
 from lingtai_kernel.message import _make_message, MSG_REQUEST
 from lingtai_kernel.state import AgentState
@@ -284,3 +286,105 @@ def test_status_code_classifier_treats_only_5xx_as_transient():
     assert turn._is_transient_provider_error(StatusError(503)) is True
     assert turn._is_transient_provider_error(StatusError(429)) is False
     assert turn._is_transient_provider_error(StatusError(400)) is False
+
+
+def test_empty_llm_response_error_carries_provider_diagnostics():
+    logs: list[tuple[str, dict]] = []
+    agent = SimpleNamespace(
+        _cancel_event=threading.Event(),
+        _executor=SimpleNamespace(guard=SimpleNamespace()),
+        _log=lambda event, **fields: logs.append((event, fields)),
+    )
+    raw = SimpleNamespace(
+        id="resp_123",
+        model="gpt-test",
+        choices=[SimpleNamespace(finish_reason="stop")],
+    )
+    response = LLMResponse(
+        text="",
+        tool_calls=[],
+        thoughts=[],
+        usage=UsageMetadata(output_tokens=0, thinking_tokens=0),
+        raw=raw,
+        api_call_id="api_123",
+    )
+
+    with pytest.raises(turn.EmptyLLMResponseError) as excinfo:
+        turn._process_response(agent, response, ledger_source="tc_wake")
+
+    err = excinfo.value
+    assert err.ledger_source == "tc_wake"
+    assert err.in_tool_loop is False
+    assert err.response_id == "resp_123"
+    assert err.response_model == "gpt-test"
+    assert err.finish_reason == "stop"
+    assert err.api_call_id == "api_123"
+    assert err.diagnostic_fields() == {
+        "ledger_source": "tc_wake",
+        "in_tool_loop": False,
+        "response_id": "resp_123",
+        "response_model": "gpt-test",
+        "finish_reason": "stop",
+        "api_call_id": "api_123",
+    }
+    assert any(
+        event == "empty_llm_response"
+        and fields["response_id"] == "resp_123"
+        and fields["api_call_id"] == "api_123"
+        for event, fields in logs
+    )
+
+
+def test_tc_wake_error_logs_empty_response_diagnostics(tmp_path):
+    from lingtai_kernel.llm.interface import ChatInterface, ToolCallBlock, ToolResultBlock
+    from lingtai_kernel.message import _make_message, MSG_TC_WAKE
+
+    iface = ChatInterface()
+    iface.add_assistant_message([ToolCallBlock(id="call_notification", name="system", args={})])
+    iface.add_user_blocks([
+        ToolResultBlock(id="call_notification", name="system", content={"ok": True})
+    ])
+
+    logs: list[tuple[str, dict]] = []
+    raw = SimpleNamespace(
+        id="resp_tc",
+        model="gpt-test",
+        choices=[SimpleNamespace(finish_reason="stop")],
+    )
+    response = LLMResponse(
+        text="",
+        tool_calls=[],
+        thoughts=[],
+        usage=UsageMetadata(output_tokens=0, thinking_tokens=0),
+        raw=raw,
+        api_call_id="api_tc",
+    )
+
+    agent = SimpleNamespace(
+        _chat=SimpleNamespace(interface=iface),
+        _tc_inbox=SimpleNamespace(drain=lambda: [], enqueue=lambda item: None),
+        _appendix_ids_by_source={},
+        _dispatch_tool=lambda *a, **kw: None,
+        service=SimpleNamespace(make_tool_result=lambda *a, **kw: None),
+        _config=SimpleNamespace(provider="test", language="en"),
+        _intrinsics={},
+        _tool_handlers={},
+        _PARALLEL_SAFE_TOOLS=set(),
+        _working_dir=tmp_path,
+        _cancel_event=threading.Event(),
+        _session=SimpleNamespace(send=lambda message: response),
+        _save_chat_history=lambda *a, **kw: None,
+        _log=lambda event, **fields: logs.append((event, fields)),
+    )
+
+    with pytest.raises(turn.EmptyLLMResponseError):
+        turn._handle_tc_wake(agent, _make_message(MSG_TC_WAKE, "system", ""))
+
+    event, fields = logs[-1]
+    assert event == "tc_wake_error"
+    assert fields["ledger_source"] == "tc_wake"
+    assert fields["in_tool_loop"] is False
+    assert fields["response_id"] == "resp_tc"
+    assert fields["response_model"] == "gpt-test"
+    assert fields["finish_reason"] == "stop"
+    assert fields["api_call_id"] == "api_tc"

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -26,6 +26,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from lingtai_kernel.notifications import (
@@ -2121,3 +2122,38 @@ def test_sync_notifications_idle_refuses_touch_when_poisoned(tmp_path: Path) -> 
         "skip_chat_history_save": True,
         "skip_save_reason": "worker_still_running_interface_unsafe",
     }]
+
+
+def test_heal_pending_tool_calls_logs_pending_tail_diagnostics(tmp_path: Path) -> None:
+    """Successful heal logs a bounded pending-tail summary without tool args."""
+    from lingtai_kernel.base_agent import BaseAgent
+    from lingtai_kernel.llm.interface import ChatInterface, TextBlock, ToolCallBlock
+
+    iface = ChatInterface()
+    iface.add_user_message("before")
+    iface.add_assistant_message([TextBlock("thinking aloud")])
+    iface.add_assistant_message([
+        ToolCallBlock(id="call_1", name="bash", args={"command": "SECRET"}),
+        ToolCallBlock(id="call_2", name="email", args={"message": "SECRET"}),
+    ])
+
+    logs: list[tuple[str, dict]] = []
+    saves: list[str] = []
+    agent = SimpleNamespace(
+        _chat=SimpleNamespace(interface=iface),
+        _log=lambda event, **fields: logs.append((event, fields)),
+        _save_chat_history=lambda *, ledger_source="main": saves.append(ledger_source),
+    )
+
+    assert BaseAgent._heal_pending_tool_calls(agent, reason="wake_inject_blocked") is True
+
+    event, fields = logs[-1]
+    assert event == "heal_pending_tool_calls"
+    assert fields["reason"] == "wake_inject_blocked"
+    assert fields["pending_tool_call_count"] == 2
+    assert fields["pending_tool_call_ids"] == ["call_1", "call_2"]
+    assert fields["pending_tool_names"] == ["bash", "email"]
+    assert fields["pending_tail_roles"] == ["user", "assistant", "assistant"]
+    assert fields["pending_tail_block_types"] == [["text"], ["text"], ["tool_call", "tool_call"]]
+    assert "SECRET" not in str(fields)
+    assert saves == ["heal"]


### PR DESCRIPTION
## Related issue

Part of #159.

Issue #159 groups several recurring runtime anomalies that are hard to diagnose from the current logs:

1. frequent `heal:idle_inject_blocked` pending-tool-call healing,
2. empty LLM responses during `tc_wake` continuation,
3. daemon subprocess exits reported only as generic signal/143 failures.

This PR addresses the diagnostics side for the first two symptoms. It intentionally does **not** change retry, recovery-loop, notification, or healing behavior.

## Why

When the runtime heals a pending tool-call tail, the current logs can say that healing happened but do not give enough bounded context to answer the next question: what pending calls were on the tail, which tools were involved, and what kind of chat tail was being healed?

Similarly, when a `tc_wake` continuation receives an empty LLM response, the thrown/logged error loses provider-level details that were already extracted in `_process_response()`. That makes it harder to correlate an empty continuation with the backend response metadata.

For #159, the next useful step is better source attribution, not a behavior change.

## What changed

- Added bounded pending-tail diagnostics to `BaseAgent._heal_pending_tool_calls()` logs:
  - pending call count,
  - pending call IDs,
  - pending tool names,
  - compact tail role/block-type context,
  - no tool arguments or large payloads.
- Extended `EmptyLLMResponseError` so it can carry provider diagnostics already known in `_process_response()`:
  - response ID,
  - response model,
  - finish reason,
  - API call ID,
  - ledger source,
  - whether the empty response happened inside a tool loop.
- Included those fields in `tc_wake_error` logging when a `tc_wake` continuation hits an empty response.

## Validation

Automated tests:

- `PYTHONPATH=$PWD/src pytest -q tests/test_notification_sync.py tests/test_aed_recovery.py`
- Result: 58 passed.
- `git diff --check`

Review summary:

- Reviewed for whether the change stays diagnostics-only.
- Reviewed for privacy/safety of log payloads; diagnostics are bounded and omit tool arguments.
- Reviewed the `tc_wake` empty-response path to confirm provider diagnostics are propagated to logs rather than changing recovery semantics.
- No blocking issues remained after review.

## Scope note

This PR is deliberately narrow. It improves observability for #159 but does not claim to fix all causes of pending-tool-call healing or empty `tc_wake` responses.
