### PR TITLE
Cap over-ceiling context banner and type overflow events

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -334,6 +334,29 @@ def _is_over_window_error(exc: Exception) -> bool:
     return any(fragment in msg for fragment in _OVER_WINDOW_MSG_FRAGMENTS)
 
 
+def _classify_over_window_event(exc: Exception) -> str:
+    """Bucket an over-window error into a stable, grep-able event ``kind``.
+
+    Issue #193 item 4: ``_is_over_window_error`` only answers yes/no, and the
+    generic ``aed_over_window_detected`` marker hides *why* the wire was
+    rejected.  A distinct typed ``kind`` lets operators tell a real provider
+    hard-cap rejection (HTTP 413) and the canonical
+    ``context_length_exceeded`` provider code apart from a merely
+    estimate/phrasing-driven overflow, so genuine hard-cap failures are
+    diagnosable in ``events.jsonl``.
+
+    Precedence is provider-truth first: an explicit 413 status is the most
+    authoritative signal, then the canonical ``context_length_exceeded``
+    fragment, then a generic ``context_overflow`` fallback.
+    """
+    if _exception_status_code(exc) == 413:
+        return "provider_413"
+    msg = (str(exc) or "").lower()
+    if "context_length_exceeded" in msg:
+        return "context_length_exceeded"
+    return "context_overflow"
+
+
 def _compact_history_before_retry(agent, *, source: str) -> "CompactionStats | None":
     """Retroactively spill oversized tool results before an AED retry.
 
@@ -574,6 +597,18 @@ def _run_loop(agent) -> None:
                             "aed_over_window_detected",
                             error=err_desc[:300],
                             exception=type(e).__name__,
+                        )
+                        # Issue #193 item 4: also emit a distinct typed event
+                        # carrying the classified ``kind`` (provider_413 /
+                        # context_length_exceeded / context_overflow) so real
+                        # provider hard-cap failures are grep-able beyond the
+                        # generic marker above.
+                        agent._log(
+                            "provider_context_overflow",
+                            kind=_classify_over_window_event(e),
+                            status_code=_exception_status_code(e),
+                            exception=type(e).__name__,
+                            error=err_desc[:300],
                         )
 
                     if not over_window and _is_transient_provider_error(e):

--- a/src/lingtai_kernel/i18n/en.json
+++ b/src/lingtai_kernel/i18n/en.json
@@ -1,6 +1,7 @@
 {
   "system.current_time": "[Current time: {time} | context: {ctx}]",
   "system.context_breakdown": "{pct} (sys {sys} + ctx {ctx})",
+  "system.context_over_ceiling": ">100% over hard ceiling; compacting (sys {sys} + ctx {ctx})",
   "system.context_unknown": "unavailable",
   "system.new_mail.no_subject": "(no subject)",
   "system.mail_bounce": "[system] Mail delivery failed: {error}\n  To: {address}\n  Subject: {subject}",

--- a/src/lingtai_kernel/i18n/wen.json
+++ b/src/lingtai_kernel/i18n/wen.json
@@ -1,6 +1,7 @@
 {
   "system.current_time": "[此时：{time} | 上下文：{ctx}]",
   "system.context_breakdown": "{pct} (系统 {sys} + 对话 {ctx})",
+  "system.context_over_ceiling": ">100% 逾硬限，方压缩 (系统 {sys} + 对话 {ctx})",
   "system.context_unknown": "未知",
   "system.new_mail.no_subject": "（无题）",
   "system.mail_bounce": "[系统] 书信未达：{error}\n  收者：{address}\n  题：{subject}",

--- a/src/lingtai_kernel/i18n/zh.json
+++ b/src/lingtai_kernel/i18n/zh.json
@@ -1,6 +1,7 @@
 {
   "system.current_time": "[此时：{time} | 上下文：{ctx}]",
   "system.context_breakdown": "{pct} (系统 {sys} + 对话 {ctx})",
+  "system.context_over_ceiling": ">100% 超出硬上限，压缩中 (系统 {sys} + 对话 {ctx})",
   "system.context_unknown": "未知",
   "system.new_mail.no_subject": "（无主题）",
   "system.mail_bounce": "[系统] 消息投递失败：{error}\n  收件人：{address}\n  主题：{subject}",

--- a/src/lingtai_kernel/meta_block.py
+++ b/src/lingtai_kernel/meta_block.py
@@ -449,6 +449,19 @@ def _render_context_fragment(agent, meta: dict) -> str:
     usage = ctx.get("usage", -1.0)
     if usage < 0:
         return _t(agent._config.language, "system.context_unknown")
+    # Issue #193 item 3: when usage runs past the hard ceiling (>100%) we must
+    # not feed a runaway percentage like ``197.2%`` back into the model's own
+    # prompt. Rewording to a bounded over-ceiling notice (while preserving the
+    # token breakdown) keeps the banner honest without anchoring the model on a
+    # nonsensical number. The breakdown is kept because operators/the model
+    # still benefit from seeing the sys/ctx split that produced the overflow.
+    if usage > 1.0:
+        return _t(
+            agent._config.language,
+            "system.context_over_ceiling",
+            sys=ctx.get("system_tokens", 0),
+            ctx=ctx.get("history_tokens", 0),
+        )
     return _t(
         agent._config.language,
         "system.context_breakdown",

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -157,6 +157,66 @@ def test_render_meta_rounds_usage_to_one_decimal():
     assert "7.2%" in result
 
 
+def test_render_meta_caps_over_100_percent_en():
+    """Issue #193 item 3: usage above the hard ceiling (>100%) must not feed
+    a raw runaway percentage like 197.2% to the model. The banner is reworded
+    to a bounded over-ceiling notice while preserving the token breakdown."""
+    agent = _fake_agent_with_lang("en")
+    meta = {
+        "current_time": "2026-04-20T10:15:23-07:00",
+        "context": {
+            "system_tokens": 48489,
+            "history_tokens": 345912,
+            "usage": 1.972005,
+        },
+    }
+    result = render_meta(agent, meta)
+    # The runaway percentage must be gone...
+    assert "197" not in result
+    assert "197.2%" not in result
+    # ...replaced by a bounded over-ceiling wording...
+    assert ">100%" in result
+    assert "over hard ceiling" in result
+    # ...while the necessary token breakdown is preserved.
+    assert "48489" in result
+    assert "345912" in result
+
+
+def test_render_meta_caps_exactly_at_100_percent_uses_breakdown():
+    """At exactly 100% (usage == 1.0) the normal breakdown still renders —
+    only values strictly above the ceiling are reworded."""
+    agent = _fake_agent_with_lang("en")
+    meta = {
+        "current_time": "T",
+        "context": {
+            "system_tokens": 1000,
+            "history_tokens": 500,
+            "usage": 1.0,
+        },
+    }
+    result = render_meta(agent, meta)
+    assert "100.0%" in result
+    assert "over hard ceiling" not in result
+
+
+def test_render_meta_caps_over_100_percent_zh():
+    agent = _fake_agent_with_lang("zh")
+    meta = {
+        "current_time": "2026-04-20T10:15:23-07:00",
+        "context": {
+            "system_tokens": 48489,
+            "history_tokens": 345912,
+            "usage": 1.972005,
+        },
+    }
+    result = render_meta(agent, meta)
+    assert "197" not in result
+    assert ">100%" in result
+    # token breakdown preserved
+    assert "48489" in result
+    assert "345912" in result
+
+
 def test_stamp_meta_writes_meta_keys_and_elapsed_ms_in_place():
     result = {"status": "ok"}
     out = stamp_meta(result, {"current_time": "2026-04-20T10:15:23-07:00"}, 42)

--- a/tests/test_retroactive_history_compaction.py
+++ b/tests/test_retroactive_history_compaction.py
@@ -683,6 +683,71 @@ def test_is_over_window_error_does_not_match_unrelated_errors():
     assert not _is_over_window_error(RuntimeError(""))
 
 
+# -- Issue #193 item 4: typed overflow classification -----------------------
+
+def test_classify_over_window_event_context_length_exceeded():
+    """A provider message carrying the canonical ``context_length_exceeded``
+    fragment classifies as that stable, grep-able type."""
+    from lingtai_kernel.base_agent.turn import _classify_over_window_event
+    assert _classify_over_window_event(
+        RuntimeError("Error code: 400 - context_length_exceeded")
+    ) == "context_length_exceeded"
+
+
+def test_classify_over_window_event_provider_413():
+    """A 413-status hard-cap failure classifies as ``provider_413`` even if
+    the message phrasing is generic, so real provider rejections are
+    distinguishable from estimate-driven overflow."""
+    from lingtai_kernel.base_agent.turn import _classify_over_window_event
+
+    class _Big(Exception):
+        status_code = 413
+
+    assert _classify_over_window_event(_Big("request too large")) == "provider_413"
+
+
+def test_classify_over_window_event_generic_overflow():
+    """An over-window error that is neither 413 nor the canonical
+    ``context_length_exceeded`` fragment still gets a typed bucket."""
+    from lingtai_kernel.base_agent.turn import _classify_over_window_event
+    assert _classify_over_window_event(
+        RuntimeError("prompt is too long for this model")
+    ) == "context_overflow"
+
+
+def test_provider_context_overflow_event_emitted_on_over_window(tmp_path, monkeypatch):
+    """Issue #193 item 4: when an over-window provider failure is detected,
+    a DISTINCT typed event ``provider_context_overflow`` is emitted carrying a
+    stable ``kind`` (here ``context_length_exceeded``) so real hard-cap
+    failures are diagnosable/grep-able — beyond the generic
+    ``aed_over_window_detected`` marker."""
+    from lingtai_kernel.base_agent import turn
+
+    big = "OW" * (RETROACTIVE_MAX_CHARS)
+    agent, iface = _make_run_loop_agent_with_oversized_history(tmp_path, big)
+
+    nonlocal_calls = {"n": 0}
+
+    def fake_handle(_agent, _msg):
+        nonlocal_calls["n"] += 1
+        if nonlocal_calls["n"] == 1:
+            raise RuntimeError("Error code: 400 - context_length_exceeded")
+        _agent._shutdown.set()
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    monkeypatch.setattr(turn.time, "sleep", lambda _seconds: None)
+    import lingtai_kernel.intrinsics.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: None)
+
+    turn._run_loop(agent)
+
+    typed = [e for e in agent._logs if e[0] == "provider_context_overflow"]
+    assert len(typed) == 1
+    assert typed[0][1]["kind"] == "context_length_exceeded"
+    # The generic marker still fires too (back-compat).
+    assert any(e[0] == "aed_over_window_detected" for e in agent._logs)
+
+
 def test_aed_over_window_takes_deterministic_branch_not_transient(tmp_path, monkeypatch):
     """An over-window error must NOT take the transient retry loop —
     retrying on the same wire would just refire the same error.  It must


