### PR TITLE
Allow Codex endpoint override

### DIFF
--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -9,7 +9,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 20 | Re-exports kernel types (`ChatSession`, `LLMResponse`, `ToolCall`, `FunctionSchema`, `ChatInterface`) + `LLMAdapter` from `base.py`. Triggers `register_all_adapters()` on import. |
-| `_register.py` | 132 | Registers adapter factories for all providers with `LLMService.register_adapter()` |
+| `_register.py` | 186 | Registers adapter factories for all providers with `LLMService.register_adapter()`. Module constant `CODEX_OFFICIAL_BASE_URL` is the Codex default endpoint. |
 | `claude_agent_sdk/` | — | Clean-room completion provider wrapping `claude_agent_sdk.query` as a next-turn generator (no SDK tools, LingTai keeps the tool loop). See its `ANATOMY.md`. |
 | `api_gate.py` | 112 | `APICallGate` — RPM rate limiter with deque timestamps, `ThreadPoolExecutor`, daemon gate thread |
 | `base.py` | 150 | `LLMAdapter` ABC (4 abstract methods), `_GatedSession` proxy |
@@ -30,7 +30,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 - **Adapter caching** — `LLMService._adapters` keyed by `(provider, base_url)` tuple (`service.py:141`). Double-checked locking via `_adapter_lock` (`service.py:142`).
 - **Session tracking** — `LLMService._sessions` dict maps `st_<12-hex>` session IDs to `ChatSession` instances (`service.py:144`). Untracked sessions get `session_id=""`.
 - **Gated sessions** — `_GatedSession` (`base.py:19`) proxies `send()` and `send_stream()` through `APICallGate.submit()`. Attribute writes land on the proxy; reads fall through to inner session via `__getattr__`.
