### PR TITLE
Add Claude Agent SDK completion provider

### DIFF
--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -9,7 +9,8 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 20 | Re-exports kernel types (`ChatSession`, `LLMResponse`, `ToolCall`, `FunctionSchema`, `ChatInterface`) + `LLMAdapter` from `base.py`. Triggers `register_all_adapters()` on import. |
-| `_register.py` | 117 | Registers adapter factories for all providers with `LLMService.register_adapter()` |
+| `_register.py` | 132 | Registers adapter factories for all providers with `LLMService.register_adapter()` |
+| `claude_agent_sdk/` | — | Experimental clean-room provider wrapping `claude_agent_sdk.query` as a next-turn generator (no SDK tools, LingTai keeps the tool loop). See its `ANATOMY.md`. |
 | `api_gate.py` | 112 | `APICallGate` — RPM rate limiter with deque timestamps, `ThreadPoolExecutor`, daemon gate thread |
 | `base.py` | 150 | `LLMAdapter` ABC (4 abstract methods), `_GatedSession` proxy |
 | `interface_converters.py` | 335 | Bidirectional converters: `to_*` / `from_*` for Anthropic, OpenAI, OpenAI Responses API, Gemini |
@@ -19,7 +20,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 
 - **Kernel types** — `__init__.py:3` imports `ChatSession`, `LLMResponse`, `ToolCall`, `FunctionSchema` from `lingtai_kernel.llm.base`; `ChatInterface` from `lingtai_kernel.llm.interface`.
 - **ABC chain** — `LLMAdapter` (`base.py:53`) → abstract `create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`. `LLMService` (`service.py:97`) extends `lingtai_kernel.llm.service.LLMService` ABC.
-- **Adapter registration** — `_register.py` registers 7 dedicated factories + 6 generic-routed providers (`grok`, `qwen`, `glm`, `zhipu`, `kimi`, `mimo`) via dedicated or `_custom` factories (`_register.py:91-106`).
+- **Adapter registration** — `_register.py` registers 7 dedicated factories + 6 generic-routed providers (`grok`, `qwen`, `glm`, `zhipu`, `kimi`, `mimo`) via dedicated or `_custom` factories, plus the experimental `claude-agent-sdk` / `claude_agent_sdk` aliases via `_claude_agent_sdk` (which drops `api_key`/`base_url` since the SDK uses CLI-login auth).
 - **Interface converters** — imported by adapter session modules (e.g. `openai.adapter` imports `to_openai`, `to_responses_input` from `interface_converters.py:120`).
 - **Rate gating** — `LLMAdapter._setup_gate(max_rpm)` creates `APICallGate`; `_wrap_with_gate()` returns `_GatedSession` proxy for sessions.
 

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -110,6 +110,23 @@ def register_all_adapters() -> None:
 
     LLMService.register_adapter("mimo", _mimo)
 
+    def _claude_agent_sdk(*, model=None, defaults=None, **kw):
+        # Experimental clean-room provider. The Claude Agent SDK authenticates
+        # through the local Claude CLI login (no per-request API key), so the
+        # env-resolved key and base_url are ignored.
+        from .claude_agent_sdk.adapter import ClaudeAgentSDKAdapter
+        kw.pop("api_key", None)
+        kw.pop("base_url", None)
+        adapter_kw: dict = {}
+        if model:
+            adapter_kw["model"] = model
+        if kw.get("max_rpm"):
+            adapter_kw["max_rpm"] = kw["max_rpm"]
+        return ClaudeAgentSDKAdapter(**adapter_kw)
+
+    for name in ("claude-agent-sdk", "claude_agent_sdk"):
+        LLMService.register_adapter(name, _claude_agent_sdk)
+
     # Providers routed through the generic custom adapter
     for name in ("grok", "qwen", "kimi"):
         LLMService.register_adapter(name, _custom)

