### PR TITLE
Centralize daemon backend metadata

### DIFF
--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -22,6 +22,7 @@ import subprocess
 import threading
 import time
 import yaml
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
@@ -356,12 +357,165 @@ _BACKEND_ALIASES = {
     "omp": "oh-my-pi",
 }
 
+_QWEN_CODE_ASK_UNSUPPORTED_MESSAGE = (
+    "qwen-code daemon backend does not support daemon(action='ask') yet; "
+    "start a new qwen-code emanation instead."
+)
+
+
+@dataclass(frozen=True)
+class _BackendSpec:
+    id: str
+    is_cli: bool
+    runner_attr: str | None
+    ask_handler_attr: str | None
+    ask_unsupported_msg: str | None
+    reserved_flags: frozenset[str]
+
+
+@dataclass(frozen=True)
+class _CliTaskContext:
+    """Passive per-task CLI context; MCP entries are registration dicts only."""
+
+    backend_argv: list[str]
+    system_prompt: str | None
+    skill_catalog: str | None
+    mcp_catalog: str | None
+    mcp_regs: list[dict]
+
+
+_CLAUDE_INTERACTIVE_RESERVED_FLAGS = frozenset(
+    _CLAUDE_COMMON_RESERVED_BACKEND_FLAGS
+    | _CLAUDE_INTERACTIVE_RESERVED_BACKEND_FLAGS
+)
+
+_BACKEND_SPECS: dict[str, _BackendSpec] = {
+    "lingtai": _BackendSpec(
+        id="lingtai",
+        is_cli=False,
+        runner_attr=None,
+        ask_handler_attr=None,
+        ask_unsupported_msg=None,
+        reserved_flags=frozenset(),
+    ),
+    "claude": _BackendSpec(
+        id="claude",
+        is_cli=True,
+        runner_attr="_run_claude_interactive_emanation",
+        ask_handler_attr="_handle_ask_claude_interactive",
+        ask_unsupported_msg=None,
+        reserved_flags=_CLAUDE_INTERACTIVE_RESERVED_FLAGS,
+    ),
+    "claude-interactive": _BackendSpec(
+        id="claude-interactive",
+        is_cli=True,
+        runner_attr="_run_claude_interactive_emanation",
+        ask_handler_attr="_handle_ask_claude_interactive",
+        ask_unsupported_msg=None,
+        reserved_flags=_CLAUDE_INTERACTIVE_RESERVED_FLAGS,
+    ),
+    "claude-p": _BackendSpec(
+        id="claude-p",
+        is_cli=True,
+        runner_attr="_run_claude_code_emanation",
+        ask_handler_attr="_handle_ask_cli",
+        ask_unsupported_msg=None,
+        reserved_flags=frozenset(_CLAUDE_COMMON_RESERVED_BACKEND_FLAGS),
+    ),
+    "claude-code": _BackendSpec(
+        id="claude-code",
+        is_cli=True,
+        runner_attr="_run_claude_code_emanation",
+        ask_handler_attr="_handle_ask_cli",
+        ask_unsupported_msg=None,
+        reserved_flags=frozenset(_CLAUDE_COMMON_RESERVED_BACKEND_FLAGS),
+    ),
+    "codex": _BackendSpec(
+        id="codex",
+        is_cli=True,
+        runner_attr="_run_codex_emanation",
+        ask_handler_attr="_handle_ask_codex",
+        ask_unsupported_msg=None,
+        reserved_flags=frozenset(),
+    ),
+    "opencode": _BackendSpec(
+        id="opencode",
+        is_cli=True,
+        runner_attr="_run_opencode_emanation",
+        ask_handler_attr="_handle_ask_opencode",
+        ask_unsupported_msg=None,
+        reserved_flags=frozenset(_OPENCODE_FAMILY_RESERVED_BACKEND_FLAGS),
+    ),
+    "mimocode": _BackendSpec(
+        id="mimocode",
+        is_cli=True,
+        runner_attr="_run_mimocode_emanation",
+        ask_handler_attr="_handle_ask_mimocode",
+        ask_unsupported_msg=None,
+        reserved_flags=frozenset(_OPENCODE_FAMILY_RESERVED_BACKEND_FLAGS),
+    ),
+    "qwen-code": _BackendSpec(
+        id="qwen-code",
+        is_cli=True,
+        runner_attr="_run_qwen_code_emanation",
+        ask_handler_attr=None,
+        ask_unsupported_msg=_QWEN_CODE_ASK_UNSUPPORTED_MESSAGE,
+        reserved_flags=frozenset(_QWEN_RESERVED_BACKEND_FLAGS),
+    ),
+    "oh-my-pi": _BackendSpec(
+        id="oh-my-pi",
+        is_cli=True,
+        runner_attr="_run_oh_my_pi_emanation",
+        ask_handler_attr="_handle_ask_oh_my_pi",
+        ask_unsupported_msg=None,
+        reserved_flags=frozenset(_OH_MY_PI_RESERVED_BACKEND_FLAGS),
+    ),
+    "cursor": _BackendSpec(
+        id="cursor",
+        is_cli=True,
+        runner_attr="_run_cursor_emanation",
+        ask_handler_attr="_handle_ask_cursor",
+        ask_unsupported_msg=None,
+        reserved_flags=frozenset(),
+    ),
+}
+
+_BACKEND_SCHEMA_ENUM = [
+    "lingtai",
+    "claude-p",
+    "claude-code",
+    "codex",
+    "opencode",
+    "mimocode",
+    "mimo",
+    "qwen-code",
+    "qwen",
+    "oh-my-pi",
+    "omp",
+    "cursor",
+]
+
+_HIDDEN_SCHEMA_BACKENDS = frozenset({"claude", "claude-interactive"})
+assert all(name == spec.id for name, spec in _BACKEND_SPECS.items())
+assert set(_BACKEND_ALIASES.values()).issubset(_BACKEND_SPECS)
+assert set(_BACKEND_SCHEMA_ENUM) == (
+    (set(_BACKEND_SPECS) - _HIDDEN_SCHEMA_BACKENDS)
+    | set(_BACKEND_ALIASES)
+)
+
 
 def _normalize_backend(backend: str | None) -> str:
     """Map a caller-supplied backend (incl. aliases) to its canonical id."""
     if not backend:
         return "lingtai"
     return _BACKEND_ALIASES.get(backend, backend)
