### PR TITLE
release: bump kernel to v0.14.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.14.2"
+version = "0.14.3"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump `lingtai` kernel package version to `0.14.3`
- base includes #519 (`fix(codex): tune summarize guidance thresholds`)

## Validation
- `git diff --check origin/main..HEAD`
- `python -m compileall -q src tests`
- `PYTHONPATH=src python -m pytest -q -p no:randomly` — 2935 passed, 4 skipped
- `python -m build`
- `python -m twine check dist/*`

Reports:
- `reports/release-20260626/kernel-gates-final-after-519.md`
- `reports/release-20260626/release-scope-audit-after-519.md`

Note: local build produced a macOS arm64 wheel and sdist; upload policy should prefer the portable sdist unless a platform wheel is intentionally wanted.
