### PR TITLE
Make capability setup failures explicit

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -162,10 +162,15 @@ class Agent(BaseAgent):
     def _setup_capability(self, name: str, **kwargs: Any) -> Any:
         """Load a named capability.
 
+        ``None`` from setup means success without a manager object. A setup that
+        cannot register must return ``CAPABILITY_UNAVAILABLE`` before adding any
+        tools so this wrapper can leave the capability absent from public
+        registration surfaces.
+
         Not directly sealed — but setup() calls add_tool() which checks the seal.
         Must only be called from __init__ (before start()).
         """
-        from .capabilities import setup_capability
+        from .capabilities import CAPABILITY_UNAVAILABLE, setup_capability
 
         serializable_kw = {
             k: v for k, v in kwargs.items()
@@ -178,6 +183,9 @@ class Agent(BaseAgent):
             # Roll back the entry so _capabilities only lists registered caps.
             self._capabilities.pop()
             raise
+        if mgr is CAPABILITY_UNAVAILABLE:
+            self._capabilities.pop()
+            return None
         self._capability_managers[name] = mgr
         return mgr
 

--- a/src/lingtai/capabilities/__init__.py
+++ b/src/lingtai/capabilities/__init__.py
@@ -7,6 +7,18 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
 
+
+class _CapabilityUnavailable:
+    """Signal that a capability setup skipped before registering tools."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "CAPABILITY_UNAVAILABLE"
+
+
+CAPABILITY_UNAVAILABLE = _CapabilityUnavailable()
+
 # Registry of built-in capability names → module paths.
 # Entries starting with "." are relative to this package (lingtai.capabilities);
 # absolute paths point at lingtai.core (the always-on agent floor). Both forms
@@ -146,8 +158,10 @@ def expand_groups(names: list[str]) -> list[str]:
 def setup_capability(agent: "BaseAgent", name: str, **kwargs: Any) -> Any:
     """Look up a capability by *name* and call its ``setup(agent, **kwargs)``.
 
-    Returns whatever the capability's ``setup`` function returns (typically
-    a manager instance).
+    A setup function returns a manager instance or ``None`` after successful
+    registration. ``None`` is success for several core capabilities. To skip
+    registration, setup must return ``CAPABILITY_UNAVAILABLE`` before calling
+    ``add_tool()``.
 
     Raises ``ValueError`` if the name is unknown or the module lacks ``setup``.
     """

--- a/src/lingtai/capabilities/vision/__init__.py
+++ b/src/lingtai/capabilities/vision/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from .. import CAPABILITY_UNAVAILABLE
 from ...i18n import t
 from ...services.vision import VisionService, create_vision_service
 
@@ -164,7 +165,7 @@ def setup(
                         f"(api_compat={api_compat!r})"
                     ),
                 )
-                return None
+                return CAPABILITY_UNAVAILABLE
         else:
             # Provider-specific kwarg injection. Each branch is opt-in because
             # vision services have heterogeneous constructor signatures —

--- a/src/lingtai/capabilities/web_search/__init__.py
+++ b/src/lingtai/capabilities/web_search/__init__.py
@@ -79,6 +79,7 @@ def setup(
     search_service: Any | None = None,
     provider: str | None = None,
     api_key: str | None = None,
+    api_key_env: str | None = None,
     model: str | None = None,
     **kwargs: Any,
 ) -> WebSearchManager:
@@ -89,9 +90,14 @@ def setup(
         search_service: A pre-built SearchService instance.
         provider: Provider name for ``create_search_service()``.
         api_key: API key for the provider.
+        api_key_env: Optional environment variable name for the API key.
         model: Optional model override for the provider.
     """
     if search_service is None and provider is not None:
+        if api_key_env:
+            from lingtai_kernel.config_resolve import resolve_env
+            api_key = resolve_env(api_key, api_key_env)
+
         # Graceful fallback: if the resolved provider isn't supported by web_search,
         # use fallback_on_inherit (duckduckgo). Never raise.
         if provider not in PROVIDERS["providers"]:

--- a/tests/test_agent_capabilities.py
+++ b/tests/test_agent_capabilities.py
@@ -34,9 +34,35 @@ def test_agent_no_capabilities_boots_core_floor(tmp_path):
         f"expected exactly the core defaults, got {registered - set(CORE_DEFAULTS)} extra / "
         f"{set(CORE_DEFAULTS) - registered} missing"
     )
+    manifest_registered = {
+        name for name, _ in agent._build_manifest().get("capabilities", [])
+    }
+    for name in CORE_DEFAULTS:
+        assert agent.has_capability(name) is True
+        assert name in manifest_registered
     assert "vision" not in registered
     assert "web_search" not in registered
     agent.stop(timeout=1.0)
