### PR TITLE
fix(codex): notification dismiss forces fresh epoch; honest stateless adapter_comment

### DIFF
--- a/src/lingtai/llm/base.py
+++ b/src/lingtai/llm/base.py
@@ -56,6 +56,11 @@ class _GatedSession:
         if callable(hook):
             hook(summarized_ids)
 
+    def on_notification_dismissed(self, channel=None):
+        hook = getattr(self._inner, "on_notification_dismissed", None)
+        if callable(hook):
+            hook(channel)
+
     def __getattr__(self, name):
         # Only fires when normal attribute lookup on the proxy fails.
         return getattr(self._inner, name)

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2609,7 +2609,65 @@ class CodexResponsesSession(OpenAIResponsesSession):
             return
         self._reset_ws_epoch("summarize")
 
+    def on_notification_dismissed(self, channel: str | None = None) -> None:
+        """Hook called after a notification dismiss/cleanup mutates the surface.
+
+        Dismissing or clearing a notification rewrites the resident
+        ``_meta.notifications`` block carried on prior tool results, which
+        breaks the strict-prefix comparison the WS incremental chain relies on
+        — exactly the same hazard ``on_history_summarized`` guards against. So
+        a dismiss intentionally starts a fresh ws_full epoch instead of letting
+        the next request continue as ws_incremental against a now-stale remote
+        baseline. ``channel`` is accepted for diagnostics/symmetry; the reset is
+        unconditional once a dismiss has actually cleared state (the caller only
+        invokes this hook on a real clear).
+        """
+        if not self._ws_enabled:
+            return
+        self._reset_ws_epoch("notification_dismiss")
+
     def adapter_comment(self):
+        # Be honest about the *active* transport. The previous_response_id epoch
+        # machinery (ws_full/ws_incremental, turns_since_epoch_reset) only exists
+        # on the experimental websocket path; when WS is disabled every request
+        # is already a full stateless replay (store=false, no previous_response_id)
+        # rebuilt from local chat_history, so advertising a ws_full/ws_incremental
+        # boundary would mislead the agent (it never resets, and the counter is
+        # permanently 0). See self-trace 2026-06-23T21:02Z: ws_enabled=false yet
+        # the comment claimed a ws_full reset, which looked like summarize "not
+        # triggering ws_full".
+        if not self._ws_enabled:
+            return {
+                "adapter": "codex",
+                "feature": "stateless_full_replay",
+                "ws_enabled": False,
+                "summary": (
+                    "Codex runs in stateless mode here (store=false, no "
+                    "previous_response_id chain). Every request is a complete "
+                    "replay rebuilt from the current local chat_history, so there "
+                    "is no remote epoch to reset and no incremental chain to "
+                    "preserve. Context-shaping actions take effect immediately on "
+                    "the next request because it is always a full replay; the "
+                    "kernel does not delete or summarize local chat_history on "
+                    "your behalf."
+                ),
+                "summarize_ws_full_note": (
+                    "Codex-specific note: this runtime is stateless (no "
+                    "ws_incremental chain). system(action='summarize') and "
+                    "notification dismiss/cleanup (notification(action='dismiss_*') "
+                    "and channel clears) both take effect by shrinking or "
+                    "rewriting the next full replay built from local chat_history "
+                    "— summarize replaces the visible tool-result payload with "
+                    "your summary, and dismiss removes the resident notification "
+                    "meta. Each such change starts a fresh full prefix, so it "
+                    "breaks the prompt cache for that request; batch summaries and "
+                    "notification dismissals (group finished items, clear several "
+                    "at once) instead of doing them one at a time to limit cache "
+                    "churn. Other providers are much less sensitive to this "
+                    "boundary."
+                ),
+            }
+
         self._refresh_ws_epoch_reset_turn_limit()
         limit = self._ws_epoch_reset_turn_limit
         next_reset_in = None
@@ -2637,10 +2695,15 @@ class CodexResponsesSession(OpenAIResponsesSession):
                 "Codex-specific caution: each summarize forces the next request "
                 "to start a fresh ws_full epoch instead of continuing as "
                 "ws_incremental, so it can hurt the previous_response_id cache "
