### PR TITLE
docs(psyche): softly encourage top-of-entry timestamp + TL;DR in molt journal

### DIFF
--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -77,6 +77,7 @@ detail belongs in the child.
 
 **YAML frontmatter safety:** `name` and `description` are real YAML, not free-form text. Prefer the template's `description: >-` block scalar. If you write a one-line value containing a colon followed by a space (for example `description: Session record for codex molt 53: runtime relay`), YAML treats the second colon as a mapping separator and the molt gate rejects the file. Quote the value or use the block scalar, then retry the same `psyche(context, molt, session_journal_path=...)` call.
 
+- **Top-of-entry timestamp + TL;DR** *(soft convention)* — open the body with a visible timestamp and a one- or two-line gist before the sections, so the next you can date and grasp the entry at a glance; the molt gate validates only frontmatter, never this
 - **What the segment was about** — the original ask, the framing
 - **Accomplishments** — what you completed/moved forward, the outputs, who was told and where
 - **Decisions and their reasoning** — the *why*, especially where an alternative was rejected

--- a/src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
@@ -17,6 +17,12 @@ where the substance lives, and stop. Reference paths/PRs/message IDs — never
 inline secrets or full file contents. After writing it, append one line to the
 parent index at `knowledge/session-journal/KNOWLEDGE.md`.
 
+It also helps to open the body with an **immediately visible timestamp and a
+one- or two-line TL;DR** before the sections — so the next you can date the
+entry and grasp its gist at a glance without reading the whole record. This is a
+soft convention, not a gate: the molt validator checks only the frontmatter
+marker and structure, never the body. Skip or reshape it when it does not fit.
+
 The frontmatter below is the on-disk format; fill every section, writing `None`
 rather than omitting one.
 
@@ -43,6 +49,10 @@ date: <YYYY-MM-DD>
 molt_count: <current molt count, before calling psyche(context, molt)>
 type: session-journal
 ---
+
+**<YYYY-MM-DD HH:MM TZ>** — TL;DR: one or two lines on what this segment did and
+where it left off, so the next you can orient at a glance. *(Soft convention —
+not validated; skip if it does not fit.)*
 
 ## What this segment was about
 The original ask and the framing. Why this segment existed.


### PR DESCRIPTION
## What

Softly encourages a molt / session-journal entry to **open with an immediately visible timestamp and a one- or two-line TL;DR** before the sections, so the next instance can date the entry and grasp its gist at a glance without reading the whole record.

## Scope — soft constraint only

This is **documentation/template guidance**, explicitly framed as a soft convention, **not** a new hard-validator requirement:

- The kernel molt gate continues to validate **only the frontmatter** (`type: session-journal` marker, location, non-empty UTF-8, valid YAML with `name`/`description`) — **never the body**. No validation expectations change.
- The added timestamp/TL;DR line lives in the *body* of the template and is flagged inline as "soft convention — not validated; skip if it does not fit."

## Files changed

- `src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md` — prose note + a top-of-body `**<timestamp>** — TL;DR: ...` line in the markdown scaffold, both flagged soft/optional. Frontmatter and required marker preserved verbatim.
- `src/lingtai/intrinsic_skills/psyche-manual/SKILL.md` — one matching soft-convention bullet in the "in roughly this shape" entry guidance.

## Tests

`PYTHONPATH=src python -m pytest tests/test_skills.py tests/test_validate_skill.py tests/test_psyche.py -q` → **66 passed** (teardown-thread warnings only, unrelated to this change). These cover skill/template loading, skill validation, and the psyche/molt-gate path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)