### PR TITLE
codex: show summarize economy as full/increment ratio

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2202,7 +2202,6 @@ class OpenAIAdapter(LLMAdapter):
 # ---------------------------------------------------------------------------
 
 
-_CODEX_DELAYED_SUMMARIZE_MIN_API_CALLS = 20
 _CODEX_CONTEXT_BUDGET_NOTE = (
     "Can wait until roughly 150k token context before proactive summarize, "
     "but if summarizing still leaves the main context above roughly 100k "
@@ -2293,13 +2292,22 @@ def _codex_static_adapter_comment(
             "Summarize rewrites older tool-result payloads and/or carried "
             "context, breaks the previous_response_id/incremental prefix, "
             "and forces the next request to open a fresh full epoch, usually "
-            "causing a cache miss. Under low pressure, wait until >=20 API "
-            "calls after the last full epoch before non-urgent summarize and "
-            "batch multiple completed noisy results together. Under high "
-            "context pressure or after a very noisy result, summarize "
-            "immediately. Notification dismiss is only notification cleanup: "
-            "it does not compact context, delete local history, or reset the "
-            "epoch."
+            "causing a cache miss. Treat summarize as an investment, not "
+            "routine cleanup: it spends a full/cache-miss cost now to buy "
+            "future context and token savings, so it only pays off when those "
+            "expected savings exceed the miss. Keep full epochs rare relative "
+            "to incremental turns: the target full:incremental ratio is at or "
+            "below 1:10 (roughly at most one full per ten incremental turns). "
+            "Under low pressure, defer and batch non-urgent summarize until "
+            "the expected savings justify reopening a full epoch, so the ratio "
+            "stays healthy; the dynamic maintenance_hint reports the current "
+            "full:incremental ratio and flags reduce_summarize_frequency when "
+            "fulls are too frequent. Under high context pressure or after a "
+            "very noisy result, the investment is worth it immediately — "
+            "summarize regardless of ratio; if context pressure stays high "
+            "after summarize, consider molt. Notification dismiss is only "
+            "notification cleanup: it does not compact context, delete local "
+            "history, or reset the epoch."
         ),
         "context_budget_note": _CODEX_CONTEXT_BUDGET_NOTE,
         "summarize_economy_note": _CODEX_SUMMARIZE_ECONOMY_NOTE,
@@ -3051,6 +3059,8 @@ class CodexResponsesSession(OpenAIResponsesSession):
                 "api_calls_ago": latest_seq - int(last_ws_full["seq"]),
                 "reason": last_ws_full["reason"] or "full",
             }
+        full_count = sum(1 for entry in entries if entry["mode"] == "F")
+        incremental_count = sum(1 for entry in entries if entry["mode"] == "I")
         return {
             "window_api_calls": 20,
             "recorded_api_calls": len(entries),
@@ -3059,9 +3069,13 @@ class CodexResponsesSession(OpenAIResponsesSession):
             "summary": {
                 "api_calls": len(entries),
                 "cache_rate": self._ws_cache_rate(total_input, total_cached),
-                "full_count": sum(1 for entry in entries if entry["mode"] == "F"),
+                "full_count": full_count,
+                "incremental_count": incremental_count,
+                "full_to_incremental_ratio": self._ws_full_to_incremental_ratio(
+                    full_count, incremental_count
+                ),
                 # Compatibility alias for older prompt/diagnostic consumers.
-                "ws_full_count": sum(1 for entry in entries if entry["mode"] == "F"),
+                "ws_full_count": full_count,
                 "miss_k": self._ws_tokens_k(total_miss),
             },
             "last_full": last_ws_full_comment,
@@ -3078,45 +3092,91 @@ class CodexResponsesSession(OpenAIResponsesSession):
         }
 
     @staticmethod
