### PR TITLE
feat(sdk): add NativeRuntime stage-1 adapter skeleton

### DIFF
--- a/docs/sdk/architecture-foundation.md
+++ b/docs/sdk/architecture-foundation.md
@@ -110,9 +110,10 @@ provider-free.
 - `RuntimeSession` / `Runtime` — the ABCs a backend implements. `Runtime.run()`
   is a small convenience that creates and starts a session.
 
-There is **no live runtime in this PR.** A thin `NativeRuntime` (wrapping the
-existing `Agent` unchanged) and any non-native backend land later, once the
-shapes have stabilized against the capability/prompt contracts.
+There is **no live runtime in this (stage 0) PR.** A thin `NativeRuntime`
+(wrapping the existing `Agent` unchanged) lands in **stage 1** (see §8 and §10);
+any non-native backend lands later, once the shapes have stabilized against the
+capability/prompt contracts.
 
 ## 6. CapabilityBundle manifest seed
 
@@ -179,10 +180,12 @@ PR, sequenced so contracts stabilize before implementations depend on them.
 
 1. **Stage 0 (this PR) — foundation.** Public doorway, import-purity guarantee,
    compatibility map, runtime + capability-bundle contract seeds, docs.
-2. **Stage 1 — live NativeRuntime.** A thin `Runtime`/`RuntimeSession`
-   implementation wrapping the existing `Agent` (no kernel turn-loop changes),
-   driven through the contract from stage 0. Wrapper-side, tested against a fake
-   agent.
+2. **Stage 1 — live NativeRuntime _(skeleton landed; see §10)_.** A thin
+   `Runtime`/`RuntimeSession` implementation wrapping the existing `Agent` (no
+   kernel turn-loop changes), driven through the contract from stage 0. Tested
+   against a fake agent — no real model, API key, or running process. Stacked on
+   the stage-0 PR. LLM-service translation and a live event bridge are follow-ups
+   within this stage.
 3. **Stage 2 — capability-bundle adoption.** Express one or two *low-risk*
    real capabilities as `BundleManifest`s and wire the wrapper to read the
    manifest. Still no `system`/`psyche`/`soul`.
@@ -195,9 +198,10 @@ PR, sequenced so contracts stabilize before implementations depend on them.
    `lingtai_sdk` is the headline import; today it rides inside the `lingtai`
    wheel.
 
-### Intentionally deferred (NOT in this PR)
+### Intentionally deferred (NOT in the stage-0 PR)
 
-- Any live runtime (`NativeRuntime` and friends).
+- Any live runtime (`NativeRuntime` and friends). _(The stage-1 skeleton lands in
+  the stacked PR described in §10.)_
 - An Anthropic (or other non-native) backend.
 - Migration of core `system` / `psyche` / `soul` bundles.
 - Distribution / package rename.
@@ -215,6 +219,7 @@ src/lingtai_sdk/
   _compat.py         # legacy -> SDK migration map
   runtime.py         # runtime contract seed (DTOs + ABCs)
   capabilities.py    # CapabilityBundle manifest seed + proof_bundle()
+  native.py          # stage 1: NativeRuntime skeleton (wraps Agent; lazy)
   ANATOMY.md         # per-folder anatomy
 
 tests/
@@ -222,4 +227,58 @@ tests/
   test_sdk_compat.py            # legacy paths resolve to the same object
   test_sdk_runtime_contract.py  # runtime DTOs + a usable concrete subclass
   test_sdk_capabilities.py      # manifest invariants + proof bundle
