### PR TITLE
Experiment with rolling Codex prompt cache keys

### DIFF
--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -92,11 +92,13 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting.
 
 ### Codex REST cache-affinity ids (`session_id` / `thread_id` / `prompt_cache_key`)
 
-**Codex-only.** The three cache-affinity values are a **single stable per-agent id**, byte-identical and NEVER changed for the life of the agent's identity:
+**Codex-only.** Within **every** request the three cache-affinity values are byte-identical:
 
 ```
-prompt_cache_key == session_id == thread_id == <stable per-agent id>
+prompt_cache_key == session_id == thread_id == <per-request affinity id>
 ```
+
+What that single id *is* across requests depends on `_CODEX_PROMPT_KEY_MODE` (see **Rolling prompt-key experiment** below). In `"stable"` mode it is one fixed per-agent id NEVER changed for the life of the agent's identity (the historical behavior described next). In the experiment default `"rolling_prev_call_time"` it changes per request after the first. The within-request equality holds in **both** modes.
 
 `CodexResponsesSession.__init__` **normalizes** whatever candidates it receives (`prompt_cache_key`, `session_id`, `thread_id`) into one id and uses it byte-identically for all three. Priority is `prompt_cache_key` > `session_id` > `thread_id` (the explicit request-body cache-affinity key wins). This closes the leak where an explicit override or a directly-constructed session could send three different values.
 
