### PR TITLE
codex: send session_id/thread_id headers (underscore) to match Codex CLI

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1708,12 +1708,20 @@ class CodexResponsesSession(OpenAIResponsesSession):
         self._time_fn = time_fn or time.time
 
     def _cache_affinity_headers(self) -> dict[str, str]:
-        """Return the current ``session-id`` / ``thread-id`` headers, if any."""
+        """Return the current ``session_id`` / ``thread_id`` headers, if any.
+
+        The header names use UNDERSCORES (``session_id`` / ``thread_id``) to match
+        what the official Codex CLI sends on its
+        ``/backend-api/codex/responses`` calls (verified by capturing real Codex
+        CLI traffic, 2026-06). The backend routes the prompt-cache slot off these
+        headers; sending the exact spelling the reference client uses avoids any
+        chance of a name mismatch defeating cache affinity.
+        """
         headers: dict[str, str] = {}
         if self._session_id:
-            headers["session-id"] = self._session_id
+            headers["session_id"] = self._session_id
         if self._thread_id:
-            headers["thread-id"] = self._thread_id
+            headers["thread_id"] = self._thread_id
         return headers
 
     def _cache_key_header(self, cache_key: str | None) -> dict[str, str]:
@@ -1837,10 +1845,10 @@ class CodexResponsesSession(OpenAIResponsesSession):
         tokens, no OAuth secret.
         """
         extra: dict[str, str] = {}
-        if affinity_headers.get("session-id"):
-            extra["codex_session_id"] = affinity_headers["session-id"]
-        if affinity_headers.get("thread-id"):
-            extra["codex_thread_id"] = affinity_headers["thread-id"]
+        if affinity_headers.get("session_id"):
+            extra["codex_session_id"] = affinity_headers["session_id"]
+        if affinity_headers.get("thread_id"):
+            extra["codex_thread_id"] = affinity_headers["thread_id"]
         if cache_key:
             extra["codex_prompt_cache_key"] = cache_key
         return extra

--- a/tests/test_codex_cache_stall_temp_key.py
+++ b/tests/test_codex_cache_stall_temp_key.py
@@ -187,8 +187,8 @@ def test_current_id_stable_within_one_session_across_requests():
 
     for sent in session._client.responses.kwargs:
         assert sent["prompt_cache_key"] == current
-        assert sent["extra_headers"]["session-id"] == current
-        assert sent["extra_headers"]["thread-id"] == current
+        assert sent["extra_headers"]["session_id"] == current
+        assert sent["extra_headers"]["thread_id"] == current
 
 
 def test_adapter_build_epoch_drives_current_id_and_changes_on_rebuild():
@@ -221,9 +221,9 @@ def test_adapter_build_epoch_drives_current_id_and_changes_on_rebuild():
     id0 = _codex_affinity_id(ANCHOR, EPOCH0)
     id1 = _codex_affinity_id(ANCHOR, EPOCH0 + 99)
     assert id0 != id1
-    assert sent0["prompt_cache_key"] == sent0["extra_headers"]["session-id"] == id0
-    assert sent0["extra_headers"]["thread-id"] == id0
-    assert sent1["prompt_cache_key"] == sent1["extra_headers"]["session-id"] == id1
+    assert sent0["prompt_cache_key"] == sent0["extra_headers"]["session_id"] == id0
+    assert sent0["extra_headers"]["thread_id"] == id0
+    assert sent1["prompt_cache_key"] == sent1["extra_headers"]["session_id"] == id1
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +240,7 @@ def test_no_rotate_before_ten_identical_hits():
 
     for sent in session._client.responses.kwargs:
         assert sent["prompt_cache_key"] == current
-        assert sent["extra_headers"]["session-id"] == current
+        assert sent["extra_headers"]["session_id"] == current
 
 
 def test_no_rotate_when_cached_values_vary():
@@ -287,8 +287,8 @@ def test_rotate_after_ten_identical_hits_persists():
     # The 11th request uses the rotated id for all three levers.
     sent11 = session._client.responses.kwargs[10]
     assert sent11["prompt_cache_key"] == rotated
-    assert sent11["extra_headers"]["session-id"] == rotated
-    assert sent11["extra_headers"]["thread-id"] == rotated
+    assert sent11["extra_headers"]["session_id"] == rotated
+    assert sent11["extra_headers"]["thread_id"] == rotated
 
 
 def test_rotated_id_persists_and_does_not_revert():
@@ -307,7 +307,7 @@ def test_rotated_id_persists_and_does_not_revert():
     assert session._client.responses.kwargs[10]["prompt_cache_key"] == rotated
     assert session._client.responses.kwargs[11]["prompt_cache_key"] == rotated
     assert session._client.responses.kwargs[12]["prompt_cache_key"] == rotated
-    assert session._client.responses.kwargs[11]["extra_headers"]["session-id"] == rotated
+    assert session._client.responses.kwargs[11]["extra_headers"]["session_id"] == rotated
     # None of the post-rotate requests fell back to the start id.
     for sent in session._client.responses.kwargs[10:]:
         assert sent["prompt_cache_key"] != start_id
@@ -440,8 +440,8 @@ def test_three_fields_always_equal_including_across_rotate():
 
     for sent in session._client.responses.kwargs:
         key = sent["prompt_cache_key"]
-        assert sent["extra_headers"]["session-id"] == key
-        assert sent["extra_headers"]["thread-id"] == key
+        assert sent["extra_headers"]["session_id"] == key
+        assert sent["extra_headers"]["thread_id"] == key
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_codex_prompt_cache_key.py
+++ b/tests/test_codex_prompt_cache_key.py
@@ -162,8 +162,8 @@ def test_lone_prompt_cache_key_stays_body_only_no_headers():
     assert sent["prompt_cache_key"] == "custom-key:v2"
     # The carve-out is about the per-agent slot routers: no session-id / thread-id.
     headers = sent.get("extra_headers") or {}
-    assert "session-id" not in headers
-    assert "thread-id" not in headers
+    assert "session_id" not in headers
+    assert "thread_id" not in headers
     # The Codex-specific cache-key header still rides on every request with a
     # prompt key, but it does not route a shared per-agent slot.
     assert headers.get("codex-cache-key") == "cus"
@@ -231,8 +231,8 @@ def test_codex_bare_adapter_omits_session_thread_headers():
 
     sent = session._client.responses.kwargs[0]
     headers = sent.get("extra_headers") or {}
-    assert "session-id" not in headers
-    assert "thread-id" not in headers
+    assert "session_id" not in headers
+    assert "thread_id" not in headers
     # prompt_cache_key behavior is untouched.
     assert sent["prompt_cache_key"] == "lingtai-codex:gpt-5.5:v1"
 
@@ -254,8 +254,8 @@ def test_codex_sends_stable_headers_from_session_anchor():
     h1 = s1["extra_headers"]
     expected = _expected_codex_hash(anchor)
     # Root/main path: session-id == thread-id == prompt_cache_key == 8-char hash.
-    assert h0["session-id"] == expected
-    assert h0["thread-id"] == expected
+    assert h0["session_id"] == expected
+    assert h0["thread_id"] == expected
     assert s0["prompt_cache_key"] == expected
     # Stable across multiple ordinary sends of the same session.
     assert h0 == h1
@@ -275,11 +275,11 @@ def test_codex_headers_differ_for_different_agents():
 
     ha = a._client.responses.kwargs[0]["extra_headers"]
     hb = b._client.responses.kwargs[0]["extra_headers"]
-    assert ha["session-id"] != hb["session-id"]
-    assert ha["thread-id"] != hb["thread-id"]
+    assert ha["session_id"] != hb["session_id"]
+    assert ha["thread_id"] != hb["thread_id"]
     # Each agent's three values are internally identical (the agent-path hash).
-    assert ha["session-id"] == ha["thread-id"]
-    assert hb["session-id"] == hb["thread-id"]
+    assert ha["session_id"] == ha["thread_id"]
+    assert hb["session_id"] == hb["thread_id"]
 
 
 def test_codex_thread_salt_does_not_split_thread_from_session():
@@ -307,8 +307,8 @@ def test_codex_thread_salt_does_not_split_thread_from_session():
     expected = _expected_codex_hash(anchor)
     h0 = salt0._client.responses.kwargs[0]["extra_headers"]
     h1 = salt1._client.responses.kwargs[0]["extra_headers"]
-    assert h0["session-id"] == h0["thread-id"] == expected
-    assert h1["session-id"] == h1["thread-id"] == expected  # salt is irrelevant
+    assert h0["session_id"] == h0["thread_id"] == expected
+    assert h1["session_id"] == h1["thread_id"] == expected  # salt is irrelevant
     assert salt0._client.responses.kwargs[0]["prompt_cache_key"] == expected
     assert salt1._client.responses.kwargs[0]["prompt_cache_key"] == expected
 
@@ -328,7 +328,7 @@ def test_codex_rest_omits_previous_response_id_with_anchored_thread():
     expected = _expected_codex_hash(anchor)
     assert "previous_response_id" not in sent
     assert sent.get("store") is False
-    assert sent["extra_headers"]["thread-id"] == expected  # anchored thread still sent
+    assert sent["extra_headers"]["thread_id"] == expected  # anchored thread still sent
     # prompt_cache_key matches the same hash alongside the stateless REST contract.
     assert sent["prompt_cache_key"] == expected
 
@@ -344,8 +344,8 @@ def test_codex_explicit_session_id_used_verbatim_for_all_three():
     sent = session._client.responses.kwargs[0]
     headers = sent["extra_headers"]
     # Explicit id is used byte-identically for session, thread, and cache key.
-    assert headers["session-id"] == explicit
-    assert headers["thread-id"] == explicit
+    assert headers["session_id"] == explicit
+    assert headers["thread_id"] == explicit
     assert sent["prompt_cache_key"] == explicit
 
 
@@ -369,8 +369,8 @@ def test_codex_explicit_prompt_cache_key_override_drives_all_three_with_anchor()
 
     sent = session._client.responses.kwargs[0]
     assert sent["prompt_cache_key"] == override
-    assert sent["extra_headers"]["session-id"] == override
-    assert sent["extra_headers"]["thread-id"] == override
+    assert sent["extra_headers"]["session_id"] == override
+    assert sent["extra_headers"]["thread_id"] == override
 
 
 def test_codex_explicit_session_id_wins_over_anchor():
@@ -383,7 +383,7 @@ def test_codex_explicit_session_id_wins_over_anchor():
 
     session.send("x")
 
-    assert session._client.responses.kwargs[0]["extra_headers"]["session-id"] == explicit
+    assert session._client.responses.kwargs[0]["extra_headers"]["session_id"] == explicit
 
 
 def test_codex_session_normalizes_mismatched_ids_to_one_effective_value():
@@ -413,8 +413,8 @@ def test_codex_session_normalizes_mismatched_ids_to_one_effective_value():
     sent = session._client.responses.kwargs[0]
     # prompt_cache_key wins; all three carry that single effective value.
     assert sent["prompt_cache_key"] == "custom-key:v2"
-    assert sent["extra_headers"]["session-id"] == "custom-key:v2"
-    assert sent["extra_headers"]["thread-id"] == "custom-key:v2"
+    assert sent["extra_headers"]["session_id"] == "custom-key:v2"
+    assert sent["extra_headers"]["thread_id"] == "custom-key:v2"
 
 
 def test_codex_session_normalization_priority_session_then_thread():
@@ -434,8 +434,8 @@ def test_codex_session_normalization_priority_session_then_thread():
 
     sent = session._client.responses.kwargs[0]
     assert sent["prompt_cache_key"] == "session-wins"
-    assert sent["extra_headers"]["session-id"] == "session-wins"
-    assert sent["extra_headers"]["thread-id"] == "session-wins"
+    assert sent["extra_headers"]["session_id"] == "session-wins"
+    assert sent["extra_headers"]["thread_id"] == "session-wins"
 
     # And ``thread_id`` alone becomes the effective id for all three.
     thread_only = CodexResponsesSession(
@@ -450,8 +450,8 @@ def test_codex_session_normalization_priority_session_then_thread():
     thread_only.send("hi")
     sent2 = thread_only._client.responses.kwargs[0]
     assert sent2["prompt_cache_key"] == "thread-only"
-    assert sent2["extra_headers"]["session-id"] == "thread-only"
-    assert sent2["extra_headers"]["thread-id"] == "thread-only"
+    assert sent2["extra_headers"]["session_id"] == "thread-only"
+    assert sent2["extra_headers"]["thread_id"] == "thread-only"
 
 
 def test_codex_bare_session_omits_headers():
@@ -729,7 +729,7 @@ def test_codex_usage_extra_carries_cache_affinity_ids_for_token_ledger():
         "codex_thread_id": "custom-key:v2",
         "codex_prompt_cache_key": "custom-key:v2",
     }
-    assert headers["session-id"] == headers["thread-id"] == sent["prompt_cache_key"]
+    assert headers["session_id"] == headers["thread_id"] == sent["prompt_cache_key"]
     # The affinity ids are short, non-secret derived values; the request body,
     # messages, and OAuth secret never ride in the usage extra payload.
     blob = json.dumps(result.usage.extra, default=str)

--- a/tests/test_codex_prompt_key_header.py
+++ b/tests/test_codex_prompt_key_header.py
@@ -110,8 +110,8 @@ def test_lone_prompt_cache_key_sends_codex_cache_key_header():
     headers = _headers(sent)
     assert headers[HEADER] == "cus"
     # The lone-key carve-out still holds for per-agent slot routers.
-    assert "session-id" not in headers
-    assert "thread-id" not in headers
+    assert "session_id" not in headers
+    assert "thread_id" not in headers
     assert sent["instructions"] == "system prompt"
 
 
@@ -144,8 +144,8 @@ def test_header_present_on_anchored_session_alongside_affinity_headers():
     sent = session._client.responses.kwargs[0]
     assert _headers(sent)[HEADER] == current[:3]
     # Existing affinity headers still ride along unchanged.
-    assert sent["extra_headers"]["session-id"] == current
-    assert sent["extra_headers"]["thread-id"] == current
+    assert sent["extra_headers"]["session_id"] == current
+    assert sent["extra_headers"]["thread_id"] == current
 
 
 def test_header_present_on_every_ordinary_request_no_threshold():


### PR DESCRIPTION
## What

Change the Codex Responses cache-affinity headers from hyphenated `session-id`/`thread-id` to the underscore form `session_id`/`thread_id`.

## Why

The Codex `/backend-api/codex/responses` backend routes the **prompt-cache slot off the session/thread HTTP header**. I captured real Codex CLI traffic (v0.130.0) through a forwarding proxy and confirmed the official client sends the **underscore** form:

```
session_id: 019ee74f-22b5-7043-b5fc-697ca0fbd5a6
thread_id:  019ee74f-22b5-7043-b5fc-697ca0fbd5a6
```

LingTai was sending the hyphenated `session-id`/`thread-id`. While the backend currently appears to accept either spelling in isolation, the **reference client uses underscores**, and the cache slot is routed by these headers, so we should match the proven-good spelling exactly to remove any risk of a header-name mismatch silently defeating cache affinity.

## Evidence (live ablation against the real endpoint)

- Auth-only, **no** session/thread headers → **0%** cache.
- Session/thread header present (stable value) → **cold once, then sticky ~90%+** for many consecutive calls.
- Changing the session/thread value re-rolls backend routing → flaps 95/0%.

So a **stable** session/thread header is the single load-bearing lever for Codex prompt caching. This PR aligns the header spelling with Codex CLI.

## Scope

- `_cache_affinity_headers()` now emits `session_id`/`thread_id`.
- `_usage_extra()` reads the same keys (ledger field names `codex_session_id`/`codex_thread_id` unchanged).
- Test assertions updated to the new header names.
- No behavior change beyond the header name. 105 codex tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)