### PR TITLE
docs: backfill kernel ANATOMY frontmatter

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -1,3 +1,24 @@
+---
+related_files:
+  - CLAUDE.md
+  - CODE_OF_CONDUCT.md
+  - CONTRIBUTING.md
+  - MANIFEST.in
+  - README.md
+  - SECURITY.md
+  - SUPPORT.md
+  - docs/references/claude-code-guide.md
+  - pyproject.toml
+  - setup.py
+  - src/lingtai/ANATOMY.md
+  - src/lingtai_kernel/ANATOMY.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # lingtai-kernel Repository Anatomy
 
 This root anatomy is a router for the repository. It intentionally stays short:

--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -1,3 +1,42 @@
+---
+related_files:
+  - ANATOMY.md
+  - src/lingtai/__init__.py
+  - src/lingtai/__main__.py
+  - src/lingtai/agent.py
+  - src/lingtai/auth/ANATOMY.md
+  - src/lingtai/capabilities/ANATOMY.md
+  - src/lingtai/capabilities/__init__.py
+  - src/lingtai/cli.py
+  - src/lingtai/core/avatar/ANATOMY.md
+  - src/lingtai/core/bash/ANATOMY.md
+  - src/lingtai/core/daemon/ANATOMY.md
+  - src/lingtai/core/knowledge/ANATOMY.md
+  - src/lingtai/core/mcp/ANATOMY.md
+  - src/lingtai/core/skills/ANATOMY.md
+  - src/lingtai/i18n/ANATOMY.md
+  - src/lingtai/init_schema.py
+  - src/lingtai/intrinsic_skills/__init__.py
+  - src/lingtai/llm/ANATOMY.md
+  - src/lingtai/mcp_catalog.json
+  - src/lingtai/mcp_servers/ANATOMY.md
+  - src/lingtai/mcp_servers/wechat/manager.py
+  - src/lingtai/network.py
+  - src/lingtai/presets.py
+  - src/lingtai/services/ANATOMY.md
+  - src/lingtai/venv_resolve.py
+  - src/lingtai_kernel/ANATOMY.md
+  - tests/test_agent_preset_manifest.py
+  - tests/test_cli.py
+  - tests/test_deep_refresh.py
+  - tests/test_kernel_migrate.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # lingtai
 
 PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset materialization, CLI, and public re-exports.

--- a/src/lingtai/auth/ANATOMY.md
+++ b/src/lingtai/auth/ANATOMY.md
@@ -1,3 +1,17 @@
+---
+related_files:
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/auth/__init__.py
+  - src/lingtai/auth/codex.py
+  - src/lingtai/llm/_register.py
+  - src/lingtai/llm/openai/ANATOMY.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/auth/
 
 Codex OAuth token management — reads TUI-written tokens, checks expiry, auto-refreshes via OpenAI OAuth endpoint.

--- a/src/lingtai/capabilities/ANATOMY.md
+++ b/src/lingtai/capabilities/ANATOMY.md
@@ -1,3 +1,19 @@
+---
+related_files:
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/agent.py
+  - src/lingtai/capabilities/__init__.py
+  - src/lingtai/capabilities/_media_host.py
+  - src/lingtai/capabilities/_zhipu_mode.py
+  - src/lingtai/capabilities/vision/ANATOMY.md
+  - src/lingtai/capabilities/web_search/ANATOMY.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/capabilities/
 
 Root capabilities package — registry, capability normalization, and setup dispatcher for composable agent capabilities.

--- a/src/lingtai/capabilities/vision/ANATOMY.md
+++ b/src/lingtai/capabilities/vision/ANATOMY.md
@@ -1,3 +1,15 @@
+---
+related_files:
+  - src/lingtai/capabilities/ANATOMY.md
+  - src/lingtai/capabilities/vision/__init__.py
+  - src/lingtai/services/vision/ANATOMY.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/capabilities/vision/
 
 Vision capability — image understanding via pluggable VisionService backends.

