### PR TITLE
test(sdk): clean stack lint debt before final review

### DIFF
--- a/tests/test_sdk_native_runtime.py
+++ b/tests/test_sdk_native_runtime.py
@@ -17,8 +17,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
 from lingtai_sdk import native
 from lingtai_sdk import runtime as rt
 

--- a/tests/test_sdk_native_runtime_events.py
+++ b/tests/test_sdk_native_runtime_events.py
@@ -158,7 +158,7 @@ def test_agent_state_change_surfaces_as_state_event(tmp_path):
     # The agent runs its own loop thread; the bridge samples agent._state when
     # events() is read and emits a STATE event when it changed.
     agent._state = "active"
-    kinds_before = list(session.events())  # sample once
+    list(session.events())  # sample once
     agent._state = "asleep"
     states = [e for e in session.events() if e.kind is rt.EventKind.STATE]
     values = [e.data["state"] for e in states]

--- a/tests/test_sdk_native_runtime_manifest.py
+++ b/tests/test_sdk_native_runtime_manifest.py
@@ -214,7 +214,7 @@ def test_explicit_options_override_manifest(tmp_path, patched_llm):
 
 def test_manifest_fills_only_absent_explicit_fields(tmp_path, patched_llm):
     # provider explicit, model from manifest; base_url explicit, api_key manifest
-    session = _start(
+    _start(
         tmp_path,
         provider="openai",
         base_url="https://explicit.example",
@@ -270,7 +270,7 @@ def test_provider_defaults_passed_through(tmp_path, patched_llm):
 def test_max_rpm_from_options_extra_native_without_manifest_llm(tmp_path, patched_llm):
     # No manifest['llm'] block, so the manifest defaults builder is not invoked;
     # the SDK still scopes the opted-in max_rpm onto provider_defaults directly.
-    session = _start(
+    _start(
         tmp_path,
         provider="anthropic",
         model="claude-opus-4-8",
@@ -284,7 +284,7 @@ def test_max_rpm_from_options_extra_native_without_manifest_llm(tmp_path, patche
 def test_max_rpm_from_options_extra_native_with_manifest_llm(tmp_path, patched_llm):
     # With a manifest['llm'] block, max_rpm from extra['native'] flows through
     # the manifest-defaults builder (extra wins over manifest['max_rpm']).
-    session = _start(
+    _start(
         tmp_path,
         manifest={
             "max_rpm": 99,
@@ -297,7 +297,7 @@ def test_max_rpm_from_options_extra_native_with_manifest_llm(tmp_path, patched_l
 
 
 def test_context_window_from_manifest_llm(tmp_path, patched_llm):
-    session = _start(
+    _start(
         tmp_path,
         manifest={
             "llm": {
@@ -312,7 +312,7 @@ def test_context_window_from_manifest_llm(tmp_path, patched_llm):
 
 
 def test_context_window_from_manifest_context_limit(tmp_path, patched_llm):
-    session = _start(
+    _start(
         tmp_path,
         manifest={
             "context_limit": 250_000,
@@ -324,7 +324,7 @@ def test_context_window_from_manifest_context_limit(tmp_path, patched_llm):
 
 
 def test_context_window_from_options_extra(tmp_path, patched_llm):
-    session = _start(
+    _start(
         tmp_path,
         provider="anthropic",
         model="claude-opus-4-8",

--- a/tests/test_tool_executor.py
+++ b/tests/test_tool_executor.py
@@ -5,15 +5,11 @@ import threading
 import time
 from unittest.mock import MagicMock
 
-import pytest
-
 import lingtai_kernel.tool_executor as tool_executor_module
 from lingtai_kernel.llm.base import ToolCall
-from lingtai_kernel.llm.interface import ToolResultBlock
 from lingtai_kernel.loop_guard import LoopGuard
 from lingtai_kernel.tool_call_guard import GuardDecision, ToolCallGuard
 from lingtai_kernel.tool_executor import ToolExecutor
-from lingtai_kernel.types import UnknownToolError
 
 
 def make_executor(
@@ -27,7 +23,10 @@ def make_executor(
     tool_call_guard=None,
 ):
     if dispatch_fn is None:
-        dispatch_fn = lambda tc: {"status": "ok", "result": f"ran {tc.name}"}
+
+        def dispatch_fn(tc):
+            return {"status": "ok", "result": f"ran {tc.name}"}
+
     make_result = MagicMock(side_effect=lambda name, result, **kw: {"name": name, "result": result})
     guard = guard or LoopGuard(max_total_calls=50)
     return ToolExecutor(
@@ -863,7 +862,6 @@ def test_unknown_tool_with_known_tools():
 
 def test_guard_property():
     executor = make_executor()
-    old_guard = executor.guard
     new_guard = LoopGuard(max_total_calls=10)
     executor.guard = new_guard
     assert executor.guard is new_guard


### PR DESCRIPTION
## Summary

Final hygiene pass before the full-stack SDK migration review/merge-order check.

This PR fixes stack-local lint debt in tests that surfaced during the trial rebase/final validation pass:

- remove unused imports / unused local assignments;
- replace one test helper lambda assignment with a small `def`;
- no production code changes.

## Validation

- trial rebase of top stack (#347) onto latest `origin/main` (including merged #328): 30 commits rebased cleanly, no conflicts
- focused stack suites on trial-rebased stack: 268 passed
- broader keyword sweep on trial-rebased stack: 442 passed, 4 skipped, 2106 deselected
- after this hygiene PR:
  - `uv run ruff check` on all 40 changed Python files in the SDK stack → clean
  - focused + hygiene-touched suites → 188 passed
  - broader keyword sweep (`sdk or guard or deep_refresh or agent_preset or codex or cache`) → 438 passed, 4 skipped, 2105 deselected

No merge without Jason's explicit approval.
