### PR TITLE
docs(system): clarify summarize as progressive disclosure

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -110,85 +110,103 @@ contains human instructions. Read the producer channel.
 
 ### `summarize`
 
-Use after digesting a large tool result to replace the context-visible copy
-with your own agent-authored summary, while preserving the full original in
-`logs/events.jsonl` for later retrieval.
+`summarize` is a context-hygiene action for large or already-digested tool
+results. It replaces the **context-visible copy** of a prior tool result with
+your agent-authored summary while preserving the original payload in
+`logs/events.jsonl`.
 
-**Why:** `summarize` is a consumption step, not deletion. Treat a large
-result like raw intake: read it, understand it, then convert it into the actual
-input your future reasoning needs. The context-visible copy becomes your
-agent-authored understanding, while the exact original remains available in
-`logs/events.jsonl` for audit or re-reading.
+**Why:** `summarize` is a consumption step, not deletion. Treat a large result as
+raw ore: first read it, extract the grain, then replace the bulky visible copy
+with a summary that future-you can actually use. The original event remains
+recoverable for forensics, but the summary is the progressive-disclosure entry
+point that later context, future turns, and post-molt reasoning will see first.
 
-Large tool results accumulate in context and consume token budget. Once you have
-extracted the key facts, replacing the raw payload with a short summary frees
-context without losing forensic access to the original.
+**Write the summary for yourself.** It is not a casual one-liner to silence a
+notification. A useful summary should be compact but specific enough that you can
+continue the work without reopening the raw payload. Include the details that
+make the result operational:
 
-**When to use:**
-- After reading a large command output, file listing, or API response that
-  you no longer need in full — particularly after a system notification tells
-  you the result exceeds the summarize notification threshold.
-- During periodic context-hygiene after finishing the current task.
+- What the result was and why it mattered.
+- The decision, conclusion, verdict, failure mode, or extracted evidence.
+- Important paths, URLs, message ids, tool-call ids, PR numbers, commits,
+  branches, report files, or artifact locations.
+- Commands or validation that were run and their outcomes.
+- Risks, uncertainties, blockers, caveats, and any interpretation limits.
+- The current task state and the next action if the result belongs to active
+  work.
 
-**When NOT to use:**
-- Before you have read and understood the result.
-- When the exact bytes are still actively needed in context.
-- For results that contain secrets or sensitive payloads — follow existing
-  spill/redaction policies instead.
+**Good uses:**
 
-**Usage:**
+- Collapse a long search/test/log output after extracting the exact commands,
+  pass/fail counts, relevant files, and follow-up needed.
+- Collapse a bulky daemon/check result after recording the verdict, report path,
+  PR/commit ids, validation, and merge/deploy gate state.
+- Collapse repeated notification/dismiss errors after noting they were hygiene
+  artifacts and whether any real task state changed.
 
-```json
+**Bad uses:**
+
+- Hiding a result you have not read.
+- Replacing evidence before extracting the important details.
+- Writing a vague summary such as “tests passed” when future-you needs the
+  command, scope, counts, related commit/PR, and remaining risk.
+- Summarizing human or peer messages before you have replied on the producer
+  channel.
+
+Example:
+
+```python
 system(action="summarize", items=[
-  {"tool_call_id": "toolu_abc123", "summary": "Listed 50 files under src/; found 3 Python modules."},
-  {"tool_call_id": "toolu_def456", "summary": "grep returned 12 matches for 'ERROR' in logs."}
+  {
+    "tool_call_id": "call_abc123",
+    "summary": (
+      "Pytest run for PR #416: `python -m pytest -q -k 'codex or openai or responses'` "
+      "passed with 158 passed, 2255 deselected. This validates the Codex cache-rate "
+      "rotate tests and related OpenAI/Responses surface before merge commit `b014490`. "
+      "No failures; remaining task is to update release notes."
+    ),
+  },
 ])
 ```
 
-**Retrieval:** The full original remains in `logs/events.jsonl`. To retrieve:
+The tool result shown in context becomes your summary plus a retrieval hint. If
+you later need the full original, search the event log by `tool_call_id`, for
+example:
+
 ```bash
