### PR TITLE
Make lingtai root import-light

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -2,13 +2,16 @@
 
 PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset materialization, CLI, and public re-exports. The public SDK doorway `lingtai_sdk` may lazily import wrapper symbols such as `Agent`; the wrapper must not depend on the SDK.
 
+**Naming principle.** `lingtai` is the Python **import root** for the whole distribution. The repo / PyPI distribution may be named `lingtai-sdk`; the SDK is the entire package, not a `lingtai.sdk` subpackage. The root `__init__.py` is a thin **namespace / fuse** (a re-export surface), not a business layer — it owns no runtime logic. (Internal components are slated to reorganize as kernel/assets/addons/cli/backends in a later PR; that file-tree move is deliberately out of scope here.)
+
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues.
 
 ## Components
 
 | File | Role |
 |---|---|
-| `__init__.py` | Public API facade — re-exports `Agent`, `BaseAgent`, `Message`, services from kernel+wrapper |
+| `__init__.py` | Public API facade / import fuse — re-exports `Agent`, `BaseAgent`, `Message`, services from kernel+wrapper. **Import-light:** kernel-backed names (`BaseAgent`/`Message`/`AgentConfig`/`EmailManager`/mail+logging services) are eager (dependency-light); wrapper-backed names (`Agent`/`setup_capability`/managers/FileIO+vision+search services) resolve lazily via PEP 562 `__getattr__` and cache in module globals. A bare `import lingtai` loads neither `lingtai.agent`/capabilities/services nor any heavy provider SDK — see `tests/test_lingtai_import_purity.py` |
+| `_version.py` | Best-effort `__version__` via `importlib.metadata.version("lingtai")`; falls back to `0+unknown` in a bare source checkout rather than raising at import time (mirrors `../lingtai_sdk/_version.py`) |
 | `__main__.py` | `python -m lingtai` → `cli.main()` |
 | `agent.py` | **THE key file.** `Agent(BaseAgent)` — layer-2 agent with capability composition, preset swap, MCP, init.json refresh |
 | `cli.py` | Compatibility shim — re-exports the host surface (`load_init`/`build_agent`/`run`/`main`, plus the patchable `LLMService`/`Agent`/`FilesystemMailService` names) from `lingtai_cli.host`. The `lingtai-agent` console script still points here. CLI host behaviour moved to the `lingtai_cli` package |

