### PR TITLE
Add LingTai SDK docs and examples

### DIFF
--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -1,0 +1,256 @@
+# LingTai SDK — developer guide
+
+> A practical, human-facing tour of the public `lingtai_sdk` surface: what it is
+> today, what it deliberately is **not** yet, the canonical import paths, and
+> runnable quick examples. For the staged engineering log — every PR, every
+> deferred slice, the rationale behind each contract — see
+> [`architecture-foundation.md`](architecture-foundation.md). This page is the
+> doorway; that file is the blueprint.
+
+## What the LingTai SDK is
+
+`lingtai_sdk` is the **curated public front door** for building and embedding
+LingTai agents in-process. It is a thin consumer of the two implementation
+packages — never a dependency of them:
+
+```
+lingtai_sdk  ──imports──▶  lingtai_kernel   (eager; zero hard deps)
+            ──imports──▶  lingtai          (lazy; the batteries-included wrapper)
+```
+
+What it gives you today:
+
+- **Programmable contracts** — provider-agnostic dataclasses/ABCs describing how
+  a runtime is driven (`RuntimeOptions` in, `RuntimeMessage` in, a stream of
+  `RuntimeEvent` out) and how a capability is declared (`BundleManifest`). These
+  are the stable shapes embedders build against.
+- **A native runtime adapter** — `NativeRuntime` wraps the existing wrapper
+  `Agent` *unchanged* and drives it through the runtime contract. It is the
+  default backend behind the client facade.
+- **A thin client/session facade** — `query`, `LingTaiClient`, `open_session`,
+  `LingTaiSession`: ergonomic one-shot and multi-message entry points over any
+  runtime.
+- **Capability / bundle declarations** — every SDK capability is declared as a
+  `BundleManifest`; `default_registry()` gives a validated, indexed view of the
+  whole declared set, and `dispatch_target()` resolves a tool name to its owning
+  bundle and declared danger posture.
+- **A guard bridge** — `lingtai_sdk.guard` turns those declared danger postures
+  into a kernel `GuardCheck` (allow / advisory-warn / deny), so a host can
+  consult declared posture *before* a tool is dispatched.
+
+`import lingtai_sdk` stays as cheap and side-effect-free as
+`import lingtai_kernel`: only the kernel is loaded eagerly. The wrapper and its
+heavy provider SDKs (anthropic, openai, google-genai, mcp, …) load **lazily** —
+the first time you touch a wrapper-backed name like `Agent`, or the first time a
+`NativeRuntime` session is actually started.
+
+## What the SDK is NOT yet
+
+This is a **foundation surface**: stable contracts and a doorway, with the
+native runtime and bundle declarations wired in. Several things are deliberately
+*deferred* — naming them here so you don't build against a promise that isn't
+there:
+
+- **CLI product assembly.** The CLI stays exactly where it is: `lingtai.cli`
+  (`lingtai-agent run …`). The SDK is the *importable* surface; it does not
+  assemble or replace the CLI.
+- **A non-native backend.** Only `NativeRuntime` (wrapping `Agent`) exists. An
+  Anthropic — or any other non-native — backend that maps `RuntimeOptions` onto
+  a provider client is a later stage.
+- **Dispatch *through* a bundle host.** The registry and guard are **read-only
+  metadata**: they answer "which bundle owns this tool" and "how dangerous is
+  it," not "call the tool." No live agent dispatches through a bundle host yet;
+  real handler wiring and guard installation remain deferred, higher-risk slices.
+- **A package split / distribution rename.** `lingtai_sdk` ships *inside* the
+  existing `lingtai` wheel. Making it the headline published package is a later
+  step.
+- **Any change to existing `lingtai` / `lingtai_kernel` runtime behavior.** This
+  whole surface is additive; it changes no kernel turn-loop behavior.
+
+## Canonical import paths (after #368) and the legacy-shim policy
+
+The SDK package is organized into four subpackages — `runtime/`, `client/`,
+`guard/`, `bundles/` — with the curated names also re-exported from the package
+root. Prefer the **package root** for the common surface and the **subpackage**
+for contract types:
+
+```python
+# The common surface — import straight from the package root:
+from lingtai_sdk import (
+    BaseAgent, Agent,                       # agents (kernel eager, wrapper lazy)
+    query, LingTaiClient, LingTaiSession, open_session, QueryResult,
+    NativeRuntime, NativeRuntimeSession,    # default backend (lazy)
+    default_registry, all_bundle_manifests, BundleRegistry, DispatchTarget,
+)
+
+# Contract types live in their subpackage:
+from lingtai_sdk.runtime import (
+    Runtime, RuntimeSession, RuntimeOptions, RuntimeMessage, RuntimeEvent,
+    RuntimeState, EventKind,
+)
+from lingtai_sdk.bundles.contracts import BundleManifest, SecurityDanger
+from lingtai_sdk.guard import GuardPolicyMode, guard_check_from_manifests
+```
+
+**Legacy-shim policy.** Every pre-#368 flat module path still resolves — to the
+*same object*, never a fork or re-implementation:
+
+| Canonical (preferred) | Legacy shim (still works) |
+|-----------------------|---------------------------|
+| `lingtai_sdk.runtime` (package) | `import lingtai_sdk.runtime` (flat module) — same path, now a package |
+| `lingtai_sdk.client` (package) | `from lingtai_sdk.client import query` — same path, now a package |
+| `lingtai_sdk.guard.bridge` | `lingtai_sdk.guard_bridge` |
+| `lingtai_sdk.bundles.contracts` | `lingtai_sdk.capabilities` |
+| `lingtai_sdk.bundles.registry` | `lingtai_sdk.bundle_registry` |
+| `lingtai_sdk.bundles.native` | `lingtai_sdk.native` |
+| `lingtai_sdk.bundles.<x>_tools` | `lingtai_sdk.<x>_tools` |
+
+`runtime` and `client` are packages whose `__init__.py` *is* the compatibility
+surface (a directory and a same-named `.py` cannot coexist, so the package
+wins). Every other moved module keeps a real `.py` shim at its old top-level
+path that re-exports from the new location. The same-object guarantee is pinned
+by `tests/test_sdk_directory_shape.py`.
+
+There is a *second*, older compatibility map for names that moved out of the
+implementation packages into the SDK (`lingtai_kernel.BaseAgent` →
+`lingtai_sdk.BaseAgent`, `lingtai.Agent` → `lingtai_sdk.Agent`, …). It lives in
+`lingtai_sdk._compat.DEPRECATIONS` and is enforced by `tests/test_sdk_compat.py`.
+No name is removed within a major version; a legacy path graduates from "active
+alias" to "removed" only across a major bump.
+
+### Choosing canonical vs legacy
+
+- **New code** → import canonical paths (package root for the common surface,
+  subpackage for contract types). They are the stable, documented home.
+- **Existing code** → no rush. Legacy paths resolve to the same objects and are
+  not removed within a major version. Migrate opportunistically when you touch
+  the file; there is no behavioral difference, only a clearer import.
+- **Tooling / type-only environments** → import `lingtai_sdk`, `lingtai_sdk.runtime`,
+  `lingtai_sdk.bundles.*`, or `lingtai_sdk.guard` freely: they are import-pure
+  (kernel-only) and pull in no provider SDK. Touch `Agent` / the service classes
+  / start a `NativeRuntime` session only where the wrapper is actually available.
+
+## Quick examples
+
+Every snippet below is a real, **offline** example committed under
+[`examples/`](examples/) and syntax/import-checked by
+`tests/test_sdk_docs_examples.py`. Run any of them directly, e.g.
+`python docs/sdk/examples/01_query_offline.py`.
+
+### `query` — one message, one result
+
+`query` (and `LingTaiClient.query`) is runtime-agnostic: it drives any object
+implementing the `Runtime` contract. The default is `NativeRuntime`, which boots
+a real `Agent` and needs an LLM key — so to stay offline these examples inject a
+tiny echo runtime (see [`01_query_offline.py`](examples/01_query_offline.py) for
+the full `EchoRuntime`):
+
+```python
+from lingtai_sdk import LingTaiClient, query
+from lingtai_sdk.runtime import RuntimeOptions
+
+options = RuntimeOptions(working_dir="/tmp/lingtai-sdk-example")
+
+client = LingTaiClient(runtime=EchoRuntime())          # inject a fake backend
+result = client.query("hello", options=options)
+print(result.text)                                      # -> "echo: hello"
+print([e.kind.value for e in result.events])            # -> ['state', 'text', 'state']
+
+# Module-level one-shot, no client to hold:
+query("hi", options=options, runtime=EchoRuntime())
+```
+
+With no injected runtime (`LingTaiClient()` / `query(..., runtime=None)`), the
+default `NativeRuntime` is used and a real agent boots — that path needs a
+provider, model, and key.
+
+### `LingTaiClient` / session — keep it open
+
+`open_session` returns a `LingTaiSession` for multi-message use. It keeps its
+own **read cursor**, so each `events()`/`text()` returns only what arrived since
+the last read (see [`02_session_offline.py`](examples/02_session_offline.py)):
+
+```python
+client = LingTaiClient(runtime=EchoRuntime(), options=options)
+
+with client.open_session() as session:        # starts; closes on exit
+    session.send("first")
+    print(session.text())                       # -> "echo: first"  (incremental)
+    session.send("second")
+    print(session.text())                       # -> "echo: second"
+    session.raw_session.events()                # full cumulative snapshot
+```
+
+### `NativeRuntime` — the default backend
+
+`NativeRuntime` wraps the wrapper `Agent` unchanged. Constructing it and a
+session is import-pure: the wrapper and provider SDKs load lazily only at
+`start()`. [`03_native_runtime.py`](examples/03_native_runtime.py) configures a
+session and stops before `start()`, so no key is needed:
+
+```python
+from lingtai_sdk import NativeRuntime
+from lingtai_sdk.runtime import RuntimeOptions, RuntimeState
+
+runtime = NativeRuntime()
+options = RuntimeOptions(
+    working_dir="/tmp/lingtai-sdk-native",
+    agent_name="demo",
+    provider="anthropic",
+    model="claude-opus-4-8",
+    capabilities=["file", "web_search"],
+    # api_key=...  # only needed once you call start()
+)
+session = runtime.create_session(options)
+assert session.state is RuntimeState.PENDING    # no Agent built yet
+# session.start()  # <- imports the wrapper + provider SDK and boots a real agent
+```
+
+### `default_registry` — declared bundles, indexed
+
+`default_registry()` is a validated view over the full declared bundle set.
+`dispatch_target` resolves a tool to its owning bundle and declared posture
+(read-only metadata; see
+[`04_registry_and_guard.py`](examples/04_registry_and_guard.py)):
+
+```python
+from lingtai_sdk import default_registry
+
+registry = default_registry()
+registry.names()
+# -> ('system', 'psyche', 'soul', 'read', 'glob', 'grep', 'write', 'edit',
+#     'email', 'daemon', 'mcp', 'knowledge', 'skills', 'bash',
+#     'avatar_spawn', 'avatar_rules')
+
+target = registry.dispatch_target("bash")
+print(target.bundle_name, target.danger.value)   # -> "bash destructive"
+```
+
+### Guard / advisory metadata — declared posture → decision
+
+`lingtai_sdk.guard` turns declared bundle postures into a kernel `GuardCheck`.
+The policy is narrow and fail-open: `safe` → clean pass-through, `caution` →
+allow-but-warn, `destructive` → deny (BLOCKING) or warn (ADVISORY), unknown
+tool → allow:
+
+```python
+from lingtai_sdk import all_bundle_manifests
+from lingtai_sdk.guard import GuardPolicyMode, guard_check_from_manifests
+from lingtai_kernel.tool_call_guard import ToolProposal
+
+check = guard_check_from_manifests(all_bundle_manifests(), mode=GuardPolicyMode.BLOCKING)
+check(ToolProposal(tool_name="read", tool_args={}))   # -> None  (clean allow)
+check(ToolProposal(tool_name="edit", tool_args={}))   # -> allow + "warn" advisory
+check(ToolProposal(tool_name="bash", tool_args={}))   # -> deny  (BLOCKING)
+```
+
+The returned check is pure and stateless over a frozen snapshot of the
+manifests. Building it wires nothing into a live agent — installing it into a
+real `ToolExecutor` guard seam is a deferred slice.
+
+## Where to go next
+
+- [`architecture-foundation.md`](architecture-foundation.md) — the full staged
+  roadmap and the rationale behind every contract.
+- [`examples/`](examples/) — the runnable scripts quoted above.
+- `src/lingtai_sdk/ANATOMY.md` — the per-folder structural map of the package.

