### PR TITLE
Refine summarize guidance and manual routing

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -8,14 +8,17 @@ description: >
   communication/memory/idle/system-operations model;
   `reference/procedures-manual/SKILL.md` for the expanded procedures/action discipline,
   skill routing, responsiveness, deliverables, artifact sharing, and issue
-  reporting guidance; and `reference/sqlite-log-query/SKILL.md` for SQLite/log.sqlite
-  runtime trace inspection and trajectory/anomaly mining from event traces. Also
+  reporting guidance; `reference/summarize-manual/SKILL.md` for tool-result
+  summarization, progressive disclosure, original-result recovery, and
+  summarize-vs-molt distinctions; and `reference/sqlite-log-query/SKILL.md` for
+  SQLite/log.sqlite runtime trace inspection and trajectory/anomaly mining from
+  event traces. Also
   route here for lifecycle operations, notification
   handling, molt/memory questions, MCP/addon ownership, preset tiers,
   collaboration/network topology, resident prompt design, and the `system` tool
   actions.
 version: 1.2.0
-tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt]
+tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize]
 ---
 
 # System Manual — Progressive Disclosure Router
@@ -55,6 +58,12 @@ selects that topic.
     idle/lifecycle procedure, molt checklist, skill routing, web/file/media/
     artifact handling, standalone HTML deliverables, sharing artifacts, issue
     reporting, and resident procedures maintenance.
+
+- name: summarize-manual
+  location: reference/summarize-manual/SKILL.md
+  description: |
+    Detailed operational guide for `system(action="summarize")`: what tool-result summarization is, why it implements progressive disclosure, when to summarize urgently versus during idle cleanup, how to write good summaries, how to recover the original result by `tool_call_id`, and how summarize differs from molt.
+
 - name: sqlite-log-query
   location: reference/sqlite-log-query/SKILL.md
   description: |
@@ -89,6 +98,7 @@ selects that topic.
 |---|---|
 | Expanded substrate; body/extensions; bash vs daemon vs avatar vs MCP; lifecycle states; ACTIVE/IDLE/ASLEEP/SUSPENDED; same-channel communication; basic notifications; memory layers; molt model; idle/soul; preset tiers; `system` operations | `reference/substrate-manual/SKILL.md` |
 | Expanded procedures; progressive disclosure; writing skills/knowledge; action discipline; responsiveness; skill routing; HTML deliverables; artifact sharing; issue reporting; when to read which manual | `reference/procedures-manual/SKILL.md` |
+| Tool-result summarization; large-result reminders; progressive disclosure of raw outputs; original-result recovery; summarize vs molt | `reference/summarize-manual/SKILL.md` |
 | SQLite; `log.sqlite`; LingTai runtime logs; JSONL traces; `lingtai-agent log doctor`; `lingtai-agent log query`; `lingtai-agent log rebuild`; events/chat_entries schema; daemon/chat-history trace indexing; WAL/live-read caveats; SQL recipes; trajectory/anomaly mining; improvement digests; cheap-model strategy | `reference/sqlite-log-query/SKILL.md` |
 | Notifications; the `notification` tool; check/dismiss_channel/dismiss_event/dismiss_ref; `.notification/<channel>.json`; channel allowlist; top-level `instructions`; protected channels; generic vs producer dismiss; stale-version/force; undismissable large-result reminders | `reference/notification-manual/SKILL.md` |
 | Goal notifications; `.notification/goal.json`; active goal source of truth; goal `instructions`; idle goal reminder; cancel/complete goal | `reference/goal-manual/SKILL.md` |

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -47,19 +47,13 @@ not bloat the resident prompt with one-off details.
 
 ### Tool-result digestion
 
-A summarized tool result is the good long-lived form once the raw output has
-served its purpose. Do not reserve `system.summarize` only for long results:
-large-result metadata/reminders are merely a stronger prompt that context hygiene
-is already at risk. Even a short or medium result should be summarized when the
-future agent only needs an index of what you learned.
-
-Good tool-result summaries preserve the grain: conclusion, key evidence, local
-paths/IDs, validation status, risks/caveats, and next steps. The full original
-remains in `events.jsonl` for fallback; the context-visible copy should become
-the concise index once digested. Timing matters: `system.summarize` can summarize
-only already-completed prior tool results, so digest a result after reading it
-and summarize it on a later step (possibly in parallel with other independent
-work).
+Progressive disclosure applies to tool results as much as to manuals. A raw tool
+result is useful while you inspect it; after you have consumed it, the better
+active-context form is an index-style summary. Runtime `_runtime.guidance` gives
+the high-attention reminder when summarization is timely. For the full procedure
+— urgent large-result handling, idle cleanup sweeps, quality checklist,
+original-result recovery, and summarize-vs-molt boundaries — read
+`reference/summarize-manual/SKILL.md`.
 
 ## 2. Action and responsiveness
 
