### PR TITLE
Delay Codex summarize epoch resets

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -2202,25 +2202,21 @@ class OpenAIAdapter(LLMAdapter):
 # ---------------------------------------------------------------------------
 
 
-_CODEX_CONTEXT_BUDGET_NOTE = (
-    "Can wait until roughly 200k token context before proactive summarize, "
-    "but if summarizing still leaves the main context above roughly 150k "
-    "tokens, consider molt to avoid repeated summarize misses and improve "
-    "token efficiency."
-)
-_CODEX_SUMMARIZE_ECONOMY_NOTE = (
-    "Summarize breaks the current continuation/cache prefix and should be "
-    "treated as an investment, not a fixed countdown. Under low pressure, "
-    "defer and batch consumed high-recoverability results; summarize when "
-    "estimated future token savings can repay the cache miss with margin, "
-    "or when current/projected context pressure risks overflow. If a "
-    "summarize pass still leaves the main context above roughly 150k tokens, "
-    "consider molting instead of repeatedly paying summarize misses."
-)
 _CODEX_PRE_MOLT_SUMMARIZE_NOTE = (
     "If you are already planning to molt, do not summarize first unless "
     "context overflow is imminent; molt is the higher-level replacement for "
     "summarize, so pre-molt summarize is wasted work."
+)
+_CODEX_SUMMARIZE_DELAY_THRESHOLD_RATIO = 0.8
+_CODEX_SUMMARIZE_DELAY_NOTE = (
+    "For Codex continuation over the Responses API, summarize calls are "
+    "accepted and recorded immediately, but their fresh full replay/cache "
+    "epoch effect is delayed until local context reaches roughly 80% of the "
+    "context window. The delay exists because Codex keeps a "
+    "previous_response_id/cache epoch; resetting that epoch for every "
+    "summarize would discard continuation/cache benefit. Before the delayed "
+    "full replay, the existing epoch continues, so you can keep working and "
+    "may issue additional summarize calls safely."
 )
 _CODEX_LONG_CONTEXT_STRATEGY = (
     "For long logs, diffs, repo scans, papers, issue sweeps, runtime traces, "
@@ -2268,13 +2264,11 @@ def _codex_static_adapter_comment(
                 "deleted by request-side resets."
             ),
             "summarize_note": (
-                "Summarize still rewrites visible history and can change the "
-                "next full request. Notification dismiss is only notification "
-                "cleanup and does not compact context. "
+                "Summarize normally when useful. In stateless full-replay mode, "
+                "each request is rebuilt from local chat_history, so no delayed "
+                "Responses continuation epoch applies. "
                 + _CODEX_PRE_MOLT_SUMMARIZE_NOTE
             ),
-            "context_budget_note": _CODEX_CONTEXT_BUDGET_NOTE,
-            "summarize_economy_note": _CODEX_SUMMARIZE_ECONOMY_NOTE,
             "long_context_strategy": _CODEX_LONG_CONTEXT_STRATEGY,
             "notification_dismiss_note": _CODEX_NOTIFICATION_DISMISS_NOTE,
             "system_prompt_update_note": _CODEX_SYSTEM_PROMPT_UPDATE_NOTE,
@@ -2295,30 +2289,11 @@ def _codex_static_adapter_comment(
             "summarized."
         ),
         "summarize_note": (
-            "Summarize rewrites older tool-result payloads and/or carried "
-            "context, breaks the previous_response_id/incremental prefix, "
-            "and forces the next request to open a fresh full epoch, usually "
-            "causing a cache miss. Treat summarize as an investment, not "
-            "routine cleanup: it spends a full/cache-miss cost now to buy "
-            "future context and token savings, so it only pays off when those "
-            "expected savings exceed the miss. Keep full epochs rare relative "
-            "to incremental turns: the target full:incremental ratio is at or "
-            "below 1:10 (roughly at most one full per ten incremental turns). "
-            "Under low pressure, defer and batch non-urgent summarize until "
-            "the expected savings justify reopening a full epoch, so the ratio "
-            "stays healthy; the dynamic maintenance_hint reports the current "
-            "full:incremental ratio and flags reduce_summarize_frequency when "
-            "fulls are too frequent. Under high context pressure or after a "
-            "very noisy result, the investment is worth it immediately — "
-            "summarize regardless of ratio; if context pressure stays high "
-            "after summarize, consider molt. "
+            "Summarize normally when useful. "
+            + _CODEX_SUMMARIZE_DELAY_NOTE
+            + " "
             + _CODEX_PRE_MOLT_SUMMARIZE_NOTE
-            + " Notification dismiss is only "
-            "notification cleanup: it does not compact context, delete local "
-            "history, or reset the epoch."
         ),
-        "context_budget_note": _CODEX_CONTEXT_BUDGET_NOTE,
-        "summarize_economy_note": _CODEX_SUMMARIZE_ECONOMY_NOTE,
         "long_context_strategy": _CODEX_LONG_CONTEXT_STRATEGY,
         "notification_dismiss_note": _CODEX_NOTIFICATION_DISMISS_NOTE,
         "system_prompt_update_note": _CODEX_SYSTEM_PROMPT_UPDATE_NOTE,
@@ -2428,6 +2403,10 @@ class CodexResponsesSession(OpenAIResponsesSession):
             self._ws_epoch_reset_turn_limit = max(0, int(ws_epoch_reset_turns))
         self._ws_turns_since_epoch_reset = 0
         self._ws_epoch_reset_reason_pending: str | None = None
+        self._summarize_delay_threshold_ratio = _CODEX_SUMMARIZE_DELAY_THRESHOLD_RATIO
+        self._summarize_effect_delayed_pending_ids: set[str] = set()
+        self._summarize_effect_delayed_last_context: dict[str, Any] = {}
+        self._summarize_effect_delayed_last_release_reason: str | None = None
         # The user's own ChatGPT account id (decoded upstream from their OAuth
         # auth data). When present it is sent as the ``ChatGPT-Account-ID`` HTTP
         # Account routing is a ChatGPT-account concern and intentionally
@@ -2935,9 +2914,51 @@ class CodexResponsesSession(OpenAIResponsesSession):
         self._ws_frozen_outputs.clear()
         self._ws_turns_since_epoch_reset = 0
         self._ws_epoch_reset_reason_pending = reason
+        if self._summarize_effect_delayed_pending_ids:
+            self._summarize_effect_delayed_pending_ids.clear()
+            self._summarize_effect_delayed_last_release_reason = reason
+
+    def _summarize_delay_context(self) -> dict[str, Any]:
+        current_tokens: int | None = None
+        context_window: int | None = None
+        usage: float | None = None
+        try:
+            current_tokens = int(self._interface.estimate_context_tokens())
+        except Exception:
+            current_tokens = None
+        try:
+            context_window = int(self.context_window())
+        except Exception:
+            context_window = None
+        if current_tokens is not None and context_window and context_window > 0:
+            usage = current_tokens / context_window
+        return {
+            "current_context_tokens": current_tokens,
+            "context_window": context_window,
+            "threshold_ratio": self._summarize_delay_threshold_ratio,
+            "threshold_context_tokens": (
+                int(context_window * self._summarize_delay_threshold_ratio)
+                if context_window and context_window > 0
+                else None
+            ),
+            "current_context_usage": usage,
+        }
+
+    def _maybe_release_delayed_summarize_effect(self) -> bool:
+        if not self._summarize_effect_delayed_pending_ids:
+            return False
+        ctx = self._summarize_delay_context()
+        self._summarize_effect_delayed_last_context = ctx
+        usage = ctx.get("current_context_usage")
+        if usage is None or usage < self._summarize_delay_threshold_ratio:
+            return False
+        self._reset_ws_epoch("summarize_delayed")
+        return True
 
     def _maybe_reset_ws_epoch(self) -> None:
         self._refresh_ws_epoch_reset_turn_limit()
+        if self._maybe_release_delayed_summarize_effect():
+            return
         limit = self._ws_epoch_reset_turn_limit
         if limit <= 0:
             return
@@ -2946,12 +2967,15 @@ class CodexResponsesSession(OpenAIResponsesSession):
         self._reset_ws_epoch("turn_count")
 
     def on_history_summarized(self, summarized_ids: list[str]) -> None:
-        # Runs for BOTH transports: summarize rewrites older tool-result payloads
-        # and breaks the strict-prefix continuation, so the next request must be a
-        # full re-send regardless of REST vs WebSocket.
+        # Runs for BOTH transports. Summarize rewrites local visible history, but
+        # Codex continuation keeps the remote previous_response_id epoch alive
+        # until local context pressure justifies a full replay. The summarized
+        # local history becomes model-facing when the delayed reset fires.
         if not summarized_ids or not self._continuation_enabled:
             return
-        self._reset_ws_epoch("summarize")
+        self._summarize_effect_delayed_pending_ids.update(str(s) for s in summarized_ids)
+        self._summarize_effect_delayed_last_context = self._summarize_delay_context()
+        self._summarize_effect_delayed_last_release_reason = None
 
     def on_notification_dismissed(self, channel: str | None = None) -> None:
         # Notification dismiss is high-frequency housekeeping, not context
@@ -2993,6 +3017,7 @@ class CodexResponsesSession(OpenAIResponsesSession):
             reset_reason = str(ws_diag.get("epoch_reset_reason") or "")
             reset_codes = {
                 "summarize": "sum",
+                "summarize_delayed": "sumd",
                 "turn_count": "turns",
             }
             if reset_reason in reset_codes:
@@ -3093,6 +3118,7 @@ class CodexResponsesSession(OpenAIResponsesSession):
                 "I": "incremental",
                 "F": "full",
                 "sum": "epoch_reset:summarize",
+                "sumd": "epoch_reset:summarize_delayed",
                 "turns": "epoch_reset:turn_count",
                 "pm": "prefix_mismatch",
                 "nb": "no_baseline",
@@ -3218,8 +3244,6 @@ class CodexResponsesSession(OpenAIResponsesSession):
         if not self._continuation_enabled:
             return comment
 
-        ledger = self._ws_cache_ledger_comment()
-        comment["cache_ledger"] = ledger
         # The mandatory turn-count epoch reset is cancelled by default
         # (``_ws_epoch_reset_turn_limit <= 0`` / disabled). When disabled, the
         # resident meta OMITS the periodic-countdown fields entirely so it never
@@ -3238,44 +3262,21 @@ class CodexResponsesSession(OpenAIResponsesSession):
                     ),
                 }
             )
