### PR TITLE
fix(daemon): preserve terminal-state notifications

### DIFF
--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -523,6 +523,99 @@ def get_schema(lang: str = "en") -> dict:
     }
 
 
+# Sentinel strings a cooperatively-exited run returns through the future.
+# ``[cancelled]`` is emitted on a timed-out/reclaimed run; ``[no output]`` on a
+# run that produced no final text. ``[intercepted]`` is a guard-handled *normal*
+# exit and must NOT be classified as a terminal abort.
+_CANCELLED_SENTINEL = "[cancelled]"
+_NO_OUTPUT_SENTINEL = "[no output]"
+
+# Fraction of the timeout past which a ``[no output]`` run is treated as a
+# timeout by the low-priority elapsed fallback (P5).
+_ELAPSED_TIMEOUT_FRACTION = 0.9
+
+
+def _classify_terminal_state(
+    entry: dict | None,
+    future_succeeded: bool,
+    text: str,
+    timeout_s: float,
+) -> str:
+    """Classify the true terminal state of a *successfully-returned* emanation.
+
+    Returns one of ``"timeout"``, ``"cancelled"``, ``"failed"``, ``"done"``.
+
+    Called only when ``future.result()`` succeeded (no exception). When the
+    future raises, ``_on_emanation_done`` sets ``status="failed"`` directly and
+    does not call this helper.
+
+    The sole purpose is to keep a non-normal terminal state (timeout / cancelled
+    / failed) from being misread as a tiny ``"done"`` and silently swallowed by
+    the ``suppressed_short`` gate. Only a genuine ``"done"`` may be suppressed.
+
+    Priority order (first match wins):
+
+      P1  ``run_dir.state_snapshot()["state"]`` — authoritative recorded state.
+          This is the same signal current main already trusts; the marker is
+          written by the run loop's ``mark_timeout`` / ``mark_cancelled`` /
+          ``mark_failed`` / ``mark_done`` before the future resolves.
+      P2  ``timeout_event.is_set()`` — watchdog fired. Fallback for when the
+          run terminated before it could record its state.
+      P3  ``cancel_event.is_set()`` — manual reclaim (only when timeout_event is
+          not also set; the watchdog sets both).
+      P4  ``[cancelled]`` sentinel text — last-resort backstop.
+      P5  elapsed >= fraction * timeout_s with a ``[no output]`` body — a
+          deliberately low-priority heuristic for the rare case where neither
+          the recorded state nor the events survived.
+      P6  ``"done"`` — genuine success (suppression-eligible).
+    """
+    run_dir = entry.get("run_dir") if entry else None
+
+    # --- P1: recorded run_dir state (authoritative) ---
+    if run_dir is not None:
+        try:
+            recorded = run_dir.state_snapshot().get("state")
+        except Exception:
+            recorded = None
+        if recorded in ("timeout", "cancelled", "failed"):
+            return recorded
+        if recorded == "done":
+            return "done"
+
+    # --- P2: watchdog timeout event ---
+    timeout_event = entry.get("timeout_event") if entry else None
+    if timeout_event is not None:
+        try:
+            if timeout_event.is_set():
+                return "timeout"
+        except Exception:
+            pass
+
+    # --- P3: manual cancel event (timeout not set) ---
+    cancel_event = entry.get("cancel_event") if entry else None
+    if cancel_event is not None:
+        try:
+            if cancel_event.is_set():
+                return "cancelled"
+        except Exception:
+            pass
+
+    # --- P4: [cancelled] sentinel backstop ---
+    if text == _CANCELLED_SENTINEL:
+        return "cancelled"
+
+    # --- P5: elapsed-near-timeout backstop (low priority) ---
+    if text == _NO_OUTPUT_SENTINEL and timeout_s > 0 and entry is not None:
+        start_time = entry.get("start_time")
+        if start_time is not None:
+            elapsed = time.time() - start_time
+            if elapsed >= timeout_s * _ELAPSED_TIMEOUT_FRACTION:
+                return "timeout"
+
+    # --- P6: genuine success ---
+    return "done"
+
+
 class DaemonManager:
     """Manages subagent (emanation) lifecycle."""
 
