### PR TITLE
fix(codex): rebuild adapter on live refresh

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -1126,9 +1126,11 @@ class Agent(BaseAgent):
         # 60 RPM cap by default. Set to 0 in init.json to disable gating.
         new_max_rpm = m.get("max_rpm", 60)
         # Pass working_dir so a Codex agent's per-agent session/thread identity
-        # (the agent path) is resolved into the provider defaults. The identity
-        # is the agent path alone, so it is stable across refresh/rebuild — a
-        # refresh never rotates session-id / thread-id / prompt_cache_key.
+        # (the agent path) is resolved into the provider defaults. The agent
+        # path anchor is stable across refresh, but #406 makes start/refresh one
+        # of the two cache-affinity rotate triggers: the Codex adapter stamps a
+        # fresh epoch at construction, so a live refresh must REBUILD the adapter
+        # to rotate the current id (see codex_force_rebuild below).
         new_provider_defaults = build_provider_defaults_from_manifest_llm(
             llm, max_rpm=new_max_rpm, working_dir=self._working_dir
         )
@@ -1139,13 +1141,26 @@ class Agent(BaseAgent):
         cur_provider_defaults_bucket = getattr(
             self.service, "_provider_defaults", {}
         ).get(new_provider.lower(), {})
-        # Codex cache-affinity identity is anchored on the agent path only, so
-        # token-ledger / molt-time churn does not rotate it. Still compare the
-        # resolved provider-defaults bucket as a whole so explicit init.json
-        # changes (codex_session_id/anchor, default_headers, compact_threshold,
-        # max_rpm, api_compat, etc.) rebuild the service coherently.
+        # Codex start/refresh is a cache-affinity rotate trigger (Jason's final
+        # #406 semantics): the adapter epoch-stamps the *current* affinity id at
+        # construction, so the 8-hit stalled-cache shuffle only becomes active
+        # once a live refresh REBUILDS the adapter at a fresh epoch. The agent
+        # path anchor is stable across refresh, so the provider-defaults bucket
+        # is byte-identical and the boot-epoch adapter (with its stale current
+        # id) would otherwise survive untouched — exactly the bug where the
+        # shuffle never went live. A *live* refresh is one that replays existing
+        # history (``saved_interface is not None``); boot has no prior session
+        # and already builds a fresh adapter, so it is excluded to avoid a
+        # redundant double-build.
+        codex_force_rebuild = (
+            new_provider.lower() == "codex" and saved_interface is not None
+        )
+        # Compare the resolved provider-defaults bucket as a whole so explicit
+        # init.json changes (codex_session_id/anchor, default_headers,
+        # compact_threshold, max_rpm, api_compat, etc.) rebuild coherently.
         if (
-            new_provider != self.service.provider
+            codex_force_rebuild
+            or new_provider != self.service.provider
             or new_model != self.service.model
             or new_base_url != getattr(self.service, "_base_url", None)
             or new_provider_defaults_bucket != cur_provider_defaults_bucket

--- a/tests/test_deep_refresh.py
+++ b/tests/test_deep_refresh.py
@@ -463,3 +463,149 @@ def test_post_molt_preserves_pad_append_pinned_reference(tmp_path):
     pad = agent._prompt_manager.read_section("pad") or ""
     assert "Working notes line." in pad
     assert "PINNED-REFERENCE-MARKER" in pad
+
+
+# ---------------------------------------------------------------------------
+# Codex cache-affinity rebuild on refresh (Jason's final #406 semantics).
+#
+# #406 makes start/refresh one of exactly two rotate triggers: a live refresh
+# must (re)build the Codex adapter so it stamps a FRESH epoch and the current
+# affinity id rotates. The agent path is stable across refresh, so without an
+# explicit rebuild the provider-defaults bucket is byte-identical and the old
+# adapter (with its boot-epoch id) survives — the 8-hit shuffle never goes
+# live. These tests prove refresh now rebuilds the Codex service/adapter while
+# preserving chat history.
+# ---------------------------------------------------------------------------
+
+
+def _codex_agent(tmp_path: Path, epoch: float):
+    """Build a real Agent backed by a real Codex LLMService at a pinned epoch.
+
+    ``time.time`` is patched for the duration of service construction so the
+    adapter's build epoch (``_codex_epoch``) is deterministic. The returned
+    agent's ``service`` is a genuine ``LLMService`` (not a mock), so
+    ``_setup_from_init`` exercises the real Codex rebuild path.
+    """
+    from unittest.mock import patch as _patch
+
+    from lingtai.agent import Agent
+    from lingtai.llm.service import (
+        LLMService,
+        build_provider_defaults_from_manifest_llm,
+    )
+    from lingtai_kernel.config import AgentConfig
+    import lingtai  # noqa: F401  (registers the codex adapter factory)
+
+    init = _make_init(provider="codex", model="gpt-5.5")
+    # Pin max_rpm so the provider-defaults bucket is byte-identical before and
+    # after refresh — otherwise an incidental max_rpm change (default 60 on
+    # refresh) would rebuild the service for the wrong reason and mask the bug.
+    init["manifest"]["max_rpm"] = 60
+    (tmp_path / "init.json").write_text(json.dumps(init))
+
+    llm = init["manifest"]["llm"]
+    provider_defaults = build_provider_defaults_from_manifest_llm(
+        llm, max_rpm=60, working_dir=tmp_path
+    )
+    with _patch("lingtai.auth.codex.CodexTokenManager") as mgr_cls, _patch(
+        "time.time", return_value=epoch
+    ):
+        mgr_cls.return_value.get_access_token.return_value = "fake-token"
+        service = LLMService(
+            provider="codex",
+            model="gpt-5.5",
+            api_key="fake",
+            provider_defaults=provider_defaults,
+        )
+        agent = Agent(
+            service,
+            agent_name="test-agent",
+            working_dir=tmp_path,
+            config=AgentConfig(),
+        )
+    return agent
+
+
+def test_refresh_rebuilds_codex_adapter_with_fresh_epoch(tmp_path):
+    """A live Codex refresh rebuilds the adapter and rotates the affinity id.
+
+    Before the fix, ``_setup_from_init`` only rebuilt ``LLMService`` when the
+    provider-defaults bucket changed; the Codex bucket is anchored on the agent
+    path only, so it stayed byte-identical across refresh and the boot-epoch
+    adapter (and its stamped current id) survived. The 8-hit cache-affinity
+    shuffle could therefore never become active. After the fix, refresh forces
+    a fresh Codex service/adapter, so the epoch-stamped current id rotates.
+    """
+    from unittest.mock import patch
+
+    agent = _codex_agent(tmp_path, epoch=1_700_000_000)
+    agent._sealed = True
+
+    old_adapter = agent.service.get_adapter("codex")
+    old_id = old_adapter._codex_id
+    assert old_id is not None  # per-agent identity is wired by default
+
+    # A later refresh stamps a different epoch -> a different current id.
+    mock_interface = MagicMock()
+    mock_session = MagicMock()
+    mock_session.chat = MagicMock()
+    mock_session.chat.interface = mock_interface
+    # The real Session._rebuild_session would call create_session; we only need
+    # to confirm refresh hands it the preserved interface and a fresh service.
+    agent._session = mock_session
+
+    with patch("lingtai.auth.codex.CodexTokenManager") as mgr_cls, patch(
+        "time.time", return_value=1_700_000_500
+    ):
+        mgr_cls.return_value.get_access_token.return_value = "fake-token"
+        agent._setup_from_init()
+
+    new_adapter = agent.service.get_adapter("codex")
+    new_id = new_adapter._codex_id
+
+    # 1. A genuinely fresh adapter instance (not the cached boot one).
+    assert new_adapter is not old_adapter
+    # 2. The current epoch-stamped affinity id rotated.
+    assert new_id != old_id
+    assert new_id is not None
+    # 3. The rotated id is the epoch-stamped form, NOT the legacy
+    #    pre-#406 _codex_session_id(anchor) value.
+    from lingtai.llm.openai.adapter import _codex_affinity_id, _codex_session_id
+
+    anchor = str((tmp_path / "init.json").resolve())
+    assert new_id == _codex_affinity_id(anchor, 1_700_000_500)
+    assert new_id != _codex_session_id(anchor)
+    # 4. The new service object is wired into the session that rebuilds history.
+    assert agent._session._llm_service is agent.service
+    # 5. Chat history is preserved: the saved interface is replayed.
+    mock_session._rebuild_session.assert_called_once_with(mock_interface)
+
+
+def test_refresh_codex_adapter_keeps_per_agent_anchor(tmp_path):
+    """The rebuilt adapter still anchors on the same agent path (identity).
+
+    Rotation must change only the epoch, not the agent's durable identity:
+    both the old and new ids derive from the same ``init.json`` anchor, so the
+    rebuilt adapter remains a per-agent identity (not a shared model-only key).
+    """
+    from unittest.mock import patch
+
+    agent = _codex_agent(tmp_path, epoch=1_700_000_000)
+    agent._sealed = True
+
+    old_anchor = agent.service.get_adapter("codex")._codex_session_anchor
+
+    mock_session = MagicMock()
+    mock_session.chat = MagicMock()
+    mock_session.chat.interface = MagicMock()
+    agent._session = mock_session
+
+    with patch("lingtai.auth.codex.CodexTokenManager") as mgr_cls, patch(
+        "time.time", return_value=1_700_000_500
+    ):
+        mgr_cls.return_value.get_access_token.return_value = "fake-token"
+        agent._setup_from_init()
+
+    new_adapter = agent.service.get_adapter("codex")
+    assert new_adapter._codex_session_anchor == old_anchor
+    assert new_adapter._codex_session_anchor == str((tmp_path / "init.json").resolve())


### PR DESCRIPTION
## Summary
- force Codex `LLMService` / adapter rebuild on live `system(refresh)` so #406's start/refresh cache-affinity rotation actually activates
- preserve chat history by replaying the saved interface through the rebuilt session
- add regression coverage using a real Codex `LLMService` to prove refresh swaps the adapter/current id while preserving the per-agent anchor

## Root cause
#406 made start/refresh one of the two cache-affinity rotate triggers: `CodexOpenAIAdapter` epoch-stamps the current affinity id at adapter construction, and the 8-hit stalled-cache shuffle only becomes active once refresh rebuilds the adapter at a fresh epoch.

`Agent._setup_from_init` only rebuilt `LLMService` when provider/model/base_url/provider-defaults changed. Codex provider defaults are intentionally anchored on the agent path, so the bucket is unchanged across a normal refresh. That kept the old cached Codex adapter instance alive. In the live process this meant refresh continued using the pre-#406 id path (`sha256(anchor)[:8]`), so the ledger kept showing stable `session/thread` ids with missing `prompt_cache_key` and no 8-hit rotation event.

## Tests
- `python -m pytest tests/test_deep_refresh.py tests/test_codex_prompt_cache_key.py tests/test_codex_cache_stall_temp_key.py tests/test_agent_preset_manifest.py tests/test_perform_refresh_handshake.py -q` → 100 passed
- `python -m pytest tests/ -q -k "refresh or codex or service or cli or agent or molt or boot"` → 510 passed, 3 skipped (run by the claude-p worker before cherry-picking the same diff to this clean PR branch)
- TDD check: the new regression test fails without the `agent.py` fix and passes with it

## Notes
- Scope is Codex-only; other providers are left unchanged.
- No merge/release/deploy performed.
