### PR TITLE
Consolidate session recovery turn helpers

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -900,6 +900,36 @@ def _check_molt_pressure(agent) -> None:
 
     clear_notification(agent._working_dir, "molt")
 
+
+def _post_send_housekeeping(agent) -> None:
+    """Run the post-send housekeeping trio after an LLM round completes.
+
+    Called from every branch that finishes an LLM send (``_handle_request``,
+    the ``_handle_tc_wake`` continuation, and the ``_process_response`` tool
+    loop), always in this order:
+
+    1. ``_check_molt_pressure`` — clear the legacy pressure-warning channel.
+    2. ``_sync_notifications`` — record same-turn notification changes (while
+       ACTIVE this defers delivery to the next IDLE boundary).
+    3. ``_rescan_large_tool_results`` — rediscover large unsummarized tool
+       results already in chat history (e.g. after refresh / migration).
+
+    Steps 2 and 3 are best-effort and must never abort the turn, so each is
+    guarded independently. This deliberately excludes the standalone
+    IDLE-boundary notification check in ``_run_loop``, which has different
+    control flow and must not be folded in here.
+    """
+    _check_molt_pressure(agent)
+    try:
+        agent._sync_notifications()
+    except Exception:
+        pass
+    try:
+        agent._rescan_large_tool_results()
+    except Exception:
+        pass
+
+
 def _is_context_molt_call(tc) -> bool:
     """Return True when ``tc`` is ``psyche(context, molt, ...)``.
 
@@ -976,25 +1006,9 @@ def _handle_request(agent, msg: Message) -> None:
         pass
     meta = build_meta(agent)
 
-    # Molt pressure — warn agent when context is getting full.
-    _check_molt_pressure(agent)
-
-    # Synchronous notification sync — record same-turn notification
-    # changes.  While ACTIVE this deliberately defers without mutating
-    # unrelated tool results; delivery happens at the next IDLE boundary.
-    try:
-        agent._sync_notifications()
-    except Exception:
-        pass
-
-    # Rescan live chat history for large unsummarized tool results that were
-    # already in context before this turn (e.g. after a refresh, notification
-    # dismissed, or history migration).  Uses skip_if_ref_id_exists so no
-    # duplicate notifications are published for results already tracked.
-    try:
-        agent._rescan_large_tool_results()
-    except Exception:
-        pass
+    # Post-send housekeeping: molt pressure + notification sync + large-result
+    # rescan (see _post_send_housekeeping).
+    _post_send_housekeeping(agent)
 
     prefix = render_meta(agent, meta)
     if prefix:
@@ -1188,20 +1202,10 @@ def _handle_tc_wake(agent, msg: Message) -> None:
         agent._last_usage = response.usage
         agent._save_chat_history(ledger_source="tc_wake")
         _process_response(agent, response, ledger_source="tc_wake")
-        # Notification-driven turns should also check pressure so
-        # warnings fire even when the agent is woken by mail/soul.
-        _check_molt_pressure(agent)
-        # Synchronous notification sync — same ACTIVE deferral semantics as
-        # _handle_request; delivery happens at the next IDLE boundary.
-        try:
-            agent._sync_notifications()
-        except Exception:
-            pass
-        # Rescan for large unsummarized results in chat history.
-        try:
-            agent._rescan_large_tool_results()
-        except Exception:
-            pass
+        # Notification-driven turns also run post-send housekeeping so molt
+        # pressure / notification sync / large-result rescan fire even when the
+        # agent is woken by mail/soul (see _post_send_housekeeping).
+        _post_send_housekeeping(agent)
     except Exception as e:
         from ..llm_utils import WorkerStillRunningError
 
@@ -1643,26 +1647,13 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
         agent._last_usage = response.usage
         agent._save_chat_history(ledger_source=ledger_source)
 
-        # Mid-loop legacy molt-notification sweep. Context pressure is now
-        # surfaced every tool result under _meta.agent_meta.context.molt
-        # (meta_block.build_meta), so this only clears any stale legacy
-        # molt.json left from older builds; it no longer publishes pressure.
-        _check_molt_pressure(agent)
-        # Synchronous notification sync — same ACTIVE deferral semantics as
-        # _handle_request; delivery happens at the next IDLE boundary.
-        try:
-            agent._sync_notifications()
-        except Exception:
-            pass
-        # Keep summarize reminders in sync across tool-loop LLM rounds too.
-        # New tool results are handled by the executor hook, but old live
-        # results (or dismissed reminders for still-unsummarized results) must
-        # be rediscovered after each continuation round, not only at external
-        # request / notification-wake boundaries.
-        try:
-            agent._rescan_large_tool_results()
-        except Exception:
-            pass
+        # Mid-loop post-send housekeeping. Context pressure is now surfaced
+        # every tool result under _meta.agent_meta.context.molt
+        # (meta_block.build_meta), so _check_molt_pressure here only clears any
+        # stale legacy molt.json; the rescan keeps summarize reminders in sync
+        # across tool-loop LLM rounds, not only at request/notification-wake
+        # boundaries (see _post_send_housekeeping).
+        _post_send_housekeeping(agent)
 
     final_text = "\n".join(collected_text_parts)
     has_errors = bool(collected_errors)

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -901,12 +901,15 @@ def _check_molt_pressure(agent) -> None:
     clear_notification(agent._working_dir, "molt")
 
 
-def _post_send_housekeeping(agent) -> None:
-    """Run the post-send housekeeping trio after an LLM round completes.
+def _turn_boundary_housekeeping(agent) -> None:
+    """Run the turn-boundary housekeeping trio.
 
-    Called from every branch that finishes an LLM send (``_handle_request``,
-    the ``_handle_tc_wake`` continuation, and the ``_process_response`` tool
-    loop), always in this order:
+    Called from every branch at an LLM-round boundary. Timing relative to the
+    ``session.send`` differs by path and is deliberately preserved from the
+    pre-refactor inline code: the request path (``_handle_request``) runs the
+    trio *before* the initial send of the turn, while the continuation paths
+    (``_handle_tc_wake`` and the ``_process_response`` tool loop) run it *after*
+    a send completes. In all cases the trio fires in this fixed order:
 
     1. ``_check_molt_pressure`` — clear the legacy pressure-warning channel.
     2. ``_sync_notifications`` — record same-turn notification changes (while
@@ -992,9 +995,10 @@ def _handle_request(agent, msg: Message) -> None:
         pass
     meta = build_meta(agent)
 
-    # Post-send housekeeping: molt pressure + notification sync + large-result
-    # rescan (see _post_send_housekeeping).
-    _post_send_housekeeping(agent)
+    # Turn-boundary housekeeping: molt pressure + notification sync +
+    # large-result rescan. On the request path this runs *before* the initial
+    # send (preserved pre-refactor timing); see _turn_boundary_housekeeping.
+    _turn_boundary_housekeeping(agent)
 
     prefix = render_meta(agent, meta)
     if prefix:
@@ -1177,10 +1181,10 @@ def _handle_tc_wake(agent, msg: Message) -> None:
         agent._last_usage = response.usage
         agent._save_chat_history(ledger_source="tc_wake")
         _process_response(agent, response, ledger_source="tc_wake")
-        # Notification-driven turns also run post-send housekeeping so molt
+        # Notification-driven turns also run turn-boundary housekeeping so molt
         # pressure / notification sync / large-result rescan fire even when the
-        # agent is woken by mail/soul (see _post_send_housekeeping).
-        _post_send_housekeeping(agent)
+        # agent is woken by mail/soul (see _turn_boundary_housekeeping).
+        _turn_boundary_housekeeping(agent)
     except Exception as e:
         from ..llm_utils import WorkerStillRunningError
 
@@ -1648,13 +1652,13 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
         agent._last_usage = response.usage
         agent._save_chat_history(ledger_source=ledger_source)
 
-        # Mid-loop post-send housekeeping. Context pressure is now surfaced
+        # Mid-loop turn-boundary housekeeping. Context pressure is now surfaced
         # every tool result under _meta.agent_meta.context.molt
         # (meta_block.build_meta), so _check_molt_pressure here only clears any
         # stale legacy molt.json; the rescan keeps summarize reminders in sync
         # across tool-loop LLM rounds, not only at request/notification-wake
-        # boundaries (see _post_send_housekeeping).
-        _post_send_housekeeping(agent)
+        # boundaries (see _turn_boundary_housekeeping).
+        _turn_boundary_housekeeping(agent)
 
     final_text = "\n".join(collected_text_parts)
     has_errors = bool(collected_errors)

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -980,21 +980,7 @@ def _handle_request(agent, msg: Message) -> None:
         dup_free_passes=dup_free,
         dup_hard_block=dup_hard,
     )
-    agent._executor = ToolExecutor(
-        dispatch_fn=agent._dispatch_tool,
-        make_tool_result_fn=lambda name, result, **kw: agent.service.make_tool_result(
-            name, result, provider=agent._config.provider, **kw
-        ),
-        guard=guard,
-        known_tools=set(agent._intrinsics) | set(agent._tool_handlers),
-        parallel_safe_tools=agent._PARALLEL_SAFE_TOOLS,
-        logger_fn=agent._log,
-        meta_fn=lambda: build_meta(agent),
-        working_dir=agent._working_dir,
-        summarize_notification_threshold=getattr(
-            agent, "_summarize_notification_threshold", None
-        ),
-    )
+    agent._executor = _make_tool_executor(agent, guard)
     content = agent._pre_request(msg)
     # If a prior worker hang left an open recovery artifact, prepend one
     # concise recovery notice to this first safe request (once per artifact).
@@ -1078,23 +1064,12 @@ def _handle_tc_wake(agent, msg: Message) -> None:
         )
         return
 
-    agent._executor = ToolExecutor(
-        dispatch_fn=agent._dispatch_tool,
-        make_tool_result_fn=lambda name, result, **kw: agent.service.make_tool_result(
-            name, result, provider=agent._config.provider, **kw
-        ),
-        guard=LoopGuard(
+    agent._executor = _make_tool_executor(
+        agent,
+        LoopGuard(
             max_total_calls=_get_guard_limits(agent)[0],
             dup_free_passes=2,
             dup_hard_block=8,
-        ),
-        known_tools=set(agent._intrinsics) | set(agent._tool_handlers),
-        parallel_safe_tools=agent._PARALLEL_SAFE_TOOLS,
-        logger_fn=agent._log,
-        meta_fn=lambda: build_meta(agent),
-        working_dir=agent._working_dir,
-        summarize_notification_threshold=getattr(
-            agent, "_summarize_notification_threshold", None
         ),
     )
 
@@ -1241,6 +1216,32 @@ def _get_guard_limits(agent) -> tuple[int, int, int]:
     so stale init.json files cannot make the runtime harsher or looser.
     """
     return (ACTIVE_TURN_TOOL_CALL_EMERGENCY_LIMIT, 3, 8)
