### PR TITLE
fix(telegram): clear handled notification mirrors

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -38,6 +38,21 @@ def _load_notification_header_template() -> str:
 
 
 _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()
+_NOTIFICATION_CHANNEL = "mcp.telegram"
+_COMPOUND_ID_RE = re.compile(r"#([^\s:#]+:-?\d+:\d+)\b")
+
+
+def _looks_like_compound_id(value: str) -> bool:
+    parts = value.split(":")
+    if len(parts) != 3 or not parts[0]:
+        return False
+    try:
+        int(parts[1])
+        int(parts[2])
+    except ValueError:
+        return False
+    return True
+
 
 # Emoji reactions for different states (Bot API 7.0+)
 REACTION_SEEN = [{"type": "emoji", "emoji": "👀"}]      # Message received
@@ -576,6 +591,18 @@ class TelegramManager:
                     "message_id": payload.get("id"),
                     "account": account_alias,
                     "chat_id": payload.get("chat", {}).get("id"),
+                    # LICC preview metadata copied into .notification/mcp.telegram.json.
+                    # Keep both the legacy Telegram-specific keys above and the
+                    # generic chat keys below so the producer can later clear a
+                    # handled notification mirror without re-reading Telegram.
+                    "platform": "telegram",
+                    "conversation_ref": f"{account_alias}:{payload.get('chat', {}).get('id')}",
+                    # Callback queries reuse the message_id of the inline-keyboard
+                    # message, so the compound ID is not unique per callback event.
+                    # Leave those mirrors for explicit handling rather than
+                    # auto-clearing a fresh callback because an older callback on
+                    # the same Telegram message was already read.
+                    "message_ref": payload.get("id") if update_type != "callback_query" else None,
                     "has_media": payload.get("media") is not None,
                     "has_callback": payload.get("callback_query") is not None,
                     "callback_data": payload.get("callback_query"),
@@ -846,6 +873,106 @@ class TelegramManager:
             if os.path.exists(tmp):
                 os.unlink(tmp)
             raise
