### PR TITLE
Fix IMAP empty optional args and flag diagnostics

### DIFF
--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -8,7 +8,7 @@ Curated MCP server package implementations shipped inside the `lingtai` Python d
 |---|---|
 | `_skill.py` | Shared bundled-skill helper: `load_skill()` loads package `SKILL.md`, `manual_action_description()` injects frontmatter into the schema, and `manual_payload()` returns the manual body + absolute path without sidecar lists (`_skill.py:72-118`). |
 | `telegram/` | Telegram MCP. It predates `_skill.py` and keeps an inline SKILL.md loader/manual payload with the same minimal contract (`telegram/manager.py:40-118`, `telegram/manager.py:1616-1633`). |
-| `imap/`, `feishu/`, `wechat/`, `whatsapp/`, `cloud_mail/` | Curated MCPs using `_skill.py` for their `action="manual"` payloads (`imap/manager.py:294-308`, `feishu/manager.py:454-466`, `wechat/manager.py:504-516`, `whatsapp/manager.py:174-186`, `cloud_mail/manager.py:213-225`). |
+| `imap/`, `feishu/`, `wechat/`, `whatsapp/`, `cloud_mail/` | Curated MCPs using `_skill.py` for their `action="manual"` payloads (`imap/manager.py:322-333`, `feishu/manager.py:454-466`, `wechat/manager.py:504-516`, `whatsapp/manager.py:174-186`, `cloud_mail/manager.py:213-225`). |
 | Per-package `SKILL.md` | The human/agent-facing bundled manual. If a manual has sidecars, the sidecar inventory and relative paths live in this markdown, not in the tool payload. |
 | `pyproject.toml` package-data entries | Ships every curated MCP `SKILL.md`; `reference/**/*` and `assets/**/*` are also packaged for future sidecar files (`pyproject.toml:81-86`). |
 

--- a/src/lingtai/mcp_servers/imap/SKILL.md
+++ b/src/lingtai/mcp_servers/imap/SKILL.md
@@ -26,11 +26,13 @@ descriptions; you do not need to call it before every send.
 
 ## READING: check / read / search
 
-- `check`: list recent envelopes from a folder (optional `folder`, `n`).
+- `check`: list recent envelopes from a folder (optional `folder`, `n`). An
+  empty or whitespace-only `folder` is treated as omitted and defaults to
+  `INBOX`.
 - `read`: fetch full email(s) by `email_id` (a single id or a list). You are
   encouraged to read multiple relevant — or even all unread — emails and think
   before acting.
-- `search`: server-side IMAP search (`query`; optional `folder`). Queries use a server-side search DSL, e.g.
+- `search`: server-side IMAP search (`query`; optional `folder`, empty/whitespace-only defaults to `INBOX`). Queries use a server-side search DSL, e.g.
   `from:addr subject:text unseen since:YYYY-MM-DD`; supported fields depend on
   the IMAP addon, so prefer examples returned by this tool over raw RFC IMAP
   search syntax.
@@ -52,7 +54,11 @@ descriptions; you do not need to call it before every send.
 ## ORGANIZING: move / flag / delete
 
 - `move`: move email(s) to another folder (`email_id`, `folder`=destination).
+  The destination `folder` is required and must be non-empty — unlike
+  check/search it is never defaulted to `INBOX`.
 - `flag`: set/clear flags (`email_id`, `flags={"seen": true, "flagged": false}`).
+  `flags` is required; e.g. `flags={"seen": true}` marks read. A missing or
+  empty `flags` returns an error rather than silently doing nothing.
 - `delete`: delete email(s) by `email_id`.
 
 ## CONTACTS / ACCOUNTS
@@ -63,7 +69,8 @@ descriptions; you do not need to call it before every send.
 - `remove_contact`: remove a contact (`address`).
 - `accounts`: list configured IMAP accounts and connection status. Most actions
   accept an optional `account` (email address); it defaults to the primary
-  account.
+  account. An empty or whitespace-only `account` is treated as omitted and
+  uses the default/sole account rather than failing with `Unknown account`.
 
 ## SIDE EFFECTS & SAFETY
 

--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -54,6 +54,20 @@ def parse_email_id(email_id: str) -> tuple[str, str, str]:
     return account, folder, uid
 
 