+
+
+def _make_tool_executor(agent, guard: LoopGuard) -> ToolExecutor:
+    """Construct the per-turn ``ToolExecutor`` with the shared wiring.
+
+    Every turn path wires the executor identically — dispatch fn, provider-aware
+    tool-result factory, known/parallel-safe tool sets, logger, meta fn, working
+    dir, and summarize threshold. Only the ``LoopGuard`` differs between paths
+    (e.g. ``dup_free_passes`` 3 for fresh requests vs 2 for tc-wake
+    continuations), so the caller supplies it.
+    """
+    return ToolExecutor(
+        dispatch_fn=agent._dispatch_tool,
+        make_tool_result_fn=lambda name, result, **kw: agent.service.make_tool_result(
+            name, result, provider=agent._config.provider, **kw
+        ),
+        guard=guard,
+        known_tools=set(agent._intrinsics) | set(agent._tool_handlers),
+        parallel_safe_tools=agent._PARALLEL_SAFE_TOOLS,
+        logger_fn=agent._log,
+        meta_fn=lambda: build_meta(agent),
+        working_dir=agent._working_dir,
+        summarize_notification_threshold=getattr(
+            agent, "_summarize_notification_threshold", None
+        ),
+    )
 
 
 def _check_external_send(agent, tool_calls, tool_results=None) -> None:

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -25,6 +25,7 @@ from ..meta_block import (
 )
 from ..sent_message_tracker import SEND_TOOLS, SEND_ACTIONS, CHECK_ACTIONS
 from ..time_veil import now_iso
