### PR TITLE
fix(sdk): reset derived bundle guards safely (stage 19)

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -12,7 +12,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 | `__main__.py` | `python -m lingtai` → `cli.main()` |
 | `agent.py` | **THE key file.** `Agent(BaseAgent)` — layer-2 agent with capability composition, preset swap, MCP, init.json refresh |
 | `cli.py` | `lingtai-agent run <dir>` / `lingtai-agent check-caps` entry points |
-| `guard_wiring.py` | Advisory-first wrapper wiring of the SDK guard bridge (stage 18, C3) — installs an advisory `ToolCallGuard` built from declared bundle manifests onto the Stage-16 `BaseAgent._tool_call_guard` seam. Default registry is empty (behaviour-neutral); fail-open |
+| `guard_wiring.py` | Advisory-first wrapper wiring of the SDK guard bridge (stage 18, C3) — installs an advisory `ToolCallGuard` built from declared bundle manifests onto the Stage-16 `BaseAgent._tool_call_guard` seam. Default registry is empty (behaviour-neutral); fail-open. Stage 19 adds provenance tracking so a re-wire with no manifests resets only a wrapper-installed guard (never a host/manual one) |
 | `network.py` | Read-only network topology crawler — avatar/contact/mail edge discovery |
 | `presets.py` | Compatibility shim re-exporting the kernel preset library (`lingtai_kernel.presets`) |
 | `init_schema.py` | `validate_init()` plus `strip_deprecated()` — strict schema for active init.json fields, simple deprecated-field cleanup, and known-but-inactive legacy fields migrated by `lingtai_kernel.migrate` |
@@ -26,7 +26,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **`cli.py`**: `load_init` :21 · `build_agent` :77 · `run` :202 · `main` :287
 
-**`guard_wiring.py`** — `DEFAULT_LIVE_GUARD_MODE` (advisory) · `default_manifest_registry` (empty) · `collect_agent_bundle_manifests` (walk `_capabilities`, fail-open per provider) · `install_bundle_guard` (build advisory `ToolCallGuard` via `lingtai_sdk.guard_bridge.tool_call_guard_from_manifests`, write to `_tool_call_guard`) · `wire_agent_guard` (live entry point; fail-open). Invoked by `Agent._wire_bundle_guard` near the end of `__init__` and `_setup_from_init`.
+**`guard_wiring.py`** — `DEFAULT_LIVE_GUARD_MODE` (advisory) · `default_manifest_registry` (empty) · `collect_agent_bundle_manifests` (walk `_capabilities`, fail-open per provider) · `install_bundle_guard` (build advisory `ToolCallGuard` via `lingtai_sdk.guard_bridge.tool_call_guard_from_manifests`, write to `_tool_call_guard`, tag provenance `PROVENANCE_FLAG`/`PROVENANCE_SOURCE` when manifests present) · `reset_bundle_guard` (Stage 19; restore a default pass-through `ToolCallGuard` and clear provenance) · `wire_agent_guard` (live entry point; fail-open — when no manifests collected, resets only a wrapper-owned guard via the `PROVENANCE_FLAG is True` identity check, leaving host/manual guards untouched). Invoked by `Agent._wire_bundle_guard` near the end of `__init__` and `_setup_from_init`.
 
 **`presets.py`**: compatibility re-export shim (`presets.py:1-21`); implementation lives in `lingtai_kernel.presets` (`load_preset` :174 · `materialize_active_preset` :289 · `expand_inherit` :503 · `discover_presets_in_dirs` :121).
 
@@ -46,7 +46,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **Cross-module:** `agent.py` → `capabilities.setup_capability`, `core.mcp.{decompress_addons,read_registry,MCPInboxPoller}`, `services.mcp.{MCPClient,HTTPMCPClient}`, `llm.service.LLMService`, `presets`, `lingtai_kernel.config_resolve`, `init_schema`, `guard_wiring.wire_agent_guard`. `cli.py` → `agent.Agent`, `lingtai_kernel.config_resolve`, `presets`.
 
