### PR TITLE
fix(system): strengthen large-result hook guidance

### DIFF
--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -1856,6 +1856,8 @@ class BaseAgent:
                 f"Read the sidecar file to access the full content, then call:\n"
                 f"  system(action=\"summarize\", items=[{{\"tool_call_id\": \"{tool_call_id}\", \"summary\": \"<your summary>\"}}])\n"
                 f"to replace the context-visible spill manifest with your own summary.\n"
+                f"Treat this notification as a prompt to act, not just FYI: if the result still matters, digest it now and summarize before continuing deep work.\n"
+                f"If you intentionally need the large payload to remain visible for a while, raise or disable the threshold explicitly and restore it later; otherwise the reminder will return until the result is summarized.\n"
                 f"The full original remains in the sidecar file and in events.jsonl by tool_call_id."
             )
         elif is_spill:
@@ -1867,7 +1869,9 @@ class BaseAgent:
                 f"Check the spill manifest in your conversation history for the path.\n"
                 f"After reading the sidecar, call:\n"
                 f"  system(action=\"summarize\", items=[{{\"tool_call_id\": \"{tool_call_id}\", \"summary\": \"<your summary>\"}}])\n"
-                f"to replace the context-visible spill manifest with your own summary."
+                f"to replace the context-visible spill manifest with your own summary.\n"
+                f"Treat this notification as a prompt to act, not just FYI: if the result still matters, digest it now and summarize before continuing deep work.\n"
+                f"If you intentionally need the large payload to remain visible for a while, raise or disable the threshold explicitly and restore it later; otherwise the reminder will return until the result is summarized."
             )
         else:
             body = (
@@ -1878,6 +1882,8 @@ class BaseAgent:
                 f"After you have digested this result, you may call:\n"
                 f"  system(action=\"summarize\", items=[{{\"tool_call_id\": \"{tool_call_id}\", \"summary\": \"<your summary>\"}}])\n"
                 f"to replace the context-visible payload with your own summary.\n"
+                f"Treat this notification as a prompt to act, not just FYI: if the result still matters, digest it now and summarize before continuing deep work.\n"
+                f"If you intentionally need the large payload to remain visible for a while, raise or disable the threshold explicitly and restore it later; otherwise the reminder will return until the result is summarized.\n"
                 f"The full original remains retrievable from events.jsonl by tool_call_id."
             )
 

--- a/tests/test_system_summarize.py
+++ b/tests/test_system_summarize.py
@@ -430,6 +430,9 @@ def test_large_result_notification_threshold_in_text(tmp_path):
     assert len(published) == 1
     body = published[0]["body"]
     assert "7500" in body, f"threshold 7500 not found in notification body:\n{body}"
+    assert "Treat this notification as a prompt to act, not just FYI" in body
+    assert "digest it now and summarize before continuing deep work" in body
+    assert "otherwise the reminder will return until the result is summarized" in body
 
 
 def test_large_result_notification_not_fired_below_threshold(tmp_path):
@@ -475,6 +478,9 @@ def test_large_result_notification_spill_manifest_original_over_threshold(tmp_pa
     )
     body = published[0]["body"]
     assert "spill" in body.lower() or "sidecar" in body.lower()
+    assert "Treat this notification as a prompt to act, not just FYI" in body
+    assert "digest it now and summarize before continuing deep work" in body
+    assert "otherwise the reminder will return until the result is summarized" in body
 
 
 def test_large_result_notification_source_field(tmp_path):
@@ -697,6 +703,9 @@ def test_large_result_notification_spill_manifest_over_threshold(tmp_path):
     assert len(published) == 1
     body = published[0]["body"]
     assert "spill" in body.lower() or "sidecar" in body.lower()
+    assert "Treat this notification as a prompt to act, not just FYI" in body
+    assert "digest it now and summarize before continuing deep work" in body
+    assert "otherwise the reminder will return until the result is summarized" in body
     assert "toolu_spill_001" in body
     assert "60000" in body or "60,000" in body or "5000" in body
 


### PR DESCRIPTION
## Summary
- strengthen direct large-tool-result notification copy from BaseAgent._maybe_notify_large_tool_result
- keep direct-hook guidance aligned with the live-history rescan notification copy from #407
- add direct-hook tests for normal and spilled notification bodies

## Tests
- PYTHONPATH=$PWD/src python -m pytest -q tests/test_system_summarize.py tests/test_large_result_rescan.py tests/test_tool_executor.py
- git diff --check

100 passed in 0.45s