-        if isinstance(ledger, dict):
-            summary = ledger.get("summary")
-            if isinstance(summary, dict):
-                comment["cache_ledger_summary"] = summary
-            last_full = ledger.get("last_full")
-            if isinstance(last_full, dict):
-                comment["last_full_api_calls_ago"] = last_full.get("api_calls_ago")
-                comment["last_full_reason"] = last_full.get("reason")
-            else:
-                comment["last_full_api_calls_ago"] = None
-                comment["last_full_reason"] = "not_recorded"
-            last_ws_full = ledger.get("last_ws_full")
-            if isinstance(last_ws_full, dict):
-                comment["last_ws_full_api_calls_ago"] = last_ws_full.get("api_calls_ago")
-                comment["last_ws_full_reason"] = last_ws_full.get("reason")
-            else:
-                comment["last_ws_full_api_calls_ago"] = comment.get(
-                    "last_full_api_calls_ago"
-                )
-                comment["last_ws_full_reason"] = comment.get("last_full_reason")
-
-        full_count = 0
-        incremental_count = 0
-        if isinstance(ledger, dict):
-            summary = ledger.get("summary")
-            if isinstance(summary, dict):
-                try:
-                    full_count = int(summary.get("full_count") or 0)
-                except (TypeError, ValueError):
-                    full_count = 0
-                try:
-                    incremental_count = int(summary.get("incremental_count") or 0)
-                except (TypeError, ValueError):
-                    incremental_count = 0
-        comment["maintenance_hint"] = self._ws_maintenance_hint(
-            full_count=full_count,
-            incremental_count=incremental_count,
-        )
+        if self._summarize_effect_delayed_pending_ids:
+            ctx = self._summarize_delay_context()
+            self._summarize_effect_delayed_last_context = ctx
+            comment["summarize_effect"] = {
+                "delayed": True,
+                "pending_count": len(self._summarize_effect_delayed_pending_ids),
+                **ctx,
+                "message": _CODEX_SUMMARIZE_DELAY_NOTE,
+            }
+        elif self._summarize_effect_delayed_last_release_reason:
+            comment["summarize_effect"] = {
+                "delayed": False,
+                "released_by": self._summarize_effect_delayed_last_release_reason,
+                "message": "Delayed Codex summarize effect has been applied by a fresh full replay.",
+            }
         return comment
 
     def adapter_comment(self):