+
+    def _notification_message_ids(self, payload: dict) -> set[str] | None:
+        """Return Telegram compound IDs referenced by an MCP notification mirror.
+
+        New Telegram events publish ``message_ref`` in LICC preview metadata.
+        Older notifications only have the bounded conversation preview body,
+        whose lines include ``#account:chat:message`` anchors; parse those as a
+        best-effort migration path so stale mirrors can be cleared after read.
+
+        Returns ``None`` when any preview entry lacks an identifiable Telegram
+        message ID. In that case clearing the coalesced notification could hide
+        another unread event, so the mirror is left for explicit handling.
+        """
+        data = payload.get("data") if isinstance(payload, dict) else None
+        previews = data.get("previews") if isinstance(data, dict) else None
+        if not isinstance(previews, list) or not previews:
+            return None
+
+        ids: set[str] = set()
+        for preview in previews:
+            if not isinstance(preview, dict):
+                return None
+
+            subject = preview.get("subject")
+            if isinstance(subject, str) and "callback_query" in subject:
+                # Telegram callback queries reuse the message_id of the inline
+                # keyboard message, so a compound ID is not a unique event ID.
+                # Keep these mirrors for explicit handling rather than clearing
+                # a fresh callback just because an older callback on that
+                # message was read.
+                return None
+
+            ref = preview.get("message_ref")
+            if isinstance(ref, str) and _looks_like_compound_id(ref):
+                ids.add(ref)
+                continue
+
+            # Backward compatibility for notification files produced before
+            # Telegram populated the generic LICC ``message_ref`` field.
+            body_preview = preview.get("preview")
+            matches = (
+                [
+                    match
+                    for match in _COMPOUND_ID_RE.findall(body_preview)
+                    if _looks_like_compound_id(match)
+                ]
+                if isinstance(body_preview, str)
+                else []
+            )
+            if not matches:
+                return None
+            ids.update(matches)
+        return ids
+
+    def _all_notification_ids_read(self, compound_ids: set[str]) -> bool:
+        read_by_account: dict[str, set[str]] = {}
+        for compound_id in compound_ids:
+            try:
+                account, _chat_id, _msg_id = self._parse_compound_id(compound_id)
+            except ValueError:
+                return False
+            if account not in read_by_account:
+                read_by_account[account] = self._read_ids(account)
+            if compound_id not in read_by_account[account]:
+                return False
+        return bool(compound_ids)
+
+    def _clear_notification_if_handled(self) -> None:
+        """Clear stale ``mcp.telegram`` notification mirrors once handled.
+
+        LICC notification files are wake-up mirrors, not Telegram's source of
+        truth. If every Telegram message referenced by the current mirror is
+        now in the producer's durable ``read.json`` state, remove the mirror so
+        a later wake/molt does not re-deliver the same handled message.
+        """
+        target = self._working_dir / ".notification" / f"{_NOTIFICATION_CHANNEL}.json"
+        try:
+            payload = json.loads(target.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return
+        except (json.JSONDecodeError, OSError) as exc:
+            log.debug("cannot inspect Telegram notification mirror: %s", exc)
+            return
+
+        notification_ids = self._notification_message_ids(payload)
+        if notification_ids is None:
+            return
+        if not self._all_notification_ids_read(notification_ids):
+            return
+
+        try:
+            from lingtai_kernel.notifications import clear as clear_notification
+
+            clear_notification(self._working_dir, _NOTIFICATION_CHANNEL)
+            log.info(
+                "telegram notification mirror cleared after read: ids=%s",
+                sorted(notification_ids),
+            )
+        except Exception as exc:
+            log.debug("failed to clear Telegram notification mirror: %s", exc)
 
     def _load_contacts(self, account: str) -> dict:
         path = self._account_dir(account) / "contacts.json"
@@ -1200,6 +1327,7 @@ class TelegramManager:
         compound_ids = [m["id"] for m in recent if m.get("id")]
         if compound_ids:
             self._mark_read(account, compound_ids)
+            self._clear_notification_if_handled()
 
         # Strip internal fields
         cleaned = []
@@ -1228,7 +1356,7 @@ class TelegramManager:
             return {"error": "text is required"}
 
         account, chat_id, tg_msg_id = self._parse_compound_id(compound_id)
-        return self._send({
+        result = self._send({
             "account": account,
             "chat_id": chat_id,
             "text": text,
@@ -1242,6 +1370,10 @@ class TelegramManager:
             # We need to pass reply_to_message_id through
             "_reply_to_message_id": tg_msg_id,
         })
+        if result.get("status") == "sent":
+            self._mark_read(account, [compound_id])
+            self._clear_notification_if_handled()
+        return result
 
     def _search(self, args: dict) -> dict:
         query = args.get("query", "")

--- a/tests/test_telegram_notification_read_state.py
+++ b/tests/test_telegram_notification_read_state.py
@@ -1,0 +1,303 @@
+"""Regression tests for Telegram notification mirror read-state handling."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+from lingtai_kernel.notifications import submit
+
+
+class _FakeAccount:
+    alias = "main"
+
+    def send_message(self, chat_id: int, text: str, **_kwargs: Any) -> dict[str, Any]:
+        return {"message_id": 9001, "chat": {"id": chat_id}, "text": text}
+
+    def set_message_reaction(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def send_chat_action(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class _FakeService:
+    default_account = _FakeAccount()
+
+    def get_account(self, _alias: str) -> _FakeAccount:
+        return self.default_account
+
+
+def _manager(workdir: Path) -> TelegramManager:
+    return TelegramManager(
+        _FakeService(),
+        working_dir=workdir,
+        on_inbound=lambda _event: None,
+    )
+
+
+def _write_inbox_message(
+    workdir: Path,
+    *,
+    account: str = "main",
+    chat_id: int = 123,
+    message_id: int = 53,
+    text: str = "hello",
+) -> str:
+    compound_id = f"{account}:{chat_id}:{message_id}"
+    msg_dir = workdir / "telegram" / account / "inbox" / f"uuid-{chat_id}-{message_id}"
+    msg_dir.mkdir(parents=True, exist_ok=True)
+    (msg_dir / "message.json").write_text(
+        json.dumps(
+            {
+                "id": compound_id,
+                "from": {"username": "alice"},
+                "chat": {"id": chat_id, "type": "private"},
+                "date": "2026-05-21T23:53:00Z",
+                "text": text,
+                "media": None,
+                "callback_query": None,
+                "reply_to_message_id": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return compound_id
+
+
+def _write_telegram_notification(workdir: Path, message_id: str, *, preview: str = "hello") -> None:
+    submit(
+        workdir,
+        "mcp.telegram",
+        header="1 new event from MCP 'telegram'",
+        icon="💬",
+        priority="high",
+        instructions="Call the MCP 'telegram' read/check action to fetch.",
+        data={
+            "count": 1,
+            "source": "telegram",
+            "has_human_messages": True,
+            "previews": [
+                {
+                    "from": "alice",
+                    "subject": "telegram message from alice via main",
+                    "preview": preview,
+                    "platform": "telegram",
+                    "conversation_ref": "main:123",
+                    "message_ref": message_id,
+                }
+            ],
+        },
+    )
+
+
+
+def test_incoming_event_populates_generic_notification_refs(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    inbound_events: list[dict[str, Any]] = []
+    manager = TelegramManager(
+        _FakeService(),
+        working_dir=workdir,
+        on_inbound=inbound_events.append,
+    )
+
+    manager.on_incoming(
+        "main",
+        {
+            "message": {
+                "message_id": 53,
+                "date": 1781600000,
+                "from": {"id": 1, "username": "alice"},
+                "chat": {"id": 123, "type": "private"},
+                "text": "hello",
+            }
+        },
+    )
+
+    assert len(inbound_events) == 1
+    metadata = inbound_events[0]["metadata"]
+    assert metadata["message_id"] == "main:123:53"
+    assert metadata["platform"] == "telegram"
+    assert metadata["conversation_ref"] == "main:123"
+    assert metadata["message_ref"] == "main:123:53"
+
+
+def test_callback_query_incoming_does_not_publish_non_unique_message_ref(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    inbound_events: list[dict[str, Any]] = []
+    manager = TelegramManager(
+        _FakeService(),
+        working_dir=workdir,
+        on_inbound=inbound_events.append,
+    )
+
+    manager.on_incoming(
+        "main",
+        {
+            "callback_query": {
+                "id": "callback-unique-id",
+                "from": {"id": 1, "username": "alice"},
+                "data": "yes",
+                "message": {
+                    "message_id": 53,
+                    "chat": {"id": 123, "type": "private"},
+                },
+            }
+        },
+    )
+
+    metadata = inbound_events[0]["metadata"]
+    assert metadata["type"] == "callback_query"
+    assert metadata["message_id"] == "main:123:53"
+    assert metadata["message_ref"] is None
+
+
+def test_callback_query_notification_is_not_cleared_by_reused_message_anchor(
+    tmp_path: Path,
+) -> None:
+    workdir = tmp_path / "agent"
+    compound_id = _write_inbox_message(workdir)
+    submit(
+        workdir,
+        "mcp.telegram",
+        header="1 new event from MCP 'telegram'",
+        icon="💬",
+        priority="high",
+        data={
+            "count": 1,
+            "source": "telegram",
+            "previews": [
+                {
+                    "from": "alice",
+                    "subject": "telegram callback_query from alice via main",
+                    "preview": f"[just now] #{compound_id} alice: yes",
+                }
+            ],
+        },
+    )
+
+    _manager(workdir).handle(
+        {"action": "read", "account": "main", "chat_id": 123, "limit": 10}
+    )
+
+    assert (workdir / ".notification" / "mcp.telegram.json").exists()
+
+def test_read_marks_message_read_and_clears_handled_notification(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    compound_id = _write_inbox_message(workdir)
+    _write_telegram_notification(workdir, compound_id)
+
+    result = _manager(workdir).handle(
+        {"action": "read", "account": "main", "chat_id": 123, "limit": 10}
+    )
+
+    assert result["status"] == "ok"
+    assert [m["id"] for m in result["messages"]] == [compound_id]
+    assert json.loads((workdir / "telegram" / "main" / "read.json").read_text()) == [
+        compound_id
+    ]
+    assert not (workdir / ".notification" / "mcp.telegram.json").exists()
+
+
+def test_read_keeps_notification_until_all_preview_messages_are_read(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    read_id = _write_inbox_message(workdir, chat_id=123, message_id=53)
+    other_id = _write_inbox_message(workdir, chat_id=456, message_id=54)
+    submit(
+        workdir,
+        "mcp.telegram",
+        header="2 new events from MCP 'telegram'",
+        icon="💬",
+        priority="high",
+        data={
+            "count": 2,
+            "source": "telegram",
+            "has_human_messages": True,
+            "previews": [
+                {"from": "alice", "subject": "one", "preview": "one", "message_ref": read_id},
+                {"from": "bob", "subject": "two", "preview": "two", "message_ref": other_id},
+            ],
+        },
+    )
+
+    result = _manager(workdir).handle(
+        {"action": "read", "account": "main", "chat_id": 123, "limit": 10}
+    )
+
+    assert result["status"] == "ok"
+    assert (workdir / ".notification" / "mcp.telegram.json").exists()
+
+
+def test_read_keeps_notification_when_preview_has_no_message_identity(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    _write_inbox_message(workdir)
+    submit(
+        workdir,
+        "mcp.telegram",
+        header="1 new event from MCP 'telegram'",
+        icon="💬",
+        priority="high",
+        data={
+            "count": 1,
+            "source": "telegram",
+            "previews": [
+                {
+                    "from": "alice",
+                    "subject": "old malformed mirror",
+                    "preview": "hello without an anchor",
+                }
+            ],
+        },
+    )
+
+    _manager(workdir).handle(
+        {"action": "read", "account": "main", "chat_id": 123, "limit": 10}
+    )
+
+    assert (workdir / ".notification" / "mcp.telegram.json").exists()
+
+
+def test_reply_marks_replied_message_read_and_clears_notification(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    compound_id = _write_inbox_message(workdir)
+    _write_telegram_notification(workdir, compound_id)
+
+    result = _manager(workdir).handle(
+        {"action": "reply", "message_id": compound_id, "text": "handled"}
+    )
+
+    assert result["status"] == "sent"
+    assert compound_id in json.loads(
+        (workdir / "telegram" / "main" / "read.json").read_text()
+    )
+    assert not (workdir / ".notification" / "mcp.telegram.json").exists()
+
+
+def test_legacy_conversation_preview_ids_can_clear_old_notification(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    compound_id = _write_inbox_message(workdir)
+    submit(
+        workdir,
+        "mcp.telegram",
+        header="1 new event from MCP 'telegram'",
+        icon="💬",
+        priority="high",
+        data={
+            "count": 1,
+            "source": "telegram",
+            "previews": [
+                {
+                    "from": "alice",
+                    "subject": "legacy telegram message",
+                    "preview": f"[just now] #{compound_id} alice: hello",
+                }
+            ],
+        },
+    )
+
+    _manager(workdir).handle(
+        {"action": "read", "account": "main", "chat_id": 123, "limit": 10}
+    )
+
+    assert not (workdir / ".notification" / "mcp.telegram.json").exists()


### PR DESCRIPTION
## Summary

Fixes stale Telegram notification mirror re-delivery after agents read/reply to Telegram messages.

`Lingtai-AI/lingtai#153` describes a loop where `.notification/mcp.telegram.json` survives across wake/molt boundaries and is re-injected as if it were new, even after `telegram(read)` and a reply. This PR ties the Telegram MCP notification mirror back to Telegram's durable producer read state.

## Changes

- Add generic Telegram LICC metadata on inbound events:
  - `platform=telegram`
  - `conversation_ref=<account>:<chat_id>`
  - `message_ref=<account>:<chat_id>:<message_id>` for ordinary message events
- After `telegram(read)`, clear `.notification/mcp.telegram.json` only when every preview message referenced by the current notification mirror is present in durable `telegram/{account}/read.json`.
- After a successful `telegram(reply)`, mark the replied-to message as read and run the same notification cleanup.
- Preserve safe fallback for old notification mirrors by parsing existing `#account:chat:message` conversation-preview anchors.
- Stay conservative on ambiguity:
  - malformed/identity-less preview → keep notification;
  - mixed coalesced notification with unread message(s) → keep notification;
  - callback-query previews → keep notification, because Telegram callback updates reuse the inline-keyboard message id and are not uniquely represented by `account:chat:message`.

## Tests

```bash
git diff --check
python -m pytest -q \
  tests/test_telegram_notification_read_state.py \
  tests/test_mcp_inbox.py \
  tests/test_mcp_licc_client.py \
  tests/test_meta_block.py \
  tests/test_notification_sync.py \
  tests/test_system_dismiss.py \
  tests/test_agent.py \
  tests/test_deep_refresh.py
```

Result: `233 passed`.

## Review notes

- DeepSeek, MiMo, GLM: APPROVE on the main read-state cleanup patch.
- Codex parent review: APPROVE on the final patch including the callback-query safety addendum.

Fixes Lingtai-AI/lingtai#153
