### PR TITLE
Trim tool result top list metadata

### DIFF
--- a/src/lingtai_kernel/meta_block.py
+++ b/src/lingtai_kernel/meta_block.py
@@ -164,6 +164,7 @@ def formal_tool_result_preview(content, limit: int = 200) -> str:
     return _visible_content_text(formal_tool_result_content(content))[:limit]
 
 
+
 def _is_tool_result_block(block) -> bool:
     """Best-effort duck-typing for ToolResultBlock without a hard import cycle."""
     return block.__class__.__name__ == "ToolResultBlock" and hasattr(block, "content")
@@ -198,19 +199,23 @@ def adapter_comment(agent):
 
 
 TOOL_RESULT_CHARS_TOP_N = 10
-TOOL_RESULT_CHARS_PREVIEW_LEN = 200
+TOOL_RESULT_CHARS_MIN_TOP_CHARS = 1000
 TOOL_RESULT_CHARS_README = (
-    "listing top 10 tool results by char count with a first-200-char preview; "
-    "no need to summarize this helper (it appears only on the latest tool "
-    "result _meta and older copies are stripped); proactively summarize "
-    "prior tool results that are useless, already digested, irrelevant, "
-    "obsolete, or no longer needed in full, using the listed result "
-    "ids/previews"
+    "listing top 10 tool results over 1000 chars by char count "
+    "(id, tool_name, chars; no preview); no need to summarize this helper "
+    "(it appears only on the latest tool result _meta and older copies are "
+    "stripped); proactively summarize prior tool results that are useless, "
+    "already digested, irrelevant, obsolete, or no longer needed in full, "
+    "using the listed ids/tool names"
 )
 
 
 def _tool_result_id(block) -> str:
     return str(getattr(block, "id", None) or getattr(block, "tool_call_id", None) or "")
+
+
+def _tool_result_name(block) -> str:
+    return str(getattr(block, "name", None) or getattr(block, "tool_name", None) or "")
 
 
 def current_tool_result_chars(agent, extra_results=()) -> dict:
@@ -233,15 +238,14 @@ def current_tool_result_chars(agent, extra_results=()) -> dict:
         content = getattr(block, "content", "")
         chars = formal_tool_result_visible_len(content)
         total += chars
-        top.append(
-            {
-                "id": _tool_result_id(block),
-                "chars": chars,
-                "preview": formal_tool_result_preview(
-                    content, TOOL_RESULT_CHARS_PREVIEW_LEN
-                ),
-            }
-        )
+        if chars > TOOL_RESULT_CHARS_MIN_TOP_CHARS:
+            top.append(
+                {
+                    "id": _tool_result_id(block),
+                    "tool_name": _tool_result_name(block),
+                    "chars": chars,
+                }
+            )
 
     for block in _iter_history_tool_result_blocks(agent) or ():
         visit(block)
@@ -290,9 +294,10 @@ def build_meta_readme() -> dict:
             "active_turn_tool_calls, current_tool_result_chars, optional "
             "adapter_comment). Latest tool result only; older copies are "
             "stripped as newer results arrive. current_tool_result_chars is "
-            "a dict with total_chars and the top 10 tool results (each with "
-            "a first-200-char preview) that are proactive summarization "
-            "candidates. adapter_comment is a small provider/adapter-authored "
+            "a dict with total_chars and the top tool results over 1000 chars "
+            "(id, tool_name, chars; no preview) that are proactive "
+            "summarization candidates. adapter_comment is a small "
+            "provider/adapter-authored "
             "note about model-facing runtime state when the active adapter "
             "has one."
         ),
@@ -547,7 +552,7 @@ def build_meta(agent) -> dict:
                 "molt": dict,                # optional pressure stage/action; present at >=50%
             },
             "stamina_left_seconds": float,   # session time remaining; -1 if unstarted
-            "current_tool_result_chars": dict, # total + top 10 formal tool results w/ preview
+            "current_tool_result_chars": dict, # total + top formal tool results >1000 chars
         }
 
     Sentinel handling: when token decomposition has not yet run, the

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -142,8 +142,8 @@ def test_build_meta_counts_current_tool_result_chars_excluding_meta():
     assert current["top_results"] == [
         {
             "id": "tc-history",
+            "tool_name": "bash",
             "chars": expected,
-            "preview": json.dumps(formal_payload, ensure_ascii=False)[:200],
         }
     ]
 
@@ -164,7 +164,7 @@ def _agent_with_history(blocks):
 def test_current_tool_result_chars_lists_top_10():
     # 15 prior results of strictly decreasing length; expect the 10 longest.
     blocks = [
-        ToolResultBlock(id=f"tc-{i}", name="bash", content={"payload": "X" * (100 - i)})
+        ToolResultBlock(id=f"tc-{i}", name="bash", content="X" * (1500 - i))
         for i in range(15)
     ]
     agent = _agent_with_history(blocks)
@@ -174,55 +174,44 @@ def test_current_tool_result_chars_lists_top_10():
     assert len(current["top_results"]) == 10
     ids = [entry["id"] for entry in current["top_results"]]
     assert ids == [f"tc-{i}" for i in range(10)]
