### PR TITLE
feat(codex): default-enable Codex WebSocket transport (LINGTAI_CODEX_WS)

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -249,11 +249,11 @@ _CODEX_WS_BETA_HEADER = "OpenAI-Beta"
 _CODEX_WS_BETA_VALUE = "responses_websockets=2026-02-06"
 _CODEX_TURN_STATE_HEADER = "x-codex-turn-state"
 
-# Env gate for the experimental websocket transport. Off by default: when unset
-# (or not truthy) the session uses the existing, proven HTTP full-replay path.
-# Set ``LINGTAI_CODEX_WS=1`` to enable the websocket path (which still falls back
-# to HTTP on any handshake/connection/auth error, unsupported runtime, or delta
-# mismatch).
+# Env gate for the websocket transport. On by default: when unset the session
+# uses the websocket path (which still falls back to HTTP full-replay on any
+# handshake/connection/auth error, unsupported runtime, or delta mismatch).
+# Set ``LINGTAI_CODEX_WS=0`` (or ``false``/``no``/``off``) to force the existing,
+# proven HTTP full-replay path.
 _CODEX_WS_ENABLED_ENV = "LINGTAI_CODEX_WS"
 _CODEX_WS_EPOCH_RESET_TURNS_ENV = "LINGTAI_CODEX_WS_EPOCH_RESET_TURNS"
 _CODEX_WS_EPOCH_RESET_TURNS_DEFAULT = 20
@@ -265,8 +265,16 @@ _CODEX_WS_EPOCH_RESET_TURNS_DEFAULT = 20
 
 
 def _codex_ws_enabled() -> bool:
-    """Return True when the experimental websocket transport is enabled."""
-    return os.environ.get(_CODEX_WS_ENABLED_ENV, "").lower() in {"1", "true", "yes", "on"}
+    """Return True when the websocket transport is enabled (default on).
+
+    Unset env means enabled. An explicit falsy value (``0``/``false``/``no``/
+    ``off``, case-insensitive) disables it and forces the HTTP full-replay path.
+    Any other value leaves the default (enabled) in place.
+    """
+    raw = os.environ.get(_CODEX_WS_ENABLED_ENV)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
 
 
 def _codex_ws_epoch_reset_turns() -> int:
@@ -2112,8 +2120,9 @@ class CodexResponsesSession(OpenAIResponsesSession):
     ):
         super().__init__(*args, **kwargs)
         # EXPERIMENTAL Codex Responses-over-WebSocket transport (#471). Gated:
-        # ``ws_enabled`` defaults to the ``LINGTAI_CODEX_WS`` env switch (off
-        # unless explicitly turned on). ``ws_transport_factory`` is an injection
+        # ``ws_enabled`` defaults to the ``LINGTAI_CODEX_WS`` env switch (on
+        # unless explicitly disabled with ``0``/``false``/``no``/``off``).
+        # ``ws_transport_factory`` is an injection
         # seam used by the mock tests; when ``None`` and the gate is on, the real
         # factory is used (and itself falls back to HTTP if ``websockets`` is
         # missing). ``_ws_session`` holds the per-turn last_request/last_response

--- a/tests/test_codex_prompt_cache_key.py
+++ b/tests/test_codex_prompt_cache_key.py
@@ -17,13 +17,29 @@ import re
 from dataclasses import dataclass
 from types import SimpleNamespace
 
+import pytest
+
 from lingtai.llm.openai.adapter import (
     CodexOpenAIAdapter,
     CodexResponsesSession,
     OpenAIResponsesSession,
+    _CODEX_WS_ENABLED_ENV,
     _lingtai_user_agent,
 )
 from lingtai_kernel.llm.base import FunctionSchema
+
+
+@pytest.fixture(autouse=True)
+def _force_codex_ws_off(monkeypatch):
+    """Pin these HTTP-path prompt-cache tests to the stateless replay transport.
+
+    Codex WS is on by default (``LINGTAI_CODEX_WS`` unset → enabled). These tests
+    assert the HTTP request kwargs and inject a ``FakeClient`` rather than a WS
+    transport, so leaving WS on would make each ``send`` attempt a real websocket
+    connect that only falls back to HTTP after a network timeout — correct result,
+    but slow and network-fragile. Forcing the gate off keeps them deterministic.
+    """
+    monkeypatch.setenv(_CODEX_WS_ENABLED_ENV, "0")
 
 
 @dataclass

--- a/tests/test_codex_ws_session.py
+++ b/tests/test_codex_ws_session.py
@@ -30,6 +30,7 @@ from lingtai.llm.openai.codex_ws import SyncCodexWebsocketTransport
 from lingtai.llm.openai.adapter import (
     CodexResponsesSession,
     _CodexWsFallback,
+    _codex_ws_enabled,
 )
 
 