--- a/tests/test_agent_meta_guidance.py
+++ b/tests/test_agent_meta_guidance.py
@@ -12,18 +12,15 @@ STATIC_CODEX_COMMENT = {
     "feature": "responses_rest_epoch_reset",
     "summary": "Codex plans turns as full or incremental.",
     "summarize_note": (
-        "Summarize is an investment, not routine cleanup: keep the "
-        "full:incremental ratio at or below 1:10 and defer non-urgent "
-        "summarize until the expected savings justify the cache miss. "
-        "If you are already planning to molt, do not summarize first unless "
-        "context overflow is imminent; molt is the higher-level replacement "
-        "for summarize."
-    ),
-    "context_budget_note": (
-        "Can wait until roughly 200k token context before proactive "
-        "summarize, but if summarizing still leaves the main context "
-        "above roughly 150k tokens, consider molt to avoid repeated "
-        "summarize misses and improve token efficiency."
+        "Summarize normally when useful. For Codex continuation over the "
+        "Responses API, summarize calls are accepted and recorded immediately, "
+        "but their fresh full replay/cache epoch effect is delayed until local "
+        "context reaches roughly 80% of the context window. The delay exists "
+        "because Codex keeps a previous_response_id/cache epoch; resetting "
+        "that epoch for every summarize would discard continuation/cache "
+        "benefit. If you are already planning to molt, do not summarize first "
+        "unless context overflow is imminent; molt is the higher-level "
+        "replacement for summarize."
     ),
 }
 
@@ -47,12 +44,16 @@ def test_agent_prompt_builder_refreshes_meta_guidance_adapter_rules(tmp_path):
     assert "## meta_guidance" in prompt
     assert "### codex runtime rules" in prompt
     assert "responses_rest_epoch_reset" in prompt
-    assert "investment, not routine cleanup" in prompt
+    assert "Summarize normally when useful" in prompt
+    assert "Responses API" in prompt
+    assert "fresh full replay/cache epoch effect is delayed" in prompt
+    assert "previous_response_id/cache epoch" in prompt
     assert "do not summarize first unless context overflow is imminent" in prompt
     assert "molt is the higher-level replacement for summarize" in prompt