@@ -205,6 +199,7 @@ mechanics here. For the checklist, templates, and summary rules, go to
 | Runtime model, lifecycle, communication, memory layers, substrate expansion | `system-manual` → `reference/substrate-manual/SKILL.md` |
 | Procedures expansion, routing logic, deliverable/reporting discipline | `system-manual` → `reference/procedures-manual/SKILL.md` |
 | SQLite, log.sqlite, runtime trace inspection, `lingtai-agent log doctor/query/rebuild` | `system-manual` → `reference/sqlite-log-query/SKILL.md` |
+| Tool-result summarization, large-result reminders, original-result recovery, summarize vs molt | `system-manual` → `reference/summarize-manual/SKILL.md` |
 | Molt, pad tending, session journaling, post-wipe recovery | `psyche-manual` |
 | Spawning/managing avatars | `avatar-manual` |
 | Internal email protocol | `email-manual` |

--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -118,107 +118,17 @@ semantics, and the undismissable large-result reminders, read
 
 ### `summarize`
 
-`summarize` is a context-hygiene action for large or already-digested tool
-results. It replaces the **context-visible copy** of a prior tool result with
-your agent-authored summary while preserving the original payload in
-`logs/events.jsonl`.
+`summarize` is the system action for tool-result context hygiene: after you have
+consumed a completed prior tool result, replace its context-visible raw payload
+with a summary that preserves the conclusion, evidence, anchors, validation,
+risks, and next steps. Runtime high-attention guidance for this behavior is
+carried in `_runtime.guidance` from `src/lingtai/prompts/guidance.json`; follow
+that latest guidance first when it appears.
 
