### PR TITLE
Wire app meta guidance to adapter static comments

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -18,6 +18,7 @@ from typing import Any
 from pathlib import Path
 
 from lingtai_kernel.base_agent import BaseAgent
+from lingtai_kernel.base_agent.prompt import _refresh_meta_guidance_section
 from lingtai.llm.service import LLMService, build_provider_defaults_from_manifest_llm
 from lingtai_kernel.prompt import build_system_prompt
 
@@ -365,8 +366,9 @@ class Agent(BaseAgent):
             )
 
     def _build_system_prompt(self) -> str:
-        """Override kernel's prompt builder to inject tool descriptions."""
+        """Override kernel's prompt builder to inject app tool descriptions."""
         self._refresh_tool_inventory_section()
+        _refresh_meta_guidance_section(self)
         return build_system_prompt(
             prompt_manager=self._prompt_manager,
             language=self._config.language,
@@ -374,9 +376,10 @@ class Agent(BaseAgent):
         )
 
     def _build_system_prompt_batches(self) -> list[str]:
-        """Override kernel's batched builder to inject tool descriptions."""
+        """Override kernel's batched builder to inject app tool descriptions."""
         from lingtai_kernel.prompt import build_system_prompt_batches
         self._refresh_tool_inventory_section()
+        _refresh_meta_guidance_section(self)
         return build_system_prompt_batches(
             prompt_manager=self._prompt_manager,
             language=self._config.language,

--- a/src/lingtai/llm/base.py
+++ b/src/lingtai/llm/base.py
@@ -109,6 +109,16 @@ class LLMAdapter(ABC):
             return session
         return _GatedSession(session, self._gate)  # type: ignore[return-value]
 
+    def static_adapter_comment(self) -> dict[str, Any] | None:
+        """Return static, prompt-safe adapter guidance before chat creation.
+
+        Dynamic per-turn state belongs on the concrete ``ChatSession``.  This
+        adapter-level hook is for rule-like guidance that the prompt builder may
+        need while constructing the very first system prompt, before a session
+        object exists.
+        """
+        return None
+
     @abstractmethod
     def create_chat(
         self,

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2168,6 +2168,72 @@ class OpenAIAdapter(LLMAdapter):
 # ---------------------------------------------------------------------------
 
 
+_CODEX_DELAYED_SUMMARIZE_MIN_API_CALLS = 20
+_CODEX_CONTEXT_BUDGET_NOTE = (
+    "Can wait until 150k token context to proactively summarize; "
+    "if summarize cannot bring context under 150k, consider molt."
+)
+
+
+def _codex_static_adapter_comment(
+    *,
+    use_responses_api: bool,
+    continuation_enabled: bool,
+    ws_enabled: bool,
+) -> dict[str, Any] | None:
+    """Return static, prompt-safe Codex adapter guidance.
+
+    Shared by the adapter-level hook (available before chat creation) and the
+    session-level compatibility hook (available after chat creation).
+    """
+    if not use_responses_api:
+        return None
+    if not continuation_enabled:
+        return {
+            "adapter": "codex",
+            "feature": "stateless_full_replay",
+            "summary": (
+                "Codex is in stateless full-replay mode: every request is "
+                "rebuilt from local chat_history. Local history is not "
+                "deleted by request-side resets."
+            ),
+            "summarize_note": (
+                "Summarize still rewrites visible history and can change the "
+                "next full request. Notification dismiss is only notification "
+                "cleanup and does not compact context."
+            ),
+            "context_budget_note": _CODEX_CONTEXT_BUDGET_NOTE,
+        }
+
+    return {
+        "adapter": "codex",
+        "feature": (
+            "responses_websocket_epoch_reset"
+            if ws_enabled
+            else "responses_rest_epoch_reset"
+        ),
+        "summary": (
+            "Codex plans turns as full or incremental over the selected "
+            "REST/WebSocket transport. A fresh full epoch clears only "
+            "request-side continuation state and rebuilds the next request "
+            "from local chat_history; local history is not deleted or "
+            "summarized."
+        ),
+        "summarize_note": (
+            "Summarize rewrites older tool-result payloads and/or carried "
+            "context, breaks the previous_response_id/incremental prefix, "
+            "and forces the next request to open a fresh full epoch, usually "
+            "causing a cache miss. Under low pressure, wait until >=20 API "
+            "calls after the last full epoch before non-urgent summarize and "
+            "batch multiple completed noisy results together. Under high "
+            "context pressure or after a very noisy result, summarize "
+            "immediately. Notification dismiss is only notification cleanup: "
+            "it does not compact context, delete local history, or reset the "
+            "epoch."
+        ),
+        "context_budget_note": _CODEX_CONTEXT_BUDGET_NOTE,
+    }
+
 class CodexResponsesSession(OpenAIResponsesSession):
     """Responses session for Codex's `/backend-api/codex/responses`.
 
@@ -2944,7 +3010,7 @@ class CodexResponsesSession(OpenAIResponsesSession):
                 "non_urgent_summarize": "ok",
                 "reason": "no full epoch in the last 20 Codex API calls",
             }
-        delayed_summarize_min_api_calls = 10
+        delayed_summarize_min_api_calls = _CODEX_DELAYED_SUMMARIZE_MIN_API_CALLS
         wait_remaining = max(
             0, delayed_summarize_min_api_calls - int(last_ws_full_api_calls_ago)
         )
@@ -2976,51 +3042,11 @@ class CodexResponsesSession(OpenAIResponsesSession):
         section because it does not depend on the current cache ledger, epoch,
         or per-turn counters.
         """
-        if not getattr(self, "_use_responses_api", True):
-            return None
-        if not self._continuation_enabled:
-            return {
-                "adapter": "codex",
-                "feature": "stateless_full_replay",
-                "summary": (
-                    "Codex is in stateless full-replay mode: every request is "
-                    "rebuilt from local chat_history. Local history is not "
-                    "deleted by request-side resets."
-                ),
-                "summarize_note": (
-                    "Summarize still rewrites visible history and can change the "
-                    "next full request. Notification dismiss is only notification "
-                    "cleanup and does not compact context."
-                ),
-            }
-
-        return {
-            "adapter": "codex",
-            "feature": (
-                "responses_websocket_epoch_reset"
-                if self._ws_enabled
-                else "responses_rest_epoch_reset"
-            ),
-            "summary": (
-                "Codex plans turns as full or incremental over the selected "
-                "REST/WebSocket transport. A fresh full epoch clears only "
-                "request-side continuation state and rebuilds the next request "
-                "from local chat_history; local history is not deleted or "
-                "summarized."
-            ),
-            "summarize_note": (
-                "Summarize rewrites older tool-result payloads and/or carried "
-                "context, breaks the previous_response_id/incremental prefix, "
-                "and forces the next request to open a fresh full epoch, usually "
-                "causing a cache miss. Under low pressure, wait until >=10 API "
-                "calls after the last full epoch before non-urgent summarize and "
-                "batch multiple completed noisy results together. Under high "
-                "context pressure or after a very noisy result, summarize "
-                "immediately. Notification dismiss is only notification cleanup: "
-                "it does not compact context, delete local history, or reset the "
-                "epoch."
-            ),
-        }
+        return _codex_static_adapter_comment(
+            use_responses_api=getattr(self, "_use_responses_api", True),
+            continuation_enabled=self._continuation_enabled,
+            ws_enabled=self._ws_enabled,
+        )
 
     def dynamic_adapter_comment(self):
         """Return dynamic, per-turn Codex adapter state for tail ``_meta``."""
@@ -3796,6 +3822,14 @@ class CodexOpenAIAdapter(OpenAIAdapter):
                 self._codex_session_anchor, self._current_molt_count()
             )
         return None
+
+    def static_adapter_comment(self):
+        """Return prompt-safe Codex guidance before a ChatSession exists."""
+        return _codex_static_adapter_comment(
+            use_responses_api=getattr(self, "_use_responses_api", True),
+            continuation_enabled=getattr(self, "_continuation_enabled", True),
+            ws_enabled=getattr(self, "_ws_enabled", False),
+        )
 
     def _resolve_codex_ids(self, model: str) -> tuple[str | None, str | None]:
         """Resolve the (session_id, thread_id) headers for ``model``.

--- a/src/lingtai/llm/service.py
+++ b/src/lingtai/llm/service.py
@@ -324,6 +324,14 @@ class LLMService(LLMServiceABC):
     def model(self) -> str:
         return self._model
 
+    def static_adapter_comment(self) -> dict | None:
+        """Return static adapter guidance before a ChatSession exists, if any."""
+        adapter = self.get_adapter(self._provider, self._base_url)
+        comment_fn = getattr(adapter, "static_adapter_comment", None)
+        if not callable(comment_fn):
+            return None
+        return comment_fn()
+
     # --- Session management ---
 
     def create_session(

--- a/src/lingtai_kernel/meta_block.py
+++ b/src/lingtai_kernel/meta_block.py
@@ -209,8 +209,20 @@ def static_adapter_comment(agent):
     turn.  It is rendered once into the resident ``meta_guidance`` system-prompt
     section rather than re-stamped onto every tail ``_meta``.  Adapters expose it
     via a ``static_adapter_comment`` method; adapters without one simply
-    contribute nothing to ``meta_guidance``.
+    contribute nothing to ``meta_guidance``.  Prefer the service/adapter-level
+    hook because the first prompt build happens before a ChatSession exists; the
+    chat-level hook remains as a compatibility fallback.
     """
+    service = getattr(agent, "service", None)
+    comment_fn = getattr(service, "static_adapter_comment", None)
+    if callable(comment_fn):
+        try:
+            comment = comment_fn()
+        except Exception:
+            comment = None
+        if comment:
+            return comment
+
     session = getattr(agent, "_session", None)
     chat = getattr(session, "chat", None)
     comment_fn = getattr(chat, "static_adapter_comment", None)

--- a/tests/test_agent_meta_guidance.py
+++ b/tests/test_agent_meta_guidance.py
@@ -1,0 +1,57 @@
+"""Regression tests for app-level Agent prompt meta_guidance refresh."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from lingtai.agent import Agent
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
+
+
+STATIC_CODEX_COMMENT = {
+    "adapter": "codex",
+    "feature": "responses_rest_epoch_reset",
+    "summary": "Codex plans turns as full or incremental.",
+    "summarize_note": "wait until >=20 API calls before non-urgent summarize.",
+    "context_budget_note": (
+        "Can wait until 150k token context to proactively "
+        "summarize; if summarize cannot bring context under "
+        "150k, consider molt."
+    ),
+}
+
+
+def _agent_with_static_comment(tmp_path):
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=tmp_path / "agent",
+        capabilities=[],
+    )
+    agent.service.static_adapter_comment = lambda: STATIC_CODEX_COMMENT
+    return agent
+
+
+def test_agent_prompt_builder_refreshes_meta_guidance_adapter_rules(tmp_path):
+    agent = _agent_with_static_comment(tmp_path)
+
+    prompt = agent._build_system_prompt()
+
+    assert "## meta_guidance" in prompt
+    assert "### codex runtime rules" in prompt
+    assert "responses_rest_epoch_reset" in prompt
+    assert ">=20 API calls" in prompt
+    assert ">=20 API calls" in prompt
+    assert "Can wait until 150k token context" in prompt
+    assert "if summarize cannot bring context under 150k, consider molt" in prompt
+
+
+def test_agent_batched_prompt_builder_refreshes_meta_guidance_adapter_rules(tmp_path):
+    agent = _agent_with_static_comment(tmp_path)
+
+    prompt = "\n".join(agent._build_system_prompt_batches())
+
+    assert "## meta_guidance" in prompt
+    assert "### codex runtime rules" in prompt
+    assert "responses_rest_epoch_reset" in prompt
+    assert "Can wait until 150k token context" in prompt
+    assert "if summarize cannot bring context under 150k, consider molt" in prompt

--- a/tests/test_codex_ws_session.py
+++ b/tests/test_codex_ws_session.py
@@ -30,6 +30,7 @@ from lingtai_kernel.llm.base import UsageMetadata
 from lingtai.llm.openai.codex_ws import SyncCodexWebsocketTransport
 
 from lingtai.llm.openai.adapter import (
+    CodexOpenAIAdapter,
     CodexResponsesSession,
     _CodexWsFallback,
     _CODEX_TRANSPORT_DEFAULT,
@@ -1003,13 +1004,19 @@ def test_codex_adapter_comment_explains_epoch_reset_and_cache_ledger():
     assert comment["summarize_ws_full_note"] == note
     assert "full epoch" in note
     assert "incremental prefix" in note
-    assert ">=10 API calls" in note
+    assert ">=20 API calls" in note
     assert "batch multiple" in note
     assert "context pressure" in note
     assert "cache miss" in note
     assert "Summarize" in note
     assert "Notification dismiss" in note
     assert "non-urgent summarize" in note
+
+    static = session.static_adapter_comment()
+    assert static["adapter"] == "codex"
+    assert static["feature"] == "responses_websocket_epoch_reset"
+    assert ">=20 API calls" in static["summarize_note"]
+    assert "Can wait until 150k token context" in static["context_budget_note"]
 
     ledger = comment["cache_ledger"]
     assert ledger["window_api_calls"] == 20
@@ -1038,6 +1045,18 @@ def test_codex_adapter_comment_explains_epoch_reset_and_cache_ledger():
     assert "no Codex continuation cache ledger" in hint["reason"]
 
 
+
+def test_codex_adapter_static_comment_available_before_chat_creation():
+    adapter = CodexOpenAIAdapter(api_key="test")
+
+    comment = adapter.static_adapter_comment()
+
+    assert comment["adapter"] == "codex"
+    assert comment["feature"] == "responses_rest_epoch_reset"
+    assert ">=20 API calls" in comment["summarize_note"]
+    assert "Can wait until 150k token context" in comment["context_budget_note"]
+    assert "if summarize cannot bring context under 150k, consider molt" in comment["context_budget_note"]
+
 def test_codex_adapter_comment_reports_compact_cache_ledger():
     session = _make_session(FakeWsTransport())
 
@@ -1062,8 +1081,8 @@ def test_codex_adapter_comment_reports_compact_cache_ledger():
     assert comment["last_ws_full_api_calls_ago"] == 0
     assert comment["last_ws_full_reason"] == "pm"
     assert comment["maintenance_hint"]["non_urgent_summarize"] == "wait"
-    assert comment["maintenance_hint"]["wait_api_calls_remaining"] == 10
-    assert "wait 10 more" in comment["maintenance_hint"]["reason"]
+    assert comment["maintenance_hint"]["wait_api_calls_remaining"] == 20
+    assert "wait 20 more" in comment["maintenance_hint"]["reason"]
     assert "context pressure is low" in comment["maintenance_hint"]["reason"]
 
     ledger = comment["cache_ledger"]
@@ -1105,7 +1124,7 @@ def test_codex_send_populates_cache_ledger_end_to_end():
     assert comment["last_ws_full_api_calls_ago"] == 1
     assert comment["last_ws_full_reason"] == "nb"
     assert comment["maintenance_hint"]["non_urgent_summarize"] == "wait"
-    assert comment["maintenance_hint"]["wait_api_calls_remaining"] == 9
+    assert comment["maintenance_hint"]["wait_api_calls_remaining"] == 19
 
     ledger = comment["cache_ledger"]
     assert ledger["recorded_api_calls"] == 2


### PR DESCRIPTION
## Summary
- refresh the concrete LingTai `Agent` prompt builders' resident `meta_guidance` section so adapter static comments appear in the actual system prompt
- expose static adapter guidance through adapter/service-level hooks so the first post-refresh prompt can render it before a `ChatSession` exists, while retaining chat-level fallback compatibility
- keep Codex static runtime guidance resident while dynamic state stays in `_meta.agent_meta.adapter_comment`
- update Codex non-urgent summarize guidance from 10 to 20 API calls after the last full epoch
- add the clarified 150k guidance: can wait until 150k token context to proactively summarize; if summarize cannot bring context under 150k, consider molt
- add real `lingtai.Agent` and Codex adapter regression coverage

## Validation
- `PYTHONPATH=src python -m pytest tests/test_agent_meta_guidance.py tests/test_meta_block.py tests/test_codex_ws_session.py -q -p no:randomly` → 138 passed
- `PYTHONPATH=src python -m pytest tests/ -q -p no:randomly` → 2929 passed, 4 skipped
- `git diff --check`
- local runtime refresh on commit `a9a6247` verified `system/system.md` contains `### codex runtime rules`, `>=20 API calls`, and the 150k summarize-then-molt guidance; tail `_meta.agent_meta.adapter_comment.maintenance_hint.wait_until_last_ws_full_api_calls_ago` is now 20