+
+
+def _backend_spec(backend: str | None) -> _BackendSpec | None:
+    """Return the runtime backend spec for a stored backend id, if known."""
+    if not backend:
+        return None
+    return _BACKEND_SPECS.get(backend)
 
 
 def _validate_claude_backend_argv(backend: str, argv: list[str]) -> None:
@@ -379,20 +533,11 @@ def _validate_claude_backend_argv(backend: str, argv: list[str]) -> None:
 
     Despite the historical name, this validator now covers all CLI backends.
     """
-    if backend in ("claude", "claude-interactive", "claude-p", "claude-code"):
-        reserved = set(_CLAUDE_COMMON_RESERVED_BACKEND_FLAGS)
-        if backend in ("claude", "claude-interactive"):
-            reserved.update(_CLAUDE_INTERACTIVE_RESERVED_BACKEND_FLAGS)
-    elif backend in ("opencode", "mimocode"):
-        reserved = set(_OPENCODE_FAMILY_RESERVED_BACKEND_FLAGS)
-    elif backend == "qwen-code":
-        reserved = set(_QWEN_RESERVED_BACKEND_FLAGS)
-    elif backend == "oh-my-pi":
-        reserved = set(_OH_MY_PI_RESERVED_BACKEND_FLAGS)
-    else:
+    spec = _backend_spec(backend)
+    if spec is None or not spec.reserved_flags:
         return
     for token in argv:
-        if token in reserved:
+        if token in spec.reserved_flags:
             raise ValueError(f"{token} is reserved by the {backend} daemon backend")
 
 
@@ -518,20 +663,7 @@ def get_schema(lang: str = "en") -> dict:
             },
             "backend": {
                 "type": "string",
-                "enum": [
-                    "lingtai",
-                    "claude-p",
-                    "claude-code",
-                    "codex",
-                    "opencode",
-                    "mimocode",
-                    "mimo",
-                    "qwen-code",
-                    "qwen",
-                    "oh-my-pi",
-                    "omp",
-                    "cursor",
-                ],
+                "enum": list(_BACKEND_SCHEMA_ENUM),
                 "description": (
                     "Execution backend: 'lingtai' (default — parallel LLM reasoning, uses your current model), "
                     "'claude-p' (Claude Code print-mode backend; 'claude-code' is a compatibility alias), "
@@ -2410,10 +2542,8 @@ class DaemonManager:
         self._pools = [(p, c) for p, c in self._pools if not c.is_set()]
 
         # --- External CLI backends: skip preset resolution entirely ---
-        if backend in (
-            "claude", "claude-interactive", "claude-p", "claude-code",
-            "codex", "opencode", "mimocode", "qwen-code", "oh-my-pi", "cursor",
-        ):
+        backend_spec = _backend_spec(backend)
+        if backend_spec is not None and backend_spec.is_cli:
             return self._handle_emanate_cli(
                 tasks, backend=backend,
                 effective_max_turns=effective_max_turns,
@@ -2625,35 +2755,43 @@ class DaemonManager:
         run directory; only terminal completion/failure emits a compact
         system notification.
         """
