### PR TITLE
fix(daemon): attribute LingTai-initiated CLI SIGTERM/143

### DIFF
--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -559,6 +559,14 @@ class DaemonManager:
         # watchdog owns them.
         self._cli_procs: list[subprocess.Popen] = []
         self._cli_proc_groups: dict[str, set[subprocess.Popen]] = {}
+        # LingTai-initiated termination reason per tracked proc, keyed by
+        # id(proc) and guarded by ``_cli_lock``. Stamped at the out-of-loop kill
+        # sites (reclaim/agent_stop/parent refresh via _drain_all_cli_procs,
+        # batch timeout via _kill_cli_group) *before* SIGTERM is sent, then read
+        # back when the read loop sees the resulting -15/143 returncode so the
+        # exit is attributed to the local cause instead of an opaque
+        # "claude CLI exited with code 143". See GH #455.
+        self._cli_term_reasons: dict[int, str] = {}
         self._cli_lock = threading.Lock()
         # Dedicated pool for CLI-backend `ask` follow-ups so they run off the
         # caller's tool-dispatch thread. The agent's `daemon(action="ask")` call
@@ -1773,8 +1781,12 @@ class DaemonManager:
 
         if proc.returncode != 0:
             detail = stderr_tail or (final_result_text or "")
+            attributed = self._attributed_cli_exit(
+                proc, "claude", detail[-500:], run_dir,
+            )
             exc = RuntimeError(
-                f"claude CLI exited with code {proc.returncode}: "
+                attributed
+                or f"claude CLI exited with code {proc.returncode}: "
                 f"{detail[-500:]}"
             )
             run_dir.mark_failed(exc)
@@ -2018,8 +2030,12 @@ class DaemonManager:
 
         if proc.returncode != 0:
             detail = stderr_tail or "\n".join(agent_message_texts[-3:])
+            attributed = self._attributed_cli_exit(
+                proc, "codex", detail[-500:], run_dir,
+            )
             exc = RuntimeError(
-                f"codex CLI exited with code {proc.returncode}: "
+                attributed
+                or f"codex CLI exited with code {proc.returncode}: "
                 f"{detail[-500:]}"
             )
             run_dir.mark_failed(exc)
@@ -3913,8 +3929,12 @@ class DaemonManager:
 
         if proc.returncode != 0:
             detail = stderr_tail or "\n".join(text_chunks[-3:])
+            attributed = self._attributed_cli_exit(
+                proc, backend_name, detail[-500:], run_dir,
+            )
             exc = RuntimeError(
-                f"{backend_name} CLI exited with code {proc.returncode}: "
+                attributed
+                or f"{backend_name} CLI exited with code {proc.returncode}: "
                 f"{detail[-500:]}"
             )
             run_dir.mark_failed(exc)
@@ -4097,8 +4117,12 @@ class DaemonManager:
 
         if proc.returncode != 0:
             detail = stderr_tail or output
+            attributed = self._attributed_cli_exit(
+                proc, "qwen-code", detail[-500:], run_dir,
+            )
             exc = RuntimeError(
-                f"qwen-code CLI exited with code {proc.returncode}: "
+                attributed
+                or f"qwen-code CLI exited with code {proc.returncode}: "
                 f"{detail[-500:]}"
             )
             run_dir.mark_failed(exc)
@@ -4523,8 +4547,12 @@ class DaemonManager:
 
         if proc.returncode != 0:
             detail = stderr_tail or "\n".join(text_chunks[-3:])
+            attributed = self._attributed_cli_exit(
+                proc, "Cursor", detail[-500:], run_dir,
+            )
             exc = RuntimeError(
-                f"Cursor CLI exited with code {proc.returncode}: "
+                attributed
+                or f"Cursor CLI exited with code {proc.returncode}: "
                 f"{detail[-500:]}"
             )
             run_dir.mark_failed(exc)
