### PR TITLE
Expose Telegram rich formatting options

### DIFF
--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -841,8 +841,17 @@ class TelegramAccount:
         reply_markup: dict | None = None,
         reply_to_message_id: int | None = None,
         parse_mode: str | None = None,
+        entities: list[dict[str, Any]] | None = None,
+        link_preview_options: dict[str, Any] | None = None,
+        disable_web_page_preview: bool | None = None,
     ) -> dict:
-        """Send a text message. Returns the sent Message object."""
+        """Send a text message. Returns the sent Message object.
+
+        Rich-formatting options (``parse_mode``, ``entities``,
+        ``link_preview_options``, ``disable_web_page_preview``) are passed
+        through to the Bot API only when supplied — omitting them preserves
+        the previous plain-text behaviour.
+        """
         payload: dict[str, Any] = {"chat_id": chat_id, "text": text}
         if reply_markup:
             payload["reply_markup"] = reply_markup
@@ -850,11 +859,22 @@ class TelegramAccount:
             payload["reply_to_message_id"] = reply_to_message_id
         if parse_mode:
             payload["parse_mode"] = parse_mode
+        if entities is not None:
+            payload["entities"] = entities
+        if link_preview_options is not None:
+            payload["link_preview_options"] = link_preview_options
+        if disable_web_page_preview is not None:
+            payload["disable_web_page_preview"] = disable_web_page_preview
         return self._request("sendMessage", json=payload)
 
     def send_photo(
-        self, chat_id: int, photo_path: str, caption: str | None = None,
+        self,
+        chat_id: int,
+        photo_path: str,
+        caption: str | None = None,
         reply_to_message_id: int | None = None,
+        parse_mode: str | None = None,
+        caption_entities: list[dict[str, Any]] | None = None,
     ) -> dict:
         """Send a photo via multipart upload."""
         with open(photo_path, "rb") as f:
@@ -864,11 +884,21 @@ class TelegramAccount:
                 data["caption"] = caption
             if reply_to_message_id:
                 data["reply_to_message_id"] = str(reply_to_message_id)
+            if parse_mode:
+                data["parse_mode"] = parse_mode
+            if caption_entities is not None:
+                # Multipart fields must be strings; serialize the array.
+                data["caption_entities"] = json.dumps(caption_entities)
             return self._request("sendPhoto", files=files, data=data)
 
     def send_document(
-        self, chat_id: int, doc_path: str, caption: str | None = None,
+        self,
+        chat_id: int,
+        doc_path: str,
+        caption: str | None = None,
         reply_to_message_id: int | None = None,
+        parse_mode: str | None = None,
+        caption_entities: list[dict[str, Any]] | None = None,
     ) -> dict:
         """Send a document via multipart upload."""
         with open(doc_path, "rb") as f:
@@ -878,11 +908,25 @@ class TelegramAccount:
                 data["caption"] = caption
             if reply_to_message_id:
                 data["reply_to_message_id"] = str(reply_to_message_id)
+            if parse_mode:
+                data["parse_mode"] = parse_mode
+            if caption_entities is not None:
+                # Multipart fields must be strings; serialize the array.
+                data["caption_entities"] = json.dumps(caption_entities)
             return self._request("sendDocument", files=files, data=data)
 
     def edit_message(
-        self, chat_id: int, message_id: int, text: str,
-        reply_markup: dict | None = None, is_caption: bool = False,
+        self,
+        chat_id: int,
+        message_id: int,
+        text: str,
+        reply_markup: dict | None = None,
+        is_caption: bool = False,
+        parse_mode: str | None = None,
+        entities: list[dict[str, Any]] | None = None,
+        caption_entities: list[dict[str, Any]] | None = None,
+        link_preview_options: dict[str, Any] | None = None,
+        disable_web_page_preview: bool | None = None,
     ) -> dict:
         """Edit a sent message's text or caption."""
         if is_caption:
@@ -891,6 +935,10 @@ class TelegramAccount:
             }
             if reply_markup:
                 payload["reply_markup"] = reply_markup
+            if parse_mode:
+                payload["parse_mode"] = parse_mode
+            if caption_entities is not None:
+                payload["caption_entities"] = caption_entities
             return self._request("editMessageCaption", json=payload)
         else:
             payload = {
@@ -898,6 +946,14 @@ class TelegramAccount:
             }
             if reply_markup:
                 payload["reply_markup"] = reply_markup
