### PR TITLE
Document MCP manual sidecar anatomy

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -17,7 +17,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 | `init_schema.py` | `validate_init()` plus `strip_deprecated()` — strict schema for active init.json fields, simple deprecated-field cleanup, and known-but-inactive legacy fields migrated by `lingtai_kernel.migrate` |
 | `venv_resolve.py` | Python venv resolution — init.json → global runtime → auto-create |
 | `intrinsic_skills/__init__.py` | Standalone skill bundles (docs-only) copied into `.library/intrinsic/` |
-| `mcp_servers/` | Curated MCP server implementations shipped in the `lingtai` distribution and launched by `mcp_catalog.json` via `python -m lingtai.mcp_servers.<name>`; historical top-level `lingtai_*` packages remain thin wrappers. Stateful curated servers may own per-agent sidecars: the WeChat manager checkpoints `wechat/state.json` cursor progress and `wechat/inbox_seen.json` replay guards in `mcp_servers/wechat/manager.py:266` and `mcp_servers/wechat/manager.py:912`. |
+| `mcp_servers/` | Curated MCP server implementations shipped in the `lingtai` distribution and launched by `mcp_catalog.json` via `python -m lingtai.mcp_servers.<name>`; see `mcp_servers/ANATOMY.md` for the bundled `SKILL.md` manual-action and sidecar packaging contract. Stateful curated servers may own per-agent sidecars: the WeChat manager checkpoints `wechat/state.json` cursor progress and `wechat/inbox_seen.json` replay guards in `mcp_servers/wechat/manager.py:266` and `mcp_servers/wechat/manager.py:912`. |
 
 ### Key functions / classes
 

--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -1,0 +1,33 @@
+# lingtai.mcp_servers
+
+Curated MCP server package implementations shipped inside the `lingtai` Python distribution. They are launched by catalog/script entry points such as `python -m lingtai.mcp_servers.<name>` and expose real addon tools (IMAP, Telegram, Feishu, WeChat, WhatsApp, Cloud Mail) plus bundled progressive-disclosure manuals.
+
+## Components
+
+| File / folder | Role |
+|---|---|
+| `_skill.py` | Shared bundled-skill helper: `load_skill()` loads package `SKILL.md`, `manual_action_description()` injects frontmatter into the schema, and `manual_payload()` returns the manual body + absolute path without sidecar lists (`_skill.py:72-118`). |
+| `telegram/` | Telegram MCP. It predates `_skill.py` and keeps an inline SKILL.md loader/manual payload with the same minimal contract (`telegram/manager.py:40-118`, `telegram/manager.py:1616-1633`). |
+| `imap/`, `feishu/`, `wechat/`, `whatsapp/`, `cloud_mail/` | Curated MCPs using `_skill.py` for their `action="manual"` payloads (`imap/manager.py:294-308`, `feishu/manager.py:454-466`, `wechat/manager.py:504-516`, `whatsapp/manager.py:174-186`, `cloud_mail/manager.py:213-225`). |
+| Per-package `SKILL.md` | The human/agent-facing bundled manual. If a manual has sidecars, the sidecar inventory and relative paths live in this markdown, not in the tool payload. |
+| `pyproject.toml` package-data entries | Ships every curated MCP `SKILL.md`; `reference/**/*` and `assets/**/*` are also packaged for future sidecar files (`pyproject.toml:81-86`). |
+
+## Connections
+
+- Catalog/script launchers (`pyproject.toml:43-49`) start these servers as subprocess MCPs; agents activate them through the generic MCP capability (`src/lingtai/core/mcp/ANATOMY.md`).
+- Manager schemas include `manual` in each action enum and use either `_skill.manual_action_description()` or Telegram's inline equivalent to advertise the bundled skill without loading the full body into the resident schema (`_skill.py:80-93`, `telegram/manager.py:111-124`).
+- Tests pin the manual contract and package-data sidecar support in `tests/test_mcp_skill_manuals.py` and Telegram's legacy path in `tests/test_telegram_rich_formatting.py`.
+
+## Composition
+
+Parent: `src/lingtai/` wrapper package (`src/lingtai/ANATOMY.md`). Sibling wrapper areas include `agent.py`, `core/`, `services/`, and `intrinsic_skills/`. Curated MCPs are independent subprocess packages, not intrinsic capabilities.
+
+## State
+
+The package itself is mostly code + packaged manuals. Runtime state is per-agent and server-specific: e.g. message caches, contacts, inbox replay guards, or credential-derived identities live under the agent workdir or `.secrets/`, not in `src/lingtai/mcp_servers/`. The shared manual helper has no persistent state.
+
+## Notes
+
+- **Manual sidecar minimal contract:** `action="manual"` returns the main `SKILL.md` body, parsed metadata, and the main `SKILL.md` absolute `path` only. Concrete `assets/` and `reference/` lists MUST NOT be returned as structured tool fields; `SKILL.md` is the single source of truth for what sidecars exist and how to follow their relative paths.
+- **Packaging discipline:** when adding manual sidecars, put their relative paths in `SKILL.md` and keep the package-data globs for `reference/**/*` / `assets/**/*` so wheels contain them (`pyproject.toml:81-86`).
+- **Telegram exception:** Telegram still has an inline copy of the helper logic for historical reasons; keep its comments/tests aligned with `_skill.py` until it is deliberately migrated.