-**Why:** `summarize` is a consumption step, not deletion. Treat a large result as
-raw ore: first read it, extract the grain, then replace the bulky visible copy
-with a summary that future-you can actually use. The original event remains
-recoverable for forensics, but the summary is the progressive-disclosure entry
-point that later context, future turns, and post-molt reasoning will see first.
-
-**Write the summary for yourself.** It is not a casual one-liner to silence a
-notification. A useful summary should be compact but specific enough that you can
-continue the work without reopening the raw payload. Include the details that
-make the result operational:
-
-- What the result was and why it mattered.
-- The decision, conclusion, verdict, failure mode, or extracted evidence.
-- Important paths, URLs, message ids, tool-call ids, PR numbers, commits,
-  branches, report files, or artifact locations.
-- Commands or validation that were run and their outcomes.
-- Risks, uncertainties, blockers, caveats, and any interpretation limits.
-- The current task state and the next action if the result belongs to active
-  work.
-
-**Good uses:**
-
-- Collapse a long search/test/log output after extracting the exact commands,
-  pass/fail counts, relevant files, and follow-up needed.
-- Collapse a bulky daemon/check result after recording the verdict, report path,
-  PR/commit ids, validation, and merge/deploy gate state.
-- Collapse repeated notification/dismiss errors after noting they were hygiene
-  artifacts and whether any real task state changed.
-
-**Bad uses:**
-
-- Hiding a result you have not read.
-- Replacing evidence before extracting the important details.
-- Writing a vague summary such as “tests passed” when future-you needs the
-  command, scope, counts, related commit/PR, and remaining risk.
-- Summarizing human or peer messages before you have replied on the producer
-  channel.
-
-Example:
-
-```python
-system(action="summarize", items=[
-  {
-    "tool_call_id": "call_abc123",
-    "summary": (
-      "Pytest run for PR #416: `python -m pytest -q -k 'codex or openai or responses'` "
-      "passed with 158 passed, 2255 deselected. This validates the Codex cache-rate "
-      "rotate tests and related OpenAI/Responses surface before merge commit `b014490`. "
-      "No failures; remaining task is to update release notes."
-    ),
-  },
-])
-```
-
-The tool result shown in context becomes your summary plus a retrieval hint. If
-you later need the full original, search the event log by `tool_call_id`, for
-example:
-
-```bash
-grep 'call_abc123' logs/events.jsonl
-# or use: lingtai-agent log query ...
-```
-
-The summary is not canonical; it records what the agent understood at the time.
-If the task is consequential, make the summary faithful and detailed enough that
-mistakes are inspectable and future-you knows where to verify.
-
-**Large-result notifications:** When a main-agent tool result exceeds the
-summarize notification threshold (default: 3,000 chars), the kernel publishes a
-`system` notification listing pending large results. This is a context-hygiene
-signal, not a separate human task. Treat it as a prompt to digest the result
-deliberately before deep work continues.
-
-Operational rules:
-
-1. Digest the result first. Extract facts, conclusions, decisions, paths, ids,
-   commands, validation, risks, blockers, and next steps.
-2. Write the summary for future-you. It is the progressive-disclosure entry point
-   shown in later context; the raw event may be expensive to retrieve and may be
-   invisible after molt unless you preserved the facts elsewhere.
-3. Call `system(action="summarize", items=[...])` for every pending large-result
-   case you have digested. Batch related cases in one call when possible. A
-   successful summarize auto-clears the matching `large_tool_result` reminder —
-   there is no separate dismiss step, and `large_tool_result` reminders are
-   undismissable through the `notification` tool (see notification-manual).
-4. For ordinary (non-large-result) stale reminder notifications, dismiss them via
-   the `notification` tool after the work is handled, or let the kernel clear
-   them when the producer state empties.
-5. Do not loop on stale notification versions. If a `notification` dismiss fails
-   with `stale_channel_version`, read the current notification state or
-   force-clear a known stale channel only after the substantive payload has been
-   digested. See `reference/notification-manual/SKILL.md` for dismiss specifics.
-
-The notification threshold is set via `manifest.summarize_notification_threshold`
-in `init.json` / defaults. It must be non-negative. Per-call overrides to
-`system(action="summarize")` at runtime return an error.
+For the full operating procedure — urgent large-result summarization, idle
+cleanup sweeps, original-result recovery by `tool_call_id`, summary quality,
+large-result notification behavior, and the distinction between summarize and
+molt — read `reference/summarize-manual/SKILL.md`.
 
 ### Sleep, lull, interrupt, suspend, CPR, clear, nirvana
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: summarize-manual
+description: Detailed operational guide for system(action="summarize"): what tool-result summarization is, why it implements progressive disclosure, when to summarize urgently versus during idle cleanup, how to write good summaries, how to recover the original tool result by tool_call_id, and how summarize differs from molt.
+---
+
+# Summarize Manual
+
+`system(action="summarize")` is context hygiene for completed tool results. It
+replaces the context-visible copy of one or more prior tool-result blocks with
+your own summary. It does **not** delete the original event; the raw result
+remains in logs for fallback.
+
+Use this manual when runtime guidance tells you to summarize, when a
+`large_tool_result` reminder appears, when tool output has served its immediate
+purpose, or when you need to explain how summarize differs from molt.
+
+## 1 · The principle: progressive disclosure
+
+A raw tool result is the first layer: it is useful while you inspect it. After
+you have consumed it, the better layer is an index that future-you can reason
+from without carrying the raw bulk.
+
+A good summary should let future-you decide whether the hidden raw result must
+be reopened. Preserve:
+
+- the conclusion or decision;
+- key evidence, measurements, or error text;
+- paths, URLs, message IDs, tool_call_ids, commit hashes, job IDs, and other
+  anchors;
+- validation status and commands/tests run;
+- risks, caveats, and unresolved questions;
+- next steps.
+
+Do not write casual one-liners for consequential results. The summary is the
+progressive-disclosure entry point.
+
+## 2 · The two summarize cadences
+
+### Urgent cadence: summarize the bulky result now
+
+Use this when a tool result is long, noisy, or raises a `large_tool_result`
+reminder.
+
+1. Read or inspect the result first.
+2. Decide what future-you needs from it.
+3. On a later step, call `system(action="summarize")` on the completed prior
+   result. Do not try to summarize the current result in the same tool batch
+   before it exists.
+4. Batch several already-digested results in one summarize call when convenient.
+
+### Idle cleanup cadence: sweep what is already consumed
+
+Use this when the task quiets down, before the context window becomes urgent.
+Look back over older tool results that are already digested, obsolete, or only
+useful as evidence anchors, and replace them with summaries. This keeps active
+context small enough that the next task starts clean.
+
+Idle cleanup is also the right time to prepare for a deliberate molt. If
+substantial work is complete, durable stores are tended, and no human reply is
+pending, prefer molting while context is still cheap over waiting until pressure
+warnings force the issue.
+
+## 3 · How to call summarize
+
+Summarize prior completed tool results only:
+
+```json
+{
+  "action": "summarize",
+  "items": [
+    {
+      "tool_call_id": "call_abc123",
+      "summary": "What future-you needs: conclusion, evidence, anchors, validation, risks, next steps."
+    }
+  ]
+}
+```
+
+Operational rules:
+
+- `tool_call_id` is the producer call ID shown on the original result, not the
+  visible `_tool_call_id` event ref.
+- A successful summarize replaces only the active-context copy; it does not
+  mutate the original event log.
+- If a large-result notification points at that result, successful summarize
+  clears the reminder.
+- If the result is still ambiguous, reopen or inspect it before summarizing.
+
+## 4 · Recovering the original result
+
+A summarized block should carry a retrieval hint. The usual fallback is to search
+the agent event log by the preserved `tool_call_id`:
+
+```bash
+grep 'call_abc123' <workdir>/logs/events.jsonl
+```
+
+For structured trace work, use the SQLite/log tooling documented in
+`reference/sqlite-log-query/SKILL.md`, for example `lingtai-agent log query`, to
+locate the event and inspect nearby context.
+
+If the original was a spill result, the log entry or summary should also point to
+the spill path under `tmp/tool-results/`. Preserve that path in the summary.
+
+## 5 · Good and bad uses
+
+Good uses:
+
+- a large test output after you know which tests passed/failed;
+- a long file read after extracting the relevant lines and path;
+- a search sweep after preserving matched files and decisions;
+- a channel read after responding and keeping the message IDs that matter;
+- a resolved error once the recovery path is known.
+
+Bad uses:
+
+- summarizing before you have read or understood the result;
+- hiding evidence that you still need to inspect line by line;
+- replacing a required deliverable with a vague recap;
+- assuming summarize is a durable memory layer.
+
+## 6 · Summarize is not molt
+
+`system(action="summarize")` reduces active-context bulk for selected tool
+results. It does not update pad, character, knowledge, skills, or the
+session-journal, and it does not shed the conversation.
+
+Molt is a psyche operation. It preserves durable stores, writes the session
+journal and molt briefing, and starts a fresh conversation context. Before
+molting, read `psyche-manual` and follow its required checklist.
+
+Use them together:
+
+1. Summarize bulky consumed tool results so the active context is navigable.
+2. Tend durable stores for facts, procedures, identity changes, and current plan.
+3. Molt deliberately while you still have enough context to write a good
+   briefing, not only when warnings become urgent.

