### PR TITLE
Fix WeChat MCP config path resolution

### DIFF
--- a/src/lingtai/core/mcp/manual/reference/curated-addons.md
+++ b/src/lingtai/core/mcp/manual/reference/curated-addons.md
@@ -83,12 +83,13 @@ WeChat has unique pitfalls that catch agents off-guard. Walk this checklist on e
 
 1. **Ensure LingTai's runtime venv is current** — the `lingtai-wechat-bootstrap` script is installed by the `lingtai` wheel and lives inside the venv, not necessarily on the system PATH.
 
-2. **Run bootstrap with the full venv path** from the project root:
+2. **Run bootstrap with the full venv path.** The `LINGTAI_WECHAT_CONFIG` relative path (typically `.secrets/wechat/config.json`) resolves against `LINGTAI_AGENT_DIR` first (the agent working dir, like imap/telegram/feishu), then falls back to the project root for backward compatibility. **Preferred:** write secrets into the agent dir, e.g. from the project root:
    ```bash
-   ~/.lingtai-tui/runtime/venv/bin/lingtai-wechat-bootstrap .secrets/wechat
+   ~/.lingtai-tui/runtime/venv/bin/lingtai-wechat-bootstrap .lingtai/<agent>/.secrets/wechat
    ```
+   Older setups that wrote `.secrets/wechat` at the **project root** still work via the backward-compat fallback — no migration is required (`Lingtai-AI/lingtai#336`).
 
-3. **No manual credential copy needed** — the MCP resolves `LINGTAI_WECHAT_CONFIG` relative to the project root (the parent of `.lingtai/`), so `.secrets/wechat/config.json` works from both bootstrap and the MCP. Credentials are written next to `config.json`.
+3. **No manual credential copy needed** — `config.json` and `credentials.json` are written together in whichever directory you point bootstrap at, and the MCP reads `credentials.json` next to `config.json`.
 
 4. **WSL users**: bootstrap auto-detects WSL and uses `cmd.exe /c start` or `wslview` to open the browser. If neither works, it prints the HTML file path for manual opening.
 

--- a/src/lingtai/mcp_servers/wechat/server.py
+++ b/src/lingtai/mcp_servers/wechat/server.py
@@ -146,16 +146,75 @@ def _canonical_resource_uri(uri: object) -> str:
     return str(uri).rstrip("/")
 
 
-def _resolve_config_path_for_status(config_path_raw: str) -> Path:
+def _resolve_config_path(config_path_raw: str) -> tuple[Path, dict[str, Any]]:
+    """Resolve ``LINGTAI_WECHAT_CONFIG`` to a concrete ``config.json`` path.
+
+    Single source of truth for both the load path and status/diagnostics —
+    keep all base-directory policy here so the two paths can never diverge.
+
+    Policy (matches imap/telegram/feishu, plus a backward-compat fallback):
+
+    - Absolute paths are returned unchanged.
+    - Relative paths prefer ``LINGTAI_AGENT_DIR / relpath`` — the agent working
+      directory, which is where the rest of the platform resolves relative MCP
+      config paths (see ``config_resolve.py``). This is where ``config.json``
+      should live for new setups.
+    - If that candidate does not exist, fall back to the *project root*
+      (``LINGTAI_AGENT_DIR.parent.parent / relpath`` — agent dirs live at
+      ``<project>/.lingtai/<agent>/``) for backward compatibility with older
+      ``lingtai-wechat-bootstrap`` installs that wrote ``.secrets/wechat/``
+      relative to the project root. See ``Lingtai-AI/lingtai#336``.
+    - If ``LINGTAI_AGENT_DIR`` is unset (not a normal kernel-launched run),
+      fall back to the current working directory.
+
+    Returns ``(resolved_path, diagnostics)``. ``diagnostics`` records the base
+    used and the candidate paths considered (paths only — no secrets) so the
+    error/status surfaces can explain *where* it looked. ``resolved_path`` is
+    the first existing candidate, or — if none exist — the preferred candidate
+    (so callers can report the canonical expected location).
+    """
     path = Path(config_path_raw).expanduser()
     if path.is_absolute():
