### PR TITLE
Fix empty Telegram parse_mode handling

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -214,8 +214,11 @@ SCHEMA = {
         },
         "parse_mode": {
             "type": "string",
-            "enum": ["HTML", "MarkdownV2", "Markdown"],
-            "description": "Telegram Bot API parse_mode for rich text (send/reply/edit, and media captions).",
+            "enum": ["HTML", "MarkdownV2", "Markdown", ""],
+            "description": (
+                "Telegram Bot API parse_mode for rich text (send/reply/edit, "
+                "and media captions). Omit or pass an empty string for plain text."
+            ),
         },
         "entities": {
             "type": "array",
@@ -930,6 +933,18 @@ class TelegramManager:
 
     _PARSE_MODES = {"HTML", "MarkdownV2", "Markdown"}
 
+    @staticmethod
+    def _normalize_parse_mode(value: Any) -> Any:
+        """Treat an empty parse_mode as omitted/plain text.
+
+        Some tool callers serialize absent optional string fields as ``""``.
+        Telegram Bot API itself omits parse_mode for plain text, so normalize
+        the empty string before validation and payload persistence.
+        """
+        if value == "":
+            return None
+        return value
+
     def _rich_text_options(self, args: dict) -> tuple[dict[str, Any], str | None]:
         """Extract Bot API rich text options for text messages from tool args.
 
@@ -938,7 +953,7 @@ class TelegramManager:
         as before.
         """
         opts: dict[str, Any] = {}
-        parse_mode = args.get("parse_mode")
+        parse_mode = self._normalize_parse_mode(args.get("parse_mode"))
         if parse_mode is not None:
             if parse_mode not in self._PARSE_MODES:
                 return {}, "parse_mode must be one of: HTML, MarkdownV2, Markdown"
@@ -958,7 +973,7 @@ class TelegramManager:
         latter is treated as caption entities for convenience.
         """
         opts: dict[str, Any] = {}
-        parse_mode = args.get("parse_mode")
+        parse_mode = self._normalize_parse_mode(args.get("parse_mode"))
         if parse_mode is not None:
             if parse_mode not in self._PARSE_MODES:
                 return {}, "parse_mode must be one of: HTML, MarkdownV2, Markdown"
@@ -1079,7 +1094,7 @@ class TelegramManager:
             "text": text,
             "media": media,
             "reply_markup": reply_markup,
-            "parse_mode": args.get("parse_mode"),
+            "parse_mode": self._normalize_parse_mode(args.get("parse_mode")),
             "entities": args.get("entities"),
             "caption_entities": args.get("caption_entities"),
             "link_preview_options": args.get("link_preview_options"),
@@ -1219,7 +1234,7 @@ class TelegramManager:
             "text": text,
             "media": args.get("media"),
             "reply_markup": args.get("reply_markup"),
-            "parse_mode": args.get("parse_mode"),
+            "parse_mode": self._normalize_parse_mode(args.get("parse_mode")),
             "entities": args.get("entities"),
             "caption_entities": args.get("caption_entities"),
             "link_preview_options": args.get("link_preview_options"),

--- a/tests/test_telegram_rich_formatting.py
+++ b/tests/test_telegram_rich_formatting.py
@@ -102,6 +102,9 @@ def test_schema_exposes_rich_formatting_fields():
     ):
         assert field in props
 
+    assert "" in props["parse_mode"]["enum"]
+    assert "plain text" in props["parse_mode"]["description"]
+
 
 # ---------------------------------------------------------------------------
 # Manager pass-through (the acceptance-critical parse_mode path lives here)
@@ -157,6 +160,51 @@ def test_send_without_formatting_is_unchanged(tmp_path):
         None,
         None,
         {},  # no rich-text options leaked in
+    )]
+
+
+def test_empty_parse_mode_is_treated_as_plain_text(tmp_path):
+    """Optional parse_mode serialized as "" should mean omitted/plain text."""
+    manager, account = _manager(tmp_path)
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "text": "plain",
+        "parse_mode": "",
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls == [(
+        "send_message",
+        123,
+        "plain",
+        None,
+        None,
+        {},
+    )]
+    sent_files = list((Path(tmp_path) / "telegram" / "mybot" / "sent").glob("*/message.json"))
+    assert len(sent_files) == 1
+    assert json.loads(sent_files[0].read_text())["parse_mode"] is None
+
+
+def test_empty_parse_mode_reply_is_treated_as_plain_text(tmp_path):
+    manager, account = _manager(tmp_path)
+
+    result = manager._reply({
+        "message_id": "mybot:123:456",
+        "text": "plain reply",
+        "parse_mode": "",
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls == [(
+        "send_message",
+        123,
+        "plain reply",
+        None,
+        456,
+        {},
     )]
 
 


### PR DESCRIPTION
## Summary
- accept an empty `parse_mode` string in the Telegram tool schema as a plain-text sentinel
- normalize `parse_mode == ""` to omitted/`None` before validation, outgoing payload construction, and sent-message persistence
- add manager tests covering empty parse_mode for send/reply plus schema exposure

## Tests
- `python -m pytest tests/test_telegram_rich_formatting.py -q`
- `python -m pytest tests/test_telegram_rich_formatting.py tests/test_mcp_capability.py -q`
