### PR TITLE
feat: nudge agents about kernel runtime updates

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -12,13 +12,15 @@ description: >
   summarization, progressive disclosure, original-result recovery, and
   summarize-vs-molt distinctions; and `reference/sqlite-log-query/SKILL.md` for
   SQLite/log.sqlite runtime trace inspection and trajectory/anomaly mining from
-  event traces. Also
-  route here for lifecycle operations, notification
-  handling, molt/memory questions, MCP/addon ownership, preset tiers,
-  collaboration/network topology, resident prompt design, and the `system` tool
-  actions.
-version: 1.2.0
-tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize]
+  event traces; and `reference/runtime-update-checks/SKILL.md` for
+  runtime/kernel self-checks, nudge-driven update reminders, editable/dev-mode
+  identification, and safe refresh/update handoffs. Also
+  route here for lifecycle operations, notification/nudge
+  handling, runtime/kernel update checks, molt/memory questions, MCP/addon
+  ownership, preset tiers, collaboration/network topology, resident prompt
+  design, and the `system` tool actions.
+version: 1.3.0
+tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize, nudge, updates, runtime-checks]
 ---
 
 # System Manual — Progressive Disclosure Router
@@ -30,7 +32,7 @@ that carries the actual detail.
 
 Use this file first when the question is about LingTai's agent runtime, resident
 prompt design, lifecycle, memory, communication, tool routing, system operations,
-or runtime trace inspection. Then open the referenced lower node.
+runtime trace inspection, runtime/kernel update checks, or nudge handling. Then open the referenced lower node.
 
 
 ## Nested reference catalog
@@ -84,6 +86,14 @@ selects that topic.
     versus producer-specific dismiss, protected channels, stale-version/force
     semantics, and undismissable large-result reminders (cleared only by
     system summarize). The `system` tool owns no notification verb.
+- name: runtime-update-checks
+  location: reference/runtime-update-checks/SKILL.md
+  description: |
+    Runtime/kernel self-check and update-nudge manual: handling `.notification/nudge.json`
+    entries with `kind: kernel_version`, distinguishing running/installed/latest
+    LingTai kernel versions, recognizing editable/dev/source installs, honoring
+    the once-per-day packaged-runtime update check, asking the human before
+    downloading/updating, and refreshing only when safe.
 - name: goal-manual
   location: reference/goal-manual/SKILL.md
   description: |
@@ -101,6 +111,7 @@ selects that topic.
 | Tool-result summarization; large-result reminders; progressive disclosure of raw outputs; original-result recovery; summarize vs molt | `reference/summarize-manual/SKILL.md` |
 | SQLite; `log.sqlite`; LingTai runtime logs; JSONL traces; `lingtai-agent log doctor`; `lingtai-agent log query`; `lingtai-agent log rebuild`; events/chat_entries schema; daemon/chat-history trace indexing; WAL/live-read caveats; SQL recipes; trajectory/anomaly mining; improvement digests; cheap-model strategy | `reference/sqlite-log-query/SKILL.md` |
 | Notifications; the `notification` tool; check/dismiss_channel/dismiss_event/dismiss_ref; `.notification/<channel>.json`; channel allowlist; top-level `instructions`; protected channels; generic vs producer dismiss; stale-version/force; undismissable large-result reminders | `reference/notification-manual/SKILL.md` |
+| Runtime/kernel state; `nudge` notification channel; `.notification/nudge.json`; `kind: kernel_version`; running vs installed vs latest LingTai kernel; editable/dev/source installs; daily update checks; safe `system(action='refresh')`; ask the human before downloading/updating | `reference/runtime-update-checks/SKILL.md` |
 | Goal notifications; `.notification/goal.json`; active goal source of truth; goal `instructions`; idle goal reminder; cancel/complete goal | `reference/goal-manual/SKILL.md` |
 | Molt mechanics, pad tending, session journals, post-wipe recovery | `psyche-manual` |
 | Authoring/publishing skills or changing skill catalog behavior | `skills-manual` |

--- a/src/lingtai/intrinsic_skills/system-manual/reference/notification-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/notification-manual/SKILL.md
@@ -8,7 +8,7 @@ description: >
   force semantics, and the undismissable large-result reminders discharged only
   by system(action="summarize").
 version: 0.2.0
-tags: [lingtai, notifications, channels, dismiss, large-result, force, stale]
+tags: [lingtai, notifications, channels, dismiss, large-result, force, stale, nudge]
 ---
 
 # Notification Manual