+
+
+def test_agent_unsupported_vision_skip_is_not_registered(tmp_path):
+    """A skipped capability must not appear registered or callable."""
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=tmp_path / "test",
+        capabilities={"vision": {"provider": "not-real"}},
+    )
+    try:
+        manifest_registered = {
+            name for name, _ in agent._build_manifest().get("capabilities", [])
+        }
+        assert agent.has_capability("vision") is False
+        assert agent.get_capability("vision") is None
+        assert "vision" not in agent._tool_handlers
+        assert "vision" not in manifest_registered
+    finally:
+        agent.stop(timeout=1.0)
 
 
 def test_agent_disable_strips_core_capability(tmp_path):

--- a/tests/test_deep_refresh.py
+++ b/tests/test_deep_refresh.py
@@ -163,6 +163,21 @@ def test_deep_refresh_loads_new_capability(tmp_path):
     assert agent._sealed is True
 
 
+def test_deep_refresh_skipped_vision_is_not_registered(tmp_path):
+    """Refresh honors CAPABILITY_UNAVAILABLE like initial setup."""
+    init = _make_init(capabilities={"vision": {"provider": "not-real"}})
+    agent = _make_agent(tmp_path, init)
+
+    agent._setup_from_init()
+
+    manifest_registered = {
+        name for name, _ in agent._build_manifest().get("capabilities", [])
+    }
+    assert agent.has_capability("vision") is False
+    assert "vision" not in agent._tool_handlers
+    assert "vision" not in manifest_registered
+
+
 def test_deep_refresh_no_init_json_is_noop(tmp_path):
     """If init.json is missing, refresh is a no-op (no crash)."""
     agent = _make_agent(tmp_path)

--- a/tests/test_inherit_fallback.py
+++ b/tests/test_inherit_fallback.py
@@ -44,9 +44,11 @@ def test_web_search_unknown_provider_falls_back_to_duckduckgo():
 
 def test_vision_unknown_provider_silently_skips():
     """vision with provider='deepseek' (no vision, no fallback) skips registration."""
+    from lingtai.capabilities import CAPABILITY_UNAVAILABLE
     from lingtai.capabilities.vision import setup as vision_setup
     a = _stub_agent()
     result = vision_setup(a, provider="deepseek", api_key=None, api_key_env="X")
+    assert result is CAPABILITY_UNAVAILABLE
     assert "vision" not in a._tool_handlers
     events = [e for e, _ in a._log_events]
     assert "capability_skipped" in events

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from lingtai.capabilities import CAPABILITY_UNAVAILABLE
 from lingtai.capabilities.vision import VisionManager, setup
 from lingtai.services.vision import VisionService, create_vision_service
 
@@ -147,15 +148,15 @@ def test_vision_setup_with_codex_provider_without_api_key(tmp_path):
 
 
 def test_vision_setup_unsupported_provider_skips(tmp_path):
-    """Unsupported providers gracefully skip: setup returns None and logs capability_skipped.
+    """Unsupported providers gracefully skip and log capability_skipped.
 
     The mock agent's `service._provider_defaults` is a MagicMock (not a dict),
     so the OpenAI-compat fallback does not engage; the graceful skip path
-    runs instead. Agent.py's capability loader handles None as a no-op.
+    runs instead.
     """
     agent = make_mock_agent(tmp_path)
     result = setup(agent, provider="not-real")
-    assert result is None
+    assert result is CAPABILITY_UNAVAILABLE
     agent.add_tool.assert_not_called()
     agent._log.assert_called_with(
         "capability_skipped",
@@ -369,7 +370,7 @@ def test_vision_fallback_unknown_api_compat_skips_with_diagnostic(tmp_path):
     """Fallback with an unhandled api_compat skips and names api_compat in the reason."""
     agent = make_custom_agent(tmp_path, api_compat="gemini")
     result = setup(agent, provider="custom", api_key="sk-test")
-    assert result is None
+    assert result is CAPABILITY_UNAVAILABLE
     agent.add_tool.assert_not_called()
     log_kwargs = agent._log.call_args.kwargs
     assert log_kwargs["capability"] == "vision"

--- a/tests/test_web_search_capability.py
+++ b/tests/test_web_search_capability.py
@@ -1,12 +1,12 @@
 """Tests for web_search capability."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from lingtai.agent import Agent
-from lingtai.capabilities.web_search import WebSearchManager
+from lingtai.capabilities.web_search import WebSearchManager, setup
 from lingtai.services.websearch import SearchResult, SearchService, create_search_service
 from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
