### PR TITLE
fix(telegram): reconcile notification mirror from durable unread (#111)

### DIFF
--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -143,6 +143,7 @@ class TelegramAccount:
         on_message: Callable[[str, dict], None] | None = None,
         state_dir: Path | None = None,
         commands: list[dict[str, str]] | None = None,
+        on_idle_tick: Callable[[], None] | None = None,
     ) -> None:
         self.alias = alias
         self._bot_token = bot_token
@@ -150,6 +151,10 @@ class TelegramAccount:
         self._poll_interval = poll_interval
         self._on_message = on_message
         self._state_dir = state_dir
+        # Fired once per poll cycle (including no-update long-poll returns) so
+        # the host can run periodic, message-independent work — e.g. the
+        # notification reconcile that recovers the post-molt stall (issue #111).
+        self._on_idle_tick = on_idle_tick
         # If commands is None, fall back to DEFAULT_COMMANDS at registration
         # time. An explicit empty list means "register no commands" and is
         # respected (Telegram clears the menu).
@@ -267,6 +272,15 @@ class TelegramAccount:
                 if self._stop_event.wait(timeout=5.0):
                     return
                 continue
+            # Periodic, message-independent reconcile (issue #111). Runs every
+            # cycle including no-update returns; best-effort, never fatal.
+            if self._on_idle_tick is not None:
+                try:
+                    self._on_idle_tick()
+                except Exception as e:
+                    logger.debug(
+                        "Telegram idle tick error (%s): %s", self.alias, e,
+                    )
             # Brief pause between poll cycles
             if self._stop_event.wait(timeout=self._poll_interval):
                 return

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -292,6 +292,119 @@ class TelegramManager:
     def _account_dir(self, account: str) -> Path:
         return self._working_dir / "telegram" / account
 
+    # ------------------------------------------------------------------
+    # Notification reconcile (issue #111)
+    # ------------------------------------------------------------------
+    #
+    # MCP→.notification/ delivery is edge-triggered: the kernel poller
+    # publishes `.notification/mcp.telegram.json` only when it consumes a
+    # *new* inbound LICC event. If that mirror is absent or was dismissed at
+    # the moment a context molt completes — while durable read state
+    # (`read.json`) still has unread Telegram messages — nothing re-derives
+    # the notification until a *fresh* inbound message creates a new edge
+    # (issue #111: the "hello?" workaround). The reconcile tick re-emits a
+    # LICC event from durable unread state so the channel resurfaces on its
+    # own, converting delivery to edge-triggered + periodic level-reconcile.
+
+    def _notification_mirror_path(self) -> Path:
+        return self._working_dir / ".notification" / "mcp.telegram.json"
+
+    def _unread_messages(self, account: str) -> list[dict]:
+        """Durable-unread inbox messages for *account* = persisted inbox
+        minus `read.json`, newest-first. Mirrors the read-state contract
+        used by `_read`/`_mark_read` so reconcile and reads agree."""
+        read_ids = self._read_ids(account)
+        unread = [
+            m for m in self._list_messages(account, "inbox")
+            if m.get("id") and m["id"] not in read_ids
+        ]
+        return unread
+
+    def reconcile_notifications(self) -> int:
+        """Republish `.notification/mcp.telegram.json` from durable unread
+        state when it is missing but unread messages remain.
+
+        Idempotent and conservative:
+          - Emits a LICC event (via the same on_inbound path as a live
+            arrival) only when there is durable unread AND no live mirror
+            exists. The kernel then publishes the mirror through its normal
+            channel, so the post-molt agent is woken without a fresh inbound
+            message (issue #111).
+          - If a live mirror already exists, do nothing — the kernel has
+            already surfaced the channel; re-emitting would churn the wire.
+          - If nothing is unread, do nothing. Clearing a stale mirror is
+            owned by the read-state cleanup (PR #310); reconcile never
+            republishes a stale mirror after the producer has read.
+
+        The mirror is a single per-channel file shared by all accounts, so a
+        present mirror short-circuits the whole tick. Returns the number of
+        LICC events emitted (0 or 1).
+        """
+        if self._notification_mirror_path().exists():
+            # The channel already has a live edge — nothing to reconcile.
+            return 0
+
+        try:
+            accounts = list(self._service.list_accounts())
+        except Exception as exc:
+            log.debug("reconcile_notifications: list_accounts failed: %s", exc)
+            return 0
+
+        unread_by_account: list[tuple[str, list[dict]]] = []
+        for account in accounts:
+            unread = self._unread_messages(account)
+            if unread:
+                unread_by_account.append((account, unread))
+
+        if not unread_by_account:
+            return 0
+
+        # Re-emit a single LICC event for the channel from the account with
+        # the newest unread message, so the kernel mirror reflects real
+        # durable unread rather than a fabricated cumulative digest.
+        account, unread = max(
+            unread_by_account,
+            key=lambda item: item[1][0].get("date", ""),
+        )
+        newest = unread[0]
+        username = (
+            (newest.get("from") or {}).get("username")
+            or (newest.get("from") or {}).get("first_name")
+            or "unknown"
+        )
+        total_unread = sum(len(u) for _, u in unread_by_account)
+        unread_ids = [m["id"] for _, msgs in unread_by_account for m in msgs if m.get("id")]
+
+        chat_id = (newest.get("chat") or {}).get("id")
+        try:
+            preview = self._build_conversation_preview(account, chat_id, newest.get("id"))
+        except Exception as exc:
+            log.debug("reconcile_notifications: preview failed: %s", exc)
+            text = newest.get("text") or newest.get("callback_query") or ""
+            preview = text[:300].replace("\n", " ")
+
+        try:
+            self._on_inbound({
+                "from": username,
+                "subject": (
+                    f"telegram {total_unread} unread message(s) via {account}"
+                ),
+                "body": preview if preview else "(unread telegram messages)",
+                "metadata": {
+                    "type": "reconcile",
+                    "account": account,
+                    "chat_id": chat_id,
+                    "message_id": newest.get("id"),
+                    "unread_count": total_unread,
+                    "unread_ids": unread_ids,
+                },
+                "wake": True,
+            })
+        except Exception as exc:
+            log.error("reconcile_notifications: on_inbound failed: %s", exc)
+            return 0
+        return 1
+
     def _resolve_account(self, args: dict) -> str:
         """Get account alias from args, defaulting to first account."""
         return args.get("account") or self._service.default_account.alias