+from .worker_recovery import is_worker_interface_poisoned
 
 logger = get_logger()
 
@@ -523,7 +524,7 @@ def _run_loop(agent) -> None:
                 # appendable from a fresh wake. Common cause: cancel
                 # mid-batch leaves the just-arrived assistant response
                 # with tool_calls on the wire but no results yet.
-                if getattr(agent, "_llm_worker_interface_poisoned", False):
+                if is_worker_interface_poisoned(agent):
                     # Poisoned interface — the worker may still be mutating
                     # it. Do not heal/save; refresh will rebuild from disk.
                     agent._log(
@@ -591,7 +592,7 @@ def _run_loop(agent) -> None:
                     # Fail closed: if a prior turn already poisoned the
                     # interface, do not run another turn against it. Request
                     # refresh and sleep instead.
-                    if getattr(agent, "_llm_worker_interface_poisoned", False):
+                    if is_worker_interface_poisoned(agent):
                         from .worker_recovery import request_worker_hang_refresh
 
                         artifact = getattr(agent, "_llm_worker_poison_artifact", None)
@@ -924,7 +925,7 @@ def _batch_includes_context_molt(tool_calls) -> bool:
 
 def _handle_request(agent, msg: Message) -> None:
     """Send request to LLM, process response with tool calls."""
-    if getattr(agent, "_llm_worker_interface_poisoned", False):
+    if is_worker_interface_poisoned(agent):
         from .worker_recovery import request_worker_hang_refresh
 
         artifact = getattr(agent, "_llm_worker_poison_artifact", None)
@@ -1025,7 +1026,7 @@ def _handle_tc_wake(agent, msg: Message) -> None:
     of no-op-and-return — the previous "tc_inbox_empty" silent
     no-op was the bug that left spliced notification pairs unread.
     """
-    if getattr(agent, "_llm_worker_interface_poisoned", False):
+    if is_worker_interface_poisoned(agent):
         from .worker_recovery import request_worker_hang_refresh
 
         artifact = getattr(agent, "_llm_worker_poison_artifact", None)

--- a/tests/test_make_tool_executor.py
+++ b/tests/test_make_tool_executor.py
@@ -1,0 +1,79 @@
+"""Parity tests for the consolidated ToolExecutor construction helper (#511).
+
+Two turn.py paths built a ToolExecutor with identical wiring and only a
+different LoopGuard. `_make_tool_executor(agent, guard)` centralizes the wiring
+while keeping the guard caller-supplied; these tests pin that the helper passes
+each field through unchanged (especially the provider on the tool-result
+factory) and honors the supplied guard.
+"""
+
+from pathlib import Path
+
+from lingtai_kernel.base_agent import turn
+from lingtai_kernel.loop_guard import LoopGuard
+
+
+class _FakeService:
+    def __init__(self):
+        self.seen = []
+
+    def make_tool_result(self, name, result, provider=None, **kw):
+        self.seen.append((name, result, provider, kw))
+        return {"name": name, "result": result, "provider": provider, **kw}
+
+
+class _FakeConfig:
+    provider = "anthropic"
+
+
+class _FakeAgent:
+    def __init__(self, tmp_path):
+        self.service = _FakeService()
+        self._config = _FakeConfig()
+        self._intrinsics = {"system": object(), "psyche": object()}
+        self._tool_handlers = {"custom_tool": object()}
+        self._PARALLEL_SAFE_TOOLS = {"read"}
+        self._working_dir = tmp_path
+        self._summarize_notification_threshold = None
+
+    def _dispatch_tool(self, *a, **k):  # pragma: no cover - identity check only
+        return None
+
+    def _log(self, *a, **k):  # pragma: no cover - identity check only
+        return None
+
+
+def test_make_tool_executor_wires_shared_fields(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    guard = LoopGuard(max_total_calls=7, dup_free_passes=3, dup_hard_block=8)
+
+    ex = turn._make_tool_executor(agent, guard)
+
+    assert ex._guard is guard
+    # Bound methods are re-created per attribute access, so compare by equality.
+    assert ex._dispatch_fn == agent._dispatch_tool
+    assert ex._known_tools == {"system", "psyche", "custom_tool"}
+    assert ex._parallel_safe_tools == {"read"}
+    assert ex._logger_fn == agent._log
+    assert ex._working_dir == Path(tmp_path)
+
+
+def test_make_tool_executor_passes_provider_through(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    ex = turn._make_tool_executor(agent, LoopGuard())
+
+    out = ex._make_tool_result_fn("tool_x", "payload", extra=1)
+
+    assert out["provider"] == "anthropic"
+    assert agent.service.seen == [("tool_x", "payload", "anthropic", {"extra": 1})]
+
+
+def test_make_tool_executor_honors_distinct_guards(tmp_path):
+    # The request path uses dup_free_passes=3, the tc-wake path uses 2; the
+    # helper must not normalize them.
+    agent = _FakeAgent(tmp_path)
+    g_request = LoopGuard(max_total_calls=5, dup_free_passes=3, dup_hard_block=8)
+    g_tcwake = LoopGuard(max_total_calls=5, dup_free_passes=2, dup_hard_block=8)
+
+    assert turn._make_tool_executor(agent, g_request)._guard is g_request
+    assert turn._make_tool_executor(agent, g_tcwake)._guard is g_tcwake

--- a/tests/test_post_send_housekeeping.py
+++ b/tests/test_post_send_housekeeping.py
@@ -1,0 +1,84 @@
+"""Parity tests for the consolidated post-send housekeeping helper (#511).
+
+Before consolidation, three turn.py branches inlined the same trio:
+
+    _check_molt_pressure(agent)          # bare — errors propagate
+    try: agent._sync_notifications()     # guarded — errors swallowed
+    except Exception: pass
+    try: agent._rescan_large_tool_results()  # guarded — errors swallowed
+    except Exception: pass
+
+These tests pin that exact contract on `_post_send_housekeeping` so the
+refactor cannot silently change which step swallows errors or the call order.
+"""
+
+import pytest
+
+from lingtai_kernel.base_agent import turn
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.calls = []
+        # No "psyche" intrinsic → real _check_molt_pressure returns early,
+        # but tests monkeypatch it anyway to assert it is invoked first.
+        self._intrinsics = {}
+        self.sync_raises = False
+        self.rescan_raises = False
+
+    def _sync_notifications(self):
+        self.calls.append("sync")
+        if self.sync_raises:
+            raise RuntimeError("boom-sync")
+
+    def _rescan_large_tool_results(self):
+        self.calls.append("rescan")
+        if self.rescan_raises:
+            raise RuntimeError("boom-rescan")
+
+
+def test_runs_trio_in_order(monkeypatch):
+    agent = _FakeAgent()
+    molt_called = []
+    monkeypatch.setattr(turn, "_check_molt_pressure", lambda a: molt_called.append(a))
+    turn._post_send_housekeeping(agent)
+    assert molt_called == [agent]
+    assert agent.calls == ["sync", "rescan"]
+
+
+def test_sync_error_is_swallowed_and_rescan_still_runs(monkeypatch):
+    agent = _FakeAgent()
+    agent.sync_raises = True
+    monkeypatch.setattr(turn, "_check_molt_pressure", lambda a: None)
+    turn._post_send_housekeeping(agent)  # must not raise
+    assert agent.calls == ["sync", "rescan"]
+
+
+def test_rescan_error_is_swallowed(monkeypatch):
+    agent = _FakeAgent()
+    agent.rescan_raises = True
+    monkeypatch.setattr(turn, "_check_molt_pressure", lambda a: None)
+    turn._post_send_housekeeping(agent)  # must not raise
+    assert agent.calls == ["sync", "rescan"]
+
+
+def test_molt_pressure_error_propagates(monkeypatch):
+    # Parity: _check_molt_pressure was a bare call, so its errors must NOT be
+    # swallowed, and the guarded steps must not run if it raises.
+    agent = _FakeAgent()
+
+    def boom(a):
+        raise RuntimeError("molt-boom")
+
+    monkeypatch.setattr(turn, "_check_molt_pressure", boom)
+    with pytest.raises(RuntimeError, match="molt-boom"):
+        turn._post_send_housekeeping(agent)
+    assert agent.calls == []
+
+
+def test_real_check_molt_pressure_noop_without_psyche():
+    # Exercises the real _check_molt_pressure early-return path (no "psyche"
+    # intrinsic), confirming the helper wires the real function, not a stub.
+    agent = _FakeAgent()
+    turn._post_send_housekeeping(agent)
+    assert agent.calls == ["sync", "rescan"]

--- a/tests/test_turn_boundary_housekeeping.py
+++ b/tests/test_turn_boundary_housekeeping.py
@@ -1,4 +1,4 @@
-"""Parity tests for the consolidated post-send housekeeping helper (#511).
+"""Parity tests for the consolidated turn-boundary housekeeping helper (#511).
 
 Before consolidation, three turn.py branches inlined the same trio:
 
@@ -8,7 +8,7 @@ Before consolidation, three turn.py branches inlined the same trio:
     try: agent._rescan_large_tool_results()  # guarded — errors swallowed
     except Exception: pass
 
-These tests pin that exact contract on `_post_send_housekeeping` so the
+These tests pin that exact contract on `_turn_boundary_housekeeping` so the
 refactor cannot silently change which step swallows errors or the call order.
 """
 
@@ -41,7 +41,7 @@ def test_runs_trio_in_order(monkeypatch):
     agent = _FakeAgent()
     molt_called = []
     monkeypatch.setattr(turn, "_check_molt_pressure", lambda a: molt_called.append(a))
-    turn._post_send_housekeeping(agent)
+    turn._turn_boundary_housekeeping(agent)
     assert molt_called == [agent]
     assert agent.calls == ["sync", "rescan"]
 
@@ -50,7 +50,7 @@ def test_sync_error_is_swallowed_and_rescan_still_runs(monkeypatch):
     agent = _FakeAgent()
     agent.sync_raises = True
     monkeypatch.setattr(turn, "_check_molt_pressure", lambda a: None)
-    turn._post_send_housekeeping(agent)  # must not raise
+    turn._turn_boundary_housekeeping(agent)  # must not raise
     assert agent.calls == ["sync", "rescan"]
 
 
@@ -58,7 +58,7 @@ def test_rescan_error_is_swallowed(monkeypatch):
     agent = _FakeAgent()
     agent.rescan_raises = True
     monkeypatch.setattr(turn, "_check_molt_pressure", lambda a: None)
-    turn._post_send_housekeeping(agent)  # must not raise
+    turn._turn_boundary_housekeeping(agent)  # must not raise
     assert agent.calls == ["sync", "rescan"]
 
 
@@ -72,7 +72,7 @@ def test_molt_pressure_error_propagates(monkeypatch):
 
     monkeypatch.setattr(turn, "_check_molt_pressure", boom)
     with pytest.raises(RuntimeError, match="molt-boom"):
-        turn._post_send_housekeeping(agent)
+        turn._turn_boundary_housekeeping(agent)
     assert agent.calls == []
 
 
@@ -80,5 +80,5 @@ def test_real_check_molt_pressure_noop_without_psyche():
     # Exercises the real _check_molt_pressure early-return path (no "psyche"
     # intrinsic), confirming the helper wires the real function, not a stub.
     agent = _FakeAgent()
-    turn._post_send_housekeeping(agent)
+    turn._turn_boundary_housekeeping(agent)
     assert agent.calls == ["sync", "rescan"]


### PR DESCRIPTION
Closes #511.

## Why

The turn loop had repeated helper wiring in recovery-sensitive paths. In this context, a turn is one receive/send/process cycle for an agent message, and duplicated turn-boundary code makes it easier for later fixes to land in one branch but miss another.

## What Changed

- Replaced raw worker-interface poison checks in `turn.py` with the existing `is_worker_interface_poisoned(agent)` predicate.
- Added `_turn_boundary_housekeeping(agent)` for the repeated molt-pressure, notification-sync, and large-result-rescan trio while preserving the previous call order and exception behavior.
- Added `_make_tool_executor(agent, guard)` so request and tc-wake paths share `ToolExecutor` construction while still supplying their own `LoopGuard`.
- Added parity tests for executor wiring and turn-boundary housekeeping behavior.

## What Intentionally Did Not Change

- This does not refactor the sequential/parallel `ToolExecutor` dispatch internals.
- This does not introduce the broader pending-tool-call close/save/log helper suggested as a later step.
- The timing of the housekeeping trio is preserved per existing path: request setup and continuation boundaries still call it at their previous points.
- The IDLE-boundary notification check remains separate because it has different control flow.

## Validation

- `python -m pytest tests/test_make_tool_executor.py tests/test_turn_boundary_housekeeping.py` could not run because `python` is not available in this shell.
- `python3 -m pytest tests/test_make_tool_executor.py tests/test_turn_boundary_housekeeping.py` could not run because `pytest` is not installed in the available Python environment.
