### PR TITLE
docs: make tool-result summary readme proactive

### DIFF
--- a/src/lingtai_kernel/meta_block.py
+++ b/src/lingtai_kernel/meta_block.py
@@ -139,8 +139,10 @@ TOOL_RESULT_CHARS_PREVIEW_LEN = 200
 TOOL_RESULT_CHARS_README = (
     "listing top 10 tool results by char count with a first-200-char preview; "
     "no need to summarize this helper (it appears only on the latest tool "
-    "result _meta and older copies are stripped); use the listed result "
-    "ids/previews to decide which prior results need summarizing"
+    "result _meta and older copies are stripped); proactively summarize "
+    "prior tool results that are useless, already digested, irrelevant, "
+    "obsolete, or no longer needed in full, using the listed result "
+    "ids/previews"
 )
 
 
@@ -225,8 +227,8 @@ def build_meta_readme() -> dict:
             "active_turn_tool_calls, current_tool_result_chars). Latest tool "
             "result only; older copies are stripped as newer results arrive. "
             "current_tool_result_chars is a dict with total_chars and the top "
-            "10 tool results (each with a first-200-char preview) to consider "
-            "for summarization."
+            "10 tool results (each with a first-200-char preview) that are "
+            "proactive summarization candidates."
         ),
         GUIDANCE_KEY: (
             "Kernel guidance sections, including the meta_readme section. "

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -203,9 +203,12 @@ def test_current_tool_result_chars_readme_says_no_need_to_summarize_helper():
     # appears on the latest tool result _meta, older copies are stripped.
     assert "no need to summarize this" in readme
     assert "latest" in readme
-    # It must still point the agent at the listed results so it can decide
-    # which prior results actually need summarizing.
-    assert "summariz" in readme
+    # It must still point the agent at the listed results and actively tell it
+    # to summarize prior results that no longer need to stay in full.
+    assert "proactively summarize" in readme
+    assert "useless" in readme
+    assert "no longer needed in full" in readme
+    assert "ids/previews" in readme
     assert "1000" not in readme
     assert "top 5" not in readme
 
@@ -215,7 +218,7 @@ def test_build_meta_readme_mentions_tool_result_char_count_and_summarize():
 
     assert "current_tool_result_chars" in readme["agent_meta"]
     assert "top" in readme["agent_meta"]
-    assert "summarization" in readme["agent_meta"]
+    assert "proactive summarization candidates" in readme["agent_meta"]
 
 
 def test_build_guidance_with_meta_readme_keeps_section_shape_without_packaged_guidance():


### PR DESCRIPTION
## Summary
- update `current_tool_result_chars._readme` to proactively tell agents to summarize useless/already digested/obsolete prior tool results using the listed result ids/previews
- keep the helper self-description clear: the helper metadata itself does not need summarizing because older copies are stripped
- update meta-block tests for the more proactive wording

## Validation
- `git diff --check`
- `PYTHONPATH="$PWD/src" python -m pytest -q tests/test_meta_block.py` (76 passed)