### PR TITLE
Fix daemon terminal notifications for short successes

### DIFF
--- a/src/lingtai/core/daemon/ANATOMY.md
+++ b/src/lingtai/core/daemon/ANATOMY.md
@@ -82,7 +82,7 @@ daemon/__init__.py
   ├── _kill_cli_group()/_drain_all_cli_procs() — kill one batch's CLI procs (watchdog) vs. drain all for reclaim/stop
   ├── _arm_batch_done_cancel()      — sets a batch's cancel_event once all its futures finish so the watchdog can't wake later
   ├── _watchdog()                   — per-batch timeout enforcement thread; on timeout kills only its own `cli_group_id` procs
-  ├── _on_emanation_done()          — future done-callback: derives the terminal status from `run_dir.state_snapshot()["state"]` (authoritative: done/failed/cancelled/timeout), suppresses only short *successful* results, and publishes the once-only terminal notification (gated by `run_dir.claim_terminal_notification()`). This is the single funnel that guarantees every terminal outcome wakes the parent.
+  ├── _on_emanation_done()          — future done-callback: derives the terminal status from `run_dir.state_snapshot()["state"]` (authoritative: done/failed/cancelled/timeout) and publishes the once-only terminal notification for every terminal state, including short successful results (gated by `run_dir.claim_terminal_notification()`). This is the single funnel that guarantees every terminal outcome wakes the parent.
   ├── _publish_daemon_notification() — publishes one compact `.notification/system.json` event (id, terminal status, task summary, run dir, result/error path, bounded preview); used by both the terminal funnel and follow-up (`ask`) completions
   └── _drain_followup()             — drains per-emanation follow-up buffer (lingtai backend only)
 

