### PR TITLE
Add Telegram media guidance manual

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ lingtai = [
     "bin/lingtai-search-sidecar",
     "bin/lingtai-search-sidecar.exe",
 ]
-"lingtai.mcp_servers.telegram" = ["notification_header.md"]
+"lingtai.mcp_servers.telegram" = ["notification_header.md", "SKILL.md"]
 "lingtai.mcp_servers.feishu" = ["notification_header.md"]
 "lingtai.mcp_servers.wechat" = ["notification_header.md"]
 "lingtai.mcp_servers.whatsapp" = ["notification_header.md"]

--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: telegram-mcp-manual
+description: |
+  Progressive-disclosure usage manual for the Telegram MCP tool. Read this when
+  you need detail beyond the one-line action descriptions: media.type='document'
+  vs 'photo' for charts/reports/generated artifacts, placeholder/progress
+  messages, reply vs send, read/check/search, parse_mode/entities, chat_action,
+  and error surfacing. Pulled on demand via action='manual'; you do not need to
+  call it before every send.
+version: 1.0.0
+---
+
+# Telegram MCP — usage manual (progressive disclosure)
+
+This manual is pulled on demand via `action='manual'` so the per-action tool
+schema can stay concise. Read it when you need detail beyond the one-line action
+descriptions; you do not need to call it before every send.
+
+## MEDIA: document vs photo
+
+- Charts, plots, reports, HTML/SVG/PNG/PDF exports, CSVs, and any other
+  generated artifact the user should open intact: send with
+  `media.type='document'`. Documents arrive as a downloadable file, uncropped
+  and uncompressed.
+- `media.type='photo'` is for native inline photo previews only. Telegram may
+  crop, compress, thumbnail, or otherwise degrade text-heavy graphics sent as a
+  photo, so a chart can look cropped or unreadable.
+- Do not paste a local file path into message text as a substitute for
+  attaching the file; attach it with `media={type, path}`.
+
+## PLACEHOLDER / PROGRESS
+
+- For responses that take more than ~5s, send `action='send'` with
+  `placeholder=true` (and your interim text). This fires a typing indicator and
+  returns a compound `message_id`.
+- Update it later with `action='edit'`, `message_id=<that id>`, `text=<final>`
+  instead of sending a second message, so the user sees one evolving reply
+  rather than silence followed by a wall of text.
+
+## REPLY vs SEND
+
+- `action='reply'` (`message_id` from read/check results, `text`) threads your
+  response to a specific message and adds a ✅ reaction to it; prefer it when
+  answering a particular incoming message.
+- `action='send'` (`chat_id`, `text`) starts a fresh message in the chat; use it
+  for unsolicited or standalone messages.
+
+## READING: read / check / search
+
+- `check`: list recent conversations with unread counts.
+- `read`: read messages from one chat (`chat_id`; optional `limit`). Reading
+  marks messages read and clears the wake notification mirror.
+- `search`: regex search over message text/sender (`query`; optional `chat_id`,
+  `account`).
+
+## RICH TEXT: parse_mode / entities
+
+- `parse_mode` accepts `'HTML'`, `'MarkdownV2'`, or `'Markdown'` for
+  send/reply/edit and media captions; omit it or pass `''` for plain text.
+- `entities` sets `MessageEntity[]` for message text; `caption_entities` does the
+  same for media captions. If `caption_entities` is omitted on a media send,
+  `entities` is reused as the caption entities.
+
+## CHAT ACTION
+
+- `chat_action` (`'typing'`, `'upload_photo'`, `'upload_document'`,
+  `'upload_voice'`) on a send with no text/media sends just the indicator. It
+  auto-expires after ~5s, so re-send periodically during long work. Pass `''`
+  for no chat action.
+
+## ERROR SURFACING
+
+- Actions return `{'status': ...}` on success or `{'error': <message>}` on
+  failure (e.g. missing `chat_id`, unreadable `media.path`, bad `parse_mode`).
+  Check for the `'error'` key and surface or act on it rather than assuming the
+  message was delivered.
+- A duplicate identical send returns `{'status': 'blocked'}`; treat that as
+  'already sent', not as a transient error to retry.

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -37,6 +37,93 @@ def _load_notification_header_template() -> str:
     )
 
 
