### PR TITLE
Fix Claude Agent SDK preset connectivity

### DIFF
--- a/src/lingtai_kernel/preset_connectivity.py
+++ b/src/lingtai_kernel/preset_connectivity.py
@@ -14,6 +14,7 @@ Concurrency: check_many() runs all checks in parallel via ThreadPoolExecutor.
 """
 from __future__ import annotations
 
+import importlib.util
 import os
 import socket
 import time
@@ -22,6 +23,15 @@ from datetime import datetime, timezone
 from urllib.parse import urlparse
 
 _PROBE_TIMEOUT_S = 2.0
+
+# Local CLI-login providers authenticate through a locally installed CLI/login
+# session (no per-request API key, no base_url) — so a TCP probe would be a
+# false negative. Health for these is "is the optional package importable?".
+# Maps the provider name (and its aliases) to the module that backs it.
+_LOCAL_CLI_LOGIN_PROVIDERS = {
+    "claude-agent-sdk": "claude_agent_sdk",
+    "claude_agent_sdk": "claude_agent_sdk",
+}
 
 # Default base_url per provider for presets that omit base_url.
 _PROVIDER_DEFAULT_URLS = {
@@ -52,6 +62,19 @@ def _probe_host(host: str, port: int, timeout: float) -> int:
     return elapsed_ms
 
 
+def _module_available(module_name: str) -> bool:
+    """Return True if ``module_name`` can be imported without importing it.
+
+    Used to gauge a local CLI-login provider's health: the optional package
+    being installed is the in-process, network-free signal that the provider
+    is usable.
+    """
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
 def _resolve_url(provider: str | None, base_url: str | None) -> str | None:
     """Pick the URL to probe: explicit base_url > provider default > None."""
     if base_url:
@@ -76,6 +99,31 @@ def check_connectivity(
          "latency_ms": int (only on ok),
          "error": str | None}
     """
+    # Local CLI-login providers (e.g. claude-agent-sdk) have no network
+    # endpoint and no API key — they authenticate through a local CLI/login
+    # session. Probing a base_url would be a false negative, so gauge health
+    # by whether the optional backing package is importable. Never reach the
+    # base_url resolution below for these.
+    module_name = _LOCAL_CLI_LOGIN_PROVIDERS.get((provider or "").lower())
+    if module_name is not None:
+        if _module_available(module_name):
+            return {
+                "status": "ok",
+                "checked_at": datetime.now(timezone.utc).isoformat(),
+                "latency_ms": None,
+                "error": None,
+            }
+        return {
+            "status": "no_credentials",
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+            "latency_ms": None,
+            "error": (
+                f"{provider} is a local CLI-login provider but its package "
+                f"{module_name!r} is not installed — run `pip install "
+                f"{module_name.replace('_', '-')}` and `claude login`"
+            ),
+        }
+
     # Credential check (free) — never makes a network call.
     if api_key_env and not os.environ.get(api_key_env):
         return {

--- a/tests/test_preset_connectivity.py
+++ b/tests/test_preset_connectivity.py
@@ -178,3 +178,65 @@ def test_check_many_preserves_input_order(monkeypatch):
 def test_check_many_empty_list_returns_empty():
     from lingtai_kernel.preset_connectivity import check_many
     assert check_many([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Local CLI-login providers (e.g. claude-agent-sdk)
+# ---------------------------------------------------------------------------
+
+
+def test_claude_agent_sdk_ok_when_package_importable(monkeypatch):
+    """A local CLI-login provider with its package importable is `ok` —
+    no base_url, no api_key_env, and crucially no TCP probe."""
+    from lingtai_kernel import preset_connectivity
+    with patch.object(preset_connectivity, "_probe_host") as probe, \
+         patch.object(preset_connectivity, "_module_available", return_value=True):
+        result = preset_connectivity.check_connectivity(
+            provider="claude-agent-sdk",
+            base_url=None,
+            api_key_env=None,
+        )
+        assert result["status"] == "ok"
+        probe.assert_not_called()  # local provider — never hits the network
+
+
+def test_claude_agent_sdk_no_base_url_does_not_error(monkeypatch):
+    """The bug: a saved claude-agent-sdk preset was reported unreachable with
+    'no base_url and no default URL'. A local CLI-login provider must never
+    fail just because it has no base_url."""
+    from lingtai_kernel import preset_connectivity
+    with patch.object(preset_connectivity, "_module_available", return_value=True):
+        result = preset_connectivity.check_connectivity(
+            provider="claude-agent-sdk",
+            base_url=None,
+            api_key_env=None,
+        )
+        assert result["status"] != "unreachable"
+        assert "no base_url" not in (result.get("error") or "")
+
+
+def test_claude_agent_sdk_underscore_alias_treated_as_local(monkeypatch):
+    """The underscore alias claude_agent_sdk is the same local provider."""
+    from lingtai_kernel import preset_connectivity
+    with patch.object(preset_connectivity, "_module_available", return_value=True):
+        result = preset_connectivity.check_connectivity(
+            provider="claude_agent_sdk",
+            base_url=None,
+            api_key_env=None,
+        )
+        assert result["status"] == "ok"
+
+
+def test_claude_agent_sdk_missing_package_reports_no_credentials(monkeypatch):
+    """When the optional package is absent, report a clear, actionable status
+    (not the misleading 'no base_url' error)."""
+    from lingtai_kernel import preset_connectivity
+    with patch.object(preset_connectivity, "_module_available", return_value=False):
+        result = preset_connectivity.check_connectivity(
+            provider="claude-agent-sdk",
+            base_url=None,
+            api_key_env=None,
+        )
+        assert result["status"] == "no_credentials"
+        assert "claude-agent-sdk" in (result.get("error") or "")
+        assert "no base_url" not in (result.get("error") or "")


### PR DESCRIPTION
## Summary

- recognize `claude-agent-sdk` / `claude_agent_sdk` as local CLI-login preset providers in kernel preset connectivity
- avoid the misleading `no base_url and no default URL` unreachable status for providers that authenticate through local Claude Code login
- report `ok` when the optional `claude_agent_sdk` package is importable, or `no_credentials` with install/login guidance when it is missing

## Context

After `lingtai#361` added a TUI Claude Code auth preset, a saved local preset using provider `claude-agent-sdk`, model `opus`, and no `base_url` could successfully generate through `LLMService('claude-agent-sdk', 'opus')`, but `system.presets` marked it unreachable because the generic connectivity checker required a URL.

This keeps kernel dependencies one-directional: the kernel does not import the TUI helper or the `lingtai` wrapper, and only checks optional module availability with `importlib.util.find_spec`.

## Tests

```bash
python -m pytest tests/test_preset_connectivity.py tests/test_system.py tests/test_adapter_registry.py tests/test_claude_agent_sdk_adapter.py tests/test_preset_auto_fallback.py tests/test_activate_preset.py -q
# 79 passed

git diff --check
```

Also smoke-checked the fixed connectivity branch against the runtime venv with `claude_agent_sdk` installed:

```text
check_connectivity(provider='claude-agent-sdk', base_url=None, api_key_env='') -> status ok
check_connectivity(provider='claude_agent_sdk', base_url=None, api_key_env='') -> status ok
```