--- a/docs/sdk/examples/01_query_offline.py
+++ b/docs/sdk/examples/01_query_offline.py
@@ -1,0 +1,88 @@
+"""One-shot ``query`` against a fake, offline runtime.
+
+The public :func:`lingtai_sdk.query` / :class:`lingtai_sdk.LingTaiClient` facade
+is *runtime-agnostic*: it drives any object implementing the
+:class:`lingtai_sdk.runtime.Runtime` contract. The default runtime is the
+:class:`~lingtai_sdk.NativeRuntime`, which boots a real wrapper ``Agent`` and
+therefore needs an LLM provider + key. To keep this example **offline and
+deterministic**, we inject a tiny echo runtime instead — exactly how the SDK's
+own test-suite exercises the facade.
+
+Run it directly::
+
+    python docs/sdk/examples/01_query_offline.py
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lingtai_sdk import LingTaiClient, query
+from lingtai_sdk.runtime import (
+    Runtime,
+    RuntimeEvent,
+    RuntimeMessage,
+    RuntimeOptions,
+    RuntimeSession,
+    RuntimeState,
+)
+
+
+class EchoSession(RuntimeSession):
+    """A contract-conformant session that echoes whatever it is sent.
+
+    Note the ``events()`` contract: it is a *non-draining cumulative snapshot* —
+    every call returns **all** events so far, in order, and reading never clears
+    them. A backend that drained on read would silently break ``query()``.
+    """
+
+    def __init__(self, options: RuntimeOptions) -> None:
+        self._options = options
+        self._events: list[RuntimeEvent] = []
+
+    @property
+    def state(self) -> RuntimeState:
+        return RuntimeState.IDLE
+
+    @property
+    def working_dir(self) -> Path:
+        return Path(self._options.working_dir)
+
+    def start(self) -> None:
+        self._events.append(RuntimeEvent.state(RuntimeState.ACTIVE))
+
+    def send(self, message: RuntimeMessage | str) -> None:
+        content = message if isinstance(message, str) else message.content
+        self._events.append(RuntimeEvent.text(f"echo: {content}"))
+
+    def events(self) -> tuple[RuntimeEvent, ...]:
+        return tuple(self._events)
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._events.append(RuntimeEvent.state(RuntimeState.STOPPED))
+
+
+class EchoRuntime(Runtime):
+    """A factory for :class:`EchoSession`."""
+
+    id = "echo"
+
+    def create_session(self, options: RuntimeOptions) -> RuntimeSession:
+        return EchoSession(options)
+
+
+def main() -> None:
+    options = RuntimeOptions(working_dir="/tmp/lingtai-sdk-example")
+
+    # Object-oriented form: construct a client over an injected runtime.
+    client = LingTaiClient(runtime=EchoRuntime())
+    result = client.query("hello", options=options)
+    print("client.query text:", result.text)
+    print("client.query events:", [e.kind.value for e in result.events])
+
+    # Module-level one-shot form: identical result, no client to hold.
+    same = query("hello again", options=options, runtime=EchoRuntime())
+    print("query() text:", same.text)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sdk/examples/02_session_offline.py
+++ b/docs/sdk/examples/02_session_offline.py
@@ -1,0 +1,89 @@
+"""A live, multi-message session via :class:`lingtai_sdk.LingTaiSession`.
+
+``query()`` is one-shot: send a message, drain events, stop. When you want to
+keep a session open — send several messages, poll events incrementally, then
+close — use :meth:`LingTaiClient.open_session` (or the module-level
+:func:`lingtai_sdk.open_session`).
+
+The key ergonomic difference from the raw runtime contract: ``LingTaiSession``
+keeps its **own read cursor**, so each ``events()`` / ``text()`` call returns
+only what arrived *since the previous read* — an incremental view over the
+underlying non-draining snapshot. The raw cumulative snapshot is still reachable
+via ``raw_session``.
+
+This example defines its own offline echo runtime so it is fully self-contained.
+
+Run it directly::
+
+    python docs/sdk/examples/02_session_offline.py
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lingtai_sdk import LingTaiClient
+from lingtai_sdk.runtime import (
+    Runtime,
+    RuntimeEvent,
+    RuntimeMessage,
+    RuntimeOptions,
+    RuntimeSession,
+    RuntimeState,
+)
+
+
+class EchoSession(RuntimeSession):
+    """A contract-conformant, non-draining session that echoes its input."""
+
+    def __init__(self, options: RuntimeOptions) -> None:
+        self._options = options
+        self._events: list[RuntimeEvent] = []
+
+    @property
+    def state(self) -> RuntimeState:
+        return RuntimeState.IDLE
+
+    @property
+    def working_dir(self) -> Path:
+        return Path(self._options.working_dir)
+
+    def start(self) -> None:
+        self._events.append(RuntimeEvent.state(RuntimeState.ACTIVE))
+
+    def send(self, message: RuntimeMessage | str) -> None:
+        content = message if isinstance(message, str) else message.content
+        self._events.append(RuntimeEvent.text(f"echo: {content}"))
+
+    def events(self) -> tuple[RuntimeEvent, ...]:
+        return tuple(self._events)
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._events.append(RuntimeEvent.state(RuntimeState.STOPPED))
+
+
+class EchoRuntime(Runtime):
+    id = "echo"
+
+    def create_session(self, options: RuntimeOptions) -> RuntimeSession:
+        return EchoSession(options)
+
+
+def main() -> None:
+    options = RuntimeOptions(working_dir="/tmp/lingtai-sdk-session")
+    client = LingTaiClient(runtime=EchoRuntime(), options=options)
+
+    # `with` starts the session and closes it on exit.
+    with client.open_session() as session:
+        session.send("first")
+        # Incremental read: only events since the last read.
+        print("after first:", session.text())
+
+        session.send("second")
+        print("after second:", session.text())
+
+        # The full cumulative snapshot is always available on the raw session.
+        print("full snapshot:", [e.kind.value for e in session.raw_session.events()])
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sdk/examples/03_native_runtime.py
+++ b/docs/sdk/examples/03_native_runtime.py
@@ -1,0 +1,55 @@
+"""Configuring the :class:`lingtai_sdk.NativeRuntime` (no network, no boot).
+
+:class:`~lingtai_sdk.NativeRuntime` is the default backend: it wraps the
+batteries-included wrapper ``Agent`` unchanged, translating a backend-neutral
+:class:`~lingtai_sdk.runtime.RuntimeOptions` into ``Agent`` constructor kwargs.
+
+Constructing a ``NativeRuntime`` and a session is import-pure and free of
+provider SDKs — **the wrapper ``Agent`` and its heavy deps load lazily, only
+when a session is actually started**. So this example stops short of
+``session.start()``: it shows the configuration surface and the lazy boundary
+without needing an API key or making a network call.
+
+To actually run an agent you would set ``provider`` / ``model`` (and supply a
+key via ``api_key`` or the manifest), then call ``session.start()`` — at which
+point the wrapper and the chosen provider SDK are imported and a real agent
+boots. That path needs credentials and is therefore not exercised here.
+
+Run it directly::
+
+    python docs/sdk/examples/03_native_runtime.py
+"""
+from __future__ import annotations
+
+from lingtai_sdk import NativeRuntime
+from lingtai_sdk.runtime import RuntimeOptions, RuntimeState
+
+
+def main() -> None:
+    runtime = NativeRuntime()
+
+    # A fully-specified, backend-neutral options object. `capabilities` and
+    # `provider`/`model` mirror what `Agent` / init.json consume today.
+    options = RuntimeOptions(
+        working_dir="/tmp/lingtai-sdk-native",
+        agent_name="demo",
+        provider="anthropic",
+        model="claude-opus-4-8",
+        capabilities=["file", "web_search"],
+        # api_key=...  # omitted here — start() is not called, so none is needed
+    )
+
+    session = runtime.create_session(options)
+
+    # Before start(), the session is PENDING and no Agent has been built.
+    print("state before start:", session.state.value)
+    assert session.state is RuntimeState.PENDING
+    print("working_dir:", session.working_dir)
+
+    # NOTE: we intentionally do NOT call session.start() — that would import the
+    # wrapper and require real LLM credentials. See the module docstring.
+    print("Configured a NativeRuntime session without booting an agent.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sdk/examples/04_registry_and_guard.py
+++ b/docs/sdk/examples/04_registry_and_guard.py
@@ -1,0 +1,63 @@
+"""The declared-bundle registry and the guard/advisory bridge (read-only).
+
+Two import-pure, network-free surfaces:
+
+* :func:`lingtai_sdk.default_registry` — a validated, name- and tool-indexed
+  view over the *full declared* SDK bundle set. It answers "which bundle owns
+  this tool, and how dangerous did that bundle declare itself" via
+  :meth:`BundleRegistry.dispatch_target`. It declares no handler and calls no
+  tool — it is the read-only lookup a router or guard installer consults
+  *before* dispatch.
+
+* :mod:`lingtai_sdk.guard` — turns those declared
+  :class:`~lingtai_sdk.bundles.contracts.SecurityDanger` postures into a kernel
+  ``GuardCheck``. The policy is deliberately narrow and fail-open: ``safe`` →
+  clean pass-through, ``caution`` → allow-but-warn advisory, ``destructive`` →
+  deny (BLOCKING) or warn (ADVISORY), unknown tool → allow (fail open).
+
+Both are pure metadata operations — nothing is wired into a live agent here.
+
+Run it directly::
+
+    python docs/sdk/examples/04_registry_and_guard.py
+"""
+from __future__ import annotations
+
+from lingtai_sdk import all_bundle_manifests, default_registry
+from lingtai_sdk.guard import (
+    GuardPolicyMode,
+    guard_check_from_manifests,
+    tool_danger_index,
+)
+from lingtai_kernel.tool_call_guard import ToolProposal
+
+
+def main() -> None:
+    registry = default_registry()
+    print("declared bundles:", registry.names())
+
+    # Resolve a tool to its owning bundle + declared danger posture.
+    for tool in ("read", "bash", "soul"):
+        target = registry.dispatch_target(tool)
+        print(f"  {tool!r} -> bundle {target.bundle_name!r}, danger {target.danger.value}")
+
+    # The danger index is the flat {tool: danger} map the guard keys on.
+    index = tool_danger_index(all_bundle_manifests())
+    print("danger postures:", {k: v.value for k, v in index.items()})
+
+    # Build a blocking guard check and ask it about a few tools. The check maps a
+    # ToolProposal to a GuardDecision (or None for a clean pass-through).
+    check = guard_check_from_manifests(
+        all_bundle_manifests(), mode=GuardPolicyMode.BLOCKING
+    )
+    for tool in ("read", "edit", "bash", "totally_unknown_tool"):
+        decision = check(ToolProposal(tool_name=tool, tool_args={}))
+        if decision is None:
+            verdict = "allow (clean pass-through)"
+        else:
+            verdict = f"{decision.action} (severity={decision.severity})"
+        print(f"  guard({tool!r}) -> {verdict}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/sdk/examples/README.md
+++ b/docs/sdk/examples/README.md
@@ -1,0 +1,28 @@
+# LingTai SDK — runnable examples
+
+Small, **offline, secret-free** scripts that exercise the public
+`lingtai_sdk` surface. Each is self-contained and runnable directly:
+
+```bash
+python docs/sdk/examples/01_query_offline.py
+```
+
+| File | Shows | Network? |
+|------|-------|----------|
+| [`01_query_offline.py`](01_query_offline.py) | `query` / `LingTaiClient.query` one-shot against an injected fake runtime | no |
+| [`02_session_offline.py`](02_session_offline.py) | `LingTaiClient.open_session` / `LingTaiSession` multi-message + incremental `events()` cursor | no |
+| [`03_native_runtime.py`](03_native_runtime.py) | Configuring `NativeRuntime` + the lazy-wrapper boundary (stops before `start()`) | no |
+| [`04_registry_and_guard.py`](04_registry_and_guard.py) | `default_registry` dispatch-target lookup + the `guard` advisory/deny bridge | no |
+
+Why they inject a fake runtime: the default backend (`NativeRuntime`) boots a
+real wrapper `Agent` and needs an LLM provider + API key. To stay offline and
+deterministic — and to keep these examples runnable in CI without credentials —
+the `query`/session examples inject a tiny echo runtime that implements the
+`lingtai_sdk.runtime.Runtime` contract. This is exactly how the SDK's own test
+suite drives the facade. Example `03` shows the *real* `NativeRuntime` but stops
+short of `start()`, so no agent boots and no key is needed.
+
+These files are syntax- and import-checked by
+`tests/test_sdk_docs_examples.py`.
+
+See the [SDK guide](../README.md) for the narrative walk-through.

--- a/src/lingtai_sdk/ANATOMY.md
+++ b/src/lingtai_sdk/ANATOMY.md
@@ -4,6 +4,8 @@
 
 The **public SDK doorway** — a curated, import-light front door for building and embedding LingTai agents. It re-exports the two implementation packages (`lingtai_kernel`, `lingtai`) under one stable path and carries the *seed contracts* (runtime, capability-bundle manifest) that later PRs will implement. This is a foundation package: it ships shapes and a doorway, not a live runtime.
 
+> **Human-facing docs.** The developer guide for this package — what the SDK is / is not yet, canonical vs legacy import paths, and runnable quick examples — lives at [`docs/sdk/README.md`](../../docs/sdk/README.md), with runnable example scripts under [`docs/sdk/examples/`](../../docs/sdk/examples/) (validated by `tests/test_sdk_docs_examples.py`). The full staged engineering log is [`docs/sdk/architecture-foundation.md`](../../docs/sdk/architecture-foundation.md).
+
 > **What is an `ANATOMY.md`?** See the canonical convention at `src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md`. This file follows the same 6-section template as every other anatomy in the tree.
 
 ## Directory shape

--- a/tests/test_sdk_docs_examples.py
+++ b/tests/test_sdk_docs_examples.py
@@ -1,0 +1,112 @@
+"""Docs-examples validation: cheap, offline, no secrets.
+
+This guards the SDK developer docs (`docs/sdk/README.md`, its examples index, and
+the committed example scripts) against rot, without booting an agent or making a
+network call:
+
+1. every fenced ```python block in the SDK docs *parses* (``ast.parse``), so a
+   snippet can never silently become invalid Python;
+2. every committed `docs/sdk/examples/*.py` *parses and compiles*;
+3. each self-contained example module *imports and runs* its ``main()`` offline
+   (they inject a fake runtime or stop before booting an agent), so the public
+   `lingtai_sdk` surface they document stays real.
+
+Matches the SDK's existing import-purity test ethos: assert behavior through the
+public doorway, cheaply, with no provider SDK or key required.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DOCS_SDK = _REPO_ROOT / "docs" / "sdk"
+_EXAMPLES_DIR = _DOCS_SDK / "examples"
+
+# Fenced ```python (or ```py) blocks, capturing the body.
+_FENCE_RE = re.compile(r"```(?:python|py)\n(.*?)```", re.DOTALL)
+
+
+def _doc_markdown_files() -> list[Path]:
+    return [_DOCS_SDK / "README.md", _EXAMPLES_DIR / "README.md"]
+
+
+def _example_files() -> list[Path]:
+    return sorted(_EXAMPLES_DIR.glob("*.py"))
+
+
+def _python_snippets(md_path: Path) -> list[tuple[int, str]]:
+    """Return (1-based start line, source) for each fenced python block."""
+    text = md_path.read_text(encoding="utf-8")
+    snippets: list[tuple[int, str]] = []
+    for match in _FENCE_RE.finditer(text):
+        start_line = text.count("\n", 0, match.start()) + 1
+        snippets.append((start_line, match.group(1)))
+    return snippets
+
+
+def test_docs_sdk_layout_exists() -> None:
+    """The guide, the examples index, and at least one example are present."""
+    assert (_DOCS_SDK / "README.md").is_file()
+    assert (_EXAMPLES_DIR / "README.md").is_file()
+    assert _example_files(), "expected at least one docs/sdk/examples/*.py"
+
+
+def test_guide_has_python_snippets() -> None:
+    """The main guide carries the quick-example snippets it promises."""
+    assert _python_snippets(_DOCS_SDK / "README.md"), (
+        "expected python snippets in the SDK guide"
+    )
+
+
+@pytest.mark.parametrize("md_path", _doc_markdown_files(), ids=lambda p: p.name)
+def test_doc_python_snippets_parse(md_path: Path) -> None:
+    """Every fenced ```python block in the SDK docs is valid Python.
+
+    A doc with no python fences (e.g. the examples index, which only shows a
+    shell command) trivially passes.
+    """
+    for start_line, source in _python_snippets(md_path):
+        try:
+            ast.parse(source)
+        except SyntaxError as exc:  # pragma: no cover - failure path
+            pytest.fail(
+                f"{md_path}: python snippet starting at line {start_line} "
+                f"does not parse: {exc}"
+            )
+
+
+@pytest.mark.parametrize("py_path", _example_files(), ids=lambda p: p.name)
+def test_example_file_compiles(py_path: Path) -> None:
+    """Every committed example script parses and compiles."""
+    source = py_path.read_text(encoding="utf-8")
+    compile(source, str(py_path), "exec")
+
+
+def _load_example_module(py_path: Path):
+    spec = importlib.util.spec_from_file_location(
+        f"_sdk_doc_example_{py_path.stem}", py_path
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("py_path", _example_files(), ids=lambda p: p.name)
+def test_example_runs_offline(py_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """Each example imports and its ``main()`` runs offline (no key, no network).
+
+    The examples either inject a fake runtime or stop before booting an agent, so
+    importing and calling ``main()`` exercises the documented public surface
+    without provider SDKs or credentials.
+    """
+    module = _load_example_module(py_path)
+    assert hasattr(module, "main"), f"{py_path} has no main()"
+    module.main()
+    out = capsys.readouterr().out
+    assert out.strip(), f"{py_path} main() produced no output"


### PR DESCRIPTION
## Summary
- add `docs/sdk/README.md`, a developer-facing guide for the current SDK surface
- add offline runnable SDK examples for `query`, sessions, `NativeRuntime`, registry, and guard bridge concepts
- add `tests/test_sdk_docs_examples.py` to parse fenced Python snippets and run examples offline
- update `src/lingtai_sdk/ANATOMY.md` with a docs/examples pointer

## Validation
- `PYTHONPATH=src pytest -q tests/test_sdk_docs_examples.py tests/test_sdk_directory_shape.py tests/test_sdk_compat.py tests/test_sdk_import_purity.py` — 64 passed
- `PYTHONPATH=src ruff check docs/sdk/examples tests/test_sdk_docs_examples.py` — passed
- `git diff --check` — clean

## Notes
- Stacked on #368 (`sdk/public-sdk-directory-shape-20260618`).
- Docs/examples only; no behavior change.
- Examples stay offline/secret-free by using an injected echo runtime; `NativeRuntime` example stops before `start()`.