--- a/src/lingtai/mcp_servers/telegram/server.py
+++ b/src/lingtai/mcp_servers/telegram/server.py
@@ -630,11 +630,20 @@ def build_manager() -> tuple[TelegramManager, Path]:
     # reach it. Same pattern as the legacy addon's lambda + mgr_ref dance.
     mgr_ref: list[TelegramManager | None] = [None]
 
+    def _on_idle_tick() -> None:
+        # Periodic, message-independent reconcile so durable unread Telegram
+        # messages resurface after a context molt even when no fresh inbound
+        # message arrives (issue #111). Best-effort.
+        mgr = mgr_ref[0]
+        if mgr is not None:
+            mgr.reconcile_notifications()
+
     svc = TelegramService(
         working_dir=working_dir,
         accounts_config=accounts,
         on_message=lambda alias, update: mgr_ref[0].on_incoming(alias, update),
         config_source=os.environ.get("LINGTAI_TELEGRAM_CONFIG"),
+        on_idle_tick=_on_idle_tick,
     )
 
     mgr = TelegramManager(

--- a/src/lingtai/mcp_servers/telegram/service.py
+++ b/src/lingtai/mcp_servers/telegram/service.py
@@ -28,10 +28,12 @@ class TelegramService:
         accounts_config: list[dict],
         on_message: Callable[[str, dict], None],
         config_source: str | None = None,
+        on_idle_tick: Callable[[], None] | None = None,
     ) -> None:
         self._working_dir = Path(working_dir)
         self._on_message = on_message
         self._config_source = config_source
+        self._on_idle_tick = on_idle_tick
         self._account_order: list[str] = []
         self._accounts: dict[str, TelegramAccount] = {}
 
@@ -46,6 +48,7 @@ class TelegramService:
                 on_message=on_message,
                 state_dir=state_dir,
                 commands=cfg.get("commands"),
+                on_idle_tick=on_idle_tick,
             )
             self._accounts[alias] = acct
             self._account_order.append(alias)

