### PR TITLE
Update repo guidance naming references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ For any non-trivial change (anything beyond a single-line typo fix), create a gi
 The convention here is `.worktrees/<slug>/` on a fresh branch off `origin/main`. Examples already on disk include `.worktrees/imap-hardening`, `.worktrees/issue73-preset-confirmation`, `.worktrees/release-0.9.7`. Use the same pattern:
 
 ```bash
-cd ~/Documents/GitHub/lingtai-kernel
+cd ~/Documents/GitHub/lingtai-sdk
 git fetch origin main
 git worktree add -b <branch-slug> .worktrees/<slug> origin/main
 cd .worktrees/<slug>
@@ -27,7 +27,7 @@ git worktree remove .worktrees/<slug>
 git branch -d <branch-slug>     # or -D if abandoned
 ```
 
-**Hard rule:** if you find yourself about to make more than ~10 lines of edits in the main checkout (the one at `~/Documents/GitHub/lingtai-kernel/`), stop and move the work to a worktree first. The 30 seconds spent setting one up are recouped many times over the first time a parallel session resets the branch out from under you.
+**Hard rule:** if you find yourself about to make more than ~10 lines of edits in the main checkout (the one at `~/Documents/GitHub/lingtai-sdk/`), stop and move the work to a worktree first. The 30 seconds spent setting one up are recouped many times over the first time a parallel session resets the branch out from under you.
 
 Single-line fixes, doc tweaks, or commits that are already staged from prior work can stay in the main checkout — the rule is about multi-step editing sessions.
 

--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -59,7 +59,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 ## Composition
 
-Parent: `src/lingtai/` under `lingtai-kernel/src/`. Children include `kernel/` (the minimal agent runtime, relocated here from the former top-level `lingtai_kernel`), `core/` (the always-on capability floor plus the capability registry, `vision`, and `web_search`), `llm/`, `services/`, `auth/`, `i18n/`. See `../ANATOMY.md`.
+Parent: `src/lingtai/` under `lingtai-sdk/src/`. Children include `kernel/` (the minimal agent runtime, relocated here from the former top-level `lingtai_kernel`), `core/` (the always-on capability floor plus the capability registry, `vision`, and `web_search`), `llm/`, `services/`, `auth/`, `i18n/`. See `../ANATOMY.md`.
 
 ## State
 


### PR DESCRIPTION
## Summary
- update `CLAUDE.md` worktree examples from the old `lingtai-kernel` checkout path to `lingtai-sdk`
- update `src/lingtai/ANATOMY.md` parent wording from `lingtai-kernel/src/` to `lingtai-sdk/src/`

## Validation
- `git diff --check`
- grep confirmed no stale `Documents/GitHub/lingtai-kernel`, `lingtai-kernel/src`, or `Lingtai-AI/lingtai-kernel` repo-path references remain in the touched files

## Notes
The `lingtai-kernel-anatomy` skill name is intentionally unchanged; that is a skill/capability name, not a stale repo path.