@@ -107,7 +109,21 @@ The REST `/backend-api/codex/responses` endpoint does **not** accept `previous_r
 - **Header carve-out (NON-NEGOTIABLE).** `session_id` / `thread_id` route the backend cache slot and MUST be per-agent. Headers are emitted **only when an explicit `session_id`/`thread_id` was supplied** (`has_header_identity`); a *lone* `prompt_cache_key` — the model-only fallback `lingtai-codex:{model}:v1`, shared by every agent on a model — stays a **body-only** cache key and promotes **no** headers. Promoting it would collapse all agents onto one session/thread, which is exactly the bug the per-agent design exists to avoid. So `_cache_affinity_headers()` emits headers iff the session was given header identity; a bare/test session with no ids sends neither. The adapter has no per-agent identity of its own, so the host wiring passes the agent path down by default (see below).
 - **Default wiring (the normal path — not opt-in, not opt-out).** For a Codex agent, `service.build_provider_defaults_from_manifest_llm(llm, ..., working_dir=...)` injects `codex_session_anchor = str((working_dir / "init.json").resolve())` (the agent path / durable identity anchor). The adapter hashes it into the id and uses it for all three values via `_resolve_codex_ids` (returns `(id, id)` — the thread tracks the session id exactly) and `_default_prompt_cache_key` (returns the same `id`). The default wiring does **not** read the token ledger, molt time, or any clock, so the same `working_dir` always yields the same id.
 - The `codex_session_id` / `codex_session_anchor` / `codex_thread_salt` keys remain settable on the manifest `llm` block (allowlisted in `../service.py` `_PROVIDER_DEFAULTS_PASS_THROUGH_KEYS`) as an **internal override / testing escape hatch** — an explicit `codex_session_id` is used verbatim for all three; `codex_thread_salt` survives as a legacy pass-through but no longer derives a separate thread id. `_resolve_codex_ids(model)` returns `(None, None)` only when no anchor/id was passed down at all (the bare/test path).
-- **Token-ledger dump.** `CodexResponsesSession._usage_extra` copies the `session_id` / `thread_id` / `prompt_cache_key` for the request into `UsageMetadata.extra` as `codex_session_id` / `codex_thread_id` / `codex_prompt_cache_key`. Because of the normalization above these three are the **same value** — the ledger never records mismatched affinity ids. `BaseAgent._save_chat_history()` merges all non-None usage extra fields into `logs/token_ledger.jsonl`, so the ids sit beside input/output/thinking/cached token counts. The values are short, non-secret derived affinity ids — no request body, messages, or OAuth secret ride along. A body-only/bare session contributes only the fields whose levers were actually sent.
+- **Token-ledger dump.** `CodexResponsesSession._usage_extra` copies the `session_id` / `thread_id` / `prompt_cache_key` for the request into `UsageMetadata.extra` as `codex_session_id` / `codex_thread_id` / `codex_prompt_cache_key`. Because of the normalization above these three are the **same value** — the ledger never records mismatched affinity ids. `BaseAgent._save_chat_history()` merges all non-None usage extra fields into `logs/token_ledger.jsonl`, so the ids sit beside input/output/thinking/cached token counts. The values are short, non-secret derived affinity ids — no request body, messages, or OAuth secret ride along. A body-only/bare session contributes only the fields whose levers were actually sent. (Under the rolling experiment these record the *rolled* id actually used for the request, so the per-request roll is visible in the ledger.)
+
+### Rolling prompt-key experiment (`_CODEX_PROMPT_KEY_MODE`)
+
+**Codex-only, experiment (Jason, 2026-06-22).** A single module switch `_CODEX_PROMPT_KEY_MODE` selects how the per-agent affinity id evolves across the requests of one ongoing session. It is fully reversible — flip to `"stable"` to restore the historical byte-stable behavior described above; nothing else changes.
+
+- `"stable"` — the old behavior: one byte-stable per-agent id (`_codex_session_id(anchor)` or an explicit override) on every request.
+- `"rolling_prev_call_time"` (**experiment default**) — the **first** request of a session still uses the stable per-agent id (no previous API-call time exists yet, so it falls back). Every **later** request uses `_codex_rolling_key(base_id, previous_api_call_time)` = `sha256(f"{base_id}:{prev_ms}").hexdigest()[:8]`, where `base_id` is the durable per-agent id and `prev_ms` is the **start time of the immediately preceding request** in integer milliseconds.
+
+Mechanics:
+- **Previous-call-time state** lives in the module dict `_CODEX_PREV_CALL_TIME_MS`, keyed by the session's stable `base_id` (globally unique per agent). `CodexResponsesSession._resolve_rolling_id()` reads the prior timestamp, then **stamps the current time** (`_codex_now_ms()`, monkeypatchable) so the *next* request rolls off *this* request's start. So the recorded instant is **request start**, and request N's key is derived from request N−1's start. `_reset_codex_prev_call_times()` clears it (test helper).
+- **Within-request invariant preserved.** `_effective_affinity()` resolves the rolled id once and writes it back to `_prompt_cache_key` / `_session_id` / `_thread_id` before the request is built, so `prompt_cache_key == session_id == thread_id` and the metadata envelope (`x-codex-window-id = <id>:0`, turn-metadata `session_id`/`thread_id`) all carry the same rolled id for that request.
+- **`x-client-request-id` is untouched.** It was already a fresh per-request UUID (matching the official client) and was never tied to the cache key, so rolling leaves it exactly as-is — only the cache-affinity trio rolls.
+- **Bare/no-anchor path never rolls.** The model-only fallback `lingtai-codex:{model}:v1` is shared across agents and has no per-agent header identity, so `base_id` is `None` there and the path keeps its stable body-only key (no headers), regardless of mode.
+- **No `codex-cache-key` resurrected.** The experiment reuses only `prompt_cache_key` / `session_id` / `thread_id`; the removed `codex-cache-key` request header stays gone.
 
 ### Codex client-identity headers (`originator` / `User-Agent`)
 
@@ -131,7 +147,7 @@ When a Codex session has a stable LingTai session/thread identity, `CodexRespons
 - **`OpenAIChatSession._request_timeout`** — per-request HTTP timeout set by caller before dispatch (line 319). Prevents race between watchdog and SDK.
 - **`OpenAIResponsesSession._response_id`** — server-side session chain pointer. Updated after each `send()` / streamed response.
 - **`CodexResponsesSession._response_id`** — transient debug aid only; never threaded into next request (line 1538).
