### PR TITLE
feat: add minimal mcp manager actions

### DIFF
--- a/src/lingtai/core/mcp/ANATOMY.md
+++ b/src/lingtai/core/mcp/ANATOMY.md
@@ -1,9 +1,19 @@
 # core/mcp
 
-MCP capability — per-agent registry of MCP (Model Context Protocol) servers.
-Pure presentation: reads the registry from disk, validates records, and renders
-it as XML into the system prompt. No tool writes; all registry mutations happen
-via file operations from the agent (`write`, `edit`).
+MCP capability — per-agent **minimal control plane** for MCP (Model Context
+Protocol) servers. The `mcp` tool has exactly three actions — `list` / `add` /
+`remove` — that edit *desired state* through a validated API: registry records
+(`mcp_registry.jsonl`) and init.json activation entries. `add` writes the
+registry record **and** the init.json activation in one step; `remove` strips
+both (plus any `addons:` entry) in one step. It still reads the registry from
+disk and renders it as XML into the system prompt. **Runtime loading is
+unchanged** — desired-state edits do not touch the live tool surface; they take
+effect only when the agent refreshes via `system(action="refresh")` (which
+writes the `.refresh` signal the kernel heartbeat consumes at a turn boundary,
+running the existing unseal→rebuild→reseal cycle). **Refresh is owned by the
+`system` tool, not `mcp`.** Anything beyond list/add/remove — fine-grained
+config edits, troubleshooting, unusual registrations — is hand-edited via
+`write`/`edit`/`bash` then `system(action="refresh")`.
 
 Also includes the **LICC v1 (LingTai Inbox Callback Contract)** — a
 filesystem-based inbox that lets out-of-process MCP servers push events into
@@ -11,18 +21,29 @@ the agent's inbox.
 
 ## Components
 
-- `mcp/__init__.py` — MCP registry management and tool surface. `get_description` (`mcp/__init__.py:374-375`), `get_schema` (`mcp/__init__.py:378-379`), `setup` (`mcp/__init__.py:382-406`). Key functions: `validate_record` (`mcp/__init__.py:82-125`), `validate_registry_line` (`mcp/__init__.py:128-138`), `read_registry` (`mcp/__init__.py:149-186`), `decompress_addons` (`mcp/__init__.py:201-257`), `_build_registry_xml` (`mcp/__init__.py:274-299`), `_reconcile` (`mcp/__init__.py:306-342`).
+- `mcp/__init__.py` — MCP registry/activation control plane and tool surface. `get_description`/`get_schema`/`setup` at the bottom; `setup`'s `handle_mcp` routes the three actions to `_handle_list`/`_handle_add`/`_handle_remove`. Key functions: `validate_record`, `validate_registry_line`, `read_registry`, `_append_record`, `_remove_record` (rewrite JSONL minus one name, best-effort comment/blank preservation), `_substitute_placeholders` (`{python}`→sys.executable, shared with `decompress_addons`), `decompress_addons`, `_build_registry_xml`, `_reconcile` (renders the registry XML into the system prompt on setup — no return value). Control-plane helpers: `_redact_config` (env/headers/token-like fields → `"<redacted>"`), `_redact_problems` (strips raw lines from registry problems), `_read_init`/`_read_init_for_write`/`_write_init` (init.json round-trip preserving unrelated keys; `_read_init_for_write` raises on invalid init.json so mutations never overwrite it), `_derive_init_config` (registry record → init.json `mcp` entry), `_activation_summary` (registry vs init.json cross-reference, redacted), `_log_action` (audit via `agent._log("mcp_manager_action", ...)`, no secrets), and the three `_handle_*` action handlers. `add` and `remove` resolve/validate init.json **before** touching the registry so a corrupt init.json aborts cleanly with no partial write.
 - `mcp/inbox.py` — LICC v1 filesystem inbox poller (the **consumer** half). `validate_event` validates required `from`/`subject`/`body` fields; `_format_notification_summary` is **deprecated** legacy helper (retained for backward compat); `_extract_preview_meta` pulls optional IM/chat scalars (`conversation_ref`, `message_ref`, `platform`) out of `event["metadata"]` when present as non-empty strings, each capped at `_PREVIEW_META_FIELD_CAP` (200 chars); `_consume_event` returns `(wake, preview)` where `preview = {"from": sender, "subject": subject, "preview": body[:_PREVIEW_FIELD_CAP], **extracted_meta}` — only the body snippet gets capped (sender/subject are bounded by upstream construction); `_dispatch_summary` publishes to `.notification/mcp.<mcp_name>.json` via `notifications.submit`, embedding full body snippets once in `data.previews` while keeping `instructions` to read/check guidance plus lightweight sender/subject/metadata routing context; `_scan_once` coalesces per MCP, threading the preview list through; `MCPInboxPoller` class drives the poll loop. Body snippet cap is `_PREVIEW_FIELD_CAP = 10000`. Defines the shared contract constants `LICC_VERSION` / `INBOX_DIRNAME` / `DEAD_DIRNAME` / `TMP_SUFFIX` / `EVENT_SUFFIX`.
 - `mcp/licc.py` — LICC v1 client (the **producer** half). One public function, `push_inbox_event(sender, subject, body, *, metadata=None, wake=True, received_at=None, agent_dir=None, mcp_name=None, event_id=None) -> bool`, that an out-of-process MCP imports to drop one event into `<agent_dir>/.mcp_inbox/<mcp_name>/<event_id>.json`. Lightweight by design — importing it starts no threads and re-exports the contract constants (`LICC_VERSION`, `INBOX_DIRNAME`, `TMP_SUFFIX`, `EVENT_SUFFIX`) straight from `inbox.py` so producer and consumer never drift. `agent_dir`/`mcp_name` default to env vars `LINGTAI_AGENT_DIR`/`LINGTAI_MCP_NAME` (kernel-injected per MCP); explicit params override for tests/advanced callers. Writes atomically: serialize → `<event_id>.json.tmp` → `flush`+`os.fsync` → `os.replace` onto the final `.json` (the poller ignores `.tmp`, so half-writes are never observed). `event_id` defaults to a fresh `uuid4().hex` (guarantees per-call uniqueness); explicit `mcp_name`/`event_id` path components are validated before use. The payload is checked with `validate_event` before writing, so the canonical producer does not intentionally emit dead-letterable events. Best-effort/silent: missing/invalid target, unsafe path component, invalid payload, or filesystem/serialization error → `False` (never raises into the MCP), with a terse, content-free log that never echoes `body`/`subject`/`metadata`.
 - `mcp/manual/` — skill documentation (`SKILL.md`) plus reference docs (`curated-addons.md`, `third-party-and-legacy.md`, `troubleshooting.md`) and scripts (`find_readme.py`).
 
 ## Public API
 
-The `mcp` tool exposes one action:
+The `mcp` tool is a minimal control plane with exactly three actions — one
+read-only inspector and two desired-state mutations. Refresh is **not** part of
+`mcp`; it is owned by the `system` tool:
 
-| Action | Description |
-|--------|-------------|
-| `show` | Return the mcp-manual skill body plus a runtime health snapshot (registry contents, problems, registry path) |
+| Action | Kind | Description |
+|--------|------|-------------|
+| `list` | read | Registry summary + activation summary (init.json `mcp` enabled/gated, redacted). No manual body, no raw problem lines. |
+| `add` | mutate | Register a new entry **and** write its init.json `mcp` activation in one step — `record` dict or `name` (catalog entry, with `{python}` substitution); optional `config` overrides the derived activation. Validates, rejects duplicates, rejects invalid init.json without overwriting. Returns `needs_refresh` + a `system(action="refresh")` reminder. |
+| `remove` | mutate | Drop a registry entry by `name` (rewrite JSONL) **and** delete its init.json `mcp` activation **and** drop `name` from init.json `addons:` if present — in one step. Errors cleanly if neither registry nor init activation has the name; rejects invalid init.json without overwriting. Returns `needs_refresh` + a `system(action="refresh")` reminder. |
+
+Mutating actions return `needs_refresh: true`, an explicit
+`system(action="refresh")` reminder in `message`, and never alter the running
+tool surface — only `system(action="refresh")` (via the kernel refresh path) does.
+Deleted in the minimal manager: `show`, `diagnose`, `validate`, `enable`,
+`disable`, and any in-tool refresh. Those workflows move to the MCP manual plus
+`write`/`edit`/`bash`.
 
 ### LICC v1 Inbox Protocol
 
