### PR TITLE
Add claude-code provider: drive the claude CLI on a Claude subscription

### DIFF
--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -9,7 +9,8 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 20 | Re-exports kernel types (`ChatSession`, `LLMResponse`, `ToolCall`, `FunctionSchema`, `ChatInterface`) + `LLMAdapter` from `base.py`. Triggers `register_all_adapters()` on import. |
-| `_register.py` | 117 | Registers adapter factories for all providers with `LLMService.register_adapter()` |
+| `_register.py` | 131 | Registers adapter factories for all providers with `LLMService.register_adapter()` |
+| `claude_code/` | — | `claude-code` provider: drives the local `claude` CLI as a stateless reasoning core on a Claude subscription (`adapter.py`, `defaults.py`). |
 | `api_gate.py` | 112 | `APICallGate` — RPM rate limiter with deque timestamps, `ThreadPoolExecutor`, daemon gate thread |
 | `base.py` | 150 | `LLMAdapter` ABC (4 abstract methods), `_GatedSession` proxy |
 | `interface_converters.py` | 335 | Bidirectional converters: `to_*` / `from_*` for Anthropic, OpenAI, OpenAI Responses API, Gemini |
@@ -19,7 +20,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 
 - **Kernel types** — `__init__.py:3` imports `ChatSession`, `LLMResponse`, `ToolCall`, `FunctionSchema` from `lingtai_kernel.llm.base`; `ChatInterface` from `lingtai_kernel.llm.interface`.
 - **ABC chain** — `LLMAdapter` (`base.py:53`) → abstract `create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`. `LLMService` (`service.py:97`) extends `lingtai_kernel.llm.service.LLMService` ABC.
-- **Adapter registration** — `_register.py` registers 7 dedicated factories + 6 generic-routed providers (`grok`, `qwen`, `glm`, `zhipu`, `kimi`, `mimo`) via dedicated or `_custom` factories (`_register.py:91-106`).
+- **Adapter registration** — `_register.py` registers 8 dedicated factories (including the two subscription/OAuth providers `codex` and `claude-code`) + 6 generic-routed providers (`grok`, `qwen`, `glm`, `zhipu`, `kimi`, `mimo`) via dedicated or `_custom` factories.
 - **Interface converters** — imported by adapter session modules (e.g. `openai.adapter` imports `to_openai`, `to_responses_input` from `interface_converters.py:120`).
 - **Rate gating** — `LLMAdapter._setup_gate(max_rpm)` creates `APICallGate`; `_wrap_with_gate()` returns `_GatedSession` proxy for sessions.
 
@@ -30,6 +31,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 - **Session tracking** — `LLMService._sessions` dict maps `st_<12-hex>` session IDs to `ChatSession` instances (`service.py:144`). Untracked sessions get `session_id=""`.
 - **Gated sessions** — `_GatedSession` (`base.py:19`) proxies `send()` and `send_stream()` through `APICallGate.submit()`. Attribute writes land on the proxy; reads fall through to inner session via `__getattr__`.
 - **Codex factory** — `_register.py:54` builds `CodexOpenAIAdapter`, monkey-patches `create_chat` and `generate` to refresh OAuth tokens before each call via `CodexTokenManager.get_access_token()`.
+- **Claude Code factory** — `_register.py:_claude_code` builds `ClaudeCodeAdapter` (drops `api_key`/`base_url`: the `claude` CLI owns auth). The adapter drives `claude -p --output-format json` as a *stateless reasoning core* — each turn serialises the canonical `ChatInterface` (system prompt + tools + conversation) into one prompt, the CLI emits a single JSON action (`tool_call`/`tool_calls`/`final`) which is parsed back into an `LLMResponse`; LingTai's own loop executes the tools. The child env strips `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` so usage stays on the subscription/OAuth path; built-in CLI tools are disabled so it acts as a pure brain. See `claude_code/adapter.py`.
 
 ## State
 

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -88,6 +88,19 @@ def register_all_adapters() -> None:
 
     LLMService.register_adapter("codex", _codex)
 
+    def _claude_code(*, model=None, defaults=None, **kw):
+        # Drive the local `claude` CLI as the agent brain on a Claude
+        # subscription. The CLI owns auth (stored OAuth / CLAUDE_CODE_OAUTH_TOKEN),
+        # so there is no api_key/base_url — drop any env-resolved ones.
+        from .claude_code.adapter import ClaudeCodeAdapter
+        kw.pop("model", None)
+        kw.pop("api_key", None)
+        kw.pop("base_url", None)
+        kw.pop("default_headers", None)
+        return ClaudeCodeAdapter(model=model, **{k: v for k, v in kw.items() if v is not None})
+
+    LLMService.register_adapter("claude-code", _claude_code)
+
     def _deepseek(*, model=None, defaults=None, **kw):
         from .deepseek.adapter import DeepSeekAdapter
         kw.pop("model", None)

