### PR TITLE
Add ChatGPT-Account-ID to Codex OAuth requests

### DIFF
--- a/src/lingtai/auth/ANATOMY.md
+++ b/src/lingtai/auth/ANATOMY.md
@@ -9,11 +9,12 @@ Codex OAuth token management — reads TUI-written tokens, checks expiry, auto-r
 | File | LOC | Role |
 |---|---|---|
 | `__init__.py` | 1 | Docstring-only package marker |
-| `codex.py` | 145 | `CodexTokenManager` — reads/refreshes OAuth tokens |
+| `codex.py` | 220 | `CodexTokenManager` — reads/refreshes OAuth tokens |
 
 **Key classes** (`codex.py`):
-- `CodexTokenManager` (L30) — main API: `is_authenticated()` (L46), `get_access_token()` (L54). Reads `~/.lingtai-tui/codex-auth.json`, auto-refreshes when within 5 min of expiry (`REFRESH_BUFFER_SECONDS`, L19).
-- `CodexAuthError` (L22) — raised on 401/403 from refresh endpoint, user-facing message points to `/login`.
+- `CodexTokenManager` (L62) — main API: `is_authenticated()` (L78), `get_access_token()` (L86), `get_account_id()` (L100). Reads `~/.lingtai-tui/codex-auth.json`, auto-refreshes when within 5 min of expiry (`REFRESH_BUFFER_SECONDS`, L21).
+  - `get_account_id()` returns the user's OWN ChatGPT account id (non-secret) for the `ChatGPT-Account-ID` header, or `None`. Source priority: an explicit `account_id` / `chatgpt_account_id` field in `codex-auth.json`, else the namespaced `https://api.openai.com/auth.chatgpt_account_id` claim decoded locally from the `id_token` JWT (`_decode_jwt_payload`, L31 — base64url-only, NO signature verification, non-raising). Never invents a value; missing/malformed → `None`.
+- `CodexAuthError` (L54) — raised on 401/403 from refresh endpoint, user-facing message points to `/login`.
 
 ## Connections
 

--- a/src/lingtai/auth/codex.py
+++ b/src/lingtai/auth/codex.py
@@ -6,6 +6,8 @@ checks expiry, and auto-refreshes via the OpenAI OAuth endpoint.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import os
 import time
@@ -17,6 +19,36 @@ from filelock import FileLock
 TOKEN_URL = "https://auth.openai.com/oauth/token"
 CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 REFRESH_BUFFER_SECONDS = 300  # refresh if within 5 minutes of expiry
+
+# Namespaced OAuth claim that carries the user's ChatGPT account id in the
+# OpenAI-issued id_token. The official OpenAI OAuth payload nests it under this
+# OIDC-style namespace key, e.g.
+#   {"https://api.openai.com/auth": {"chatgpt_account_id": "<uuid>", ...}, ...}
+_OAUTH_AUTH_CLAIM = "https://api.openai.com/auth"
+_ACCOUNT_ID_CLAIM = "chatgpt_account_id"
+
+
+def _decode_jwt_payload(token: str) -> dict:
+    """Decode a JWT's payload segment locally (NO signature verification).
+
+    This only base64url-decodes the middle segment to read non-secret metadata
+    claims the issuer put there. We never verify the signature — we are not
+    authenticating the token, just reading our own account metadata out of it.
+    Returns ``{}`` for anything that is not a well-formed JWT-with-JSON-payload
+    rather than raising, so callers can treat "no account id" uniformly.
+    """
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return {}
+        payload_b64 = parts[1]
+        # base64url, padding stripped by the JWT spec — restore it before decode.
+        padding = "=" * (-len(payload_b64) % 4)
+        raw = base64.urlsafe_b64decode(payload_b64 + padding)
+        decoded = json.loads(raw)
+        return decoded if isinstance(decoded, dict) else {}
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return {}
 
 
 class CodexAuthError(Exception):
@@ -64,6 +96,49 @@ class CodexTokenManager:
             data = self._read()
 
         return data["access_token"]
