### PR TITLE
fix(codex): scope prompt cache key to agent init path

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -1126,7 +1126,7 @@ class Agent(BaseAgent):
         # 60 RPM cap by default. Set to 0 in init.json to disable gating.
         new_max_rpm = m.get("max_rpm", 60)
         new_provider_defaults = build_provider_defaults_from_manifest_llm(
-            llm, max_rpm=new_max_rpm
+            llm, max_rpm=new_max_rpm, agent_init_path=self._working_dir / "init.json"
         )
 
         cur_provider_defaults_bucket = getattr(
@@ -1138,6 +1138,7 @@ class Agent(BaseAgent):
             or new_base_url != getattr(self.service, "_base_url", None)
             or new_max_rpm != cur_provider_defaults_bucket.get("max_rpm", 0)
             or llm.get("api_compat") != cur_provider_defaults_bucket.get("api_compat")
+            or (new_provider_defaults or {}).get(new_provider.lower(), {}).get("agent_init_path") != cur_provider_defaults_bucket.get("agent_init_path")
         ):
             self.service = LLMService(
                 provider=new_provider, model=new_model,

--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -102,7 +102,7 @@ def build_agent(data: dict, working_dir: Path) -> Agent:
     # by default. Set to 0 in init.json to disable gating.
     max_rpm = m.get("max_rpm", 60)
     provider_defaults = build_provider_defaults_from_manifest_llm(
-        llm, max_rpm=max_rpm
+        llm, max_rpm=max_rpm, agent_init_path=working_dir / "init.json"
     )
     service = LLMService(
         provider=llm["provider"],

--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -19,7 +19,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 ## Connections
 
 - **Kernel types** — `__init__.py:3` imports `ChatSession`, `LLMResponse`, `ToolCall`, `FunctionSchema` from `lingtai_kernel.llm.base`; `ChatInterface` from `lingtai_kernel.llm.interface`.
-- **ABC chain** — `LLMAdapter` (`base.py:53`) → abstract `create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`. `LLMService` (`service.py:97`) extends `lingtai_kernel.llm.service.LLMService` ABC.
+- **ABC chain** — `LLMAdapter` (`base.py:53`) → abstract `create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`. `LLMService` (`service.py:98`) extends `lingtai_kernel.llm.service.LLMService` ABC.
 - **Adapter registration** — `_register.py` registers 7 dedicated factories + 6 generic-routed providers (`grok`, `qwen`, `glm`, `zhipu`, `kimi`, `mimo`) via dedicated or `_custom` factories, plus the `claude-agent-sdk` / `claude_agent_sdk` aliases via `_claude_agent_sdk` (which drops `api_key`/`base_url` since the SDK uses CLI-login auth).
 - **Interface converters** — imported by adapter session modules (e.g. `openai.adapter` imports `to_openai`, `to_responses_input` from `interface_converters.py:120`).
 - **Rate gating** — `LLMAdapter._setup_gate(max_rpm)` creates `APICallGate`; `_wrap_with_gate()` returns `_GatedSession` proxy for sessions.
@@ -27,22 +27,22 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 ## Composition
 
 - **Factory pattern** — `LLMService._adapter_registry` (class-level dict) maps provider name → `Callable[..., LLMAdapter]`. Each factory receives `(model, defaults, **kw)` and lazy-imports the adapter module.
-- **Adapter caching** — `LLMService._adapters` keyed by `(provider, base_url)` tuple (`service.py:141`). Double-checked locking via `_adapter_lock` (`service.py:142`).
-- **Session tracking** — `LLMService._sessions` dict maps `st_<12-hex>` session IDs to `ChatSession` instances (`service.py:144`). Untracked sessions get `session_id=""`.
+- **Adapter caching** — `LLMService._adapters` keyed by `(provider, base_url)` tuple (`service.py:149`). Double-checked locking via `_adapter_lock` (`service.py:150`).
+- **Session tracking** — `LLMService._sessions` dict maps `st_<12-hex>` session IDs to `ChatSession` instances (`service.py:152`). Untracked sessions get `session_id=""`.
 - **Gated sessions** — `_GatedSession` (`base.py:19`) proxies `send()` and `send_stream()` through `APICallGate.submit()`. Attribute writes land on the proxy; reads fall through to inner session via `__getattr__`.
-- **Codex factory** — `_register.py:54` builds `CodexOpenAIAdapter`, monkey-patches `create_chat` and `generate` to refresh OAuth tokens before each call via `CodexTokenManager.get_access_token()`.
+- **Codex factory** — `_register.py:61` builds `CodexOpenAIAdapter`, forwards the resolved agent `init.json` path as `agent_init_path` for per-agent prompt-cache-key hashing, and monkey-patches `create_chat` and `generate` to refresh OAuth tokens before each call via `CodexTokenManager.get_access_token()`.
 
 ## State
 
 - **Class-level** — `LLMService._adapter_registry` (shared across all instances); `LLMAdapter._gate` (per-adapter instance).
 - **Instance-level** — `LLMService._adapters` cache; `LLMService._sessions` registry; `APICallGate._timestamps` deque for RPM window.
-- **Provider defaults** — `LLMService._provider_defaults` dict injected at construction (`service.py:140`). Drives model, base_url, max_rpm, api_compat, and OpenAI Responses `compact_threshold` settings. Build it from `manifest.llm` via `build_provider_defaults_from_manifest_llm()` (`service.py:66`) — opt-in safelists ensure adapter-consulted fields propagate: `_PROVIDER_DEFAULTS_PASS_THROUGH_KEYS` skips `None` values such as `api_compat`, while `_PROVIDER_DEFAULTS_PRESERVE_NONE_KEYS` preserves explicit `None` for settings like `compact_threshold` where `null` means “disable”. Both `cli.py:_load_init` and `agent.py:_setup_from_init` use this helper to stay in sync.
-- **Key resolution** — `LLMService._key_resolver` callable (`service.py:94`); defaults to `os.environ.get(f"{PROVIDER}_API_KEY")`.
+- **Provider defaults** — `LLMService._provider_defaults` dict injected at construction (`service.py:148`). Drives model, base_url, max_rpm, api_compat, OpenAI Responses `compact_threshold`, and Codex-only `agent_init_path` settings. Build it from `manifest.llm` via `build_provider_defaults_from_manifest_llm()` (`service.py:67`) — opt-in safelists ensure adapter-consulted fields propagate: `_PROVIDER_DEFAULTS_PASS_THROUGH_KEYS` skips `None` values such as `api_compat`, while `_PROVIDER_DEFAULTS_PRESERVE_NONE_KEYS` preserves explicit `None` for settings like `compact_threshold` where `null` means “disable”. Both `cli.py:_load_init` and `agent.py:_setup_from_init` use this helper to stay in sync.
+- **Key resolution** — `LLMService._key_resolver` callable (`service.py:147`); defaults to `os.environ.get(f"{PROVIDER}_API_KEY")`.
 
 ## Notes
 
 - **Abstract methods** — `LLMAdapter` requires: `create_chat()` (line 86), `generate()` (line 119), `make_tool_result_message()` (line 136), `is_quota_error()` (line 148).
-- **Tool-call ID dual system** — Provider-issued wire IDs (e.g. Anthropic `tool_use_id`, OpenAI `tool_call_id`) flow through `tool_call_id` kwarg. LingTai issues its own `_tool_call_id` (`service.py:35`: `tc_<unix>_<4-hex>`) stamped onto every result dict for agent-level correlation.
+- **Tool-call ID dual system** — Provider-issued wire IDs (e.g. Anthropic `tool_use_id`, OpenAI `tool_call_id`) flow through `tool_call_id` kwarg. LingTai issues its own `_tool_call_id` (`service.py:36`: `tc_<unix>_<4-hex>`) stamped onto every result dict for agent-level correlation.
 - **Interface converters** — Four bidirectional pairs:
   - `to_anthropic`/`from_anthropic` — Anthropic Messages format (system excluded, ThinkingBlock with signature round-trip)
   - `to_openai` — Chat Completions format (tool results as `role=tool`, ThinkingBlocks emit as `reasoning_content` for DeepSeek and MiMo thinking-mode round-trip; other OpenAI-compat providers ignore the field). One-way only — OpenAI history rehydration goes through `content_block_from_dict` on the canonical interface, not a reverse converter.

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -70,6 +70,7 @@ def register_all_adapters() -> None:
             base_url="https://chatgpt.com/backend-api/codex",
             use_responses=True,
             force_responses=True,
+            agent_init_path=kw.get("agent_init_path"),
         )
         # Store the token manager so we can refresh before each API call.
         # The openai SDK's client.api_key is mutable — we update it in-place.

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -9,33 +9,34 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 3 | Re-exports `OpenAIAdapter`, `OpenAIChatSession` |
-| `adapter.py` | 1778 | 5 classes + helpers: `OpenAIChatSession`, `OpenAIResponsesSession`, `OpenAIAdapter`, `CodexResponsesSession`, `CodexOpenAIAdapter` |
+| `adapter.py` | 1813 | 5 classes + helpers: `OpenAIChatSession`, `OpenAIResponsesSession`, `OpenAIAdapter`, `CodexResponsesSession`, `CodexOpenAIAdapter` |
 | `defaults.py` | 7 | `DEFAULTS` dict: `api_compat="openai"`, `use_responses_api=True` |
 
 ### adapter.py class map
 
 | Class | Lines | Role |
 |-------|-------|------|
-| `OpenAIChatSession` | 492–1003 | Chat Completions session with context overflow auto-recovery; sends optional `prompt_cache_key` |
-| `OpenAIResponsesSession` | 1006–1204 | Responses API session with server-side `previous_response_id` chaining, optional `context_management` compaction, and optional `prompt_cache_key` |
-| `OpenAIAdapter` | 1207–1520 | `LLMAdapter` implementation; dispatches to Completions or Responses path; receives injected `compact_threshold`; derives the default `prompt_cache_key` via `_default_prompt_cache_key` / `_resolve_prompt_cache_key` |
-| `CodexResponsesSession` | 1523–1709 | Stateless Responses variant for ChatGPT-OAuth `/backend-api/codex` |
-| `CodexOpenAIAdapter` | 1711–1778 | Adapter variant that builds `CodexResponsesSession`; overrides `_default_prompt_cache_key` → `lingtai-codex:{model}:v1` |
+| `OpenAIChatSession` | 521–1032 | Chat Completions session with context overflow auto-recovery; sends optional `prompt_cache_key` |
+| `OpenAIResponsesSession` | 1035–1233 | Responses API session with server-side `previous_response_id` chaining, optional `context_management` compaction, and optional `prompt_cache_key` |
+| `OpenAIAdapter` | 1236–1551 | `LLMAdapter` implementation; dispatches to Completions or Responses path; receives injected `compact_threshold`; derives the default `prompt_cache_key` via `_default_prompt_cache_key` / `_resolve_prompt_cache_key`; stores optional `agent_init_path` for Codex cache affinity |
+| `CodexResponsesSession` | 1554–1739 | Stateless Responses variant for ChatGPT-OAuth `/backend-api/codex` |
+| `CodexOpenAIAdapter` | 1742–1813 | Adapter variant that builds `CodexResponsesSession`; overrides `_default_prompt_cache_key` to include a local `init.json` path hash when available (`lingtai-codex:{model}:init-<hash>:v2`), falling back to the historical `lingtai-codex:{model}:v1` when no agent context exists |
 
 ### adapter.py helpers
 
 | Function | Lines | Role |
 |----------|-------|------|
 | `_base_url_namespace()` | 53–66 | Stable namespace token for an OpenAI-compatible `base_url` (URL host, or short hash fallback) used in the default `prompt_cache_key` |
-| `_validate_compact_threshold()` | 69–83 | Validates/normalizes OpenAI Responses auto-compaction threshold; positive `int` or explicit `None` (disable) only |
-| `_codex_responses_trace_path()` / `_codex_responses_trace_record()` | 63–157 | Opt-in Codex Responses stream diagnostic trace helpers; safe metadata only, default off |
-| `_build_http_timeout()` | 159–173 | `httpx.Timeout` per-phase caps (connect≤30s, read≤60s, pool=10s) |
-| `_build_tools()` | 165–179 | `FunctionSchema` → OpenAI CC tool format (`{type, function: {name, description, parameters}}`) |
-| `_build_responses_tools()` | 189–213 | `FunctionSchema` → Responses API flat format (`{type, name, description, parameters}`); scrubs disallowed top-level JSON-Schema combinators (`allOf`, `oneOf`, etc.) |
-| `_parse_tool_calls()` | 216–233 | Raw SDK `tool_calls` → `list[ToolCall]` |
-| `_parse_response()` | 236–280 | ChatCompletion → `LLMResponse` (extracts reasoning from `reasoning_content` or `reasoning`) |
-| `_handle_responses_reasoning_event()` | 303–346 | Responses stream reasoning-summary event handler; accumulates `summary_text` deltas/done fallback without raw reasoning text |
-| `_parse_responses_api_response()` | 349–391 | Responses API output → `LLMResponse` (handles `message`, `function_call`, `reasoning` output items) |
+| `_resolve_agent_init_path()` / `_agent_init_path_hash()` | 69–95 | Resolve a local agent `init.json` path (explicit or `LINGTAI_AGENT_DIR`) and return a short non-reversible hash for Codex cache affinity without leaking filesystem paths |
+| `_validate_compact_threshold()` | 98–112 | Validates/normalizes OpenAI Responses auto-compaction threshold; positive `int` or explicit `None` (disable) only |
+| `_codex_responses_trace_path()` / `_codex_responses_trace_record()` | 114–208 | Opt-in Codex Responses stream diagnostic trace helpers; safe metadata only, default off |
+| `_build_http_timeout()` | 211–226 | `httpx.Timeout` per-phase caps (connect≤30s, read≤60s, pool=10s) |
+| `_build_tools()` | 233–249 | `FunctionSchema` → OpenAI CC tool format (`{type, function: {name, description, parameters}}`) |
+| `_build_responses_tools()` | 309–335 | `FunctionSchema` → Responses API flat format (`{type, name, description, parameters}`); scrubs disallowed top-level JSON-Schema combinators (`allOf`, `oneOf`, etc.) |
+| `_parse_tool_calls()` | 338–355 | Raw SDK `tool_calls` → `list[ToolCall]` |
+| `_parse_response()` | 358–404 | ChatCompletion → `LLMResponse` (extracts reasoning from `reasoning_content` or `reasoning`) |
+| `_handle_responses_reasoning_event()` | 425–468 | Responses stream reasoning-summary event handler; accumulates `summary_text` deltas/done fallback without raw reasoning text |
+| `_parse_responses_api_response()` | 471–513 | Responses API output → `LLMResponse` (handles `message`, `function_call`, `reasoning` output items) |
 
 ## Connections
 
@@ -44,33 +45,33 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 - **Interface converters** — imports `to_openai` and `to_responses_input` from `lingtai.llm.interface_converters` (line 31).
 - **Streaming** — imports `StreamingAccumulator` from `lingtai_kernel.llm.streaming` (line 32).
 - **HTTP client** — imports `httpx` for timeout construction (line 16); `openai` SDK for all API calls (line 17).
-- **Subclass hooks** — `_session_class` (line 1215) for Completions path; `_adapter_extra_body()` (line 1446) for provider-specific `extra_body`; `_default_prompt_cache_key()` (line 1265) for the provider-namespaced cache key.
+- **Subclass hooks** — `_session_class` (line 1244) for Completions path; `_adapter_extra_body()` (line 1477) for provider-specific `extra_body`; `_default_prompt_cache_key()` (line 1296) for the provider-namespaced cache key.
 
 ## Composition
 
 ### Two session paths
 
-The adapter forks at `create_chat()` (line 1295):
-1. **Responses API** (`_create_responses_session`, line 1335) — when `use_responses=True` AND (`base_url` is None OR `force_responses=True`). Builds `OpenAIResponsesSession`.
-2. **Chat Completions** (`_create_completions_session`, line 1387) — fallback for compatible providers. Builds `self._session_class` (subclass-overridable).
+The adapter forks at `create_chat()` (line 1326):
+1. **Responses API** (`_create_responses_session`, line 1366) — when `use_responses=True` AND (`base_url` is None OR `force_responses=True`). Builds `OpenAIResponsesSession`.
+2. **Chat Completions** (`_create_completions_session`, line 1418) — fallback for compatible providers. Builds `self._session_class` (subclass-overridable).
 
 Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 
-### Chat Completions session flow (`OpenAIChatSession.send`, line 438)
+### Chat Completions session flow (`OpenAIChatSession.send`, line 678)
 
 1. Record user input into `ChatInterface` (str → `add_user_message`; list → `add_tool_results`)
 2. `_build_kwargs()`: enforce tool pairing → serialize via `_build_messages()` → `_pair_orphan_tool_calls()` wire guard
 3. `_run_with_overflow_recovery(_do_call)` — retries with context trimming on 400 context-length errors
 4. On success: record assistant response into interface via `_record_assistant_response()`
 
-### Responses API session flow (`OpenAIResponsesSession.send`, line 853)
+### Responses API session flow (`OpenAIResponsesSession.send`, line 1070)
 
 1. `_convert_input(message)` → Responses API input items
 2. Chain `previous_response_id` if available
 3. Call `client.responses.create(**kwargs)`
 4. Store `response_id` for next turn
 
-### Codex stateless flow (`CodexResponsesSession.send_stream`, line 1266)
+### Codex stateless flow (`CodexResponsesSession.send_stream`, line 1570)
 
 1. Record message into canonical `ChatInterface`
 2. `to_responses_input(interface)` — replay full conversation as input items
@@ -82,7 +83,7 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 **Default-on for every OpenAI-compatible path.** Both `OpenAIChatSession` and `OpenAIResponsesSession` accept an optional `prompt_cache_key` and, when set, add it to the request kwargs on all send paths (Chat Completions `send` / `send_stream`; Responses `send` / `send_stream`; Codex `send_stream`). A bare directly-constructed session leaves it `None` (opt-in) — the *adapter* supplies the namespaced default:
 
 - `OpenAIAdapter._default_prompt_cache_key(model)` derives the namespace from identity: official OpenAI (no `base_url`) → `lingtai-openai:{model}:v1`; any custom/compatible `base_url` → `lingtai-openai-compat:{host}:{model}:v1` (host from `_base_url_namespace`, hash fallback). Distinct endpoints/models never share a cache slot.
-- Provider subclasses with a fixed identity override it: DeepSeek → `lingtai-deepseek:{model}:v1`, Zhipu/GLM → `lingtai-zhipu:{model}:v1`, MiMo → `lingtai-mimo:{model}:v1`, Codex → `lingtai-codex:{model}:v1`. The compat probe (`reports/prompt-cache-key-openai-compat-probe-*.json`) confirmed DeepSeek/Zhipu/MiMo Chat Completions accept the field.
+- Provider subclasses with a fixed identity override it: DeepSeek → `lingtai-deepseek:{model}:v1`, Zhipu/GLM → `lingtai-zhipu:{model}:v1`, MiMo → `lingtai-mimo:{model}:v1`, Codex → `lingtai-codex:{model}:init-<hash>:v2` when an agent `init.json` path is available, falling back to `lingtai-codex:{model}:v1` for direct/library construction without agent context. The compat probe (`reports/prompt-cache-key-openai-compat-probe-*.json`) confirmed DeepSeek/Zhipu/MiMo Chat Completions accept the field.
 - `_resolve_prompt_cache_key(model)` applies the adapter's policy from the constructor kwarg `prompt_cache_key`: `None` (default) → auto-derive; an explicit string → override for every session; `False` → disable (never sent). Both `_create_completions_session` and `_create_responses_session` (and the Codex variant) pass `_resolve_prompt_cache_key(model)` into the session.
 
 `prompt_cache_retention` is deliberately never sent — Codex rejects it (`Unsupported parameter`) and the whole OpenAI-compatible surface is kept uniform — and no Anthropic-style `cache_control` is emitted (Codex rejects `Unknown parameter`). MiniMax is Anthropic-compatible in this repo and is unaffected.
@@ -146,8 +147,8 @@ The Codex / Responses path has the same invariant: `to_responses_input` ends wit
 
 ### Subclass hooks
 
-- `_session_class` (line 1215) — override to inject provider-specific session behavior on the CC path.
-- `_adapter_extra_body()` (line 1446) — override to add `extra_body` JSON fields (e.g. OpenRouter `reasoning: {include: true}`).
+- `_session_class` (line 1244) — override to inject provider-specific session behavior on the CC path.
+- `_adapter_extra_body()` (line 1477) — override to add `extra_body` JSON fields (e.g. OpenRouter `reasoning: {include: true}`).
 - `_default_prompt_cache_key(model)` (line 1265) — override to give a provider a clean cache namespace (DeepSeek/Zhipu/MiMo/Codex do).
 
 ### `send(None)` contract — continue from wire

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -66,6 +66,35 @@ def _base_url_namespace(base_url: str | None) -> str:
     return "h" + hashlib.sha256(base_url.encode("utf-8")).hexdigest()[:12]
 
 
+def _resolve_agent_init_path(agent_init_path: str | os.PathLike[str] | None) -> Path | None:
+    """Resolve the local ``init.json`` path used for Codex cache affinity.
+
+    The preferred source is an explicit ``agent_init_path`` injected by the
+    LingTai host. As a fallback for direct construction and daemon preset
+    sessions, use ``LINGTAI_AGENT_DIR/init.json`` when the host environment is
+    present. Returns ``None`` for library/test callers with no agent context,
+    preserving the historical model-scoped default.
+    """
+    candidate: Path | None = None
+    if agent_init_path:
+        candidate = Path(agent_init_path).expanduser()
+    else:
+        agent_dir = os.environ.get("LINGTAI_AGENT_DIR")
+        if agent_dir:
+            candidate = Path(agent_dir).expanduser() / "init.json"
+    if candidate is None:
+        return None
+    return candidate.resolve(strict=False)
+
+
+def _agent_init_path_hash(agent_init_path: str | os.PathLike[str] | None) -> str | None:
+    """Return a short non-reversible hash for a resolved agent ``init.json`` path."""
+    resolved = _resolve_agent_init_path(agent_init_path)
+    if resolved is None:
+        return None
+    return hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()[:16]
+
+
 def _validate_compact_threshold(value: int | None) -> int | None:
     """Normalize the OpenAI Responses auto-compaction threshold.
 
@@ -1226,10 +1255,12 @@ class OpenAIAdapter(LLMAdapter):
         default_headers: dict | None = None,
         compact_threshold: int | None = 100_000,
         prompt_cache_key: str | bool | None = None,
+        agent_init_path: str | os.PathLike[str] | None = None,
     ):
         self.base_url = base_url
         self._use_responses = use_responses
         self._force_responses = force_responses
+        self._agent_init_path = str(agent_init_path) if agent_init_path else None
         # Prompt-cache-key policy for this adapter's OpenAI-compatible sessions:
         #   None  -> auto-derive a stable, namespaced default per model
         #   str   -> use this exact key for every session (override)
@@ -1718,11 +1749,15 @@ class CodexOpenAIAdapter(OpenAIAdapter):
 
     def _default_prompt_cache_key(self, model: str) -> str:
         # Stable, conservative default so successive Codex turns hit the
-        # backend prompt cache. Keyed by model so distinct models don't share
-        # a cache namespace; `:v1` lets us bump it if the stable prefix ever
-        # changes shape. Never paired with `prompt_cache_retention` (Codex
-        # rejects that parameter). This intentionally ignores the codex
-        # base_url host — the namespace is the fixed ``lingtai-codex`` prefix.
+        # backend prompt cache. Keyed by model plus the local agent init.json
+        # path hash so one persistent agent/workstream keeps cache affinity
+        # without leaking machine paths or forcing unrelated agents into the
+        # same Codex cache bucket. `:v2` marks the schema change from the
+        # earlier model-only key. Never paired with `prompt_cache_retention`
+        # (Codex rejects that parameter).
+        init_hash = _agent_init_path_hash(self._agent_init_path)
+        if init_hash:
+            return f"lingtai-codex:{model}:init-{init_hash}:v2"
         return f"lingtai-codex:{model}:v1"
 
     def _create_responses_session(
@@ -1771,7 +1806,7 @@ class CodexOpenAIAdapter(OpenAIAdapter):
             previous_response_id=None,
             compact_threshold=None,
             interface=interface,
-            # Resolves to ``lingtai-codex:{model}:v1`` by default (see
+            # Resolves to an agent-init-path-hashed Codex key by default (see
             # ``_default_prompt_cache_key``), but honors an explicit override
             # or a ``prompt_cache_key=False`` disable passed to the adapter.
             prompt_cache_key=self._resolve_prompt_cache_key(model),

--- a/src/lingtai/llm/service.py
+++ b/src/lingtai/llm/service.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import threading
+from pathlib import Path
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -67,6 +68,7 @@ def build_provider_defaults_from_manifest_llm(
     llm: dict,
     *,
     max_rpm: int,
+    agent_init_path: str | os.PathLike[str] | None = None,
 ) -> dict | None:
     """Convert a manifest.llm block into LLMService.provider_defaults.
 
@@ -79,6 +81,8 @@ def build_provider_defaults_from_manifest_llm(
     per_provider: dict = {}
     if max_rpm > 0:
         per_provider["max_rpm"] = max_rpm
+    if provider_key == "codex" and agent_init_path is not None:
+        per_provider["agent_init_path"] = str(Path(agent_init_path).expanduser().resolve(strict=False))
     user_headers = llm.get("default_headers")
     if isinstance(user_headers, dict) and user_headers:
         # Pass-through; LLMService._default_headers_for honors caller-supplied
@@ -170,10 +174,14 @@ class LLMService(LLMServiceABC):
                 f"If using lingtai, ensure 'import lingtai' runs before creating LLMService."
             )
 
+        extra_kw: dict = {}
+        if p == "codex" and defaults and defaults.get("agent_init_path") is not None:
+            extra_kw["agent_init_path"] = defaults["agent_init_path"]
+
         return factory(
             model=self._model,
             defaults=defaults,
-            **key_kw, **url_kw, **rpm_kw, **headers_kw,
+            **key_kw, **url_kw, **rpm_kw, **headers_kw, **extra_kw,
         )
 
     def _default_headers_for(self, provider: str, defaults: dict | None) -> dict | None:

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -40,6 +40,33 @@ class TestAdapterRegistry:
         adapter = svc.get_adapter("myprovider")
         assert adapter._init_kwargs["api_key"] == "test-key"
 
+
+    def test_codex_receives_agent_init_path_default(self, tmp_path):
+        LLMService.register_adapter("codex", _make_stub_adapter)
+        init_path = tmp_path / "agent" / "init.json"
+        svc = LLMService(
+            "codex",
+            "gpt-5.5",
+            api_key="test-key",
+            provider_defaults={"codex": {"agent_init_path": str(init_path)}},
+        )
+
+        adapter = svc.get_adapter("codex")
+        assert adapter._init_kwargs["agent_init_path"] == str(init_path)
+
+    def test_agent_init_path_default_is_codex_only(self, tmp_path):
+        LLMService.register_adapter("openai", _make_stub_adapter)
+        init_path = tmp_path / "agent" / "init.json"
+        svc = LLMService(
+            "openai",
+            "gpt-5.5",
+            api_key="test-key",
+            provider_defaults={"openai": {"agent_init_path": str(init_path)}},
+        )
+
+        adapter = svc.get_adapter("openai")
+        assert "agent_init_path" not in adapter._init_kwargs
+
     def test_create_adapter_unknown_provider_raises(self):
         import pytest
         with pytest.raises(RuntimeError, match="No adapter registered"):

--- a/tests/test_codex_prompt_cache_key.py
+++ b/tests/test_codex_prompt_cache_key.py
@@ -12,8 +12,10 @@ parameter``). These tests assert the wire kwargs the session sends:
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 
 from lingtai.llm.openai.adapter import (
@@ -77,12 +79,23 @@ def _function_schema() -> FunctionSchema:
     )
 
 
