### PR TITLE
feat(wechat): validate inbound media by magic bytes

### DIFF
--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -349,7 +349,8 @@ class WechatManager:
                         path = await media_mod.download_media(
                             item.image_item.media, self._media_dir, fname,
                         )
-                        body_parts.append(f"[Image: {path}]")
+                        suffix = media_mod.validate_image_bytes(path).render_suffix()
+                        body_parts.append(f"[Image: {path}]{suffix}")
                     except Exception as e:
                         body_parts.append(f"[Image: download failed — {e}]")
 
@@ -383,7 +384,8 @@ class WechatManager:
                         path = await media_mod.download_media(
                             item.file_item.media, self._media_dir, fname,
                         )
-                        body_parts.append(f"[File: {fname} ({path})]")
+                        suffix = media_mod.validate_media_bytes(path).render_suffix()
+                        body_parts.append(f"[File: {fname} ({path})]{suffix}")
                     except Exception as e:
                         body_parts.append(f"[File: download failed — {e}]")
 

--- a/src/lingtai/mcp_servers/wechat/media.py
+++ b/src/lingtai/mcp_servers/wechat/media.py
@@ -40,6 +40,165 @@ class UploadedMediaInfo:
 
 log = logging.getLogger(__name__)
 
+
+# ── Magic-byte validation ──────────────────────────────────────────────────
+#
+# WeChat attachments sometimes arrive under a normal-looking name/extension
+# (".pdf", ".zip", ".jpg") while the bytes saved under wechat/media/ are
+# encrypted / cache / private-container data rather than the real exported
+# file. Downstream agents then fail late in PDF/ZIP/vision tooling with
+# confusing errors. We validate the saved bytes against the declared
+# extension's magic bytes right after download and surface a structured
+# warning so the agent can ask the user to re-export ("Save As") instead of
+# repeatedly running parsers on unusable bytes. The raw bytes are always
+# preserved on disk for inspection — we only annotate, never delete.
+
+# Declared extension → list of acceptable leading-byte signatures.
+# Signatures are matched at the start of the file (RIFF/WEBP needs a windowed
+# check, handled below).
+_MAGIC_SIGNATURES: dict[str, list[bytes]] = {
+    ".pdf": [b"%PDF-"],
+    ".zip": [
+        b"PK\x03\x04",  # normal local file header
+        b"PK\x05\x06",  # empty archive (end-of-central-directory only)
+        b"PK\x07\x08",  # spanned archive marker
+    ],
+    ".png": [b"\x89PNG\r\n\x1a\n"],
+    ".jpg": [b"\xff\xd8\xff"],
+    ".jpeg": [b"\xff\xd8\xff"],
+    ".gif": [b"GIF87a", b"GIF89a"],
+    ".bmp": [b"BM"],
+    # .webp is a RIFF container: "RIFF" .... "WEBP"; checked specially.
+    ".webp": [b"RIFF"],
+}
+
+# How many bytes we need to read to cover the longest signature + WEBP window.
+_MAGIC_READ_LEN = 32
+
+_RECOVERY_HINT = (
+    "This attachment's bytes do not match its '{ext}' extension — it is "
+    "likely WeChat/QQ cache, encrypted, or private-container data rather "
+    "than the real exported file. Do not run PDF/ZIP/image parsers on it. "
+    "Ask the sender to open WeChat and use right-click / long-press → "
+    "\"Save As\" to export the original file, or send it via a cloud-drive "
+    "link / original file upload."
+)
+
+
+@dataclass
+class MediaValidation:
+    """Result of validating saved attachment bytes against the declared
+    extension's magic bytes.
+
+    status:
+      - "ok":       bytes match the declared type's signature.
+      - "mismatch": a signature is known for the extension but the bytes
+                    don't match it — likely cache/encrypted/private data.
+      - "unknown":  no signature is known for this extension (or no
+                    extension), so no judgement is made. Never a warning.
+    """
+
+    status: str
+    declared_ext: str
+    path: str
+    warning: str | None = None
+    hint: str | None = None
+
+    def render_suffix(self) -> str:
+        """Compact inline annotation for the conversation body. Empty unless
+        this is a mismatch the agent should be warned about."""
+        if self.status != "mismatch":
+            return ""
+        return f" ⚠ WARNING: {self.warning} {self.hint}"
+
+
+_IMAGE_EXTS = (".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp")
+
+
+def _matches_signature(head: bytes, ext: str) -> bool:
+    sigs = _MAGIC_SIGNATURES.get(ext, [])
+    if ext == ".webp":
+        # RIFF container with a "WEBP" form type at offset 8.
+        return head[:4] == b"RIFF" and head[8:12] == b"WEBP"
+    return any(head.startswith(sig) for sig in sigs)
+
+
+def _matches_any_image_signature(head: bytes) -> bool:
+    return any(_matches_signature(head, ext) for ext in _IMAGE_EXTS)
+
+
+def _read_magic_head(path: Path) -> bytes | None:
+    try:
+        with path.open("rb") as fh:
+            return fh.read(_MAGIC_READ_LEN)
+    except OSError as e:
+        log.warning("validate_media_bytes: cannot read %s: %s", path, e)
+        return None
+
+
+def validate_image_bytes(file_path: str | Path) -> MediaValidation:
+    """Validate an inbound WeChat IMAGE download as any known image type.
+
+    WeChat IMAGE payloads are saved under generated ``.jpg`` names because the
+    protocol item does not reliably carry the original extension. Valid PNG,
+    WebP, GIF, or BMP bytes must therefore not be rejected merely because the
+    fabricated filename ends with ``.jpg``. This generic image check still flags
+    cache/encrypted/private-container bytes that are not any recognized image.
+    """
+    path = Path(file_path)
+    head = _read_magic_head(path)
+    if head is None:
+        return MediaValidation(status="unknown", declared_ext="image", path=str(path))
+    if _matches_any_image_signature(head):
+        return MediaValidation(status="ok", declared_ext="image", path=str(path))
+
+    warning = (
+        f"saved '{path.name}' is not a recognized image file "
+        "(magic bytes do not match known image signatures)"
+    )
+    return MediaValidation(
+        status="mismatch",
+        declared_ext="image",
+        path=str(path),
+        warning=warning,
+        hint=_RECOVERY_HINT.format(ext="image"),
+    )
+
+
+def validate_media_bytes(file_path: str | Path) -> MediaValidation:
+    """Validate a saved media file's bytes against its declared extension.
+
+    Returns a MediaValidation. Never raises for content reasons — a missing
+    or unreadable file is reported as "unknown" so validation can never break
+    the download path itself.
+    """
+    path = Path(file_path)
+    ext = path.suffix.lower()
+
+    if ext not in _MAGIC_SIGNATURES:
+        return MediaValidation(status="unknown", declared_ext=ext, path=str(path))
+
+    head = _read_magic_head(path)
+    if head is None:
+        return MediaValidation(status="unknown", declared_ext=ext, path=str(path))
+
+    if _matches_signature(head, ext):
+        return MediaValidation(status="ok", declared_ext=ext, path=str(path))
+
+    kind = ext.lstrip(".")
+    warning = (
+        f"saved '{path.name}' is not a valid {kind} file "
+        f"(magic bytes do not match {ext})"
+    )
+    return MediaValidation(
+        status="mismatch",
+        declared_ext=ext,
+        path=str(path),
+        warning=warning,
+        hint=_RECOVERY_HINT.format(ext=ext),
+    )
+
+
 # Extension → UploadMediaType mapping
 _UPLOAD_TYPE_MAP = {
     ".jpg": UploadMediaType.IMAGE,

--- a/tests/test_wechat_media_validation.py
+++ b/tests/test_wechat_media_validation.py
@@ -1,0 +1,168 @@
+"""Tests for magic-byte validation of downloaded WeChat attachments.
+
+WeChat attachments can arrive under normal-looking `.pdf` / `.zip` / `.jpg`
+names while the saved bytes are encrypted / cache / private-container data
+rather than a real exported file. The addon must detect the
+extension-vs-content mismatch and surface a structured warning instead of
+silently presenting the file as a normal attachment.
+
+Ported from Lingtai-AI/lingtai-wechat#15 into the in-kernel WeChat addon.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.wechat import media
+
+
+# ── Sample bytes ───────────────────────────────────────────────────────────
+
+# A minimal-but-real PDF (starts with %PDF-).
+VALID_PDF = b"%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>\n%%EOF\n"
+# A minimal real ZIP (PK\x03\x04 local file header).
+VALID_ZIP = b"PK\x03\x04" + b"\x00" * 26 + b"PK\x05\x06" + b"\x00" * 18
+VALID_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+VALID_JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 16
+VALID_WEBP = b"RIFF\x24\x00\x00\x00WEBPVP8 " + b"\x00" * 16
+VALID_GIF = b"GIF89a" + b"\x00" * 16
+VALID_BMP = b"BM" + b"\x00" * 16
+
+# An encrypted/cache-like header for a bogus ".zip" attachment.
+ENCRYPTED_ZIP_LIKE = bytes.fromhex(
+    "241f07f6bcab69005d87b05f3c095e27"
+) + b"\x00" * 32
+# A bogus ".pdf" header.
+ENCRYPTED_PDF_LIKE = bytes.fromhex("bb1d453de956099e") + b"\x00" * 32
+
+
+def _write(tmp_path: Path, name: str, data: bytes) -> str:
+    p = tmp_path / name
+    p.write_bytes(data)
+    return str(p)
+
+
+# ── Valid files validate as OK ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("name,data", [
+    ("doc.pdf", VALID_PDF),
+    ("archive.zip", VALID_ZIP),
+    ("pic.png", VALID_PNG),
+    ("pic.jpg", VALID_JPEG),
+    ("pic.jpeg", VALID_JPEG),
+    ("pic.webp", VALID_WEBP),
+    ("pic.gif", VALID_GIF),
+    ("pic.bmp", VALID_BMP),
+])
+def test_valid_files_report_ok(tmp_path, name, data):
+    path = _write(tmp_path, name, data)
+    result = media.validate_media_bytes(path)
+    assert result.status == "ok", result
+    assert result.warning is None
+    assert result.hint is None
+
+
+# ── Mismatched encrypted/cache bytes are flagged ───────────────────────────
+
+def test_encrypted_zip_like_bytes_flagged(tmp_path):
+    path = _write(tmp_path, "archive.zip", ENCRYPTED_ZIP_LIKE)
+    result = media.validate_media_bytes(path)
+    assert result.status == "mismatch"
+    assert result.declared_ext == ".zip"
+    # Warning + actionable recovery hint must be present.
+    assert result.warning and "zip" in result.warning.lower()
+    assert result.hint and "save as" in result.hint.lower()
+
+
+def test_encrypted_pdf_like_bytes_flagged(tmp_path):
+    path = _write(tmp_path, "report.pdf", ENCRYPTED_PDF_LIKE)
+    result = media.validate_media_bytes(path)
+    assert result.status == "mismatch"
+    assert result.declared_ext == ".pdf"
+    assert result.warning and "pdf" in result.warning.lower()
+    assert result.hint
+
+
+def test_non_image_bytes_under_jpg_flagged(tmp_path):
+    path = _write(tmp_path, "screenshot.jpg", ENCRYPTED_PDF_LIKE)
+    result = media.validate_media_bytes(path)
+    assert result.status == "mismatch"
+    assert result.declared_ext == ".jpg"
+
+
+# ── Inbound IMAGE items use generated .jpg names, so validate as any image ──
+
+@pytest.mark.parametrize("data", [VALID_JPEG, VALID_PNG, VALID_WEBP, VALID_GIF, VALID_BMP])
+def test_validate_image_bytes_accepts_any_known_image_signature(tmp_path, data):
+    path = _write(tmp_path, "generated.jpg", data)
+    result = media.validate_image_bytes(path)
+    assert result.status == "ok", result
+    assert result.declared_ext == "image"
+    assert result.render_suffix() == ""
+
+
+def test_validate_image_bytes_flags_non_image_bytes(tmp_path):
+    path = _write(tmp_path, "generated.jpg", ENCRYPTED_ZIP_LIKE)
+    result = media.validate_image_bytes(path)
+    assert result.status == "mismatch"
+    assert result.declared_ext == "image"
+    assert result.warning and "recognized image" in result.warning
+    assert result.hint and "save as" in result.hint.lower()
+
+
+# ── Extensions we don't have a signature for: unknown, never a false alarm ──
+
+def test_unknown_extension_is_not_flagged(tmp_path):
+    path = _write(tmp_path, "note.txt", b"hello world")
+    result = media.validate_media_bytes(path)
+    assert result.status == "unknown"
+    assert result.warning is None
+
+
+def test_no_extension_is_unknown(tmp_path):
+    path = _write(tmp_path, "blob", ENCRYPTED_PDF_LIKE)
+    result = media.validate_media_bytes(path)
+    assert result.status == "unknown"
+
+
+def test_missing_file_is_unknown_not_error(tmp_path):
+    # A signature is known for .pdf, but the file does not exist: never raise,
+    # never flag — report unknown so the download path can't break.
+    result = media.validate_media_bytes(str(tmp_path / "absent.pdf"))
+    assert result.status == "unknown"
+    assert result.warning is None
+
+
+# ── Cross-type confusion: a real PNG saved as .pdf is a mismatch ───────────
+
+def test_real_png_saved_as_pdf_is_mismatch(tmp_path):
+    path = _write(tmp_path, "fake.pdf", VALID_PNG)
+    result = media.validate_media_bytes(path)
+    assert result.status == "mismatch"
+
+
+# ── A jpg signature variant (EXIF, \xff\xd8\xff\xe1) also validates ────────
+
+def test_jpeg_exif_variant_ok(tmp_path):
+    data = b"\xff\xd8\xff\xe1\x00\x10Exif" + b"\x00" * 16
+    path = _write(tmp_path, "photo.jpg", data)
+    result = media.validate_media_bytes(path)
+    assert result.status == "ok"
+
+
+# ── render_suffix(): a compact tag agents can read inline ──────────────────
+
+def test_mismatch_render_suffix_contains_warning_and_hint(tmp_path):
+    path = _write(tmp_path, "archive.zip", ENCRYPTED_ZIP_LIKE)
+    result = media.validate_media_bytes(path)
+    rendered = result.render_suffix()
+    assert rendered  # non-empty for a mismatch
+    assert "⚠" in rendered or "WARNING" in rendered.upper()
+    assert result.hint in rendered
+
+
+def test_ok_render_suffix_is_empty(tmp_path):
+    path = _write(tmp_path, "doc.pdf", VALID_PDF)
+    result = media.validate_media_bytes(path)
+    assert result.render_suffix() == ""

--- a/tests/test_wechat_media_warning_integration.py
+++ b/tests/test_wechat_media_warning_integration.py
@@ -1,0 +1,132 @@
+"""Integration: _on_incoming surfaces a magic-byte mismatch warning.
+
+When a FILE attachment downloads as encrypted/cache bytes (extension says
+.pdf/.zip but content doesn't match), the conversation body landed in the
+inbox must carry a clear warning and a recovery hint instead of presenting a
+normal-looking file path. Valid attachments land with no warning suffix.
+
+Ported from Lingtai-AI/lingtai-wechat#15 into the in-kernel WeChat addon.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from lingtai.mcp_servers.wechat import media as media_mod
+from lingtai.mcp_servers.wechat.manager import WechatManager
+from lingtai.mcp_servers.wechat.types import (
+    CDNMedia, FileItem, ImageItem, MessageItem, MessageItemType, WeixinMessage,
+)
+
+ENCRYPTED_ZIP_LIKE = bytes.fromhex("241f07f6bcab69005d87b05f3c095e27") + b"\x00" * 32
+VALID_PDF = b"%PDF-1.4\n%%EOF\n"
+VALID_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def _manager(tmp_path: Path, events: list[dict]) -> WechatManager:
+    return WechatManager(
+        token="test-token",
+        user_id="test-bot",
+        working_dir=tmp_path,
+        on_inbound=events.append,
+    )
+
+
+def _patch_download(monkeypatch, payload: bytes) -> None:
+    """Stub download_media to write `payload` to the destination path instead
+    of hitting the CDN, returning the local path like the real function."""
+
+    async def _fake_download(cdn_media, dest_dir, filename="media"):
+        dest_dir = Path(dest_dir)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest_path = dest_dir / filename
+        dest_path.write_bytes(payload)
+        return str(dest_path)
+
+    monkeypatch.setattr(media_mod, "download_media", _fake_download)
+
+
+def _file_msg(filename: str) -> WeixinMessage:
+    return WeixinMessage(
+        message_id=1001,
+        from_user_id="wxid_alice@im.wechat",
+        message_type=1,
+        item_list=[
+            MessageItem(
+                type=MessageItemType.FILE,
+                file_item=FileItem(
+                    media=CDNMedia(full_url="https://cdn.example/x"),
+                    file_name=filename,
+                ),
+            )
+        ],
+    )
+
+
+def _image_msg() -> WeixinMessage:
+    return WeixinMessage(
+        message_id=1002,
+        from_user_id="wxid_alice@im.wechat",
+        message_type=1,
+        item_list=[
+            MessageItem(
+                type=MessageItemType.IMAGE,
+                image_item=ImageItem(media=CDNMedia(full_url="https://cdn.example/y")),
+            )
+        ],
+    )
+
+
+def _landed_body(tmp_path: Path) -> str:
+    inbox = tmp_path / "wechat" / "inbox"
+    dirs = [d for d in inbox.iterdir() if (d / "message.json").is_file()]
+    assert len(dirs) == 1, dirs
+    data = json.loads((dirs[0] / "message.json").read_text(encoding="utf-8"))
+    return data["body"]
+
+
+def test_mismatched_file_attachment_lands_with_warning(tmp_path, monkeypatch):
+    _patch_download(monkeypatch, ENCRYPTED_ZIP_LIKE)
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+    asyncio.run(mgr._on_incoming(_file_msg("archive.zip")))
+
+    body = _landed_body(tmp_path)
+    assert "[File: archive.zip" in body
+    assert "WARNING" in body.upper()
+    assert "save as" in body.lower()
+
+
+def test_valid_file_attachment_lands_without_warning(tmp_path, monkeypatch):
+    _patch_download(monkeypatch, VALID_PDF)
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+    asyncio.run(mgr._on_incoming(_file_msg("report.pdf")))
+
+    body = _landed_body(tmp_path)
+    assert "[File: report.pdf" in body
+    assert "WARNING" not in body.upper()
+
+
+def test_valid_image_lands_without_warning(tmp_path, monkeypatch):
+    # PNG bytes under a fabricated .jpg name must NOT warn.
+    _patch_download(monkeypatch, VALID_PNG)
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+    asyncio.run(mgr._on_incoming(_image_msg()))
+
+    body = _landed_body(tmp_path)
+    assert "[Image:" in body
+    assert "WARNING" not in body.upper()
+
+
+def test_non_image_under_image_item_warns(tmp_path, monkeypatch):
+    _patch_download(monkeypatch, ENCRYPTED_ZIP_LIKE)
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+    asyncio.run(mgr._on_incoming(_image_msg()))
+
+    body = _landed_body(tmp_path)
+    assert "[Image:" in body
+    assert "WARNING" in body.upper()


### PR DESCRIPTION
## Summary

Ports the valuable part of stale `Lingtai-AI/lingtai-wechat` #15 into the current in-kernel WeChat addon: downloaded inbound image/file attachments are now validated by magic bytes instead of trusting filename/extension alone.

This keeps the old safety intent, but targets the canonical `lingtai-kernel` implementation rather than the deprecated standalone addon repo.

## What changed

- Adds WeChat media magic-byte validation helpers for `.pdf`, `.zip`, `.png`, `.jpg/.jpeg`, `.gif`, `.bmp`, and `.webp`.
- Appends an inline warning + “Save As” recovery hint when a downloaded FILE/IMAGE has a known declared type but bytes do not match that type.
- Treats unknown extensions, missing/unreadable files, and unsupported types as `unknown` (no warning), so validation never breaks the download path.
- Validates inbound IMAGE items against any known image signature because WeChat image downloads use generated `.jpg` filenames.
- Adds unit and `_on_incoming` integration coverage.

## Scope notes

- Warn-only: bytes are never deleted or rejected.
- Image/File paths only; voice/video are intentionally out of scope to avoid container false positives.
- Does not include old Telegram #34/#36 stale PR changes.

## Validation

- `git diff --check origin/main...HEAD`
- `PYTHONPATH=src python -m pytest tests/test_wechat_media_validation.py tests/test_wechat_media_warning_integration.py -q` → `28 passed`
- `PYTHONPATH=src python -m pytest tests/test_wechat_inbound_replay.py -q` → `7 passed`
- `PYTHONPATH=src python -m pytest tests/test_wechat*.py -q` → `35 passed`

## Provenance

Stale standalone PR cleanup follow-up. Ports/supersedes the useful media-validation intent from `Lingtai-AI/lingtai-wechat` #15 after that standalone repo PR was closed.