@@ -34,6 +34,12 @@ The kernel uses an allowlist: built-in channels such as `email`, `system`,
 and `goal` are accepted; MCP bridge channels are accepted by the `mcp.` prefix.
 Unknown `.json` files are ignored by `collect_notifications()` and kernel helper
 publish/dismiss calls reject non-allowlisted channel names.
+
+The `nudge` channel is the formal surface for mechanical, throttled checks. For
+example, kernel runtime/update checks publish `data.nudges[]` entries with
+`kind: kernel_version`; interpret those with
+`reference/runtime-update-checks/SKILL.md` before asking the human to update or
+refresh.
 
 ## Envelope shape
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: runtime-update-checks
+description: >
+  Nested system-manual reference for LingTai runtime/kernel self-checks and
+  update nudges: handle `.notification/nudge.json` entries with
+  `kind: kernel_version`, identify editable/dev/source installs, compare the
+  running, installed, and latest kernel versions, respect the once-per-day
+  packaged-runtime check, ask the human before downloading/updating, and refresh
+  only when safe.
+version: 0.1.0
+tags: [lingtai, runtime, kernel, nudge, updates, refresh, editable, dev-mode]
+---
+
+# Runtime Update Checks
+
+Nested system-manual reference for mechanical runtime/kernel checks and update
+nudges. Read this when:
+
+- a `nudge` notification contains an entry with `kind: kernel_version`;
+- you suspect the running LingTai kernel is not the code currently installed on
+  disk;
+- a refresh did not seem to pick up a kernel change;
+- you need to tell whether this agent is in editable/source/dev mode; or
+- about once per day, a packaged runtime reports that a newer LingTai kernel is
+  available.
+
+This reference is about **checking and reporting**. It does not authorize
+installing, downloading, publishing, or refreshing across important work without
+human confirmation.
+
+## Nudge payload contract
+
+Kernel-owned periodic checks publish mechanical nudges through
+`.notification/nudge.json`. The shared channel stores a list under
+`data.nudges`; each entry has a unique `kind`. Kernel version/update entries use
+`kind: kernel_version`.
+
+Common fields:
+
+| Field | Meaning |
+| --- | --- |
+| `running` | Version frozen in the currently running process (`lingtai.__version__`). |
+| `installed` | Version visible from the installed `lingtai` distribution on disk. |
+| `latest` | Latest package version found by the daily packaged-runtime check, or `null` for local refresh nudges. |
+| `source` | `installed-distribution` for local refresh nudges, `pypi-json` for package-update nudges. |
+| `cadence` | `fast-local-check` or `at-most-once-per-utc-day`. |
+| `suggested_action` | The safe next-step hint; still verify context before acting. |
+
+After handling, clear the channel with:
+
+```text
+notification(action="dismiss_channel", channel="nudge")
+```
+
+## How to respond
+
+### Local refresh nudge (`source: installed-distribution`)
+
+If `running != installed`, the package on disk differs from the process already
+in memory. This usually means code was updated while the agent kept running.
+
+1. Check whether the agent is in the middle of sensitive work, active daemons, or
+   a task where refresh would lose useful in-flight state.
+2. If safe, call `system(action="refresh", reason="Load installed LingTai kernel update")`.
+3. After refresh, verify the import path/version and report any blocker to the
+   human or peer who requested the update.
+
+### Package-update nudge (`source: pypi-json`)
+
+If `latest > installed`, a newer LingTai kernel package exists for packaged
+runtimes. This check is throttled to at most once per UTC day per agent and is
+skipped for editable/source/dev installs.
+
+1. Tell the human the current `running`, `installed`, and `latest` versions.
+2. Explain that this is an update availability nudge, not an automatic upgrade.
+3. Ask whether they want you to update through their normal LingTai runtime/TUI
+   upgrade path.
+4. Do **not** download, install, edit config, or refresh until the human gives an
+   explicit imperative confirmation for that side effect.
+
+For user-facing instructions, follow the project standing rule: do not present a
+bare `pip install --upgrade lingtai` as the normal user upgrade path unless the
+human explicitly asks for development/diagnostic PyPI validation.
+
+## Editable/source/dev installs
+
+Package-update nudges are skipped when the kernel can identify the runtime as an
+editable install, a source checkout, or a dev/local version. In those modes the
+source of truth is usually the local checkout and git state, not the package
+index. Diagnose with:
+
+- the Python executable used by the agent runtime;
+- `lingtai.__version__`, `lingtai.__file__`, and `lingtai_kernel.__file__`;
+- installed distribution metadata, especially `direct_url.json` with
+  `dir_info.editable: true`;
+- the nearest git checkout, branch, HEAD, dirty state, and relation to remote;
+- whether `system.refresh` has reloaded the code already present on disk.
+
+A refresh reloads configuration and imports in a fresh process. It does not pull
+new commits, install packages, or publish anything.
+
+## Quick manual check
+
+Use a short local Python probe when the nudge payload is ambiguous:
+
+```bash
+python - <<'PY'
+import importlib.metadata as md
+import sys
+import lingtai, lingtai_kernel
+print('python=', sys.executable)
+print('lingtai_version=', getattr(lingtai, '__version__', 'unknown'))
+print('lingtai_dist=', md.version('lingtai'))
+print('lingtai_file=', getattr(lingtai, '__file__', 'unknown'))
+print('lingtai_kernel_file=', getattr(lingtai_kernel, '__file__', 'unknown'))
+try:
+    dist = md.distribution('lingtai')
+    print('direct_url=', dist.read_text('direct_url.json'))
+except Exception as exc:
+    print('direct_url_error=', type(exc).__name__, str(exc)[:120])
+PY
+```
+
+Do not print credentials, tokens, or environment dumps while doing update checks.
+
+## Relationship to notification-manual
+
+`notification-manual` owns the generic channel protocol and dismissal mechanics.
+This reference owns the `kernel_version` nudge interpretation and the safe human
+handoff for runtime updates.