-- **`CodexResponsesSession._current_id`** — the single stable per-agent affinity id (a pure hash of the agent path), used byte-identically for `_prompt_cache_key` / `_session_id` / `_thread_id`. Set once at construction and never changed (no rotation, no epoch, no clock).
+- **`CodexResponsesSession._current_id`** — the per-agent affinity id resolved at construction (a pure hash of the agent path, or an explicit override), used byte-identically for `_prompt_cache_key` / `_session_id` / `_thread_id`. In `"stable"` mode it is fixed for the session's life; in the rolling experiment `_effective_affinity()` rewrites the trio per request off `_codex_base_id` (the same construction id) + the previous call time. See **Rolling prompt-key experiment**.
 - **Codex Responses trace** — opt-in diagnostics write JSONL metadata to `logs/codex_responses_trace.jsonl` when `LINGTAI_CODEX_RESPONSES_TRACE=1` (override path with `LINGTAI_CODEX_RESPONSES_TRACE_PATH`). Default off; stores event/item shapes, lengths/hashes, usage, and accumulator counts, not raw content.
 - **`OpenAIAdapter._client`** — shared `openai.OpenAI` instance. `_client_kwargs` stored for session `reset()`.
 - **`OpenAIAdapter._session_class`** — class var, subclasses override (e.g. DeepSeek and MiMo inject `reasoning_content` round-trip fallbacks).

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -106,6 +106,69 @@ def _codex_session_id(anchor: str) -> str:
     """
     return hashlib.sha256(anchor.encode("utf-8")).hexdigest()[:8]
 
+
+# --- Rolling prompt-cache-key experiment (Jason, 2026-06-22, issue #471 line) -
+#
+# EXPERIMENT: instead of pinning ONE stable per-agent affinity id for the life
+# of the session, derive a NEW affinity id for each request after the first from
+# ``hash(agent_anchor + previous_api_call_time)``. The hypothesis is that a
+# rolling key probes how the ChatGPT backend keys/segments its prompt cache
+# across requests of one ongoing session (vs. the stable-id baseline).
+#
+# Invariant preserved (verified in fresh ``codex exec`` / ``codex-tui``
+# captures): WITHIN each request ``prompt_cache_key == session_id == thread_id``
+# byte-identically. Rolling moves all three together to the same new id; it does
+# NOT touch ``x-client-request-id`` / ``turn_id``, which were already fresh
+# per-request UUIDs (the official client and the pre-experiment code both emit a
+# fresh ``x-client-request-id`` every request — it was never tied to the cache
+# key, so we leave that behavior exactly as-is).
+#
+# REVERSIBLE: a single module switch. Set ``_CODEX_PROMPT_KEY_MODE = "stable"``
+# to restore the old byte-stable per-agent id wholesale; nothing else changes.
+#
+#   "rolling_prev_call_time" (experiment default) -> request #1 uses the stable
+#       per-agent fallback (no previous call time yet); request N (N>1) uses
+#       ``hash(base_id + previous_api_call_time)``.
+#   "stable"                                       -> the old behavior: one
+#       byte-stable per-agent id on every request.
+_CODEX_PROMPT_KEY_MODE = "rolling_prev_call_time"
+
+# Previous API-call time per agent, in integer milliseconds, keyed by the
+# session's stable base id (the per-agent hash or explicit override — the value
+# that uniquely identifies the ongoing agent/session). A module-level dict is
+# acceptable for this experiment: the rolling key must persist across the
+# distinct request calls of one long-lived session, and the session base id is
+# globally unique per agent. Recorded at request START (see ``send_stream``), so
+# request N rolls off request N-1's start time.
+_CODEX_PREV_CALL_TIME_MS: dict[str, int] = {}
+
+
+def _codex_now_ms() -> int:
+    """Current wall-clock time in integer milliseconds.
+
+    Factored out so tests can monkeypatch a deterministic clock without touching
+    ``time.time`` globally.
+    """
+    return int(time.time() * 1000)
+
+
+def _reset_codex_prev_call_times() -> None:
+    """Clear the per-agent previous-call-time state (test helper)."""
+    _CODEX_PREV_CALL_TIME_MS.clear()
+
+
+def _codex_rolling_key(base_id: str, prev_call_time_ms: int) -> str:
+    """Derive a rolling 8-char Codex affinity id from a base id + a timestamp.
+
+    ``base_id`` is the session's stable per-agent id (the ``init.json``-path hash
+    or an explicit override) — i.e. the durable agent/session anchor. The result
+    is shaped exactly like :func:`_codex_session_id` (8-char lowercase-hex
+    sha256 prefix) so it drops into ``session_id`` / ``thread_id`` /
+    ``prompt_cache_key`` byte-identically. Pure function: same inputs -> same id.
+    """
+    material = f"{base_id}:{int(prev_call_time_ms)}"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:8]
+
 # Codex cache-affinity identity is a SINGLE STABLE per-agent value: a pure
 # deterministic hash of the agent's durable identity anchor (the resolved
 # ``init.json`` / agent-dir path), used byte-identically for ``session_id`` /
@@ -1787,6 +1850,15 @@ class CodexResponsesSession(OpenAIResponsesSession):
         else:
             self._session_id = None
             self._thread_id = None
+        # Stable base id for the rolling prompt-key experiment: the durable
+        # per-agent anchor (the per-agent hash or an explicit override). It is
+        # the value rolled with the previous API-call time and the key into the
+        # module-level previous-call-time state. Only the per-agent header path
+        # rolls — the bare/no-anchor path's body-only ``prompt_cache_key`` is the
+        # SHARED model-only fallback (``lingtai-codex:{model}:v1``); rolling it
+        # would invent a fake per-agent key for an adapter that has no per-agent
+        # identity, so that path is left ``None`` and never rolls.
+        self._codex_base_id = self._current_id if self._has_header_identity else None
 
     def _cache_affinity_headers(self) -> dict[str, str]:
         """Return the stable ``session_id`` / ``thread_id`` headers, if any.