-**Outbound — SDK (wrapper → SDK edge, allowed):** `guard_wiring.py` → `lingtai_sdk.guard_bridge.{GuardPolicyMode, tool_call_guard_from_manifests}` and `lingtai_sdk.capabilities.BundleManifest`. The wrapper may depend on the SDK; the kernel must never import the SDK, so the guard chain is built wrapper-side and installed onto the kernel's `_tool_call_guard` seam — no `lingtai_kernel → lingtai_sdk` inversion.
+**Outbound — SDK (wrapper → SDK edge, allowed):** `guard_wiring.py` → `lingtai_sdk.guard_bridge.{GuardPolicyMode, tool_call_guard_from_manifests}` and `lingtai_sdk.capabilities.BundleManifest`. The wrapper may depend on the SDK; the kernel must never import the SDK, so the guard chain is built wrapper-side and installed onto the kernel's `_tool_call_guard` seam — no `lingtai_kernel → lingtai_sdk` inversion. `guard_wiring.py` also imports `lingtai_kernel.tool_call_guard.ToolCallGuard` (wrapper → kernel, allowed) to construct the Stage-19 default pass-through reset guard.
 
 **Agent → BaseAgent:** Three-layer hierarchy: `BaseAgent` (kernel) → `Agent` (capabilities) → `CustomAgent` (domain). Agent adds capability registration, MCP auto-loading, preset swap, full init.json reconstruct.
 

--- a/src/lingtai/guard_wiring.py
+++ b/src/lingtai/guard_wiring.py
@@ -40,11 +40,22 @@ from __future__ import annotations
 
 from typing import Any, Callable, Iterable
 
+from lingtai_kernel.tool_call_guard import ToolCallGuard
 from lingtai_sdk.capabilities import BundleManifest
 from lingtai_sdk.guard_bridge import (
     GuardPolicyMode,
     tool_call_guard_from_manifests,
 )
+
+#: Private agent attribute set to ``True`` when this wrapper wiring has
+#: installed a bundle-derived guard onto the agent's ``_tool_call_guard`` seam.
+#: Used to distinguish a wrapper-owned guard from a host/subclass manually
+#: installed one, so a later wiring call with *no* manifests can safely reset
+#: only its own stale guard and never clobber a manual one.
+PROVENANCE_FLAG = "_bundle_guard_installed"
+#: Private agent attribute recording the names of the bundle manifests the
+#: currently installed wrapper guard was derived from (provenance/debug only).
+PROVENANCE_SOURCE = "_bundle_guard_source"
 
 #: A capability→manifest provider maps an enabled capability name to a
 #: zero-arg callable returning that capability's declared :class:`BundleManifest`.
