### PR TITLE
Document learning from human daemon usage patterns

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -135,6 +135,16 @@ Use this methodology for substantial daemon work:
    claims, and deposit durable results in pad/knowledge/skills. Do not drag every
    daemon transcript back into the main conversation.
 
+Daemon usage is cultivated from observed practice, not mandated by a daemon-first
+rule. Watch how humans route work to daemons and subagents — which tasks they hand
+off, what they correct, and what they approve or reject — and treat that as the
+training signal for your own routing. After a meaningful daemon workflow, deposit
+the lesson into the layer that fits its lifetime: pad for active workflow state,
+lingtai/character for durable operating style, knowledge for private project facts
+and patterns, skills for reusable procedures. The parent remains responsible for
+framing, review, synthesis, and human-facing decisions; the daemon protects the
+main context by executing bounded work.
+
 Tool results may carry `_advisory.type == "duplicate_tool_call"` when the same
 semantic tool call repeats more than the free-pass threshold. This is
 advisory-only: the tool already ran and the kernel did not block it. Treat it as

--- a/src/lingtai/prompts/procedures.md
+++ b/src/lingtai/prompts/procedures.md
@@ -29,7 +29,16 @@ long scans, batch analysis, and exploratory branches instead of dragging their
 full context through the main agent. Daemon turns carry no resident system prompt,
 so they are often the token-efficient body for temporary work. Choose the daemon
 or model by exercising judgment about the task; when the human gives an explicit
-instruction, follow that instruction. For the full daemon methodology — pad
+instruction, follow that instruction.
+
+Treat daemon use as a practice to learn from, not a rigid policy: daemon need not
+always come first. Observe how humans route work to daemons and subagents — what
+they correct, what they approve, what they reject — and after a meaningful daemon
+workflow, deposit the lesson into the right durable layer: pad for active workflow
+state, lingtai/character for durable operating style, knowledge for private project
+facts and patterns, skills for reusable procedures. The parent stays responsible
+for framing, review, synthesis, and human-facing decisions; the daemon protects
+the main context by executing bounded work. For the full daemon methodology — pad
 workflow, cost efficiency, context hygiene, and parent/daemon division of labor —
 read `system-manual` → `reference/procedures-manual/SKILL.md`.
 


### PR DESCRIPTION
## Summary

Follow-up to the discussion around #389. Rather than making “daemon-first” a rigid LingTai policy, this documents the LingTai-shaped lesson: agents should learn from how humans actually route work to daemons/subagents, then deposit those learned workflow habits into the right durable memory layer.

This keeps the parent/daemon split as practice and cultivation:
- daemon protects main context by executing bounded work;
- parent remains responsible for framing, review, synthesis, and human-facing decisions;
- after a meaningful daemon workflow, record the lesson in pad / lingtai / knowledge / skills as appropriate.

## Scope

- Updates resident `procedures.md` source narrowly.
- Adds a matching note to the expanded procedures manual.
- Does **not** recreate #389’s broader daemon-first policy, capsule handoff template, or daemon-manual changes.

## Validation

- `git diff --check`
- `uv run pytest tests/test_skills.py tests/test_deep_refresh.py -q` → 45 passed
- HTML preview generated for Jason: `reports/lingtai-org-triage/human-daemon-usage-memory-pr.html`

## Notes

Jason asked to review this via HTML before deciding whether to merge.