@@ -291,8 +292,8 @@ def test_fallback_to_http_when_delta_mismatch():
     assert "hello" in flat and "again" in flat
 
 
-def test_ws_disabled_by_default_uses_http():
-    """Without the gate, the session uses the existing HTTP path (no transport)."""
+def test_ws_explicitly_disabled_uses_http():
+    """With the gate explicitly off, the session uses the HTTP path (no transport)."""
     session = CodexResponsesSession(
         client=_HttpFallbackClient(),
         model="gpt-5.5",
@@ -302,13 +303,58 @@ def test_ws_disabled_by_default_uses_http():
         extra_kwargs={},
         session_id="sess-stable",
         thread_id="sess-stable",
-        # ws_enabled defaults to False
+        ws_enabled=False,
     )
 
     session.send("hello")
 
     assert len(session._client.responses.kwargs) == 1
     assert session._client.responses.kwargs[0]["store"] is False
+
+
+def test_codex_ws_enabled_defaults_on_when_env_unset(monkeypatch):
+    """Unset ``LINGTAI_CODEX_WS`` means the websocket transport is on by default."""
+    monkeypatch.delenv("LINGTAI_CODEX_WS", raising=False)
+    assert _codex_ws_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "FALSE", "Off", " no "])
+def test_codex_ws_enabled_explicit_off_disables(monkeypatch, value):
+    """An explicit falsy value forces the HTTP full-replay path."""
+    monkeypatch.setenv("LINGTAI_CODEX_WS", value)
+    assert _codex_ws_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "", "anything"])
+def test_codex_ws_enabled_other_values_stay_on(monkeypatch, value):
+    """Any non-falsy value (including empty/unrecognized) leaves the default on."""
+    monkeypatch.setenv("LINGTAI_CODEX_WS", value)
+    assert _codex_ws_enabled() is True
+
+
+def test_ws_enabled_by_default_when_env_unset_uses_transport(monkeypatch):
+    """With env unset and a transport factory available, the session uses WS."""
+    monkeypatch.delenv("LINGTAI_CODEX_WS", raising=False)
+    transport = FakeWsTransport()
+    session = CodexResponsesSession(
+        client=_HttpFallbackClient(),
+        model="gpt-5.5",
+        instructions="system prompt",
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+        session_id="sess-stable",
+        thread_id="sess-stable",
+        ws_transport_factory=lambda url, headers: transport,
+        # ws_enabled left as None -> resolved from env default (on)
+    )
+
+    assert session._ws_enabled is True
+    session.send("hello")
+
+    # WS path used: the injected transport saw the frame, HTTP fallback untouched.
+    assert transport.sent_frames
+    assert len(session._client.responses.kwargs) == 0
 
 
 class _ErrorWsConnection:


### PR DESCRIPTION
Per Jason's clarification (写一个小pr关于这个), default-on Codex WS is split out of #481 into its own small PR.

## What this does
Flips the `LINGTAI_CODEX_WS` gate to **on by default**:

- **unset** → WS enabled
- explicit **`0`/`false`/`no`/`off`** (case-insensitive, whitespace-trimmed) → disabled, forces the proven HTTP full-replay path
- any other value → leaves the default (enabled) in place

WS still falls back to HTTP on any handshake/connection/auth error, unsupported runtime, or delta mismatch, so the off-switch is a hard override, not the only safety net.

## Files
- `src/lingtai/llm/openai/adapter.py` — `_codex_ws_enabled()` default + comments (gate, function docstring, constructor comment)
- `tests/test_codex_ws_session.py` — default-on tests: env-unset → on, explicit-off → http, parametrized falsy/truthy parsing, and an unset-env session that drives the injected WS transport
- `tests/test_codex_prompt_cache_key.py` — autouse fixture pinning `LINGTAI_CODEX_WS=0` so the HTTP-path prompt-cache tests stay on the stateless replay transport (with the default flipped on, each `send()` would otherwise attempt a real websocket connect and only fall back after a network timeout — correct result, but slow and network-fragile)

## Tests
```
tests/test_codex_ws_session.py          43 passed
tests/test_codex_prompt_cache_key.py    41 passed
tests/test_codex_raw_reasoning_replay.py + test_openai_responses_streaming.py  31 passed
```

## Scope
This PR deliberately contains **only** the default-on change. The notification dismiss / fresh-epoch / honest `adapter_comment` work stays in #481 (restored to `967f3fc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)