--- a/src/lingtai/llm/claude_code/__init__.py
+++ b/src/lingtai/llm/claude_code/__init__.py
@@ -1,0 +1,29 @@
+"""Claude Code provider — drive the local ``claude`` CLI as the agent brain.
+
+This adapter lets a LingTai agent think on a Claude **subscription** (Pro/Max)
+through the official ``claude`` command-line binary, rather than calling the
+Anthropic API with a key. It is the Claude analogue of the Codex provider:
+log in once with ``claude`` (or ``claude setup-token``), then point a preset at
+``provider: "claude-code"``.
+
+Design: the ``claude`` CLI is used in print mode (``claude -p --output-format
+json``) as a *stateless reasoning core*. Each turn the adapter serialises the
+canonical ChatInterface (system prompt + tool schemas + conversation) into a
+single prompt, asks the CLI to emit exactly one JSON *action* (a tool call or a
+final answer), and parses that back into the kernel's ``LLMResponse``. LingTai's
+own message loop still executes the tools — so the main agent loop, intrinsics,
+capabilities and MCP all stay intact. Claude's built-in tools are disabled so it
+behaves as a pure brain.
+
+Auth is owned entirely by the ``claude`` CLI (its stored OAuth credentials or
+``CLAUDE_CODE_OAUTH_TOKEN``). The adapter never reads, stores, or replays a
+token — it only strips ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN`` from the
+child env so the subprocess cannot fall back to API-key billing. This keeps
+usage on the sanctioned Claude Code / subscription channel.
+"""
+
+from __future__ import annotations
+
+from .adapter import ClaudeCodeAdapter, ClaudeCodeChatSession
+
+__all__ = ["ClaudeCodeAdapter", "ClaudeCodeChatSession"]