@@ -2424,6 +2517,11 @@ class DaemonManager:
                 "start_time": time.time(),
                 "cancel_event": cancel_event,
                 "timeout_event": timeout_event,
+                # Per-batch timeout actually applied (may differ from the
+                # manager default when the caller overrode it). Recorded so
+                # _on_emanation_done classifies the terminal state and logs
+                # against the real deadline, not self._timeout.
+                "timeout_s": effective_timeout,
                 "followup_buffer": "",
                 "followup_lock": threading.Lock(),
                 "run_dir": run_dir,
@@ -2601,6 +2699,11 @@ class DaemonManager:
                 "start_time": time.time(),
                 "cancel_event": cancel_event,
                 "timeout_event": timeout_event,
+                # Per-batch timeout actually applied (may differ from the
+                # manager default when the caller overrode it). Recorded so
+                # _on_emanation_done classifies the terminal state and logs
+                # against the real deadline, not self._timeout.
+                "timeout_s": effective_timeout,
                 "followup_buffer": "",
                 "followup_lock": threading.Lock(),
                 "run_dir": run_dir,
@@ -4982,40 +5085,41 @@ class DaemonManager:
         return {"status": "reclaimed", "cancelled": cancelled}
 
     def _on_emanation_done(self, em_id: str, task_summary: str, future) -> None:
-        elapsed = 0.0
         entry = self._emanations.get(em_id)
-        if entry:
-            elapsed = time.time() - entry["start_time"]
+        elapsed = time.time() - entry["start_time"] if entry else 0.0
+        timeout_s = entry.get("timeout_s", self._timeout) if entry else self._timeout
         run_dir = entry.get("run_dir") if entry else None
 
-        # Derive a fallback status from the future result. The future returns
-        # text on cooperative exit (including the short ``[cancelled]`` sentinel
-        # a timed-out/reclaimed run returns) and raises on a hard failure.
-        status = "done"
+        # Extract the result. The future returns text on cooperative exit
+        # (including the short ``[cancelled]`` / ``[no output]`` sentinels a
+        # timed-out/reclaimed run returns) and raises on a hard failure.
+        future_succeeded = False
+        exc = None
         try:
             text = future.result()
-            self._log("daemon_result", em_id=em_id, status="done",
-                      text_length=len(text), elapsed_ms=round(elapsed * 1000))
+            future_succeeded = True
         except Exception as e:
-            status = "failed"
+            exc = e
             text = f"Failed: {e}"
-            self._log("daemon_error", em_id=em_id,
-                      exception=type(e).__name__, exception_message=str(e))
 
-        # The run directory's recorded state is authoritative for the terminal
-        # status: a cancelled/timed-out run returns the short ``[cancelled]``
-        # sentinel through the future, which would otherwise be misclassified as
-        # a tiny "done" and swallowed by the short-result gate below. Prefer it
-        # so every terminal status (done / failed / cancelled / timeout) is
-        # labelled and reported correctly, and the parent always learns the
-        # daemon terminated even when it failed silently.
-        if run_dir is not None:
-            try:
-                recorded = run_dir.state_snapshot().get("state")
-            except Exception:
-                recorded = None
-            if recorded in ("done", "failed", "cancelled", "timeout"):
-                status = recorded
+        # Classify the terminal state. ``_classify_terminal_state`` keeps the
+        # recorded ``run_dir`` state authoritative (current main's behaviour) and
+        # layers timeout_event / cancel_event / sentinel / elapsed fallbacks on
+        # top, so a non-normal terminal state (timeout / cancelled / failed) is
+        # never misclassified as a tiny ``done`` and swallowed by the short-
+        # result gate below. The parent always learns the daemon terminated even
+        # when it failed silently. A raised future is ``failed`` unconditionally.
+        if future_succeeded:
+            status = _classify_terminal_state(entry, future_succeeded, text, timeout_s)
+        else:
+            status = "failed"
+
+        self._log("daemon_result", em_id=em_id, status=status,
+                  text_length=len(text), elapsed_ms=round(elapsed * 1000),
+                  timeout_s=timeout_s)
+        if not future_succeeded and exc is not None:
+            self._log("daemon_error", em_id=em_id,
+                      exception=type(exc).__name__, exception_message=str(exc))
 
         # Suppress notifications only for short *successful* results to prevent
         # notification storms. Every non-success terminal state (failed,

