### PR TITLE
[codex] implement explicit NoKV integration boundary

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -14,7 +14,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 | `cli.py` | `lingtai-agent run <dir>` / `lingtai-agent check-caps` entry points |
 | `network.py` | Read-only network topology crawler — avatar/contact/mail edge discovery |
 | `presets.py` | Compatibility shim re-exporting the kernel preset library (`lingtai_kernel.presets`) |
-| `init_schema.py` | `validate_init()` plus `strip_deprecated()` — strict schema for active init.json fields, simple deprecated-field cleanup, and known-but-inactive legacy fields migrated by `lingtai_kernel.migrate` |
+| `init_schema.py` | `validate_init()` plus `strip_deprecated()` — strict schema for active init.json fields, simple deprecated-field cleanup, `manifest.nokv`, and known-but-inactive legacy fields migrated by `lingtai_kernel.migrate` |
 | `venv_resolve.py` | Python venv resolution — init.json → global runtime → auto-create |
 | `intrinsic_skills/__init__.py` | Standalone skill bundles (docs-only) copied into `.library/intrinsic/` |
 | `mcp_servers/` | Curated MCP server implementations shipped in the `lingtai` distribution and launched by `mcp_catalog.json` via `python -m lingtai.mcp_servers.<name>`; historical top-level `lingtai_*` packages remain thin wrappers |
@@ -27,7 +27,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **`presets.py`**: compatibility re-export shim (`presets.py:1-21`); implementation lives in `lingtai_kernel.presets` (`load_preset` :174 · `materialize_active_preset` :289 · `expand_inherit` :503 · `discover_presets_in_dirs` :121).
 
-**`init_schema.py`**: `DEPRECATED_TOP_FIELDS` :28 (plain deprecated top-level fields stripped by `strip_deprecated`), `LEGACY_MIGRATED_TOP_FIELDS` :38 (legacy fields removed by version-controlled agent migrations and known only as inactive schema), `validate_init` :94, `TOP_OPTIONAL` :13, `MANIFEST_OPTIONAL` :55; `manifest.llm.compact_threshold` is validated as positive int or null in the LLM block.
+**`init_schema.py`**: `DEPRECATED_TOP_FIELDS` :32 (plain deprecated top-level fields stripped by `strip_deprecated`), `LEGACY_MIGRATED_TOP_FIELDS` :42 (legacy fields removed by version-controlled agent migrations and known only as inactive schema), `validate_init` :120, `TOP_OPTIONAL` :15, `MANIFEST_OPTIONAL` :57; `manifest.nokv` is shape-validated at :242 and `manifest.llm.compact_threshold` is validated as positive int or null in the LLM block.
 
 **`network.py`**: `build_network` :306 · `_discover_agents` :143 · `_build_avatar_edges` :168
 
@@ -45,7 +45,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **Agent → BaseAgent:** Three-layer hierarchy: `BaseAgent` (kernel) → `Agent` (capabilities) → `CustomAgent` (domain). Agent adds capability registration, MCP auto-loading, preset swap, full init.json reconstruct.
 
-**Capability registration:** `setup_capability()` in `capabilities/__init__.py`; the registry is `_BUILTIN` (per-capability module paths) plus `CORE_DEFAULTS` (which boot automatically). Agent calls `apply_core_defaults` + `_setup_capability` (agent.py:152) during `__init__` and `_setup_from_init`. Hosts disable defaults via the `disable=[...]` kwarg or `manifest.disable` in init.json.
+**Capability registration:** `setup_capability()` in `capabilities/__init__.py`; the registry is `_BUILTIN` (per-capability module paths, including explicit opt-in `nokv` at `capabilities/__init__.py:15-31`) plus `CORE_DEFAULTS` (which boot automatically). Agent calls `apply_core_defaults` + `_setup_capability` (agent.py:152) during `__init__` and `_setup_from_init`. Hosts disable defaults via the `disable=[...]` kwarg or `manifest.disable` in init.json.
 
 **Agent init migration + preset materialization:** `run_agent_migrations` (`lingtai_kernel/migrate/migrate.py:285`) is called by `cli.load_init` (boot) and `Agent._read_init` (refresh) before `init.json` is read/validated. Then `materialize_active_preset` (`lingtai_kernel/presets.py:289`) reads `manifest.preset.active`, loads preset, substitutes `llm`+`capabilities` into manifest before validation. The preset owns explicit opt-in capabilities, but per-agent init.json kwargs survive in two ways: (1) for capabilities the preset *also* enables, init.json wins key-by-key; (2) for always-on `CORE_DEFAULTS` capabilities the preset *omits* (daemon, bash, knowledge, …), init.json kwargs are carried forward so `apply_core_defaults` doesn't re-add an empty entry and lose e.g. `daemon.max_emanations`. Non-core optional caps the preset omits are dropped (the swap). `CORE_DEFAULTS` lives in `lingtai.capabilities` and is injected via the `core_defaults=` arg by both callers (`agent._read_init` :866, `cli.load_init` :49) — the kernel does not import the wrapper. `skills.paths` additionally append-merges (preset defaults first).
 

--- a/src/lingtai/__init__.py
+++ b/src/lingtai/__init__.py
@@ -19,7 +19,16 @@ from .core.avatar import AvatarManager
 from lingtai_kernel.intrinsics.email import EmailManager
 
 # Services
