### PR TITLE
Fix empty Telegram chat_action handling

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -263,12 +263,13 @@ SCHEMA = {
         },
         "chat_action": {
             "type": "string",
-            "enum": ["typing", "upload_photo", "upload_document", "upload_voice"],
+            "enum": ["typing", "upload_photo", "upload_document", "upload_voice", ""],
             "description": (
                 "For send action only. When set and no text/media is provided, "
                 "sends a chat action indicator (e.g. 'typing...') instead of a "
                 "message. Auto-expires after 5 seconds — re-send periodically "
-                "during long tasks to keep it visible."
+                "during long tasks to keep it visible. Omit or pass an empty "
+                "string for no chat action."
             ),
         },
     },
@@ -945,6 +946,18 @@ class TelegramManager:
             return None
         return value
 
+    @staticmethod
+    def _normalize_chat_action(value: Any) -> Any:
+        """Treat an empty chat_action as omitted/no typing indicator.
+
+        Optional enum-like tool arguments may be serialized as ``""`` by some
+        callers.  Telegram only needs chat_action when the caller explicitly
+        asks for one, so normalize an empty string before action dispatch.
+        """
+        if value == "":
+            return None
+        return value
+
     def _rich_text_options(self, args: dict) -> tuple[dict[str, Any], str | None]:
         """Extract Bot API rich text options for text messages from tool args.
 
@@ -997,7 +1010,7 @@ class TelegramManager:
         if media and isinstance(media, dict) and not (media.get("path") or "").strip():
             media = None
         reply_markup = args.get("reply_markup")
-        chat_action = args.get("chat_action")
+        chat_action = self._normalize_chat_action(args.get("chat_action"))
         placeholder = bool(args.get("placeholder", False))
         rich_text_options, rich_text_error = self._rich_text_options(args)
         caption_options, caption_error = self._caption_options(args)

--- a/tests/test_telegram_rich_formatting.py
+++ b/tests/test_telegram_rich_formatting.py
@@ -106,6 +106,12 @@ def test_schema_exposes_rich_formatting_fields():
     assert "plain text" in props["parse_mode"]["description"]
 
 
+def test_schema_allows_empty_chat_action():
+    props = SCHEMA["properties"]
+    assert "" in props["chat_action"]["enum"]
+    assert "empty string" in props["chat_action"]["description"]
+
+
 # ---------------------------------------------------------------------------
 # Manager pass-through (the acceptance-critical parse_mode path lives here)
 # ---------------------------------------------------------------------------
@@ -186,6 +192,28 @@ def test_empty_parse_mode_is_treated_as_plain_text(tmp_path):
     sent_files = list((Path(tmp_path) / "telegram" / "mybot" / "sent").glob("*/message.json"))
     assert len(sent_files) == 1
     assert json.loads(sent_files[0].read_text())["parse_mode"] is None
+
+
+def test_empty_chat_action_with_text_is_treated_as_omitted(tmp_path):
+    """Optional chat_action serialized as "" should not block text sends."""
+    manager, account = _manager(tmp_path)
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "text": "plain",
+        "chat_action": "",
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls == [(
+        "send_message",
+        123,
+        "plain",
+        None,
+        None,
+        {},
+    )]
 
 
 def test_empty_parse_mode_reply_is_treated_as_plain_text(tmp_path):


### PR DESCRIPTION
## Summary
- allow Telegram `chat_action` schema to accept an empty string for omitted/no action
- normalize `chat_action: ""` to `None` before send dispatch
- add regression coverage for empty `chat_action` plus schema exposure

## Tests
- `python -m pytest tests/test_telegram_rich_formatting.py -q` (15 passed)
- `python -m pytest tests/test_telegram_rich_formatting.py tests/test_mcp_capability.py -q` (40 passed)

## Notes
This mirrors the prior empty `parse_mode` fix for another optional enum-like Telegram argument. It fixes tool calls that serialize optional `chat_action` as `""` while sending ordinary text.