### PR TITLE
chore(tests): de-duplicate suite scaffolding and fold redundant cases

### DIFF
--- a/tests/_molt_helpers.py
+++ b/tests/_molt_helpers.py
@@ -1,0 +1,41 @@
+"""Shared helpers for the molt-persistence test modules.
+
+``VALID_SESSION_JOURNAL`` and ``write_session_journal`` were copy-pasted
+verbatim across ``test_molt_task_persistence.py``,
+``test_molt_notification_persistence.py`` and ``test_post_molt_notification.py``.
+The molt session-journal gate requires a real journal on disk before context
+shed, so every molt test needs to stage one — there is exactly one canonical
+journal, so it lives here once.
+"""
+from __future__ import annotations
+
+
+VALID_SESSION_JOURNAL = """\
+---
+name: 2026-06-19-molt-1-test
+description: A test session journal entry for the molt gate.
+date: 2026-06-19
+molt_count: 1
+type: session-journal
+---
+
+## What this segment was about
+Testing.
+
+## Accomplishments
+Wrote a valid session journal.
+"""
+
+
+def write_session_journal(
+    agent,
+    rel: str = "knowledge/session-journal/2026-06-19-molt-1-test/KNOWLEDGE.md",
+) -> str:
+    """Write the canonical valid session journal under *agent*'s working dir.
+
+    Returns the *rel* path the gate expects to be passed back into molt.
+    """
+    path = agent._working_dir / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(VALID_SESSION_JOURNAL, encoding="utf-8")
+    return rel

--- a/tests/_notification_helpers.py
+++ b/tests/_notification_helpers.py
@@ -1,0 +1,84 @@
+"""Shared test helpers for the notification-cluster tests.
+
+These were previously copy-pasted verbatim between ``test_notification_tool.py``
+and ``test_system_dismiss.py``.  They are plain helpers (not pytest fixtures) so
+the existing test bodies can keep calling them by name with no signature churn —
+each module just imports the names it uses.
+
+Note: ``test_system_notifications.py`` deliberately keeps its own, differently
+shaped ``_StubAgent`` (it carries ``_tc_inbox``/``_session`` for the wire/inbox
+integration path) and is intentionally not unified here.
+"""
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from lingtai_kernel.notifications import notification_fingerprint, publish
+
+
+@dataclass
+class StubAgent:
+    """Minimal agent stub for the atomic dismiss/notification paths.
+
+    Pre-seeded with stale ``_pending_notification_*`` state so tests can assert
+    that a successful dismiss clears it.
+    """
+
+    _working_dir: Path
+    _logs: list[tuple[str, dict]] = field(default_factory=list)
+    _notification_fp: tuple = ()
+    _pending_notification_meta: str | None = "stale"
+    _pending_notification_fp: tuple | None = (("soul.json", 1, 2),)
+    _system_notification_lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def _log(self, event_type: str, **fields: Any) -> None:
+        self._logs.append((event_type, fields))
+
+
+def events(agent: StubAgent, name: str) -> list[dict]:
+    """Return the field dicts of every ``_log`` call of type *name*."""
+    return [fields for event, fields in agent._logs if event == name]
+
+
+def mark_delivered(agent: StubAgent) -> None:
+    """Stamp the agent's notification fingerprint as current (delivered)."""
+    agent._notification_fp = notification_fingerprint(agent._working_dir)
+
+
+def publish_large_result_reminder(
+    tmp_path: Path,
+    *,
+    tool_call_id: str = "toolu_big",
+    extra_events: list[dict] | None = None,
+) -> None:
+    """Publish a ``system.json`` containing one ``large_tool_result`` reminder.
+
+    Any *extra_events* are prepended before the reminder event.  *tmp_path* (and
+    any missing parents) is created first so callers may pass a nested,
+    not-yet-existing working dir.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    events_payload = [
+        {
+            "event_id": "evt_lr",
+            "source": "large_tool_result",
+            "ref_id": f"large_tool_result:{tool_call_id}",
+            "body": "summarize me",
+        }
+    ]
+    if extra_events:
+        events_payload = list(extra_events) + events_payload
+    publish(
+        tmp_path,
+        "system",
+        {
+            "header": f"{len(events_payload)} system notifications",
+            "icon": "🔔",
+            "priority": "normal",
+            "published_at": "2026-06-20T00:00:00Z",
+            "data": {"events": events_payload},
+        },
+    )

--- a/tests/_service_helpers.py
+++ b/tests/_service_helpers.py
@@ -1,0 +1,38 @@
+"""Shared mock LLM-service factories for tests.
+
+Across the suite, dozens of test modules each defined an identical
+``make_mock_service()`` (or ``_make_mock_service()``) returning a ``MagicMock``
+service.  Two shapes dominated, so they live here as named factories and the
+modules import whichever they need — no behaviour change, just one definition
+instead of ~20 copies.
+
+Modules with a genuinely different service stub (e.g. a ``create_session``
+side-effect factory for the molt tests, a ``_key_resolver`` for vision, or the
+Codex ``provider="p"`` shim) keep their own local definition on purpose.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def make_gemini_mock_service() -> MagicMock:
+    """The common adapter-backed stub: a Gemini provider/model with an adapter.
+
+    This is the shape ~19 modules copied verbatim.
+    """
+    svc = MagicMock()
+    svc.get_adapter.return_value = MagicMock()
+    svc.provider = "gemini"
+    svc.model = "gemini-test"
+    return svc
+
+
+def make_tool_result_mock_service() -> MagicMock:
+    """The messaging/heartbeat stub: a model plus a canned ``make_tool_result``.
+
+    This is the shape the base-agent / heartbeat / watchdog / logging tests copied.
+    """
+    svc = MagicMock()
+    svc.model = "test-model"
+    svc.make_tool_result.return_value = {"role": "tool", "content": "ok"}
+    return svc

