### PR TITLE
Fix embedded IMAP reply attachments

### DIFF
--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -66,7 +66,7 @@ SCHEMA = {
                 "check: list recent envelopes from a folder (optional folder, n). "
                 "read: fetch full email by ID list (email_id=[id1, ...]). "
                 "You are encouraged to read multiple relevant or even all unread emails and think before acting. "
-                "reply: reply to an email (requires email_id, message; optional cc). "
+                "reply: reply to an email (requires email_id, message; optional cc, attachments). "
                 "search: server-side IMAP search (requires query, optional folder). "
                 "delete: delete email(s) by ID (email_id). "
                 "move: move email(s) to another folder (email_id, folder=destination). "
@@ -391,21 +391,30 @@ class IMAPMailManager:
     # Actions
     # ------------------------------------------------------------------
 
+    def _resolve_attachment_paths(self, raw_attachments: object) -> list[str]:
+        """Resolve tool-supplied attachment paths relative to the agent workdir."""
+        if not raw_attachments:
+            return []
+        if isinstance(raw_attachments, (str, Path)):
+            raw_items = [raw_attachments]
+        else:
+            raw_items = list(raw_attachments)
+
+        attachments: list[str] = []
+        for item in raw_items:
+            path = Path(item)
+            if not path.is_absolute():
+                path = self._working_dir / path
+            attachments.append(str(path))
+        return attachments
+
     def _send(self, args: dict, account: "IMAPAccount") -> dict:
         to_list = self._normalize_addresses(args.get("address"))
         subject = args.get("subject", "")
         message_text = args.get("message", "")
         cc = self._normalize_addresses(args.get("cc"))
         bcc = self._normalize_addresses(args.get("bcc"))
-        raw_attachments = args.get("attachments", [])
-
-        # Resolve attachment paths (relative -> absolute from working dir)
-        attachments: list[str] = []
-        for p in raw_attachments:
-            path = Path(p)
-            if not path.is_absolute():
-                path = self._working_dir / p
-            attachments.append(str(path))
+        attachments = self._resolve_attachment_paths(args.get("attachments", []))
 
         if not to_list:
             return {"error": "address is required"}
@@ -549,8 +558,9 @@ class IMAPMailManager:
         in_reply_to = orig_message_id
         references = (orig_references + " " + orig_message_id).strip()
 
-        # CC
+        # CC and attachments
         cc = self._normalize_addresses(args.get("cc"))
+        attachments = self._resolve_attachment_paths(args.get("attachments", []))
 
         # Reply to sender
         reply_to = original.get("from_address") or original.get("from", "")
@@ -559,6 +569,7 @@ class IMAPMailManager:
             subject=subject,
             body=message_text,
             cc=cc or None,
+            attachments=attachments or None,
             in_reply_to=in_reply_to or None,
             references=references or None,
         )

--- a/tests/test_imap_reply_attachments.py
+++ b/tests/test_imap_reply_attachments.py
@@ -1,0 +1,87 @@
+"""Regression tests for the embedded IMAP MCP reply attachment path."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lingtai.mcp_servers.imap.manager import IMAPMailManager
+
+
+class FakeAccount:
+    address = "me@example.com"
+
+    def __init__(self) -> None:
+        self.sent_kwargs: dict | None = None
+        self.stored_flags: list[tuple[str, str, list[str]]] = []
+
+    def fetch_full(self, folder: str, uid: str) -> dict:
+        return {
+            "from": "Sender <sender@example.com>",
+            "from_address": "sender@example.com",
+            "subject": "Question",
+            "message_id": "<orig@example.com>",
+            "references": "<parent@example.com>",
+        }
+
+    def send_email(self, **kwargs):
+        self.sent_kwargs = kwargs
+        return None
+
+    def store_flags(self, folder: str, uid: str, flags: list[str]) -> bool:
+        self.stored_flags.append((folder, uid, flags))
+        return True
+
+
+class FakeService:
+    def __init__(self, account: FakeAccount) -> None:
+        self.default_account = account
+        self._account = account
+
+    def get_account(self, address: str | None):
+        return self._account
+
+
+def _manager(account: FakeAccount) -> IMAPMailManager:
+    return IMAPMailManager(
+        FakeService(account),
+        working_dir=Path("/tmp/imap-agent-workdir"),
+        tcp_alias="/tmp/imap-bridge",
+        on_inbound=lambda payload: None,
+    )
+
+
+def test_reply_forwards_resolved_attachments_to_send_email():
+    account = FakeAccount()
+
+    result = _manager(account).handle({
+        "action": "reply",
+        "email_id": "me@example.com:INBOX:42",
+        "message": "Here is the file.",
+        "attachments": ["relative.txt", "/abs/file.pdf"],
+    })
+
+    assert result["status"] == "delivered"
+    assert account.sent_kwargs is not None
+    assert account.sent_kwargs["to"] == ["sender@example.com"]
+    assert account.sent_kwargs["subject"] == "Re: Question"
+    assert account.sent_kwargs["body"] == "Here is the file."
+    assert account.sent_kwargs["attachments"] == [
+        "/tmp/imap-agent-workdir/relative.txt",
+        "/abs/file.pdf",
+    ]
+    assert account.sent_kwargs["in_reply_to"] == "<orig@example.com>"
+    assert account.sent_kwargs["references"] == "<parent@example.com> <orig@example.com>"
+    assert account.stored_flags == [("INBOX", "42", ["\\Answered"])]
+
+
+def test_reply_keeps_attachments_none_when_absent():
+    account = FakeAccount()
+
+    result = _manager(account).handle({
+        "action": "reply",
+        "email_id": "me@example.com:INBOX:42",
+        "message": "No file this time.",
+    })
+
+    assert result["status"] == "delivered"
+    assert account.sent_kwargs is not None
+    assert account.sent_kwargs["attachments"] is None


### PR DESCRIPTION
## Summary
- pass `attachments` through the embedded IMAP MCP `reply` action
- factor shared attachment path resolution for `send` and `reply`
- update the embedded tool description so reply advertises optional attachments
- add regression coverage for reply attachments and the no-attachment path

## Root cause
The curated/embedded IMAP server accepted `attachments` in the tool schema, and `send` already forwarded them to `IMAPAccount.send_email(...)`, but `reply` never forwarded `args["attachments"]`. The result was a dangerous silent failure: the tool returned `delivered`, while the sent reply had no attachment.

This mirrors the standalone `lingtai-imap` fix in https://github.com/Lingtai-AI/lingtai-imap/pull/10, but this PR fixes the embedded copy used by the current kernel curated addon path (`python -m lingtai.mcp_servers.imap`).

## Validation
- `python -m pytest tests/test_imap_reply_attachments.py -q` → `2 passed`
- `python -m pytest tests/test_imap_reply_attachments.py tests/test_mcp_capability.py -q` → `27 passed`