@@ -97,3 +97,77 @@ def test_web_search_with_provider_kwarg(tmp_path):
         capabilities={"web_search": {"provider": "duckduckgo"}},
     )
     assert "web_search" in agent._tool_handlers
+
+
+def test_web_search_setup_resolves_api_key_env(monkeypatch):
+    """setup() resolves api_key_env before constructing provider services."""
+    monkeypatch.setenv("WEB_SEARCH_TEST_API_KEY", "sk-from-env")
+    agent = MagicMock()
+    agent._config.language = "en"
+    agent.service._base_url = None
+
+    with patch("lingtai.capabilities.web_search.create_search_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=SearchService)
+        mgr = setup(agent, provider="gemini", api_key_env="WEB_SEARCH_TEST_API_KEY")
+
+    assert isinstance(mgr, WebSearchManager)
+    mock_factory.assert_called_once()
+    assert mock_factory.call_args.args == ("gemini",)
+    assert mock_factory.call_args.kwargs["api_key"] == "sk-from-env"
+
+
+def test_web_search_setup_api_key_env_overrides_raw_key(monkeypatch):
+    """api_key_env takes precedence over a raw api_key, matching vision."""
+    monkeypatch.setenv("WEB_SEARCH_TEST_API_KEY", "sk-from-env")
+    agent = MagicMock()
+    agent._config.language = "en"
+    agent.service._base_url = None
+
+    with patch("lingtai.capabilities.web_search.create_search_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=SearchService)
+        setup(
+            agent,
+            provider="gemini",
+            api_key="sk-raw",
+            api_key_env="WEB_SEARCH_TEST_API_KEY",
+        )
+
+    assert mock_factory.call_args.kwargs["api_key"] == "sk-from-env"
+
+
+def test_inherited_web_search_env_key_registers(tmp_path, monkeypatch):
+    """A provider:inherit web_search with env-only credentials boots."""
+    from lingtai_kernel.presets import expand_inherit
+
+    monkeypatch.setenv("WEB_SEARCH_TEST_API_KEY", "sk-from-env")
+    capabilities = {"web_search": {"provider": "inherit"}}
+    expand_inherit(
+        capabilities,
+        {
+            "provider": "gemini",
+            "api_key": None,
+            "api_key_env": "WEB_SEARCH_TEST_API_KEY",
+        },
+    )
+
+    with patch("lingtai.capabilities.web_search.create_search_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=SearchService)
+        service = make_mock_service()
+        service._base_url = None
+        agent = Agent(
+            service=service,
+            agent_name="test",
+            working_dir=tmp_path / "test",
+            capabilities=capabilities,
+        )
+
+    try:
+        assert agent.has_capability("web_search") is True
+        assert "web_search" in agent._tool_handlers
+        call = next(
+            call for call in mock_factory.call_args_list
+            if call.args == ("gemini",)
+        )
+        assert call.kwargs["api_key"] == "sk-from-env"
+    finally:
+        agent.stop(timeout=1.0)


### PR DESCRIPTION
## Summary

- Add an explicit `CAPABILITY_UNAVAILABLE` sentinel for optional capability setup paths that should be skipped without being registered as working tools.
- Make vision's unsupported-provider setup return that sentinel instead of `None`, while preserving `None` as successful setup for core capabilities.
- Prevent unavailable capabilities from leaving `has_capability`, manifest, or tool-call false positives; add `web_search.api_key_env` setup coverage.

## Why

Capability setup previously used `None` both for successful core setup and for optional-provider unavailability. That made capability availability harder to reason about and could leave confusing registration state after a provider was intentionally skipped.

This change keeps the existing core success contract intact while giving optional setup failures a model-visible, test-pinned outcome.

## Validation

- `.venv/bin/python -m pytest tests/test_agent_capabilities.py tests/test_vision_capability.py tests/test_web_search_capability.py tests/test_inherit_fallback.py tests/test_deep_refresh.py -q` — `79 passed`.
- `.venv/bin/python -m compileall -q src/lingtai/capabilities src/lingtai/agent.py tests/test_agent_capabilities.py tests/test_vision_capability.py tests/test_web_search_capability.py tests/test_inherit_fallback.py tests/test_deep_refresh.py` — passed.
- `git diff --check` — passed.
- Independent focused rerun reproduced the 79-pass focused suite and the five new tests.

Full locked-environment `uv run pytest ...` is blocked on this macOS x86_64 host before test execution because `onnxruntime==1.27.0` has no compatible wheel/source distribution. The focused suite was run in a local editable venv with only the dependencies needed by this capability-surface test set.