--- a/tests/test_active_stuck_watchdog.py
+++ b/tests/test_active_stuck_watchdog.py
@@ -15,13 +15,9 @@ Both cases used to be invisible to the heartbeat-only liveness check.
 import json
 import time
 from unittest.mock import MagicMock
+from tests._service_helpers import make_tool_result_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.model = "test-model"
-    svc.make_tool_result.return_value = {"role": "tool", "content": "ok"}
-    return svc
 
 
 class TestProgressBookkeeping:

--- a/tests/test_agent_capabilities.py
+++ b/tests/test_agent_capabilities.py
@@ -6,14 +6,9 @@ from unittest.mock import MagicMock
 from lingtai.agent import Agent
 from lingtai.services.vision import VisionService
 from lingtai.services.websearch import SearchService, SearchResult
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 class FakeVisionService(VisionService):

--- a/tests/test_avatar_rules.py
+++ b/tests/test_avatar_rules.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from lingtai.core.avatar import AvatarManager
 
 import pytest
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
 def _fake_launch_return(pid: int = 12345):
@@ -145,12 +146,6 @@ class TestRulesHeartbeatWatch:
         assert (wd / ".rules").is_file()
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 class TestAvatarRulesAction:

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -9,13 +9,9 @@ from lingtai_kernel.base_agent import BaseAgent
 from lingtai_kernel.message import Message, _make_message, MSG_REQUEST, MSG_USER_INPUT
 from lingtai_kernel.state import AgentState
 from lingtai_kernel.types import UnknownToolError
+from tests._service_helpers import make_tool_result_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.model = "test-model"
-    svc.make_tool_result.return_value = {"role": "tool", "content": "ok"}
-    return svc
 
 
 def test_agent_no_name(tmp_path):

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -6,40 +6,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from lingtai_kernel.base_agent import BaseAgent
-
-
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
-
-
-_VALID_SESSION_JOURNAL = """\
----
-name: 2026-06-19-molt-1-test
-description: A test session journal entry for the molt gate.
-date: 2026-06-19
-molt_count: 1
-type: session-journal
----
-
-## What this segment was about
-Testing.
-
-## Accomplishments
-Wrote a valid session journal.
-"""
-
-
-def _write_session_journal(agent, rel="knowledge/session-journal/2026-06-19-molt-1-test/KNOWLEDGE.md"):
-    """Write a valid session-journal entry so an agent-initiated molt passes
-    the session-journal gate (issue #350). Returns the workdir-relative path."""
-    path = agent._working_dir / rel
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_VALID_SESSION_JOURNAL, encoding="utf-8")
-    return rel
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
+from tests._molt_helpers import write_session_journal as _write_session_journal
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_email_abs_reply_route.py
+++ b/tests/test_email_abs_reply_route.py
@@ -19,14 +19,9 @@ from uuid import uuid4
 import pytest
 
 from lingtai.agent import Agent
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _seed_agent_dir(path: Path, *, agent_name: str = "mimo-1") -> None:

--- a/tests/test_email_identity.py
+++ b/tests/test_email_identity.py
@@ -11,14 +11,9 @@ from unittest.mock import MagicMock
 
 from lingtai.agent import Agent
 from lingtai_kernel.intrinsics import email as email_mod
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _make_agent(tmp_path, *, agent_name="alice", admin=None):

--- a/tests/test_git_init.py
+++ b/tests/test_git_init.py
@@ -13,14 +13,9 @@ import pytest
 
 from lingtai_kernel.base_agent import BaseAgent
 from lingtai_kernel.config import AgentConfig
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _git_enabled_config() -> AgentConfig:

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,13 +1,9 @@
 """Tests for heartbeat — always-on agent health monitor with AED timeout."""
 import time
 from unittest.mock import MagicMock
+from tests._service_helpers import make_tool_result_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.model = "test-model"
-    svc.make_tool_result.return_value = {"role": "tool", "content": "ok"}
-    return svc
 
 
 class TestHeartbeatInit:

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -11,14 +11,9 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from lingtai.agent import Agent
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _mk_agent(tmp_path: Path, knowledge_cfg: dict | None = None):