--- a/src/lingtai/capabilities/web_search/ANATOMY.md
+++ b/src/lingtai/capabilities/web_search/ANATOMY.md
@@ -1,3 +1,15 @@
+---
+related_files:
+  - src/lingtai/capabilities/ANATOMY.md
+  - src/lingtai/capabilities/web_search/__init__.py
+  - src/lingtai/services/websearch/ANATOMY.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/capabilities/web_search/
 
 Web search capability — web lookup via pluggable SearchService backends.

--- a/src/lingtai/core/avatar/ANATOMY.md
+++ b/src/lingtai/core/avatar/ANATOMY.md
@@ -1,3 +1,16 @@
+---
+related_files:
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/core/avatar/__init__.py
+  - src/lingtai/core/avatar/manual/SKILL.md
+  - tests/test_avatar_rules.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # core/avatar
 
 Avatar capability — spawn independent peer agents (分身) as fully detached

--- a/src/lingtai/core/bash/ANATOMY.md
+++ b/src/lingtai/core/bash/ANATOMY.md
@@ -1,3 +1,18 @@
+---
+related_files:
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/core/bash/__init__.py
+  - src/lingtai/core/bash/bash_policy.json
+  - src/lingtai/core/bash/manual/SKILL.md
+  - tests/test_bash_async.py
+  - tests/test_layers_bash.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # core/bash
 
 Bash capability — shell command execution with file-based policy. Adds the

--- a/src/lingtai/core/daemon/ANATOMY.md
+++ b/src/lingtai/core/daemon/ANATOMY.md
@@ -1,3 +1,19 @@
+---
+related_files:
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/core/daemon/__init__.py
+  - src/lingtai/core/daemon/claude_interactive.py
+  - src/lingtai/core/daemon/manual/SKILL.md
+  - src/lingtai/core/daemon/run_dir.py
+  - tests/test_daemon.py
+  - tests/test_daemon_run_dir.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # core/daemon
 
 Daemon capability (分神) — dispatch ephemeral subagents (分神) that operate

--- a/src/lingtai/core/knowledge/ANATOMY.md
+++ b/src/lingtai/core/knowledge/ANATOMY.md
@@ -1,3 +1,17 @@
+---
+related_files:
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/core/knowledge/CONTRACT.md
+  - src/lingtai/core/knowledge/__init__.py
+  - src/lingtai/core/knowledge/manual/SKILL.md
+  - tests/test_knowledge.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # core/knowledge
 
 Knowledge capability — private durable knowledge across molts. The catalog is

--- a/src/lingtai/core/mcp/ANATOMY.md
+++ b/src/lingtai/core/mcp/ANATOMY.md
@@ -1,3 +1,20 @@
+---
+related_files:
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/core/mcp/__init__.py
+  - src/lingtai/core/mcp/inbox.py
+  - src/lingtai/core/mcp/licc.py
+  - src/lingtai/core/mcp/manual/SKILL.md
+  - src/lingtai/mcp_servers/ANATOMY.md
+  - tests/test_mcp_capability.py
+  - tests/test_mcp_inbox.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # core/mcp
 
 MCP capability — per-agent registry of MCP (Model Context Protocol) servers.

--- a/src/lingtai/core/skills/ANATOMY.md
+++ b/src/lingtai/core/skills/ANATOMY.md
@@ -1,3 +1,20 @@
+---
+related_files:
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/agent.py
+  - src/lingtai/core/daemon/__init__.py
+  - src/lingtai/core/skills/__init__.py
+  - src/lingtai/core/skills/manual/SKILL.md
+  - src/lingtai/init_schema.py
+  - tests/test_skills.py
+  - tests/test_validate_skill.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # core/skills
 
 Skills capability — per-agent skill catalog and skill-manual surface. This is the renamed successor of the old `library` capability. It scans the existing `.library/` directory plus configured extra paths, renders a YAML catalog (one `- name:` block per skill with `location:` and a `description:` block scalar), and injects it into the `skills` prompt section. It never writes skill files; installation remains the Agent initializer's job.

