### PR TITLE
Tune Codex summarize guidance

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2944,22 +2944,29 @@ class CodexResponsesSession(OpenAIResponsesSession):
                 "non_urgent_summarize": "ok",
                 "reason": "no full epoch in the last 20 Codex API calls",
             }
-        wait_remaining = max(0, 5 - int(last_ws_full_api_calls_ago))
+        delayed_summarize_min_api_calls = 10
+        wait_remaining = max(
+            0, delayed_summarize_min_api_calls - int(last_ws_full_api_calls_ago)
+        )
         if wait_remaining > 0:
             return {
                 "non_urgent_summarize": "wait",
-                "wait_until_last_ws_full_api_calls_ago": 5,
+                "wait_until_last_ws_full_api_calls_ago": delayed_summarize_min_api_calls,
                 "wait_api_calls_remaining": wait_remaining,
                 "reason": (
                     f"last full epoch was {last_ws_full_api_calls_ago} API calls ago; "
-                    f"wait {wait_remaining} more if not urgent"
+                    f"wait {wait_remaining} more if context pressure is low"
                 ),
             }
         return {
             "non_urgent_summarize": "ok",
-            "wait_until_last_ws_full_api_calls_ago": 5,
+            "wait_until_last_ws_full_api_calls_ago": delayed_summarize_min_api_calls,
             "wait_api_calls_remaining": 0,
-            "reason": f"last full epoch was {last_ws_full_api_calls_ago} API calls ago",
+            "reason": (
+                f"last full epoch was {last_ws_full_api_calls_ago} API calls ago; "
+                "delayed summarize window satisfied; prefer batching multiple "
+                "already-consumed results when practical"
+            ),
         }
 
     def adapter_comment(self) -> dict[str, Any] | None:
@@ -3001,10 +3008,13 @@ class CodexResponsesSession(OpenAIResponsesSession):
             "Summarize rewrites older tool-result payloads, compacts redundant "
             "carried-forward context, and can break Codex's previous_response_id/"
             "incremental prefix; the next request must open a fresh full epoch, "
-            "usually causing more cache miss. Wait until >=5 API calls after the "
-            "last full epoch before non-urgent summarize. Notification dismiss is "
-            "only notification cleanup: it does not compact redundant context and "
-            "does not trigger a full epoch reset."
+            "usually causing more cache miss. When context pressure is low, "
+            "prefer delaying non-urgent summarize until >=10 API calls after the "
+            "last full epoch, then batch multiple already-consumed long tool "
+            "results into one summarize call when practical. If context pressure "
+            "is high or a noisy result blocks work, summarize immediately. "
+            "Notification dismiss is only notification cleanup: it does not "
+            "compact redundant context and does not trigger a full epoch reset."
         )
         cache_ledger = self._ws_cache_ledger_comment()
         last_full = cache_ledger["last_full"]

--- a/tests/test_codex_ws_session.py
+++ b/tests/test_codex_ws_session.py
@@ -1003,7 +1003,9 @@ def test_codex_adapter_comment_explains_epoch_reset_and_cache_ledger():
     assert comment["summarize_ws_full_note"] == note
     assert "full epoch" in note
     assert "incremental prefix" in note
-    assert ">=5 API calls" in note
+    assert ">=10 API calls" in note
+    assert "batch multiple" in note
+    assert "context pressure" in note
     assert "cache miss" in note
     assert "Summarize" in note
     assert "Notification dismiss" in note
@@ -1060,8 +1062,9 @@ def test_codex_adapter_comment_reports_compact_cache_ledger():
     assert comment["last_ws_full_api_calls_ago"] == 0
     assert comment["last_ws_full_reason"] == "pm"
     assert comment["maintenance_hint"]["non_urgent_summarize"] == "wait"
-    assert comment["maintenance_hint"]["wait_api_calls_remaining"] == 5
-    assert "wait 5 more" in comment["maintenance_hint"]["reason"]
+    assert comment["maintenance_hint"]["wait_api_calls_remaining"] == 10
+    assert "wait 10 more" in comment["maintenance_hint"]["reason"]
+    assert "context pressure is low" in comment["maintenance_hint"]["reason"]
 
     ledger = comment["cache_ledger"]
     assert ledger["recorded_api_calls"] == 3
@@ -1102,7 +1105,7 @@ def test_codex_send_populates_cache_ledger_end_to_end():
     assert comment["last_ws_full_api_calls_ago"] == 1
     assert comment["last_ws_full_reason"] == "nb"
     assert comment["maintenance_hint"]["non_urgent_summarize"] == "wait"
-    assert comment["maintenance_hint"]["wait_api_calls_remaining"] == 4
+    assert comment["maintenance_hint"]["wait_api_calls_remaining"] == 9
 
     ledger = comment["cache_ledger"]
     assert ledger["recorded_api_calls"] == 2


### PR DESCRIPTION
## Summary
- raise the Codex adapter comment's non-urgent summarize delay guidance from 5 to 10 API calls after the last full epoch
- clarify that low-pressure cleanup should batch multiple already-consumed long tool results into one summarize call when practical
- explicitly say high context pressure or blocking noisy results should still be summarized immediately

## Tests
- `uv run pytest tests/test_codex_ws_session.py -k 'adapter_comment or cache_ledger or send_populates_cache_ledger'`
- `uv run pytest tests/test_codex_ws_session.py`