@@ -1833,14 +1905,52 @@ class CodexResponsesSession(OpenAIResponsesSession):
             return {}
         return {"x-codex-installation-id": self._installation_id}
 
+    def _resolve_rolling_id(self) -> str | None:
+        """Resolve THIS request's effective affinity id, honoring the mode.
+
+        Stable mode (or no per-agent base id) -> the durable stable id,
+        unchanged. Rolling mode -> the stable id for request #1 (no previous
+        API-call time recorded yet) and ``hash(base_id + previous_call_time)``
+        for every later request. The previous call time is then (re)stamped to
+        *now* so the NEXT request rolls off this request's start (see
+        ``send_stream``, which calls this before building the request).
+
+        Returns ``None`` only on the bare/no-anchor path, which keeps its
+        model-only body ``prompt_cache_key`` and never rolls.
+        """
+        base = self._codex_base_id
+        if not base:
+            return None  # bare/no-anchor path: nothing to roll, no headers
+        if _CODEX_PROMPT_KEY_MODE != "rolling_prev_call_time":
+            return base  # stable mode: byte-stable per-agent id
+        prev = _CODEX_PREV_CALL_TIME_MS.get(base)
+        # Record this request's start time so the NEXT request can roll off it.
+        # First request: ``prev`` is None -> stable fallback this time.
+        _CODEX_PREV_CALL_TIME_MS[base] = _codex_now_ms()
+        if prev is None:
+            return base
+        return _codex_rolling_key(base, prev)
+
     def _effective_affinity(self) -> tuple[str | None, dict[str, str]]:
         """Resolve this request's (prompt_cache_key, headers) pair.
 
-        Always the single stable per-agent id — fixed for the life of the
-        session, used byte-identically for ``prompt_cache_key`` / ``session_id``
-        / ``thread_id`` on every request. No rotation, no epoch, no time
-        dependence.
+        Honors ``_CODEX_PROMPT_KEY_MODE``. In the (default) rolling mode the
+        per-agent affinity id changes per request — derived from the previous
+        API-call time — while the WITHIN-request invariant is preserved: the
+        single resolved id is written back to ``prompt_cache_key`` /
+        ``session_id`` / ``thread_id`` so all three (and the metadata envelope
+        that reads them) stay byte-identical for this request. In stable mode the
+        id is the fixed per-agent hash on every request, as before.
         """
+        rolled = self._resolve_rolling_id()
+        if rolled is not None:
+            self._prompt_cache_key = rolled
+            # Keep the header trio in lockstep with the body cache key, but only
+            # where the per-agent header identity exists (the bare path stays
+            # header-silent — see ``__init__``).
+            if self._has_header_identity:
+                self._session_id = rolled
+                self._thread_id = rolled
         return self._prompt_cache_key, self._cache_affinity_headers()
 
     @staticmethod

--- a/tests/test_codex_prompt_cache_key.py
+++ b/tests/test_codex_prompt_cache_key.py
@@ -17,6 +17,9 @@ import re
 from dataclasses import dataclass
 from types import SimpleNamespace
 