--- a/src/lingtai/i18n/ANATOMY.md
+++ b/src/lingtai/i18n/ANATOMY.md
@@ -1,3 +1,18 @@
+---
+related_files:
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/i18n/__init__.py
+  - src/lingtai/i18n/en.json
+  - src/lingtai/i18n/wen.json
+  - src/lingtai/i18n/zh.json
+  - src/lingtai_kernel/i18n/ANATOMY.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/i18n/
 
 Wrapper-side i18n loader — language-aware string tables for lingtai capabilities, with kernel-level key injection.

--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -1,3 +1,30 @@
+---
+related_files:
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/llm/__init__.py
+  - src/lingtai/llm/_register.py
+  - src/lingtai/llm/anthropic/ANATOMY.md
+  - src/lingtai/llm/api_gate.py
+  - src/lingtai/llm/base.py
+  - src/lingtai/llm/claude_code/adapter.py
+  - src/lingtai/llm/custom/ANATOMY.md
+  - src/lingtai/llm/deepseek/ANATOMY.md
+  - src/lingtai/llm/gemini/ANATOMY.md
+  - src/lingtai/llm/interface_converters.py
+  - src/lingtai/llm/minimax/ANATOMY.md
+  - src/lingtai/llm/openai/ANATOMY.md
+  - src/lingtai/llm/openai/adapter.py
+  - src/lingtai/llm/openrouter/ANATOMY.md
+  - src/lingtai/llm/service.py
+  - src/lingtai_kernel/llm/ANATOMY.md
+  - tests/test_codex_endpoint_pool.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/llm/
 
 LLM adapter layer — multi-provider support with adapter registry, base classes, rate limiting, and interface converters.

--- a/src/lingtai/llm/anthropic/ANATOMY.md
+++ b/src/lingtai/llm/anthropic/ANATOMY.md
@@ -1,3 +1,16 @@
+---
+related_files:
+  - src/lingtai/llm/ANATOMY.md
+  - src/lingtai/llm/anthropic/__init__.py
+  - src/lingtai/llm/anthropic/adapter.py
+  - src/lingtai/llm/anthropic/defaults.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/llm/anthropic
 
 Anthropic Claude adapter — Messages API with prompt caching, tool use, and extended thinking.

--- a/src/lingtai/llm/custom/ANATOMY.md
+++ b/src/lingtai/llm/custom/ANATOMY.md
@@ -1,3 +1,16 @@
+---
+related_files:
+  - src/lingtai/llm/ANATOMY.md
+  - src/lingtai/llm/custom/__init__.py
+  - src/lingtai/llm/custom/adapter.py
+  - src/lingtai/llm/custom/defaults.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/llm/custom
 
 Custom adapter — factory for named provider aliases routing to OpenAI, Anthropic, or Gemini backends.

--- a/src/lingtai/llm/deepseek/ANATOMY.md
+++ b/src/lingtai/llm/deepseek/ANATOMY.md
@@ -1,3 +1,16 @@
+---
+related_files:
+  - src/lingtai/llm/ANATOMY.md
+  - src/lingtai/llm/deepseek/__init__.py
+  - src/lingtai/llm/deepseek/adapter.py
+  - src/lingtai/llm/openai/adapter.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/llm/deepseek
 
 DeepSeek adapter — thin OpenAI-compat wrapper that satisfies DeepSeek V4 thinking mode's `reasoning_content` round-trip contract.

--- a/src/lingtai/llm/gemini/ANATOMY.md
+++ b/src/lingtai/llm/gemini/ANATOMY.md
@@ -1,3 +1,16 @@
+---
+related_files:
+  - src/lingtai/llm/ANATOMY.md
+  - src/lingtai/llm/gemini/__init__.py
+  - src/lingtai/llm/gemini/adapter.py
+  - src/lingtai/llm/gemini/defaults.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/llm/gemini
 
 Gemini adapter — `google-genai` SDK with Chat API and Interactions API, thinking budget, function declarations.

