### PR TITLE
Centralize agent workdir path layout

### DIFF
--- a/src/lingtai_kernel/handshake.py
+++ b/src/lingtai_kernel/handshake.py
@@ -11,6 +11,8 @@ import json
 import time
 from pathlib import Path
 
+from .workdir import workdir_layout
+
 
 def resolve_address(address: str | Path, base_dir: str | Path) -> Path:
     """Resolve an agent address to an absolute Path.
@@ -26,7 +28,7 @@ def resolve_address(address: str | Path, base_dir: str | Path) -> Path:
 
 def is_agent(path: str | Path) -> bool:
     """Check if an agent exists at *path* (has .agent.json)."""
-    return (Path(path) / ".agent.json").is_file()
+    return workdir_layout(path).agent_manifest.is_file()
 
 
 def is_human(path: str | Path) -> bool:
@@ -47,7 +49,7 @@ def is_alive(path: str | Path, threshold: float = 2.0) -> bool:
     """
     if is_human(path):
         return True
-    hb = Path(path) / ".agent.heartbeat"
+    hb = workdir_layout(path).heartbeat
     if not hb.is_file():
         return False
     try:
@@ -63,7 +65,7 @@ def manifest(path: str | Path) -> dict:
     Raises FileNotFoundError if .agent.json does not exist.
     Raises json.JSONDecodeError if file is not valid JSON.
     """
-    agent_json = Path(path) / ".agent.json"
+    agent_json = workdir_layout(path).agent_manifest
     if not agent_json.is_file():
         raise FileNotFoundError(f"No .agent.json at {path}")
     return json.loads(agent_json.read_text(encoding="utf-8"))

--- a/src/lingtai_kernel/notifications.py
+++ b/src/lingtai_kernel/notifications.py
@@ -24,6 +24,8 @@ import json
 import re
 from pathlib import Path
 
+from .workdir import workdir_layout
+
 
 _CHANNEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
@@ -233,7 +235,7 @@ def notification_fingerprint(workdir: Path) -> tuple:
     equivalent JSON with different whitespace or key order is still considered
     changed.
     """
-    notif_dir = workdir / ".notification"
+    notif_dir = workdir_layout(workdir).notification_dir
     if not notif_dir.is_dir():
         return ()
     entries = []
@@ -260,7 +262,7 @@ def collect_notifications(workdir: Path) -> dict:
     producer should not break the agent.  (Producer authors see the
     skip in their own logs and fix.)
     """
-    notif_dir = workdir / ".notification"
+    notif_dir = workdir_layout(workdir).notification_dir
     if not notif_dir.is_dir():
         return {}
     out = {}
@@ -285,9 +287,10 @@ def publish(workdir: Path, tool_name: str, payload: dict) -> None:
     rename`` makes the rename appear atomically to readers.
     """
     validate_allowed_channel(tool_name)
-    notif_dir = workdir / ".notification"
+    layout = workdir_layout(workdir)
+    notif_dir = layout.notification_dir
     notif_dir.mkdir(exist_ok=True)
-    target = notif_dir / f"{tool_name}.json"
+    target = layout.notification_file(tool_name)
     tmp = target.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
     tmp.rename(target)
@@ -301,7 +304,7 @@ def clear(workdir: Path, tool_name: str) -> None:
     the kernel's next sync tick will strip the wire's notification block.
     """
     validate_allowed_channel(tool_name)
-    target = workdir / ".notification" / f"{tool_name}.json"
+    target = workdir_layout(workdir).notification_file(tool_name)
     try:
         target.unlink()
     except (FileNotFoundError, OSError):
@@ -316,7 +319,7 @@ def clear_with_result(workdir: Path, channel: str) -> bool:
     so agent-facing dismiss can surface honest failures.
     """
     validate_allowed_channel(channel)
-    target = workdir / ".notification" / f"{channel}.json"
+    target = workdir_layout(workdir).notification_file(channel)
     try:
         target.unlink()
     except FileNotFoundError:
