### PR TITLE
Add bundled manuals for curated MCPs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,11 @@ lingtai = [
     "bin/lingtai-search-sidecar.exe",
 ]
 "lingtai.mcp_servers.telegram" = ["notification_header.md", "SKILL.md"]
-"lingtai.mcp_servers.feishu" = ["notification_header.md"]
-"lingtai.mcp_servers.wechat" = ["notification_header.md"]
-"lingtai.mcp_servers.whatsapp" = ["notification_header.md"]
+"lingtai.mcp_servers.feishu" = ["notification_header.md", "SKILL.md"]
+"lingtai.mcp_servers.wechat" = ["notification_header.md", "SKILL.md"]
+"lingtai.mcp_servers.whatsapp" = ["notification_header.md", "SKILL.md"]
+"lingtai.mcp_servers.imap" = ["SKILL.md"]
+"lingtai.mcp_servers.cloud_mail" = ["SKILL.md"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/lingtai/mcp_servers/_skill.py
+++ b/src/lingtai/mcp_servers/_skill.py
@@ -1,0 +1,111 @@
+"""Shared bundled-skill (SKILL.md) helpers for curated MCP servers.
+
+Each curated MCP ships a standard skill file (``SKILL.md``: YAML frontmatter +
+markdown body) in its package folder. The ``manual`` tool action reads the full
+body on demand (progressive disclosure), while the frontmatter ``name`` +
+``description`` are injected into the tool schema's ``manual`` action line as a
+catalog entry. This module factors out the tiny frontmatter parser, the loader,
+the schema catalog line, and the ``action='manual'`` payload so every MCP can
+share one understandable implementation instead of copying Telegram's.
+
+The original Telegram MCP keeps its own inline copy of this logic for historical
+reasons; new/curated MCPs use this shared helper.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+
+SKILL_FILENAME = "SKILL.md"
+
+
+def split_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Split a SKILL.md into (frontmatter dict, body markdown).
+
+    Tiny dependency-free parser for the leading ``---`` YAML block. Handles the
+    flat ``key: value`` and ``key: |``/``key: >`` block-scalar forms used by our
+    skill frontmatter; it does not attempt to be a general YAML parser. Returns
+    an empty mapping and the original text when no frontmatter is present.
+    """
+    if not text.startswith("---"):
+        return {}, text
+    lines = text.splitlines(keepends=True)
+    # lines[0] is the opening '---'; find the closing fence.
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\n").strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}, text
+
+    fm_lines = [ln.rstrip("\n") for ln in lines[1:end]]
+    body = "".join(lines[end + 1:]).lstrip("\n")
+
+    meta: dict[str, str] = {}
+    key: str | None = None
+    block_parts: list[str] = []
+
+    def _flush() -> None:
+        if key is not None:
+            meta[key] = " ".join(" ".join(block_parts).split())
+
+    for raw in fm_lines:
+        if key is not None and (raw.startswith((" ", "\t")) or not raw.strip()):
+            # Continuation line of a block scalar (key: | / key: >).
+            block_parts.append(raw.strip())
+            continue
+        if ":" in raw and not raw.startswith((" ", "\t")):
+            _flush()
+            k, _, v = raw.partition(":")
+            key = k.strip()
+            block_parts = []
+            v = v.strip()
+            if v in ("|", ">", "|-", ">-", "|+", ">+"):
+                # Block scalar — value continues on indented lines below.
+                continue
+            block_parts.append(v.strip("'\""))
+    _flush()
+    return meta, body
+
+
+def load_skill(package: str) -> tuple[dict[str, str], str, str]:
+    """Load a package's bundled SKILL.md → (frontmatter, body, path)."""
+    resource = resources.files(package).joinpath(SKILL_FILENAME)
+    text = resource.read_text(encoding="utf-8")
+    frontmatter, body = split_frontmatter(text)
+    return frontmatter, body, str(resource)
+
+
+def manual_action_description(frontmatter: dict[str, str], default_name: str) -> str:
+    """Build the schema 'manual' action line from the skill frontmatter.
+
+    Injects the skill name + description (the frontmatter/catalog entry) so the
+    tool schema advertises the skill while the full body stays
+    progressive-disclosure behind ``action='manual'``.
+    """
+    name = frontmatter.get("name", default_name)
+    description = frontmatter.get("description", "")
+    return (
+        f"manual: progressive-disclosure usage manual (skill '{name}') — "
+        "call this (no other args) to pull the full bundled SKILL.md. "
+        f"{description}"
+    ).strip()
+
+
+def manual_payload(
+    frontmatter: dict[str, str], body: str, path: str, default_name: str
+) -> dict:
+    """Build the ``action='manual'`` response payload.
+
+    Returns the full skill markdown plus parsed metadata and the resolved
+    SKILL.md path, mirroring the Telegram MCP's ``_manual`` result shape.
+    """
+    return {
+        "status": "ok",
+        "action": "manual",
+        "skill": frontmatter.get("name", default_name),
+        "metadata": dict(frontmatter),
+        "path": path,
+        "manual": body,
+    }

--- a/src/lingtai/mcp_servers/cloud_mail/SKILL.md
+++ b/src/lingtai/mcp_servers/cloud_mail/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: cloud-mail-mcp-manual
+description: |
+  Progressive-disclosure usage manual for the Cloud Mail REST email MCP tool.
+  Read this when you need detail beyond the one-line action descriptions:
+  check/search filters, the compound id (account:emailId) for read, send (needs
+  user credentials), plain vs HTML bodies, accounts/add_user basics, and the
+  external-email side-effect caveats. Pulled on demand via action='manual'; you
+  do not need to call it before every send.
+version: 1.0.0
+---
+
+# Cloud Mail MCP — usage manual (progressive disclosure)
+
+This manual is pulled on demand via `action='manual'` so the per-action tool
+schema can stay concise. Read it when you need detail beyond the one-line action
+descriptions; you do not need to call it before every send.
+
+Cloud Mail is a REST email client for a self-hosted Cloud Mail deployment
+(Cloudflare Workers). Inbound mail also arrives automatically in your inbox via
+per-account polling, so you don't have to poll `check` yourself.
+
+## EMAIL IDS
+
+- `read` takes a compound id `id='<account>:<emailId>'`, or `account` plus a
+  numeric `email_id`. Use the ids returned by `check`/`search`; do not construct
+  them by hand.
+
+## READING: check / search / read
+
+- `check`: list recent inbound emails (optional `limit`/`n`, plus the same
+  filters as search).
+- `search`: filter the public email list by `to_email`, `send_email`,
+  `send_name`, `subject`, `content`, `time_sort` (`asc`/`desc`), and paginate
+  with `num`/`size`. Filters are LIKE matches.
+- `read`: fetch the full content of one email by compound `id`.
+
+## SEND
+
+- `send` requires user credentials in config (it logs in, then posts to
+  `/email/send`). Provide `address` (recipient or list), and a body via
+  `message`/`text` (plain) and/or `html`/`content_html` (HTML). Optional
+  `subject`, `name` (sender display name), `send_account_id` (override sender).
+- Attachments are NOT supported in this first pass.
+
+## ACCOUNTS / ADD_USER
+
+- `accounts`: redacted per-account status (no tokens/passwords).
+- `add_user`: create a Cloud Mail user (`email`, `password`; optional
+  `role_name`). Admin operation — use deliberately.
+
+## SIDE EFFECTS & SAFETY
+
+- `send` delivers real email to real recipients — an external, hard-to-undo side
+  effect. Confirm the recipient(s) and body before sending unsolicited mail.
+- `add_user` mutates the Cloud Mail deployment's user set; double-check before
+  running it.
+- Actions return `{'status': 'ok', ...}` on success or `{'status': 'error',
+  'error': <message>}` on failure. Check the status and surface or act on errors
+  rather than assuming delivery.

--- a/src/lingtai/mcp_servers/cloud_mail/manager.py
+++ b/src/lingtai/mcp_servers/cloud_mail/manager.py
@@ -21,8 +21,15 @@ from typing import Any, Callable
 
 from .client import CloudMailClient, CloudMailError
 from ._watermark import WatermarkStore
+from .. import _skill
 
 log = logging.getLogger("lingtai_cloud_mail")
+
+# Bundled usage manual (skill format) — SKILL.md ships in this package folder.
+# action='manual' reads the full body; the YAML frontmatter name/description are
+# injected into the tool schema as a progressive-disclosure catalog entry.
+_SKILL_NAME = "cloud-mail-mcp-manual"
+_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _skill.load_skill(__package__)
 
 DESCRIPTION = (
     "Cloud Mail REST email client for a self-hosted Cloud Mail deployment "
@@ -38,8 +45,11 @@ SCHEMA: dict[str, Any] = {
     "properties": {
         "action": {
             "type": "string",
-            "enum": ["check", "search", "read", "send", "accounts", "add_user"],
-            "description": "Which Cloud Mail operation to perform.",
+            "enum": ["check", "search", "read", "send", "accounts", "add_user", "manual"],
+            "description": (
+                "Which Cloud Mail operation to perform. "
+                + _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME)
+            ),
         },
         "account": {
             "type": "string",
@@ -191,12 +201,24 @@ class CloudMailManager:
                 return {"status": "ok", "accounts": [a.status() for a in self._accounts]}
             if action == "add_user":
                 return self._handle_add_user(args)
+            if action == "manual":
+                return self._handle_manual()
             return {"status": "error", "error": f"unknown action: {action!r}"}
         except CloudMailError as exc:
             return {"status": "error", "error": str(exc), "error_type": "CloudMailError"}
         except Exception as exc:  # defensive — never leak a traceback to the model
             log.exception("cloud_mail action %r failed", action)
             return {"status": "error", "error": str(exc), "error_type": type(exc).__name__}
+
+    def _handle_manual(self) -> dict:
+        # The manual lives in this package's bundled SKILL.md (standard skill
+        # format: YAML frontmatter + markdown body), loaded at import time.
+        # action='manual' returns the full skill markdown plus parsed metadata
+        # and the resolved path; the frontmatter is also injected into the
+        # schema's 'manual' action description as a catalog entry.
+        return _skill.manual_payload(
+            _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
+        )
 
     def _handle_check(self, args: dict) -> dict:
         acct = self._resolve(args.get("account"))

--- a/src/lingtai/mcp_servers/feishu/SKILL.md
+++ b/src/lingtai/mcp_servers/feishu/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: feishu-mcp-manual
+description: |
+  Progressive-disclosure usage manual for the Feishu (Lark) MCP tool. Read this
+  when you need detail beyond the one-line action descriptions: receive_id vs
+  receive_id_type (open_id/chat_id), send vs reply, check/read/search, placeholder
+  + edit for long responses, contacts/accounts basics, and side-effect caveats.
+  Pulled on demand via action='manual'; you do not need to call it before every
+  send.
+version: 1.0.0
+---
+
+# Feishu (Lark) MCP — usage manual (progressive disclosure)
+
+This manual is pulled on demand via `action='manual'` so the per-action tool
+schema can stay concise. Read it when you need detail beyond the one-line action
+descriptions; you do not need to call it before every send.
+
+## RECIPIENTS: receive_id / receive_id_type
+
+- `send` targets a recipient by `receive_id` plus `receive_id_type`. Use
+  `receive_id_type='open_id'` for an individual user (`ou_xxx`) and
+  `receive_id_type='chat_id'` for a group chat (`oc_xxx`). `receive_id_type`
+  defaults to `open_id` when omitted.
+- `email`, `user_id`, and `union_id` are also accepted as `receive_id_type`
+  values when you only have that identifier for a user.
+
+## SEND vs REPLY
+
+- `reply` (`message_id` from read/check results, `text`) threads your response to
+  a specific incoming message; prefer it when answering a particular message.
+- `send` (`receive_id`, `receive_id_type`, `text`) starts a fresh message; use it
+  for unsolicited or standalone messages.
+
+## READING: check / read / search
+
+- `check`: list recent conversations with unread counts (optional `account`).
+- `read`: read messages from one chat (`chat_id`; optional `limit`, `account`).
+- `search`: regex search over inbox messages (`query`; optional `account`,
+  `chat_id`).
+
+## PLACEHOLDER / PROGRESS
+
+- For responses that take more than ~5s, send `action='send'` with
+  `placeholder=true` and your interim text. This returns a compound `message_id`.
+- Update it later with `action='edit'`, `message_id=<that id>`, `text=<final>`
+  instead of sending a second message, so the user sees one evolving reply.
+
+## CONTACTS / ACCOUNTS
+
+- `contacts`: list saved contacts (optional `account`).
+- `add_contact`: save a contact alias (`open_id`, `alias`; optional `name`,
+  `chat_id`). Saving an alias does not grant inbound permission on its own.
+- `remove_contact`: remove a contact (`alias` or `open_id`).
+- `accounts`: list configured app accounts.
+
+## MESSAGE IDS
+
+- `message_id` is the compound id returned by read/check
+  (`{alias}:{chat_id}:{feishu_message_id}`); pass it back verbatim to
+  `reply`/`edit`/`delete`.
+
+## SIDE EFFECTS & ERROR SURFACING
+
+- `send`, `reply`, and `edit` deliver to real users — they are external
+  side effects, so confirm recipient and content before sending unsolicited
+  messages.
+- Actions return a result dict on success or `{'error': <message>}` on failure
+  (e.g. missing `receive_id`, bad `message_id`). Check for the `'error'` key and
+  surface or act on it rather than assuming delivery.

--- a/src/lingtai/mcp_servers/feishu/manager.py
+++ b/src/lingtai/mcp_servers/feishu/manager.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import Any, Callable, TYPE_CHECKING
 from uuid import uuid4
 
+from .. import _skill
+
 if TYPE_CHECKING:
     from .service import FeishuService
 
@@ -37,6 +39,12 @@ def _load_notification_header_template() -> str:
 
 
 _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()
+
+# Bundled usage manual (skill format) — SKILL.md ships in this package folder.
+# action='manual' reads the full body; the YAML frontmatter name/description are
+# injected into the tool schema as a progressive-disclosure catalog entry.
+_SKILL_NAME = "feishu-mcp-manual"
+_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _skill.load_skill(__package__)
 
 # Emoji reactions for different states
 # Feishu supported emoji types: OK, THUMBSUP, SMILE, HEART, THANKS, etc.
@@ -229,7 +237,7 @@ SCHEMA = {
                 "send", "check", "read", "reply", "search",
                 "delete", "edit",
                 "contacts", "add_contact", "remove_contact",
-                "accounts",
+                "accounts", "manual",
             ],
             "description": (
                 "send: send a text message to a user or chat "
@@ -251,7 +259,8 @@ SCHEMA = {
                 "add_contact: save a contact "
                 "(open_id, alias; optional name, chat_id). "
                 "remove_contact: remove a contact (alias or open_id). "
-                "accounts: list configured app accounts."
+                "accounts: list configured app accounts. "
+                + _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME)
             ),
         },
         "account": {
@@ -435,10 +444,22 @@ class FeishuManager:
                 return self._remove_contact(args)
             elif action == "accounts":
                 return self._accounts()
+            elif action == "manual":
+                return self._manual()
             else:
                 return {"error": f"Unknown feishu action: {action!r}"}
         except Exception as e:
             return {"error": str(e)}
+
+    def _manual(self) -> dict:
+        # The manual lives in this package's bundled SKILL.md (standard skill
+        # format: YAML frontmatter + markdown body), loaded at import time.
+        # action='manual' returns the full skill markdown plus parsed metadata
+        # and the resolved path; the frontmatter is also injected into the
+        # schema's 'manual' action description as a catalog entry.
+        return _skill.manual_payload(
+            _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
+        )
 
     # ------------------------------------------------------------------
     # Incoming messages — called by FeishuService via on_message callback

--- a/src/lingtai/mcp_servers/imap/SKILL.md
+++ b/src/lingtai/mcp_servers/imap/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: imap-mcp-manual
+description: |
+  Progressive-disclosure usage manual for the IMAP/SMTP email MCP tool. Read this
+  when you need detail beyond the one-line action descriptions: send vs reply,
+  check/read/search over folders, the compound email_id (account:folder:uid),
+  attachments, move/flag/delete/folders, contacts/accounts basics, and the
+  important external-email side-effect caveats (real outbound mail — confirm
+  before sending). Pulled on demand via action='manual'; you do not need to call
+  it before every send.
+version: 1.0.0
+---
+
+# IMAP/SMTP email MCP — usage manual (progressive disclosure)
+
+This manual is pulled on demand via `action='manual'` so the per-action tool
+schema can stay concise. Read it when you need detail beyond the one-line action
+descriptions; you do not need to call it before every send.
+
+## EMAIL IDS
+
+- `email_id` is a compound key: `account:folder:uid` (e.g.
+  `me@example.com:INBOX:1234`). `read`, `reply`, `delete`, `move`, and `flag`
+  take one id or a list of ids. Use the ids returned by `check`/`search`; do not
+  construct them by hand.
+
+## READING: check / read / search
+
+- `check`: list recent envelopes from a folder (optional `folder`, `n`).
+- `read`: fetch full email(s) by `email_id` (a single id or a list). You are
+  encouraged to read multiple relevant — or even all unread — emails and think
+  before acting.
+- `search`: server-side IMAP search (`query`; optional `folder`). Queries use a server-side search DSL, e.g.
+  `from:addr subject:text unseen since:YYYY-MM-DD`; supported fields depend on
+  the IMAP addon, so prefer examples returned by this tool over raw RFC IMAP
+  search syntax.
+- `folders`: list available IMAP folders.
+
+## SEND vs REPLY
+
+- `send`: compose a new email (`address`, `message`; optional `subject`, `cc`,
+  `bcc`, `attachments`). `address`/`cc`/`bcc` accept a single string or a list.
+- `reply`: reply to an existing email (`email_id`, `message`; optional `cc`,
+  `attachments`). Reply preserves threading/subject from the original.
+
+## ATTACHMENTS
+
+- `attachments` is a list of file paths (absolute or relative to the working
+  dir) for `send`/`reply`. Attach generated artifacts (charts, reports, CSVs,
+  PDFs) as files rather than pasting a path into the body.
+
+## ORGANIZING: move / flag / delete
+
+- `move`: move email(s) to another folder (`email_id`, `folder`=destination).
+- `flag`: set/clear flags (`email_id`, `flags={"seen": true, "flagged": false}`).
+- `delete`: delete email(s) by `email_id`.
+
+## CONTACTS / ACCOUNTS
+
+- `contacts`: list all contacts.
+- `add_contact`: add/update a contact (`address`, `name`; optional `note`).
+- `edit_contact`: update contact fields (`address`; optional `name`, `note`).
+- `remove_contact`: remove a contact (`address`).
+- `accounts`: list configured IMAP accounts and connection status. Most actions
+  accept an optional `account` (email address); it defaults to the primary
+  account.
+
+## SIDE EFFECTS & SAFETY
+
+- `send` and `reply` deliver real email to real recipients over SMTP — this is an
+  external, hard-to-undo side effect. Confirm the recipient list (including
+  `cc`/`bcc`) and the body before sending unsolicited mail.
+- When replying to external addresses, follow the caller's standing reply
+  policy. Unknown external senders require explicit guidance, or confirmation
+  that the sender is the same human who contacted you through an internal
+  channel, before sending a real reply.
+- `delete` and `move` change server-side mailbox state; double-check the
+  `email_id`/`folder` before running them.
+- Actions return a result dict on success or one carrying an `'error'` key on
+  failure (e.g. unknown account, bad `email_id`, unreadable attachment). Check
+  for the error and surface or act on it rather than assuming delivery.

--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -16,11 +16,19 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
+from .. import _skill
+
 if TYPE_CHECKING:
     from .account import IMAPAccount
     from .service import IMAPMailService
 
 log = logging.getLogger(__name__)
+
+# Bundled usage manual (skill format) — SKILL.md ships in this package folder.
+# action='manual' reads the full body; the YAML frontmatter name/description are
+# injected into the tool schema as a progressive-disclosure catalog entry.
+_SKILL_NAME = "imap-mcp-manual"
+_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _skill.load_skill(__package__)
 
 
 # ---------------------------------------------------------------------------
@@ -59,7 +67,7 @@ SCHEMA = {
                 "send", "check", "read", "reply", "search",
                 "delete", "move", "flag", "folders",
                 "contacts", "add_contact", "remove_contact", "edit_contact",
-                "accounts",
+                "accounts", "manual",
             ],
             "description": (
                 "send: send email via IMAP/SMTP (requires address, message; optional subject, cc, bcc, attachments). "
@@ -76,7 +84,8 @@ SCHEMA = {
                 "add_contact: add/update contact (requires address, name; optional note). "
                 "remove_contact: remove contact (requires address). "
                 "edit_contact: update contact fields (requires address; optional name, note). "
-                "accounts: list configured IMAP accounts and connection status."
+                "accounts: list configured IMAP accounts and connection status. "
+                + _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME)
             ),
         },
         "account": {
@@ -251,6 +260,8 @@ class IMAPMailManager:
 
     def handle(self, args: dict) -> dict:
         action = args.get("action")
+        if action == "manual":
+            return self._manual()
         account = self._service.get_account(args.get("account"))
         if account is None and action != "accounts":
             return self._inject_meta(
@@ -279,6 +290,17 @@ class IMAPMailManager:
             return self._inject_meta(dispatch[action](args, account))
         else:
             return self._inject_meta({"error": f"Unknown imap action: {action}"})
+
+    def _manual(self) -> dict:
+        # The manual lives in this package's bundled SKILL.md (standard skill
+        # format: YAML frontmatter + markdown body), loaded at import time.
+        # action='manual' returns the full skill markdown plus parsed metadata
+        # and the resolved path; the frontmatter is also injected into the
+        # schema's 'manual' action description as a catalog entry. It is
+        # account-independent, so it skips the account lookup / meta injection.
+        return _skill.manual_payload(
+            _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
+        )
 
     # ------------------------------------------------------------------
     # Receive handler — called by IMAPMailService IMAP poll

--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: wechat-mcp-manual
+description: |
+  Progressive-disclosure usage manual for the WeChat MCP tool. Read this when you
+  need detail beyond the one-line action descriptions: user_id targeting, send vs
+  reply, check/read/search, media_path attachments (image/video/voice/file),
+  contacts/accounts basics, and external-delivery side-effect caveats. Pulled on
+  demand via action='manual'; you do not need to call it before every send.
+version: 1.0.0
+---
+
+# WeChat MCP — usage manual (progressive disclosure)
+
+This manual is pulled on demand via `action='manual'` so the per-action tool
+schema can stay concise. Read it when you need detail beyond the one-line action
+descriptions; you do not need to call it before every send.
+
+## RECIPIENTS: user_id
+
+- Messages target a WeChat user by `user_id` (e.g. `wxid_abc123@im.wechat`). Use
+  the `user_id` returned by `check`/`read`/`contacts`; do not invent one.
+
+## SEND vs REPLY
+
+- `reply` (`message_id` from read results, `text`) threads your response to a
+  specific incoming message; prefer it when answering a particular message.
+- `send` (`user_id`, `text`) starts a fresh message; use it for unsolicited or
+  standalone messages.
+
+## MEDIA / ATTACHMENTS
+
+- `send` with `media_path` (absolute path) attaches a file. Type is detected from
+  the extension: `.jpg`/`.png` → image, `.mp4` → video, `.wav`/`.mp3` → voice,
+  anything else → file.
+- For charts, reports, and other artifacts the user should open intact, send them
+  as a file/document rather than pasting a local path into the message text.
+
+## INBOUND MEDIA / FILES
+
+- Inbound media is rendered into message text as tags such as `[Image: path]`,
+  `[Voice: "transcript" (audio: path)]`, `[File: name (path)]`, and
+  `[Video: path]`. Use those paths as local artifacts, not as messages to paste
+  back to the user.
+- WeChat document downloads may be encrypted/cache placeholders rather than the
+  real PDF/ZIP/etc. Before parsing a received file, validate its magic bytes
+  (for example `%PDF-` for PDFs, `PK` for ZIP/DOCX). If the bytes do not match
+  the claimed file type, ask the user to re-export with WeChat "Save As" or send
+  a cloud/download link. This is an agent-side validation practice, not a
+  guarantee from the MCP transport.
+- Images and transcribed voice messages are usually more directly usable, but
+  still verify file existence/readability before analysis.
+
+## READING: check / read / search
+
+- `check`: list recent conversations with unread counts; treat previews as
+  hints, not complete context.
+- `read`: read messages from one user (`user_id`; optional `limit`). The read
+  view merges inbox and sent messages, which helps confirm whether you already
+  replied.
+- `search`: regex search over inbox messages (`query`; optional `user_id`). It is
+  for locating inbound content, not proving that no sent reply exists.
+
+## WAKE / REPLAY / DUPLICATE-REPLY DISCIPLINE
+
+- `user_id` is the routing truth; aliases are convenience labels only. When in
+  doubt, use the `user_id` returned by `read`/`check`, especially for replies.
+- Reply once per inbound `message_id`. Before sending after a refresh, molt, or
+  worker-hang recovery, use `read` to reconcile the merged inbox+sent view and
+  avoid duplicate replies.
+- If a wake notification is based on a preview and an immediate `read`/`check`
+  seems blocked by idle/sleep recovery, acknowledge from the preview if safe,
+  then retry the producer read once the agent is active. Avoid tight polling
+  loops.
+- Some runtimes deduplicate upstream inbound replay by provider `message_id` and
+  cursor checkpoints; if investigating inflated unread counts, confirm the
+  runtime version/state before assuming the MCP lost messages.
+
+## CONTACTS / ACCOUNTS
+
+- `contacts`: list saved contacts.
+- `add_contact`: save a contact alias (`user_id`, `alias`).
+- `remove_contact`: remove a contact (`alias` or `user_id`).
+- `accounts`: list configured WeChat accounts.
+
+## SIDE EFFECTS & ERROR SURFACING
+
+- `send` and `reply` deliver to real users — external side effects. Confirm
+  recipient and content before sending unsolicited messages.
+- Actions return a result dict on success or `{'error': <message>}` on failure
+  (e.g. missing `user_id`, unreadable `media_path`). Check for the `'error'` key
+  and surface or act on it rather than assuming delivery.

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -25,6 +25,7 @@ from .types import (
 from . import api
 from . import media as media_mod
 from .lockfile import AccountLock, PollerLockBusy
+from .. import _skill
 
 if TYPE_CHECKING:
     pass
@@ -39,6 +40,12 @@ def _load_notification_header_template() -> str:
 
 
 _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()
+
+# Bundled usage manual (skill format) — SKILL.md ships in this package folder.
+# action='manual' reads the full body; the YAML frontmatter name/description are
+# injected into the tool schema as a progressive-disclosure catalog entry.
+_SKILL_NAME = "wechat-mcp-manual"
+_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _skill.load_skill(__package__)
 
 TEXT_CHUNK_LIMIT = 4000
 SESSION_EXPIRED_ERRCODE = -14
@@ -57,6 +64,7 @@ SCHEMA = {
             "enum": [
                 "send", "check", "read", "reply", "search",
                 "contacts", "add_contact", "remove_contact", "accounts",
+                "manual",
             ],
             "description": (
                 "send: send a message to a WeChat user "
@@ -70,7 +78,8 @@ SCHEMA = {
                 "contacts: list saved contacts. "
                 "add_contact: save a contact (user_id, alias). "
                 "remove_contact: remove a contact (alias or user_id). "
-                "accounts: list configured WeChat accounts."
+                "accounts: list configured WeChat accounts. "
+                + _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME)
             ),
         },
         "user_id": {
@@ -485,10 +494,22 @@ class WechatManager:
                 return self._handle_remove_contact(args)
             elif action == "accounts":
                 return self._handle_accounts()
+            elif action == "manual":
+                return self._handle_manual()
             else:
                 return {"error": f"Unknown wechat action: {action!r}"}
         except Exception as e:
             return {"error": str(e)}
+
+    def _handle_manual(self) -> dict:
+        # The manual lives in this package's bundled SKILL.md (standard skill
+        # format: YAML frontmatter + markdown body), loaded at import time.
+        # action='manual' returns the full skill markdown plus parsed metadata
+        # and the resolved path; the frontmatter is also injected into the
+        # schema's 'manual' action description as a catalog entry.
+        return _skill.manual_payload(
+            _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
+        )
 
     # ── Action handlers ────────────────────────────────────────
 

--- a/src/lingtai/mcp_servers/whatsapp/SKILL.md
+++ b/src/lingtai/mcp_servers/whatsapp/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: whatsapp-mcp-manual
+description: |
+  Progressive-disclosure usage manual for the WhatsApp Cloud API MCP tool. Read
+  this when you need detail beyond the one-line action descriptions: the 24-hour
+  customer-service window and approved templates, send vs reply vs react,
+  check/read/search, media attachments, contacts/accounts/status basics, and
+  external-delivery side-effect caveats. Pulled on demand via action='manual'; you
+  do not need to call it before every send.
+version: 1.0.0
+---
+
+# WhatsApp MCP — usage manual (progressive disclosure)
+
+This manual is pulled on demand via `action='manual'` so the per-action tool
+schema can stay concise. Read it when you need detail beyond the one-line action
+descriptions; you do not need to call it before every send.
+
+This client uses the official Meta WhatsApp Cloud API only (no WhatsApp Web
+bridge).
+
+## 24-HOUR WINDOW / TEMPLATES
+
+- WhatsApp Cloud API allows free-form business replies only inside the 24-hour
+  customer-service window (24h since the user's last message). Outside that
+  window you must send an approved message `template`, not free text.
+- `templates`: list approved message templates. Use a template's `name` +
+  `language.code` to send outside the window.
+
+## RECIPIENTS
+
+- Messages target a recipient by `to` (or `wa_id`) — the WhatsApp `wa_id`. Use
+  ids returned by `check`/`read`/`contacts`.
+
+## SEND / REPLY / REACT
+
+- `send` (`to`/`wa_id`, plus `text`, `media`, or `template`) starts a message.
+  `media` is an object with `type` (image/document/audio/video) and the media
+  fields; `template` is an object requiring `name` and `language.code`.
+- `reply` threads to a specific message (`message_id`, then `text`/`media`/
+  `template`). `message_id` is the compound `account:wa_id:wamid` id.
+- `react` adds an emoji reaction to a message (`message_id`, `emoji`).
+- For text sends, `preview_url=true` enables link previews.
+
+## READING: check / read / search
+
+- `check`: list recent conversations.
+- `read`: read messages from one conversation (`wa_id`; optional `limit`,
+  `mark_read`).
+- `search`: regex search over message text (`query`).
+
+## CONTACTS / ACCOUNTS / STATUS
+
+- `contacts`: list saved contacts. `add_contact`/`remove_contact` manage aliases.
+- `accounts`: list configured WhatsApp accounts (redacted).
+- `status`: connection/health status for an account.
+
+## SIDE EFFECTS & ERROR SURFACING
+
+- `send`, `reply`, and `react` deliver to real users — external side effects.
+  Confirm recipient and content before sending unsolicited messages, and respect
+  the 24-hour window rule above.
+- Actions return `{'status': 'ok', ...}` on success or `{'status': 'error',
+  'error': <message>, 'error_type': ...}` on failure (e.g. missing `to`, invalid
+  template, outside-window free text). Check the status and surface or act on
+  errors rather than assuming delivery.

--- a/src/lingtai/mcp_servers/whatsapp/manager.py
+++ b/src/lingtai/mcp_servers/whatsapp/manager.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 from .client import WhatsAppClient
 from .redaction import redact_account
 from .webhook import extract_events
+from .. import _skill
 
 
 def _load_notification_header_template() -> str:
@@ -22,6 +23,12 @@ def _load_notification_header_template() -> str:
 
 
 _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()
+
+# Bundled usage manual (skill format) — SKILL.md ships in this package folder.
+# action='manual' reads the full body; the YAML frontmatter name/description are
+# injected into the tool schema as a progressive-disclosure catalog entry.
+_SKILL_NAME = "whatsapp-mcp-manual"
+_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _skill.load_skill(__package__)
 
 _CS_WINDOW_NOTE = (
     "WhatsApp Cloud API allows free-form business replies only inside the "
@@ -31,7 +38,7 @@ _CS_WINDOW_NOTE = (
 
 ACTIONS = [
     "send", "check", "read", "reply", "search", "react", "contacts", "add_contact",
-    "remove_contact", "templates", "accounts", "status",
+    "remove_contact", "templates", "accounts", "status", "manual",
 ]
 
 DESCRIPTION = "WhatsApp Cloud API client for LingTai. Official Meta API only; no WhatsApp Web bridge."
@@ -39,7 +46,11 @@ DESCRIPTION = "WhatsApp Cloud API client for LingTai. Official Meta API only; no
 SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "action": {"type": "string", "enum": ACTIONS},
+        "action": {
+            "type": "string",
+            "enum": ACTIONS,
+            "description": _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME),
+        },
         "account": {"type": "string"},
         "to": {"type": "string", "description": "WhatsApp wa_id recipient"},
         "wa_id": {"type": "string"},
@@ -159,6 +170,16 @@ class WhatsAppManager:
             return getattr(self, f"_{action}")(args)
         except Exception as e:
             return {"status": "error", "error": str(e), "error_type": type(e).__name__}
+
+    def _manual(self, args: dict[str, Any]) -> dict[str, Any]:
+        # The manual lives in this package's bundled SKILL.md (standard skill
+        # format: YAML frontmatter + markdown body), loaded at import time.
+        # action='manual' returns the full skill markdown plus parsed metadata
+        # and the resolved path; the frontmatter is also injected into the
+        # schema's 'action' description as a catalog entry.
+        return _skill.manual_payload(
+            _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
+        )
 
     def _client(self, alias: str) -> WhatsAppClient:
         a = self.accounts[alias]

--- a/tests/test_mcp_skill_manuals.py
+++ b/tests/test_mcp_skill_manuals.py
@@ -1,0 +1,143 @@
+"""Bundled-skill (SKILL.md) `manual` action tests for curated MCP servers.
+
+Each curated MCP ships a standard skill file (``SKILL.md``: YAML frontmatter +
+markdown body) in its package folder, exposes an ``action='manual'`` that returns
+the full body plus parsed metadata, and injects the frontmatter name/description
+into its tool schema as a progressive-disclosure catalog entry. This mirrors the
+Telegram MCP pattern (covered by tests/test_telegram_rich_formatting.py).
+
+The ``manual`` action is account-independent and reads only module-level
+constants, so we call it on a bare instance (``object.__new__``) without standing
+up real accounts/services.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers import _skill
+
+from lingtai.mcp_servers.feishu import manager as feishu_mgr
+from lingtai.mcp_servers.wechat import manager as wechat_mgr
+from lingtai.mcp_servers.imap import manager as imap_mgr
+from lingtai.mcp_servers.cloud_mail import manager as cloud_mail_mgr
+from lingtai.mcp_servers.whatsapp import manager as whatsapp_mgr
+
+
+# (module, package-folder name, manual-method name, expected skill name)
+_CASES = [
+    (feishu_mgr, "feishu", "_manual", "feishu-mcp-manual"),
+    (wechat_mgr, "wechat", "_handle_manual", "wechat-mcp-manual"),
+    (imap_mgr, "imap", "_manual", "imap-mcp-manual"),
+    (cloud_mail_mgr, "cloud_mail", "_handle_manual", "cloud-mail-mcp-manual"),
+    (whatsapp_mgr, "whatsapp", "_manual", "whatsapp-mcp-manual"),
+]
+
+_MANAGER_CLS = {
+    "feishu": "FeishuManager",
+    "wechat": "WechatManager",
+    "imap": "IMAPMailManager",
+    "cloud_mail": "CloudMailManager",
+    "whatsapp": "WhatsAppManager",
+}
+
+
+def _ids(case):
+    return case[1]
+
+
+def _call_manual(module, folder, method_name):
+    """Call the manual handler on a bare instance (no __init__)."""
+    cls = getattr(module, _MANAGER_CLS[folder])
+    inst = object.__new__(cls)
+    method = getattr(inst, method_name)
+    # whatsapp's dispatcher passes args; others take none — support both.
+    try:
+        return method({"action": "manual"})
+    except TypeError:
+        return method()
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_ids)
+def test_skill_file_exists_with_valid_frontmatter(case):
+    module, folder, _method, expected_name = case
+    skill_path = Path(module._SKILL_PATH)
+    assert skill_path.name == "SKILL.md"
+    assert skill_path.is_file()
+    # parent folder is the MCP package
+    assert skill_path.parent.name == folder
+
+    assert module._SKILL_FRONTMATTER.get("name") == expected_name
+    assert module._SKILL_FRONTMATTER.get("description")
+    # body is the markdown after the frontmatter fence (no leading '---')
+    assert module._SKILL_BODY.strip()
+    assert not module._SKILL_BODY.lstrip().startswith("---")
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_ids)
+def test_schema_exposes_manual_action(case):
+    module, _folder, _method, expected_name = case
+    props = module.SCHEMA["properties"]
+    assert "manual" in props["action"]["enum"]
+    action_description = props["action"]["description"]
+    assert "manual:" in action_description
+    assert "progressive-disclosure" in action_description
+    # The frontmatter/catalog entry is injected: name + a phrase from the
+    # skill description survive into the schema.
+    assert expected_name in action_description
+    assert "progressive-disclosure usage manual" in action_description
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_ids)
+def test_manual_action_returns_usage_guidance(case):
+    module, folder, method, expected_name = case
+    result = _call_manual(module, folder, method)
+
+    assert result["status"] == "ok"
+    assert result["action"] == "manual"
+    manual = result["manual"]
+    assert isinstance(manual, str) and manual.strip()
+
+    # surfaces parsed metadata + the resolved SKILL.md path
+    assert result["skill"] == expected_name
+    assert result["metadata"].get("name") == expected_name
+    assert result["metadata"].get("description")
+    assert Path(result["path"]).name == "SKILL.md"
+
+    # the returned body is read from SKILL.md, not a hardcoded string
+    assert manual == module._SKILL_BODY
+
+    lowered = manual.lower()
+    # progressive disclosure framing + the core facets every skeleton covers
+    assert "progressive disclosure" in lowered
+    assert "send" in lowered
+    assert "read" in lowered
+    assert "search" in lowered
+    # side-effect / safety caveat
+    assert "side effect" in lowered or "error" in lowered
+
+
+def test_shared_split_frontmatter_handles_block_scalar():
+    fm, body = _skill.split_frontmatter(
+        "---\nname: x\ndescription: |\n  line one\n  line two\n---\nbody text\n"
+    )
+    assert fm["name"] == "x"
+    assert fm["description"] == "line one line two"
+    assert body.strip() == "body text"
+
+
+def test_shared_split_frontmatter_no_frontmatter_passthrough():
+    text = "no frontmatter here"
+    fm, body = _skill.split_frontmatter(text)
+    assert fm == {}
+    assert body == text
+
+
+def test_email_manuals_warn_about_external_side_effects():
+    # IMAP and Cloud Mail send real outbound email — the skeleton must call out
+    # the external, hard-to-undo side effect.
+    for module in (imap_mgr, cloud_mail_mgr):
+        lowered = module._SKILL_BODY.lower()
+        assert "real" in lowered
+        assert "side effect" in lowered


### PR DESCRIPTION
## Summary
- add a shared bundled-skill helper for MCP package manuals
- add `SKILL.md` + `manual` action skeletons for IMAP, Feishu, WeChat, WhatsApp, and cloud_mail
- inject each skill frontmatter/catalog entry into the relevant MCP action schema
- package the new bundled skill files and add focused regression tests
- incorporate GLM/zhipu review wording for IMAP external-reply safety and WeChat file/wake/replay/duplicate-reply guidance

## Validation
- `PYTHONPATH=src python -m pytest tests/test_mcp_skill_manuals.py -q` → 18 passed
- `PYTHONPATH=src python -m pytest tests/test_mcp_capability.py tests/test_telegram_rich_formatting.py tests/test_cloud_mail_addon.py tests/test_imap_reply_attachments.py tests/test_wechat_inbound_replay.py -q` → 73 passed
- `PYTHONPATH=src python -m pytest tests/test_validate_skill.py tests/test_skills.py -q` → 42 passed

## Review
- Claude-p implemented the branch.
- zhipu/GLM review returned `NO_BLOCKER` with optional wording tweaks, now incorporated.

Not merged yet.
