### PR TITLE
release: bump kernel to v0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.14.3"
+version = "0.15.0"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump `lingtai` kernel package version from `0.14.3` to `0.15.0`
- follows Jason's release target change to TUI/Portal `v0.10.0` and kernel `0.15.0`

## Validation
- `git diff --check origin/main..HEAD`
- `python -m compileall -q src tests`
- `PYTHONPATH=src python -m pytest -q -p no:randomly` — PASS
- `python -m build`
- `python -m twine check dist/*`

Reports:
- `reports/release-20260626/kernel-gates-final-v0.15.0.md`
- `reports/release-20260626/tui-gates-final-v0.10.0.md`

Note: local build produced a macOS arm64 wheel and sdist; upload policy should prefer the portable sdist unless a platform wheel is intentionally wanted.