+import pytest
+
+import lingtai.llm.openai.adapter as adapter_mod
 from lingtai.llm.openai.adapter import (
     CodexOpenAIAdapter,
     CodexResponsesSession,
@@ -24,6 +27,20 @@ from lingtai.llm.openai.adapter import (
     _lingtai_user_agent,
 )
 from lingtai_kernel.llm.base import FunctionSchema
+
+
+@pytest.fixture(autouse=True)
+def _clean_codex_rolling_state():
+    """Isolate the module-level rolling prompt-key state between tests.
+
+    The rolling experiment keeps previous-API-call times in a module dict keyed
+    by the per-agent base id; without a reset, a session built on the same anchor
+    in an earlier test would make a *later* test's first request roll instead of
+    using the stable fallback. Reset before AND after so order never matters.
+    """
+    adapter_mod._reset_codex_prev_call_times()
+    yield
+    adapter_mod._reset_codex_prev_call_times()
 
 
 @dataclass
@@ -309,7 +326,12 @@ def test_codex_bare_adapter_omits_session_thread_headers():
     assert sent["prompt_cache_key"] == "lingtai-codex:gpt-5.5:v1"
 
 
-def test_codex_sends_stable_headers_from_session_anchor():
+def test_codex_sends_stable_headers_from_session_anchor(monkeypatch):
+    # Stable-mode contract: with the rolling experiment pinned OFF, the per-agent
+    # id is byte-stable across requests (the pre-experiment behavior, still
+    # reachable via ``_CODEX_PROMPT_KEY_MODE``). The rolling default is covered
+    # in tests/test_codex_rolling_prompt_key.py.
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "stable")
     anchor = "/agents/alice/init.json"
     session = _create_codex_session_cfg(
         [_completed(), _completed()],
@@ -361,13 +383,17 @@ def test_codex_headers_differ_for_different_agents():
     assert hb["session_id"] == hb["thread_id"]
 
 
-def test_codex_thread_salt_does_not_split_thread_from_session():
+def test_codex_thread_salt_does_not_split_thread_from_session(monkeypatch):
     """A legacy ``codex_thread_salt`` no longer derives a separate thread.
 
     The salt is accepted as a manifest pass-through for backward compatibility,
     but the root/main thread tracks the session id exactly, so two different
     salts on the same anchor still produce byte-identical session/thread/key.
+
+    Pinned to stable mode: this guards the salt-irrelevance contract, which is
+    about the durable per-agent id, not the rolling experiment.
     """
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "stable")
     anchor = "/agents/alice/init.json"
     salt0 = _create_codex_session_cfg(
         [_completed()],
@@ -608,11 +634,14 @@ def test_codex_account_id_preserves_app_name_identity():
     assert headers["User-Agent"].startswith("codex_cli_rs/")
 
 
-def test_codex_account_id_does_not_affect_cache_affinity():
+def test_codex_account_id_does_not_affect_cache_affinity(monkeypatch):
     """Adding the account header leaves session/thread/prompt_cache_key untouched.
 
     Regression guard: the ChatGPT-Account-ID plumbing must not perturb the
-    cache-affinity identity (issue #378) in any way."""
+    cache-affinity identity (issue #378) in any way. Pinned to stable mode so two
+    sessions sharing one explicit id stay byte-identical (under rolling they
+    would roll off each other's recorded call time — covered separately)."""
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "stable")
     explicit = "11111111-2222-3333-4444-555555555555"
     with_acct = _create_codex_session_cfg(
         [_completed()],

--- a/tests/test_codex_rolling_prompt_key.py
+++ b/tests/test_codex_rolling_prompt_key.py
@@ -1,0 +1,360 @@
+"""Tests for the Codex rolling prompt-cache-key experiment.
+
+Background (Jason, 2026-06-22): the stable per-agent Codex affinity id pins one
+sticky-warm cache slot for the life of the agent. This experiment trades that
+for a *rolling* key: the FIRST request of a session still uses the stable
+per-agent id (no previous API-call time exists yet), but every subsequent
+request derives its key from ``hash(agent_anchor + previous_api_call_time)``.
+
+The official invariant observed in fresh captures still holds within each
+request: ``prompt_cache_key == session_id == thread_id`` (byte-identical). Only
+``x-client-request-id`` / ``turn_id`` stay fresh-per-request UUIDs, exactly as
+the official client and the pre-experiment code already emitted them.
+
+The mode is a single reversible module switch (``_CODEX_PROMPT_KEY_MODE``):
+
+  * ``"rolling_prev_call_time"`` (experiment default) -> roll after request #1.
+  * ``"stable"``                                       -> old byte-stable id.
+
+The previous API-call time is recorded per anchor at request START (a module
+dict keyed by the stable base id) so request N derives from request N-1's start.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import lingtai.llm.openai.adapter as adapter_mod
+from lingtai.llm.openai.adapter import (
+    CodexOpenAIAdapter,
+    _codex_rolling_key,
+    _codex_session_id,
+)
+
+
+@dataclass
+class Event:
+    type: str
+    delta: str | None = None
+    item: object | None = None
+    response: object | None = None
+    item_id: str | None = None
+    text: str | None = None
+
+
+class FakeResponses:
+    def __init__(self, events: list[Event]):
+        self.events = events
+        self.kwargs: list[dict] = []
+
+    def create(self, **kwargs):
+        self.kwargs.append(kwargs)
+        yield from self.events
+
+
+class FakeClient:
+    def __init__(self, events: list[Event]):
+        self.responses = FakeResponses(events)
+
+
+def _usage() -> SimpleNamespace:
+    return SimpleNamespace(
+        input_tokens=10,
+        output_tokens=20,
+        input_tokens_details=SimpleNamespace(cached_tokens=0),
+        output_tokens_details=SimpleNamespace(reasoning_tokens=0),
+    )
+
+
+def _completed() -> Event:
+    return Event(
+        "response.completed",
+        response=SimpleNamespace(id="resp_fake", usage=_usage()),
+    )
+
+
+def _function_schema():
+    from lingtai_kernel.llm.base import FunctionSchema
+
+    return FunctionSchema(
+        name="report_answer",
+        description="Report answer",
+        parameters={
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+        },
+    )
+
+
+def _create_codex_session_cfg(events, *, model="gpt-5.5", **adapter_kw):
+    adapter = CodexOpenAIAdapter(
+        api_key="fake",
+        base_url="http://fake",
+        use_responses=True,
+        force_responses=True,
+        **adapter_kw,
+    )
+    adapter._client = FakeClient(events)
+    return adapter.create_chat(
+        model,
+        "system prompt",
+        tools=[_function_schema()],
+        force_tool_call=True,
+        thinking="high",
+    )
+
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level switch / helper invariants
+# ---------------------------------------------------------------------------
+
+
+def test_rolling_mode_is_the_experiment_default():
+    """The experiment ships with rolling mode on by Jason's request."""
+    assert adapter_mod._CODEX_PROMPT_KEY_MODE == "rolling_prev_call_time"
+
+
+def test_codex_rolling_key_is_deterministic_for_same_inputs():
+    """``hash(base + prev_time)`` is a pure function: same inputs -> same id."""
+    a = _codex_rolling_key("abcd1234", 1_700_000_000_000)
+    b = _codex_rolling_key("abcd1234", 1_700_000_000_000)
+    assert a == b
+    # Shaped like the stable id (8-char lowercase hex) so it drops into the
+    # same session/thread/prompt_cache_key slot byte-identically.
+    assert re.fullmatch(r"[0-9a-f]{8}", a)
+
+
+def test_codex_rolling_key_varies_with_prev_time_and_anchor():
+    base = "abcd1234"
+    t0 = _codex_rolling_key(base, 1_700_000_000_000)
+    t1 = _codex_rolling_key(base, 1_700_000_000_001)
+    other = _codex_rolling_key("ffff0000", 1_700_000_000_000)
+    assert t0 != t1  # different prev time -> different key
+    assert t0 != other  # different anchor -> different key
+
+
+# ---------------------------------------------------------------------------
+# First request falls back to the stable per-agent key
+# ---------------------------------------------------------------------------
+
+
+def test_first_request_falls_back_to_stable_per_agent_key(monkeypatch):
+    """No previous API-call time exists for request #1 -> stable id."""
+    adapter_mod._reset_codex_prev_call_times()
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "rolling_prev_call_time")
+
+    anchor = "/agents/alice/init.json"
+    session = _create_codex_session_cfg([_completed()], codex_session_anchor=anchor)
+    session.send("first")
+
+    sent = session._client.responses.kwargs[0]
+    headers = sent["extra_headers"]
+    stable = _codex_session_id(anchor)
+    assert sent["prompt_cache_key"] == stable
+    assert headers["session_id"] == stable
+    assert headers["thread_id"] == stable
+
+
+# ---------------------------------------------------------------------------
+# Second request rolls off the first request's recorded call time
+# ---------------------------------------------------------------------------
+
+
+def test_second_request_uses_hash_of_first_call_time(monkeypatch):
+    """Request #2 derives ``hash(base + prev_call_time)`` from request #1's
+    recorded start time; request #1 still uses the stable fallback."""
+    adapter_mod._reset_codex_prev_call_times()
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "rolling_prev_call_time")
+
+    # Deterministic clock: request #1 starts at t=1000ms, request #2 at t=2000ms.
+    times = iter([1000, 2000])
+    monkeypatch.setattr(adapter_mod, "_codex_now_ms", lambda: next(times))
+
+    anchor = "/agents/alice/init.json"
+    session = _create_codex_session_cfg([_completed(), _completed()], codex_session_anchor=anchor)
+    session.send("first")
+    session.send("second")
+
+    stable = _codex_session_id(anchor)
+    expected_second = _codex_rolling_key(stable, 1000)  # rolls off req #1's start
+
+    s0 = session._client.responses.kwargs[0]
+    s1 = session._client.responses.kwargs[1]
+    assert s0["prompt_cache_key"] == stable
+    assert s1["prompt_cache_key"] == expected_second
+    assert s1["prompt_cache_key"] != s0["prompt_cache_key"]
+
+
+def test_third_request_rolls_off_second_call_time(monkeypatch):
+    """Each request rolls off the immediately preceding request's start time."""
+    adapter_mod._reset_codex_prev_call_times()
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "rolling_prev_call_time")
+    times = iter([1000, 2000, 3000])
+    monkeypatch.setattr(adapter_mod, "_codex_now_ms", lambda: next(times))
+
+    anchor = "/agents/alice/init.json"
+    session = _create_codex_session_cfg(
+        [_completed(), _completed(), _completed()], codex_session_anchor=anchor
+    )
+    session.send("first")
+    session.send("second")
+    session.send("third")
+
+    stable = _codex_session_id(anchor)
+    s1 = session._client.responses.kwargs[1]
+    s2 = session._client.responses.kwargs[2]
+    assert s1["prompt_cache_key"] == _codex_rolling_key(stable, 1000)
+    assert s2["prompt_cache_key"] == _codex_rolling_key(stable, 2000)
+
+
+# ---------------------------------------------------------------------------
+# Within-request invariant: key == session_id == thread_id (every request)
+# ---------------------------------------------------------------------------
+
+
+def test_within_each_request_key_session_thread_are_byte_identical(monkeypatch):
+    adapter_mod._reset_codex_prev_call_times()
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "rolling_prev_call_time")
+    times = iter([1000, 2000])
+    monkeypatch.setattr(adapter_mod, "_codex_now_ms", lambda: next(times))
+
+    anchor = "/agents/alice/init.json"
+    session = _create_codex_session_cfg([_completed(), _completed()], codex_session_anchor=anchor)
+    session.send("first")
+    session.send("second")
+
+    for sent in session._client.responses.kwargs:
+        headers = sent["extra_headers"]
+        key = sent["prompt_cache_key"]
+        assert headers["session_id"] == key
+        assert headers["thread_id"] == key
+        # The window id and turn-metadata envelope track the same rolled id.
+        assert headers["x-codex-window-id"] == f"{key}:0"
+        turn = json.loads(headers["x-codex-turn-metadata"])
+        assert turn["session_id"] == key
+        assert turn["thread_id"] == key
+
+
+def test_rolling_preserves_fresh_per_request_client_request_id(monkeypatch):
+    """``x-client-request-id`` was NOT tied to the cache key before this
+    experiment (it is a fresh UUID per request) and stays that way — rolling
+    only moves the cache-affinity trio, not the request id."""
+    adapter_mod._reset_codex_prev_call_times()
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "rolling_prev_call_time")
+    times = iter([1000, 2000])
+    monkeypatch.setattr(adapter_mod, "_codex_now_ms", lambda: next(times))
+
+    anchor = "/agents/alice/init.json"
+    session = _create_codex_session_cfg([_completed(), _completed()], codex_session_anchor=anchor)
+    session.send("first")
+    session.send("second")
+
+    h0 = session._client.responses.kwargs[0]["extra_headers"]
+    h1 = session._client.responses.kwargs[1]["extra_headers"]
+    assert _UUID_RE.match(h0["x-client-request-id"])
+    assert _UUID_RE.match(h1["x-client-request-id"])
+    assert h0["x-client-request-id"] != h1["x-client-request-id"]
+
+
+# ---------------------------------------------------------------------------
+# Stable mode restores the old byte-stable behavior
+# ---------------------------------------------------------------------------
+
+
+def test_stable_mode_restores_byte_stable_key_across_requests(monkeypatch):
+    adapter_mod._reset_codex_prev_call_times()
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "stable")
+    times = iter([1000, 2000, 3000])
+    monkeypatch.setattr(adapter_mod, "_codex_now_ms", lambda: next(times))
+
+    anchor = "/agents/alice/init.json"
+    session = _create_codex_session_cfg(
+        [_completed(), _completed(), _completed()], codex_session_anchor=anchor
+    )
+    session.send("a")
+    session.send("b")
+    session.send("c")
+
+    stable = _codex_session_id(anchor)
+    keys = [kw["prompt_cache_key"] for kw in session._client.responses.kwargs]
+    assert keys == [stable, stable, stable]
+
+
+# ---------------------------------------------------------------------------
+# Independent agents roll independently / explicit override never rolls
+# ---------------------------------------------------------------------------
+
+
+def test_rolling_keys_are_independent_per_agent(monkeypatch):
+    """Two agents keep separate previous-call-time state -> separate rolls."""
+    adapter_mod._reset_codex_prev_call_times()
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "rolling_prev_call_time")
+    # alice: req1 @1000, req2 @2000 ; bob: req1 @1500, req2 @2500.
+    times = iter([1000, 1500, 2000, 2500])
+    monkeypatch.setattr(adapter_mod, "_codex_now_ms", lambda: next(times))
+
+    alice = _create_codex_session_cfg(
+        [_completed(), _completed()], codex_session_anchor="/agents/alice/init.json"
+    )
+    bob = _create_codex_session_cfg(
+        [_completed(), _completed()], codex_session_anchor="/agents/bob/init.json"
+    )
+    alice.send("a1")
+    bob.send("b1")
+    alice.send("a2")
+    bob.send("b2")
+
+    a_stable = _codex_session_id("/agents/alice/init.json")
+    b_stable = _codex_session_id("/agents/bob/init.json")
+    a2 = alice._client.responses.kwargs[1]["prompt_cache_key"]
+    b2 = bob._client.responses.kwargs[1]["prompt_cache_key"]
+    assert a2 == _codex_rolling_key(a_stable, 1000)
+    assert b2 == _codex_rolling_key(b_stable, 1500)
+    assert a2 != b2
+
+
+def test_bare_session_without_anchor_never_rolls_and_sends_no_headers(monkeypatch):
+    """No per-agent identity -> the bare/model-only path is untouched by rolling
+    and still emits no session/thread headers."""
+    adapter_mod._reset_codex_prev_call_times()
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "rolling_prev_call_time")
+
+    session = _create_codex_session_cfg([_completed(), _completed()])  # no anchor
+    session.send("a")
+    session.send("b")
+
+    for sent in session._client.responses.kwargs:
+        headers = sent.get("extra_headers") or {}
+        assert "session_id" not in headers
+        assert "thread_id" not in headers
+        assert sent["prompt_cache_key"] == "lingtai-codex:gpt-5.5:v1"
+
+
+# ---------------------------------------------------------------------------
+# No legacy codex-cache-key resurrected by this experiment
+# ---------------------------------------------------------------------------
+
+
+def test_rolling_never_emits_legacy_codex_cache_key_header(monkeypatch):
+    adapter_mod._reset_codex_prev_call_times()
+    monkeypatch.setattr(adapter_mod, "_CODEX_PROMPT_KEY_MODE", "rolling_prev_call_time")
+    times = iter([1000, 2000])
+    monkeypatch.setattr(adapter_mod, "_codex_now_ms", lambda: next(times))
+
+    anchor = "/agents/alice/init.json"
+    session = _create_codex_session_cfg([_completed(), _completed()], codex_session_anchor=anchor)
+    session.send("a")
+    session.send("b")
+
+    for sent in session._client.responses.kwargs:
+        blob = json.dumps(sent, default=str)
+        assert "codex-cache-key" not in blob