--- a/src/lingtai/mcp_servers/_skill.py
+++ b/src/lingtai/mcp_servers/_skill.py
@@ -105,7 +105,8 @@ def manual_payload(
     add concrete asset/reference lists to this tool payload: the stable minimal
     contract is the main manual body + the absolute SKILL.md path, and callers
     can follow relative paths documented by the skill when they need bundled
-    side files.
+    side files. This keeps MCP schemas small and makes SKILL.md the single
+    source of truth for sidecar organization.
     """
     return {
         "status": "ok",

--- a/src/lingtai/mcp_servers/cloud_mail/manager.py
+++ b/src/lingtai/mcp_servers/cloud_mail/manager.py
@@ -215,7 +215,9 @@ class CloudMailManager:
         # format: YAML frontmatter + markdown body), loaded at import time.
         # action='manual' returns the full skill markdown plus parsed metadata
         # and the resolved path; the frontmatter is also injected into the
-        # schema's 'manual' action description as a catalog entry.
+        # schema's 'manual' action description as a catalog entry. Bundled
+        # asset/reference sidecars, if any, are documented inside SKILL.md and
+        # are not returned as structured tool fields.
         return _skill.manual_payload(
             _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
         )

--- a/src/lingtai/mcp_servers/feishu/manager.py
+++ b/src/lingtai/mcp_servers/feishu/manager.py
@@ -456,7 +456,9 @@ class FeishuManager:
         # format: YAML frontmatter + markdown body), loaded at import time.
         # action='manual' returns the full skill markdown plus parsed metadata
         # and the resolved path; the frontmatter is also injected into the
-        # schema's 'manual' action description as a catalog entry.
+        # schema's 'manual' action description as a catalog entry. Bundled
+        # asset/reference sidecars, if any, are documented inside SKILL.md and
+        # are not returned as structured tool fields.
         return _skill.manual_payload(
             _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
         )

--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -296,8 +296,10 @@ class IMAPMailManager:
         # format: YAML frontmatter + markdown body), loaded at import time.
         # action='manual' returns the full skill markdown plus parsed metadata
         # and the resolved path; the frontmatter is also injected into the
-        # schema's 'manual' action description as a catalog entry. It is
-        # account-independent, so it skips the account lookup / meta injection.
+        # schema's 'manual' action description as a catalog entry. Bundled
+        # asset/reference sidecars, if any, are documented inside SKILL.md and
+        # are not returned as structured tool fields.
+        # It is account-independent, so it skips account lookup/meta injection.
         return _skill.manual_payload(
             _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
         )

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -1620,7 +1620,7 @@ class TelegramManager:
     # the resolved path; the frontmatter is also injected into the schema's
     # 'manual' action description as a catalog entry. Bundled assets/references,
     # if any, are documented inside SKILL.md and are not returned as a structured
-    # tool-side list.
+    # tool-side list; do not add assets/references fields here.
 
     def _manual(self) -> dict:
         return {

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -506,7 +506,9 @@ class WechatManager:
         # format: YAML frontmatter + markdown body), loaded at import time.
         # action='manual' returns the full skill markdown plus parsed metadata
         # and the resolved path; the frontmatter is also injected into the
-        # schema's 'manual' action description as a catalog entry.
+        # schema's 'manual' action description as a catalog entry. Bundled
+        # asset/reference sidecars, if any, are documented inside SKILL.md and
+        # are not returned as structured tool fields.
         return _skill.manual_payload(
             _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
         )

--- a/src/lingtai/mcp_servers/whatsapp/manager.py
+++ b/src/lingtai/mcp_servers/whatsapp/manager.py
@@ -176,7 +176,9 @@ class WhatsAppManager:
         # format: YAML frontmatter + markdown body), loaded at import time.
         # action='manual' returns the full skill markdown plus parsed metadata
         # and the resolved path; the frontmatter is also injected into the
-        # schema's 'action' description as a catalog entry.
+        # schema's 'action' description as a catalog entry. Bundled
+        # asset/reference sidecars, if any, are documented inside SKILL.md and
+        # are not returned as structured tool fields.
         return _skill.manual_payload(
             _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
         )


### PR DESCRIPTION
## Summary
- add `src/lingtai/mcp_servers/ANATOMY.md` documenting curated MCP manual-action shape and the minimal sidecar contract
- point the root wrapper anatomy at the new MCP-server anatomy
- strengthen code comments in `_skill.py`, Telegram's inline manual loader, and curated MCP managers: asset/reference sidecars are documented in `SKILL.md`, not returned as structured tool fields

## Tests
- `PYTHONPATH=src python -m pytest tests/test_mcp_skill_manuals.py tests/test_telegram_rich_formatting.py tests/test_mcp_capability.py -q` → 63 passed
- `python tools/check_anatomy_drift.py --root src/lingtai --check` → no drift