+        backend_spec = _backend_spec(backend)
+        if (
+            backend_spec is None
+            or not backend_spec.is_cli
+            or backend_spec.runner_attr is None
+        ):
+            return {"status": "error", "message": f"Unknown CLI backend: {backend}"}
+
         # Pre-flight: validate per-task backend_options BEFORE creating any
         # run_dir or scheduling work, so a single bad spec refuses the whole
         # batch with a clear message instead of leaving half-spawned daemons.
-        resolved_backend_argv: list[list[str]] = []
-        task_system_prompts: list[str | None] = []
-        task_skill_catalogs: list[str | None] = []
-        task_mcp_catalogs: list[str | None] = []
-        task_mcp_registrations: list[list[dict]] = []
+        contexts: list[_CliTaskContext] = []
         for i, spec in enumerate(tasks):
             try:
-                task_system_prompts.append(self._task_system_prompt(spec))
-                task_skill_catalogs.append(self._task_skill_catalog(spec))
+                task_system_prompt = self._task_system_prompt(spec)
+                task_skill_catalog = self._task_skill_catalog(spec)
                 task_mcp_regs, task_mcp_catalog = self._task_mcp_registrations(spec)
-                task_mcp_registrations.append(task_mcp_regs)
-                task_mcp_catalogs.append(task_mcp_catalog)
             except ValueError as e:
                 return {"status": "error",
                         "message": f"tasks[{i}]: {e}"}
             raw_opts = spec.get("backend_options")
             if raw_opts is None:
-                resolved_backend_argv.append([])
-                continue
-            try:
-                argv = _backend_options_to_argv(raw_opts)
-                _validate_claude_backend_argv(backend, argv)
-                resolved_backend_argv.append(argv)
-            except ValueError as e:
-                return {"status": "error",
-                        "message": f"tasks[{i}].backend_options: {e}"}
+                backend_argv = []
+            else:
+                try:
+                    backend_argv = _backend_options_to_argv(raw_opts)
+                    _validate_claude_backend_argv(backend, backend_argv)
+                except ValueError as e:
+                    return {"status": "error",
+                            "message": f"tasks[{i}].backend_options: {e}"}
+            contexts.append(_CliTaskContext(
+                backend_argv=backend_argv,
+                system_prompt=task_system_prompt,
+                skill_catalog=task_skill_catalog,
+                mcp_catalog=task_mcp_catalog,
+                mcp_regs=task_mcp_regs,
+            ))
 
         cancel_event = threading.Event()
         timeout_event = threading.Event()
