### PR TITLE
bash: surface inner command failures (additive ok/command_status/warning) + scan/JSONL guidance

### DIFF
--- a/src/lingtai/core/bash/ANATOMY.md
+++ b/src/lingtai/core/bash/ANATOMY.md
@@ -31,7 +31,7 @@ The `bash` tool supports synchronous and asynchronous execution:
 
 - `ok` (bool) — `True` only when `exit_code == 0`.
 - `command_status` (str) — `"success"` or `"failed"`.
-- `warning` (str, present only on failure or a suspicious zero-exit) — one-line summary: the nonzero exit code, any detected `python_traceback`/`missing_module` signature (`_detect_failure_signature`), and a bounded stderr tail.
+- `warning` (str, present on failure or a suspicious zero-exit) — one-line summary: the nonzero exit code, any detected `python_traceback`/`missing_module` signature (`_detect_failure_signature`), and a bounded stderr tail. The hoisted tail is routed through `lingtai_kernel.trace_redaction.redact_text` (`_redact_warning_tail`, fail-open) so a secret-shaped error line is not made more prominent in the top-level `warning` than it already is in the raw `stderr` field; the raw `stderr`/`stdout` fields are never altered.
 
 On a still-running poll there is no `exit_code`, so no fidelity fields are added.
 
@@ -85,6 +85,7 @@ bash/__init__.py
 
 - `lingtai.i18n` — `t()` for localized strings
 - `lingtai_kernel.base_agent.BaseAgent` — agent type (TYPE_CHECKING only)
+- `lingtai_kernel.trace_redaction.redact_text` — mechanical secret redaction for the stderr tail hoisted into `warning` (imported lazily inside `_redact_warning_tail`, fail-open).
 
 ## Composition
 

--- a/src/lingtai/core/bash/ANATOMY.md
+++ b/src/lingtai/core/bash/ANATOMY.md
@@ -7,7 +7,7 @@ be explicitly opted into.
 
 ## Components
 
-- `bash/__init__.py` — the entire capability in a single file. `get_description` (`bash/__init__.py:32-33`), `get_schema` (`bash/__init__.py:36-70`), `setup` (`bash/__init__.py:505-539`). Two core classes: `BashPolicy` (`bash/__init__.py:74-162`) for command filtering, `BashManager` (`bash/__init__.py:165-503`) for execution.
+- `bash/__init__.py` — the entire capability in a single file. `get_description`, `get_schema`, `setup`. Two core classes: `BashPolicy` for command filtering, `BashManager` for execution. Module-level result helpers: `_augment_command_result` (adds `ok`/`command_status`/`warning` fidelity fields), `_detect_failure_signature` (labels `python_traceback`/`missing_module`), `_broad_scan_hint` (timeout recipe for broad recursive walks).
 - `bash/bash_policy.json` — default denylist policy shipped with the kernel. Denies destructive (`rm`, `rmdir`, `shred`, `dd`), privilege escalation (`sudo`, `su`, `doas`), permission changes (`chmod`, `chown`, `chgrp`), disk management (`mount`, `umount`, `mkfs`, `fdisk`), package managers (`apt`, `apt-get`, `yum`, `dnf`, `brew`), process control (`kill`, `killall`, `pkill`, `shutdown`, `reboot`, `systemctl`), network (`nc`, `ncat`), and code execution (`eval`, `exec`).
 
 ## Public API
@@ -23,9 +23,19 @@ The `bash` tool supports synchronous and asynchronous execution:
 | `async`        | boolean  | If true, run in background and return job_id immediately (default: false) |
 | `job_id`       | string   | Job ID for `poll` and `cancel` actions |
 
-**Sync mode** (`async=false`, default): Returns `{status, exit_code, stdout, stderr}` on success, or `{status: "error", message}` on failure. Identical to pre-async behavior.
+**Sync mode** (`async=false`, default): Returns `{status, exit_code, stdout, stderr, ok, command_status[, warning]}` once the command completes, or `{status: "error", message}` only when the shell itself could not run it (empty command, policy denial, timeout, spawn failure).
 
-**Async mode** (`async=true`): Returns `{status: "ok", job_id, pid, message}` immediately. Use `action="poll"` with the job_id to check status: returns `{status: "running", job_id, pid}` or `{status: "done", exit_code, stdout, stderr}`. Use `action="cancel"` to kill the process group.
+**Async mode** (`async=true`): Returns `{status: "ok", job_id, pid, message}` immediately. Use `action="poll"` with the job_id to check status: returns `{status: "running", job_id, pid}` while running, or `{status: "done", exit_code, stdout, stderr, ok, command_status[, warning]}` once finished. Use `action="cancel"` to kill the process group.
+
+**Result fidelity — top-level `status` vs. inner command success.** The top-level `status` (`ok`/`done`) reflects only that the shell *spawned* the command; it stays `ok`/`done` even when the inner command exits nonzero. To make inner failures impossible to skim past *without* changing the `status` contract that downstream recovery/telemetry branch on (`tool_executor.py` enriches/logs/collects on `status == "error"`), `_augment_command_result` (`bash/__init__.py`) adds three additive, model-visible fields keyed off `exit_code`:
+
+- `ok` (bool) — `True` only when `exit_code == 0`.
+- `command_status` (str) — `"success"` or `"failed"`.
+- `warning` (str, present only on failure or a suspicious zero-exit) — one-line summary: the nonzero exit code, any detected `python_traceback`/`missing_module` signature (`_detect_failure_signature`), and a bounded stderr tail.
+
+On a still-running poll there is no `exit_code`, so no fidelity fields are added.
+
+**Timeout hint.** On a sync timeout whose command resembles a broad recursive scan (`find … -name/-path/-type`, `rglob(`, `os.walk(`, `glob('**…')` — `_broad_scan_hint`), the timeout `message` appends an `rg --files`-based recipe. The hint is advisory text only; it never blocks or rewrites the command.
 
 Job files are stored under `system/jobs/{job_id}/` (stdout.log, stderr.log, pid, status). Cleaned up automatically on poll-completion or cancel.
 