-                "chain. Strongly avoid consecutive summarize calls within about "
+                "chain. Notification dismiss/cleanup (notification(action='dismiss_*') "
+                "and channel clears) does the same thing: it rewrites the resident "
+                "notification meta on older tool results, breaking the incremental "
+                "chain and forcing the next request to start a fresh ws_full epoch. "
+                "Strongly avoid consecutive summarize or dismiss calls within about "
                 "five turns; for ordinary long results, group several finished "
-                "items and summarize them together. Other providers are much less "
-                "sensitive to this Codex cache boundary."
+                "items and summarize them together, and batch notification dismissals "
+                "rather than clearing them one at a time. Other providers are much "
+                "less sensitive to this Codex cache boundary."
             ),
         }
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2659,12 +2659,13 @@ class CodexResponsesSession(OpenAIResponsesSession):
                     "rewriting the next full replay built from local chat_history "
                     "— summarize replaces the visible tool-result payload with "
                     "your summary, and dismiss removes the resident notification "
-                    "meta. Each such change starts a fresh full prefix, so it "
-                    "breaks the prompt cache for that request; batch summaries and "
-                    "notification dismissals (group finished items, clear several "
-                    "at once) instead of doing them one at a time to limit cache "
-                    "churn. Other providers are much less sensitive to this "
-                    "boundary."
+                    "meta. Each such change alters the replay shape from the "
+                    "mutation point onward and can reduce cached-token reuse after "
+                    "that point; the stable prefix before it may still cache. Batch "
+                    "summaries and notification dismissals (group finished items, "
+                    "clear several at once) instead of doing them one at a time to "
+                    "limit cache churn. Other providers are much less sensitive to "
+                    "this boundary."
                 ),
             }
 

--- a/src/lingtai_kernel/llm/base.py
+++ b/src/lingtai_kernel/llm/base.py
@@ -169,6 +169,16 @@ class ChatSession(ABC):
 
         return None
 
+    def on_notification_dismissed(self, channel: str | None = None) -> None:
+        """Hook called after a notification dismiss/cleanup mutates the surface.
+
+        A dismiss rewrites the resident notification meta on prior tool results,
+        so — like ``on_history_summarized`` — adapters that reuse remote state
+        (e.g. Codex WS) use this to start a fresh ws_full epoch. Default no-op.
+        """
+
+        return None
+
     @property
     @abstractmethod
     def interface(self) -> ChatInterface:

--- a/src/lingtai_kernel/notifications.py
+++ b/src/lingtai_kernel/notifications.py
@@ -1039,9 +1039,57 @@ def dismiss_channel(
 
     if channel == "system":
         with agent._system_notification_lock:
-            return _dismiss_system_event()
+            result = _dismiss_system_event()
+    else:
+        result = _clear_current_channel()
 
-    return _clear_current_channel()
+    if _dismiss_changed_surface(result):
+        _signal_notification_dismissed(agent, channel)
+    return result
+
+
+def _dismiss_changed_surface(result: dict) -> bool:
+    """Return True iff a dismiss result reflects a real change to the surface.
+
+    A real change is what rewrites the resident ``_meta.notifications`` block on
+    older tool results and therefore breaks the Codex WS incremental chain. A
+    no-op (file already absent), a refusal (guarded/protected/stale/invalid), or
+    a zero-match event dismiss leaves the surface untouched and must NOT trigger
+    a fresh-epoch reset.
+    """
+    if not isinstance(result, dict) or result.get("status") != "ok":
+        return False
+    return bool(
+        result.get("cleared")
+        or result.get("removed")
+        or result.get("acked_large_result_refs")
+    )
+
+
+def _signal_notification_dismissed(agent, channel: str) -> None:
+    """Tell the chat session a dismiss rewrote the notification surface.
+
+    Mirrors ``on_history_summarized``: a notification dismiss/cleanup forces the
+    next Codex request to start a fresh ws_full epoch instead of continuing as
+    ws_incremental. Best-effort and adapter-agnostic — adapters without the hook
+    (or providers that don't care about the boundary) treat it as a no-op.
+    """
+    chat = getattr(agent, "_chat", None)
+    if chat is None:
+        return
+    hook = getattr(chat, "on_notification_dismissed", None)
+    if not callable(hook):
+        return
+    try:
+        hook(channel)
+    except Exception:  # pragma: no cover - defensive hook isolation
+        try:
+            agent._log(
+                "notification_dismiss_hook_failed",
+                channel=channel,
+            )
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_codex_ws_session.py
+++ b/tests/test_codex_ws_session.py
@@ -97,6 +97,7 @@ class FakeWsTransport:
 
 def _make_session(transport: FakeWsTransport, **kwargs):
     """A Codex session wired to use the injected transport, gate forced on."""
+    kwargs.setdefault("ws_enabled", True)
     return CodexResponsesSession(
         client=_HttpFallbackClient(),
         model="gpt-5.5",
@@ -106,7 +107,6 @@ def _make_session(transport: FakeWsTransport, **kwargs):
         extra_kwargs={},
         session_id="sess-stable",
         thread_id="sess-stable",
-        ws_enabled=True,
         ws_transport_factory=lambda url, headers: transport,
         **kwargs,
     )
@@ -709,11 +709,14 @@ def test_new_user_turn_after_tool_loop_keeps_incremental_chain():
 
 
 def test_codex_adapter_comment_explains_epoch_reset_and_summarize_delay():
-    session = _make_session(FakeWsTransport())
+    # WS-enabled path: the comment describes the previous_response_id epoch
+    # reset and the ws_full/ws_incremental cache boundary that actually exists.
+    session = _make_session(FakeWsTransport(), ws_enabled=True)
 
     comment = session.adapter_comment()
 
     assert comment["adapter"] == "codex"
+    assert comment["ws_enabled"] is True
     assert comment["feature"] == "responses_websocket_epoch_reset"
     assert comment["epoch_reset_turns"] == 20
     assert comment["turns_since_epoch_reset"] == 0
@@ -723,6 +726,42 @@ def test_codex_adapter_comment_explains_epoch_reset_and_summarize_delay():
     assert "five turns" in note
     assert "Codex-specific" in note
     assert "summarize them together" in note
+    # The note must also warn that notification dismiss/cleanup breaks the
+    # incremental/cache chain and forces a fresh ws_full epoch, just like
+    # summarize — so the agent does not assume only summarize is sensitive.
+    assert "notification" in note
+    assert "dismiss" in note
+
+
+def test_codex_adapter_comment_is_honest_when_ws_disabled():
+    # Stateless HTTP path (the default runtime): there is NO previous_response_id
+    # chain and NO ws_full/ws_incremental boundary, so the comment must not claim
+    # one. Every request is already a full stateless replay rebuilt from local
+    # chat_history; summarize/dismiss take effect by shrinking that next full
+    # request, not by toggling an incremental chain.
+    session = _make_session(FakeWsTransport(), ws_enabled=False)
+
+    comment = session.adapter_comment()
+
+    assert comment["adapter"] == "codex"
+    assert comment["ws_enabled"] is False
+    # The inert WS epoch counter must not masquerade as a live signal.
+    assert comment["feature"] != "responses_websocket_epoch_reset"
+    assert "turns_since_epoch_reset" not in comment
+    assert "next_reset_in" not in comment
+    note = comment["summarize_ws_full_note"]
+    # Stateless honesty: no incremental chain to preserve, every request is a
+    # full replay; summarize and notification dismiss/cleanup both take effect
+    # by shrinking the next full request from mutated local history.
+    assert "stateless" in note
+    # Must not claim a live ws_full/ws_incremental boundary; if it mentions the
+    # term at all it is to say there is NO such chain.
+    assert "ws_full epoch" not in note
+    assert "no ws_incremental" in note
+    assert "full replay" in note
+    assert "summarize" in note
+    assert "notification" in note
+    assert "dismiss" in note
 
 
 def test_history_summarized_forces_next_ws_full_epoch_reset():
@@ -739,6 +778,26 @@ def test_history_summarized_forces_next_ws_full_epoch_reset():
     assert third.usage.extra["codex_request_mode"] == "ws_full"
     assert third.usage.extra["codex_ws_delta_reason"] == "epoch_reset"
     assert third.usage.extra["codex_ws_epoch_reset_reason"] == "summarize"
+    assert "previous_response_id" not in t.sent_frames[2]
+
+
+def test_notification_dismissed_forces_next_ws_full_epoch_reset():
+    t = FakeWsTransport()
+    session = _make_session(t)
+
+    first = session.send("one")
+    second = session.send("two")
+    # A notification dismiss/cleanup rewrites the resident-meta off older
+    # tool results, so — exactly like summarize — it must force the next
+    # request to start a fresh ws_full epoch instead of ws_incremental.
+    session.on_notification_dismissed("system")
+    third = session.send("three")
+
+    assert first.usage.extra["codex_request_mode"] == "ws_full"
+    assert second.usage.extra["codex_request_mode"] == "ws_incremental"
+    assert third.usage.extra["codex_request_mode"] == "ws_full"
+    assert third.usage.extra["codex_ws_delta_reason"] == "epoch_reset"
+    assert third.usage.extra["codex_ws_epoch_reset_reason"] == "notification_dismiss"
     assert "previous_response_id" not in t.sent_frames[2]
 
 

--- a/tests/test_max_rpm_plumbing.py
+++ b/tests/test_max_rpm_plumbing.py
@@ -113,6 +113,24 @@ def test_gated_session_history_summarized_delegates_to_inner():
     a._gate.shutdown()
 
 
+def test_gated_session_notification_dismissed_delegates_to_inner():
+    class _StubAdapter(LLMAdapter):
+        def create_chat(self, *a, **kw): pass
+        def generate(self, *a, **kw): pass
+        def make_tool_result_message(self, *a, **kw): pass
+        def is_quota_error(self, exc): return False
+
+    a = _StubAdapter()
+    a._setup_gate(60)
+    inner = MagicMock()
+    wrapped = a._wrap_with_gate(inner)
+
+    wrapped.on_notification_dismissed("system")
+
+    inner.on_notification_dismissed.assert_called_once_with("system")
+    a._gate.shutdown()
+
+
 def test_wrap_with_gate_returns_inner_when_no_gate():
     class _StubAdapter(LLMAdapter):
         def create_chat(self, *a, **kw): pass

--- a/tests/test_system_dismiss.py
+++ b/tests/test_system_dismiss.py
@@ -566,3 +566,81 @@ def test_system_event_dismiss_with_malformed_data_is_noop(tmp_path: Path) -> Non
     assert result["removed"] == 0
     assert result["remaining"] == 0
     assert collect_notifications(tmp_path)["system"]["data"] == ["not", "a", "dict"]
+
+
+# ---------------------------------------------------------------------------
+# Codex ws_full / fresh-epoch reset on notification dismiss/cleanup.
+#
+# Dismissing or clearing a notification rewrites the resident
+# ``_meta.notifications`` block on older tool results, breaking the Codex WS
+# incremental (previous_response_id) chain — exactly like summarize. So a real
+# dismiss must notify the chat session via ``on_notification_dismissed`` so the
+# adapter starts a fresh ws_full epoch. A no-op / refused dismiss must NOT.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingChat:
+    """Records ``on_notification_dismissed`` invocations from the dismiss path."""
+
+    def __init__(self) -> None:
+        self.dismiss_calls: list[object] = []
+
+    def on_notification_dismissed(self, channel=None) -> None:
+        self.dismiss_calls.append(channel)
+
+
+def _agent_with_chat(tmp_path: Path):
+    agent = _StubAgent(tmp_path)
+    agent._chat = _RecordingChat()
+    return agent
+
+
+def test_real_channel_clear_signals_chat_for_ws_full_epoch(tmp_path: Path) -> None:
+    agent = _agent_with_chat(tmp_path)
+    publish(tmp_path, "soul", {"header": "soul flow"})
+    _mark_delivered(agent)
+
+    res = _dismiss_channel(agent, "soul")
+
+    assert res["cleared"] is True
+    assert agent._chat.dismiss_calls == ["soul"]
+
+
+def test_real_event_dismiss_signals_chat_for_ws_full_epoch(tmp_path: Path) -> None:
+    agent = _agent_with_chat(tmp_path)
+    publish(
+        tmp_path,
+        "system",
+        {
+            "header": "1 system notification",
+            "data": {"events": [{"event_id": "evt_a", "source": "btw"}]},
+        },
+    )
+    agent._notification_fp = notification_fingerprint(tmp_path)
+
+    res = _dismiss_event(agent, event_id="evt_a")
+
+    assert res["removed"] == 1
+    assert agent._chat.dismiss_calls == ["system"]
+
+
+def test_noop_dismiss_does_not_signal_chat(tmp_path: Path) -> None:
+    agent = _agent_with_chat(tmp_path)
+
+    res = _dismiss_channel(agent, "soul")
+
+    assert res["cleared"] is False
+    assert agent._chat.dismiss_calls == []
+
+
+def test_refused_dismiss_does_not_signal_chat(tmp_path: Path) -> None:
+    import lingtai_kernel.intrinsics.email  # noqa: F401 - import performs registration
+
+    agent = _agent_with_chat(tmp_path)
+    publish(tmp_path, "email", {"header": "1 unread"})
+
+    res = _dismiss_channel(agent, "email")
+
+    assert res["status"] == "error"
+    assert res["reason"] == "guarded"
+    assert agent._chat.dismiss_calls == []


### PR DESCRIPTION
## Summary

Two tightly-related Codex correctness fixes, requested by Jason.

### 1. Notification dismiss/cleanup forces a fresh epoch (like summarize)
A notification dismiss/cleanup rewrites the resident `_meta.notifications` block on prior tool results, which breaks the Codex WS strict-prefix incremental chain **exactly like `system(action='summarize')` does**. Previously only summarize signaled the adapter; dismiss did not. Now both do.

- New `on_notification_dismissed` hook on the chat session: ABC default no-op (`lingtai_kernel/llm/base.py`) + `_GatedSession` proxy (`lingtai/llm/base.py`).
- `CodexResponsesSession.on_notification_dismissed` → `_reset_ws_epoch("notification_dismiss")` (WS path only; no-op when WS disabled).
- `notifications.dismiss_channel` signals the hook **only on a real clear** (`cleared` / `removed>0` / `acked_large_result_refs`). No-ops, refusals, and guarded/protected/stale rejections do **not** reset — mirroring summarize firing only when `summarized_count>0`.

### 2. Honest `adapter_comment` per transport (the bug behind "summarize didn't trigger ws_full")
Self-trace of the reporting agent at **2026-06-23T21:02Z** showed `ws_enabled=false` (`codex_request_mode=stateless_full_store_forced_false`), yet `adapter_comment` still advertised a `ws_full`/`ws_incremental` boundary and a permanently-`0` `turns_since_epoch_reset`. That looked like "summarize isn't triggering ws_full."

**Root cause: a guidance/metadata-honesty mismatch, not a summarize bug.** The `previous_response_id` epoch machinery only exists on the experimental websocket path (opt-in env var, off by default). On the default **stateless full-replay** path every request is already a complete replay from local `chat_history`, so the epoch reset is inert by design — and summarize genuinely worked (request input dropped **260K → 47K** tokens across the 21:02:13Z summarize).

`adapter_comment` now branches on `_ws_enabled`:
- **stateless** (`ws_enabled=false`): `feature=stateless_full_replay`, omits the inert WS counters, and explains that summarize / notification dismiss take effect by shrinking the next full replay from local history (and break the prompt cache for that one request, so batch them).
- **WS** (`ws_enabled=true`): keeps the epoch-reset note and now also names notification dismiss/cleanup as a `ws_full`-forcing action.

## Behavior confirmed (evidence)
- `tool_result_summarized` at 2026-06-23T21:02:13Z; token ledger input collapsed 260,447 → 46,933 the same turn → **summarize is effective**.
- Runtime `adapter_comment` captured in chat history: `"ws_enabled": false … "turns_since_epoch_reset": 0` → the field was inert/misleading, now fixed.

## Tests
- `tests/test_system_dismiss.py`: real channel/event dismiss signals the chat hook; no-op and guarded/refused dismiss do **not**.
- `tests/test_codex_ws_session.py`: dismiss → next request `ws_full` with `epoch_reset_reason="notification_dismiss"` (WS); both honest `adapter_comment` branches (WS vs stateless).
- `tests/test_max_rpm_plumbing.py`: `_GatedSession` delegates `on_notification_dismissed` to inner.
- Focused: **169 passed**. Full suite: **2722 passed, 4 skipped**.

## Scope / risk
- Small, additive: new hook (default no-op) + one chokepoint signal in `dismiss_channel` + per-path comment text. No behavior change on the stateless path beyond honest guidance. Summarize behavior unchanged.
- Pre-existing `ruff` findings in untouched code (duplicate `datetime`/`ToolResultBlock` imports in `notifications.py`/`llm/base.py`) were left alone to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)