### PR TITLE
Clarify Codex pre-molt summarize guidance

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2217,6 +2217,11 @@ _CODEX_SUMMARIZE_ECONOMY_NOTE = (
     "summarize pass still leaves the main context above roughly 150k tokens, "
     "consider molting instead of repeatedly paying summarize misses."
 )
+_CODEX_PRE_MOLT_SUMMARIZE_NOTE = (
+    "If you are already planning to molt, do not summarize first unless "
+    "context overflow is imminent; molt is the higher-level replacement for "
+    "summarize, so pre-molt summarize is wasted work."
+)
 _CODEX_LONG_CONTEXT_STRATEGY = (
     "For long logs, diffs, repo scans, papers, issue sweeps, runtime traces, "
     "or other noisy high-context reads, prefer daemon/file-based exploration "
@@ -2265,7 +2270,8 @@ def _codex_static_adapter_comment(
             "summarize_note": (
                 "Summarize still rewrites visible history and can change the "
                 "next full request. Notification dismiss is only notification "
-                "cleanup and does not compact context."
+                "cleanup and does not compact context. "
+                + _CODEX_PRE_MOLT_SUMMARIZE_NOTE
             ),
             "context_budget_note": _CODEX_CONTEXT_BUDGET_NOTE,
             "summarize_economy_note": _CODEX_SUMMARIZE_ECONOMY_NOTE,
@@ -2305,7 +2311,9 @@ def _codex_static_adapter_comment(
             "fulls are too frequent. Under high context pressure or after a "
             "very noisy result, the investment is worth it immediately — "
             "summarize regardless of ratio; if context pressure stays high "
-            "after summarize, consider molt. Notification dismiss is only "
+            "after summarize, consider molt. "
+            + _CODEX_PRE_MOLT_SUMMARIZE_NOTE
+            + " Notification dismiss is only "
             "notification cleanup: it does not compact context, delete local "
             "history, or reset the epoch."
         ),

--- a/tests/test_agent_meta_guidance.py
+++ b/tests/test_agent_meta_guidance.py
@@ -14,7 +14,10 @@ STATIC_CODEX_COMMENT = {
     "summarize_note": (
         "Summarize is an investment, not routine cleanup: keep the "
         "full:incremental ratio at or below 1:10 and defer non-urgent "
-        "summarize until the expected savings justify the cache miss."
+        "summarize until the expected savings justify the cache miss. "
+        "If you are already planning to molt, do not summarize first unless "
+        "context overflow is imminent; molt is the higher-level replacement "
+        "for summarize."
     ),
     "context_budget_note": (
         "Can wait until roughly 200k token context before proactive "
@@ -45,6 +48,8 @@ def test_agent_prompt_builder_refreshes_meta_guidance_adapter_rules(tmp_path):
     assert "### codex runtime rules" in prompt
     assert "responses_rest_epoch_reset" in prompt
     assert "investment, not routine cleanup" in prompt
+    assert "do not summarize first unless context overflow is imminent" in prompt
+    assert "molt is the higher-level replacement for summarize" in prompt
     assert "1:10" in prompt
     assert "roughly 200k token context" in prompt
     assert "above roughly 150k tokens, consider molt" in prompt
@@ -58,5 +63,6 @@ def test_agent_batched_prompt_builder_refreshes_meta_guidance_adapter_rules(tmp_
     assert "## meta_guidance" in prompt
     assert "### codex runtime rules" in prompt
     assert "responses_rest_epoch_reset" in prompt
+    assert "do not summarize first unless context overflow is imminent" in prompt
     assert "roughly 200k token context" in prompt
     assert "above roughly 150k tokens, consider molt" in prompt

--- a/tests/test_codex_ws_session.py
+++ b/tests/test_codex_ws_session.py
@@ -1097,6 +1097,8 @@ def test_codex_adapter_comment_explains_epoch_reset_and_cache_ledger():
     assert "investment" in note
     assert "buy future context" in note
     assert "consider molt" in note
+    assert "do not summarize first unless context overflow is imminent" in note
+    assert "molt is the higher-level replacement for summarize" in note
 
     static = session.static_adapter_comment()
     assert static["adapter"] == "codex"
@@ -1104,6 +1106,7 @@ def test_codex_adapter_comment_explains_epoch_reset_and_cache_ledger():
     assert ">=20 API calls" not in static["summarize_note"]
     assert "1:10" in static["summarize_note"]
     assert "reduce_summarize_frequency" in static["summarize_note"]
+    assert "do not summarize first unless context overflow is imminent" in static["summarize_note"]
     assert "roughly 200k token context" in static["context_budget_note"]
     assert "above roughly 150k" in static["context_budget_note"]
     assert "investment, not a fixed countdown" in static["summarize_economy_note"]
@@ -1165,6 +1168,7 @@ def test_codex_adapter_static_comment_available_before_chat_creation():
     assert ">=20 API calls" not in comment["summarize_note"]
     assert "1:10" in comment["summarize_note"]
     assert "reduce_summarize_frequency" in comment["summarize_note"]
+    assert "do not summarize first unless context overflow is imminent" in comment["summarize_note"]
     assert "roughly 200k token context" in comment["context_budget_note"]
     assert "above roughly 150k" in comment["context_budget_note"]
     assert "investment, not a fixed countdown" in comment["summarize_economy_note"]
@@ -1373,6 +1377,7 @@ def test_codex_adapter_comment_stateless_only_when_continuation_off():
     assert "stateless" in comment["summary"]
     assert "Summarize" in note
     assert "Notification dismiss" in note
+    assert "do not summarize first unless context overflow is imminent" in note
 
 
 def test_history_summarized_forces_next_ws_full_epoch_reset():


### PR DESCRIPTION
## Summary
- Add a Codex static adapter comment sentence discouraging summarize immediately before a planned molt unless context overflow is imminent.
- Keep the guidance explicit that molt is the higher-level replacement for summarize in this case.
- Cover continuation, stateless compatibility, and meta-guidance rendering tests.

## Validation
- `git diff --check`
- `PYTHONPATH=src python -m py_compile src/lingtai/llm/openai/adapter.py`
- `PYTHONPATH=src python -m pytest -q tests/test_codex_ws_session.py tests/test_agent_meta_guidance.py` (`58 passed`)
