### PR TITLE
Add MCP inbox latency diagnostics

### DIFF
--- a/reports/issue-167-initial-diagnostics-explainer.html
+++ b/reports/issue-167-initial-diagnostics-explainer.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Issue #167 Initial Diagnostics PR</title>
+  <style>
+    :root { color-scheme: light; --bg:#f8fafc; --card:#ffffff; --ink:#0f172a; --muted:#475569; --line:#cbd5e1; --accent:#2563eb; --good:#047857; --warn:#b45309; }
+    body { margin:0; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; background:var(--bg); color:var(--ink); line-height:1.55; }
+    main { max-width:980px; margin:0 auto; padding:40px 20px 64px; }
+    header { border-left:6px solid var(--accent); padding:18px 22px; background:var(--card); box-shadow:0 1px 3px rgba(15,23,42,.08); }
+    h1 { margin:0 0 8px; font-size:1.9rem; }
+    h2 { margin-top:30px; border-bottom:1px solid var(--line); padding-bottom:6px; }
+    .muted { color:var(--muted); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:16px; }
+    .card { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:18px; }
+    code { background:#e2e8f0; padding:1px 5px; border-radius:5px; }
+    pre { background:#0f172a; color:#e2e8f0; padding:14px; border-radius:10px; overflow:auto; }
+    .tag { display:inline-block; border-radius:999px; padding:2px 10px; font-size:.85rem; font-weight:600; margin-right:6px; }
+    .tag.good { background:#d1fae5; color:var(--good); }
+    .tag.warn { background:#fef3c7; color:var(--warn); }
+    ul { padding-left:1.35rem; }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>Initial diagnostics and wire cleanup for lingtai-kernel #167</h1>
+    <p class="muted">This PR is intentionally narrow: it adds evidence for the Telegram delivery gap investigation and hardens one kernel exit path. It does <strong>not</strong> claim to fix the full 15-minute Telegram delay.</p>
+    <p><span class="tag good">diagnostics</span><span class="tag good">kernel hygiene</span><span class="tag warn">not a root-cause fix</span></p>
+  </header>
+
+  <h2>Issue context</h2>
+  <p>
+    <a href="https://github.com/Lingtai-AI/lingtai-kernel/issues/167">Issue #167</a>
+    reports a post-turn IDLE case where a live Telegram message surfaced about 15 minutes late,
+    then delivery recovered through a pending-tool-call heal path. The first PR should help separate
+    three possibilities: the producer/addon wrote the event late, the kernel inbox poller failed to
+    drain an existing event promptly, or the host/runtime was suspended or frozen.
+  </p>
+
+  <h2>What changed</h2>
+  <div class="grid">
+    <section class="card">
+      <h3>MCP inbox boundary telemetry</h3>
+      <p><code>mcp_inbox_event</code> logs now include <code>drain_latency_s</code>, measuring how long a LICC event file sat in the kernel inbox before consumption.</p>
+      <p>If the event carries a parseable top-level <code>received_at</code> timestamp, the log also includes <code>producer_lag_s</code> for producer-to-kernel timing.</p>
+    </section>
+    <section class="card">
+      <h3>Poll-backoff wire cleanup</h3>
+      <p>When the turn exits via <code>idle_after_poll_backoff</code>, the kernel now defensively closes any still-pending tail tool calls using the distinct reason <code>poll_backoff_exit</code>.</p>
+      <p>Normal adapters already commit tool results, so this is a no-op in the expected path and an attribution improvement in the abnormal path.</p>
+    </section>
+    <section class="card">
+      <h3>Doc reconciliation</h3>
+      <p>The poll-backoff docstring now matches actual behavior: counters reset on sends and on check/read results that found messages. No unsupported notification-arrival reset was added.</p>
+      <p>The LICC <code>received_at</code> comment now describes it as an optional producer timestamp for lag telemetry.</p>
+    </section>
+  </div>
+
+  <h2>What this intentionally does not do</h2>
+  <ul>
+    <li>No Telegram addon listener heartbeat or <code>.alive</code> supervision.</li>
+    <li>No auto-restart or broad listener supervision rewrite.</li>
+    <li>No claim that the exact observed 15-minute root cause is fixed.</li>
+    <li>No change to notification preview payload semantics beyond additive log telemetry.</li>
+  </ul>
+
+  <h2>Validation</h2>
+  <pre><code>git diff --check
+python3 -m py_compile src/lingtai/core/mcp/inbox.py src/lingtai_kernel/base_agent/turn.py tests/test_mcp_inbox.py tests/test_sent_message_tracker.py
+PYTHONPATH=$PWD/src pytest -q tests/test_mcp_inbox.py tests/test_sent_message_tracker.py
+PYTHONPATH=$PWD/src pytest -q tests/test_notification_sync.py tests/test_aed_recovery.py tests/test_tc_wake_orphan_heal.py tests/test_mcp_licc_client.py</code></pre>
+  <p class="muted">Focused result: 67 passed. Broader notification/MCP/tc-wake result: 84 passed.</p>
+
+  <h2>Review notes</h2>
+  <ul>
+    <li>The telemetry fields are additive and tolerate missing or malformed <code>received_at</code> without dead-lettering the event.</li>
+    <li>Timing tests assert non-negative presence/absence rather than exact wall-clock values.</li>
+    <li>Final independent review found no blockers and confirmed the PR stays within the initial diagnostic/cleanup scope.</li>
+  </ul>
+</main>
+</body>
+</html>

--- a/src/lingtai/core/mcp/inbox.py
+++ b/src/lingtai/core/mcp/inbox.py
@@ -14,7 +14,7 @@ into the agent's inbox. The contract:
         "body": "full message body (required)",
         "metadata": {...optional},
         "wake": true,                 // optional, default true
-        "received_at": "ISO 8601"     // optional, kernel fills in if missing
+        "received_at": "ISO 8601"     // optional producer timestamp for lag telemetry
       }
 - The kernel polls all subdirs at the same cadence as the mailbox listener
   (0.5s), validates each file, dispatches to the agent's inbox via
@@ -84,6 +84,7 @@ _PREVIEW_FIELD_CAP = 10000  # chars of body to inline as the snippet (raised for
 # stuffs a kilobyte into `conversation_ref` won't bloat the notification.
 _PREVIEW_META_FIELDS = ("conversation_ref", "message_ref", "platform")
 _PREVIEW_META_FIELD_CAP = 200
+_TELEMETRY_ROUND_DIGITS = 3
 
 
 # ---------------------------------------------------------------------------
@@ -173,7 +174,59 @@ def _extract_preview_meta(event: dict) -> dict:
     return out
 
 
-def _consume_event(agent: "BaseAgent", mcp_name: str, event: dict) -> tuple[bool, dict]:
+def _bounded_elapsed_s(start_ts: float, end_ts: float) -> float:
+    """Return a rounded nonnegative elapsed duration in seconds."""
+    return round(max(0.0, end_ts - start_ts), _TELEMETRY_ROUND_DIGITS)
+
+
+def _parse_received_at_ts(value: object) -> float | None:
+    """Parse a producer supplied top-level received_at timestamp.
+
+    LICC producers emit timezone-aware ISO 8601 strings. Accept the common
+    ``Z`` UTC suffix plus explicit offsets; return None for missing, naive,
+    or malformed values so legacy/sloppy events still dispatch.
+    """
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        return None
+    return dt.timestamp()
+
+
+def _event_telemetry_fields(
+    event: dict,
+    *,
+    queued_at_ts: float | None,
+    consumed_at_ts: float,
+) -> dict:
+    """Build additive per-event timing fields for the mcp_inbox_event log."""
+    baseline_ts = consumed_at_ts if queued_at_ts is None else queued_at_ts
+    fields = {
+        "drain_latency_s": _bounded_elapsed_s(baseline_ts, consumed_at_ts),
+    }
+    producer_ts = _parse_received_at_ts(event.get("received_at"))
+    if producer_ts is not None:
+        fields["producer_lag_s"] = _bounded_elapsed_s(producer_ts, consumed_at_ts)
+    return fields
+
+
+def _consume_event(
+    agent: "BaseAgent",
+    mcp_name: str,
+    event: dict,
+    *,
+    queued_at_ts: float | None = None,
+    consumed_at_ts: float | None = None,
+) -> tuple[bool, dict]:
     """Record the per-event log entry; return (wake, preview).
 
     The preview surfaces sender, subject, and a bounded body preview so the
@@ -201,12 +254,18 @@ def _consume_event(agent: "BaseAgent", mcp_name: str, event: dict) -> tuple[bool
     sender = event["from"]
     subject = event["subject"]
     body = event["body"]
+    consumed_at = time.time() if consumed_at_ts is None else consumed_at_ts
     agent._log(
         "mcp_inbox_event",
         mcp=mcp_name,
         sender=sender,
         subject=subject,
         wake=wake,
+        **_event_telemetry_fields(
+            event,
+            queued_at_ts=queued_at_ts,
+            consumed_at_ts=consumed_at,
+        ),
     )
     preview = {
         "from": sender,
@@ -375,7 +434,17 @@ def _scan_once(agent: "BaseAgent", inbox_root: Path) -> int:
 
             # Consume (log per-event + collect wake intent + preview) and delete on success.
             try:
-                wake, preview = _consume_event(agent, mcp_name, event)
+                try:
+                    queued_at_ts = entry.stat().st_mtime
+                except OSError:
+                    queued_at_ts = None
+                wake, preview = _consume_event(
+                    agent,
+                    mcp_name,
+                    event,
+                    queued_at_ts=queued_at_ts,
+                    consumed_at_ts=time.time(),
+                )
             except Exception as e:
                 _dead_letter(entry, f"dispatch failed: {e}")
                 continue

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -458,6 +458,48 @@ def _restore_tool_results_after_continuation_failure(
     return True
 
 
+def _close_pending_tool_calls_after_poll_backoff(
+    agent,
+    *,
+    ledger_source: str,
+) -> None:
+    """Defensively close any tail tool_calls left after poll-backoff commit.
+
+    Normal adapters append the real tool results via ``commit_tool_results``,
+    so this is a no-op. If an adapter leaves the assistant tool-call tail
+    pending, close it here with a distinct reason before the later IDLE
+    notification path can attribute the cleanup to generic idle injection.
+    """
+    chat = getattr(agent, "_chat", None)
+    iface = getattr(chat, "interface", None)
+    if iface is None or not iface.has_pending_tool_calls():
+        return
+
+    pending_fields = _pending_tool_call_summary(iface)
+    phase = "close_pending_tool_calls"
+    try:
+        iface.close_pending_tool_calls(
+            reason="poll_backoff_exit",
+            tool_completed=True,
+        )
+        phase = "save_chat_history"
+        agent._save_chat_history(ledger_source=ledger_source)
+        agent._log(
+            "heal_pending_tool_calls",
+            reason="poll_backoff_exit",
+            **pending_fields,
+        )
+    except Exception as e:
+        fields = {
+            "reason": "poll_backoff_exit",
+            "failed_at": phase,
+            "error": (str(e) or repr(e))[:200],
+        }
+        if phase == "save_chat_history":
+            fields["side_effect"] = "memory_state_may_be_ahead_of_disk"
+        agent._log("heal_pending_tool_calls_failed", **fields)
+
+
 def _run_loop(agent) -> None:
     """Wait for messages, process them. Agent persists between messages."""
     from ..state import AgentState
@@ -1178,9 +1220,8 @@ def _check_poll_backoff(agent, tool_calls, tool_results=None) -> bool:
     the same turn. After ``max_poll_retries`` consecutive checks on the
     same channel, returns True to signal the agent should go IDLE.
 
-    The counter resets when a send action occurs, when new messages
-    arrive via the notification system, or when a check/read action
-    actually returns messages (found_new=True).
+    The counter resets when a send action occurs, or when a check/read
+    action actually returns messages (found_new=True).
     """
     # Build a lookup from tool-call id to result for found-new detection.
     # ToolResultBlock stores the correlated tool-call id on `.id` (the same
@@ -1427,6 +1468,10 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
                 # and the post-turn save in _run_loop can see a stale wire
                 # and heal the (already-committed) tool calls.
                 agent._save_chat_history(ledger_source=ledger_source)
+                _close_pending_tool_calls_after_poll_backoff(
+                    agent,
+                    ledger_source=ledger_source,
+                )
             agent._log("idle_after_poll_backoff",
                        reason="poll_retries_exhausted")
             return {

--- a/tests/test_mcp_inbox.py
+++ b/tests/test_mcp_inbox.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -59,6 +60,18 @@ def _write_event(workdir: Path, mcp_name: str, event_id: str, event: dict) -> Pa
     tmp.write_text(json.dumps(event), encoding="utf-8")
     tmp.rename(final)
     return final
+
+
+def _capture_logs(agent):
+    events: list[tuple[str, dict]] = []
+    agent._log = lambda event, **fields: events.append((event, fields))
+    return events
+
+
+def _only_mcp_event(logs: list[tuple[str, dict]]) -> dict:
+    matches = [fields for event, fields in logs if event == "mcp_inbox_event"]
+    assert len(matches) == 1
+    return matches[0]
 
 
 # ---------------------------------------------------------------------------
@@ -146,6 +159,61 @@ def test_scan_dispatches_valid_event_to_notification(tmp_path):
 
     # File was deleted on success.
     assert not (inbox_root / "telegram" / "ev1.json").exists()
+
+
+def test_scan_logs_drain_latency_and_producer_lag(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    logs = _capture_logs(agent)
+    received_at = (
+        datetime.now(timezone.utc) - timedelta(seconds=2)
+    ).isoformat().replace("+00:00", "Z")
+    _write_event(workdir, "telegram", "ev1", {
+        "from": "alice",
+        "subject": "hi",
+        "body": "hello",
+        "received_at": received_at,
+    })
+
+    assert _scan_once(agent, workdir / INBOX_DIRNAME) == 1
+
+    fields = _only_mcp_event(logs)
+    assert "drain_latency_s" in fields
+    assert fields["drain_latency_s"] >= 0
+    assert "producer_lag_s" in fields
+    assert fields["producer_lag_s"] >= 0
+
+
+def test_scan_legacy_event_logs_drain_latency_without_producer_lag(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    logs = _capture_logs(agent)
+    _write_event(workdir, "telegram", "ev1", {
+        "from": "alice", "subject": "hi", "body": "hello",
+    })
+
+    assert _scan_once(agent, workdir / INBOX_DIRNAME) == 1
+
+    fields = _only_mcp_event(logs)
+    assert "drain_latency_s" in fields
+    assert fields["drain_latency_s"] >= 0
+    assert "producer_lag_s" not in fields
+
+
+def test_scan_invalid_received_at_does_not_dead_letter_or_log_lag(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    logs = _capture_logs(agent)
+    _write_event(workdir, "telegram", "ev1", {
+        "from": "alice",
+        "subject": "hi",
+        "body": "hello",
+        "received_at": "not-a-timestamp",
+    })
+
+    assert _scan_once(agent, workdir / INBOX_DIRNAME) == 1
+
+    fields = _only_mcp_event(logs)
+    assert fields["drain_latency_s"] >= 0
+    assert "producer_lag_s" not in fields
+    assert not (workdir / INBOX_DIRNAME / "telegram" / DEAD_DIRNAME).exists()
 
 
 def test_scan_coalesces_multiple_events_into_one_notification(tmp_path):

--- a/tests/test_sent_message_tracker.py
+++ b/tests/test_sent_message_tracker.py
@@ -1,7 +1,9 @@
 """Tests for SentMessageTracker — dedup and poll backoff."""
 from __future__ import annotations
 
+import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -418,6 +420,100 @@ class TestCheckPollBackoff:
         tc = self._make_tc("email", {"action": "check"})
         for _ in range(5):
             assert not _check_poll_backoff(agent, [tc])
+
+
+    def test_poll_backoff_exit_closes_pending_tool_calls_after_commit(self, tmp_path, monkeypatch):
+        from lingtai_kernel.base_agent import turn
+        from lingtai_kernel.llm.interface import ChatInterface, ToolCallBlock, ToolResultBlock
+
+        class _Guard:
+            def check_limit(self, _count):
+                return None
+
+            def check_invalid_tool_limit(self):
+                return None
+
+            def record_calls(self, _count):
+                pass
+
+            def clear_progress_notice(self):
+                pass
+
+        class _Executor:
+            def __init__(self):
+                self.guard = _Guard()
+
+            def execute(self, *_args, **_kwargs):
+                return (
+                    [ToolResultBlock(id="tc-poll", name="telegram", content={})],
+                    False,
+                    "",
+                )
+
+        class _Chat:
+            def __init__(self, tc):
+                self.interface = ChatInterface()
+                self.interface.add_system("system")
+                self.interface.add_user_message("poll")
+                self.interface.add_assistant_message([tc])
+                self.committed = []
+
+            def commit_tool_results(self, results):
+                self.committed.append(list(results))
+                # Deliberately leave the pending tail in place to exercise
+                # the poll_backoff_exit defensive cleanup branch.
+
+        tc = ToolCallBlock(id="tc-poll", name="telegram", args={"action": "check"})
+        chat = _Chat(tc)
+        agent = SimpleNamespace(
+            _cancel_event=threading.Event(),
+            _executor=_Executor(),
+            _on_tool_result_hook=None,
+            _notification_live_holder=None,
+            _chat=chat,
+            _sent_tracker=SentMessageTracker(),
+            _working_dir=tmp_path,
+            logs=[],
+            save_sources=[],
+        )
+        agent._log = lambda event, **fields: agent.logs.append((event, fields))
+        agent._save_chat_history = (
+            lambda *, ledger_source=None: agent.save_sources.append(ledger_source)
+        )
+        agent._sent_tracker.record_poll("telegram", found_new=False)
+        agent._sent_tracker.record_poll("telegram", found_new=False)
+        monkeypatch.setattr(
+            turn,
+            "attach_active_notifications",
+            lambda _agent, _results, prior_holder=None: prior_holder,
+        )
+
+        response = SimpleNamespace(
+            text="",
+            thoughts=[],
+            tool_calls=[tc],
+            usage=SimpleNamespace(),
+            raw=None,
+        )
+        result = turn._process_response(agent, response, ledger_source="test")
+
+        assert result == {"text": "", "failed": False, "errors": []}
+        assert chat.committed
+        assert not chat.interface.has_pending_tool_calls()
+        assert agent.save_sources == ["test", "test"]
+        heal_logs = [
+            fields for event, fields in agent.logs
+            if event == "heal_pending_tool_calls"
+        ]
+        assert heal_logs == [{
+            "reason": "poll_backoff_exit",
+            "pending_tool_call_count": 1,
+            "pending_tool_call_ids": ["tc-poll"],
+            "pending_tool_names": ["telegram"],
+        }]
+        tail_result = chat.interface.entries[-1].content[0]
+        assert tail_result.synthesized is True
+        assert "Reason recorded by the kernel: poll_backoff_exit" in tail_result.content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Related to #167 (initial diagnostic/cleanup slice only; does not close the full issue).

## Summary

This is a deliberately narrow first PR for the post-turn Telegram delivery gap reported in #167. It does **not** claim to solve the full ~15-minute delivery delay. Instead, it adds kernel-side evidence at the MCP inbox boundary and cleans up a universally-correct pending-tool-call exit path so future incidents can be attributed more precisely.

## Why this matters

In the #167 incident, a live Telegram message appeared to surface long after the agent had gone IDLE on `poll_retries_exhausted`, and the eventual wake routed through the generic `idle_inject_blocked` pending-tool-call heal path. From the existing logs alone, it is hard to distinguish whether:

1. the producer/addon wrote the inbox event late;
2. the kernel MCP inbox poller failed to drain an already-written event promptly; or
3. the host/runtime was suspended or frozen.

This PR adds the minimum kernel telemetry and wire hygiene needed to make that distinction clearer without over-claiming a root-cause fix.

## What changed

- Adds additive timing fields to each `mcp_inbox_event` log:
  - `drain_latency_s`: nonnegative time from the inbox event file's mtime to kernel consumption.
  - `producer_lag_s`: nonnegative time from a parseable top-level producer `received_at` timestamp to kernel consumption, omitted when missing or malformed.
- Keeps legacy LICC events compatible: missing, naive, or malformed `received_at` values do not dead-letter the event.
- Updates the LICC contract comment for `received_at` to describe it as an optional producer timestamp for lag telemetry rather than claiming the kernel fills it in.
- Adds a defensive `idle_after_poll_backoff` cleanup step: after committing and saving real tool results, if the chat interface still has pending tail tool calls, close them with reason `poll_backoff_exit` and save/log via the existing heal pattern.
- Corrects the `_check_poll_backoff` docstring so it matches actual reset behavior: sends reset the counter, and check/read results that actually contain messages reset it.
- Adds a self-contained explainer under `reports/` for human review.

## What this does not change

- No Telegram addon `.alive` heartbeat or listener supervision.
- No auto-restart behavior.
- No broad listener supervision rewrite.
- No claim that the exact 15-minute delay root cause is fixed.
- No behavior change to reset poll counters on notification arrival; the previous docstring claim was inaccurate, so this PR corrects documentation rather than inventing unsupported behavior.

## Validation

```bash
git diff --check
python3 -m py_compile src/lingtai/core/mcp/inbox.py src/lingtai_kernel/base_agent/turn.py tests/test_mcp_inbox.py tests/test_sent_message_tracker.py
PYTHONPATH=$PWD/src python -m pytest -q tests/test_mcp_inbox.py tests/test_sent_message_tracker.py
PYTHONPATH=$PWD/src python -m pytest -q tests/test_notification_sync.py tests/test_aed_recovery.py tests/test_tc_wake_orphan_heal.py tests/test_mcp_licc_client.py
PYTHONPATH=$PWD/src python -m pytest -q tests/test_mcp_inbox.py tests/test_sent_message_tracker.py tests/test_notification_sync.py tests/test_aed_recovery.py tests/test_tc_wake_orphan_heal.py tests/test_mcp_licc_client.py
```

Results:

- Focused MCP inbox / sent-message tracker tests: `67 passed`.
- Broader notification / AED / tc-wake / MCP LICC tests: `84 passed`.
- Combined focused + broader suite after commit: `151 passed`.
- Final independent review of the reconstructed diff: PASS, no blockers.