@@ -2665,19 +2803,15 @@ class DaemonManager:
         parent_addr = self._agent._working_dir.name
         parent_pid = os.getpid()
 
-        for i, spec in enumerate(tasks):
+        for spec, context in zip(tasks, contexts):
             em_id = f"em-{self._next_id}"
             self._next_id += 1
             ids.append(em_id)
-            backend_argv = resolved_backend_argv[i]
+            backend_argv = context.backend_argv
             backend_options = spec.get("backend_options") or None
 
-            task_system_prompt = task_system_prompts[i]
-            task_skill_catalog = task_skill_catalogs[i]
-            task_mcp_catalog = task_mcp_catalogs[i]
-            task_mcp_regs = task_mcp_registrations[i]
             task_context = self._combine_oneshot_context(
-                task_system_prompt, task_skill_catalog, task_mcp_catalog
+                context.system_prompt, context.skill_catalog, context.mcp_catalog
             )
             system_prompt = f"[{backend} backend — task delegated to external CLI]"
             if task_context:
@@ -2703,8 +2837,11 @@ class DaemonManager:
                         "task": spec["task"],
                         "tools": spec.get("tools", []),
                         "skills": spec.get("skills", []),
-                        "mcp": [self._redact_mcp_registration_for_prompt(r) for r in task_mcp_regs],
-                        "system_prompt": task_system_prompt,
+                        "mcp": [
+                            self._redact_mcp_registration_for_prompt(r)
+                            for r in context.mcp_regs
+                        ],
+                        "system_prompt": context.system_prompt,
                         "backend_options": backend_options,
                     },
                     log_callback=self._log,
@@ -2726,25 +2863,7 @@ class DaemonManager:
                       em_id=em_id, backend=backend,
                       argv=list(backend_argv))
 