-def _create_codex_session(events: list[Event], *, model: str = "gpt-5.5"):
+def _expected_init_key(init_path: Path, *, model: str = "gpt-5.5") -> str:
+    init_hash = hashlib.sha256(str(init_path.resolve(strict=False)).encode("utf-8")).hexdigest()[:16]
+    return f"lingtai-codex:{model}:init-{init_hash}:v2"
+
+
+def _create_codex_session(
+    events: list[Event],
+    *,
+    model: str = "gpt-5.5",
+    agent_init_path: Path | None = None,
+):
     adapter = CodexOpenAIAdapter(
         api_key="fake",
         base_url="http://fake",
         use_responses=True,
         force_responses=True,
+        agent_init_path=agent_init_path,
     )
     adapter._client = FakeClient(events)
     return adapter.create_chat(
@@ -108,6 +121,37 @@ def test_codex_request_includes_default_prompt_cache_key():
     assert sent["prompt_cache_key"] == "lingtai-codex:gpt-5.5:v1"
 
 
+def test_codex_request_uses_agent_init_path_hash_when_available(tmp_path):
+    init_path = tmp_path / "agent-a" / "init.json"
+    session = _create_codex_session(
+        [_completed()],
+        model="gpt-5.5",
+        agent_init_path=init_path,
+    )
+
+    session.send("please answer via tool")
+
+    sent = session._client.responses.kwargs[0]
+    assert sent["prompt_cache_key"] == _expected_init_key(init_path)
+    assert str(init_path) not in sent["prompt_cache_key"]
+
+
+def test_codex_agent_init_path_hash_distinguishes_agents(tmp_path):
+    init_a = tmp_path / "agent-a" / "init.json"
+    init_b = tmp_path / "agent-b" / "init.json"
+
+    session_a = _create_codex_session([_completed()], agent_init_path=init_a)
+    session_b = _create_codex_session([_completed()], agent_init_path=init_b)
+    session_a.send("hi")
+    session_b.send("hi")
+
+    key_a = session_a._client.responses.kwargs[0]["prompt_cache_key"]
+    key_b = session_b._client.responses.kwargs[0]["prompt_cache_key"]
+    assert key_a == _expected_init_key(init_a)
+    assert key_b == _expected_init_key(init_b)
+    assert key_a != key_b
+
+
 def test_codex_request_omits_prompt_cache_retention():
     session = _create_codex_session([_completed()])
 
@@ -126,14 +170,19 @@ def test_codex_request_has_no_cache_control_anywhere():
     assert _no_cache_control(sent)
 
 
-def test_codex_prompt_cache_key_is_stable_across_requests():
-    session = _create_codex_session([_completed(), _completed()], model="gpt-5.5")
+def test_codex_prompt_cache_key_is_stable_across_requests(tmp_path):
+    init_path = tmp_path / "agent-a" / "init.json"
+    session = _create_codex_session(
+        [_completed(), _completed()],
+        model="gpt-5.5",
+        agent_init_path=init_path,
+    )
 
     session.send("first")
     session.send("second")
 
     keys = [kw["prompt_cache_key"] for kw in session._client.responses.kwargs]
-    assert keys == ["lingtai-codex:gpt-5.5:v1", "lingtai-codex:gpt-5.5:v1"]
+    assert keys == [_expected_init_key(init_path), _expected_init_key(init_path)]
 
 
 def test_explicit_prompt_cache_key_overrides_default():

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -73,6 +73,20 @@ def test_build_provider_defaults_returns_none_when_nothing_set():
     assert out is None
 
 
+
+
+def test_build_provider_defaults_includes_agent_init_path(tmp_path):
+    init_path = tmp_path / "agent" / "init.json"
+    out = build_provider_defaults_from_manifest_llm(
+        {"provider": "codex", "model": "gpt-5.5"},
+        max_rpm=0,
+        agent_init_path=init_path,
+    )
+    assert out == {
+        "codex": {"agent_init_path": str(init_path.resolve(strict=False))},
+    }
+
+
 def test_build_provider_defaults_includes_default_headers():
     out = build_provider_defaults_from_manifest_llm(
         {


### PR DESCRIPTION
## Summary

Derive Codex `prompt_cache_key` from a stable, non-reversible hash of the local agent `init.json` path when the adapter is running inside a LingTai agent.

Before this change, Codex defaulted to a coarse model-wide key:

```text
lingtai-codex:{model}:v1
```

That makes unrelated Codex agents share the same cache route/bucket, and it does not encode the persistent workstream identity that matters for LingTai's long-running agent sessions. This patch changes the Codex default, when an agent context is available, to:

```text
lingtai-codex:{model}:init-<sha256(init.json path)[:16]>:v2
```

The raw filesystem path is never sent to Codex; only the short hash is included. Direct/library construction without a LingTai agent context still falls back to the historical `lingtai-codex:{model}:v1` default.

## Motivation

Recent machine-wide token-ledger analysis showed intermittent GPT-5.5/Codex prompt-cache collapses in persistent agents: same agent/same ledger calls only seconds apart could go from ~95-99% cache hit to ~0-6%, then recover. A stable per-agent cache key is not guaranteed to eliminate backend cache-shard/retention instability, but it is the smallest adapter-side fix that:

- gives each persistent LingTai agent/workstream a deterministic Codex cache-affinity key;
- avoids forcing all Codex agents on the machine into one coarse model-wide key;
- avoids leaking local paths or agent names to the backend;
- preserves the existing explicit `prompt_cache_key` override and `prompt_cache_key=False` disable behavior.

## Implementation

- Add `_resolve_agent_init_path()` / `_agent_init_path_hash()` in `src/lingtai/llm/openai/adapter.py`.
  - Preferred source: explicit `agent_init_path` injected by the LingTai host.
  - Fallback: `LINGTAI_AGENT_DIR/init.json` for direct adapter construction in an agent process.
  - Hash: `sha256(str(Path(...).resolve(strict=False)))[:16]`.
- Extend `OpenAIAdapter(..., agent_init_path=...)`; `CodexOpenAIAdapter._default_prompt_cache_key()` uses it for `init-<hash>:v2` keys.
- Plumb the local `init.json` path from both boot and refresh:
  - `cli.py:build_agent()` passes `working_dir / "init.json"`.
  - `Agent._setup_from_init()` passes `self._working_dir / "init.json"` and includes the resolved path in the service-rebuild comparison.
- Keep the new default Codex-only:
  - `build_provider_defaults_from_manifest_llm()` records `agent_init_path` only for provider `codex`.
  - `LLMService._create_adapter()` forwards it only to the Codex factory.
- Update `ANATOMY.md` files for the LLM/OpenAI adapter structure.

## Compatibility / safety

- No raw local path is emitted in `prompt_cache_key`.
- Non-Codex OpenAI-compatible providers are unchanged.
- Explicit user/operator controls keep working:
  - `prompt_cache_key="custom"` overrides the derived default.
  - `prompt_cache_key=False` still omits the field.
- `prompt_cache_retention` remains deliberately omitted because the Codex backend rejects it.

## Test plan

Focused tests:

```bash
python -m pytest tests/test_adapter_registry.py tests/test_codex_prompt_cache_key.py tests/test_llm_service.py tests/test_openai_prompt_cache_key.py
```

Result: `40 passed in 1.08s`.

Full suite:

```bash
python -m pytest
```

Result: `2253 passed, 2 skipped`.