+    assert all(entry["tool_name"] == "bash" for entry in current["top_results"])
+    assert all("preview" not in entry for entry in current["top_results"])
 
 
-def test_current_tool_result_chars_no_1000_char_threshold():
-    # Two short results, both well under 1000 chars, must still be listed.
+def test_current_tool_result_chars_filters_results_at_or_below_1000_chars():
     blocks = [
-        ToolResultBlock(id="tc-short-a", name="bash", content={"payload": "A" * 10}),
-        ToolResultBlock(id="tc-short-b", name="bash", content={"payload": "B" * 5}),
+        ToolResultBlock(id="tc-short", name="bash", content="A" * 1000),
+        ToolResultBlock(id="tc-long", name="read", content="B" * 1001),
     ]
     agent = _agent_with_history(blocks)
 
     current = current_tool_result_chars(agent)
 
-    ids = {entry["id"] for entry in current["top_results"]}
-    assert ids == {"tc-short-a", "tc-short-b"}
+    assert current["top_results"] == [
+        {"id": "tc-long", "tool_name": "read", "chars": 1001}
+    ]
 
 
-def test_current_tool_result_chars_includes_first_200_char_preview():
-    body = "Z" * 500
-    block = ToolResultBlock(id="tc-preview", name="bash", content={"payload": body})
+def test_current_tool_result_chars_entries_include_tool_name_and_no_preview():
+    block = ToolResultBlock(id="tc-preview", name="bash", content="Z" * 1200)
     agent = _agent_with_history([block])
 
     current = current_tool_result_chars(agent)
 
-    entry = current["top_results"][0]
-    preview = entry["preview"]
-    assert len(preview) == 200
-    # Preview is taken from the visible (JSON-serialized) formal payload.
-    assert preview == json.dumps({"payload": body}, ensure_ascii=False)[:200]
+    assert current["top_results"] == [
+        {"id": "tc-preview", "tool_name": "bash", "chars": 1200}
+    ]
 
 
-def test_current_tool_result_chars_preview_handles_short_body():
-    block = ToolResultBlock(id="tc-tiny", name="bash", content={"payload": "hi"})
-    agent = _agent_with_history([block])
-
-    current = current_tool_result_chars(agent)
-
-    entry = current["top_results"][0]
-    assert entry["preview"] == json.dumps({"payload": "hi"}, ensure_ascii=False)
-    assert len(entry["preview"]) < 200
-
-
-def test_current_tool_result_chars_readme_drops_top5_and_1000_wording():
+def test_current_tool_result_chars_readme_describes_threshold_and_no_preview():
     agent = _agent_with_history([])
 
     current = current_tool_result_chars(agent)
 
     readme = current["_readme"]
     assert "top 10" in readme
-    assert "1000" not in readme
+    assert "over 1000 chars" in readme
+    assert "no preview" in readme
     assert "top 5" not in readme
 
 
@@ -241,8 +230,8 @@ def test_current_tool_result_chars_readme_says_no_need_to_summarize_helper():
     assert "proactively summarize" in readme
     assert "useless" in readme
     assert "no longer needed in full" in readme
-    assert "ids/previews" in readme
-    assert "1000" not in readme
+    assert "ids/tool names" in readme
+    assert "ids/previews" not in readme
     assert "top 5" not in readme
 
 
@@ -980,7 +969,7 @@ def _stamped_result(meta, elapsed_ms):
 
 def test_attach_active_runtime_counts_current_batch_tool_result_chars():
     agent = _fake_agent()
-    result = {"payload": "batch"}
+    result = {"payload": "B" * 1200}
     stamp_meta(result, build_meta(agent), elapsed_ms=12)
     block = ToolResultBlock(id="tc-batch", name="bash", content=result)
 
@@ -988,14 +977,13 @@ def test_attach_active_runtime_counts_current_batch_tool_result_chars():
 
     agent_meta = block.content["_meta"]["agent_meta"]
     current = agent_meta["current_tool_result_chars"]
-    expected = len(json.dumps({"payload": "batch"}, ensure_ascii=False, default=str))
+    expected = len(json.dumps({"payload": "B" * 1200}, ensure_ascii=False, default=str))
     assert current["total_chars"] == expected
-    # No >1000 threshold any more: the current batch result is always listed.
     assert current["top_results"] == [
         {
             "id": "tc-batch",
+            "tool_name": "bash",
             "chars": expected,
-            "preview": json.dumps({"payload": "batch"}, ensure_ascii=False)[:200],
         }
     ]
 


### PR DESCRIPTION
## Summary
- list only tool results above 1000 visible chars in `current_tool_result_chars.top_results`
- remove the per-entry `preview` field and include `tool_name` with `id` and `chars`
- update meta readme/schema comments and regression tests for the slimmer shape

## Validation
- `python -m py_compile src/lingtai_kernel/meta_block.py`
- `python -m pytest tests/test_meta_block.py -q`
- `git diff --check`