@@ -70,18 +91,31 @@ mcp/__init__.py
   │
   ├── Registry I/O
   │   ├── read_registry()           — reads mcp_registry.jsonl, returns (valid, problems)
-  │   └── _append_record()          — appends a validated record as a JSONL line
+  │   ├── _append_record()          — appends a validated record as a JSONL line
+  │   ├── _remove_record()          — rewrites JSONL minus one name (keeps comments/blanks)
+  │   └── _substitute_placeholders()— {python}→sys.executable (shared with decompress + add)
+  │
+  ├── Control plane (desired-state edits + inspection)
+  │   ├── _redact_config()              — env/headers/token-like fields → "<redacted>"
+  │   ├── _redact_problems()            — strips raw lines from registry problems
+  │   ├── _read_init / _read_init_for_write / _write_init
+  │   │                                 — init.json round-trip; _for_write raises on invalid JSON
+  │   ├── _derive_init_config()         — registry record → init.json mcp entry
+  │   ├── _activation_summary()         — registry vs init.json mcp (enabled/gated, redacted)
+  │   ├── _log_action()                 — audit via agent._log("mcp_manager_action", ...)
+  │   └── _handle_{list,add,remove}()   — the three actions; add/remove edit registry + init together
   │
   ├── XML builder
   │   ├── _escape_xml()             — XML entity escaping
   │   └── _build_registry_xml()     — renders registry records as <registered_mcp> XML
   │
   ├── Reconciliation
-  │   └── _reconcile()              — reads registry, renders into prompt, returns health snapshot
+  │   └── _reconcile()              — reads registry, renders XML into prompt (no return value)
   │
   └── Tool surface
-      ├── get_description/schema()  — module-level
-      └── setup()                   — registers mcp tool, runs initial _reconcile
+      ├── get_description/schema()  — module-level (3-action enum: list/add/remove)
+      └── setup()                   — runs initial _reconcile, registers mcp tool,
+                                      routes list/add/remove to _handle_*
 
 mcp/inbox.py
   ├── Validation