+            if parse_mode:
+                payload["parse_mode"] = parse_mode
+            if entities is not None:
+                payload["entities"] = entities
+            if link_preview_options is not None:
+                payload["link_preview_options"] = link_preview_options
+            if disable_web_page_preview is not None:
+                payload["disable_web_page_preview"] = disable_web_page_preview
             return self._request("editMessageText", json=payload)
 
     def delete_message(self, chat_id: int, message_id: int) -> dict:

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -24,7 +24,6 @@ from uuid import uuid4
 
 import logging
 import threading
-import time
 
 if TYPE_CHECKING:
     from .service import TelegramService
@@ -169,15 +168,15 @@ SCHEMA = {
                 "accounts",
             ],
             "description": (
-                "send: send message to a chat (chat_id, text; optional media, reply_markup, placeholder, chat_action). "
+                "send: send message to a chat (chat_id, text; optional media, reply_markup, placeholder, chat_action, parse_mode/entities). "
                 "If chat_action is set and no text/media is provided, sends a typing "
                 "indicator (auto-expires after 5s) instead of a message. "
                 "check: list recent conversations with unread counts (optional account). "
                 "read: read messages from a chat (chat_id; optional limit). "
-                "reply: reply to a specific message (message_id from read results, text). "
+                "reply: reply to a specific message (message_id from read results, text; optional parse_mode/entities). "
                 "search: search messages (query; optional account, chat_id). "
                 "delete: delete a bot message (message_id). "
-                "edit: edit a bot message (message_id, text; optional reply_markup). "
+                "edit: edit a bot message (message_id, text; optional reply_markup, parse_mode/entities). "
                 "contacts: list saved contacts. "
                 "add_contact: save a chat alias (chat_id, alias); this does not grant inbound permission. "
                 "To receive messages from that user, their Telegram user ID must also be in allowed_users. "
@@ -212,6 +211,27 @@ SCHEMA = {
         "reply_markup": {
             "type": "object",
             "description": "Inline keyboard markup",
+        },
+        "parse_mode": {
+            "type": "string",
+            "enum": ["HTML", "MarkdownV2", "Markdown"],
+            "description": "Telegram Bot API parse_mode for rich text (send/reply/edit, and media captions).",
+        },
+        "entities": {
+            "type": "array",
+            "description": "Telegram MessageEntity[] for message text formatting (send/reply/edit).",
+        },
+        "caption_entities": {
+            "type": "array",
+            "description": "Telegram MessageEntity[] for media captions.",
+        },
+        "link_preview_options": {
+            "type": "object",
+            "description": "Telegram LinkPreviewOptions for text messages.",
+        },
+        "disable_web_page_preview": {
+            "type": "boolean",
+            "description": "Compatibility shortcut to disable link previews for text messages.",
         },
         "placeholder": {
             "type": "boolean",
@@ -259,7 +279,7 @@ DESCRIPTION = (
     "do not attempt to configure or reconfigure this MCP — your orchestrator "
     "manages it, and if the network needs this MCP to reach you the wiring "
     "is propagated to your session automatically. "
-    "Use 'send' for outgoing messages (text, photos, documents, inline keyboards). "
+    "Use 'send' for outgoing messages (text, photos, documents, inline keyboards, rich formatting). "
     "'check' to see recent conversations. "
     "'read' to read messages from a specific chat. "
     "'reply' to respond to a message (use compound ID from read results). "
@@ -908,6 +928,48 @@ class TelegramManager:
     # Actions
     # ------------------------------------------------------------------
 
+    _PARSE_MODES = {"HTML", "MarkdownV2", "Markdown"}
+
+    def _rich_text_options(self, args: dict) -> tuple[dict[str, Any], str | None]:
+        """Extract Bot API rich text options for text messages from tool args.
+
+        Returns (options, error). When nothing relevant is supplied the
+        options dict is empty, so existing plain-text callers behave exactly
+        as before.
+        """
+        opts: dict[str, Any] = {}
+        parse_mode = args.get("parse_mode")
+        if parse_mode is not None:
+            if parse_mode not in self._PARSE_MODES:
+                return {}, "parse_mode must be one of: HTML, MarkdownV2, Markdown"
+            opts["parse_mode"] = parse_mode
+        if args.get("entities") is not None:
+            opts["entities"] = args.get("entities")
+        if args.get("link_preview_options") is not None:
+            opts["link_preview_options"] = args.get("link_preview_options")
+        if args.get("disable_web_page_preview") is not None:
+            opts["disable_web_page_preview"] = bool(args.get("disable_web_page_preview"))
+        return opts, None
+
+    def _caption_options(self, args: dict) -> tuple[dict[str, Any], str | None]:
+        """Extract Bot API rich caption options for media sends from tool args.
+
+        If ``caption_entities`` is omitted but ``entities`` is supplied, the
+        latter is treated as caption entities for convenience.
+        """
+        opts: dict[str, Any] = {}
+        parse_mode = args.get("parse_mode")
+        if parse_mode is not None:
+            if parse_mode not in self._PARSE_MODES:
+                return {}, "parse_mode must be one of: HTML, MarkdownV2, Markdown"
+            opts["parse_mode"] = parse_mode
+        caption_entities = args.get("caption_entities")
+        if caption_entities is None:
+            caption_entities = args.get("entities")
+        if caption_entities is not None:
+            opts["caption_entities"] = caption_entities
+        return opts, None
+
     def _send(self, args: dict) -> dict:
         account = self._resolve_account(args)
         chat_id = args.get("chat_id")
@@ -922,6 +984,10 @@ class TelegramManager:
         reply_markup = args.get("reply_markup")
         chat_action = args.get("chat_action")
         placeholder = bool(args.get("placeholder", False))
+        rich_text_options, rich_text_error = self._rich_text_options(args)
+        caption_options, caption_error = self._caption_options(args)
+        if rich_text_error or caption_error:
+            return {"error": rich_text_error or caption_error}
 
         if not chat_id:
             return {"error": "chat_id is required"}
@@ -980,11 +1046,13 @@ class TelegramManager:
                 result = acct.send_photo(
                     chat_id, media_path, caption=text or None,
                     reply_to_message_id=reply_to,
+                    **caption_options,
                 )
             elif media_type == "document":
                 result = acct.send_document(
                     chat_id, media_path, caption=text or None,
                     reply_to_message_id=reply_to,
+                    **caption_options,
                 )
             else:
                 return {"error": f"Unknown media type: {media_type}"}
@@ -992,6 +1060,7 @@ class TelegramManager:
             result = acct.send_message(
                 chat_id, text, reply_markup=reply_markup,
                 reply_to_message_id=reply_to,
+                **rich_text_options,
             )
 
         # Track for duplicate detection
@@ -1010,6 +1079,11 @@ class TelegramManager:
             "text": text,
             "media": media,
             "reply_markup": reply_markup,
+            "parse_mode": args.get("parse_mode"),
+            "entities": args.get("entities"),
+            "caption_entities": args.get("caption_entities"),
+            "link_preview_options": args.get("link_preview_options"),
+            "disable_web_page_preview": args.get("disable_web_page_preview"),
             "sent_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "status": "placeholder" if placeholder else "sent",
         }
@@ -1145,6 +1219,11 @@ class TelegramManager:
             "text": text,
             "media": args.get("media"),
             "reply_markup": args.get("reply_markup"),
+            "parse_mode": args.get("parse_mode"),
+            "entities": args.get("entities"),
+            "caption_entities": args.get("caption_entities"),
+            "link_preview_options": args.get("link_preview_options"),
+            "disable_web_page_preview": args.get("disable_web_page_preview"),
             # We need to pass reply_to_message_id through
             "_reply_to_message_id": tg_msg_id,
         })
@@ -1199,6 +1278,10 @@ class TelegramManager:
             return {"error": "text is required"}
         account, chat_id, tg_msg_id = self._parse_compound_id(compound_id)
         reply_markup = args.get("reply_markup")
+        rich_text_options, rich_text_error = self._rich_text_options(args)
+        caption_options, caption_error = self._caption_options(args)
+        if rich_text_error or caption_error:
+            return {"error": rich_text_error or caption_error}
         acct = self._service.get_account(account)
 
         # Detect if original message had media (caption edit vs text edit)
@@ -1216,9 +1299,11 @@ class TelegramManager:
                     except (json.JSONDecodeError, OSError):
                         continue
 
+        edit_options = caption_options if is_caption else rich_text_options
         acct.edit_message(
             chat_id=chat_id, message_id=tg_msg_id, text=text,
             reply_markup=reply_markup, is_caption=is_caption,
+            **edit_options,
         )
         return {"status": "edited", "message_id": compound_id}
 

--- a/tests/test_telegram_rich_formatting.py
+++ b/tests/test_telegram_rich_formatting.py
@@ -1,0 +1,321 @@
+"""Tests for Telegram MCP rich-formatting pass-through (issue #301).
+
+Proves that the in-kernel Telegram MCP manager forwards Bot API
+formatting options (parse_mode / entities / caption_entities /
+link_preview_options / disable_web_page_preview) through to the account
+wrapper for send / reply / edit / media-caption paths, and that callers
+who supply none of these options get exactly the previous behaviour.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lingtai.mcp_servers.telegram.account import TelegramAccount
+from lingtai.mcp_servers.telegram.manager import SCHEMA, TelegramManager
+
+
+class FakeAccount:
+    alias = "mybot"
+
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def send_message(
+        self,
+        chat_id,
+        text,
+        reply_markup=None,
+        reply_to_message_id=None,
+        **kwargs,
+    ):
+        self.calls.append(
+            ("send_message", chat_id, text, reply_markup, reply_to_message_id, kwargs)
+        )
+        return {"message_id": 111}
+
+    def send_photo(
+        self,
+        chat_id,
+        path,
+        caption=None,
+        reply_to_message_id=None,
+        **kwargs,
+    ):
+        self.calls.append(
+            ("send_photo", chat_id, path, caption, reply_to_message_id, kwargs)
+        )
+        return {"message_id": 333}
+
+    def send_document(
+        self,
+        chat_id,
+        path,
+        caption=None,
+        reply_to_message_id=None,
+        **kwargs,
+    ):
+        self.calls.append(
+            ("send_document", chat_id, path, caption, reply_to_message_id, kwargs)
+        )
+        return {"message_id": 222}
+
+    def edit_message(self, **kwargs):
+        self.calls.append(("edit_message", kwargs))
+        return {"ok": True}
+
+    def set_message_reaction(self, *args, **kwargs):
+        # Best-effort reaction call in _send; record nothing meaningful.
+        return True
+
+
+class FakeService:
+    def __init__(self) -> None:
+        self.default_account = FakeAccount()
+
+    def get_account(self, alias):
+        assert alias == "mybot"
+        return self.default_account
+
+
+def _manager(tmp_path):
+    service = FakeService()
+    manager = TelegramManager(
+        service, working_dir=Path(tmp_path), on_inbound=lambda _: None
+    )
+    return manager, service.default_account
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_schema_exposes_rich_formatting_fields():
+    props = SCHEMA["properties"]
+    for field in (
+        "parse_mode",
+        "entities",
+        "caption_entities",
+        "link_preview_options",
+        "disable_web_page_preview",
+    ):
+        assert field in props
+
+
+# ---------------------------------------------------------------------------
+# Manager pass-through (the acceptance-critical parse_mode path lives here)
+# ---------------------------------------------------------------------------
+
+
+def test_send_passes_parse_mode_entities_and_link_preview(tmp_path):
+    manager, account = _manager(tmp_path)
+    entities = [{"type": "bold", "offset": 0, "length": 4}]
+    link_preview_options = {"is_disabled": True}
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "text": "bold link",
+        "parse_mode": "HTML",
+        "entities": entities,
+        "link_preview_options": link_preview_options,
+        "disable_web_page_preview": True,
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls == [(
+        "send_message",
+        123,
+        "bold link",
+        None,
+        None,
+        {
+            "parse_mode": "HTML",
+            "entities": entities,
+            "link_preview_options": link_preview_options,
+            "disable_web_page_preview": True,
+        },
+    )]
+
+
+def test_send_without_formatting_is_unchanged(tmp_path):
+    """Backward compatibility: a plain send forwards no formatting kwargs."""
+    manager, account = _manager(tmp_path)
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "text": "plain",
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls == [(
+        "send_message",
+        123,
+        "plain",
+        None,
+        None,
+        {},  # no rich-text options leaked in
+    )]
+
+
+def test_reply_passes_rich_formatting_options(tmp_path):
+    manager, account = _manager(tmp_path)
+    entities = [{"type": "code", "offset": 0, "length": 1}]
+
+    result = manager._reply({
+        "message_id": "mybot:123:456",
+        "text": "x",
+        "parse_mode": "MarkdownV2",
+        "entities": entities,
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls == [(
+        "send_message",
+        123,
+        "x",
+        None,
+        456,
+        {"parse_mode": "MarkdownV2", "entities": entities},
+    )]
+
+
+def test_send_media_passes_caption_entities(tmp_path):
+    media_path = tmp_path / "demo.txt"
+    media_path.write_text("demo", encoding="utf-8")
+    manager, account = _manager(tmp_path)
+    caption_entities = [{"type": "italic", "offset": 0, "length": 4}]
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "text": "demo",
+        "media": {"type": "document", "path": str(media_path)},
+        "parse_mode": "HTML",
+        "caption_entities": caption_entities,
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:222"}
+    assert account.calls == [(
+        "send_document",
+        123,
+        str(media_path),
+        "demo",
+        None,
+        {"parse_mode": "HTML", "caption_entities": caption_entities},
+    )]
+
+
+def test_edit_text_passes_parse_mode(tmp_path):
+    manager, account = _manager(tmp_path)
+
+    result = manager._edit({
+        "message_id": "mybot:123:456",
+        "text": "<b>x</b>",
+        "parse_mode": "HTML",
+    })
+
+    assert result == {"status": "edited", "message_id": "mybot:123:456"}
+    assert account.calls == [(
+        "edit_message",
+        {
+            "chat_id": 123,
+            "message_id": 456,
+            "text": "<b>x</b>",
+            "reply_markup": None,
+            "is_caption": False,
+            "parse_mode": "HTML",
+        },
+    )]
+
+
+def test_invalid_parse_mode_is_rejected(tmp_path):
+    manager, account = _manager(tmp_path)
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "text": "hello",
+        "parse_mode": "BBCode",
+    })
+
+    assert result == {"error": "parse_mode must be one of: HTML, MarkdownV2, Markdown"}
+    assert account.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Account wrapper payload shaping
+# ---------------------------------------------------------------------------
+
+
+class CaptureAccount(TelegramAccount):
+    def __init__(self):
+        # Bypass TelegramAccount.__init__ — we only exercise payload building.
+        pass
+
+    def _request(self, method, **kwargs):
+        return {"method": method, "kwargs": kwargs, "message_id": 99}
+
+
+def test_account_send_message_payload_includes_rich_options():
+    acct = CaptureAccount()
+    entities = [{"type": "bold", "offset": 0, "length": 4}]
+    result = acct.send_message(
+        123,
+        "bold",
+        parse_mode="HTML",
+        entities=entities,
+        link_preview_options={"is_disabled": True},
+        disable_web_page_preview=False,
+    )
+
+    assert result["method"] == "sendMessage"
+    payload = result["kwargs"]["json"]
+    assert payload["parse_mode"] == "HTML"
+    assert payload["entities"] == entities
+    assert payload["link_preview_options"] == {"is_disabled": True}
+    assert payload["disable_web_page_preview"] is False
+
+
+def test_account_send_message_payload_plain_has_no_rich_options():
+    """Backward compatibility at the wrapper layer."""
+    acct = CaptureAccount()
+    result = acct.send_message(123, "plain")
+
+    payload = result["kwargs"]["json"]
+    assert payload == {"chat_id": 123, "text": "plain"}
+
+
+def test_account_send_document_serializes_caption_entities(tmp_path):
+    media_path = tmp_path / "demo.txt"
+    media_path.write_text("demo", encoding="utf-8")
+    acct = CaptureAccount()
+    caption_entities = [{"type": "code", "offset": 0, "length": 4}]
+
+    result = acct.send_document(
+        123,
+        str(media_path),
+        caption="demo",
+        parse_mode="HTML",
+        caption_entities=caption_entities,
+    )
+
+    assert result["method"] == "sendDocument"
+    data = result["kwargs"]["data"]
+    assert data["parse_mode"] == "HTML"
+    # Multipart fields must be strings: caption_entities is JSON-serialized.
+    assert json.loads(data["caption_entities"]) == caption_entities
+
+
+def test_account_edit_caption_payload_includes_parse_mode():
+    acct = CaptureAccount()
+    result = acct.edit_message(
+        123, 456, "new caption", is_caption=True, parse_mode="MarkdownV2",
+    )
+
+    assert result["method"] == "editMessageCaption"
+    payload = result["kwargs"]["json"]
+    assert payload["caption"] == "new caption"
+    assert payload["parse_mode"] == "MarkdownV2"


### PR DESCRIPTION
## Summary
- expose Telegram Bot API rich-formatting options on the **current in-kernel** Telegram MCP surface (`src/lingtai/mcp_servers/telegram`), not the old standalone addon repo
- pass through `parse_mode`, `entities`, `caption_entities`, `link_preview_options`, and `disable_web_page_preview` for send/reply/edit/media-caption paths while preserving plain-text defaults
- add focused tests for schema exposure, pass-through behavior, invalid `parse_mode`, media caption serialization, and backward compatibility

Fixes #301.

## Validation
- `python -m ruff check src/lingtai/mcp_servers/telegram/account.py src/lingtai/mcp_servers/telegram/manager.py tests/test_telegram_rich_formatting.py`
- `git diff --check`
- `python -m py_compile src/lingtai/mcp_servers/telegram/account.py src/lingtai/mcp_servers/telegram/manager.py tests/test_telegram_rich_formatting.py`
- `python -m pytest -q tests/test_telegram_rich_formatting.py tests/test_mcp_capability.py tests/test_mcp_inbox.py` → 65 passed

## Notes
- `Lingtai-AI/lingtai-telegram#36` was used only as historical reference; that standalone repo is not the landing repo.
- `Markdown` is retained alongside `MarkdownV2` for compatibility with existing direct uses.
- No live Telegram Bot API call was made.