@@ -352,7 +355,7 @@ def clear_large_result_reminders(agent, tool_call_ids) -> list[str]:
     if not wanted_ref_ids:
         return []
 
-    target = agent._working_dir / ".notification" / "system.json"
+    target = workdir_layout(agent._working_dir).notification_file("system")
 
     def _do_clear() -> list[str]:
         try:
@@ -524,7 +527,7 @@ def _ack_and_remove_large_result_events(
             from datetime import datetime, timezone
             current_payload: dict = {}
             try:
-                target = agent._working_dir / ".notification" / "system.json"
+                target = workdir_layout(agent._working_dir).notification_file("system")
                 current_payload = json.loads(target.read_text(encoding="utf-8"))
             except Exception:
                 pass
@@ -728,7 +731,7 @@ def dismiss_channel(
             large_result_events: list = []
             all_events: list = []
             try:
-                payload = json.loads((agent._working_dir / ".notification" / "system.json").read_text(encoding="utf-8"))
+                payload = json.loads(workdir_layout(agent._working_dir).notification_file("system").read_text(encoding="utf-8"))
                 data_obj = payload.get("data") if isinstance(payload, dict) else {}
                 events = data_obj.get("events", []) if isinstance(data_obj, dict) else []
                 all_events = events if isinstance(events, list) else []
@@ -876,7 +879,7 @@ def dismiss_channel(
                         current=current,
                     )
 
-        target = agent._working_dir / ".notification" / "system.json"
+        target = workdir_layout(agent._working_dir).notification_file("system")
         try:
             payload = json.loads(target.read_text(encoding="utf-8"))
         except FileNotFoundError:

--- a/src/lingtai_kernel/tool_result_artifacts.py
+++ b/src/lingtai_kernel/tool_result_artifacts.py
@@ -37,6 +37,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
+from .workdir import workdir_layout
+
 # Stable, namespaced literal stamped into every manifest produced by this
 # module.  Detectors require it for new manifests; older manifests that
 # pre-date this field are still accepted by ``is_spill_manifest`` via the
@@ -191,7 +193,7 @@ def spill_oversized_result(
     spill_failed: str | None = None
     if working_dir is not None:
         wd = Path(working_dir)
-        spill_dir = wd / "tmp" / "tool-results"
+        spill_dir = workdir_layout(wd).tool_results_dir
         try:
             spill_dir.mkdir(parents=True, exist_ok=True)
             spill_path = spill_dir / filename
@@ -405,7 +407,7 @@ def mark_expired_spill_manifests(working_dir: Path | str) -> int:
     marked ``"expired"``).
     """
     wd = Path(working_dir)
-    history_path = wd / "history" / "chat_history.jsonl"
+    history_path = workdir_layout(wd).chat_history
     if not history_path.is_file():
         return 0
 

--- a/src/lingtai_kernel/workdir.py
+++ b/src/lingtai_kernel/workdir.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -31,9 +32,113 @@ else:
 
 _LOCK_FILE = ".agent.lock"
 _MANIFEST_FILE = ".agent.json"
+_MANIFEST_CORRUPT_FILE = ".agent.json.corrupt"
+_HEARTBEAT_FILE = ".agent.heartbeat"
+_STATUS_FILE = ".status.json"
+_INIT_FILE = "init.json"
+_SYSTEM_DIR = "system"
+_LOGS_DIR = "logs"
+_HISTORY_DIR = "history"
+_NOTIFICATION_DIR = ".notification"
 
 _RESOLVED_MANIFEST_FILE = "manifest.resolved.json"
 _RESOLVED_MANIFEST_SCHEMA = "lingtai.manifest.resolved/v1"
+
+
+@dataclass(frozen=True)
+class WorkdirLayout:
+    """Names the kernel-owned paths inside an agent working directory.
+
+    Deliberately dumb: it only *names* paths from a root. No validation, no
+    file creation, no policy — those stay in the owning modules
+    (``handshake.is_alive``, ``notifications.validate_allowed_channel``, …).
+    The point is a single discoverable surface for the agent workdir
+    filesystem protocol (``.agent.json``, ``.agent.heartbeat``,
+    ``.notification/<channel>.json``, ``tmp/tool-results/``, …) so the same
+    relative names are not retyped across runtime modules and tests.
+
+    Internal by convention: import from ``lingtai_kernel.workdir``; not
+    re-exported from ``lingtai_kernel.__init__``.
+    """
+
+    root: Path
+
+    @property
+    def agent_lock(self) -> Path:
+        return self.root / _LOCK_FILE
+
+    @property
+    def agent_manifest(self) -> Path:
+        return self.root / _MANIFEST_FILE
+
+    @property
+    def agent_manifest_corrupt(self) -> Path:
+        return self.root / _MANIFEST_CORRUPT_FILE
+
+    @property
+    def heartbeat(self) -> Path:
+        return self.root / _HEARTBEAT_FILE
+
+    @property
+    def status_json(self) -> Path:
+        return self.root / _STATUS_FILE
+
+    @property
+    def init_json(self) -> Path:
+        return self.root / _INIT_FILE
+
+    @property
+    def system_dir(self) -> Path:
+        return self.root / _SYSTEM_DIR
+
+    @property
+    def logs_dir(self) -> Path:
+        return self.root / _LOGS_DIR
+
+    @property
+    def history_dir(self) -> Path:
+        return self.root / _HISTORY_DIR
+
+    @property
+    def chat_history(self) -> Path:
+        return self.history_dir / "chat_history.jsonl"
+
+    @property
+    def notification_dir(self) -> Path:
+        return self.root / _NOTIFICATION_DIR
+
+    @property
+    def tool_results_dir(self) -> Path:
+        return self.root / "tmp" / "tool-results"
+
+    @property
+    def resolved_manifest(self) -> Path:
+        return self.system_dir / _RESOLVED_MANIFEST_FILE
+
+    @property
+    def resolved_manifest_tmp(self) -> Path:
+        return self.system_dir / (_RESOLVED_MANIFEST_FILE + ".tmp")
+
+    def notification_file(self, channel: str) -> Path:
+        """Path to a ``.notification/<channel>.json`` file (no validation)."""
+        return self.notification_dir / f"{channel}.json"
+
+    def system_file(self, name: str) -> Path:
+        """Path to a file inside the ``system/`` directory."""
+        return self.system_dir / name
+
+
+def workdir_layout(path: Path | str) -> WorkdirLayout:
+    """Return the :class:`WorkdirLayout` rooted at *path*.
+
+    A ``str`` is coerced to ``Path`` (so ``handshake.is_agent(str(dir))`` keeps
+    working); anything else — a real ``Path`` or a duck-typed stand-in such as a
+    test ``MagicMock`` — is stored as-is so the ``root / name`` joins stay on
+    whatever object the caller passed. This mirrors the pre-helper behavior
+    where producers used ``workdir / "…"`` directly without coercion.
+    """
+    root = Path(path) if isinstance(path, str) else path
+    return WorkdirLayout(root)
 
 # Key names that carry (or point at) secret material — dropped recursively
 # before the resolved manifest is published. `*_env` names are included to
@@ -114,10 +219,10 @@ def write_resolved_manifest(working_dir: Path | str, data: dict) -> Path | None:
         artifact["preset"] = _redact_secrets(preset)
 
     try:
-        system_dir = Path(working_dir) / "system"
-        system_dir.mkdir(parents=True, exist_ok=True)
-        target = system_dir / _RESOLVED_MANIFEST_FILE
-        tmp = system_dir / (_RESOLVED_MANIFEST_FILE + ".tmp")
+        layout = workdir_layout(working_dir)
+        layout.system_dir.mkdir(parents=True, exist_ok=True)
+        target = layout.resolved_manifest
+        tmp = layout.resolved_manifest_tmp
         tmp.write_text(
             json.dumps(artifact, indent=2, ensure_ascii=False) + "\n",
             encoding="utf-8",
@@ -134,6 +239,7 @@ class WorkingDir:
     def __init__(self, working_dir: Path | str) -> None:
         self._path = Path(working_dir)
         self._path.mkdir(parents=True, exist_ok=True)
+        self._layout = workdir_layout(self._path)
         self._lock_file: Any = None
 
     @property
@@ -149,7 +255,7 @@ class WorkingDir:
             timeout: Max seconds to wait for the lock. 0 = fail immediately
                 (default, backward compatible). Polls at 250ms intervals.
         """
-        lock_path = self._path / _LOCK_FILE
+        lock_path = self._layout.agent_lock
         deadline = time.monotonic() + timeout
         while True:
             self._lock_file = open(lock_path, "w")
@@ -168,7 +274,7 @@ class WorkingDir:
 
     def release_lock(self) -> None:
         if self._lock_file is not None:
-            lock_path = self._path / _LOCK_FILE
+            lock_path = self._layout.agent_lock
             try:
                 _unlock_fd(self._lock_file)
                 self._lock_file.close()
@@ -356,14 +462,14 @@ class WorkingDir:
 
     def read_manifest(self) -> str:
         """Read the covenant from the manifest file. Returns empty string if missing."""
-        path = self._path / _MANIFEST_FILE
+        path = self._layout.agent_manifest
         if not path.is_file():
             return ""
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             return data.get("covenant", "")
         except (json.JSONDecodeError, OSError):
-            corrupt = self._path / ".agent.json.corrupt"
+            corrupt = self._layout.agent_manifest_corrupt
             try:
                 path.rename(corrupt)
             except OSError:
@@ -372,7 +478,7 @@ class WorkingDir:
 
     def read_full_manifest(self) -> dict:
         """Read entire .agent.json as dict. Returns empty dict if missing or corrupt."""
-        path = self._path / _MANIFEST_FILE
+        path = self._layout.agent_manifest
         if not path.is_file():
             return {}
         try:
@@ -386,4 +492,4 @@ class WorkingDir:
         # byte-identical to the previous inline implementation.
         from ._fsutil import atomic_write_json
 
-        atomic_write_json(self._path / _MANIFEST_FILE, manifest)
+        atomic_write_json(self._layout.agent_manifest, manifest)

--- a/tests/_agent_dir_helpers.py
+++ b/tests/_agent_dir_helpers.py
@@ -1,0 +1,59 @@
+"""Shared filesystem factory for tests that need a minimal agent working dir.
+
+Several test modules each spelled out the same ``.agent.json`` + heartbeat
+setup (``test_handshake.py``, ``test_filesystem_mail.py``, …).  This is the one
+definition; modules import it directly or via the ``make_agent_dir`` fixture in
+``conftest.py``.
+
+Deliberately raw: the protocol filenames (``.agent.json``,
+``.agent.heartbeat``) are spelled out here rather than routed through
+``lingtai_kernel.workdir.workdir_layout`` so the factory stays an independent
+oracle — a drift in the layout helper is caught by the exact-path assertions in
+``test_workdir.py`` instead of being papered over by a shared constant.
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+def make_agent_dir(
+    base: Path,
+    name: str = "agent",
+    *,
+    heartbeat: bool = True,
+    heartbeat_ts: float | None = None,
+    human: bool = False,
+    manifest: dict[str, Any] | None = None,
+    mailbox: bool = False,
+) -> Path:
+    """Create a minimal agent working directory and return its ``Path``.
+
+    Args:
+        base: Parent directory (usually ``tmp_path``).
+        name: Subdirectory name. Pass ``""`` to use *base* itself.
+        heartbeat: Write a ``.agent.heartbeat`` file. Forced off for humans.
+        heartbeat_ts: Heartbeat timestamp; defaults to ``time.time()`` (fresh).
+        human: Write ``admin=null`` (a human pseudo-agent) and skip heartbeat.
+        manifest: Full ``.agent.json`` contents; overrides the default shape.
+        mailbox: Also create ``mailbox/inbox``.
+    """
+    d = base / name if name else base
+    d.mkdir(parents=True, exist_ok=True)
+
+    if manifest is None:
+        manifest = {"agent_name": "test", "admin": None if human else {}}
+    (d / ".agent.json").write_text(json.dumps(manifest))
+
+    if human:
+        heartbeat = False
+    if heartbeat:
+        ts = time.time() if heartbeat_ts is None else heartbeat_ts
+        (d / ".agent.heartbeat").write_text(str(ts))
+
+    if mailbox:
+        (d / "mailbox" / "inbox").mkdir(parents=True, exist_ok=True)
+
+    return d

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,19 @@ from __future__ import annotations
 
 import pytest
 
+from ._agent_dir_helpers import make_agent_dir as _make_agent_dir
+
+
+@pytest.fixture
+def make_agent_dir():
+    """Factory fixture: create a minimal agent working dir.
+
+    Returns the :func:`tests._agent_dir_helpers.make_agent_dir` callable so a
+    single test can build several agent dirs with different shapes (heartbeat,
+    human, mailbox, …).
+    """
+    return _make_agent_dir
+
 
 @pytest.fixture(autouse=True)
 def _isolate_notification_dismiss_guards():

--- a/tests/test_filesystem_mail.py
+++ b/tests/test_filesystem_mail.py
@@ -3,21 +3,10 @@ from __future__ import annotations
 
 import json
 import time
-from pathlib import Path
 
 import pytest
 
-
-def _make_agent_dir(base: Path, name: str) -> Path:
-    """Create a minimal agent working dir with .agent.json and fresh heartbeat."""
-    d = base / name
-    d.mkdir()
-    (d / ".agent.json").write_text(json.dumps({
-        "agent_name": "test",
-        "admin": {},
-    }))
-    (d / ".agent.heartbeat").write_text(str(time.time()))
-    return d
+from ._agent_dir_helpers import make_agent_dir as _make_agent_dir
 
 
 class TestSend:

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -1,7 +1,6 @@
 """Tests for lingtai_kernel.handshake utility."""
 from __future__ import annotations
 
-import json
 import time
 from pathlib import Path
 
@@ -11,17 +10,21 @@ from lingtai_kernel.handshake import is_agent, is_alive, manifest
 
 
 @pytest.fixture
-def agent_dir(tmp_path):
+def agent_dir(tmp_path, make_agent_dir):
     """Create a minimal agent working directory.
 
     The ``admin`` field MUST be non-null — ``is_alive()`` short-circuits
     True for human pseudo-agents (admin=null), so a manifest without an
     explicit admin block makes every is_alive call return True regardless
-    of heartbeat state.
+    of heartbeat state.  Heartbeat is left off here; the liveness tests
+    write their own with a controlled timestamp.
     """
-    meta = {"agent_id": "abc123", "agent_name": "test", "admin": {}}
-    (tmp_path / ".agent.json").write_text(json.dumps(meta))
-    return tmp_path
+    return make_agent_dir(
+        tmp_path,
+        name="",
+        manifest={"agent_id": "abc123", "agent_name": "test", "admin": {}},
+        heartbeat=False,
+    )
 
 
 def test_is_agent_true(agent_dir):

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -7,7 +7,60 @@ from pathlib import Path
 
 import pytest
 
-from lingtai_kernel.workdir import WorkingDir
+from lingtai_kernel.workdir import WorkingDir, WorkdirLayout, workdir_layout
+
+
+class TestWorkdirLayout:
+    """Lock down the exact relative names the layout helper hands out.
+
+    These are the agent-workdir filesystem protocol — separate processes read
+    and write them by name — so each property is pinned to an exact path. A
+    silent rename here would break mail delivery, notification sync, handshake,
+    and spill recovery; the assertions make any drift fail loudly.
+    """
+
+    def test_returns_frozen_layout_rooted_at_path(self, tmp_path):
+        layout = workdir_layout(tmp_path)
+        assert isinstance(layout, WorkdirLayout)
+        assert layout.root == tmp_path
+        with pytest.raises(Exception):
+            layout.root = tmp_path / "other"  # frozen dataclass
+
+    def test_accepts_str_path(self, tmp_path):
+        assert workdir_layout(str(tmp_path)).root == tmp_path
+
+    def test_agent_protocol_files(self, tmp_path):
+        layout = workdir_layout(tmp_path)
+        assert layout.agent_lock == tmp_path / ".agent.lock"
+        assert layout.agent_manifest == tmp_path / ".agent.json"
+        assert layout.agent_manifest_corrupt == tmp_path / ".agent.json.corrupt"
+        assert layout.heartbeat == tmp_path / ".agent.heartbeat"
+        assert layout.status_json == tmp_path / ".status.json"
+        assert layout.init_json == tmp_path / "init.json"
+
+    def test_directories(self, tmp_path):
+        layout = workdir_layout(tmp_path)
+        assert layout.system_dir == tmp_path / "system"
+        assert layout.logs_dir == tmp_path / "logs"
+        assert layout.history_dir == tmp_path / "history"
+        assert layout.notification_dir == tmp_path / ".notification"
+        assert layout.tool_results_dir == tmp_path / "tmp" / "tool-results"
+
+    def test_derived_files(self, tmp_path):
+        layout = workdir_layout(tmp_path)
+        assert layout.chat_history == tmp_path / "history" / "chat_history.jsonl"
+        assert layout.resolved_manifest == tmp_path / "system" / "manifest.resolved.json"
+        assert layout.resolved_manifest_tmp == tmp_path / "system" / "manifest.resolved.json.tmp"
+
+    def test_notification_file(self, tmp_path):
+        layout = workdir_layout(tmp_path)
+        assert layout.notification_file("email") == tmp_path / ".notification" / "email.json"
+        assert layout.notification_file("system") == tmp_path / ".notification" / "system.json"
+        assert layout.notification_file("mcp.telegram") == tmp_path / ".notification" / "mcp.telegram.json"
+
+    def test_system_file(self, tmp_path):
+        layout = workdir_layout(tmp_path)
+        assert layout.system_file("covenant.md") == tmp_path / "system" / "covenant.md"
 
 
 def test_workdir_accepts_path(tmp_path):


### PR DESCRIPTION
Closes #514.

## Summary

This PR centralizes the repeated agent-workdir path conventions behind a small `WorkdirLayout` helper so callers do not keep re-spelling protocol filenames and sibling directories by hand.

## What changed

- Adds a frozen `WorkdirLayout` dataclass plus `workdir_layout()` constructor in `lingtai_kernel.workdir`.
- Routes existing workdir path users through the shared layout in focused places:
  - workdir/status helpers,
  - handshake path resolution,
  - notification channel paths,
  - tool-result artifact paths.
- Adds independent test helpers/fixtures for raw agent-directory layouts so tests can build protocol-shaped directories without depending on implementation helpers.

## Compatibility / non-goals

- Protocol filenames and locations are intentionally unchanged: `.agent.json`, `.agent.heartbeat`, `.agent.env`, `.agent.outbox`, `.notification/`, `.clear/`, etc. keep the same on-disk shape.
- This does not attempt a broad rewrite of every path construction site; it keeps the first cleanup small and behavior-preserving.

## Validation

Post-rebase on current `canonical/main` (`d98abb7b`):

- `git diff --check canonical/main...HEAD`
- `PYTHONPATH=src /private/tmp/lt-venv-512/bin/python -m pytest -q -p no:cacheprovider tests/test_workdir.py tests/test_handshake.py tests/test_filesystem_mail.py tests/test_tool_result_spill.py tests/test_expired_spill_messaging.py tests/test_notification_tool.py tests/test_system_dismiss.py`
  - `150 passed in 17.77s`

Independent cold-read review also found no blockers. A broader pre-rebase full-suite run for this branch passed (`3149 passed, 4 skipped`).