--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -575,9 +575,11 @@ def _classify_terminal_state(
     future raises, ``_on_emanation_done`` sets ``status="failed"`` directly and
     does not call this helper.
 
-    The sole purpose is to keep a non-normal terminal state (timeout / cancelled
-    / failed) from being misread as a tiny ``"done"`` and silently swallowed by
-    the ``suppressed_short`` gate. Only a genuine ``"done"`` may be suppressed.
+    The sole purpose is to preserve the true terminal state (timeout /
+    cancelled / failed / done) before publishing the parent-facing daemon
+    notification. Every terminal state, including a short successful
+    ``"done"`` result, is now surfaced so the parent can safely go idle after
+    dispatch and wake when the run ends.
 
     Priority order (first match wins):
 
@@ -593,7 +595,7 @@ def _classify_terminal_state(
       P5  elapsed >= fraction * timeout_s with a ``[no output]`` body — a
           deliberately low-priority heuristic for the rare case where neither
           the recorded state nor the events survived.
-      P6  ``"done"`` — genuine success (suppression-eligible).
+      P6  ``"done"`` — genuine success.
     """
     run_dir = entry.get("run_dir") if entry else None
 
@@ -645,10 +647,11 @@ def _classify_terminal_state(
 class DaemonManager:
     """Manages subagent (emanation) lifecycle."""
 
-    # Minimum text length to trigger a parent notification for a *successful*
-    # (done) run — short happy-path results are suppressed to avoid notification
-    # storms. Non-success terminal states (failed / cancelled / timeout) always
-    # notify regardless of length; see _on_emanation_done.
+    # Historical constructor default for ``notify_threshold``. Terminal daemon
+    # completions are no longer suppressed by result length: the compact system
+    # notification is the parent wake signal for every terminal state. The
+    # constructor argument remains accepted for compatibility with existing
+    # callers/configs.
     _NOTIFY_MIN_LEN = 20
 
     def __init__(self, agent: "Agent", max_emanations: int = 100,
@@ -5318,9 +5321,9 @@ class DaemonManager:
         # recorded ``run_dir`` state authoritative (current main's behaviour) and
         # layers timeout_event / cancel_event / sentinel / elapsed fallbacks on
         # top, so a non-normal terminal state (timeout / cancelled / failed) is
-        # never misclassified as a tiny ``done`` and swallowed by the short-
-        # result gate below. The parent always learns the daemon terminated even
-        # when it failed silently. A raised future is ``failed`` unconditionally.
+        # never misclassified as a tiny ``done``. The parent always learns the
+        # daemon terminated, and with the correct terminal label, even when it
+        # failed silently. A raised future is ``failed`` unconditionally.
         if future_succeeded:
             status = _classify_terminal_state(entry, future_succeeded, text, timeout_s)
         else:
@@ -5333,15 +5336,9 @@ class DaemonManager:
             self._log("daemon_error", em_id=em_id,
                       exception=type(exc).__name__, exception_message=str(exc))
 
-        # Suppress notifications only for short *successful* results to prevent
-        # notification storms. Every non-success terminal state (failed,
-        # cancelled, timeout) always notifies so the parent can safely go idle
-        # after dispatch and still learn the run ended.
-        if status == "done" and len(text) < self._notify_threshold:
-            self._log("daemon_result", em_id=em_id, status="suppressed_short",
-                      text_length=len(text))
-            return
-
+        # Deliver every terminal state, including short successful results: the
+        # compact system notification is the wake signal that lets the parent
+        # safely go idle after dispatch and still learn the run ended.
         # Deliver exactly once per run: the done-callback can fire more than
         # once for the same em_id (racing reclaim, re-entrant callbacks). The
         # run directory owns the once-only claim, decoupled from the system

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1475,7 +1475,7 @@ def test_on_emanation_done_failure_always_notifies(tmp_path):
     assert "[daemon:em-" not in events[0]["body"]
 
 
-def test_on_emanation_done_short_success_still_suppressed(tmp_path):
+def test_on_emanation_done_short_success_notifies(tmp_path):
     from lingtai_kernel.notifications import collect_notifications
 
     agent = _make_agent(tmp_path, ["daemon"])
@@ -1495,14 +1495,18 @@ def test_on_emanation_done_short_success_still_suppressed(tmp_path):
     mgr._on_emanation_done("em-short", "test task", future)
 
     assert agent.inbox.empty()
-    assert collect_notifications(agent._working_dir) == {}
+    events = collect_notifications(agent._working_dir)["system"]["data"]["events"]
+    assert len(events) == 1
+    assert events[0]["source"] == "daemon"
+    assert events[0]["ref_id"] == "em-short"
+    assert "Daemon em-short done." in events[0]["body"]
+    assert "Preview:\nok" in events[0]["body"]
 
 
 def test_on_emanation_done_cancelled_notifies_despite_short_text(tmp_path):
     """A cancelled run returns the short ``[cancelled]`` sentinel but its
-    run_dir state is authoritative. The short-result suppression must NOT
-    swallow a non-success terminal state — the parent must always learn the
-    daemon terminated."""
+    run_dir state is authoritative. The parent must always learn the daemon
+    terminated, with the correct terminal label."""
     from lingtai_kernel.notifications import collect_notifications
 
     agent = _make_agent(tmp_path, ["daemon"])

--- a/tests/test_daemon_terminal_state_gate.py
+++ b/tests/test_daemon_terminal_state_gate.py
@@ -8,7 +8,9 @@ P1 signal) and delivers each terminal notification exactly once via
 signals layered on top of that: when the run_dir state was never recorded
 (crash before mark_*, missing run_dir), the timeout_event / cancel_event /
 ``[cancelled]`` sentinel / elapsed-near-timeout signals still keep a
-timeout/cancelled run from being swallowed by the ``suppressed_short`` gate.
+timeout/cancelled run from being mislabeled as an ordinary success. Every
+terminal state now publishes the compact daemon notification, including short
+successful results.
 
 The once-only terminal-notification dedupe and the run_dir-authoritative
 classification are exercised in tests/test_daemon.py and must remain intact;
@@ -84,8 +86,7 @@ class TestClassifyRunDirAuthority:
         assert _classify_terminal_state(entry, True, "anything", 3600.0) == "failed"
 
     def test_run_dir_done_with_short_text_stays_done(self):
-        """A genuinely-done run with a short body stays 'done' and is eligible
-        for suppression."""
+        """A genuinely-done run with a short body stays 'done'."""
         entry = _make_entry(run_dir_state="done")
         assert _classify_terminal_state(entry, True, "ok", 3600.0) == "done"
 
@@ -177,7 +178,7 @@ class TestClassifyFallbackSignals:
         assert _classify_terminal_state(entry, True, "real result body", 3600.0) == "done"
 
     def test_genuine_short_success_stays_done(self):
-        """No abnormal signal anywhere -> 'done' (suppression eligible)."""
+        """No abnormal signal anywhere -> 'done'."""
         entry = _make_entry(run_dir_state=None)
         assert _classify_terminal_state(entry, True, "42", 3600.0) == "done"
 
@@ -235,10 +236,10 @@ class TestOnEmanationDoneIntegration:
     """Verify the gate is wired into _on_emanation_done end-to-end and that the
     once-only terminal-notification dedupe (current main) is preserved."""
 
-    def test_timeout_event_not_suppressed_without_run_dir_state(self, tmp_path):
+    def test_timeout_event_notifies_without_run_dir_state(self, tmp_path):
         """The key #194 case via the *event* fallback: a timed-out run whose
         run_dir never recorded 'timeout' (e.g. crash before mark_timeout) still
-        notifies because timeout_event is set — not swallowed as a short success.
+        notifies with the correct terminal label because timeout_event is set.
         """
         from lingtai_kernel.notifications import collect_notifications
 
@@ -266,7 +267,7 @@ class TestOnEmanationDoneIntegration:
         assert len(events) == 1
         assert "timeout" in events[0]["body"].lower()
 
-    def test_cancel_event_not_suppressed_without_run_dir_state(self, tmp_path):
+    def test_cancel_event_notifies_without_run_dir_state(self, tmp_path):
         from lingtai_kernel.notifications import collect_notifications
 
         agent = _make_agent(tmp_path)
@@ -292,8 +293,10 @@ class TestOnEmanationDoneIntegration:
         assert len(events) == 1
         assert "cancelled" in events[0]["body"].lower()
 
-    def test_genuine_short_success_still_suppressed(self, tmp_path):
-        """No abnormal signal -> 'done' + short text -> suppressed, no notify."""
+    def test_genuine_short_success_notifies(self, tmp_path):
+        """Even a tiny successful result must wake the parent: the daemon
+        terminal notification is the completion signal, not a long-output echo.
+        """
         from lingtai_kernel.notifications import collect_notifications
 
         agent = _make_agent(tmp_path)
@@ -316,7 +319,11 @@ class TestOnEmanationDoneIntegration:
 
         mgr._on_emanation_done("em-short", "test task", future)
 
-        assert collect_notifications(agent._working_dir) == {}
+        events = collect_notifications(agent._working_dir)["system"]["data"]["events"]
+        assert len(events) == 1
+        assert events[0]["ref_id"] == "em-short"
+        assert "Daemon em-short done." in events[0]["body"]
+        assert "Preview:\n42" in events[0]["body"]
 
     def test_timeout_terminal_notified_only_once(self, tmp_path):
         """Dedupe preservation: a timeout surfaced via the event fallback is


### PR DESCRIPTION
## Summary
- always publish the compact daemon terminal notification, including short successful `done` results
- keep the once-only `run_dir.claim_terminal_notification()` dedupe gate
- update daemon docs/anatomy and regression tests so short success no longer bypasses notification delivery

## Evidence / root cause
A real daemon completion (em-3) ended with `daemon_result status=done text_length=11` and was immediately logged as `status=suppressed_short`, so `_publish_daemon_notification()` was never called. The parent therefore saw no daemon completion notification/wake even though the daemon wrote its report.

## Tests
- `python -m pytest tests/test_daemon.py tests/test_daemon_terminal_state_gate.py -q` → 108 passed
- `python -m pytest tests/test_daemon.py tests/test_daemon_terminal_state_gate.py tests/test_notification_tool.py tests/test_system_notifications.py tests/test_notification_sync.py -q` → 200 passed
- `git diff --check`