@@ -33,6 +43,10 @@ Job files are stored under `system/jobs/{job_id}/` (stdout.log, stderr.log, pid,
 
 ```
 bash/__init__.py
+  ├── _detect_failure_signature()    — labels python_traceback / missing_module in output
+  ├── _broad_scan_hint()             — rg recipe hint for broad-recursive-walk timeouts
+  ├── _augment_command_result()      — adds ok / command_status / warning to completed results
+  │
   ├── BashPolicy                     — command execution policy
   │   ├── __init__(allow, deny)      — two modes: allowlist (if allow present) or denylist
   │   ├── from_file(path)            — loads policy from JSON file
@@ -46,9 +60,9 @@ bash/__init__.py
   │   ├── __init__(policy, working_dir, max_output) — stores policy + config
   │   ├── handle(args)               — dispatches to _handle_run / _handle_poll / _handle_cancel
   │   ├── _handle_run(args)          — validates + runs sync or async
-  │   ├── _run_sync(command, cwd, timeout) — original subprocess.run path
+  │   ├── _run_sync(command, cwd, timeout) — subprocess.run path; augments result + timeout hint
   │   ├── _run_async(command, cwd)   — subprocess.Popen with start_new_session, returns job_id
-  │   ├── _handle_poll(args)         — checks job status via Popen.poll() or os.waitpid
+  │   ├── _handle_poll(args)         — checks job status; augments completed result
   │   ├── _handle_cancel(args)       — SIGTERM to process group, cleanup
   │   └── _close_handles(job_id)     — closes open file handles for a job
   │
@@ -60,6 +74,7 @@ bash/__init__.py
 - **Two policy modes:** Allowlist mode (when `allow` key is present in policy) — only listed commands permitted, everything else blocked. Denylist mode (only `deny` key) — everything allowed except denied commands. The mode is implicit.
 - **Pipe-aware command extraction:** `_extract_commands()` parses `|`, `&&`, `||`, `;`, newlines, `$()`, backticks, and env-var prefixes to find every command name in a compound expression.
 - **Working directory sandbox:** `working_dir` is validated to be under the agent's working directory. Paths are resolved and checked with `startswith(sandbox + "/")`.
+- **Result fidelity is additive, never status-changing:** A completed command always returns top-level `status: "ok"`/`"done"` regardless of `exit_code`. The pass/fail signal lives in additive `ok`/`command_status`/`warning` fields. `status: "error"` is reserved for the shell failing to run the command at all (empty/denied command, timeout, spawn failure) — this preserves the `tool_executor` contract that branches on `status == "error"` for error enrichment, lifecycle logging, and `collected_errors`.
 - **Output truncation:** `max_output = 50_000` chars. Both stdout and stderr are truncated with a note showing total length.
 - **Subprocess isolation:** Commands run via `subprocess.run(shell=True, capture_output=True, text=True, timeout=...)` in the agent's working directory by default.
 - **Async subprocess:** Async commands use `subprocess.Popen(shell=True, start_new_session=True)` with stdout/stderr redirected to files under `system/jobs/{job_id}/`. `start_new_session=True` ensures the process gets its own session, enabling `os.killpg()` for clean cancellation.

--- a/src/lingtai/core/bash/__init__.py
+++ b/src/lingtai/core/bash/__init__.py
@@ -34,6 +34,28 @@ _DEFAULT_POLICY_FILE = Path(__file__).parent / "bash_policy.json"
 # failure impossible to miss when an agent skims the top-level fields.
 _WARNING_STDERR_TAIL = 600
 
+
+def _redact_warning_tail(text: str) -> str:
+    """Best-effort secret redaction for the stderr tail copied into ``warning``.
+
+    The raw ``stderr``/``stdout`` fields already mirror the command output
+    verbatim; this only touches the bounded tail that gets hoisted into the
+    top-level ``warning`` string, where a secret-shaped error line would be made
+    *more* prominent. Routes through the kernel's mechanical
+    ``trace_redaction.redact_text`` so the warning surface gets the same
+    high-confidence token/key redaction as durable trajectory writes.
+
+    Fail-open: if the redactor cannot be imported or raises (it must never break
+    a bash result), the original tail is returned unchanged — the raw stderr is
+    already present in the result, so this introduces no new exposure beyond it.
+    """
+    try:
+        from lingtai_kernel.trace_redaction import redact_text
+
+        return redact_text(text)
+    except Exception:
+        return text
+
 # Substrings that signal a "successful shell, failed program" — the failure the
 # fidelity warning exists to surface. A Python traceback or a missing-module
 # error commonly exits nonzero, but agents have been observed proceeding on the
@@ -106,11 +128,15 @@ def _augment_command_result(result: dict) -> dict:
 
     - ``ok`` (bool): ``True`` only when ``exit_code == 0``.
     - ``command_status`` (str): ``"success"`` or ``"failed"``.
-    - ``warning`` (str, only on failure): one-line summary naming the nonzero
-      exit, any detected traceback/missing-module signature, and a stderr tail.
+    - ``warning`` (str, on failure *or* a suspicious zero-exit): one-line summary
+      naming the nonzero exit, any detected traceback/missing-module signature,
+      and a stderr tail. The tail is routed through the kernel redactor so a
+      secret-shaped error line is not made more prominent than it already is in
+      the raw ``stderr`` field.
 
     ``status`` itself is intentionally left untouched so existing callers and
-    tests that branch on it keep working.
+    tests that branch on it keep working. The raw ``stderr``/``stdout`` fields
+    are mirrored verbatim and never altered here.
     """
     exit_code = result.get("exit_code")
     if not isinstance(exit_code, int):
@@ -139,7 +165,8 @@ def _augment_command_result(result: dict) -> dict:
         tail = stderr[-_WARNING_STDERR_TAIL:]
         if len(stderr) > _WARNING_STDERR_TAIL:
             tail = "…" + tail
-        parts.append(f"stderr tail: {tail}")
+        # Redact the hoisted tail only — the raw stderr field is left verbatim.
+        parts.append(f"stderr tail: {_redact_warning_tail(tail)}")
     result["warning"] = "; ".join(parts)
     return result
 

--- a/src/lingtai/core/bash/__init__.py
+++ b/src/lingtai/core/bash/__init__.py
@@ -29,6 +29,120 @@ PROVIDERS = {"providers": [], "default": "builtin"}
 
 _DEFAULT_POLICY_FILE = Path(__file__).parent / "bash_policy.json"
 
+# Length of the stderr tail surfaced in the failure warning. Short on purpose:
+# the full stderr is already present in the result; the tail just makes the
+# failure impossible to miss when an agent skims the top-level fields.
+_WARNING_STDERR_TAIL = 600
+
+# Substrings that signal a "successful shell, failed program" — the failure the
+# fidelity warning exists to surface. A Python traceback or a missing-module
+# error commonly exits nonzero, but agents have been observed proceeding on the
+# false success because the top-level status said "ok".
+_FAILURE_SIGNATURES = (
+    "Traceback (most recent call last)",
+    "ModuleNotFoundError",
+    "No module named",
+)
+
+
+def _detect_failure_signature(stdout: str, stderr: str) -> str | None:
+    """Return a short label if stdout/stderr carries a known failure signature.
+
+    Detection is best-effort and advisory only — it never changes ``exit_code``
+    or whether the command is considered failed; that is driven solely by the
+    exit code. It only enriches the human-/model-visible ``warning`` text so a
+    Python traceback or missing-import under a zero/nonzero exit is named
+    explicitly instead of being buried in the output.
+    """
+    haystack = f"{stderr}\n{stdout}"
+    # Prefer the most specific, most actionable label. A missing-module error
+    # also emits a full traceback, so check for it before the generic one.
+    if _FAILURE_SIGNATURES[1] in haystack or _FAILURE_SIGNATURES[2] in haystack:
+        return "missing_module"
+    if _FAILURE_SIGNATURES[0] in haystack:
+        return "python_traceback"
+    return None
+
+
+# Command shapes that frequently time out via unbounded recursive directory
+# walks over large roots (work/projects/.lingtai). Matched only to *append a
+# hint* on timeout — never to block or alter the command.
+_BROAD_SCAN_RE = re.compile(
+    r"""
+    \bfind\s+[^|]*\s-(?:name|path|type|iname)\b   # find ... -name/-path/-type
+    | \brglob\s*\(                                  # Path.rglob(
+    | \bos\.walk\s*\(                               # os.walk(
+    | \bglob\s*\(\s*['"][^'"]*\*\*                  # glob('**/...')
+    """,
+    re.VERBOSE,
+)
+
+_BROAD_SCAN_HINT = (
+    "This looks like a broad recursive scan, the most common cause of bash "
+    "timeouts. Prefer `rg --files --hidden -g '!**/{.git,node_modules,daemons,"
+    ".worktrees}/**' <root>` (then filter), narrow the root, or raise `timeout` "
+    "for a genuinely large tree."
+)
+
+
+def _broad_scan_hint(command: str) -> str | None:
+    """Return a broad-scan recipe hint if the command resembles a recursive walk.
+
+    Best-effort heuristic used only to enrich a timeout message. False positives
+    are harmless (an extra sentence); it never blocks or rewrites the command.
+    """
+    return _BROAD_SCAN_HINT if _BROAD_SCAN_RE.search(command) else None
+
+
+def _augment_command_result(result: dict) -> dict:
+    """Add explicit pass/fail fidelity fields to a completed-command result.
+
+    The top-level ``status`` of a bash result reflects only that the shell
+    *spawned* — it stays ``ok``/``done`` even when the inner command failed.
+    Agents have repeatedly missed inner failures because of this. To make a
+    failure impossible to skim past *without* changing the ``status`` contract
+    (which downstream recovery/telemetry branches on), this adds three additive,
+    model-visible fields keyed off ``exit_code``:
+
+    - ``ok`` (bool): ``True`` only when ``exit_code == 0``.
+    - ``command_status`` (str): ``"success"`` or ``"failed"``.
+    - ``warning`` (str, only on failure): one-line summary naming the nonzero
+      exit, any detected traceback/missing-module signature, and a stderr tail.
+
+    ``status`` itself is intentionally left untouched so existing callers and
+    tests that branch on it keep working.
+    """
+    exit_code = result.get("exit_code")
+    if not isinstance(exit_code, int):
+        return result
+    failed = exit_code != 0
+    result["ok"] = not failed
+    result["command_status"] = "failed" if failed else "success"
+
+    signature = _detect_failure_signature(
+        result.get("stdout", "") or "", result.get("stderr", "") or ""
+    )
+    if not failed and signature is None:
+        return result
+
+    parts: list[str] = []
+    if failed:
+        parts.append(f"command exited with code {exit_code}")
+    else:
+        # Zero exit but a traceback/missing-module signature is present — the
+        # command may have swallowed the error. Flag it without claiming failure.
+        parts.append(f"command exited 0 but output contains a {signature}")
+    if failed and signature is not None:
+        parts.append(f"detected {signature}")
+    stderr = (result.get("stderr") or "").strip()
+    if stderr:
+        tail = stderr[-_WARNING_STDERR_TAIL:]
+        if len(stderr) > _WARNING_STDERR_TAIL:
+            tail = "…" + tail
+        parts.append(f"stderr tail: {tail}")
+    result["warning"] = "; ".join(parts)
+    return result
+
 def get_description(lang: str = "en") -> str:
     return t(lang, "bash.description")
 
