### PR TITLE
Clarify session journal YAML frontmatter

### DIFF
--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -75,6 +75,8 @@ detail belongs in the child.
 
 **The sub-entry `<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md` is the substance** — write it as the molt-history record of the segment, *before* you molt. Use `assets/session-journal-entry-template.md` from this skill directory for the frontmatter (including the `molt_count` field **and the required `type: session-journal` marker**) and section layout. This sub-entry's path is what you pass to `psyche(context, molt, session_journal_path=...)`, and the kernel validates the marker before letting the molt proceed (see §6). It is a journal, not a transcript — capture, in roughly this shape:
 
+**YAML frontmatter safety:** `name` and `description` are real YAML, not free-form text. Prefer the template's `description: >-` block scalar. If you write a one-line value containing a colon followed by a space (for example `description: Session record for codex molt 53: runtime relay`), YAML treats the second colon as a mapping separator and the molt gate rejects the file. Quote the value or use the block scalar, then retry the same `psyche(context, molt, session_journal_path=...)` call.
+
 - **What the segment was about** — the original ask, the framing
 - **Accomplishments** — what you completed/moved forward, the outputs, who was told and where
 - **Decisions and their reasoning** — the *why*, especially where an alternative was rejected

--- a/src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
@@ -28,10 +28,17 @@ rather than omitting one.
 > YAML frontmatter with `name` and `description`. You pass this file's path to
 > `psyche(context, molt, session_journal_path=...)`.
 
+> **YAML scalar safety:** keep `description` in the block-scalar form shown
+> below. Plain YAML values break when they contain a colon followed by a space
+> (for example `molt 53: runtime relay`), causing `mapping values are not
+> allowed here` during the molt gate.
+
 ```markdown
 ---
 name: <YYYY-MM-DD>-molt-<molt-count>-<slug>
-description: One-sentence hook — what this session segment did. Used in the parent index line.
+description: >-
+  One-sentence hook — what this session segment did. Use this block style so
+  colons such as "molt 53: runtime relay" remain valid YAML.
 date: <YYYY-MM-DD>
 molt_count: <current molt count, before calling psyche(context, molt)>
 type: session-journal

--- a/src/lingtai_kernel/intrinsics/psyche/_session_journal.py
+++ b/src/lingtai_kernel/intrinsics/psyche/_session_journal.py
@@ -45,7 +45,8 @@ _RECOVERY_HINT = (
     "knowledge/session-journal/<entry>/KNOWLEDGE.md "
     "(a per-segment sub-entry, NOT the parent index). "
     "It must exist, be non-empty UTF-8, have valid YAML frontmatter with "
-    "`name` and `description`, and identify itself as session knowledge via "
+    "`name` and `description` (quote values containing `: ` or use "
+    "`description: >-`), and identify itself as session knowledge via "
     "`type: session-journal` or `session_journal: true`."
 )
 

--- a/tests/test_session_journal_gate.py
+++ b/tests/test_session_journal_gate.py
@@ -164,6 +164,30 @@ def test_validate_invalid_yaml_rejects(tmp_path):
     assert "yaml" in err.lower() or "frontmatter" in err.lower()
 
 
+def test_validate_colon_description_error_mentions_yaml_scalar_fix(tmp_path):
+    bad = """---
+name: Broken
+description: Session record for codex molt 53: runtime relay handling
+type: session-journal
+---
+""".strip()
+    _write_journal(
+        tmp_path,
+        "knowledge/session-journal/2026-06-19-molt-1-x/KNOWLEDGE.md",
+        content=bad,
+    )
+
+    ok, err, resolved = validate_session_journal_path(
+        tmp_path, "knowledge/session-journal/2026-06-19-molt-1-x/KNOWLEDGE.md"
+    )
+
+    assert ok is False
+    assert err is not None
+    assert "invalid YAML frontmatter" in err
+    assert "description: >-" in err
+    assert resolved is None
+
+
 def test_validate_no_marker_rejects(tmp_path):
     # Valid frontmatter with name+description but NO session-journal marker.
     no_marker = (


### PR DESCRIPTION
## Summary
- switch the session-journal entry template to a YAML block-scalar `description: >-`
- add psyche-manual guidance that one-line YAML descriptions containing `: ` must be quoted or block-scalared
- add the same recovery hint to the runtime session-journal gate error path
- cover the `description: Session record for codex molt 53: ...` failure mode with a regression test

## Evidence / why
Jason pointed at `/Users/huangzesen/work/projects/lingtai-researches/spiritual-bliss-attractor/.lingtai` as an example of agents getting refused by the new session-journal molt gate. I checked that network first via `lingtai-tui list --detailed` and then parsed actual `psyche(context,molt)` tool results. The refusals I found were not wrong paths or missing markers; they were invalid YAML frontmatter from unquoted `description:` values containing a colon followed by a space (PyYAML: `mapping values are not allowed here`). In both observed cases the agent later fixed the same path by quoting the description or using a block scalar and the molt succeeded.

The shipped template previously used a plain unquoted one-line `description: ...` example and the manual only said “valid YAML,” so this PR makes the safe form explicit.

## Validation
- `python -m pytest tests/test_session_journal_gate.py -q` → `24 passed`
- `git diff --check`
- `python -m py_compile src/lingtai_kernel/intrinsics/psyche/_session_journal.py`