--- a/src/lingtai/llm/minimax/ANATOMY.md
+++ b/src/lingtai/llm/minimax/ANATOMY.md
@@ -1,3 +1,18 @@
+---
+related_files:
+  - src/lingtai/llm/ANATOMY.md
+  - src/lingtai/llm/anthropic/adapter.py
+  - src/lingtai/llm/minimax/__init__.py
+  - src/lingtai/llm/minimax/adapter.py
+  - src/lingtai/llm/minimax/defaults.py
+  - src/lingtai/llm/minimax/mcp_client.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/llm/minimax
 
 MiniMax adapter — inherits Anthropic-compatible endpoint, adds MCP client factory for MiniMax coding-plan tools.

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -1,3 +1,23 @@
+---
+related_files:
+  - docs/references/codex-http-anatomy-investigation.md
+  - src/lingtai/auth/ANATOMY.md
+  - src/lingtai/llm/ANATOMY.md
+  - src/lingtai/llm/_register.py
+  - src/lingtai/llm/interface_converters.py
+  - src/lingtai/llm/openai/__init__.py
+  - src/lingtai/llm/openai/adapter.py
+  - src/lingtai/llm/openai/codex_ws.py
+  - src/lingtai/llm/openai/defaults.py
+  - src/lingtai/llm/service.py
+  - tests/test_codex_prompt_cache_key.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/llm/openai/
 
 OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses APIs, with Codex OAuth variant.

--- a/src/lingtai/llm/openrouter/ANATOMY.md
+++ b/src/lingtai/llm/openrouter/ANATOMY.md
@@ -1,3 +1,16 @@
+---
+related_files:
+  - src/lingtai/llm/ANATOMY.md
+  - src/lingtai/llm/openai/adapter.py
+  - src/lingtai/llm/openrouter/__init__.py
+  - src/lingtai/llm/openrouter/adapter.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/llm/openrouter
 
 OpenRouter adapter — thin OpenAI-compat shim pinned to `openrouter.ai/api/v1`, opts out of reasoning text.

--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -1,3 +1,27 @@
+---
+related_files:
+  - pyproject.toml
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/core/mcp/ANATOMY.md
+  - src/lingtai/mcp_catalog.json
+  - src/lingtai/mcp_servers/__init__.py
+  - src/lingtai/mcp_servers/_skill.py
+  - src/lingtai/mcp_servers/cloud_mail/manager.py
+  - src/lingtai/mcp_servers/feishu/manager.py
+  - src/lingtai/mcp_servers/imap/manager.py
+  - src/lingtai/mcp_servers/telegram/manager.py
+  - src/lingtai/mcp_servers/wechat/manager.py
+  - src/lingtai/mcp_servers/whatsapp/manager.py
+  - tests/test_cloud_mail_addon.py
+  - tests/test_mcp_skill_manuals.py
+  - tests/test_telegram_rich_formatting.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # lingtai.mcp_servers
 
 Curated MCP server package implementations shipped inside the `lingtai` Python distribution. They are launched by catalog/script entry points such as `python -m lingtai.mcp_servers.<name>` and expose real addon tools (IMAP, Telegram, Feishu, WeChat, WhatsApp, Cloud Mail) plus bundled progressive-disclosure manuals.

--- a/src/lingtai/services/ANATOMY.md
+++ b/src/lingtai/services/ANATOMY.md
@@ -1,3 +1,23 @@
+---
+related_files:
+  - setup.py
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/services/__init__.py
+  - src/lingtai/services/file_io.py
+  - src/lingtai/services/file_io_sidecar.py
+  - src/lingtai/services/mail.py
+  - src/lingtai/services/mcp.py
+  - src/lingtai/services/vision/ANATOMY.md
+  - src/lingtai/services/websearch/ANATOMY.md
+  - src/lingtai_kernel/services/ANATOMY.md
+  - tests/test_mcp_closed_resource_restart.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/services/
 
 Root services package — pluggable backends for intrinsic tools and MCP clients.

