### PR TITLE
docs: clarify daemon context discipline

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -86,6 +86,28 @@ research, or spawn/contact an avatar when the capability should persist. For the
 runtime model, read `reference/substrate-manual/SKILL.md`; for a specific tool, read
 that tool's manual.
 
+### Daemon workflow discipline
+
+Protect the main agent's context. The parent agent should stay in the strategic
+seat: decide the objective, negate the first plan before acting, write the
+workflow, and keep the durable state. Daemons should carry the noisy execution:
+file scans, deterministic transformations, read-only reviews, batch conversion,
+log mining, and other work whose details would pollute the main context.
+
+Before dispatching substantial daemon work:
+
+1. Write the workflow in pad (or a task artifact when it is too large): objective,
+   assumptions to test, daemon task split, expected artifacts, and stop criteria.
+2. Choose the cheapest capable body. Prefer low-tier or CLI-backed daemons for
+   deterministic or mechanical work; reserve the main/premium model for planning,
+   synthesis, and decisions that need the full context.
+3. Constrain the daemon prompt. Ask for the artifact path, summary shape, and
+   evidence needed; tell it what not to do. The parent coordinates; the daemon
+   executes.
+4. Reclaim only the grain. Read the daemon's report/artifact, verify key claims,
+   and deposit durable results in pad/knowledge/skills. Do not drag every daemon
+   transcript back into the main conversation.
+
 Tool results may carry `_advisory.type == "duplicate_tool_call"` when the same
 semantic tool call repeats more than the free-pass threshold. This is
 advisory-only: the tool already ran and the kernel did not block it. Treat it as

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -86,27 +86,35 @@ research, or spawn/contact an avatar when the capability should persist. For the
 runtime model, read `reference/substrate-manual/SKILL.md`; for a specific tool, read
 that tool's manual.
 
-### Daemon workflow discipline
+### Daemon workflow methodology
 
 Protect the main agent's context. The parent agent should stay in the strategic
-seat: decide the objective, negate the first plan before acting, write the
-workflow, and keep the durable state. Daemons should carry the noisy execution:
-file scans, deterministic transformations, read-only reviews, batch conversion,
-log mining, and other work whose details would pollute the main context.
+seat: define the objective, negate the first plan before acting, design the
+workflow, choose the bodies, and synthesize the result. Daemons should carry the
+execution: file scans, deterministic transformations, read-only reviews, batch
+conversion, log mining, and other noisy work whose details would pollute the main
+context.
 
-Before dispatching substantial daemon work:
+Use this methodology for substantial daemon work:
 
-1. Write the workflow in pad (or a task artifact when it is too large): objective,
-   assumptions to test, daemon task split, expected artifacts, and stop criteria.
-2. Choose the cheapest capable body. Prefer low-tier or CLI-backed daemons for
-   deterministic or mechanical work; reserve the main/premium model for planning,
-   synthesis, and decisions that need the full context.
-3. Constrain the daemon prompt. Ask for the artifact path, summary shape, and
-   evidence needed; tell it what not to do. The parent coordinates; the daemon
-   executes.
-4. Reclaim only the grain. Read the daemon's report/artifact, verify key claims,
-   and deposit durable results in pad/knowledge/skills. Do not drag every daemon
-   transcript back into the main conversation.
+1. **Plan in pad first.** Record the objective, assumptions to test, daemon task
+   split, expected artifacts, stop criteria, and who/what waits on the result. If
+   the workflow is too large for pad, write a small task artifact and link it from
+   pad.
+2. **Negate before acting.** Ask what could make the daemon unnecessary, too
+   expensive, unsafe, or misleading. Prefer bash for a tiny deterministic command;
+   prefer an avatar when the capability must persist; prefer daemon when the work
+   is bounded and disposable.
+3. **Optimize cost and context.** Choose the cheapest capable body: low-tier or
+   CLI-backed daemons for deterministic/mechanical work, stronger models only for
+   genuinely hard review or reasoning. The point is not only money; it is to keep
+   the main model's context clean.
+4. **Constrain execution.** Give each daemon a precise prompt: allowed paths,
+   forbidden side effects, artifact path, evidence standard, and summary shape.
+   The parent coordinates and decides; the daemon executes.
+5. **Reclaim only the grain.** Read the daemon's report/artifact, verify key
+   claims, and deposit durable results in pad/knowledge/skills. Do not drag every
+   daemon transcript back into the main conversation.
 
 Tool results may carry `_advisory.type == "duplicate_tool_call"` when the same
 semantic tool call repeats more than the free-pass threshold. This is

--- a/src/lingtai/prompts/procedures.md
+++ b/src/lingtai/prompts/procedures.md
@@ -18,9 +18,10 @@ Use bash for one-off deterministic host work, daemons for disposable parallel
 exploration and cheap deterministic work that would otherwise consume the main
 agent's context, avatars for persistent specialists, MCPs for durable external
 integrations, knowledge for private facts, and skills for reusable procedures.
-Protecting the main context is a LingTai principle: negate before acting, make a
-plan, and control daemon work with an explicit workflow. When unsure, read
-`system-manual`.
+Protecting the main context is a LingTai principle: the parent plans and
+synthesizes, daemons execute noisy work. For the full daemon methodology — pad
+workflow, cost efficiency, context hygiene, and parent/daemon division of labor —
+read `system-manual` → `reference/procedures-manual/SKILL.md`.
 
 ### Communication and Responsiveness
 

--- a/src/lingtai/prompts/procedures.md
+++ b/src/lingtai/prompts/procedures.md
@@ -15,9 +15,12 @@ knowledge and reusable procedures in skills.
 ### Use the Right Body
 
 Use bash for one-off deterministic host work, daemons for disposable parallel
-exploration, avatars for persistent specialists, MCPs for durable external
+exploration and cheap deterministic work that would otherwise consume the main
+agent's context, avatars for persistent specialists, MCPs for durable external
 integrations, knowledge for private facts, and skills for reusable procedures.
-When unsure, read `system-manual`.
+Protecting the main context is a LingTai principle: negate before acting, make a
+plan, and control daemon work with an explicit workflow. When unsure, read
+`system-manual`.
 
 ### Communication and Responsiveness
 


### PR DESCRIPTION
## Summary
- add a concise resident-procedures hook for daemon context discipline: parent plans/synthesizes, daemons execute noisy work
- expand `procedures-manual` with a daemon workflow methodology covering pad workflow, negate-before-acting, cost/context efficiency, constrained execution, and reclaiming only the grain
- keep the change documentation-only and scoped to daemon/procedure guidance

## Validation
- `git diff --check`
- `python -m pytest -q tests/test_deep_refresh.py -k procedures` → `5 passed, 14 deselected`
- `python -m pytest -q tests/test_skills.py` → `23 passed`
