### PR TITLE
test: move wheel sidecar smoke into pytest

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,7 +50,8 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: >-
             PATH="$HOME/.cargo/bin:$PATH"
             LINGTAI_REQUIRE_RUST_BUILD=1
-          CIBW_TEST_COMMAND: "python {project}/scripts/smoke_wheel_sidecar.py"
+          CIBW_TEST_REQUIRES: "pytest"
+          CIBW_TEST_COMMAND: "python -m pytest {project}/tests/test_wheel_sidecar_smoke.py -q"
 
       - name: Build source distribution
         if: runner.os == 'Linux'

--- a/tests/test_wheel_sidecar_smoke.py
+++ b/tests/test_wheel_sidecar_smoke.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python3
 """Smoke-test that an installed lingtai wheel carries and uses the Rust sidecar.
 
-This script is intended for cibuildwheel's CIBW_TEST_COMMAND. It runs against
+This test is intended for cibuildwheel's ``CIBW_TEST_COMMAND``. It runs against
 an installed wheel inside cibuildwheel's test virtualenv, not against the source
-tree. Keep it dependency-free.
+tree. When run from a source checkout, it skips rather than requiring a packaged
+binary in ``src/lingtai/bin``.
 """
 
 from __future__ import annotations
@@ -11,6 +11,9 @@ from __future__ import annotations
 import pathlib
 import tempfile
 
+import pytest
+
+import lingtai
 from lingtai.services.file_io_sidecar import (
     RustFileIOBackend,
     default_file_io_service,
@@ -18,7 +21,20 @@ from lingtai.services.file_io_sidecar import (
 )
 
 
-def main() -> None:
+def _is_source_tree_import() -> bool:
+    package_path = pathlib.Path(lingtai.__file__).resolve()
+    project_root = pathlib.Path(__file__).resolve().parents[1]
+    try:
+        package_path.relative_to(project_root / "src")
+    except ValueError:
+        return False
+    return True
+
+
+def test_installed_wheel_carries_and_uses_rust_sidecar() -> None:
+    if _is_source_tree_import():
+        pytest.skip("wheel sidecar smoke test requires an installed wheel")
+
     binary = resolve_sidecar_binary(skip_env=True, skip_dev_tree=True)
     assert binary is not None, "packaged lingtai-search-sidecar was not found"
     binary_path = pathlib.Path(binary)
@@ -37,9 +53,3 @@ def main() -> None:
         matches = service.grep("native", str(root))
         got = [(pathlib.Path(m.path).resolve(), m.line_number, m.line) for m in matches]
         assert got == [(target.resolve(), 1, "hello native sidecar")], got
-
-    print(f"Rust sidecar wheel smoke passed: {binary_path}")
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- move the cibuildwheel Rust sidecar smoke check from `scripts/` into `tests/`
- make the wheel smoke check a pytest test that skips when imported from a source checkout
- update the wheel workflow to install pytest and run the dedicated smoke test

## Rationale
`scripts/smoke_wheel_sidecar.py` was a CI-only wheel test fixture, not a runtime script or console entry point. Moving it under `tests/` removes the bare root `scripts/` directory while keeping the installed-wheel coverage.

## Validation
- `git diff --check`
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m py_compile tests/test_wheel_sidecar_smoke.py`
- `PYTHONPATH=$PWD/src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_wheel_sidecar_smoke.py` → skipped in source checkout as intended