@@ -4885,7 +4913,7 @@ class DaemonManager:
         # Kill all tracked CLI process groups first — this terminates child
         # shells/tools that cancel_event alone cannot reach (GH #122).
         # Snapshot under lock, kill outside to avoid holding lock during wait.
-        procs_to_kill = self._drain_all_cli_procs()
+        procs_to_kill = self._drain_all_cli_procs(reason=reason)
         for proc in procs_to_kill:
             try:
                 _kill_process_group(proc)
@@ -5028,10 +5056,21 @@ class DaemonManager:
             self._cli_procs.append(proc)
             if group_id is not None:
                 self._cli_proc_groups.setdefault(group_id, set()).add(proc)
+            # CPython may recycle a previous proc's id() for this fresh object.
+            # Drop any stale termination reason left under that id (e.g. a kill
+            # stamped on a proc that then exited 0 before SIGTERM landed) so it
+            # cannot be mis-attributed to this new subprocess. See GH #455.
+            self._cli_term_reasons.pop(id(proc), None)
 
     def _unregister_cli_proc(self, proc: subprocess.Popen,
                              group_id: str | None = None) -> None:
-        """Detach *proc* from global and group tracking. Idempotent."""
+        """Detach *proc* from global and group tracking. Idempotent.
+
+        The recorded termination reason (if any) is intentionally NOT cleared
+        here: ``_unregister_cli_proc`` runs in the read-loop's ``finally`` block,
+        immediately before the returncode is classified, so the reason must
+        survive until ``_take_cli_term_reason`` consumes it.
+        """
         with self._cli_lock:
             try:
                 self._cli_procs.remove(proc)
@@ -5044,18 +5083,38 @@ class DaemonManager:
                     if not bucket:
                         del self._cli_proc_groups[group_id]
 
-    def _kill_cli_group(self, group_id: str) -> None:
+    def _note_cli_term_reason(self, proc: subprocess.Popen, reason: str) -> None:
+        """Record the LingTai-initiated termination *reason* for *proc*.
+
+        Called at the out-of-loop kill sites (reclaim/agent_stop/refresh and
+        batch timeout) just before SIGTERM. First reason wins so a follow-up
+        teardown kill cannot overwrite the original causal reason (e.g. a
+        timeout that is then swept by reclaim stays "timeout"). See GH #455.
+        """
+        with self._cli_lock:
+            self._cli_term_reasons.setdefault(id(proc), reason)
+
+    def _take_cli_term_reason(self, proc: subprocess.Popen) -> str | None:
+        """Pop and return the recorded termination reason for *proc*, if any."""
+        with self._cli_lock:
+            return self._cli_term_reasons.pop(id(proc), None)
+
+    def _kill_cli_group(self, group_id: str, reason: str = "timeout") -> None:
         """Kill only the CLI process groups owned by *group_id*.
 
         Snapshots the group's procs under the lock, detaches them from both
         the group index and the global list, then kills outside the lock so we
         never hold ``_cli_lock`` across a multi-second ``proc.wait``. Procs from
         other batches (and ungrouped ``ask`` procs) are left untouched.
+
+        *reason* (default "timeout", the only current caller) is stamped on each
+        proc before SIGTERM so the read loop can attribute the signal exit.
         """
         with self._cli_lock:
             bucket = self._cli_proc_groups.pop(group_id, None)
             procs_to_kill = list(bucket) if bucket else []
             for proc in procs_to_kill:
+                self._cli_term_reasons.setdefault(id(proc), reason)
                 try:
                     self._cli_procs.remove(proc)
                 except ValueError:
@@ -5063,13 +5122,73 @@ class DaemonManager:
         for proc in procs_to_kill:
             _kill_process_group(proc)
 
