### PR TITLE
feat(mcp): surface non-secret MCP account identity in show + registry XML

### DIFF
--- a/src/lingtai/core/mcp/ANATOMY.md
+++ b/src/lingtai/core/mcp/ANATOMY.md
@@ -11,7 +11,7 @@ the agent's inbox.
 
 ## Components
 
-- `mcp/__init__.py` — MCP registry management and tool surface. `get_description` (`mcp/__init__.py:374-375`), `get_schema` (`mcp/__init__.py:378-379`), `setup` (`mcp/__init__.py:382-406`). Key functions: `validate_record` (`mcp/__init__.py:82-125`), `validate_registry_line` (`mcp/__init__.py:128-138`), `read_registry` (`mcp/__init__.py:149-186`), `decompress_addons` (`mcp/__init__.py:201-257`), `_build_registry_xml` (`mcp/__init__.py:274-299`), `_reconcile` (`mcp/__init__.py:306-342`).
+- `mcp/__init__.py` — MCP registry management and tool surface. `get_description` (`mcp/__init__.py:538-539`), `get_schema` (`mcp/__init__.py:542-543`), `setup` (`mcp/__init__.py:546`). Key functions: `validate_record` (`mcp/__init__.py:82-125`), `validate_registry_line` (`mcp/__init__.py:128-138`), `read_registry` (`mcp/__init__.py:149-186`), `read_identities` (`mcp/__init__.py:261-323`), `decompress_addons` (`mcp/__init__.py:324-380`), `_build_registry_xml` (`mcp/__init__.py:423-457`), `_reconcile` (`mcp/__init__.py:467-504`). **Account-identity discovery** (`mcp/__init__.py:198-323`): `read_identities` reads each addon's non-secret identity document at `system/mcp_identities/<name>.json` (schema `lingtai.mcp.identity.v1`) and projects every account through the secret-safe allowlist `IDENTITY_SAFE_ACCOUNT_KEYS` (`mcp/__init__.py:221-247`) via `_project_account` (`mcp/__init__.py:250`). `_reconcile` attaches the projected identity to each `registered` entry (`_registered_entry`, `mcp/__init__.py:459`) and to the prompt XML (`_build_identity_xml`, `mcp/__init__.py:397`). The projection is an allowlist, not a passthrough — tokens/passwords/secrets/headers and any unrecognized field are dropped even if an on-disk identity file contains them, so the generic surface can never leak what a producer bug might persist.
 - `mcp/inbox.py` — LICC v1 filesystem inbox poller (the **consumer** half). `validate_event` validates required `from`/`subject`/`body` fields; `_format_notification_summary` is **deprecated** legacy helper (retained for backward compat); `_extract_preview_meta` pulls optional IM/chat scalars (`conversation_ref`, `message_ref`, `platform`) out of `event["metadata"]` when present as non-empty strings, each capped at `_PREVIEW_META_FIELD_CAP` (200 chars); `_consume_event` returns `(wake, preview)` where `preview = {"from": sender, "subject": subject, "preview": body[:_PREVIEW_FIELD_CAP], **extracted_meta}` — only the body snippet gets capped (sender/subject are bounded by upstream construction); `_dispatch_summary` publishes to `.notification/mcp.<mcp_name>.json` via `notifications.submit`, embedding full body snippets once in `data.previews` while keeping `instructions` to read/check guidance plus lightweight sender/subject/metadata routing context; `_scan_once` coalesces per MCP, threading the preview list through; `MCPInboxPoller` class drives the poll loop. Body snippet cap is `_PREVIEW_FIELD_CAP = 10000`. Defines the shared contract constants `LICC_VERSION` / `INBOX_DIRNAME` / `DEAD_DIRNAME` / `TMP_SUFFIX` / `EVENT_SUFFIX`.
 - `mcp/licc.py` — LICC v1 client (the **producer** half). One public function, `push_inbox_event(sender, subject, body, *, metadata=None, wake=True, received_at=None, agent_dir=None, mcp_name=None, event_id=None) -> bool`, that an out-of-process MCP imports to drop one event into `<agent_dir>/.mcp_inbox/<mcp_name>/<event_id>.json`. Lightweight by design — importing it starts no threads and re-exports the contract constants (`LICC_VERSION`, `INBOX_DIRNAME`, `TMP_SUFFIX`, `EVENT_SUFFIX`) straight from `inbox.py` so producer and consumer never drift. `agent_dir`/`mcp_name` default to env vars `LINGTAI_AGENT_DIR`/`LINGTAI_MCP_NAME` (kernel-injected per MCP); explicit params override for tests/advanced callers. Writes atomically: serialize → `<event_id>.json.tmp` → `flush`+`os.fsync` → `os.replace` onto the final `.json` (the poller ignores `.tmp`, so half-writes are never observed). `event_id` defaults to a fresh `uuid4().hex` (guarantees per-call uniqueness); explicit `mcp_name`/`event_id` path components are validated before use. The payload is checked with `validate_event` before writing, so the canonical producer does not intentionally emit dead-letterable events. Best-effort/silent: missing/invalid target, unsafe path component, invalid payload, or filesystem/serialization error → `False` (never raises into the MCP), with a terse, content-free log that never echoes `body`/`subject`/`metadata`.
 - `mcp/manual/` — skill documentation (`SKILL.md`) plus reference docs (`curated-addons.md`, `third-party-and-legacy.md`, `troubleshooting.md`) and scripts (`find_readme.py`).