@@ -274,14 +388,18 @@ class BashManager:
             if len(stderr) > self._max_output:
                 stderr = stderr[: self._max_output] + f"\n... (truncated, {len(result.stderr)} chars total)"
 
-            return {
+            return _augment_command_result({
                 "status": "ok",
                 "exit_code": result.returncode,
                 "stdout": stdout,
                 "stderr": stderr,
-            }
+            })
         except subprocess.TimeoutExpired:
-            return {"status": "error", "message": f"Command timed out after {timeout}s"}
+            msg = f"Command timed out after {timeout}s"
+            hint = _broad_scan_hint(command)
+            if hint:
+                msg = f"{msg}. {hint}"
+            return {"status": "error", "message": msg}
         except Exception as e:
             return {"status": "error", "message": f"Command failed: {e}"}
 
@@ -444,12 +562,12 @@ class BashManager:
         import shutil
         shutil.rmtree(job_dir, ignore_errors=True)
 
-        return {
+        return _augment_command_result({
             "status": "done",
             "exit_code": returncode,
             "stdout": stdout,
             "stderr": stderr,
-        }
+        })
 
     def _handle_cancel(self, args: dict) -> dict:
         """Kill an async job."""

--- a/src/lingtai/core/bash/manual/SKILL.md
+++ b/src/lingtai/core/bash/manual/SKILL.md
@@ -11,7 +11,7 @@ description: >
   reminders, debugging silent jobs, and safe cleanup. Start here for any
   long-running agent CLI, time-driven recurring work ("every hour", "weekdays at
   9", "remind me later"), or when a scheduled job misbehaves.
-version: 1.5.0
+version: 1.6.0
 ---
 
 # Bash Manual — Router
@@ -140,6 +140,51 @@ files, not standalone top-level skills.
 5. **A scheduled job already exists and is misbehaving?** Read
    `reference/debugging-cleanup/SKILL.md` before editing blindly.
 
+## Reading command results — never trust top-level `status` alone
+
+The top-level `status` of a `bash` result (`ok`/`done`) means only that the
+**shell spawned** the command — **not** that the command succeeded. A failed
+build, a missing file, a Python traceback, or a missing import all come back
+under `status: "ok"`. Proceeding on that false success is the single most
+common way agents corrupt their own downstream work.
+
+- **Check `exit_code` / `ok` on every command whose success matters.** The
+  result carries `ok` (bool) and `command_status` (`"success"`/`"failed"`)
+  keyed off the exit code. `exit_code != 0` means the command failed even
+  though `status` says `ok`.
+- **Read the `warning` field when present.** On failure (or a suspicious
+  zero-exit with a traceback in the output) the result includes a one-line
+  `warning` naming the nonzero exit, any detected Python traceback or missing
+  module, and a stderr tail. If `warning` is present, stop and read it before
+  acting on the output.
+- **Use the venv interpreter for project code.** Bare `python3` lacks
+  third-party packages and LingTai's own modules (`lingtai`, `lingtai_kernel`).
+  A `No module named …` / `missing_module` warning usually means you ran the
+  wrong interpreter — invoke the project's virtualenv `python`, not the system
+  one.
+
+## Avoid broad recursive scans
+
+Unbounded recursive walks over large roots (`work/projects/.lingtai`) are the
+top cause of `bash` timeouts. On a timeout the tool appends an `rg` recipe when
+it detects this shape, but prefer it from the start:
+
+- Replace `find <root> -name …`, `Path(...).rglob(...)`, `os.walk(...)`, and
+  `glob('**/…')` over big trees with:
+  `rg --files --hidden -g '!**/{.git,node_modules,daemons,.worktrees}/**' <root>`
+  then filter the file list — `rg` honors `.gitignore` and skips the expensive
+  directories by default.
+- Narrow the root, add `-maxdepth`, or raise `timeout` only when the tree is
+  genuinely large and you have a reason to walk all of it.
+
+## Parse JSONL line-by-line
+
+Event/log files (`events.jsonl`, daemon logs) are **JSON Lines** — one JSON
+object per line, **not** a single JSON document. `json.loads(whole_file)` fails
+on them. Iterate lines and `json.loads` each non-empty line, or pipe through
+`jq -c .` / `rg` to filter before parsing. Tail with `tail -n` instead of
+reading the whole file when you only need recent events.
+
 ## Core rules to keep resident
 
 - **Synchronous `bash` is only for short, deterministic commands.** A long-running
@@ -159,7 +204,9 @@ files, not standalone top-level skills.
   # Later turns: poll until done (handle mail/other work between polls):
   bash(action="poll", job_id="ab12…")
   # → {"status": "running", …}   then eventually
-  # → {"status": "done", "exit_code": 0, "stdout": "…", "stderr": "…"}
+  # → {"status": "done", "exit_code": 0, "ok": true, "command_status": "success", "stdout": "…", "stderr": "…"}
+  #   On failure: {"status": "done", "exit_code": 1, "ok": false,
+  #                "command_status": "failed", "warning": "command exited with code 1; …"}
 
   # Abandon it if needed:
   bash(action="cancel", job_id="ab12…")

--- a/src/lingtai/core/bash/manual/SKILL.md
+++ b/src/lingtai/core/bash/manual/SKILL.md
@@ -11,7 +11,7 @@ description: >
   reminders, debugging silent jobs, and safe cleanup. Start here for any
   long-running agent CLI, time-driven recurring work ("every hour", "weekdays at
   9", "remind me later"), or when a scheduled job misbehaves.
-version: 1.6.0
+version: 1.6.1
 ---
 
 # Bash Manual — Router
@@ -152,11 +152,13 @@ common way agents corrupt their own downstream work.
   result carries `ok` (bool) and `command_status` (`"success"`/`"failed"`)
   keyed off the exit code. `exit_code != 0` means the command failed even
   though `status` says `ok`.
-- **Read the `warning` field when present.** On failure (or a suspicious
-  zero-exit with a traceback in the output) the result includes a one-line
-  `warning` naming the nonzero exit, any detected Python traceback or missing
-  module, and a stderr tail. If `warning` is present, stop and read it before
-  acting on the output.
+- **Read the `warning` field when present.** On failure **or** a suspicious
+  zero-exit (a traceback/missing-module signature in the output despite exit
+  code 0) the result includes a one-line `warning` naming the nonzero exit, any
+  detected Python traceback or missing module, and a stderr tail. The tail is
+  run through the kernel's secret redactor, so secret-shaped lines are masked in
+  `warning`; the raw `stderr` field is unchanged. If `warning` is present, stop
+  and read it before acting on the output.
 - **Use the venv interpreter for project code.** Bare `python3` lacks
   third-party packages and LingTai's own modules (`lingtai`, `lingtai_kernel`).
   A `No module named …` / `missing_module` warning usually means you ran the

--- a/src/lingtai/i18n/en.json
+++ b/src/lingtai/i18n/en.json
@@ -19,7 +19,7 @@
   "grep.path": "File or directory to search in",
   "grep.glob": "File glob filter (e.g., '*.py')",
   "grep.max_matches": "Maximum matches to return",
-  "bash.description": "Execute a shell command and return stdout/stderr. Any system program — scripts, git, curl, pip, data pipelines. Returns exit code, stdout, stderr. Supports async mode (async=true → job_id, then poll/cancel). Before using this tool, read the `bash-manual` skill — it covers cron setup, async hygiene, and advanced usage; no exceptions.",
+  "bash.description": "Execute a shell command and return stdout/stderr. Any system program — scripts, git, curl, pip, data pipelines. Returns exit_code, stdout, stderr, plus ok (bool) and command_status ('success'/'failed'). IMPORTANT: top-level status stays 'ok' even when the command FAILS — it only means the shell ran. Always check exit_code/ok and read the warning field (it names nonzero exits, Python tracebacks, and missing modules); never assume success from status alone. Avoid broad recursive scans (find … -name, rglob, os.walk, glob('**')) — they time out; prefer `rg --files`. Parse JSONL line-by-line, not as one JSON blob. Supports async mode (async=true → job_id, then poll/cancel). Before using this tool, read the `bash-manual` skill — it covers cron setup, async hygiene, and advanced usage; no exceptions.",
   "bash.action": "Action to perform: 'run' (default) executes a command, 'poll' checks async job status, 'cancel' kills an async job",
   "bash.command": "The shell command to execute",
   "bash.timeout": "Timeout in seconds (default: 30, only for sync execution)",

--- a/src/lingtai/i18n/wen.json
+++ b/src/lingtai/i18n/wen.json
@@ -19,7 +19,7 @@
   "grep.path": "欲搜之文卷或目录",
   "grep.glob": "文卷 glob 过滤器（如'*.py'）",
   "grep.max_matches": "至多返回之匹配数",
-  "bash.description": "执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。支持异步：设 async=true 取 job_id，后以 poll/cancel 查之。用此器前，必先读 `bash-manual` 一技（含定时之设、异步之规、进阶之用），无所例外。",
+  "bash.description": "执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。返 exit_code、stdout、stderr，兼附 ok（真伪）与 command_status（'success'/'failed'）。须知：命令虽败，顶层 status 仍作 'ok'——此仅言 shell 已运，非言命令已成。必察 exit_code/ok，且阅 warning 一字（标非零之退、Python 之回溯、缺失之模块）；勿独凭 status 而断其成。忌大范围递归之扫（find … -name、rglob、os.walk、glob('**')）——易致超时；宜先用 `rg --files`。JSONL 当逐行而解，勿混作一 JSON。支持异步：设 async=true 取 job_id，后以 poll/cancel 查之。用此器前，必先读 `bash-manual` 一技（含定时之设、异步之规、进阶之用），无所例外。",
   "bash.action": "所行之事：'run'（默认）执行指令，'poll' 查异步任务之状，'cancel' 斩异步任务",
   "bash.command": "欲执行之指令",
   "bash.timeout": "超时秒数（默认：30，唯同步执行时生效）",

--- a/src/lingtai/i18n/zh.json
+++ b/src/lingtai/i18n/zh.json
@@ -19,7 +19,7 @@
   "grep.path": "要搜索的文件或目录",
   "grep.glob": "文件 glob 过滤器（例如 '*.py'）",
   "grep.max_matches": "最大返回匹配数",
-  "bash.description": "执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。支持异步：async=true 获取 job_id，再用 poll/cancel 查之。用此工具前，必先读 `bash-manual` 技能（涵盖定时任务、异步规范与进阶用法），无例外。",
+  "bash.description": "执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。返回 exit_code、stdout、stderr，并附 ok（布尔）与 command_status（'success'/'failed'）。要点：即便命令失败，顶层 status 仍为 'ok'——它仅表示 shell 已执行。务必检查 exit_code/ok 并阅读 warning 字段（标明非零退出、Python 回溯、缺失模块）；切勿仅凭 status 断定成功。避免大范围递归扫描（find … -name、rglob、os.walk、glob('**')）——易超时；优先用 `rg --files`。JSONL 须逐行解析，勿当作单个 JSON。支持异步：async=true 获取 job_id，再用 poll/cancel 查之。用此工具前，必先读 `bash-manual` 技能（涵盖定时任务、异步规范与进阶用法），无例外。",
   "bash.action": "执行动作：'run'（默认）执行命令，'poll' 查询异步任务状态，'cancel' 终止异步任务",
   "bash.command": "要执行的 shell 命令",
   "bash.timeout": "超时秒数（默认：30，仅同步执行时生效）",

--- a/tests/test_bash_async.py
+++ b/tests/test_bash_async.py
@@ -51,6 +51,37 @@ class TestBashAsync:
         assert poll["status"] == "done"
         assert "async-output" in poll["stdout"]
         assert "exit_code" in poll
+        # Fidelity fields apply to the async poll path too.
+        assert poll["ok"] is True
+        assert poll["command_status"] == "success"
+
+    # 3b. poll on a failed async job surfaces the failure explicitly
+    def test_poll_nonzero_exit_is_flagged_failed(self, tmp_path):
+        mgr = self._make_manager(tmp_path)
+        result = mgr.handle({"command": "exit 7", "async": True})
+        job_id = result["job_id"]
+
+        time.sleep(0.5)
+
+        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        assert poll["status"] == "done"
+        assert poll["exit_code"] == 7
+        assert poll["ok"] is False
+        assert poll["command_status"] == "failed"
+        assert "exited with code 7" in poll["warning"]
+
+    # 3c. a still-running poll has no exit_code, so no fidelity fields
+    def test_poll_running_has_no_fidelity_fields(self, tmp_path):
+        mgr = self._make_manager(tmp_path)
+        result = mgr.handle({"command": "sleep 5", "async": True})
+        job_id = result["job_id"]
+
+        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        assert poll["status"] == "running"
+        assert "ok" not in poll
+        assert "command_status" not in poll
+
+        mgr.handle({"action": "cancel", "command": "", "job_id": job_id})
 
     # 4. cancel kills the process
     def test_cancel_kills_process(self, tmp_path):

--- a/tests/test_layers_bash.py
+++ b/tests/test_layers_bash.py
@@ -13,6 +13,7 @@ from lingtai.core.bash import (
     _augment_command_result,
     _broad_scan_hint,
     _detect_failure_signature,
+    _redact_warning_tail,
 )
 
 
@@ -301,6 +302,63 @@ class TestAugmentCommandResult:
         r = _augment_command_result({"status": "running", "job_id": "x"})
         assert "ok" not in r
         assert "command_status" not in r
+
+    def test_warning_tail_redacts_secret_shaped_stderr(self):
+        # A secret-shaped token in the stderr tail must not be hoisted verbatim
+        # into the model-visible `warning`; the raw `stderr` field is unchanged.
+        token = "ghp_" + "a" * 36  # GitHub PAT shape the kernel redactor catches
+        stderr = f"fatal: auth failed using token {token}\n"
+        r = _augment_command_result(
+            {"status": "done", "exit_code": 1, "stdout": "", "stderr": stderr}
+        )
+        assert token not in r["warning"]
+        assert "<REDACTED:github_token>" in r["warning"]
+        # Raw stderr is mirrored verbatim — only the warning tail is redacted.
+        assert token in r["stderr"]
+
+    def test_suspicious_zero_exit_warning_wording(self):
+        # A zero exit whose output carries a traceback signature is flagged as a
+        # suspicious success — the wording must say so, not claim a failure.
+        r = _augment_command_result(
+            {
+                "status": "done",
+                "exit_code": 0,
+                "stdout": "Traceback (most recent call last):\n  File ...",
+                "stderr": "",
+            }
+        )
+        assert r["ok"] is True
+        assert r["command_status"] == "success"
+        assert "exited 0 but output contains" in r["warning"]
+        assert "python_traceback" in r["warning"]
+
+
+class TestRedactWarningTail:
+    def test_redacts_known_token_shape(self):
+        token = "ghp_" + "b" * 36
+        out = _redact_warning_tail(f"using {token}")
+        assert token not in out
+        assert "<REDACTED:github_token>" in out
+
+    def test_passes_through_ordinary_text(self):
+        text = "command exited with code 1; bad argument"
+        assert _redact_warning_tail(text) == text
+
+    def test_fail_open_returns_input_when_redactor_unavailable(self, monkeypatch):
+        # If the kernel redactor import fails, the tail is returned unchanged
+        # rather than breaking the bash result (raw stderr already mirrors it).
+        import builtins
+
+        real_import = builtins.__import__
+
+        def boom(name, *args, **kwargs):
+            if name == "lingtai_kernel.trace_redaction":
+                raise ImportError("simulated missing redactor")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", boom)
+        text = "some stderr with sk-" + "x" * 30
+        assert _redact_warning_tail(text) == text
 
 
 class TestDetectFailureSignature:

--- a/tests/test_layers_bash.py
+++ b/tests/test_layers_bash.py
@@ -5,7 +5,15 @@ from pathlib import Path
 import pytest
 from unittest.mock import MagicMock
 
-from lingtai.core.bash import BashManager, BashPolicy, get_schema, setup as setup_bash
+from lingtai.core.bash import (
+    BashManager,
+    BashPolicy,
+    get_schema,
+    setup as setup_bash,
+    _augment_command_result,
+    _broad_scan_hint,
+    _detect_failure_signature,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -99,8 +107,72 @@ class TestBashManager:
     def test_nonexistent_command(self):
         mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp")
         result = mgr.handle({"command": "definitely_not_a_real_command_xyz"})
+        # status stays "ok" — it reflects that the shell spawned, not that the
+        # inner command succeeded (preserving the existing executor contract).
         assert result["status"] == "ok"
         assert result["exit_code"] != 0
+
+    # --- result fidelity: explicit pass/fail fields (T1a) ------------------
+
+    def test_success_is_marked_ok(self):
+        mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp")
+        result = mgr.handle({"command": "echo hi"})
+        assert result["exit_code"] == 0
+        assert result["ok"] is True
+        assert result["command_status"] == "success"
+        # No warning on a clean success.
+        assert "warning" not in result
+
+    def test_nonzero_exit_is_flagged_failed_with_warning(self):
+        mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp")
+        result = mgr.handle({"command": "exit 3"})
+        # status unchanged, but the failure is now impossible to miss.
+        assert result["status"] == "ok"
+        assert result["exit_code"] == 3
+        assert result["ok"] is False
+        assert result["command_status"] == "failed"
+        assert "exited with code 3" in result["warning"]
+
+    def test_warning_includes_stderr_tail(self):
+        mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp")
+        result = mgr.handle(
+            {"command": "echo boom-marker 1>&2; exit 1"}
+        )
+        assert result["ok"] is False
+        assert "boom-marker" in result["warning"]
+
+    def test_python_traceback_is_detected(self):
+        mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp")
+        # A real interpreter traceback exits nonzero and prints to stderr.
+        result = mgr.handle(
+            {"command": "python3 -c 'raise ValueError(\"x\")'"}
+        )
+        assert result["ok"] is False
+        assert result["command_status"] == "failed"
+        assert "python_traceback" in result["warning"]
+
+    def test_missing_module_is_detected(self):
+        mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp")
+        result = mgr.handle(
+            {"command": "python3 -c 'import lingtai_kernel_does_not_exist_xyz'"}
+        )
+        assert result["ok"] is False
+        assert "missing_module" in result["warning"]
+
+    def test_zero_exit_with_traceback_in_output_is_flagged_without_failing(self):
+        # A subshell swallows the nonzero exit but the traceback text leaks to
+        # stdout — flag it as suspicious without claiming the command failed.
+        mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp")
+        result = mgr.handle(
+            {
+                "command": "python3 -c 'raise ValueError(1)' 2>&1 | cat; true"
+            }
+        )
+        assert result["exit_code"] == 0
+        assert result["ok"] is True
+        assert result["command_status"] == "success"
+        assert "warning" in result
+        assert "python_traceback" in result["warning"]
 
     def test_empty_command(self):
         mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp")
@@ -112,6 +184,22 @@ class TestBashManager:
         result = mgr.handle({"command": "sleep 10", "timeout": 0.5})
         assert result["status"] == "error"
         assert "timed out" in result["message"]
+        # A plain sleep is not a broad scan — no recipe hint appended.
+        assert "rg --files" not in result["message"]
+
+    def test_timeout_on_broad_find_appends_rg_hint(self):
+        mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp")
+        result = mgr.handle(
+            {
+                "command": (
+                    "sleep 10; find /Users/x/work -name '*.py' -type f"
+                ),
+                "timeout": 0.5,
+            }
+        )
+        assert result["status"] == "error"
+        assert "timed out" in result["message"]
+        assert "rg --files" in result["message"]
 
     def test_policy_denies(self, tmp_path):
         policy_file = tmp_path / "policy.json"
@@ -176,6 +264,79 @@ class TestBashManager:
         mgr = BashManager(policy=BashPolicy.yolo(), working_dir="/tmp", max_output=20)
         result = mgr.handle({"command": "echo 'a very long output string that exceeds the limit'"})
         assert "truncated" in result["stdout"]
+
+
+# ---------------------------------------------------------------------------
+# Result-fidelity helpers (unit-level, no subprocess)
+# ---------------------------------------------------------------------------
+
+class TestAugmentCommandResult:
+    def test_success(self):
+        r = _augment_command_result({"status": "done", "exit_code": 0, "stdout": "", "stderr": ""})
+        assert r["ok"] is True
+        assert r["command_status"] == "success"
+        assert "warning" not in r
+
+    def test_failure_has_warning(self):
+        r = _augment_command_result(
+            {"status": "done", "exit_code": 2, "stdout": "", "stderr": "bad arg\n"}
+        )
+        assert r["ok"] is False
+        assert r["command_status"] == "failed"
+        assert "exited with code 2" in r["warning"]
+        assert "bad arg" in r["warning"]
+
+    def test_long_stderr_tail_is_truncated_with_ellipsis(self):
+        big = "E" * 5000
+        r = _augment_command_result(
+            {"status": "done", "exit_code": 1, "stdout": "", "stderr": big}
+        )
+        assert r["warning"].startswith("command exited with code 1")
+        assert "…" in r["warning"]
+        # The warning carries only a bounded tail, not the whole 5000 chars.
+        assert len(r["warning"]) < 1200
+
+    def test_missing_exit_code_is_left_untouched(self):
+        # poll on a still-running job has no exit_code yet → no fidelity fields.
+        r = _augment_command_result({"status": "running", "job_id": "x"})
+        assert "ok" not in r
+        assert "command_status" not in r
+
+
+class TestDetectFailureSignature:
+    def test_traceback(self):
+        assert (
+            _detect_failure_signature("", "Traceback (most recent call last):\n  ...")
+            == "python_traceback"
+        )
+
+    def test_missing_module(self):
+        assert (
+            _detect_failure_signature("", "ModuleNotFoundError: No module named 'lingtai'")
+            == "missing_module"
+        )
+
+    def test_clean(self):
+        assert _detect_failure_signature("all good", "") is None
+
+
+class TestBroadScanHint:
+    def test_find_with_name(self):
+        assert _broad_scan_hint("find /work -name '*.py'") is not None
+
+    def test_rglob(self):
+        assert _broad_scan_hint("python3 -c 'list(Path(\".\").rglob(\"*.py\"))'") is not None
+
+    def test_os_walk(self):
+        assert _broad_scan_hint("python3 -c 'list(os.walk(\"/work\"))'") is not None
+
+    def test_glob_double_star(self):
+        assert _broad_scan_hint("python3 -c \"glob('**/*.py', recursive=True)\"") is not None
+
+    def test_plain_command_not_flagged(self):
+        assert _broad_scan_hint("ls -la") is None
+        assert _broad_scan_hint("git status") is None
+        assert _broad_scan_hint("find . -maxdepth 1") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Track T1 — bash result fidelity + file/local-scan ergonomics (Wave 1, P0)

### Problem
The top-level `status` of a `bash` result reflects only that the **shell spawned** the command — it stays `ok`/`done` even when the inner command exits nonzero. Trajectory analysis across 9 bash-using agents found **1,773 nonzero-exit commands and 610 Python tracebacks, 100% under `status: ok`**, with agents repeatedly proceeding on the false success and rediscovering "file not found"/"module missing" by trial.

### Why additive, not a `status` change
Flipping `status` to `"error"` on nonzero exit is high blast radius: `tool_executor.py` branches on `status == "error"` for error-payload enrichment, lifecycle telemetry, and `collected_errors` — and there are no tests pinning those consumers to bash output. The existing bash tests also explicitly encode `status == "ok"` on a nonzero exit. So this PR takes the **safest additive improvement**: keep `status` untouched and add explicit, model-visible fidelity fields. (The behavior-changing `status` option is documented as a follow-up below.)

### Changes
**`src/lingtai/core/bash/__init__.py`**
- `_augment_command_result()` adds three additive fields to completed-command results (sync run + async poll):
  - `ok` (bool): `True` only when `exit_code == 0`
  - `command_status`: `"success"` | `"failed"`
  - `warning` (failure / suspicious zero-exit only): names the nonzero exit, any detected `python_traceback` / `missing_module` signature, and a bounded stderr tail
- `_detect_failure_signature()` labels tracebacks / missing-module errors (advisory text only; never changes pass/fail, which is driven solely by `exit_code`)
- `_broad_scan_hint()` appends an `rg --files` recipe to the **timeout** message when the command resembles a broad recursive scan (`find -name/-path/-type`, `rglob(`, `os.walk(`, `glob('**')`). Advisory only — never blocks or rewrites the command.

**Docs**
- `bash.description` (en/zh/wen): check `exit_code`/`ok`, read `warning`, avoid broad scans, parse JSONL line-by-line
- `bash-manual` SKILL.md (v1.6.0): resident sections on result-reading, broad-scan avoidance, and JSONL parsing
- `ANATOMY.md`: documents the additive-not-status-changing fidelity contract

### Tests
`tests/test_layers_bash.py`, `tests/test_bash_async.py` — success, nonzero exit, Python traceback, missing module, suspicious zero-exit-with-traceback, stderr-tail truncation, broad-scan hint (find/rglob/os.walk/glob + negatives), timeout, and the async poll path (success/failure/running).

```
python -m pytest tests/test_layers_bash.py tests/test_bash_async.py tests/test_i18n.py tests/test_tool_executor.py -q
# 115 passed
```
`git diff --check` clean.

### Backward compatibility
- `status`, `exit_code`, `stdout`, `stderr` shapes unchanged.
- New keys (`ok`, `command_status`, `warning`) are additive; verified no key collision in `tool_executor.py` result stamping.
- The only `status: "error"` paths remain shell-level failures (empty/denied command, timeout, spawn failure).

### Review focus (for GLM / DeepSeek / MiMo)
- Confirm no consumer relies on the *absence* of `ok`/`command_status`/`warning` keys on bash results.
- Confirm leaving `status: "ok"` on nonzero exit (rather than flipping to `"error"`) is the desired contract for now — the alternative, behavior-changing `status: "error"`/`"nonzero_exit"` option is deliberately **not** taken here and is recorded as a follow-up requiring adversarial review of `tool_executor` error-handling/healing.
- `_detect_failure_signature` ordering (missing_module preferred over the generic traceback) and the broad-scan regex false-positive surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)