### PR TITLE
Stabilize Codex websocket tool outputs

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -465,6 +465,68 @@ def _ws_is_synthesized_orphan_output(item: Any) -> bool:
     )
 
 
+def _freeze_responses_outputs(
+    items: list[dict[str, Any]],
+    frozen: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Stabilize ``function_call_output.output`` strings across WS replay turns.
+
+    The kernel carries *latest-only* resident-meta blocks (``_meta.agent_meta`` /
+    ``_meta.guidance`` / ``_meta.notifications``) and MOVES them off an older tool
+    result onto the freshest one each turn (``meta_block.attach_active_runtime`` /
+    ``attach_active_notifications``). That rewrites an older
+    ``ToolResultBlock.content`` *in place*, so the same ``call_id``'s
+    ``function_call_output.output`` serializes differently on a later turn even
+    though, semantically, the model already saw that result.
+
+    For Codex's stateful WS delta path the next request's converted input must
+    strict-prefix-match the prior baseline. A changed older
+    ``function_call_output`` (same ``call_id`` and keys, different ``output``
+    hash) breaks the prefix and forces ``ws_full`` every turn (the observed
+    ``prefix_mismatch``).
+
+    This freezes each output by ``call_id`` at first send for the life of the
+    session: the first time a ``call_id`` is converted, its ``output`` is
+    recorded; every later conversion replays the recorded string. Replay is
+    therefore byte-identical regardless of in-place resident-meta movement.
+
+    Fidelity is preserved, not lost: the model already saw the frozen version
+    when it was first sent, and the freshest result is *first-seen on its own
+    turn*, so it freezes WITH its live meta — live guidance / notifications still
+    reach the model on the result that is supposed to carry them.
+
+    Pure and content-free: returns a new list (shallow-copying only the rewritten
+    items), never mutates the caller's items, and records nothing to diagnostics.
+    Non-``function_call_output`` items and outputs missing a ``call_id`` pass
+    through untouched.
+    """
+    out: list[dict[str, Any]] = []
+    for item in items:
+        if (
+            isinstance(item, dict)
+            and item.get("type") == "function_call_output"
+            and isinstance(item.get("call_id"), str)
+            # The synthesized orphan placeholder (issue #170 wire guard) is a
+            # transient stand-in, NOT the real tool result. Never freeze it:
+            # doing so would replay the placeholder once the real continuation
+            # arrives, hiding the actual result from the model. Let it pass
+            # through so the real output freezes when it first appears.
+            and not _ws_is_synthesized_orphan_output(item)
+        ):
+            call_id = item["call_id"]
+            cached = frozen.get(call_id)
+            if cached is None:
+                frozen[call_id] = item.get("output")
+                out.append(item)
+            else:
+                replayed = dict(item)
+                replayed["output"] = cached
+                out.append(replayed)
+        else:
+            out.append(item)
+    return out
+
+
 def _ws_dump_item(item: Any) -> dict[str, Any] | None:
     """Normalize a streamed output item to a plain dict.
 
@@ -2068,6 +2130,15 @@ class CodexResponsesSession(OpenAIResponsesSession):
         # sent this turn, used by ``_ws_record_baseline_from_interface`` to derive
         # a converter-stable delta baseline once the assistant turn is recorded.
         self._ws_pending_baseline_input: list[dict[str, Any]] | None = None
+        # Per-session freeze of model-facing ``function_call_output.output`` strings
+        # keyed by ``call_id``. The kernel moves latest-only resident-meta blocks
+        # off older tool results onto the freshest one each turn, which rewrites an
+        # older ``ToolResultBlock.content`` in place and would change that result's
+        # converted ``output`` on replay — breaking the strict-prefix WS delta
+        # baseline. Freezing the first-seen output per call_id keeps replay
+        # byte-identical while the freshest result still carries live meta (it is
+        # first-seen on its own turn). See ``_freeze_responses_outputs``.
+        self._ws_frozen_outputs: dict[str, str] = {}
         # Last websocket delta decision diagnostic (safe metadata only): why the
         # request went ``ws_incremental`` vs ``ws_full``. Surfaced in usage.extra.
         self._ws_last_diag: dict[str, Any] = {}
@@ -2448,7 +2519,7 @@ class CodexResponsesSession(OpenAIResponsesSession):
         if pending is None or last is None or not last.response_id:
             self._ws_pending_baseline_input = None
             return
-        full_now = to_responses_input(self._interface)
+        full_now = self._frozen_responses_input(self._interface)
         base_len = len(pending)
         # Only treat the tail as server-added output when the interface still
         # strictly extends what we sent (it always should: we appended an
@@ -2498,8 +2569,21 @@ class CodexResponsesSession(OpenAIResponsesSession):
         """
         self._ws_session.turn_state = None
 
-    @staticmethod
-    def _interface_entries_to_responses_input(entries: list[Any]) -> list[dict[str, Any]]:
+    def _frozen_responses_input(self, iface: ChatInterface) -> list[dict[str, Any]]:
+        """``to_responses_input`` with per-session tool-result output freezing.
+
+        Routes every Codex WS conversion through ``_freeze_responses_outputs`` so
+        the model-facing ``function_call_output.output`` for a given ``call_id``
+        stays byte-identical across turns, even after the kernel moves latest-only
+        resident-meta off an older result. All three WS conversion sites (full
+        replay, per-turn delta, baseline tail) share ``self._ws_frozen_outputs`` so
+        the baseline and the next full request remain strict-prefix comparable.
+        """
+        return _freeze_responses_outputs(
+            to_responses_input(iface), self._ws_frozen_outputs
+        )
+
+    def _interface_entries_to_responses_input(self, entries: list[Any]) -> list[dict[str, Any]]:
         """Serialize newly-added ChatInterface entries for stateful Codex turns."""
 
         if not entries:
@@ -2509,7 +2593,7 @@ class CodexResponsesSession(OpenAIResponsesSession):
         # populate a temporary interface so the normal converter preserves
         # reasoning/tool-result shapes and pairing behavior for the delta.
         delta_interface.entries.extend(entries)
-        return to_responses_input(delta_interface)
+        return self._frozen_responses_input(delta_interface)
 
     def send_stream(self, message, on_chunk=None) -> LLMResponse:
         # Maintain the canonical interface for local recovery and full-replay
@@ -2554,7 +2638,7 @@ class CodexResponsesSession(OpenAIResponsesSession):
             ):
                 prebuilt_items.extend(self._convert_input(message))
 
-            full_replay_input_items = to_responses_input(self._interface)
+            full_replay_input_items = self._frozen_responses_input(self._interface)
             full_replay_input_items.extend(prebuilt_items)
 
             delta_entries = self._interface.entries[interface_start:]

--- a/tests/test_codex_ws_session.py
+++ b/tests/test_codex_ws_session.py
@@ -531,6 +531,97 @@ def test_tool_result_continuation_stays_incremental():
     assert "synthesized placeholder" not in str(only)
 
 
+class _PerTurnToolCallWsTransport(FakeWsTransport):
+    """Emits a distinct tool call (``call_1``, ``call_2``, …) on every turn.
+
+    This drives a multi-step tool loop so the kernel-side resident-meta movement
+    (latest-only ``_meta`` blocks hopping from an older tool result onto the
+    freshest one) can be simulated between turns.
+    """
+
+    def stream(self, frame):
+        self.sent_frames.append(frame)
+        self._resp_counter += 1
+        rid = f"resp_ws_{self._resp_counter}"
+        call_id = f"call_{self._resp_counter}"
+        yield Event("response.output_item.added", item=_ToolCallItem(call_id=call_id))
+        yield Event("response.function_call_arguments.delta", delta='{"a": 1}')
+        yield Event("response.output_item.done", item=_ToolCallItem(call_id=call_id))
+        yield _completed(rid)
+
+
+def _strip_resident_meta_from_oldest_tool_result(session) -> bool:
+    """Mimic ``attach_active_runtime``: strip the latest-only ``_meta`` blocks
+    from the OLDEST tool result's content in place (the kernel moves them onto
+    the freshest result each turn). Returns True if a result was mutated."""
+    from lingtai_kernel.llm.interface import ToolResultBlock
+
+    for entry in session._interface.entries:
+        for block in getattr(entry, "content", []) or []:
+            if isinstance(block, ToolResultBlock) and isinstance(block.content, dict):
+                meta = block.content.get("_meta")
+                if isinstance(meta, dict) and (
+                    "agent_meta" in meta or "guidance" in meta or "notifications" in meta
+                ):
+                    meta.pop("agent_meta", None)
+                    meta.pop("guidance", None)
+                    meta.pop("notifications", None)
+                    if not meta:
+                        block.content.pop("_meta", None)
+                    return True
+    return False
+
+
+def test_resident_meta_movement_does_not_break_incremental_delta():
+    """Core regression for resident-meta canonicalization.
+
+    The kernel moves latest-only ``_meta`` blocks off an older tool result onto
+    the freshest one each turn, mutating the older ``ToolResultBlock.content`` in
+    place. Without per-session output freezing that older
+    ``function_call_output.output`` changes between turns, breaking the strict
+    prefix and forcing ``ws_full`` (``prefix_mismatch``). With freezing the older
+    output replays byte-identically and the delta stays ``ws_incremental``.
+    """
+    from lingtai_kernel.llm.interface import ToolResultBlock
+
+    t = _PerTurnToolCallWsTransport()
+    session = _make_session(t)
+
+    session.send("start the tool loop")  # turn 1 -> assistant emits call_1
+    # Turn 2: answer call_1. As the freshest result it carries resident meta.
+    session.send([
+        ToolResultBlock(
+            id="call_1",
+            name="do_x",
+            content={"ok": True, "_meta": {"agent_meta": {"stamina": 9}, "tool_meta": {"id": "call_1"}}},
+        )
+    ])  # assistant emits call_2
+
+    # Kernel boundary: the meta hops off call_1's result onto the newer one.
+    # Simulate that in-place mutation BEFORE the next send re-converts history.
+    assert _strip_resident_meta_from_oldest_tool_result(session)
+
+    # Turn 3: answer call_2. The re-converted history now contains call_1 with
+    # its resident meta stripped — the exact prefix-mismatch trigger.
+    third = session.send([
+        ToolResultBlock(
+            id="call_2",
+            name="do_x",
+            content={"ok": True, "_meta": {"agent_meta": {"stamina": 8}, "tool_meta": {"id": "call_2"}}},
+        )
+    ])
+
+    # The frozen call_1 output keeps the prefix byte-identical: stays incremental.
+    assert third.usage.extra["codex_request_mode"] == "ws_incremental"
+    assert third.usage.extra["codex_ws_delta_reason"] == "ok"
+    # No prefix divergence was recorded (mismatch_index stays the -1 sentinel).
+    assert str(third.usage.extra.get("codex_ws_mismatch_index", "-1")) == "-1"
+    # The delta carries only the new call_2 result, not a full replay.
+    assert t.sent_frames[2]["previous_response_id"] == "resp_ws_2"
+    delta = t.sent_frames[2]["input"]
+    assert [i.get("call_id") for i in delta if i.get("type") == "function_call_output"] == ["call_2"]
+
+
 def test_mismatch_falls_back_to_ws_full_with_safe_reason():
     """A non-input field change (tools) forces ``ws_full`` with a safe diagnostic
     naming only the changed KEY, never any value."""

--- a/tests/test_codex_ws_tool_result_freeze.py
+++ b/tests/test_codex_ws_tool_result_freeze.py
@@ -1,0 +1,148 @@
+"""Tests for Codex WS tool-result output freezing (resident-meta canonicalization).
+
+Root cause being guarded here (see report
+``reports/claude-p-codex-tool-result-canonicalization.md``):
+
+The kernel moves the *latest-only* ``_meta`` blocks (``agent_meta`` / ``guidance``
+/ ``notifications``) off an older tool result and onto the freshest one each turn
+(``meta_block.attach_active_runtime`` / ``attach_active_notifications``). That
+mutation rewrites an OLDER ``ToolResultBlock.content`` in place, so the same tool
+call's ``function_call_output.output`` string legitimately differs between turns.
+
+For the stateful Codex WS delta path that is fatal: the next request's full
+converted input must *strict-prefix-match* the prior baseline, and a changed
+older ``function_call_output`` (same ``call_id`` / keys, different ``output``
+hash) breaks the prefix and forces ``ws_full`` every turn — the exact
+``prefix_mismatch`` Jason observed.
+
+The fix freezes each ``function_call_output.output`` by ``call_id`` at first
+send for the life of the WS session, so replay is byte-identical regardless of
+in-place resident-meta movement. The freshest result is first-seen on its own
+turn, so it is frozen WITH its live meta — the model never loses guidance /
+notifications it must see.
+
+These tests are content-free: they assert structure/identity only and never log
+tool-result bodies.
+"""
+
+from __future__ import annotations
+
+from lingtai.llm.interface_converters import _RESPONSES_ORPHAN_OUTPUT_PLACEHOLDER
+from lingtai.llm.openai.adapter import _freeze_responses_outputs
+
+
+def _fco(call_id: str, output: str) -> dict:
+    return {"type": "function_call_output", "call_id": call_id, "output": output}
+
+
+def test_freeze_registers_first_seen_output_unchanged():
+    frozen: dict[str, str] = {}
+    items = [
+        {"role": "user", "content": "hi"},
+        _fco("call_a", '{"ok": true, "_meta": {"agent_meta": {"x": 1}}}'),
+    ]
+
+    out = _freeze_responses_outputs(items, frozen)
+
+    # First pass returns the items byte-equal and records the output.
+    assert out == items
+    assert frozen == {"call_a": '{"ok": true, "_meta": {"agent_meta": {"x": 1}}}'}
+
+
+def test_freeze_replays_frozen_output_when_resident_meta_moves_away():
+    frozen: dict[str, str] = {}
+    # Turn N: call_a is the LAST result and carries the moving meta.
+    turn_n = [_fco("call_a", '{"ok": true, "_meta": {"agent_meta": {"x": 1}}}')]
+    _freeze_responses_outputs(turn_n, frozen)
+
+    # Turn N+1: a newer result arrived; the kernel stripped call_a's latest-only
+    # meta and moved it onto call_b. call_a's raw content now serializes
+    # differently (meta gone) — but the frozen replay must keep the original.
+    turn_n1 = [
+        _fco("call_a", '{"ok": true}'),  # resident meta stripped in place
+        _fco("call_b", '{"done": true, "_meta": {"agent_meta": {"x": 2}}}'),
+    ]
+
+    out = _freeze_responses_outputs(turn_n1, frozen)
+
+    # call_a replays its FROZEN (turn-N) output byte-for-byte: strict prefix holds.
+    assert out[0]["output"] == '{"ok": true, "_meta": {"agent_meta": {"x": 1}}}'
+    # call_b is first-seen and freezes WITH its live meta (model still sees it).
+    assert out[1]["output"] == '{"done": true, "_meta": {"agent_meta": {"x": 2}}}'
+    assert frozen["call_b"] == '{"done": true, "_meta": {"agent_meta": {"x": 2}}}'
+
+
+def test_freeze_is_idempotent_across_repeated_calls():
+    frozen: dict[str, str] = {}
+    items = [_fco("call_a", "result-1")]
+
+    first = _freeze_responses_outputs(items, frozen)
+    # Even if the underlying raw output changes on a later pass, replay is stable.
+    mutated = [_fco("call_a", "result-1-with-meta-appended")]
+    second = _freeze_responses_outputs(mutated, frozen)
+    third = _freeze_responses_outputs(mutated, frozen)
+
+    assert first[0]["output"] == "result-1"
+    assert second[0]["output"] == "result-1"
+    assert third[0]["output"] == "result-1"
+
+
+def test_freeze_does_not_mutate_caller_items():
+    frozen = {"call_a": "frozen-original"}
+    original = _fco("call_a", "live-mutated")
+    items = [original]
+
+    out = _freeze_responses_outputs(items, frozen)
+
+    # A fresh dict is returned; the caller's item is untouched.
+    assert out[0]["output"] == "frozen-original"
+    assert original["output"] == "live-mutated"
+    assert out[0] is not original
+
+
+def test_freeze_leaves_non_tool_result_items_untouched():
+    frozen: dict[str, str] = {}
+    items = [
+        {"role": "user", "content": "u"},
+        {"type": "function_call", "call_id": "c1", "name": "bash", "arguments": "{}"},
+        {"role": "assistant", "content": "a"},
+        _fco("c1", "tool-out"),
+    ]
+
+    out = _freeze_responses_outputs(items, frozen)
+
+    assert out[0] == {"role": "user", "content": "u"}
+    assert out[1] == {"type": "function_call", "call_id": "c1", "name": "bash", "arguments": "{}"}
+    assert out[2] == {"role": "assistant", "content": "a"}
+    assert out[3]["output"] == "tool-out"
+    # Only the function_call_output registered a freeze entry.
+    assert set(frozen) == {"c1"}
+
+
+def test_freeze_never_freezes_synthesized_orphan_placeholder():
+    # Turn N ends on an unanswered function_call -> to_responses_input injects
+    # the orphan placeholder for call_a (issue #170 wire guard). It must NOT be
+    # frozen, or the real continuation next turn would be hidden behind it.
+    frozen: dict[str, str] = {}
+    turn_n = [_fco("call_a", _RESPONSES_ORPHAN_OUTPUT_PLACEHOLDER)]
+    _freeze_responses_outputs(turn_n, frozen)
+    assert "call_a" not in frozen
+
+    # Turn N+1: the REAL tool result arrives for call_a. It freezes for real and
+    # is replayed (not the placeholder) on subsequent passes.
+    turn_n1 = [_fco("call_a", '{"real": "result"}')]
+    out = _freeze_responses_outputs(turn_n1, frozen)
+    assert out[0]["output"] == '{"real": "result"}'
+    assert frozen["call_a"] == '{"real": "result"}'
+
+
+def test_freeze_ignores_function_call_output_without_call_id():
+    frozen: dict[str, str] = {}
+    # Defensive: a malformed item missing call_id must pass through untouched and
+    # never register a None key.
+    items = [{"type": "function_call_output", "output": "x"}]
+
+    out = _freeze_responses_outputs(items, frozen)
+
+    assert out == items
+    assert frozen == {}


### PR DESCRIPTION
## Summary
- freeze Codex WS `function_call_output.output` strings per `call_id` inside a websocket session
- keep the first model-facing tool output (including resident meta/guidance) stable across later replays
- add regression coverage for latest-only resident meta moving between tool results

## Why
After #473, live diagnostics showed remaining `ws_full` fallbacks came from `function_call_output` prefix mismatches with identical keys (`call_id,output,type`) but different hashes. The newest tool result carries latest-only resident meta/guidance/notification blocks, and those blocks can move by mutating older `ToolResultBlock.content`. `to_responses_input()` serializes that dict into `function_call_output.output`, so the same tool result can change bytes across turns.

## Validation
- `python -m py_compile src/lingtai/llm/openai/adapter.py`
- `PYTHONPATH=src LINGTAI_CODEX_WS= python -m pytest tests/test_codex_ws_delta.py tests/test_codex_ws_session.py tests/test_codex_prompt_cache_key.py tests/test_responses_converter.py tests/test_codex_ws_tool_result_freeze.py tests/test_codex_raw_reasoning_replay.py tests/test_tool_result_recovery.py tests/test_tool_result_restore_after_continuation_failure.py tests/test_tool_result_spill.py -q`
- `git diff --check`

## Live smoke
Local refresh/live smoke on this patch produced:
- first request after refresh: `ws_full`, `codex_ws_delta_reason=no_baseline`
- next two requests: `ws_incremental`, `codex_ws_delta_reason=ok`, `delta_len=1`
- no `invalid_request_error 400`