--- a/src/lingtai/llm/claude_code/adapter.py
+++ b/src/lingtai/llm/claude_code/adapter.py
@@ -1,0 +1,585 @@
+"""Claude Code adapter — drives the local ``claude`` CLI as a stateless brain.
+
+See ``__init__.py`` for the high-level design. This module implements the
+``LLMAdapter`` / ``ChatSession`` contract by spawning ``claude -p --output-format
+json`` once per turn and parsing a single JSON *action* out of the result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+
+from lingtai_kernel.llm.base import (
+    ChatSession,
+    FunctionSchema,
+    LLMResponse,
+    ToolCall,
+    UsageMetadata,
+)
+from lingtai_kernel.llm.interface import (
+    ChatInterface,
+    TextBlock,
+    ThinkingBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+)
+from lingtai_kernel.logging import get_logger
+
+from lingtai.llm.base import LLMAdapter
+
+logger = get_logger()
+
+
+# Claude Code built-in tools we disable so the CLI behaves as a pure reasoning
+# core: it must only emit our JSON action, never go off and read/edit/run things.
+# Unknown names here are harmless (the CLI just warns on stderr).
+DEFAULT_DISALLOWED_TOOLS = (
+    "Bash",
+    "BashOutput",
+    "KillShell",
+    "Read",
+    "Edit",
+    "Write",
+    "NotebookEdit",
+    "Glob",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "Task",
+    "TodoWrite",
+)
+
+# Stripped from the child env so the subprocess can never bill an API key —
+# forcing the subscription / OAuth path. ``CLAUDE_CODE_OAUTH_TOKEN`` is kept on
+# purpose: it is the supported headless subscription credential.
+DEFAULT_STRIP_ENV = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+
+_DEFAULT_TIMEOUT_S = 600
+_DEFAULT_CONTEXT_WINDOW = 200_000
+
+_OVERFLOW_MARKERS = (
+    "prompt is too long",
+    "context window",
+    "context length",
+    "too many tokens",
+    "maximum context",
+    "input is too long",
+)
+
+
+class ClaudeCodeError(RuntimeError):
+    """A ``claude`` CLI invocation failed (non-zero exit, no output, etc.)."""
+
+
+class ClaudeCodeAuthError(ClaudeCodeError):
+    """The ``claude`` CLI is not logged in. Run ``claude`` or ``claude setup-token``."""
+
+
+class ClaudeCodeContextOverflow(ClaudeCodeError):
+    """The serialised conversation exceeded the model's context window."""
+
+
+# Protocol the CLI must follow. Kept terse — it is re-sent every turn.
+_PROTOCOL = """\
+You are the REASONING CORE of an external agent runtime called LingTai. You do \
+NOT execute tools yourself; the runtime executes them and returns their results \
+to you on the next turn.
+
+On every turn, read the whole conversation and the agent's own system \
+instructions below, then decide the SINGLE next action and output EXACTLY ONE \
+JSON object on a single line — no prose before or after, no markdown code fences.
+
+Choose exactly one form:
+  {"action": "tool_call", "name": "<tool_name>", "input": { <arguments> }}
+  {"action": "final", "text": "<your reply to the user / agent>"}
+
+Rules:
+- Only call a tool listed under AVAILABLE TOOLS, and match its input schema exactly.
+- To call several tools at once, use {"action": "tool_calls", "calls": [ {"name": ..., "input": {...}}, ... ]}.
+- When you have enough information to respond, use the "final" form.
+- Output ONLY the JSON object. Never wrap it in ``` fences and never add commentary.\
+"""
+
+
+def _map_usage(usage: dict | None) -> UsageMetadata:
+    """Map the CLI's ``usage`` block to the kernel's UsageMetadata."""
+    usage = usage or {}
+    cache_read = int(usage.get("cache_read_input_tokens", 0) or 0)
+    cache_create = int(usage.get("cache_creation_input_tokens", 0) or 0)
+    return UsageMetadata(
+        input_tokens=int(usage.get("input_tokens", 0) or 0) + cache_read + cache_create,
+        output_tokens=int(usage.get("output_tokens", 0) or 0),
+        thinking_tokens=0,
+        cached_tokens=cache_read,
+    )
+
+
+def _extract_json_object(text: str) -> dict | None:
+    """Best-effort: pull the first balanced ``{...}`` JSON object out of *text*.
+
+    Tolerates leading/trailing prose and ``json`` markdown fences that a model
+    might emit despite instructions. Returns None when no object parses.
+    """
+    s = text.strip()
+    if s.startswith("```"):
+        s = s.strip("`")
+        s = re.sub(r"^\s*json\s*", "", s, flags=re.IGNORECASE)
+        s = s.strip()
+    # Fast path: the whole string is the object.
+    try:
+        obj = json.loads(s)
+        return obj if isinstance(obj, dict) else None
+    except json.JSONDecodeError:
+        pass
+    # Scan for the first balanced object, respecting string literals.
+    start = s.find("{")
+    while start != -1:
+        depth = 0
+        in_str = False
+        escape = False
+        for i in range(start, len(s)):
+            ch = s[i]
+            if in_str:
+                if escape:
+                    escape = False
+                elif ch == "\\":
+                    escape = True
+                elif ch == '"':
+                    in_str = False
+                continue
+            if ch == '"':
+                in_str = True
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    candidate = s[start : i + 1]
+                    try:
+                        obj = json.loads(candidate)
+                        if isinstance(obj, dict):
+                            return obj
+                    except json.JSONDecodeError:
+                        break
+        start = s.find("{", start + 1)
+    return None
+
+
+class ClaudeCodeChatSession(ChatSession):
+    """Multi-turn session backed by repeated ``claude -p`` invocations.
+
+    Holds the canonical ChatInterface; each ``send`` re-serialises it into one
+    CLI prompt. Stateless on the CLI side — LingTai owns all context, so its
+    molt / trim / pairing invariants stay authoritative.
+    """
+
+    def __init__(
+        self,
+        *,
+        adapter: "ClaudeCodeAdapter",
+        model: str,
+        system_prompt: str,
+        tools: list[FunctionSchema],
+        interface: ChatInterface,
+        context_window: int,
+    ) -> None:
+        self._adapter = adapter
+        self._model = model
+        self._system_prompt = system_prompt
+        self._tools = tools
+        self._interface = interface
+        self._context_window = context_window
+
+    # -- ChatSession contract -------------------------------------------------
+
+    @property
+    def interface(self) -> ChatInterface:
+        return self._interface
+
+    def send(self, message) -> LLMResponse:
+        if isinstance(message, str):
+            self._interface.add_user_message(message)
+        elif isinstance(message, list):
+            self._interface.add_tool_results(message)
+        # message is None -> caller pre-staged the interface; just generate.
+
+        if self.pre_request_hook is not None:
+            self.pre_request_hook(self._interface)
+
+        def _do_call():
+            self._interface.enforce_tool_pairing()
+            prompt = self._render_prompt()
+            return self._adapter._invoke(prompt, self._model)
+
+        (action, usage, raw), _dropped, _rounds = self._run_with_overflow_recovery(_do_call)
+        return self._record_response(action, usage, raw)
+
+    def update_tools(self, tools: list[FunctionSchema] | None) -> None:
+        self._tools = list(tools) if tools else []
+        self._interface.add_system(
+            self._system_prompt,
+            tools=[t.to_dict() for t in self._tools] if self._tools else None,
+        )
+
+    def update_system_prompt(self, system_prompt: str) -> None:
+        self._system_prompt = system_prompt
+        self._interface.add_system(
+            system_prompt,
+            tools=[t.to_dict() for t in self._tools] if self._tools else None,
+        )
+
+    def commit_tool_results(self, tool_results: list) -> None:
+        self._interface.add_tool_results(tool_results)
+
+    def context_window(self) -> int:
+        return self._context_window
+
+    @staticmethod
+    def _is_context_overflow_error(exc: Exception) -> bool:
+        return isinstance(exc, ClaudeCodeContextOverflow)
+
+    # -- internals ------------------------------------------------------------
+
+    def _record_response(self, action: dict, usage: UsageMetadata, raw: Any) -> LLMResponse:
+        """Turn the parsed action into assistant blocks + an LLMResponse."""
+        blocks: list = []
+        tool_calls: list[ToolCall] = []
+        text = ""
+
+        kind = action.get("action")
+        if kind == "tool_calls":
+            for call in action.get("calls", []) or []:
+                name = call.get("name")
+                if not name:
+                    continue
+                args = call.get("input") or call.get("args") or {}
+                cid = f"cc_{uuid.uuid4().hex[:24]}"
+                blocks.append(ToolCallBlock(id=cid, name=name, args=args))
+                tool_calls.append(ToolCall(name=name, args=args, id=cid))
+        elif kind == "tool_call" or (kind is None and action.get("name")):
+            name = action.get("name")
+            args = action.get("input") or action.get("args") or {}
+            if name:
+                cid = f"cc_{uuid.uuid4().hex[:24]}"
+                blocks.append(ToolCallBlock(id=cid, name=name, args=args))
+                tool_calls.append(ToolCall(name=name, args=args, id=cid))
+
+        if not tool_calls:
+            # "final", or an unrecognised shape we fall back to as plain text.
+            text = action.get("text")
+            if text is None:
+                text = action.get("_raw", "")
+            text = str(text)
+            blocks.append(TextBlock(text=text))
+
+        self._interface.add_assistant_message(
+            blocks,
+            model=self._model,
+            provider="claude-code",
+            usage={
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "thinking_tokens": usage.thinking_tokens,
+                "cached_tokens": usage.cached_tokens,
+            },
+        )
+        return LLMResponse(text=text, tool_calls=tool_calls, usage=usage, raw=raw)
+
+    def _render_prompt(self) -> str:
+        """Serialise system prompt + tools + conversation into one CLI prompt."""
+        parts: list[str] = [_PROTOCOL, ""]
+        parts.append("# AGENT SYSTEM INSTRUCTIONS")
+        parts.append(self._system_prompt or "(none)")
+        parts.append("")
+
+        parts.append("# AVAILABLE TOOLS")
+        if self._tools:
+            for t in self._tools:
+                parts.append(f"## {t.name}")
+                if t.description:
+                    parts.append(t.description.strip())
+                try:
+                    schema = json.dumps(t.parameters, ensure_ascii=False)
+                except (TypeError, ValueError):
+                    schema = str(t.parameters)
+                parts.append(f"input schema: {schema}")
+                parts.append("")
+        else:
+            parts.append("(no tools available — respond with a final answer)")
+            parts.append("")
+
+        parts.append("# CONVERSATION")
+        parts.append(self._render_conversation())
+        parts.append("")
+        parts.append("# NOW")
+        parts.append("Decide your next action and output the single JSON object.")
+        return "\n".join(parts)
+
+    def _render_conversation(self) -> str:
+        lines: list[str] = []
+        for entry in self._interface._entries:
+            role = entry.role
+            if role == "system":
+                continue  # system prompt + tools rendered separately
+            for block in entry.content:
+                if isinstance(block, ThinkingBlock):
+                    continue
+                if isinstance(block, TextBlock):
+                    if role == "assistant":
+                        lines.append(f"ASSISTANT: {block.text}")
+                    else:
+                        lines.append(f"USER: {block.text}")
+                elif isinstance(block, ToolCallBlock):
+                    try:
+                        args = json.dumps(block.args, ensure_ascii=False)
+                    except (TypeError, ValueError):
+                        args = str(block.args)
+                    lines.append(
+                        f"ASSISTANT_ACTION: called tool `{block.name}` with input {args}"
+                    )
+                elif isinstance(block, ToolResultBlock):
+                    content = block.content
+                    if not isinstance(content, str):
+                        try:
+                            content = json.dumps(content, ensure_ascii=False)
+                        except (TypeError, ValueError):
+                            content = str(content)
+                    lines.append(f"TOOL_RESULT [{block.name}]: {content}")
+        return "\n".join(lines) if lines else "(no messages yet)"
+
+
+class ClaudeCodeAdapter(LLMAdapter):
+    """LLMAdapter that drives the ``claude`` CLI as a stateless reasoning core."""
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        cli_path: str = "claude",
+        disallowed_tools: tuple[str, ...] | list[str] | None = None,
+        timeout_s: int = _DEFAULT_TIMEOUT_S,
+        max_rpm: int = 0,
+        strip_env: tuple[str, ...] | list[str] | None = None,
+        extra_argv: list[str] | None = None,
+        context_window: int = _DEFAULT_CONTEXT_WINDOW,
+    ) -> None:
+        self._model = model or "sonnet"
+        self._cli_path = cli_path
+        self._disallowed = (
+            list(disallowed_tools)
+            if disallowed_tools is not None
+            else list(DEFAULT_DISALLOWED_TOOLS)
+        )
+        self._timeout_s = timeout_s
+        self._strip_env = tuple(strip_env) if strip_env is not None else DEFAULT_STRIP_ENV
+        self._extra_argv = list(extra_argv or [])
+        self._context_window = context_window
+        self._setup_gate(max_rpm)
+        # Neutral, empty cwd so the CLI does not load a project's CLAUDE.md,
+        # settings, or MCP servers (which could inject context or extra tools).
+        self._cwd = Path(tempfile.gettempdir()) / "lingtai-claude-brain"
+        try:
+            self._cwd.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            self._cwd = Path(tempfile.gettempdir())
+
+    # -- LLMAdapter contract --------------------------------------------------
+
+    def create_chat(
+        self,
+        model: str,
+        system_prompt: str,
+        tools: list[FunctionSchema] | None = None,
+        *,
+        json_schema: dict | None = None,
+        force_tool_call: bool = False,
+        interface: ChatInterface | None = None,
+        thinking: str = "default",
+        interaction_id: str | None = None,
+        context_window: int = 0,
+    ) -> ChatSession:
+        iface = interface or ChatInterface()
+        tool_list = list(tools) if tools else []
+        if interface is None:
+            iface.add_system(
+                system_prompt,
+                tools=[t.to_dict() for t in tool_list] if tool_list else None,
+            )
+        session = ClaudeCodeChatSession(
+            adapter=self,
+            model=model or self._model,
+            system_prompt=system_prompt,
+            tools=tool_list,
+            interface=iface,
+            context_window=context_window or self._context_window,
+        )
+        return self._wrap_with_gate(session)
+
+    def generate(
+        self,
+        model: str,
+        contents: str | list,
+        *,
+        system_prompt: str | None = None,
+        temperature: float | None = None,
+        json_schema: dict | None = None,
+        max_output_tokens: int | None = None,
+    ) -> LLMResponse:
+        """One-shot generation (no action protocol — plain text out)."""
+        if isinstance(contents, list):
+            text_parts = []
+            for c in contents:
+                if isinstance(c, dict):
+                    text_parts.append(c.get("text", ""))
+                else:
+                    text_parts.append(str(c))
+            user_text = "\n".join(p for p in text_parts if p)
+        else:
+            user_text = str(contents)
+
+        prompt_parts = []
+        if system_prompt:
+            prompt_parts.append(system_prompt)
+            prompt_parts.append("")
+        prompt_parts.append(user_text)
+        if json_schema:
+            prompt_parts.append("")
+            prompt_parts.append(
+                "Respond with ONLY a JSON object matching this schema, no prose: "
+                + json.dumps(json_schema, ensure_ascii=False)
+            )
+        prompt = "\n".join(prompt_parts)
+
+        result_str, usage, raw = self._invoke_raw(prompt, model or self._model)
+        return LLMResponse(text=result_str, usage=usage, raw=raw)
+
+    def make_tool_result_message(
+        self, tool_name: str, result: dict, *, tool_call_id: str | None = None
+    ) -> ToolResultBlock:
+        return ToolResultBlock(
+            id=tool_call_id or f"cc_{uuid.uuid4().hex[:24]}",
+            name=tool_name,
+            content=result,
+        )
+
+    def is_quota_error(self, exc: Exception) -> bool:
+        msg = str(exc).lower()
+        return "rate limit" in msg or "429" in msg or "usage limit" in msg
+
+    # -- CLI plumbing ---------------------------------------------------------
+
+    def _build_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        for key in self._strip_env:
+            env.pop(key, None)
+        return env
+
+    def _invoke_raw(self, prompt: str, model: str) -> tuple[str, UsageMetadata, dict]:
+        """Run ``claude -p`` once. Returns (result_text, usage, envelope)."""
+        cmd = [self._cli_path, "-p", "--output-format", "json"]
+        if model:
+            cmd += ["--model", model]
+        if self._disallowed:
+            cmd += ["--disallowedTools", *self._disallowed]
+        cmd += self._extra_argv
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                env=self._build_env(),
+                cwd=str(self._cwd),
+                timeout=self._timeout_s,
+            )
+        except FileNotFoundError as e:
+            raise ClaudeCodeAuthError(
+                f"`{self._cli_path}` not found on PATH. Install Claude Code and run "
+                f"`claude` (or `claude setup-token`) to log in with your subscription."
+            ) from e
+        except subprocess.TimeoutExpired as e:
+            raise ClaudeCodeError(
+                f"claude CLI timed out after {self._timeout_s}s"
+            ) from e
+
+        stdout = (proc.stdout or "").strip()
+        stderr = (proc.stderr or "").strip()
+
+        if proc.returncode != 0 and not stdout:
+            low = stderr.lower()
+            if any(m in low for m in _OVERFLOW_MARKERS):
+                raise ClaudeCodeContextOverflow(stderr[:500])
+            if "login" in low or "not authenticated" in low or "setup-token" in low or "/login" in low:
+                raise ClaudeCodeAuthError(
+                    "claude CLI is not logged in. Run `claude` or `claude setup-token` "
+                    f"to authenticate with your subscription. Detail: {stderr[:300]}"
+                )
+            raise ClaudeCodeError(
+                f"claude CLI exited {proc.returncode}: {stderr[:500] or '(no stderr)'}"
+            )
+
+        if not stdout:
+            raise ClaudeCodeError(
+                f"claude CLI produced no output (exit {proc.returncode}). "
+                f"stderr: {stderr[:300]}"
+            )
+
+        envelope = self._parse_envelope(stdout)
+
+        if envelope.get("is_error") or envelope.get("subtype") not in (None, "success"):
+            msg = str(envelope.get("result") or envelope.get("error") or envelope.get("subtype") or "unknown error")
+            low = msg.lower()
+            if any(m in low for m in _OVERFLOW_MARKERS):
+                raise ClaudeCodeContextOverflow(msg[:500])
+            if "usage limit" in low or "rate limit" in low:
+                raise ClaudeCodeError(f"claude usage/rate limit: {msg[:300]}")
+            raise ClaudeCodeError(f"claude returned an error: {msg[:500]}")
+
+        result_str = str(envelope.get("result") or "")
+        usage = _map_usage(envelope.get("usage"))
+        return result_str, usage, envelope
+
+    @staticmethod
+    def _parse_envelope(stdout: str) -> dict:
+        """Parse the CLI's JSON envelope (tolerate a trailing-line stream)."""
+        try:
+            obj = json.loads(stdout)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            pass
+        # Fall back to the last JSON object on its own line.
+        for line in reversed(stdout.splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                if isinstance(obj, dict):
+                    return obj
+            except json.JSONDecodeError:
+                continue
+        raise ClaudeCodeError(f"could not parse claude CLI output as JSON: {stdout[:300]}")
+
+    def _invoke(self, prompt: str, model: str) -> tuple[dict, UsageMetadata, dict]:
+        """Run the CLI and parse one JSON *action* from its result."""
+        result_str, usage, envelope = self._invoke_raw(prompt, model)
+        action = _extract_json_object(result_str)
+        if action is None:
+            # Model ignored the protocol — treat the whole reply as a final answer
+            # so the agent still makes progress rather than crashing.
+            logger.warning("[claude-code] no JSON action parsed; treating as final text")
+            action = {"action": "final", "_raw": result_str}
+        return action, usage, envelope
+
+    @property
+    def context_window_size(self) -> int:
+        return self._context_window

--- a/src/lingtai/llm/claude_code/defaults.py
+++ b/src/lingtai/llm/claude_code/defaults.py
@@ -1,0 +1,14 @@
+"""Default configuration for the claude-code provider.
+
+``api_key_env`` is intentionally absent: the ``claude`` CLI owns authentication
+(stored OAuth credentials / ``CLAUDE_CODE_OAUTH_TOKEN``), so LingTai needs no
+key. ``base_url`` is None — there is no HTTP endpoint; the adapter shells out to
+the local binary.
+"""
+
+DEFAULTS = {
+    "base_url": None,
+    # Model alias passed to ``claude --model``. "sonnet"/"opus"/"haiku" resolve
+    # to the latest of that tier; full ids (e.g. "claude-sonnet-4-5") also work.
+    "model": "sonnet",
+}

--- a/tests/integration_test_claude_code.py
+++ b/tests/integration_test_claude_code.py
@@ -1,0 +1,57 @@
+"""Live end-to-end test for the claude-code provider against the real `claude` CLI.
+
+Not collected by default (filename doesn't match ``test_*.py``). Run explicitly:
+
+    PYTHONPATH=src python -m pytest tests/integration_test_claude_code.py -v
+
+Requires the `claude` CLI installed and logged in with a Claude subscription.
+"""
+
+import shutil
+
+import pytest
+
+from lingtai.llm.claude_code.adapter import ClaudeCodeAdapter
+from lingtai.llm.service import LLMService
+from lingtai_kernel.llm.base import FunctionSchema
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("claude") is None, reason="claude CLI not installed / not on PATH"
+)
+
+
+def _weather_tool():
+    return FunctionSchema(
+        name="get_weather",
+        description="Get the current weather for a city.",
+        parameters={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    )
+
+
+def test_live_tool_call_then_final():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "You are Aria, a concise weather agent.", [_weather_tool()])
+
+    r1 = sess.send("What's the weather in Paris right now?")
+    assert r1.tool_calls, "expected a tool call"
+    assert r1.tool_calls[0].name == "get_weather"
+    assert r1.tool_calls[0].args.get("city", "").lower() == "paris"
+
+    tc = r1.tool_calls[0]
+    tr = ad.make_tool_result_message(tc.name, {"temp_c": 18, "conditions": "light rain"}, tool_call_id=tc.id)
+    r2 = sess.send([tr])
+    assert not r2.tool_calls
+    assert "18" in r2.text or "rain" in r2.text.lower()
+
+
+def test_live_service_path_keyless():
+    svc = LLMService(provider="claude-code", model="sonnet", api_key=None)
+    sess = svc.create_session(system_prompt="You are a concise assistant.", tools=[_weather_tool()])
+    sess.update_system_prompt_batches(["You are a concise assistant.", "Be brief."])
+    sess.update_tools([_weather_tool()])
+    r = sess.send("Reply with exactly: READY")
+    assert "READY" in r.text