--- a/tests/test_telegram_idle_tick.py
+++ b/tests/test_telegram_idle_tick.py
@@ -1,0 +1,87 @@
+"""The poll loop fires a periodic idle tick (issue #111 wiring).
+
+The notification reconcile only helps if it runs independently of new inbound
+messages — otherwise it cannot recover the post-molt stall, which by definition
+happens when no fresh message arrives. The account poll loop therefore invokes
+an `on_idle_tick` callback once per poll cycle (including the common no-update
+long-poll return), which the manager wires to `reconcile_notifications`.
+"""
+from __future__ import annotations
+
+import threading
+
+from lingtai.mcp_servers.telegram.account import TelegramAccount
+
+
+def _make_account(on_idle_tick) -> TelegramAccount:
+    return TelegramAccount(
+        alias="main",
+        bot_token="x:y",
+        allowed_users=None,
+        poll_interval=0.0,
+        on_message=None,
+        state_dir=None,
+        commands=[],
+        on_idle_tick=on_idle_tick,
+    )
+
+
+def test_poll_loop_calls_idle_tick_after_each_cycle():
+    """One getUpdates cycle (no updates) fires the idle tick exactly once,
+    then the loop stops cleanly."""
+    ticks: list[int] = []
+    acct = _make_account(lambda: ticks.append(1))
+
+    # Stub the network call: return no updates, then signal stop so the loop
+    # exits after a single cycle.
+    def _fake_request(method, **kwargs):
+        acct._stop_event.set()
+        return []
+
+    acct._request = _fake_request  # type: ignore[assignment]
+    acct._poll_loop()
+
+    assert ticks == [1]
+
+
+def test_idle_tick_failure_does_not_break_poll_loop():
+    """A raising idle tick is swallowed — the poll loop must never die on a
+    best-effort reconcile failure."""
+    calls: list[int] = []
+
+    def _boom():
+        calls.append(1)
+        raise RuntimeError("reconcile blew up")
+
+    acct = _make_account(_boom)
+
+    def _fake_request(method, **kwargs):
+        acct._stop_event.set()
+        return []
+
+    acct._request = _fake_request  # type: ignore[assignment]
+    # Should not raise.
+    acct._poll_loop()
+
+    assert calls == [1]
+
+
+def test_idle_tick_optional():
+    """on_idle_tick defaults to None and the loop runs without it."""
+    acct = TelegramAccount(
+        alias="main",
+        bot_token="x:y",
+        allowed_users=None,
+        poll_interval=0.0,
+        on_message=None,
+        state_dir=None,
+        commands=[],
+    )
+
+    def _fake_request(method, **kwargs):
+        acct._stop_event.set()
+        return []
+
+    acct._request = _fake_request  # type: ignore[assignment]
+    # No callback wired — must not raise.
+    acct._poll_loop()