--- a/src/lingtai/llm/claude_agent_sdk/ANATOMY.md
+++ b/src/lingtai/llm/claude_agent_sdk/ANATOMY.md
@@ -1,0 +1,45 @@
+# src/lingtai/llm/claude_agent_sdk/
+
+Experimental clean-room LLM provider that drives the public `claude_agent_sdk`
+package as a plain next-turn text generator. The SDK's own agentic tool loop is
+disabled — LingTai keeps its tool loop and parses tool calls from the assistant
+text upstream.
+
+> **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues.
+
+## Components
+
+| File | LOC | Role |
+|------|-----|------|
+| `__init__.py` | 3 | Re-exports `ClaudeAgentSDKAdapter`, `ClaudeAgentSDKChatSession` from `adapter.py` |
+| `adapter.py` | 445 | `ClaudeAgentSDKAdapter` (LLMAdapter) + `ClaudeAgentSDKChatSession` (ChatSession); lazy SDK import, prompt rendering, response/usage collection |
+| `defaults.py` | 10 | `DEFAULTS` dict — `api_compat`, no `base_url`/`api_key_env` (CLI-login auth), default `model` |
+
+## Connections
+
+- **Kernel types** — `adapter.py` imports `ChatSession`, `FunctionSchema`, `LLMResponse`, `ToolCall`, `UsageMetadata` from `lingtai_kernel.llm.base`; `ChatInterface`, `TextBlock`, `ToolResultBlock` from `lingtai_kernel.llm.interface`.
+- **ABC** — `ClaudeAgentSDKAdapter` extends `lingtai.llm.base.LLMAdapter` (implements `create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`); `ClaudeAgentSDKChatSession` extends `lingtai_kernel.llm.base.ChatSession`.
+- **Registration** — `_register.py` registers `_claude_agent_sdk` factory under both `claude-agent-sdk` and `claude_agent_sdk` (`_register.py`, after `mimo`). The factory drops `api_key`/`base_url` (CLI-login auth) and lazy-imports the adapter.
+- **Optional SDK** — `claude_agent_sdk` is imported only inside `_import_sdk()` on the call path; never at module import. Absent package → `RuntimeError` with install/auth guidance.
+
+## Composition
+
+- **Single-turn generator** — `_build_options` sets `allowed_tools=[]`, `max_turns=1`. Each `send()` produces exactly one assistant text turn.
+- **Canonical interface as source of truth** — `send()` commits the incoming message, fires `pre_request_hook`, calls `enforce_tool_pairing()`, renders the whole conversation via `_build_prompt` into one role-labeled string, then appends the assistant text back.
+- **Prompt rendering** — `_build_prompt` joins `conversation_entries()` as `User:` / `Assistant:` blocks (system excluded — carried in `ClaudeAgentOptions.system_prompt`) and appends a trailing `Assistant:` nudge. `_render_block` flattens text/tool-result/tool-call/thinking blocks.
+- **Async bridge** — `_run_query` drives the SDK's async-generator `query()` to completion via `asyncio.run`, returning the full message list.
+- **Response collection** — `_collect_response` duck-types `AssistantMessage`/`TextBlock` for text and `ResultMessage.usage` for tokens; `tool_calls` always empty. `_parse_usage` normalizes input tokens as `input + cache_read + cache_write` (Anthropic semantics).
+
+## State
+
+- **Session-level** — `_model`, `_system`, `_interface`, `_cwd`, `_extra_options`, `_context_window`. No persistent HTTP client (SDK manages the CLI session).
+- **Adapter-level** — `_default_model`, `_cwd`, optional `_gate` (via `_setup_gate`).
+
+## Notes
+
+- **No API key** — the SDK authenticates through the local Claude CLI login. `defaults.py` omits `api_key_env`; the registry factory discards any env-resolved key/base_url.
+- **`send(None)` contract** — honored: `None` means the caller pre-staged the wire; the adapter skips the input-append and does not `drop_trailing` on failure.
+- **Streaming** — `send_stream` is non-streaming under the hood: it runs `send()` and emits the final text once via `on_chunk`.
+- **Unsupported knobs** — `generate()` ignores `temperature`, `json_schema`, `max_output_tokens` (no SDK surface for them in this mode). `json_schema`/`force_tool_call`/`thinking` on `create_chat` are accepted for ABC compatibility but not applied.
+- **Quota detection** — `is_quota_error` is best-effort string matching ("rate limit" / "429") — the SDK exposes no typed rate-limit error.
+- **Tests** — `tests/test_claude_agent_sdk_adapter.py` fakes `claude_agent_sdk` in `sys.modules`; CI needs no Claude login or network. Covers missing-SDK error, text/usage extraction, role-labeled prompt, multi-turn accumulation, error revert, registration.

--- a/src/lingtai/llm/claude_agent_sdk/__init__.py
+++ b/src/lingtai/llm/claude_agent_sdk/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import ClaudeAgentSDKAdapter, ClaudeAgentSDKChatSession
+
+__all__ = ["ClaudeAgentSDKAdapter", "ClaudeAgentSDKChatSession"]