-    assert "1:10" in prompt
-    assert "roughly 200k token context" in prompt
-    assert "above roughly 150k tokens, consider molt" in prompt
+    codex_note = agent.service.static_adapter_comment()["summarize_note"]
+    assert "1:10" not in codex_note
+    assert "roughly 200k token context" not in codex_note
+    assert "above roughly 150k tokens" not in codex_note
 
 
 def test_agent_batched_prompt_builder_refreshes_meta_guidance_adapter_rules(tmp_path):
@@ -63,6 +64,9 @@ def test_agent_batched_prompt_builder_refreshes_meta_guidance_adapter_rules(tmp_
     assert "## meta_guidance" in prompt
     assert "### codex runtime rules" in prompt
     assert "responses_rest_epoch_reset" in prompt
+    assert "Responses API" in prompt
+    assert "fresh full replay/cache epoch effect is delayed" in prompt
     assert "do not summarize first unless context overflow is imminent" in prompt
-    assert "roughly 200k token context" in prompt
-    assert "above roughly 150k tokens, consider molt" in prompt
+    codex_note = agent.service.static_adapter_comment()["summarize_note"]
+    assert "roughly 200k token context" not in codex_note
+    assert "above roughly 150k tokens" not in codex_note

--- a/tests/test_codex_ws_session.py
+++ b/tests/test_codex_ws_session.py
@@ -764,11 +764,31 @@ def test_rest_incremental_never_sends_previous_response_id():
     assert "codex_fallback_error_type" not in second.usage.extra
 
 
-def test_rest_summarize_forces_next_full_epoch_reset():
-    """``on_history_summarized`` resets the continuation epoch on REST too, so the
-    next turn is a full request even though it was a strict additive extension."""
+def test_rest_summarize_delays_epoch_reset_below_context_threshold(monkeypatch):
+    """REST also delays the Codex epoch reset label until local context pressure
+    reaches the threshold; summarize still returns normally before then."""
     client = RealisticRestClient()
     session = _make_rest_session(client)
+    monkeypatch.setattr(session._interface, "estimate_context_tokens", lambda: 100)
+    monkeypatch.setattr(session, "context_window", lambda: 1000)
+
+    first = session.send("one")
+    second = session.send("two")
+    session.on_history_summarized(["call_old"])
+    third = session.send("three")
+
+    assert first.usage.extra["codex_request_mode"] == "rest_full"
+    assert second.usage.extra["codex_request_mode"] == "rest_incremental"
+    assert third.usage.extra["codex_request_mode"] == "rest_incremental"
+    assert third.usage.extra["codex_ws_delta_reason"] == "ok"
+    assert session.dynamic_adapter_comment()["summarize_effect"]["delayed"] is True
+
+
+def test_rest_summarize_releases_delayed_epoch_reset_at_context_threshold(monkeypatch):
+    client = RealisticRestClient()
+    session = _make_rest_session(client)
+    monkeypatch.setattr(session._interface, "estimate_context_tokens", lambda: 850)
+    monkeypatch.setattr(session, "context_window", lambda: 1000)
 
     first = session.send("one")
     second = session.send("two")
@@ -779,6 +799,7 @@ def test_rest_summarize_forces_next_full_epoch_reset():
     assert second.usage.extra["codex_request_mode"] == "rest_incremental"
     assert third.usage.extra["codex_request_mode"] == "rest_full"
     assert third.usage.extra["codex_ws_delta_reason"] == "epoch_reset"
+    assert third.usage.extra["codex_ws_epoch_reset_reason"] == "summarize_delayed"
 
 
 class _MultiToolCallRestResponses:
@@ -1057,105 +1078,42 @@ def test_new_user_turn_after_tool_loop_keeps_incremental_chain():
     assert "call the tool" not in flat3
 
 
-def test_codex_adapter_comment_explains_epoch_reset_and_cache_ledger():
-    session = _make_session(FakeWsTransport())
+def test_codex_adapter_comment_explains_delayed_summarize_without_soft_constraints():
+    t = FakeWsTransport()
+    session = _make_session(t)
 
+    session.send("hello")
+    session.send("again")
+    session.on_history_summarized(["call_old"])
     comment = session.adapter_comment()
-
-    assert comment["adapter"] == "codex"
-    assert comment["ws_enabled"] is True
-    assert comment["feature"] == "responses_websocket_epoch_reset"
-    # The routine turn-count epoch reset is cancelled: the default limit is 0
-    # (disabled), so no full is forced by turn count. The resident meta omits the
-    # periodic-countdown fields entirely so it never implies a reset that won't
-    # happen; they reappear only when an operator explicitly opts back in.
-    assert "epoch_reset_turns" not in comment
-    assert "turns_since_epoch_reset" not in comment
-    assert "next_reset_in" not in comment
-    assert comment["last_full_api_calls_ago"] is None
-    assert comment["last_full_reason"] == "not_recorded"
-    assert comment["last_ws_full_api_calls_ago"] is None
-    assert comment["last_ws_full_reason"] == "not_recorded"
+    static = session.static_adapter_comment()
 
     note = comment["cache_note"]
-    assert comment["summarize_full_note"] == note
-    assert comment["summarize_ws_full_note"] == note
-    assert "full epoch" in note
-    assert "incremental prefix" in note
-    # Ratio-oriented guidance replaces the old ">=20 API calls" interval rule.
-    assert ">=20 API calls" not in note
-    assert "1:10" in note
-    assert "ratio" in note
-    assert "reduce_summarize_frequency" in note
-    assert "context pressure" in note
-    assert "cache miss" in note
-    assert "Summarize" in note
-    assert "Notification dismiss" in note
-    assert "non-urgent summarize" in note
-    # summarize is framed as an investment that buys future savings, and molt
-    # is the escalation when context pressure stays high afterwards.
-    assert "investment" in note
-    assert "buy future context" in note
-    assert "consider molt" in note
+    assert "Responses API" in note
+    assert "fresh full replay/cache epoch effect is delayed" in note
+    assert "previous_response_id/cache epoch" in note
+    assert "roughly 80%" in note
+    assert "additional summarize calls safely" in note
     assert "do not summarize first unless context overflow is imminent" in note
-    assert "molt is the higher-level replacement for summarize" in note
 
-    static = session.static_adapter_comment()
-    assert static["adapter"] == "codex"
-    assert static["feature"] == "responses_websocket_epoch_reset"
-    assert ">=20 API calls" not in static["summarize_note"]
-    assert "1:10" in static["summarize_note"]
-    assert "reduce_summarize_frequency" in static["summarize_note"]
-    assert "do not summarize first unless context overflow is imminent" in static["summarize_note"]
-    assert "roughly 200k token context" in static["context_budget_note"]
-    assert "above roughly 150k" in static["context_budget_note"]
-    assert "investment, not a fixed countdown" in static["summarize_economy_note"]
-    assert "cache miss with margin" in static["summarize_economy_note"]
-    assert "prefer daemon/file-based exploration" in static["long_context_strategy"]
-    assert "Avoid ingesting large raw outputs" in static["long_context_strategy"]
-    assert "dismiss-only turns" in static["notification_dismiss_note"]
-    assert "dismiss itself causing a reset" in static["notification_dismiss_note"]
-    assert "FROZEN" in static["system_prompt_update_note"]
-    assert "update_system_prompt is a no-op" in static["system_prompt_update_note"]
-    assert "molt / refresh / restart / bootstrap" in static["system_prompt_update_note"]
+    summarize_effect = comment["summarize_effect"]
+    assert summarize_effect["delayed"] is True
+    assert summarize_effect["pending_count"] == 1
+    assert summarize_effect["threshold_ratio"] == 0.8
 
-    ledger = comment["cache_ledger"]
-    assert ledger["window_api_calls"] == 20
-    assert ledger["recorded_api_calls"] == 0
-    assert ledger["cols"] == ["ago", "mode", "cache", "in_k", "miss_k", "reason"]
-    assert ledger["rows"] == []
-    assert ledger["summary"] == {
-        "api_calls": 0,
-        "cache_rate": None,
-        "full_count": 0,
-        "incremental_count": 0,
-        "full_to_incremental_ratio": "0:0",
-        "ws_full_count": 0,
-        "miss_k": 0.0,
-    }
-    expected_last_full = {
-        "api_calls_ago": None,
-        "reason": "not_recorded",
-    }
-    assert ledger["last_full"] == expected_last_full
-    assert ledger["last_ws_full"] == expected_last_full
-    assert ledger["legend"]["I"] == "incremental"
-    assert ledger["legend"]["F"] == "full"
-    assert ledger["legend"]["sum"] == "epoch_reset:summarize"
-
-    # The maintenance hint is ratio-oriented (full:incremental), not an
-    # interval/countdown. With no entries it is "unknown" and carries no
-    # wait_api_calls_remaining countdown.
-    hint = comment["maintenance_hint"]
-    assert hint["summarize_economy"] == "unknown"
-    assert hint["full_count"] == 0
-    assert hint["incremental_count"] == 0
-    assert hint["full_to_incremental_ratio"] == "0:0"
-    assert hint["target_full_to_incremental_ratio"] == "1:10"
-    assert "no Codex continuation cache ledger" in hint["reason"]
-    assert "non_urgent_summarize" not in hint
-    assert "wait_api_calls_remaining" not in hint
-
+    for payload in (comment, static):
+        assert "context_budget_note" not in payload
+        assert "summarize_economy_note" not in payload
+        assert "cache_ledger" not in payload
+        assert "cache_ledger_summary" not in payload
+        assert "maintenance_hint" not in payload
+        assert "last_full_reason" not in payload
+        assert "last_ws_full_reason" not in payload
+    assert "1:10" not in note
+    assert "150k" not in note
+    assert "200k" not in note
+    assert "full:incremental" not in note
+    assert "reduce_summarize_frequency" not in note
 
 
 def test_codex_adapter_static_comment_available_before_chat_creation():
@@ -1166,14 +1124,17 @@ def test_codex_adapter_static_comment_available_before_chat_creation():
     assert comment["adapter"] == "codex"
     assert comment["feature"] == "responses_rest_epoch_reset"
     assert ">=20 API calls" not in comment["summarize_note"]
-    assert "1:10" in comment["summarize_note"]
-    assert "reduce_summarize_frequency" in comment["summarize_note"]
+    assert "Responses API" in comment["summarize_note"]
+    assert "fresh full replay/cache epoch effect is delayed" in comment["summarize_note"]
+    assert "previous_response_id/cache epoch" in comment["summarize_note"]
+    assert "roughly 80%" in comment["summarize_note"]
     assert "do not summarize first unless context overflow is imminent" in comment["summarize_note"]
-    assert "roughly 200k token context" in comment["context_budget_note"]
-    assert "above roughly 150k" in comment["context_budget_note"]
-    assert "investment, not a fixed countdown" in comment["summarize_economy_note"]
-    assert "current/projected context pressure risks overflow" in comment["summarize_economy_note"]
-    assert "consider molting" in comment["summarize_economy_note"]
+    assert "context_budget_note" not in comment
+    assert "summarize_economy_note" not in comment
+    assert "1:10" not in comment["summarize_note"]
+    assert "150k" not in comment["summarize_note"]
+    assert "200k" not in comment["summarize_note"]
+    assert "reduce_summarize_frequency" not in comment["summarize_note"]
     assert "prefer daemon/file-based exploration" in comment["long_context_strategy"]
     assert "main Codex context" in comment["long_context_strategy"]
     assert "does not compact history" in comment["notification_dismiss_note"]
@@ -1207,182 +1168,90 @@ def test_codex_update_system_prompt_is_no_op_and_keeps_instructions_frozen():
     assert second.usage.extra["codex_request_mode"] == "rest_incremental"
 
 
-def test_codex_adapter_comment_reports_compact_cache_ledger():
-    session = _make_session(FakeWsTransport())
-
-    session._record_ws_cache_ledger(
-        request_mode="ws_full",
-        usage=UsageMetadata(input_tokens=100_000, output_tokens=0, thinking_tokens=0, cached_tokens=50_000),
-        ws_diag={"reason": "epoch_reset", "epoch_reset_reason": "summarize"},
-    )
-    session._record_ws_cache_ledger(
-        request_mode="ws_incremental",
-        usage=UsageMetadata(input_tokens=100_000, output_tokens=0, thinking_tokens=0, cached_tokens=90_000),
-        ws_diag={"reason": "ok"},
-    )
-    session._record_ws_cache_ledger(
-        request_mode="ws_full",
-        usage=UsageMetadata(input_tokens=50_000, output_tokens=0, thinking_tokens=0, cached_tokens=30_000),
-        ws_diag={"reason": "prefix_mismatch"},
-    )
-
-    comment = session.adapter_comment()
-
-    assert comment["last_ws_full_api_calls_ago"] == 0
-    assert comment["last_ws_full_reason"] == "pm"
-    # 2 fulls vs 1 incremental is far worse than the 1:10 target, so the hint
-    # flags reduce_summarize_frequency and reports the current ratio.
-    hint = comment["maintenance_hint"]
-    assert hint["summarize_economy"] == "reduce_summarize_frequency"
-    assert hint["full_count"] == 2
-    assert hint["incremental_count"] == 1
-    assert hint["full_to_incremental_ratio"] == "1:0.5"
-    assert hint["target_full_to_incremental_ratio"] == "1:10"
-    assert "reduce summarize frequency" in hint["reason"]
-    # The poor-ratio reason frames the tradeoff: summarize is an investment
-    # that must earn back more than the cache miss it spends.
-    assert "investment" in hint["reason"]
-    assert "expected savings justify" in hint["reason"]
-    assert "wait_api_calls_remaining" not in hint
-
-    ledger = comment["cache_ledger"]
-    assert ledger["recorded_api_calls"] == 3
-    assert ledger["rows"] == [
-        [2, "F", 0.5, 100.0, 50.0, "sum"],
-        [1, "I", 0.9, 100.0, 10.0, ""],
-        [0, "F", 0.6, 50.0, 20.0, "pm"],
-    ]
-    assert ledger["summary"] == {
-        "api_calls": 3,
-        "cache_rate": 0.68,
-        "full_count": 2,
-        "incremental_count": 1,
-        "full_to_incremental_ratio": "1:0.5",
-        "ws_full_count": 2,
-        "miss_k": 80.0,
-    }
-    expected_last_full = {
-        "api_calls_ago": 0,
-        "reason": "pm",
-    }
-    assert ledger["last_full"] == expected_last_full
-    assert ledger["last_ws_full"] == expected_last_full
-
-
-def test_codex_maintenance_hint_ok_when_full_to_incremental_ratio_within_target():
-    """A healthy continuation keeps fulls rare: 1 full per 12 incremental turns
-    (1:12) is at/under the 1:10 target, so the ratio-oriented hint reports an
-    economical summarize cadence with no reduce_summarize_frequency flag."""
-    session = _make_session(FakeWsTransport())
-
-    session._record_ws_cache_ledger(
-        request_mode="ws_full",
-        usage=UsageMetadata(input_tokens=100_000, output_tokens=0, thinking_tokens=0, cached_tokens=50_000),
-        ws_diag={"reason": "no_baseline"},
-    )
-    for _ in range(12):
-        session._record_ws_cache_ledger(
-            request_mode="ws_incremental",
-            usage=UsageMetadata(input_tokens=100_000, output_tokens=0, thinking_tokens=0, cached_tokens=95_000),
-            ws_diag={"reason": "ok"},
-        )
-
-    comment = session.adapter_comment()
-
-    summary = comment["cache_ledger"]["summary"]
-    assert summary["full_count"] == 1
-    assert summary["incremental_count"] == 12
-    assert summary["full_to_incremental_ratio"] == "1:12"
-
-    hint = comment["maintenance_hint"]
-    assert hint["summarize_economy"] == "ok"
-    assert hint["full_to_incremental_ratio"] == "1:12"
-    assert hint["target_full_to_incremental_ratio"] == "1:10"
-    assert "healthy" in hint["reason"]
-    assert "wait_api_calls_remaining" not in hint
-    assert "non_urgent_summarize" not in hint
-
-
-def test_codex_send_populates_cache_ledger_end_to_end():
+def test_codex_cache_ledger_stays_internal_not_adapter_comment():
     t = FakeWsTransport()
     session = _make_session(t)
 
-    first = session.send("one")
-    second = session.send("two")
+    session.send("one")
+    session.send("two")
+    session.on_history_summarized(["call_old"])
 
-    assert first.usage.extra["codex_request_mode"] == "ws_full"
-    assert second.usage.extra["codex_request_mode"] == "ws_incremental"
-    assert t.sent_frames[1]["previous_response_id"] == "resp_ws_1"
-
+    ledger = session._ws_cache_ledger_comment()
+    assert isinstance(ledger, dict)
+    assert ledger["legend"]["sumd"] == "epoch_reset:summarize_delayed"
+    assert isinstance(ledger["rows"], list)
     comment = session.adapter_comment()
-    assert comment["last_full_api_calls_ago"] == 1
-    assert comment["last_full_reason"] == "nb"
-    assert comment["last_ws_full_api_calls_ago"] == 1
-    assert comment["last_ws_full_reason"] == "nb"
-    # 1 full + 1 incremental = 1:1, worse than the 1:10 target.
-    assert (
-        comment["maintenance_hint"]["summarize_economy"]
-        == "reduce_summarize_frequency"
-    )
-    assert comment["maintenance_hint"]["full_to_incremental_ratio"] == "1:1"
-
-    ledger = comment["cache_ledger"]
-    assert ledger["recorded_api_calls"] == 2
-    assert [row[1] for row in ledger["rows"]] == ["F", "I"]
-    assert [row[5] for row in ledger["rows"]] == ["nb", ""]
-    expected_last_full = {
-        "api_calls_ago": 1,
-        "reason": "nb",
-    }
-    assert ledger["last_full"] == expected_last_full
-    assert ledger["last_ws_full"] == expected_last_full
+    assert "cache_ledger" not in comment
+    assert "cache_ledger_summary" not in comment
+    assert "maintenance_hint" not in comment
 
 
-def test_codex_adapter_comment_is_rest_continuation_when_ws_disabled():
-    """``ws_enabled=False`` now means the REST transport, which STILL runs the
-    full/incremental continuation machine (not stateless-full-every-turn)."""
-    session = _make_session(FakeWsTransport(), ws_enabled=False)
+def test_codex_adapter_comment_is_rest_continuation_without_soft_constraints():
+    client = RealisticRestClient()
+    session = _make_rest_session(client)
+    comment = session.dynamic_adapter_comment()
 
-    comment = session.adapter_comment()
-
-    assert comment["adapter"] == "codex"
     assert comment["transport"] == "rest"
     assert comment["ws_enabled"] is False
     assert comment["continuation_enabled"] is True
-    assert comment["feature"] == "responses_rest_epoch_reset"
-    # The continuation comment carries the cache-ledger machinery, but with the
-    # routine turn-count reset cancelled (default 0) it omits the periodic-reset
-    # countdown fields so the resident meta never implies a forced reset.
-    assert "turns_since_epoch_reset" not in comment
-    assert "epoch_reset_turns" not in comment
-    assert "next_reset_in" not in comment
-    assert "cache_ledger" in comment
-    assert "maintenance_hint" in comment
-    assert "cache_note" in comment
+    assert "periodic_reset_turns" not in comment
+    assert "cache_ledger" not in comment
+    assert "cache_ledger_summary" not in comment
+    assert "maintenance_hint" not in comment
 
 
 def test_codex_adapter_comment_stateless_only_when_continuation_off():
-    """The legacy stateless-full-replay comment surfaces only when the
-    continuation machine itself is disabled (a future stateless mode)."""
-    session = _make_session(FakeWsTransport(), ws_enabled=False)
-    session._continuation_enabled = False
-
-    comment = session.adapter_comment()
-
-    assert comment["feature"] == "stateless_full_replay"
-    assert comment["continuation_enabled"] is False
-    assert comment["transport"] == "rest"
-    assert "cache_ledger" not in comment
-    note = comment["summarize_ws_full_note"]
-    assert "stateless" in comment["summary"]
-    assert "Summarize" in note
-    assert "Notification dismiss" in note
-    assert "do not summarize first unless context overflow is imminent" in note
-
-
-def test_history_summarized_forces_next_ws_full_epoch_reset():
     t = FakeWsTransport()
     session = _make_session(t)
+    session._continuation_enabled = False
+
+    comment = session.dynamic_adapter_comment()
+    static = session.static_adapter_comment()
+
+    assert comment["continuation_enabled"] is False
+    assert "cache_ledger" not in comment
+    assert "cache_ledger_summary" not in comment
+    assert "maintenance_hint" not in comment
+    assert "summarize_effect" not in comment
+    assert "fresh full replay/cache epoch effect is delayed" not in static["summarize_note"]
+    assert "context_budget_note" not in static
+    assert "summarize_economy_note" not in static
+
+
+def test_history_summarized_delays_next_ws_full_below_context_threshold(monkeypatch):
+    t = FakeWsTransport()
+    session = _make_session(t)
+    monkeypatch.setattr(session._interface, "estimate_context_tokens", lambda: 100)
+    monkeypatch.setattr(session, "context_window", lambda: 1000)
+
+    first = session.send("one")
+    second = session.send("two")
+    session.on_history_summarized(["call_old"])
+
+    comment = session.dynamic_adapter_comment()
+    summarize_effect = comment["summarize_effect"]
+    assert summarize_effect["delayed"] is True
+    assert summarize_effect["pending_count"] == 1
+    assert summarize_effect["threshold_ratio"] == 0.8
+    assert summarize_effect["threshold_context_tokens"] == 800
+    assert summarize_effect["current_context_usage"] == 0.1
+    assert "additional summarize calls safely" in summarize_effect["message"]
+
+    third = session.send("three")
+
+    assert first.usage.extra["codex_request_mode"] == "ws_full"
+    assert second.usage.extra["codex_request_mode"] == "ws_incremental"
+    assert third.usage.extra["codex_request_mode"] == "ws_incremental"
+    assert third.usage.extra["codex_ws_delta_reason"] == "ok"
+    assert "codex_ws_epoch_reset_reason" not in third.usage.extra
+    assert t.sent_frames[2]["previous_response_id"] == "resp_ws_2"
+
+
+def test_history_summarized_releases_delayed_ws_full_at_context_threshold(monkeypatch):
+    t = FakeWsTransport()
+    session = _make_session(t)
+    monkeypatch.setattr(session._interface, "estimate_context_tokens", lambda: 850)
+    monkeypatch.setattr(session, "context_window", lambda: 1000)
 
     first = session.send("one")
     second = session.send("two")
@@ -1393,8 +1262,12 @@ def test_history_summarized_forces_next_ws_full_epoch_reset():
     assert second.usage.extra["codex_request_mode"] == "ws_incremental"
     assert third.usage.extra["codex_request_mode"] == "ws_full"
     assert third.usage.extra["codex_ws_delta_reason"] == "epoch_reset"
-    assert third.usage.extra["codex_ws_epoch_reset_reason"] == "summarize"
+    assert third.usage.extra["codex_ws_epoch_reset_reason"] == "summarize_delayed"
     assert "previous_response_id" not in t.sent_frames[2]
+
+    summarize_effect = session.dynamic_adapter_comment()["summarize_effect"]
+    assert summarize_effect["delayed"] is False
+    assert summarize_effect["released_by"] == "summarize_delayed"
 
 
 def test_notification_dismissed_keeps_incremental_ws_chain():


### PR DESCRIPTION
## Summary
- delay Codex summarize-triggered fresh full replay/cache epoch reset until local context reaches roughly 80% of the context window
- surface the pending delayed effect in `_meta.agent_meta.adapter_comment.summarize_effect` so agents can keep working and issue additional summarize calls safely
- remove agent-facing Codex comment soft constraints: 150k/200k context hints, full:increment ratio guidance, maintenance hints, and cache-ledger/last-full summaries
- keep static Codex guidance explicit about the Responses API / previous_response_id cache-epoch reason for the delay

## Validation
- `git diff --check origin/main...HEAD`
- `PYTHONPATH=src python -m py_compile src/lingtai/llm/openai/adapter.py tests/test_codex_ws_session.py tests/test_agent_meta_guidance.py tests/test_system_summarize.py`
- `PYTHONPATH=src python -m pytest -q tests/test_codex_ws_session.py tests/test_agent_meta_guidance.py tests/test_system_summarize.py` → `126 passed`

## Review
- GLM review completed. Product code verdict: OK.
- GLM found one test-only blocker (negative `1:10` assertion against the full system prompt could match timestamps); fixed by scoping the negative check to `static_adapter_comment()["summarize_note"]`, then revalidated.
