### PR TITLE
Add gated Codex websocket session reuse

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -336,29 +336,146 @@ def _codex_incremental_items(
     Returns ``None`` whenever a strict extension cannot be proven, so the caller
     falls back to sending the full input rather than a bad delta.
     """
+    delta, _reason = _codex_incremental_diagnose(
+        previous_request,
+        previous_items_added,
+        request,
+        allow_empty_delta=allow_empty_delta,
+    )
+    return delta
+
+
+def _codex_diff_keys(prev_no_input: dict[str, Any], cur_no_input: dict[str, Any]) -> list[str]:
+    """Return the sorted set of non-input request keys that changed.
+
+    Used only for safe diagnostics: it records WHICH non-input field names
+    diverged (e.g. ``tools``, ``include``), never their values, so the reason
+    string carries no prompt/tool/secret content.
+    """
+    keys = set(prev_no_input) | set(cur_no_input)
+    return sorted(k for k in keys if prev_no_input.get(k) != cur_no_input.get(k))
+
+
+def _codex_item_safe_diag(item: Any) -> dict[str, str]:
+    """Return safe, content-free diagnostics for one Responses input item."""
+    if not isinstance(item, dict):
+        return {"type": type(item).__name__, "role": "", "keys": "", "hash": ""}
+    payload = json.dumps(item, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+    return {
+        "type": str(item.get("type") or "")[:80],
+        "role": str(item.get("role") or "")[:80],
+        "keys": ",".join(sorted(str(k) for k in item.keys()))[:160],
+        # Short hash only: enough to tell whether two opaque items differ,
+        # without leaking prompt/tool/result content into provider metadata.
+        "hash": hashlib.sha256(payload.encode("utf-8", "replace")).hexdigest()[:12],
+    }
+
+
+def _codex_incremental_diagnose(
+    previous_request: dict[str, Any],
+    previous_items_added: list[dict[str, Any]],
+    request: dict[str, Any],
+    *,
+    allow_empty_delta: bool,
+) -> tuple[list[dict[str, Any]] | None, dict[str, Any]]:
+    """Like :func:`_codex_incremental_items` but also return a safe diagnostic.
+
+    The second element is a small metadata dict explaining the decision. It
+    records ONLY classes/counts/lengths/short-hash/booleans — never prompt,
+    tool-result, reasoning, token, header, or secret content — so it is safe to
+    surface in provider metadata / the token ledger:
+
+      * ``reason``: ``ok`` | ``non_input_fields_changed`` | ``prefix_mismatch``
+        | ``empty_delta_rejected``
+      * ``changed_fields``: list of non-input KEY NAMES that diverged (no values)
+      * ``baseline_len`` / ``cur_input_len`` / ``delta_len``: item counts
+      * ``mismatch_index``: first baseline index where the prefix diverged (or -1)
+    """
     prev_no_input = {k: v for k, v in previous_request.items() if k != "input"}
     cur_no_input = {k: v for k, v in request.items() if k != "input"}
-    if prev_no_input != cur_no_input:
-        return None
 
     baseline = list(previous_request.get("input") or [])
     baseline.extend(previous_items_added or [])
     baseline_len = len(baseline)
-
     cur_input = list(request.get("input") or [])
-    starts_with = cur_input[:baseline_len] == baseline
-    if starts_with and (allow_empty_delta or baseline_len < len(cur_input)):
-        return cur_input[baseline_len:]
-    return None
+    cur_len = len(cur_input)
+
+    diag: dict[str, Any] = {
+        "reason": "ok",
+        "changed_fields": [],
+        "baseline_len": baseline_len,
+        "cur_input_len": cur_len,
+        "delta_len": 0,
+        "mismatch_index": -1,
+    }
+
+    if prev_no_input != cur_no_input:
+        diag["reason"] = "non_input_fields_changed"
+        diag["changed_fields"] = _codex_diff_keys(prev_no_input, cur_no_input)
+        return None, diag
+
+    # Find the first position where the current input diverges from the baseline.
+    prefix = cur_input[:baseline_len]
+    if prefix != baseline:
+        mismatch = baseline_len  # default: current input is shorter than baseline
+        for idx in range(min(len(prefix), baseline_len)):
+            if prefix[idx] != baseline[idx]:
+                mismatch = idx
+                break
+        diag["reason"] = "prefix_mismatch"
+        diag["mismatch_index"] = mismatch
+        if mismatch < baseline_len:
+            prev_diag = _codex_item_safe_diag(baseline[mismatch])
+            diag["mismatch_prev_type"] = prev_diag.get("type")
+            diag["mismatch_prev_role"] = prev_diag.get("role")
+            diag["mismatch_prev_keys"] = prev_diag.get("keys")
+            diag["mismatch_prev_hash"] = prev_diag.get("hash")
+        if mismatch < cur_len:
+            cur_diag = _codex_item_safe_diag(cur_input[mismatch])
+            diag["mismatch_cur_type"] = cur_diag.get("type")
+            diag["mismatch_cur_role"] = cur_diag.get("role")
+            diag["mismatch_cur_keys"] = cur_diag.get("keys")
+            diag["mismatch_cur_hash"] = cur_diag.get("hash")
+        return None, diag
+
+    if not (allow_empty_delta or baseline_len < cur_len):
+        diag["reason"] = "empty_delta_rejected"
+        return None, diag
+
+    delta = cur_input[baseline_len:]
+    diag["delta_len"] = len(delta)
+    return delta, diag
+
+
+def _ws_is_synthesized_orphan_output(item: Any) -> bool:
+    """True if ``item`` is the synthesized orphan ``function_call_output`` guard.
+
+    ``to_responses_input`` injects a placeholder ``function_call_output`` for any
+    unanswered ``function_call`` (issue #170). That placeholder must not enter the
+    websocket delta baseline: the real tool-result continuation replaces it next
+    turn, so a baseline containing it can never strict-prefix-match. Detect it by
+    the sentinel output string so the baseline builder can trim it.
+    """
+    from ..interface_converters import _RESPONSES_ORPHAN_OUTPUT_PLACEHOLDER
+
+    return (
+        isinstance(item, dict)
+        and item.get("type") == "function_call_output"
+        and item.get("output") == _RESPONSES_ORPHAN_OUTPUT_PLACEHOLDER
+    )
 
 
 def _ws_dump_item(item: Any) -> dict[str, Any] | None:
-    """Normalize a streamed output item to a plain dict for the delta baseline.
+    """Normalize a streamed output item to a plain dict.
 
-    The baseline (previous request input + server output items) must compare
-    equal to the next request's serialized input items, which are plain dicts
-    from ``to_responses_input``. SDK event items are pydantic models, so dump
-    them; pass through dicts; ignore anything else.
+    Retained as a small, well-tested normalizer for SDK event items (pydantic
+    models -> dict; dicts pass through; anything else -> ``None``). It is NO
+    LONGER the delta-baseline source: the server's streamed output items are in
+    the Responses *output* schema and never strict-prefix-match the *input*
+    schema this session re-derives next turn, which forced ``ws_full`` every
+    turn. The baseline is now built from the converter via
+    ``CodexResponsesSession._ws_record_baseline_from_interface``. This helper is
+    kept for diagnostics / potential reuse and to preserve its unit contract.
     """
     if item is None:
         return None
@@ -1947,6 +2064,13 @@ class CodexResponsesSession(OpenAIResponsesSession):
         self._ws_base_url = base_url
         self._ws_api_key = api_key if isinstance(api_key, str) and api_key else None
         self._ws_session = _CodexWebsocketSession()
+        # Set while a websocket request is in flight: the full converted input we
+        # sent this turn, used by ``_ws_record_baseline_from_interface`` to derive
+        # a converter-stable delta baseline once the assistant turn is recorded.
+        self._ws_pending_baseline_input: list[dict[str, Any]] | None = None
+        # Last websocket delta decision diagnostic (safe metadata only): why the
+        # request went ``ws_incremental`` vs ``ws_full``. Surfaced in usage.extra.
+        self._ws_last_diag: dict[str, Any] = {}
         # One Codex websocket connection may carry multiple ``response.create``
         # frames. Live smoke showed ChatGPT Codex resolves
         # ``previous_response_id`` only when the follow-up request stays on the
@@ -2056,6 +2180,7 @@ class CodexResponsesSession(OpenAIResponsesSession):
         store: bool | None = None,
         fallback_error_type: str | None = None,
         fallback_error_message: str | None = None,
+        ws_diag: dict[str, Any] | None = None,
     ) -> dict[str, str]:
         """Build the token-ledger ``UsageMetadata.extra`` for this request.
 
@@ -2063,6 +2188,13 @@ class CodexResponsesSession(OpenAIResponsesSession):
         visible in ``token_ledger.jsonl`` alongside the pre-rotation requests.
         Only the short non-secret affinity ids ride here — no prompt body, no
         tokens, no OAuth secret.
+
+        ``ws_diag`` carries the websocket delta decision — ONLY safe metadata
+        (reason class, item counts, changed non-input KEY names, a mismatch
+        index). It explains why a turn went ``ws_full`` vs ``ws_incremental``
+        (``no_baseline`` / ``missing_response_id`` / ``missing_output_items`` /
+        ``prefix_mismatch`` / ``non_input_fields_changed`` / ``ok`` …). No prompt,
+        tool-result, reasoning, token, header, or secret content is included.
         """
         extra: dict[str, str] = {}
         if affinity_headers.get("session_id"):
@@ -2081,6 +2213,30 @@ class CodexResponsesSession(OpenAIResponsesSession):
             extra["codex_fallback_error_type"] = fallback_error_type
         if fallback_error_message:
             extra["codex_fallback_error_message"] = fallback_error_message[:240]
+        if ws_diag:
+            reason = ws_diag.get("reason")
+            if reason:
+                extra["codex_ws_delta_reason"] = str(reason)
+            changed = ws_diag.get("changed_fields")
+            if changed:
+                # Key NAMES only (e.g. "tools,include"), never their values.
+                extra["codex_ws_changed_fields"] = ",".join(str(k) for k in changed)[:240]
+            for key in (
+                "baseline_len",
+                "cur_input_len",
+                "delta_len",
+                "mismatch_index",
+                "mismatch_prev_type",
+                "mismatch_prev_role",
+                "mismatch_prev_keys",
+                "mismatch_prev_hash",
+                "mismatch_cur_type",
+                "mismatch_cur_role",
+                "mismatch_cur_keys",
+                "mismatch_cur_hash",
+            ):
+                if ws_diag.get(key) is not None:
+                    extra[f"codex_ws_{key}"] = str(ws_diag[key])[:240]
         return extra
 
     def send(self, message) -> LLMResponse:
@@ -2144,18 +2300,38 @@ class CodexResponsesSession(OpenAIResponsesSession):
         previous_response_id: str | None = None
         frame_input = full_replay_input_items
         request_mode = "ws_full"
+        # Safe fallback diagnostics (no prompt/tool/secret content): explains why
+        # we are sending full input instead of a delta. Surfaced via
+        # ``self._ws_last_diag`` so ``send_stream`` can ride it into ``usage.extra``
+        # / the token ledger. Only classes / counts / key-names / a short hash.
+        diag: dict[str, Any]
         last = self._ws_session.last_response
-        if last is not None and last.response_id:
-            delta = _codex_incremental_items(
-                self._ws_session.last_request or {},
+        if last is None:
+            diag = {"reason": "no_baseline"}
+        elif not last.response_id:
+            diag = {"reason": "missing_response_id"}
+        elif self._ws_session.last_request is None:
+            diag = {"reason": "missing_baseline_request"}
+        else:
+            delta, diag = _codex_incremental_diagnose(
+                self._ws_session.last_request,
                 last.items_added,
                 full_request,
                 allow_empty_delta=True,
             )
+            if delta is None and not last.items_added:
+                # Baseline lacks the server's output items (e.g. the previous turn
+                # completed but produced no recordable output item). Make the
+                # reason explicit rather than a generic prefix mismatch.
+                if diag.get("reason") == "prefix_mismatch" and diag.get("baseline_len") == len(
+                    self._ws_session.last_request.get("input") or []
+                ):
+                    diag = {**diag, "reason": "missing_output_items"}
             if delta is not None:
                 previous_response_id = last.response_id
                 frame_input = delta
                 request_mode = "ws_incremental"
+        self._ws_last_diag = dict(diag)
 
         # Build the transmitted frame (delta or full).
         frame = dict(full_request)
@@ -2198,38 +2374,52 @@ class CodexResponsesSession(OpenAIResponsesSession):
         previous_last_request = self._ws_session.last_request
         previous_last_response = self._ws_session.last_response
         self._ws_session.last_request = full_request
+        # Park the baseline for THIS request's input length so the post-stream
+        # baseline (recomputed from the canonical interface in ``send_stream``)
+        # knows where the server-added output items begin. The previous-baseline
+        # values above are restored on any stream failure.
+        self._ws_pending_baseline_input = list(full_replay_input_items)
 
         def _events():
             response_id_local: str | None = None
-            items_added: list[dict[str, Any]] = []
             try:
                 for event in transport.stream(frame):
                     etype = getattr(event, "type", None)
-                    if etype == "response.output_item.done":
-                        item = getattr(event, "item", None)
-                        dumped = _ws_dump_item(item)
-                        if dumped is not None:
-                            items_added.append(dumped)
-                    elif etype == "response.completed":
+                    if etype == "response.completed":
                         response_id_local = getattr(getattr(event, "response", None), "id", None)
                     yield event
             except _CodexWsFallback:
                 self._ws_session.last_request = previous_last_request
                 self._ws_session.last_response = previous_last_response
+                self._ws_pending_baseline_input = None
                 self._close_ws_transport(transport)
                 raise
             except Exception:
                 self._ws_session.last_request = previous_last_request
                 self._ws_session.last_response = previous_last_response
+                self._ws_pending_baseline_input = None
                 self._close_ws_transport(transport)
                 raise
             # Record the completed response so the next request can delta off it,
             # then notify the server it was processed (official posts
             # ``response.processed`` after handling a completed response).
+            #
+            # NOTE: ``items_added`` is intentionally left EMPTY here. The server's
+            # streamed ``response.output_item.done`` items are in the Responses
+            # *output* schema (``{"type":"message","id":...,"status":...,
+            # "content":[{"type":"output_text",...}]}``), which does NOT compare
+            # equal to the *input* schema this session re-derives next turn via
+            # ``to_responses_input`` (``{"role":"assistant","content":<str>}`` +
+            # ``{"type":"reasoning","summary":[...]}``). Using the raw output items
+            # as the delta baseline therefore failed the strict-prefix check on
+            # EVERY follow-up turn, collapsing every real agent turn to ``ws_full``.
+            # The correct, converter-stable baseline is filled in by
+            # ``_ws_record_baseline_from_interface`` after ``send_stream`` records
+            # the assistant turn into the canonical interface (#471 delta fix).
             if response_id_local:
                 self._ws_session.last_response = _CodexLastResponse(
                     response_id=response_id_local,
-                    items_added=items_added,
+                    items_added=[],
                 )
                 try:
                     transport.send_response_processed(response_id_local)
@@ -2237,6 +2427,51 @@ class CodexResponsesSession(OpenAIResponsesSession):
                     logger.debug("codex ws response.processed failed: %s", exc)
 
         return _events(), request_mode, previous_response_id
+
+    def _ws_record_baseline_from_interface(self) -> None:
+        """Fill the WS delta baseline from the converter, not raw server output.
+
+        Called by ``send_stream`` AFTER the just-completed assistant turn has been
+        recorded into the canonical interface. The next turn's full input is
+        ``to_responses_input(interface)`` (plus that turn's new user/tool items),
+        so the only baseline that can ever strict-prefix-match it is one expressed
+        in the SAME converter schema. We therefore derive ``items_added`` as the
+        suffix of the current full converted input beyond the input we actually
+        sent this turn — i.e. exactly the assistant turn the server added,
+        rendered in input schema. This is the conservative fix for the
+        ``ws_full``-every-turn root cause: it makes the baseline and the next full
+        request byte-comparable by construction. No prompt/secret content leaves
+        the process; this only rearranges in-memory request dicts.
+        """
+        pending = getattr(self, "_ws_pending_baseline_input", None)
+        last = self._ws_session.last_response
+        if pending is None or last is None or not last.response_id:
+            self._ws_pending_baseline_input = None
+            return
+        full_now = to_responses_input(self._interface)
+        base_len = len(pending)
+        # Only treat the tail as server-added output when the interface still
+        # strictly extends what we sent (it always should: we appended an
+        # assistant turn). If it does not, leave ``items_added`` empty so the next
+        # turn falls back to ``ws_full`` with a ``missing_output_items`` reason
+        # rather than chaining off a baseline we cannot prove.
+        if full_now[:base_len] == pending and base_len <= len(full_now):
+            tail = full_now[base_len:]
+            # Drop trailing SYNTHESIZED orphan tool-result placeholders from the
+            # baseline. When the assistant turn ends on an unanswered
+            # ``function_call``, ``to_responses_input`` injects a placeholder
+            # ``function_call_output`` (issue #170 wire guard). That placeholder is
+            # NOT what the next tool-result continuation actually sends (the real
+            # output replaces it), so keeping it in the baseline guarantees a
+            # ``prefix_mismatch`` and forces ``ws_full`` on every tool loop. Trim
+            # the trailing placeholder(s) so the real continuation strictly extends
+            # the baseline and stays ``ws_incremental``.
+            while tail and _ws_is_synthesized_orphan_output(tail[-1]):
+                tail = tail[:-1]
+            last.items_added = tail
+        else:
+            last.items_added = []
+        self._ws_pending_baseline_input = None
 
     def _close_ws_transport(self, transport=None) -> None:
         current = self._ws_transport
@@ -2564,6 +2799,7 @@ class CodexResponsesSession(OpenAIResponsesSession):
                                 store=request_store,
                                 fallback_error_type=fallback_error_type,
                                 fallback_error_message=fallback_error_message,
+                                ws_diag=(self._ws_last_diag if self._ws_enabled else None),
                             ),
                         )
         except Exception:
@@ -2622,6 +2858,14 @@ class CodexResponsesSession(OpenAIResponsesSession):
                 "thinking_tokens": usage.thinking_tokens,
             },
         )
+
+        # Fix the ``ws_full``-every-turn root cause: now that the assistant turn
+        # is in the canonical interface, recompute the websocket delta baseline in
+        # the SAME converter schema the next full request will use, so a strict
+        # prefix can actually match. Only runs on the websocket path; a no-op on
+        # the HTTP fallback. See ``_ws_record_baseline_from_interface``.
+        if self._ws_enabled:
+            self._ws_record_baseline_from_interface()
 
         # Stateless: don't persist the response_id beyond this single turn.
         # Stored only as a transient debug aid; never threaded into the next

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -14,8 +14,9 @@ import json
 import os
 import time
 import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlsplit
 
 import httpx
@@ -238,6 +239,185 @@ def _codex_identity_headers() -> dict[str, str]:
     the identity-policy note above (#436 / #471).
     """
     return {"originator": _CODEX_ORIGINATOR, "User-Agent": _lingtai_user_agent()}
+
+
+# ---------------------------------------------------------------------------
+# Codex Responses-over-WebSocket incremental turn state (EXPERIMENTAL, #471).
+#
+# This mirrors the official Codex CLI source path (repo openai/codex, tag
+# ``rust-v0.130.0``, commit 58573da). The high-cache/stateful behavior on the
+# ChatGPT Codex backend is NOT server-side Responses storage (``store`` is
+# ``false`` there by construction — ``codex-rs/core/src/client.rs:722``); it is
+# Responses-over-WebSocket incremental ``response.create`` frames that carry
+# ``previous_response_id`` plus only the delta input when the new full request is
+# a strict extension of (previous request input + previous response output
+# items). See ``get_incremental_items`` (``client.rs:949-985``) and
+# ``prepare_websocket_request`` (``client.rs:998-1024``).
+#
+# These objects are pure Python data + a pure algorithm so the request-shape
+# logic is unit-testable without any network. The actual websocket wire goes
+# through an injectable transport (``_CodexWebsocketTransport``) so tests can
+# substitute a fake.
+# ---------------------------------------------------------------------------
+
+# Official websocket beta header value (``client.rs:142``) and the per-turn
+# sticky-routing state header (``client.rs:134`` /
+# ``responses_websocket.rs:155``). Kept as data so the wire stays auditable.
+_CODEX_WS_BETA_HEADER = "OpenAI-Beta"
+_CODEX_WS_BETA_VALUE = "responses_websockets=2026-02-06"
+_CODEX_TURN_STATE_HEADER = "x-codex-turn-state"
+
+# Env gate for the experimental websocket transport. Off by default: when unset
+# (or not truthy) the session uses the existing, proven HTTP full-replay path.
+# Set ``LINGTAI_CODEX_WS=1`` to enable the websocket path (which still falls back
+# to HTTP on any handshake/connection/auth error, unsupported runtime, or delta
+# mismatch).
+_CODEX_WS_ENABLED_ENV = "LINGTAI_CODEX_WS"
+
+# Non-input request fields that must match between two requests for an
+# incremental delta to be valid. Mirrors the official ``get_incremental_items``
+# which clones both requests, clears ``.input`` on each, and compares the rest
+# for strict equality (``client.rs:960-970``).
+
+
+def _codex_ws_enabled() -> bool:
+    """Return True when the experimental websocket transport is enabled."""
+    return os.environ.get(_CODEX_WS_ENABLED_ENV, "").lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class _CodexLastResponse:
+    """The previous completed websocket response, for delta computation.
+
+    Mirrors the official ``LastResponse`` (``client.rs:1748-1774``): the
+    ``response_id`` becomes the next request's ``previous_response_id``, and
+    ``items_added`` are the server-added output items that form part of the
+    delta baseline so they are never resent.
+    """
+
+    response_id: str
+    items_added: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class _CodexWebsocketSession:
+    """Per-turn websocket state: last full request + last completed response.
+
+    Mirrors the fields the official ``ModelClientSession`` caches for the turn
+    (``client.rs:214-226``): ``last_request`` (the full request) and the last
+    response. The captured ``turn_state`` token is sticky-routing state replayed
+    within the same turn and reset across turns (``client.rs:227-240``).
+    """
+
+    last_request: dict[str, Any] | None = None
+    last_response: _CodexLastResponse | None = None
+    turn_state: str | None = None
+
+
+def _codex_incremental_items(
+    previous_request: dict[str, Any],
+    previous_items_added: list[dict[str, Any]],
+    request: dict[str, Any],
+    *,
+    allow_empty_delta: bool,
+) -> list[dict[str, Any]] | None:
+    """Compute the incremental input delta, or ``None`` to send full input.
+
+    Faithful port of the official ``get_incremental_items``
+    (``codex-rs/core/src/client.rs:949-985``):
+
+      1. All non-input request fields must be identical between the previous and
+         current request (compare both with ``input`` cleared).
+      2. The baseline is ``previous_request.input + previous_items_added``.
+      3. The current ``input`` must start with that baseline; the suffix after
+         the baseline is the delta. An empty delta is only returned when
+         ``allow_empty_delta`` is true (the websocket prewarm/no-op case).
+
+    Returns ``None`` whenever a strict extension cannot be proven, so the caller
+    falls back to sending the full input rather than a bad delta.
+    """
+    prev_no_input = {k: v for k, v in previous_request.items() if k != "input"}
+    cur_no_input = {k: v for k, v in request.items() if k != "input"}
+    if prev_no_input != cur_no_input:
+        return None
+
+    baseline = list(previous_request.get("input") or [])
+    baseline.extend(previous_items_added or [])
+    baseline_len = len(baseline)
+
+    cur_input = list(request.get("input") or [])
+    starts_with = cur_input[:baseline_len] == baseline
+    if starts_with and (allow_empty_delta or baseline_len < len(cur_input)):
+        return cur_input[baseline_len:]
+    return None
+
+
+def _ws_dump_item(item: Any) -> dict[str, Any] | None:
+    """Normalize a streamed output item to a plain dict for the delta baseline.
+
+    The baseline (previous request input + server output items) must compare
+    equal to the next request's serialized input items, which are plain dicts
+    from ``to_responses_input``. SDK event items are pydantic models, so dump
+    them; pass through dicts; ignore anything else.
+    """
+    if item is None:
+        return None
+    if hasattr(item, "model_dump"):
+        try:
+            return item.model_dump(exclude_none=True)
+        except Exception:  # pragma: no cover - defensive
+            return None
+    if isinstance(item, dict):
+        return item
+    return None
+
+
+class _CodexWsFallback(Exception):
+    """Raised by a websocket transport to request a fall back to HTTP.
+
+    Mirrors the official ``WebsocketStreamOutcome::FallbackToHttp`` decision
+    (``client.rs:1361-1364``): a handshake ``426 UPGRADE_REQUIRED``, a
+    connection/handshake failure, an unsupported runtime (e.g. the optional
+    ``websockets`` dependency is absent), or any condition under which we cannot
+    safely use the websocket path. The caller catches it and replays the full
+    input over HTTP with ``store=false``.
+    """
+
+
+def _codex_ws_url(base_url: str | None) -> str:
+    """Convert the Codex HTTP base URL to the websocket ``responses`` URL.
+
+    Mirrors ``Provider::websocket_url_for_path`` (``provider.rs:92-103``):
+    ``https://chatgpt.com/backend-api/codex`` -> ``wss://.../responses``.
+    """
+    base = (base_url or "https://chatgpt.com/backend-api/codex").rstrip("/")
+    path = base + "/responses"
+    if path.startswith("https://"):
+        return "wss://" + path[len("https://"):]
+    if path.startswith("http://"):
+        return "ws://" + path[len("http://"):]
+    return path
+
+
+def _default_codex_ws_transport_factory(url: str, headers: dict[str, str]):
+    """Build the real websocket transport, or raise ``_CodexWsFallback``.
+
+    Lazily imports the optional ``websockets`` package; if it is not installed
+    (the kernel does not hard-depend on it), the websocket path is treated as an
+    unsupported runtime and the caller falls back to HTTP. The real transport is
+    intentionally NOT exercised by the unit tests (which inject a fake) — a live
+    smoke test is gated behind ``LINGTAI_CODEX_WS`` + parent approval.
+    """
+    try:  # pragma: no cover - import guard, exercised only with the dep present
+        import websockets  # noqa: F401
+    except Exception as exc:  # pragma: no cover
+        raise _CodexWsFallback(f"websockets unavailable: {exc}") from exc
+    # The synchronous wire driver lives in a companion module to keep the import
+    # cost and event-loop plumbing out of the hot adapter import path. It is only
+    # reached on a live run, never in the mock tests.
+    from .codex_ws import SyncCodexWebsocketTransport  # pragma: no cover
+
+    return SyncCodexWebsocketTransport(url=url, headers=headers)  # pragma: no cover
 
 
 def _base_url_namespace(base_url: str | None) -> str:
@@ -1747,9 +1927,32 @@ class CodexResponsesSession(OpenAIResponsesSession):
         account_id: str | None = None,
         installation_id: str | None = None,
         metadata_sandbox: str = "lingtai",
+        ws_enabled: bool | None = None,
+        ws_transport_factory: "Callable[[str, dict[str, str]], Any] | None" = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        # EXPERIMENTAL Codex Responses-over-WebSocket transport (#471). Gated:
+        # ``ws_enabled`` defaults to the ``LINGTAI_CODEX_WS`` env switch (off
+        # unless explicitly turned on). ``ws_transport_factory`` is an injection
+        # seam used by the mock tests; when ``None`` and the gate is on, the real
+        # factory is used (and itself falls back to HTTP if ``websockets`` is
+        # missing). ``_ws_session`` holds the per-turn last_request/last_response
+        # + captured ``x-codex-turn-state`` used to compute incremental deltas
+        # exactly like the official ``ModelClientSession`` (``client.rs:214-240``).
+        self._ws_enabled = _codex_ws_enabled() if ws_enabled is None else bool(ws_enabled)
+        self._ws_transport_factory = ws_transport_factory
+        self._ws_base_url = base_url
+        self._ws_api_key = api_key if isinstance(api_key, str) and api_key else None
+        self._ws_session = _CodexWebsocketSession()
+        # One Codex websocket connection may carry multiple ``response.create``
+        # frames. Live smoke showed ChatGPT Codex resolves
+        # ``previous_response_id`` only when the follow-up request stays on the
+        # same websocket session. Keep the transport alive across sequential
+        # sends in this ChatSession, and close/reset it on transport failures.
+        self._ws_transport = None
         # The user's own ChatGPT account id (decoded upstream from their OAuth
         # auth data). When present it is sent as the ``ChatGPT-Account-ID`` HTTP
         # header so the request is attributed to the right ChatGPT account. It is
@@ -1845,7 +2048,14 @@ class CodexResponsesSession(OpenAIResponsesSession):
 
     @staticmethod
     def _usage_extra(
-        affinity_headers: dict[str, str], cache_key: str | None
+        affinity_headers: dict[str, str],
+        cache_key: str | None,
+        *,
+        request_mode: str | None = None,
+        previous_response_id: str | None = None,
+        store: bool | None = None,
+        fallback_error_type: str | None = None,
+        fallback_error_message: str | None = None,
     ) -> dict[str, str]:
         """Build the token-ledger ``UsageMetadata.extra`` for this request.
 
@@ -1861,32 +2071,231 @@ class CodexResponsesSession(OpenAIResponsesSession):
             extra["codex_thread_id"] = affinity_headers["thread_id"]
         if cache_key:
             extra["codex_prompt_cache_key"] = cache_key
+        if request_mode:
+            extra["codex_request_mode"] = request_mode
+        if previous_response_id:
+            extra["codex_previous_response_id"] = previous_response_id
+        if store is not None:
+            extra["codex_store"] = str(bool(store)).lower()
+        if fallback_error_type:
+            extra["codex_fallback_error_type"] = fallback_error_type
+        if fallback_error_message:
+            extra["codex_fallback_error_message"] = fallback_error_message[:240]
         return extra
 
     def send(self, message) -> LLMResponse:
         # Force the streaming path — Codex doesn't serve non-streaming JSON.
         return self.send_stream(message, on_chunk=None)
 
+    # -- Experimental Responses-over-WebSocket transport (#471) ---------------
+
+    # Request-body keys that are NOT part of the websocket ``response.create``
+    # frame's comparable shape — SDK transport-only kwargs. They are excluded
+    # when building the request dict used for the delta-extension check (the
+    # official algorithm compares the request struct, which never contains
+    # transport headers). ``input`` is compared separately by the algorithm.
+    _WS_NON_FRAME_KEYS = ("extra_headers", "extra_body", "timeout")
+
+    def _ws_frame_request(self, kwargs: dict[str, Any], input_items: list[dict[str, Any]]) -> dict[str, Any]:
+        """Build the comparable ``response.create`` request dict from ``kwargs``.
+
+        Drops SDK transport-only keys (headers/body/timeout) and forces
+        ``store=false`` (the ChatGPT Codex backend rejects ``store=true`` —
+        ``client.rs:722``). ``client_metadata`` from ``extra_body`` is folded in
+        as a body field so it participates in the non-input equality check, like
+        the official request struct's ``client_metadata`` (``common.rs:189``).
+        """
+        frame: dict[str, Any] = {
+            k: v for k, v in kwargs.items() if k not in self._WS_NON_FRAME_KEYS
+        }
+        frame["type"] = "response.create"
+        frame["store"] = False
+        frame["stream"] = True
+        frame["input"] = list(input_items)
+        extra_body = kwargs.get("extra_body") or {}
+        if isinstance(extra_body, dict) and extra_body.get("client_metadata"):
+            frame["client_metadata"] = extra_body["client_metadata"]
+        return frame
+
+    def _codex_ws_open(
+        self,
+        kwargs: dict[str, Any],
+        *,
+        full_replay_input_items: list[dict[str, Any]],
+    ) -> tuple[Any, str, str | None]:
+        """Open a websocket ``response.create`` stream, or raise ``_CodexWsFallback``.
+
+        Returns ``(event_iterable, request_mode, previous_response_id_or_None)``.
+
+        Mirrors the official path: build the full request, then via
+        ``prepare_websocket_request`` (``client.rs:998-1024``) decide whether to
+        send only the delta input with ``previous_response_id`` (when the new
+        full request is a strict extension of the previous request + its output
+        items) or the full input with no previous id (first request / mismatch).
+        The connection captures ``x-codex-turn-state`` from the handshake and
+        replays it within the turn; ``response.processed`` is sent after the
+        completed response (``responses_websocket.rs:208-240``).
+        """
+        # The full request shape (full input) is what we record as
+        # ``last_request`` for the NEXT turn's delta baseline, regardless of what
+        # we actually transmit this turn.
+        full_request = self._ws_frame_request(kwargs, full_replay_input_items)
+
+        previous_response_id: str | None = None
+        frame_input = full_replay_input_items
+        request_mode = "ws_full"
+        last = self._ws_session.last_response
+        if last is not None and last.response_id:
+            delta = _codex_incremental_items(
+                self._ws_session.last_request or {},
+                last.items_added,
+                full_request,
+                allow_empty_delta=True,
+            )
+            if delta is not None:
+                previous_response_id = last.response_id
+                frame_input = delta
+                request_mode = "ws_incremental"
+
+        # Build the transmitted frame (delta or full).
+        frame = dict(full_request)
+        frame["input"] = list(frame_input)
+        if previous_response_id:
+            frame["previous_response_id"] = previous_response_id
+
+        # Handshake headers: the per-request Codex headers plus the websocket
+        # beta header, plus the captured per-turn ``x-codex-turn-state`` (only
+        # after it has been captured earlier in the same turn).
+        headers = dict(kwargs.get("extra_headers") or {})
+        if self._ws_api_key and not any(k.lower() == "authorization" for k in headers):
+            bearer = self._ws_api_key.strip()
+            if not bearer.lower().startswith("bearer "):
+                bearer = f"Bearer {bearer}"
+            headers["Authorization"] = bearer
+        headers[_CODEX_WS_BETA_HEADER] = _CODEX_WS_BETA_VALUE
+        if self._ws_session.turn_state:
+            headers[_CODEX_TURN_STATE_HEADER] = self._ws_session.turn_state
+
+        transport = self._ws_transport
+        if transport is None:
+            factory = self._ws_transport_factory or _default_codex_ws_transport_factory
+            url = _codex_ws_url(self._ws_base_url)
+            transport = factory(url, headers)
+
+            # connect() may raise _CodexWsFallback (426/connect/auth); let it
+            # propagate to the caller which falls back to HTTP.
+            captured_turn_state = transport.connect(headers=headers)
+            if captured_turn_state and not self._ws_session.turn_state:
+                # Capture once per turn. With a persistent websocket connection
+                # there may be no second handshake to replay this header on, but
+                # keep it for reconnects within the same turn.
+                self._ws_session.turn_state = captured_turn_state
+            self._ws_transport = transport
+
+        # Record the FULL request as the next delta baseline before streaming.
+        # If streaming fails before a completed response, restore the previous
+        # baseline so a later retry does not compare against an unaccepted turn.
+        previous_last_request = self._ws_session.last_request
+        previous_last_response = self._ws_session.last_response
+        self._ws_session.last_request = full_request
+
+        def _events():
+            response_id_local: str | None = None
+            items_added: list[dict[str, Any]] = []
+            try:
+                for event in transport.stream(frame):
+                    etype = getattr(event, "type", None)
+                    if etype == "response.output_item.done":
+                        item = getattr(event, "item", None)
+                        dumped = _ws_dump_item(item)
+                        if dumped is not None:
+                            items_added.append(dumped)
+                    elif etype == "response.completed":
+                        response_id_local = getattr(getattr(event, "response", None), "id", None)
+                    yield event
+            except _CodexWsFallback:
+                self._ws_session.last_request = previous_last_request
+                self._ws_session.last_response = previous_last_response
+                self._close_ws_transport(transport)
+                raise
+            except Exception:
+                self._ws_session.last_request = previous_last_request
+                self._ws_session.last_response = previous_last_response
+                self._close_ws_transport(transport)
+                raise
+            # Record the completed response so the next request can delta off it,
+            # then notify the server it was processed (official posts
+            # ``response.processed`` after handling a completed response).
+            if response_id_local:
+                self._ws_session.last_response = _CodexLastResponse(
+                    response_id=response_id_local,
+                    items_added=items_added,
+                )
+                try:
+                    transport.send_response_processed(response_id_local)
+                except Exception as exc:  # pragma: no cover - best-effort ack
+                    logger.debug("codex ws response.processed failed: %s", exc)
+
+        return _events(), request_mode, previous_response_id
+
+    def _close_ws_transport(self, transport=None) -> None:
+        current = self._ws_transport
+        if transport is not None and current is not transport:
+            return
+        self._ws_transport = None
+        if current is not None:
+            try:
+                current.close()
+            except Exception:
+                pass
+
+    def reset_provider_turn_state(self) -> None:
+        self.reset_ws_turn()
+
+    def reset_ws_turn(self) -> None:
+        """Reset per-turn websocket state at a new user turn boundary.
+
+        The official ``x-codex-turn-state`` is per-turn volatile: captured on the
+        first request of a turn, replayed within the turn, and reset for the next
+        user turn (``client.rs:227-240`` / ``turn_state.rs`` tests). Callers that
+        track turn boundaries invoke this between user turns; within a tool loop
+        it must NOT be called so the token (and incremental chain) persist.
+        """
+        self._ws_session.turn_state = None
+
+    @staticmethod
+    def _interface_entries_to_responses_input(entries: list[Any]) -> list[dict[str, Any]]:
+        """Serialize newly-added ChatInterface entries for stateful Codex turns."""
+
+        if not entries:
+            return []
+        delta_interface = ChatInterface()
+        # ChatInterface.entries intentionally exposes the mutable backing list;
+        # populate a temporary interface so the normal converter preserves
+        # reasoning/tool-result shapes and pairing behavior for the delta.
+        delta_interface.entries.extend(entries)
+        return to_responses_input(delta_interface)
+
     def send_stream(self, message, on_chunk=None) -> LLMResponse:
-        # Codex's backend is stateless — no previous_response_id, so the full
-        # conversation must ride along on every request. Record the new
-        # message into the canonical interface, then build wire input from
-        # the entire interface (mirrors OpenAIChatSession.send's contract).
-        # ``message is None`` is the "continue from wire" signal — the
-        # caller pre-staged the canonical interface (e.g. notification
-        # sync), so we just replay it without any additional append.
+        # Maintain the canonical interface for local recovery and full-replay
+        # fallback, but capture the entries added by this turn so subsequent
+        # stored-response requests can send only the incremental delta.
+        interface_start = len(self._interface.entries)
+        trailing_entries = 0
         if message is None:
             pass
         elif isinstance(message, str):
             self._interface.add_user_message(message)
+            trailing_entries = 1
         elif isinstance(message, list):
             # ToolResultBlock list, the canonical kernel shape coming back
             # from ToolExecutor via _make_tool_result_fn.
             if message and all(isinstance(b, ToolResultBlock) for b in message):
                 self._interface.add_tool_results(message)
+                trailing_entries = len(message)
             else:
                 # Pre-built wire dicts (legacy / tests). Fall back to the
-                # parent's converter so behavior matches what callers
+                # parent's converter below so behavior matches what callers
                 # passing dicts expect.
                 pass
         elif isinstance(message, dict):
@@ -1894,35 +2303,47 @@ class CodexResponsesSession(OpenAIResponsesSession):
         else:
             raise TypeError(f"Unsupported message type: {type(message)}")
 
-        # Pre-request hook — kernel-side splice point. The Codex stateless
-        # path replays the full canonical interface on every request, so
-        # any (call, result) pair the hook splices in is included in the
-        # current request's input items. See OpenAIChatSession.send for
-        # the contract.
+        # Pre-request hook — kernel-side splice point. Include hook-spliced
+        # entries in the delta so notification wake pairs remain visible in the
+        # same request even when previous_response_id is active.
         if self.pre_request_hook is not None:
             self.pre_request_hook(self._interface)
 
         try:
             self._interface.enforce_tool_pairing()
-            input_items = to_responses_input(self._interface)
-            # If the caller passed pre-built wire dicts (not str / not
-            # ToolResultBlock list), append them after the replay so the
-            # behavior is additive rather than dropped.
+            prebuilt_items: list[dict[str, Any]] = []
             if isinstance(message, dict):
-                input_items.append(message)
+                prebuilt_items.append(message)
             elif isinstance(message, list) and not (
                 message and all(isinstance(b, ToolResultBlock) for b in message)
             ):
-                for item in self._convert_input(message):
-                    input_items.append(item)
+                prebuilt_items.extend(self._convert_input(message))
+
+            full_replay_input_items = to_responses_input(self._interface)
+            full_replay_input_items.extend(prebuilt_items)
+
+            delta_entries = self._interface.entries[interface_start:]
+            delta_input_items = self._interface_entries_to_responses_input(delta_entries)
+            delta_input_items.extend(prebuilt_items)
+
+            stateful_store_enabled = False
+            previous_response_id = (
+                self._response_id if stateful_store_enabled and self._response_id and delta_input_items else None
+            )
+            input_items = delta_input_items if previous_response_id else full_replay_input_items
+            request_mode = "stateful_incremental" if previous_response_id else "stateless_full_store_forced_false"
 
             kwargs: dict[str, Any] = {
                 "model": self._model,
                 "input": input_items,
                 "stream": True,
-                "store": False,
                 **self._extra_kwargs,
             }
+            # The ChatGPT Codex endpoint explicitly rejects store=True with
+            # `{'detail': 'Store must be set to false'}`. Keep store=false for
+            # normal turns; future turn-state experiments must use Codex-specific
+            # state headers/body, not Responses API storage.
+            kwargs["store"] = bool(previous_response_id)
             # Ensure reasoning.encrypted_content is requested so the raw
             # reasoning item can be preserved for prompt-cache-stable replay.
             existing_include = kwargs.get("include") or []
@@ -1941,7 +2362,8 @@ class CodexResponsesSession(OpenAIResponsesSession):
                 kwargs["tools"] = self._tools
                 if self._tool_choice:
                     kwargs["tool_choice"] = self._tool_choice
-            # Deliberately omit previous_response_id — backend is stateless.
+            if previous_response_id:
+                kwargs["previous_response_id"] = previous_response_id
             if self._compact_threshold:
                 kwargs["context_management"] = [
                     {"type": "compaction", "compact_threshold": self._compact_threshold}
@@ -1995,8 +2417,59 @@ class CodexResponsesSession(OpenAIResponsesSession):
             # Raw reasoning item dicts for replay, in provider output order.
             raw_reasoning_items: list[dict[str, Any]] = []
             trace_path = _codex_responses_trace_path()
+            fallback_error_type: str | None = None
+            fallback_error_message: str | None = None
 
-            stream = self._client.responses.create(**kwargs)
+            request_store = bool(kwargs.get("store"))
+
+            # EXPERIMENTAL websocket path (#471). When enabled, try to send a
+            # Responses ``response.create`` frame over the websocket with an
+            # incremental delta + ``previous_response_id`` (or full input on the
+            # first request / on any mismatch). On ANY websocket problem
+            # (handshake 426, connect/auth error, missing runtime, delta
+            # mismatch) we raise ``_CodexWsFallback`` internally and drop to the
+            # existing HTTP full-replay path below. ``store`` stays ``false``.
+            ws_stream = None
+            if self._ws_enabled:
+                try:
+                    ws_stream, ws_mode, ws_prev_id = self._codex_ws_open(
+                        kwargs,
+                        full_replay_input_items=full_replay_input_items,
+                    )
+                except _CodexWsFallback as exc:
+                    logger.info(
+                        "Codex websocket path unavailable; using HTTP full replay: %s",
+                        str(exc)[:240],
+                    )
+                    ws_stream = None
+                else:
+                    request_mode = ws_mode
+                    previous_response_id = ws_prev_id
+                    request_store = False
+
+            if ws_stream is not None:
+                stream = ws_stream
+            else:
+                try:
+                    stream = self._client.responses.create(**kwargs)
+                except Exception as exc:
+                    if not (previous_response_id or request_store):
+                        raise
+                    fallback_error_type = type(exc).__name__
+                    fallback_error_message = str(exc)
+                    logger.info(
+                        "Codex stateful Responses request failed; falling back to full replay store=false: %s: %s",
+                        fallback_error_type,
+                        fallback_error_message[:240],
+                    )
+                    fallback_kwargs = dict(kwargs)
+                    fallback_kwargs["input"] = full_replay_input_items
+                    fallback_kwargs["store"] = False
+                    fallback_kwargs.pop("previous_response_id", None)
+                    request_mode = "stateless_full_fallback"
+                    previous_response_id = None
+                    request_store = False
+                    stream = self._client.responses.create(**fallback_kwargs)
             for event in stream:
                 thoughts_before = acc.thoughts
                 pending_thought_chars_before = len("".join(acc._thought_parts))
@@ -2084,7 +2557,13 @@ class CodexResponsesSession(OpenAIResponsesSession):
                             or 0,
                             cached_tokens=cached_tokens,
                             extra=self._usage_extra(
-                                affinity_headers, effective_cache_key
+                                affinity_headers,
+                                effective_cache_key,
+                                request_mode=request_mode,
+                                previous_response_id=previous_response_id,
+                                store=request_store,
+                                fallback_error_type=fallback_error_type,
+                                fallback_error_message=fallback_error_message,
                             ),
                         )
         except Exception:
@@ -2217,6 +2696,16 @@ class CodexOpenAIAdapter(OpenAIAdapter):
         (e.g. a bare adapter built directly in a test). In the normal host path
         the agent path is always supplied, so both ids are the same stable
         per-agent hash — the thread id tracks the session id exactly.
+
+        Restored to the stable-identity form (was an experimental
+        ``(None, None)`` prompt-cache-only probe) because the official Codex CLI
+        source path depends on a stable ``session_id`` / ``thread_id`` /
+        ``prompt_cache_key`` identity: the websocket incremental
+        ``previous_response_id`` path and per-turn ``x-codex-turn-state`` sticky
+        routing all ride on top of a stable session/thread (see
+        ``codex-rs/core/src/client.rs:863-864, 873`` — ``build_session_headers``
+        with both ids on every request). Dropping the headers would defeat the
+        official path this experiment is mirroring.
         """
         return self._codex_id, self._codex_id
 
@@ -2295,4 +2784,6 @@ class CodexOpenAIAdapter(OpenAIAdapter):
             # token refresh that changes it is reflected on newly built sessions).
             account_id=self.codex_account_id,
             installation_id=self._codex_installation_id,
+            base_url=self.base_url,
+            api_key=self._client_kwargs.get("api_key"),
         )

--- a/src/lingtai/llm/openai/codex_ws.py
+++ b/src/lingtai/llm/openai/codex_ws.py
@@ -1,0 +1,195 @@
+"""Live synchronous Codex Responses-over-WebSocket transport (EXPERIMENTAL).
+
+This is the real wire driver for the experimental websocket path mirrored from
+the official Codex CLI (repo openai/codex, tag ``rust-v0.130.0``). It is GATED
+behind ``LINGTAI_CODEX_WS`` and only reached on a live run — the unit tests in
+``tests/test_codex_ws_session.py`` inject a fake transport and never import this
+module. It is deliberately kept out of the hot ``adapter`` import path and only
+loaded lazily by ``_default_codex_ws_transport_factory``.
+
+Design notes / source citations (all in the official source clone):
+
+  * URL: ``wss://chatgpt.com/backend-api/codex/responses`` — the HTTP base with
+    ``https`` swapped to ``wss`` (``provider.rs:92-103``).
+  * Handshake header ``OpenAI-Beta: responses_websockets=2026-02-06``
+    (``client.rs:142``) and the captured per-turn ``x-codex-turn-state``
+    (``client.rs:134`` / ``responses_websocket.rs:438-445``).
+  * Frames: JSON text frames; ``{"type":"response.create", ...}`` and
+    ``{"type":"response.processed","response_id":...}`` (``common.rs:269-277``).
+  * Stop on ``response.completed`` (``responses_websocket.rs:574-684``).
+  * A handshake ``426 UPGRADE_REQUIRED`` (or any connect failure) maps to a
+    fallback to HTTP (``client.rs:1361-1364``) — surfaced here as
+    ``_CodexWsFallback``.
+
+The events yielded by :meth:`stream` are lightweight objects shaped like the
+OpenAI SDK Responses stream events (``.type``, ``.delta``, ``.item``,
+``.response``) so the adapter's existing event loop consumes them unchanged.
+
+NOTE: This live driver has NOT been exercised against the real Codex backend in
+this pass (no authenticated calls were made). The parent should validate it live
+after an auth refresh — see the patch report's live-validation plan.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, Iterator
+
+from lingtai_kernel.logging import get_logger
+
+logger = get_logger()
+
+
+def _to_event(payload: dict[str, Any]) -> Any:
+    """Map a parsed websocket JSON frame into an SDK-shaped stream event.
+
+    Recursively wraps nested dicts as SimpleNamespace so attribute access
+    (``event.response.id``, ``event.item.type`` …) works like the SDK objects.
+    """
+
+    def wrap(value: Any) -> Any:
+        if isinstance(value, dict):
+            return SimpleNamespace(**{k: wrap(v) for k, v in value.items()})
+        if isinstance(value, list):
+            return [wrap(v) for v in value]
+        return value
+
+    return wrap(payload)
+
+
+class SyncCodexWebsocketTransport:
+    """One Codex websocket connection, driven synchronously.
+
+    Lifecycle matches the adapter's expectations:
+      * :meth:`connect` performs the handshake and returns the captured
+        ``x-codex-turn-state`` (or ``None``); raises ``_CodexWsFallback`` on a
+        426 / connection / auth failure.
+      * :meth:`stream` sends one ``response.create`` frame and yields events
+        until ``response.completed``.
+      * :meth:`send_response_processed` sends the post-completion ack frame.
+    """
+
+    def __init__(self, *, url: str, headers: dict[str, str], open_timeout: float = 30.0):
+        self._url = url
+        self._headers = dict(headers)
+        self._open_timeout = open_timeout
+        self._conn = None
+
+    def connect(self, *, headers: dict[str, str] | None = None) -> str | None:
+        # Import here so the dependency is only required on the live path; the
+        # adapter factory already guards import availability, but re-raise as a
+        # fallback signal to be safe.
+        from lingtai.llm.openai.adapter import _CODEX_TURN_STATE_HEADER, _CodexWsFallback
+
+        try:
+            from websockets.sync.client import connect as ws_connect
+            from websockets.exceptions import InvalidStatus
+        except Exception as exc:  # pragma: no cover - guarded upstream too
+            raise _CodexWsFallback(f"websockets unavailable: {exc}") from exc
+
+        hdrs = dict(self._headers)
+        if headers:
+            hdrs.update(headers)
+        try:
+            self._conn = ws_connect(
+                self._url,
+                additional_headers=hdrs,
+                open_timeout=self._open_timeout,
+            )
+        except Exception as exc:  # pragma: no cover - live only
+            # A 426 UPGRADE_REQUIRED (or 401, or any handshake failure) means
+            # "do not use websockets" — fall back to HTTP. ``InvalidStatus``
+            # carries the response; surface its status for diagnostics.
+            status = None
+            try:
+                status = getattr(getattr(exc, "response", None), "status_code", None)
+            except Exception:
+                status = None
+            # Do not interpolate ``exc`` into the fallback message: some
+            # websocket implementations attach the request/headers to handshake
+            # exceptions, and those headers may include the bearer token.
+            raise _CodexWsFallback(
+                f"websocket handshake failed (status={status}): {type(exc).__name__}"
+            ) from exc
+
+        # Best-effort capture of x-codex-turn-state from the handshake response
+        # headers. The attribute path varies across websockets versions, so try
+        # the known locations and degrade gracefully (no turn-state replay) if
+        # none are present.
+        return self._capture_turn_state(_CODEX_TURN_STATE_HEADER)
+
+    def _capture_turn_state(self, header_name: str) -> str | None:  # pragma: no cover - live only
+        conn = self._conn
+        candidates = []
+        resp = getattr(conn, "response", None)
+        if resp is not None:
+            candidates.append(resp)
+        proto = getattr(conn, "protocol", None)
+        if proto is not None:
+            candidates.append(getattr(proto, "handshake_response", None))
+            candidates.append(getattr(proto, "response", None))
+        for resp in candidates:
+            headers = getattr(resp, "headers", None)
+            if headers is None:
+                continue
+            try:
+                value = headers.get(header_name)
+            except Exception:
+                value = None
+            if value:
+                return value
+        return None
+
+    def stream(self, frame: dict[str, Any]) -> Iterator[Any]:  # pragma: no cover - live only
+        from lingtai.llm.openai.adapter import _CodexWsFallback
+
+        conn = self._conn
+        if conn is None:
+            raise _CodexWsFallback("websocket connection is closed")
+        conn.send(json.dumps(frame))
+        for message in conn:
+            if isinstance(message, (bytes, bytearray)):
+                message = message.decode("utf-8", errors="replace")
+            try:
+                payload = json.loads(message)
+            except Exception as exc:
+                raise _CodexWsFallback(f"bad websocket frame: {exc}") from exc
+            if isinstance(payload, dict):
+                event_type = str(payload.get("type") or "")
+                if event_type == "error" or event_type.endswith(".error"):
+                    error = payload.get("error")
+                    error_type = error.get("type") if isinstance(error, dict) else None
+                    status = payload.get("status")
+                    parts = [event_type or "unknown"]
+                    if error_type:
+                        parts.append(str(error_type))
+                    if status is not None:
+                        parts.append(f"status={status}")
+                    # Do not include the whole payload: live error frames may echo
+                    # request details, and requests may contain prompts or headers.
+                    raise _CodexWsFallback(
+                        f"websocket error frame: {'; '.join(parts)}"
+                    )
+            event = _to_event(payload)
+            yield event
+            if isinstance(payload, dict) and payload.get("type") == "response.completed":
+                break
+
+    def send_response_processed(self, response_id: str) -> None:  # pragma: no cover - live only
+        conn = self._conn
+        if conn is None:
+            return
+        try:
+            conn.send(json.dumps({"type": "response.processed", "response_id": response_id}))
+        except Exception as exc:
+            logger.debug("codex ws response.processed send failed: %s", exc)
+
+    def close(self) -> None:  # pragma: no cover - live only
+        conn = self._conn
+        self._conn = None
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass

--- a/src/lingtai_kernel/llm/base.py
+++ b/src/lingtai_kernel/llm/base.py
@@ -168,6 +168,15 @@ class ChatSession(ABC):
         - A list of ToolResultBlock (canonical tool results)
         """
 
+    def reset_provider_turn_state(self) -> None:
+        """Reset transient provider turn state before a new user text turn.
+
+        Most providers have no extra turn-scoped transport state. Adapters that
+        do (for example Codex Responses-over-WebSocket turn-state headers) may
+        override this hook. The kernel calls it only before string user-text
+        messages, not before tool-result continuations.
+        """
+
     def get_history(self) -> list[dict]:
         """Return serializable conversation history (canonical format)."""
         return self.interface.to_dict()

--- a/src/lingtai_kernel/session.py
+++ b/src/lingtai_kernel/session.py
@@ -224,6 +224,13 @@ class SessionManager:
         """
         self.ensure_session()
 
+        if isinstance(message, str):
+            reset_provider_turn_state = getattr(
+                type(self._chat), "reset_provider_turn_state", None
+            )
+            if callable(reset_provider_turn_state):
+                reset_provider_turn_state(self._chat)
+
         # Rebuild system prompt and tools every turn — they may have changed
         # (e.g. memory loaded, identity updated, capabilities added after refresh).
         # If the content is identical, this is a no-op at the LLM level.

--- a/tests/test_codex_prompt_cache_key.py
+++ b/tests/test_codex_prompt_cache_key.py
@@ -923,12 +923,22 @@ def test_codex_usage_extra_carries_cache_affinity_ids_for_token_ledger():
     headers = sent["extra_headers"]
     # The actual ids used this request ride in usage.extra so token_ledger.jsonl
     # can record them — all three the same normalized effective id, so a
-    # cache-affinity rotation (Jason's follow-up) is visible too.
-    assert result.usage.extra == {
+    # cache-affinity rotation (Jason's follow-up) is visible too. The WS
+    # experiment additionally records the request mode + store flag (additive
+    # observability), so assert the affinity ids as a subset rather than exact
+    # dict equality.
+    affinity = {
+        k: v for k, v in result.usage.extra.items() if k.startswith("codex_") and k.endswith(("_id", "_key"))
+    }
+    assert affinity == {
         "codex_session_id": "custom-key:v2",
         "codex_thread_id": "custom-key:v2",
         "codex_prompt_cache_key": "custom-key:v2",
     }
+    # The new request-mode / store telemetry is present and reflects the
+    # stateless full-replay store=false contract for a normal HTTP turn.
+    assert result.usage.extra["codex_store"] == "false"
+    assert "full" in result.usage.extra["codex_request_mode"]
     assert headers["session_id"] == headers["thread_id"] == sent["prompt_cache_key"]
     # The affinity ids are short, non-secret derived values; the request body,
     # messages, and OAuth secret never ride in the usage extra payload.
@@ -952,10 +962,14 @@ def test_codex_usage_extra_empty_when_no_cache_affinity_headers():
     result = session.send("hi")
 
     # Identity headers are always sent (#436), but no cache-affinity headers and
-    # therefore no token-ledger id fields on the bare path.
+    # therefore no token-ledger id fields on the bare path. The WS experiment's
+    # request-mode / store telemetry is still recorded (additive); only the
+    # cache-affinity id fields are absent without a per-agent identity.
     headers = session._client.responses.kwargs[0].get("extra_headers", {})
     assert "session_id" not in headers and "thread_id" not in headers
-    assert result.usage.extra == {}
+    assert "codex_session_id" not in result.usage.extra
+    assert "codex_thread_id" not in result.usage.extra
+    assert "codex_prompt_cache_key" not in result.usage.extra
 
 
 def test_token_ledger_entry_merges_usage_extra(tmp_path):

--- a/tests/test_codex_ws_delta.py
+++ b/tests/test_codex_ws_delta.py
@@ -1,0 +1,81 @@
+"""Tests for the Codex Responses-over-WebSocket incremental delta algorithm.
+
+These mirror the official Codex CLI source (``codex-rs/core/src/client.rs``
+``get_incremental_items`` at 949-985 and ``prepare_websocket_request`` at
+998-1024, tag ``rust-v0.130.0``). They are pure/mock tests — no network.
+
+The algorithm decides whether the current full request is a strict extension of
+(previous request input + the previous response's server-added output items). If
+so, only the suffix ("delta") is sent over the websocket with
+``previous_response_id``; otherwise the full input is sent with no previous id.
+"""
+
+from __future__ import annotations
+
+from lingtai.llm.openai.adapter import (
+    _CodexLastResponse,
+    _codex_incremental_items,
+)
+
+
+def _req(input_items, **fields):
+    """Build a minimal Codex request dict: ``input`` plus non-input fields."""
+    base = {"model": "gpt-5.5", "store": False, "stream": True}
+    base.update(fields)
+    base["input"] = list(input_items)
+    return base
+
+
+def test_incremental_returns_suffix_when_strict_extension():
+    prev = _req([{"role": "user", "content": "a"}])
+    last = _CodexLastResponse(
+        response_id="resp_1",
+        items_added=[{"type": "message", "role": "assistant", "content": "b"}],
+    )
+    cur = _req(
+        [
+            {"role": "user", "content": "a"},
+            {"type": "message", "role": "assistant", "content": "b"},
+            {"role": "user", "content": "c"},
+        ]
+    )
+
+    delta = _codex_incremental_items(prev, last.items_added, cur, allow_empty_delta=False)
+
+    # Baseline = prev.input + items_added; only the trailing new user turn is sent.
+    assert delta == [{"role": "user", "content": "c"}]
+
+
+def test_incremental_none_when_non_input_field_differs():
+    """All non-input request fields must match, else no delta (full replay)."""
+    prev = _req([{"role": "user", "content": "a"}], tools=[{"name": "x"}])
+    last = _CodexLastResponse(response_id="resp_1", items_added=[])
+    cur = _req(
+        [{"role": "user", "content": "a"}, {"role": "user", "content": "c"}],
+        tools=[{"name": "DIFFERENT"}],
+    )
+
+    delta = _codex_incremental_items(prev, last.items_added, cur, allow_empty_delta=False)
+
+    assert delta is None
+
+
+def test_incremental_none_when_input_not_a_prefix_extension():
+    """If the current input diverges from the baseline prefix, no delta."""
+    prev = _req([{"role": "user", "content": "a"}])
+    last = _CodexLastResponse(response_id="resp_1", items_added=[])
+    cur = _req([{"role": "user", "content": "EDITED"}, {"role": "user", "content": "c"}])
+
+    delta = _codex_incremental_items(prev, last.items_added, cur, allow_empty_delta=False)
+
+    assert delta is None
+
+
+def test_incremental_empty_delta_rejected_unless_allowed():
+    """A request equal to the baseline yields an empty delta only when allowed."""
+    prev = _req([{"role": "user", "content": "a"}])
+    last = _CodexLastResponse(response_id="resp_1", items_added=[])
+    cur = _req([{"role": "user", "content": "a"}])  # identical, nothing new
+
+    assert _codex_incremental_items(prev, [], cur, allow_empty_delta=False) is None
+    assert _codex_incremental_items(prev, [], cur, allow_empty_delta=True) == []

--- a/tests/test_codex_ws_delta.py
+++ b/tests/test_codex_ws_delta.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from lingtai.llm.openai.adapter import (
     _CodexLastResponse,
+    _codex_incremental_diagnose,
     _codex_incremental_items,
 )
 
@@ -79,3 +80,85 @@ def test_incremental_empty_delta_rejected_unless_allowed():
 
     assert _codex_incremental_items(prev, [], cur, allow_empty_delta=False) is None
     assert _codex_incremental_items(prev, [], cur, allow_empty_delta=True) == []
+
+
+# ---------------------------------------------------------------------------
+# Safe diagnostics: the diagnose() sibling explains WHY a delta was/ wasn't
+# possible using only classes/counts/key-names — never prompt/secret content.
+# ---------------------------------------------------------------------------
+
+
+def test_diagnose_ok_returns_delta_and_safe_metadata():
+    prev = _req([{"role": "user", "content": "a"}])
+    last = _CodexLastResponse(
+        response_id="resp_1",
+        items_added=[{"role": "assistant", "content": "b"}],
+    )
+    cur = _req(
+        [
+            {"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+            {"role": "user", "content": "c"},
+        ]
+    )
+
+    delta, diag = _codex_incremental_diagnose(
+        prev, last.items_added, cur, allow_empty_delta=False
+    )
+
+    assert delta == [{"role": "user", "content": "c"}]
+    assert diag["reason"] == "ok"
+    assert diag["baseline_len"] == 2
+    assert diag["cur_input_len"] == 3
+    assert diag["delta_len"] == 1
+    assert diag["mismatch_index"] == -1
+
+
+def test_diagnose_non_input_change_names_only_keys_not_values():
+    prev = _req([{"role": "user", "content": "a"}], tools=[{"name": "secret_tool"}])
+    cur = _req(
+        [{"role": "user", "content": "a"}, {"role": "user", "content": "c"}],
+        tools=[{"name": "OTHER"}],
+    )
+
+    delta, diag = _codex_incremental_diagnose(prev, [], cur, allow_empty_delta=False)
+
+    assert delta is None
+    assert diag["reason"] == "non_input_fields_changed"
+    assert diag["changed_fields"] == ["tools"]
+    # The values (which could be sensitive) never appear in the diagnostic.
+    import json as _json
+
+    blob = _json.dumps(diag)
+    assert "secret_tool" not in blob and "OTHER" not in blob
+
+
+def test_diagnose_prefix_mismatch_reports_first_divergent_index():
+    prev = _req([{"role": "user", "content": "a"}, {"role": "user", "content": "b"}])
+    cur = _req(
+        [
+            {"role": "user", "content": "a"},
+            {"role": "user", "content": "EDITED"},
+            {"role": "user", "content": "c"},
+        ]
+    )
+
+    delta, diag = _codex_incremental_diagnose(prev, [], cur, allow_empty_delta=False)
+
+    assert delta is None
+    assert diag["reason"] == "prefix_mismatch"
+    assert diag["mismatch_index"] == 1
+    # Content never leaks into the diagnostic.
+    import json as _json
+
+    assert "EDITED" not in _json.dumps(diag)
+
+
+def test_diagnose_empty_delta_reason_when_not_allowed():
+    prev = _req([{"role": "user", "content": "a"}])
+    cur = _req([{"role": "user", "content": "a"}])
+
+    delta, diag = _codex_incremental_diagnose(prev, [], cur, allow_empty_delta=False)
+
+    assert delta is None
+    assert diag["reason"] == "empty_delta_rejected"

--- a/tests/test_codex_ws_session.py
+++ b/tests/test_codex_ws_session.py
@@ -1,0 +1,406 @@
+"""Mock tests for the experimental Codex Responses-over-WebSocket session path.
+
+No network: a fake websocket transport is injected so the tests assert only the
+*request shapes* the session produces. They mirror the official Codex CLI source
+(repo openai/codex, tag ``rust-v0.130.0``):
+
+  * first WS request: full input, no ``previous_response_id`` (``client.rs:1003``)
+  * second same-turn request: delta input + ``previous_response_id``
+    (``client.rs:998-1024``)
+  * ``store`` is always ``false`` — the ChatGPT Codex backend rejects
+    ``store=true`` (``client.rs:722`` builds ``store=false`` for ChatGPT)
+  * fallback to HTTP full replay on handshake 426 / connect error / delta
+    mismatch (``client.rs:1361-1364`` FallbackToHttp)
+  * ``x-codex-turn-state`` captured from the handshake and replayed within the
+    turn (``client.rs:227-240``)
+  * ``response.processed`` sent after a completed response
+    (``responses_websocket.rs:208-240``)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from lingtai.llm.openai.codex_ws import SyncCodexWebsocketTransport
+
+from lingtai.llm.openai.adapter import (
+    CodexResponsesSession,
+    _CodexWsFallback,
+)
+
+
+@dataclass
+class Event:
+    type: str
+    delta: str | None = None
+    item: object | None = None
+    response: object | None = None
+    item_id: str | None = None
+    text: str | None = None
+
+
+def _usage() -> SimpleNamespace:
+    return SimpleNamespace(
+        input_tokens=10,
+        output_tokens=20,
+        input_tokens_details=SimpleNamespace(cached_tokens=0),
+        output_tokens_details=SimpleNamespace(reasoning_tokens=0),
+    )
+
+
+def _completed(resp_id: str = "resp_ws_1") -> Event:
+    return Event(
+        "response.completed",
+        response=SimpleNamespace(id=resp_id, usage=_usage()),
+    )
+
+
+class FakeWsTransport:
+    """Records frames + handshake; yields a single completed response per stream.
+
+    One transport instance models one connection that may carry multiple
+    ``response.create`` frames within a turn (the official model reuses the
+    connection). ``turn_state`` is the value returned from the handshake.
+    """
+
+    def __init__(self, *, turn_state="ts-server-1", fallback_on_connect=False):
+        self._turn_state = turn_state
+        self._fallback_on_connect = fallback_on_connect
+        self.connect_calls = 0
+        self.sent_frames: list[dict] = []
+        self.processed: list[str] = []
+        self.handshake_headers: list[dict] = []
+        self._resp_counter = 0
+
+    def connect(self, *, headers):
+        self.connect_calls += 1
+        self.handshake_headers.append(dict(headers))
+        if self._fallback_on_connect:
+            raise _CodexWsFallback("handshake 426 UPGRADE_REQUIRED")
+        return self._turn_state
+
+    def stream(self, frame):
+        self.sent_frames.append(frame)
+        self._resp_counter += 1
+        yield _completed(f"resp_ws_{self._resp_counter}")
+
+    def send_response_processed(self, response_id):
+        self.processed.append(response_id)
+
+    def close(self):
+        pass
+
+
+def _make_session(transport: FakeWsTransport, **kwargs):
+    """A Codex session wired to use the injected transport, gate forced on."""
+    return CodexResponsesSession(
+        client=_HttpFallbackClient(),
+        model="gpt-5.5",
+        instructions="system prompt",
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+        session_id="sess-stable",
+        thread_id="sess-stable",
+        ws_enabled=True,
+        ws_transport_factory=lambda url, headers: transport,
+        **kwargs,
+    )
+
+
+class _HttpResponses:
+    def __init__(self):
+        self.kwargs: list[dict] = []
+
+    def create(self, **kwargs):
+        self.kwargs.append(kwargs)
+        yield _completed("resp_http_fallback")
+
+
+class _HttpFallbackClient:
+    """Stands in for the OpenAI SDK client; records the HTTP fallback path."""
+
+    def __init__(self):
+        self.responses = _HttpResponses()
+
+
+def test_first_ws_request_sends_full_input_and_no_previous_id():
+    t = FakeWsTransport()
+    session = _make_session(t)
+
+    session.send("hello")
+
+    assert len(t.sent_frames) == 1
+    frame = t.sent_frames[0]
+    assert frame["type"] == "response.create"
+    assert frame["store"] is False
+    assert "previous_response_id" not in frame
+    # Full input: the single user turn.
+    assert frame["input"] and frame["input"][-1]["role"] == "user"
+    # No HTTP fallback happened.
+    assert session._client.responses.kwargs == []
+
+
+
+
+def test_ws_handshake_includes_bearer_without_body_or_usage_leak():
+    t = FakeWsTransport()
+    session = _make_session(t, api_key="test-secret-token")
+
+    response = session.send("hello")
+
+    assert t.handshake_headers[0]["Authorization"] == "Bearer test-secret-token"
+    assert "Authorization" not in t.sent_frames[0]
+    assert "test-secret-token" not in str(response.usage.extra)
+
+
+def test_second_ws_request_sends_delta_and_previous_response_id():
+    t = FakeWsTransport()
+    session = _make_session(t)
+
+    session.send("hello")  # establishes last_request + last_response(resp_ws_1)
+    session.send("again")  # should be a strict extension -> delta
+
+    assert len(t.sent_frames) == 2
+    assert t.connect_calls == 1
+    second = t.sent_frames[1]
+    assert second["type"] == "response.create"
+    assert second["store"] is False
+    assert second["previous_response_id"] == "resp_ws_1"
+    # Delta input must NOT replay the first user turn; it carries only the new
+    # items appended since the previous request + its response output.
+    flat = [str(i) for i in second["input"]]
+    assert not any("hello" in s for s in flat), f"delta leaked prior turn: {second['input']}"
+
+
+def test_store_is_never_true_on_ws_frames():
+    t = FakeWsTransport()
+    session = _make_session(t)
+
+    session.send("a")
+    session.send("b")
+
+    assert all(f.get("store") is False for f in t.sent_frames)
+
+
+
+
+def test_reset_provider_turn_state_clears_replayed_turn_state_on_reconnect():
+    t = FakeWsTransport(turn_state="ts-77")
+    session = _make_session(t)
+
+    session.send("first")
+    session.reset_provider_turn_state()
+    session._close_ws_transport()
+    t.handshake_headers.clear()
+
+    session.send("second")
+
+    assert t.connect_calls == 2
+    assert _CodexTurnStateHeader not in t.handshake_headers[0]
+
+
+def test_turn_state_uses_persistent_connection_and_replays_on_reconnect():
+    t = FakeWsTransport(turn_state="ts-77")
+    session = _make_session(t)
+
+    session.send("a")
+    session.send("b")
+
+    assert t.connect_calls == 1
+    assert len(t.handshake_headers) == 1
+    assert _CodexTurnStateHeader not in t.handshake_headers[0]
+
+    session._close_ws_transport()
+    session.send("c")
+
+    assert t.connect_calls == 2
+    assert t.handshake_headers[1][_CodexTurnStateHeader] == "ts-77"
+
+
+def test_response_processed_sent_after_completed():
+    t = FakeWsTransport()
+    session = _make_session(t)
+
+    session.send("a")
+
+    assert t.processed == ["resp_ws_1"]
+
+
+def test_fallback_to_http_full_replay_on_handshake_426():
+    t = FakeWsTransport(fallback_on_connect=True)
+    session = _make_session(t)
+
+    session.send("hello")
+
+    # No frames sent over WS; the HTTP fallback path was used with full input
+    # and store=false.
+    assert t.sent_frames == []
+    assert len(session._client.responses.kwargs) == 1
+    http = session._client.responses.kwargs[0]
+    assert http["store"] is False
+    assert "previous_response_id" not in http
+    assert http["input"][-1]["role"] == "user"
+
+
+class _FailingSecondStreamTransport(FakeWsTransport):
+    def stream(self, frame):
+        if self.sent_frames:
+            self.sent_frames.append(frame)
+            raise _CodexWsFallback("stream failed")
+        yield from super().stream(frame)
+
+
+def test_ws_stream_failure_restores_delta_baseline_and_closes_transport():
+    t = _FailingSecondStreamTransport()
+    session = _make_session(t)
+
+    session.send("first")
+    previous_request = session._ws_session.last_request
+    previous_response = session._ws_session.last_response
+
+    with pytest.raises(_CodexWsFallback):
+        session.send("second")
+
+    assert session._ws_session.last_request == previous_request
+    assert session._ws_session.last_response == previous_response
+    assert session._ws_transport is None
+
+
+def test_fallback_to_http_when_delta_mismatch():
+    """If the new request is not a strict extension (non-input field changed),
+    the session must NOT send a bad delta — it falls back to a full WS request
+    (no previous id), exactly like the official prepare_websocket_request which
+    returns ResponseCreate(payload) with full input on mismatch."""
+    t = FakeWsTransport()
+    session = _make_session(t)
+
+    session.send("hello")
+    # Mutate a non-input field to force a mismatch on the second request.
+    session._tools = [{"type": "function", "name": "newtool", "parameters": {}}]
+    session.send("again")
+
+    second = t.sent_frames[1]
+    assert "previous_response_id" not in second
+    # Full input replayed (both user turns present somewhere).
+    flat = "".join(str(i) for i in second["input"])
+    assert "hello" in flat and "again" in flat
+
+
+def test_ws_disabled_by_default_uses_http():
+    """Without the gate, the session uses the existing HTTP path (no transport)."""
+    session = CodexResponsesSession(
+        client=_HttpFallbackClient(),
+        model="gpt-5.5",
+        instructions="system prompt",
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+        session_id="sess-stable",
+        thread_id="sess-stable",
+        # ws_enabled defaults to False
+    )
+
+    session.send("hello")
+
+    assert len(session._client.responses.kwargs) == 1
+    assert session._client.responses.kwargs[0]["store"] is False
+
+
+class _ErrorWsConnection:
+    def __init__(self, payload):
+        self.payload = payload
+        self.sent = []
+
+    def send(self, message):
+        self.sent.append(message)
+
+    def __iter__(self):
+        yield json.dumps(self.payload)
+
+
+def test_sync_ws_transport_top_level_error_falls_back_without_payload_leak():
+    transport = SyncCodexWebsocketTransport(url="wss://example.invalid", headers={})
+    transport._conn = _ErrorWsConnection(
+        {
+            "type": "error",
+            "status": 400,
+            "error": {
+                "type": "invalid_request_error",
+                "message": "boom with prompt/header-like details",
+            },
+        }
+    )
+
+    with pytest.raises(_CodexWsFallback) as excinfo:
+        list(transport.stream({"type": "response.create"}))
+
+    text = str(excinfo.value)
+    assert "error" in text
+    assert "invalid_request_error" in text
+    assert "status=400" in text
+    assert "prompt/header-like" not in text
+
+
+def test_default_factory_falls_back_when_websockets_missing(monkeypatch):
+    """The real transport factory raises _CodexWsFallback (caught -> HTTP) when
+    the optional ``websockets`` dependency is unavailable — modeling an
+    unsupported runtime (official disables WS for the session on such failures)."""
+    import builtins
+
+    from lingtai.llm.openai.adapter import _default_codex_ws_transport_factory
+
+    real_import = builtins.__import__
+
+    def _no_websockets(name, *args, **kwargs):
+        if name == "websockets" or name.startswith("websockets."):
+            raise ImportError("simulated missing websockets")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_websockets)
+    with pytest.raises(_CodexWsFallback):
+        _default_codex_ws_transport_factory("wss://x/responses", {})
+
+
+def test_unsupported_runtime_falls_back_to_http_end_to_end(monkeypatch):
+    """With the gate on but no usable transport, the session still completes via
+    the HTTP full-replay path (store=false), never raising to the caller."""
+    session = CodexResponsesSession(
+        client=_HttpFallbackClient(),
+        model="gpt-5.5",
+        instructions="system prompt",
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+        session_id="sess-stable",
+        thread_id="sess-stable",
+        ws_enabled=True,
+        ws_transport_factory=lambda url, headers: (_ for _ in ()).throw(
+            _CodexWsFallback("no runtime")
+        ),
+    )
+
+    session.send("hello")
+
+    assert len(session._client.responses.kwargs) == 1
+    assert session._client.responses.kwargs[0]["store"] is False
+
+
+def test_ws_url_builder_maps_https_to_wss():
+    from lingtai.llm.openai.adapter import _codex_ws_url
+
+    assert (
+        _codex_ws_url("https://chatgpt.com/backend-api/codex")
+        == "wss://chatgpt.com/backend-api/codex/responses"
+    )
+    # Trailing slash tolerated; default base used when None.
+    assert _codex_ws_url("https://host/base/").endswith("/base/responses")
+    assert _codex_ws_url(None).startswith("wss://")
+
+
+# Imported here (not at top) so a missing symbol fails the import test loudly.
+from lingtai.llm.openai.adapter import _CODEX_TURN_STATE_HEADER as _CodexTurnStateHeader  # noqa: E402

--- a/tests/test_codex_ws_session.py
+++ b/tests/test_codex_ws_session.py
@@ -402,5 +402,220 @@ def test_ws_url_builder_maps_https_to_wss():
     assert _codex_ws_url(None).startswith("wss://")
 
 
+# ---------------------------------------------------------------------------
+# Converter-stable delta baseline (#471 ws_full root-cause fix).
+#
+# The server streams output items in the Responses *output* schema, but this
+# session re-derives its input next turn via ``to_responses_input`` in the
+# *input* schema. Using the raw output items as the delta baseline can never
+# strict-prefix-match the next full input, so every real agent turn collapsed to
+# ``ws_full``. The fix records the baseline from the converter after the
+# assistant turn lands in the interface. These tests pin that behavior end to
+# end with a transport that streams realistic output items.
+# ---------------------------------------------------------------------------
+
+
+class _MessageItem:
+    """A streamed ``response.output_item.done`` message in the OUTPUT schema."""
+
+    def __init__(self, text: str):
+        self.type = "message"
+        self.id = "msg_out_1"
+        self.role = "assistant"
+        self.status = "completed"
+        self._text = text
+
+    def model_dump(self, exclude_none=True):
+        return {
+            "type": "message",
+            "id": self.id,
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": self._text}],
+        }
+
+
+class _ToolCallItem:
+    def __init__(self, call_id="call_a", name="do_x"):
+        self.type = "function_call"
+        self.call_id = call_id
+        self.name = name
+
+
+class RealisticWsTransport(FakeWsTransport):
+    """Streams an assistant *message* output item then completes.
+
+    Mirrors the live wire: a text delta, an ``output_item.done`` carrying the
+    message in the OUTPUT schema, then ``response.completed``. The point is that
+    the raw output item must NOT be what the next-turn baseline compares against.
+    """
+
+    def __init__(self, *, text="hi there", **kw):
+        super().__init__(**kw)
+        self._text = text
+
+    def stream(self, frame):
+        self.sent_frames.append(frame)
+        self._resp_counter += 1
+        rid = f"resp_ws_{self._resp_counter}"
+        yield Event("response.output_text.delta", delta=self._text)
+        yield Event("response.output_item.done", item=_MessageItem(self._text))
+        yield _completed(rid)
+
+
+class ToolCallWsTransport(FakeWsTransport):
+    """First stream returns an assistant tool call; later streams return text."""
+
+    def stream(self, frame):
+        self.sent_frames.append(frame)
+        self._resp_counter += 1
+        rid = f"resp_ws_{self._resp_counter}"
+        if self._resp_counter == 1:
+            yield Event("response.output_item.added", item=_ToolCallItem())
+            yield Event("response.function_call_arguments.delta", delta='{"a": 1}')
+            yield Event("response.output_item.done", item=_ToolCallItem())
+        else:
+            yield Event("response.output_text.delta", delta="done")
+        yield _completed(rid)
+
+
+def test_second_turn_is_incremental_with_realistic_output_items():
+    """Root-cause regression: a normal text turn followed by a new user turn
+    sends a clean delta + ``previous_response_id`` even though the server streamed
+    the assistant message in the OUTPUT schema. Before the fix this was
+    ``ws_full`` because the output item never prefix-matched the re-derived input.
+    """
+    t = RealisticWsTransport()
+    session = _make_session(t)
+
+    first = session.send("hello")
+    assert first.usage.extra["codex_request_mode"] == "ws_full"
+    assert first.usage.extra["codex_ws_delta_reason"] == "no_baseline"
+
+    second = session.send("again")
+
+    assert second.usage.extra["codex_request_mode"] == "ws_incremental"
+    assert second.usage.extra["codex_ws_delta_reason"] == "ok"
+    frame = t.sent_frames[1]
+    assert frame["previous_response_id"] == "resp_ws_1"
+    # Only the new user turn is sent; the prior turn is NOT replayed.
+    flat = "".join(str(i) for i in frame["input"])
+    assert "hello" not in flat and "hi there" not in flat
+    assert "again" in flat
+    assert int(second.usage.extra["codex_ws_delta_len"]) == 1
+
+
+def test_tool_result_continuation_stays_incremental():
+    """A tool-result continuation (the assistant ended on an unanswered
+    ``function_call``) must NOT reset to ``ws_full``. The converter injects an
+    orphan-output placeholder into the baseline; the fix trims it so the real
+    tool result strictly extends the baseline and rides as a delta."""
+    from lingtai_kernel.llm.interface import ToolResultBlock
+
+    t = ToolCallWsTransport()
+    session = _make_session(t)
+
+    session.send("call the tool")  # turn 1: assistant emits a tool call
+    result = session.send([ToolResultBlock(id="call_a", name="do_x", content={"ok": True})])
+
+    assert result.usage.extra["codex_request_mode"] == "ws_incremental"
+    assert result.usage.extra["codex_ws_delta_reason"] == "ok"
+    frame = t.sent_frames[1]
+    assert frame["previous_response_id"] == "resp_ws_1"
+    # The delta carries the REAL function_call_output, not the synthesized
+    # placeholder, and does not replay the prior user turn or the tool call.
+    assert len(frame["input"]) == 1
+    only = frame["input"][0]
+    assert only["type"] == "function_call_output"
+    assert only["call_id"] == "call_a"
+    assert "synthesized placeholder" not in str(only)
+
+
+def test_mismatch_falls_back_to_ws_full_with_safe_reason():
+    """A non-input field change (tools) forces ``ws_full`` with a safe diagnostic
+    naming only the changed KEY, never any value."""
+    t = RealisticWsTransport()
+    session = _make_session(t)
+
+    session.send("hello")
+    session._tools = [{"type": "function", "name": "newtool", "parameters": {}}]
+    result = session.send("again")
+
+    assert result.usage.extra["codex_request_mode"] == "ws_full"
+    assert result.usage.extra["codex_ws_delta_reason"] == "non_input_fields_changed"
+    assert "tools" in result.usage.extra["codex_ws_changed_fields"]
+    # The diagnostic carries only key names + counts — no prompt/tool/secret body.
+    blob = json.dumps(result.usage.extra, default=str)
+    assert "hello" not in blob and "again" not in blob and "newtool" not in blob
+    # Full input replayed over WS, no previous id.
+    assert "previous_response_id" not in t.sent_frames[1]
+
+
+def test_baseline_updates_after_each_successful_response():
+    """After a successful turn the baseline advances so the NEXT turn chains off
+    the latest response id, not the first."""
+    t = RealisticWsTransport()
+    session = _make_session(t)
+
+    session.send("a")
+    session.send("b")
+    third = session.send("c")
+
+    assert third.usage.extra["codex_request_mode"] == "ws_incremental"
+    assert t.sent_frames[2]["previous_response_id"] == "resp_ws_2"
+
+
+def test_failed_stream_restores_prior_baseline_and_next_turn_chains_off_it():
+    """If a turn's stream fails mid-flight, the prior baseline is restored, so a
+    retry after a fresh successful turn still chains off the last GOOD response —
+    the failed turn never poisons the delta chain."""
+    class _FailSecond(RealisticWsTransport):
+        def stream(self, frame):
+            self.sent_frames.append(frame)
+            self._resp_counter += 1
+            if self._resp_counter == 2:
+                raise _CodexWsFallback("stream blew up after first")
+            rid = f"resp_ws_{self._resp_counter}"
+            yield Event("response.output_text.delta", delta="hi")
+            yield Event("response.output_item.done", item=_MessageItem("hi"))
+            yield _completed(rid)
+
+    t = _FailSecond()
+    session = _make_session(t)
+
+    session.send("first")
+    good_request = session._ws_session.last_request
+    good_response = session._ws_session.last_response
+
+    with pytest.raises(_CodexWsFallback):
+        session.send("second")
+
+    # Baseline restored to the last good turn; transport closed.
+    assert session._ws_session.last_request == good_request
+    assert session._ws_session.last_response == good_response
+    assert session._ws_transport is None
+
+
+def test_new_user_turn_after_tool_loop_keeps_incremental_chain():
+    """Boundary: tool call -> tool result -> new user text all stay incremental
+    within the same websocket session (no spurious reset breaks the delta)."""
+    from lingtai_kernel.llm.interface import ToolResultBlock
+
+    t = ToolCallWsTransport()
+    session = _make_session(t)
+
+    session.send("call the tool")  # ws_full (first)
+    r2 = session.send([ToolResultBlock(id="call_a", name="do_x", content={"ok": True})])
+    r3 = session.send("now continue in plain text")
+
+    assert r2.usage.extra["codex_request_mode"] == "ws_incremental"
+    assert r3.usage.extra["codex_request_mode"] == "ws_incremental"
+    assert t.sent_frames[2]["previous_response_id"] == "resp_ws_2"
+    flat3 = "".join(str(i) for i in t.sent_frames[2]["input"])
+    assert "now continue in plain text" in flat3
+    # Earlier turns are not replayed in the third delta.
+    assert "call the tool" not in flat3
+
+
 # Imported here (not at top) so a missing symbol fails the import test loudly.
 from lingtai.llm.openai.adapter import _CODEX_TURN_STATE_HEADER as _CodexTurnStateHeader  # noqa: E402


### PR DESCRIPTION
## Summary
- add a gated Codex Responses-over-WebSocket transport path for ChatGPT Codex (`LINGTAI_CODEX_WS=1`)
- send safe WS bearer/account headers, flat `response.create` frames, `response.processed`, and sanitized WS fallback errors
- preserve one WS connection per `CodexResponsesSession` so `previous_response_id + delta` works across sequential turns
- add provider turn-state reset hooks and restore delta baselines if a WS stream fails before completion

## Live smoke
Using the local official Codex CLI credential source (`~/.codex/auth.json` access token + account id; token/header not printed):
- first turn: `ws_full` -> `pong`, no fallback
- second turn on the same session/connection: `ws_incremental` with `previous_response_id` -> `pong2`, no fallback

Before persistent connection reuse, the second turn reached the server but failed with `Previous response ... not found`; a manual same-WS probe confirmed that response id continuity is connection/session-bound.

## Tests
- `PYTHONPATH=src python -m pytest tests/test_session.py tests/test_codex_prompt_cache_key.py tests/test_codex_raw_reasoning_replay.py tests/test_codex_ws_delta.py tests/test_codex_ws_session.py tests/test_openai_compact_threshold.py tests/test_openai_overflow_recovery.py tests/test_openai_prompt_cache_key.py tests/test_openai_responses_streaming.py tests/test_responses_converter.py -q` → `182 passed`
- `git diff --check` → pass
- `PYTHONPATH=src python -m pytest -q` → `1 failed, 2654 passed, 4 skipped`; the lone failure was `tests/test_filesystem_mail.py::TestListen::test_listen_detects_multiple_messages`, an unrelated listener timing test
- `PYTHONPATH=src python -m pytest tests/test_filesystem_mail.py::TestListen::test_listen_detects_multiple_messages -q` → `1 passed`

## Notes
- The WS path remains off by default and falls back to HTTP when unavailable.
- `websockets` is available in the current lock/runtime but is not added as a direct dependency in this PR; the lazy import/fallback behavior is preserved.
- Unrelated untracked `experimental/` Rust target artifacts were intentionally not included.