+    def _ws_full_to_incremental_ratio(
+        full_count: int, incremental_count: int
+    ) -> str:
+        """Render the full:incremental count as a ``"1:N"``-style ratio string.
+
+        Normalized so the full side is ``1`` whenever any full was recorded
+        (``"1:10"``); ``"0:N"`` when no full has been seen yet, and ``"1:0"`` when
+        only fulls were recorded.
+        """
+        if full_count <= 0:
+            return f"0:{int(incremental_count)}"
+        per_full = incremental_count / full_count
+        return f"1:{per_full:.1f}".replace(".0", "")
+
+    @staticmethod
     def _ws_maintenance_hint(
         *,
-        recorded_api_calls: int,
-        last_ws_full_api_calls_ago: int | None,
+        full_count: int,
+        incremental_count: int,
     ) -> dict[str, Any]:
-        if recorded_api_calls <= 0:
+        """Ratio-oriented summarize-economy hint for the dynamic adapter comment.
+
+        Replaces the older interval/countdown guidance ("wait N API calls after
+        the last full epoch"), which was misleading: summarize is an investment,
+        not a fixed cooldown. Each summarize spends a fresh ``full`` epoch (a
+        cache miss) now to buy future context/token savings, so it only pays off
+        when those savings exceed the miss. A healthy continuation keeps fulls
+        rare relative to incremental turns: the target is a full:incremental
+        ratio at or below ``1:10`` (≈ at most one full per ten incremental
+        turns). When fulls are too frequent the actionable fix is to summarize
+        less often / batch more so each full epoch earns its cost.
+        """
+        target_ratio = "1:10"
+        # full:incremental <= 1:10  <=>  full_count <= incremental_count / 10.
+        target_max_full_per_incremental = 0.1
+        if full_count <= 0:
             return {
-                "non_urgent_summarize": "unknown",
-                "reason": "no Codex continuation cache ledger entries yet",
-            }
-        if last_ws_full_api_calls_ago is None:
-            return {
-                "non_urgent_summarize": "ok",
-                "reason": "no full epoch in the last 20 Codex API calls",
-            }
-        delayed_summarize_min_api_calls = _CODEX_DELAYED_SUMMARIZE_MIN_API_CALLS
-        wait_remaining = max(
-            0, delayed_summarize_min_api_calls - int(last_ws_full_api_calls_ago)
-        )
-        if wait_remaining > 0:
-            return {
-                "non_urgent_summarize": "wait",
-                "wait_until_last_ws_full_api_calls_ago": delayed_summarize_min_api_calls,
-                "wait_api_calls_remaining": wait_remaining,
+                "summarize_economy": "ok" if incremental_count > 0 else "unknown",
+                "full_count": int(full_count),
+                "incremental_count": int(incremental_count),
+                "full_to_incremental_ratio": (
+                    CodexResponsesSession._ws_full_to_incremental_ratio(
+                        full_count, incremental_count
+                    )
+                ),
+                "target_full_to_incremental_ratio": target_ratio,
                 "reason": (
-                    f"last full epoch was {last_ws_full_api_calls_ago} API calls ago; "
-                    f"wait {wait_remaining} more if context pressure is low"
+                    "no full epoch in the last 20 Codex API calls; summarize "
+                    "frequency is healthy"
+                    if incremental_count > 0
+                    else "no Codex continuation cache ledger entries yet"
                 ),
             }
