### PR TITLE
fix(turn): surface post-tool continuation hangs

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -129,6 +129,33 @@ def _tool_call_summary(tool_calls) -> dict:
     }
 
 
+def _tool_result_context(tool_results) -> dict:
+    """Extract diagnostic metadata from tool results before a continuation send.
+
+    Captures predecessor tool names, count, and approximate payload size so
+    callers can log this context if the continuation send fails.
+    """
+    results = list(tool_results or [])
+    names = [getattr(r, "name", None) for r in results]
+    payload_chars = 0
+    for r in results:
+        content = getattr(r, "content", None)
+        if isinstance(content, str):
+            payload_chars += len(content)
+        elif isinstance(content, dict):
+            try:
+                payload_chars += len(json.dumps(content))
+            except Exception:
+                payload_chars += len(str(content))
+        elif content is not None:
+            payload_chars += len(str(content))
+    return {
+        "predecessor_tool_count": len(results),
+        "predecessor_tool_names": names,
+        "predecessor_payload_chars": payload_chars,
+    }
+
+
 def _pending_tool_call_summary(iface) -> dict:
     entries = getattr(iface, "entries", None) or []
     tail = entries[-1] if entries else None
@@ -547,7 +574,26 @@ def _run_loop(agent) -> None:
                         # unsafe to mutate from this thread. Skip chat
                         # save and put the agent to sleep; a refresh will
                         # bring up a fresh interface.
-                        agent._log("llm_worker_still_running", error=err_desc[:300])
+                        worker_context = {
+                            "predecessor_tool_count": getattr(
+                                e, "predecessor_tool_count", None
+                            ),
+                            "predecessor_tool_names": getattr(
+                                e, "predecessor_tool_names", None
+                            ),
+                            "predecessor_payload_chars": getattr(
+                                e, "predecessor_payload_chars", None
+                            ),
+                            "ledger_source": getattr(e, "ledger_source", None),
+                        }
+                        worker_context = {
+                            k: v for k, v in worker_context.items() if v is not None
+                        }
+                        agent._log(
+                            "llm_worker_still_running",
+                            error=err_desc[:300],
+                            **worker_context,
+                        )
                         agent._set_state(AgentState.STUCK, reason=err_desc)
                         agent._asleep.set()
                         agent._set_state(
@@ -556,6 +602,48 @@ def _run_loop(agent) -> None:
                         )
                         sleep_state = AgentState.ASLEEP
                         skip_post_turn_save = True
+                        # Publish an operator-visible system notification so
+                        # the hung-worker condition is surfaced beyond the
+                        # log event.  Safe to write .notification/ here even
+                        # though ChatInterface is unsafe: _enqueue_system_notification
+                        # only touches the filesystem (system.json), not the
+                        # in-memory interface.
+                        try:
+                            from .messaging import _enqueue_system_notification
+
+                            tool_names = worker_context.get("predecessor_tool_names")
+                            tool_count = worker_context.get("predecessor_tool_count")
+                            payload_chars = worker_context.get("predecessor_payload_chars")
+                            predecessor_note = ""
+                            if tool_names:
+                                names = ", ".join(str(n) for n in tool_names)
+                                predecessor_note = f" Previous tools: {names}"
+                                if tool_count is not None:
+                                    predecessor_note += f" ({tool_count})."
+                                else:
+                                    predecessor_note += "."
+                            if payload_chars is not None:
+                                predecessor_note += (
+                                    f" Tool result payload: ~{payload_chars} chars."
+                                )
+                            _enqueue_system_notification(
+                                agent,
+                                source="kernel.llm_worker_hang",
+                                ref_id=f"llm_worker_hang:{getattr(e, 'elapsed', 0):.0f}s",
+                                body=(
+                                    "LLM worker thread did not settle after "
+                                    f"{getattr(e, 'elapsed', 0):.0f}s + "
+                                    f"{getattr(e, 'grace', 0):.0f}s grace."
+                                    f"{predecessor_note} "
+                                    "Agent is ASLEEP. Use /refresh to recover. "
+                                    "The LLM provider call may still be in flight."
+                                ),
+                            )
+                        except Exception as _notif_err:
+                            agent._log(
+                                "llm_worker_still_running_notification_failed",
+                                error=(str(_notif_err) or repr(_notif_err))[:200],
+                            )
                         break
 
                     # Issue #144: over-window / context-pressure errors must
