### PR TITLE
Bump kernel version to 0.14.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.14.0"
+version = "0.14.1"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump the LingTai kernel package version from 0.14.0 to 0.14.1 for the 2026-06-23 kernel release

## Release scope
This release includes the post-0.14.0 runtime work already merged to main:
- daemon terminal-state notification preservation
- Codex ChatGPT identity/cache diagnostics and honest LingTai identity docs
- tool-result guidance/comment overflow metadata
- Codex websocket session reuse, tool-output freeze/baseline handling, epoch reset, and concise Codex summarize-cache guidance
- stale ANATOMY citation cleanup

## Validation
- python tomllib parse confirmed `project.version == 0.14.1`
- git diff --check
- python -m pytest -q → 2715 passed, 4 skipped in 304.41s

Build, twine check, exact artifact hashes, GitHub release, and PyPI upload will be run from the merged release candidate before tagging/publishing.