### PR TITLE
perf(grep): prune glob filter before file reads

### DIFF
--- a/src/lingtai/core/grep/__init__.py
+++ b/src/lingtai/core/grep/__init__.py
@@ -4,7 +4,6 @@ Usage: Agent(capabilities=["grep"]) or capabilities=["file"]
 """
 from __future__ import annotations
 
-import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -46,22 +45,22 @@ def setup(agent: "BaseAgent") -> None:
         max_matches = args.get("max_matches", 200)
         glob_filter = args.get("glob", "*")
         try:
-            raw_results = agent._file_io.grep(pattern, path=search_path, max_results=max_matches)
-            raw_truncated = len(raw_results) >= max_matches
-            if glob_filter == "*":
-                matches = [{"file": r.path, "line": r.line_number, "text": r.line} for r in raw_results]
-            else:
-                matches = [
-                    {"file": r.path, "line": r.line_number, "text": r.line}
-                    for r in raw_results
-                    if fnmatch.fnmatch(Path(r.path).name, glob_filter)
-                ]
-            # truncated: true when the raw scan hit its cap (there may be
-            # more matching files beyond what was scanned), OR when glob
-            # filtering was active and we got fewer results than the cap
-            # (meaning the glob may have discarded results that masked
-            # additional matches).
-            truncated = raw_truncated
+            # Push the glob filter into the service so excluded files are
+            # pruned *before* stat / read, instead of scanning every file
+            # under the search root and post-filtering the matches. ``"*"``
+            # is the schema default and means "no filter".
+            service_glob = None if glob_filter in (None, "", "*") else glob_filter
+            raw_results = agent._file_io.grep(
+                pattern,
+                path=search_path,
+                max_results=max_matches,
+                glob_filter=service_glob,
+            )
+            matches = [{"file": r.path, "line": r.line_number, "text": r.line} for r in raw_results]
+            # truncated: true when the (already glob-pruned) scan hit its
+            # cap — there may be more matching files beyond what was
+            # scanned.
+            truncated = len(raw_results) >= max_matches
             result: dict[str, Any] = {
                 "matches": matches,
                 "count": len(matches),

--- a/src/lingtai/services/ANATOMY.md
+++ b/src/lingtai/services/ANATOMY.md
@@ -9,8 +9,8 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 | File | LOC | Role |
 |---|---|---|
 | `__init__.py` | 1 | Docstring-only package marker |
-| `file_io.py` | 491 | `FileIOService` facade contract + `FileIOBackend`/`LocalFileIOBackend` — backs read/edit/write/glob/grep |
-| `file_io_sidecar.py` | 619 | Rust-backed grep/glob: `RustFileIOBackend`, `SidecarAdapter`, `SidecarError`, plus the `resolve_sidecar_binary` resolver and the `default_file_io_service` factory used by `Agent.__init__` |
+| `file_io.py` | 530 | `FileIOService` facade contract + `FileIOBackend`/`LocalFileIOBackend` — backs read/edit/write/glob/grep. `grep` accepts an optional basename `glob_filter` that prunes the candidate set before stat/read |
+| `file_io_sidecar.py` | 698 | Rust-backed grep/glob: `RustFileIOBackend`, `SidecarAdapter`, `SidecarError`, plus the `resolve_sidecar_binary` resolver and the `default_file_io_service` factory used by `Agent.__init__`. `grep`'s `glob_filter` is applied as a Python-side basename post-filter (the sidecar wire protocol carries no glob field yet) |
 | `mail.py` | 4 | Re-exports `MailService`, `FilesystemMailService` from `lingtai_kernel.services.mail` |
 | `mcp.py` | 510 | `MCPClient` (stdio) + `HTTPMCPClient` (streamable HTTP) — async-to-sync MCP bridges |
 

--- a/src/lingtai/services/file_io.py
+++ b/src/lingtai/services/file_io.py
@@ -117,8 +117,23 @@ class FileIOService(ABC):
         ...
 
     @abstractmethod
-    def grep(self, pattern: str, path: str | None = None, max_results: int = 50) -> list[GrepMatch]:
-        """Search file contents by regex pattern."""
+    def grep(
+        self,
+        pattern: str,
+        path: str | None = None,
+        max_results: int = 50,
+        *,
+        glob_filter: str | None = None,
+    ) -> list[GrepMatch]:
+        """Search file contents by regex pattern.
+
+        ``glob_filter`` is an optional fnmatch-style pattern matched
+        against each file's basename. Implementations should use it to
+        prune the candidate set *before* opening / reading, so callers
+        that narrow by basename (e.g. the ``grep`` tool's ``glob``
+        argument) pay no I/O for excluded files. ``None`` (or ``"*"``)
+        means "no filter".
+        """
         ...
 
 
@@ -170,6 +185,7 @@ class FileIOBackend(ABC):
         path: str | None = None,
         max_results: int = 50,
         *,
+        glob_filter: str | None = None,
         exclude_dirs: frozenset[str] | set[str] | None = None,
         walltime_s: float | None = DEFAULT_WALLTIME_S,
         max_visited: int | None = DEFAULT_MAX_VISITED,
@@ -340,6 +356,7 @@ class LocalFileIOBackend(FileIOBackend):
         path: str | None = None,
         max_results: int = 50,
         *,
+        glob_filter: str | None = None,
         exclude_dirs: frozenset[str] | set[str] | None = None,
         walltime_s: float | None = DEFAULT_WALLTIME_S,
         max_visited: int | None = DEFAULT_MAX_VISITED,
@@ -347,15 +364,30 @@ class LocalFileIOBackend(FileIOBackend):
     ) -> list[GrepMatch]:
         """Search file contents by regex.
 
