### PR TITLE
feat: add runtime source-fingerprint and drift-detection nudge (#178)

### DIFF
--- a/src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
@@ -320,6 +320,44 @@ def collect_lifecycle(report: Report) -> dict[str, Any]:
         if status_age is not None and status_age > 300:
             sec.add("WARN", "status file is stale", f".status.json has not changed for {status_age:.0f}s.", age_seconds=round(status_age, 1))
 
+        # Issue #178 — read nested runtime fingerprint for drift visibility
+        runtime_block = status_json.get("runtime")
+        if isinstance(runtime_block, dict):
+            fp = runtime_block.get("fingerprint")
+            if isinstance(fp, dict):
+                fp_fields = {
+                    "git_rev": fp.get("git_rev"),
+                    "source_digest": fp.get("source_digest"),
+                    "captured_at": fp.get("captured_at"),
+                }
+                python_ver = runtime_block.get("python_version")
+                plat = runtime_block.get("platform")
+                if python_ver:
+                    fp_fields["python_version"] = python_ver
+                if plat:
+                    fp_fields["platform"] = plat
+                sec.add(
+                    "OK",
+                    "runtime fingerprint available",
+                    f"Fingerprint captured at {fp.get('captured_at', 'unknown')}; "
+                    f"git={fp.get('git_rev', 'n/a')}, digest={fp.get('source_digest', 'n/a')}.",
+                    fingerprint=fp_fields,
+                )
+            else:
+                sec.add(
+                    "WARN",
+                    "runtime fingerprint missing",
+                    "The .status.json runtime block does not contain a fingerprint; "
+                    "the agent may be running an older kernel version that predates issue #178.",
+                )
+        else:
+            sec.add(
+                "WARN",
+                "runtime fingerprint missing",
+                "The .status.json does not contain a runtime block; "
+                "the agent may be running an older kernel version that predates issue #178.",
+            )
+
     heartbeat = report.agent_dir / ".agent.heartbeat"
     hb = parse_heartbeat(heartbeat)
     if not hb.get("exists"):

--- a/src/lingtai_kernel/base_agent/identity.py
+++ b/src/lingtai_kernel/base_agent/identity.py
@@ -5,6 +5,8 @@ serializes to disk, and how it reports runtime status.
 """
 from __future__ import annotations
 
+import platform
+import sys
 import time
 
 
@@ -257,6 +259,12 @@ def _status(agent) -> dict:
             "state_changed_at", "last_progress_at", "no_progress_seconds",
         ),
     )
+
+    # Issue #178 — expose runtime fingerprint for drift detection
+    fp = getattr(agent, "_runtime_fingerprint", None)
+    runtime_block["fingerprint"] = fp if isinstance(fp, dict) else None
+    runtime_block["python_version"] = sys.version.split()[0]
+    runtime_block["platform"] = platform.system().lower()
 
     result = {
         "identity": {

--- a/src/lingtai_kernel/base_agent/lifecycle.py
+++ b/src/lingtai_kernel/base_agent/lifecycle.py
@@ -7,10 +7,81 @@ snapshots.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import subprocess
+import sys
 import time
 import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# Key source files to hash for the runtime fingerprint.  A small curated
+# list keeps startup cost low (<5ms) while still catching the most common
+# source-level drift vectors.
+_FP_KEY_FILES: list[str] = [
+    "base_agent/__init__.py",
+    "base_agent/lifecycle.py",
+    "base_agent/turn.py",
+    "nudge/__init__.py",
+    "nudge/kernel_version.py",
+    "intrinsics/system/__init__.py",
+    "meta_block.py",
+    "notifications.py",
+    "workdir.py",
+]
+
+
+def _capture_runtime_fingerprint() -> dict:
+    """Capture a dual fingerprint of the running lingtai_kernel source.
+
+    Returns a dict with:
+      - ``git_rev``: short git HEAD hash, or ``None`` if unavailable
+      - ``source_digest``: SHA-256 hex prefix (12 chars) of key source files
+      - ``captured_at``: ISO-8601 timestamp
+    """
+    # Resolve the lingtai_kernel package source directory
+    try:
+        import lingtai_kernel
+        pkg_dir = Path(lingtai_kernel.__file__).resolve().parent  # type: ignore[arg-type]
+    except Exception:
+        pkg_dir = None
+
+    # git rev-parse --short HEAD
+    git_rev: str | None = None
+    if pkg_dir is not None:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=str(pkg_dir),
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            if result.returncode == 0:
+                git_rev = result.stdout.strip() or None
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            pass
+
+    # Hash key source files
+    source_digest: str | None = None
+    if pkg_dir is not None:
+        h = hashlib.sha256()
+        for rel in _FP_KEY_FILES:
+            fp = pkg_dir / rel
+            try:
+                h.update(fp.read_bytes())
+            except OSError:
+                h.update(b"\x00")  # missing file marker
+        source_digest = h.hexdigest()[:12]
+
+    return {
+        "git_rev": git_rev,
+        "source_digest": source_digest,
+        "captured_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
 
 
 def _active_stuck_threshold_s() -> float:
@@ -78,6 +149,12 @@ def _start(agent) -> None:
             agent._mail_service.listen(on_message=lambda payload: agent._on_mail_received(payload))
         except RuntimeError:
             pass  # Already listening — that's fine
+
+    # Capture runtime fingerprint for drift detection
+    try:
+        agent._runtime_fingerprint = _capture_runtime_fingerprint()
+    except Exception:
+        agent._runtime_fingerprint = None
 
     agent._thread = threading.Thread(
         target=agent._run_loop,

--- a/src/lingtai_kernel/nudge/__init__.py
+++ b/src/lingtai_kernel/nudge/__init__.py
@@ -35,7 +35,7 @@ otherwise lose entries. The lock is created lazily on first use.
 from __future__ import annotations
 import threading
 
-from . import kernel_version, goal
+from . import kernel_version, goal, source_drift
 
 
 __all__ = ["run_checks", "upsert", "remove"]
@@ -49,6 +49,7 @@ def run_checks(agent) -> None:
     not block subsequent checks.
     """
     _run_one(agent, "kernel_version", kernel_version.check)
+    _run_one(agent, "source_drift", source_drift.check)
     _run_one(agent, "goal", goal.check)
 
 

--- a/src/lingtai_kernel/nudge/source_drift.py
+++ b/src/lingtai_kernel/nudge/source_drift.py
@@ -1,0 +1,99 @@
+"""Nudge: warn the agent when on-disk source has drifted since startup.
+
+A long-running agent process may have imported old code before a fix landed
+in the repository (e.g. ``git pull`` + ``pip install -e .`` on a dev
+install).  This nudge re-runs the same dual fingerprint that was captured
+at startup (git rev + source digest) and compares with
+``agent._runtime_fingerprint``.  When the two disagree, the running
+interpreter is stale: only a full process relaunch (``system(action='refresh')``)
+picks up the new code.
+
+Throttled to one check per 60 seconds so a long-running agent doesn't get
+a flood of nudge entries on every heartbeat tick.  If the on-disk state
+returns to match the startup fingerprint (revert, or stale state from a
+prior process), the previously-emitted entry is cleared.
+"""
+from __future__ import annotations
+
+import time
+
+_INTERVAL_SECONDS = 60.0
+_KIND = "source_drift"
+
+
+def check(agent) -> None:
+    """Check for source-level drift between startup and on-disk code."""
+    state = _state(agent)
+    now = time.time()
+    if now - state.get("last_probe_ts", 0.0) < _INTERVAL_SECONDS:
+        return
+    state["last_probe_ts"] = now
+
+    from ..base_agent.lifecycle import _capture_runtime_fingerprint
+    from . import upsert, remove
+
+    startup_fp = getattr(agent, "_runtime_fingerprint", None)
+    if not isinstance(startup_fp, dict):
+        return  # no startup fingerprint — nothing to compare
+
+    try:
+        disk_fp = _capture_runtime_fingerprint()
+    except Exception:
+        return
+
+    # Compare the two fingerprints
+    drift_signals: list[str] = []
+
+    startup_git = startup_fp.get("git_rev")
+    disk_git = disk_fp.get("git_rev")
+    if startup_git is not None and disk_git is not None and startup_git != disk_git:
+        drift_signals.append(f"git_rev: {startup_git} → {disk_git}")
+
+    startup_digest = startup_fp.get("source_digest")
+    disk_digest = disk_fp.get("source_digest")
+    if startup_digest is not None and disk_digest is not None and startup_digest != disk_digest:
+        drift_signals.append(f"source_digest: {startup_digest} → {disk_digest}")
+
+    if not drift_signals:
+        # No drift — clear any prior nudge
+        if state.get("emitted"):
+            remove(agent, _KIND)
+            state["emitted"] = False
+        return
+
+    # Drift detected — avoid duplicate nudge if signals unchanged
+    drift_key = "; ".join(drift_signals)
+    if state.get("emitted_for") == drift_key:
+        return
+
+    body = {
+        "title": "Source drift detected — running code is stale",
+        "detail": (
+            f"On-disk source has changed since this process started. "
+            f"Drift: {'; '.join(drift_signals)}. "
+            f"Call system(action='refresh') when convenient to relaunch "
+            f"with the latest code. No urgency — finish the current task first."
+        ),
+        "suggested_action": "system(action='refresh')",
+        "startup_fingerprint": startup_fp,
+        "disk_fingerprint": disk_fp,
+    }
+    try:
+        upsert(agent, _KIND, body)
+        state["emitted"] = True
+        state["emitted_for"] = drift_key
+        agent._log(
+            "nudge_emitted",
+            kind=_KIND,
+            drift_signals=drift_signals,
+        )
+    except Exception as e:
+        agent._log("nudge_emit_error", kind=_KIND, error=str(e)[:200])
+
+
+def _state(agent) -> dict:
+    s = getattr(agent, "_nudge_source_drift_state", None)
+    if s is None:
+        s = {}
+        agent._nudge_source_drift_state = s
+    return s

--- a/tests/test_source_drift.py
+++ b/tests/test_source_drift.py
@@ -1,0 +1,515 @@
+"""Tests for runtime fingerprint capture, source drift nudge, and doctor parsing (issue #178)."""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. Fingerprint capture
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureRuntimeFingerprint:
+    """Unit tests for _capture_runtime_fingerprint()."""
+
+    def test_returns_expected_keys(self):
+        from lingtai_kernel.base_agent.lifecycle import _capture_runtime_fingerprint
+
+        fp = _capture_runtime_fingerprint()
+        assert "git_rev" in fp
+        assert "source_digest" in fp
+        assert "captured_at" in fp
+
+    def test_source_digest_is_12_hex_chars(self):
+        from lingtai_kernel.base_agent.lifecycle import _capture_runtime_fingerprint
+
+        fp = _capture_runtime_fingerprint()
+        digest = fp["source_digest"]
+        assert digest is not None
+        assert len(digest) == 12
+        int(digest, 16)  # should not raise
+
+    def test_captured_at_is_iso8601(self):
+        from lingtai_kernel.base_agent.lifecycle import _capture_runtime_fingerprint
+
+        fp = _capture_runtime_fingerprint()
+        ts = fp["captured_at"]
+        assert ts.endswith("Z")
+        # Should parse without error
+        from datetime import datetime, timezone
+        datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+    def test_git_rev_null_when_not_in_repo(self):
+        from lingtai_kernel.base_agent.lifecycle import _capture_runtime_fingerprint
+
+        with patch("lingtai_kernel.base_agent.lifecycle.subprocess") as mock_sub:
+            mock_sub.run.side_effect = FileNotFoundError
+            mock_sub.TimeoutExpired = subprocess.TimeoutExpired
+            fp = _capture_runtime_fingerprint()
+        # git_rev might be None (if the fixture isn't in a repo) or a string
+        # — either is acceptable. The key point is no crash.
+
+    def test_git_rev_null_on_timeout(self):
+        import subprocess as _sp
+
+        from lingtai_kernel.base_agent.lifecycle import _capture_runtime_fingerprint
+
+        with patch("lingtai_kernel.base_agent.lifecycle.subprocess") as mock_sub:
+            mock_sub.run.side_effect = _sp.TimeoutExpired(cmd="git", timeout=2)
+            mock_sub.TimeoutExpired = _sp.TimeoutExpired
+            mock_sub.CalledProcessError = _sp.CalledProcessError
+            mock_sub.FileNotFoundError = FileNotFoundError
+            fp = _capture_runtime_fingerprint()
+        # Should not crash; git_rev may or may not be None depending on real git
+        assert "git_rev" in fp
+
+    def test_source_digest_changes_on_file_change(self, tmp_path):
+        """Simulate source file change and verify digest changes."""
+        import lingtai_kernel
+        from lingtai_kernel.base_agent.lifecycle import _capture_runtime_fingerprint, _FP_KEY_FILES
+
+        fp1 = _capture_runtime_fingerprint()
+
+        # Modify one of the key files temporarily
+        pkg_dir = Path(lingtai_kernel.__file__).resolve().parent
+        target = pkg_dir / _FP_KEY_FILES[0]
+        original = target.read_bytes()
+        try:
+            target.write_text(original.decode("utf-8") + "\n# drift marker\n")
+            fp2 = _capture_runtime_fingerprint()
+            assert fp1["source_digest"] != fp2["source_digest"]
+        finally:
+            target.write_bytes(original)
+
+
+# We need subprocess at module level for the mock patch
+import subprocess
+
+
+# ---------------------------------------------------------------------------
+# 2. Status JSON includes runtime block
+# ---------------------------------------------------------------------------
+
+
+class TestStatusJsonRuntime:
+    """Verify that _status() includes fingerprint, python_version, platform."""
+
+    def test_status_includes_fingerprint_fields(self):
+        """Test via the _status function with a mock agent."""
+        from lingtai_kernel.base_agent.identity import _status
+
+        agent = MagicMock()
+        agent._working_dir = Path("/tmp/test")
+        agent.agent_name = "test"
+        agent._mail_service = None
+        agent._uptime_anchor = time.monotonic()
+        agent._config.stamina = 3600
+        agent._state = MagicMock()
+        agent._state.value = "idle"
+        agent._state_changed_at = time.time()
+        agent._last_progress_at = time.time()
+        agent._active_turn_kind = None
+        agent._active_turn_id = None
+        agent._active_turn_started_at = None
+        agent._deferred_notifications_count = 0
+        agent._deferred_notifications_oldest_at = None
+        agent._session = MagicMock()
+        agent._session.get_token_usage.return_value = {
+            "input_tokens": 0, "output_tokens": 0,
+            "thinking_tokens": 0, "cached_tokens": 0,
+            "total_tokens": 0, "api_calls": 0,
+            "ctx_system_tokens": 0, "ctx_tools_tokens": 0,
+            "ctx_history_tokens": 0, "ctx_total_tokens": 0,
+        }
+        agent._session._token_fallback_warned = False
+        agent._chat = None
+        agent._config.context_limit = None
+
+        # Set a runtime fingerprint
+        agent._runtime_fingerprint = {
+            "git_rev": "abc1234",
+            "source_digest": "deadbeef0123",
+            "captured_at": "2026-06-14T12:00:00Z",
+        }
+
+        result = _status(agent)
+        runtime = result["runtime"]
+        assert "fingerprint" in runtime
+        assert runtime["fingerprint"]["git_rev"] == "abc1234"
+        assert runtime["fingerprint"]["source_digest"] == "deadbeef0123"
+        assert "python_version" in runtime
+        assert "platform" in runtime
+
+    def test_status_fingerprint_none_when_missing(self):
+        """When _runtime_fingerprint is not set, fingerprint should be None."""
+        from lingtai_kernel.base_agent.identity import _status
+
+        agent = MagicMock()
+        agent._working_dir = Path("/tmp/test")
+        agent.agent_name = "test"
+        agent._mail_service = None
+        agent._uptime_anchor = time.monotonic()
+        agent._config.stamina = 3600
+        agent._state = MagicMock()
+        agent._state.value = "idle"
+        agent._state_changed_at = time.time()
+        agent._last_progress_at = time.time()
+        agent._active_turn_kind = None
+        agent._active_turn_id = None
+        agent._active_turn_started_at = None
+        agent._deferred_notifications_count = 0
+        agent._deferred_notifications_oldest_at = None
+        agent._session = MagicMock()
+        agent._session.get_token_usage.return_value = {
+            "input_tokens": 0, "output_tokens": 0,
+            "thinking_tokens": 0, "cached_tokens": 0,
+            "total_tokens": 0, "api_calls": 0,
+            "ctx_system_tokens": 0, "ctx_tools_tokens": 0,
+            "ctx_history_tokens": 0, "ctx_total_tokens": 0,
+        }
+        agent._session._token_fallback_warned = False
+        agent._chat = None
+        agent._config.context_limit = None
+
+        # No _runtime_fingerprint attribute
+        del agent._runtime_fingerprint  # ensure it doesn't exist
+        type(agent)._runtime_fingerprint = property(
+            lambda self: (_ for _ in ()).throw(AttributeError)
+        )
+
+        result = _status(agent)
+        runtime = result["runtime"]
+        assert "fingerprint" in runtime
+        assert runtime["fingerprint"] is None
+
+
+# ---------------------------------------------------------------------------
+# 3-5. Source drift nudge
+# ---------------------------------------------------------------------------
+
+
+class TestSourceDriftNudge:
+    """Tests for nudge/source_drift.py check function."""
+
+    def _make_agent(self, startup_fp: dict | None = None):
+        """Create a minimal mock agent for nudge testing."""
+        agent = MagicMock()
+        agent._working_dir = Path("/tmp/test-nudge")
+        agent._runtime_fingerprint = startup_fp
+        agent._nudge_source_drift_state = {}
+        agent._nudge_channel_lock = None
+        return agent
+
+    # Patch target: _capture_runtime_fingerprint is imported locally inside
+    # source_drift.check(), so we must patch it at its definition site.
+    _PATCH_TARGET = "lingtai_kernel.base_agent.lifecycle._capture_runtime_fingerprint"
+
+    def test_no_drift_removes_prior_nudge(self):
+        """When startup and disk fingerprints match, no nudge emitted."""
+        from lingtai_kernel.nudge.source_drift import check
+
+        fp = {
+            "git_rev": "abc1234",
+            "source_digest": "deadbeef0123",
+            "captured_at": "2026-06-14T12:00:00Z",
+        }
+        agent = self._make_agent(startup_fp=fp)
+
+        with patch(self._PATCH_TARGET, return_value=fp):
+            check(agent)
+
+        from lingtai_kernel.nudge import source_drift
+        state = source_drift._state(agent)
+        assert not state.get("emitted", False)
+
+    def test_drift_detected_emits_nudge(self):
+        """When fingerprints differ, nudge is emitted."""
+        from lingtai_kernel.nudge.source_drift import check
+
+        startup_fp = {
+            "git_rev": "abc1234",
+            "source_digest": "deadbeef0123",
+            "captured_at": "2026-06-14T12:00:00Z",
+        }
+        disk_fp = {
+            "git_rev": "xyz9999",
+            "source_digest": "cafebabe4567",
+            "captured_at": "2026-06-14T13:00:00Z",
+        }
+        agent = self._make_agent(startup_fp=startup_fp)
+
+        with (
+            patch(self._PATCH_TARGET, return_value=disk_fp),
+            patch("lingtai_kernel.nudge.upsert") as mock_upsert,
+        ):
+            check(agent)
+            mock_upsert.assert_called_once()
+
+        from lingtai_kernel.nudge import source_drift
+        state = source_drift._state(agent)
+        assert state.get("emitted") is True
+        assert "abc1234" in state.get("emitted_for", "")
+        assert "xyz9999" in state.get("emitted_for", "")
+
+    def test_throttle_skips_within_interval(self):
+        """Second call within 60s should be a no-op."""
+        from lingtai_kernel.nudge.source_drift import check, _state
+
+        startup_fp = {"git_rev": "aaa", "source_digest": "bbb", "captured_at": "t1"}
+        disk_fp = {"git_rev": "ccc", "source_digest": "ddd", "captured_at": "t2"}
+        agent = self._make_agent(startup_fp=startup_fp)
+
+        with patch(self._PATCH_TARGET, return_value=disk_fp):
+            check(agent)
+            state = _state(agent)
+            first_ts = state["last_probe_ts"]
+
+            # Second call immediately — should be throttled
+            check(agent)
+            state = _state(agent)
+            assert state["last_probe_ts"] == first_ts  # unchanged
+
+    def test_throttle_allows_after_interval(self):
+        """After 60s, check should run again."""
+        from lingtai_kernel.nudge.source_drift import check, _state
+
+        startup_fp = {"git_rev": "aaa", "source_digest": "bbb", "captured_at": "t1"}
+        disk_fp = {"git_rev": "aaa", "source_digest": "bbb", "captured_at": "t2"}
+        agent = self._make_agent(startup_fp=startup_fp)
+
+        with patch(self._PATCH_TARGET, return_value=disk_fp):
+            check(agent)
+            state = _state(agent)
+            # Artificially set last_probe_ts to >60s ago
+            state["last_probe_ts"] = time.time() - 61
+            check(agent)
+            state = _state(agent)
+            assert state["last_probe_ts"] > time.time() - 5
+
+    def test_no_startup_fingerprint_is_noop(self):
+        """If agent has no startup fingerprint, check is a no-op."""
+        from lingtai_kernel.nudge.source_drift import check
+
+        agent = self._make_agent(startup_fp=None)
+        # Should not raise
+        check(agent)
+
+    def test_partial_drift_git_only(self):
+        """Only git_rev differs → still detected as drift."""
+        from lingtai_kernel.nudge.source_drift import check, _state
+
+        startup_fp = {"git_rev": "aaa1111", "source_digest": "bbb2222", "captured_at": "t1"}
+        disk_fp = {"git_rev": "ccc3333", "source_digest": "bbb2222", "captured_at": "t2"}
+        agent = self._make_agent(startup_fp=startup_fp)
+
+        with (
+            patch(self._PATCH_TARGET, return_value=disk_fp),
+            patch("lingtai_kernel.nudge.upsert"),
+        ):
+            check(agent)
+
+        state = _state(agent)
+        assert state.get("emitted") is True
+
+    def test_partial_drift_digest_only(self):
+        """Only source_digest differs → still detected as drift."""
+        from lingtai_kernel.nudge.source_drift import check, _state
+
+        startup_fp = {"git_rev": "aaa1111", "source_digest": "bbb2222", "captured_at": "t1"}
+        disk_fp = {"git_rev": "aaa1111", "source_digest": "xxx9999", "captured_at": "t2"}
+        agent = self._make_agent(startup_fp=startup_fp)
+
+        with (
+            patch(self._PATCH_TARGET, return_value=disk_fp),
+            patch("lingtai_kernel.nudge.upsert"),
+        ):
+            check(agent)
+
+        state = _state(agent)
+        assert state.get("emitted") is True
+
+    def test_null_git_rev_not_counted_as_drift(self):
+        """When startup git_rev is None, git drift should not be flagged."""
+        from lingtai_kernel.nudge.source_drift import check, _state
+
+        startup_fp = {"git_rev": None, "source_digest": "bbb2222", "captured_at": "t1"}
+        disk_fp = {"git_rev": "ccc3333", "source_digest": "bbb2222", "captured_at": "t2"}
+        agent = self._make_agent(startup_fp=startup_fp)
+
+        with patch(self._PATCH_TARGET, return_value=disk_fp):
+            check(agent)
+
+        state = _state(agent)
+        # Only git differs but startup git is None → no drift signal
+        assert not state.get("emitted", False)
+
+
+# ---------------------------------------------------------------------------
+# 6. Doctor parsing
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorFingerprintParsing:
+    """Test that the doctor script correctly reads runtime fingerprint."""
+
+    def test_doctor_displays_fingerprint(self, tmp_path):
+        """Doctor should display fingerprint info when present in .status.json."""
+        agent = tmp_path / "agent"
+        agent.mkdir()
+        (agent / ".agent.json").write_text(
+            json.dumps({"name": "test", "state": "idle"}), encoding="utf-8"
+        )
+        (agent / ".status.json").write_text(
+            json.dumps({
+                "state": "idle",
+                "runtime": {
+                    "current_time": "2026-06-14T12:00:00Z",
+                    "state": "idle",
+                    "fingerprint": {
+                        "git_rev": "abc1234",
+                        "source_digest": "deadbeef0123",
+                        "captured_at": "2026-06-14T12:00:00Z",
+                    },
+                    "python_version": "3.11.5",
+                    "platform": "darwin",
+                },
+            }),
+            encoding="utf-8",
+        )
+        (agent / ".agent.heartbeat").write_text("ok", encoding="utf-8")
+
+        import subprocess
+        import sys
+        ROOT = Path(__file__).resolve().parents[1]
+        DOCTOR = ROOT / "src" / "lingtai" / "intrinsic_skills" / "lingtai-doctor" / "scripts" / "doctor.py"
+
+        proc = subprocess.run(
+            [sys.executable, str(DOCTOR), "--agent-dir", str(agent), "--json"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        data = json.loads(proc.stdout)
+        # Find the lifecycle section
+        lifecycle = next(s for s in data["sections"] if s["name"] == "lifecycle")
+        # Should have a "runtime fingerprint available" finding
+        fp_findings = [
+            f for f in lifecycle["findings"]
+            if f["title"] == "runtime fingerprint available"
+        ]
+        assert len(fp_findings) == 1
+        fp_data = fp_findings[0]["data"]["fingerprint"]
+        assert fp_data["git_rev"] == "abc1234"
+        assert fp_data["source_digest"] == "deadbeef0123"
+        assert fp_data["python_version"] == "3.11.5"
+
+    def test_doctor_warns_when_fingerprint_missing(self, tmp_path):
+        """Doctor should warn when runtime.fingerprint is absent."""
+        agent = tmp_path / "agent"
+        agent.mkdir()
+        (agent / ".agent.json").write_text(
+            json.dumps({"name": "test", "state": "idle"}), encoding="utf-8"
+        )
+        (agent / ".status.json").write_text(
+            json.dumps({
+                "state": "idle",
+                "runtime": {
+                    "current_time": "2026-06-14T12:00:00Z",
+                    "state": "idle",
+                },
+            }),
+            encoding="utf-8",
+        )
+        (agent / ".agent.heartbeat").write_text("ok", encoding="utf-8")
+
+        import subprocess
+        import sys
+        ROOT = Path(__file__).resolve().parents[1]
+        DOCTOR = ROOT / "src" / "lingtai" / "intrinsic_skills" / "lingtai-doctor" / "scripts" / "doctor.py"
+
+        proc = subprocess.run(
+            [sys.executable, str(DOCTOR), "--agent-dir", str(agent), "--json"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        data = json.loads(proc.stdout)
+        lifecycle = next(s for s in data["sections"] if s["name"] == "lifecycle")
+        missing_findings = [
+            f for f in lifecycle["findings"]
+            if f["title"] == "runtime fingerprint missing"
+        ]
+        assert len(missing_findings) == 1
+        assert missing_findings[0]["severity"] == "WARN"
+
+    def test_doctor_handles_no_runtime_block(self, tmp_path):
+        """Doctor should warn when runtime block is entirely absent (old agent)."""
+        agent = tmp_path / "agent"
+        agent.mkdir()
+        (agent / ".agent.json").write_text(
+            json.dumps({"name": "test", "state": "idle"}), encoding="utf-8"
+        )
+        (agent / ".status.json").write_text(
+            json.dumps({"state": "idle"}), encoding="utf-8"
+        )
+        (agent / ".agent.heartbeat").write_text("ok", encoding="utf-8")
+
+        import subprocess
+        import sys
+        ROOT = Path(__file__).resolve().parents[1]
+        DOCTOR = ROOT / "src" / "lingtai" / "intrinsic_skills" / "lingtai-doctor" / "scripts" / "doctor.py"
+
+        proc = subprocess.run(
+            [sys.executable, str(DOCTOR), "--agent-dir", str(agent), "--json"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        data = json.loads(proc.stdout)
+        lifecycle = next(s for s in data["sections"] if s["name"] == "lifecycle")
+        missing_findings = [
+            f for f in lifecycle["findings"]
+            if f["title"] == "runtime fingerprint missing"
+        ]
+        assert len(missing_findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. Integration: nudge registered in run_checks
+# ---------------------------------------------------------------------------
+
+
+class TestSourceDriftRegistered:
+    """Verify that source_drift.check is wired into run_checks."""
+
+    def test_source_drift_imported_in_nudge_init(self):
+        import lingtai_kernel.nudge as nudge_mod
+        assert hasattr(nudge_mod, "source_drift")
+
+    def test_run_checks_calls_source_drift(self):
+        """run_checks should dispatch to source_drift.check."""
+        import lingtai_kernel.nudge as nudge_mod
+
+        agent = MagicMock()
+        agent._working_dir = Path("/tmp/test")
+        agent._nudge_kernel_version_state = {}
+        agent._nudge_source_drift_state = {}
+        agent._nudge_goal_state = {}
+        agent._nudge_channel_lock = None
+
+        with (
+            patch.object(nudge_mod.kernel_version, "check") as mock_kv,
+            patch.object(nudge_mod.source_drift, "check") as mock_sd,
+            patch.object(nudge_mod.goal, "check") as mock_gc,
+        ):
+            nudge_mod.run_checks(agent)
+            mock_sd.assert_called_once_with(agent)


### PR DESCRIPTION
## Problem

A long-running agent process may have imported old code before a fix landed in the repository (e.g. `git pull` + `pip install -e .` on a dev install). The loaded code in memory diverges from the code on disk, but there is no way to see this from the outside. The existing `kernel_version.py` nudge only catches **package version** changes (via `importlib.metadata`), not source-level drift.

The incident that motivated #178: a dev-2 bot appeared stuck with blocking `daemon.ask` behavior even though the fix (#153) was already on `main`. The agent process had imported pre-#153 code before the editable checkout was updated.

## What changed

### 1. Runtime fingerprint capture (base_agent/lifecycle.py)
- New `_capture_runtime_fingerprint()` helper captures a dual fingerprint at startup:
  - `git_rev`: short git HEAD hash (or null if not in a git repo)
  - `source_digest`: SHA-256 hex prefix (12 chars) of key entry-point source files
- Called in `_start()`, stored on `agent._runtime_fingerprint`

### 2. Status JSON exposure (base_agent/identity.py)
- New `runtime` block in `.status.json` containing:
  - `fingerprint`: the startup fingerprint (git_rev, source_digest, captured_at)
  - `python_version`: runtime Python version
  - `platform`: OS platform

### 3. Source drift nudge (nudge/source_drift.py)
- New nudge module modeled on `kernel_version.py`
- Throttled to 60s intervals
- Re-computes the fingerprint from disk and compares with startup snapshot
- When drift detected: emits `source_drift` nudge advising `system(action=refresh)`
- When drift clears: removes the nudge
- Registered in `nudge/__init__.py` run_checks()

### 4. Doctor fix (lingtai-doctor/scripts/doctor.py)
- Parses the nested `runtime.fingerprint` from `.status.json`
- Displays fingerprint info in doctor output
- Warns when fingerprint is missing (old agent that has not restarted)

### 5. Tests (tests/test_source_drift.py)
- 21 tests covering: fingerprint capture, status JSON, nudge no-drift, nudge drift-detected, nudge throttle, doctor parsing, nudge registration
- All 21 pass, zero regressions in 117 existing tests

## Non-goals
- No hot reload
- No auto-restart
- No broad daemon.ask rewrite
- No unrelated lifecycle behavior changes

## Validation
- Focused tests: 21 passed in 0.83s
- Broader regression suite: 138 passed in 36.06s (test_lingtai_doctor, test_workdir, test_heartbeat, test_agent, test_notification_sync, test_time_awareness_status, test_goal_notification)

Closes #178