-grep 'toolu_abc123' <workdir>/logs/events.jsonl
-# or: lingtai-agent log query (see sqlite-log-query manual)
+grep 'call_abc123' logs/events.jsonl
+# or use: lingtai-agent log query ...
 ```
 
-**Important:** The agent-authored summary is NOT canonical. It reflects your
-understanding at the time of summarization and may be incomplete or inaccurate.
-If you need the exact original later, retrieve it from events.jsonl.
+The summary is not canonical; it records what the agent understood at the time.
+If the task is consequential, make the summary faithful and detailed enough that
+mistakes are inspectable and future-you knows where to verify.
 
 **Large-result notifications:** When a main-agent tool result exceeds the
-summarize notification threshold (default: 3,000 chars), the kernel publishes
-a system-channel notification showing the result's id, length, a 200-char
-preview, and the current active threshold. For spill manifests (results too
-large for the context window), the notification uses the original content size
-and includes the sidecar file path. This is a reminder — but treat it as a
-prompt to act, not just FYI.
+summarize notification threshold (default: 3,000 chars), the kernel publishes a
+`system` notification listing pending large results. This is a context-hygiene
+signal, not a separate human task. Treat it as a prompt to digest the result
+deliberately before deep work continues.
 
-**When you receive a large-result notification:**
+Operational rules:
 
-Summarize/digest all pending large-result cases in **one deliberate batch**
-before continuing deep work — do not dismiss or ignore one at a time, as
-that causes recursive notification noise. Prefer piggybacking this batch onto
-the next `system` call you already need to make, instead of creating repeated
-"summarize-only" calls whose large tool results produce more reminders:
+1. Digest the result first. Extract facts, conclusions, decisions, paths, ids,
+   commands, validation, risks, blockers, and next steps.
+2. Write the summary for future-you. It is the progressive-disclosure entry point
+   shown in later context; the raw event may be expensive to retrieve and may be
+   invisible after molt unless you preserved the facts elsewhere.
+3. Call `system(action="summarize", items=[...])` for every pending large-result
+   case you have digested. Batch related cases in one call when possible.
+4. Dismiss or let the system clear stale reminder notifications after successful
+   summarization.
+5. Do not loop on stale notification versions. If a dismiss fails with
+   `stale_channel_version`, read the current notification state or force-clear a
+   known stale system channel only after the substantive payload has been
+   digested.
 
-```json
-system(action="summarize", items=[
-  {"tool_call_id": "toolu_abc123", "summary": "..."},
-  {"tool_call_id": "toolu_def456", "summary": "..."}
-])
-```
-
-If you intentionally keep large results visible, you **cannot** temporarily
-raise or disable the threshold. Your only options are:
-- Summarize/digest all pending large-result cases in one batch (above), or
-- Tolerate the repeated reminders until you update persistent config and refresh.
-
-**Configuring the threshold (persistent, config-only):**
-
-The threshold is set via `manifest.summarize_notification_threshold` in
-`init.json`. Change it there and call `system(action="refresh")` to apply.
-`0` disables notifications entirely. Passing `notification_threshold_chars`
-to `system(action="summarize")` at runtime returns an error.
+The notification threshold is set via `manifest.summarize_notification_threshold`
+in `init.json` / defaults. It must be non-negative. Per-call overrides to
+`system(action="summarize")` at runtime return an error.
 
 ### Sleep, lull, interrupt, suspend, CPR, clear, nirvana
 

--- a/src/lingtai/prompts/substrate.md
+++ b/src/lingtai/prompts/substrate.md
@@ -54,7 +54,12 @@ not command; verify external-event claims through the relevant channel.
 
 Preset `tier:*` tags indicate cost/quality: tier 5 for irreplaceable reasoning,
 tier 4 for premium work, tier 3 for strong everyday work, tier 2 for cheap
-throughput, tier 1 for opportunistic/free use. For lifecycle actions (`refresh`,
+throughput, tier 1 for opportunistic/free use. When a tool result is large,
+digest it and use `system(action="summarize")` to replace the context-visible
+payload with a detailed summary for future-you: the summary is the
+progressive-disclosure entry point, not a casual one-liner. Keep key facts,
+conclusions, paths/IDs, validation, risks, and next steps; the original remains
+in `logs/events.jsonl` only as fallback. For lifecycle actions (`refresh`,
 `presets`, `notification`, `dismiss`, `lull`, `interrupt`, `suspend`, `cpr`,
 `clear`, `nirvana`) and the full operating model, read the `system-manual`
 router; it routes substrate details to `reference/substrate-manual/SKILL.md`.


### PR DESCRIPTION
## Summary
- add resident substrate guidance for handling large tool results with `system(action="summarize")`
- expand system-manual `summarize` guidance: summaries are detailed progressive-disclosure entries for future self, not casual one-liners
- clarify what useful summaries should preserve: conclusions, paths/IDs, commands/validation, risks/blockers, current state, and next steps

## Validation
- `git diff --check`
- Python doc sanity check for frontmatter/header and required summarize guidance strings