+
+    def get_account_id(self) -> str | None:
+        """Return the user's own ChatGPT account id, or ``None`` if unavailable.
+
+        Source priority (the user's OWN auth data only — never invented):
+          1. An explicit ``account_id`` / ``chatgpt_account_id`` field written
+             into ``codex-auth.json`` by the TUI, if present.
+          2. The namespaced claim decoded locally from the ``id_token`` JWT:
+             ``payload["https://api.openai.com/auth"]["chatgpt_account_id"]``
+             (no signature verification — local metadata extraction only).
+
+        Always non-raising: a missing file, malformed JSON, or absent claim all
+        yield ``None`` so callers can simply omit the header. The returned id is
+        a non-secret account identifier; the access/refresh tokens are never
+        read or returned here.
+        """
+        try:
+            data = self._read()
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+
+        return self._extract_account_id(data)
+
+    @staticmethod
+    def _extract_account_id(data: dict) -> str | None:
+        """Pull the ChatGPT account id out of already-loaded auth data."""
+        # 1. Explicit field wins — the TUI may persist it directly.
+        for key in ("account_id", "chatgpt_account_id"):
+            val = data.get(key)
+            if isinstance(val, str) and val:
+                return val
+
+        # 2. Fall back to decoding the id_token JWT's namespaced auth claim.
+        id_token = data.get("id_token")
+        if not isinstance(id_token, str) or not id_token:
+            return None
+        payload = _decode_jwt_payload(id_token)
+        auth_claim = payload.get(_OAUTH_AUTH_CLAIM)
+        if isinstance(auth_claim, dict):
+            val = auth_claim.get(_ACCOUNT_ID_CLAIM)
+            if isinstance(val, str) and val:
+                return val
+        return None
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -30,7 +30,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 - **Adapter caching** — `LLMService._adapters` keyed by `(provider, base_url)` tuple (`service.py:141`). Double-checked locking via `_adapter_lock` (`service.py:142`).
 - **Session tracking** — `LLMService._sessions` dict maps `st_<12-hex>` session IDs to `ChatSession` instances (`service.py:144`). Untracked sessions get `session_id=""`.
 - **Gated sessions** — `_GatedSession` (`base.py:19`) proxies `send()` and `send_stream()` through `APICallGate.submit()`. Attribute writes land on the proxy; reads fall through to inner session via `__getattr__`.
-- **Codex factory** — `_register.py:54` builds `CodexOpenAIAdapter`, monkey-patches `create_chat` and `generate` to refresh OAuth tokens before each call via `CodexTokenManager.get_access_token()`.
+- **Codex factory** — `_register.py:54` builds `CodexOpenAIAdapter`, monkey-patches `create_chat` and `generate` to refresh OAuth tokens before each call via `CodexTokenManager.get_access_token()`; the same refresh hook re-reads `get_account_id()` into `adapter.codex_account_id` (the user's own `ChatGPT-Account-ID`, passed to the adapter at build time and kept current across refreshes).
 
 ## State
 

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -85,19 +85,29 @@ def register_all_adapters() -> None:
             base_url="https://chatgpt.com/backend-api/codex",
             use_responses=True,
             force_responses=True,
+            # The user's own ChatGPT account id (sent as the ``ChatGPT-Account-ID``
+            # header when present). Read from their OAuth auth data; ``None`` when
+            # unavailable. Does NOT impersonate the official Codex CLI.
+            codex_account_id=mgr.get_account_id(),
             **codex_id_kw,
         )
         # Store the token manager so we can refresh before each API call.
         # The openai SDK's client.api_key is mutable — we update it in-place.
         adapter._codex_token_mgr = mgr
+        def _refresh_codex_auth():
+            # Keep the access token current (refreshes on disk if near expiry) and
+            # re-read the account id so a refresh that changes it stays current on
+            # sessions built afterwards. No token/account value is logged.
+            adapter._client.api_key = mgr.get_access_token()
+            adapter.codex_account_id = mgr.get_account_id()
         _orig_create_chat = adapter.create_chat
         def _refreshing_create_chat(*a, **kwa):
-            adapter._client.api_key = mgr.get_access_token()
+            _refresh_codex_auth()
             return _orig_create_chat(*a, **kwa)
         adapter.create_chat = _refreshing_create_chat
         _orig_generate = adapter.generate
         def _refreshing_generate(*a, **kwa):