+        ``glob_filter`` (optional) — fnmatch-style pattern matched
+        against the file's *basename*. When supplied, non-matching files
+        are skipped before ``stat`` / ``read_text``, so callers (e.g. the
+        ``grep`` tool's ``glob`` argument) prune the candidate set
+        cheaply instead of post-filtering full match results. The pattern
+        ``"*"`` (or ``None``) is treated as "no filter".
+
         Per-file: skipped (counted) when larger than ``max_file_bytes``
         or when ``read_text(utf-8)`` raises ``UnicodeDecodeError`` /
         ``PermissionError`` / ``OSError`` (binary, unreadable). Across
         files: bounded by ``walltime_s`` and ``max_visited``. See module
         docstring for default values.
         """
+        import fnmatch
         import re
 
         regex = re.compile(pattern)
+        # Pre-translate the basename glob to a regex once instead of
+        # letting fnmatch translate-and-cache per file. Translating
+        # ourselves also lets us cheaply detect the no-op "*" filter.
+        compiled_glob: re.Pattern[str] | None = None
+        if glob_filter and glob_filter != "*":
+            compiled_glob = re.compile(fnmatch.translate(glob_filter))
+
         self.last_traversal = TraversalStats()
         search_path = Path(path) if path else (self._root or Path("."))
         results: list[GrepMatch] = []
@@ -366,6 +398,11 @@ class LocalFileIOBackend(FileIOBackend):
             walltime_s=walltime_s,
             max_visited=max_visited,
         ):
+            # Cheapest filter first: basename glob match. This runs
+            # before stat / read_text so excluded files contribute zero
+            # file I/O.
+            if compiled_glob is not None and not compiled_glob.match(f.name):
+                continue
             if not f.is_file():
                 continue
             try:
@@ -475,6 +512,7 @@ class LocalFileIOService(FileIOService):
         path: str | None = None,
         max_results: int = 50,
         *,
+        glob_filter: str | None = None,
         exclude_dirs: frozenset[str] | set[str] | None = None,
         walltime_s: float | None = DEFAULT_WALLTIME_S,
         max_visited: int | None = DEFAULT_MAX_VISITED,
@@ -484,6 +522,7 @@ class LocalFileIOService(FileIOService):
             pattern,
             path=path,
             max_results=max_results,
+            glob_filter=glob_filter,
             exclude_dirs=exclude_dirs,
             walltime_s=walltime_s,
             max_visited=max_visited,

--- a/src/lingtai/services/file_io_sidecar.py
+++ b/src/lingtai/services/file_io_sidecar.py
@@ -524,11 +524,22 @@ class RustFileIOBackend(FileIOBackend):
         path: str | None = None,
         max_results: int = 50,
         *,
+        glob_filter: str | None = None,
         exclude_dirs: frozenset[str] | set[str] | None = None,
         walltime_s: float | None = DEFAULT_WALLTIME_S,
         max_visited: int | None = DEFAULT_MAX_VISITED,
         max_file_bytes: int | None = DEFAULT_MAX_FILE_BYTES,
     ) -> list[GrepMatch]:
+        # ``glob_filter`` is honored here as a basename post-filter on the
+        # sidecar's results. The wire protocol (``SidecarRequest`` /
+        # ``to_payload``) and the Rust crate do not yet carry a glob field,
+        # so we cannot push the prune below the native scan without a
+        # protocol change — that native pushdown is a deliberate follow-up.
+        # Post-filtering here keeps observable behavior identical to the
+        # pure-Python backend (and to the old tool-wrapper post-filter):
+        # ``grep(..., glob_filter="*.py")`` returns only matches whose
+        # basename matches the glob, with ``None`` / ``"*"`` meaning
+        # "no filter".
         search_path, sandbox_root = self._sandbox_paths(path)
         envelope = self._adapter.call(
             SidecarRequest(
@@ -544,7 +555,14 @@ class RustFileIOBackend(FileIOBackend):
             )
         )
         self.last_traversal = _stats_from_envelope(envelope)
-        return _matches_from_envelope(envelope, str(sandbox_root))
+        matches = _matches_from_envelope(envelope, str(sandbox_root))
+        if glob_filter and glob_filter != "*":
+            import fnmatch
+            import re
+
+            compiled_glob = re.compile(fnmatch.translate(glob_filter))
+            matches = [m for m in matches if compiled_glob.match(Path(m.path).name)]
+        return matches
 
     # ------------------------------------------------------------------
     # Path resolution

--- a/tests/test_file_io_sidecar.py
+++ b/tests/test_file_io_sidecar.py
@@ -131,6 +131,39 @@ def _glob_sidecar(tmp_path: Path) -> Path:
     )
 
 
+def _multi_grep_sidecar(tmp_path: Path) -> Path:
+    """Fake sidecar that returns two grep matches: one .py and one .log.
+
+    Lets us prove the ``glob_filter`` basename post-filter on the Rust
+    path — the sidecar itself is glob-agnostic, so the backend must drop
+    the non-matching basename after the call.
+    """
+    return _write_fake_sidecar(
+        tmp_path,
+        "multi-grep.py",
+        """
+        env = {
+            "ok": True,
+            "backend": "fake-multi",
+            "op": payload.get("op"),
+            "matches": [
+                {"path": "good.py", "line_number": 1, "line": "needle py"},
+                {"path": "noisy.log", "line_number": 2, "line": "needle log"},
+            ],
+            "paths": [],
+            "visited": 2,
+            "files_skipped_size": 0,
+            "files_skipped_binary": 0,
+            "dirs_pruned": 0,
+            "elapsed_ms": 1,
+            "truncated_reason": None,
+            "error": None,
+        }
+        sys.stdout.write(json.dumps(env))
+        """,
+    )
+
+
 def _failing_sidecar(tmp_path: Path) -> Path:
     """Fake sidecar that returns a structured error envelope and exits 2."""
     return _write_fake_sidecar(
@@ -393,6 +426,23 @@ class TestRustFileIOBackend:
         assert echoed["max_visited"] == 11
         assert echoed["max_file_bytes"] == 99
         assert echoed["max_results"] == 3
+
+    def test_grep_glob_filter_post_filters_basenames(self, tmp_path: Path) -> None:
+        # The sidecar is glob-agnostic and returns both a .py and a .log
+        # match; the backend must drop the .log when glob_filter="*.py".
+        sidecar = _multi_grep_sidecar(tmp_path)
+        backend = RustFileIOBackend(root=tmp_path, binary_path=str(sidecar))
+
+        matches = backend.grep("needle", glob_filter="*.py")
+        names = [Path(m.path).name for m in matches]
+        assert names == ["good.py"]
+
+    def test_grep_glob_filter_star_is_noop(self, tmp_path: Path) -> None:
+        sidecar = _multi_grep_sidecar(tmp_path)
+        backend = RustFileIOBackend(root=tmp_path, binary_path=str(sidecar))
+
+        assert len(backend.grep("needle", glob_filter="*")) == 2
+        assert len(backend.grep("needle", glob_filter=None)) == 2
 
     def test_grep_populates_last_traversal_from_envelope(self, tmp_path: Path) -> None:
         sidecar = _write_fake_sidecar(

--- a/tests/test_services_file_io.py
+++ b/tests/test_services_file_io.py
@@ -214,6 +214,113 @@ class TestTraversalBudgets:
         assert any(".git" in r for r in results)
 
 
+class TestGrepGlobFilter:
+    """``glob_filter`` prunes the candidate set *before* stat / read.
+
+    Before this, the ``grep`` tool wrapper post-filtered full
+    ``GrepMatch`` results: every file under the search root was opened
+    and scanned even when the caller narrowed by ``glob`` (e.g.
+    ``glob="*.py"`` over a repo full of logs / json / bundles). The
+    contract these tests pin:
+
+    1. Non-matching files are not read (no ``read_text`` on them).
+    2. Matching files still yield the same results as an unfiltered run.
+    3. ``glob_filter=None`` / ``"*"`` is a no-op (back-compat).
+    """
+
+    def test_glob_filter_skips_non_matching_files_before_read(
+        self, svc, tmp_dir, monkeypatch
+    ):
+        # One .py file that matches the regex, one .log file that would
+        # also match — the glob filter should hide (and never read) the
+        # .log.
+        svc.write("good.py", "needle here\n")
+        svc.write("noisy.log", "needle here\n")
+
+        read_paths: list[str] = []
+        original = Path.read_text
+
+        def spy(self, *a, **kw):
+            read_paths.append(str(self))
+            return original(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "read_text", spy)
+
+        results = svc.grep("needle", glob_filter="*.py")
+
+        # Only the .py file's match comes back.
+        assert len(results) == 1
+        assert results[0].path.endswith("/good.py")
+        # And the .log was never read — the pre-filter pruned it before
+        # any file I/O.
+        read_logs = [p for p in read_paths if p.endswith(".log")]
+        assert read_logs == [], f"unexpected reads of excluded files: {read_logs}"
+
+    def test_glob_filter_none_matches_all(self, svc, tmp_dir):
+        svc.write("a.py", "needle\n")
+        svc.write("b.txt", "needle\n")
+        results = svc.grep("needle", glob_filter=None)
+        files = {r.path for r in results}
+        assert any(p.endswith("/a.py") for p in files)
+        assert any(p.endswith("/b.txt") for p in files)
+
+    def test_glob_filter_star_matches_all(self, svc, tmp_dir):
+        # "*" is the schema default for the grep tool; treat it as no-op.
+        svc.write("a.py", "needle\n")
+        svc.write("b.txt", "needle\n")
+        results = svc.grep("needle", glob_filter="*")
+        assert len(results) == 2
+
+    def test_glob_filter_works_with_nested_layout(self, svc, tmp_dir):
+        svc.write("src/main.py", "needle\n")
+        svc.write("src/data.json", "needle\n")
+        svc.write("tests/test_main.py", "needle\n")
+        results = svc.grep("needle", glob_filter="*.py")
+        files = {r.path for r in results}
+        assert any(p.endswith("/src/main.py") for p in files)
+        assert any(p.endswith("/tests/test_main.py") for p in files)
+        assert not any(p.endswith(".json") for p in files)
+
+    def test_glob_filter_via_tool_wrapper_prunes_before_read(self, tmp_path, monkeypatch):
+        # End-to-end through the grep capability: the tool's ``glob`` arg
+        # must reach the service as ``glob_filter`` and prune before read.
+        captured: dict = {}
+        svc = LocalFileIOService(root=tmp_path)
+        original_grep = svc.grep
+
+        def spy_grep(pattern, path=None, max_results=50, **kwargs):
+            captured["glob_filter"] = kwargs.get("glob_filter")
+            return original_grep(pattern, path=path, max_results=max_results, **kwargs)
+
+        monkeypatch.setattr(svc, "grep", spy_grep)
+        svc.write("good.py", "needle\n")
+        svc.write("noisy.log", "needle\n")
+
+        from lingtai.core.grep import setup as grep_setup
+
+        class _StubConfig:
+            language = "en"
+
+        class _StubAgent:
+            _config = _StubConfig()
+            _working_dir = tmp_path
+            _file_io = svc
+
+            def __init__(self):
+                self.handlers = {}
+
+            def add_tool(self, name, *, schema, handler, description):
+                self.handlers[name] = handler
+
+        agent = _StubAgent()
+        grep_setup(agent)
+        result = agent.handlers["grep"]({"pattern": "needle", "glob": "*.py"})
+
+        assert captured["glob_filter"] == "*.py"
+        files = {m["file"] for m in result["matches"]}
+        assert any(p.endswith("/good.py") for p in files)
+        assert not any(p.endswith(".log") for p in files)
+
 
 class RecordingBackend:
     """Small backend double proving LocalFileIOService is now a facade."""
@@ -271,6 +378,7 @@ def test_local_file_io_service_delegates_all_operations_to_backend():
             "max_results": 2000,
         }),
         ("grep", "needle", "src", 3, {
+            "glob_filter": None,
             "exclude_dirs": None,
             "walltime_s": DEFAULT_WALLTIME_S,
             "max_visited": DEFAULT_MAX_VISITED,


### PR DESCRIPTION
## Summary

Port the still-useful intent from stale `Lingtai-AI/lingtai-kernel` PR #168 into the current kernel FileIO architecture.

`grep(..., glob="*.py")` used to scan/read broadly and then post-filter matches in `core/grep`. This PR pushes the existing public `glob` argument down into the FileIO grep service so the Python local backend can prune basename-mismatching files before `is_file` / `stat` / `read_text`.

## What changed

- Keep the public grep tool schema unchanged: `pattern`, `path`, `glob`, `max_matches`.
- Add an internal keyword-only `glob_filter` to FileIO grep service/backend implementations.
- `LocalFileIOBackend.grep` compiles basename glob once and skips non-matching files before reading.
- `core/grep` forwards the existing `glob` value to FileIO and no longer post-filters tool results.
- `RustFileIOBackend.grep` accepts the same internal keyword and preserves behavior via Python-side post-filtering because the sidecar wire protocol has no glob field yet.
- Add focused tests for local pre-read pruning and Rust sidecar behavior parity.
- Update `src/lingtai/services/ANATOMY.md`.

## Validation

Parent validation:

- `git diff --check origin/main...HEAD` ✅
- `PYTHONPATH=src python -m pytest tests/test_services_file_io.py tests/test_layers_file.py tests/test_file_io_sidecar.py tests/test_agent_capabilities.py tests/test_daemon_preset_capabilities.py -q` ✅ `127 passed`
- import / py_compile sanity ✅
- grep signature/caller consistency check ✅

GLM reviews:

- General review: `APPROVE`, no blockers / required changes.
- Jason-requested release gate: `PASS` — no regression and no new public tool option/parameter.
  - The agent-facing `grep` schema is byte-identical to `origin/main`.
  - Focused GLM reruns: `73 passed` for touched FileIO/sidecar tests and `349 passed, 2733 deselected` for broadened grep/glob/file/capability/tool keyword net.
  - Runtime smoke confirmed `glob="*.py"` does not read excluded `.log` files through the local backend.

## Caveats / follow-ups

- Rust sidecar path is behavior-correct but does **not** get native I/O pushdown yet; it can only post-filter returned matches until the sidecar request protocol and Rust crate gain a glob field.
- `truncated` semantics become more accurate for the Python path because the flag now reflects the filtered result set; Rust sidecar still has a small caveat because the sidecar caps before Python post-filtering.
- `glob_filter` is an internal service/backend contract addition, not a new public tool option. External custom subclasses with fixed grep signatures and no `**kwargs` may need to accept the new keyword.

## Stale PR cleanup notes

- Old PR #168 was not merged directly because the FileIO architecture changed and the old patch bundled broader read-path behavior changes (line streaming / binary sniff / error replacement) that are intentionally not included here.
- This PR ports only the narrow, still-useful glob pre-pruning intent.