+  test_sdk_native_runtime.py    # stage 1: translation, lifecycle, purity (fake agent)
 ```
+
+## 10. Stage 1 — the NativeRuntime skeleton (stacked PR)
+
+Stage 1 is a small PR **stacked on top of stage 0**. It adds the first live
+runtime adapter — `lingtai_sdk.native.NativeRuntime` — proving the stage-0
+contract can wrap the existing wrapper `Agent` without making the import
+boundary worse. It deliberately stops at a *skeleton*: no kernel turn-loop
+changes, no `LLMService` construction, no non-native backend.
+
+### What it adds
+
+- **`NativeRuntime(Runtime)`** (`id = "native"`) — a factory whose
+  `create_session(options)` returns a `NativeRuntimeSession`. An injectable
+  `agent_factory` lets tests substitute a fake agent.
+- **`NativeRuntimeSession(RuntimeSession)`** — wraps an `Agent`:
+  - `start()` builds the agent (lazily, via the factory), calls `Agent.start()`,
+    and transitions `PENDING → ACTIVE`, emitting a `STATE` event. Idempotent.
+  - `send(message)` normalizes `str`/`RuntimeMessage` and routes onto
+    `Agent.send()` — the existing fire-and-forget inbox path, so it never blocks
+    on a turn. Before `start()` it emits a non-fatal `ERROR` event and no-ops.
+  - `events()` yields a non-blocking, re-iterable snapshot of queued
+    lifecycle / notification / error events.
+  - `stop()` calls `Agent.stop()` and transitions `→ STOPPED`. Idempotent.
+- **`_agent_kwargs_from_options(options)`** — a pure translation helper
+  returning `(agent_kwargs, deferred)`.
+
+### Translation: applied vs. deferred
+
+| `RuntimeOptions` field | Stage-1 handling |
+|---|---|
+| `working_dir` | → `Agent(working_dir=...)` (required) |
+| `agent_name`, `capabilities`, `addons`, `streaming` | → `Agent(...)` kwargs when set |
+| `provider`, `model`, `base_url`, `api_key` | **deferred** → `session.deferred['llm']` (building an `LLMService` is a later stage; `Agent` takes a ready service, not raw provider fields) |
+| `manifest`, `system_prompt_overrides`, `extra` | **deferred** → `session.deferred[...]` (recorded, not applied) |
+
+Deferring rather than force-applying keeps stage 1 honest: anything recognized
+but not yet wired is visible on the session, never silently dropped.
+
+### Import purity
+
+`native.py` imports only the pure `runtime` contract at module load. The
+wrapper `Agent` is imported **lazily**, inside `start()` / the default factory.
+`NativeRuntime` / `NativeRuntimeSession` are exported from the package root via
+a separate `_LAZY_SDK_EXPORTS` map that resolves from the import-pure `.native`
+module — so accessing the names and *constructing* a `NativeRuntime` stays free
+of the wrapper's provider SDKs; they load only when a session actually starts.
+A subprocess test asserts this.
+
+### Tested without a model
+
+All stage-1 tests run with no API key and no real agent process: a fake agent
+is injected through `agent_factory`, so lifecycle transitions, event emission,
+`send()` routing, and the translation table are all exercised in-memory.

--- a/src/lingtai_sdk/ANATOMY.md
+++ b/src/lingtai_sdk/ANATOMY.md
@@ -15,19 +15,22 @@ The **public SDK doorway** — a curated, import-light front door for building a
 - `_compat.py` — the machine-readable migration map: `Deprecation` dataclass, `DEPRECATIONS` tuple, `active_aliases()`, `migration_for()`. Drives the docs migration table and the same-object round-trip test.
 - `runtime.py` — **runtime contract seed** (pure DTOs/ABCs, no kernel import): `RuntimeState`, `EventKind`, `RuntimeOptions`, `RuntimeMessage`, `RuntimeEvent` (with `state`/`text`/`error` constructors), and the `RuntimeSession`/`Runtime` ABCs. Describes how a *future* live runtime is driven (options in, messages in, events out). No live runtime here.
 - `capabilities.py` — **CapabilityBundle manifest seed** (pure DTOs, no kernel import): `BackendReplaceability`, `RoleFlags`, `CapabilitySurfaces`, `SecurityPolicy`, `TransportSpec`, `BundleManifest` (with `validate()`/`to_dict()`), and `proof_bundle()` — a harmless metadata-only synthetic bundle. Public schema only; native privileged handlers stay in the kernel/wrapper.
+- `native.py` — **stage-1 live `NativeRuntime` adapter skeleton** (NOT a full backend). `NativeRuntime(Runtime)` (id `"native"`) is a factory for `NativeRuntimeSession(RuntimeSession)`, which wraps the wrapper `Agent` unchanged: translates `RuntimeOptions` → `Agent` kwargs (`_agent_kwargs_from_options`), drives `start()`/`stop()` lifecycle (`PENDING`→`ACTIVE`→`STOPPED`), routes `send()` onto `Agent.send()` (fire-and-forget queue), and exposes a non-blocking `events()` snapshot of lifecycle/notification/error events. Import-pure at module load (imports only `runtime`); the wrapper `Agent` is imported lazily on first `start()` via the injectable `agent_factory` (tests pass a fake). LLM/provider fields are deferred to `session.deferred['llm']`, not applied — building an `LLMService` is a later stage.
 
 ## Connections
 
 - **The kernel must never import this package.** Dependency flows one way: `lingtai_sdk` → (`lingtai`, `lingtai_kernel`). The SDK is a consumer of the other two, never a dependency of them.
-- **Eager kernel, lazy wrapper.** `import lingtai_sdk` loads the dependency-light kernel only. Wrapper-backed names import `lingtai` on first attribute access, keeping the wrapper's provider SDKs (anthropic/openai/google-genai/mcp/…) optional for pure-kernel consumers. Enforced by `tests/test_sdk_import_purity.py`.
-- `runtime.py` and `capabilities.py` import **nothing** from `lingtai`/`lingtai_kernel` — they are standalone contract modules, so importing them stays provider-free (`tests/test_sdk_runtime_contract.py`, `tests/test_sdk_capabilities.py`).
+- **Eager kernel, lazy wrapper.** `import lingtai_sdk` loads the dependency-light kernel only. Wrapper-backed names (`_LAZY_WRAPPER_EXPORTS`) import `lingtai` on first attribute access, keeping the wrapper's provider SDKs (anthropic/openai/google-genai/mcp/…) optional for pure-kernel consumers. Enforced by `tests/test_sdk_import_purity.py`.
+- **Lazy SDK-internal names.** `NativeRuntime`/`NativeRuntimeSession` (`_LAZY_SDK_EXPORTS`) resolve from the import-pure `.native` module, NOT from the wrapper — accessing them and constructing a `NativeRuntime` stays provider-free; the wrapper `Agent` loads only when a session is started. Enforced by `tests/test_sdk_native_runtime.py::test_importing_native_and_constructing_runtime_is_pure`.
+- `runtime.py`, `capabilities.py`, and `native.py` import **nothing** from `lingtai`/`lingtai_kernel` at module load — `native.py` imports only the local `runtime` contract; its wrapper `Agent` import is deferred to `start()` (`tests/test_sdk_runtime_contract.py`, `tests/test_sdk_capabilities.py`, `tests/test_sdk_native_runtime.py`).
 - Compatibility is **by re-export, not re-implementation**: `_compat.DEPRECATIONS` records legacy→SDK path moves; the round-trip test asserts each pair resolves to the *same object* (`tests/test_sdk_compat.py`).
 
 ## Seeds vs. implementations
 
-This package deliberately stops at the contract boundary. The following are **intentionally deferred** to later PRs and are NOT present here:
+This package implements only the runtime *adapter* boundary; everything below it stops at the contract. **Present** (stage 1): the `NativeRuntime` skeleton in `native.py` — it wraps the existing `Agent` and drives its start/stop lifecycle, but does not build an `LLMService`, change the kernel turn loop, or implement a non-native backend. The following remain **intentionally deferred** to later PRs and are NOT present here:
 
-- A live `NativeRuntime` (thin wrapper over the existing `Agent`) and any non-native backend (e.g. an Anthropic backend).
+- An `LLMService`-building translation (provider/model/api_key are recorded in `session.deferred`, not applied) and a non-native backend (e.g. an Anthropic backend).
+- A live event bridge from the agent's output stream onto `RuntimeEvent` — `events()` is currently a snapshot of lifecycle/notification/error events only.
 - Migration of the core `system` / `psyche` / `soul` bundles into `BundleManifest` form. The only bundle here is the synthetic `proof_bundle()`.
 - A distribution/package rename (the SDK ships inside the existing `lingtai` wheel for now).
 

--- a/src/lingtai_sdk/__init__.py
+++ b/src/lingtai_sdk/__init__.py
@@ -60,6 +60,15 @@ _LAZY_WRAPPER_EXPORTS: dict[str, tuple[str, str]] = {
     "VisionService": ("lingtai", "VisionService"),
 }
 
+# Lazy SDK-internal exports. Unlike ``_LAZY_WRAPPER_EXPORTS``, the target module
+# lives inside ``lingtai_sdk`` and is import-pure: accessing these names does
+# NOT import the ``lingtai`` wrapper. ``NativeRuntime`` only imports the wrapper
+# when a session is actually started.
+_LAZY_SDK_EXPORTS: dict[str, tuple[str, str]] = {
+    "NativeRuntime": (".native", "NativeRuntime"),
+    "NativeRuntimeSession": (".native", "NativeRuntimeSession"),
+}
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from lingtai import (  # noqa: F401
         Agent,
@@ -69,13 +78,22 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
         SearchService,
         VisionService,
     )
+    from .native import NativeRuntime, NativeRuntimeSession  # noqa: F401
 
 
 def __getattr__(name: str):  # PEP 562 module-level lazy attributes
+    import importlib
+
+    sdk_target = _LAZY_SDK_EXPORTS.get(name)
+    if sdk_target is not None:
+        module = importlib.import_module(sdk_target[0], __name__)
+        value = getattr(module, sdk_target[1])
+        globals()[name] = value
+        return value
+
     target = _LAZY_WRAPPER_EXPORTS.get(name)
     if target is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    import importlib
 
     module = importlib.import_module(target[0])
     value = getattr(module, target[1])
@@ -92,6 +110,9 @@ __all__ = [
     # Runtime entrypoints
     "BaseAgent",  # kernel (eager)
     "Agent",  # wrapper (lazy)
+    # Native runtime adapter (lazy, SDK-internal; wrapper loads only on start)
+    "NativeRuntime",
+    "NativeRuntimeSession",
     # Configuration / state / messaging
     "AgentConfig",
     "AgentState",

--- a/src/lingtai_sdk/native.py
+++ b/src/lingtai_sdk/native.py
@@ -1,0 +1,214 @@
+"""NativeRuntime — the stage-1 live runtime skeleton.
+
+A thin :class:`~lingtai_sdk.runtime.Runtime` / :class:`RuntimeSession`
+implementation that wraps the existing wrapper ``Agent`` **unchanged**. It
+translates a backend-neutral :class:`RuntimeOptions` into ``Agent`` constructor
+kwargs, drives the agent's start/stop lifecycle, and surfaces lifecycle / error
+/ notification events through the stage-0 contract.
+
+Scope (intentionally small — see ``docs/sdk/architecture-foundation.md`` §8):
+
+- This wraps ``Agent``; it does **not** change the kernel turn loop, build an
+  ``LLMService``, or implement a non-native backend.
+- LLM/provider fields (``provider`` / ``model`` / ``base_url`` / ``api_key``)
+  are **deferred, not applied** — ``Agent`` takes a ready ``LLMService``, not
+  raw provider fields, and constructing that service is a later stage. They are
+  recorded on the session (``session.deferred['llm']``) for transparency.
+- ``send()`` routes to ``Agent.send()`` — the existing fire-and-forget queue
+  path. It does not block on a turn, so it is safe and deterministic in tests.
+
+Import purity
+-------------
+``import lingtai_sdk.native`` imports only the pure contract module
+(:mod:`lingtai_sdk.runtime`); the wrapper ``Agent`` is imported **lazily**, the
+first time a session is actually started (or via the default agent factory).
+Constructing a :class:`NativeRuntime` therefore stays free of the wrapper's
+heavy provider SDKs — they load only when an agent boots. ``NativeRuntime`` and
+``NativeRuntimeSession`` are exported from the package root via PEP 562 lazy
+attributes (see ``lingtai_sdk.__getattr__``).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from .runtime import (
+    EventKind,
+    Runtime,
+    RuntimeEvent,
+    RuntimeMessage,
+    RuntimeOptions,
+    RuntimeSession,
+    RuntimeState,
+)
+
+#: A factory that builds the underlying agent from translated kwargs. The
+#: default imports the wrapper ``Agent`` lazily; tests inject a fake.
+AgentFactory = Callable[..., Any]
+
+_SOURCE = "native"
+
+#: Fields copied verbatim onto ``Agent`` constructor kwargs when present. These
+#: are the options ``Agent`` accepts directly without changing runtime
+#: semantics. ``working_dir`` is handled separately (it is required).
+_SAFE_AGENT_FIELDS = ("agent_name", "capabilities", "addons", "streaming")
+
+#: LLM/provider fields that cannot be applied without building an ``LLMService``
+#: (a later stage). Collected into ``deferred['llm']`` instead of forced onto
+#: the ``Agent`` constructor.
+_LLM_FIELDS = ("provider", "model", "base_url", "api_key")
+
+
+def _agent_kwargs_from_options(
+    options: RuntimeOptions,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Translate ``RuntimeOptions`` into ``(agent_kwargs, deferred)``.
+
+    ``agent_kwargs`` is what is safe to pass to ``Agent(**agent_kwargs)`` today.
+    ``deferred`` records everything that is recognized but **not** applied in
+    this stage (LLM/provider config, manifest, prompt overrides, adapter
+    extras), so callers and tests can see exactly what was held back rather than
+    silently dropped.
+    """
+    agent_kwargs: dict[str, Any] = {"working_dir": options.working_dir}
+
+    for field in _SAFE_AGENT_FIELDS:
+        value = getattr(options, field, None)
+        # ``streaming`` is a plain bool (default False) and is always forwarded;
+        # the rest are forwarded only when explicitly provided.
+        if field == "streaming":
+            if value:
+                agent_kwargs[field] = value
+        elif value is not None:
+            agent_kwargs[field] = value
+
+    llm = {f: getattr(options, f) for f in _LLM_FIELDS if getattr(options, f) is not None}
+
+    deferred: dict[str, Any] = {
+        "llm": llm,
+        "manifest": dict(options.manifest or {}),
+        "system_prompt_overrides": dict(options.system_prompt_overrides or {}),
+        "extra": dict(options.extra or {}),
+    }
+    return agent_kwargs, deferred
+
+
+def _default_agent_factory(**kwargs: Any) -> Any:
+    """Lazily import and construct the wrapper ``Agent``.
+
+    Imported here (not at module top) so ``import lingtai_sdk.native`` and
+    constructing a ``NativeRuntime`` stay free of the wrapper's provider SDKs.
+    """
+    from lingtai import Agent  # lazy: pulls the wrapper only on first boot
+
+    return Agent(**kwargs)
+
+
+class NativeRuntimeSession(RuntimeSession):
+    """A single agent session backed by the wrapper ``Agent``.
+
+    The agent is built lazily in :meth:`start` via the runtime's factory, so a
+    freshly created (but unstarted) session holds no agent and imports no
+    wrapper code.
+    """
+
+    source = _SOURCE
+
+    def __init__(
+        self, options: RuntimeOptions, *, agent_factory: AgentFactory | None = None
+    ) -> None:
+        self._options = options
+        self._agent_factory = agent_factory or _default_agent_factory
+        self._agent: Any | None = None
+        self._state = RuntimeState.PENDING
+        self._events: list[RuntimeEvent] = []
+        self._agent_kwargs, self.deferred = _agent_kwargs_from_options(options)
+
+    # -- contract properties ------------------------------------------------
+    @property
+    def state(self) -> RuntimeState:
+        return self._state
+
+    @property
+    def working_dir(self) -> Path:
+        return Path(self._options.working_dir)
+
+    @property
+    def agent(self) -> Any | None:
+        """The underlying wrapper ``Agent``, or ``None`` before :meth:`start`."""
+        return self._agent
+
+    # -- lifecycle ----------------------------------------------------------
+    def start(self) -> None:
+        if self._state in (RuntimeState.ACTIVE, RuntimeState.STOPPED):
+            return  # idempotent: never rebuild a running or stopped session
+        self._agent = self._agent_factory(**self._agent_kwargs)
+        self._agent.start()
+        self._set_state(RuntimeState.ACTIVE)
+
+    def send(self, message: RuntimeMessage | str) -> None:
+        if self._state is not RuntimeState.ACTIVE or self._agent is None:
+            self._emit(
+                RuntimeEvent.error(
+                    f"send() ignored: session is {self._state.value}, not active",
+                    fatal=False,
+                    source=self.source,
+                )
+            )
+            return
+        if isinstance(message, RuntimeMessage):
+            content, sender = message.content, message.sender
+        else:
+            content, sender = message, "user"
+        # Fire-and-forget enqueue onto the agent's inbox (no synchronous turn).
+        self._agent.send(content, sender)
+        self._emit(
+            RuntimeEvent(
+                EventKind.NOTIFICATION,
+                {"queued": True, "sender": sender},
+                source=self.source,
+            )
+        )
+
+    def events(self) -> Iterator[RuntimeEvent]:
+        # Stage 1: a non-blocking, re-iterable snapshot of the queue. A future
+        # stage bridges the agent's live output stream onto these events.
+        return iter(list(self._events))
+
+    def stop(self, timeout: float = 5.0) -> None:
+        if self._state is RuntimeState.STOPPED:
+            return
+        if self._agent is not None:
+            self._agent.stop(timeout=timeout)
+        self._set_state(RuntimeState.STOPPED)
+
+    # -- internals ----------------------------------------------------------
+    def _emit(self, event: RuntimeEvent) -> None:
+        self._events.append(event)
+
+    def _set_state(self, state: RuntimeState) -> None:
+        self._state = state
+        self._emit(RuntimeEvent.state(state, source=self.source))
+
+
+class NativeRuntime(Runtime):
+    """Factory for :class:`NativeRuntimeSession`s.
+
+    ``agent_factory`` is injectable so tests can substitute a fake agent and
+    avoid booting a real model / process.
+    """
+
+    id = _SOURCE
+
+    def __init__(self, *, agent_factory: AgentFactory | None = None) -> None:
+        self._agent_factory = agent_factory
+
+    def create_session(self, options: RuntimeOptions) -> NativeRuntimeSession:
+        return NativeRuntimeSession(options, agent_factory=self._agent_factory)
+
+
+__all__ = [
+    "NativeRuntime",
+    "NativeRuntimeSession",
+    "AgentFactory",
+]

--- a/tests/test_sdk_native_runtime.py
+++ b/tests/test_sdk_native_runtime.py
@@ -1,0 +1,235 @@
+"""Stage 1 — the live ``NativeRuntime`` skeleton wraps the existing wrapper
+``Agent`` behind the stage-0 runtime contract.
+
+These tests must run with **no real model, no API key, and no long-running
+agent process**: the heavy ``Agent`` is replaced by an injected fake factory
+so we exercise translation, lifecycle state transitions, event emission, and
+``send`` routing without booting a real agent.
+
+Import purity is preserved: ``import lingtai_sdk.native`` and *constructing* a
+``NativeRuntime`` must not pull in the ``lingtai`` wrapper or any heavy
+provider SDK — the wrapper loads only when a session actually starts.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from lingtai_sdk import native
+from lingtai_sdk import runtime as rt
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src"
+
+
+# --------------------------------------------------------------------------
+# Fake Agent — stands in for the heavy wrapper Agent. Records the kwargs it
+# was constructed with so translation can be asserted, and tracks start/stop.
+# --------------------------------------------------------------------------
+class _FakeAgent:
+    last_kwargs: dict | None = None
+
+    def __init__(self, **kwargs):
+        type(self).last_kwargs = kwargs
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        self.sent: list[tuple] = []
+        self.working_dir = Path(kwargs["working_dir"])
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self.stopped = True
+
+    def send(self, content, sender: str = "user") -> None:
+        self.sent.append((content, sender))
+
+
+def _factory(**kwargs):
+    return _FakeAgent(**kwargs)
+
+
+# --------------------------------------------------------------------------
+# Translation helper
+# --------------------------------------------------------------------------
+def test_translate_minimal_working_dir_only():
+    opts = rt.RuntimeOptions(working_dir="/tmp/a")
+    agent_kwargs, deferred = native._agent_kwargs_from_options(opts)
+    assert agent_kwargs["working_dir"] == "/tmp/a"
+    # No agent_name / capabilities / addons declared -> not forced in.
+    assert "agent_name" not in agent_kwargs
+    assert "capabilities" not in agent_kwargs
+    assert deferred["llm"] == {}
+
+
+def test_translate_passes_safe_fields():
+    opts = rt.RuntimeOptions(
+        working_dir="/tmp/b",
+        agent_name="alice",
+        capabilities=["file", "web_search"],
+        addons=["imap"],
+        streaming=True,
+    )
+    agent_kwargs, _ = native._agent_kwargs_from_options(opts)
+    assert agent_kwargs["agent_name"] == "alice"
+    assert agent_kwargs["capabilities"] == ["file", "web_search"]
+    assert agent_kwargs["addons"] == ["imap"]
+    assert agent_kwargs["streaming"] is True
+
+
+def test_translate_defers_llm_and_manifest_fields():
+    opts = rt.RuntimeOptions(
+        working_dir="/tmp/c",
+        provider="anthropic",
+        model="claude-opus-4-8",
+        base_url="https://example",
+        api_key="sk-secret",
+        manifest={"covenant": "be good"},
+        system_prompt_overrides={"rules": "no harm"},
+    )
+    agent_kwargs, deferred = native._agent_kwargs_from_options(opts)
+    # LLM/provider fields are NOT forced onto Agent (Agent takes a service).
+    assert "provider" not in agent_kwargs
+    assert "model" not in agent_kwargs
+    assert "api_key" not in agent_kwargs
+    assert deferred["llm"] == {
+        "provider": "anthropic",
+        "model": "claude-opus-4-8",
+        "base_url": "https://example",
+        "api_key": "sk-secret",
+    }
+    assert deferred["manifest"] == {"covenant": "be good"}
+    assert deferred["system_prompt_overrides"] == {"rules": "no harm"}
+
+
+# --------------------------------------------------------------------------
+# Session lifecycle (fake Agent injected)
+# --------------------------------------------------------------------------
+def test_create_session_is_pending_before_start(tmp_path):
+    rtm = native.NativeRuntime(agent_factory=_factory)
+    session = rtm.create_session(rt.RuntimeOptions(working_dir=tmp_path))
+    assert session.state is rt.RuntimeState.PENDING
+    assert session.working_dir == Path(tmp_path)
+    # No agent built yet.
+    assert session.agent is None
+
+
+def test_start_builds_agent_and_goes_active(tmp_path):
+    rtm = native.NativeRuntime(agent_factory=_factory)
+    session = rtm.create_session(
+        rt.RuntimeOptions(working_dir=tmp_path, agent_name="bob")
+    )
+    session.start()
+    assert session.state is rt.RuntimeState.ACTIVE
+    assert isinstance(session.agent, _FakeAgent)
+    assert session.agent.started is True
+    assert session.agent.kwargs["agent_name"] == "bob"
+    # A STATE event was emitted on activation.
+    kinds = [e.kind for e in session.events()]
+    assert rt.EventKind.STATE in kinds
+
+
+def test_start_is_idempotent(tmp_path):
+    rtm = native.NativeRuntime(agent_factory=_factory)
+    session = rtm.create_session(rt.RuntimeOptions(working_dir=tmp_path))
+    session.start()
+    first_agent = session.agent
+    session.start()
+    assert session.agent is first_agent  # not rebuilt
+
+
+def test_send_routes_to_agent_when_active(tmp_path):
+    rtm = native.NativeRuntime(agent_factory=_factory)
+    session = rtm.create_session(rt.RuntimeOptions(working_dir=tmp_path))
+    session.start()
+    session.send("hello")
+    session.send(rt.RuntimeMessage(content="world", sender="ops"))
+    assert session.agent.sent == [("hello", "user"), ("world", "ops")]
+    # Each enqueue surfaced a NOTIFICATION event.
+    notes = [e for e in session.events() if e.kind is rt.EventKind.NOTIFICATION]
+    assert len(notes) == 2
+
+
+def test_send_before_start_emits_non_fatal_error(tmp_path):
+    rtm = native.NativeRuntime(agent_factory=_factory)
+    session = rtm.create_session(rt.RuntimeOptions(working_dir=tmp_path))
+    session.send("too early")
+    errs = [e for e in session.events() if e.kind is rt.EventKind.ERROR]
+    assert len(errs) == 1
+    assert errs[0].data["fatal"] is False
+    assert session.agent is None  # nothing was built / no agent touched
+
+
+def test_stop_transitions_to_stopped(tmp_path):
+    rtm = native.NativeRuntime(agent_factory=_factory)
+    session = rtm.create_session(rt.RuntimeOptions(working_dir=tmp_path))
+    session.start()
+    agent = session.agent
+    session.stop()
+    assert session.state is rt.RuntimeState.STOPPED
+    assert agent.stopped is True
+
+
+def test_stop_before_start_is_safe(tmp_path):
+    rtm = native.NativeRuntime(agent_factory=_factory)
+    session = rtm.create_session(rt.RuntimeOptions(working_dir=tmp_path))
+    session.stop()
+    assert session.state is rt.RuntimeState.STOPPED
+
+
+def test_context_manager_runs_and_stops(tmp_path):
+    rtm = native.NativeRuntime(agent_factory=_factory)
+    opts = rt.RuntimeOptions(working_dir=tmp_path)
+    with rtm.run(opts) as session:
+        assert session.state is rt.RuntimeState.ACTIVE
+    assert session.state is rt.RuntimeState.STOPPED
+
+
+def test_runtime_id_is_native():
+    assert native.NativeRuntime().id == "native"
+    assert native.NativeRuntimeSession.source == "native"
+
+
+# --------------------------------------------------------------------------
+# Lazy export from the package root
+# --------------------------------------------------------------------------
+def test_native_runtime_exported_lazily_from_package():
+    import lingtai_sdk
+
+    assert lingtai_sdk.NativeRuntime is native.NativeRuntime
+    assert lingtai_sdk.NativeRuntimeSession is native.NativeRuntimeSession
+
+
+# --------------------------------------------------------------------------
+# Import purity: importing native + constructing the runtime stays wrapper-free
+# --------------------------------------------------------------------------
+def test_importing_native_and_constructing_runtime_is_pure():
+    code = (
+        "import sys\n"
+        "import lingtai_sdk.native as native\n"
+        "import lingtai_sdk\n"
+        "rtm = lingtai_sdk.NativeRuntime()\n"
+        "_ = native.NativeRuntimeSession\n"
+        "providers = ('anthropic','openai','google.genai',"
+        "'google.generativeai','mcp','trafilatura','ddgs')\n"
+        "bad = [m for m in sys.modules if m == 'lingtai' or m.startswith('lingtai.')]\n"
+        "bad += [m for m in sys.modules "
+        "if any(m == p or m.startswith(p + '.') for p in providers)]\n"
+        "assert not bad, bad\n"
+        "print('OK')\n"
+    )
+    r = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        env={**os.environ, "PYTHONPATH": str(SRC)},
+    )
+    assert r.returncode == 0, r.stderr
+    assert "OK" in r.stdout


### PR DESCRIPTION
## Summary

Stage 1 stacked on #322. Adds a minimal `NativeRuntime` adapter skeleton that proves the stage-0 runtime contract can wrap the existing wrapper `Agent` without changing the kernel turn loop or worsening import boundaries.

- add `lingtai_sdk.native.NativeRuntime` / `NativeRuntimeSession`
- translate safe `RuntimeOptions` fields into `Agent` kwargs and defer unwired provider/manifest/prompt fields visibly
- keep `import lingtai_sdk` and `lingtai_sdk.NativeRuntime()` wrapper/provider-free; wrapper `Agent` loads only when a session starts
- add fake-agent tests for lifecycle, send routing, translation, lazy export, and import purity
- update SDK anatomy and architecture-foundation docs with the stage-1 stacked-PR note

## Scope boundaries

Intentionally not included:

- no `system` / `psyche` / `soul` CapabilityBundle migration
- no Anthropic backend
- no `BaseAgent` / `Agent` turn-loop rewrite
- no real model/API-key/process dependency in tests

## Validation

- `uv run pytest tests/test_sdk_import_purity.py tests/test_sdk_runtime_contract.py tests/test_sdk_capabilities.py tests/test_sdk_native_runtime.py -q`
  - `32 passed in 0.78s`
- `git diff --check sdk/architecture-foundation-20260617...HEAD`
  - clean

## Stack

Base PR: #322 (`sdk/architecture-foundation-20260617` @ `6c909cb`)

This PR is meant to be reviewed as the diff from #322 only. If/when #322 merges, this branch can be retargeted/rebased to `main` from its independent worktree.