-            if backend == "codex":
-                run_fn = self._run_codex_emanation
-            elif backend == "opencode":
-                run_fn = self._run_opencode_emanation
-            elif backend == "mimocode":
-                run_fn = self._run_mimocode_emanation
-            elif backend == "qwen-code":
-                run_fn = self._run_qwen_code_emanation
-            elif backend == "oh-my-pi":
-                run_fn = self._run_oh_my_pi_emanation
-            elif backend == "cursor":
-                run_fn = self._run_cursor_emanation
-            elif backend in ("claude", "claude-interactive"):
-                run_fn = self._run_claude_interactive_emanation
-            else:
-                # ``claude-p`` is the new explicit name for the existing
-                # print-mode backend; ``claude-code`` remains a compatibility
-                # alias for older callers and stored daemon entries.
-                run_fn = self._run_claude_code_emanation
+            run_fn = getattr(self, backend_spec.runner_attr)
             future = pool.submit(
                 run_fn,
                 em_id, run_dir, cli_task,
@@ -3245,23 +3364,13 @@ class DaemonManager:
         # All stream progress into the daemon run directory so
         # `daemon(check)` shows live progress.
         backend = entry.get("backend")
-        if backend in ("claude", "claude-interactive"):
-            return self._handle_ask_claude_interactive(em_id, entry, message)
-        if backend in ("claude-p", "claude-code"):
-            return self._handle_ask_cli(em_id, entry, message)
-        if backend == "codex":
-            return self._handle_ask_codex(em_id, entry, message)
-        if backend == "opencode":
-            return self._handle_ask_opencode(em_id, entry, message)
-        if backend == "mimocode":
-            return self._handle_ask_mimocode(em_id, entry, message)
-        if backend == "oh-my-pi":
-            return self._handle_ask_oh_my_pi(em_id, entry, message)
-        if backend == "qwen-code":
-            return {"status": "error", "id": em_id,
-                    "message": "qwen-code daemon backend does not support daemon(action='ask') yet; start a new qwen-code emanation instead."}
-        if backend == "cursor":
-            return self._handle_ask_cursor(em_id, entry, message)
+        backend_spec = _backend_spec(backend)
+        if backend_spec is not None and backend_spec.is_cli:
+            if backend_spec.ask_handler_attr is None:
+                return {"status": "error", "id": em_id,
+                        "message": backend_spec.ask_unsupported_msg}
+            ask_handler = getattr(self, backend_spec.ask_handler_attr)
+            return ask_handler(em_id, entry, message)
 
         if entry["future"].done():
             return {"status": "error", "message": "not running"}

--- a/tests/test_daemon_backend_options.py
+++ b/tests/test_daemon_backend_options.py
@@ -18,7 +18,11 @@ import pytest
 
 from lingtai_kernel.config import AgentConfig
 from lingtai.core.daemon import (
+    _BACKEND_ALIASES,
     _backend_options_to_argv,
+    _BACKEND_SCHEMA_ENUM,
+    _BACKEND_SPECS,
+    _normalize_backend,
 )
 
 
@@ -279,6 +283,39 @@ def test_lingtai_backend_ignores_backend_options(tmp_path):
     assert result["status"] == "dispatched"
 
 
+def test_unknown_backend_falls_back_to_lingtai_path(tmp_path):
+    """Direct callers that bypass schema validation keep the old fallback.
+
+    Unknown backend strings are not CLI backends; they route to the in-process
+    LingTai worker and therefore do not store a CLI ``backend`` field.
+    """
+    agent = _make_agent(tmp_path)
+    mgr = agent.get_capability("daemon")
+    captured: dict = {}
+
+    def fake_run(em_id, run_dir, schemas, dispatch, task, cancel_event,
+                 timeout_event=None, preset_llm=None, max_turns=None,
+                 task_mcp_clients=None):
+        captured["task"] = task
+        captured["state"] = dict(run_dir._state)
+        run_dir.mark_done("[fake done]")
+        return "[fake done]"
+
+    with patch.object(mgr, "_run_emanation", side_effect=fake_run):
+        result = mgr.handle({
+            "action": "emanate",
+            "backend": "not-real",
+            "tasks": [{"task": "fall back", "tools": []}],
+        })
+        assert result["status"] == "dispatched"
+        em_id = result["ids"][0]
+        mgr._emanations[em_id]["future"].result(timeout=5)
+
+    assert captured["task"] == "fall back"
+    assert captured["state"]["backend"] == "lingtai"
+    assert "backend" not in mgr._emanations[em_id]
+
+
 # ---------------------------------------------------------------------------
 # Runner cmd construction: backend_argv lands before the task prompt
 # ---------------------------------------------------------------------------
@@ -440,6 +477,53 @@ def test_schema_includes_backend_options():
     assert "--help" in task_props["backend_options"]["description"]
 
 
+def test_backend_schema_enum_matches_ordered_contract():
+    from lingtai.core.daemon import get_schema
+
+    expected = [
+        "lingtai",
+        "claude-p",
+        "claude-code",
+        "codex",
+        "opencode",
+        "mimocode",
+        "mimo",
+        "qwen-code",
+        "qwen",
+        "oh-my-pi",
+        "omp",
+        "cursor",
+    ]
+    assert list(_BACKEND_SCHEMA_ENUM) == expected
+    assert get_schema("en")["properties"]["backend"]["enum"] == expected
+
+
+def test_backend_metadata_consistency_keeps_hidden_legacy_claude():
+    hidden = {"claude", "claude-interactive"}
+    assert set(_BACKEND_SCHEMA_ENUM) == (
+        (set(_BACKEND_SPECS) - hidden) | set(_BACKEND_ALIASES)
+    )
+    assert hidden.isdisjoint(_BACKEND_SCHEMA_ENUM)
+    assert _BACKEND_ALIASES == {
+        "mimo": "mimocode",
+        "qwen": "qwen-code",
+        "omp": "oh-my-pi",
+    }
+    assert all(target in _BACKEND_SPECS for target in _BACKEND_ALIASES.values())
+    assert _BACKEND_SPECS["claude-code"].runner_attr == "_run_claude_code_emanation"
+    assert _BACKEND_SPECS["claude-p"].runner_attr == "_run_claude_code_emanation"
+
+
+def test_normalize_backend_aliases_only_true_aliases():
+    assert _normalize_backend("mimo") == "mimocode"
+    assert _normalize_backend("qwen") == "qwen-code"
+    assert _normalize_backend("omp") == "oh-my-pi"
+    assert _normalize_backend(None) == "lingtai"
+    assert _normalize_backend("") == "lingtai"
+    assert _normalize_backend("claude-code") == "claude-code"
+    assert _normalize_backend("not-real") == "not-real"
+
+
 def test_schema_includes_mimocode_and_qwen_code_backends():
     from lingtai.core.daemon import get_schema
 
@@ -476,6 +560,68 @@ def test_mimocode_alias_dispatches_to_canonical_backend(tmp_path):
     assert captured["backend"] == "mimocode"
     assert captured["model"] == "mimocode"
     assert captured["backend_argv"] == ["--model", "mimo-auto"]
+
+
+def test_cli_contexts_keep_per_task_argv_and_passive_mcp(tmp_path):
+    agent = _make_agent(tmp_path)
+    mgr = agent.get_capability("daemon")
+    captured: dict[str, dict] = {}
+
+    def fake_run(em_id, run_dir, task, cancel_event, timeout_event, backend_argv=None):
+        captured[run_dir._state["task"]] = {
+            "backend_argv": list(backend_argv or []),
+            "call_parameters": run_dir._state["call_parameters"],
+            "state": dict(run_dir._state),
+        }
+        run_dir.mark_done("[fake done]")
+        return "[fake done]"
+
+    with (
+        patch.object(mgr, "_run_claude_code_emanation", side_effect=fake_run),
+        patch.object(
+            mgr,
+            "_connect_task_mcp_registrations",
+            side_effect=AssertionError("CLI backend must not connect MCP clients"),
+        ),
+    ):
+        result = mgr.handle({
+            "action": "emanate",
+            "backend": "claude-code",
+            "tasks": [
+                {
+                    "task": "task with argv",
+                    "tools": [],
+                    "backend_options": {"model": "claude-opus-4-7"},
+                },
+                {
+                    "task": "task with mcp",
+                    "tools": [],
+                    "mcp": [{
+                        "name": "demo",
+                        "command": "demo-mcp",
+                        "args": ["--serve"],
+                        "env": {"TOKEN": "secret"},
+                    }],
+                },
+            ],
+        })
+        assert result["status"] == "dispatched"
+        for em_id in result["ids"]:
+            mgr._emanations[em_id]["future"].result(timeout=5)
+
+    assert captured["task with argv"]["backend_argv"] == [
+        "--model", "claude-opus-4-7",
+    ]
+    assert captured["task with argv"]["call_parameters"]["mcp"] == []
+    assert captured["task with mcp"]["backend_argv"] == []
+    assert "backend_argv" not in captured["task with mcp"]["state"]
+    assert captured["task with mcp"]["call_parameters"]["mcp"] == [{
+        "name": "demo",
+        "command": "demo-mcp",
+        "args": ["--serve"],
+        "env": {"TOKEN": "<redacted>"},
+        "transport": "stdio",
+    }]
 
 
 def test_mimocode_cmd_appends_backend_argv_before_prompt(tmp_path):
@@ -613,7 +759,10 @@ def test_qwen_code_ask_is_explicitly_unsupported(tmp_path):
     ask = mgr.handle({"action": "ask", "id": em_id, "message": "follow up"})
 
     assert ask["status"] == "error"
-    assert "does not support" in ask["message"]
+    assert ask["message"] == (
+        "qwen-code daemon backend does not support daemon(action='ask') yet; "
+        "start a new qwen-code emanation instead."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_daemon_claude_interactive_backend.py
+++ b/tests/test_daemon_claude_interactive_backend.py
@@ -220,6 +220,56 @@ def test_emanate_claude_p_dispatches_legacy_print_runner(tmp_path):
     assert captured == {"backend": "claude-p", "task": "Use print mode"}
 
 
+@pytest.mark.parametrize(
+    ("backend", "expected_runner"),
+    [
+        ("claude", "interactive"),
+        ("claude-interactive", "interactive"),
+        ("claude-p", "print"),
+        ("claude-code", "print"),
+    ],
+)
+def test_claude_backend_ids_are_preserved_while_sharing_runners(
+    tmp_path, backend, expected_runner,
+):
+    agent = _make_agent(tmp_path)
+    mgr = agent.get_capability("daemon")
+    captured = {}
+
+    def fake_interactive(em_id, run_dir, task, cancel_event, timeout_event,
+                         backend_argv=None):
+        captured["runner"] = "interactive"
+        captured["backend"] = run_dir._state["backend"]
+        run_dir.mark_done("done")
+        return "done"
+
+    def fake_print(em_id, run_dir, task, cancel_event, timeout_event,
+                   backend_argv=None):
+        captured["runner"] = "print"
+        captured["backend"] = run_dir._state["backend"]
+        run_dir.mark_done("done")
+        return "done"
+
+    with (
+        patch.object(
+            mgr,
+            "_run_claude_interactive_emanation",
+            side_effect=fake_interactive,
+        ),
+        patch.object(mgr, "_run_claude_code_emanation", side_effect=fake_print),
+    ):
+        result = mgr.handle({
+            "action": "emanate",
+            "backend": backend,
+            "tasks": [{"task": "Use Claude", "tools": []}],
+        })
+        assert result["status"] == "dispatched"
+        em_id = result["ids"][0]
+        mgr._emanations[em_id]["future"].result(timeout=5)
+
+    assert captured == {"runner": expected_runner, "backend": backend}
+
+
 
 def test_claude_reserved_backend_options_are_rejected(tmp_path):
     agent = _make_agent(tmp_path)


### PR DESCRIPTION
## Summary

- Add a small centralized daemon backend metadata/spec layer for backend IDs, aliases, schema exposure, and CLI context behavior.
- Preserve existing unknown-backend fallback and existing stored backend IDs, including `claude-code` alias behavior.
- Keep CLI context passive and leave session-state-key centralization out of scope for this PR.

## Why

Daemon backend handling had repeated alias/schema/runtime metadata scattered through the daemon module. This made it easy for public schema names, stored IDs, and runtime backend behavior to drift. The new metadata layer gives one place for that mapping while keeping the behavior-compatible fallback paths and legacy names.

## Notes

The original planning note referred to a 14-entry schema enum, but current `main` exposes 12 public enum values. Two legacy Claude interactive spellings remain hidden compatibility specs rather than public schema entries. This PR preserves that current behavior instead of expanding the public enum.

## Validation

Focused daemon tests were run with `PYTHONPATH=src` and `uv run --no-project` to avoid unrelated locked-environment dependency resolution:

- `tests/test_daemon_backend_options.py tests/test_daemon_claude_interactive_backend.py` — `53 passed`.
- Named ask/env regression cases in `tests/test_daemon.py` — `4 passed`.
- Independent rerun of the above daemon backend/env coverage — `57 passed`.
- Adjacent daemon backend/check/run-dir suites: `test_daemon_opencode_backend.py`, `test_daemon_cursor_backend.py`, `test_daemon_check.py`, `test_daemon_run_dir.py` — `117 passed`.
- `git diff --check canonical/main...HEAD` — passed during pre-PR verification.

Full locked-environment `uv run pytest ...` is blocked on this macOS x86_64 host before test execution because `onnxruntime==1.27.0` has no compatible wheel/source distribution.