### PR TITLE
mcp: suppress WeChat inbound replay

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -17,7 +17,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 | `init_schema.py` | `validate_init()` plus `strip_deprecated()` — strict schema for active init.json fields, simple deprecated-field cleanup, and known-but-inactive legacy fields migrated by `lingtai_kernel.migrate` |
 | `venv_resolve.py` | Python venv resolution — init.json → global runtime → auto-create |
 | `intrinsic_skills/__init__.py` | Standalone skill bundles (docs-only) copied into `.library/intrinsic/` |
-| `mcp_servers/` | Curated MCP server implementations shipped in the `lingtai` distribution and launched by `mcp_catalog.json` via `python -m lingtai.mcp_servers.<name>`; historical top-level `lingtai_*` packages remain thin wrappers |
+| `mcp_servers/` | Curated MCP server implementations shipped in the `lingtai` distribution and launched by `mcp_catalog.json` via `python -m lingtai.mcp_servers.<name>`; historical top-level `lingtai_*` packages remain thin wrappers. Stateful curated servers may own per-agent sidecars: the WeChat manager checkpoints `wechat/state.json` cursor progress and `wechat/inbox_seen.json` replay guards in `mcp_servers/wechat/manager.py:266` and `mcp_servers/wechat/manager.py:912`. |
 
 ### Key functions / classes
 

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -41,6 +42,12 @@ _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()
 
 TEXT_CHUNK_LIMIT = 4000
 SESSION_EXPIRED_ERRCODE = -14
+
+# Max number of stable inbound signatures retained in the replay-guard
+# index (inbox_seen.json). Sized well above a single refresh backlog so the
+# guard never forgets a message inside the replay window, while keeping the
+# state file bounded.
+SEEN_KEYS_MAX = 5000
 
 SCHEMA = {
     "type": "object",
@@ -163,6 +170,16 @@ class WechatManager:
         self._context_tokens: dict[str, str] = {}  # user_id -> context_token
         self._contacts: dict[str, dict] = {}  # alias -> {user_id, name}
         self._read_ids: set[str] = set()
+        # Replay/idempotency guard. Maps a stable inbound signature (derived
+        # from upstream-stable fields, NOT the local UUID) to the local UUID
+        # we first landed it under. Survives refresh/relaunch so that a stale
+        # get_updates cursor re-fetching the same upstream messages does not
+        # re-land them as fresh unread with new UUIDs. See _stable_key().
+        self._seen_keys: dict[str, str] = {}
+        # Bounded FIFO of stable keys to cap inbox_seen.json growth. The
+        # WeChat replay bug only re-fetches a recent backlog, so a window of
+        # the last N keys is sufficient and avoids unbounded state files.
+        self._seen_order: list[str] = []
         self._lock = threading.Lock()  # guards shared mutable state
         self._loop: asyncio.AbstractEventLoop | None = None
         self._poll_thread: threading.Thread | None = None
@@ -240,11 +257,23 @@ class WechatManager:
                     self._running = False
                     return
 
-                if resp.get_updates_buf:
-                    self._get_updates_buf = resp.get_updates_buf
-
                 for msg in resp.msgs:
                     await self._on_incoming(msg)
+
+                # Advance and checkpoint the cursor only AFTER the batch has
+                # been landed. Previously the cursor was bumped in-memory and
+                # persisted only on a clean stop(), which never runs on a
+                # worker-hang refresh/kill — so the next launch re-fetched from
+                # the stale offset (the replay). Persisting here narrows that
+                # window to a single in-flight batch; the inbox_seen.json guard
+                # in _on_incoming is the durable backstop for whatever still
+                # slips through.
+                if resp.get_updates_buf and resp.get_updates_buf != self._get_updates_buf:
+                    self._get_updates_buf = resp.get_updates_buf
+                    try:
+                        self._save_state()
+                    except Exception as e:  # checkpoint is best-effort
+                        log.warning("WeChat cursor checkpoint failed: %s", e)
 
             except asyncio.CancelledError:
                 return
@@ -362,6 +391,24 @@ class WechatManager:
 
         body = "\n".join(body_parts) if body_parts else "(empty message)"
 
+        # Replay guard. After a worker hang the kernel refreshes via the
+        # chat_history_save_skipped path and relaunches without committing the
+        # WeChat get_updates cursor, so the iLink server re-delivers the same
+        # backlog. Those re-deliveries arrive with identical upstream ids but
+        # would otherwise be landed under brand-new local UUIDs and counted as
+        # fresh unread. Detect them by their stable upstream signature and skip
+        # the second landing entirely — no new inbox entry, no LICC wake.
+        stable_key = self._stable_key(msg, from_user, body)
+        if self._is_replay(stable_key):
+            with self._lock:
+                first_id = self._seen_keys.get(stable_key)
+            log.info(
+                "WeChat inbound replay suppressed: stable_key=%s "
+                "first_local_id=%s from=%s (skipped duplicate landing)",
+                stable_key, first_id, from_user,
+            )
+            return
+
         # Persist to inbox
         msg_id = str(uuid.uuid4())
         msg_dir = self._inbox_dir / msg_id
@@ -372,10 +419,19 @@ class WechatManager:
             "body": body,
             "date": datetime.now(timezone.utc).isoformat(),
             "raw_item_types": [item.type for item in msg.item_list],
+            # Replay-guard provenance: the stable upstream signature this
+            # message was first landed under. Recorded for traceability so a
+            # suppressed duplicate can always be traced back to its original.
+            "stable_key": stable_key,
+            "upstream_message_id": msg.message_id,
+            "upstream_create_time_ms": msg.create_time_ms,
         }
         (msg_dir / "message.json").write_text(
             json.dumps(msg_data, ensure_ascii=False, indent=2), encoding="utf-8",
         )
