### PR TITLE
feat(sdk): wire bundle guard advisory mode (stage 18)

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -12,6 +12,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 | `__main__.py` | `python -m lingtai` → `cli.main()` |
 | `agent.py` | **THE key file.** `Agent(BaseAgent)` — layer-2 agent with capability composition, preset swap, MCP, init.json refresh |
 | `cli.py` | `lingtai-agent run <dir>` / `lingtai-agent check-caps` entry points |
+| `guard_wiring.py` | Advisory-first wrapper wiring of the SDK guard bridge (stage 18, C3) — installs an advisory `ToolCallGuard` built from declared bundle manifests onto the Stage-16 `BaseAgent._tool_call_guard` seam. Default registry is empty (behaviour-neutral); fail-open |
 | `network.py` | Read-only network topology crawler — avatar/contact/mail edge discovery |
 | `presets.py` | Compatibility shim re-exporting the kernel preset library (`lingtai_kernel.presets`) |
 | `init_schema.py` | `validate_init()` plus `strip_deprecated()` — strict schema for active init.json fields, simple deprecated-field cleanup, and known-but-inactive legacy fields migrated by `lingtai_kernel.migrate` |
@@ -24,6 +25,8 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 **`agent.py`** — `Agent(BaseAgent)`: `__init__` :33 (accept `capabilities=` + `disable=`, expand groups, `apply_core_defaults`, decompress addons, setup caps, install manuals, load MCP) · `_setup_capability` :152 · `_persist_llm_config` :127 · `_install_intrinsic_manuals` :174 · `_load_mcp_from_workdir` :376 (also tracks specs in `_mcp_init_specs`) · `_retry_failed_mcps` :524 (re-spawn dead MCPs on `system(refresh)` — issue #34) · `_read_init` :833 (runs `lingtai_kernel.migrate.run_agent_migrations()` before reading `init.json`, then materializes preset, strips plain deprecated fields, validates, resolves paths, and publishes the resolved manifest to `system/manifest.resolved.json` via `lingtai_kernel.workdir.write_resolved_manifest` — issue #259) · `_setup_from_init` :989 (**full reconstruct** — shared by boot and live refresh; reads `manifest.disable` and re-applies `apply_core_defaults`) · `_activate_preset` :915 (runtime swap, atomic write) · `_reload_prompt_sections` :1229 (writes `covenant`/`substrate`/`rules`/`principle`/`procedures`/`brief`/`comment`; delegates `character` to `_lingtai_load` and `pad` to `_pad_load` — the canonical composers — so boot/refresh/molt are consistent and hook-order-independent) · `connect_mcp` :704 / `connect_mcp_http` :756 · `start` :697 / `stop` :802
 
 **`cli.py`**: `load_init` :21 · `build_agent` :77 · `run` :202 · `main` :287
+
+**`guard_wiring.py`** — `DEFAULT_LIVE_GUARD_MODE` (advisory) · `default_manifest_registry` (empty) · `collect_agent_bundle_manifests` (walk `_capabilities`, fail-open per provider) · `install_bundle_guard` (build advisory `ToolCallGuard` via `lingtai_sdk.guard_bridge.tool_call_guard_from_manifests`, write to `_tool_call_guard`) · `wire_agent_guard` (live entry point; fail-open). Invoked by `Agent._wire_bundle_guard` near the end of `__init__` and `_setup_from_init`.
 
 **`presets.py`**: compatibility re-export shim (`presets.py:1-21`); implementation lives in `lingtai_kernel.presets` (`load_preset` :174 · `materialize_active_preset` :289 · `expand_inherit` :503 · `discover_presets_in_dirs` :121).
 
@@ -41,7 +44,9 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **Outbound — kernel:** `lingtai_kernel.base_agent.BaseAgent`, `.config.AgentConfig`, `.prompt.build_system_prompt`, `.handshake.resolve_address`, `.intrinsics.{email,psyche}`, `.services.mail.FilesystemMailService`, `.migrate.run_migrations` (preset libraries) and `.migrate.run_agent_migrations` (agent workdir/init migrations; see `../lingtai_kernel/migrate/ANATOMY.md`).
 
-**Cross-module:** `agent.py` → `capabilities.setup_capability`, `core.mcp.{decompress_addons,read_registry,MCPInboxPoller}`, `services.mcp.{MCPClient,HTTPMCPClient}`, `llm.service.LLMService`, `presets`, `lingtai_kernel.config_resolve`, `init_schema`. `cli.py` → `agent.Agent`, `lingtai_kernel.config_resolve`, `presets`.
+**Cross-module:** `agent.py` → `capabilities.setup_capability`, `core.mcp.{decompress_addons,read_registry,MCPInboxPoller}`, `services.mcp.{MCPClient,HTTPMCPClient}`, `llm.service.LLMService`, `presets`, `lingtai_kernel.config_resolve`, `init_schema`, `guard_wiring.wire_agent_guard`. `cli.py` → `agent.Agent`, `lingtai_kernel.config_resolve`, `presets`.
+
+**Outbound — SDK (wrapper → SDK edge, allowed):** `guard_wiring.py` → `lingtai_sdk.guard_bridge.{GuardPolicyMode, tool_call_guard_from_manifests}` and `lingtai_sdk.capabilities.BundleManifest`. The wrapper may depend on the SDK; the kernel must never import the SDK, so the guard chain is built wrapper-side and installed onto the kernel's `_tool_call_guard` seam — no `lingtai_kernel → lingtai_sdk` inversion.
 
 **Agent → BaseAgent:** Three-layer hierarchy: `BaseAgent` (kernel) → `Agent` (capabilities) → `CustomAgent` (domain). Agent adds capability registration, MCP auto-loading, preset swap, full init.json reconstruct.
 

--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -128,6 +128,28 @@ class Agent(BaseAgent):
         if self._capabilities:
             self._workdir.write_manifest(self._build_manifest())
 
+        # Advisory-first SDK guard wiring (stage 18, C3). Installs an advisory
+        # ToolCallGuard from any declared bundle manifests onto the Stage-16
+        # `_tool_call_guard` seam. Default registry is empty, so this is a
+        # behaviour-neutral pass-through for existing agents; fail-open.
+        self._wire_bundle_guard()
+
+    def _wire_bundle_guard(self) -> None:
+        """Install the advisory SDK bundle guard onto the Stage-16 seam.
+
+        Thin, fail-open delegation to :func:`lingtai.guard_wiring.wire_agent_guard`.
+        Advisory-first: declared destructive tools warn, never block, by default;
+        the default (empty) manifest registry leaves the seam a pure
+        ``default_allow`` pass-through, so existing/default agents are unaffected.
+        Kept as a method so reconstruct (``_setup_from_init``) and any subclass
+        can share one wiring path. Never raises.
+        """
+        try:
+            from .guard_wiring import wire_agent_guard
+            wire_agent_guard(self)
+        except Exception as e:  # fail open — never break construction
+            self._log("guard_wiring_failed", reason=str(e))
+
     def _persist_llm_config(self) -> None:
         """Persist LLM config to llm.json for agent revive.
 
@@ -1274,6 +1296,11 @@ class Agent(BaseAgent):
 
         # Re-write manifest and identity
         self._update_identity()
+
+        # Re-wire the advisory SDK bundle guard for the reconstructed capability
+        # set (stage 18, C3). Reconstruct rebuilds `_capabilities` from scratch,
+        # so re-derive the guard from the new manifests; fail-open.
+        self._wire_bundle_guard()
 
         # Re-seal
         self._sealed = True

--- a/src/lingtai/guard_wiring.py
+++ b/src/lingtai/guard_wiring.py
@@ -1,0 +1,184 @@
+"""Advisory-first wrapper wiring of the SDK guard bridge (stage 18, C3).
+
+Stage 17 built a pure, import-light SDK adapter
+(:mod:`lingtai_sdk.guard_bridge`) that turns one or more
+:class:`~lingtai_sdk.capabilities.BundleManifest` objects into a kernel
+:class:`~lingtai_kernel.tool_call_guard.ToolCallGuard` — but wired *nothing* into
+a live agent. This module is the thin wrapper-layer seam that finally installs
+such a guard onto the Stage-16 ``BaseAgent._tool_call_guard`` slot, so the turn
+loop's ``ToolExecutor`` consults declared bundle posture before a tool is
+dispatched.
+
+Behaviour contract (deliberately advisory-first / fail-open)
+------------------------------------------------------------
+* **Default live mode is advisory.** :data:`DEFAULT_LIVE_GUARD_MODE` is
+  :attr:`~lingtai_sdk.guard_bridge.GuardPolicyMode.ADVISORY`: a manifest-declared
+  ``destructive`` tool is surfaced as a *warning*, never denied, in default live
+  wiring. Blocking is reachable only by an explicit ``mode=`` opt-in and is never
+  the wrapper default.
+* **Default/existing agents stay pass-through.** The default capability→manifest
+  registry (:func:`default_manifest_registry`) is empty, so nothing is wired
+  unless a capability genuinely declares a bundle manifest. A freshly built
+  agent therefore keeps the unchanged ``default_allow`` pass-through.
+* **Unknown / unmanifested tools fail open.** MCP tools, ``add_tool`` tools, and
+  any capability tool without a manifest are unknown to the bridge and pass
+  through cleanly — this slice can only ever *add advisories* for explicitly
+  declared surfaces, never block an undeclared tool.
+* **No lifecycle/system tool is blocked.** Because the live mode is advisory,
+  even a destructive core tool (e.g. ``system``) would only warn, never deny.
+* **Fail open on any error.** If manifest collection or guard construction
+  raises, the seam is left at its existing safe value rather than failing closed.
+
+Import direction
+----------------
+The wrapper (``src/lingtai/...``) may import the SDK bridge/types; the kernel
+must stay SDK-free. This module therefore imports
+:mod:`lingtai_sdk.guard_bridge` (a wrapper→SDK edge, which is allowed), and the
+kernel never imports it back.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable
+
+from lingtai_sdk.capabilities import BundleManifest
+from lingtai_sdk.guard_bridge import (
+    GuardPolicyMode,
+    tool_call_guard_from_manifests,
+)
+
+#: A capability→manifest provider maps an enabled capability name to a
+#: zero-arg callable returning that capability's declared :class:`BundleManifest`.
+ManifestProvider = Callable[[], BundleManifest]
+ManifestRegistry = dict[str, ManifestProvider]
+
+#: The wrapper's default live policy mode. Advisory-first: declared destructive
+#: tools warn, they are never blocked by default live wiring.
+DEFAULT_LIVE_GUARD_MODE: GuardPolicyMode = GuardPolicyMode.ADVISORY
+
+
+def default_manifest_registry() -> ManifestRegistry:
+    """The default capability→manifest registry — empty.
+
+    No shipping capability declares an SDK bundle manifest yet, so the default
+    registry is empty and live wiring is behaviour-neutral: existing/default
+    agents keep the unchanged ``default_allow`` pass-through. A capability gains
+    advisory posture only by registering a provider here (or by passing a
+    ``registry`` into :func:`wire_agent_guard`).
+    """
+    return {}
+
+
+def collect_agent_bundle_manifests(
+    agent: Any,
+    *,
+    registry: ManifestRegistry | None = None,
+) -> list[BundleManifest]:
+    """Collect declared bundle manifests for an agent's enabled capabilities.
+
+    Walks the agent's ``_capabilities`` (a list of ``(name, kwargs)`` pairs set
+    by wrapper ``Agent`` construction) and, for each capability that has a
+    provider in ``registry``, calls the provider to obtain its
+    :class:`BundleManifest`. Capabilities with no provider contribute nothing —
+    their tools remain unknown to the bridge and fail open.
+
+    Fail-open: a provider that raises is skipped (logged via the agent's
+    ``_log`` if available) rather than aborting collection, so one broken
+    manifest can never deny an otherwise-clean agent its construction.
+    """
+    if registry is None:
+        registry = default_manifest_registry()
+    if not registry:
+        return []
+
+    capabilities = getattr(agent, "_capabilities", None) or []
+    manifests: list[BundleManifest] = []
+    seen: set[str] = set()
+    for entry in capabilities:
+        name = entry[0] if isinstance(entry, (tuple, list)) and entry else entry
+        if not isinstance(name, str) or name in seen:
+            continue
+        seen.add(name)
+        provider = registry.get(name)
+        if provider is None:
+            continue
+        try:
+            manifest = provider()
+        except Exception as exc:  # fail open — never block construction
+            _safe_log(agent, "guard_wiring_manifest_skipped", capability=name,
+                      reason=str(exc))
+            continue
+        if isinstance(manifest, BundleManifest):
+            manifests.append(manifest)
+    return manifests
+
+
+def install_bundle_guard(
+    agent: Any,
+    *,
+    manifests: Iterable[BundleManifest],
+    mode: GuardPolicyMode = DEFAULT_LIVE_GUARD_MODE,
+) -> None:
+    """Build a guard from ``manifests`` and install it on the Stage-16 seam.
+
+    Replaces ``agent._tool_call_guard`` with the chain
+    :func:`~lingtai_sdk.guard_bridge.tool_call_guard_from_manifests` returns for
+    the supplied manifests and ``mode`` (advisory by default). With no manifests
+    this is the unchanged ``default_allow`` pass-through, so calling it is always
+    safe. The turn loop already threads ``_tool_call_guard`` into every
+    ``ToolExecutor`` it builds (Stage 16), so the installed guard becomes live
+    without any executor/turn change.
+    """
+    guard = tool_call_guard_from_manifests(list(manifests), mode=mode)
+    agent._tool_call_guard = guard
+
+
+def wire_agent_guard(
+    agent: Any,
+    *,
+    registry: ManifestRegistry | None = None,
+    mode: GuardPolicyMode = DEFAULT_LIVE_GUARD_MODE,
+) -> None:
+    """Live entry point: collect an agent's declared manifests and install them.
+
+    Called once near the end of wrapper ``Agent`` construction (and reconstruct).
+    Advisory-first and fail-open:
+
+    * collects manifests for enabled capabilities from ``registry`` (default:
+      the empty :func:`default_manifest_registry`, i.e. behaviour-neutral);
+    * installs an advisory guard (default ``mode``) onto the Stage-16 seam;
+    * on **any** error leaves the seam untouched (safe pass-through) rather than
+      failing closed.
+
+    A default (empty-registry) call leaves the seam a pure pass-through, so
+    existing/default agents are unaffected.
+    """
+    try:
+        manifests = collect_agent_bundle_manifests(agent, registry=registry)
+        if not manifests:
+            # Nothing declared — leave the existing (default pass-through) seam
+            # untouched. Avoids needlessly replacing a guard a host may have set.
+            return
+        install_bundle_guard(agent, manifests=manifests, mode=mode)
+    except Exception as exc:  # fail open — never break construction
+        _safe_log(agent, "guard_wiring_failed", reason=str(exc))
+
+
+def _safe_log(agent: Any, event: str, **fields: Any) -> None:
+    """Best-effort structured log via the agent's ``_log``; never raises."""
+    log = getattr(agent, "_log", None)
+    if callable(log):
+        try:
+            log(event, **fields)
+        except Exception:
+            pass
+
+
+__all__ = [
+    "ManifestProvider",
+    "ManifestRegistry",
+    "DEFAULT_LIVE_GUARD_MODE",
+    "default_manifest_registry",
+    "collect_agent_bundle_manifests",
+    "install_bundle_guard",
+    "wire_agent_guard",
+]

--- a/tests/test_wrapper_guard_wiring.py
+++ b/tests/test_wrapper_guard_wiring.py
@@ -1,0 +1,352 @@
+"""Stage 18 (C3) — advisory-first wrapper wiring of the SDK guard bridge.
+
+The wrapper ``Agent`` construction path installs the SDK ``guard_bridge`` into
+the Stage-16 ``BaseAgent._tool_call_guard`` seam so declared SDK bundle
+manifests can advise on a proposed tool call before dispatch. This stage is
+behaviour-visible but **advisory-first**:
+
+* default live wiring NEVER introduces a blocking denial — a manifest-declared
+  ``destructive`` tool becomes a *warning*, not a block, in default live mode;
+* default/existing agents stay pure pass-through — nothing is wired unless a
+  capability actually declares a bundle manifest, and the default registry is
+  empty, so a freshly built agent's guard is the unchanged ``default_allow``
+  pass-through;
+* unknown / unmanifested tools (MCP, add_tool, capability tools without a
+  manifest) fail open — they are never blocked by this slice;
+* the installed guard is actually threaded through the Stage-16 seam to the
+  ``ToolExecutor`` the turn loop builds;
+* no lifecycle/system tool is blocked by default wiring.
+
+Import direction is one-way: the wrapper may import the SDK ``guard_bridge`` /
+``capabilities``; the kernel never imports the SDK.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lingtai_kernel.tool_call_guard import ToolCallGuard, ToolProposal
+from lingtai_sdk import capabilities as cap
+from lingtai_sdk import core_bundles as core
+from lingtai_sdk.guard_bridge import GuardPolicyMode
+
+from lingtai import guard_wiring as gw
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src"
+
+
+def _proposal(tool_name: str) -> ToolProposal:
+    return ToolProposal(tool_name=tool_name, tool_args={})
+
+
+def _manifest(name: str, tools: tuple[str, ...], danger: str) -> cap.BundleManifest:
+    return cap.BundleManifest(
+        name=name,
+        version="0.0.1",
+        surfaces=cap.CapabilitySurfaces(tools=tools),
+        security=cap.SecurityPolicy(danger=danger),
+        transport=cap.TransportSpec(kind=cap.TransportKind.IN_PROCESS.value),
+    )
+
+
+def _make_mock_service():
+    svc = MagicMock()
+    svc.provider = "gemini"
+    svc.model = "gemini-test"
+    return svc
+
+
+# --- module-level defaults --------------------------------------------------
+
+
+def test_default_live_mode_is_advisory():
+    """The wrapper's default live policy mode is advisory (non-blocking)."""
+    assert gw.DEFAULT_LIVE_GUARD_MODE is GuardPolicyMode.ADVISORY
+
+
+def test_default_manifest_registry_is_empty():
+    """No capability declares a bundle manifest by default, so collecting from a
+    default registry yields nothing — keeping existing agents pass-through."""
+    assert gw.default_manifest_registry() == {}
+
+
+# --- install_bundle_guard: the seam writer ----------------------------------
+
+
+def test_install_bundle_guard_writes_advisory_guard_to_seam():
+    """A manifest-declared destructive tool becomes a *warning* (not blocked)
+    under the default advisory live mode, and the guard lands on the seam."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()  # default empty pass-through
+
+    destructive = _manifest("danger_bundle", ("nuke",), cap.SecurityDanger.DESTRUCTIVE.value)
+    gw.install_bundle_guard(agent, manifests=[destructive])
+
+    guard = agent._tool_call_guard
+    assert isinstance(guard, ToolCallGuard)
+    decision = guard.evaluate(_proposal("nuke"))
+    # advisory-first: allowed, surfaced as a warning, never denied.
+    assert decision.allowed is True
+    assert decision.action == "warn"
+    assert decision.severity == "warning"
+    assert decision.metadata["danger"] == "destructive"
+    assert decision.metadata["policy_mode"] == "advisory"
+
+
+def test_install_bundle_guard_unknown_tool_fails_open():
+    """An unmanifested / unknown tool is never blocked — clean pass-through."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    destructive = _manifest("danger_bundle", ("nuke",), cap.SecurityDanger.DESTRUCTIVE.value)
+    gw.install_bundle_guard(agent, manifests=[destructive])
+
+    decision = agent._tool_call_guard.evaluate(_proposal("some_mcp_tool"))
+    assert decision.allowed is True
+    assert decision.approval_mode == "pass_through"
+
+
+def test_install_bundle_guard_empty_manifests_is_pass_through():
+    """No manifests → the installed guard is the unchanged default_allow
+    pass-through (existing default agents are unaffected)."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    gw.install_bundle_guard(agent, manifests=[])
+
+    decision = agent._tool_call_guard.evaluate(_proposal("anything"))
+    assert decision.allowed is True
+    assert decision.approval_mode == "pass_through"
+
+
+def test_install_bundle_guard_blocking_mode_is_opt_in_only():
+    """Blocking is reachable only by explicit opt-in, never the live default."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    destructive = _manifest("danger_bundle", ("nuke",), cap.SecurityDanger.DESTRUCTIVE.value)
+    gw.install_bundle_guard(
+        agent, manifests=[destructive], mode=GuardPolicyMode.BLOCKING
+    )
+    decision = agent._tool_call_guard.evaluate(_proposal("nuke"))
+    assert decision.allowed is False
+
+
+# --- wire_agent_guard: the live construction entry point ---------------------
+
+
+def test_wire_agent_guard_default_registry_keeps_pass_through():
+    """With the default (empty) registry, wiring a live agent leaves the seam a
+    pure pass-through — destructive-free, advisory-free, behaviour-neutral."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    agent._capabilities = [("psyche", {}), ("vision", {})]
+
+    gw.wire_agent_guard(agent)
+
+    decision = agent._tool_call_guard.evaluate(_proposal("psyche"))
+    assert decision.allowed is True
+    assert decision.approval_mode == "pass_through"
+
+
+def test_wire_agent_guard_advises_declared_destructive_capability_tool():
+    """A capability that declares a destructive bundle manifest gets its tool
+    advised (warn), never blocked, under default live wiring."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    agent._capabilities = [("scary", {})]
+
+    registry = {
+        "scary": lambda: _manifest(
+            "scary", ("delete_everything",), cap.SecurityDanger.DESTRUCTIVE.value
+        )
+    }
+    gw.wire_agent_guard(agent, registry=registry)
+
+    decision = agent._tool_call_guard.evaluate(_proposal("delete_everything"))
+    assert decision.allowed is True
+    assert decision.action == "warn"
+    assert decision.severity == "warning"
+
+
+def test_wire_agent_guard_never_blocks_lifecycle_system_tool():
+    """Even if the core ``system`` (destructive) manifest is somehow in the
+    registry, default live wiring is advisory — ``system`` warns, never blocks.
+    No lifecycle/system tool is denied by this slice."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    agent._capabilities = [("system", {})]
+
+    registry = {"system": core.system_bundle}
+    gw.wire_agent_guard(agent, registry=registry)
+
+    decision = agent._tool_call_guard.evaluate(_proposal("system"))
+    assert decision.allowed is True  # advisory, NOT blocked
+    assert decision.action == "warn"
+
+
+def test_wire_agent_guard_ignores_capabilities_without_manifest():
+    """A capability with no registry entry contributes nothing — its tools fail
+    open (unknown → pass-through)."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    agent._capabilities = [("scary", {}), ("plain", {})]
+
+    registry = {
+        "scary": lambda: _manifest(
+            "scary", ("delete_everything",), cap.SecurityDanger.DESTRUCTIVE.value
+        )
+    }
+    gw.wire_agent_guard(agent, registry=registry)
+
+    # 'plain' declared no manifest → its tool is unknown → pass-through.
+    decision = agent._tool_call_guard.evaluate(_proposal("plain_tool"))
+    assert decision.allowed is True
+    assert decision.approval_mode == "pass_through"
+
+
+def test_wire_agent_guard_fails_open_on_registry_error():
+    """A manifest provider that raises must not break agent construction — the
+    seam is left at a safe pass-through (fail open, never fail closed)."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    agent._capabilities = [("boom", {})]
+
+    def _explode():
+        raise RuntimeError("manifest build failed")
+
+    registry = {"boom": _explode}
+    # Must not raise.
+    gw.wire_agent_guard(agent, registry=registry)
+
+    decision = agent._tool_call_guard.evaluate(_proposal("anything"))
+    assert decision.allowed is True
+    assert decision.approval_mode == "pass_through"
+
+
+# --- live Agent construction: end-to-end seam wiring ------------------------
+
+
+def test_live_agent_default_construction_is_pass_through(tmp_path):
+    """A real wrapper ``Agent`` built with the default registry owns a
+    pass-through guard — no behaviour change for existing/default agents."""
+    from lingtai.agent import Agent
+
+    agent = Agent(
+        service=_make_mock_service(),
+        agent_name="t",
+        working_dir=tmp_path / "agent",
+        capabilities=["psyche"],
+    )
+    guard = agent._tool_call_guard
+    assert isinstance(guard, ToolCallGuard)
+    decision = guard.evaluate(_proposal("psyche"))
+    assert decision.allowed is True
+    assert decision.approval_mode == "pass_through"
+
+
+def test_installed_guard_threads_through_stage16_seam_to_executor(tmp_path):
+    """The guard installed on the wrapper seam is the very object the Stage-16
+    turn loop hands to the ``ToolExecutor`` — proving the wiring is live."""
+    import lingtai_kernel.base_agent.turn as turn_module
+    from lingtai_kernel.base_agent.turn import _handle_request
+    from lingtai_kernel.message import _make_message, MSG_REQUEST
+    from lingtai.agent import Agent
+
+    agent = Agent(
+        service=_make_mock_service(),
+        agent_name="t2",
+        working_dir=tmp_path / "agent2",
+        capabilities=["psyche"],
+    )
+
+    # Install an advisory guard for a declared destructive tool on the seam.
+    destructive = _manifest("scary", ("wipe",), cap.SecurityDanger.DESTRUCTIVE.value)
+    gw.install_bundle_guard(agent, manifests=[destructive])
+    installed = agent._tool_call_guard
+
+    # Drive _handle_request far enough to build the executor, stubbing the LLM
+    # round-trip collaborators (mirrors the Stage-16 injection test).
+    def _no_tool_response():
+        resp = MagicMock()
+        resp.text = "done"
+        resp.tool_calls = []
+        resp.usage = MagicMock(
+            input_tokens=0, output_tokens=0, thinking_tokens=0, cached_tokens=0
+        )
+        return resp
+
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(turn_module, "_check_molt_pressure", lambda agent: None)
+    monkey.setattr(turn_module, "_process_response", lambda agent, response, **kw: None)
+    agent._pre_request = MagicMock(return_value="hi")
+    agent._sync_notifications = MagicMock()
+    agent._session = MagicMock()
+    agent._session.send.return_value = _no_tool_response()
+    agent._save_chat_history = MagicMock()
+    agent._post_request = MagicMock()
+    try:
+        _handle_request(agent, _make_message(MSG_REQUEST, "user", "go"))
+    finally:
+        monkey.undo()
+
+    assert agent._executor._tool_call_guard is installed
+    # And that executor's guard actually advises the declared destructive tool.
+    decision = agent._executor._tool_call_guard.evaluate(_proposal("wipe"))
+    assert decision.allowed is True
+    assert decision.action == "warn"
+
+
+# --- import direction: kernel stays SDK-free --------------------------------
+
+
+def test_wrapper_guard_wiring_import_does_not_invert_into_kernel():
+    """Importing ``lingtai.guard_wiring`` must NOT make the *kernel* import the
+    SDK — the kernel package stays SDK-free even though the wrapper bridges it."""
+    # The wrapper may import lingtai_sdk, but importing the wrapper guard-wiring
+    # module must not make any *kernel* module depend on the SDK. We import the
+    # wrapper module, then assert that re-importing the kernel guard module in a
+    # fresh interpreter (below) stays SDK-free; here we just prove the wrapper
+    # module imports cleanly and the kernel is present.
+    code = (
+        "import sys\n"
+        "import lingtai.guard_wiring\n"
+        "import lingtai_kernel.tool_call_guard\n"
+        "kernel_loaded = [m for m in sys.modules if m == 'lingtai_kernel' "
+        "or m.startswith('lingtai_kernel.')]\n"
+        "assert kernel_loaded, 'kernel not loaded?'\n"
+        "print('OK')\n"
+    )
+    r = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        env={**os.environ, "PYTHONPATH": str(SRC)},
+    )
+    assert r.returncode == 0, r.stderr
+    assert "OK" in r.stdout
+
+
+def test_kernel_guard_import_is_sdk_free_in_isolation():
+    """Kernel ``tool_call_guard`` imported alone must not load the SDK."""
+    code = (
+        "import sys\n"
+        "import lingtai_kernel.tool_call_guard  # noqa: F401\n"
+        "bad = [m for m in sys.modules if m == 'lingtai_sdk' "
+        "or m.startswith('lingtai_sdk.')]\n"
+        "assert not bad, bad\n"
+        "print('OK')\n"
+    )
+    r = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        env={**os.environ, "PYTHONPATH": str(SRC)},
+    )
+    assert r.returncode == 0, r.stderr
+    assert "OK" in r.stdout


### PR DESCRIPTION
## Summary
- add wrapper-layer guard wiring that collects SDK bundle manifests and installs an advisory ToolCallGuard into the Stage16 agent guard seam
- keep live defaults pass-through by using an empty manifest registry and advisory mode only when a manifest provider exists
- add focused wrapper guard wiring tests and update wrapper anatomy

## Validation
- /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_wrapper_guard_wiring.py -q (15 passed)
- /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_sdk_guard_bridge.py tests/test_turn_tool_guard_injection.py tests/test_tool_executor.py -q (48 passed)
- uv run ruff check src/lingtai/guard_wiring.py src/lingtai/agent.py tests/test_wrapper_guard_wiring.py (All checks passed)
- GLM 5.2 candidate review: APPROVE / no blockers (report in worktree reports/sdk-wrapper-guard-wiring-stage18-20260617/glm-review-candidate-stage18.md)

Stacked on #341. Do not merge until the full SDK migration stack is ready and Jason approves.