@@ -112,7 +146,11 @@ mcp/licc.py  (client-side producer; mirrors inbox.py's consumer)
 
 ## Key Invariants
 
-- **Registry is append-only JSONL:** One record per line. Duplicates by name are flagged as problems during read. Mutations (register, deregister, update) happen via agent-side file operations.
+- **Registry is line-oriented JSONL:** One record per line. `add` appends; `remove` rewrites the file minus the matching name (preserving other lines, comments, and blanks best-effort). Duplicates by name are flagged as problems during read and rejected by `add`. Hand-editing via `write`/`edit` remains valid.
+- **Control plane edits desired state only:** `add`/`remove` write `mcp_registry.jsonl` **and** `init.json` together and return `needs_refresh: true` with an explicit `system(action="refresh")` reminder. They never touch the live tool surface or the seal. Refresh is owned by the `system` tool — `mcp` has no refresh action; `system(action="refresh")` routes through the existing `.refresh` signal-file path (`base_agent/lifecycle.py` heartbeat → `_perform_refresh` at a turn boundary).
+- **add/remove are all-or-nothing across registry + init:** Both resolve and validate `init.json` (via `_read_init_for_write`, which raises on invalid JSON) **before** mutating the registry. An invalid `init.json` aborts with an error and **no** file is overwritten — registry and init never drift out of sync. `add` derives the init activation from the record (or an explicit `config`) and rejects duplicates; `remove` errors cleanly when neither the registry nor the init activation holds the name.
+- **Secrets never leave the agent:** Any returned config (`list` activation entries, `add` config echo) and audit log passes through `_redact_config` — values under `env`/`headers` and token/password/secret/key/authorization-like field names become `"<redacted>"`. Registry problems pass through `_redact_problems` so raw invalid lines (which may carry env/token fragments) are never echoed. The registry XML rendered into the prompt holds no secrets.
+- **init.json round-trip preserves unrelated keys:** `add`/`remove` read the full manifest, mutate only `mcp[name]` (and, on remove, the `addons:` list), and rewrite — provider, model, and other keys are untouched. The registry gate (a live init entry must be in `mcp_registry.jsonl`) is preserved: `add` writes the registry record alongside the activation; `remove` strips both so it leaves nothing gated.
 - **Name convention:** Lowercase, dash-separated, bounded length (`^[a-z][a-z0-9_-]{0,30}$`).
 - **Transport validation:** `stdio` requires `command` + `args`; `http` requires `url`.
 - **Addons decompression is idempotent:** Running `decompress_addons()` multiple times produces the same registry. Existing records are never modified.
@@ -123,7 +161,7 @@ mcp/licc.py  (client-side producer; mirrors inbox.py's consumer)
 - **LICC bounded work:** `MAX_EVENTS_PER_CYCLE = 100` per MCP per sweep prevents pathological backlog from blocking the poller.
 - **LICC notification shape (post-#37 + previews):** The coalesced notification carries the MCP name, event count, plus a `previews` list — one entry per consumed event with `{"from": <sender>, "subject": <subject>, "preview": <body[:_PREVIEW_FIELD_CAP]>}` and, **when the event opts in via `metadata`**, optional IM/chat scalars `conversation_ref`, `message_ref`, `platform` (each capped at `_PREVIEW_META_FIELD_CAP = 200` chars). Only well-formed non-empty string metadata values are copied; non-string/empty/unknown keys are silently ignored, so legacy events without metadata produce the identical preview shape as before. The body snippet is hard-truncated at `_PREVIEW_FIELD_CAP` (10000 chars); `from` and `subject` pass through uncapped (sender bounded by upstream construction; subject already validated `<= 200` chars by `validate_event`). Full message **bodies** are still NOT inlined — those stay behind the `<mcp>(action="check"/"read")` tool result. The original issue #37 invariant (no body duplication → no agent re-processing loop) is preserved; previews exist purely to let the agent triage which MCPs/messages deserve a read call. Multiple events from the same MCP in one sweep are coalesced into a single summary; `wake` is the OR of all per-event `wake` flags. Preview list length is naturally bounded by `MAX_EVENTS_PER_CYCLE` (100).
 - **LICC uses `.notification/` filesystem-as-protocol:** `_dispatch_summary` publishes via `notifications.submit` to `.notification/mcp.<mcp_name>.json` instead of posting to the legacy inbox queue. This unifies MCP events with all other notification producers (email, soul, system events) in the kernel's `_sync_notifications` wire injection path.
-- **Pure presentation:** The capability never writes to the registry file. It only reads and renders.
+- **Audit:** Every mutating action (`add`/`remove`) calls `_log_action` → `agent._log("mcp_manager_action", action, name, status)`. The audit carries names and outcomes only — never config or secrets.
 
 ## Dependencies
 

--- a/src/lingtai/core/mcp/__init__.py
+++ b/src/lingtai/core/mcp/__init__.py
@@ -1,21 +1,23 @@
-"""MCP capability — per-agent registry of MCP servers (pure presentation).
-
-Symmetric to the ``library`` capability:
+"""MCP capability — per-agent control plane for MCP servers.
 
 - Per-agent registry lives at ``<agent>/mcp_registry.jsonl`` (sibling to
-  ``init.json``). One JSON record per line.
+  ``init.json``). One JSON record per line. Activation lives in
+  ``init.json["mcp"]`` (gated by the registry).
 - Capability scans the registry on setup, validates each line, renders the
   registry as XML into the system prompt's ``mcp`` section.
 - Boot-time decompression: any name in ``init.json``'s ``addons: [...]`` list
   that isn't already in the registry gets appended from the kernel-shipped
   catalog (``lingtai/mcp_catalog.json``). Append-only, idempotent.
-- All registry mutations (register, deregister, update) happen via file
-  operations from the agent (``write``, ``edit``). The capability provides
-  guidance via the umbrella SKILL.md and a single ``show`` action that
-  re-renders the prompt section.
-
-Tool surface: a single ``show`` action that returns the umbrella manual body,
-the current registry, and a runtime health snapshot.
+- The ``mcp`` tool is a minimal 3-action control plane: ``list`` inspects the
+  registry + init activation (secrets redacted); ``add`` registers an MCP and
+  writes its init.json activation in one step; ``remove`` deregisters it and
+  strips its init.json activation in one step. ``add``/``remove`` return
+  ``needs_refresh: true`` and remind the agent to call
+  ``system(action="refresh")``. The runtime loader, MCP transport, and the
+  post-start tool seal are untouched — desired-state edits never mutate the
+  live tool surface. Refresh is owned by the ``system`` tool, not ``mcp``.
+  Complex troubleshooting/manual work goes through the MCP manual plus
+  bash/file tools, not this tool.
 
 Usage: ``Agent(capabilities=["mcp"])`` or via init.json.
 """
@@ -41,6 +43,11 @@ CATALOG_FILENAME = "mcp_catalog.json"
 _NAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,30}$")
 _VALID_TRANSPORTS = {"stdio", "http"}
 _MAX_SUMMARY_LEN = 200
+
+_REFRESH_REMINDER = (
+    'Run system(action="refresh") to apply this change — '
+    "nothing changes in your live tool surface until you do."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +201,63 @@ def _append_record(working_dir: Path, record: dict) -> None:
         f.write(line)
 
 
+def _remove_record(working_dir: Path, name: str) -> bool:
+    """Remove the registry line whose record name == ``name``.
+
+    Rewrites ``mcp_registry.jsonl`` preserving every other line verbatim —
+    including comments and blank lines (best effort). Lines that fail to
+    parse, or whose parsed ``name`` differs, are kept untouched. Returns True
+    if at least one matching record line was dropped.
+    """
+    path = _registry_path(working_dir)
+    if not path.is_file():
+        return False
+    text = path.read_text(encoding="utf-8")
+    kept: list[str] = []
+    removed = False
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if stripped:
+            try:
+                rec = json.loads(stripped)
+            except json.JSONDecodeError:
+                rec = None
+            if isinstance(rec, dict) and rec.get("name") == name:
+                removed = True
+                continue
+        kept.append(raw)
+    if removed:
+        body = "\n".join(kept)
+        if body and not body.endswith("\n"):
+            body += "\n"
+        path.write_text(body, encoding="utf-8")
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# {python} substitution — shared by decompress_addons and the `add` action.
+# ---------------------------------------------------------------------------
+
+def _substitute_placeholders(value):
+    """Resolve catalog placeholders (currently ``{python}`` → sys.executable).
+
+    Recurses into lists/dicts. Mirrors the substitution ``decompress_addons``
+    applies so the ``add`` action treats catalog entries identically.
+    """
+    import sys
+    substitutions = {"{python}": sys.executable}
+    if isinstance(value, str):
+        for k, v in substitutions.items():
+            if k in value:
+                value = value.replace(k, v)
+        return value
+    if isinstance(value, list):
+        return [_substitute_placeholders(x) for x in value]
+    if isinstance(value, dict):
+        return {k: _substitute_placeholders(v) for k, v in value.items()}
+    return value
+
+
 # ---------------------------------------------------------------------------
 # Boot-time decompression: addons:[...] → registry
 # ---------------------------------------------------------------------------
@@ -216,21 +280,6 @@ def decompress_addons(working_dir: Path, addons: list[str]) -> dict:
     unknown: list[str] = []
     invalid: list[dict] = []
 
-    import sys
-    substitutions = {"{python}": sys.executable}
-
-    def _substitute(value):
-        if isinstance(value, str):
-            for k, v in substitutions.items():
-                if k in value:
-                    value = value.replace(k, v)
-            return value
-        if isinstance(value, list):
-            return [_substitute(x) for x in value]
-        if isinstance(value, dict):
-            return {k: _substitute(v) for k, v in value.items()}
-        return value
-
     for name in addons:
         if name in existing_names:
             skipped.append(name)
@@ -239,7 +288,7 @@ def decompress_addons(working_dir: Path, addons: list[str]) -> dict:
             unknown.append(name)
             log.warning("mcp: addon %r not found in catalog", name)
             continue
-        record = _substitute(dict(catalog[name]))
+        record = _substitute_placeholders(dict(catalog[name]))
         ok, err = validate_record(record)
         if not ok:
             invalid.append({"name": name, "error": err})
@@ -300,46 +349,317 @@ def _build_registry_xml(records: list[dict]) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Reconciliation (shared by setup and `show` action)
+# Reconciliation (renders registry into the system prompt on setup)
 # ---------------------------------------------------------------------------
 
-def _reconcile(agent: "BaseAgent") -> dict:
-    """Read registry, render into prompt, return health snapshot."""
-    working_dir = agent._working_dir
-    records, problems = read_registry(working_dir)
-
+def _reconcile(agent: "BaseAgent") -> None:
+    """Read the registry and render it into the system prompt's ``mcp`` section."""
+    records, _problems = read_registry(agent._working_dir)
     xml = _build_registry_xml(records)
     agent.update_system_prompt("mcp", xml, protected=True)
 
-    # Health: the umbrella manual must be present.
-    intrinsic_dir = working_dir / ".library" / "intrinsic"
-    manual_path = intrinsic_dir / "capabilities" / "mcp" / "SKILL.md"
-    status = "ok"
-    error: str | None = None
-    if not manual_path.is_file():
-        status = "degraded"
-        error = (
-            "mcp manual missing — initializer may have failed or "
-            "capability not installed correctly"
-        )
-        manual_body = ""
-    else:
-        manual_body = manual_path.read_text(encoding="utf-8")
 
-    result = {
-        "status": status,
-        "mcp_manual": manual_body,
+# ---------------------------------------------------------------------------
+# Secret redaction — never echo env/header/token values into tool results,
+# the prompt, or audit logs.
+# ---------------------------------------------------------------------------
+
+_REDACTED = "<redacted>"
+# Field names whose *values* are secrets and must be replaced wholesale.
+_SECRET_KEY_DICTS = {"env", "headers"}
+# Substrings that mark a scalar field name as secret-bearing.
+_SECRET_NAME_HINTS = ("token", "password", "secret", "key", "authorization")
+
+
+def _is_secret_name(name: str) -> bool:
+    lowered = name.lower()
+    return any(hint in lowered for hint in _SECRET_NAME_HINTS)
+
+
+def _redact_problems(problems: list[dict]) -> list[dict]:
+    """Return registry problems without echoing raw registry lines.
+
+    Invalid JSONL lines can contain headers/env/token-like fragments. The line
+    number and validation error are enough for diagnosis; never surface raw.
+    """
+    return [
+        {k: v for k, v in problem.items() if k != "raw"}
+        for problem in problems
+    ]
+
+
+def _redact_config(value):
+    """Return a deep copy of ``value`` with secret-bearing fields redacted.
+
+    - Any value under an ``env`` / ``headers`` key is redacted, even if the
+      value has an unexpected non-dict shape.
+    - Any scalar field whose name looks token/password/secret/key-like is
+      replaced with ``"<redacted>"``.
+    Recurses into nested dicts/lists so secrets cannot hide one level down.
+    """
+    if isinstance(value, dict):
+        out: dict = {}
+        for k, v in value.items():
+            if k in _SECRET_KEY_DICTS:
+                out[k] = ({ik: _REDACTED for ik in v}
+                          if isinstance(v, dict) else _REDACTED)
+            elif _is_secret_name(str(k)) and not isinstance(v, (dict, list)):
+                out[k] = _REDACTED
+            else:
+                out[k] = _redact_config(v)
+        return out
+    if isinstance(value, list):
+        return [_redact_config(x) for x in value]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# init.json desired-state I/O (activation layer)
+# ---------------------------------------------------------------------------
+
+def _init_path(working_dir: Path) -> Path:
+    return working_dir / "init.json"
+
+
+def _read_init(working_dir: Path) -> dict:
+    """Read init.json as a dict for diagnostics. Missing/invalid → empty dict."""
+    path = _init_path(working_dir)
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _read_init_for_write(working_dir: Path) -> dict:
+    """Read init.json before mutation. Missing → {}, invalid/non-object → error."""
+    path = _init_path(working_dir)
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise ValueError(f"cannot mutate invalid init.json: {e}") from e
+    if not isinstance(data, dict):
+        raise ValueError("cannot mutate init.json: top-level JSON must be an object")
+    return data
+
+
+def _write_init(working_dir: Path, data: dict) -> None:
+    """Write init.json, preserving key order and pretty-printing."""
+    path = _init_path(working_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def _derive_init_config(record: dict) -> dict:
+    """Build an init.json ``mcp`` entry from a validated registry record.
+
+    stdio → ``{type, command, args, [env]}``; http → ``{type, url, [headers]}``.
+    Only structural fields are copied; the registry holds no secrets, so this
+    never carries credentials (callers pass an explicit ``config`` for those).
+    """
+    transport = record.get("transport")
+    if transport == "http":
+        cfg: dict = {"type": "http", "url": record.get("url")}
+        if isinstance(record.get("headers"), dict):
+            cfg["headers"] = record["headers"]
+        return cfg
+    cfg = {
+        "type": "stdio",
+        "command": record.get("command"),
+        "args": list(record.get("args", [])),
+    }
+    if isinstance(record.get("env"), dict):
+        cfg["env"] = record["env"]
+    return cfg
+
+
+def _activation_summary(working_dir: Path, records: list[dict]) -> dict:
+    """Cross-reference registry vs init.json ``mcp`` (redacted).
+
+    Returns ``{enabled: [...names...], gated: [...names...], entries: {...}}``
+    where ``gated`` names are present in init.json but missing from the
+    registry (the loader would skip them), and ``entries`` maps each enabled
+    name → its redacted config.
+    """
+    init = _read_init(working_dir)
+    init_mcp = init.get("mcp") if isinstance(init.get("mcp"), dict) else {}
+    registered = {r["name"] for r in records}
+    enabled: list[str] = []
+    gated: list[str] = []
+    entries: dict[str, dict] = {}
+    for name, cfg in init_mcp.items():
+        entries[name] = (
+            _redact_config(cfg) if isinstance(cfg, dict)
+            else {"error": "activation config is not an object"}
+        )
+        if name in registered:
+            enabled.append(name)
+        else:
+            gated.append(name)
+    return {"enabled": enabled, "gated": gated, "entries": entries}
+
+
+# ---------------------------------------------------------------------------
+# Manager action handlers — minimal 3-action surface (list/add/remove).
+# Each takes (agent, args) and returns a JSON-serializable result dict.
+# ---------------------------------------------------------------------------
+
+def _log_action(agent: "BaseAgent", action: str, name: str | None, status: str) -> None:
+    """Audit a control-plane mutation. Never logs config/secrets."""
+    log_fn = getattr(agent, "_log", None)
+    if callable(log_fn):
+        try:
+            log_fn("mcp_manager_action", action=action, name=name, status=status)
+        except Exception:
+            pass
+
+
+def _handle_list(agent: "BaseAgent") -> dict:
+    working_dir = agent._working_dir
+    records, problems = read_registry(working_dir)
+    return {
+        "status": "ok",
         "registry_path": str(_registry_path(working_dir)),
-        "registered_count": len(records),
-        "registered": [
-            {"name": r["name"], "summary": r["summary"]}
+        "registry": [
+            {"name": r["name"], "summary": r["summary"],
+             "transport": r["transport"]}
             for r in records
         ],
-        "problems": problems,
+        "problems": _redact_problems(problems),
+        "activation": _activation_summary(working_dir, records),
     }
-    if error:
-        result["error"] = error
-    return result
+
+
+def _handle_add(agent: "BaseAgent", args: dict) -> dict:
+    """Register an MCP AND write its init.json activation in one step.
+
+    ``add`` implies enable: it appends the validated record to the registry
+    and writes the matching ``init.json["mcp"]`` entry. Pass ``name`` for a
+    catalog entry or ``record`` for a full record; pass ``config`` to override
+    the derived init.json activation (else derived from the record).
+    """
+    working_dir = agent._working_dir
+    record = args.get("record")
+    name_arg = args.get("name")
+
+    if record is None and isinstance(name_arg, str):
+        catalog = _load_catalog()
+        if name_arg not in catalog:
+            _log_action(agent, "add", name_arg, "error")
+            return {"status": "error",
+                    "message": f"{name_arg!r} not found in catalog"}
+        record = _substitute_placeholders(dict(catalog[name_arg]))
+
+    if not isinstance(record, dict):
+        _log_action(agent, "add", None, "error")
+        return {"status": "error",
+                "message": "provide either 'record' (dict) or 'name' (catalog entry)"}
+
+    ok, err = validate_record(record)
+    if not ok:
+        _log_action(agent, "add", record.get("name"), "error")
+        return {"status": "error", "message": f"invalid record: {err}"}
+
+    name = record["name"]
+    existing, _problems = read_registry(working_dir)
+    if name in {r["name"] for r in existing}:
+        _log_action(agent, "add", name, "error")
+        return {"status": "error",
+                "message": f"registry already has an entry named {name!r} (duplicate)"}
+
+    # Resolve the init.json activation config before touching any file, so an
+    # invalid 'config' or invalid init.json aborts cleanly with no partial write.
+    config = args.get("config")
+    if config is None:
+        config = _derive_init_config(record)
+    elif not isinstance(config, dict):
+        _log_action(agent, "add", name, "error")
+        return {"status": "error", "message": "'config' must be a dict when provided"}
+
+    try:
+        init = _read_init_for_write(working_dir)
+    except ValueError as e:
+        _log_action(agent, "add", name, "error")
+        return {"status": "error", "message": str(e)}
+
+    _append_record(working_dir, record)
+    mcp = init.get("mcp")
+    if not isinstance(mcp, dict):
+        mcp = {}
+    mcp[name] = config
+    init["mcp"] = mcp
+    _write_init(working_dir, init)
+    _log_action(agent, "add", name, "ok")
+    return {
+        "status": "ok",
+        "name": name,
+        "needs_refresh": True,
+        "config": _redact_config(config),
+        "message": (
+            f"registered {name!r} and activated it in init.json. "
+            + _REFRESH_REMINDER
+        ),
+    }
+
+
+def _handle_remove(agent: "BaseAgent", args: dict) -> dict:
+    """Deregister an MCP AND strip its init.json activation in one step.
+
+    ``remove`` implies disable: it drops the registry record, removes
+    ``init.json["mcp"][name]``, and drops ``name`` from ``init.json["addons"]``
+    if present (so a catalog addon won't be re-decompressed on next boot).
+    """
+    working_dir = agent._working_dir
+    name = args.get("name")
+    if not isinstance(name, str) or not name:
+        return {"status": "error", "message": "remove requires 'name' (string)"}
+
+    existing, _problems = read_registry(working_dir)
+    init_mcp_has = name in (_read_init(working_dir).get("mcp") or {})
+    if name not in {r["name"] for r in existing} and not init_mcp_has:
+        _log_action(agent, "remove", name, "error")
+        return {"status": "error",
+                "message": f"no registry entry or init.json activation named {name!r}"}
+
+    # Read init.json for write FIRST — a corrupt init.json aborts before any
+    # registry mutation, so we never leave the registry and init out of sync.
+    try:
+        init = _read_init_for_write(working_dir)
+    except ValueError as e:
+        _log_action(agent, "remove", name, "error")
+        return {"status": "error", "message": str(e)}
+
+    _remove_record(working_dir, name)
+
+    init_changed = False
+    mcp = init.get("mcp")
+    if isinstance(mcp, dict) and name in mcp:
+        del mcp[name]
+        init["mcp"] = mcp
+        init_changed = True
+    addons = init.get("addons")
+    if isinstance(addons, list) and name in addons:
+        init["addons"] = [a for a in addons if a != name]
+        init_changed = True
+    if init_changed:
+        _write_init(working_dir, init)
+
+    _log_action(agent, "remove", name, "ok")
+    return {
+        "status": "ok",
+        "name": name,
+        "needs_refresh": True,
+        "message": (
+            f"deregistered {name!r} and removed its init.json activation. "
+            + _REFRESH_REMINDER
+        ),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -347,14 +667,20 @@ def _reconcile(agent: "BaseAgent") -> dict:
 # ---------------------------------------------------------------------------
 
 _DESCRIPTION = (
-    "Your per-agent MCP server registry. The <registered_mcp> catalog in your "
-    "system prompt lists every MCP server currently registered. Before using "
-    "this tool (registering, deregistering, updating, or troubleshooting MCP "
-    "servers), read the `mcp-manual` skill — call `show` to fetch its body "
-    "(registration contract, file paths, schema) plus a runtime health "
-    "snapshot; no exceptions. To register, deregister, or update MCPs, edit "
-    "mcp_registry.jsonl directly with write/edit and call "
-    "system(action=\"refresh\")."
+    "MCP control plane for this agent — a minimal three-action surface for "
+    "registering and deregistering MCP servers. The <registered_mcp> catalog "
+    "in your system prompt lists every server currently registered. For "
+    "anything beyond list/add/remove (config fields, troubleshooting, manual "
+    "registration), read the `mcp-manual` skill and use bash/file tools. "
+    "Actions: `list` (inspect registry + init.json activation, secrets "
+    "redacted), `add` (register an MCP and activate it in init.json in one "
+    "step — by catalog `name` or full `record`, optional `config`), `remove` "
+    "(deregister by `name` and strip its init.json activation in one step). "
+    "`add`/`remove` edit desired state only and return `needs_refresh: true`; "
+    "nothing changes in the running tool surface until you call "
+    "system(action=\"refresh\"). Refresh belongs to the `system` tool, not "
+    "`mcp`. Hand-editing mcp_registry.jsonl / init.json then calling "
+    "system(action=\"refresh\") still works as an escape hatch."
 )
 
 _SCHEMA = {
@@ -362,10 +688,39 @@ _SCHEMA = {
     "properties": {
         "action": {
             "type": "string",
-            "enum": ["show"],
+            "enum": ["list", "add", "remove"],
             "description": (
-                "show: return the mcp-manual skill body plus a runtime health "
-                "snapshot (registry contents, problems, registry path)."
+                "list: registry summary + init.json activation summary "
+                "(secrets redacted). add: register a new entry AND activate it "
+                "in init.json in one step — pass 'name' (catalog entry) or "
+                "'record' (dict); optional 'config' overrides the derived "
+                "init.json activation; rejects duplicates; returns "
+                "needs_refresh. remove: deregister 'name' AND strip its "
+                "init.json activation (and addons entry) in one step; returns "
+                "needs_refresh. add/remove require system(action=\"refresh\") "
+                "to take effect."
+            ),
+        },
+        "name": {
+            "type": "string",
+            "description": (
+                "Target MCP name. For add: a catalog entry name. For remove: "
+                "the registry/activation entry name."
+            ),
+        },
+        "record": {
+            "type": "object",
+            "description": (
+                "A full registry record for add "
+                "(name, summary, transport, command/args or url, source)."
+            ),
+        },
+        "config": {
+            "type": "object",
+            "description": (
+                "Optional init.json activation config for add "
+                "(type, command/args/env or url/headers). Derived from the "
+                "record when omitted."
             ),
         },
     },
@@ -382,22 +737,31 @@ def get_schema(lang: str = "en") -> dict:
 
 
 def setup(agent: "BaseAgent", **_ignored) -> None:
-    """Set up the mcp capability.
+    """Set up the mcp control-plane capability.
 
-    The capability is pure presentation: it reads the registry from disk and
-    renders it into the system prompt. Decompression of init.json's addons:
-    field happens in the Agent initializer via decompress_addons() before
-    setup is called.
+    Reads the registry from disk and renders it into the system prompt, then
+    registers the minimal 3-action ``mcp`` tool. ``list`` inspects desired
+    state; ``add``/``remove`` edit the desired-state files (mcp_registry.jsonl
+    + init.json) in one step each and return ``needs_refresh: true``. Refresh
+    is owned by the ``system`` tool; the runtime loader, transport, and seal
+    model are untouched. Decompression of init.json's addons: field happens in
+    the Agent initializer via decompress_addons() before setup is called.
     """
     _reconcile(agent)
 
     def handle_mcp(args: dict) -> dict:
         action = args.get("action", "")
-        if action == "show":
-            return _reconcile(agent)
+        if action == "list":
+            return _handle_list(agent)
+        if action == "add":
+            return _handle_add(agent, args)
+        if action == "remove":
+            return _handle_remove(agent, args)
         return {
             "status": "error",
-            "message": f"unknown action: {action!r}, only 'show' is supported",
+            "message": (
+                f"unknown action: {action!r}. Valid actions: list, add, remove."
+            ),
         }
 
     agent.add_tool(

--- a/src/lingtai/core/mcp/manual/SKILL.md
+++ b/src/lingtai/core/mcp/manual/SKILL.md
@@ -18,8 +18,13 @@ description: >
       needed, inspect the shipped module docs/resources or the catalog homepage.
       Field names like `email_password`, `bot_token`, `app_id`/`app_secret`,
       and gewechat hosts are documented by the addon docs — do NOT guess.
-    - You want to know what MCPs you currently have. `mcp(action="show")`
-      returns the registry plus health; this manual explains the output.
+    - You want to know what MCPs you currently have, or to register / remove
+      one through a validated API. `mcp(action="list")` reports state;
+      `add` registers + activates an MCP in one step and `remove` deregisters +
+      deactivates it in one step; then `system(action="refresh")` commits it.
+      This manual explains the three actions and their output. Anything beyond
+      list/add/remove — fine-grained config edits, troubleshooting — goes
+      through this manual plus `write`/`edit`/`bash`, not the tool.
     - An MCP isn't behaving — registry validation, `problems` list,
       refresh-after-edit verification, common boot errors are here.
     - You're exploring an unfamiliar third-party MCP. The doc-discovery flow
@@ -29,8 +34,8 @@ description: >
   registry → active), the curated-vs-third-party install paths, the legacy
   `mcp/servers.json` direct mount route (still functional, ungated), HTTP
   and stdio server configurations, where the registry file
-  (`mcp_registry.jsonl`) lives and how to mutate it (`write` / `edit` /
-  `bash` — the `mcp` capability is read-only), the `<homepage>` field as
+  (`mcp_registry.jsonl`) lives and how to mutate it (the `mcp` control-plane
+  `add`/`remove` actions, or `write` / `edit` / `bash` directly), the `<homepage>` field as
   fallback documentation, and the relationship between `init.json`'s
   `addons:` list, `mcp:` activation entries, and the registry. Replaces the
   deprecated `lingtai-mcp` skill.
@@ -40,12 +45,12 @@ description: >
   variables), the LICC v1 inbox callback contract, and the validator's
   internal logic all live in `lingtai-kernel-anatomy reference/mcp-protocol.md`.
   Read this for *what to do*; read anatomy for *how it works*.
-version: 3.2.0
+version: 4.0.0
 ---
 
 # MCP Capability — How To Use It
 
-The `mcp` capability is your interface to Model Context Protocol (MCP) servers — both generic third-party servers and the six kernel-curated LingTai addons (`imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, `cloud_mail`). Like the `library` capability, it is **pure presentation**: registered MCPs are listed in your system prompt under `<registered_mcp>`, and the registry itself is a JSONL file you edit directly with `write` / `edit` / `bash`.
+The `mcp` capability is your interface to Model Context Protocol (MCP) servers — both generic third-party servers and the six kernel-curated LingTai addons (`imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, `cloud_mail`). It is a deliberately **minimal control plane** with exactly three actions — `list`, `add`, `remove`. Registered MCPs are listed in your system prompt under `<registered_mcp>`, and the registry is a JSONL file. `add` registers an MCP **and** writes its `init.json` activation in one step; `remove` deregisters **and** strips its `init.json` activation in one step. Anything more granular — editing a single config field, troubleshooting a stuck server, hand-crafting an unusual registration — is done through this manual plus `write` / `edit` / `bash` on `mcp_registry.jsonl` / `init.json` directly, then `system(action="refresh")`. **Desired-state edits only take effect after a refresh, and refresh belongs to the `system` tool, not `mcp`.**
 
 This is the router. Detail lives in `reference/`. Load only what you need.
 
@@ -119,9 +124,26 @@ If neither path yields docs, fall back to the MCP's own runtime self-description
 
 ## Tool surface
 
-One action: `mcp(action="show")`. Returns this manual body, the current registry contents, and a runtime health snapshot (registry path, count, problems).
+The `mcp` tool is a **minimal control plane** with exactly three actions. `list`
+inspects state; `add`/`remove` edit *desired state* (the registry **and**
+init.json activation together) and return `needs_refresh: true`.
 
-All registry mutations happen via `write` / `edit` / `bash`. The `mcp` capability never writes to the registry.
+| Action | Use |
+|---|---|
+| `mcp(action="list")` | Registry summary + activation summary (what's enabled/gated in init.json). Secrets redacted. No manual body. |
+| `mcp(action="add", name="<catalog>")` or `add, record={...}` | Register an MCP **and** activate it in init.json in one step — by catalog name or a full record; optional `config` overrides the derived activation. Rejects duplicates. |
+| `mcp(action="remove", name="<name>")` | Deregister an MCP **and** strip its init.json activation (and its `addons:` entry) in one step. |
+
+**Refresh-after-desired-state discipline:** `add`/`remove` only edit files —
+nothing changes in your live tool surface until you call
+`system(action="refresh")`. Refresh is **not** part of `mcp`; it belongs to the
+`system` tool. Batch your desired-state edits, then refresh **once**. Mutations
+return `needs_refresh: true` and a `system(action="refresh")` reminder.
+
+For anything beyond list/add/remove — fine-grained config edits, troubleshooting,
+unusual registrations — hand-edit `mcp_registry.jsonl` / `init.json` with
+`write` / `edit` / `bash` and call `system(action="refresh")`. The three actions
+are a validated convenience for the common case, not a full editor.
 
 ## See also
 

--- a/src/lingtai/core/mcp/manual/reference/third-party-and-legacy.md
+++ b/src/lingtai/core/mcp/manual/reference/third-party-and-legacy.md
@@ -12,11 +12,10 @@ For any non-curated MCP — typically `npx`/`uvx`-launched servers from the broa
      .library/intrinsic/capabilities/mcp/scripts/find_readme.py <pkg-name>
    ```
    Otherwise (npx/uvx servers), `web_read` the homepage URL. Either way, get the install command, env vars, and config schema before writing any config.
-2. Append a single JSON record to `mcp_registry.jsonl` (one line, atomic write). For the schema, see `lingtai-kernel-anatomy reference/file-formats.md` §6.5.
-3. Add an `init.json` `mcp.<name>` activation entry.
-4. Run `system(action="refresh")`.
+2. Register + activate it. Easiest: `mcp(action="add", record={...})` writes both the `mcp_registry.jsonl` record **and** the `init.json` `mcp.<name>` activation in one step (pass `config={...}` to override the derived activation). For the record schema, see `lingtai-kernel-anatomy reference/file-formats.md` §6.5. Equivalently, hand-append the registry line and the `init.json` entry with `write`/`edit`.
+3. Run `system(action="refresh")`.
 
-Benefits: gives you the `<homepage>` field (used by `SKILL.md` §Reading an MCP's README → fallback URL), allow-listing, and registry health diagnostics via `mcp(action="show")`.
+Benefits: gives you the `<homepage>` field (used by `SKILL.md` §Reading an MCP's README → fallback URL), allow-listing, and registry health diagnostics via `mcp(action="list")`.
 
 ## Legacy `mcp/servers.json` route
 

--- a/src/lingtai/core/mcp/manual/reference/troubleshooting.md
+++ b/src/lingtai/core/mcp/manual/reference/troubleshooting.md
@@ -2,17 +2,17 @@
 
 ## Updating, deregistering
 
-- **Update**: edit the matching line in `mcp_registry.jsonl` in place. Same schema. Then `system(action="refresh")`.
-- **Deregister**: remove the matching line. Note: this does NOT stop a running MCP — to deactivate, also remove the entry from `init.json`'s `mcp` section.
+- **Update**: there is no `mcp` update action. Edit the matching line in `mcp_registry.jsonl` (and the `init.json` `mcp.<name>` entry) in place with `write`/`edit`/`bash`. Same schema. Then `system(action="refresh")`.
+- **Deregister**: `mcp(action="remove", name="<name>")` drops the registry line **and** the `init.json` activation in one step (and its `addons:` entry). It does NOT stop an already-running MCP subprocess — `system(action="refresh")` tears it down.
 
 ## Diagnosing problems
 
-Call `mcp(action="show")` to see:
+Call `mcp(action="list")` to see:
 - The current registry contents
-- The `problems` list (invalid registry lines, missing config, etc.)
-- A runtime health snapshot (registry path, count, status per server)
+- The `problems` list (invalid registry lines — line number + error, raw lines redacted)
+- The activation summary (what's enabled/gated in `init.json`, secrets redacted)
 
-Invalid registry lines are skipped silently with a warning at refresh time, so always verify with `show` after editing.
+Invalid registry lines are skipped silently with a warning at refresh time, so always verify with `list` after editing.
 
 ## Common boot failures
 
@@ -30,7 +30,7 @@ Check the exact field name spelling — `email_password` not `password`, `bot_to
 The `command` path in your `init.json` `mcp.<name>` entry doesn't have the executable. For Python addons, confirm the venv path is correct (typically `~/.lingtai-tui/runtime/venv/bin/python`). For `npx`/`uvx` servers, confirm those tools are on `PATH`.
 
 **Tools not appearing in your tool surface**
-You forgot to `system(action="refresh")` after editing config. Refresh and re-check `mcp(action="show")`.
+You forgot to `system(action="refresh")` after editing config. Refresh and re-check `mcp(action="list")`.
 
 **HTTP 401 / 403 from an http-type server**
 API key missing or malformed in the `headers` field. Format is usually `"Authorization": "Bearer <key>"`. Check the MCP's README for the exact header name and value format.
@@ -45,6 +45,6 @@ Eager-start failed silently. Check the agent's stderr / `logs/agent.log` for the
    ~/.lingtai-tui/runtime/venv/bin/python3 \
      .library/intrinsic/capabilities/mcp/scripts/find_readme.py <pkg-name>
    ```
-2. `mcp(action="show")` to see registry + problems.
+2. `mcp(action="list")` to see registry + problems.
 3. Tail `logs/agent.log` for the actual error message.
 4. Re-read the setup/troubleshooting section — most MCP docs document common errors with exact symptom strings.

--- a/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
@@ -97,6 +97,6 @@ Suggested recovery order:
 
 This intrinsic skill is the shared diagnostic foundation. TUI `/doctor` should
 become a thin caller of these scripts instead of maintaining a separate copy of
-logic. Kernel-level `mcp(action="show")` executable validation is also a natural
+logic. Kernel-level `mcp(action="list")` executable validation is also a natural
 follow-up, but the doctor script remains useful because it checks the whole
 agent footprint, not only MCP registry syntax.

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -241,21 +241,21 @@ def test_addons_dict_still_works_for_legacy(tmp_path):
     assert not registry_path.exists()
 
 
-def test_mcp_show_action_returns_health_snapshot(tmp_path):
+def test_mcp_list_action_reports_registry(tmp_path):
     agent, workdir = _mk_agent(tmp_path, addons=["imap"])
     handler = agent._tool_handlers.get("mcp")
     assert handler is not None
-    result = handler({"action": "show"})
+    result = handler({"action": "list"})
     assert result["status"] == "ok"
-    assert result["registered_count"] == 1
-    assert result["registered"][0]["name"] == "imap"
-    assert "mcp_manual" in result and result["mcp_manual"]  # umbrella SKILL.md body
+    names = [r["name"] for r in result["registry"]]
+    assert names == ["imap"]
+    assert "mcp_manual" not in result  # list never carries the manual body
 
 
-def test_mcp_show_unknown_action_returns_error(tmp_path):
+def test_mcp_unknown_action_returns_error(tmp_path):
     agent, workdir = _mk_agent(tmp_path, addons=["imap"])
     handler = agent._tool_handlers.get("mcp")
-    result = handler({"action": "register"})  # not supported in slice
+    result = handler({"action": "register"})  # not supported
     assert result["status"] == "error"
 
 

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -1,0 +1,417 @@
+"""Tests for the minimal 3-action mcp control-plane manager.
+
+Jason rejected the thick 8-action manager. The surviving surface is exactly
+``list`` / ``add`` / ``remove``:
+
+- ``list``   — read-only: registry summary + init.json activation summary,
+               secrets redacted, no manual body.
+- ``add``    — register an MCP AND activate it in init.json in one step.
+- ``remove`` — deregister an MCP AND strip its init.json activation in one step.
+
+``add``/``remove`` edit desired state only and return ``needs_refresh`` with an
+explicit ``system(action="refresh")`` reminder. Refresh belongs to the
+``system`` tool, not ``mcp``. The runtime loader / transport / seal model are
+untouched. ``show``/``diagnose``/``validate``/``enable``/``disable`` are gone.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lingtai.agent import Agent
+from lingtai.core.mcp import REGISTRY_FILENAME, get_schema, read_registry
+
+
+def make_mock_service():
+    svc = MagicMock()
+    svc.get_adapter.return_value = MagicMock()
+    svc.provider = "gemini"
+    svc.model = "gemini-test"
+    return svc
+
+
+def _mk_agent(tmp_path: Path, *, addons=None):
+    workdir = tmp_path / "agent"
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=workdir,
+        capabilities={"mcp": {}},
+        addons=addons,
+    )
+    return agent, workdir
+
+
+def _handler(agent):
+    h = agent._tool_handlers.get("mcp")
+    assert h is not None
+    return h
+
+
+def _write_registry(workdir: Path, *records: dict) -> None:
+    workdir.mkdir(parents=True, exist_ok=True)
+    path = workdir / REGISTRY_FILENAME
+    path.write_text(
+        "".join(json.dumps(r) + "\n" for r in records), encoding="utf-8"
+    )
+
+
+def _stdio_record(name="srv", **over):
+    rec = {
+        "name": name,
+        "summary": "test server",
+        "transport": "stdio",
+        "command": "/bin/true",
+        "args": [],
+        "source": "user",
+    }
+    rec.update(over)
+    return rec
+
+
+def _http_record(name="remote", **over):
+    rec = {
+        "name": name,
+        "summary": "remote server",
+        "transport": "http",
+        "url": "https://example.com/mcp",
+        "source": "user",
+    }
+    rec.update(over)
+    return rec
+
+
+def _refresh_reminder_present(message: str) -> bool:
+    return 'system(action="refresh")' in message
+
+
+# ---------------------------------------------------------------------------
+# Schema — exactly list/add/remove, nothing else.
+# ---------------------------------------------------------------------------
+
+def test_schema_enum_is_exactly_list_add_remove():
+    enum = get_schema()["properties"]["action"]["enum"]
+    assert enum == ["list", "add", "remove"]
+
+
+@pytest.mark.parametrize("gone", ["show", "diagnose", "validate", "enable", "disable"])
+def test_deleted_actions_not_in_schema(gone):
+    enum = get_schema()["properties"]["action"]["enum"]
+    assert gone not in enum
+
+
+@pytest.mark.parametrize(
+    "gone", ["show", "diagnose", "validate", "enable", "disable", "apply_refresh", "frobnicate"]
+)
+def test_deleted_action_returns_error(tmp_path, gone):
+    agent, _ = _mk_agent(tmp_path)
+    result = _handler(agent)({"action": gone})
+    assert result["status"] == "error"
+    assert "unknown action" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+def test_list_reports_registry_and_activation(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    _write_registry(workdir, _stdio_record("srv"))
+    (workdir / "init.json").write_text(json.dumps({
+        "mcp": {"srv": {"type": "stdio", "command": "x"}},
+    }))
+    result = _handler(agent)({"action": "list"})
+    assert result["status"] == "ok"
+    names = [r["name"] for r in result["registry"]]
+    assert "srv" in names
+    # activation summary present and cross-references init.json
+    assert "activation" in result
+    assert "srv" in result["activation"]["enabled"]
+
+
+def test_list_has_no_manual_body(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    _write_registry(workdir, _stdio_record("srv"))
+    result = _handler(agent)({"action": "list"})
+    assert "mcp_manual" not in result
+
+
+def test_list_redacts_secrets(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    _write_registry(workdir, _stdio_record("srv"))
+    (workdir / "init.json").write_text(json.dumps({
+        "mcp": {
+            "srv": {
+                "type": "stdio",
+                "command": "x",
+                "env": {"API_KEY": "super-secret-value"},
+                "token": "tok-secret",
+            },
+        },
+    }))
+    result = _handler(agent)({"action": "list"})
+    blob = json.dumps(result)
+    assert "super-secret-value" not in blob
+    assert "tok-secret" not in blob
+    assert "<redacted>" in blob
+
+
+def test_list_does_not_echo_raw_problem_lines(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    workdir.mkdir(parents=True, exist_ok=True)
+    (workdir / REGISTRY_FILENAME).write_text(
+        (
+            '{"name":"bad","summary":"x","transport":"stdio",'
+            '"command":"x","source":"s","env":{"API_KEY":"LEAK_RAW"}}\n'
+            '{not json with LEAK_RAW_TOO}\n'
+        ),
+        encoding="utf-8",
+    )
+    result = _handler(agent)({"action": "list"})
+    blob = json.dumps(result)
+    assert "LEAK_RAW" not in blob
+    assert "LEAK_RAW_TOO" not in blob
+    assert '"raw"' not in blob  # the raw problem-line key is never echoed
+
+
+def test_list_does_not_echo_non_object_activation_value(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    _write_registry(workdir, _stdio_record("srv"))
+    (workdir / "init.json").write_text(json.dumps({
+        "mcp": {"srv": "SECRET_STRING_SHOULD_NOT_LEAK"},
+    }))
+    result = _handler(agent)({"action": "list"})
+    blob = json.dumps(result)
+    assert "SECRET_STRING_SHOULD_NOT_LEAK" not in blob
+    assert "activation config is not an object" in blob
+
+
+# ---------------------------------------------------------------------------
+# add — registers registry record + writes init.json activation in one step.
+# ---------------------------------------------------------------------------
+
+def test_add_from_catalog_writes_registry_and_init(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    result = _handler(agent)({"action": "add", "name": "imap"})
+    assert result["status"] == "ok"
+    assert result["needs_refresh"] is True
+    assert _refresh_reminder_present(result["message"])
+
+    # registry got the record
+    records, _ = read_registry(workdir)
+    assert "imap" in [r["name"] for r in records]
+    imap = next(r for r in records if r["name"] == "imap")
+    # {python} substitution must have happened (catalog uses {python})
+    assert "{python}" not in imap["command"]
+
+    # init.json got the activation in the same action
+    init = json.loads((workdir / "init.json").read_text())
+    assert "imap" in init["mcp"]
+    assert init["mcp"]["imap"]["type"] == "stdio"
+
+
+def test_add_explicit_record_derives_init_config(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    rec = _stdio_record("srv", command="/usr/bin/server", args=["--flag"])
+    result = _handler(agent)({"action": "add", "record": rec})
+    assert result["status"] == "ok"
+    assert result["needs_refresh"] is True
+    assert _refresh_reminder_present(result["message"])
+
+    records, _ = read_registry(workdir)
+    assert "srv" in [r["name"] for r in records]
+
+    init = json.loads((workdir / "init.json").read_text())
+    entry = init["mcp"]["srv"]
+    assert entry["type"] == "stdio"
+    assert entry["command"] == "/usr/bin/server"
+    assert entry["args"] == ["--flag"]
+
+
+def test_add_http_record_derives_url(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    result = _handler(agent)({"action": "add", "record": _http_record("remote")})
+    assert result["status"] == "ok"
+    init = json.loads((workdir / "init.json").read_text())
+    entry = init["mcp"]["remote"]
+    assert entry["type"] == "http"
+    assert entry["url"] == "https://example.com/mcp"
+
+
+def test_add_with_explicit_config_overrides_derived(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    cfg = {"type": "stdio", "command": "/custom", "args": ["-x"], "env": {"K": "v"}}
+    result = _handler(agent)({"action": "add", "record": _stdio_record("srv"), "config": cfg})
+    assert result["status"] == "ok"
+    init = json.loads((workdir / "init.json").read_text())
+    assert init["mcp"]["srv"]["command"] == "/custom"
+
+
+def test_add_preserves_other_init_keys(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    workdir.mkdir(parents=True, exist_ok=True)
+    (workdir / "init.json").write_text(json.dumps({
+        "provider": "anthropic",
+        "mcp": {"other": {"type": "stdio", "command": "x"}},
+    }))
+    result = _handler(agent)({"action": "add", "record": _stdio_record("srv")})
+    assert result["status"] == "ok"
+    init = json.loads((workdir / "init.json").read_text())
+    assert init["provider"] == "anthropic"
+    assert "other" in init["mcp"]
+    assert "srv" in init["mcp"]
+
+
+def test_add_rejects_duplicate(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    _write_registry(workdir, _stdio_record("srv"))
+    result = _handler(agent)({"action": "add", "record": _stdio_record("srv")})
+    assert result["status"] == "error"
+    assert "duplicate" in result["message"].lower() or "exists" in result["message"].lower()
+    records, _ = read_registry(workdir)
+    assert len(records) == 1
+    # no init.json activation should have leaked in
+    assert not (workdir / "init.json").exists() or \
+        "srv" not in json.loads((workdir / "init.json").read_text()).get("mcp", {})
+
+
+def test_add_invalid_record_rejected(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    result = _handler(agent)({"action": "add", "record": _stdio_record("BAD-NAME")})
+    assert result["status"] == "error"
+    records, _ = read_registry(workdir)
+    assert records == []
+    assert not (workdir / "init.json").exists()
+
+
+def test_add_unknown_catalog_name_rejected(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    result = _handler(agent)({"action": "add", "name": "no-such-catalog-entry"})
+    assert result["status"] == "error"
+    records, _ = read_registry(workdir)
+    assert records == []
+
+
+def test_add_rejects_invalid_init_json_without_overwriting(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    workdir.mkdir(parents=True, exist_ok=True)
+    (workdir / "init.json").write_text("{not json", encoding="utf-8")
+    result = _handler(agent)({"action": "add", "record": _stdio_record("srv")})
+    assert result["status"] == "error"
+    assert "invalid init.json" in result["message"]
+    # init.json untouched AND registry untouched — no partial write
+    assert (workdir / "init.json").read_text(encoding="utf-8") == "{not json"
+    records, _ = read_registry(workdir)
+    assert records == []
+
+
+# ---------------------------------------------------------------------------
+# remove — drops registry record + strips init.json activation in one step.
+# ---------------------------------------------------------------------------
+
+def test_remove_drops_registry_and_init_activation(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    _write_registry(workdir, _stdio_record("srv"), _stdio_record("keep"))
+    (workdir / "init.json").write_text(json.dumps({
+        "provider": "anthropic",
+        "mcp": {
+            "srv": {"type": "stdio", "command": "x"},
+            "keep": {"type": "stdio", "command": "y"},
+        },
+    }))
+    result = _handler(agent)({"action": "remove", "name": "srv"})
+    assert result["status"] == "ok"
+    assert result["needs_refresh"] is True
+    assert _refresh_reminder_present(result["message"])
+
+    records, _ = read_registry(workdir)
+    names = [r["name"] for r in records]
+    assert "srv" not in names
+    assert "keep" in names
+
+    init = json.loads((workdir / "init.json").read_text())
+    assert "srv" not in init["mcp"]
+    assert "keep" in init["mcp"]
+    assert init["provider"] == "anthropic"
+
+
+def test_remove_also_strips_addons_entry(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    _write_registry(workdir, _stdio_record("imap"))
+    (workdir / "init.json").write_text(json.dumps({
+        "addons": ["imap", "telegram"],
+        "mcp": {"imap": {"type": "stdio", "command": "x"}},
+    }))
+    result = _handler(agent)({"action": "remove", "name": "imap"})
+    assert result["status"] == "ok"
+    init = json.loads((workdir / "init.json").read_text())
+    assert "imap" not in init.get("addons", [])
+    assert "telegram" in init["addons"]
+    assert "imap" not in init.get("mcp", {})
+
+
+def test_remove_works_when_no_init_activation(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    _write_registry(workdir, _stdio_record("srv"))
+    result = _handler(agent)({"action": "remove", "name": "srv"})
+    assert result["status"] == "ok"
+    assert result["needs_refresh"] is True
+    records, _ = read_registry(workdir)
+    assert "srv" not in [r["name"] for r in records]
+
+
+def test_remove_missing_name_errors_cleanly(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    _write_registry(workdir, _stdio_record("keep"))
+    result = _handler(agent)({"action": "remove", "name": "ghost"})
+    assert result["status"] == "error"
+    # registry untouched
+    records, _ = read_registry(workdir)
+    assert [r["name"] for r in records] == ["keep"]
+
+
+def test_remove_blank_name_errors(tmp_path):
+    agent, _ = _mk_agent(tmp_path)
+    result = _handler(agent)({"action": "remove", "name": ""})
+    assert result["status"] == "error"
+
+
+def test_remove_rejects_invalid_init_json_without_overwriting(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    _write_registry(workdir, _stdio_record("srv"))
+    (workdir / "init.json").write_text("{not json", encoding="utf-8")
+    result = _handler(agent)({"action": "remove", "name": "srv"})
+    assert result["status"] == "error"
+    assert "invalid init.json" in result["message"]
+    # init.json untouched AND registry record still present — no partial write
+    assert (workdir / "init.json").read_text(encoding="utf-8") == "{not json"
+    records, _ = read_registry(workdir)
+    assert "srv" in [r["name"] for r in records]
+
+
+# ---------------------------------------------------------------------------
+# Audit logging — mutations logged, secrets never logged.
+# ---------------------------------------------------------------------------
+
+def test_mutating_actions_are_logged(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    events = []
+    agent._log = lambda event_type, **f: events.append((event_type, f))  # type: ignore
+    _handler(agent)({"action": "add", "record": _stdio_record("srv")})
+    logged = [e for e in events if e[0] == "mcp_manager_action"]
+    assert logged
+    assert logged[0][1]["action"] == "add"
+    assert logged[0][1]["name"] == "srv"
+
+
+def test_logging_does_not_leak_secrets(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    events = []
+    agent._log = lambda event_type, **f: events.append((event_type, f))  # type: ignore
+    cfg = {"type": "stdio", "command": "x", "env": {"API_KEY": "secret-xyz"}}
+    _handler(agent)({"action": "add", "record": _stdio_record("srv"), "config": cfg})
+    blob = json.dumps(events)
+    assert "secret-xyz" not in blob


### PR DESCRIPTION
## Summary
- turn the `mcp` intrinsic from a manual/show surface into a minimal manager with only `list`, `add`, and `remove`
- make `add` register and activate an MCP in `init.json`, and `remove` deregister/deactivate it while stripping same-name `addons`
- keep refresh ownership in `system(action="refresh")`; mutating results return `needs_refresh: true` and include the refresh reminder
- update MCP manual/anatomy plus tests, with redaction and bad-`init.json` safety coverage

## Validation
- `PYTHONPATH="$PWD/src" python -m pytest -q tests/test_mcp_manager.py tests/test_mcp_capability.py tests/test_mcp_closed_resource_restart.py tests/test_mcp_inbox.py tests/test_mcp_licc_client.py tests/test_sdk_namespace_mcp.py tests/test_sdk_namespace_fileio.py` → 148 passed
- `git diff --check`
- `PYTHONPATH="$PWD/src" python -m pytest -q` → 2314 passed, 3 skipped

## Notes
- No `show`, `diagnose`, `validate`, `enable`, `disable`, or `apply_refresh` actions remain.
- Complex inspection/troubleshooting stays in MCP manual + bash/file workflows.
- The runtime loader, MCP transport, registry catalog rendering, LICC inbox, and curated MCP servers are intentionally left in place for later split decisions.
