### PR TITLE
Isolate pad from stable prompt cache batches

### DIFF
--- a/src/lingtai/kernel/prompt.py
+++ b/src/lingtai/kernel/prompt.py
@@ -244,7 +244,8 @@ class SystemPromptManager:
     # "unordered" bucket rendered just before the tail batch.
     _BATCHES: tuple[tuple[str, ...], ...] = (
         ("principle", "covenant", "tools", "substrate", "procedures", "comment"),
-        ("rules", "brief", "skills", "knowledge", "identity", "character", "pad"),
+        ("rules", "brief", "skills", "knowledge", "identity", "character"),
+        ("pad",),
     )
 
     def render(self) -> str:

--- a/src/lingtai/llm/anthropic/adapter.py
+++ b/src/lingtai/llm/anthropic/adapter.py
@@ -101,32 +101,35 @@ def _build_system_batches_with_cache(
 
     ``batches`` is the ordered output of build_system_prompt_batches:
     typically [immovable, rarely-mutated, per-idle]. Empty batches are
-    dropped. A ``cache_control`` marker is placed on each batch boundary
-    *except the last* — the last batch is volatile (e.g. grows every
-    idle) and caching it would churn. This places up to
-    ``max_breakpoints - 1`` in-system breakpoints; combined with the
-    1 breakpoint on tools, that totals ``max_breakpoints`` and stays
-    under Anthropic's 4-slot-per-request cap.
+    skipped when emitting Anthropic content blocks, but their original
+    indexes still matter: the configured final batch is the volatile tail
+    whether or not it is currently empty. A ``cache_control`` marker is
+    placed on each non-empty batch boundary *before* that final tail; the
+    tail itself is left unmarked because caching it would churn. This places
+    up to ``max_breakpoints - 1`` in-system breakpoints; combined with the
+    1 breakpoint on tools, that totals ``max_breakpoints`` and stays under
+    Anthropic's 4-slot-per-request cap.
 
     When only a single non-empty batch exists, falls back to the
     single-block form (one breakpoint at the end).
     """
-    non_empty = [b for b in batches if b]
-    if not non_empty:
+    indexed_non_empty = [(i, b) for i, b in enumerate(batches) if b]
+    if not indexed_non_empty:
         return []
-    if len(non_empty) == 1:
-        return _build_system_with_cache(non_empty[0])
+    if len(indexed_non_empty) == 1:
+        return _build_system_with_cache(indexed_non_empty[0][1])
 
     # Cap the number of cache markers we emit inside the system list.
-    # The final batch gets no marker (too volatile to cache effectively).
-    # Earlier batches get markers up to the cap.
+    # The configured final batch gets no marker (too volatile to cache
+    # effectively), even when it is empty and therefore emits no block. Earlier
+    # batches get markers up to the cap.
     max_markers = max(0, max_breakpoints - 1)
+    final_batch_idx = len(batches) - 1
     blocks: list[dict] = []
     num_marked = 0
-    last_idx = len(non_empty) - 1
-    for i, text in enumerate(non_empty):
+    for batch_idx, text in indexed_non_empty:
         block: dict = {"type": "text", "text": text}
-        if i < last_idx and num_marked < max_markers:
+        if batch_idx < final_batch_idx and num_marked < max_markers:
             block["cache_control"] = {"type": "ephemeral"}
             num_marked += 1
         blocks.append(block)

--- a/tests/test_anthropic_prompt_batches.py
+++ b/tests/test_anthropic_prompt_batches.py
@@ -1,0 +1,32 @@
+"""Tests for Anthropic per-batch cache breakpoints."""
+
+from lingtai.llm.anthropic.adapter import _build_system_batches_with_cache
+
+
+def test_anthropic_marks_stable_batches_when_tail_batch_is_empty():
+    blocks = _build_system_batches_with_cache(["stable-0", "stable-1", ""])
+
+    assert [b["text"] for b in blocks] == ["stable-0", "stable-1"]
+    assert blocks[0]["cache_control"] == {"type": "ephemeral"}
+    assert blocks[1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_anthropic_leaves_non_empty_tail_uncached():
+    blocks = _build_system_batches_with_cache(["stable-0", "stable-1", "volatile-pad"])
+
+    assert [b["text"] for b in blocks] == ["stable-0", "stable-1", "volatile-pad"]
+    assert blocks[0]["cache_control"] == {"type": "ephemeral"}
+    assert blocks[1]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in blocks[2]
+
+
+def test_anthropic_single_non_empty_batch_keeps_legacy_cache_marker():
+    blocks = _build_system_batches_with_cache(["stable-only", "", ""])
+
+    assert blocks == [
+        {
+            "type": "text",
+            "text": "stable-only",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]

--- a/tests/test_anthropic_prompt_batches.py
+++ b/tests/test_anthropic_prompt_batches.py
@@ -1,5 +1,6 @@
 """Tests for Anthropic per-batch cache breakpoints."""
 
+from lingtai.kernel.prompt import SystemPromptManager, build_system_prompt_batches
 from lingtai.llm.anthropic.adapter import _build_system_batches_with_cache
 
 
@@ -18,6 +19,56 @@ def test_anthropic_leaves_non_empty_tail_uncached():
     assert blocks[0]["cache_control"] == {"type": "ephemeral"}
     assert blocks[1]["cache_control"] == {"type": "ephemeral"}
     assert "cache_control" not in blocks[2]
+
+
+def _prompt_manager_with_stable_sections(*, pad: str | None) -> SystemPromptManager:
+    mgr = SystemPromptManager()
+    mgr.write_section("principle", "Core principle.", protected=True)
+    mgr.write_section("tools", "### bash\nRun commands.", protected=True)
+    mgr.write_section("rules", "No deleting files.", protected=True)
+    mgr.write_section("skills", "- name: bash-manual", protected=True)
+    mgr.write_section("identity", "You are test-agent.", protected=True)
+    mgr.write_section("character", "Meticulous archivist.", protected=True)
+    if pad is not None:
+        mgr.write_section("pad", pad)
+    return mgr
+
+
+def test_anthropic_real_prompt_batches_cache_stable_prefix_when_pad_non_empty():
+    batches = build_system_prompt_batches(
+        _prompt_manager_with_stable_sections(pad="Volatile working notes."),
+        language="en",
+    )
+
+    assert len(batches) == 3
+    assert "Core principle." in batches[0]
+    assert "No deleting files." in batches[1]
+    assert "Volatile working notes." in batches[2]
+
+    blocks = _build_system_batches_with_cache(batches)
+    assert [b["cache_control"] for b in blocks[:2]] == [
+        {"type": "ephemeral"},
+        {"type": "ephemeral"},
+    ]
+    assert "Volatile working notes." in blocks[2]["text"]
+    assert "cache_control" not in blocks[2]
+
+
+def test_anthropic_real_prompt_batches_cache_batch1_when_pad_empty_tail_filtered():
+    batches = build_system_prompt_batches(
+        _prompt_manager_with_stable_sections(pad=None),
+        language="en",
+    )
+
+    assert len(batches) == 3
+    assert "Core principle." in batches[0]
+    assert "No deleting files." in batches[1]
+    assert batches[2] == ""
+
+    blocks = _build_system_batches_with_cache(batches)
+    assert [b["text"] for b in blocks] == [batches[0], batches[1]]
+    assert blocks[0]["cache_control"] == {"type": "ephemeral"}
+    assert blocks[1]["cache_control"] == {"type": "ephemeral"}
 
 
 def test_anthropic_single_non_empty_batch_keeps_legacy_cache_marker():

--- a/tests/test_codex_prompt_cache_key.py
+++ b/tests/test_codex_prompt_cache_key.py
@@ -112,13 +112,25 @@ def _no_cache_control(payload) -> bool:
     return "cache_control" not in json.dumps(payload, default=str)
 
 
-def test_codex_request_includes_default_prompt_cache_key():
+def test_codex_request_includes_default_prompt_cache_key_without_agent_env(monkeypatch):
+    monkeypatch.delenv("LINGTAI_AGENT_DIR", raising=False)
     session = _create_codex_session([_completed()], model="gpt-5.5")
 
     session.send("please answer via tool")
 
     sent = session._client.responses.kwargs[0]
     assert sent["prompt_cache_key"] == "lingtai-codex:gpt-5.5:v1"
+
+
+def test_codex_request_uses_agent_dir_env_for_default_prompt_cache_key(monkeypatch, tmp_path):
+    agent_dir = tmp_path / "agent-env"
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(agent_dir))
+    session = _create_codex_session([_completed()], model="gpt-5.5")
+
+    session.send("please answer via tool")
+
+    sent = session._client.responses.kwargs[0]
+    assert sent["prompt_cache_key"] == _expected_init_key(agent_dir / "init.json")
 
 
 def test_codex_request_uses_agent_init_path_hash_when_available(tmp_path):

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -3,6 +3,12 @@ from lingtai.kernel.prompt import build_system_prompt_batches
 from lingtai.kernel.prompt import SystemPromptManager
 
 
+def _batch_hash(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
 def test_build_system_prompt_minimal():
     mgr = SystemPromptManager()
     prompt = build_system_prompt(mgr)
@@ -198,4 +204,54 @@ def test_batches_byte_identical_when_empty():
     batches = build_system_prompt_batches(mgr, language="zh")
     assert "\n\n".join(seg for seg in batches if seg) == full
     # Batch shape is preserved: still one string per batch.
-    assert len(batches) == 2
+    assert len(batches) == 3
+
+
+def test_pad_is_isolated_in_volatile_tail_batch():
+    """Changing pad should not perturb the stable prefix batches."""
+    mgr_v1 = SystemPromptManager()
+    mgr_v1.write_section("covenant", "Be good.", protected=True)
+    mgr_v1.write_section("tools", "### bash\nRun commands.", protected=True)
+    mgr_v1.write_section("skills", "- name: bash-manual", protected=True)
+    mgr_v1.write_section("knowledge", "- name: project-memory", protected=True)
+    mgr_v1.write_section("identity", "name: alice", protected=True)
+    mgr_v1.write_section("character", "I am a meticulous archivist.", protected=True)
+    mgr_v1.write_section("pad", "Working notes v1.")
+
+    mgr_v2 = SystemPromptManager()
+    mgr_v2.write_section("covenant", "Be good.", protected=True)
+    mgr_v2.write_section("tools", "### bash\nRun commands.", protected=True)
+    mgr_v2.write_section("skills", "- name: bash-manual", protected=True)
+    mgr_v2.write_section("knowledge", "- name: project-memory", protected=True)
+    mgr_v2.write_section("identity", "name: alice", protected=True)
+    mgr_v2.write_section("character", "I am a meticulous archivist.", protected=True)
+    mgr_v2.write_section("pad", "Working notes v2.")
+
+    batches_v1 = build_system_prompt_batches(mgr_v1, language="en")
+    batches_v2 = build_system_prompt_batches(mgr_v2, language="en")
+
+    assert len(batches_v1) == 3
+    assert len(batches_v2) == 3
+    assert "Working notes v1." in batches_v1[2]
+    assert "Working notes v1." not in batches_v1[0]
+    assert "Working notes v1." not in batches_v1[1]
+    assert "- name: bash-manual" in batches_v1[1]
+    assert "- name: project-memory" in batches_v1[1]
+    assert "I am a meticulous archivist." in batches_v1[1]
+
+    assert _batch_hash(batches_v1[0]) == _batch_hash(batches_v2[0])
+    assert _batch_hash(batches_v1[1]) == _batch_hash(batches_v2[1])
+    assert _batch_hash(batches_v1[2]) != _batch_hash(batches_v2[2])
+
+
+def test_unordered_sections_do_not_spill_into_pad_tail():
+    mgr = SystemPromptManager()
+    mgr.write_section("custom", "Custom stable context.")
+    mgr.write_section("pad", "Volatile notes.")
+
+    batches = build_system_prompt_batches(mgr, language="en")
+
+    assert len(batches) == 3
+    assert "Custom stable context." in batches[1]
+    assert "Custom stable context." not in batches[2]
+    assert "Volatile notes." in batches[2]


### PR DESCRIPTION
## Summary

This PR isolates the mutable `pad` section into its own final system-prompt batch so Anthropic per-block prompt caching can preserve the stable prefix when pad changes between turns.

It also fixes the Anthropic batch helper to treat the configured final batch as the volatile tail even when that tail is currently empty. Without this, an empty `pad` would be dropped before cache marker placement, making the semi-stable batch look like the final block and leaving it uncached.

## Changes

- Split `SystemPromptManager._BATCHES` from 2 layers to 3:
  1. stable deployment layer: `principle/covenant/tools/substrate/procedures/comment`
  2. semi-stable session layer: `rules/brief/skills/knowledge/identity/character`
  3. volatile tail: `pad`
- Update Anthropic `_build_system_batches_with_cache()` to preserve original batch indexes while skipping empty emitted blocks.
- Add prompt batch tests for:
  - joined prompt byte identity,
  - stable hash under pad-only changes,
  - unordered sections staying out of the pad tail.
- Add Anthropic cache-control tests for:
  - empty tail still marks stable batches,
  - non-empty tail remains uncached,
  - single non-empty batch preserves legacy behavior.

## Token impact

This is the first runtime change in the PR123 sequence that can reduce uncached prompt tokens for Anthropic-backed agents: changing `pad` no longer invalidates the semi-stable `skills/knowledge/identity/character` batch.

Scope caveat: this PR does **not** send Anthropic `cache_control` to OpenAI-compatible/Codex providers. Those providers continue to rely on their own `prompt_cache_key` path and need separate provider validation.

## Tests

```text
pytest tests/test_prompt.py tests/test_anthropic_prompt_batches.py tests/test_openai_prompt_cache_key.py -q
35 passed in 0.85s

git diff --check
passed

python -m py_compile src/lingtai/kernel/prompt.py src/lingtai/llm/anthropic/adapter.py
passed
```

Additional check:

```text
pytest tests/test_codex_prompt_cache_key.py -q
1 failed, 7 passed
```

The single failure is the existing/stale Codex cache-key expectation already observed on `origin/main`: the test expects `lingtai-codex:gpt-5.5:v1`, while current code emits `lingtai-codex:gpt-5.5:init-<hash>:v2`. This PR does not touch Codex behavior and still does not leak `cache_control` there.
## Engineer notes — pad tail verification

- Adapter code is unchanged. Added real prompt-batch tests for both cases:
  - non-empty pad: batch2 exists; batch0 and batch1 carry `cache_control`, pad tail does not.
  - empty pad: adapter filters the empty tail; batch1 remains cache-marked, so no pad placeholder is needed.
- Acceptance should compare before/after **per-call `cache_ratio` mean** for the same task/provider/model. Do not compare total tokens across different workloads.
- Also fixed the adjacent Codex cache-key test: default model-scoped key is asserted with `LINGTAI_AGENT_DIR` cleared, and env-derived `init-...:v2` behavior now has explicit coverage.

Validation on this branch:

```bash
uv run pytest tests/test_codex_prompt_cache_key.py tests/test_openai_prompt_cache_key.py tests/test_anthropic_prompt_batches.py tests/test_prompt.py -q
# 46 passed
```