--- a/src/lingtai/services/vision/ANATOMY.md
+++ b/src/lingtai/services/vision/ANATOMY.md
@@ -1,3 +1,23 @@
+---
+related_files:
+  - src/lingtai/capabilities/vision/ANATOMY.md
+  - src/lingtai/services/ANATOMY.md
+  - src/lingtai/services/vision/__init__.py
+  - src/lingtai/services/vision/anthropic.py
+  - src/lingtai/services/vision/codex.py
+  - src/lingtai/services/vision/gemini.py
+  - src/lingtai/services/vision/local.py
+  - src/lingtai/services/vision/mimo.py
+  - src/lingtai/services/vision/minimax.py
+  - src/lingtai/services/vision/openai.py
+  - src/lingtai/services/vision/zhipu.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/services/vision/
 
 Provider-specific image understanding — standalone services that own their own API clients.

--- a/src/lingtai/services/websearch/ANATOMY.md
+++ b/src/lingtai/services/websearch/ANATOMY.md
@@ -1,3 +1,21 @@
+---
+related_files:
+  - src/lingtai/capabilities/web_search/ANATOMY.md
+  - src/lingtai/services/ANATOMY.md
+  - src/lingtai/services/websearch/__init__.py
+  - src/lingtai/services/websearch/anthropic.py
+  - src/lingtai/services/websearch/duckduckgo.py
+  - src/lingtai/services/websearch/gemini.py
+  - src/lingtai/services/websearch/minimax.py
+  - src/lingtai/services/websearch/openai.py
+  - src/lingtai/services/websearch/zhipu.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # src/lingtai/services/websearch/
 
 Provider-specific web search — standalone services behind a common `SearchService` ABC.

--- a/src/lingtai_kernel/ANATOMY.md
+++ b/src/lingtai_kernel/ANATOMY.md
@@ -1,3 +1,69 @@
+---
+related_files:
+  - ANATOMY.md
+  - MANIFEST.in
+  - pyproject.toml
+  - src/lingtai/ANATOMY.md
+  - src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
+  - src/lingtai/intrinsic_skills/system-manual/SKILL.md
+  - src/lingtai_kernel/__init__.py
+  - src/lingtai_kernel/_frontmatter.py
+  - src/lingtai_kernel/_fsutil.py
+  - src/lingtai_kernel/base_agent/ANATOMY.md
+  - src/lingtai_kernel/base_agent/__init__.py
+  - src/lingtai_kernel/base_agent/lifecycle.py
+  - src/lingtai_kernel/base_agent/messaging.py
+  - src/lingtai_kernel/base_agent/prompt.py
+  - src/lingtai_kernel/base_agent/turn.py
+  - src/lingtai_kernel/base_agent/worker_recovery.py
+  - src/lingtai_kernel/config.py
+  - src/lingtai_kernel/config_resolve.py
+  - src/lingtai_kernel/handshake.py
+  - src/lingtai_kernel/i18n/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/notification/__init__.py
+  - src/lingtai_kernel/intrinsics/soul/flow.py
+  - src/lingtai_kernel/llm/ANATOMY.md
+  - src/lingtai_kernel/llm/interface.py
+  - src/lingtai_kernel/llm_utils.py
+  - src/lingtai_kernel/logging.py
+  - src/lingtai_kernel/loop_guard.py
+  - src/lingtai_kernel/maintenance/ANATOMY.md
+  - src/lingtai_kernel/message.py
+  - src/lingtai_kernel/meta_block.py
+  - src/lingtai_kernel/migrate/ANATOMY.md
+  - src/lingtai_kernel/notifications.py
+  - src/lingtai_kernel/nudge/ANATOMY.md
+  - src/lingtai_kernel/preset_connectivity.py
+  - src/lingtai_kernel/presets.py
+  - src/lingtai_kernel/prompt.py
+  - src/lingtai_kernel/prompt_catalog.py
+  - src/lingtai_kernel/runtime_identity.py
+  - src/lingtai_kernel/safety_limits.py
+  - src/lingtai_kernel/sent_message_tracker.py
+  - src/lingtai_kernel/services/ANATOMY.md
+  - src/lingtai_kernel/services/logging.py
+  - src/lingtai_kernel/session.py
+  - src/lingtai_kernel/state.py
+  - src/lingtai_kernel/tc_inbox.py
+  - src/lingtai_kernel/time_veil.py
+  - src/lingtai_kernel/token_counter.py
+  - src/lingtai_kernel/token_ledger.py
+  - src/lingtai_kernel/tool_call_guard.py
+  - src/lingtai_kernel/tool_executor.py
+  - src/lingtai_kernel/tool_result_artifacts.py
+  - src/lingtai_kernel/tool_result_recovery.py
+  - src/lingtai_kernel/tool_timing.py
+  - src/lingtai_kernel/trace_redaction.py
+  - src/lingtai_kernel/types.py
+  - src/lingtai_kernel/workdir.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # lingtai_kernel
 
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues/mail/PR proposals; do not silently fix.