--- a/src/lingtai/llm/claude_agent_sdk/adapter.py
+++ b/src/lingtai/llm/claude_agent_sdk/adapter.py
@@ -1,0 +1,444 @@
+"""Claude Agent SDK adapter — experimental clean-room provider.
+
+This wraps the public ``claude_agent_sdk`` package and treats it as a plain
+next-turn text generator. The SDK normally runs its *own* agentic tool loop;
+LingTai already owns the tool loop, so this adapter deliberately disables the
+SDK's tools (``allowed_tools=[]``, ``max_turns=1``) and only asks for one
+assistant text turn per ``send()``.
+
+Design (see ANATOMY.md):
+
+- The canonical :class:`ChatInterface` is the single source of truth. Every
+  ``send()`` commits the incoming message, runs the pre-request hook, then
+  renders the whole conversation into a single role-labeled prompt string
+  that is handed to ``query()``.
+- The SDK authenticates through the local Claude CLI / login (no per-request
+  API key), so there is no key handling here. A missing ``claude_agent_sdk``
+  package raises a clear :class:`RuntimeError` only when first used — importing
+  ``lingtai.llm`` never fails just because the optional SDK is absent.
+- ``AssistantMessage`` text blocks are concatenated into ``LLMResponse.text``;
+  ``ResultMessage.usage`` (when present) is parsed into ``UsageMetadata``.
+  ``tool_calls`` is always empty — the SDK runs no tools in this mode.
+
+This adapter is the **only** module that imports ``claude_agent_sdk``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from lingtai_kernel.llm.base import (
+    ChatSession,
+    FunctionSchema,
+    LLMResponse,
+    ToolCall,
+    UsageMetadata,
+)
+from lingtai_kernel.llm.interface import ChatInterface, TextBlock, ToolResultBlock
+from lingtai_kernel.logging import get_logger
+from lingtai.llm.base import LLMAdapter
+
+logger = get_logger()
+
+
+_IMPORT_ERROR_HINT = (
+    "The 'claude-agent-sdk' provider requires the optional 'claude_agent_sdk' "
+    "package and a working Claude CLI login.\n"
+    "  1. pip install claude-agent-sdk\n"
+    "  2. Install the Claude CLI and run `claude login` (the SDK authenticates "
+    "through the local CLI session, not an API key).\n"
+    "Original import error: {err}"
+)
+
+
+def _import_sdk():
+    """Lazily import ``claude_agent_sdk``.
+
+    Raises a clear :class:`RuntimeError` with install/auth guidance if the
+    package is missing, so importing ``lingtai.llm`` never breaks when the
+    optional SDK is absent — only first *use* of the provider does.
+    """
+    try:
+        import claude_agent_sdk  # type: ignore
+    except ImportError as err:  # pragma: no cover - exercised via fake module
+        raise RuntimeError(_IMPORT_ERROR_HINT.format(err=err)) from err
+    return claude_agent_sdk
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering
+# ---------------------------------------------------------------------------
+
+
+_ROLE_LABELS = {
+    "user": "User",
+    "assistant": "Assistant",
+}
+
+
+def _render_block(block: Any) -> str:
+    """Render one canonical content block as plain transcript text."""
+    if isinstance(block, TextBlock):
+        return block.text
+    if isinstance(block, ToolResultBlock):
+        content = block.content
+        if not isinstance(content, str):
+            import json
+
+            content = json.dumps(content, default=str)
+        return f"[tool result: {block.name}]\n{content}"
+    # ToolCallBlock / ThinkingBlock — surface a compact form so the transcript
+    # round-trips even though this provider issues no tool calls itself.
+    text = getattr(block, "text", None)
+    if text:
+        return text
+    name = getattr(block, "name", None)
+    if name:
+        import json
+
+        args = getattr(block, "args", {})
+        return f"[tool call: {name}({json.dumps(args, default=str)})]"
+    return ""
+
+
+def _build_prompt(interface: ChatInterface) -> str:
+    """Render the conversation (excluding system) into one role-labeled prompt.
+
+    The SDK's ``system_prompt`` carries the system text separately, so here we
+    only join the user/assistant turns. Each entry becomes a ``Role:`` block;
+    the trailing line nudges the model to produce the next assistant turn.
+    """
+    lines: list[str] = []
+    for entry in interface.conversation_entries():
+        label = _ROLE_LABELS.get(entry.role, entry.role.capitalize())
+        rendered = "\n".join(
+            part for part in (_render_block(b) for b in entry.content) if part
+        )
+        if rendered:
+            lines.append(f"{label}: {rendered}")
+    lines.append("Assistant:")
+    return "\n\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Response collection
+# ---------------------------------------------------------------------------
+
+
+def _collect_response(sdk, messages: list[Any]) -> LLMResponse:
+    """Gather SDK message objects into a provider-agnostic LLMResponse.
+
+    Pulls text from ``AssistantMessage`` ``TextBlock``s and usage from a
+    ``ResultMessage`` if one is present. Detection is duck-typed (``type``
+    name + attribute presence) so a faked SDK in tests works without the
+    real classes.
+    """
+    text_parts: list[str] = []
+    usage = UsageMetadata()
+
+    assistant_cls = getattr(sdk, "AssistantMessage", None)
+    text_block_cls = getattr(sdk, "TextBlock", None)
+    result_cls = getattr(sdk, "ResultMessage", None)
+
+    for msg in messages:
+        if assistant_cls is not None and isinstance(msg, assistant_cls):
+            for block in getattr(msg, "content", []) or []:
+                if text_block_cls is not None and isinstance(block, text_block_cls):
+                    text_parts.append(getattr(block, "text", ""))
+                elif getattr(block, "text", None) is not None:
+                    # Duck-typed fallback for text-bearing blocks.
+                    text_parts.append(block.text)
+        elif result_cls is not None and isinstance(msg, result_cls):
+            usage = _parse_usage(getattr(msg, "usage", None)) or usage
+
+    return LLMResponse(
+        text="".join(text_parts),
+        tool_calls=[],  # LingTai owns the tool loop; the SDK runs no tools here
+        usage=usage,
+        raw=messages,
+    )
+
+
+def _parse_usage(raw_usage: Any) -> UsageMetadata | None:
+    """Parse a ``ResultMessage.usage`` payload into UsageMetadata.
+
+    The SDK reports usage as a dict shaped like the Anthropic Messages API
+    (``input_tokens`` / ``output_tokens`` plus optional cache fields). Tolerate
+    both dict and attribute access, and a missing payload.
+    """
+    if raw_usage is None:
+        return None
+
+    def _get(key: str) -> int:
+        if isinstance(raw_usage, dict):
+            return int(raw_usage.get(key, 0) or 0)
+        return int(getattr(raw_usage, key, 0) or 0)
+
+    cache_read = _get("cache_read_input_tokens")
+    cache_write = _get("cache_creation_input_tokens")
+    return UsageMetadata(
+        input_tokens=_get("input_tokens") + cache_read + cache_write,
+        output_tokens=_get("output_tokens"),
+        cached_tokens=cache_read,
+    )
+
+
+def _run_query(sdk, prompt: str, options: Any) -> list[Any]:
+    """Drive the SDK's async ``query()`` to completion, returning all messages.
+
+    ``query()`` is an async generator; we collect it on a private event loop so
+    the synchronous ChatSession contract holds regardless of the caller's loop
+    state.
+    """
+
+    async def _collect() -> list[Any]:
+        out: list[Any] = []
+        async for message in sdk.query(prompt=prompt, options=options):
+            out.append(message)
+        return out
+
+    return asyncio.run(_collect())
+
+
+# ---------------------------------------------------------------------------
+# ClaudeAgentSDKChatSession
+# ---------------------------------------------------------------------------
+
+
+class ClaudeAgentSDKChatSession(ChatSession):
+    """Single-turn chat session backed by ``claude_agent_sdk.query``.
+
+    Uses :class:`ChatInterface` as the single source of truth and rebuilds a
+    role-labeled prompt from it on every call.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        system_prompt: str,
+        interface: ChatInterface,
+        *,
+        cwd: str | None = None,
+        extra_options: dict | None = None,
+        context_window: int = 0,
+    ):
+        self._model = model
+        self._system = system_prompt
+        self._interface = interface
+        self._cwd = cwd
+        self._extra_options = extra_options or {}
+        self._context_window = context_window
+
+    @property
+    def interface(self) -> ChatInterface:
+        return self._interface
+
+    def _build_options(self, sdk) -> Any:
+        """Build ``ClaudeAgentOptions`` for a single next-turn generation.
+
+        No SDK tools (``allowed_tools=[]``), a single turn (``max_turns=1``):
+        LingTai keeps the tool loop, so the SDK is just a text generator.
+        """
+        opts: dict[str, Any] = {
+            "model": self._model,
+            "system_prompt": self._system,
+            "allowed_tools": [],
+            "max_turns": 1,
+        }
+        if self._cwd:
+            opts["cwd"] = self._cwd
+        opts.update(self._extra_options)
+        return sdk.ClaudeAgentOptions(**opts)
+
+    def send(self, message) -> LLMResponse:
+        """Send a user message (str), tool results (list), or continue (``None``).
+
+        Commits the message to the canonical interface, fires the pre-request
+        hook, renders the full transcript into one prompt, and asks the SDK for
+        one assistant turn. The assistant text is appended back to the
+        interface. On failure the trailing user entry is reverted.
+        """
+        if message is None:
+            pass  # caller pre-staged the wire
+        elif isinstance(message, str):
+            self._interface.add_user_message(message)
+        elif isinstance(message, list):
+            self._interface.add_tool_results(message)
+        else:
+            raise TypeError(f"Unsupported message type: {type(message)}")
+
+        try:
+            if self.pre_request_hook is not None:
+                self.pre_request_hook(self._interface)
+
+            sdk = _import_sdk()
+            self._interface.enforce_tool_pairing()
+            prompt = _build_prompt(self._interface)
+            options = self._build_options(sdk)
+            messages = _run_query(sdk, prompt, options)
+        except Exception:
+            if message is not None:
+                self._interface.drop_trailing(lambda e: e.role == "user")
+            raise
+
+        response = _collect_response(sdk, messages)
+
+        if response.text:
+            self._interface.add_assistant_message(
+                [TextBlock(text=response.text)],
+                model=self._model,
+                provider="claude-agent-sdk",
+                usage={
+                    "input_tokens": response.usage.input_tokens,
+                    "output_tokens": response.usage.output_tokens,
+                },
+            )
+
+        return response
+
+    def send_stream(
+        self,
+        message,
+        on_chunk: Callable[[str], None] | None = None,
+    ) -> LLMResponse:
+        """Non-streaming under the hood — deliver the final text as one chunk.
+
+        The SDK exposes incremental messages, but this provider treats it as a
+        plain next-turn generator, so we run ``send()`` and emit the final text
+        once via ``on_chunk`` if provided.
+        """
+        response = self.send(message)
+        if on_chunk and response.text:
+            on_chunk(response.text)
+        return response
+
+    def commit_tool_results(self, tool_results: list) -> None:
+        if tool_results:
+            self._interface.add_tool_results(tool_results)
+
+    def update_system_prompt(self, system_prompt: str) -> None:
+        self._system = system_prompt
+        self._interface.add_system(system_prompt, tools=self._interface.current_tools)
+
+    def context_window(self) -> int:
+        return self._context_window
+
+
+# ---------------------------------------------------------------------------
+# ClaudeAgentSDKAdapter
+# ---------------------------------------------------------------------------
+
+
+class ClaudeAgentSDKAdapter(LLMAdapter):
+    """Adapter that drives ``claude_agent_sdk.query`` as a next-turn generator.
+
+    Experimental and clean-room: it relies only on the public SDK surface
+    (``query``, ``ClaudeAgentOptions``, ``AssistantMessage``, ``TextBlock``,
+    ``ResultMessage``). The SDK is imported lazily inside the call path.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        cwd: str | None = None,
+        max_rpm: int = 0,
+    ):
+        self._default_model = model or "claude-sonnet-4-20250514"
+        self._cwd = cwd
+        self._setup_gate(max_rpm)
+
+    # -- LLMAdapter interface --------------------------------------------------
+
+    def create_chat(
+        self,
+        model: str,
+        system_prompt: str,
+        tools: list[FunctionSchema] | None = None,
+        *,
+        json_schema: dict | None = None,
+        force_tool_call: bool = False,
+        interface: ChatInterface | None = None,
+        thinking: str = "default",
+        interaction_id: str | None = None,  # ignored
+        context_window: int = 0,
+    ) -> ClaudeAgentSDKChatSession:
+        # Tools are recorded in the canonical interface for transcript/usage
+        # bookkeeping, but the SDK is never given them — LingTai dispatches all
+        # tools itself, parsing them out of the assistant text turn upstream.
+        if interface is not None:
+            iface = interface
+        else:
+            iface = ChatInterface()
+            tool_dicts = FunctionSchema.list_to_dicts(tools)
+            iface.add_system(system_prompt, tools=tool_dicts)
+
+        session = ClaudeAgentSDKChatSession(
+            model=model or self._default_model,
+            system_prompt=system_prompt,
+            interface=iface,
+            cwd=self._cwd,
+            context_window=context_window,
+        )
+        return self._wrap_with_gate(session)
+
+    def generate(
+        self,
+        model: str,
+        contents: str | list,
+        *,
+        system_prompt: str | None = None,
+        temperature: float | None = None,  # unsupported by this provider
+        json_schema: dict | None = None,  # unsupported by this provider
+        max_output_tokens: int | None = None,  # unsupported by this provider
+    ) -> LLMResponse:
+        """One-shot generation. Renders ``contents`` into a single prompt."""
+        sdk = _import_sdk()
+
+        if isinstance(contents, str):
+            prompt = contents
+        elif isinstance(contents, list):
+            parts: list[str] = []
+            for item in contents:
+                if isinstance(item, str):
+                    parts.append(item)
+                else:
+                    parts.append(str(item))
+            prompt = "\n\n".join(parts)
+        else:
+            prompt = str(contents)
+
+        opts: dict[str, Any] = {
+            "model": model or self._default_model,
+            "allowed_tools": [],
+            "max_turns": 1,
+        }
+        if system_prompt:
+            opts["system_prompt"] = system_prompt
+        if self._cwd:
+            opts["cwd"] = self._cwd
+        options = sdk.ClaudeAgentOptions(**opts)
+
+        messages = self._gated_call(lambda: _run_query(sdk, prompt, options))
+        return _collect_response(sdk, messages)
+
+    def make_tool_result_message(
+        self, tool_name: str, result: dict, *, tool_call_id: str | None = None
+    ) -> ToolResultBlock:
+        return ToolResultBlock(
+            id=tool_call_id or f"toolu_{uuid.uuid4().hex[:24]}",
+            name=tool_name,
+            content=result,
+        )
+
+    def is_quota_error(self, exc: Exception) -> bool:
+        """Best-effort rate-limit detection by message text.
+
+        The SDK does not expose a typed rate-limit error, so match on the
+        usual signals (HTTP 429 / "rate limit") in the exception string.
+        """
+        msg = (str(exc) or "").lower()
+        return "rate limit" in msg or "429" in msg

--- a/src/lingtai/llm/claude_agent_sdk/defaults.py
+++ b/src/lingtai/llm/claude_agent_sdk/defaults.py
@@ -1,0 +1,8 @@
+DEFAULTS = {
+    # Experimental clean-room provider. The Claude Agent SDK authenticates
+    # through the local Claude CLI / login (no per-request API key), so there
+    # is no ``api_key_env`` here — the adapter tolerates a missing key.
+    "api_compat": "claude_agent_sdk",
+    "base_url": None,
+    "model": "claude-sonnet-4-20250514",
+}

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -62,7 +62,7 @@ def test_default_adapters_registered():
     saved = dict(LLMService._adapter_registry)
     LLMService._adapter_registry.clear()
     register_all_adapters()
-    expected = {"gemini", "anthropic", "openai", "minimax", "deepseek", "grok", "qwen", "glm", "kimi", "custom"}
+    expected = {"gemini", "anthropic", "openai", "minimax", "deepseek", "grok", "qwen", "glm", "kimi", "custom", "claude-agent-sdk", "claude_agent_sdk"}
     assert expected.issubset(set(LLMService._adapter_registry.keys()))
     LLMService._adapter_registry.clear()
     LLMService._adapter_registry.update(saved)

--- a/tests/test_claude_agent_sdk_adapter.py
+++ b/tests/test_claude_agent_sdk_adapter.py
@@ -1,0 +1,318 @@
+"""Tests for the experimental Claude Agent SDK provider.
+
+CI must not require a Claude CLI login or network access. The real
+``claude_agent_sdk`` package is therefore *faked* in ``sys.modules`` for the
+tests that exercise the call path. One test deliberately removes any module so
+the missing-SDK error path is covered.
+
+What's covered:
+- Missing SDK raises a clear RuntimeError (not an ImportError at lingtai
+  import time).
+- Basic assistant text is gathered into LLMResponse.text.
+- ResultMessage.usage is parsed into UsageMetadata (with cache normalization).
+- The canonical ChatInterface accumulates the turn and the prompt is built
+  role-labeled from the conversation.
+- The provider is registered (both hyphen and underscore aliases).
+"""
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from lingtai.llm.claude_agent_sdk.adapter import (
+    ClaudeAgentSDKAdapter,
+    ClaudeAgentSDKChatSession,
+    _build_prompt,
+)
+from lingtai_kernel.llm.interface import ChatInterface, TextBlock
+
+
+# ---------------------------------------------------------------------------
+# Fake claude_agent_sdk
+# ---------------------------------------------------------------------------
+
+
+class _FakeTextBlock:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeAssistantMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeResultMessage:
+    def __init__(self, usage=None):
+        self.usage = usage
+
+
+class _FakeOptions:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _make_fake_sdk(scripted_messages, *, record=None):
+    """Build a fake claude_agent_sdk module.
+
+    ``scripted_messages`` is the list of message objects the fake ``query()``
+    yields. ``record`` (if given) receives the (prompt, options) of each call.
+    """
+    mod = ModuleType("claude_agent_sdk")
+    mod.TextBlock = _FakeTextBlock
+    mod.AssistantMessage = _FakeAssistantMessage
+    mod.ResultMessage = _FakeResultMessage
+    mod.ClaudeAgentOptions = _FakeOptions
+
+    async def _query(*, prompt, options):
+        if record is not None:
+            record.append((prompt, options))
+        for msg in scripted_messages:
+            yield msg
+
+    mod.query = _query
+    return mod
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch):
+    """Install a fake claude_agent_sdk; yield a setter for the scripted output."""
+    state = {"record": []}
+
+    def _install(messages):
+        mod = _make_fake_sdk(messages, record=state["record"])
+        monkeypatch.setitem(sys.modules, "claude_agent_sdk", mod)
+        return mod
+
+    state["install"] = _install
+    yield state
+
+
+# ---------------------------------------------------------------------------
+# Missing-SDK error path
+# ---------------------------------------------------------------------------
+
+
+def test_missing_sdk_raises_runtime_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", None)
+    adapter = ClaudeAgentSDKAdapter()
+    session = adapter.create_chat("claude-sonnet-4-20250514", "be helpful")
+    with pytest.raises(RuntimeError, match="claude-agent-sdk"):
+        session.send("hello")
+    # Missing optional SDK is a call-path failure; the staged user turn should
+    # be reverted so retrying after installation does not duplicate it.
+    assert session.interface.conversation_entries() == []
+
+
+def test_missing_sdk_does_not_break_import():
+    """Importing the adapter module must not require the SDK."""
+    # If we got here, the module-level import already succeeded without the SDK.
+    import importlib
+
+    mod = importlib.import_module("lingtai.llm.claude_agent_sdk.adapter")
+    assert hasattr(mod, "ClaudeAgentSDKAdapter")
+
+
+# ---------------------------------------------------------------------------
+# Basic response text
+# ---------------------------------------------------------------------------
+
+
+def test_basic_response_text(fake_sdk):
+    fake_sdk["install"]([
+        _FakeAssistantMessage([_FakeTextBlock("Hello "), _FakeTextBlock("world")]),
+        _FakeResultMessage(),
+    ])
+    adapter = ClaudeAgentSDKAdapter()
+    session = adapter.create_chat("claude-sonnet-4-20250514", "be helpful")
+    resp = session.send("hi")
+    assert resp.text == "Hello world"
+    assert resp.tool_calls == []
+
+
+def test_assistant_text_appended_to_interface(fake_sdk):
+    fake_sdk["install"]([
+        _FakeAssistantMessage([_FakeTextBlock("answer")]),
+    ])
+    adapter = ClaudeAgentSDKAdapter()
+    session = adapter.create_chat("claude-sonnet-4-20250514", "be helpful")
+    session.send("question")
+    entries = session.interface.conversation_entries()
+    # user(question) + assistant(answer)
+    assert len(entries) == 2
+    assert entries[0].role == "user"
+    assert entries[1].role == "assistant"
+    assert entries[1].content[0].text == "answer"
+    assert entries[1].provider == "claude-agent-sdk"
+
+
+# ---------------------------------------------------------------------------
+# Usage extraction
+# ---------------------------------------------------------------------------
+
+
+def test_usage_extraction(fake_sdk):
+    fake_sdk["install"]([
+        _FakeAssistantMessage([_FakeTextBlock("ok")]),
+        _FakeResultMessage(usage={
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_read_input_tokens": 5,
+            "cache_creation_input_tokens": 3,
+        }),
+    ])
+    adapter = ClaudeAgentSDKAdapter()
+    session = adapter.create_chat("claude-sonnet-4-20250514", "be helpful")
+    resp = session.send("hi")
+    # input normalized to raw + cache_read + cache_write
+    assert resp.usage.input_tokens == 108
+    assert resp.usage.output_tokens == 20
+    assert resp.usage.cached_tokens == 5
+
+
+def test_usage_absent_is_zero(fake_sdk):
+    fake_sdk["install"]([
+        _FakeAssistantMessage([_FakeTextBlock("ok")]),
+    ])
+    adapter = ClaudeAgentSDKAdapter()
+    session = adapter.create_chat("claude-sonnet-4-20250514", "be helpful")
+    resp = session.send("hi")
+    assert resp.usage.input_tokens == 0
+    assert resp.usage.output_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Canonical history / transcript behavior
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_is_role_labeled():
+    iface = ChatInterface()
+    iface.add_system("system text")
+    iface.add_user_message("first")
+    iface.add_assistant_message([TextBlock(text="reply")])
+    iface.add_user_message("second")
+    prompt = _build_prompt(iface)
+    assert "User: first" in prompt
+    assert "Assistant: reply" in prompt
+    assert "User: second" in prompt
+    # System text excluded from the transcript prompt
+    assert "system text" not in prompt
+    # Trailing nudge for the next assistant turn
+    assert prompt.rstrip().endswith("Assistant:")
+
+
+def test_options_disable_tools_single_turn(fake_sdk):
+    record = fake_sdk["record"]
+    fake_sdk["install"]([_FakeAssistantMessage([_FakeTextBlock("ok")])])
+    adapter = ClaudeAgentSDKAdapter()
+    session = adapter.create_chat("claude-sonnet-4-20250514", "be helpful")
+    session.send("hi")
+    assert len(record) == 1
+    _, options = record[0]
+    assert options.kwargs["allowed_tools"] == []
+    assert options.kwargs["max_turns"] == 1
+    assert options.kwargs["model"] == "claude-sonnet-4-20250514"
+    assert options.kwargs["system_prompt"] == "be helpful"
+
+
+def test_multi_turn_accumulates(fake_sdk):
+    adapter = ClaudeAgentSDKAdapter()
+    session = adapter.create_chat("claude-sonnet-4-20250514", "be helpful")
+
+    fake_sdk["install"]([_FakeAssistantMessage([_FakeTextBlock("one")])])
+    session.send("q1")
+    fake_sdk["install"]([_FakeAssistantMessage([_FakeTextBlock("two")])])
+    resp = session.send("q2")
+
+    assert resp.text == "two"
+    # The second prompt should contain the full prior transcript.
+    last_prompt = fake_sdk["record"][-1][0]
+    assert "User: q1" in last_prompt
+    assert "Assistant: one" in last_prompt
+    assert "User: q2" in last_prompt
+
+
+def test_send_error_reverts_trailing_user(fake_sdk, monkeypatch):
+    fake_sdk["install"]([_FakeAssistantMessage([_FakeTextBlock("ok")])])
+    adapter = ClaudeAgentSDKAdapter()
+    session = adapter.create_chat("claude-sonnet-4-20250514", "be helpful")
+
+    # Make the query path blow up after the user message is committed.
+    import lingtai.llm.claude_agent_sdk.adapter as mod
+
+    def _boom(*a, **k):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(mod, "_run_query", _boom)
+    with pytest.raises(RuntimeError, match="network down"):
+        session.send("doomed")
+    # The trailing user entry must have been reverted.
+    assert session.interface.conversation_entries() == []
+
+
+def test_send_stream_delivers_final_chunk(fake_sdk):
+    fake_sdk["install"]([_FakeAssistantMessage([_FakeTextBlock("streamed")])])
+    adapter = ClaudeAgentSDKAdapter()
+    session = adapter.create_chat("claude-sonnet-4-20250514", "be helpful")
+    chunks = []
+    resp = session.send_stream("hi", on_chunk=chunks.append)
+    assert resp.text == "streamed"
+    assert chunks == ["streamed"]
+
+
+# ---------------------------------------------------------------------------
+# generate() one-shot
+# ---------------------------------------------------------------------------
+
+
+def test_generate_one_shot(fake_sdk):
+    fake_sdk["install"]([
+        _FakeAssistantMessage([_FakeTextBlock("oneshot")]),
+        _FakeResultMessage(usage={"input_tokens": 10, "output_tokens": 4}),
+    ])
+    adapter = ClaudeAgentSDKAdapter()
+    resp = adapter.generate("claude-sonnet-4-20250514", "do a thing", system_prompt="sys")
+    assert resp.text == "oneshot"
+    assert resp.usage.input_tokens == 10
+    prompt, options = fake_sdk["record"][0]
+    assert prompt == "do a thing"
+    assert options.kwargs["system_prompt"] == "sys"
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_provider_registered():
+    from lingtai.llm.service import LLMService
+    from lingtai.llm._register import register_all_adapters
+
+    saved = dict(LLMService._adapter_registry)
+    LLMService._adapter_registry.clear()
+    try:
+        register_all_adapters()
+        keys = set(LLMService._adapter_registry.keys())
+        assert "claude-agent-sdk" in keys
+        assert "claude_agent_sdk" in keys
+    finally:
+        LLMService._adapter_registry.clear()
+        LLMService._adapter_registry.update(saved)
+
+
+def test_make_tool_result_message():
+    adapter = ClaudeAgentSDKAdapter()
+    block = adapter.make_tool_result_message("read", {"ok": True}, tool_call_id="toolu_x")
+    assert block.id == "toolu_x"
+    assert block.name == "read"
+    assert block.content == {"ok": True}
+
+
+def test_is_quota_error():
+    adapter = ClaudeAgentSDKAdapter()
+    assert adapter.is_quota_error(RuntimeError("rate limit exceeded"))
+    assert adapter.is_quota_error(RuntimeError("HTTP 429"))
+    assert not adapter.is_quota_error(RuntimeError("boom"))


### PR DESCRIPTION
## Summary
- add `claude-agent-sdk` completion-style LLM provider (`claude-agent-sdk` plus `claude_agent_sdk` alias)
- wrap the public `claude_agent_sdk.query()` API as a normal next-turn completion generator: `allowed_tools=[]`, `max_turns=1`, `setting_sources=[]`
- default to Claude Code model alias `sonnet` (live smoke showed dated API model IDs can be rejected by the Claude CLI SDK)
- lazy-import the optional SDK so `lingtai.llm` still imports without `claude-agent-sdk` installed
- maintain canonical `ChatInterface` history, collect AssistantMessage/TextBlock text, and map ResultMessage usage into `UsageMetadata`
- add provider anatomy and fake-SDK tests with no live Claude login/network requirement

## Tests
- `PYTHONPATH=src python -m pytest tests/test_claude_agent_sdk_adapter.py tests/test_adapter_registry.py tests/test_llm_service.py -q` → 31 passed
- `git diff --check`
- live local smoke via existing Claude CLI/OAuth + `claude_agent_sdk`: `status=ok`, text `LINGTAI_CLAUDE_AGENT_SDK_PROVIDER_OK`, usage recorded, history entries=2 (`reports/claude-agent-sdk-provider-live-smoke.txt`)

## Notes
- No hard dependency was added; the provider raises a clear runtime error on first use if `claude_agent_sdk` is missing.
- This is a completion provider, not a native SDK-tool provider; `tool_calls` remains empty and LingTai owns tool execution.
- CI does not require Claude login/network; the live smoke is local evidence only.