-from .services.file_io import FileIOBackend, FileIOService, GrepMatch, LocalFileIOBackend, LocalFileIOService
+from .services.file_io import (
+    FileIOBackend,
+    FileIOService,
+    GrepMatch,
+    HybridFileIOBackend,
+    LocalFileIOBackend,
+    LocalFileIOService,
+    NoKVFileIOBackend,
+)
+from .services.nokv import NoKVConfig, NoKVUnsupportedError
 from .services.file_io_sidecar import (
     BACKEND_ENV_VAR,
     RustFileIOBackend,
@@ -52,8 +61,12 @@ __all__ = [
     # Services
     "FileIOService",
     "FileIOBackend",
+    "HybridFileIOBackend",
     "LocalFileIOBackend",
     "LocalFileIOService",
+    "NoKVConfig",
+    "NoKVFileIOBackend",
+    "NoKVUnsupportedError",
     "RustFileIOBackend",
     "SidecarAdapter",
     "SidecarError",

--- a/src/lingtai/capabilities/__init__.py
+++ b/src/lingtai/capabilities/__init__.py
@@ -25,6 +25,7 @@ _BUILTIN: dict[str, str] = {
     "edit": "lingtai.core.edit",
     "glob": "lingtai.core.glob",
     "grep": "lingtai.core.grep",
+    "nokv": "lingtai.core.nokv",
     # Optional/multimodal capabilities (this package)
     "vision": ".vision",
     "web_search": ".web_search",
@@ -176,6 +177,7 @@ def get_all_providers() -> dict[str, dict]:
     """
     _USER_FACING: dict[str, str] = {
         "file": "lingtai.core.read",
+        "nokv": "lingtai.core.nokv",
         "bash": "lingtai.core.bash",
         "web_search": ".web_search",
         "knowledge": "lingtai.core.knowledge",

--- a/src/lingtai/core/edit/__init__.py
+++ b/src/lingtai/core/edit/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...i18n import t
+from ...services.nokv import is_nokv_uri
 
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
@@ -39,7 +40,7 @@ def setup(agent: "BaseAgent") -> None:
         path = args.get("file_path", "")
         if not path:
             return {"status": "error", "message": "file_path is required"}
-        if not Path(path).is_absolute():
+        if not is_nokv_uri(path) and not Path(path).is_absolute():
             path = str(agent._working_dir / path)
         old = args.get("old_string", "")
         new = args.get("new_string", "")

--- a/src/lingtai/core/glob/__init__.py
+++ b/src/lingtai/core/glob/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...i18n import t
+from ...services.nokv import is_nokv_uri
 
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
@@ -38,7 +39,7 @@ def setup(agent: "BaseAgent") -> None:
         if not pattern:
             return {"status": "error", "message": "pattern is required"}
         search_dir = args.get("path", str(agent._working_dir))
-        if not Path(search_dir).is_absolute():
+        if not is_nokv_uri(search_dir) and not Path(search_dir).is_absolute():
             search_dir = str(agent._working_dir / search_dir)
         try:
             matches = agent._file_io.glob(pattern, root=search_dir)

--- a/src/lingtai/core/grep/__init__.py
+++ b/src/lingtai/core/grep/__init__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ...i18n import t
+from ...services.nokv import is_nokv_uri
 
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
@@ -41,7 +42,7 @@ def setup(agent: "BaseAgent") -> None:
         if not pattern:
             return {"status": "error", "message": "pattern is required"}
         search_path = args.get("path", str(agent._working_dir))
-        if not Path(search_path).is_absolute():
+        if not is_nokv_uri(search_path) and not Path(search_path).is_absolute():
             search_path = str(agent._working_dir / search_path)
         max_matches = args.get("max_matches", 200)
         glob_filter = args.get("glob", "*")

--- a/src/lingtai/core/nokv/__init__.py
+++ b/src/lingtai/core/nokv/__init__.py
@@ -1,0 +1,176 @@
+"""NoKV capability — explicit read-first NoKV namespace inspection."""
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from ...services.file_io import NoKVFileIOBackend
+from ...services.nokv import (
+    DEFAULT_NOKV_URI_PREFIXES,
+    NoKVUnsupportedError,
+    format_nokv_uri,
+)
+
+if TYPE_CHECKING:
+    from lingtai_kernel.base_agent import BaseAgent
+
+PROVIDERS = {"providers": [], "default": "builtin"}
+
+
+def get_description(lang: str = "en") -> str:
+    return (
+        "Inspect an explicitly configured NoKV namespace. Use for NoKV ls/stat/"
+        "catalog/find/read/grep/snapshot operations; ordinary local file paths "
+        "remain handled by read/write/edit/glob/grep."
+    )
+
+
+def get_schema(lang: str = "en") -> dict:
+    return {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["ls", "stat", "catalog", "find", "read", "grep", "snapshot"],
+                "description": "NoKV action to perform.",
+            },
+            "path": {
+                "type": "string",
+                "description": "NoKV URI or object path, for example nokv://lingtai/projects/p.",
+            },
+            "query": {
+                "type": "string",
+                "description": "Optional substring query for find/catalog filtering.",
+            },
+            "pattern": {
+                "type": "string",
+                "description": "Regex pattern for grep.",
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Maximum grep/find results.",
+                "default": 50,
+            },
+        },
+        "required": ["action"],
+    }
+
+
+class NoKVManager:
+    def __init__(
+        self,
+        *,
+        client: Any | None = None,
+        uri_prefixes: tuple[str, ...] = DEFAULT_NOKV_URI_PREFIXES,
+        default_namespace: str | None = None,
+    ):
+        self.default_namespace = default_namespace
+        self.backend = NoKVFileIOBackend(client, uri_prefixes=uri_prefixes)
+
+    def _path(self, args: dict) -> str:
+        path = args.get("path") or self.default_namespace
+        if not path:
+            return "nokv://"
+        return str(path)
+
+    def _uri_entry(self, entry: dict) -> dict:
+        out = dict(entry)
+        out["path"] = format_nokv_uri(str(entry.get("path", "")))
+        return out
+
+    def _grep(self, path: str, pattern: str, max_results: int) -> dict:
+        regex = re.compile(pattern)
+        matches: list[dict] = []
+        for entry in self.backend.list(path):
+            content = self.backend.read(str(entry["path"]))
+            for line_number, line in enumerate(content.splitlines(), 1):
+                if not regex.search(line):
+                    continue
+                matches.append({
+                    "path": format_nokv_uri(str(entry["path"])),
+                    "line": line_number,
+                    "text": line,
+                    "generation": entry.get("generation"),
+                    "metadata": entry.get("metadata") or {},
+                })
+                if len(matches) >= max_results:
+                    return {"status": "ok", "action": "grep", "matches": matches, "truncated": True}
+        return {"status": "ok", "action": "grep", "matches": matches, "truncated": False}
+
+    def handle(self, args: dict) -> dict:
+        action = args.get("action", "")
+        path = self._path(args)
+        try:
+            if action in {"ls", "catalog"}:
+                return {
+                    "status": "ok",
+                    "action": action,
+                    "entries": [self._uri_entry(entry) for entry in self.backend.list(path)],
+                }
+            if action == "find":
+                query = str(args.get("query") or "")
+                max_results = int(args.get("max_results") or 50)
+                entries = [
+                    self._uri_entry(entry)
+                    for entry in self.backend.list(path)
+                    if not query or query in str(entry.get("path", ""))
+                ][:max_results]
+                return {"status": "ok", "action": "find", "entries": entries}
+            if action == "stat":
+                return {"status": "ok", "action": "stat", "stat": self._uri_entry(self.backend.stat(path))}
+            if action == "read":
+                stat = self.backend.stat(path)
+                return {
+                    "status": "ok",
+                    "action": "read",
+                    "path": format_nokv_uri(stat["path"]),
+                    "content": self.backend.read(path),
+                    "generation": stat.get("generation"),
+                    "metadata": stat.get("metadata") or {},
+                }
+            if action == "grep":
+                pattern = args.get("pattern")
+                if not pattern:
+                    return {"status": "error", "message": "pattern is required for grep"}
+                return self._grep(path, str(pattern), int(args.get("max_results") or 50))
+            if action == "snapshot":
+                snapshot = self.backend.snapshot(path)
+                snapshot["path"] = format_nokv_uri(str(snapshot.get("path", path)))
+                return {"status": "ok", "action": "snapshot", "snapshot": snapshot}
+            return {
+                "status": "error",
+                "message": (
+                    "unknown action: "
+                    f"{action!r}; expected ls/stat/catalog/find/read/grep/snapshot"
+                ),
+            }
+        except NoKVUnsupportedError as e:
+            return {"status": "error", "message": str(e)}
+        except FileNotFoundError as e:
+            return {"status": "error", "message": str(e)}
+        except KeyError as e:
+            return {"status": "error", "message": f"NoKV object not found: {e}"}
+        except Exception as e:
+            return {"status": "error", "message": f"NoKV {action or 'operation'} failed: {e}"}
+
+
+def setup(
+    agent: "BaseAgent",
+    *,
+    client: Any | None = None,
+    default_namespace: str | None = None,
+    uri_prefixes: list[str] | tuple[str, ...] | None = None,
+    **_ignored: Any,
+) -> NoKVManager:
+    manager = NoKVManager(
+        client=client,
+        uri_prefixes=tuple(uri_prefixes or DEFAULT_NOKV_URI_PREFIXES),
+        default_namespace=default_namespace,
+    )
+    agent.add_tool(
+        "nokv",
+        schema=get_schema(agent._config.language),
+        handler=manager.handle,
+        description=get_description(agent._config.language),
+    )
+    return manager

--- a/src/lingtai/core/read/__init__.py
+++ b/src/lingtai/core/read/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from lingtai_kernel.tool_result_artifacts import PREVENTIVE_MAX_CHARS
 
 from ...i18n import t
+from ...services.nokv import is_nokv_uri
 
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
@@ -132,7 +133,7 @@ def setup(agent: "BaseAgent") -> None:
         path = args.get("file_path", "")
         if not path:
             return {"status": "error", "message": "file_path is required"}
-        if not Path(path).is_absolute():
+        if not is_nokv_uri(path) and not Path(path).is_absolute():
             path = str(agent._working_dir / path)
         offset = args.get("offset", 1)
         limit = args.get("limit", 2000)

--- a/src/lingtai/core/write/__init__.py
+++ b/src/lingtai/core/write/__init__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...i18n import t
+from ...services.nokv import is_nokv_uri
 
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
@@ -38,7 +39,7 @@ def setup(agent: "BaseAgent") -> None:
         content = args.get("content", "")
         if not path:
             return {"status": "error", "message": "file_path is required"}
-        if not Path(path).is_absolute():
+        if not is_nokv_uri(path) and not Path(path).is_absolute():
             path = str(agent._working_dir / path)
         try:
             agent._file_io.write(path, content)

--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -75,6 +75,7 @@ MANIFEST_OPTIONAL: dict[str, type | tuple[type, ...]] = {
     "timezone_awareness": bool,
     "pseudo_agent_subscriptions": list,
     "preset": dict,
+    "nokv": dict,
     # Large-result notification threshold.  When a tool result's serialized
     # length exceeds this value it becomes a pending large-result case; the
     # system-channel notification fires only once the combined length of all
@@ -237,6 +238,30 @@ def validate_init(data: dict) -> list[str]:
         for key in preset:
             if key not in {"active", "default", "allowed"}:
                 warnings.append(f"unknown field in manifest.preset: {key}")
+
+    nokv = manifest.get("nokv")
+    if nokv is not None:
+        if not isinstance(nokv, dict):
+            raise ValueError(f"manifest.nokv: expected object, got {type(nokv).__name__}")
+        _optional_keys(nokv, {
+            "enabled": bool,
+            "endpoint": (str, type(None)),
+            "default_namespace": (str, type(None)),
+        }, prefix="manifest.nokv")
+        for list_key in ("uri_prefixes", "selected_subtrees"):
+            values = nokv.get(list_key)
+            if values is not None:
+                if not isinstance(values, list) or not all(isinstance(v, str) and v for v in values):
+                    raise ValueError(f"manifest.nokv.{list_key}: expected list[str]")
+        for key in nokv:
+            if key not in {
+                "enabled",
+                "endpoint",
+                "default_namespace",
+                "uri_prefixes",
+                "selected_subtrees",
+            }:
+                warnings.append(f"unknown field in manifest.nokv: {key}")
 
     for key in manifest:
         if key not in MANIFEST_KNOWN:

--- a/src/lingtai/services/ANATOMY.md
+++ b/src/lingtai/services/ANATOMY.md
@@ -9,10 +9,11 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 | File | LOC | Role |
 |---|---|---|
 | `__init__.py` | 1 | Docstring-only package marker |
-| `file_io.py` | 491 | `FileIOService` facade contract + `FileIOBackend`/`LocalFileIOBackend` — backs read/edit/write/glob/grep |
-| `file_io_sidecar.py` | 619 | Rust-backed grep/glob: `RustFileIOBackend`, `SidecarAdapter`, `SidecarError`, plus the `resolve_sidecar_binary` resolver and the `default_file_io_service` factory used by `Agent.__init__` |
+| `file_io.py` | 785 | `FileIOService` facade contract + `LocalFileIOBackend`, `NoKVFileIOBackend`, and `HybridFileIOBackend` — backs read/edit/write/glob/grep |
+| `file_io_sidecar.py` | 680 | Rust-backed grep/glob: `RustFileIOBackend`, `SidecarAdapter`, `SidecarError`, plus the `resolve_sidecar_binary` resolver and the `default_file_io_service` factory used by `Agent.__init__` |
 | `mail.py` | 4 | Re-exports `MailService`, `FilesystemMailService` from `lingtai_kernel.services.mail` |
-| `mcp.py` | 510 | `MCPClient` (stdio) + `HTTPMCPClient` (streamable HTTP) — async-to-sync MCP bridges |
+| `mcp.py` | 530 | `MCPClient` (stdio) + `HTTPMCPClient` (streamable HTTP) — async-to-sync MCP bridges |
+| `nokv.py` | 123 | NoKV config/URI helpers, `NoKVUnsupportedError`, and selected-subtree classification |
 
 **Sub-packages (not covered here):** `vision/` (7 provider files), `websearch/` (6 provider files).
 **Sibling crates:** `crates/lingtai-search-sidecar/` (Rust) — opt-in binary that backs `RustFileIOBackend`. Not required for install/tests.
@@ -24,17 +25,21 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 - **→ `mcp.client.stdio`**, **`mcp.client.streamable_http`**, **`mcp.client.session`** (mcp.py:224, 406-407) — third-party MCP SDK. Imported lazily inside async connect methods.
 - **← `lingtai.capabilities.vision`** — uses `services.vision.VisionService`.
 - **← `lingtai.capabilities.web_search`** — uses `services.websearch.SearchService`.
-- **← `lingtai.core.*`** — read/write/edit/glob/grep use `FileIOService`.
+- **← `lingtai.core.*`** — read/write/edit/glob/grep use `FileIOService`; `lingtai.core.nokv` uses `NoKVFileIOBackend`.
+- **`file_io.py` → `nokv.py`** — `NoKVFileIOBackend` / `HybridFileIOBackend` import URI normalization and disabled-backend errors.
 
 ## Composition
 
-`file_io.py` is a pure stdlib abstraction layer. `LocalFileIOService` is the tool-facing facade while `LocalFileIOBackend` owns the default Python local filesystem implementation. `file_io_sidecar.py` provides `RustFileIOBackend`, an opt-in alternative backend that delegates `read`/`write`/`edit` to a private `LocalFileIOBackend` but routes `grep`/`glob` to the Rust binary under `crates/lingtai-search-sidecar/` via short-lived JSON subprocess calls. `mail.py` is a passthrough re-export. `mcp.py` is the heavy module — two parallel client classes sharing the same pattern.
+`file_io.py` is a pure stdlib abstraction layer. `LocalFileIOService` is the tool-facing facade while `LocalFileIOBackend` owns the default Python local filesystem implementation. `NoKVFileIOBackend` owns explicit `nokv://` object operations (`file_io.py:402-594`), and `HybridFileIOBackend` routes ordinary paths to local storage while requiring configured NoKV for `nokv://` (`file_io.py:597-685`). `nokv.py` keeps URI/config/subtree policy outside the low-level backend (`nokv.py:13-123`). `file_io_sidecar.py` provides `RustFileIOBackend`, an opt-in alternative backend that delegates `read`/`write`/`edit` to a private `LocalFileIOBackend` but routes `grep`/`glob` to the Rust binary under `crates/lingtai-search-sidecar/` via short-lived JSON subprocess calls. `mail.py` is a passthrough re-export. `mcp.py` is the heavy module — two parallel client classes sharing the same pattern.
 
 ## State
 
 - **`MCPClient` / `HTTPMCPClient`**: each instance manages a background daemon thread (L68, 292), an asyncio event loop (`_loop`), a `ClientSession` (`_session`), and a 50-entry activity log (`_activity_log`, L54, 286). Thread-safe via `threading.Lock` and `threading.Event`.
 - **`LocalFileIOService`**: facade over a `_backend`; exposes `last_traversal` from the backend for tool metadata.
 - **`LocalFileIOBackend`**: default Python local filesystem backend; state is optional `_root` plus `last_traversal`.
+- **`NoKVConfig`**: immutable optional NoKV config shape; default `enabled=False` keeps runtime local (`nokv.py:43-56`).
+- **`NoKVFileIOBackend`**: injected NoKV client plus URI prefixes and traversal stats; imports no NoKV SDK at module load (`file_io.py:402-418`).
+- **`HybridFileIOBackend`**: local backend, optional NoKV backend, and `_last_backend` for `last_traversal` routing (`file_io.py:597-610`).
 - **`RustFileIOBackend`**: holds an embedded `LocalFileIOBackend` (for read/write/edit), a `SidecarAdapter` (subprocess client), and a `last_traversal` rebuilt from each sidecar envelope.
 - **`SidecarAdapter`**: stateless apart from the resolved binary path; one subprocess per `call()`.
 - **`FileIOService` / `FileIOBackend` ABCs**: pure interfaces, no state.
@@ -47,3 +52,4 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 - `mcp.py` has significant code duplication between the two classes — same `call_tool()`, `list_tools()`, `_run_loop()`, `_async_cleanup()` pattern.
 - `mail.py` is a thin shim — the real implementation lives in `lingtai_kernel.services.mail`.
 - `file_io_sidecar.py` is the **default native backend** for `Agent`-created file-I/O services. `default_file_io_service` is the factory that `Agent.__init__` calls; it consults `LINGTAI_FILE_IO_BACKEND` (`auto` / `rust` / `python`, default `auto`) and `resolve_sidecar_binary` to pick between Rust and the pure-Python `LocalFileIOBackend`. Resolver priority: explicit `binary_path=` > `LINGTAI_FILE_IO_SIDECAR` env > `LINGTAI_SEARCH_SIDECAR` (legacy) env > packaged `lingtai/bin/` binary (shipped in platform-specific wheels by `setup.py`) > dev-tree `crates/lingtai-search-sidecar/target/{release,debug}/`. The strict `SidecarAdapter()` constructor still ignores packaged / dev-tree sources — opt-in callers see `not_configured` rather than picking up a stale binary. Defaults (`DEFAULT_*` constants) are imported from `file_io.py` so both backends stay in lock-step. Cargo is **not** required for install or the normal test suite — tests use a Python-script "sidecar"; only `test_rust_sidecar_integration_grep_and_glob` is cargo-gated.
+- NoKV remains explicit: ordinary local paths never route to NoKV, and `nokv://` raises `NoKVUnsupportedError` unless a NoKV backend/client is injected.

--- a/src/lingtai/services/file_io.py
+++ b/src/lingtai/services/file_io.py
@@ -32,6 +32,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
+from .nokv import (
+    DEFAULT_NOKV_URI_PREFIXES,
+    NoKVUnsupportedError,
+    format_nokv_uri,
+    is_nokv_uri,
+    normalize_nokv_path,
+)
+
 
 @dataclass
 class GrepMatch:
@@ -389,6 +397,293 @@ class LocalFileIOBackend(FileIOBackend):
                         )
                         return results
         return results
+
+
+class NoKVFileIOBackend(FileIOBackend):
+    """NoKV backend for explicit ``nokv://`` object paths.
+
+    The backend intentionally accepts an injected client instead of importing a
+    NoKV SDK at module import time. That keeps LingTai runnable when NoKV is
+    not installed and lets hosts wire the concrete client they own.
+    """
+
+    def __init__(
+        self,
+        client: Any | None = None,
+        *,
+        uri_prefixes: tuple[str, ...] = DEFAULT_NOKV_URI_PREFIXES,
+    ):
+        self._client = client
+        self._uri_prefixes = tuple(uri_prefixes)
+        self.last_traversal: TraversalStats = TraversalStats()
+
+    def _require_client(self) -> Any:
+        if self._client is None:
+            raise NoKVUnsupportedError(
+                "NoKV is not configured; pass a NoKV client before using nokv:// paths"
+            )
+        return self._client
+
+    def _object_path(self, path: str) -> str:
+        return normalize_nokv_path(path, self._uri_prefixes)
+
+    def _uri(self, path: str) -> str:
+        return format_nokv_uri(path, self._uri_prefixes[0])
+
+    def _call(self, method_names: tuple[str, ...], *args: Any, **kwargs: Any) -> Any:
+        client = self._require_client()
+        for name in method_names:
+            method = getattr(client, name, None)
+            if not callable(method):
+                continue
+            if kwargs:
+                try:
+                    return method(*args, **kwargs)
+                except TypeError:
+                    return method(*args)
+            return method(*args)
+        raise NoKVUnsupportedError(
+            "NoKV client does not support any of: " + ", ".join(method_names)
+        )
+
+    @staticmethod
+    def _content_from_result(result: Any) -> str:
+        if isinstance(result, bytes):
+            return result.decode("utf-8")
+        if isinstance(result, str):
+            return result
+        if isinstance(result, dict):
+            for key in ("content", "text", "body"):
+                value = result.get(key)
+                if isinstance(value, bytes):
+                    return value.decode("utf-8")
+                if isinstance(value, str):
+                    return value
+        return str(result)
+
+    def _entry_from_result(self, result: Any) -> dict:
+        if isinstance(result, dict):
+            path = result.get("path") or result.get("key") or result.get("name")
+            if path is None:
+                path = ""
+            return {
+                "path": normalize_nokv_path(str(path), self._uri_prefixes),
+                "generation": result.get("generation") or result.get("snapshot"),
+                "metadata": result.get("metadata") or {},
+            }
+        return {
+            "path": normalize_nokv_path(str(result), self._uri_prefixes),
+            "generation": None,
+            "metadata": {},
+        }
+
+    def _entries_from_result(self, result: Any) -> list[dict]:
+        if isinstance(result, dict):
+            for key in ("entries", "items", "objects", "results"):
+                entries = result.get(key)
+                if isinstance(entries, list):
+                    return [self._entry_from_result(entry) for entry in entries]
+            if "path" in result or "key" in result:
+                return [self._entry_from_result(result)]
+        if isinstance(result, list):
+            return [self._entry_from_result(entry) for entry in result]
+        return []
+
+    def read(self, path: str) -> str:
+        object_path = self._object_path(path)
+        result = self._call(("read", "cat", "get"), object_path)
+        return self._content_from_result(result)
+
+    def write(self, path: str, content: str) -> None:
+        object_path = self._object_path(path)
+        self._call(
+            ("write", "put", "put_file", "put_artifact", "pipe_file"),
+            object_path,
+            content,
+            metadata=None,
+        )
+
+    def edit(self, path: str, old_string: str, new_string: str) -> str:
+        content = self.read(path)
+        if old_string not in content:
+            raise ValueError(f"old_string not found in {path}")
+        count = content.count(old_string)
+        if count > 1:
+            raise ValueError(
+                f"old_string appears {count} times in {path} — must be unique. "
+                "Provide more context to make it unique."
+            )
+        content = content.replace(old_string, new_string, 1)
+        self.write(path, content)
+        return content
+
+    def list(self, path: str) -> list[dict]:
+        object_path = self._object_path(path)
+        result = self._call(("list", "ls", "find"), object_path)
+        return self._entries_from_result(result)
+
+    def stat(self, path: str) -> dict:
+        object_path = self._object_path(path)
+        result = self._call(("stat", "metadata", "info"), object_path)
+        entry = self._entry_from_result(result)
+        entry["path"] = object_path
+        return entry
+
+    def snapshot(self, path: str) -> dict:
+        object_path = self._object_path(path)
+        result = self._call(("snapshot", "pin", "stat"), object_path)
+        if isinstance(result, dict):
+            out = dict(result)
+            out["path"] = object_path
+            return out
+        return {"path": object_path, "generation": result}
+
+    def glob(
+        self,
+        pattern: str,
+        root: str | None = None,
+        *,
+        exclude_dirs: frozenset[str] | set[str] | None = None,
+        walltime_s: float | None = DEFAULT_WALLTIME_S,
+        max_visited: int | None = DEFAULT_MAX_VISITED,
+        max_results: int | None = 2000,
+    ) -> list[str]:
+        import fnmatch
+        import os
+
+        self.last_traversal = TraversalStats()
+        root_path = self._object_path(root or "/")
+        results: list[str] = []
+        for entry in self.list(root_path):
+            self.last_traversal.visited += 1
+            rel = os.path.relpath(entry["path"], root_path)
+            if fnmatch.fnmatch(rel, pattern):
+                results.append(self._uri(entry["path"]))
+                if max_results is not None and len(results) >= max_results:
+                    self.last_traversal.truncated_reason = "max_results"
+                    break
+        results.sort()
+        return results
+
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        max_results: int = 50,
+        *,
+        exclude_dirs: frozenset[str] | set[str] | None = None,
+        walltime_s: float | None = DEFAULT_WALLTIME_S,
+        max_visited: int | None = DEFAULT_MAX_VISITED,
+        max_file_bytes: int | None = DEFAULT_MAX_FILE_BYTES,
+    ) -> list[GrepMatch]:
+        import re
+
+        regex = re.compile(pattern)
+        self.last_traversal = TraversalStats()
+        root_path = self._object_path(path or "/")
+        results: list[GrepMatch] = []
+        for entry in self.list(root_path):
+            self.last_traversal.visited += 1
+            content = self.read(entry["path"])
+            for i, line in enumerate(content.splitlines(), 1):
+                if regex.search(line):
+                    results.append(GrepMatch(self._uri(entry["path"]), i, line))
+                    if len(results) >= max_results:
+                        self.last_traversal.truncated_reason = "max_results"
+                        return results
+        return results
+
+
+class HybridFileIOBackend(FileIOBackend):
+    """Route ordinary paths to local storage and ``nokv://`` paths to NoKV."""
+
+    def __init__(
+        self,
+        *,
+        local_backend: FileIOBackend | None = None,
+        nokv_backend: NoKVFileIOBackend | None = None,
+        uri_prefixes: tuple[str, ...] = DEFAULT_NOKV_URI_PREFIXES,
+    ):
+        self._local_backend = local_backend or LocalFileIOBackend()
+        self._nokv_backend = nokv_backend
+        self._uri_prefixes = tuple(uri_prefixes)
+        self._last_backend: FileIOBackend = self._local_backend
+
+    @property
+    def last_traversal(self) -> TraversalStats:
+        return self._last_backend.last_traversal
+
+    @last_traversal.setter
+    def last_traversal(self, value: TraversalStats) -> None:
+        self._last_backend.last_traversal = value
+
+    def _nokv(self) -> NoKVFileIOBackend:
+        if self._nokv_backend is None:
+            raise NoKVUnsupportedError(
+                "NoKV is not configured; nokv:// paths require a NoKV backend"
+            )
+        self._last_backend = self._nokv_backend
+        return self._nokv_backend
+
+    def _backend_for_path(self, path: str) -> FileIOBackend:
+        if is_nokv_uri(path, self._uri_prefixes):
+            return self._nokv()
+        self._last_backend = self._local_backend
+        return self._local_backend
+
+    def read(self, path: str) -> str:
+        return self._backend_for_path(path).read(path)
+
+    def write(self, path: str, content: str) -> None:
+        self._backend_for_path(path).write(path, content)
+
+    def edit(self, path: str, old_string: str, new_string: str) -> str:
+        return self._backend_for_path(path).edit(path, old_string, new_string)
+
+    def glob(
+        self,
+        pattern: str,
+        root: str | None = None,
+        *,
+        exclude_dirs: frozenset[str] | set[str] | None = None,
+        walltime_s: float | None = DEFAULT_WALLTIME_S,
+        max_visited: int | None = DEFAULT_MAX_VISITED,
+        max_results: int | None = 2000,
+    ) -> list[str]:
+        backend = self._nokv() if root and is_nokv_uri(root, self._uri_prefixes) else self._local_backend
+        self._last_backend = backend
+        return backend.glob(
+            pattern,
+            root=root,
+            exclude_dirs=exclude_dirs,
+            walltime_s=walltime_s,
+            max_visited=max_visited,
+            max_results=max_results,
+        )
+
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        max_results: int = 50,
+        *,
+        exclude_dirs: frozenset[str] | set[str] | None = None,
+        walltime_s: float | None = DEFAULT_WALLTIME_S,
+        max_visited: int | None = DEFAULT_MAX_VISITED,
+        max_file_bytes: int | None = DEFAULT_MAX_FILE_BYTES,
+    ) -> list[GrepMatch]:
+        backend = self._nokv() if path and is_nokv_uri(path, self._uri_prefixes) else self._local_backend
+        self._last_backend = backend
+        return backend.grep(
+            pattern,
+            path=path,
+            max_results=max_results,
+            exclude_dirs=exclude_dirs,
+            walltime_s=walltime_s,
+            max_visited=max_visited,
+            max_file_bytes=max_file_bytes,
+        )
+
 
 class LocalFileIOService(FileIOService):
     """Tool-facing file I/O service facade using a pluggable backend.

--- a/src/lingtai/services/nokv.py
+++ b/src/lingtai/services/nokv.py
@@ -1,0 +1,123 @@
+"""NoKV integration helpers.
+
+This module owns the safe first boundary for NoKV support: URI parsing,
+optional config shape, and selected LingTai subtree classification. It does
+not import a NoKV SDK at module import time.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any, Mapping, Sequence
+
+DEFAULT_NOKV_URI_PREFIXES: tuple[str, ...] = ("nokv://",)
+DEFAULT_NOKV_SELECTED_SUBTREES: tuple[str, ...] = (
+    "artifacts",
+    "reports",
+    "checkpoints",
+    "knowledge",
+)
+
+_LOCAL_RUNTIME_PARTS: frozenset[str] = frozenset({
+    ".agent.lock",
+    ".agent.heartbeat",
+    ".status.json",
+    ".sleep",
+    ".suspend",
+    ".interrupt",
+    ".prompt",
+    ".refresh",
+    "mailbox",
+    "logs",
+    "history",
+    "tmp",
+    "daemons",
+    ".notification",
+})
+
+
+class NoKVUnsupportedError(RuntimeError):
+    """Raised when a NoKV path is requested without a configured backend."""
+
+
+@dataclass(frozen=True)
+class NoKVConfig:
+    """Resolved optional NoKV config.
+
+    Hosts may pass this structure explicitly. Runtime defaults stay local:
+    ``enabled=False`` means no NoKV reads or writes are attempted.
+    """
+
+    enabled: bool = False
+    endpoint: str | None = None
+    default_namespace: str | None = None
+    uri_prefixes: tuple[str, ...] = DEFAULT_NOKV_URI_PREFIXES
+    selected_subtrees: tuple[str, ...] = DEFAULT_NOKV_SELECTED_SUBTREES
+    client: Any | None = field(default=None, compare=False, repr=False)
+
+
+def parse_nokv_config(raw: Mapping[str, Any] | None) -> NoKVConfig:
+    """Return a typed NoKVConfig from an already-schema-validated mapping."""
+    if not raw:
+        return NoKVConfig()
+    return NoKVConfig(
+        enabled=bool(raw.get("enabled", False)),
+        endpoint=raw.get("endpoint"),
+        default_namespace=raw.get("default_namespace"),
+        uri_prefixes=tuple(raw.get("uri_prefixes") or DEFAULT_NOKV_URI_PREFIXES),
+        selected_subtrees=tuple(
+            raw.get("selected_subtrees") or DEFAULT_NOKV_SELECTED_SUBTREES
+        ),
+        client=raw.get("client"),
+    )
+
+
+def is_nokv_uri(path: str, uri_prefixes: Sequence[str] = DEFAULT_NOKV_URI_PREFIXES) -> bool:
+    return any(path.startswith(prefix) for prefix in uri_prefixes)
+
+
+def normalize_nokv_path(
+    path: str,
+    uri_prefixes: Sequence[str] = DEFAULT_NOKV_URI_PREFIXES,
+) -> str:
+    """Normalize a NoKV URI or object path to an absolute NoKV object path."""
+    raw = path
+    for prefix in uri_prefixes:
+        if raw.startswith(prefix):
+            raw = raw[len(prefix):]
+            break
+    raw = raw.strip()
+    if not raw:
+        return "/"
+    if not raw.startswith("/"):
+        raw = "/" + raw
+    return "/" + "/".join(part for part in raw.split("/") if part)
+
+
+def format_nokv_uri(path: str, prefix: str = DEFAULT_NOKV_URI_PREFIXES[0]) -> str:
+    object_path = normalize_nokv_path(path)
+    return prefix + object_path.lstrip("/")
+
+
+def classify_lingtai_subtree(
+    path: str,
+    *,
+    selected_subtrees: Sequence[str] = DEFAULT_NOKV_SELECTED_SUBTREES,
+) -> str:
+    """Classify a LingTai path for the selected-subtree smoke boundary.
+
+    Returns:
+        ``"nokv-candidate"`` for output-like subtrees that may be mapped to
+        NoKV, ``"local-runtime"`` for locks/mail/logs/signals that must stay
+        local, and ``"outside"`` for paths outside this first boundary.
+    """
+    normalized = str(path).replace("\\", "/")
+    parts = tuple(
+        part for part in PurePosixPath(normalized).parts
+        if part not in {"", "/"}
+    )
+    if any(part in _LOCAL_RUNTIME_PARTS for part in parts):
+        return "local-runtime"
+    if any(part in selected_subtrees for part in parts):
+        return "nokv-candidate"
+    return "outside"

--- a/tests/test_check_caps.py
+++ b/tests/test_check_caps.py
@@ -12,7 +12,7 @@ def test_get_all_providers_returns_all_capabilities():
     result = get_all_providers()
     expected = {
         "file", "bash", "web_search", "knowledge",
-        "skills", "vision", "avatar", "daemon",
+        "skills", "vision", "avatar", "daemon", "nokv",
     }
     assert expected == set(result.keys())
 
@@ -27,7 +27,7 @@ def test_get_all_providers_structure():
 
 def test_builtin_capabilities_have_empty_providers():
     result = get_all_providers()
-    builtins = ["file", "bash", "knowledge", "skills", "avatar", "daemon"]
+    builtins = ["file", "bash", "knowledge", "skills", "avatar", "daemon", "nokv"]
     for name in builtins:
         assert result[name]["providers"] == [], f"{name} should have empty providers"
         assert result[name]["default"] == "builtin", f"{name} should default to builtin"

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -116,6 +116,30 @@ def test_wrong_type_capabilities():
         validate_init(data)
 
 
+def test_nokv_manifest_config_shape_valid():
+    data = _valid_init()
+    data["manifest"]["nokv"] = {
+        "enabled": False,
+        "endpoint": "http://127.0.0.1:7373",
+        "default_namespace": "/lingtai/projects/project-hash",
+        "uri_prefixes": ["nokv://"],
+        "selected_subtrees": ["artifacts", "reports", "checkpoints", "knowledge"],
+    }
+
+    validate_init(data)
+
+
+def test_nokv_manifest_config_rejects_bad_uri_prefixes():
+    data = _valid_init()
+    data["manifest"]["nokv"] = {
+        "enabled": True,
+        "uri_prefixes": "nokv://",
+    }
+
+    with pytest.raises(ValueError, match=r"manifest\.nokv\.uri_prefixes.*list\[str\]"):
+        validate_init(data)
+
+
 def test_wrong_type_streaming():
     data = _valid_init()
     data["manifest"]["streaming"] = "yes"

--- a/tests/test_nokv_capability.py
+++ b/tests/test_nokv_capability.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lingtai.agent import Agent
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
+
+
+class FakeNoKVClient:
+    def __init__(self):
+        self.objects = {
+            "/lingtai/projects/p/artifacts/a.md": {
+                "content": "alpha\nneedle\n",
+                "generation": "g1",
+                "metadata": {"producer": "test"},
+            },
+            "/lingtai/projects/p/reports/r.md": {
+                "content": "report body\n",
+                "generation": "g2",
+                "metadata": {"producer": "test"},
+            },
+        }
+
+    def list(self, path: str):
+        prefix = path.rstrip("/") + "/"
+        return [
+            {"path": key, "generation": value["generation"], "metadata": value["metadata"]}
+            for key, value in sorted(self.objects.items())
+            if key == path or key.startswith(prefix)
+        ]
+
+    def read(self, path: str):
+        return self.objects[path]
+
+    def stat(self, path: str):
+        value = self.objects[path]
+        return {"path": path, "generation": value["generation"], "metadata": value["metadata"]}
+
+    def snapshot(self, path: str):
+        value = self.objects[path]
+        return {"path": path, "generation": value["generation"]}
+
+
+def _mk_agent(tmp_path: Path, nokv_kwargs: dict):
+    return Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=tmp_path / "agent",
+        capabilities={"nokv": nokv_kwargs},
+    )
+
+
+def test_nokv_capability_registers_explicit_tool_and_lists_namespace(tmp_path):
+    agent = _mk_agent(tmp_path, {"client": FakeNoKVClient()})
+    try:
+        result = agent._tool_handlers["nokv"](
+            {"action": "ls", "path": "nokv://lingtai/projects/p"}
+        )
+
+        assert result["status"] == "ok"
+        assert result["action"] == "ls"
+        assert [entry["path"] for entry in result["entries"]] == [
+            "nokv://lingtai/projects/p/artifacts/a.md",
+            "nokv://lingtai/projects/p/reports/r.md",
+        ]
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_nokv_capability_reads_greps_and_reports_snapshot_generations(tmp_path):
+    agent = _mk_agent(tmp_path, {"client": FakeNoKVClient()})
+    try:
+        read = agent._tool_handlers["nokv"](
+            {"action": "read", "path": "nokv://lingtai/projects/p/artifacts/a.md"}
+        )
+        grep = agent._tool_handlers["nokv"](
+            {"action": "grep", "path": "nokv://lingtai/projects/p", "pattern": "needle"}
+        )
+        snapshot = agent._tool_handlers["nokv"](
+            {"action": "snapshot", "path": "nokv://lingtai/projects/p/artifacts/a.md"}
+        )
+
+        assert read["content"] == "alpha\nneedle\n"
+        assert read["generation"] == "g1"
+        assert grep["matches"] == [
+            {
+                "path": "nokv://lingtai/projects/p/artifacts/a.md",
+                "line": 2,
+                "text": "needle",
+                "generation": "g1",
+                "metadata": {"producer": "test"},
+            }
+        ]
+        assert snapshot["snapshot"]["generation"] == "g1"
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_nokv_capability_reports_actionable_error_when_unconfigured(tmp_path):
+    agent = _mk_agent(tmp_path, {"enabled": True})
+    try:
+        result = agent._tool_handlers["nokv"](
+            {"action": "ls", "path": "nokv://lingtai/projects/p"}
+        )
+
+        assert result["status"] == "error"
+        assert "NoKV is not configured" in result["message"]
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_nokv_capability_does_not_change_default_local_file_io(tmp_path):
+    agent = _mk_agent(tmp_path, {"client": FakeNoKVClient()})
+    try:
+        agent._file_io.write("local.txt", "local")
+
+        assert agent._file_io.read("local.txt") == "local"
+    finally:
+        agent.stop(timeout=1.0)

--- a/tests/test_nokv_services.py
+++ b/tests/test_nokv_services.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from lingtai.agent import Agent
+from lingtai.services.file_io import (
+    GrepMatch,
+    HybridFileIOBackend,
+    LocalFileIOBackend,
+    LocalFileIOService,
+    NoKVFileIOBackend,
+    NoKVUnsupportedError,
+)
+from lingtai.services.nokv import classify_lingtai_subtree
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
+
+
+@dataclass
+class FakeObject:
+    content: str
+    generation: str
+    metadata: dict
+
+
+class FakeNoKVClient:
+    def __init__(self):
+        self.objects: dict[str, FakeObject] = {}
+        self.write_calls: list[tuple[str, str, dict | None]] = []
+
+    def read(self, path: str) -> dict:
+        obj = self.objects[path]
+        return {
+            "content": obj.content,
+            "generation": obj.generation,
+            "metadata": obj.metadata,
+        }
+
+    def write(self, path: str, content: str, metadata: dict | None = None) -> dict:
+        generation = f"gen-{len(self.write_calls) + 1}"
+        self.objects[path] = FakeObject(content, generation, metadata or {})
+        self.write_calls.append((path, content, metadata))
+        return {"path": path, "generation": generation}
+
+    def list(self, path: str) -> list[dict]:
+        prefix = path.rstrip("/") + "/"
+        return [
+            {"path": obj_path, "generation": obj.generation, "metadata": obj.metadata}
+            for obj_path, obj in sorted(self.objects.items())
+            if obj_path == path or obj_path.startswith(prefix)
+        ]
+
+    def stat(self, path: str) -> dict:
+        obj = self.objects[path]
+        return {"path": path, "generation": obj.generation, "metadata": obj.metadata}
+
+    def snapshot(self, path: str) -> dict:
+        return {"path": path, "generation": self.objects[path].generation}
+
+
+def test_selected_subtree_policy_allows_outputs_and_keeps_runtime_state_local():
+    assert (
+        classify_lingtai_subtree(".lingtai/alice/artifacts/report.md")
+        == "nokv-candidate"
+    )
+    assert (
+        classify_lingtai_subtree(".lingtai/alice/checkpoints/rank0.pt")
+        == "nokv-candidate"
+    )
+    assert classify_lingtai_subtree(".lingtai/alice/mailbox/inbox/msg.json") == "local-runtime"
+    assert classify_lingtai_subtree(".lingtai/alice/logs/events.jsonl") == "local-runtime"
+    assert classify_lingtai_subtree(".lingtai/alice/.agent.heartbeat") == "local-runtime"
+
+
+def test_hybrid_file_io_routes_local_paths_to_local_backend(tmp_path):
+    fake = FakeNoKVClient()
+    backend = HybridFileIOBackend(
+        local_backend=LocalFileIOBackend(root=tmp_path),
+        nokv_backend=NoKVFileIOBackend(fake),
+    )
+    svc = LocalFileIOService(backend=backend)
+
+    svc.write("local.txt", "local")
+
+    assert svc.read("local.txt") == "local"
+    assert fake.write_calls == []
+
+
+def test_hybrid_file_io_routes_nokv_uris_to_nokv_backend(tmp_path):
+    fake = FakeNoKVClient()
+    backend = HybridFileIOBackend(
+        local_backend=LocalFileIOBackend(root=tmp_path),
+        nokv_backend=NoKVFileIOBackend(fake),
+    )
+    svc = LocalFileIOService(backend=backend)
+
+    svc.write("nokv://project/artifacts/a.md", "hello\nneedle\n")
+
+    assert fake.write_calls[0][0] == "/project/artifacts/a.md"
+    assert svc.read("nokv://project/artifacts/a.md") == "hello\nneedle\n"
+    assert svc.grep("needle", path="nokv://project") == [
+        GrepMatch("nokv://project/artifacts/a.md", 2, "needle")
+    ]
+
+
+def test_nokv_file_io_edit_preserves_unique_replace_contract():
+    fake = FakeNoKVClient()
+    backend = NoKVFileIOBackend(fake)
+    backend.write("nokv://project/reports/r.md", "alpha beta")
+
+    assert backend.edit("nokv://project/reports/r.md", "beta", "gamma") == "alpha gamma"
+    assert backend.read("nokv://project/reports/r.md") == "alpha gamma"
+
+    with pytest.raises(ValueError, match="not found"):
+        backend.edit("nokv://project/reports/r.md", "missing", "x")
+
+    backend.write("nokv://project/reports/r.md", "dup dup")
+    with pytest.raises(ValueError, match="appears 2 times"):
+        backend.edit("nokv://project/reports/r.md", "dup", "x")
+
+
+def test_hybrid_file_io_rejects_nokv_uri_when_backend_disabled(tmp_path):
+    backend = HybridFileIOBackend(local_backend=LocalFileIOBackend(root=tmp_path))
+
+    with pytest.raises(NoKVUnsupportedError, match="NoKV is not configured"):
+        backend.read("nokv://project/artifacts/a.md")
+
+
+def test_file_capability_handlers_preserve_nokv_uri_paths(tmp_path):
+    fake = FakeNoKVClient()
+    file_io = LocalFileIOService(
+        backend=HybridFileIOBackend(
+            local_backend=LocalFileIOBackend(root=tmp_path),
+            nokv_backend=NoKVFileIOBackend(fake),
+        )
+    )
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=tmp_path / "agent",
+        file_io=file_io,
+        capabilities=["read", "write", "glob", "grep"],
+    )
+    try:
+        write = agent._tool_handlers["write"]({
+            "file_path": "nokv://project/artifacts/a.md",
+            "content": "hello\nneedle\n",
+        })
+        read = agent._tool_handlers["read"]({"file_path": "nokv://project/artifacts/a.md"})
+        grep = agent._tool_handlers["grep"]({
+            "path": "nokv://project",
+            "pattern": "needle",
+        })
+        glob = agent._tool_handlers["glob"]({
+            "path": "nokv://project",
+            "pattern": "**/*.md",
+        })
+
+        assert write["status"] == "ok"
+        assert fake.write_calls[0][0] == "/project/artifacts/a.md"
+        assert "needle" in read["content"]
+        assert grep["matches"][0]["file"] == "nokv://project/artifacts/a.md"
+        assert glob["matches"] == ["nokv://project/artifacts/a.md"]
+    finally:
+        agent.stop(timeout=1.0)