@@ -127,9 +138,43 @@ def install_bundle_guard(
     safe. The turn loop already threads ``_tool_call_guard`` into every
     ``ToolExecutor`` it builds (Stage 16), so the installed guard becomes live
     without any executor/turn change.
+
+    Provenance (Stage 19): when manifests are supplied this tags the agent with
+    :data:`PROVENANCE_FLAG`/:data:`PROVENANCE_SOURCE` so a later wiring call can
+    recognise the guard as wrapper-derived and safely reset it (see
+    :func:`reset_bundle_guard`). With *no* manifests the guard is a plain
+    pass-through and no provenance is claimed — there is nothing to later reset,
+    and claiming ownership of a default guard could wrongly mask a host guard.
     """
-    guard = tool_call_guard_from_manifests(list(manifests), mode=mode)
+    manifest_list = list(manifests)
+    guard = tool_call_guard_from_manifests(manifest_list, mode=mode)
     agent._tool_call_guard = guard
+    if manifest_list:
+        setattr(agent, PROVENANCE_FLAG, True)
+        setattr(
+            agent,
+            PROVENANCE_SOURCE,
+            tuple(m.name for m in manifest_list if isinstance(m, BundleManifest)),
+        )
+
+
+def reset_bundle_guard(agent: Any) -> None:
+    """Reset a wrapper-installed bundle guard back to a pass-through.
+
+    Stage 19 safety seam. Restores ``agent._tool_call_guard`` to a default,
+    empty :class:`~lingtai_kernel.tool_call_guard.ToolCallGuard` (the same
+    pass-through posture a freshly built default agent owns) and clears the
+    provenance markers. Intended for the case where a previous wiring installed
+    a bundle-derived guard but a later wiring collects no manifests — without
+    this, the stale advisory guard would linger.
+
+    Caller responsibility: only invoke when the agent's current guard is known
+    to be wrapper-derived (i.e. :data:`PROVENANCE_FLAG` is truthy), so a
+    host/subclass manually-installed guard is never clobbered.
+    """
+    agent._tool_call_guard = ToolCallGuard()
+    setattr(agent, PROVENANCE_FLAG, False)
+    setattr(agent, PROVENANCE_SOURCE, ())
 
 
 def wire_agent_guard(
@@ -146,17 +191,28 @@ def wire_agent_guard(
     * collects manifests for enabled capabilities from ``registry`` (default:
       the empty :func:`default_manifest_registry`, i.e. behaviour-neutral);
     * installs an advisory guard (default ``mode``) onto the Stage-16 seam;
+    * when **no** manifests are collected, resets *only* a previously
+      wrapper-installed bundle guard back to a pass-through (Stage 19), leaving
+      any host/subclass manually-installed guard untouched;
     * on **any** error leaves the seam untouched (safe pass-through) rather than
       failing closed.
 
-    A default (empty-registry) call leaves the seam a pure pass-through, so
-    existing/default agents are unaffected.
+    A default (empty-registry) call on a default agent leaves the seam a pure
+    pass-through, so existing/default agents are unaffected.
     """
     try:
         manifests = collect_agent_bundle_manifests(agent, registry=registry)
         if not manifests:
-            # Nothing declared — leave the existing (default pass-through) seam
-            # untouched. Avoids needlessly replacing a guard a host may have set.
+            # Nothing declared. Only reset a guard *this wrapper* previously
+            # installed (provenance flag set); never clobber a host/subclass
+            # manual guard, and never needlessly churn an already-default seam.
+            # The flag is set to the literal ``True`` by install_bundle_guard;
+            # an identity check (rather than truthiness) is deliberate so a host
+            # agent that never had the flag — including a test double whose
+            # missing attributes auto-vivify to a truthy stand-in — is treated
+            # as *not* wrapper-owned and left untouched.
+            if getattr(agent, PROVENANCE_FLAG, False) is True:
+                reset_bundle_guard(agent)
             return
         install_bundle_guard(agent, manifests=manifests, mode=mode)
     except Exception as exc:  # fail open — never break construction
@@ -177,8 +233,11 @@ __all__ = [
     "ManifestProvider",
     "ManifestRegistry",
     "DEFAULT_LIVE_GUARD_MODE",
+    "PROVENANCE_FLAG",
+    "PROVENANCE_SOURCE",
     "default_manifest_registry",
     "collect_agent_bundle_manifests",
     "install_bundle_guard",
+    "reset_bundle_guard",
     "wire_agent_guard",
 ]

--- a/tests/test_wrapper_guard_wiring.py
+++ b/tests/test_wrapper_guard_wiring.py
@@ -300,6 +300,187 @@ def test_installed_guard_threads_through_stage16_seam_to_executor(tmp_path):
     assert decision.action == "warn"
 
 
+# --- Stage 19: provenance / reset safety before registry population ---------
+#
+# Stage 18 wired an advisory bundle guard but its ``wire_agent_guard`` returns
+# early when no manifests are collected, so it could not *clear* a stale guard
+# this wrapper had previously installed (e.g. a later refresh/reconstruct with
+# an emptied registry/capabilities). Stage 19 adds provenance tracking so the
+# wrapper can reset its own bundle-derived guard back to a pass-through while
+# never clobbering a host/subclass manually-installed guard.
+
+
+def test_install_bundle_guard_sets_provenance_marker():
+    """Installing a bundle-derived guard tags the agent so later wiring can
+    recognise the guard as wrapper-installed (and safely reset it)."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    destructive = _manifest("scary", ("wipe",), cap.SecurityDanger.DESTRUCTIVE.value)
+
+    gw.install_bundle_guard(agent, manifests=[destructive])
+
+    assert getattr(agent, "_bundle_guard_installed", False) is True
+    # The source records which bundles derived the installed guard.
+    assert "scary" in (getattr(agent, "_bundle_guard_source", None) or ())
+
+
+def test_install_bundle_guard_empty_manifests_does_not_mark_provenance():
+    """Installing with no manifests is a pass-through and must NOT claim
+    provenance — there is no wrapper-derived posture to later reset."""
+    agent = MagicMock(spec=[])  # bare object; no attrs unless we set them
+    agent._tool_call_guard = ToolCallGuard()
+
+    gw.install_bundle_guard(agent, manifests=[])
+
+    assert getattr(agent, "_bundle_guard_installed", False) is False
+
+
+def test_wire_agent_guard_resets_stale_bundle_guard_when_no_manifests():
+    """A previously wrapper-installed (bundle-derived) guard is reset to a
+    pass-through when a subsequent wiring call collects no manifests."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    agent._capabilities = [("scary", {})]
+    registry = {
+        "scary": lambda: _manifest(
+            "scary", ("wipe",), cap.SecurityDanger.DESTRUCTIVE.value
+        )
+    }
+    # First wiring installs a bundle-derived advisory guard.
+    gw.wire_agent_guard(agent, registry=registry)
+    assert agent._tool_call_guard.evaluate(_proposal("wipe")).action == "warn"
+    assert getattr(agent, "_bundle_guard_installed", False) is True
+
+    # Now capabilities/registry go empty (refresh/reconstruct). Re-wiring must
+    # clear the stale bundle-derived guard back to a clean pass-through.
+    agent._capabilities = []
+    gw.wire_agent_guard(agent)
+
+    decision = agent._tool_call_guard.evaluate(_proposal("wipe"))
+    assert decision.allowed is True
+    assert decision.approval_mode == "pass_through"
+    # Provenance cleared so we don't keep "owning" a now-default guard.
+    assert getattr(agent, "_bundle_guard_installed", False) is False
+
+
+def test_wire_agent_guard_does_not_clobber_manual_guard_when_no_manifests():
+    """A host/subclass manually-installed guard (no wrapper provenance) is left
+    untouched when wiring collects no manifests — never clobbered."""
+    from lingtai_kernel.tool_call_guard import GuardDecision
+
+    def _deny_check(proposal):
+        return GuardDecision(allowed=False, check_name="host_manual", reason="nope")
+
+    manual_guard = ToolCallGuard([_deny_check])
+    agent = MagicMock()
+    agent._tool_call_guard = manual_guard
+    agent._capabilities = []  # no manifests will be collected
+
+    gw.wire_agent_guard(agent)  # default empty registry → no manifests
+
+    # The host's manual guard object is preserved untouched.
+    assert agent._tool_call_guard is manual_guard
+    assert agent._tool_call_guard.evaluate(_proposal("anything")).allowed is False
+
+
+def test_wire_agent_guard_rederives_bundle_guard_when_manifests_change():
+    """A bundle-derived guard can be replaced/re-derived when manifests change
+    on a later wiring call (e.g. a different capability set)."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    agent._capabilities = [("scary", {})]
+    registry = {
+        "scary": lambda: _manifest(
+            "scary", ("wipe",), cap.SecurityDanger.DESTRUCTIVE.value
+        ),
+        "spooky": lambda: _manifest(
+            "spooky", ("erase",), cap.SecurityDanger.DESTRUCTIVE.value
+        ),
+    }
+    gw.wire_agent_guard(agent, registry=registry)
+    assert agent._tool_call_guard.evaluate(_proposal("wipe")).action == "warn"
+    assert agent._tool_call_guard.evaluate(_proposal("erase")).approval_mode == "pass_through"
+
+    # Capability set changes to a different declared bundle.
+    agent._capabilities = [("spooky", {})]
+    gw.wire_agent_guard(agent, registry=registry)
+
+    # New bundle advises its tool; the old bundle's tool is no longer known.
+    assert agent._tool_call_guard.evaluate(_proposal("erase")).action == "warn"
+    assert agent._tool_call_guard.evaluate(_proposal("wipe")).approval_mode == "pass_through"
+    assert "spooky" in (getattr(agent, "_bundle_guard_source", None) or ())
+
+
+def test_wire_agent_guard_reset_failure_is_fail_open():
+    """If resetting the stale guard raises, wiring must not break the agent —
+    fail open, leaving the prior (safe, advisory) seam rather than failing."""
+    agent = MagicMock()
+    agent._tool_call_guard = ToolCallGuard()
+    agent._capabilities = [("scary", {})]
+    registry = {
+        "scary": lambda: _manifest(
+            "scary", ("wipe",), cap.SecurityDanger.DESTRUCTIVE.value
+        )
+    }
+    gw.wire_agent_guard(agent, registry=registry)
+
+    # Make assignment to the seam blow up to simulate a pathological reset.
+    class _Boom:
+        def __setattr__(self, name, value):
+            if name == "_tool_call_guard":
+                raise RuntimeError("cannot set guard")
+            object.__setattr__(self, name, value)
+
+    boom = _Boom()
+    object.__setattr__(boom, "_capabilities", [])
+    object.__setattr__(boom, "_bundle_guard_installed", True)
+    object.__setattr__(boom, "_tool_call_guard", agent._tool_call_guard)
+
+    # Must not raise.
+    gw.wire_agent_guard(boom)
+
+
+def test_agent_rewire_clears_stale_bundle_guard_on_emptied_capabilities():
+    """Refresh-like path: the agent's own ``_wire_bundle_guard`` shares the
+    wiring seam, so re-running it after capabilities/registry are emptied must
+    not leave a stale bundle-derived guard. Mock-level: we exercise the real
+    ``BaseAgent._wire_bundle_guard`` against a minimal stand-in agent rather
+    than building a full live Agent."""
+    from lingtai.agent import Agent
+
+    # A minimal object exposing just what wiring touches; bind the real method.
+    class _Stub:
+        _wire_bundle_guard = Agent._wire_bundle_guard
+
+        def __init__(self):
+            self._tool_call_guard = ToolCallGuard()
+            self._capabilities = [("scary", {})]
+            self._logs = []
+
+        def _log(self, event, **fields):
+            self._logs.append((event, fields))
+
+    stub = _Stub()
+    registry = {
+        "scary": lambda: _manifest(
+            "scary", ("wipe",), cap.SecurityDanger.DESTRUCTIVE.value
+        )
+    }
+    # Install a bundle-derived guard via the shared seam.
+    gw.wire_agent_guard(stub, registry=registry)
+    assert getattr(stub, "_bundle_guard_installed", False) is True
+
+    # Capabilities go empty; the agent re-wires via its own (default-registry)
+    # path — the stale bundle guard must be reset to pass-through.
+    stub._capabilities = []
+    stub._wire_bundle_guard()
+
+    decision = stub._tool_call_guard.evaluate(_proposal("wipe"))
+    assert decision.allowed is True
+    assert decision.approval_mode == "pass_through"
+    assert getattr(stub, "_bundle_guard_installed", False) is False
+
+
 # --- import direction: kernel stays SDK-free --------------------------------
 
 


### PR DESCRIPTION
## Summary
- tag wrapper-installed bundle guards with provenance metadata
- reset only wrapper-derived bundle guards back to pass-through when manifests become empty
- preserve host/manual guards and keep advisory-first/fail-open behavior unchanged
- add provenance/reset regression tests and update wrapper anatomy

## Validation
- /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_wrapper_guard_wiring.py -q (22 passed)
- /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_sdk_guard_bridge.py tests/test_turn_tool_guard_injection.py tests/test_tool_executor.py tests/test_loop_guard.py tests/test_preset_context_guard.py tests/test_agent.py tests/test_deep_refresh.py tests/test_perform_refresh_handshake.py -q (144 passed)
- ruff check src/lingtai/guard_wiring.py tests/test_wrapper_guard_wiring.py (All checks passed)
- GLM 5.2 candidate review: APPROVE / no blockers (report in worktree reports/sdk-wrapper-guard-reset-stage19-20260617/glm-review-candidate-stage19.md)

Stacked on #342. Do not merge until the full SDK migration stack is ready and Jason approves.