--- a/src/lingtai_kernel/base_agent/ANATOMY.md
+++ b/src/lingtai_kernel/base_agent/ANATOMY.md
@@ -1,3 +1,22 @@
+---
+related_files:
+  - src/lingtai/agent.py
+  - src/lingtai_kernel/ANATOMY.md
+  - src/lingtai_kernel/base_agent/__init__.py
+  - src/lingtai_kernel/base_agent/identity.py
+  - src/lingtai_kernel/base_agent/lifecycle.py
+  - src/lingtai_kernel/base_agent/messaging.py
+  - src/lingtai_kernel/base_agent/prompt.py
+  - src/lingtai_kernel/base_agent/tools.py
+  - src/lingtai_kernel/base_agent/turn.py
+  - src/lingtai_kernel/base_agent/worker_recovery.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # base_agent
 
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues/mail/PR proposals; do not silently fix.

--- a/src/lingtai_kernel/i18n/ANATOMY.md
+++ b/src/lingtai_kernel/i18n/ANATOMY.md
@@ -1,3 +1,19 @@
+---
+related_files:
+  - src/lingtai/i18n/ANATOMY.md
+  - src/lingtai/i18n/__init__.py
+  - src/lingtai_kernel/ANATOMY.md
+  - src/lingtai_kernel/i18n/__init__.py
+  - src/lingtai_kernel/i18n/en.json
+  - src/lingtai_kernel/i18n/wen.json
+  - src/lingtai_kernel/i18n/zh.json
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # i18n
 
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues/mail/PR proposals; do not silently fix.

--- a/src/lingtai_kernel/intrinsics/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/ANATOMY.md
@@ -1,3 +1,20 @@
+---
+related_files:
+  - src/lingtai_kernel/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/__init__.py
+  - src/lingtai_kernel/intrinsics/email/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/notification/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/psyche/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/psyche/_molt.py
+  - src/lingtai_kernel/intrinsics/soul/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/system/ANATOMY.md
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # intrinsics
 
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues/mail/PR proposals; do not silently fix.

--- a/src/lingtai_kernel/intrinsics/email/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/email/ANATOMY.md
@@ -1,3 +1,18 @@
+---
+related_files:
+  - src/lingtai/__init__.py
+  - src/lingtai_kernel/intrinsics/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/email/__init__.py
+  - src/lingtai_kernel/intrinsics/email/manager.py
+  - src/lingtai_kernel/intrinsics/email/primitives.py
+  - src/lingtai_kernel/intrinsics/email/schema.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # intrinsics/email
 
 Filesystem-based email system — mailbox I/O, composition, search, contacts, recurring schedules, and delivery. The agent's primary inter-process communication channel.