--- a/tests/test_daemon_terminal_state_gate.py
+++ b/tests/test_daemon_terminal_state_gate.py
@@ -1,0 +1,349 @@
+# tests/test_daemon_terminal_state_gate.py
+"""Tests for the daemon terminal-state priority gate.
+
+Modernized from PR #296 (#194) against current main. Current main already
+keys the terminal status off ``run_dir.state_snapshot()`` (the authoritative
+P1 signal) and delivers each terminal notification exactly once via
+``run_dir.claim_terminal_notification()``. These tests verify the *fallback*
+signals layered on top of that: when the run_dir state was never recorded
+(crash before mark_*, missing run_dir), the timeout_event / cancel_event /
+``[cancelled]`` sentinel / elapsed-near-timeout signals still keep a
+timeout/cancelled run from being swallowed by the ``suppressed_short`` gate.
+
+The once-only terminal-notification dedupe and the run_dir-authoritative
+classification are exercised in tests/test_daemon.py and must remain intact;
+a regression test for the dedupe lives here too.
+"""
+import queue
+import threading
+import time
+from unittest.mock import MagicMock
+
+from lingtai.core.daemon import DaemonManager, _classify_terminal_state
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(is_set: bool) -> threading.Event:
+    """Return a threading.Event in the desired state."""
+    ev = threading.Event()
+    if is_set:
+        ev.set()
+    return ev
+
+
+def _make_state_run_dir(state):
+    """Return a mock run_dir whose state_snapshot reports *state*."""
+    rd = MagicMock()
+    rd.state_snapshot.return_value = {"state": state}
+    return rd
+
+
+def _make_entry(
+    *,
+    timeout_event_set: bool = False,
+    cancel_event_set: bool = False,
+    run_dir_state=None,
+    start_time: float | None = None,
+    timeout_s: float = 3600.0,
+    include_run_dir: bool = True,
+) -> dict:
+    """Build a synthetic emanation entry dict for classify-level unit tests."""
+    entry: dict = {
+        "start_time": start_time if start_time is not None else time.time() - 10.0,
+        "timeout_event": _make_event(timeout_event_set),
+        "cancel_event": _make_event(cancel_event_set),
+        "timeout_s": timeout_s,
+    }
+    if include_run_dir:
+        entry["run_dir"] = _make_state_run_dir(run_dir_state)
+    else:
+        entry["run_dir"] = None
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# _classify_terminal_state — P1 run_dir authority (preserve current main)
+# ---------------------------------------------------------------------------
+
+class TestClassifyRunDirAuthority:
+    """P1: the recorded run_dir state is the most authoritative signal."""
+
+    def test_run_dir_timeout_is_authoritative(self):
+        entry = _make_entry(run_dir_state="timeout")
+        assert _classify_terminal_state(entry, True, "[cancelled]", 3600.0) == "timeout"
+
+    def test_run_dir_cancelled_is_authoritative(self):
+        entry = _make_entry(run_dir_state="cancelled")
+        assert _classify_terminal_state(entry, True, "[cancelled]", 3600.0) == "cancelled"
+
+    def test_run_dir_failed_is_authoritative(self):
+        entry = _make_entry(run_dir_state="failed")
+        assert _classify_terminal_state(entry, True, "anything", 3600.0) == "failed"
+
+    def test_run_dir_done_with_short_text_stays_done(self):
+        """A genuinely-done run with a short body stays 'done' and is eligible
+        for suppression."""
+        entry = _make_entry(run_dir_state="done")
+        assert _classify_terminal_state(entry, True, "ok", 3600.0) == "done"
+
+    def test_run_dir_state_overrides_events(self):
+        """run_dir state wins over a stale event flag."""
+        entry = _make_entry(run_dir_state="done", timeout_event_set=True)
+        assert _classify_terminal_state(entry, True, "ok", 3600.0) == "done"
+
+    def test_run_dir_running_is_not_terminal(self):
+        """A non-terminal recorded state does not classify; fall through."""
+        entry = _make_entry(run_dir_state="running")
+        assert _classify_terminal_state(entry, True, "some text", 3600.0) == "done"
+
+    def test_run_dir_snapshot_raises_falls_through(self):
+        """A run_dir that raises on snapshot must not crash classification."""
+        rd = MagicMock()
+        rd.state_snapshot.side_effect = RuntimeError("disk gone")
+        entry = {
+            "start_time": time.time() - 10.0,
+            "timeout_event": _make_event(True),
+            "cancel_event": _make_event(False),
+            "timeout_s": 3600.0,
+            "run_dir": rd,
+        }
+        # P1 unavailable -> P2 timeout_event takes over.
+        assert _classify_terminal_state(entry, True, "[cancelled]", 3600.0) == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# _classify_terminal_state — fallback signals (the #296 contribution)
+# ---------------------------------------------------------------------------
+
+class TestClassifyFallbackSignals:
+    """P2-P5: signals used only when run_dir did not record a terminal state."""
+
+    def test_timeout_event_when_no_run_dir_state(self):
+        """P2: timeout_event set, run_dir state unrecorded -> 'timeout'."""
+        entry = _make_entry(run_dir_state=None, timeout_event_set=True)
+        assert _classify_terminal_state(entry, True, "[cancelled]", 3600.0) == "timeout"
+
+    def test_timeout_event_no_run_dir_at_all(self):
+        """P2 still fires when there is no run_dir object."""
+        entry = _make_entry(include_run_dir=False, timeout_event_set=True)
+        assert _classify_terminal_state(entry, True, "[cancelled]", 3600.0) == "timeout"
+
+    def test_cancel_event_when_no_run_dir_state(self):
+        """P3: cancel_event set (timeout not set) -> 'cancelled'."""
+        entry = _make_entry(run_dir_state=None, cancel_event_set=True)
+        assert _classify_terminal_state(entry, True, "[cancelled]", 3600.0) == "cancelled"
+
+    def test_timeout_event_priority_over_cancel_event(self):
+        """P2 before P3: watchdog timeout sets BOTH events; timeout wins."""
+        entry = _make_entry(
+            run_dir_state=None, timeout_event_set=True, cancel_event_set=True,
+        )
+        assert _classify_terminal_state(entry, True, "[cancelled]", 3600.0) == "timeout"
+
+    def test_cancelled_sentinel_backstop(self):
+        """P4: no events, no run_dir state, text is the sentinel -> 'cancelled'."""
+        entry = _make_entry(run_dir_state=None)
+        assert _classify_terminal_state(entry, True, "[cancelled]", 3600.0) == "cancelled"
+
+    def test_elapsed_near_timeout_low_priority_fallback(self):
+        """P5: '[no output]' near the deadline -> 'timeout' (low-priority)."""
+        entry = _make_entry(
+            run_dir_state=None,
+            start_time=time.time() - 3300.0,  # 0.917 of 3600
+            timeout_s=3600.0,
+        )
+        assert _classify_terminal_state(entry, True, "[no output]", 3600.0) == "timeout"
+
+    def test_elapsed_far_from_timeout_stays_done(self):
+        """'[no output]' from a quick run is NOT a timeout."""
+        entry = _make_entry(
+            run_dir_state=None,
+            start_time=time.time() - 5.0,
+            timeout_s=3600.0,
+        )
+        assert _classify_terminal_state(entry, True, "[no output]", 3600.0) == "done"
+
+    def test_elapsed_fallback_requires_no_output_sentinel(self):
+        """Elapsed-near-timeout only upgrades the '[no output]' sentinel, not
+        an arbitrary long-running success."""
+        entry = _make_entry(
+            run_dir_state=None,
+            start_time=time.time() - 3300.0,
+            timeout_s=3600.0,
+        )
+        assert _classify_terminal_state(entry, True, "real result body", 3600.0) == "done"
+
+    def test_genuine_short_success_stays_done(self):
+        """No abnormal signal anywhere -> 'done' (suppression eligible)."""
+        entry = _make_entry(run_dir_state=None)
+        assert _classify_terminal_state(entry, True, "42", 3600.0) == "done"
+
+    def test_entry_none_uses_sentinel_backstop(self):
+        """entry=None: no events/run_dir, only the sentinel backstop applies."""
+        assert _classify_terminal_state(None, True, "[cancelled]", 3600.0) == "cancelled"
+
+    def test_entry_none_normal_text_is_done(self):
+        assert _classify_terminal_state(None, True, "all good", 3600.0) == "done"
+
+    def test_intercepted_sentinel_is_done(self):
+        """'[intercepted]' is a guard-handled normal exit, not a terminal abort."""
+        entry = _make_entry(run_dir_state=None)
+        assert _classify_terminal_state(entry, True, "[intercepted]", 3600.0) == "done"
+
+
+# ---------------------------------------------------------------------------
+# Integration: _on_emanation_done uses the gate AND preserves dedupe
+# ---------------------------------------------------------------------------
+
+def _make_agent(tmp_path):
+    from lingtai.agent import Agent
+    from lingtai_kernel.config import AgentConfig
+    svc = MagicMock()
+    svc.provider = "mock"
+    svc.model = "mock-model"
+    svc.create_session = MagicMock()
+    svc.make_tool_result = MagicMock()
+    return Agent(
+        svc,
+        working_dir=tmp_path / "daemon-agent",
+        capabilities=["daemon"],
+        config=AgentConfig(),
+    )
+
+
+def _real_run_dir(agent, em_id, task="test task"):
+    from lingtai.core.daemon.run_dir import DaemonRunDir
+    return DaemonRunDir(
+        parent_working_dir=agent._working_dir,
+        handle=em_id,
+        task=task,
+        tools=["file"],
+        model="mock-model",
+        max_turns=30,
+        timeout_s=300.0,
+        parent_addr=agent._working_dir.name,
+        parent_pid=12345,
+        system_prompt="You are a daemon.",
+        call_parameters=None,
+    )
+
+
+class TestOnEmanationDoneIntegration:
+    """Verify the gate is wired into _on_emanation_done end-to-end and that the
+    once-only terminal-notification dedupe (current main) is preserved."""
+
+    def test_timeout_event_not_suppressed_without_run_dir_state(self, tmp_path):
+        """The key #194 case via the *event* fallback: a timed-out run whose
+        run_dir never recorded 'timeout' (e.g. crash before mark_timeout) still
+        notifies because timeout_event is set — not swallowed as a short success.
+        """
+        from lingtai_kernel.notifications import collect_notifications
+
+        agent = _make_agent(tmp_path)
+        agent.inbox = queue.Queue()
+        mgr = agent.get_capability("daemon")
+        rd = _real_run_dir(agent, "em-to-event")  # state stays 'running'
+
+        future = MagicMock()
+        future.result.return_value = "[cancelled]"
+        mgr._emanations["em-to-event"] = {
+            "future": future,
+            "task": "test task",
+            "start_time": time.time() - 3601.0,
+            "cancel_event": _make_event(True),
+            "timeout_event": _make_event(True),
+            "run_dir": rd,
+            "timeout_s": 3600.0,
+        }
+
+        mgr._on_emanation_done("em-to-event", "test task", future)
+
+        assert agent.inbox.empty()
+        events = collect_notifications(agent._working_dir)["system"]["data"]["events"]
+        assert len(events) == 1
+        assert "timeout" in events[0]["body"].lower()
+
+    def test_cancel_event_not_suppressed_without_run_dir_state(self, tmp_path):
+        from lingtai_kernel.notifications import collect_notifications
+
+        agent = _make_agent(tmp_path)
+        agent.inbox = queue.Queue()
+        mgr = agent.get_capability("daemon")
+        rd = _real_run_dir(agent, "em-cancel-event")
+
+        future = MagicMock()
+        future.result.return_value = "[cancelled]"
+        mgr._emanations["em-cancel-event"] = {
+            "future": future,
+            "task": "test task",
+            "start_time": time.time() - 45.0,
+            "cancel_event": _make_event(True),
+            "timeout_event": _make_event(False),
+            "run_dir": rd,
+            "timeout_s": 3600.0,
+        }
+
+        mgr._on_emanation_done("em-cancel-event", "test task", future)
+
+        events = collect_notifications(agent._working_dir)["system"]["data"]["events"]
+        assert len(events) == 1
+        assert "cancelled" in events[0]["body"].lower()
+
+    def test_genuine_short_success_still_suppressed(self, tmp_path):
+        """No abnormal signal -> 'done' + short text -> suppressed, no notify."""
+        from lingtai_kernel.notifications import collect_notifications
+
+        agent = _make_agent(tmp_path)
+        agent.inbox = queue.Queue()
+        mgr = agent.get_capability("daemon")
+        rd = _real_run_dir(agent, "em-short")
+        rd.mark_done("42")
+
+        future = MagicMock()
+        future.result.return_value = "42"
+        mgr._emanations["em-short"] = {
+            "future": future,
+            "task": "test task",
+            "start_time": time.time() - 2.0,
+            "cancel_event": _make_event(False),
+            "timeout_event": _make_event(False),
+            "run_dir": rd,
+            "timeout_s": 3600.0,
+        }
+
+        mgr._on_emanation_done("em-short", "test task", future)
+
+        assert collect_notifications(agent._working_dir) == {}
+
+    def test_timeout_terminal_notified_only_once(self, tmp_path):
+        """Dedupe preservation: a timeout surfaced via the event fallback is
+        still delivered exactly once across duplicate done-callbacks."""
+        from lingtai_kernel.notifications import collect_notifications
+
+        agent = _make_agent(tmp_path)
+        agent.inbox = queue.Queue()
+        mgr = agent.get_capability("daemon")
+        rd = _real_run_dir(agent, "em-once")
+
+        future = MagicMock()
+        future.result.return_value = "[cancelled]"
+        mgr._emanations["em-once"] = {
+            "future": future,
+            "task": "test task",
+            "start_time": time.time() - 3601.0,
+            "cancel_event": _make_event(True),
+            "timeout_event": _make_event(True),
+            "run_dir": rd,
+            "timeout_s": 3600.0,
+        }
+
+        mgr._on_emanation_done("em-once", "test task", future)
+        mgr._on_emanation_done("em-once", "test task", future)
+
+        events = collect_notifications(agent._working_dir)["system"]["data"]["events"]
+        daemon_events = [e for e in events if e["ref_id"] == "em-once"]
+        assert len(daemon_events) == 1
+        assert "timeout" in daemon_events[0]["body"].lower()