@@ -1436,9 +1524,10 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
             }
 
         in_tool_loop = True
+        _ctx = _tool_result_context(tool_results)
         try:
             response = agent._session.send(tool_results)
-        except Exception:
+        except Exception as _send_exc:
             # The local tools have already executed and returned results; only
             # the post-tool LLM continuation failed. Some adapters append tool
             # results as part of send(tool_results) and roll that user entry
@@ -1447,6 +1536,16 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
             # completion notice and the real result payload is lost. Restore the
             # real results before re-raising so recovery paths preserve truthful
             # tool completion state.
+            agent._log(
+                "post_tool_continuation_failed",
+                ledger_source=ledger_source,
+                error=(str(_send_exc) or repr(_send_exc))[:300],
+                exception=type(_send_exc).__name__,
+                **_ctx,
+            )
+            for _key, _value in _ctx.items():
+                setattr(_send_exc, _key, _value)
+            setattr(_send_exc, "ledger_source", ledger_source)
             _restore_tool_results_after_continuation_failure(
                 agent, tool_results, ledger_source=ledger_source,
             )

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -79,6 +79,52 @@ def test_run_loop_skips_chat_history_save_after_worker_still_running(tmp_path, m
     assert not (tmp_path / ".llm_hang").exists()
 
 
+def test_run_loop_publishes_system_notification_on_worker_still_running(tmp_path, monkeypatch):
+    """When WorkerStillRunningError fires, the run loop publishes an operator-
+    visible system notification so the hung-worker condition is surfaced
+    beyond the log event and operators don't have to grep events.jsonl."""
+    import json
+    agent = _make_run_loop_agent(tmp_path)
+
+    def fake_handle(_agent, _msg):
+        exc = WorkerStillRunningError(elapsed=305.0, grace=5.0, agent_name="test")
+        exc.predecessor_tool_count = 1
+        exc.predecessor_tool_names = ["bash"]
+        exc.predecessor_payload_chars = 42
+        exc.ledger_source = "main"
+        raise exc
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+
+    import lingtai_kernel.intrinsics.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    notif_path = tmp_path / ".notification" / "system.json"
+    assert notif_path.exists(), "Expected .notification/system.json to be written after WorkerStillRunningError"
+    notif = json.loads(notif_path.read_text(encoding="utf-8"))
+    events = notif.get("data", {}).get("events", [])
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["source"] == "kernel.llm_worker_hang"
+    assert "305" in ev["ref_id"] or "305" in ev["body"]
+    assert "Previous tools: bash (1)" in ev["body"]
+    assert "~42 chars" in ev["body"]
+    assert "ASLEEP" in ev["body"]
+    assert "/refresh" in ev["body"]
+    # Log event must also be present, with the same predecessor context.
+    worker_logs = [
+        fields for name, fields in agent._logs
+        if name == "llm_worker_still_running"
+    ]
+    assert worker_logs
+    assert worker_logs[0]["predecessor_tool_names"] == ["bash"]
+    assert worker_logs[0]["predecessor_tool_count"] == 1
+    assert worker_logs[0]["predecessor_payload_chars"] == 42
+    assert worker_logs[0]["ledger_source"] == "main"
+
+
 # ---------------------------------------------------------------------------
 # AED transient provider retry
 # ---------------------------------------------------------------------------
@@ -119,6 +165,9 @@ def _make_run_loop_agent(tmp_path):
     agent.inbox.put(_make_message(MSG_REQUEST, "human", "go"))
     agent._preset_fallback_attempted = False
     agent._can_fallback_preset = lambda: False
+    # Required by _enqueue_system_notification when WorkerStillRunningError fires.
+    agent._system_notification_lock = threading.Lock()
+    agent._wake_nap = lambda _reason: None
     return agent
 
 

--- a/tests/test_tool_result_restore_after_continuation_failure.py
+++ b/tests/test_tool_result_restore_after_continuation_failure.py
@@ -16,8 +16,10 @@ import pytest
 from lingtai_kernel.base_agent.turn import (
     _process_response,
     _restore_tool_results_after_continuation_failure,
+    _tool_result_context,
 )
 from lingtai_kernel.llm.base import LLMResponse, ToolCall
+from lingtai_kernel.llm_utils import WorkerStillRunningError
 from lingtai_kernel.llm.interface import (
     ChatInterface,
     TextBlock,
@@ -227,6 +229,15 @@ class _FailingSession:
         raise RuntimeError("provider continuation failed")
 
 
+class _WorkerStillRunningSession:
+    def __init__(self) -> None:
+        self.sent = []
+
+    def send(self, content):
+        self.sent.append(content)
+        raise WorkerStillRunningError(elapsed=305.0, grace=5.0, agent_name="test")
+
+
 class _ContinuingSession:
     def __init__(self, chat: _FakeChat, responses: list[LLMResponse]) -> None:
         self.chat = chat
@@ -300,6 +311,80 @@ def test_process_response_restores_real_results_when_continuation_send_fails():
         {"result_count": 1},
     )
 
+
+def test_process_response_logs_predecessor_context_on_continuation_failure():
+    """When the post-tool LLM continuation fails, _process_response emits
+    post_tool_continuation_failed with predecessor tool names, count, and
+    approximate payload chars so operators can diagnose without grepping
+    raw interface entries."""
+    agent = _FakeAgent()
+    real_result = ToolResultBlock(
+        id="call_1",
+        name="bash",
+        content="exit_code=1\nstdout=timeout after 60s",
+    )
+    agent._executor = _ProcessExecutor(real_result)
+    agent._session = _FailingSession()
+    agent._cancel_event = threading.Event()
+    agent._on_tool_result_hook = None
+    agent._intermediate_text_streamed = True
+    agent._sent_tracker = _NoopSentTracker()
+    agent._working_dir = Path("/nonexistent/lingtai-test-predecessor-context")
+
+    response = LLMResponse(
+        text="",
+        tool_calls=[ToolCall(id="call_1", name="bash", args={"command": "find / -name .env"})],
+    )
+
+    with pytest.raises(RuntimeError, match="provider continuation failed"):
+        _process_response(agent, response, ledger_source="main")
+
+    failure_events = [
+        (name, fields) for name, fields in agent.logs
+        if name == "post_tool_continuation_failed"
+    ]
+    assert len(failure_events) == 1
+    _, fields = failure_events[0]
+    assert fields["ledger_source"] == "main"
+    assert fields["exception"] == "RuntimeError"
+    assert "provider continuation failed" in fields["error"]
+    assert fields["predecessor_tool_count"] == 1
+    assert fields["predecessor_tool_names"] == ["bash"]
+    assert fields["predecessor_payload_chars"] > 0
+
+
+
+def test_process_response_attaches_predecessor_context_to_worker_hang():
+    """A real WorkerStillRunningError raised by send(tool_results) carries
+    predecessor context to the outer run-loop handler."""
+    agent = _FakeAgent()
+    real_result = ToolResultBlock(
+        id="call_1",
+        name="bash",
+        content="Command timed out after 60s",
+    )
+    agent._executor = _ProcessExecutor(real_result)
+    agent._session = _WorkerStillRunningSession()
+    agent._cancel_event = threading.Event()
+    agent._on_tool_result_hook = None
+    agent._intermediate_text_streamed = True
+    agent._sent_tracker = _NoopSentTracker()
+    agent._working_dir = Path("/nonexistent/lingtai-test-worker-context")
+
+    response = LLMResponse(
+        text="",
+        tool_calls=[ToolCall(id="call_1", name="bash", args={"command": "sleep 999"})],
+    )
+
+    with pytest.raises(WorkerStillRunningError) as exc_info:
+        _process_response(agent, response, ledger_source="main")
+
+    exc = exc_info.value
+    assert exc.predecessor_tool_count == 1
+    assert exc.predecessor_tool_names == ["bash"]
+    assert exc.predecessor_payload_chars == len("Command timed out after 60s")
+    assert exc.ledger_source == "main"
+    assert any(name == "post_tool_continuation_failed" for name, _ in agent.logs)
 
 def test_process_response_third_identical_tool_error_still_continues(tmp_path):
     """The third identical tool error remains a normal tool-result continuation.
@@ -845,6 +930,28 @@ def test_tc_wake_legacy_path_restores_real_item_result_when_send_fails():
     ]
     assert len(restore_logs) == 1
     assert restore_logs[0] == {"result_count": 1}
+
+
+def test_tool_result_context_captures_str_payload():
+    """_tool_result_context returns tool name, count, and approximate payload chars."""
+    results = [
+        ToolResultBlock(id="c1", name="bash", content="exit_code=0\nstdout=hello world"),
+        ToolResultBlock(id="c2", name="system", content={"status": "ok"}),
+    ]
+    ctx = _tool_result_context(results)
+    assert ctx["predecessor_tool_count"] == 2
+    assert ctx["predecessor_tool_names"] == ["bash", "system"]
+    # str content len + json-encoded dict len > 0
+    assert ctx["predecessor_payload_chars"] > 0
+
+
+def test_tool_result_context_empty():
+    ctx = _tool_result_context([])
+    assert ctx == {
+        "predecessor_tool_count": 0,
+        "predecessor_tool_names": [],
+        "predecessor_payload_chars": 0,
+    }
 
 
 def test_codex_responses_wire_pairs_tail_orphan_with_synthetic_output():


### PR DESCRIPTION
## Summary

Fixes the observability gap from the forwarded Dulin/Jason incident report: a `bash` timeout was correctly delivered as a structured tool result, but the following post-tool LLM continuation logged `llm_call` with no `llm_response` before manual refresh, making the agent look dead.

Current `main` already has important recovery primitives (`send_with_timeout`, `WorkerStillRunningError`, and real tool-result restoration after continuation failure). This PR keeps that design and adds the missing operator-visible diagnostics:

- records `post_tool_continuation_failed` with predecessor tool names, count, and approximate tool-result payload chars;
- carries that metadata through `WorkerStillRunningError` when the post-tool continuation worker is still alive;
- publishes a `kernel.llm_worker_hang` system notification that says the agent is ASLEEP, recommends `/refresh`, and includes predecessor tool context when available;
- adds regression coverage for the notification and predecessor-context logging.

## Validation

- `python -m py_compile src/lingtai_kernel/base_agent/turn.py tests/test_aed_recovery.py tests/test_tool_result_restore_after_continuation_failure.py`
- `git diff --check`
- `PYTHONPATH=$PWD/src python -m pytest -q tests/test_aed_recovery.py tests/test_tool_result_restore_after_continuation_failure.py`
  - `25 passed in 0.41s`

## Review / notes

- Claude Code produced the first draft but the CLI did not finish its final JSON report after ~7 minutes; I cancelled it, reviewed the retained patch, tightened the context propagation/notification assertions, and reran tests.
- A direct GLM 5.2 read-only review attempt timed out after 90s. The patch is intentionally small: no provider adapter changes, no AED redesign, and no broad bash-output compression.
- Local HTML explainer: `reports/post-tool-continuation-visible-20260615.html` in the worktree (ignored/local-only).

## Non-goals

- Does not replace provider-specific overflow recovery.
- Does not implement global bash output compression/truncation.
- Does not change the existing worker-hang recovery state machine beyond adding notification/log metadata.
