### PR TITLE
Update root docs for LingTai SDK naming

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-lingtai-kernel
+lingtai-sdk
 Copyright 2026 LingTai-AI contributors
 
 This product includes software developed by LingTai-AI.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 > — Zhuangzi · Gengsang Chu (庄子 · 庚桑楚)
 
 [![PyPI](https://img.shields.io/pypi/v/lingtai?color=%237dab8f)](https://pypi.org/project/lingtai/)
-[![License](https://img.shields.io/github/license/Lingtai-AI/lingtai-kernel?color=%237dab8f)](LICENSE)
+[![License](https://img.shields.io/github/license/Lingtai-AI/lingtai-sdk?color=%237dab8f)](LICENSE)
 [![Blog](https://img.shields.io/badge/blog-lingtai.ai-%23d4a853)](https://lingtai.ai)
 
 [lingtai.ai](https://lingtai.ai)
@@ -140,6 +140,6 @@ Apache-2.0 — [Zesen Huang](https://github.com/huangzesen), 2025–2026
 
 <div align="center">
 
-[lingtai.ai](https://lingtai.ai) · [GitHub](https://github.com/Lingtai-AI/lingtai-kernel) · [TUI](https://github.com/Lingtai-AI/lingtai)
+[lingtai.ai](https://lingtai.ai) · [GitHub](https://github.com/Lingtai-AI/lingtai-sdk) · [TUI](https://github.com/Lingtai-AI/lingtai)
 
 </div>

--- a/README.wen.md
+++ b/README.wen.md
@@ -1,85 +1,67 @@
-# 灵台内核
+# 灵台 Python 运行时与 SDK
 
 > [English](README.md) | [中文](README.zh.md) | [文言](README.wen.md)
 
-> *灵台者有持，而不知其所持，而不可持者也。*
-> — 庄子·庚桑楚
-
-器灵之最小内核 — 思、通、简、承器。
-
-## 道
-
-**灵台，心也。** 庄子言灵台，谓其自然持守灵魂所需之一切，不自知其所持，亦不可强持之。
-
-此框架中，器灵之灵台即其**工作目录**——磁盘之上一隅，简牍、盟约、名号、书信皆寄于此。目录即器灵。予内核以一目录、一语言服务，器灵即生；去其目录，器灵即灭。内核承载器灵之一切而不解其意——有持而不知其所持。
-
-内核循 Unix 之道：
-
-- **万物皆文卷。** 器灵之身份即其目录路径。无抽象之号——路径即地址、即锁、即真。
-- **内核定规矩，不定实现。** `LLMService` 与 `ChatSession` 皆抽象之约。何以实现——适配之器、密钥、流量之限——皆调用者之事。
-- **一灵一进程。** 独立之目录、独立之语言服务、独立之书信、独立之日志。器灵之间以文件系统传书通信，非共享内存。
-- **内核至简。** 思（LLM）、通（传书）、简（手简）、承器。能力、文卷读写、编排——皆在 [lingtai](https://github.com/user/lingtai) 中。
+灵台者，器灵所居之方寸也。此仓承其 Python 运行之身：内核、能力、命令、诸 addon 与原生辅器，皆归一发行包 `lingtai`。
 
 ## 安装
 
 ```bash
-pip install lingtai-kernel
+pip install lingtai
 ```
 
-## 内核所含
+## 命令
 
-| 器 | 用 |
-|------|------|
-| **BaseAgent** | 内核之主——生灭、消息循环、器之派发 |
-| **四固有之器** | 传书（通信）、观己（生灭）、核心自治（简/名号）、灵魂（内心之声） |
-| **LLM 之约** | `LLMService` 抽象之约、`ChatSession` 抽象之约 |
-| **服务** | 文件系统传书、JSONL 日志 |
-| **工作目录** | 目录管理——锁、git、清单 |
+`lingtai-agent` 者，启一器灵于其工作目录也：
 
-## 内核不含
-
-能力、文卷读写、MCP、观象、游历、bash、化身、LLM 适配之器、流量之限——皆在 `lingtai` 中。
-
-## 速启
-
-```python
-from lingtai.kernel import BaseAgent
-
-# 调用者供语言服务（抽象之约的任何实现）
-agent = BaseAgent(
-    service=my_llm_service,
-    working_dir="/agents/alice",    # 灵台——灵魂所居
-    agent_name="alice",             # 真名（可不设）
-)
-
-agent.add_tool("hello", schema={...}, handler=lambda args: {"msg": "hi"})
-agent.start()
-agent.send("Say hello")
-agent.stop()
+```bash
+lingtai-agent run /path/to/agent/
+lingtai-agent check-caps
 ```
 
-内核受一目录路径与一服务，不问其从何而来。
+若欲图形设定、巡看、起灭诸灵，当用 TUI：
+
+```bash
+brew install lingtai-ai/lingtai/lingtai-tui
+```
+
+## 包之分职
+
+| 名 | 职 |
+|---|---|
+| `lingtai.kernel` | 至简内核：`BaseAgent`、固有诸器、LLM 之约、传书与日志。 |
+| `lingtai` | 具足运行时：Agent、能力、适配器、MCP 与 addon。 |
+| `lingtai_cli` | Python 命令宿主，组装运行时而启之。 |
+| `lingtai.mcp_servers` | 内置诸 addon：IMAP、Telegram、飞书、微信、WhatsApp、cloud mail 等。 |
+
+其 Python 引入之根仍曰 `lingtai`；仓与发行之名从今称 `lingtai-sdk`，非令用者改作 `import lingtai_sdk`。
 
 ## 灵台之制
 
-```
-/agents/alice/              ← 此路径即器灵
-  .agent.lock               ← 独占之锁
-  .agent.heartbeat          ← 存活之证
-  .agent.json               ← 清单
+```text
+/agents/wukong/
+  .agent.lock               # 独占之锁
+  .agent.heartbeat          # 存活之证
+  .agent.json               # 清单
   system/
-    covenant.md             ← 盟约
-    pad.md                  ← 简
+    covenant.md             # 盟约
+    pad.md                  # 手简
   mailbox/
-    inbox/                  ← 所收之书信
-    outbox/                 ← 待发之书信
-    sent/                   ← 已发之记录
+    inbox/                  # 所受之书
+    outbox/                 # 待发之书
+    sent/                   # 已发之录
   logs/
-    events.jsonl            ← 事件日志
+    events.jsonl            # 事记
 ```
 
-无需 `agent_id`。路径即身份。心跳证存活。锁证独占。
+路径即名，目录即身；诸灵以信匣传书，不假共享内存。
+
+## 相关
+
+- Python runtime / SDK: <https://github.com/Lingtai-AI/lingtai-sdk>
+- TUI / portal: <https://github.com/Lingtai-AI/lingtai>
+- 灵台文: <https://lingtai.ai>
 
 ## 许可
 
-MIT
+Apache-2.0。Zesen Huang 与 LingTai-AI 诸贡献者共持。

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,85 +1,73 @@
-# lingtai-kernel 灵台内核
+# 灵台 LingTai Python 运行时 / SDK
 
 > [English](README.md) | [中文](README.zh.md) | [文言](README.wen.md)
 
-> *灵台者有持，而不知其所持，而不可持者也。*
-> — 庄子·庚桑楚
-
-最小智能体内核 — 思考、通信、手记、承载工具。
-
-## 设计哲学
-
-**灵台，心也。** 在庄子笔下，灵台是意识栖居之所：自然地承载灵魂所需的一切，却不自知其所承载，也无法被刻意掌控。
-
-在本框架中，智能体的灵台就是它的**工作目录**——磁盘上的一个文件夹，手记、盟约、身份、信箱都在其中。目录即智能体。给内核一个文件夹和一个 LLM 服务，它便赋予智能体生命。拿走文件夹，智能体便不复存在。内核承载智能体的一切，但不解读其内容——正如庄子的灵台，有持而不知其所持。
-
-本内核遵循 Unix 设计哲学：
-
-- **一切皆文件。** 智能体的身份就是其目录路径。没有抽象 ID——路径即地址、即锁、即真实。
-- **内核只定义协议，不定义实现。** `LLMService` 和 `ChatSession` 是抽象接口。如何实现——适配器、API 密钥、速率限制——是调用者的事。
-- **每个智能体都是独立进程。** 独立的目录、独立的 LLM 服务、独立的信箱、独立的日志。智能体之间通过文件系统信件通信，而非共享内存。
-- **内核是最小的。** 思考（LLM）、通信（信件）、手记（手记）、承载工具。能力、文件读写、编排——这些在 [lingtai](https://github.com/user/lingtai) 中。
+LingTai 的 Python 运行时与 SDK：提供 agent runtime、`lingtai.kernel` 最小内核、能力系统、CLI host、MCP addons、以及可选 native helper。完整交互式体验请使用 [TUI](https://github.com/Lingtai-AI/lingtai)。
 
 ## 安装
 
 ```bash
-pip install lingtai-kernel
+pip install lingtai
 ```
 
-## 内核所含
+## CLI
 
-| 组件 | 用途 |
-|------|------|
-| **BaseAgent** | 内核调度器——生命周期、消息循环、工具派发 |
-| **四种内置工具** | mail（进程间通信）、system（生命周期）、eigen（手记/身份）、soul（内心声音） |
-| **LLM 协议** | `LLMService` 抽象基类、`ChatSession` 抽象基类、供应商无关类型 |
-| **服务** | 文件系统信件传输、JSONL 结构化日志 |
-| **WorkingDir** | 目录管理——锁、git、清单 |
+`lingtai-agent` 用来从工作目录启动和运行 agent：
 
-## 内核不含
-
-能力、文件读写、MCP、视觉、搜索、bash、化身、LLM 适配器、速率限制——这些在 `lingtai` 中。
-
-## 快速开始
-
-```python
-from lingtai.kernel import BaseAgent
-
-# 调用者提供 LLM 服务（抽象基类的任意实现）
-agent = BaseAgent(
-    service=my_llm_service,
-    working_dir="/agents/alice",    # 灵台——灵魂栖居之所
-    agent_name="alice",             # 可选的显示名称
-)
-
-agent.add_tool("hello", schema={...}, handler=lambda args: {"msg": "hi"})
-agent.start()
-agent.send("Say hello")
-agent.stop()
+```bash
+lingtai-agent run /path/to/agent/
+lingtai-agent check-caps
 ```
 
-内核接收一个目录路径和一个服务，不关心它们如何创建。
+日常创建、配置、监控 agent，推荐使用 TUI：
 
-## 灵台之结构
-
+```bash
+brew install lingtai-ai/lingtai/lingtai-tui
 ```
-/agents/alice/              ← 此路径即智能体
-  .agent.lock               ← 独占锁（每个目录只能运行一个进程）
-  .agent.heartbeat          ← 存活证明（定期更新）
-  .agent.json               ← 清单（名称、地址、配置）
+
+## 包结构
+
+本仓库发行一个 Python distribution（`lingtai`），其中包含若干职责分明的包：
+
+| 包 / 模块 | 作用 |
+|---|---|
+| `lingtai.kernel` | 最小 runtime：`BaseAgent`、内置工具协议、LLM protocol、mail、logging。 |
+| `lingtai` | batteries-included 运行时：Agent、能力系统、LLM adapters、MCP/addon 集成；同时保留顶层便捷导出。 |
+| `lingtai_cli` | Python CLI host / product assembly 层；`lingtai-agent` 与 `lingtai-cli` 的入口。 |
+| `lingtai.mcp_servers` | vendored curated addons：IMAP、Telegram、Feishu、WeChat、WhatsApp、cloud mail 等。 |
+
+Python import root 仍是 `lingtai`；仓库/发布方向是 `lingtai-sdk`，但不会改成 `import lingtai_sdk`。
+
+## 能力
+
+LingTai runtime 可组合视觉、网页搜索、文件读写、bash、知识、技能、内心/身份、avatar、daemon、MCP/addons 等能力。具体能力由 agent manifest、runtime options 与工具 guard 共同决定。
+
+## Agent = 目录
+
+```text
+/agents/wukong/
+  .agent.lock               # 独占锁
+  .agent.heartbeat          # 存活证明
+  .agent.json               # manifest
   system/
-    covenant.md             ← 受保护的指令（盟约）
-    pad.md                  ← 工作笔记（手记）
+    covenant.md             # 受保护指令
+    pad.md                  # 工作手记
   mailbox/
-    inbox/                  ← 收到的信件
-    outbox/                 ← 待发送
-    sent/                   ← 发送记录
+    inbox/                  # 收信
+    outbox/                 # 待发
+    sent/                   # 已发记录
   logs/
-    events.jsonl            ← 结构化事件日志
+    events.jsonl            # 结构化事件日志
 ```
 
-无需 `agent_id`。路径即身份。心跳证明存活。锁证明独占。
+路径即身份；agent 之间通过 mailbox 文件系统通信。
+
+## 相关项目
+
+- Python runtime / SDK: <https://github.com/Lingtai-AI/lingtai-sdk>
+- TUI / portal: <https://github.com/Lingtai-AI/lingtai>
+- Website / manifesto: <https://lingtai.ai>
 
 ## 许可
 
-MIT
+Apache-2.0 — Zesen Huang 与 LingTai-AI contributors。


### PR DESCRIPTION
## Summary
- update root README links and NOTICE from the old `lingtai-kernel` repo/name to `lingtai-sdk`
- replace the stale Chinese and Wenyan root READMEs with shorter SDK/runtime-oriented versions that match the current package shape
- keep the Python import root as `lingtai` and install command as `pip install lingtai`

## Validation
- `git diff --check`
- grep confirmed no remaining `lingtai-kernel` / `Lingtai-AI/lingtai-kernel` references in `README.md`, `README.zh.md`, `README.wen.md`, or `NOTICE`

## Notes
This is docs/metadata only. It does not touch package code, release metadata, tags, or publishing.