+        # Record the signature only after the inbox write has succeeded, so a
+        # crash mid-write cannot mark a message as seen without landing it.
+        self._record_seen(stable_key, msg_id)
 
         # Forward to host via LICC. Body is a conversation preview with
         # guidance directing the agent to react only to the latest
@@ -853,6 +909,19 @@ class WechatManager:
             state = json.loads(state_file.read_text(encoding="utf-8"))
             self._get_updates_buf = state.get("get_updates_buf", "")
             self._context_tokens = state.get("context_tokens", {})
+        seen_file = self._wechat_dir / "inbox_seen.json"
+        if seen_file.is_file():
+            try:
+                seen = json.loads(seen_file.read_text(encoding="utf-8"))
+                self._seen_keys = dict(seen.get("keys", {}))
+                self._seen_order = [
+                    k for k in seen.get("order", []) if k in self._seen_keys
+                ]
+            except (ValueError, AttributeError) as e:
+                # Corrupt index degrades to "no guard", never crashes boot.
+                log.warning("Failed to load inbox_seen.json (ignoring): %s", e)
+                self._seen_keys = {}
+                self._seen_order = []
 
     def _save_state(self) -> None:
         state = {
@@ -874,6 +943,79 @@ class WechatManager:
         self._atomic_write(
             self._wechat_dir / "read.json",
             json.dumps(list(self._read_ids), ensure_ascii=False),
+        )
+
+    # ── Inbound replay / idempotency guard ─────────────────────
+
+    @staticmethod
+    def _stable_key(msg: WeixinMessage, from_user: str, body: str) -> str:
+        """Derive a stable, replay-resistant signature for an inbound message.
+
+        The local inbox UUID is regenerated on every fetch, so it cannot be
+        used to detect replays. Instead we prefer upstream-stable identifiers
+        that the iLink server assigns once per message and repeats verbatim
+        when a stale cursor re-fetches the same backlog:
+
+          1. ``message_id``        — upstream per-message id (most stable)
+          2. ``seq``               — upstream monotonic sequence
+          3. first item ``msg_id`` — item-level upstream id
+
+        When none is present we fall back to a content signature over
+        ``(from_user_id, create_time_ms, body_hash)``. ``create_time_ms`` is
+        the upstream send time (NOT the local landing time, which the bug
+        rewrites on replay), so two genuinely distinct messages with the same
+        text at different times still produce different keys — we never drop a
+        real new message.
+        """
+        upstream_id = None
+        if msg.message_id is not None:
+            upstream_id = f"mid:{msg.message_id}"
+        elif msg.seq is not None:
+            upstream_id = f"seq:{msg.seq}"
+        else:
+            for item in msg.item_list:
+                if getattr(item, "msg_id", None):
+                    upstream_id = f"item:{item.msg_id}"
+                    break
+        if upstream_id is not None:
+            # Namespace by sender so an id collision across users (should not
+            # happen, but cheap insurance) cannot suppress a real message.
+            return f"{from_user}|{upstream_id}"
+
+        # Content-signature fallback. Hash the body so we never persist or
+        # log message text in the dedup index, only an opaque digest.
+        body_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()[:16]
+        ctime = msg.create_time_ms if msg.create_time_ms is not None else ""
+        return f"{from_user}|content:{ctime}:{body_hash}"
+
+    def _is_replay(self, key: str) -> bool:
+        """True if this stable key was already landed (replay guard hit)."""
+        with self._lock:
+            return key in self._seen_keys
+
+    def _record_seen(self, key: str, local_id: str) -> None:
+        """Persist that ``key`` was landed under ``local_id`` (atomic)."""
+        with self._lock:
+            if key in self._seen_keys:
+                return
+            self._seen_keys[key] = local_id
+            self._seen_order.append(key)
+            # Evict oldest beyond the window to bound the state file.
+            while len(self._seen_order) > SEEN_KEYS_MAX:
+                evicted = self._seen_order.pop(0)
+                self._seen_keys.pop(evicted, None)
+        self._save_seen()
+
+    def _save_seen(self) -> None:
+        with self._lock:
+            payload = {
+                "version": 1,
+                "order": list(self._seen_order),
+                "keys": dict(self._seen_keys),
+            }
+        self._atomic_write(
+            self._wechat_dir / "inbox_seen.json",
+            json.dumps(payload, ensure_ascii=False),
         )
 
     @staticmethod

--- a/tests/test_wechat_inbound_replay.py
+++ b/tests/test_wechat_inbound_replay.py
@@ -1,0 +1,183 @@
+"""Regression tests for inbound WeChat message replay after worker-hang refresh.
+
+Bug: after an LLM worker hangs for 300s, the kernel refreshes via the
+``chat_history_save_skipped`` path and relaunches without committing the
+WeChat ``get_updates`` cursor. The iLink server then re-delivers the same
+backlog, which used to land as brand-new inbox entries with fresh local UUIDs
+and counted as new unread — polluting unread/notification state. These tests
+pin the idempotency guard that suppresses such replays while preserving
+genuinely new messages.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from lingtai.mcp_servers.wechat.manager import WechatManager
+from lingtai.mcp_servers.wechat.types import (
+    MessageItem, MessageItemType, TextItem, WeixinMessage,
+)
+
+
+def _manager(tmp_path: Path, events: list[dict]) -> WechatManager:
+    return WechatManager(
+        token="test-token",
+        user_id="test-bot",
+        working_dir=tmp_path,
+        on_inbound=events.append,
+    )
+
+
+def _text_msg(
+    *,
+    from_user: str,
+    text: str,
+    message_id: int | None = None,
+    seq: int | None = None,
+    item_msg_id: str | None = None,
+    create_time_ms: int | None = None,
+) -> WeixinMessage:
+    """Build a USER (type=1) text WeixinMessage as msg_from_dict would."""
+    return WeixinMessage(
+        seq=seq,
+        message_id=message_id,
+        from_user_id=from_user,
+        message_type=1,
+        create_time_ms=create_time_ms,
+        item_list=[
+            MessageItem(
+                type=MessageItemType.TEXT,
+                msg_id=item_msg_id,
+                text_item=TextItem(text=text),
+            )
+        ],
+    )
+
+
+def _inbox_count(tmp_path: Path) -> int:
+    inbox = tmp_path / "wechat" / "inbox"
+    return sum(1 for d in inbox.iterdir() if (d / "message.json").is_file())
+
+
+def _deliver(mgr: WechatManager, msg: WeixinMessage) -> None:
+    asyncio.run(mgr._on_incoming(msg))
+
+
+# ── Replay suppression (the bug) ──────────────────────────────────────────
+
+def test_replay_same_upstream_id_lands_once(tmp_path):
+    """Same upstream message_id re-delivered with a new fetch lands ONCE
+    and wakes the host ONCE, even though the local UUID would differ."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+    user = "wxid_alice@im.wechat"
+
+    first = _text_msg(from_user=user, text="hi", message_id=12345)
+    # Replay: identical upstream id, distinct WeixinMessage object (the
+    # addon never sees the old local UUID, only the upstream payload).
+    replay = _text_msg(from_user=user, text="hi", message_id=12345)
+
+    _deliver(mgr, first)
+    _deliver(mgr, replay)
+
+    assert _inbox_count(tmp_path) == 1, "replay must not create a 2nd inbox entry"
+    assert len(events) == 1, "replay must not trigger a 2nd LICC wake"
+
+
+def test_replay_falls_back_to_content_signature(tmp_path):
+    """When upstream omits message_id/seq/item msg_id, dedup falls back to
+    (from_user, create_time_ms, body_hash) — same content + same upstream
+    send time is a replay even though the local landing date differs."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+    user = "wxid_bob@im.wechat"
+
+    first = _text_msg(from_user=user, text="status?", create_time_ms=1_700_000_000_000)
+    replay = _text_msg(from_user=user, text="status?", create_time_ms=1_700_000_000_000)
+
+    _deliver(mgr, first)
+    _deliver(mgr, replay)
+
+    assert _inbox_count(tmp_path) == 1
+    assert len(events) == 1
+
+
+def test_replay_survives_relaunch_via_persisted_index(tmp_path):
+    """The guard is durable: a fresh manager (simulating refresh+relaunch)
+    loads inbox_seen.json and still suppresses the replay."""
+    events1: list[dict] = []
+    mgr1 = _manager(tmp_path, events1)
+    user = "wxid_carol@im.wechat"
+    _deliver(mgr1, _text_msg(from_user=user, text="ping", message_id=99))
+    assert (tmp_path / "wechat" / "inbox_seen.json").is_file()
+
+    # New manager instance == relaunch after refresh.
+    events2: list[dict] = []
+    mgr2 = _manager(tmp_path, events2)
+    _deliver(mgr2, _text_msg(from_user=user, text="ping", message_id=99))
+
+    assert _inbox_count(tmp_path) == 1
+    assert events2 == [], "replay after relaunch must not re-wake the host"
+
+
+# ── Genuine messages must NOT be dropped ──────────────────────────────────
+
+def test_distinct_upstream_ids_both_land(tmp_path):
+    """Two different upstream messages (different ids) both land, even with
+    identical text."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+    user = "wxid_dave@im.wechat"
+
+    _deliver(mgr, _text_msg(from_user=user, text="ok", message_id=1))
+    _deliver(mgr, _text_msg(from_user=user, text="ok", message_id=2))
+
+    assert _inbox_count(tmp_path) == 2
+    assert len(events) == 2
+
+
+def test_same_text_different_time_both_land(tmp_path):
+    """Content-signature fallback keys on create_time_ms, so the same text
+    sent at two different upstream times is two real messages, not a replay."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+    user = "wxid_erin@im.wechat"
+
+    _deliver(mgr, _text_msg(from_user=user, text="here", create_time_ms=1_700_000_000_000))
+    _deliver(mgr, _text_msg(from_user=user, text="here", create_time_ms=1_700_000_060_000))
+
+    assert _inbox_count(tmp_path) == 2
+    assert len(events) == 2
+
+
+def test_same_text_different_users_both_land(tmp_path):
+    """Stable key is namespaced by sender — same text from two users is not
+    a replay."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+
+    _deliver(mgr, _text_msg(from_user="wxid_a@im.wechat", text="yo", create_time_ms=42))
+    _deliver(mgr, _text_msg(from_user="wxid_b@im.wechat", text="yo", create_time_ms=42))
+
+    assert _inbox_count(tmp_path) == 2
+    assert len(events) == 2
+
+
+# ── Provenance / traceability ─────────────────────────────────────────────
+
+def test_landed_message_records_stable_key_provenance(tmp_path):
+    """The landed message.json carries the stable_key + upstream ids so a
+    suppressed duplicate is always traceable to its original (no silent loss)."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+    user = "wxid_frank@im.wechat"
+    _deliver(mgr, _text_msg(from_user=user, text="trace me", message_id=777,
+                            create_time_ms=123))
+
+    inbox = tmp_path / "wechat" / "inbox"
+    msg_file = next(inbox.iterdir()) / "message.json"
+    data = json.loads(msg_file.read_text(encoding="utf-8"))
+    assert data["stable_key"] == f"{user}|mid:777"
+    assert data["upstream_message_id"] == 777
+    assert data["upstream_create_time_ms"] == 123


### PR DESCRIPTION
## Summary

- Suppress replayed inbound WeChat messages when iLink re-delivers a backlog after a worker hang / refresh.
- Add a stable inbound replay key (upstream `message_id` / `seq` / item `msg_id`, with sender+timestamp+body-hash fallback) and persist a bounded `wechat/inbox_seen.json` guard.
- Checkpoint `wechat/state.json` cursor progress after each landed batch, so a crash/refresh has a smaller replay window.
- Store replay provenance (`stable_key`, upstream id, upstream timestamp) in landed `message.json` without logging message bodies.
- Add regression tests for replay suppression, relaunch persistence, distinct upstream messages, sender/time separation, and provenance.
- Update `src/lingtai/ANATOMY.md` to mention stateful curated MCP sidecars for WeChat cursor/replay state.

## Context

A handoff from mimo-2-5-pro diagnosed WeChat inbound unread inflation after two 300s worker hangs: the standalone `lingtai-wechat` candidate patch validated the addon-level direction, but that repository is archived/read-only. I ported the verified fix into the maintained in-kernel curated WeChat MCP under `src/lingtai/mcp_servers/wechat/`.

This does **not** clean historical duplicate inbox entries and does **not** fix the underlying 300s worker hang. It only prevents the same upstream inbound message from being landed again as fresh unread after replay.

## Testing

Standalone candidate validation before porting:

- `uv run --with pytest python -m pytest -q` in the standalone candidate worktree — `43 passed, 3 warnings`

Kernel validation after porting:

- `python3 -m compileall -q src/lingtai/mcp_servers/wechat/manager.py tests/test_wechat_inbound_replay.py`
- `git diff --check`
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_wechat_inbound_replay.py -q` — `7 passed`
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q -k wechat` — `7 passed, 2914 deselected`
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_mcp_inbox.py tests/test_mcp_licc_client.py tests/test_mcp_capability.py` — `76 passed`