--- a/tests/test_claude_code_adapter.py
+++ b/tests/test_claude_code_adapter.py
@@ -1,0 +1,288 @@
+"""Tests for the claude-code provider adapter.
+
+These mock the ``claude`` CLI subprocess so they run in CI without the binary.
+A live end-to-end check against the real CLI lives in
+``tests/integration_test_claude_code.py``.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from lingtai.llm.claude_code.adapter import (
+    ClaudeCodeAdapter,
+    ClaudeCodeAuthError,
+    ClaudeCodeContextOverflow,
+    ClaudeCodeError,
+    _extract_json_object,
+)
+from lingtai_kernel.llm.base import FunctionSchema
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _envelope(result_str, *, is_error=False, usage=None, subtype="success"):
+    return json.dumps(
+        {
+            "type": "result",
+            "subtype": subtype,
+            "is_error": is_error,
+            "result": result_str,
+            "session_id": "sess-123",
+            "usage": usage
+            or {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_input_tokens": 50,
+                "cache_creation_input_tokens": 10,
+            },
+        }
+    )
+
+
+def _weather_tool():
+    return FunctionSchema(
+        name="get_weather",
+        description="Get the current weather for a city.",
+        parameters={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON action extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_plain_object():
+    assert _extract_json_object('{"action":"final","text":"hi"}') == {
+        "action": "final",
+        "text": "hi",
+    }
+
+
+def test_extract_fenced_object():
+    raw = '```json\n{"action":"tool_call","name":"x","input":{"a":1}}\n```'
+    assert _extract_json_object(raw) == {
+        "action": "tool_call",
+        "name": "x",
+        "input": {"a": 1},
+    }
+
+
+def test_extract_object_with_surrounding_prose():
+    raw = 'Sure, here you go: {"action":"final","text":"done"} hope that helps'
+    assert _extract_json_object(raw) == {"action": "final", "text": "done"}
+
+
+def test_extract_object_with_nested_braces_and_strings():
+    raw = '{"action":"tool_call","name":"f","input":{"q":"a } b","n":{"x":1}}}'
+    assert _extract_json_object(raw) == {
+        "action": "tool_call",
+        "name": "f",
+        "input": {"q": "a } b", "n": {"x": 1}},
+    }
+
+
+def test_extract_returns_none_on_garbage():
+    assert _extract_json_object("no json here at all") is None
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_claude_code_is_registered():
+    import lingtai.llm  # noqa: F401 — triggers register_all_adapters
+    from lingtai.llm.service import LLMService
+
+    assert "claude-code" in LLMService._adapter_registry
+
+
+def test_service_builds_keyless():
+    from lingtai.llm.service import LLMService
+
+    svc = LLMService(provider="claude-code", model="sonnet", api_key=None)
+    assert isinstance(svc.get_adapter("claude-code"), ClaudeCodeAdapter)
+
+
+# ---------------------------------------------------------------------------
+# send(): tool call / final / tool results
+# ---------------------------------------------------------------------------
+
+
+def test_send_returns_tool_call():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", [_weather_tool()])
+    out = _envelope('{"action":"tool_call","name":"get_weather","input":{"city":"Paris"}}')
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", return_value=_FakeProc(stdout=out)):
+        resp = sess.send("weather in paris?")
+    assert resp.text == ""
+    assert len(resp.tool_calls) == 1
+    tc = resp.tool_calls[0]
+    assert tc.name == "get_weather" and tc.args == {"city": "Paris"}
+    assert tc.id and tc.id.startswith("cc_")
+    # usage mapping: input includes cache read + creation
+    assert resp.usage.input_tokens == 160
+    assert resp.usage.output_tokens == 20
+    assert resp.usage.cached_tokens == 50
+
+
+def test_send_returns_final_text():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", [_weather_tool()])
+    out = _envelope('{"action":"final","text":"It is sunny."}')
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", return_value=_FakeProc(stdout=out)):
+        resp = sess.send("hi")
+    assert resp.tool_calls == []
+    assert resp.text == "It is sunny."
+
+
+def test_non_json_reply_falls_back_to_final_text():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", None)
+    out = _envelope("just some prose, no json")
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", return_value=_FakeProc(stdout=out)):
+        resp = sess.send("hi")
+    assert resp.tool_calls == []
+    assert resp.text == "just some prose, no json"
+
+
+def test_parallel_tool_calls():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", [_weather_tool()])
+    out = _envelope(
+        '{"action":"tool_calls","calls":[{"name":"get_weather","input":{"city":"A"}},'
+        '{"name":"get_weather","input":{"city":"B"}}]}'
+    )
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", return_value=_FakeProc(stdout=out)):
+        resp = sess.send("two cities")
+    assert [c.args["city"] for c in resp.tool_calls] == ["A", "B"]
+    assert resp.tool_calls[0].id != resp.tool_calls[1].id
+
+
+def test_tool_result_roundtrip_updates_interface():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", [_weather_tool()])
+    out1 = _envelope('{"action":"tool_call","name":"get_weather","input":{"city":"Paris"}}')
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", return_value=_FakeProc(stdout=out1)):
+        r1 = sess.send("weather?")
+    tc = r1.tool_calls[0]
+    tr = ad.make_tool_result_message("get_weather", {"temp_c": 18}, tool_call_id=tc.id)
+    assert tr.id == tc.id
+    out2 = _envelope('{"action":"final","text":"18C"}')
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", return_value=_FakeProc(stdout=out2)):
+        r2 = sess.send([tr])
+    assert r2.text == "18C"
+    roles = [e.role for e in sess.interface._entries]
+    assert roles == ["system", "user", "assistant", "user", "assistant"]
+
+
+# ---------------------------------------------------------------------------
+# Command line + environment
+# ---------------------------------------------------------------------------
+
+
+def test_command_includes_print_json_model_and_disallowed_tools():
+    ad = ClaudeCodeAdapter(model="opus")
+    sess = ad.create_chat("opus", "sys", None)
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        captured["kw"] = kw
+        return _FakeProc(stdout=_envelope('{"action":"final","text":"ok"}'))
+
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run):
+        sess.send("hi")
+    cmd = captured["cmd"]
+    assert cmd[0] == "claude"
+    assert "-p" in cmd and "--output-format" in cmd and "json" in cmd
+    assert "--model" in cmd and "opus" in cmd
+    assert "--disallowedTools" in cmd and "Bash" in cmd
+    # prompt is piped via stdin, not argv
+    assert captured["kw"]["input"]
+    assert "AVAILABLE TOOLS" in captured["kw"]["input"]
+
+
+def test_env_strips_api_keys_but_keeps_oauth_token(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-secret")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok-secret")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-keep")
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", None)
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["env"] = kw["env"]
+        return _FakeProc(stdout=_envelope('{"action":"final","text":"ok"}'))
+
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run):
+        sess.send("hi")
+    env = captured["env"]
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+    assert env.get("CLAUDE_CODE_OAUTH_TOKEN") == "oauth-keep"
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_missing_cli_raises_auth_error():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", None)
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=FileNotFoundError()):
+        with pytest.raises(ClaudeCodeAuthError):
+            sess.send("hi")
+
+
+def test_not_logged_in_raises_auth_error():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", None)
+    proc = _FakeProc(stdout="", stderr="Please run /login to authenticate", returncode=1)
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", return_value=proc):
+        with pytest.raises(ClaudeCodeAuthError):
+            sess.send("hi")
+
+
+def test_context_overflow_detected_from_stderr():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", None)
+    proc = _FakeProc(stdout="", stderr="Error: prompt is too long for this model", returncode=1)
+    # Overflow recovery will try to trim; with a tiny interface it can't, so it re-raises.
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", return_value=proc):
+        with pytest.raises(ClaudeCodeContextOverflow):
+            sess.send("hi")
+
+
+def test_generic_cli_error_raises():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", None)
+    proc = _FakeProc(stdout="", stderr="some unexpected failure", returncode=2)
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", return_value=proc):
+        with pytest.raises(ClaudeCodeError):
+            sess.send("hi")
+
+
+def test_is_quota_error():
+    ad = ClaudeCodeAdapter(model="sonnet")
+    assert ad.is_quota_error(Exception("hit usage limit")) is True
+    assert ad.is_quota_error(Exception("429 too many requests")) is True
+    assert ad.is_quota_error(Exception("some other error")) is False


### PR DESCRIPTION
## Add `claude-code` provider: drive the `claude` CLI on a Claude subscription

Adds a `claude-code` LLM provider so a LingTai agent can think on a Claude
Pro/Max **subscription** via the official `claude` CLI, instead of an Anthropic
API key. It is the Claude analogue of the existing `codex` provider.

### Design
The `claude` CLI is used in print mode (`claude -p --output-format json`) as a
**stateless reasoning core**. Each turn the adapter serialises the canonical
`ChatInterface` (system prompt + tool schemas + conversation) into one prompt and
asks the CLI to emit exactly one JSON *action* — a tool call or a final answer —
which is parsed back into the kernel's `LLMResponse`. LingTai's own message loop
still executes the tools, so the main agent loop, intrinsics, capabilities and
MCP all stay intact; the CLI's built-in tools are disabled so it acts as a pure
brain.

### Auth / ToS
Auth is owned entirely by the `claude` CLI (its stored OAuth credentials or
`CLAUDE_CODE_OAUTH_TOKEN`). The adapter never reads, stores, or replays a token —
it only strips `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` from the child env so
the subprocess can't fall back to API-key billing. This keeps usage on the
sanctioned Claude Code / subscription channel (per Anthropic's 2026 credit-pool
policy, third-party tools authenticating through the Agent SDK / CLI draw from a
metered subscription credit), rather than the prohibited raw-token "harness
spoofing" path.

### Changes
- `src/lingtai/llm/claude_code/{__init__,adapter,defaults}.py` — adapter + session
- `src/lingtai/llm/_register.py` — register the keyless `claude-code` factory
- `src/lingtai/llm/ANATOMY.md` — document the provider
- `tests/test_claude_code_adapter.py` — 19 CI-safe unit tests (subprocess mocked)
- `tests/integration_test_claude_code.py` — live end-to-end test vs the real CLI

### Testing
- 19/19 unit tests pass (mocked subprocess, no CLI needed).
- 2/2 live integration tests pass against the real `claude` CLI.
- Existing `tests/test_adapter_registry.py` still green (no regression).
- Full-stack: a real `Agent(provider="claude-code", capabilities=["write"])` was
  started, reasoned via the CLI, called its `write` tool, and produced the exact
  file contents — the whole BaseAgent loop on a subscription.

Pairs with the lingtai TUI PR that surfaces this provider in the preset picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