--- a/src/lingtai/__init__.py
+++ b/src/lingtai/__init__.py
@@ -1,37 +1,120 @@
-"""lingtai — generic AI agent framework with intrinsic tools, composable capabilities, and pluggable services."""
+"""lingtai — generic AI agent framework with intrinsic tools, composable capabilities, and pluggable services.
 
-from importlib.metadata import version as _pkg_version
+Naming principle
+----------------
+``lingtai`` is the **Python import root** for the whole distribution. The repo /
+PyPI distribution may be named ``lingtai-sdk``; the SDK is the entire package,
+not a ``lingtai.sdk`` subpackage. This ``__init__`` is a thin namespace / fuse
+— a re-export surface, not a business layer. It owns no runtime logic; every
+exported name is resolved from the kernel or the wrapper submodules.
 
-__version__ = _pkg_version("lingtai")
+Import-light boundary
+---------------------
+A bare ``import lingtai`` stays cheap and side-effect-free: this ``__init__``
+imports only the dependency-light **kernel** eagerly. It does NOT pull in
+``lingtai.agent``, the capabilities layer, the FileIO / vision / search
+services, the LLM adapters, MCP, or any addon — and therefore no heavy provider
+SDK is loaded at import time.
 
+Wrapper-backed names (``Agent``, ``setup_capability``, the manager and service
+classes) resolve lazily via :pep:`562` ``__getattr__``. Touching one of them
+imports its wrapper submodule on first access only, then caches it in module
+globals so subsequent access skips ``__getattr__``. Kernel-backed names
+(``BaseAgent``, ``Message``, ``AgentConfig``, …) stay eager because the kernel
+has zero hard heavy dependencies. This mirrors the lazy boundary in
+``lingtai_sdk`` and ``lingtai_cli``.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._version import __version__
+
+# --- Kernel-backed surface (eager; dependency-light, no heavy provider SDKs) ---
 from lingtai_kernel.types import UnknownToolError
 from lingtai_kernel.config import AgentConfig
 from lingtai_kernel.base_agent import BaseAgent
-from .agent import Agent
 from lingtai_kernel.state import AgentState
 from lingtai_kernel.message import Message, MSG_REQUEST, MSG_USER_INPUT
-
-# Capabilities
-from .capabilities import setup_capability
-from .core.bash import BashManager
-from .core.avatar import AvatarManager
-# EmailManager is now exported by the kernel intrinsic; re-export for backwards compat.
+# EmailManager is exported by the kernel intrinsic; re-export for backwards compat.
 from lingtai_kernel.intrinsics.email import EmailManager
-
-# Services
-from .services.file_io import FileIOBackend, FileIOService, GrepMatch, LocalFileIOBackend, LocalFileIOService
-from .services.file_io_sidecar import (
-    BACKEND_ENV_VAR,
-    RustFileIOBackend,
-    SidecarAdapter,
-    SidecarError,
-    default_file_io_service,
-    resolve_sidecar_binary,
-)
 from lingtai_kernel.services.mail import MailService, FilesystemMailService
 from lingtai_kernel.services.logging import LoggingService, JSONLLoggingService
-from .services.vision import VisionService, create_vision_service
-from .services.websearch import SearchService, SearchResult, create_search_service
+
+# --- Wrapper-backed surface (lazy; resolved on first attribute access) ---------
+# Maps exported attribute name -> (wrapper submodule, attribute). Each is pulled
+# in only when accessed, so the wrapper's capabilities / services / adapters and
+# their heavy deps stay out of a bare ``import lingtai``.
+_LAZY_WRAPPER_EXPORTS: dict[str, tuple[str, str]] = {
+    "Agent": (".agent", "Agent"),
+    "setup_capability": (".capabilities", "setup_capability"),
+    "BashManager": (".core.bash", "BashManager"),
+    "AvatarManager": (".core.avatar", "AvatarManager"),
+    # services.file_io
+    "FileIOBackend": (".services.file_io", "FileIOBackend"),
+    "FileIOService": (".services.file_io", "FileIOService"),
+    "GrepMatch": (".services.file_io", "GrepMatch"),
+    "LocalFileIOBackend": (".services.file_io", "LocalFileIOBackend"),
+    "LocalFileIOService": (".services.file_io", "LocalFileIOService"),
+    # services.file_io_sidecar
+    "BACKEND_ENV_VAR": (".services.file_io_sidecar", "BACKEND_ENV_VAR"),
+    "RustFileIOBackend": (".services.file_io_sidecar", "RustFileIOBackend"),
+    "SidecarAdapter": (".services.file_io_sidecar", "SidecarAdapter"),
+    "SidecarError": (".services.file_io_sidecar", "SidecarError"),
+    "default_file_io_service": (".services.file_io_sidecar", "default_file_io_service"),
+    "resolve_sidecar_binary": (".services.file_io_sidecar", "resolve_sidecar_binary"),
+    # services.vision
+    "VisionService": (".services.vision", "VisionService"),
+    "create_vision_service": (".services.vision", "create_vision_service"),
+    # services.websearch
+    "SearchService": (".services.websearch", "SearchService"),
+    "SearchResult": (".services.websearch", "SearchResult"),
+    "create_search_service": (".services.websearch", "create_search_service"),
+}
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .agent import Agent  # noqa: F401
+    from .capabilities import setup_capability  # noqa: F401
+    from .core.bash import BashManager  # noqa: F401
+    from .core.avatar import AvatarManager  # noqa: F401
+    from .services.file_io import (  # noqa: F401
+        FileIOBackend,
+        FileIOService,
+        GrepMatch,
+        LocalFileIOBackend,
+        LocalFileIOService,
+    )
+    from .services.file_io_sidecar import (  # noqa: F401
+        BACKEND_ENV_VAR,
+        RustFileIOBackend,
+        SidecarAdapter,
+        SidecarError,
+        default_file_io_service,
+        resolve_sidecar_binary,
+    )
+    from .services.vision import VisionService, create_vision_service  # noqa: F401
+    from .services.websearch import (  # noqa: F401
+        SearchResult,
+        SearchService,
+        create_search_service,
+    )
+
+
+def __getattr__(name: str):  # PEP 562 module-level lazy attributes
+    import importlib
+
+    target = _LAZY_WRAPPER_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(target[0], __name__)
+    value = getattr(module, target[1])
+    globals()[name] = value  # cache: subsequent access skips __getattr__
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__))
+
 
 __all__ = [
     "__version__",

--- a/src/lingtai/_version.py
+++ b/src/lingtai/_version.py
@@ -1,0 +1,21 @@
+"""Best-effort version resolution for the ``lingtai`` import root.
+
+The whole distribution is published as the ``lingtai`` PyPI package, so the
+import root's version tracks that distribution's metadata. Resolving via
+``importlib.metadata`` keeps a bare ``import lingtai`` dependency-free; if the
+metadata is unavailable (e.g. running straight from a source checkout that was
+never installed) we fall back to a sentinel rather than raising at import time.
+"""
+from __future__ import annotations
+
+
+def _resolve_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("lingtai")
+    except Exception:  # noqa: BLE001 - never break import over version metadata
+        return "0+unknown"
+
+
+__version__ = _resolve_version()

--- a/tests/test_lingtai_import_purity.py
+++ b/tests/test_lingtai_import_purity.py
@@ -1,0 +1,148 @@
+"""The ``lingtai`` import root must stay import-light: a bare ``import lingtai``
+pulls only the dependency-light kernel, never the wrapper's agent / capabilities
+/ services layer nor any heavy provider SDK. Wrapper-backed names resolve lazily
+via :pep:`562` and must resolve to the SAME object the wrapper submodule exports.
+
+Each check runs in a fresh subprocess so module-import state is pristine and the
+lazy ``__getattr__`` caching does not leak between assertions.
+
+Note on the provider list: importing the kernel loads the *bare* ``google``
+namespace package (an ambient site-packages artifact pulled in transitively by
+``filelock``; ``google.__file__ is None``). That stub is harmless and is NOT a
+provider SDK, so we target the heavy provider *submodules*
+(``google.genai`` / ``google.generativeai``) rather than bare ``google``.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src"
+
+# Heavy provider SDKs that must NOT be loaded by a bare ``import lingtai``.
+# Bare ``google`` is intentionally excluded (ambient namespace stub); only the
+# real Google AI SDK submodules count.
+_HEAVY_PROVIDERS = (
+    "anthropic",
+    "openai",
+    "google.genai",
+    "google.generativeai",
+    "mcp",
+    "trafilatura",
+    "ddgs",
+)
+
+# Wrapper submodules that carry the agent / capabilities / services layer. A
+# bare ``import lingtai`` must not eagerly load any of these.
+_WRAPPER_SUBMODULES = (
+    "lingtai.agent",
+    "lingtai.capabilities",
+    "lingtai.core",
+    "lingtai.llm",
+    "lingtai.services",
+)
+
+
+def _run(code: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "PYTHONPATH": str(SRC)}
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+
+
+_PROVIDERS_LITERAL = repr(_HEAVY_PROVIDERS)
+_WRAPPER_LITERAL = repr(_WRAPPER_SUBMODULES)
+
+
+def test_import_lingtai_does_not_load_wrapper_or_providers():
+    code = (
+        "import sys, lingtai\n"
+        f"providers = {_PROVIDERS_LITERAL}\n"
+        f"wrapper = {_WRAPPER_LITERAL}\n"
+        "bad = [m for m in sys.modules "
+        "if any(m == w or m.startswith(w + '.') for w in wrapper)]\n"
+        "bad += [m for m in sys.modules "
+        "if any(m == p or m.startswith(p + '.') for p in providers)]\n"
+        "assert not bad, bad\n"
+        "assert hasattr(lingtai, 'BaseAgent')\n"
+        "assert lingtai.__version__\n"
+        "print('OK')\n"
+    )
+    r = _run(code)
+    assert r.returncode == 0, r.stderr
+    assert "OK" in r.stdout
+
+
+def test_touching_kernel_names_stays_clean():
+    code = (
+        "import sys, lingtai\n"
+        "_ = (lingtai.BaseAgent, lingtai.AgentState, lingtai.AgentConfig,\n"
+        "     lingtai.Message, lingtai.MSG_REQUEST, lingtai.UnknownToolError,\n"
+        "     lingtai.EmailManager, lingtai.MailService, lingtai.FilesystemMailService,\n"
+        "     lingtai.LoggingService, lingtai.JSONLLoggingService)\n"
+        f"wrapper = {_WRAPPER_LITERAL}\n"
+        "bad = [m for m in sys.modules "
+        "if any(m == w or m.startswith(w + '.') for w in wrapper)]\n"
+        "assert not bad, bad\n"
+        "print('OK')\n"
+    )
+    r = _run(code)
+    assert r.returncode == 0, r.stderr
+    assert "OK" in r.stdout
+
+
+def test_lazy_names_resolve_to_wrapper_objects():
+    # Each lazy name must be the SAME object its wrapper submodule exports, so
+    # ``from lingtai import Agent`` and ``from lingtai.agent import Agent`` agree.
+    code = (
+        "import lingtai\n"
+        "import lingtai.agent, lingtai.capabilities, lingtai.core.bash\n"
+        "import lingtai.services.vision, lingtai.services.websearch, lingtai.services.file_io\n"
+        "assert lingtai.Agent is lingtai.agent.Agent\n"
+        "assert lingtai.setup_capability is lingtai.capabilities.setup_capability\n"
+        "assert lingtai.BashManager is lingtai.core.bash.BashManager\n"
+        "assert lingtai.VisionService is lingtai.services.vision.VisionService\n"
+        "assert lingtai.SearchService is lingtai.services.websearch.SearchService\n"
+        "assert lingtai.FileIOService is lingtai.services.file_io.FileIOService\n"
+        "print('OK')\n"
+    )
+    r = _run(code)
+    assert r.returncode == 0, r.stderr
+    assert "OK" in r.stdout
+
+
+def test_lazy_access_caches_in_module_globals():
+    # After first access the name is cached in module globals, so subsequent
+    # access returns the same object without re-entering ``__getattr__``.
+    code = (
+        "import lingtai\n"
+        "first = lingtai.Agent\n"
+        "assert 'Agent' in vars(lingtai), 'lazy name not cached in globals'\n"
+        "assert lingtai.Agent is first\n"
+        "print('OK')\n"
+    )
+    r = _run(code)
+    assert r.returncode == 0, r.stderr
+    assert "OK" in r.stdout
+
+
+def test_unknown_attribute_raises_attribute_error():
+    code = (
+        "import lingtai\n"
+        "try:\n"
+        "    lingtai.NoSuchName\n"
+        "except AttributeError:\n"
+        "    print('OK')\n"
+        "else:\n"
+        "    raise SystemExit('expected AttributeError')\n"
+    )
+    r = _run(code)
+    assert r.returncode == 0, r.stderr
+    assert "OK" in r.stdout


