### PR TITLE
feat(codex): send honest metadata envelope

### DIFF
--- a/docs/references/codex-http-anatomy-investigation.md
+++ b/docs/references/codex-http-anatomy-investigation.md
@@ -1,0 +1,143 @@
+# Codex HTTP anatomy investigation: LingTai vs. Codex CLI
+
+Date: 2026-06-22  
+Scope: ChatGPT-backed Codex Responses requests emitted by LingTai and by the
+local Codex CLI (`codex-cli 0.130.0`).
+
+## Why this document exists
+
+LingTai's Codex provider had already moved to the native Responses route and had
+recently gained stable cache-affinity headers and honest client identity. A local
+wire-shape investigation compared LingTai with the official Codex CLI to answer
+three engineering questions:
+
+1. Which endpoint/body shape do both clients use?
+2. Which identity/cache/account/metadata headers are present in Codex CLI but
+   absent in LingTai?
+3. Which fields can LingTai add honestly without impersonating Codex CLI?
+
+This document records the investigation so the adapter anatomy can point to a
+stable reference instead of re-explaining the capture history inline.
+
+## Capture method and safety
+
+The investigation intentionally avoided TLS MITM and did not forward either
+capture to the real OpenAI/ChatGPT upstream. Both clients were routed to local
+fake Responses endpoints on `127.0.0.1`; each fake endpoint recorded the request
+and returned a minimal SSE response.
+
+- LingTai capture: invoked the real local `CodexOpenAIAdapter` against a fake
+  `base_url` ending in `/backend-api/codex`.
+- Codex CLI capture: invoked installed `codex exec` v0.130.0 with a local fake
+  model provider configured as `wire_api='responses'` and `OPENAI_API_KEY` set to
+  a fake value.
+- Secrets and stable account identifiers were redacted in shareable artifacts.
+- Raw local artifacts were kept outside the repository; this document records the
+  reproducible structure, not secrets.
+
+## Endpoint shape
+
+| Client | Captured method/path | Real/default interpretation |
+|---|---|---|
+| LingTai native Codex adapter | `POST /backend-api/codex/responses` | Corresponds to `https://chatgpt.com/backend-api/codex/responses`. |
+| Codex CLI v0.130.0, fake provider | `POST /v1/responses` | The forced provider used OpenAI-style `/v1/responses`; the header/body structure came from the real CLI process. |
+
+Both clients use a Responses-style request body and streaming SSE response shape,
+not Chat Completions.
+
+## LingTai request shape before the metadata PR
+
+A minimal no-tool LingTai capture sent:
+
+- Headers: `Authorization`, `originator: lingtai`, `User-Agent: LingTai/<version>`,
+  Python OpenAI SDK `X-Stainless-*`, and cache-affinity headers
+  `session_id` / `thread_id` when a stable Codex identity exists.
+- Body keys: `model`, `instructions`, `input`, `reasoning`, `store: false`,
+  `stream: true`, `include: ["reasoning.encrypted_content"]`, and
+  `prompt_cache_key`.
+- Cache affinity: `prompt_cache_key == session_id == thread_id == <stable
+  per-agent id>` in LingTai's normal root-agent path.
+
+PR #454 separately added an honest `ChatGPT-Account-ID` header when the user's
+own account id can be derived from Codex OAuth/auth metadata. It preserves
+`originator: lingtai` and does not impersonate Codex CLI.
+
+## Codex CLI v0.130.0 request shape observed locally
+
+The local CLI capture sent these notable headers:
+
+- `originator: codex_exec`
+- `User-Agent: codex_exec/0.130.0 (...)`
+- `chatgpt-account-id`
+- `session_id` and `thread_id` as UUID-shaped values
+- `x-client-request-id`
+- `x-codex-window-id`, observed as `<session_uuid>:0`
+- `x-codex-turn-metadata`, JSON containing session/thread/turn/sandbox/timestamp
+- `x-codex-beta-features: terminal_resize_reflow`
+
+Its body included the common Responses fields plus CLI-specific scaffolding:
+`tools`, `tool_choice: auto`, `parallel_tool_calls: true`, `text.verbosity`, and
+`client_metadata.x-codex-installation-id`.
+
+The blog post that motivated the check described `codex_cli_rs`; this machine's
+installed CLI v0.130.0 used `codex_exec`. LingTai must treat the exact string as
+version-specific implementation detail, not as an identity to copy.
+
+## Fields LingTai can add honestly
+
+LingTai can add a small compatibility metadata envelope without pretending to be
+Codex CLI:
+
+| Field | LingTai meaning |
+|---|---|
+| `x-client-request-id` | Fresh UUID per request. |
+| `x-codex-window-id` | `<session_id>:0` for LingTai's current single-window Codex session model. |
+| `x-codex-turn-metadata` | Compact JSON with `session_id`, `thread_id`, generated `turn_id`, truthful `sandbox`, and `turn_started_at_unix_ms`. |
+| `client_metadata.x-codex-installation-id` | UUID-shaped LingTai installation id derived from LingTai's own non-secret anchor/id. |
+
+The OpenAI Python SDK exposes no typed `client_metadata` argument on
+`responses.create`, so LingTai passes it via `extra_body={"client_metadata": ...}`.
+
+## Fields LingTai should not copy blindly
+
+- Do not change `originator` or `User-Agent` to official CLI values.
+- Do not use `~/.codex/installation_id`; LingTai derives its own id.
+- Do not send `x-codex-beta-features: terminal_resize_reflow` unless LingTai
+  actually implements and intends to advertise that feature.
+- Do not invent attestation or other official-CLI-only fields.
+
+## Implementation notes
+
+The metadata PR extends `CodexResponsesSession` in `src/lingtai/llm/openai/adapter.py`:
+
+1. Build cache-affinity headers exactly as before: literal underscore
+   `session_id` / `thread_id`.
+2. Add metadata headers only when both session and thread identity are present.
+3. Generate request and turn ids per request.
+4. Keep `ChatGPT-Account-ID` behavior from PR #454 independent of the metadata
+   envelope.
+5. Add body `client_metadata` through `extra_body` and preserve any existing
+   caller-supplied `extra_body.client_metadata` keys.
+6. Keep tests focused on the separation between stable cache/identity fields and
+   intentionally variable per-request metadata.
+
+## Validation performed during development
+
+Before merging PR #454:
+
+- Targeted Codex auth/cache/reasoning tests: `70 passed`.
+- Full kernel pytest: `2548 passed, 4 skipped`.
+- PR #454 merged as `bd72689`.
+
+For the metadata PR before final merge:
+
+- `tests/test_codex_prompt_cache_key.py`: `40 passed`.
+- Codex auth/cache/raw-reasoning targeted suite: `72 passed`.
+- Full kernel pytest should be run before merge and recorded in the PR/merge
+  report.
+
+## Design principle
+
+The compatibility goal is not to look like Codex CLI. It is to give the Codex
+backend honest, useful metadata that LingTai can actually stand behind while
+keeping LingTai's own identity explicit.

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -19,8 +19,8 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | `OpenAIChatSession` | 492–1003 | Chat Completions session with context overflow auto-recovery; sends optional `prompt_cache_key` |
 | `OpenAIResponsesSession` | 1006–1204 | Responses API session with server-side `previous_response_id` chaining, optional `context_management` compaction, and optional `prompt_cache_key` |
 | `OpenAIAdapter` | 1207–1520 | `LLMAdapter` implementation; dispatches to Completions or Responses path; receives injected `compact_threshold`; derives the default `prompt_cache_key` via `_default_prompt_cache_key` / `_resolve_prompt_cache_key` |