-    def _drain_all_cli_procs(self) -> list[subprocess.Popen]:
-        """Clear all CLI tracking and return the procs to kill (reclaim path)."""
+    def _drain_all_cli_procs(self, reason: str | None = None) -> list[subprocess.Popen]:
+        """Clear all CLI tracking and return the procs to kill (reclaim path).
+
+        When *reason* is given (agent_stop / parent refresh / reclaim) it is
+        stamped on each drained proc before the caller sends SIGTERM, so the
+        read loop attributes the resulting -15/143 exit to that local cause
+        instead of reporting an opaque CLI failure (GH #455).
+        """
         with self._cli_lock:
             procs_to_kill = list(self._cli_procs)
+            if reason is not None:
+                for proc in procs_to_kill:
+                    self._cli_term_reasons.setdefault(id(proc), reason)
             self._cli_procs.clear()
             self._cli_proc_groups.clear()
         return procs_to_kill
+
+    @staticmethod
+    def _signal_exit_name(returncode: int | None) -> str | None:
+        """Map a Popen returncode to a signal name, or None if not a signal.
+
+        Covers both subprocess conventions: negative (``-15``) when Python
+        reaps the child directly, and ``128 + signum`` (``143``) when the exit
+        propagates through a shell.
+        """
+        if returncode in (-15, 143):
+            return "SIGTERM"
+        if returncode in (-9, 137):
+            return "SIGKILL"
+        return None
+
+    def _attributed_cli_exit(
+        self,
+        proc: subprocess.Popen,
+        backend_name: str,
+        detail: str,
+        run_dir: "DaemonRunDir | None" = None,
+    ) -> str | None:
+        """Attribute a signal-terminated CLI exit to its local cause.
+
+        Returns a human-readable message naming the LingTai-initiated reason
+        (e.g. ``agent_stop`` / ``reclaim`` / ``timeout``) when this manager
+        recorded one before sending the signal, and records the reason on
+        *run_dir* for forensic inspection. The raw exit code is always kept in
+        the message. Returns ``None`` when the exit is not a signal we attribute
+        or no local reason was recorded — the caller then keeps its existing
+        opaque message so external/unknown SIGTERMs are not mislabeled as
+        deliberate cancellations. See GH #455.
+        """
+        reason = self._take_cli_term_reason(proc)
+        signal_name = self._signal_exit_name(getattr(proc, "returncode", None))
+        if signal_name is None or reason is None:
+            return None
+        if run_dir is not None:
+            try:
+                run_dir.record_cli_termination(
+                    reason=reason,
+                    signal_name=signal_name,
+                    returncode=proc.returncode,
+                )
+            except Exception:
+                pass
+        msg = (
+            f"{backend_name} CLI terminated by LingTai ({reason}, "
+            f"{signal_name}, code {proc.returncode})"
+        )
+        return f"{msg}: {detail}" if detail else msg
 
     def _arm_batch_done_cancel(self, futures: list,
                                cancel_event: threading.Event) -> None:

--- a/src/lingtai/core/daemon/run_dir.py
+++ b/src/lingtai/core/daemon/run_dir.py
@@ -602,6 +602,39 @@ class DaemonRunDir:
             )
         self._safe("mark_failed", _write)
 
+    def record_cli_termination(
+        self, *, reason: str, signal_name: str, returncode: int | None
+    ) -> None:
+        """Record that LingTai signalled this run's CLI subprocess.
+
+        Writes a structured ``daemon_cli_terminate`` event and stamps
+        ``cli_termination`` onto daemon.json so a later ``daemon(check)`` or a
+        post-mortem run-dir inspection can attribute an otherwise-opaque
+        signal exit (e.g. SIGTERM/143) to its local cause — parent
+        refresh/agent_stop, reclaim, or watchdog timeout. This is forensic
+        metadata only; it does not itself transition terminal state (the run
+        loop still records failed/cancelled/timeout). See GH #455.
+        """
+        def _write():
+            self._state["cli_termination"] = {
+                "reason": reason,
+                "signal": signal_name,
+                "returncode": returncode,
+                "ts": self._now_iso(),
+            }
+            self._atomic_write_json(self.daemon_json_path, self._state)
+            self._append_jsonl(
+                self.events_path,
+                {
+                    "event": "daemon_cli_terminate",
+                    "reason": reason,
+                    "signal": signal_name,
+                    "returncode": returncode,
+                    "ts": self._now_iso(),
+                },
+            )
+        self._safe("record_cli_termination", _write)
+
     def mark_cancelled(self) -> None:
         """Cancel event observed. Sets state=cancelled."""
         self._mark_terminal("cancelled", "daemon_cancelled")