--- a/tests/test_large_result_rescan.py
+++ b/tests/test_large_result_rescan.py
@@ -88,6 +88,47 @@ def _add_synthesized_tool_pair(iface: ChatInterface, call_id: str, tool_name: st
     iface.add_tool_results([ToolResultBlock(id=call_id, name=tool_name, content=result_content, synthesized=True)])
 
 
+def _run_executor_metadata(
+    tmp_path: Path,
+    *,
+    output,
+    tool_name: str = "bash",
+    tool_call_id: str = "tc-001",
+    threshold: int | None = None,
+):
+    """Run one tool call through a real ToolExecutor and return its result content.
+
+    Centralises the ToolExecutor + dispatch/make_result boilerplate that the
+    ``_tool_result_metadata`` tests below would otherwise each copy verbatim.
+    *output* is wrapped in the standard ``{"output": ..., "status": "ok"}`` dict
+    result; pass *threshold* to override ``summarize_notification_threshold``.
+    """
+    from lingtai_kernel.tool_executor import ToolExecutor
+    from lingtai_kernel.loop_guard import LoopGuard
+    from lingtai_kernel.llm.interface import ToolResultBlock as _TRB
+    from lingtai_kernel.llm.base import ToolCall as _TC
+
+    def _dispatch(tc):
+        return {"output": output, "status": "ok"}
+
+    def _make_result(name, content, *, tool_call_id=None):
+        return _TRB(id=tool_call_id, name=name, content=content)
+
+    kwargs = {}
+    if threshold is not None:
+        kwargs["summarize_notification_threshold"] = threshold
+    executor = ToolExecutor(
+        dispatch_fn=_dispatch,
+        make_tool_result_fn=_make_result,
+        guard=LoopGuard(),
+        working_dir=tmp_path,
+        **kwargs,
+    )
+    tc = _TC(name=tool_name, args={}, id=tool_call_id)
+    results, _, _ = executor.execute([tc])
+    return results[0].content
+
+
 # ---------------------------------------------------------------------------
 # 1. Existing large ToolResultBlock triggers notification on rescan
 # ---------------------------------------------------------------------------
@@ -708,7 +749,8 @@ def test_rescan_spill_body_no_raise_disable_threshold_wording():
 
 
 # ---------------------------------------------------------------------------
-# 13. Rescan body wording: summarize clears the reminder; dismiss cannot bypass
+# 13. Rescan body wording: summarize is the preferred discharge; dismiss is an
+#     allowed escape hatch (#430).
 # ---------------------------------------------------------------------------
 
 
@@ -944,28 +986,7 @@ def test_large_result_hint_in_tool_result(tmp_path):
 
 def test_no_hint_for_small_result(tmp_path):
     """ToolExecutor injects _tool_result_metadata with long_tool_result=False for small results."""
-    from lingtai_kernel.tool_executor import ToolExecutor
-    from lingtai_kernel.loop_guard import LoopGuard
-    from lingtai_kernel.llm.interface import ToolResultBlock as _TRB
-    from lingtai_kernel.llm.base import ToolCall as _TC
-
-    def _dispatch(tc):
-        return {"output": "tiny", "status": "ok"}
-
-    def _make_result(tool_name, content, *, tool_call_id=None):
-        return _TRB(id=tool_call_id, name=tool_name, content=content)
-
-    executor = ToolExecutor(
-        dispatch_fn=_dispatch,
-        make_tool_result_fn=_make_result,
-        guard=LoopGuard(),
-        working_dir=tmp_path,
-    )
-
-    tc = _TC(name="bash", args={}, id="tc-small-001")
-    results, _, _ = executor.execute([tc], on_result_hook=None)
-
-    content = results[0].content
+    content = _run_executor_metadata(tmp_path, output="tiny", tool_call_id="tc-small-001")
     assert "_tool_result_metadata" in content, "_tool_result_metadata is always present"
     assert content["_tool_result_metadata"]["long_tool_result"] is False, (
         "small result must have long_tool_result=False"
@@ -1000,122 +1021,20 @@ def test_no_hint_for_string_result(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# 17. ToolExecutor uses configured threshold, not hardcoded default
-# ---------------------------------------------------------------------------
-
-
-def test_hint_uses_custom_threshold(tmp_path):
-    """ToolExecutor uses its configured summarize_notification_threshold in _tool_result_metadata.
-
-    A result of 600 chars should have long_tool_result=False with threshold=3000 (default),
-    but long_tool_result=True when threshold=500 (the configured custom value).
-    """
-    from lingtai_kernel.tool_executor import ToolExecutor
-    from lingtai_kernel.loop_guard import LoopGuard
-    from lingtai_kernel.llm.interface import ToolResultBlock as _TRB
-    from lingtai_kernel.llm.base import ToolCall as _TC
-
-    def _dispatch(tc):
-        return {"output": "X" * 600, "status": "ok"}
-
-    def _make_result(tool_name, content, *, tool_call_id=None):
-        return _TRB(id=tool_call_id, name=tool_name, content=content)
-
-    # With default threshold (3000), 600 chars → long_tool_result=False
-    executor_default = ToolExecutor(
-        dispatch_fn=_dispatch,
-        make_tool_result_fn=_make_result,
-        guard=LoopGuard(),
-        working_dir=tmp_path,
-    )
-    tc = _TC(name="bash", args={}, id="tc-custom-thresh-001")
-    results, _, _ = executor_default.execute([tc])
-    meta = results[0].content["_tool_result_metadata"]
-    assert meta["long_tool_result"] is False, (
-        "default threshold (3000): 600-char result must have long_tool_result=False"
-    )
-
-    # With custom threshold=500, 600 chars → long_tool_result=True
-    executor_custom = ToolExecutor(
-        dispatch_fn=_dispatch,
-        make_tool_result_fn=_make_result,
-        guard=LoopGuard(),
-        working_dir=tmp_path,
-        summarize_notification_threshold=500,
-    )
-    tc2 = _TC(name="bash", args={}, id="tc-custom-thresh-002")
-    results2, _, _ = executor_custom.execute([tc2])
-    meta2 = results2[0].content["_tool_result_metadata"]
-    assert meta2["long_tool_result"] is True, (
-        "custom threshold (500): 600-char result must have long_tool_result=True"
-    )
-    assert meta2["threshold_chars"] == 500
-
-
-def test_hint_disabled_when_threshold_zero(tmp_path):
-    """ToolExecutor with summarize_notification_threshold=0: metadata present but long_tool_result=False."""
-    from lingtai_kernel.tool_executor import ToolExecutor
-    from lingtai_kernel.loop_guard import LoopGuard
-    from lingtai_kernel.llm.interface import ToolResultBlock as _TRB
-    from lingtai_kernel.llm.base import ToolCall as _TC
-
-    def _dispatch(tc):
-        # Use a size within spill cap so result is not spilled (spill manifests are excluded).
-        return {"output": "X" * 5000, "status": "ok"}
-
-    def _make_result(tool_name, content, *, tool_call_id=None):
-        return _TRB(id=tool_call_id, name=tool_name, content=content)
-
-    executor = ToolExecutor(
-        dispatch_fn=_dispatch,
-        make_tool_result_fn=_make_result,
-        guard=LoopGuard(),
-        working_dir=tmp_path,
-        summarize_notification_threshold=0,
-    )
-
-    tc = _TC(name="bash", args={}, id="tc-zero-thresh-001")
-    results, _, _ = executor.execute([tc])
-    content = results[0].content
-    assert "_tool_result_metadata" in content, (
-        "threshold=0 disables long-result hinting but _tool_result_metadata must still be present"
-    )
-    meta = content["_tool_result_metadata"]
-    assert meta["long_tool_result"] is False, (
-        "threshold=0 means long-result hinting is disabled; long_tool_result must be False"
-    )
-    assert meta["threshold_chars"] == 0
-
-
-# ---------------------------------------------------------------------------
-# 18. _tool_result_metadata always present (Jason's PR #430 requirement)
+# 17. _tool_result_metadata always present (Jason's PR #430 requirement), and
+#     long_tool_result honours the configured threshold (default / custom / zero).
+#
+# The custom-threshold and threshold-zero cases below prove the executor uses its
+# *configured* summarize_notification_threshold rather than a hardcoded default,
+# subsuming the earlier standalone "hint_*" tests.
 # ---------------------------------------------------------------------------
 
 
 def test_tool_result_metadata_always_present_for_small_result(tmp_path):
     """Every dict result gets _tool_result_metadata even when below the large-result threshold."""
-    from lingtai_kernel.tool_executor import ToolExecutor
-    from lingtai_kernel.loop_guard import LoopGuard
-    from lingtai_kernel.llm.interface import ToolResultBlock as _TRB
-    from lingtai_kernel.llm.base import ToolCall as _TC
-
-    def _dispatch(tc):
-        return {"output": "tiny result", "status": "ok"}
-
-    def _make_result(tool_name, content, *, tool_call_id=None):
-        return _TRB(id=tool_call_id, name=tool_name, content=content)
-
-    executor = ToolExecutor(
-        dispatch_fn=_dispatch,
-        make_tool_result_fn=_make_result,
-        guard=LoopGuard(),
-        working_dir=tmp_path,
+    content = _run_executor_metadata(
+        tmp_path, output="tiny result", tool_call_id="tc-meta-small-001"
     )
-
-    tc = _TC(name="bash", args={}, id="tc-meta-small-001")
-    results, _, _ = executor.execute([tc], on_result_hook=None)
-
-    content = results[0].content
     assert isinstance(content, dict), "result should be a dict"
     assert "_tool_result_metadata" in content, "_tool_result_metadata must always be present"
     meta = content["_tool_result_metadata"]
@@ -1130,28 +1049,9 @@ def test_tool_result_metadata_always_present_for_small_result(tmp_path):
 
 def test_tool_result_metadata_long_result_has_true_flag(tmp_path):
     """_tool_result_metadata.long_tool_result is True when result exceeds threshold."""
-    from lingtai_kernel.tool_executor import ToolExecutor
-    from lingtai_kernel.loop_guard import LoopGuard
-    from lingtai_kernel.llm.interface import ToolResultBlock as _TRB
-    from lingtai_kernel.llm.base import ToolCall as _TC
-
-    def _dispatch(tc):
-        return {"output": "X" * 5000, "status": "ok"}
-
-    def _make_result(tool_name, content, *, tool_call_id=None):
-        return _TRB(id=tool_call_id, name=tool_name, content=content)
-
-    executor = ToolExecutor(
-        dispatch_fn=_dispatch,
-        make_tool_result_fn=_make_result,
-        guard=LoopGuard(),
-        working_dir=tmp_path,
+    content = _run_executor_metadata(
+        tmp_path, output="X" * 5000, tool_name="read", tool_call_id="tc-meta-large-001"
     )
-
-    tc = _TC(name="read", args={}, id="tc-meta-large-001")
-    results, _, _ = executor.execute([tc], on_result_hook=None)
-
-    content = results[0].content
     assert "_tool_result_metadata" in content, "_tool_result_metadata must always be present"
     meta = content["_tool_result_metadata"]
     assert meta["tool_call_id"] == "tc-meta-large-001"
@@ -1166,42 +1066,21 @@ def test_tool_result_metadata_long_result_has_true_flag(tmp_path):
 
 
 def test_tool_result_metadata_custom_threshold(tmp_path):
-    """_tool_result_metadata reflects the custom threshold and correct long_tool_result flag."""
-    from lingtai_kernel.tool_executor import ToolExecutor
-    from lingtai_kernel.loop_guard import LoopGuard
-    from lingtai_kernel.llm.interface import ToolResultBlock as _TRB
-    from lingtai_kernel.llm.base import ToolCall as _TC
+    """Executor uses its *configured* threshold, not a hardcoded default.
 
-    def _dispatch(tc):
-        return {"output": "X" * 600, "status": "ok"}
-
-    def _make_result(tool_name, content, *, tool_call_id=None):
-        return _TRB(id=tool_call_id, name=tool_name, content=content)
-
-    # With default threshold (3000): 600-char result → long_tool_result: false
-    executor_default = ToolExecutor(
-        dispatch_fn=_dispatch,
-        make_tool_result_fn=_make_result,
-        guard=LoopGuard(),
-        working_dir=tmp_path,
-    )
-    tc = _TC(name="bash", args={}, id="tc-meta-thresh-001")
-    results, _, _ = executor_default.execute([tc])
-    meta = results[0].content["_tool_result_metadata"]
+    A 600-char result is below the default (3000) but above a custom 500 — the
+    metadata's long_tool_result flag and threshold_chars track whichever
+    threshold the executor was built with.  (Subsumes the former test_hint_* pair.)
+    """
+    meta = _run_executor_metadata(
+        tmp_path, output="X" * 600, tool_call_id="tc-meta-thresh-001"
+    )["_tool_result_metadata"]
     assert meta["long_tool_result"] is False
     assert meta["threshold_chars"] == 3000
 
-    # With custom threshold=500: 600-char result → long_tool_result: true
-    executor_custom = ToolExecutor(
-        dispatch_fn=_dispatch,
-        make_tool_result_fn=_make_result,
-        guard=LoopGuard(),
-        working_dir=tmp_path,
-        summarize_notification_threshold=500,
-    )
-    tc2 = _TC(name="bash", args={}, id="tc-meta-thresh-002")
-    results2, _, _ = executor_custom.execute([tc2])
-    meta2 = results2[0].content["_tool_result_metadata"]
+    meta2 = _run_executor_metadata(
+        tmp_path, output="X" * 600, tool_call_id="tc-meta-thresh-002", threshold=500
+    )["_tool_result_metadata"]
     assert meta2["long_tool_result"] is True
     assert meta2["threshold_chars"] == 500
 
@@ -1209,32 +1088,12 @@ def test_tool_result_metadata_custom_threshold(tmp_path):
 def test_tool_result_metadata_threshold_zero_still_present(tmp_path):
     """With threshold=0 (disabled), _tool_result_metadata is still present but long_tool_result=False.
 
-    Use a result large enough to exceed threshold 0 semantically (any non-zero size) but
-    small enough that it is not spilled to a sidecar file (spill manifests are excluded).
+    The 5000-char output is a "would-be" long result, but well within the spill
+    cap so it is not spilled to a sidecar (spill manifests are excluded).
     """
-    from lingtai_kernel.tool_executor import ToolExecutor
-    from lingtai_kernel.loop_guard import LoopGuard
-    from lingtai_kernel.llm.interface import ToolResultBlock as _TRB
-    from lingtai_kernel.llm.base import ToolCall as _TC
-
-    def _dispatch(tc):
-        # Large enough to be a "would-be" long result, but well within the spill cap.
-        return {"output": "X" * 5000, "status": "ok"}
-
-    def _make_result(tool_name, content, *, tool_call_id=None):
-        return _TRB(id=tool_call_id, name=tool_name, content=content)
-
-    executor = ToolExecutor(
-        dispatch_fn=_dispatch,
-        make_tool_result_fn=_make_result,
-        guard=LoopGuard(),
-        working_dir=tmp_path,
-        summarize_notification_threshold=0,
+    content = _run_executor_metadata(
+        tmp_path, output="X" * 5000, tool_call_id="tc-meta-zero-001", threshold=0
     )
-
-    tc = _TC(name="bash", args={}, id="tc-meta-zero-001")
-    results, _, _ = executor.execute([tc])
-    content = results[0].content
     assert "_tool_result_metadata" in content, (
         "threshold=0 disables long-result hinting but metadata itself must still be present"
     )

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -7,14 +7,9 @@ import pytest
 
 from lingtai.core.bash import BashManager
 from lingtai.core.avatar import AvatarManager, setup as setup_avatar
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 @pytest.fixture

--- a/tests/test_layers_email.py
+++ b/tests/test_layers_email.py
@@ -8,14 +8,9 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 from lingtai.agent import Agent
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _make_inbox_email(working_dir, *, sender="sender", to=None, subject="test",

--- a/tests/test_layers_file.py
+++ b/tests/test_layers_file.py
@@ -7,14 +7,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from lingtai.agent import Agent
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def test_file_sugar_expands_to_five(tmp_path):

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -21,14 +21,9 @@ from lingtai.core.mcp import (
     read_registry,
     validate_record,
 )
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _mk_agent(tmp_path: Path, *, addons=None, capabilities=None):

--- a/tests/test_mcp_inbox.py
+++ b/tests/test_mcp_inbox.py
@@ -30,14 +30,9 @@ from lingtai.core.mcp.inbox import (
     _scan_once,
     validate_event,
 )
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _mk_agent(tmp_path: Path):

--- a/tests/test_mcp_licc_client.py
+++ b/tests/test_mcp_licc_client.py
@@ -38,6 +38,7 @@ from lingtai.core.mcp.inbox import (
     _scan_once,
     validate_event,
 )
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
 # ---------------------------------------------------------------------------
@@ -62,12 +63,6 @@ def _read_event(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _mk_agent(tmp_path: Path):

--- a/tests/test_molt_notification_persistence.py
+++ b/tests/test_molt_notification_persistence.py
@@ -13,28 +13,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 
-_VALID_SESSION_JOURNAL = """\
----
-name: 2026-06-19-molt-1-test
-description: A test session journal entry for the molt gate.
-date: 2026-06-19
-molt_count: 1
-type: session-journal
----
-
-## What this segment was about
-Testing.
-
-## Accomplishments
-Wrote a valid session journal.
-"""
-
-
-def _write_session_journal(agent, rel="knowledge/session-journal/2026-06-19-molt-1-test/KNOWLEDGE.md"):
-    path = agent._working_dir / rel
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_VALID_SESSION_JOURNAL, encoding="utf-8")
-    return rel
+from tests._molt_helpers import write_session_journal as _write_session_journal
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_molt_task_persistence.py
+++ b/tests/test_molt_task_persistence.py
@@ -16,28 +16,7 @@ import pytest
 from lingtai_kernel.llm.interface import ChatInterface, TextBlock, ToolCallBlock
 
 
-_VALID_SESSION_JOURNAL = """\
----
-name: 2026-06-19-molt-1-test
-description: A test session journal entry for the molt gate.
-date: 2026-06-19
-molt_count: 1
-type: session-journal
----
-
-## What this segment was about
-Testing.
-
-## Accomplishments
-Wrote a valid session journal.
-"""
-
-
-def _write_session_journal(agent, rel="knowledge/session-journal/2026-06-19-molt-1-test/KNOWLEDGE.md"):
-    path = agent._working_dir / rel
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_VALID_SESSION_JOURNAL, encoding="utf-8")
-    return rel
+from tests._molt_helpers import write_session_journal as _write_session_journal
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_notification_tool.py
+++ b/tests/test_notification_tool.py
@@ -15,9 +15,11 @@ compatibility aliases.  Dismissal is **atomic**:
 
 ``summarize`` is NOT here — it stays a ``system`` action.
 
-#424 semantics (``large_tool_result`` reminders undismissable; only a
-successful ``system(action="summarize")`` clears them) must hold through every
-atomic notification action, including ``force``.
+``large_tool_result`` reminders are dismissable as an escape hatch (#430,
+superseding the original #424 "undismissable" rule): every atomic notification
+action — with or without ``force`` — clears such a reminder and acks its
+``ref_id``.  ``system(action="summarize")`` remains the preferred discharge and
+still auto-clears the matching reminder on success.
 """
 from __future__ import annotations
 
@@ -38,61 +40,13 @@ from lingtai_kernel.notifications import (
     publish,
 )
 
-
-# ---------------------------------------------------------------------------
-# Stub agent — mirrors the one used by test_system_dismiss.py.
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class _StubAgent:
-    _working_dir: Path
-    _logs: list[tuple[str, dict]] = field(default_factory=list)
-    _notification_fp: tuple = ()
-    _pending_notification_meta: str | None = "stale"
-    _pending_notification_fp: tuple | None = (("soul.json", 1, 2),)
-    _system_notification_lock: threading.Lock = field(default_factory=threading.Lock)
-
-    def _log(self, event_type: str, **fields: Any) -> None:
-        self._logs.append((event_type, fields))
-
-
-def _events(agent: _StubAgent, name: str) -> list[dict]:
-    return [fields for event, fields in agent._logs if event == name]
-
-
-def _mark_delivered(agent: _StubAgent) -> None:
-    agent._notification_fp = notification_fingerprint(agent._working_dir)
-
-
-def _publish_large_result_reminder(
-    tmp_path: Path,
-    *,
-    tool_call_id: str = "toolu_big",
-    extra_events: list[dict] | None = None,
-) -> None:
-    tmp_path.mkdir(parents=True, exist_ok=True)
-    events = [
-        {
-            "event_id": "evt_lr",
-            "source": "large_tool_result",
-            "ref_id": f"large_tool_result:{tool_call_id}",
-            "body": "summarize me",
-        }
-    ]
-    if extra_events:
-        events = list(extra_events) + events
-    publish(
-        tmp_path,
-        "system",
-        {
-            "header": f"{len(events)} system notifications",
-            "icon": "🔔",
-            "priority": "normal",
-            "published_at": "2026-06-20T00:00:00Z",
-            "data": {"events": events},
-        },
-    )
+# Shared with test_system_dismiss.py — see tests/_notification_helpers.py.
+from tests._notification_helpers import (
+    StubAgent as _StubAgent,
+    events as _events,
+    mark_delivered as _mark_delivered,
+    publish_large_result_reminder as _publish_large_result_reminder,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -344,46 +298,18 @@ def test_dismiss_ref_missing_ref_id(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# #424: large_tool_result guard via EVERY atomic action, including force.
+# large_tool_result escape hatch (#430): every atomic dismiss action — with or
+# without force — now clears a large_tool_result reminder and acks its ref_id.
+# (Supersedes the original #424 "undismissable" guard.)  The per-action matrix
+# below is the single source of truth; there are no per-action singletons.
 # ---------------------------------------------------------------------------
-
-
-def test_large_result_guard_dismiss_channel(tmp_path: Path) -> None:
-    """large_tool_result reminders can now be dismissed as an escape hatch."""
-    agent = _StubAgent(tmp_path)
-    _publish_large_result_reminder(tmp_path)
-    _mark_delivered(agent)
-
-    res = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "channel": "system"})
-
-    assert res["status"] == "ok"
-    assert "acked_large_result_refs" in res
-    # The event is removed from the channel.
-    notifs = collect_notifications(tmp_path)
-    events = notifs.get("system", {}).get("data", {}).get("events", [])
-    assert not any(ev["source"] == "large_tool_result" for ev in events)
-
-
-def test_large_result_guard_dismiss_channel_force(tmp_path: Path) -> None:
-    """large_tool_result reminders can be dismissed with force — same result."""
-    agent = _StubAgent(tmp_path)
-    _publish_large_result_reminder(tmp_path)
-    _mark_delivered(agent)
-
-    res = notif_intrinsic.handle(
-        agent, {"action": "dismiss_channel", "channel": "system", "force": True}
-    )
-
-    assert res["status"] == "ok"
-    assert "acked_large_result_refs" in res
-    notifs = collect_notifications(tmp_path)
-    events = notifs.get("system", {}).get("data", {}).get("events", [])
-    assert not any(ev["source"] == "large_tool_result" for ev in events)
 
 
 def test_large_result_guard_every_atomic_action(tmp_path: Path) -> None:
     """All atomic actions — channel/event/ref, with or without force — now succeed
-    for large_tool_result reminders (escape hatch behaviour from issue #425)."""
+    for large_tool_result reminders (escape-hatch behaviour from #430): each
+    returns status=ok, reports ``acked_large_result_refs``, and removes the
+    reminder from the channel."""
     cases = [
         {"action": "dismiss_channel", "channel": "system"},
         {"action": "dismiss_channel", "channel": "system", "force": True},

--- a/tests/test_override_intrinsic.py
+++ b/tests/test_override_intrinsic.py
@@ -6,14 +6,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from lingtai_kernel.base_agent import BaseAgent
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def test_override_intrinsic_removes_from_dict(tmp_path):

--- a/tests/test_post_molt_notification.py
+++ b/tests/test_post_molt_notification.py
@@ -23,28 +23,7 @@ import json
 from unittest.mock import MagicMock
 
 
-_VALID_SESSION_JOURNAL = """\
----
-name: 2026-06-19-molt-1-test
-description: A test session journal entry for the molt gate.
-date: 2026-06-19
-molt_count: 1
-type: session-journal
----
-
-## What this segment was about
-Testing.
-
-## Accomplishments
-Wrote a valid session journal.
-"""
-
-
-def _write_session_journal(agent, rel="knowledge/session-journal/2026-06-19-molt-1-test/KNOWLEDGE.md"):
-    path = agent._working_dir / rel
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_VALID_SESSION_JOURNAL, encoding="utf-8")
-    return rel
+from tests._molt_helpers import write_session_journal as _write_session_journal
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -7,14 +7,9 @@ import pytest
 
 from lingtai.agent import Agent
 from lingtai_kernel.base_agent import BaseAgent
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _call(agent, args: dict) -> dict:

--- a/tests/test_secondary_schema.py
+++ b/tests/test_secondary_schema.py
@@ -4,14 +4,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from lingtai_kernel.base_agent import BaseAgent
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _schema_by_name(agent: BaseAgent) -> dict[str, dict]:

--- a/tests/test_services_logging.py
+++ b/tests/test_services_logging.py
@@ -13,6 +13,7 @@ from lingtai_kernel.services.logging import (
     query_sqlite_event_index,
     rebuild_sqlite_event_index,
 )
+from tests._service_helpers import make_tool_result_mock_service as make_mock_service
 
 
 class TestJSONLLoggingService:
@@ -118,11 +119,6 @@ from lingtai_kernel.llm import ToolCall
 from lingtai_kernel.loop_guard import LoopGuard
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.model = "test-model"
-    svc.make_tool_result.return_value = {"role": "tool", "content": "ok"}
-    return svc
 
 
 class TestBaseAgentLoggingIntegration:

--- a/tests/test_session_journal_gate.py
+++ b/tests/test_session_journal_gate.py
@@ -20,6 +20,7 @@ from lingtai.agent import Agent
 from lingtai_kernel.intrinsics.psyche._session_journal import (
     validate_session_journal_path,
 )
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
 # ---------------------------------------------------------------------------
@@ -27,12 +28,6 @@ from lingtai_kernel.intrinsics.psyche._session_journal import (
 # ---------------------------------------------------------------------------
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 VALID_JOURNAL = """\

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -9,14 +9,9 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from lingtai.agent import Agent
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _mk_agent(tmp_path: Path, skills_cfg: dict | None = None):

--- a/tests/test_system_dismiss.py
+++ b/tests/test_system_dismiss.py
@@ -17,11 +17,8 @@ semantics.
 from __future__ import annotations
 
 import json
-import threading
-from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -33,18 +30,13 @@ from lingtai_kernel.notifications import (
     publish,
 )
 
-
-@dataclass
-class _StubAgent:
-    _working_dir: Path
-    _logs: list[tuple[str, dict]] = field(default_factory=list)
-    _notification_fp: tuple = ()
-    _pending_notification_meta: str | None = "stale"
-    _pending_notification_fp: tuple | None = (("soul.json", 1, 2),)
-    _system_notification_lock: threading.Lock = field(default_factory=threading.Lock)
-
-    def _log(self, event_type: str, **fields: Any) -> None:
-        self._logs.append((event_type, fields))
+# Shared with test_notification_tool.py — see tests/_notification_helpers.py.
+from tests._notification_helpers import (
+    StubAgent as _StubAgent,
+    events as _events,
+    mark_delivered as _mark_delivered,
+    publish_large_result_reminder as _publish_large_result_reminder,
+)
 
 
 class _RecordingLock:
@@ -57,14 +49,6 @@ class _RecordingLock:
 
     def __exit__(self, *_exc) -> None:
         return None
-
-
-def _events(agent: _StubAgent, name: str) -> list[dict]:
-    return [fields for event, fields in agent._logs if event == name]
-
-
-def _mark_delivered(agent: _StubAgent) -> None:
-    agent._notification_fp = notification_fingerprint(agent._working_dir)
 
 
 def _dismiss_channel(agent, channel, **kwargs):
@@ -431,36 +415,6 @@ def test_system_event_dismiss_by_ref_id_clears_file_when_last_event(tmp_path: Pa
     assert result["removed"] == 1
     assert result["remaining"] == 0
     assert not (tmp_path / ".notification" / "system.json").exists()
-
-
-def _publish_large_result_reminder(
-    tmp_path: Path,
-    *,
-    tool_call_id: str = "toolu_big",
-    extra_events: list[dict] | None = None,
-) -> None:
-    """Publish a system.json containing one large_tool_result reminder."""
-    events = [
-        {
-            "event_id": "evt_lr",
-            "source": "large_tool_result",
-            "ref_id": f"large_tool_result:{tool_call_id}",
-            "body": "summarize me",
-        }
-    ]
-    if extra_events:
-        events = list(extra_events) + events
-    publish(
-        tmp_path,
-        "system",
-        {
-            "header": f"{len(events)} system notifications",
-            "icon": "🔔",
-            "priority": "normal",
-            "published_at": "2026-06-20T00:00:00Z",
-            "data": {"events": events},
-        },
-    )
 
 
 def test_large_result_reminder_cleared_by_whole_channel_dismiss(tmp_path: Path) -> None:

--- a/tests/test_system_summarize.py
+++ b/tests/test_system_summarize.py
@@ -1047,11 +1047,12 @@ def test_large_result_notification_batch_digest_wording(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Requirement #3: notification text — summarize clears, dismiss cannot bypass
+# Notification text — summarize is the preferred discharge; dismiss is an
+# allowed escape hatch (#430).
 # ---------------------------------------------------------------------------
 
 
-def test_large_result_notification_body_says_dismiss_cannot_bypass(tmp_path):
+def test_large_result_notification_body_prefers_summarize_over_dismiss(tmp_path):
     """Plain large-result notification must mention dismiss and summarize.
     Summarize is the preferred discharge; dismiss is now an escape hatch."""
     agent = _make_base_agent_for_notification(tmp_path)
@@ -1072,8 +1073,8 @@ def test_large_result_notification_body_says_dismiss_cannot_bypass(tmp_path):
     assert "escape hatch" in body or "preferred" in body
 
 
-def test_large_result_spill_notification_body_says_dismiss_cannot_bypass(tmp_path):
-    """Spill large-result notification must carry the same dismiss-cannot-bypass wording."""
+def test_large_result_spill_notification_body_prefers_summarize_over_dismiss(tmp_path):
+    """Spill large-result notification must carry the same prefer-summarize wording."""
     from lingtai_kernel.tool_result_artifacts import ARTIFACT_MARKER
 
     agent = _make_base_agent_for_notification(tmp_path)

--- a/tests/test_three_agent_email.py
+++ b/tests/test_three_agent_email.py
@@ -22,14 +22,9 @@ from unittest.mock import MagicMock
 from lingtai.agent import Agent
 from lingtai_kernel.config import AgentConfig
 from lingtai_kernel.services.mail import FilesystemMailService
+from tests._service_helpers import make_gemini_mock_service as _make_mock_service
 
 
-def _make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def _setup_agent_dir(path: Path) -> None:

--- a/tests/test_web_search_capability.py
+++ b/tests/test_web_search_capability.py
@@ -8,14 +8,9 @@ import pytest
 from lingtai.agent import Agent
 from lingtai.capabilities.web_search import WebSearchManager
 from lingtai.services.websearch import SearchResult, SearchService, create_search_service
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
-def make_mock_service():
-    svc = MagicMock()
-    svc.get_adapter.return_value = MagicMock()
-    svc.provider = "gemini"
-    svc.model = "gemini-test"
-    return svc
 
 
 def test_web_search_added_by_capability(tmp_path):


### PR DESCRIPTION
## What & why

Jason: 「清理一下现在的 test，感觉又多又臭了」 — and on the follow-up: 「我说的是整个 test suite」. A behaviour-preserving cleanup scoped to the **entire** `tests/` suite (the recent notification tests are one part). **No production code is touched** — `src/` untouched, tests-only.

The dominant suite-wide smell was massive copy-paste of small scaffolding helpers, enabled by a near-empty `conftest.py`. This PR consolidates the byte-identical copies into a few small shared helper modules and folds a handful of strict-subset tests into clearer combined siblings, preserving semantic coverage.

**Net: 34 files, +291 / −594.**

## Changes

### New shared helper modules
- **`tests/_service_helpers.py`** — `make_gemini_mock_service` / `make_tool_result_mock_service`, replacing **24 verbatim copies** of `make_mock_service` / `_make_mock_service` across the suite. Call sites are unchanged (each module imports the factory under its existing local name). Modules with a genuinely different stub are left alone on purpose: vision (`_key_resolver`), codex (`provider="p"`), the molt `create_session` side-effect factory, and the `test_cli_integration` hybrid.
- **`tests/_notification_helpers.py`** — `StubAgent` / `events` / `mark_delivered` / `publish_large_result_reminder`, previously byte-identical between `test_notification_tool.py` and `test_system_dismiss.py`. (`test_system_notifications.py` keeps its own differently-shaped stub by design.)
- **`tests/_molt_helpers.py`** — `VALID_SESSION_JOURNAL` + `write_session_journal`, previously identical across the three molt-persistence modules and `test_eigen.py`.

### Notification cluster
- Remove `test_large_result_guard_dismiss_channel{,_force}` — strict subsets of the parameterized `test_large_result_guard_every_atomic_action` (channel/event/ref × {plain, force}).
- Fix **stale** comments / test names that still asserted large-result reminders are "undismissable" / "dismiss cannot bypass". Current `main` (post-#430) makes them dismissable as an escape hatch; the test *bodies* already reflected this — only the prose lied. Renamed two `*_says_dismiss_cannot_bypass` tests to `*_prefers_summarize_over_dismiss`.

### Large-result rescan (`test_large_result_rescan.py`)
- Add a local `_run_executor_metadata()` helper; drop the ~10-line per-test `ToolExecutor` + dispatch/make_result boilerplate.
- Fold `test_hint_uses_custom_threshold` / `test_hint_disabled_when_threshold_zero` into their strict-superset `test_tool_result_metadata_*` siblings.

## Coverage preservation
Only **4 tests removed**, each a demonstrated strict subset of a sibling that remains (2 guard tests → the parameterized `every_atomic_action`; 2 `test_hint_*` → `test_tool_result_metadata_custom_threshold` / `_threshold_zero_still_present`).

Preserved semantics still have explicit, reviewable tests: notification actions remain exactly `check`/`dismiss_channel`/`dismiss_event`/`dismiss_ref`; no `notification.summarize`; `system.summarize` exists and auto-clears the matching large-result reminder on success; no agent-callable `system.notification`/`system.dismiss`; synthesized delivery pair stays `notification(action="check")`; producer canonical state and stale/force boundaries intact.

> The task brief listed "large-result reminders cannot be dismissed via atomic notification actions/force" as an invariant, but that was based on the older `a5e46ab` snapshot. Current `main` (PR #430, `adeb88c`) deliberately made them **dismissable**. This PR preserves the **current** behaviour and fixes the stale prose that contradicted it.

## Validation
- `python -m pytest tests/ -q` → **2528 passed, 4 skipped** (the 4 skips pre-exist, unrelated).
- `git diff --check` → clean.

## Out of scope / suggested follow-ups
Riskier or larger opportunities the audit surfaced, intentionally left for separate PRs:
- Parameterize the daemon argv / per-batch-limit / check-validation matrices (`test_daemon_backend_options.py`, `test_daemon_per_batch_limits.py`, `test_daemon_check.py`).
- Share the `Event` / `FakeResponses` / `FakeClient` / `_usage` fakes duplicated across the codex/openai adapter tests (~7 files).
- Share `_make_agent` / `_make_run_dir` / a `_FakeProc` across the daemon test files.
- Replace sleep-based timing in `test_heartbeat.py` / `test_active_stuck_watchdog.py` / `test_cli_integration.py` / mail integration tests with event-driven waits.
- Fold `_setup_mock_chat` (near-identical, value-level differences) across the molt tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