-| `CodexResponsesSession` | ~1594–1900 | Stateless Responses variant for ChatGPT-OAuth `/backend-api/codex`. **Normalizes** its three affinity inputs at construction into ONE stable id (priority `prompt_cache_key` > `session_id` > `thread_id`) so `prompt_cache_key == session_id == thread_id` always. Sends `session_id` / `thread_id` REST headers (`_cache_affinity_headers`, underscore spelling) only when a per-agent identity was supplied (a lone cache key stays body-only — header carve-out). Always sends honest `originator` / `User-Agent` identity headers. Copies the single id into `UsageMetadata.extra` (`_usage_extra`) for `token_ledger.jsonl`. The id never changes for the life of the session — no rotation, no epoch |
-| `CodexOpenAIAdapter` | ~1905–2070 | Adapter variant that builds `CodexResponsesSession`; derives the per-agent id as a PURE hash of the anchor (`_codex_session_id(anchor)`; explicit `codex_session_id` used verbatim); `_resolve_codex_ids` returns `(id, id)` — thread tracks session — and `(None, None)` only for a bare/test adapter; `_default_prompt_cache_key` returns the SAME per-agent value (falls back to `lingtai-codex:{model}:v1` only on the bare/no-anchor path). No epoch, no clock, no event sink |
+| `CodexResponsesSession` | `adapter.py:1641` | Stateless Responses session for ChatGPT-backed Codex: full-history replay, encrypted reasoning include, cache-affinity headers, honest client/account identity, and honest Codex metadata envelope. |
+| `CodexOpenAIAdapter` | `adapter.py:2017` | Codex provider specialization: forces Responses mode, derives stable per-agent cache/session ids plus a LingTai installation id from the configured anchor, and wires account/metadata hints into Codex sessions. |
 
 ### adapter.py helpers
 