--- a/tests/test_daemon_cli_143_attribution.py
+++ b/tests/test_daemon_cli_143_attribution.py
@@ -1,0 +1,216 @@
+"""Regression tests for LingTai-initiated daemon CLI SIGTERM/143 attribution.
+
+Issue #455: a ``claude-p`` daemon (``em-5``) was SIGTERM'd in the same second
+its parent ran ``system.refresh`` -> ``shutdown_for_agent_stop(reason="agent_stop")``
+-> ``_drain_all_cli_procs`` -> ``_kill_process_group``. The local reason was
+known at the kill site but discarded, so the run failed with the opaque
+``RuntimeError: claude CLI exited with code 143``.
+
+These tests pin the small fix: stamp the reason at the out-of-loop kill sites
+(``_drain_all_cli_procs`` / ``_kill_cli_group``) and recover it when the read
+loop classifies the resulting -15/143 returncode, producing an attributed
+message and a structured forensic record — while leaving an external/unknown
+SIGTERM (no recorded reason) as the existing opaque failure.
+"""
+from unittest.mock import MagicMock
+
+from lingtai_kernel.config import AgentConfig
+
+
+class _FakeProc:
+    """Minimal stand-in for subprocess.Popen the kill/classify helpers use."""
+
+    _next_pid = 7000
+
+    def __init__(self, returncode=None):
+        type(self)._next_pid += 1
+        self.pid = type(self)._next_pid
+        self.returncode = returncode
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+
+def _make_manager(tmp_path):
+    from lingtai.agent import Agent
+
+    svc = MagicMock()
+    svc.provider = "mock"
+    svc.model = "mock-model"
+    agent = Agent(
+        svc,
+        working_dir=tmp_path / "daemon-agent",
+        capabilities=["daemon"],
+        config=AgentConfig(),
+    )
+    return agent.get_capability("daemon")
+
+
+def _make_run_dir(tmp_path, handle="em-5"):
+    from lingtai.core.daemon.run_dir import DaemonRunDir
+
+    parent_wd = tmp_path / "rd-parent"
+    parent_wd.mkdir(exist_ok=True)
+    return DaemonRunDir(
+        parent_working_dir=parent_wd,
+        handle=handle,
+        task="patch the kernel",
+        tools=["file"],
+        model="mock-model",
+        max_turns=30,
+        timeout_s=1800.0,
+        parent_addr="parent",
+        parent_pid=12345,
+        system_prompt="You are a daemon emanation.",
+        backend="claude-p",
+    )
+
+
+# --- signal-name mapping -------------------------------------------------
+
+
+def test_signal_exit_name_covers_both_conventions():
+    from lingtai.core.daemon import DaemonManager
+
+    # subprocess negative convention and shell 128+signum convention
+    assert DaemonManager._signal_exit_name(-15) == "SIGTERM"
+    assert DaemonManager._signal_exit_name(143) == "SIGTERM"
+    assert DaemonManager._signal_exit_name(-9) == "SIGKILL"
+    assert DaemonManager._signal_exit_name(137) == "SIGKILL"
+    # a genuine non-zero CLI error is not a signal
+    assert DaemonManager._signal_exit_name(1) is None
+    assert DaemonManager._signal_exit_name(0) is None
+    assert DaemonManager._signal_exit_name(None) is None
+
+
+# --- reason stamping at the out-of-loop kill sites -----------------------
+
+
+def test_drain_all_stamps_reason(tmp_path, monkeypatch):
+    """The agent_stop / parent-refresh / reclaim path records the reason.
+
+    This is the exact em-5 path: the kill is issued from the shutdown thread,
+    so the read loop only observes the returncode and must recover the reason.
+    """
+    mgr = _make_manager(tmp_path)
+    monkeypatch.setattr("lingtai.core.daemon._kill_process_group", lambda p: None)
+
+    proc = _FakeProc()
+    mgr._register_cli_proc(proc, group_id="g")
+
+    drained = mgr._drain_all_cli_procs(reason="agent_stop")
+    assert drained == [proc]
+    assert mgr._take_cli_term_reason(proc) == "agent_stop"
+    # consumed exactly once
+    assert mgr._take_cli_term_reason(proc) is None
+
+
+def test_drain_all_without_reason_stamps_nothing(tmp_path):
+    """Reclaim callers that pass no reason must not invent attribution."""
+    mgr = _make_manager(tmp_path)
+    proc = _FakeProc()
+    mgr._register_cli_proc(proc, group_id=None)
+
+    mgr._drain_all_cli_procs()
+    assert mgr._take_cli_term_reason(proc) is None
+
+
+def test_kill_cli_group_stamps_timeout(tmp_path, monkeypatch):
+    """A batch timeout watchdog kill attributes its procs as ``timeout``."""
+    mgr = _make_manager(tmp_path)
+    monkeypatch.setattr("lingtai.core.daemon._kill_process_group", lambda p: None)
+
+    proc = _FakeProc()
+    mgr._register_cli_proc(proc, group_id="grp")
+
+    mgr._kill_cli_group("grp")
+    assert mgr._take_cli_term_reason(proc) == "timeout"
+
+
+def test_first_reason_wins(tmp_path):
+    """A later teardown kill must not overwrite the original causal reason."""
+    mgr = _make_manager(tmp_path)
+    proc = _FakeProc()
+
+    mgr._note_cli_term_reason(proc, "timeout")
+    mgr._note_cli_term_reason(proc, "agent_stop")  # later sweep — must not win
+    assert mgr._take_cli_term_reason(proc) == "timeout"
+
+
+def test_register_clears_stale_reason(tmp_path):
+    """A recycled id() must not carry a previous proc's reason onto a new one."""
+    mgr = _make_manager(tmp_path)
+    proc = _FakeProc()
+    mgr._note_cli_term_reason(proc, "reclaim")
+
+    # Re-registering the same object id (models id() recycling) drops the stale
+    # reason so a fresh subprocess is never mis-attributed.
+    mgr._register_cli_proc(proc, group_id=None)
+    assert mgr._take_cli_term_reason(proc) is None
+
+
+# --- classification at the returncode site -------------------------------
+
+
+def test_attributed_exit_names_reason_and_records(tmp_path, monkeypatch):
+    """A -15 exit with a recorded reason -> attributed message + forensic record."""
+    mgr = _make_manager(tmp_path)
+    monkeypatch.setattr("lingtai.core.daemon._kill_process_group", lambda p: None)
+    run_dir = _make_run_dir(tmp_path)
+
+    proc = _FakeProc(returncode=-15)
+    mgr._register_cli_proc(proc, group_id="g")
+    mgr._drain_all_cli_procs(reason="agent_stop")
+
+    msg = mgr._attributed_cli_exit(proc, "claude", "stderr tail", run_dir)
+    assert msg is not None
+    assert "terminated by LingTai" in msg
+    assert "agent_stop" in msg
+    assert "SIGTERM" in msg
+    assert "-15" in msg  # raw exit code preserved for forensics
+    assert "stderr tail" in msg
+
+    state = run_dir.state_snapshot()
+    assert state["cli_termination"]["reason"] == "agent_stop"
+    assert state["cli_termination"]["signal"] == "SIGTERM"
+    assert state["cli_termination"]["returncode"] == -15
+    # The reason is consumed by classification.
+    assert mgr._take_cli_term_reason(proc) is None
+
+
+def test_attributed_exit_handles_143_shell_convention(tmp_path):
+    """143 (128 + SIGTERM through a shell) is attributed identically to -15."""
+    mgr = _make_manager(tmp_path)
+    run_dir = _make_run_dir(tmp_path)
+
+    proc = _FakeProc(returncode=143)
+    mgr._note_cli_term_reason(proc, "reclaim")
+
+    msg = mgr._attributed_cli_exit(proc, "codex", "", run_dir)
+    assert msg is not None
+    assert "reclaim" in msg
+    assert "143" in msg
+
+
+def test_external_sigterm_stays_opaque(tmp_path):
+    """No recorded reason -> None, so the caller keeps its existing message.
+
+    This is the external/unknown-kill case: we must not relabel it as a
+    deliberate LingTai cancellation.
+    """
+    mgr = _make_manager(tmp_path)
+    run_dir = _make_run_dir(tmp_path)
+
+    proc = _FakeProc(returncode=143)  # killed, but not via a tracked path
+    assert mgr._attributed_cli_exit(proc, "claude", "tail", run_dir) is None
+    assert "cli_termination" not in run_dir.state_snapshot()
+
+
+def test_nonsignal_error_not_attributed(tmp_path):
+    """A genuine non-zero CLI error (exit 1) is never reason-attributed."""
+    mgr = _make_manager(tmp_path)
+    run_dir = _make_run_dir(tmp_path)
+
+    proc = _FakeProc(returncode=1)
+    mgr._note_cli_term_reason(proc, "agent_stop")  # even if a reason leaked in
+    assert mgr._attributed_cli_exit(proc, "claude", "boom", run_dir) is None


