### PR TITLE
docs: add GitHub community entry points

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report a reproducible problem in lingtai-kernel
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please remove secrets, tokens, private mailbox contents, and unrelated logs before submitting.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps or commands that reproduce the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior / logs
+      description: Include the smallest useful excerpt. Redact secrets.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: LingTai / Python / OS versions
+      placeholder: "lingtai 0.x, Python 3.11, macOS/Linux/..."
+  - type: checkboxes
+    id: hygiene
+    attributes:
+      label: Submission hygiene
+      options:
+        - label: I removed secrets, tokens, private paths that are not needed, and unrelated logs.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Lingtai-AI/lingtai-kernel/security/advisories/new
+    about: Please report security-sensitive issues privately when possible.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest a capability, documentation improvement, or design change
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / need
+      description: What user or maintainer need should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the change you want.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, examples, or constraints. Do not include secrets.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+- TODO
+
+## Validation
+
+- [ ] `git diff --check`
+- [ ] Relevant tests or documentation checks:
+
+## Notes
+
+- Link related issues or context here.
+- Confirm that logs, screenshots, and examples do not contain secrets.

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -6,7 +6,7 @@ while long-form references live under [`docs/`](docs/).
 
 ## Components
 
-- [`.github/`](.github/) — GitHub Actions and repository automation.
+- [`.github/`](.github/) — GitHub Actions, issue templates, and pull request templates.
 - [`crates/lingtai-search-sidecar/`](crates/lingtai-search-sidecar/) — Rust
   file-search sidecar crate packaged with the Python runtime.
 - [`docs/`](docs/) — durable documentation, plans, language-specific readmes,
@@ -23,9 +23,10 @@ while long-form references live under [`docs/`](docs/).
 - [`README.md`](README.md) — public English entry point; links to translated
   readmes under `docs/readmes/`.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — contributor entry point.
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), [`SECURITY.md`](SECURITY.md), and [`SUPPORT.md`](SUPPORT.md) — GitHub community and safety entry points.
 - [`CLAUDE.md`](CLAUDE.md) — short Claude Code entry point; full guidance is
   [`docs/references/claude-code-guide.md`](docs/references/claude-code-guide.md).
-- [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE) — legal metadata.
+- [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE) — legal metadata; both are kept at root and included in source distributions.
 - [`pyproject.toml`](pyproject.toml), [`setup.py`](setup.py), and
   [`MANIFEST.in`](MANIFEST.in) — Python packaging and Rust sidecar build hooks.
 - [`.gitignore`](.gitignore) — local scratch/build/cache exclusions.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+LingTai is a research and developer community. We expect contributors and users
+to treat one another with respect, assume good intent, and keep discussions
+focused on improving the project.
+
+## Expected behavior
+
+- Be respectful and constructive in issues, pull requests, reviews, and chats.
+- Critique ideas and code, not people.
+- Welcome newcomers and explain project norms when they are relevant.
+- Avoid harassment, personal attacks, discriminatory language, and sustained
+  off-topic disruption.
+
+## Reporting concerns
+
+If you see behavior that makes the project unsafe or unwelcoming, contact the
+maintainers privately when possible. If private contact is unavailable, open a
+GitHub issue with only the minimum public detail needed to ask for maintainer
+attention, and do not share private personal information.
+
+Maintainers may remove comments, close threads, or block participants to protect
+project health.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to lingtai-kernel
 
-Thank you for helping improve the LingTai Python runtime.
+Thank you for helping improve the LingTai Python runtime. GitHub discovers this root file as the repository contributing guide.
 
 ## Start here
 
@@ -9,6 +9,12 @@ Thank you for helping improve the LingTai Python runtime.
   [`docs/references/claude-code-guide.md`](docs/references/claude-code-guide.md)
 - Source-root anatomy: [`src/lingtai_kernel/ANATOMY.md`](src/lingtai_kernel/ANATOMY.md)
 - Rust sidecar notes: [`crates/lingtai-search-sidecar/README.md`](crates/lingtai-search-sidecar/README.md)
+
+## Community and safety
+
+- Code of conduct: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+- Security reporting: [`SECURITY.md`](SECURITY.md)
+- Support guidance: [`SUPPORT.md`](SUPPORT.md)
 
 ## Workflow
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,4 +22,5 @@ prune src/lingtai/bin
 include setup.py
 include MANIFEST.in
 include LICENSE