### PR DESCRIPTION
## Summary

Addresses the residual banner/typed-event portions of Lingtai-AI/lingtai-kernel#193 (items 3 and 4). This **complements #293**, which covers the core pre-send hard gate; this PR does **not** subsume #293, and #193 should remain open until both land and retest.

> Note: this PR intentionally does not auto-close #193 — #193 also depends on #293.

## Changes

**Item 3 — cap / reword the over-ceiling context banner**
- `meta_block._render_context_fragment` no longer feeds a runaway percentage (e.g. `context: 197.2%`) into the model's own prompt.
- When usage > 1.0 it renders a bounded over-ceiling notice via the new i18n key `system.context_over_ceiling` (en/zh/wen), preserving the sys/ctx token breakdown.
- `usage == 1.0` still uses the normal breakdown.

**Item 4 — typed provider-overflow event**
- Adds `_classify_over_window_event` (`provider_413` / `context_length_exceeded` / `context_overflow`).
- Emits a distinct typed `provider_context_overflow` event alongside the existing generic `aed_over_window_detected` marker, so real provider hard-cap failures are diagnosable/grep-able in `events.jsonl`.
- Back-compat preserved: the generic marker still fires.

## Relationship to #293
- **Zero file overlap** with #293. #293 covers the core pre-send hard gate on the send path; this PR covers the residual items 3 and 4 (banner cap + typed event).
- The two are independent and can land in either order.

## Tests
- Implementation run: full suite **2256 passed / 3 skipped**.
- Review reran **100 focused + 7 new + 214 adjacent** tests — all passed.
- New coverage: +3 `meta_block` cases (>100% cap, ==100% breakdown, zh), +3 classifier unit cases, +1 emission integration case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