-        return path
-    agent_dir = os.environ.get("LINGTAI_AGENT_DIR")
-    if agent_dir:
-        base = Path(agent_dir).parent.parent
+        return path, {
+            "base": "absolute",
+            "agent_dir": os.environ.get("LINGTAI_AGENT_DIR"),
+            "candidates": [str(path)],
+            "resolved_via": "absolute",
+        }
+
+    agent_dir_raw = os.environ.get("LINGTAI_AGENT_DIR")
+    candidates: list[tuple[str, Path]] = []
+    if agent_dir_raw:
+        agent_dir = Path(agent_dir_raw)
+        # Preferred: agent dir (consistent with imap/telegram/feishu).
+        candidates.append(("agent_dir", agent_dir / path))
+        # Backward-compat: project root (two parents up from the agent dir).
+        candidates.append(("project_root", agent_dir.parent.parent / path))
     else:
-        base = Path.cwd()
-    return base / path
+        candidates.append(("cwd", Path.cwd() / path))
+
+    resolved_via = None
+    resolved = candidates[0][1]
+    for label, cand in candidates:
+        if cand.is_file():
+            resolved = cand
+            resolved_via = label
+            break
+
+    diagnostics = {
+        "base": candidates[0][0],
+        "agent_dir": agent_dir_raw,
+        "candidates": [str(c) for _, c in candidates],
+        # ``None`` means no candidate existed; the resolved path is the
+        # preferred (first) candidate, reported as the canonical location.
+        "resolved_via": resolved_via,
+    }
+    return resolved, diagnostics
+
+
+def _resolve_config_path_for_status(config_path_raw: str) -> Path:
+    path, _ = _resolve_config_path(config_path_raw)
+    return path
 
 
 def _safe_status_payload(
@@ -178,11 +237,18 @@ def _safe_status_payload(
     poll_interval = None
     notes: list[str] = []
 
+    resolution: dict[str, Any] | None = None
     if config_path_raw:
         try:
-            path = _resolve_config_path_for_status(config_path_raw)
+            path, resolution = _resolve_config_path(config_path_raw)
             config_path = str(path)
             credentials_path = str(path.parent / "credentials.json")
+            if resolution.get("resolved_via") not in (None, "absolute", "agent_dir"):
+                notes.append(
+                    "WeChat config resolved via backward-compat "
+                    f"'{resolution['resolved_via']}' base; prefer placing it under "
+                    "LINGTAI_AGENT_DIR."
+                )
             if path.is_file():
                 config_readable = True
                 cfg = json.loads(path.read_text(encoding="utf-8"))
@@ -194,7 +260,12 @@ def _safe_status_payload(
                 cdn_base_url = cfg.get("cdn_base_url")
                 poll_interval = cfg.get("poll_interval")
             else:
-                notes.append("WeChat config path is set but config.json is not readable.")
+                cand = resolution.get("candidates") if resolution else None
+                cand_str = f" Looked in: {', '.join(cand)}." if cand else ""
+                notes.append(
+                    "WeChat config path is set but config.json is not readable."
+                    + cand_str
+                )
 
             creds_path = path.parent / "credentials.json"
             if creds_path.is_file():
@@ -226,6 +297,7 @@ def _safe_status_payload(
         "running": running,
         "config_path_set": bool(config_path_raw),
         "config_path": config_path,
+        "config_resolution": resolution,
         "config_readable": config_readable,
         "credentials_path": credentials_path,
         "credentials_readable": credentials_readable,
@@ -318,9 +390,11 @@ reads `config.json` from the path in `LINGTAI_WECHAT_CONFIG` and reads sibling
 
 ## Environment
 
-- `LINGTAI_WECHAT_CONFIG` — path to `config.json`. Relative paths resolve against
-  the project root (`<project>/.lingtai/<agent>/` → `<project>`), matching the
-  `lingtai-wechat-bootstrap` convention.
+- `LINGTAI_WECHAT_CONFIG` — path to `config.json`. Absolute paths are used as-is.
+  Relative paths resolve against `LINGTAI_AGENT_DIR` (the agent working dir),
+  matching imap/telegram/feishu. For backward compatibility with older
+  `lingtai-wechat-bootstrap` installs, if no file is found there the project
+  root (`<project>/.lingtai/<agent>/` → `<project>`) is tried as a fallback.
 - `LINGTAI_AGENT_DIR` — injected by LingTai; used for state, media, contacts, and LICC.
 - `LINGTAI_MCP_NAME` — injected by LingTai; usually `wechat`.
 
@@ -355,10 +429,11 @@ Security notes:
 
 ## Bootstrap / login
 
-Recommended interactive setup:
+Recommended interactive setup — write secrets under the agent dir (preferred);
+the MCP also accepts a project-root `.secrets/wechat` for backward compat:
 
 ```bash
-lingtai-wechat-bootstrap .secrets/wechat
+lingtai-wechat-bootstrap .lingtai/<agent>/.secrets/wechat
 ```
 
 Headless fallback:
@@ -383,8 +458,12 @@ Set `LINGTAI_WECHAT_CONFIG` to the `config.json` path.
 
 ## `WeChat config not found`
 
-Check the path in `LINGTAI_WECHAT_CONFIG`. Relative paths resolve against the
-project root, not the agent directory. Refresh the agent after config changes.
+Check the path in `LINGTAI_WECHAT_CONFIG`. Relative paths resolve against
+`LINGTAI_AGENT_DIR` first (preferred), then fall back to the project root for
+backward compatibility — the error message lists every candidate path it tried.
+Place `config.json` under the agent directory and refresh the agent after config
+changes. (`wechat(action="check")` status reports the resolution base and
+candidates under `config_resolution`.)
 
 ## `WeChat credentials not found`
 
@@ -649,22 +728,26 @@ def load_config_and_credentials() -> tuple[dict, dict, Path]:
             "LINGTAI_WECHAT_CONFIG env var not set — point it at your "
             "WeChat config.json file"
         )
-    config_path = Path(config_path_raw).expanduser()
-    if not config_path.is_absolute():
-        # Resolve relative paths against the *project root*, not the agent
-        # working directory.  Agent dirs live at <project>/.lingtai/<agent>/,
-        # so the project root is two parents up from LINGTAI_AGENT_DIR.  This
-        # matches the convention used by lingtai-wechat-bootstrap, which writes
-        # config.json + credentials.json relative to the project root (e.g.
-        # .secrets/wechat/).  See GH #2.
-        agent_dir = os.environ.get("LINGTAI_AGENT_DIR")
-        if agent_dir:
-            base = Path(agent_dir).parent.parent  # .lingtai/<agent>/ -> project root
-        else:
-            base = Path.cwd()
-        config_path = base / config_path
+    # Single resolution policy shared with the status/diagnostics path: prefer
+    # LINGTAI_AGENT_DIR (like imap/telegram/feishu), fall back to the project
+    # root for backward compatibility.  See _resolve_config_path / GH #336.
+    config_path, resolution = _resolve_config_path(config_path_raw)
     if not config_path.is_file():
-        raise FileNotFoundError(f"WeChat config not found: {config_path}")
+        candidates = "\n".join(f"  - {c}" for c in resolution["candidates"])
+        if resolution["base"] == "absolute":
+            raise FileNotFoundError(
+                "WeChat config not found. The absolute path "
+                f"{config_path_raw!r} does not exist:\n{candidates}\n"
+                "Point LINGTAI_WECHAT_CONFIG at an existing config.json, "
+                "then refresh the agent."
+            )
+        raise FileNotFoundError(
+            "WeChat config not found. Looked for the relative path "
+            f"{config_path_raw!r} at (in order):\n{candidates}\n"
+            f"LINGTAI_AGENT_DIR={resolution['agent_dir']!r}. "
+            "Place config.json under LINGTAI_AGENT_DIR (preferred) or the "
+            "project root, then refresh the agent."
+        )
 
     file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
 

--- a/tests/test_wechat_config_resolution.py
+++ b/tests/test_wechat_config_resolution.py
@@ -1,0 +1,202 @@
+"""Tests for WeChat MCP config-path resolution (``Lingtai-AI/lingtai#336``).
+
+WeChat used to resolve a relative ``LINGTAI_WECHAT_CONFIG`` only against the
+project root (``LINGTAI_AGENT_DIR.parent.parent``), diverging from imap/telegram/
+feishu which resolve against ``LINGTAI_AGENT_DIR``. That divergence caused a
+``FileNotFoundError`` when an agent's WeChat secrets lived in the agent dir.
+
+These tests pin the new policy: absolute paths unchanged; relative paths prefer
+the agent dir; project root is a backward-compat fallback; a clear, secret-free
+diagnostic is surfaced when neither exists; and the ``LINGTAI_AGENT_DIR``-unset
+case falls back to cwd. The load path and the status/diagnostics path must use
+the same helper.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.wechat import server
+
+
+def _write_config(dir_path: Path) -> Path:
+    dir_path.mkdir(parents=True, exist_ok=True)
+    cfg = dir_path / "config.json"
+    cfg.write_text(json.dumps({"poll_interval": 1.0}), encoding="utf-8")
+    return cfg
+
+
+def _agent_layout(tmp_path: Path) -> tuple[Path, Path]:
+    """Return (project_root, agent_dir) for ``<project>/.lingtai/<agent>/``."""
+    project_root = tmp_path / "project"
+    agent_dir = project_root / ".lingtai" / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    return project_root, agent_dir
+
+
+# --- absolute paths ---------------------------------------------------------
+
+def test_absolute_config_path_unchanged(tmp_path, monkeypatch):
+    abs_cfg = tmp_path / "elsewhere" / "config.json"
+    _write_config(abs_cfg.parent)
+    # agent dir set but must be ignored for absolute paths
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path / "agent"))
+
+    resolved, diag = server._resolve_config_path(str(abs_cfg))
+
+    assert resolved == abs_cfg
+    assert diag["base"] == "absolute"
+    assert diag["resolved_via"] == "absolute"
+    assert diag["candidates"] == [str(abs_cfg)]
+
+
+# --- relative under the agent dir (preferred) -------------------------------
+
+def test_relative_config_prefers_agent_dir(tmp_path, monkeypatch):
+    project_root, agent_dir = _agent_layout(tmp_path)
+    _write_config(agent_dir / ".secrets" / "wechat")
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(agent_dir))
+
+    resolved, diag = server._resolve_config_path(".secrets/wechat/config.json")
+
+    assert resolved == agent_dir / ".secrets" / "wechat" / "config.json"
+    assert diag["resolved_via"] == "agent_dir"
+    assert diag["base"] == "agent_dir"
+
+
+def test_agent_dir_wins_over_project_root_when_both_exist(tmp_path, monkeypatch):
+    project_root, agent_dir = _agent_layout(tmp_path)
+    _write_config(agent_dir / ".secrets" / "wechat")
+    _write_config(project_root / ".secrets" / "wechat")
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(agent_dir))
+
+    resolved, diag = server._resolve_config_path(".secrets/wechat/config.json")
+
+    assert resolved == agent_dir / ".secrets" / "wechat" / "config.json"
+    assert diag["resolved_via"] == "agent_dir"
+
+
+# --- project-root backward-compat fallback ----------------------------------
+
+def test_relative_config_falls_back_to_project_root(tmp_path, monkeypatch):
+    project_root, agent_dir = _agent_layout(tmp_path)
+    # Only the project-root copy exists (old bootstrap convention / #336 workaround)
+    _write_config(project_root / ".secrets" / "wechat")
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(agent_dir))
+
+    resolved, diag = server._resolve_config_path(".secrets/wechat/config.json")
+
+    assert resolved == project_root / ".secrets" / "wechat" / "config.json"
+    assert diag["resolved_via"] == "project_root"
+    # agent dir is still the preferred base reported in diagnostics
+    assert diag["base"] == "agent_dir"
+
+
+# --- neither exists: clear diagnostics, no secrets --------------------------
+
+def test_no_candidate_exists_reports_candidates(tmp_path, monkeypatch):
+    project_root, agent_dir = _agent_layout(tmp_path)
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(agent_dir))
+
+    resolved, diag = server._resolve_config_path(".secrets/wechat/config.json")
+
+    # Resolves to the preferred (agent-dir) candidate as the canonical location
+    assert resolved == agent_dir / ".secrets" / "wechat" / "config.json"
+    assert diag["resolved_via"] is None
+    # Both candidate bases are surfaced for diagnosis
+    assert any(".lingtai" in c and "agent" in c for c in diag["candidates"])
+    project_cand = str(project_root / ".secrets" / "wechat" / "config.json")
+    assert project_cand in diag["candidates"]
+
+
+def test_load_config_failure_lists_candidates_without_secrets(tmp_path, monkeypatch):
+    project_root, agent_dir = _agent_layout(tmp_path)
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(agent_dir))
+    monkeypatch.setenv("LINGTAI_WECHAT_CONFIG", ".secrets/wechat/config.json")
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        server.load_config_and_credentials()
+
+    msg = str(excinfo.value)
+    # Both candidate paths appear so the user can see where it looked
+    assert str(agent_dir / ".secrets" / "wechat" / "config.json") in msg
+    assert str(project_root / ".secrets" / "wechat" / "config.json") in msg
+    # Diagnostic names the env var that controls resolution
+    assert "LINGTAI_AGENT_DIR" in msg
+
+
+def test_load_config_failure_absolute_path_not_called_relative(tmp_path, monkeypatch):
+    # Absolute, non-existent config path: the error must not call it "relative".
+    abs_cfg = tmp_path / "nowhere" / "config.json"
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path / "agent"))
+    monkeypatch.setenv("LINGTAI_WECHAT_CONFIG", str(abs_cfg))
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        server.load_config_and_credentials()
+
+    msg = str(excinfo.value)
+    # Lists the absolute candidate...
+    assert str(abs_cfg) in msg
+    # ...and explicitly calls it absolute, never "relative path".
+    assert "absolute path" in msg
+    assert "relative path" not in msg
+    # Agent-dir / project-root guidance is irrelevant for an absolute path.
+    assert "project root" not in msg
+
+
+# --- LINGTAI_AGENT_DIR unset: cwd fallback ----------------------------------
+
+def test_missing_agent_dir_falls_back_to_cwd(tmp_path, monkeypatch):
+    monkeypatch.delenv("LINGTAI_AGENT_DIR", raising=False)
+    _write_config(tmp_path / ".secrets" / "wechat")
+    monkeypatch.chdir(tmp_path)
+
+    resolved, diag = server._resolve_config_path(".secrets/wechat/config.json")
+
+    assert resolved == tmp_path / ".secrets" / "wechat" / "config.json"
+    assert diag["base"] == "cwd"
+    assert diag["resolved_via"] == "cwd"
+    assert diag["agent_dir"] is None
+
+
+# --- load path and status path share the same resolution --------------------
+
+def test_load_and_status_resolve_identically(tmp_path, monkeypatch):
+    project_root, agent_dir = _agent_layout(tmp_path)
+    cfg = _write_config(agent_dir / ".secrets" / "wechat")
+    (cfg.parent / "credentials.json").write_text(
+        json.dumps({"bot_token": "x", "user_id": "wxid_x"}), encoding="utf-8"
+    )
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(agent_dir))
+    monkeypatch.setenv("LINGTAI_WECHAT_CONFIG", ".secrets/wechat/config.json")
+
+    _file_cfg, _creds, config_dir = server.load_config_and_credentials()
+    status_path = server._resolve_config_path_for_status(".secrets/wechat/config.json")
+
+    assert config_dir == cfg.parent
+    assert status_path == cfg
+
+
+def test_status_payload_exposes_resolution_without_secrets(tmp_path, monkeypatch):
+    project_root, agent_dir = _agent_layout(tmp_path)
+    # project-root-only layout exercises the backward-compat note
+    cfg = _write_config(project_root / ".secrets" / "wechat")
+    (cfg.parent / "credentials.json").write_text(
+        json.dumps({"bot_token": "secret-token", "user_id": "wxid_x"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(agent_dir))
+    monkeypatch.setenv("LINGTAI_WECHAT_CONFIG", ".secrets/wechat/config.json")
+
+    payload = server._safe_status_payload(None)
+
+    resolution = payload["config_resolution"]
+    assert resolution["resolved_via"] == "project_root"
+    assert resolution["candidates"]
+    # bot_token must never leak into status
+    assert "secret-token" not in json.dumps(payload)
+    assert payload["has_bot_token"] is True
+    # backward-compat resolution is flagged in notes
+    assert any("backward-compat" in n for n in payload["notes"])


### PR DESCRIPTION
## Summary
- Align the in-kernel WeChat MCP with sibling MCPs by resolving relative `LINGTAI_WECHAT_CONFIG` against the agent directory first.
- Preserve backward compatibility by falling back to the historical project-root `.secrets/wechat/...` location when no agent-dir config exists.
- Share one config-resolution helper between load and status paths, improve diagnostics, and update curated addon docs.
- Add focused tests for absolute paths, agent-dir preference, project-root fallback, missing-path diagnostics, no-env cwd fallback, and status payload secrecy.

Refs Lingtai-AI/lingtai#336

## Validation
- `git diff --check`
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m pytest tests/test_wechat_config_resolution.py -p no:cacheprovider -q` — 10 passed
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m pytest -k wechat -p no:cacheprovider -q` — 48 passed, 3076 deselected
- `/Users/huangzesen/anaconda3/bin/python -m py_compile src/lingtai/mcp_servers/wechat/server.py`

## Notes
- No live cold-boot test on the original reporter agent was run.
- Full repository test suite was not run; focused WeChat tests passed.