### PR DESCRIPTION
## Summary
- make the `lingtai` import root import-light/lazy without moving packages
- preserve the existing `from lingtai import ...` re-export surface via PEP 562 `__getattr__`
- add `src/lingtai/_version.py` so bare source checkouts do not fail on version metadata
- document the naming principle in `src/lingtai/ANATOMY.md`: repo/dist may be `lingtai-sdk`, Python import root remains `lingtai`, and SDK is the whole package rather than a `lingtai.sdk` subpackage
- add subprocess-isolated import-purity tests for the `lingtai` root

## Validation
- `ruff check src/lingtai/__init__.py src/lingtai/_version.py tests/test_lingtai_import_purity.py`
- `PYTHONPATH=src python -m pytest tests/test_lingtai_import_purity.py tests/test_sdk_import_purity.py -q` → 9 passed
- `PYTHONPATH=src python -c "import lingtai.cli; print('cli shim ok', hasattr(lingtai.cli, 'main'))"`
- `PYTHONPATH=src python -c "from lingtai import Agent, BaseAgent, Message, MailService, setup_capability, FileIOService; print('compat ok')"`
- `PYTHONPATH=src python -m lingtai --help`
- bare-import smoke: heavy providers `[]`, eager `lingtai.*` submodules only `['lingtai._version']`
- Claude Code full suite: `python -m pytest tests/ -q -x` → 2989 passed, 7 skipped
- `git diff --check`

## Notes
- No package moves in this PR: no `lingtai_kernel -> lingtai.kernel`, no `lingtai_sdk` deletion, no addon/assets/CLI relocation.
- Entrypoints stay intact: `python -m lingtai`, `lingtai-agent`, and `lingtai-cli`.
- Local HTML explainer: `reports/pr0-root-import-purity-20260618/root-import-purity-explainer.html` (ignored local report, not committed).
