### PR TITLE
docs(procedures): emphasize daemon context isolation

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -74,7 +74,8 @@ standing exceptions.
 Choose the smallest durable body:
 
 - Use bash for deterministic local work.
-- Use daemon for noisy, isolated, disposable exploration.
+- Use daemon for noisy, isolated, disposable exploration, batch analysis, and
+  long-context branches that would otherwise burden the parent.
 - Use avatar for persistent specialization or recurring collaboration.
 - Use MCP for durable external integrations.
 - Use knowledge for private durable facts.
@@ -88,12 +89,20 @@ that tool's manual.
 
 ### Daemon workflow methodology
 
-Protect the main agent's context. The parent agent should stay in the strategic
-seat: define the objective, negate the first plan before acting, design the
-workflow, choose the bodies, and synthesize the result. Daemons should carry the
-execution: file scans, deterministic transformations, read-only reviews, batch
-conversion, log mining, and other noisy work whose details would pollute the main
-context.
+Protect the main agent's context and use tokens deliberately. The parent agent
+should stay in the strategic seat: define the objective, negate the first plan
+before acting, design the workflow, choose the bodies, and synthesize the result.
+Daemons should carry the execution: file scans, deterministic transformations,
+read-only reviews, batch conversion, log mining, and other noisy work whose
+details would pollute the main context. Be proactive rather than waiting for an
+explicit delegation request: if the useful output is a conclusion or artifact,
+not the full transcript, isolate the work in a daemon.
+
+Daemon turns do not carry the full resident system prompt, so they are often the
+more token-efficient body for temporary exploration. Choose the daemon/model by
+exercising judgment about the task: match capability, cost, latency, privacy, and
+expected output to the work instead of blindly mirroring the parent. When the
+human gives an explicit instruction about which daemon/model to use, follow it.
 
 Use this methodology for substantial daemon work:
 

--- a/src/lingtai/prompts/procedures.md
+++ b/src/lingtai/prompts/procedures.md
@@ -19,7 +19,12 @@ exploration and cheap deterministic work that would otherwise consume the main
 agent's context, avatars for persistent specialists, MCPs for durable external
 integrations, knowledge for private facts, and skills for reusable procedures.
 Protecting the main context is a LingTai principle: the parent plans and
-synthesizes, daemons execute noisy work. For the full daemon methodology — pad
+synthesizes, daemons execute noisy work. Be proactive: use daemons to isolate
+long scans, batch analysis, and exploratory branches instead of dragging their
+full context through the main agent. Daemon turns carry no resident system prompt,
+so they are often the token-efficient body for temporary work. Choose the daemon
+or model by exercising judgment about the task; when the human gives an explicit
+instruction, follow that instruction. For the full daemon methodology — pad
 workflow, cost efficiency, context hygiene, and parent/daemon division of labor —
 read `system-manual` → `reference/procedures-manual/SKILL.md`.
 


### PR DESCRIPTION
## Summary
- emphasize proactive daemon use in resident procedures to isolate noisy/long-context work from the main agent
- expand procedures manual guidance on daemon token efficiency and parent/daemon division of labor
- document daemon/model selection as an agent-judgment call: match capability, cost, latency, privacy, and expected output to the task; follow explicit human instructions when provided

## Validation
- git diff --check
- python -m pytest -q tests/test_deep_refresh.py -k procedures
- python -m pytest -q tests/test_skills.py

Requested by Jason after lingtai#373. Updated per Jason feedback to remove the earlier default-to-main-model wording.
