### PR TITLE
docs(avatar): clarify lingtai seed inheritance

### DIFF
--- a/src/lingtai/core/avatar/ANATOMY.md
+++ b/src/lingtai/core/avatar/ANATOMY.md
@@ -60,7 +60,7 @@ avatar/__init__.py
 
 - **Name validation:** Avatar names must match `^[\w-]+$` (Unicode-aware), max 64 chars, no dots or path separators. The name doubles as the working directory basename.
 - **Path scope:** The avatar's working directory must be a direct sibling of the parent's (same parent directory). Resolved path is checked against the network root to prevent escape.
-- **No identity inheritance:** Avatars get no name (`agent_name` is set to the avatar name), no admin privileges, no comment, no brief, no addons (IMAP/Telegram). The inherited prompt is blanked; the first prompt arrives via a `.prompt` signal file.
+- **No identity inheritance:** Avatars get no name (`agent_name` is set to the avatar name), no admin privileges, no comment, no brief, no addons (IMAP/Telegram). The inherited `lingtai` seed is blanked; the first turn still arrives via a separate `.prompt` signal file.
 - **Preset stability:** Avatars always spawn on the parent's DEFAULT preset, not its currently-active one. Materialized `llm` + `capabilities` are stripped so the avatar re-materializes from the preset on first boot.
 - **Relative path re-rooting:** Preset paths (`default`, `active`, `allowed`) that are relative are re-rooted against the parent's working dir so they remain valid from the avatar's different directory.
 - **Liveness check:** Before spawning, existing ledger entries are checked via `handshake.is_alive()`. If a live avatar with the same name exists, the spawn is refused with `already_active`.


### PR DESCRIPTION
## Summary
- clarify the avatar ANATOMY invariant after the init seed rename from `prompt` to `lingtai`
- keep `.prompt` described as the separate runtime signal file for the avatar's first turn

## Validation
- `git diff --check`
- `python tools/check_anatomy_drift.py --check`

## Notes
Follow-up from GLM's nonblocking review note on the #550/#551/#552 init prompt stack.