### PR DESCRIPTION
## Summary
- modernizes the terminal-state priority gate idea from #296 / #194 on top of current `main`
- classifies daemon completion state before short-result suppression, prioritizing recorded run-dir terminal state, timeout/cancel events, cancelled sentinel, no-output timeout fallback, then normal `done`
- preserves current `run_dir.claim_terminal_notification()` once-only dedupe so timeout/cancelled/failed notifications are not swallowed or duplicated
- records the effective per-batch timeout on daemon entries so elapsed-time fallback and `daemon_result` logging use the real timeout

## Validation
- `git diff --check`
- `python3 -m py_compile src/lingtai/core/daemon/__init__.py tests/test_daemon_terminal_state_gate.py`
- `PYTHONPATH="$PWD/src" python -m pytest -q tests/test_daemon_terminal_state_gate.py tests/test_daemon.py` → `106 passed`
- GLM implementation sweep report: `tests/test_daemon_terminal_state_gate.py` 23 passed; `tests/test_daemon.py` 83 passed; broader daemon regression sweep 338 passed / 0 failed

## Notes
- This is a new current-main implementation inspired by #296; it does not merge the old conflicting PR branch wholesale.
- The elapsed-time timeout heuristic is intentionally low priority and only applies to `[no output]` results after explicit state/event sources are absent.