@@ -28,6 +28,7 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 |----------|-------|------|
 | `_base_url_namespace()` | 102–116 | Stable namespace token for an OpenAI-compatible `base_url` (URL host, or short hash fallback) used in the default `prompt_cache_key` |
 | `_codex_session_id()` | ~80–94 | Derive the stable 8-char Codex cache-affinity id (issue #378): `sha256(anchor).hexdigest()[:8]`, lowercase hex, where `anchor` MUST be a per-agent identity (the resolved `init.json` path). The same value is used byte-identically for `session_id`, `thread_id`, and the default `prompt_cache_key` on the root/main path. PURE hash — no time/epoch — so it is stable across restarts |
+| `_codex_installation_id()` | `adapter.py:154` | Derives a UUID-shaped, non-secret LingTai installation id for Codex `client_metadata` from the same local anchor/id; never reuses `~/.codex/installation_id`. |
 | `_codex_identity_headers()` | ~140–155 | Honest LingTai client-identity headers sent on every Codex request (#436): `{originator: lingtai, User-Agent: LingTai/<version>}`. Cache-irrelevant; account hygiene only |
 | `_validate_compact_threshold()` | 69–83 | Validates/normalizes OpenAI Responses auto-compaction threshold; positive `int` or explicit `None` (disable) only |
 | `_codex_responses_trace_path()` / `_codex_responses_trace_record()` | 63–157 | Opt-in Codex Responses stream diagnostic trace helpers; safe metadata only, default off |
@@ -116,7 +117,15 @@ The REST `/backend-api/codex/responses` endpoint does **not** accept `previous_r
 
 **Codex-only.** When the user's OAuth auth data supplies an account id (`CodexTokenManager.get_account_id()`, see `../../auth/ANATOMY.md`), `CodexResponsesSession` sends it as the canonical `ChatGPT-Account-ID` header so the request is attributed to the right ChatGPT account. It does NOT change the honest `originator`/`User-Agent` identity above — no Codex-CLI impersonation. The value flows `_register.py` (`codex_account_id=mgr.get_account_id()`) → `CodexOpenAIAdapter.codex_account_id` (mutable; the OAuth-refresh monkey-patch re-reads it via `get_account_id()` so a refresh that changes the id stays current on later-built sessions) → `CodexResponsesSession(account_id=...)` (`self._account_id`). Emitted only when non-empty; otherwise the header is omitted entirely. The account id is a non-secret identifier and — unlike the affinity ids — is **NOT** copied into `UsageMetadata.extra` or any log/ledger.
 
+### Codex honest metadata envelope
+
+See `docs/references/codex-http-anatomy-investigation.md` for the capture history, Codex CLI comparison, and the safety rationale behind which metadata LingTai does and does not send.
+
+When a Codex session has a stable LingTai session/thread identity, `CodexResponsesSession` adds an honest metadata envelope alongside the cache-affinity headers (`adapter.py:1730`, `adapter.py:1885`, `adapter.py:1900`). Each request gets a fresh `x-client-request-id`; `x-codex-window-id` is the LingTai window id `<session_id>:0`; `x-codex-turn-metadata` is compact JSON carrying `session_id`, `thread_id`, a generated `turn_id`, a truthful LingTai `sandbox` label, and `turn_started_at_unix_ms`; and body `client_metadata.x-codex-installation-id` is carried through `extra_body` because the OpenAI Python SDK has no typed `client_metadata` argument. This is compatibility metadata, not CLI impersonation: LingTai keeps `originator: lingtai` / `User-Agent: LingTai/<version>`, does not send `x-codex-beta-features`, and derives its installation id from LingTai state rather than from the official Codex CLI installation file.
+
 ## State
+
+- `CodexResponsesSession._installation_id` / `_metadata_sandbox`: optional honest Codex metadata state used to build `client_metadata.x-codex-installation-id` and turn metadata without leaking local paths or claiming official CLI features.
 
 - **`OpenAIChatSession._interface`** — canonical `ChatInterface`, single source of truth. Mutated in-place: `add_user_message`, `add_tool_results`, `add_assistant_message`, `drop_trailing`.
 - **`OpenAIChatSession._request_timeout`** — per-request HTTP timeout set by caller before dispatch (line 319). Prevents race between watchdog and SDK.

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -151,6 +151,19 @@ def _lingtai_user_agent() -> str:
         return "LingTai"
 
 
+def _codex_installation_id(anchor: str | None) -> str | None:
+    """Return a stable, honest LingTai installation id for Codex metadata.
+
+    Codex CLI sends an opaque UUID-shaped ``x-codex-installation-id``. LingTai
+    must not borrow ``~/.codex/installation_id`` or impersonate the CLI, so we
+    derive our own UUID-shaped identifier from the same non-secret local anchor
+    used for Codex cache affinity. The raw path/anchor is never sent.
+    """
+
+    if not anchor:
+        return None
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"lingtai-codex-installation:{anchor}"))
+
 def _codex_identity_headers() -> dict[str, str]:
     """Honest client-identity headers sent on every Codex request (see #436)."""
     return {"originator": _CODEX_ORIGINATOR, "User-Agent": _lingtai_user_agent()}
@@ -1650,6 +1663,8 @@ class CodexResponsesSession(OpenAIResponsesSession):
         session_id: str | None = None,
         thread_id: str | None = None,
         account_id: str | None = None,
+        installation_id: str | None = None,
+        metadata_sandbox: str = "lingtai",
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -1661,6 +1676,8 @@ class CodexResponsesSession(OpenAIResponsesSession):
         # is a non-secret account identifier and is never copied into usage
         # metadata or logs.
         self._account_id = account_id if isinstance(account_id, str) and account_id else None
+        self._installation_id = installation_id
+        self._metadata_sandbox = metadata_sandbox or "lingtai"
         # Codex REST cache-affinity identity: ONE stable per-agent value used
         # byte-identically for ``prompt_cache_key`` / ``session_id`` /
         # ``thread_id`` on EVERY request, and NEVER changed for the life of the
@@ -1709,6 +1726,29 @@ class CodexResponsesSession(OpenAIResponsesSession):
         if self._thread_id:
             headers["thread_id"] = self._thread_id
         return headers
+
+    def _codex_metadata_headers(self) -> dict[str, str]:
+        """Return honest LingTai Codex metadata headers for this request."""
+
+        if not (self._session_id and self._thread_id):
+            return {}
+        turn_metadata = {
+            "session_id": self._session_id,
+            "thread_id": self._thread_id,
+            "turn_id": str(uuid.uuid4()),
+            "sandbox": self._metadata_sandbox,
+            "turn_started_at_unix_ms": int(time.time() * 1000),
+        }
+        return {
+            "x-client-request-id": str(uuid.uuid4()),
+            "x-codex-window-id": f"{self._session_id}:0",
+            "x-codex-turn-metadata": json.dumps(turn_metadata, separators=(",", ":"), sort_keys=True),
+        }
+
+    def _codex_client_metadata(self) -> dict[str, str]:
+        if not self._installation_id:
+            return {}
+        return {"x-codex-installation-id": self._installation_id}
 
     def _effective_affinity(self) -> tuple[str | None, dict[str, str]]:
         """Resolve this request's (prompt_cache_key, headers) pair.
@@ -1842,6 +1882,7 @@ class CodexResponsesSession(OpenAIResponsesSession):
             extra_headers = {
                 **_codex_identity_headers(),
                 **affinity_headers,
+                **self._codex_metadata_headers(),
             }
             # The user's own ChatGPT account id, when available. Canonical
             # official spelling ``ChatGPT-Account-ID`` (HTTP header names are
@@ -1856,6 +1897,12 @@ class CodexResponsesSession(OpenAIResponsesSession):
                     **extra_headers,
                     **kwargs.get("extra_headers", {}),
                 }
+            client_metadata = self._codex_client_metadata()
+            if client_metadata:
+                extra_body = dict(kwargs.get("extra_body") or {})
+                existing_client_metadata = dict(extra_body.get("client_metadata") or {})
+                extra_body["client_metadata"] = {**existing_client_metadata, **client_metadata}
+                kwargs["extra_body"] = extra_body
             acc = StreamingAccumulator()
             response_id = None
             usage = UsageMetadata()
@@ -2068,6 +2115,8 @@ class CodexOpenAIAdapter(OpenAIAdapter):
         else:
             self._codex_id = None  # no per-agent identity -> no headers
         self._codex_thread_salt = codex_thread_salt  # legacy pass-through; unused
+        installation_anchor = self._codex_session_anchor or self._codex_id
+        self._codex_installation_id = _codex_installation_id(installation_anchor)
         # The user's own ChatGPT account id, resolved upstream from their OAuth
         # auth data (explicit ``account_id`` field or decoded id_token claim).
         # Mutable so the token-refresh path can keep it current if refreshed
@@ -2161,4 +2210,5 @@ class CodexOpenAIAdapter(OpenAIAdapter):
             # The user's own ChatGPT account id (read fresh from the adapter so a
             # token refresh that changes it is reflected on newly built sessions).
             account_id=self.codex_account_id,
+            installation_id=self._codex_installation_id,
         )

--- a/tests/test_codex_prompt_cache_key.py
+++ b/tests/test_codex_prompt_cache_key.py
@@ -308,9 +308,16 @@ def test_codex_sends_stable_headers_from_session_anchor():
     assert h0["session_id"] == expected
     assert h0["thread_id"] == expected
     assert s0["prompt_cache_key"] == expected
-    # Stable across multiple ordinary sends of the same session.
-    assert h0 == h1
+    # Cache-affinity / identity headers stay stable across ordinary sends.
+    stable_keys = {"originator", "User-Agent", "session_id", "thread_id"}
+    assert {key: h0[key] for key in stable_keys} == {key: h1[key] for key in stable_keys}
     assert s1["prompt_cache_key"] == expected
+    # Request/turn metadata is honest per-request metadata and intentionally varies.
+    assert h0["x-client-request-id"] != h1["x-client-request-id"]
+    assert h0["x-codex-window-id"] == h1["x-codex-window-id"] == f"{expected}:0"
+    assert json.loads(h0["x-codex-turn-metadata"])["turn_id"] != json.loads(
+        h1["x-codex-turn-metadata"]
+    )["turn_id"]
 
 
 def test_codex_headers_differ_for_different_agents():
@@ -981,3 +988,60 @@ def _expected_codex_hash(anchor: str) -> str:
     from lingtai.llm.openai.adapter import _codex_session_id
 
     return _codex_session_id(anchor)
+
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def test_codex_sends_honest_request_and_turn_metadata_headers():
+    session = _create_codex_session_cfg(
+        [_completed()],
+        codex_session_id="stable123",
+        codex_account_id=_TEST_ACCOUNT_ID,
+    )
+
+    session.send("x")
+
+    kwargs = session._client.responses.kwargs[0]
+    headers = kwargs["extra_headers"]
+    assert headers["originator"] == "lingtai"
+    assert "codex_exec" not in headers["User-Agent"]
+    assert headers["ChatGPT-Account-ID"] == _TEST_ACCOUNT_ID
+    assert kwargs["prompt_cache_key"] == "stable123"
+    assert headers["session_id"] == "stable123"
+    assert headers["thread_id"] == "stable123"
+
+    assert _UUID_RE.match(headers["x-client-request-id"])
+    assert headers["x-codex-window-id"] == "stable123:0"
+    assert "x-codex-beta-features" not in headers
+
+    turn_metadata = json.loads(headers["x-codex-turn-metadata"])
+    assert turn_metadata["session_id"] == "stable123"
+    assert turn_metadata["thread_id"] == "stable123"
+    assert _UUID_RE.match(turn_metadata["turn_id"])
+    assert turn_metadata["sandbox"] == "lingtai"
+    assert isinstance(turn_metadata["turn_started_at_unix_ms"], int)
+    assert turn_metadata["turn_started_at_unix_ms"] > 0
+
+    client_metadata = kwargs["extra_body"]["client_metadata"]
+    assert set(client_metadata) == {"x-codex-installation-id"}
+    assert _UUID_RE.match(client_metadata["x-codex-installation-id"])
+
+
+def test_codex_omits_x_codex_metadata_without_session_identity():
+    session = _create_codex_session_cfg([_completed()])
+
+    session.send("x")
+
+    kwargs = session._client.responses.kwargs[0]
+    headers = kwargs["extra_headers"]
+    assert headers["originator"] == "lingtai"
+    assert "session_id" not in headers
+    assert "thread_id" not in headers
+    assert "x-client-request-id" not in headers
+    assert "x-codex-window-id" not in headers
+    assert "x-codex-turn-metadata" not in headers
+    assert "x-codex-beta-features" not in headers
+    assert "extra_body" not in kwargs


### PR DESCRIPTION
## Summary

- add an honest Codex metadata envelope for LingTai's ChatGPT-backed Codex Responses requests:
  - `x-client-request-id` (fresh UUID per request)
  - `x-codex-window-id` (`<session_id>:0` for LingTai's current single-window model)
  - `x-codex-turn-metadata` (JSON with session/thread/generated turn id, truthful `sandbox: lingtai`, and timestamp)
  - body `client_metadata.x-codex-installation-id` via OpenAI SDK `extra_body`
- derive the installation id from LingTai's own non-secret anchor/id; do not read/reuse `~/.codex/installation_id`
- preserve honest `originator: lingtai` and `User-Agent: LingTai/<version>`
- preserve PR #454 `ChatGPT-Account-ID` behavior and existing cache affinity
- explicitly do **not** send `x-codex-beta-features` / `terminal_resize_reflow`
- add `docs/references/codex-http-anatomy-investigation.md` and point `openai/ANATOMY.md` to it

## Validation

- `PYTHONPATH="$WT/src" /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_codex_prompt_cache_key.py -q`
  - `40 passed`
- `PYTHONPATH="$WT/src" /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/unit/auth/test_codex_auth.py tests/test_codex_prompt_cache_key.py tests/test_codex_raw_reasoning_replay.py -q`
  - `72 passed`
- `PYTHONPATH="$WT/src" /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q`
  - `2550 passed, 4 skipped in 273.18s (0:04:33)`
- `git diff --check`
  - passed

## GLM review status

Jason requested a GLM review before merge. I attempted a direct GLM/Zhipu API review using the local configured Zhipu CN and international keys. The review could not be completed because all available keys lack usable GLM quota/resource:

- CN keys on `open.bigmodel.cn`: `glm-4.5` / `glm-4-plus` returned 429 code 1113 (`余额不足或无可用资源包，请充值`); other tried names were unknown models.
- Intl keys on `api.z.ai`: `glm-4.5` / `glm-4-plus` returned 429 code 1113 (`Insufficient balance or no resource package`); other tried names were unknown models.

Because GLM review is a merge gate requested by Jason, this PR should remain open until either a GLM review is available or Jason explicitly approves merging based on the successful local validation above.