--- a/src/lingtai_kernel/nudge/ANATOMY.md
+++ b/src/lingtai_kernel/nudge/ANATOMY.md
@@ -1,10 +1,12 @@
 # Nudge
 
 Per-agent periodic checks that emit notification nudges or reminders when
-something needs the agent's attention. Kernel-version nudges share
-`.notification/nudge.json`; goal reminders read protected `.notification/goal.json`
-and publish short dismissible events into `.notification/system.json`. Designed so
-additional checks land as small additions (e.g. MCP version drift, addon updates).
+something needs the agent's attention. Runtime/kernel update nudges share
+`.notification/nudge.json` and keep throttle state in
+`.notification/.nudge_state.json`; goal reminders read protected
+`.notification/goal.json` and publish short dismissible events into
+`.notification/system.json`. Designed so additional mechanical checks land as
+small additions (e.g. MCP version drift, addon updates).
 
 ## Entry point
 
@@ -19,9 +21,14 @@ bad check never breaks the loop). It dispatches to each check's
   helpers (`upsert`, `remove`) that operate on the `nudge.json`
   multi-entry payload under a lazy per-agent lock. Runs `kernel_version.check`
   and then `goal.check` once per heartbeat tick.
-- `kernel_version.py` — compares `lingtai.__version__` (frozen at import time)
-  against `importlib.metadata.version("lingtai")` (rescans dist-info on each
-  call). Emits into `nudge.json` when they differ; clears when they re-agree.
+- `kernel_version.py` — read-only runtime/update check. It first detects
+  whether the installed `lingtai` distribution on disk differs from the running
+  `lingtai.__version__` and emits a fast local refresh nudge. For packaged,
+  non-editable/non-dev runtimes, it also performs an at-most-once-per-UTC-day
+  package-index check for a newer kernel version and nudges the agent to read
+  `system-manual -> reference/runtime-update-checks/SKILL.md` before asking the
+  human whether to update. It stores daily throttle state in the hidden
+  `.notification/.nudge_state.json` helper file, which is not a channel.
 - `goal.py` — IDLE-only goal reminder check. It reads the allowlisted protected
   `.notification/goal.json`; if and only if that file exists, is active, and the
   idle delay has elapsed, it publishes one short `goal.reminder` event into
@@ -39,7 +46,7 @@ All nudges share `.notification/nudge.json` with this shape:
   "header": "1 nudge",
   "icon": "🔔",
   "priority": "low",