+def _opt_str(value: object) -> str | None:
+    """Normalize an optional string arg: empty/whitespace-only → None.
+
+    LLMs frequently pass ``""`` for an optional field they mean to omit. Treat
+    empty or whitespace-only strings exactly like an absent value so callers
+    fall back to the default (default account, default ``INBOX`` folder).
+    Non-string values are returned unchanged.
+    """
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return value
+
+
 # ---------------------------------------------------------------------------
 # Tool schema
 # ---------------------------------------------------------------------------
@@ -78,7 +92,7 @@ SCHEMA = {
                 "search: server-side IMAP search (requires query, optional folder). "
                 "delete: delete email(s) by ID (email_id). "
                 "move: move email(s) to another folder (email_id, folder=destination). "
-                "flag: set/clear flags on email(s) (email_id, flags={flag: bool}). "
+                "flag: set/clear flags on email(s) (email_id, flags={flag: bool}, e.g. flags={'seen': true}). "
                 "folders: list available IMAP folders. "
                 "contacts: list all contacts. "
                 "add_contact: add/update contact (requires address, name; optional note). "
@@ -90,7 +104,11 @@ SCHEMA = {
         },
         "account": {
             "type": "string",
-            "description": "Which account to use (email address). Defaults to the primary account.",
+            "description": (
+                "Which account to use (email address). Optional — an empty or "
+                "whitespace-only string is treated as omitted and defaults to "
+                "the primary account."
+            ),
         },
         "address": {
             "oneOf": [
@@ -133,11 +151,16 @@ SCHEMA = {
         },
         "folder": {
             "type": "string",
-            "description": "IMAP folder name (e.g. INBOX, [Gmail]/Sent Mail). For move: destination folder.",
+            "description": (
+                "IMAP folder name (e.g. INBOX, [Gmail]/Sent Mail). For "
+                "check/search an empty or whitespace-only string is treated as "
+                "omitted and defaults to INBOX. For move this is the "
+                "destination folder and must be a non-empty name."
+            ),
         },
         "flags": {
             "type": "object",
-            "description": "Dict of flag name to bool — e.g. {\"seen\": true, \"flagged\": false}",
+            "description": "Required for flag — dict of flag name to bool, e.g. {\"seen\": true, \"flagged\": false}",
         },
         "name": {
             "type": "string",
@@ -262,11 +285,16 @@ class IMAPMailManager:
         action = args.get("action")
         if action == "manual":
             return self._manual()
-        account = self._service.get_account(args.get("account"))
+        # Treat empty/whitespace-only account exactly like omitted/None so the
+        # default (or sole) account is used instead of failing the lookup.
+        requested_account = _opt_str(args.get("account"))
+        account = self._service.get_account(requested_account)
         if account is None and action != "accounts":
-            return self._inject_meta(
-                {"error": f"Unknown account: {args.get('account')}"}
-            )
+            return self._inject_meta({
+                "status": "error",
+                "error": f"Unknown account: {requested_account}",
+                "requested_account": requested_account,
+            })
 
         dispatch = {
             "send": self._send,
@@ -486,7 +514,8 @@ class IMAPMailManager:
             return {"status": "error", "error": err}
 
     def _check(self, args: dict, account: "IMAPAccount") -> dict:
-        folder = args.get("folder", "INBOX")
+        # Empty/whitespace-only folder is treated like omitted → default INBOX.
+        folder = _opt_str(args.get("folder")) or "INBOX"
         n = args.get("n", 10)
         envelopes = account.fetch_envelopes(folder, n)
         return {"status": "ok", "total": len(envelopes), "emails": envelopes}
@@ -614,7 +643,8 @@ class IMAPMailManager:
         if not query:
             return {"error": "query is required for search"}
 
-        folder = args.get("folder", "INBOX")
+        # Empty/whitespace-only folder is treated like omitted → default INBOX.
+        folder = _opt_str(args.get("folder")) or "INBOX"
         uids = account.search(folder, query)
         if not uids:
             return {"status": "ok", "total": 0, "emails": []}
@@ -640,7 +670,9 @@ class IMAPMailManager:
         ids = self._normalize_email_ids(args)
         if not ids:
             return {"error": "email_id is required"}
-        dest_folder = args.get("folder", "")
+        # Unlike check/search, an empty destination is a hard error for move —
+        # we never silently default the target folder.
+        dest_folder = _opt_str(args.get("folder"))
         if not dest_folder:
             return {"error": "folder (destination) is required for move"}
 
@@ -659,7 +691,14 @@ class IMAPMailManager:
             return {"error": "email_id is required"}
         flags_dict = args.get("flags", {})
         if not flags_dict:
-            return {"error": "flags is required"}
+            return {
+                "status": "error",
+                "error": (
+                    "flags is required for flag — pass a dict mapping flag "
+                    "name to bool, e.g. flags={'seen': true} to mark read or "
+                    "flags={'flagged': false} to clear a star."
+                ),
+            }
 
         # Convert dict of {flag_name: bool} to +FLAGS / -FLAGS calls
         add_flags: list[str] = []

--- a/tests/test_imap_empty_args.py
+++ b/tests/test_imap_empty_args.py
@@ -1,0 +1,186 @@
+"""Regression tests for IMAP empty-argument ergonomics and clearer errors.
+
+Covers the fix for empty/whitespace-only optional ``account`` and ``folder``
+being treated like omitted (so the default account / ``INBOX`` are used), plus
+more visible error dicts for unknown accounts and missing ``flags``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lingtai.mcp_servers.imap.manager import IMAPMailManager
+
+
+class FakeAccount:
+    address = "me@example.com"
+
+    def __init__(self) -> None:
+        self.checked_folders: list[str] = []
+        self.searched: list[tuple[str, str]] = []
+        self.moved: list[tuple[str, str, str]] = []
+        self.flag_calls: list[tuple[str, str, list[str], str]] = []
+
+    def fetch_envelopes(self, folder: str, n: int) -> list[dict]:
+        self.checked_folders.append(folder)
+        return []
+
+    def search(self, folder: str, query: str) -> list[str]:
+        self.searched.append((folder, query))
+        return []
+
+    def fetch_headers_by_uids(self, folder: str, uids: list[str]) -> list[dict]:
+        return []
+
+    def move_message(self, folder: str, uid: str, dest: str) -> bool:
+        self.moved.append((folder, uid, dest))
+        return True
+
+    def store_flags(self, folder: str, uid: str, flags: list[str],
+                    action: str = "+FLAGS") -> bool:
+        self.flag_calls.append((folder, uid, flags, action))
+        return True
+
+
+class FakeService:
+    """Fake service that, unlike the reply-attachments fake, honors the
+    requested account address so the unknown-account path is exercisable."""
+
+    def __init__(self, account: FakeAccount) -> None:
+        self.default_account = account
+        self._map = {account.address: account}
+
+    def get_account(self, address):
+        if address is None:
+            return self.default_account
+        return self._map.get(address)
+
+
+def _manager(account: FakeAccount) -> IMAPMailManager:
+    return IMAPMailManager(
+        FakeService(account),
+        working_dir=Path("/tmp/imap-agent-workdir"),
+        tcp_alias="/tmp/imap-bridge",
+        on_inbound=lambda payload: None,
+    )
+
+
+# --- empty/whitespace account treated like omitted -------------------------
+
+def test_empty_account_uses_default_account():
+    account = FakeAccount()
+    result = _manager(account).handle({"action": "check", "account": ""})
+    assert result["status"] == "ok"
+    assert result["account"] == "me@example.com"
+
+
+def test_whitespace_account_uses_default_account():
+    account = FakeAccount()
+    result = _manager(account).handle({"action": "check", "account": "   "})
+    assert result["status"] == "ok"
+    assert result["account"] == "me@example.com"
+
+
+# --- empty/whitespace folder treated like omitted (INBOX) ------------------
+
+def test_empty_folder_for_check_uses_inbox():
+    account = FakeAccount()
+    result = _manager(account).handle({"action": "check", "folder": ""})
+    assert result["status"] == "ok"
+    assert account.checked_folders == ["INBOX"]
+
+
+def test_whitespace_folder_for_check_uses_inbox():
+    account = FakeAccount()
+    result = _manager(account).handle({"action": "check", "folder": "  \t "})
+    assert result["status"] == "ok"
+    assert account.checked_folders == ["INBOX"]
+
+
+def test_empty_folder_for_search_uses_inbox():
+    account = FakeAccount()
+    result = _manager(account).handle({
+        "action": "search", "query": "unseen", "folder": "",
+    })
+    assert result["status"] == "ok"
+    assert account.searched == [("INBOX", "unseen")]
+
+
+def test_whitespace_folder_for_search_uses_inbox():
+    account = FakeAccount()
+    result = _manager(account).handle({
+        "action": "search", "query": "unseen", "folder": "   ",
+    })
+    assert result["status"] == "ok"
+    assert account.searched == [("INBOX", "unseen")]
+
+
+# --- move destination must NOT be normalized away --------------------------
+
+def test_move_empty_destination_still_errors():
+    account = FakeAccount()
+    result = _manager(account).handle({
+        "action": "move",
+        "email_id": "me@example.com:INBOX:42",
+        "folder": "",
+    })
+    assert "error" in result
+    assert account.moved == []
+
+
+def test_move_whitespace_destination_still_errors():
+    account = FakeAccount()
+    result = _manager(account).handle({
+        "action": "move",
+        "email_id": "me@example.com:INBOX:42",
+        "folder": "   ",
+    })
+    assert "error" in result
+    assert account.moved == []
+
+
+# --- flag error ergonomics --------------------------------------------------
+
+def test_flag_missing_flags_returns_helpful_error():
+    account = FakeAccount()
+    result = _manager(account).handle({
+        "action": "flag",
+        "email_id": "me@example.com:INBOX:42",
+    })
+    assert result.get("status") == "error"
+    assert "flags is required" in result.get("error", "")
+    assert "flags={'seen': true}" in result.get("error", "")
+    assert account.flag_calls == []
+
+
+def test_flag_empty_flags_returns_helpful_error():
+    account = FakeAccount()
+    result = _manager(account).handle({
+        "action": "flag",
+        "email_id": "me@example.com:INBOX:42",
+        "flags": {},
+    })
+    assert result.get("status") == "error"
+    assert "flags is required" in result.get("error", "")
+    assert account.flag_calls == []
+
+
+def test_flag_success_still_calls_store_flags():
+    account = FakeAccount()
+    result = _manager(account).handle({
+        "action": "flag",
+        "email_id": "me@example.com:INBOX:42",
+        "flags": {"seen": True},
+    })
+    assert result["status"] == "ok"
+    assert account.flag_calls == [("INBOX", "42", ["\\Seen"], "+FLAGS")]
+
+
+# --- unknown account after normalization -----------------------------------
+
+def test_unknown_account_returns_visible_error():
+    account = FakeAccount()
+    result = _manager(account).handle({
+        "action": "check", "account": "nobody@example.com",
+    })
+    assert result.get("status") == "error"
+    assert "nobody@example.com" in result.get("error", "")


### PR DESCRIPTION
## Summary
- Treat empty/whitespace optional IMAP `account` as omitted so it uses the default account instead of `Unknown account: `.
- Treat empty/whitespace IMAP `folder` for `check`/`search` as omitted and default to `INBOX`, while keeping `move` destination validation strict.
- Make empty `flag` requests visibly actionable with `status: error` and a concrete `flags={'seen': true}` example.
- Update bundled IMAP manual/schema text and anatomy citation; add focused regression tests.

## Why
This comes from a diary/log audit of repeated tool gotchas. Empty strings often arrive from schema-filled optional fields and should behave like omitted values for optional selectors. The old behavior surfaced `Unknown account:` / `Unknown Mailbox` or a terse `flags is required`, making agents loop or misdiagnose successful-looking MCP calls.

## Validation
- `PYTHONPATH=src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_imap_empty_args.py tests/test_imap_reply_attachments.py tests/test_mcp_skill_manuals.py tests/test_mcp_capability.py -q` → 58 passed
- `git diff --check HEAD^` → clean
- `PYTHONPATH=src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python tools/check_anatomy_drift.py --root src/lingtai --check` → no drift

## Review
- Parent agent reviewed diff and reran validation.
- zhipu-1 read-only review returned `NO_BLOCKER`; non-blocking suggestions are follow-up items (broader MCP error-envelope unification, optional `_opt_str` typing cleanup, stronger fake-service call-param assertion).