--- a/src/lingtai_kernel/intrinsics/notification/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/notification/ANATOMY.md
@@ -1,3 +1,17 @@
+---
+related_files:
+  - src/lingtai_kernel/intrinsics/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/notification/__init__.py
+  - src/lingtai_kernel/intrinsics/notification/schema.py
+  - tests/test_notification_tool.py
+  - tests/test_system_dismiss.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # intrinsics/notification
 
 Standalone notification surface — the **only** agent-callable home for the

--- a/src/lingtai_kernel/intrinsics/psyche/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/psyche/ANATOMY.md
@@ -1,3 +1,20 @@
+---
+related_files:
+  - src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
+  - src/lingtai_kernel/intrinsics/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/psyche/__init__.py
+  - src/lingtai_kernel/intrinsics/psyche/_lingtai.py
+  - src/lingtai_kernel/intrinsics/psyche/_molt.py
+  - src/lingtai_kernel/intrinsics/psyche/_pad.py
+  - src/lingtai_kernel/intrinsics/psyche/_session_journal.py
+  - src/lingtai_kernel/intrinsics/psyche/_snapshots.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # intrinsics/psyche
 
 Agent identity, working notes, and context lifecycle — the "bare essentials of self." Provides the agent with tools to manage its own identity, working notes (pad), and conversation context (molt). The core shed-and-reload machinery that enables cross-session persistence.

--- a/src/lingtai_kernel/intrinsics/soul/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/soul/ANATOMY.md
@@ -1,3 +1,18 @@
+---
+related_files:
+  - src/lingtai_kernel/intrinsics/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/soul/__init__.py
+  - src/lingtai_kernel/intrinsics/soul/config.py
+  - src/lingtai_kernel/intrinsics/soul/consultation.py
+  - src/lingtai_kernel/intrinsics/soul/flow.py
+  - src/lingtai_kernel/intrinsics/soul/inquiry.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # intrinsics/soul
 
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues/mail/PR proposals; do not silently fix.

--- a/src/lingtai_kernel/intrinsics/system/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/system/ANATOMY.md
@@ -1,3 +1,18 @@
+---
+related_files:
+  - src/lingtai_kernel/intrinsics/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/system/__init__.py
+  - src/lingtai_kernel/intrinsics/system/karma.py
+  - src/lingtai_kernel/intrinsics/system/preset.py
+  - src/lingtai_kernel/intrinsics/system/schema.py
+  - src/lingtai_kernel/intrinsics/system/summarize.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # intrinsics/system
 
 System intrinsic — runtime, lifecycle, and synchronization. Provides the agent with refresh (hot-reload config/presets), karma-gated lifecycle actions on other agents (sleep, lull, suspend, cpr, interrupt, clear, nirvana), preset listing, and context summarization. **System no longer owns any notification verb** — voluntary notification reads and generic dismiss moved to the standalone `notification` tool (sibling package `intrinsics/notification/`, atomic actions `check`/`dismiss_channel`/`dismiss_event`/`dismiss_ref`). The system module remains the **conceptual home** of the notification *producer* surface, though — it re-exports `publish_notification` / `clear_notification` from the kernel-root `notifications.py` so any in-process producer (intrinsic, capability, or wired-in MCP server) submits through one canonical entry point.