+# ---------------------------------------------------------------------------
+# Bundled usage manual (skill format) — SKILL.md ships in this package folder.
+# action='manual' reads the full body; the YAML frontmatter is parsed and the
+# name/description are injected into the tool schema as a progressive-disclosure
+# catalog entry, while the full body stays behind action='manual'.
+# ---------------------------------------------------------------------------
+
+_SKILL_FILENAME = "SKILL.md"
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Split a SKILL.md into (frontmatter dict, body markdown).
+
+    Tiny dependency-free parser for the leading ``---`` YAML block. Handles the
+    flat ``key: value`` and ``key: |``/``key: >`` block-scalar forms used by our
+    skill frontmatter; it does not attempt to be a general YAML parser. Returns
+    an empty mapping and the original text when no frontmatter is present.
+    """
+    if not text.startswith("---"):
+        return {}, text
+    lines = text.splitlines(keepends=True)
+    # lines[0] is the opening '---'; find the closing fence.
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\n").strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}, text
+
+    fm_lines = [ln.rstrip("\n") for ln in lines[1:end]]
+    body = "".join(lines[end + 1:]).lstrip("\n")
+
+    meta: dict[str, str] = {}
+    key: str | None = None
+    block_parts: list[str] = []
+
+    def _flush() -> None:
+        if key is not None:
+            meta[key] = " ".join(" ".join(block_parts).split())
+
+    for raw in fm_lines:
+        if key is not None and (raw.startswith((" ", "\t")) or not raw.strip()):
+            # Continuation line of a block scalar (key: | / key: >).
+            block_parts.append(raw.strip())
+            continue
+        if ":" in raw and not raw.startswith((" ", "\t")):
+            _flush()
+            k, _, v = raw.partition(":")
+            key = k.strip()
+            block_parts = []
+            v = v.strip()
+            if v in ("|", ">", "|-", ">-", "|+", ">+"):
+                # Block scalar — value continues on indented lines below.
+                continue
+            block_parts.append(v.strip("'\""))
+    _flush()
+    return meta, body
+
+
+def _load_skill() -> tuple[dict[str, str], str, str]:
+    """Load the bundled SKILL.md → (frontmatter, body, path)."""
+    resource = resources.files(__package__).joinpath(_SKILL_FILENAME)
+    text = resource.read_text(encoding="utf-8")
+    frontmatter, body = _split_frontmatter(text)
+    return frontmatter, body, str(resource)
+
+
+_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _load_skill()
+
+
+def _manual_action_description() -> str:
+    """Build the schema 'manual' action line from the skill frontmatter.
+
+    Injects the skill name + description (the frontmatter/catalog entry) so the
+    tool schema advertises the skill while the full body stays progressive-
+    disclosure behind action='manual'.
+    """
+    name = _SKILL_FRONTMATTER.get("name", "telegram-mcp-manual")
+    description = _SKILL_FRONTMATTER.get("description", "")
+    return (
+        f"manual: progressive-disclosure usage manual (skill '{name}') — "
+        "call this (no other args) to pull the full bundled SKILL.md. "
+        f"{description}"
+    ).strip()
+
+
 _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()
 _NOTIFICATION_CHANNEL = "mcp.telegram"
 _COMPOUND_ID_RE = re.compile(r"#([^\s:#]+:-?\d+:\d+)\b")
@@ -180,10 +267,11 @@ SCHEMA = {
                 "send", "check", "read", "reply", "search",
                 "delete", "edit",
                 "contacts", "add_contact", "remove_contact",
-                "accounts",
+                "accounts", "manual",
             ],
             "description": (
                 "send: send message to a chat (chat_id, text; optional media, reply_markup, placeholder, chat_action, parse_mode/entities). "
+                "For charts, reports, generated artifacts, and other files the user should open intact, prefer media.type='document'; use media.type='photo' only when an inline Telegram photo preview is desired, because photo previews may crop, compress, or display poorly for text-heavy graphics. "
                 "If chat_action is set and no text/media is provided, sends a typing "
                 "indicator (auto-expires after 5s) instead of a message. "
                 "check: list recent conversations with unread counts (optional account). "
@@ -196,7 +284,8 @@ SCHEMA = {
                 "add_contact: save a chat alias (chat_id, alias); this does not grant inbound permission. "
                 "To receive messages from that user, their Telegram user ID must also be in allowed_users. "
                 "remove_contact: remove a contact (alias or chat_id). "
-                "accounts: list configured bot accounts."
+                "accounts: list configured bot accounts. "
+                + _manual_action_description()
             ),
         },
         "account": {
@@ -221,7 +310,12 @@ SCHEMA = {
                 "type": {"type": "string", "enum": ["photo", "document", "voice", "audio"]},
                 "path": {"type": "string"},
             },
-            "description": "Media attachment: {type: 'photo'|'document'|'voice'|'audio', path: '/path/to/file'}",
+            "description": (
+                "Media attachment: {type: 'photo'|'document'|'voice'|'audio', path: '/path/to/file'}. "
+                "For charts, HTML/SVG/PNG reports, CSVs, PDFs, and other generated artifacts that should arrive as an intact file, use type='document'. "
+                "Use type='photo' only for native inline photo previews; Telegram photo delivery can crop, compress, thumbnail, or otherwise display text-heavy charts poorly. "
+                "Do not paste local file paths in message text as a substitute for attaching the file."
+            ),
         },
         "reply_markup": {
             "type": "object",
@@ -383,6 +477,8 @@ class TelegramManager:
                 return self._remove_contact(args)
             elif action == "accounts":
                 return self._accounts()
+            elif action == "manual":
+                return self._manual()
             else:
                 return {"error": f"Unknown telegram action: {action}"}
         except Exception as e:
@@ -1512,4 +1608,24 @@ class TelegramManager:
             "accounts": self._service.list_accounts(),
             "details": self._service.account_details(),
             "identity_path": str(self._service.identity_path()),
+        }
+
+    # ------------------------------------------------------------------
+    # Manual — progressive-disclosure usage guidance
+    # ------------------------------------------------------------------
+    #
+    # The manual lives in this package's bundled SKILL.md (standard skill
+    # format: YAML frontmatter + markdown body), loaded at import time above.
+    # action='manual' returns the full skill markdown plus parsed metadata and
+    # the resolved path; the frontmatter is also injected into the schema's
+    # 'manual' action description as a catalog entry.
+
+    def _manual(self) -> dict:
+        return {
+            "status": "ok",
+            "action": "manual",
+            "skill": _SKILL_FRONTMATTER.get("name", "telegram-mcp-manual"),
+            "metadata": dict(_SKILL_FRONTMATTER),
+            "path": _SKILL_PATH,
+            "manual": _SKILL_BODY,
         }

--- a/tests/test_telegram_rich_formatting.py
+++ b/tests/test_telegram_rich_formatting.py
@@ -112,6 +112,92 @@ def test_schema_allows_empty_chat_action():
     assert "empty string" in props["chat_action"]["description"]
 
 
+def test_schema_guides_generated_charts_to_documents():
+    props = SCHEMA["properties"]
+    media_description = props["media"]["description"]
+    action_description = props["action"]["description"]
+
+    assert "charts" in media_description
+    assert "generated artifacts" in media_description
+    assert "type='document'" in media_description
+    assert "type='photo'" in media_description
+    assert "crop" in media_description
+    assert "compress" in media_description
+    assert "charts" in action_description
+    assert "media.type='document'" in action_description
+
+
+def test_skill_file_exists_with_valid_frontmatter():
+    """The manual ships as a standard skill file (SKILL.md) in the Telegram MCP
+    package folder, with YAML frontmatter exposing at least name + description."""
+    from lingtai.mcp_servers.telegram.manager import (
+        _SKILL_BODY,
+        _SKILL_FRONTMATTER,
+        _SKILL_PATH,
+    )
+
+    skill_path = Path(_SKILL_PATH)
+    assert skill_path.name == "SKILL.md"
+    assert skill_path.is_file()
+    # parent folder is the Telegram MCP package
+    assert skill_path.parent.name == "telegram"
+
+    assert _SKILL_FRONTMATTER.get("name")
+    assert _SKILL_FRONTMATTER.get("description")
+    # body is the markdown after the frontmatter fence (no leading '---')
+    assert _SKILL_BODY.strip()
+    assert not _SKILL_BODY.lstrip().startswith("---")
+
+
+def test_schema_exposes_manual_action():
+    props = SCHEMA["properties"]
+    assert "manual" in props["action"]["enum"]
+    action_description = props["action"]["description"]
+    assert "manual:" in action_description
+    assert "progressive-disclosure" in action_description
+    # The frontmatter/catalog entry is injected into the schema: the action
+    # description advertises the skill name + its description.
+    from lingtai.mcp_servers.telegram.manager import _SKILL_FRONTMATTER
+
+    assert _SKILL_FRONTMATTER["name"] in action_description
+    # a distinctive phrase from the skill description survives injection
+    assert "media.type='document'" in action_description
+
+
+def test_manual_action_returns_usage_guidance(tmp_path):
+    manager, _account = _manager(tmp_path)
+    result = manager.handle({"action": "manual"})
+
+    assert result["status"] == "ok"
+    manual = result["manual"]
+    assert isinstance(manual, str) and manual.strip()
+
+    # manual action surfaces parsed metadata + the resolved SKILL.md path
+    assert result["skill"]
+    assert result["metadata"].get("name") == result["skill"]
+    assert result["metadata"].get("description")
+    assert Path(result["path"]).name == "SKILL.md"
+
+    # the returned body is read from SKILL.md, not a hardcoded string
+    from lingtai.mcp_servers.telegram.manager import _SKILL_BODY
+
+    assert manual == _SKILL_BODY
+
+    lowered = manual.lower()
+    # document / photo / chart guidance
+    assert "document" in lowered
+    assert "photo" in lowered
+    assert "chart" in lowered
+    # progressive disclosure framing
+    assert "progressive disclosure" in lowered
+    # the other facets the manual should cover
+    assert "placeholder" in lowered
+    assert "reply" in lowered
+    assert "parse_mode" in manual
+    assert "chat_action" in manual
+    assert "error" in lowered
+
+
 # ---------------------------------------------------------------------------
 # Manager pass-through (the acceptance-critical parse_mode path lives here)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a bundled Telegram MCP manual as `src/lingtai/mcp_servers/telegram/SKILL.md` in standard skill format (YAML frontmatter + body)
- inject the skill's frontmatter/catalog entry into the Telegram tool schema, while `action='manual'` returns the full bundled skill on demand
- steer generated charts/reports/artifacts toward `media.type='document'` and warn that `photo` previews can crop/compress/thumbnail text-heavy graphics
- add schema/manual/SKILL.md regression tests and package the skill file in the wheel

## Validation
- `PYTHONPATH=src python -m pytest tests/test_telegram_rich_formatting.py tests/test_mcp_capability.py -q` → 44 passed
- `PYTHONPATH=src python -m pytest tests/ -q -k "telegram"` → 27 passed

Requested by Jason after generated cache-rate charts were accidentally sent through Telegram photo/preview delivery and appeared cropped; revised after feedback to keep the manual as a standard skill file rather than a large hardcoded manager string.