--- a/src/lingtai/prompts/guidance.json
+++ b/src/lingtai/prompts/guidance.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
-  "guidance_version": "0.2.0",
+  "guidance_version": "0.3.0",
   "priority": "high",
   "render_mode": "latest_tool_result_only",
   "sections": [
     {
       "id": "summarize_best_practice",
-      "title": "Summarize digested tool results",
-      "body": "Tool results are raw working material. When a result is long, noisy, or no longer needed verbatim, first consume it: inspect the output, decide what future-you needs, then summarize that completed prior result with system(action=\"summarize\"). Do not summarize a result you have not read, and do not try to summarize the current result in the same tool batch. A good summary is a progressive-disclosure index: conclusion, key evidence, paths/IDs, validation status, risks, and next steps, while the full original remains in events/logs for fallback. When work quiets down, bulk-summarize older tool results you are unlikely to need soon so active context keeps the grain, not the raw bulk."
+      "title": "Summarize and molt deliberately",
+      "body": "Use progressive disclosure for tool results: raw output is for immediate inspection; once consumed, replace the context-visible copy with a concise index via system(action=\"summarize\"). There are two cadences. Urgent: when a tool result is long/noisy or raises a large-result reminder, read it, keep conclusion/key evidence/paths or IDs/validation/risks/next steps, then summarize that completed prior result on a later step. Idle cleanup: when work quiets down, bulk-summarize older tool results that are already digested or obsolete so active context keeps grain rather than raw bulk. The original remains recoverable from logs by tool_call_id (for example grep events.jsonl or use lingtai-agent log query); the summary should preserve enough IDs and evidence to make that recovery possible. After substantial work is quiet and durable stores are tended, prefer an intentional molt while context is still cheap instead of waiting for pressure warnings; summarize helps prepare for molt but is not a substitute for the psyche-manual molt procedure."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- refine runtime summarize guidance around urgent long-result digestion, idle cleanup, progressive disclosure, original-result recovery, and proactive molt while context is cheap
- add a system-manual summarize nested reference explaining summarize, good summaries, retrieval by tool_call_id, and summarize vs molt
- route substrate/procedures manuals to runtime guidance + the new summarize manual instead of duplicating the long summarize section

## Validation
- `python -m json.tool src/lingtai/prompts/guidance.json`
- quick frontmatter check for `system-manual/SKILL.md` and `reference/summarize-manual/SKILL.md`
- `git diff --check`
- `python -m pytest tests/test_prompt.py tests/test_meta_block.py tests/test_system_summarize.py` (`137 passed`)