@@ -22,7 +22,7 @@ The `mcp` tool exposes one action:
 
 | Action | Description |
 |--------|-------------|
-| `show` | Return the mcp-manual skill body plus a runtime health snapshot (registry contents, problems, registry path) |
+| `show` | Return the mcp-manual skill body plus a runtime health snapshot (registry contents, problems, registry path). Each `registered` entry may carry a non-secret `identity` block (account alias, provider username/id/display name, non-secret routing counts) read from `system/mcp_identities/<name>.json` when the addon has published one. |
 
 ### LICC v1 Inbox Protocol
 
@@ -72,12 +72,19 @@ mcp/__init__.py
   │   ├── read_registry()           — reads mcp_registry.jsonl, returns (valid, problems)
   │   └── _append_record()          — appends a validated record as a JSONL line
   │
+  ├── Account-identity discovery (read-only, secret-safe)
+  │   ├── IDENTITY_SAFE_ACCOUNT_KEYS — allowlist of non-secret per-account keys
+  │   ├── _project_account()        — projects one account dict to the allowlist
+  │   └── read_identities()         — reads system/mcp_identities/*.json (lingtai.mcp.identity.v1)
+  │
   ├── XML builder
   │   ├── _escape_xml()             — XML entity escaping
+  │   ├── _build_identity_xml()     — renders a non-secret <identity> block per MCP
   │   └── _build_registry_xml()     — renders registry records as <registered_mcp> XML
   │
   ├── Reconciliation
-  │   └── _reconcile()              — reads registry, renders into prompt, returns health snapshot
+  │   ├── _registered_entry()       — builds one registered entry, attaching identity when present
+  │   └── _reconcile()              — reads registry + identities, renders into prompt, returns snapshot
   │
   └── Tool surface
       ├── get_description/schema()  — module-level

--- a/src/lingtai/core/mcp/__init__.py
+++ b/src/lingtai/core/mcp/__init__.py
@@ -195,6 +195,129 @@ def _append_record(working_dir: Path, record: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Account-identity discovery (read-only, secret-safe).
+#
+# Curated addon servers (telegram, feishu, wechat, whatsapp, ...) persist a
+# non-secret identity document to ``system/mcp_identities/<name>.json`` using
+# the shared ``lingtai.mcp.identity.v1`` schema. Those documents let an agent
+# tell *which* configured account/bot/channel a registered MCP surface
+# represents — without reading private config or making network calls. Before
+# this reader they were only reachable through each addon's own ``accounts``
+# action, invisible from the generic ``mcp(action="show")`` surface.
+#
+# This reader is a strict projection, never a passthrough: it surfaces only an
+# explicit allowlist of non-secret keys. Even if an identity file on disk were
+# to contain a secret-shaped field (a producer bug, a hand-edited file), the
+# projection drops it. Tokens, passwords, app secrets, refresh/access tokens,
+# headers, and any unrecognized key never propagate.
+# ---------------------------------------------------------------------------
+
+IDENTITY_DIRNAME = "mcp_identities"
+IDENTITY_SCHEMA = "lingtai.mcp.identity.v1"
+
+# Allowlist of non-secret per-account identity keys. Anything not listed here
+# is dropped by the projection. Keep this list secret-free: no *token,
+# *secret, *password, api_key, headers, or authorization keys.
+IDENTITY_SAFE_ACCOUNT_KEYS: tuple[str, ...] = (
+    # generic identity
+    "alias",
+    "display_name",
+    "username",
+    "account_id",
+    "last_verified_at",
+    "is_bot",
+    # telegram
+    "bot_id",
+    "bot_username",
+    "bot_display_name",
+    # feishu / lark
+    "app_id",
+    # email-style addons
+    "address",
+    "email",
+    # non-secret routing / size hints
+    "allowed_users_count",
+    "contact_count",
+    "channel_count",
+    "config_source",
+)
+
+
+def _identities_dir(working_dir: Path) -> Path:
+    return Path(working_dir) / "system" / IDENTITY_DIRNAME
+
+
+def _project_account(raw: object) -> dict:
+    """Project one account dict down to the non-secret allowlist."""
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        k: raw[k]
+        for k in IDENTITY_SAFE_ACCOUNT_KEYS
+        if k in raw and not isinstance(raw[k], (dict, list))
+    }
+
+
+def read_identities(working_dir: Path) -> dict[str, dict]:
+    """Read all per-MCP identity documents, projected to non-secret fields.
+
+    Returns a mapping ``{mcp_name: summary}`` where each ``summary`` is::
+
+        {
+            "mcp": <name>,
+            "account_count": <int>,
+            "accounts": [ {<safe keys only>}, ... ],
+            "generated_at": <iso str>,        # when present
+            "last_verified_at": <iso str>,    # when present
+        }
+
+    Files that are missing, unreadable, malformed, or that do not carry the
+    expected ``lingtai.mcp.identity.v1`` schema are skipped silently — identity
+    discovery is best-effort and must never break the ``show`` surface.
+    """
+    base = _identities_dir(working_dir)
+    if not base.is_dir():
+        return {}
+
+    out: dict[str, dict] = {}
+    for path in sorted(base.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            log.warning("mcp: skipping unreadable identity file %s: %s", path, e)
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("schema") != IDENTITY_SCHEMA:
+            continue
+
+        name = payload.get("mcp") or path.stem
+        if not isinstance(name, str) or not name:
+            continue
+
+        raw_accounts = payload.get("accounts")
+        accounts = [
+            _project_account(a) for a in raw_accounts
+        ] if isinstance(raw_accounts, list) else []
+        accounts = [a for a in accounts if a]
+
+        summary: dict = {
+            "mcp": name,
+            "account_count": len(accounts),
+            "accounts": accounts,
+        }
+        gen = payload.get("generated_at")
+        if isinstance(gen, str):
+            summary["generated_at"] = gen
+        verified = payload.get("last_verified_at")
+        if isinstance(verified, str):
+            summary["last_verified_at"] = verified
+        out[name] = summary
+
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Boot-time decompression: addons:[...] → registry
 # ---------------------------------------------------------------------------
 
@@ -271,9 +394,38 @@ def _escape_xml(s: str) -> str:
     )
 
 
-def _build_registry_xml(records: list[dict]) -> str:
+def _build_identity_xml(identity: dict | None, indent: str = "    ") -> list[str]:
+    """Render a non-secret <identity> block for one MCP, or [] if absent."""
+    if not identity:
+        return []
+    accounts = identity.get("accounts") or []
+    if not accounts:
+        return []
+    lines = [f"{indent}<identity>"]
+    verified = identity.get("last_verified_at")
+    if verified:
+        lines.append(
+            f"{indent}  <last_verified_at>"
+            f"{_escape_xml(str(verified))}</last_verified_at>"
+        )
+    for acct in accounts:
+        lines.append(f"{indent}  <account>")
+        for key in IDENTITY_SAFE_ACCOUNT_KEYS:
+            if key in acct:
+                lines.append(
+                    f"{indent}    <{key}>{_escape_xml(str(acct[key]))}</{key}>"
+                )
+        lines.append(f"{indent}  </account>")
+    lines.append(f"{indent}</identity>")
+    return lines
+
+
+def _build_registry_xml(
+    records: list[dict], identities: dict[str, dict] | None = None
+) -> str:
     if not records:
         return ""
+    identities = identities or {}
     lines = [
         "The following MCP servers are registered for this agent. To activate "
         "one, add an entry under `mcp` in your init.json and run "
@@ -294,6 +446,7 @@ def _build_registry_xml(records: list[dict]) -> str:
         homepage = r.get("homepage")
         if homepage:
             lines.append(f"    <homepage>{_escape_xml(homepage)}</homepage>")
+        lines.extend(_build_identity_xml(identities.get(r["name"])))
         lines.append("  </mcp>")
     lines.append("</registered_mcp>")
     return "\n".join(lines)
@@ -303,12 +456,21 @@ def _build_registry_xml(records: list[dict]) -> str:
 # Reconciliation (shared by setup and `show` action)
 # ---------------------------------------------------------------------------
 
+def _registered_entry(record: dict, identity: dict | None) -> dict:
+    """Build one ``registered`` entry, attaching identity only when present."""
+    entry = {"name": record["name"], "summary": record["summary"]}
+    if identity and identity.get("accounts"):
+        entry["identity"] = identity
+    return entry
+
+
 def _reconcile(agent: "BaseAgent") -> dict:
     """Read registry, render into prompt, return health snapshot."""
     working_dir = agent._working_dir
     records, problems = read_registry(working_dir)
+    identities = read_identities(working_dir)
 
-    xml = _build_registry_xml(records)
+    xml = _build_registry_xml(records, identities)
     agent.update_system_prompt("mcp", xml, protected=True)
 
     # Health: the umbrella manual must be present.
@@ -332,7 +494,7 @@ def _reconcile(agent: "BaseAgent") -> dict:
         "registry_path": str(_registry_path(working_dir)),
         "registered_count": len(records),
         "registered": [
-            {"name": r["name"], "summary": r["summary"]}
+            _registered_entry(r, identities.get(r["name"]))
             for r in records
         ],
         "problems": problems,

--- a/src/lingtai/core/mcp/__init__.py
+++ b/src/lingtai/core/mcp/__init__.py
@@ -232,7 +232,9 @@ IDENTITY_SAFE_ACCOUNT_KEYS: tuple[str, ...] = (
     "bot_display_name",
     # feishu / lark
     "app_id",
-    # email-style addons
+    # email-style addons. These fields may identify a human/account and can
+    # surface in always-on prompt XML; keep them only when an addon identity
+    # writer intentionally publishes them for routing, never for authentication.
     "address",
     "email",
     # non-secret routing / size hints

--- a/src/lingtai/core/mcp/manual/SKILL.md
+++ b/src/lingtai/core/mcp/manual/SKILL.md
@@ -121,6 +121,26 @@ If neither path yields docs, fall back to the MCP's own runtime self-description
 
 One action: `mcp(action="show")`. Returns this manual body, the current registry contents, and a runtime health snapshot (registry path, count, problems).
 
+Each `registered` entry may also carry a non-secret **`identity`** block, so you can tell *which* configured account/bot/channel an MCP surface represents without reading private config:
+
+```json
+{
+  "name": "telegram",
+  "summary": "...",
+  "identity": {
+    "mcp": "telegram",
+    "account_count": 1,
+    "last_verified_at": "2026-06-24T09:59:00+00:00",
+    "accounts": [
+      {"alias": "main", "bot_username": "my_agent_bot", "bot_id": 123456789,
+       "bot_display_name": "My Agent", "is_bot": true}
+    ]
+  }
+}
+```
+
+Identity comes from the addon-written, non-secret document at `system/mcp_identities/<name>.json` (schema `lingtai.mcp.identity.v1`), surfaced both here and as an `<identity>` block under the server in your `<registered_mcp>` prompt section. It is a **strict allowlist projection** — only non-secret identity fields (alias, provider username/id/display name, non-secret routing counts) are ever shown; tokens, passwords, app secrets, refresh/access tokens, headers, and any unrecognized field are dropped. The block appears only for servers that have published an identity file (currently the curated messaging addons: `telegram`, `feishu`, `wechat`, `whatsapp`); it is absent otherwise and reflects each account's last-cached state (no live network call). For richer per-account detail, the addon's own `accounts` action remains authoritative.
+
 All registry mutations happen via `write` / `edit` / `bash`. The `mcp` capability never writes to the registry.
 
 ## See also

--- a/tests/test_mcp_identity_discovery.py
+++ b/tests/test_mcp_identity_discovery.py
@@ -1,0 +1,308 @@
+"""Tests for generic MCP account-identity discoverability.
+
+The curated addon servers (telegram, feishu, wechat, whatsapp) each persist a
+non-secret identity document to ``system/mcp_identities/<name>.json`` using the
+shared ``lingtai.mcp.identity.v1`` schema. Before this change those documents
+were only reachable via each addon's own ``accounts`` action — invisible from
+the generic ``mcp(action="show")`` surface that agents use to discover which
+MCP servers they have.
+
+These tests cover the generic reader (``read_identities``) and its surfacing
+through ``mcp(action="show")`` and the system-prompt registry XML, and — most
+importantly — prove that NO secret-shaped fields are ever propagated, even when
+a (hypothetical) malformed identity file on disk contains them.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.agent import Agent
+from lingtai.core.mcp import (
+    IDENTITY_SAFE_ACCOUNT_KEYS,
+    read_identities,
+)
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+def _write_identity(workdir: Path, name: str, payload: dict) -> Path:
+    path = workdir / "system" / "mcp_identities" / f"{name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _telegram_identity() -> dict:
+    return {
+        "schema": "lingtai.mcp.identity.v1",
+        "mcp": "telegram",
+        "generated_at": "2026-06-24T10:00:00+00:00",
+        "last_verified_at": "2026-06-24T09:59:00+00:00",
+        "accounts": [
+            {
+                "alias": "main",
+                "bot_id": 123456789,
+                "bot_username": "my_agent_bot",
+                "bot_display_name": "My Agent",
+                "is_bot": True,
+                "last_verified_at": "2026-06-24T09:59:00+00:00",
+                "allowed_users_count": 2,
+                "contact_count": 5,
+            }
+        ],
+    }
+
+
+def _mk_agent(tmp_path: Path, *, addons=None):
+    workdir = tmp_path / "agent"
+    return Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=workdir,
+        capabilities={"mcp": {}},
+        addons=addons,
+    ), workdir
+
+
+# ---------------------------------------------------------------------------
+# read_identities — the generic reader
+# ---------------------------------------------------------------------------
+
+def test_read_identities_empty_when_no_dir(tmp_path):
+    assert read_identities(tmp_path / "agent") == {}
+
+
+def test_read_identities_surfaces_safe_fields(tmp_path):
+    workdir = tmp_path / "agent"
+    _write_identity(workdir, "telegram", _telegram_identity())
+
+    ids = read_identities(workdir)
+    assert "telegram" in ids
+    tg = ids["telegram"]
+    assert tg["mcp"] == "telegram"
+    assert tg["account_count"] == 1
+    assert tg["last_verified_at"] == "2026-06-24T09:59:00+00:00"
+    acct = tg["accounts"][0]
+    assert acct["alias"] == "main"
+    assert acct["bot_username"] == "my_agent_bot"
+    assert acct["bot_id"] == 123456789
+    assert acct["bot_display_name"] == "My Agent"
+
+
+def test_read_identities_ignores_wrong_schema(tmp_path):
+    workdir = tmp_path / "agent"
+    _write_identity(
+        workdir,
+        "telegram",
+        {"schema": "something.else.v9", "mcp": "telegram", "accounts": []},
+    )
+    assert read_identities(workdir) == {}
+
+
+def test_read_identities_skips_malformed_json(tmp_path):
+    workdir = tmp_path / "agent"
+    path = workdir / "system" / "mcp_identities" / "telegram.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    # Malformed file must not crash the reader; it is simply skipped.
+    assert read_identities(workdir) == {}
+
+
+def test_read_identities_handles_multiple_servers(tmp_path):
+    workdir = tmp_path / "agent"
+    _write_identity(workdir, "telegram", _telegram_identity())
+    _write_identity(
+        workdir,
+        "feishu",
+        {
+            "schema": "lingtai.mcp.identity.v1",
+            "mcp": "feishu",
+            "generated_at": "2026-06-24T10:00:00+00:00",
+            "accounts": [{"alias": "ops", "app_id": "cli_xxx"}],
+        },
+    )
+    ids = read_identities(workdir)
+    assert set(ids) == {"telegram", "feishu"}
+
+
+# ---------------------------------------------------------------------------
+# SECRET SAFETY — the heart of the change
+# ---------------------------------------------------------------------------
+
+SECRET_KEYS = [
+    "bot_token",
+    "token",
+    "password",
+    "email_password",
+    "app_secret",
+    "client_secret",
+    "refresh_token",
+    "access_token",
+    "api_key",
+    "secret",
+    "headers",
+    "authorization",
+]
+
+
+def test_secret_fields_are_stripped_from_accounts(tmp_path):
+    """Even if an identity file on disk somehow contains secret-shaped keys,
+    the generic reader must project to the safe allowlist and drop them."""
+    workdir = tmp_path / "agent"
+    poisoned_account = {
+        "alias": "main",
+        "bot_username": "my_agent_bot",
+        "bot_id": 1,
+        # Secrets that must NEVER survive projection:
+        "bot_token": "123456:AAH-supersecrettoken",
+        "password": "hunter2",
+        "app_secret": "shhh",
+        "refresh_token": "rt_abc",
+        "access_token": "at_xyz",
+        "api_key": "sk-live-leak",
+        "headers": {"Authorization": "Bearer leak"},
+        "authorization": "Bearer leak",
+        "secret": "leak",
+    }
+    _write_identity(
+        workdir,
+        "telegram",
+        {
+            "schema": "lingtai.mcp.identity.v1",
+            "mcp": "telegram",
+            "accounts": [poisoned_account],
+        },
+    )
+
+    ids = read_identities(workdir)
+    acct = ids["telegram"]["accounts"][0]
+    blob = json.dumps(ids)
+
+    # Safe fields survive.
+    assert acct["alias"] == "main"
+    assert acct["bot_username"] == "my_agent_bot"
+    # No secret-shaped key survives, anywhere in the serialized output.
+    for key in SECRET_KEYS:
+        assert key not in acct, f"secret key {key!r} leaked into account"
+    assert "supersecrettoken" not in blob
+    assert "hunter2" not in blob
+    assert "Bearer leak" not in blob
+    assert "sk-live-leak" not in blob
+
+
+def test_allowlist_keys_are_all_non_secret():
+    """Guard: the safe-key allowlist must not contain any secret-shaped key."""
+    for key in IDENTITY_SAFE_ACCOUNT_KEYS:
+        low = key.lower()
+        assert "token" not in low
+        assert "secret" not in low
+        assert "password" not in low
+        assert low not in {"api_key", "headers", "authorization"}
+
+
+def test_unknown_account_fields_are_dropped_by_default(tmp_path):
+    """Defense in depth: keys not on the allowlist are dropped, not passed
+    through — so a future producer adding a sensitive field cannot leak it
+    through the generic reader without an explicit allowlist update."""
+    workdir = tmp_path / "agent"
+    _write_identity(
+        workdir,
+        "telegram",
+        {
+            "schema": "lingtai.mcp.identity.v1",
+            "mcp": "telegram",
+            "accounts": [{"alias": "main", "some_future_private_field": "x"}],
+        },
+    )
+    acct = read_identities(workdir)["telegram"]["accounts"][0]
+    assert acct == {"alias": "main"}
+
+
+# ---------------------------------------------------------------------------
+# mcp(action="show") surfacing
+# ---------------------------------------------------------------------------
+
+def test_show_action_includes_identity_when_present(tmp_path):
+    agent, workdir = _mk_agent(tmp_path, addons=["telegram"])
+    _write_identity(workdir, "telegram", _telegram_identity())
+
+    handler = agent._tool_handlers.get("mcp")
+    result = handler({"action": "show"})
+
+    registered = {r["name"]: r for r in result["registered"]}
+    assert "telegram" in registered
+    ident = registered["telegram"].get("identity")
+    assert ident is not None
+    assert ident["account_count"] == 1
+    assert ident["accounts"][0]["bot_username"] == "my_agent_bot"
+    # No secret anywhere in the identity-bearing portion of the payload.
+    # (The `mcp_manual` field embeds SKILL.md docs that legitimately mention
+    # field names like "bot_token", so we scope the check to `registered`.)
+    assert "bot_token" not in json.dumps(result["registered"])
+
+
+def test_show_action_omits_identity_when_absent(tmp_path):
+    agent, workdir = _mk_agent(tmp_path, addons=["telegram"])
+    # No identity file written.
+    handler = agent._tool_handlers.get("mcp")
+    result = handler({"action": "show"})
+    registered = {r["name"]: r for r in result["registered"]}
+    assert "identity" not in registered["telegram"]
+
+
+def test_show_action_ignores_identity_without_registry_match(tmp_path):
+    """An identity file for an MCP not in the registry should not invent a
+    registered entry."""
+    agent, workdir = _mk_agent(tmp_path, addons=["telegram"])
+    _write_identity(workdir, "ghost", _telegram_identity())
+    handler = agent._tool_handlers.get("mcp")
+    result = handler({"action": "show"})
+    names = {r["name"] for r in result["registered"]}
+    assert "ghost" not in names
+
+
+# ---------------------------------------------------------------------------
+# System-prompt XML surfacing
+# ---------------------------------------------------------------------------
+
+def test_identity_rendered_into_prompt_xml(tmp_path):
+    agent, workdir = _mk_agent(tmp_path, addons=["telegram"])
+    _write_identity(workdir, "telegram", _telegram_identity())
+
+    # Re-render the registry now that the identity file exists.
+    handler = agent._tool_handlers.get("mcp")
+    handler({"action": "show"})
+
+    section = agent._prompt_manager._sections.get("mcp")
+    body = section.body if hasattr(section, "body") else str(section)
+    assert "<identity>" in body
+    assert "my_agent_bot" in body
+    # Secret must never reach the prompt.
+    assert "bot_token" not in body
+
+
+def test_prompt_xml_has_no_secret_even_with_poisoned_file(tmp_path):
+    agent, workdir = _mk_agent(tmp_path, addons=["telegram"])
+    _write_identity(
+        workdir,
+        "telegram",
+        {
+            "schema": "lingtai.mcp.identity.v1",
+            "mcp": "telegram",
+            "accounts": [
+                {"alias": "main", "bot_username": "b", "bot_token": "123:SECRET"}
+            ],
+        },
+    )
+    handler = agent._tool_handlers.get("mcp")
+    handler({"action": "show"})
+    section = agent._prompt_manager._sections.get("mcp")
+    body = section.body if hasattr(section, "body") else str(section)
+    assert "SECRET" not in body
+    assert "bot_token" not in body


### PR DESCRIPTION
## Summary

Make the **generic** `mcp(action="show")` surface (and the `<registered_mcp>` prompt section) expose a **non-secret identity block** per registered MCP, so an agent can tell *which* configured account/bot/channel a server represents — without reading private config, calling an addon-specific action, or making a network call.

### Motivation

Agents discover MCPs via `mcp(action="show")` / the `<registered_mcp>` prompt section, but those only carried `{name, summary, transport, source, homepage}`. To learn the account behind a server (which Telegram bot? which Feishu app?), an agent had to already know each addon's own `accounts` action existed and call it server by server.

The curated messaging addons (`telegram`, `feishu`, `wechat`, `whatsapp`) **already** persist a non-secret identity document to `system/mcp_identities/<name>.json` using the shared `lingtai.mcp.identity.v1` schema (alias, bot/app username/id/display name, last_verified_at, non-secret counts). This PR makes the generic surface read those cached files — the smallest safe change, reusing existing secret-safe producers rather than adding new ones.

## Changes

- **`read_identities(working_dir)`** in `core/mcp/__init__.py` — reads `system/mcp_identities/*.json`, validates the `lingtai.mcp.identity.v1` schema, and projects every account through an explicit non-secret allowlist (`IDENTITY_SAFE_ACCOUNT_KEYS`). Missing / unreadable / malformed / wrong-schema files are skipped silently so identity discovery never breaks `show`.
- **`_reconcile`** attaches the projected identity to each `registered` entry (when present) and to the prompt XML (`<identity>` block per server).
- Docs: `mcp/manual/SKILL.md` (Tool surface) and `core/mcp/ANATOMY.md`.

### Example `show` output

```json
{
  "name": "telegram",
  "summary": "...",
  "identity": {
    "mcp": "telegram",
    "account_count": 1,
    "last_verified_at": "2026-06-24T09:59:00+00:00",
    "accounts": [
      {"alias": "main", "bot_username": "my_agent_bot", "bot_id": 123456789,
       "bot_display_name": "My Agent", "is_bot": true}
    ]
  }
}
```

## Secret safety

The reader is a **strict allowlist projection, never a passthrough**. Only `IDENTITY_SAFE_ACCOUNT_KEYS` survive (alias, provider username/id/display name, non-secret routing counts). Tokens, passwords, app secrets, refresh/access tokens, headers, and **any unrecognized key** are dropped — even if a malformed or hand-edited identity file on disk contains them. So the generic surface cannot leak what a producer bug might persist. No new code path ever touches `bot_token` / config secrets; the change is read-only over already-non-secret files. No network calls — reflects last-cached account state; for live/richer detail the addon's own `accounts` action stays authoritative.

## Tests

`tests/test_mcp_identity_discovery.py` (13 cases): safe fields appear in `read_identities` / `show` / prompt XML; secret-shaped keys never propagate, including via a deliberately **poisoned on-disk identity file**; unknown keys are dropped by default; allowlist asserted secret-free; wrong-schema / malformed-JSON / absent files handled gracefully; identity for an unregistered MCP does not invent a `registered` entry.

```
tests/test_mcp_identity_discovery.py ............. 13 passed
tests/test_mcp_capability.py ..................... 25 passed (regression)
-k "mcp or telegram or feishu or whatsapp or wechat or identity or notification": 361 passed
git diff --check: clean
```

Developed test-first (TDD). Additive: +165 lines in one source file, no deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)