+include NOTICE
 include README.md

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![License](https://img.shields.io/github/license/Lingtai-AI/lingtai-kernel?color=%237dab8f)](LICENSE)
 [![Blog](https://img.shields.io/badge/blog-lingtai.ai-%23d4a853)](https://lingtai.ai)
 
-[lingtai.ai](https://lingtai.ai) · [简体中文](docs/readmes/README.zh.md) · [文言](docs/readmes/README.wen.md)
+[lingtai.ai](https://lingtai.ai) · [简体中文](docs/readmes/README.zh.md) · [文言](docs/readmes/README.wen.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md)
 
 </div>
 
@@ -130,6 +130,10 @@ No `agent_id`. The path is the identity. Agents find each other by path, communi
 
 Read the full manifesto at [lingtai.ai](https://lingtai.ai).
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution workflow and repository navigation entry points. For responsible disclosure, read [SECURITY.md](SECURITY.md); for help, read [SUPPORT.md](SUPPORT.md).
+
 ## Acknowledgements
 
 See [docs/references/acknowledgements.md](docs/references/acknowledgements.md).
@@ -140,6 +144,6 @@ Apache-2.0 — [Zesen Huang](https://github.com/huangzesen), 2025–2026
 
 <div align="center">
 
-[lingtai.ai](https://lingtai.ai) · [GitHub](https://github.com/Lingtai-AI/lingtai-kernel) · [TUI](https://github.com/Lingtai-AI/lingtai)
+[lingtai.ai](https://lingtai.ai) · [GitHub](https://github.com/Lingtai-AI/lingtai-kernel) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md) · [TUI](https://github.com/Lingtai-AI/lingtai)
 
 </div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** disclose security-sensitive details in a public issue.
+
+Preferred reporting path:
+
+1. Use GitHub's private vulnerability reporting / Security Advisory flow for this
+   repository if it is available.
+2. If private reporting is not available, contact a maintainer directly and keep
+   details minimal until a private channel is established.
+
+Include enough information for maintainers to reproduce and assess the issue:
+
+- affected component or command
+- LingTai / Python / OS versions when relevant
+- minimal reproduction steps
+- expected impact
+- whether secrets, tokens, local files, or external services may be exposed
+
+## Scope
+
+Security issues include credential leaks, unintended filesystem access, unsafe
+external side effects, privilege bypasses, prompt/tool-channel injection hazards,
+and vulnerabilities in bundled runtime components.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,19 @@
+# Support
+
+For questions and help with `lingtai-kernel`:
+
+- Check [`README.md`](README.md) for the runtime overview.
+- Check [`CONTRIBUTING.md`](CONTRIBUTING.md) for repository navigation and the
+  contribution workflow.
+- Use GitHub Issues for reproducible bugs, documentation problems, and feature
+  requests.
+
+When asking for help, include:
+
+- what you were trying to do
+- the command or workflow you ran
+- relevant LingTai / Python / OS versions
+- the smallest useful log excerpt or error message
+
+Do not post tokens, API keys, private mailbox contents, or other secrets in
+public issues.

--- a/docs/readmes/README.wen.md
+++ b/docs/readmes/README.wen.md
@@ -1,6 +1,6 @@
 # 灵台内核
 
-> [English](../../README.md) | [中文](README.zh.md) | [文言](README.wen.md)
+> [English](../../README.md) | [中文](README.zh.md) | [文言](README.wen.md) | [贡献](../../CONTRIBUTING.md) | [安全](../../SECURITY.md) | [支持](../../SUPPORT.md)
 
 > *灵台者有持，而不知其所持，而不可持者也。*
 > — 庄子·庚桑楚

--- a/docs/readmes/README.zh.md
+++ b/docs/readmes/README.zh.md
@@ -1,6 +1,6 @@
 # lingtai-kernel 灵台内核
 
-> [English](../../README.md) | [中文](README.zh.md) | [文言](README.wen.md)
+> [English](../../README.md) | [中文](README.zh.md) | [文言](README.wen.md) | [贡献](../../CONTRIBUTING.md) | [安全](../../SECURITY.md) | [支持](../../SUPPORT.md)
 
 > *灵台者有持，而不知其所持，而不可持者也。*
 > — 庄子·庚桑楚


### PR DESCRIPTION
## Summary
- add GitHub community/profile entry points: code of conduct, security policy, support guide, issue templates, and PR template
- make README/readme language variants link to contributing/security/support entry points
- include NOTICE in MANIFEST.in so source distributions carry the Apache NOTICE file

## Validation
- git diff --cached --check
- internal markdown link check over touched markdown entry points
- YAML parse for .github/ISSUE_TEMPLATE/*.yml
- grep check for MANIFEST.in including NOTICE

Requested by Jason after the root-hygiene cleanup.