### PR TITLE
Document minimal MCP manual sidecar contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,12 +78,12 @@ lingtai = [
     "bin/lingtai-search-sidecar",
     "bin/lingtai-search-sidecar.exe",
 ]
-"lingtai.mcp_servers.telegram" = ["notification_header.md", "SKILL.md"]
-"lingtai.mcp_servers.feishu" = ["notification_header.md", "SKILL.md"]
-"lingtai.mcp_servers.wechat" = ["notification_header.md", "SKILL.md"]
-"lingtai.mcp_servers.whatsapp" = ["notification_header.md", "SKILL.md"]
-"lingtai.mcp_servers.imap" = ["SKILL.md"]
-"lingtai.mcp_servers.cloud_mail" = ["SKILL.md"]
+"lingtai.mcp_servers.telegram" = ["notification_header.md", "SKILL.md", "reference/**/*", "assets/**/*"]
+"lingtai.mcp_servers.feishu" = ["notification_header.md", "SKILL.md", "reference/**/*", "assets/**/*"]
+"lingtai.mcp_servers.wechat" = ["notification_header.md", "SKILL.md", "reference/**/*", "assets/**/*"]
+"lingtai.mcp_servers.whatsapp" = ["notification_header.md", "SKILL.md", "reference/**/*", "assets/**/*"]
+"lingtai.mcp_servers.imap" = ["SKILL.md", "reference/**/*", "assets/**/*"]
+"lingtai.mcp_servers.cloud_mail" = ["SKILL.md", "reference/**/*", "assets/**/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/lingtai/mcp_servers/_skill.py
+++ b/src/lingtai/mcp_servers/_skill.py
@@ -100,6 +100,12 @@ def manual_payload(
 
     Returns the full skill markdown plus parsed metadata and the resolved
     SKILL.md path, mirroring the Telegram MCP's ``_manual`` result shape.
+
+    Asset/reference discovery deliberately stays in the SKILL.md text. Do not
+    add concrete asset/reference lists to this tool payload: the stable minimal
+    contract is the main manual body + the absolute SKILL.md path, and callers
+    can follow relative paths documented by the skill when they need bundled
+    side files.
     """
     return {
         "status": "ok",

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -1618,7 +1618,9 @@ class TelegramManager:
     # format: YAML frontmatter + markdown body), loaded at import time above.
     # action='manual' returns the full skill markdown plus parsed metadata and
     # the resolved path; the frontmatter is also injected into the schema's
-    # 'manual' action description as a catalog entry.
+    # 'manual' action description as a catalog entry. Bundled assets/references,
+    # if any, are documented inside SKILL.md and are not returned as a structured
+    # tool-side list.
 
     def _manual(self) -> dict:
         return {

--- a/tests/test_mcp_skill_manuals.py
+++ b/tests/test_mcp_skill_manuals.py
@@ -13,6 +13,7 @@ up real accounts/services.
 from __future__ import annotations
 
 from pathlib import Path
+import tomllib
 
 import pytest
 
@@ -99,11 +100,19 @@ def test_manual_action_returns_usage_guidance(case):
     manual = result["manual"]
     assert isinstance(manual, str) and manual.strip()
 
-    # surfaces parsed metadata + the resolved SKILL.md path
+    # Minimal manual contract: return the main SKILL.md body plus its absolute
+    # path and parsed metadata. Concrete asset/reference catalogs stay in the
+    # SKILL.md text rather than expanding the tool payload/schema.
+    assert set(result) == {"status", "action", "skill", "metadata", "path", "manual"}
     assert result["skill"] == expected_name
     assert result["metadata"].get("name") == expected_name
     assert result["metadata"].get("description")
-    assert Path(result["path"]).name == "SKILL.md"
+    skill_path = Path(result["path"])
+    assert skill_path.is_absolute()
+    assert skill_path.name == "SKILL.md"
+    assert skill_path.is_file()
+    assert "assets" not in result
+    assert "references" not in result
 
     # the returned body is read from SKILL.md, not a hardcoded string
     assert manual == module._SKILL_BODY
@@ -141,3 +150,21 @@ def test_email_manuals_warn_about_external_side_effects():
         lowered = module._SKILL_BODY.lower()
         assert "real" in lowered
         assert "side effect" in lowered
+
+
+def test_mcp_skill_package_data_keeps_reference_and_asset_sidecars_packaged():
+    """Side files are discovered from SKILL.md text, but must ship in wheels."""
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    package_data = tomllib.loads(pyproject.read_text())["tool"]["setuptools"]["package-data"]
+    for package in [
+        "lingtai.mcp_servers.telegram",
+        "lingtai.mcp_servers.feishu",
+        "lingtai.mcp_servers.wechat",
+        "lingtai.mcp_servers.whatsapp",
+        "lingtai.mcp_servers.imap",
+        "lingtai.mcp_servers.cloud_mail",
+    ]:
+        entries = package_data[package]
+        assert "SKILL.md" in entries
+        assert "reference/**/*" in entries
+        assert "assets/**/*" in entries

--- a/tests/test_telegram_rich_formatting.py
+++ b/tests/test_telegram_rich_formatting.py
@@ -172,11 +172,19 @@ def test_manual_action_returns_usage_guidance(tmp_path):
     manual = result["manual"]
     assert isinstance(manual, str) and manual.strip()
 
-    # manual action surfaces parsed metadata + the resolved SKILL.md path
+    # Minimal manual contract: return the main SKILL.md body plus its absolute
+    # path and parsed metadata. Concrete asset/reference catalogs stay in the
+    # SKILL.md text rather than expanding the tool payload/schema.
+    assert set(result) == {"status", "action", "skill", "metadata", "path", "manual"}
     assert result["skill"]
     assert result["metadata"].get("name") == result["skill"]
     assert result["metadata"].get("description")
-    assert Path(result["path"]).name == "SKILL.md"
+    skill_path = Path(result["path"])
+    assert skill_path.is_absolute()
+    assert skill_path.name == "SKILL.md"
+    assert skill_path.is_file()
+    assert "assets" not in result
+    assert "references" not in result
 
     # the returned body is read from SKILL.md, not a hardcoded string
     from lingtai.mcp_servers.telegram.manager import _SKILL_BODY


### PR DESCRIPTION
## Summary
- document and test the minimal bundled MCP manual sidecar contract: `action='manual'` returns the main `SKILL.md` body plus an absolute `path`, while concrete `assets/` / `reference/` catalogs remain in the skill text
- add package-data globs so future MCP manual sidecars under `reference/**/*` and `assets/**/*` ship in wheels without adding tool-return fields
- assert manual payloads do not grow `assets` / `references` structured lists

## Tests
- `PYTHONPATH=src python -m pytest tests/test_mcp_skill_manuals.py tests/test_telegram_rich_formatting.py tests/test_mcp_capability.py -q` → 63 passed