-- **Codex factory** — `_register.py:54` builds `CodexOpenAIAdapter`, monkey-patches `create_chat` and `generate` to refresh OAuth tokens before each call via `CodexTokenManager.get_access_token()`; the same refresh hook re-reads `get_account_id()` into `adapter.codex_account_id` (the user's own `ChatGPT-Account-ID`, passed to the adapter at build time and kept current across refreshes). The token file is the default `~/.lingtai-tui/codex-auth.json` unless the provider defaults carry a non-blank `codex_auth_path`, in which case the factory builds `CodexTokenManager(token_path=codex_auth_path)` — this is the seam for true multiple Codex accounts (a preset/manifest picks the token file per agent).
+- **Codex factory** — `_register.py:68` builds `CodexOpenAIAdapter`, monkey-patches `create_chat` and `generate` to refresh OAuth tokens before each call via `CodexTokenManager.get_access_token()`; the same refresh hook re-reads `get_account_id()` into `adapter.codex_account_id` (the user's own `ChatGPT-Account-ID`, passed to the adapter at build time and kept current across refreshes). The token file is the default `~/.lingtai-tui/codex-auth.json` unless the provider defaults carry a non-blank `codex_auth_path`, in which case the factory builds `CodexTokenManager(token_path=codex_auth_path)` — this is the seam for true multiple Codex accounts (a preset/manifest picks the token file per agent). The endpoint defaults to `CODEX_OFFICIAL_BASE_URL` (`https://chatgpt.com/backend-api/codex`) but honors an explicit `base_url` resolved generically by `_create_adapter` (manifest `base_url` / `provider_defaults['base_url']`) — the seam for a future local `lingtai-codex-pool` to front this provider without a separate adapter. The unchanged `prompt_cache_key`/`session_id`/`thread_id` identity is what the pool routes off later.
 
 ## State
 

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -6,6 +6,13 @@ to the adapter's actual constructor signature.
 """
 from __future__ import annotations
 
+# Official Codex REST endpoint. Used as the default ``base_url`` for the
+# ``codex`` provider when the manifest/provider-defaults do not configure one.
+# A configured ``base_url`` (the generic provider convention) overrides it so a
+# future local ``lingtai-codex-pool`` endpoint can front the same provider
+# without a separate adapter.
+CODEX_OFFICIAL_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
 
 def register_all_adapters() -> None:
     from lingtai.llm.service import LLMService
@@ -63,7 +70,19 @@ def register_all_adapters() -> None:
         from lingtai.auth.codex import CodexTokenManager
         kw.pop("model", None)
         kw.pop("api_key", None)  # ignore env-resolved key
-        kw.pop("base_url", None)  # we set our own
+        # Honor an explicitly configured endpoint (manifest ``base_url`` /
+        # ``provider_defaults['base_url']``, already resolved into ``base_url``
+        # by LLMService._create_adapter) so a future local ``lingtai-codex-pool``
+        # can front this provider. Absent/blank -> the official Codex endpoint.
+        # The pool routes later off the unchanged ``prompt_cache_key`` /
+        # ``session_id`` / ``thread_id`` identity emitted below; the OAuth bearer
+        # may reach localhost in that use case, which is acceptable here.
+        configured_base_url = kw.pop("base_url", None)
+        codex_base_url = (
+            configured_base_url.strip()
+            if isinstance(configured_base_url, str) and configured_base_url.strip()
+            else CODEX_OFFICIAL_BASE_URL
+        )
         # Per-agent Codex REST cache-affinity header config (issue #378). The
         # host wiring (service.build_provider_defaults_from_manifest_llm) passes
         # down the agent path as ``codex_session_anchor`` by default; the adapter
@@ -91,7 +110,7 @@ def register_all_adapters() -> None:
         mgr = CodexTokenManager(**mgr_kw)
         adapter = CodexOpenAIAdapter(
             api_key=mgr.get_access_token(),
-            base_url="https://chatgpt.com/backend-api/codex",
+            base_url=codex_base_url,
             use_responses=True,
             force_responses=True,
             # The user's own ChatGPT account id (sent as the ``ChatGPT-Account-ID``

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -3263,7 +3263,10 @@ class CodexOpenAIAdapter(OpenAIAdapter):
     standard server-stateful OpenAIResponsesSession.
 
     Use this with `provider=codex` only. Always set `use_responses=True,
-    force_responses=True, base_url='https://chatgpt.com/backend-api/codex'`.
+    force_responses=True`. `base_url` defaults to the official Codex endpoint
+    (`https://chatgpt.com/backend-api/codex`) but is configurable — the `codex`
+    factory forwards an explicit `manifest.llm['base_url']` so a future local
+    `lingtai-codex-pool` can front this provider without a separate adapter.
     """
 
     def __init__(

--- a/tests/test_codex_endpoint_override.py
+++ b/tests/test_codex_endpoint_override.py
@@ -1,0 +1,182 @@
+"""Tests for the configurable Codex endpoint / ``base_url`` override.
+
+The ``codex`` provider historically hardcoded the official endpoint
+``https://chatgpt.com/backend-api/codex`` and discarded any caller-supplied
+``base_url``. To support a future local ``lingtai-codex-pool`` endpoint, the
+factory now honors an explicit ``base_url`` (already plumbed generically by
+``LLMService._create_adapter`` from ``manifest.llm['base_url']`` /
+``provider_defaults['base_url']``) while keeping the official endpoint as the
+default when none is configured.
+
+These tests make NO network calls — the OAuth ``CodexTokenManager`` is mocked,
+and we inspect the constructed adapter's OpenAI client ``base_url`` (the real
+end-to-end value, the same one ``BaseAgent`` records via ``service._base_url``).
+Codex per-agent identity (``codex_session_anchor``) and token-file selection
+(``codex_auth_path``) behavior must remain intact.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import lingtai  # noqa: F401  (registers adapters / loads service module)
+from lingtai.llm.service import LLMService
+
+# The official Codex REST endpoint — the default when nothing is configured.
+_OFFICIAL_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+
+def _client_base_url(adapter) -> str:
+    """The adapter's effective endpoint, trailing slash normalized away.
+
+    The OpenAI SDK appends a trailing slash to ``base_url``; strip it so the
+    assertion compares the configured endpoint, not an SDK formatting quirk.
+    """
+    return str(adapter._client.base_url).rstrip("/")
+
+
+def test_codex_defaults_to_official_endpoint_when_base_url_absent():
+    """No configured base_url -> Codex adapter still uses the official endpoint."""
+    with mock.patch("lingtai.auth.codex.CodexTokenManager") as mgr_cls:
+        mgr_cls.return_value.get_access_token.return_value = "fake-token"
+        mgr_cls.return_value.get_account_id.return_value = None
+
+        svc = LLMService(provider="codex", model="gpt-5.5")
+        adapter = svc.get_adapter("codex")
+
+        assert _client_base_url(adapter) == _OFFICIAL_CODEX_BASE_URL
+
+
+def test_codex_honors_configured_base_url():
+    """An explicit base_url reaches CodexOpenAIAdapter for provider codex.
+
+    This is the seam the future local ``lingtai-codex-pool`` endpoint needs:
+    point the existing ``codex`` provider at a local pool URL instead of the
+    hardcoded official endpoint.
+    """
+    pool_url = "http://127.0.0.1:8810/backend-api/codex"
+    with mock.patch("lingtai.auth.codex.CodexTokenManager") as mgr_cls:
+        mgr_cls.return_value.get_access_token.return_value = "fake-token"
+        mgr_cls.return_value.get_account_id.return_value = None
+
+        svc = LLMService(provider="codex", model="gpt-5.5", base_url=pool_url)
+        adapter = svc.get_adapter("codex", pool_url)
+
+        assert _client_base_url(adapter) == pool_url
+
+
+def test_codex_base_url_from_provider_defaults_reaches_adapter():
+    """base_url supplied via provider_defaults (manifest convention) is honored.
+
+    ``LLMService._create_adapter`` resolves ``effective_url = base_url or
+    defaults['base_url']``; the codex factory must consume that the same way the
+    generic providers do.
+    """
+    pool_url = "http://127.0.0.1:8810/backend-api/codex"
+    with mock.patch("lingtai.auth.codex.CodexTokenManager") as mgr_cls:
+        mgr_cls.return_value.get_access_token.return_value = "fake-token"
+        mgr_cls.return_value.get_account_id.return_value = None
+
+        svc = LLMService(
+            provider="codex",
+            model="gpt-5.5",
+            provider_defaults={"codex": {"base_url": pool_url}},
+        )
+        adapter = svc.get_adapter("codex")
+
+        assert _client_base_url(adapter) == pool_url
+
+
+def test_codex_configured_base_url_preserves_session_anchor_identity():
+    """Pointing at a local pool must NOT change the per-agent cache identity.
+
+    The pool routes later using the existing ``prompt_cache_key`` /
+    ``session_id`` / ``thread_id`` identity emitted by the Codex adapter. A
+    configured base_url alongside a ``codex_session_anchor`` must leave that
+    identity (the 8-char agent-path hash) untouched.
+    """
+    from lingtai.llm.openai.adapter import _codex_session_id
+
+    pool_url = "http://127.0.0.1:8810/backend-api/codex"
+    anchor = "/agents/alice/init.json"
+    with mock.patch("lingtai.auth.codex.CodexTokenManager") as mgr_cls:
+        mgr_cls.return_value.get_access_token.return_value = "fake-token"
+        mgr_cls.return_value.get_account_id.return_value = None
+
+        svc = LLMService(
+            provider="codex",
+            model="gpt-5.5",
+            base_url=pool_url,
+            provider_defaults={"codex": {"codex_session_anchor": anchor}},
+        )
+        adapter = svc.get_adapter("codex", pool_url)
+
+        # Endpoint is the pool; identity is still the pure agent-path hash.
+        assert _client_base_url(adapter) == pool_url
+        sid, tid = adapter._resolve_codex_ids("gpt-5.5")
+        assert sid == tid == _codex_session_id(anchor)
+
+
+def test_codex_configured_base_url_preserves_auth_path_selection():
+    """A configured base_url must not disturb ``codex_auth_path`` token-file wiring."""
+    pool_url = "http://127.0.0.1:8810/backend-api/codex"
+    auth_path = "/secrets/alice/codex-auth.json"
+    with mock.patch("lingtai.auth.codex.CodexTokenManager") as mgr_cls:
+        mgr_cls.return_value.get_access_token.return_value = "fake-token"
+        mgr_cls.return_value.get_account_id.return_value = None
+
+        svc = LLMService(
+            provider="codex",
+            model="gpt-5.5",
+            base_url=pool_url,
+            provider_defaults={"codex": {"codex_auth_path": auth_path}},
+        )
+        adapter = svc.get_adapter("codex", pool_url)
+
+        # base_url reached the adapter and the per-agent token file is still used.
+        assert _client_base_url(adapter) == pool_url
+        mgr_cls.assert_called_once_with(token_path=auth_path)
+
+
+def test_codex_configured_base_url_reaches_websocket_url():
+    """The configured endpoint also drives the Codex websocket URL.
+
+    Codex WS is on by default, so a local pool must be reachable over WS too:
+    the per-session ``_ws_base_url`` carries the configured HTTP base and
+    ``_codex_ws_url`` derives ``ws://`` for an http (localhost) pool. This is a
+    pure URL-derivation check — no socket is opened.
+    """
+    from lingtai.llm.openai.adapter import _codex_ws_url
+
+    pool_url = "http://127.0.0.1:8810/backend-api/codex"
+    with mock.patch("lingtai.auth.codex.CodexTokenManager") as mgr_cls:
+        mgr_cls.return_value.get_access_token.return_value = "fake-token"
+        mgr_cls.return_value.get_account_id.return_value = None
+
+        svc = LLMService(provider="codex", model="gpt-5.5", base_url=pool_url)
+        adapter = svc.get_adapter("codex", pool_url)
+        chat = adapter.create_chat(
+            "gpt-5.5", "system prompt", tools=None,
+            force_tool_call=False, thinking="high",
+        )
+
+        # Sessions may be gate-wrapped; the Codex session is the inner object.
+        session = getattr(chat, "_session", chat)
+        assert session._ws_base_url == pool_url
+        assert (
+            _codex_ws_url(session._ws_base_url)
+            == "ws://127.0.0.1:8810/backend-api/codex/responses"
+        )
+
+
+def test_codex_factory_strips_configured_base_url() -> None:
+    pool_url = "http://127.0.0.1:51999/backend-api/codex"
+    configured_url = f"  {pool_url}  "
+    with mock.patch("lingtai.auth.codex.CodexTokenManager") as mgr_cls:
+        mgr_cls.return_value.get_access_token.return_value = "fake-token"
+        mgr_cls.return_value.get_account_id.return_value = None
+
+        svc = LLMService(provider="codex", model="gpt-5.5", base_url=configured_url)
+        adapter = svc.get_adapter("codex", configured_url)
+
+        assert _client_base_url(adapter) == pool_url


### PR DESCRIPTION
## Summary
- Allow the existing `codex` provider to honor an explicit configured `base_url` instead of always forcing the official Codex endpoint.
- Preserve the current default endpoint (`https://chatgpt.com/backend-api/codex`) when no non-blank `base_url` is configured.
- Keep the existing `codex` adapter/provider path intact: no new `codex-pool` provider, no pool routing policy, no token/WS/protocol reimplementation.
- Add no-network regression tests covering endpoint override, default fallback, whitespace trimming, `codex_auth_path`, session/cache identity, and WebSocket URL derivation.
- Update the LLM anatomy note for the endpoint seam and future local `lingtai-codex-pool` use.

## Why
This is the kernel foundation for a future local `lingtai-codex-pool`: the pool can be exposed as a local endpoint while the existing Codex adapter continues to generate stable `prompt_cache_key` / `session_id` / `thread_id` identity for routing.

## Validation
- `PYTHONPATH=src python -m pytest -q tests/test_codex_endpoint_override.py tests/test_llm_service.py tests/test_codex_prompt_cache_key.py tests/test_codex_ws_session.py tests/test_codex_ws_delta.py tests/test_codex_ws_tool_result_freeze.py tests/test_codex_raw_reasoning_replay.py tests/test_deep_refresh.py tests/test_openai_compact_threshold.py tests/test_agent.py tests/test_cli.py` → `258 passed in 11.41s`
- `git diff --check origin/main..HEAD` → pass
- `python -m ruff check src/lingtai/llm/_register.py src/lingtai/llm/openai/adapter.py tests/test_codex_endpoint_override.py` → reports existing `E701` one-line-if findings in the pre-existing Gemini factory lines, unrelated to this PR.

## Out of scope
- `lingtai-codex-pool` CLI/server implementation.
- Account weights, call-count epochs (`N=200` default), manual rebalance controls, TUI balance controls.
- Any merge/release/deploy.