-        return {
-            "non_urgent_summarize": "ok",
-            "wait_until_last_ws_full_api_calls_ago": delayed_summarize_min_api_calls,
-            "wait_api_calls_remaining": 0,
-            "reason": (
-                f"last full epoch was {last_ws_full_api_calls_ago} API calls ago; "
-                "delayed summarize window satisfied; prefer batching multiple "
-                "already-consumed results when practical"
+        full_per_incremental = full_count / max(incremental_count, 1)
+        ratio_ok = (
+            incremental_count > 0
+            and full_per_incremental <= target_max_full_per_incremental
+        )
+        hint = {
+            "summarize_economy": "ok" if ratio_ok else "reduce_summarize_frequency",
+            "full_count": int(full_count),
+            "incremental_count": int(incremental_count),
+            "full_to_incremental_ratio": (
+                CodexResponsesSession._ws_full_to_incremental_ratio(
+                    full_count, incremental_count
+                )
             ),
+            "target_full_to_incremental_ratio": target_ratio,
         }
+        if ratio_ok:
+            hint["reason"] = (
+                f"full:incremental is {hint['full_to_incremental_ratio']} over the "
+                f"last 20 Codex API calls, within the {target_ratio} target; "
+                "summarize frequency is healthy"
+            )
+        else:
+            hint["reason"] = (
+                f"full:incremental is {hint['full_to_incremental_ratio']} over the "
+                f"last 20 Codex API calls, worse than the {target_ratio} target; "
+                "each full epoch is a cache miss, and summarize is an investment "
+                "that must buy back more than it spends — reduce summarize "
+                "frequency (defer/batch non-urgent summarize until the expected "
+                "savings justify the miss, or molt if context pressure stays high)"
+            )
+        return hint
 
     def static_adapter_comment(self):
         """Return the static, rule-like Codex adapter guidance.
@@ -3191,18 +3251,22 @@ class CodexResponsesSession(OpenAIResponsesSession):
                 )
                 comment["last_ws_full_reason"] = comment.get("last_full_reason")
 
-        recorded_api_calls = 0
+        full_count = 0
+        incremental_count = 0
         if isinstance(ledger, dict):
-            try:
-                recorded_api_calls = int(ledger.get("recorded_api_calls") or 0)
-            except (TypeError, ValueError):
-                recorded_api_calls = 0
-        last_ws_full_ago = comment.get("last_ws_full_api_calls_ago")
+            summary = ledger.get("summary")
+            if isinstance(summary, dict):
+                try:
+                    full_count = int(summary.get("full_count") or 0)
+                except (TypeError, ValueError):
+                    full_count = 0
+                try:
+                    incremental_count = int(summary.get("incremental_count") or 0)
+                except (TypeError, ValueError):
+                    incremental_count = 0
         comment["maintenance_hint"] = self._ws_maintenance_hint(
-            recorded_api_calls=recorded_api_calls,
-            last_ws_full_api_calls_ago=(
-                last_ws_full_ago if isinstance(last_ws_full_ago, int) else None
-            ),
+            full_count=full_count,
+            incremental_count=incremental_count,
         )
         return comment
 

--- a/tests/test_agent_meta_guidance.py
+++ b/tests/test_agent_meta_guidance.py
@@ -11,7 +11,11 @@ STATIC_CODEX_COMMENT = {
     "adapter": "codex",
     "feature": "responses_rest_epoch_reset",
     "summary": "Codex plans turns as full or incremental.",
-    "summarize_note": "wait until >=20 API calls before non-urgent summarize.",
+    "summarize_note": (
+        "Summarize is an investment, not routine cleanup: keep the "
+        "full:incremental ratio at or below 1:10 and defer non-urgent "
+        "summarize until the expected savings justify the cache miss."
+    ),
     "context_budget_note": (
         "Can wait until roughly 150k token context before proactive "
         "summarize, but if summarizing still leaves the main context "
@@ -40,8 +44,8 @@ def test_agent_prompt_builder_refreshes_meta_guidance_adapter_rules(tmp_path):
     assert "## meta_guidance" in prompt
     assert "### codex runtime rules" in prompt
     assert "responses_rest_epoch_reset" in prompt
-    assert ">=20 API calls" in prompt
-    assert ">=20 API calls" in prompt
+    assert "investment, not routine cleanup" in prompt
+    assert "1:10" in prompt
     assert "roughly 150k token context" in prompt
     assert "above roughly 100k tokens, consider molt" in prompt
 

--- a/tests/test_codex_ws_session.py
+++ b/tests/test_codex_ws_session.py
@@ -1082,18 +1082,28 @@ def test_codex_adapter_comment_explains_epoch_reset_and_cache_ledger():
     assert comment["summarize_ws_full_note"] == note
     assert "full epoch" in note
     assert "incremental prefix" in note
-    assert ">=20 API calls" in note
-    assert "batch multiple" in note
+    # Ratio-oriented guidance replaces the old ">=20 API calls" interval rule.
+    assert ">=20 API calls" not in note
+    assert "1:10" in note
+    assert "ratio" in note
+    assert "reduce_summarize_frequency" in note
     assert "context pressure" in note
     assert "cache miss" in note
     assert "Summarize" in note
     assert "Notification dismiss" in note
     assert "non-urgent summarize" in note
+    # summarize is framed as an investment that buys future savings, and molt
+    # is the escalation when context pressure stays high afterwards.
+    assert "investment" in note
+    assert "buy future context" in note
+    assert "consider molt" in note
 
     static = session.static_adapter_comment()
     assert static["adapter"] == "codex"
     assert static["feature"] == "responses_websocket_epoch_reset"
-    assert ">=20 API calls" in static["summarize_note"]
+    assert ">=20 API calls" not in static["summarize_note"]
+    assert "1:10" in static["summarize_note"]
+    assert "reduce_summarize_frequency" in static["summarize_note"]
     assert "roughly 150k token context" in static["context_budget_note"]
     assert "above roughly 100k" in static["context_budget_note"]
     assert "investment, not a fixed countdown" in static["summarize_economy_note"]
@@ -1115,6 +1125,8 @@ def test_codex_adapter_comment_explains_epoch_reset_and_cache_ledger():
         "api_calls": 0,
         "cache_rate": None,
         "full_count": 0,
+        "incremental_count": 0,
+        "full_to_incremental_ratio": "0:0",
         "ws_full_count": 0,
         "miss_k": 0.0,
     }
@@ -1128,9 +1140,18 @@ def test_codex_adapter_comment_explains_epoch_reset_and_cache_ledger():
     assert ledger["legend"]["F"] == "full"
     assert ledger["legend"]["sum"] == "epoch_reset:summarize"
 
+    # The maintenance hint is ratio-oriented (full:incremental), not an
+    # interval/countdown. With no entries it is "unknown" and carries no
+    # wait_api_calls_remaining countdown.
     hint = comment["maintenance_hint"]
-    assert hint["non_urgent_summarize"] == "unknown"
+    assert hint["summarize_economy"] == "unknown"
+    assert hint["full_count"] == 0
+    assert hint["incremental_count"] == 0
+    assert hint["full_to_incremental_ratio"] == "0:0"
+    assert hint["target_full_to_incremental_ratio"] == "1:10"
     assert "no Codex continuation cache ledger" in hint["reason"]
+    assert "non_urgent_summarize" not in hint
+    assert "wait_api_calls_remaining" not in hint
 
 
 
@@ -1141,7 +1162,9 @@ def test_codex_adapter_static_comment_available_before_chat_creation():
 
     assert comment["adapter"] == "codex"
     assert comment["feature"] == "responses_rest_epoch_reset"
-    assert ">=20 API calls" in comment["summarize_note"]
+    assert ">=20 API calls" not in comment["summarize_note"]
+    assert "1:10" in comment["summarize_note"]
+    assert "reduce_summarize_frequency" in comment["summarize_note"]
     assert "roughly 150k token context" in comment["context_budget_note"]
     assert "above roughly 100k" in comment["context_budget_note"]
     assert "investment, not a fixed countdown" in comment["summarize_economy_note"]
@@ -1203,10 +1226,20 @@ def test_codex_adapter_comment_reports_compact_cache_ledger():
 
     assert comment["last_ws_full_api_calls_ago"] == 0
     assert comment["last_ws_full_reason"] == "pm"
-    assert comment["maintenance_hint"]["non_urgent_summarize"] == "wait"
-    assert comment["maintenance_hint"]["wait_api_calls_remaining"] == 20
-    assert "wait 20 more" in comment["maintenance_hint"]["reason"]
-    assert "context pressure is low" in comment["maintenance_hint"]["reason"]
+    # 2 fulls vs 1 incremental is far worse than the 1:10 target, so the hint
+    # flags reduce_summarize_frequency and reports the current ratio.
+    hint = comment["maintenance_hint"]
+    assert hint["summarize_economy"] == "reduce_summarize_frequency"
+    assert hint["full_count"] == 2
+    assert hint["incremental_count"] == 1
+    assert hint["full_to_incremental_ratio"] == "1:0.5"
+    assert hint["target_full_to_incremental_ratio"] == "1:10"
+    assert "reduce summarize frequency" in hint["reason"]
+    # The poor-ratio reason frames the tradeoff: summarize is an investment
+    # that must earn back more than the cache miss it spends.
+    assert "investment" in hint["reason"]
+    assert "expected savings justify" in hint["reason"]
+    assert "wait_api_calls_remaining" not in hint
 
     ledger = comment["cache_ledger"]
     assert ledger["recorded_api_calls"] == 3
@@ -1219,6 +1252,8 @@ def test_codex_adapter_comment_reports_compact_cache_ledger():
         "api_calls": 3,
         "cache_rate": 0.68,
         "full_count": 2,
+        "incremental_count": 1,
+        "full_to_incremental_ratio": "1:0.5",
         "ws_full_count": 2,
         "miss_k": 80.0,
     }
@@ -1228,6 +1263,40 @@ def test_codex_adapter_comment_reports_compact_cache_ledger():
     }
     assert ledger["last_full"] == expected_last_full
     assert ledger["last_ws_full"] == expected_last_full
+
+
+def test_codex_maintenance_hint_ok_when_full_to_incremental_ratio_within_target():
+    """A healthy continuation keeps fulls rare: 1 full per 12 incremental turns
+    (1:12) is at/under the 1:10 target, so the ratio-oriented hint reports an
+    economical summarize cadence with no reduce_summarize_frequency flag."""
+    session = _make_session(FakeWsTransport())
+
+    session._record_ws_cache_ledger(
+        request_mode="ws_full",
+        usage=UsageMetadata(input_tokens=100_000, output_tokens=0, thinking_tokens=0, cached_tokens=50_000),
+        ws_diag={"reason": "no_baseline"},
+    )
+    for _ in range(12):
+        session._record_ws_cache_ledger(
+            request_mode="ws_incremental",
+            usage=UsageMetadata(input_tokens=100_000, output_tokens=0, thinking_tokens=0, cached_tokens=95_000),
+            ws_diag={"reason": "ok"},
+        )
+
+    comment = session.adapter_comment()
+
+    summary = comment["cache_ledger"]["summary"]
+    assert summary["full_count"] == 1
+    assert summary["incremental_count"] == 12
+    assert summary["full_to_incremental_ratio"] == "1:12"
+
+    hint = comment["maintenance_hint"]
+    assert hint["summarize_economy"] == "ok"
+    assert hint["full_to_incremental_ratio"] == "1:12"
+    assert hint["target_full_to_incremental_ratio"] == "1:10"
+    assert "healthy" in hint["reason"]
+    assert "wait_api_calls_remaining" not in hint
+    assert "non_urgent_summarize" not in hint
 
 
 def test_codex_send_populates_cache_ledger_end_to_end():
@@ -1246,8 +1315,12 @@ def test_codex_send_populates_cache_ledger_end_to_end():
     assert comment["last_full_reason"] == "nb"
     assert comment["last_ws_full_api_calls_ago"] == 1
     assert comment["last_ws_full_reason"] == "nb"
-    assert comment["maintenance_hint"]["non_urgent_summarize"] == "wait"
-    assert comment["maintenance_hint"]["wait_api_calls_remaining"] == 19
+    # 1 full + 1 incremental = 1:1, worse than the 1:10 target.
+    assert (
+        comment["maintenance_hint"]["summarize_economy"]
+        == "reduce_summarize_frequency"
+    )
+    assert comment["maintenance_hint"]["full_to_incremental_ratio"] == "1:1"
 
     ledger = comment["cache_ledger"]
     assert ledger["recorded_api_calls"] == 2

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -329,8 +329,9 @@ def test_build_meta_guidance_renders_guidance_meta_readme_and_adapter():
         "summary": "Codex plans turns as full or incremental.",
         "summarize_note": (
             "Summarize breaks the incremental prefix and opens a fresh full epoch; "
-            "delay non-urgent summarize until >=10 API calls and batch results; "
-            "summarize immediately under high context pressure."
+            "it is an investment, so keep the full:incremental ratio at or below "
+            "1:10 and defer non-urgent summarize until the savings justify the "
+            "cache miss; summarize immediately under high context pressure."
         ),
     }
     agent = _meta_guidance_agent(static_comment)
@@ -346,7 +347,7 @@ def test_build_meta_guidance_renders_guidance_meta_readme_and_adapter():
     assert "agent_meta" in section
     # Static adapter rules are present (the 4 required Codex points).
     assert "full epoch" in section
-    assert ">=10 API calls" in section
+    assert "1:10" in section
 
 
 def test_build_meta_guidance_without_adapter_comment_still_renders():
@@ -369,8 +370,8 @@ def test_slim_adapter_comment_for_tail_trims_ledger_without_static_key_guessing(
             "summary": {"api_calls": 1, "cache_rate": 0.5},
         },
         "maintenance_hint": {
-            "non_urgent_summarize": "wait",
-            "wait_api_calls_remaining": 7,
+            "summarize_economy": "reduce_summarize_frequency",
+            "full_to_incremental_ratio": "1:1",
             "reason": "long prose reason",
         },
     }
@@ -389,7 +390,7 @@ def test_slim_adapter_comment_for_tail_trims_ledger_without_static_key_guessing(
     assert "rows" not in json.dumps(slim)
     assert slim["cache_ledger_summary"] == {"api_calls": 1, "cache_rate": 0.5}
     # maintenance decision survives, long prose reason dropped.
-    assert slim["maintenance_hint"]["non_urgent_summarize"] == "wait"
+    assert slim["maintenance_hint"]["summarize_economy"] == "reduce_summarize_frequency"
     assert "reason" not in slim["maintenance_hint"]
     # A hook points at the resident meta_guidance section.
     assert "meta_guidance_ref" not in slim


### PR DESCRIPTION
## Summary
- Replace wait-N-calls / countdown-style Codex summarize reminders with full-vs-incremental ratio signals in the dynamic `adapter_comment`.
- Add `incremental_count`, `full_to_incremental_ratio`, `target_full_to_incremental_ratio: 1:10`, and `summarize_economy` (`ok` / `reduce_summarize_frequency` / `unknown`).
- Frame summarize as an investment: it spends a full/cache-miss cost to buy future context/token savings, so low-pressure summarize should be deferred/batched until the savings justify the cost; high-pressure/noisy cases can still summarize immediately, and persistent pressure should consider molt.
- Keep notification-dismiss no-op guidance intact.

## Validation
- `git diff --check origin/main..HEAD`
- `PYTHONPATH=src python -m pytest ...` focused/broader adapter/meta sweeps from the claude-p implementation run (144 focused tests)
- GLM final review ran read-only checks including focused pytest over `tests/test_codex_ws_session.py`, `tests/test_agent_meta_guidance.py`, and `tests/test_meta_block.py`, import/compile probes, old-reminder greps, and anatomy-reference checks.

## Review
- GLM final review report: `reports/kernel-adapter-comment-ratio-hints-20260626/glm-review-final.md`
- Verdict: APPROVE — safe to push / open PR / merge.

## Notes
- Earlier GLM report `glm-review.md` was for a superseded commit and is explicitly marked obsolete; use only `glm-review-final.md`.