### PR DESCRIPTION
## Summary

Implements the first explicit NoKV integration boundary for LingTai without changing the default local runtime behavior.

- adds NoKV URI/config/subtree helpers and clear unsupported-backend errors
- adds `NoKVFileIOBackend` and `HybridFileIOBackend` for explicit `nokv://` routing
- adds an opt-in `nokv` capability for namespace inspection, read, grep, and snapshot operations
- preserves `nokv://` paths in existing read/write/edit/glob/grep capability handlers
- validates optional `manifest.nokv` config and updates anatomy docs

## Impact

LingTai continues to run locally by default and without a NoKV SDK installed. NoKV access is explicit: ordinary paths stay local, while `nokv://` paths require an injected NoKV backend/client and fail closed when unconfigured.

## Validation

- `git diff --check`
- `PYTHONPATH=src uv run --with pytest python -m pytest -q tests/test_services_file_io.py tests/test_file_io_sidecar.py tests/test_layers_file.py tests/test_init_schema.py tests/test_agent_capabilities.py tests/test_nokv_services.py tests/test_nokv_capability.py tests/test_check_caps.py -k 'not rust_sidecar_integration_grep_and_glob'` - 170 passed, 1 deselected
- `PYTHONPATH=src uv run --with pytest python -m pytest -q --tb=short tests/test_eigen.py::test_snapshot_filename_uses_molt_count tests/test_psyche.py::test_context_forget_still_works tests/test_session_journal_gate.py::test_system_forget_does_not_require_journal` - 3 passed, 1 warning

Known local environment exclusions: `test_rust_sidecar_integration_grep_and_glob` needs a newer Cargo than the installed 1.57.0 lockfile support; one preset-materialization path requires a local Codex auth file outside this repo.