### PR DESCRIPTION
## Summary
- add an experimental rolling Codex affinity mode for `prompt_cache_key` / `session_id` / `thread_id`
- first request keeps the existing stable per-agent key; later requests derive a new key from the previous API-call timestamp and the stable agent identity
- preserve the within-request invariant `prompt_cache_key == session_id == thread_id`; keep the old stable behavior behind a mode switch
- add focused regression coverage and update the OpenAI adapter ANATOMY notes

## Validation
- `python -m pytest tests/test_codex_rolling_prompt_key.py tests/test_codex_prompt_cache_key.py tests/test_codex_raw_reasoning_replay.py tests/test_openai_prompt_cache_key.py tests/test_openai_responses_streaming.py tests/test_openai_overflow_recovery.py tests/test_openai_compact_threshold.py tests/test_llm_adapter_timeouts.py tests/unit/auth/test_codex_auth.py -q` → 159 passed
- `python -m pytest tests/test_deep_refresh.py -k 'codex or refresh' -q` → 22 passed
- `git diff --check`

## Notes / risks
- This is intentionally an experiment requested by Jason; it may reduce cache hits if the backend prefers long-lived stable keys.
- The rolling timestamp is in-memory and per runtime process; refresh/restart resets the previous-call state.
- `x-client-request-id` remains the existing fresh per-request metadata value rather than being forced to match the rolling affinity key.
- Same official TUI multi-turn prompt-cache-key behavior remains unproven because local fake-terminal captures could not get a second TUI request to fire.