### PR DESCRIPTION
## Summary
- record LingTai-owned CLI termination reasons (`agent_stop`, `reclaim`, `timeout`) before sending daemon backend process-group termination
- attribute CLI `SIGTERM`/143 and `SIGKILL`/137 exits to that local cause when a reason was recorded, while preserving the raw exit code/signal for forensics
- add run-dir forensic output (`cli_termination` in `daemon.json` plus a `daemon_cli_terminate` event) so future 143s are no longer opaque backend/model failures

## Why
Refs #455. The current failure string (`claude CLI exited with code 143:`) hides whether LingTai itself terminated the CLI during lifecycle cleanup. Recent local trajectory samples around parent refresh showed exactly this ambiguity, and one replacement daemon in this task reproduced the post-refresh inspectability problem.

## Scope
This is intentionally a small attribution patch. It does **not** redesign daemon lifecycle/discovery, so the separate post-refresh `daemon check em-N` / registry inspectability issue remains follow-up work. Unknown/external SIGTERM still remains opaque instead of being over-attributed.

## Validation
- claude-p implementation daemon: 238 daemon-related tests passed using `PYTHONPATH=src`
- parent validation:
  - `git diff --check origin/main..HEAD`
  - `PYTHONPATH=src <main-repo-venv>/python -m py_compile src/lingtai/core/daemon/__init__.py src/lingtai/core/daemon/run_dir.py tests/test_daemon_cli_143_attribution.py`
  - `PYTHONPATH=src <main-repo-venv>/python -m pytest tests/test_daemon_cli_143_attribution.py tests/test_daemon_run_dir.py tests/test_lifecycle_daemon_shutdown.py tests/test_daemon_check.py -q` → `82 passed in 1.22s`
- GLM-5.2 read-only review: **APPROVE**; independently reran new attribution tests and broader daemon suite (`238 passed in 20.21s`). Review file kept locally at `reports/claude-cli-143-fix-glm-review-20260621.md`.

## Notes from GLM review
GLM noted a low-impact consistency gap: follow-up/ask helper exit sites are not included in this small patch, while the primary main-run lifecycle/timeout paths are. It approved the patch as-is and recommended handling that later only if we want broader consistency.