--- a/tests/test_telegram_notification_reconcile.py
+++ b/tests/test_telegram_notification_reconcile.py
@@ -1,0 +1,164 @@
+"""Producer-side notification reconcile for the Telegram MCP (issue #111).
+
+Covers the residual gap in #111: delivery of `.notification/mcp.telegram.json`
+is edge-triggered off new inbound LICC events. If that mirror is absent or was
+dismissed at the moment a context molt completes — while durable read state
+(`read.json`) still has unread Telegram messages — nothing re-derives the
+notification until a *fresh* inbound message creates a new edge. The reconcile
+tick converts delivery to edge-triggered + periodic level-reconcile.
+
+Contract under test (`TelegramManager.reconcile_notifications`):
+  - unread > 0 AND no live `.notification/mcp.telegram.json` -> emit a LICC
+    event so the kernel republishes the mirror (post-molt recovery).
+  - unread > 0 AND a live mirror already exists -> no-op (idempotent; the
+    kernel already surfaced it — don't churn the wire).
+  - unread == 0 (all read) -> no-op; clearing the stale mirror is owned by the
+    read-state cleanup (PR #310), reconcile must not republish a stale mirror.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+
+
+class _FakeService:
+    """Minimal stand-in for TelegramService — reconcile only needs the alias
+    list; no network, no accounts."""
+
+    def __init__(self, aliases: list[str]) -> None:
+        self._aliases = list(aliases)
+
+    def list_accounts(self) -> list[str]:
+        return list(self._aliases)
+
+
+def _make_manager(tmp_path: Path, aliases: list[str], inbound):
+    return TelegramManager(
+        service=_FakeService(aliases),
+        working_dir=tmp_path,
+        on_inbound=inbound,
+    )
+
+
+def _write_inbox_message(tmp_path: Path, account: str, compound_id: str,
+                         text: str, *, date: str | None = None) -> None:
+    """Persist one inbox message the way on_incoming() does."""
+    chat_id = int(compound_id.split(":")[1])
+    msg_dir = tmp_path / "telegram" / account / "inbox" / compound_id.replace(":", "_")
+    msg_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "id": compound_id,
+        "from": {"username": "jason", "first_name": "Jason"},
+        "chat": {"id": chat_id},
+        "date": date or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "text": text,
+        "media": None,
+        "reply_to_message_id": None,
+        "callback_query": None,
+    }
+    (msg_dir / "message.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_read_json(tmp_path: Path, account: str, compound_ids: list[str]) -> None:
+    acct_dir = tmp_path / "telegram" / account
+    acct_dir.mkdir(parents=True, exist_ok=True)
+    (acct_dir / "read.json").write_text(json.dumps(sorted(compound_ids)), encoding="utf-8")
+
+
+def _write_notification_mirror(tmp_path: Path) -> Path:
+    notif = tmp_path / ".notification"
+    notif.mkdir(parents=True, exist_ok=True)
+    path = notif / "mcp.telegram.json"
+    path.write_text(json.dumps({"data": {"count": 1}}), encoding="utf-8")
+    return path
+
+
+def test_republishes_when_unread_exists_and_mirror_absent(tmp_path):
+    """Durable unread present, no live mirror -> emit a LICC event so the
+    kernel republishes mcp.telegram (the #111 post-molt recovery path)."""
+    events: list[dict] = []
+    mgr = _make_manager(tmp_path, ["main"], events.append)
+
+    _write_inbox_message(tmp_path, "main", "main:100:1", "first")
+    _write_inbox_message(tmp_path, "main", "main:100:2", "hello?")
+    # read.json marks only the first as read -> #2 is durable unread.
+    _write_read_json(tmp_path, "main", ["main:100:1"])
+    # No .notification/mcp.telegram.json on disk.
+
+    published = mgr.reconcile_notifications()
+
+    assert published == 1
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["wake"] is True
+    assert ev["metadata"]["type"] == "reconcile"
+    assert ev["metadata"]["account"] == "main"
+    assert ev["metadata"]["unread_count"] == 1
+    # The unread message id is carried so the kernel mirror reflects it.
+    assert "main:100:2" in ev["metadata"]["unread_ids"]
+    assert "main:100:1" not in ev["metadata"]["unread_ids"]
+
+
+def test_noop_when_all_messages_read(tmp_path):
+    """No durable unread -> reconcile is a no-op. It must not republish a
+    stale mirror; clearing is owned by the read-state cleanup (PR #310)."""
+    events: list[dict] = []
+    mgr = _make_manager(tmp_path, ["main"], events.append)
+
+    _write_inbox_message(tmp_path, "main", "main:100:1", "first")
+    _write_inbox_message(tmp_path, "main", "main:100:2", "second")
+    _write_read_json(tmp_path, "main", ["main:100:1", "main:100:2"])
+
+    published = mgr.reconcile_notifications()
+
+    assert published == 0
+    assert events == []
+
+
+def test_noop_when_mirror_already_present(tmp_path):
+    """Durable unread present but a live mirror already exists -> no-op
+    (idempotent: the kernel already surfaced it; don't churn the wire)."""
+    events: list[dict] = []
+    mgr = _make_manager(tmp_path, ["main"], events.append)
+
+    _write_inbox_message(tmp_path, "main", "main:100:2", "hello?")
+    _write_read_json(tmp_path, "main", [])
+    _write_notification_mirror(tmp_path)
+
+    published = mgr.reconcile_notifications()
+
+    assert published == 0
+    assert events == []
+
+
+def test_noop_when_inbox_empty(tmp_path):
+    """No inbox at all -> nothing to reconcile."""
+    events: list[dict] = []
+    mgr = _make_manager(tmp_path, ["main"], events.append)
+
+    published = mgr.reconcile_notifications()
+
+    assert published == 0
+    assert events == []
+
+
+def test_does_not_double_publish_across_accounts_with_existing_mirror(tmp_path):
+    """The mirror is a single channel file shared by all telegram accounts.
+    Once any account has caused the mirror to exist, a second account with
+    unread must not emit again — the existing edge already covers the channel."""
+    events: list[dict] = []
+    mgr = _make_manager(tmp_path, ["main", "alt"], events.append)
+
+    _write_inbox_message(tmp_path, "alt", "alt:200:9", "unread on alt")
+    _write_read_json(tmp_path, "alt", [])
+    _write_notification_mirror(tmp_path)
+
+    published = mgr.reconcile_notifications()
+
+    assert published == 0
+    assert events == []

--- a/tests/test_telegram_service_idle_tick.py
+++ b/tests/test_telegram_service_idle_tick.py
@@ -1,0 +1,35 @@
+"""TelegramService forwards an on_idle_tick callback to every account
+(issue #111 wiring). build_manager() wires this to the manager's reconcile."""
+from __future__ import annotations
+
+from lingtai.mcp_servers.telegram.service import TelegramService
+
+
+def test_service_forwards_idle_tick_to_accounts(tmp_path):
+    ticks: list[int] = []
+    svc = TelegramService(
+        working_dir=tmp_path,
+        accounts_config=[
+            {"alias": "main", "bot_token": "a:b", "poll_interval": 0.0},
+            {"alias": "alt", "bot_token": "c:d", "poll_interval": 0.0},
+        ],
+        on_message=lambda alias, update: None,
+        on_idle_tick=lambda: ticks.append(1),
+    )
+
+    # Each account received the same callback.
+    for alias in svc.list_accounts():
+        acct = svc.get_account(alias)
+        assert acct._on_idle_tick is not None
+        acct._on_idle_tick()
+
+    assert ticks == [1, 1]
+
+
+def test_service_idle_tick_optional(tmp_path):
+    svc = TelegramService(
+        working_dir=tmp_path,
+        accounts_config=[{"alias": "main", "bot_token": "a:b"}],
+        on_message=lambda alias, update: None,
+    )
+    assert svc.get_account("main")._on_idle_tick is None


### PR DESCRIPTION
# fix(telegram): reconcile notification mirror from durable unread (#111)

Closes Lingtai-AI/lingtai#111.

## Problem

`.notification/mcp.telegram.json` delivery is **edge-triggered**: the kernel MCP-inbox poller publishes the mirror only when it consumes a *new* inbound LICC event. PR #31 (preserve `.notification/` across molt) and PR #190 (post-molt IDLE re-inject + wake) fixed the case where a mirror **is present** at molt completion — but neither changed the edge-triggered-only delivery contract.

So if the mirror is **absent or already-dismissed** at the moment a context molt completes, while durable read state (`read.json`) still marks Telegram messages unread, **nothing re-derives the notification** until a *fresh* inbound message creates a new edge. The post-molt agent reads its summary, sees no pending notification, and idles — exactly the stall in #111, where the user's `hello?` was the workaround that created the new edge.

## Fix

A minimal, producer-side **level-reconcile** in the Telegram MCP (no kernel changes):

- **`TelegramManager.reconcile_notifications()`** — when durable unread (inbox minus `read.json`) is non-empty **and** no live mirror exists, re-emit a LICC event via the existing `on_inbound` path so the kernel republishes the mirror through its normal channel and `_sync_notifications` (PR #190) re-injects + wakes the post-molt agent **without a second inbound message**.
  - A present mirror short-circuits the tick (idempotent — the mirror is a single per-channel file shared by all accounts).
  - All-read is a no-op: reconcile **never** clears and **never** republishes a stale mirror after the producer has read.
- **`on_idle_tick`** — `TelegramAccount`/`TelegramService` gain an optional per-poll-cycle callback (fired even on no-update long-poll returns), wired in `build_manager()` to `reconcile_notifications()`. This runs independently of new inbound messages — and therefore independently of molts — converting delivery to **edge-triggered + periodic level-reconcile**.

Re-emitting a LICC event (instead of writing `.notification/` directly) keeps the LICC contract intact and reuses the kernel's existing coalescing/publish/fingerprint machinery — no duplicate notification logic, no read-state schema leaking into the kernel.

## Composes with PR #310 (stale-mirror clear, #153)

This is the complementary half of one reconcile:

- #310 **clears** the mirror once all previewed messages are read.
- This PR **republishes** the mirror from still-unread state when it is missing.

Conditions are non-overlapping (all-read vs. unread-with-no-mirror), so reconcile never pre-empts #310's clear, and #310 may clear freely — the next idle tick republishes if unread remains. This closes gap #3 from the investigation (aggressive clearing widening #111). PR #310 is **not** required as a base for this change; this builds directly on `main`.

## Tests

- `tests/test_telegram_notification_reconcile.py` — unread→republish, all-read no-op, mirror-present no-op, empty-inbox no-op, multi-account single-channel.
- `tests/test_telegram_idle_tick.py` — poll loop fires the tick per cycle; raising tick is non-fatal; callback optional.
- `tests/test_telegram_service_idle_tick.py` — service forwards the tick to every account.

```
new tests:                                                10 passed
test_mcp_inbox / notification_sync / molt_persistence /
  post_molt_notification / mcp_licc_client:              113 passed
test_sent_message_tracker / system_dismiss /
  mcp_capability (regression guard):                      84 passed
git diff --check:                                          clean
```

Developed test-first (TDD). +139 lines, additive, no deletions, no kernel edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