-  "instructions": "Call system(action='dismiss', channel='nudge') ...",
+  "instructions": "Call notification(action='dismiss_channel', channel='nudge') ...",
   "data": {
     "nudges": [
       {"kind": "kernel_version", "title": "...", "detail": "...", ...}
@@ -52,14 +59,15 @@ Each entry's `kind` is its slot key — `upsert(agent, kind, body)`
 replaces by `kind`, `remove(agent, kind)` drops by `kind`. When the
 list empties, the channel file is deleted entirely so the wire surface
 drops the notification cleanly. The agent dismisses everything at once
-with `system(action='dismiss', channel='nudge')`.
+with `notification(action='dismiss_channel', channel='nudge')`.
 
 ## Adding a new nudge
 
 1. Drop `nudge/<name>.py` with a top-level `check(agent) -> None`
    function. Inside:
-   - Throttle (compare wall-clock against a state dict you stash on
-     the agent as `agent._nudge_<name>_state`).
+   - Throttle. In-memory state on `agent._nudge_<name>_state` is fine for
+     short cadence checks; use a small non-channel state file (for example
+     `.notification/.nudge_state.json`) when the cadence must survive refreshes.
    - Probe whatever you need to check.
    - On hit: call `upsert(agent, "<unique_kind>", body)` where `body`
      is the per-kind payload dict you want the agent to read.

--- a/src/lingtai_kernel/nudge/kernel_version.py
+++ b/src/lingtai_kernel/nudge/kernel_version.py
@@ -1,88 +1,337 @@
-"""Nudge: warn the agent when a newer lingtai wheel is installed on disk
-than the version this Python process started with.
+"""Kernel runtime/update nudges.
 
-``lingtai.__version__`` is computed from ``importlib.metadata`` at import
-time and frozen in the module dict for the life of the process. Calling
-``importlib.metadata.version("lingtai")`` again rescans dist-info on
-disk — so a wheel installed mid-run by the TUI auto-upgrader, or a
-manual ``pip install -U lingtai``, is visible immediately. When the
-two disagree, the running interpreter is stale: only a full process
-relaunch (``system(action='refresh')``) picks up the new code, because
-Python caches imported modules in ``sys.modules`` and there is no
-reliable way to reload them mid-process.
+This check is deliberately read-only. It exists to surface mechanical runtime
+facts through the shared ``nudge`` notification channel, not to mutate the
+installation by itself.
 
-Throttled to one filesystem probe per 60 seconds and deduped per
-installed version, so a long-running agent gets exactly one nudge per
-upgrade rather than a flood every heartbeat tick. If the on-disk
-version returns to match running (downgrade, or stale state from a
-prior process), the previously-emitted entry is cleared so the agent
-isn't told to refresh into the version it's already on.
+Two related cases share one nudge ``kind``:
+
+* local refresh available: the installed ``lingtai`` distribution on disk is
+  newer than the currently running process, so a safe ``system.refresh`` may
+  load code that is already present;
+* package update available: a packaged, non-editable runtime is behind the
+  latest published ``lingtai`` kernel package. This is checked at most once per
+  UTC day per agent and asks the agent to read the system runtime-update skill
+  and ask the human before downloading/updating.
+
+Editable/source/dev installs are skipped for the package-update check: their
+source of truth is the checkout, not the package index.
 """
+
 from __future__ import annotations
+
+import json
+import re
 import time
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
 
-
-_INTERVAL_SECONDS = 60.0
+_FAST_INTERVAL_SECONDS = 60.0
+_REMOTE_TIMEOUT_SECONDS = 3.0
+_PYPI_JSON_URL = "https://pypi.org/pypi/lingtai/json"
+_STATE_FILE = Path(".notification") / ".nudge_state.json"
 _KIND = "kernel_version"
+_SKILL_HINT = "system-manual -> reference/runtime-update-checks/SKILL.md"
+
+
+@dataclass(frozen=True)
+class _RuntimeInfo:
+    running_version: str
+    installed_version: str
+    dev_reason: str | None = None
+
+    @property
+    def dev_mode(self) -> bool:
+        return self.dev_reason is not None
 
 
 def check(agent) -> None:
+    """Emit or clear the kernel-version nudge for ``agent``."""
+
     state = _state(agent)
     now = time.time()
-    if now - state.get("last_probe_ts", 0.0) < _INTERVAL_SECONDS:
+    if now - float(state.get("last_probe_ts") or 0.0) < _FAST_INTERVAL_SECONDS:
         return
     state["last_probe_ts"] = now
 
-    from importlib.metadata import version as pkg_version, PackageNotFoundError
-    from . import upsert, remove
-    import lingtai
-
-    running = getattr(lingtai, "__version__", None)
-    if not running:
-        return
     try:
-        installed = pkg_version("lingtai")
-    except PackageNotFoundError:
+        from . import remove, upsert
+
+        info = _runtime_info()
+    except Exception as e:  # pragma: no cover - defensive: nudge must be inert
+        _log(agent, "kernel_version_probe_error", error=str(e)[:200])
         return
 
-    if installed == running:
-        if state.get("emitted_for_version") is not None:
-            remove(agent, _KIND)
-            state["emitted_for_version"] = None
+    if info.dev_mode:
+        remove(agent, _KIND)
+        _store_kernel_state(
+            agent,
+            {
+                "last_skip_date": _today_utc(),
+                "skip_reason": info.dev_reason,
+                "checked_installed_version": info.installed_version,
+                "last_error": None,
+            },
+        )
         return
 
-    if state.get("emitted_for_version") == installed:
-        return
-
-    body = {
-        "title": f"Kernel upgrade available: {running} → {installed}",
-        "running": running,
-        "installed": installed,
-        "detail": (
-            f"This process is running lingtai {running}, but lingtai "
-            f"{installed} is now installed on disk. Call "
-            f"system(action='refresh', reason='pick up lingtai "
-            f"{installed}') when convenient to relaunch into the new "
-            f"version. No urgency — finish the current task first."
-        ),
-        "suggested_action": "system(action='refresh')",
-    }
-    try:
-        upsert(agent, _KIND, body)
-        state["emitted_for_version"] = installed
-        agent._log(
+    if info.installed_version != info.running_version:
+        upsert(
+            agent,
+            _KIND,
+            {
+                "title": (
+                    "LingTai kernel refresh available: "
+                    f"{info.running_version} -> {info.installed_version}"
+                ),
+                "detail": (
+                    "The LingTai package on disk differs from the currently "
+                    "running kernel. Read "
+                    f"`{_SKILL_HINT}` first; if the current work can be "
+                    "safely reloaded, use `system(action='refresh')` to load "
+                    "the installed runtime."
+                ),
+                "running": info.running_version,
+                "installed": info.installed_version,
+                "latest": None,
+                "source": "installed-distribution",
+                "cadence": "fast-local-check",
+                "suggested_action": "read-runtime-update-skill-then-refresh-if-safe",
+                "skill": _SKILL_HINT,
+            },
+        )
+        _log(
+            agent,
             "nudge_emitted",
             kind=_KIND,
-            running=running,
-            installed=installed,
+            running=info.running_version,
+            installed=info.installed_version,
+            source="installed-distribution",
         )
+        return
+
+    persistent = _load_persistent_state(agent)
+    kernel_state = persistent.setdefault(_KIND, {})
+    today = _today_utc()
+    if not _remote_check_due(kernel_state, info.installed_version, today):
+        return
+
+    try:
+        latest = _fetch_latest_version()
     except Exception as e:
-        agent._log("nudge_emit_error", kind=_KIND, error=str(e)[:200])
+        kernel_state.update(
+            {
+                "last_remote_check_date": today,
+                "checked_installed_version": info.installed_version,
+                "last_error": str(e)[:200],
+            }
+        )
+        _save_persistent_state(agent, persistent)
+        _log(agent, "kernel_version_update_check_error", error=str(e)[:200])
+        return
+
+    kernel_state.update(
+        {
+            "last_remote_check_date": today,
+            "checked_installed_version": info.installed_version,
+            "latest_seen": latest,
+            "last_error": None,
+        }
+    )
+
+    if _is_newer(latest, info.installed_version):
+        kernel_state["emitted_for_latest"] = latest
+        _save_persistent_state(agent, persistent)
+        upsert(
+            agent,
+            _KIND,
+            {
+                "title": (
+                    "LingTai kernel update available: "
+                    f"{info.installed_version} -> {latest}"
+                ),
+                "detail": (
+                    "A newer LingTai kernel package is available. Read "
+                    f"`{_SKILL_HINT}`, tell the human what changed, and ask "
+                    "whether they want to update through their normal LingTai "
+                    "runtime/TUI upgrade path. Do not download or refresh "
+                    "without human confirmation."
+                ),
+                "running": info.running_version,
+                "installed": info.installed_version,
+                "latest": latest,
+                "source": "pypi-json",
+                "cadence": "at-most-once-per-utc-day",
+                "checked_at_date": today,
+                "suggested_action": "read-runtime-update-skill-and-ask-human",
+                "skill": _SKILL_HINT,
+            },
+        )
+        _log(
+            agent,
+            "nudge_emitted",
+            kind=_KIND,
+            installed=info.installed_version,
+            latest=latest,
+            source="pypi-json",
+        )
+        return
+
+    kernel_state["emitted_for_latest"] = None
+    _save_persistent_state(agent, persistent)
+    remove(agent, _KIND)
+
+
+def _runtime_info() -> _RuntimeInfo:
+    from importlib import metadata
+
+    import lingtai
+
+    running = str(getattr(lingtai, "__version__", "unknown"))
+    try:
+        dist = metadata.distribution("lingtai")
+        installed = str(dist.version)
+    except metadata.PackageNotFoundError:
+        return _RuntimeInfo(
+            running_version=running,
+            installed_version=running,
+            dev_reason="no-installed-distribution",
+        )
+
+    return _RuntimeInfo(
+        running_version=running,
+        installed_version=installed,
+        dev_reason=_dev_install_reason(dist, lingtai, running, installed),
+    )
+
+
+def _dev_install_reason(dist: Any, module: Any, running: str, installed: str) -> str | None:
+    if _direct_url_is_editable(dist):
+        return "editable-install"
+    if _looks_like_dev_version(running) or _looks_like_dev_version(installed):
+        return "dev-version"
+    if _module_from_source_checkout(module):
+        return "source-checkout"
+    return None
+
+
+def _direct_url_is_editable(dist: Any) -> bool:
+    try:
+        raw = dist.read_text("direct_url.json")
+    except Exception:
+        return False
+    if not raw:
+        return False
+    try:
+        data = json.loads(raw)
+    except Exception:
+        return False
+    return bool(data.get("dir_info", {}).get("editable"))
+
+
+def _looks_like_dev_version(version: str) -> bool:
+    v = (version or "").lower()
+    return ".dev" in v or "+" in v or "editable" in v
+
+
+def _module_from_source_checkout(module: Any) -> bool:
+    raw = getattr(module, "__file__", None)
+    if not raw:
+        return False
+    try:
+        path = Path(raw).resolve()
+    except Exception:
+        return False
+    if any(part in {"site-packages", "dist-packages"} for part in path.parts):
+        return False
+    return any((parent / ".git").exists() and (parent / "pyproject.toml").exists() for parent in path.parents)
+
+
+def _remote_check_due(kernel_state: dict[str, Any], installed_version: str, today: str) -> bool:
+    return (
+        kernel_state.get("last_remote_check_date") != today
+        or kernel_state.get("checked_installed_version") != installed_version
+    )
+
+
+def _fetch_latest_version() -> str:
+    req = urllib.request.Request(
+        _PYPI_JSON_URL,
+        headers={"User-Agent": "lingtai-kernel-nudge/1"},
+    )
+    with urllib.request.urlopen(req, timeout=_REMOTE_TIMEOUT_SECONDS) as resp:
+        raw = resp.read()
+    data = json.loads(raw.decode("utf-8"))
+    latest = str(data.get("info", {}).get("version") or "")
+    if not latest:
+        raise RuntimeError("PyPI response did not include info.version")
+    return latest
+
+
+def _is_newer(candidate: str, current: str) -> bool:
+    if not candidate or candidate == current:
+        return False
+    try:
+        from packaging.version import Version
+
+        return Version(candidate) > Version(current)
+    except Exception:
+        return _version_tuple(candidate) > _version_tuple(current)
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in re.findall(r"\d+", version or ""))
+
+
+def _today_utc() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _persistent_path(agent) -> Path:
+    return Path(agent._working_dir) / _STATE_FILE
+
+
+def _load_persistent_state(agent) -> dict[str, Any]:
+    path = _persistent_path(agent)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_persistent_state(agent, state: dict[str, Any]) -> None:
+    path = _persistent_path(agent)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _store_kernel_state(agent, fields: dict[str, Any]) -> None:
+    persistent = _load_persistent_state(agent)
+    kernel_state = persistent.setdefault(_KIND, {})
+    if all(kernel_state.get(k) == v for k, v in fields.items()):
+        return
+    kernel_state.update(fields)
+    _save_persistent_state(agent, persistent)
 
 
 def _state(agent) -> dict:
-    s = getattr(agent, "_nudge_kernel_version_state", None)
-    if s is None:
-        s = {}
-        agent._nudge_kernel_version_state = s
-    return s
+    state = getattr(agent, "_nudge_kernel_version_state", None)
+    if not isinstance(state, dict):
+        state = {}
+        setattr(agent, "_nudge_kernel_version_state", state)
+    return state
+
+
+def _log(agent, event: str, **fields: Any) -> None:
+    try:
+        agent._log(event, **fields)
+    except Exception:
+        pass

--- a/tests/test_kernel_version_nudge.py
+++ b/tests/test_kernel_version_nudge.py
@@ -1,0 +1,157 @@
+import json
+
+from lingtai_kernel.notifications import collect_notifications
+from lingtai_kernel.nudge import upsert
+from lingtai_kernel.nudge import kernel_version as kv
+
+
+class _Agent:
+    def __init__(self, workdir):
+        self._working_dir = workdir
+        self.logs = []
+
+    def _log(self, event, **fields):
+        self.logs.append((event, fields))
+
+
+def _entries(workdir):
+    return (
+        collect_notifications(workdir)
+        .get("nudge", {})
+        .get("data", {})
+        .get("nudges", [])
+    )
+
+
+def _reset_fast_gate(agent):
+    agent._nudge_kernel_version_state["last_probe_ts"] = 0.0
+
+
+def test_installed_runtime_refresh_nudge_does_not_hit_remote(tmp_path, monkeypatch):
+    agent = _Agent(tmp_path)
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo(
+            running_version="0.14.1",
+            installed_version="0.14.2",
+            dev_reason=None,
+        ),
+    )
+    monkeypatch.setattr(
+        kv,
+        "_fetch_latest_version",
+        lambda: (_ for _ in ()).throw(AssertionError("remote should not be queried")),
+    )
+
+    kv.check(agent)
+
+    entries = _entries(tmp_path)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["kind"] == "kernel_version"
+    assert entry["source"] == "installed-distribution"
+    assert entry["running"] == "0.14.1"
+    assert entry["installed"] == "0.14.2"
+    assert entry["suggested_action"] == "read-runtime-update-skill-then-refresh-if-safe"
+    assert "runtime-update-checks" in entry["skill"]
+    assert "system(action='refresh')" in entry["detail"]
+
+
+def test_remote_update_check_is_daily_and_persistent(tmp_path, monkeypatch):
+    agent = _Agent(tmp_path)
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo(
+            running_version="0.14.1",
+            installed_version="0.14.1",
+            dev_reason=None,
+        ),
+    )
+    monkeypatch.setattr(kv, "_today_utc", lambda: "2026-06-24")
+
+    def latest():
+        calls["n"] += 1
+        return "0.14.2"
+
+    monkeypatch.setattr(kv, "_fetch_latest_version", latest)
+
+    kv.check(agent)
+
+    entries = _entries(tmp_path)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["source"] == "pypi-json"
+    assert entry["cadence"] == "at-most-once-per-utc-day"
+    assert entry["latest"] == "0.14.2"
+    assert entry["suggested_action"] == "read-runtime-update-skill-and-ask-human"
+    assert "human" in entry["detail"].lower()
+    assert calls["n"] == 1
+
+    state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
+    assert state["kernel_version"]["last_remote_check_date"] == "2026-06-24"
+    assert state["kernel_version"]["checked_installed_version"] == "0.14.1"
+    assert state["kernel_version"]["latest_seen"] == "0.14.2"
+
+    _reset_fast_gate(agent)
+    monkeypatch.setattr(
+        kv,
+        "_fetch_latest_version",
+        lambda: (_ for _ in ()).throw(AssertionError("daily throttle failed")),
+    )
+    kv.check(agent)
+    assert calls["n"] == 1
+    assert _entries(tmp_path)[0]["latest"] == "0.14.2"
+
+
+def test_dev_or_editable_runtime_skips_and_clears_kernel_nudge(tmp_path, monkeypatch):
+    agent = _Agent(tmp_path)
+    upsert(agent, "kernel_version", {"title": "old", "source": "pypi-json"})
+    assert _entries(tmp_path)
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo(
+            running_version="0.14.1.dev0",
+            installed_version="0.14.1.dev0",
+            dev_reason="editable-install",
+        ),
+    )
+    monkeypatch.setattr(kv, "_today_utc", lambda: "2026-06-24")
+    monkeypatch.setattr(
+        kv,
+        "_fetch_latest_version",
+        lambda: (_ for _ in ()).throw(AssertionError("dev mode should skip remote")),
+    )
+
+    kv.check(agent)
+
+    assert "nudge" not in collect_notifications(tmp_path)
+    state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
+    assert state["kernel_version"]["last_skip_date"] == "2026-06-24"
+    assert state["kernel_version"]["skip_reason"] == "editable-install"
+
+
+def test_current_remote_version_clears_existing_kernel_nudge(tmp_path, monkeypatch):
+    agent = _Agent(tmp_path)
+    upsert(agent, "kernel_version", {"title": "old", "source": "pypi-json"})
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo(
+            running_version="0.14.1",
+            installed_version="0.14.1",
+            dev_reason=None,
+        ),
+    )
+    monkeypatch.setattr(kv, "_today_utc", lambda: "2026-06-24")
+    monkeypatch.setattr(kv, "_fetch_latest_version", lambda: "0.14.1")
+
+    kv.check(agent)
+
+    assert "nudge" not in collect_notifications(tmp_path)
+    state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
+    assert state["kernel_version"]["latest_seen"] == "0.14.1"
+    assert state["kernel_version"]["emitted_for_latest"] is None

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -184,12 +184,14 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "reference/substrate-manual/SKILL.md" in system_manual_body
         assert "reference/procedures-manual/SKILL.md" in system_manual_body
         assert "reference/sqlite-log-query/SKILL.md" in system_manual_body
+        assert "reference/runtime-update-checks/SKILL.md" in system_manual_body
         assert "lingtai-agent log doctor" in system_manual_body
         assert "lingtai-agent log query" in system_manual_body
         assert "lingtai-agent log rebuild" in system_manual_body
         assert "name: substrate-manual" in system_manual_body
         assert "name: procedures-manual" in system_manual_body
         assert "name: sqlite-log-query" in system_manual_body
+        assert "name: runtime-update-checks" in system_manual_body
         assert "Nested reference catalog" in system_manual_body
 
         substrate_ref = system_manual_md.parent / "reference" / "substrate-manual" / "SKILL.md"
@@ -214,6 +216,20 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "Human-facing deliverables" in procedures_body
         assert "external side effects" in procedures_body
         assert "Resident procedures maintenance" in procedures_body
+
+        runtime_update_ref = (
+            system_manual_md.parent / "reference" / "runtime-update-checks" / "SKILL.md"
+        )
+        assert runtime_update_ref.is_file()
+        runtime_update_body = runtime_update_ref.read_text(encoding="utf-8")
+        assert "name: runtime-update-checks" in runtime_update_body
+        assert "Nested system-manual reference" in runtime_update_body
+        assert "# Runtime Update Checks" in runtime_update_body
+        assert "kind: kernel_version" in runtime_update_body
+        assert ".notification/nudge.json" in runtime_update_body
+        assert "once per UTC day" in runtime_update_body
+        assert "editable/source/dev" in runtime_update_body
+        assert "ask the human" in runtime_update_body
 
         psyche_md = (
             workdir


### PR DESCRIPTION
## Summary
- Extend the existing `nudge` notification subsystem with a formal kernel runtime/update check:
  - fast local refresh nudge when the running kernel version differs from the installed distribution on disk;
  - at-most-once-per-UTC-day packaged-runtime update nudge that checks the latest published LingTai kernel version;
  - editable/source/dev installs are skipped for package-update checks.
- Add a new `system-manual` nested reference, `reference/runtime-update-checks/SKILL.md`, and surface it in the top-level router/YAML so agents know how to interpret `kind: kernel_version` nudges and ask humans before updating.
- Refresh nudge/notification docs and anatomy, including the `.notification/nudge.json` channel and hidden `.notification/.nudge_state.json` throttle state.

## Safety / behavior
- The update checker is read-only: it emits a `nudge` entry and never downloads, installs, refreshes, or mutates config by itself.
- Package-index checks are throttled to once per UTC day per agent and use a short timeout.
- Editable/dev/source runtimes do not run the package-update check.
- The skill explicitly says to ask the human before any download/update and to refresh only when safe.

## Validation
- `git diff --check`
- `python -m pytest tests/test_kernel_version_nudge.py tests/test_goal_notification.py tests/test_notification_sync.py tests/test_system_dismiss.py tests/test_skills.py -q` → 123 passed
- `python -m compileall -q src/lingtai_kernel/nudge tests/test_kernel_version_nudge.py`