### PR TITLE
Fix _check_duplicate_process prefix/substring false-positives

### DIFF
--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -184,21 +184,49 @@ def _check_duplicate_process(working_dir: Path) -> None:
         )
     except Exception:
         return  # ps unavailable — fall through to flock
-    needle = f"lingtai run {abs_dir}"
+    # Match the working-dir argument exactly. A substring test false-positives
+    # on prefix-sharing siblings (e.g. starting "codex" while "codex_colleague"
+    # is alive — "codex" is a prefix of "codex_colleague") and on shell wrappers
+    # whose argv merely contains the path, so tokenize each command line and
+    # require a `lingtai ... run <abs_dir>` invocation where the token after
+    # `run` resolves to exactly our working dir.
+    import shlex as _shlex
+    my_pid = os.getpid()
     for line in out.splitlines():
         trimmed = line.strip()
-        if needle in trimmed:
-            # Exclude our own PID
-            pid_str = trimmed.split(None, 1)[0]
-            if pid_str.isdigit() and int(pid_str) == os.getpid():
+        if not trimmed:
+            continue
+        parts = trimmed.split(None, 1)
+        if len(parts) != 2:
+            continue
+        pid_str, command = parts
+        if not pid_str.isdigit() or int(pid_str) == my_pid:
+            continue
+        try:
+            tokens = _shlex.split(command)
+        except ValueError:
+            continue  # unparseable command line — let flock be the backstop
+        matched = False
+        for i in range(1, len(tokens) - 1):
+            if tokens[i] != "run" or "lingtai" not in tokens[i - 1]:
                 continue
-            print(
-                f"error: another lingtai agent is already running in {abs_dir}\n"
-                f"  PID {pid_str}: {trimmed}\n"
-                f"  If this is a stale process, kill it first.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+            candidate = tokens[i + 1]
+            try:
+                candidate = str(Path(candidate).resolve())
+            except Exception:
+                pass
+            if candidate == abs_dir:
+                matched = True
+                break
+        if not matched:
+            continue
+        print(
+            f"error: another lingtai agent is already running in {abs_dir}\n"
+            f"  PID {pid_str}: {trimmed}\n"
+            f"  If this is a stale process, kill it first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def run(working_dir: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -403,3 +403,75 @@ def test_load_init_runs_agent_migrations_before_validation(tmp_path):
     digest = hashlib.sha256(legacy.encode("utf-8")).hexdigest()
     archive = tmp_path / "system" / "migrations" / f"init-procedures-{digest}.md"
     assert archive.read_text(encoding="utf-8") == legacy
+
+
+# ---------------------------------------------------------------------------
+# _check_duplicate_process — must match the working-dir argument exactly
+# ---------------------------------------------------------------------------
+
+
+def _ps_line(pid: int, working_dir) -> str:
+    """A realistic `ps -eo pid=,command=` line for a `lingtai run <dir>` agent."""
+    py = "/usr/local/.../Python"
+    return f"{pid} {py} -m lingtai run {working_dir}"
+
+
+def test_check_duplicate_process_ignores_prefix_sibling(tmp_path):
+    """Starting `.../codex` must not be blocked by a running `.../codex_colleague`.
+
+    Regression: `codex` is a prefix of `codex_colleague`, and the old substring
+    match treated the colleague's `ps` line as a duplicate codex process.
+    """
+    from lingtai.cli import _check_duplicate_process
+
+    codex = tmp_path / "codex"
+    colleague = tmp_path / "codex_colleague"
+    codex.mkdir()
+    colleague.mkdir()
+
+    ps_out = _ps_line(42779, colleague.resolve()) + "\n"
+    with patch("subprocess.check_output", return_value=ps_out):
+        # Must NOT raise SystemExit — the colleague is a different agent.
+        _check_duplicate_process(codex)
+
+
+def test_check_duplicate_process_detects_exact_match(tmp_path):
+    """A genuine same-workdir `lingtai run` process is still flagged."""
+    from lingtai.cli import _check_duplicate_process
+
+    codex = tmp_path / "codex"
+    codex.mkdir()
+
+    ps_out = _ps_line(99999, codex.resolve()) + "\n"
+    with patch("subprocess.check_output", return_value=ps_out):
+        with pytest.raises(SystemExit):
+            _check_duplicate_process(codex)
+
+
+def test_check_duplicate_process_ignores_shell_wrapper(tmp_path):
+    """A shell wrapper that merely *evals* the run command is not a duplicate.
+
+    Regression (discussions/covenant-distillation-and-per-agent-profile.md): a
+    `zsh -ic '... lingtai run <dir> ...'` wrapper carries the whole command as a
+    single quoted argv token, so `run` is never its own token and must not match.
+    """
+    from lingtai.cli import _check_duplicate_process
+
+    codex = tmp_path / "codex"
+    codex.mkdir()
+
+    wrapper = f"67192 /bin/zsh -ic 'lingtai run {codex.resolve()} && echo done'"
+    with patch("subprocess.check_output", return_value=wrapper + "\n"):
+        _check_duplicate_process(codex)
+
+
+def test_check_duplicate_process_excludes_own_pid(tmp_path):
+    """The current process's own `ps` line must never count as a duplicate."""
+    from lingtai.cli import _check_duplicate_process
+
+    codex = tmp_path / "codex"
+    codex.mkdir()
+
+    ps_out = _ps_line(os.getpid(), codex.resolve()) + "\n"
+    with patch("subprocess.check_output", return_value=ps_out):
+        _check_duplicate_process(codex)


### PR DESCRIPTION
## Problem

`_check_duplicate_process` (the friendly defense-in-depth guard alongside the kernel flock) matched `lingtai run <abs_dir>` as a **bare substring** of each `ps` line. Two false-positive classes:

1. **Prefix-sharing siblings.** Starting `.../.lingtai/codex` while `.../.lingtai/codex_colleague` is alive aborts with `another lingtai agent is already running`, because `"...run .../codex"` is a substring of `"...run .../codex_colleague"`. The agent can **never relaunch** while the colleague runs, even though they are distinct agents the flock would happily allow. Observed live: a dead `codex` agent stuck in a TUI relaunch loop, repeatedly blamed on the `codex_colleague` PID.
2. **Shell wrappers.** A `zsh -ic '... lingtai run <dir> ...'` wrapper whose argv merely carries the command as a quoted blob (see `discussions/covenant-distillation-and-per-agent-profile.md`).

## Fix

Tokenize each `ps` command line with `shlex` and require a genuine `lingtai ... run <abs_dir>` invocation: a `run` token preceded by a lingtai entrypoint token, whose following token resolves to exactly the working dir. Unparseable command lines are skipped (flock remains the real backstop).

## Tests

Adds 4 regression tests in `tests/test_cli.py`:
- prefix sibling is **not** flagged (`codex` vs `codex_colleague`)
- a genuine same-workdir process **is** flagged
- quoted shell wrapper is **not** flagged
- the calling process own PID is excluded

`pytest tests/test_cli.py` -> 23 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