-            adapter._client.api_key = mgr.get_access_token()
+            _refresh_codex_auth()
             return _orig_generate(*a, **kwa)
         adapter.generate = _refreshing_generate
         return adapter

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -112,6 +112,10 @@ The REST `/backend-api/codex/responses` endpoint does **not** accept `previous_r
 
 **Codex-only (#436).** Every Codex request carries honest LingTai identity headers — `originator: lingtai` and `User-Agent: LingTai/<version>` (`_codex_identity_headers()`), merged as the base layer of `extra_headers` so cache-affinity and caller-supplied headers still override. We identify HONESTLY as LingTai, NOT as the Codex CLI (`codex_exec`). These do **not** affect prompt caching (verified empirically — identical cache rate with or without); they are account hygiene, mirroring the Kimi User-Agent policy in `../service.py` `_default_headers_for`.
 
+### Codex `ChatGPT-Account-ID` header (the user's own account id)
+
+**Codex-only.** When the user's OAuth auth data supplies an account id (`CodexTokenManager.get_account_id()`, see `../../auth/ANATOMY.md`), `CodexResponsesSession` sends it as the canonical `ChatGPT-Account-ID` header so the request is attributed to the right ChatGPT account. It does NOT change the honest `originator`/`User-Agent` identity above — no Codex-CLI impersonation. The value flows `_register.py` (`codex_account_id=mgr.get_account_id()`) → `CodexOpenAIAdapter.codex_account_id` (mutable; the OAuth-refresh monkey-patch re-reads it via `get_account_id()` so a refresh that changes the id stays current on later-built sessions) → `CodexResponsesSession(account_id=...)` (`self._account_id`). Emitted only when non-empty; otherwise the header is omitted entirely. The account id is a non-secret identifier and — unlike the affinity ids — is **NOT** copied into `UsageMetadata.extra` or any log/ledger.
+
 ## State
 
 - **`OpenAIChatSession._interface`** — canonical `ChatInterface`, single source of truth. Mutated in-place: `add_user_message`, `add_tool_results`, `add_assistant_message`, `drop_trailing`.

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1649,9 +1649,18 @@ class CodexResponsesSession(OpenAIResponsesSession):
         *args,
         session_id: str | None = None,
         thread_id: str | None = None,
+        account_id: str | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        # The user's own ChatGPT account id (decoded upstream from their OAuth
+        # auth data). When present it is sent as the ``ChatGPT-Account-ID`` HTTP
+        # header so the request is attributed to the right ChatGPT account —
+        # this does NOT impersonate the official Codex CLI (we keep the honest
+        # ``originator: lingtai`` / ``User-Agent: LingTai/<ver>`` identity). It
+        # is a non-secret account identifier and is never copied into usage
+        # metadata or logs.
+        self._account_id = account_id if isinstance(account_id, str) and account_id else None
         # Codex REST cache-affinity identity: ONE stable per-agent value used
         # byte-identically for ``prompt_cache_key`` / ``session_id`` /
         # ``thread_id`` on EVERY request, and NEVER changed for the life of the
@@ -1834,6 +1843,14 @@ class CodexResponsesSession(OpenAIResponsesSession):
                 **_codex_identity_headers(),
                 **affinity_headers,
             }
+            # The user's own ChatGPT account id, when available. Canonical
+            # official spelling ``ChatGPT-Account-ID`` (HTTP header names are
+            # case-insensitive). Attributes the request to the right ChatGPT
+            # account WITHOUT impersonating the official Codex CLI — the honest
+            # ``originator``/``User-Agent`` identity above is unchanged. Omitted
+            # entirely when no account id is known.
+            if self._account_id:
+                extra_headers["ChatGPT-Account-ID"] = self._account_id
             if extra_headers:
                 kwargs["extra_headers"] = {
                     **extra_headers,
@@ -2016,6 +2033,7 @@ class CodexOpenAIAdapter(OpenAIAdapter):
         codex_session_id: str | None = None,
         codex_session_anchor: str | None = None,
         codex_thread_salt: str | None = None,
+        codex_account_id: str | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -2050,6 +2068,13 @@ class CodexOpenAIAdapter(OpenAIAdapter):
         else:
             self._codex_id = None  # no per-agent identity -> no headers
         self._codex_thread_salt = codex_thread_salt  # legacy pass-through; unused
+        # The user's own ChatGPT account id, resolved upstream from their OAuth
+        # auth data (explicit ``account_id`` field or decoded id_token claim).
+        # Mutable so the token-refresh path can keep it current if refreshed
+        # auth data changes it. ``None`` -> no ``ChatGPT-Account-ID`` header.
+        self.codex_account_id: str | None = (
+            str(codex_account_id) if codex_account_id else None
+        )
 
     def _resolve_codex_ids(self, model: str) -> tuple[str | None, str | None]:
         """Resolve the (session_id, thread_id) headers for ``model``.
@@ -2133,4 +2158,7 @@ class CodexOpenAIAdapter(OpenAIAdapter):
             # a bare/test adapter. Never rotated.
             session_id=session_id,
             thread_id=thread_id,
+            # The user's own ChatGPT account id (read fresh from the adapter so a
+            # token refresh that changes it is reflected on newly built sessions).
+            account_id=self.codex_account_id,
         )

--- a/tests/test_codex_prompt_cache_key.py
+++ b/tests/test_codex_prompt_cache_key.py
@@ -530,6 +530,118 @@ def test_codex_bare_session_omits_cache_headers_but_sends_identity():
 
 
 # ---------------------------------------------------------------------------
+# ChatGPT-Account-ID header — the user's own account id, when available.
+# Sent so the request is attributed to the right ChatGPT account WITHOUT
+# impersonating the official Codex CLI (honest originator/User-Agent unchanged).
+# ---------------------------------------------------------------------------
+
+# Placeholder, non-secret account-id value used only in tests.
+_TEST_ACCOUNT_ID = "acct-test-deadbeef"
+
+
+def test_codex_sends_chatgpt_account_id_header_when_present():
+    """When the adapter carries an account id, every request sends the canonical
+    ``ChatGPT-Account-ID`` header verbatim."""
+    session = _create_codex_session_cfg(
+        [_completed()], codex_account_id=_TEST_ACCOUNT_ID
+    )
+
+    session.send("x")
+
+    headers = session._client.responses.kwargs[0]["extra_headers"]
+    assert headers["ChatGPT-Account-ID"] == _TEST_ACCOUNT_ID
+
+
+def test_codex_omits_chatgpt_account_id_header_when_absent():
+    """No account id → no ``ChatGPT-Account-ID`` header at all (omitted, not empty)."""
+    session = _create_codex_session_cfg([_completed()])  # no codex_account_id
+
+    session.send("x")
+
+    headers = session._client.responses.kwargs[0]["extra_headers"]
+    assert "ChatGPT-Account-ID" not in headers
+
+
+def test_codex_account_id_preserves_honest_identity():
+    """Sending ChatGPT-Account-ID does NOT alter the honest LingTai identity —
+    no Codex CLI impersonation creeps in alongside the account header."""
+    session = _create_codex_session_cfg(
+        [_completed()], codex_account_id=_TEST_ACCOUNT_ID
+    )
+
+    session.send("x")
+
+    headers = session._client.responses.kwargs[0]["extra_headers"]
+    assert headers["ChatGPT-Account-ID"] == _TEST_ACCOUNT_ID
+    # Honest identity is unchanged; we are still LingTai, not the Codex CLI.
+    assert headers["originator"] == "lingtai"
+    assert headers["User-Agent"].startswith("LingTai")
+    assert "codex_exec" not in headers["User-Agent"]
+
+
+def test_codex_account_id_does_not_affect_cache_affinity():
+    """Adding the account header leaves session/thread/prompt_cache_key untouched.
+
+    Regression guard: the ChatGPT-Account-ID plumbing must not perturb the
+    cache-affinity identity (issue #378) in any way."""
+    explicit = "11111111-2222-3333-4444-555555555555"
+    with_acct = _create_codex_session_cfg(
+        [_completed()],
+        codex_session_id=explicit,
+        codex_account_id=_TEST_ACCOUNT_ID,
+    )
+    without_acct = _create_codex_session_cfg(
+        [_completed()],
+        codex_session_id=explicit,
+    )
+
+    with_acct.send("x")
+    without_acct.send("x")
+
+    h_with = with_acct._client.responses.kwargs[0]["extra_headers"]
+    h_without = without_acct._client.responses.kwargs[0]["extra_headers"]
+    # The cache-affinity headers + body key are identical with and without the
+    # account header.
+    assert h_with["session_id"] == h_without["session_id"] == explicit
+    assert h_with["thread_id"] == h_without["thread_id"] == explicit
+    assert (
+        with_acct._client.responses.kwargs[0]["prompt_cache_key"]
+        == without_acct._client.responses.kwargs[0]["prompt_cache_key"]
+        == explicit
+    )
+
+
+def test_codex_account_id_not_in_usage_metadata():
+    """The account id never leaks into usage metadata returned to the caller."""
+    session = _create_codex_session_cfg(
+        [_completed()], codex_account_id=_TEST_ACCOUNT_ID
+    )
+
+    result = session.send("x")
+
+    # The streamed result/usage must not carry the account id anywhere.
+    assert _TEST_ACCOUNT_ID not in json.dumps(result, default=str)
+
+
+def test_codex_session_account_id_used_verbatim_on_direct_construction():
+    """A directly-constructed session honors the ``account_id`` kwarg."""
+    session = CodexResponsesSession(
+        client=FakeClient([_completed()]),
+        model="gpt-5.5",
+        instructions="system prompt",
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+        account_id=_TEST_ACCOUNT_ID,
+    )
+
+    session.send("hi")
+
+    headers = session._client.responses.kwargs[0]["extra_headers"]
+    assert headers["ChatGPT-Account-ID"] == _TEST_ACCOUNT_ID
+
+
+# ---------------------------------------------------------------------------
 # Manifest config seam — per-agent identity flows factory -> adapter (#378).
 # This is the internal override / testing escape hatch; the default path
 # (agent path hash only) is covered in the section after this one.

--- a/tests/unit/auth/test_codex_auth.py
+++ b/tests/unit/auth/test_codex_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import time
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,19 @@ import httpx
 import pytest
 
 from lingtai.auth.codex import REFRESH_BUFFER_SECONDS, CodexAuthError, CodexTokenManager
+
+
+def _make_id_token(payload: dict) -> str:
+    """Build a syntactically valid (unsigned) JWT carrying ``payload``.
+
+    Only the payload segment matters here — ``get_account_id`` reads it without
+    verifying the signature, so the header/signature are throwaway fillers.
+    """
+    def _seg(obj) -> str:
+        raw = json.dumps(obj).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+    return f"{_seg({'alg': 'RS256', 'typ': 'JWT'})}.{_seg(payload)}.sig-not-verified"
 
 
 def _write_token_file(path, *, access_token="tok_valid", refresh_token="rt_abc",
@@ -180,3 +194,125 @@ class TestRefreshErrors:
         mgr = CodexTokenManager(token_path=str(token_file))
         with pytest.raises(httpx.HTTPStatusError):
             mgr.get_access_token()
+
+
+# ------------------------------------------------------------------
+# get_account_id  (ChatGPT-Account-ID source resolution)
+# ------------------------------------------------------------------
+
+# Placeholder, non-secret account-id values used only in tests. These are not
+# real account identifiers — just opaque strings to assert pass-through.
+_ACCT_EXPLICIT = "acct-explicit-0000"
+_ACCT_FROM_TOKEN = "acct-from-token-1111"
+
+
+class TestGetAccountId:
+    def _write(self, path, extra: dict):
+        """Write a token file with arbitrary extra top-level fields."""
+        data = {
+            "access_token": "tok_valid",
+            "refresh_token": "rt_abc",
+            "expires_at": int(time.time()) + 3600,
+            "email": "user@example.com",
+        }
+        data.update(extra)
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    def test_explicit_account_id_field(self, tmp_path):
+        """An explicit ``account_id`` field is returned verbatim."""
+        token_file = tmp_path / "codex-auth.json"
+        self._write(token_file, {"account_id": _ACCT_EXPLICIT})
+
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() == _ACCT_EXPLICIT
+
+    def test_explicit_chatgpt_account_id_field(self, tmp_path):
+        """The alternate ``chatgpt_account_id`` field is also honored."""
+        token_file = tmp_path / "codex-auth.json"
+        self._write(token_file, {"chatgpt_account_id": _ACCT_EXPLICIT})
+
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() == _ACCT_EXPLICIT
+
+    def test_extracted_from_id_token_namespaced_claim(self, tmp_path):
+        """Falls back to the namespaced claim decoded from the id_token JWT."""
+        token_file = tmp_path / "codex-auth.json"
+        id_token = _make_id_token(
+            {"https://api.openai.com/auth": {"chatgpt_account_id": _ACCT_FROM_TOKEN}}
+        )
+        self._write(token_file, {"id_token": id_token})
+
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() == _ACCT_FROM_TOKEN
+
+    def test_explicit_field_wins_over_id_token(self, tmp_path):
+        """An explicit field takes priority over the id_token claim."""
+        token_file = tmp_path / "codex-auth.json"
+        id_token = _make_id_token(
+            {"https://api.openai.com/auth": {"chatgpt_account_id": _ACCT_FROM_TOKEN}}
+        )
+        self._write(
+            token_file, {"account_id": _ACCT_EXPLICIT, "id_token": id_token}
+        )
+
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() == _ACCT_EXPLICIT
+
+    def test_none_when_no_account_anywhere(self, tmp_path):
+        """No explicit field and no id_token claim → None (header omitted)."""
+        token_file = tmp_path / "codex-auth.json"
+        self._write(token_file, {})  # only the base fields, no account id
+
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() is None
+
+    def test_none_when_id_token_lacks_claim(self, tmp_path):
+        """An id_token without the namespaced auth claim yields None."""
+        token_file = tmp_path / "codex-auth.json"
+        id_token = _make_id_token({"sub": "user-123", "email": "u@example.com"})
+        self._write(token_file, {"id_token": id_token})
+
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() is None
+
+    def test_none_when_id_token_malformed(self, tmp_path):
+        """A malformed (non-JWT) id_token is tolerated and yields None."""
+        token_file = tmp_path / "codex-auth.json"
+        self._write(token_file, {"id_token": "not-a-jwt"})
+
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() is None
+
+    def test_none_when_id_token_payload_not_base64(self, tmp_path):
+        """A JWT-shaped token with an undecodable payload yields None."""
+        token_file = tmp_path / "codex-auth.json"
+        # Three segments, but the middle is not valid base64url JSON.
+        self._write(token_file, {"id_token": "aaa.!!!not-base64!!!.ccc"})
+
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() is None
+
+    def test_none_when_file_missing(self, tmp_path):
+        """A missing token file yields None rather than raising."""
+        token_file = tmp_path / "nonexistent" / "codex-auth.json"
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() is None
+
+    def test_none_when_file_malformed_json(self, tmp_path):
+        """A token file that is not valid JSON yields None rather than raising."""
+        token_file = tmp_path / "codex-auth.json"
+        token_file.write_text("{not valid json", encoding="utf-8")
+
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() is None
+
+    def test_ignores_non_string_account_field(self, tmp_path):
+        """A non-string explicit field is ignored; falls through to id_token."""
+        token_file = tmp_path / "codex-auth.json"
+        id_token = _make_id_token(
+            {"https://api.openai.com/auth": {"chatgpt_account_id": _ACCT_FROM_TOKEN}}
+        )
+        self._write(token_file, {"account_id": 12345, "id_token": id_token})
+
+        mgr = CodexTokenManager(token_path=str(token_file))
+        assert mgr.get_account_id() == _ACCT_FROM_TOKEN


### PR DESCRIPTION
## Summary
- extract the user's ChatGPT account id from Codex OAuth auth data or id_token metadata
- send `ChatGPT-Account-ID` on native Codex Responses requests when available
- preserve honest LingTai client identity (`originator: lingtai`, `User-Agent: LingTai/<version>`) and avoid Codex CLI impersonation
- add tests for direct/id_token extraction, header present/absent, usage metadata hygiene, and cache-affinity regressions

## Validation
- `python -m pytest tests/unit/auth/test_codex_auth.py tests/test_codex_prompt_cache_key.py tests/test_deep_refresh.py -q` (79 passed)
- `python -m py_compile src/lingtai/auth/codex.py src/lingtai/llm/_register.py src/lingtai/llm/openai/adapter.py`
- `git diff --check origin/main..HEAD`
- account/token leakage scan over diff

## Notes
- no live Codex backend call was made
- absent or malformed id_token degrades to no account header rather than inventing one