--- a/src/lingtai_kernel/llm/ANATOMY.md
+++ b/src/lingtai_kernel/llm/ANATOMY.md
@@ -1,3 +1,21 @@
+---
+related_files:
+  - src/lingtai/llm/ANATOMY.md
+  - src/lingtai/llm/service.py
+  - src/lingtai_kernel/ANATOMY.md
+  - src/lingtai_kernel/llm/__init__.py
+  - src/lingtai_kernel/llm/base.py
+  - src/lingtai_kernel/llm/interface.py
+  - src/lingtai_kernel/llm/service.py
+  - src/lingtai_kernel/llm/streaming.py
+  - tests/test_llm_service.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # llm
 
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues/mail/PR proposals; do not silently fix.

--- a/src/lingtai_kernel/maintenance/ANATOMY.md
+++ b/src/lingtai_kernel/maintenance/ANATOMY.md
@@ -1,3 +1,15 @@
+---
+related_files:
+  - src/lingtai_kernel/ANATOMY.md
+  - src/lingtai_kernel/maintenance/__init__.py
+  - src/lingtai_kernel/maintenance/retention.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # maintenance
 
 Kernel-owned maintenance reporters and future maintenance actions.

--- a/src/lingtai_kernel/migrate/ANATOMY.md
+++ b/src/lingtai_kernel/migrate/ANATOMY.md
@@ -1,3 +1,23 @@
+---
+related_files:
+  - src/lingtai_kernel/ANATOMY.md
+  - src/lingtai_kernel/migrate/__init__.py
+  - src/lingtai_kernel/migrate/agent_m001_init_procedures_override.py
+  - src/lingtai_kernel/migrate/agent_m002_mcp_launch_args_rewrite.py
+  - src/lingtai_kernel/migrate/agent_m003_init_prompt_contract.py
+  - src/lingtai_kernel/migrate/m001_context_limit_relocation.py
+  - src/lingtai_kernel/migrate/m002_description_object.py
+  - src/lingtai_kernel/migrate/migrate.py
+  - tests/test_cli.py
+  - tests/test_deep_refresh.py
+  - tests/test_kernel_migrate.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # migrate
 
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues/mail/PR proposals; do not silently fix.

--- a/src/lingtai_kernel/nudge/ANATOMY.md
+++ b/src/lingtai_kernel/nudge/ANATOMY.md
@@ -1,3 +1,18 @@
+---
+related_files:
+  - CLAUDE.md
+  - src/lingtai_kernel/ANATOMY.md
+  - src/lingtai_kernel/nudge/__init__.py
+  - src/lingtai_kernel/nudge/goal.py
+  - src/lingtai_kernel/nudge/kernel_version.py
+  - src/lingtai_kernel/nudge/source_drift.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # Nudge
 
 Per-agent periodic checks that emit notification nudges or reminders when

--- a/src/lingtai_kernel/services/ANATOMY.md
+++ b/src/lingtai_kernel/services/ANATOMY.md
@@ -1,3 +1,20 @@
+---
+related_files:
+  - src/lingtai/cli.py
+  - src/lingtai/services/ANATOMY.md
+  - src/lingtai_kernel/ANATOMY.md
+  - src/lingtai_kernel/services/__init__.py
+  - src/lingtai_kernel/services/logging.py
+  - src/lingtai_kernel/services/mail.py
+  - tests/test_services_logging.py
+  - tests/test_services_mail.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
 # services
 
 > **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues/mail/PR proposals; do not silently fix.


### PR DESCRIPTION
## Summary
- prepend the new ANATOMY frontmatter contract to all 39 `ANATOMY.md` files
- add repo-relative `related_files` for source/test/config/manual files and meaningful neighboring `ANATOMY.md` links
- keep anatomy-to-anatomy links bidirectional and avoid isolated/complete graphs

## Validation
- `git diff --check`
- parent frontmatter/path/graph validation: 39 ANATOMY files, 46 undirected anatomy edges, all paths valid, all anatomy edges bidirectional, no isolated nodes, not complete graph
- `python tools/check_anatomy_drift.py --check`

## Notes
- Body text is intentionally unchanged in this PR. Existing semantic drift hazards, if any, are reported for follow-up rather than fixed here.
