### PR TITLE
Require last_changed_at for LingTai skills

### DIFF
--- a/src/lingtai/core/avatar/manual/SKILL.md
+++ b/src/lingtai/core/avatar/manual/SKILL.md
@@ -3,6 +3,7 @@ name: avatar-manual
 description: |
   Complete operational guide for the avatar tool — spawning, managing, and communicating with 他我 (alter-ego agents). Read this when: you are about to spawn an avatar; an avatar you spawned goes quiet; you need to decide between avatar, daemon, or bash; or you are an avatar and need to know how to escalate to your parent. Covers spawn types, naming rules, discipline, escalation protocol, and the parent_prompt contract.
 version: 1.0.0
+last_changed_at: "2026-06-14T00:11:48-07:00"
 ---
 
 # Avatar Manual

--- a/src/lingtai/core/bash/manual/SKILL.md
+++ b/src/lingtai/core/bash/manual/SKILL.md
@@ -12,6 +12,7 @@ description: >
   long-running agent CLI, time-driven recurring work ("every hour", "weekdays at
   9", "remind me later"), or when a scheduled job misbehaves.
 version: 1.6.1
+last_changed_at: "2026-06-24T14:38:03-07:00"
 ---
 
 # Bash Manual — Router

--- a/src/lingtai/core/bash/manual/reference/bash-aider/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-aider/SKILL.md
@@ -5,6 +5,7 @@ description: >
   validate, or document `aider` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
+last_changed_at: "2026-06-13T04:32:46-07:00"
 ---
 
 # Aider CLI

--- a/src/lingtai/core/bash/manual/reference/bash-claude-code/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-claude-code/SKILL.md
@@ -9,6 +9,7 @@ description: >
   that would be faster delegated than done manually.
 version: 1.0.2
 tags: [cli, code, delegation, claude, implementation]
+last_changed_at: "2026-06-14T00:11:48-07:00"
 ---
 
 # Claude Code CLI — Code Delegation

--- a/src/lingtai/core/bash/manual/reference/bash-crush/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-crush/SKILL.md
@@ -5,6 +5,7 @@ description: >
   validate, or document `crush` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
+last_changed_at: "2026-06-13T04:32:46-07:00"
 ---
 
 # Charm Crush CLI

--- a/src/lingtai/core/bash/manual/reference/bash-cursor-agent/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-cursor-agent/SKILL.md
@@ -5,6 +5,7 @@ description: >
   validate, or document `cursor-agent` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
+last_changed_at: "2026-06-13T04:32:46-07:00"
 ---
 
 # Cursor Agent CLI

--- a/src/lingtai/core/bash/manual/reference/bash-gemini-cli/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-gemini-cli/SKILL.md
@@ -5,6 +5,7 @@ description: >
   validate, or document `gemini` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
+last_changed_at: "2026-06-13T04:32:46-07:00"
 ---
 
 # Gemini CLI

--- a/src/lingtai/core/bash/manual/reference/bash-goose/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-goose/SKILL.md
@@ -5,6 +5,7 @@ description: >
   validate, or document `goose` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
+last_changed_at: "2026-06-13T04:32:46-07:00"
 ---
 
 # Goose CLI

--- a/src/lingtai/core/bash/manual/reference/bash-mimocode/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-mimocode/SKILL.md
@@ -5,6 +5,7 @@ description: >
   validate, or document `mimocode / mimo` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
+last_changed_at: "2026-06-13T04:32:46-07:00"
 ---
 
 # MiMo Code CLI

--- a/src/lingtai/core/bash/manual/reference/bash-oh-my-pi/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-oh-my-pi/SKILL.md
@@ -5,6 +5,7 @@ description: >
   validate, or document `omp` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
+last_changed_at: "2026-06-13T04:32:46-07:00"
 ---
 
 # Oh-My-Pi CLI

--- a/src/lingtai/core/bash/manual/reference/bash-openai-codex/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-openai-codex/SKILL.md
@@ -9,6 +9,7 @@ description: >
   configuration.
 version: 1.0.1
 tags: [cli, code, delegation, openai, codex]
+last_changed_at: "2026-06-13T04:41:27-07:00"
 ---
 
 # OpenAI Codex CLI

--- a/src/lingtai/core/bash/manual/reference/bash-opencode/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-opencode/SKILL.md
@@ -9,6 +9,7 @@ description: >
   coding tasks from bash.
 version: 1.0.0
 tags: [cli, code, delegation, opencode, automation]
+last_changed_at: "2026-06-13T04:32:46-07:00"
 ---
 
 # OpenCode CLI — Local Coding Agent

--- a/src/lingtai/core/bash/manual/reference/bash-openhands/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-openhands/SKILL.md
@@ -5,6 +5,7 @@ description: >
   validate, or document `openhands` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
+last_changed_at: "2026-06-13T04:32:46-07:00"
 ---
 
 # OpenHands CLI

--- a/src/lingtai/core/bash/manual/reference/bash-qwen-code/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-qwen-code/SKILL.md
@@ -5,6 +5,7 @@ description: >
   validate, or document `qwen-code / qwen` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
+last_changed_at: "2026-06-13T04:32:46-07:00"
 ---
 
 # Qwen Code CLI

--- a/src/lingtai/core/bash/manual/reference/bash-zed-acp/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/bash-zed-acp/SKILL.md
@@ -5,6 +5,7 @@ description: >
   validate, or document `ACP servers` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
+last_changed_at: "2026-06-13T04:41:27-07:00"
 ---
 
 # Zed / ACP agent bridge

--- a/src/lingtai/core/bash/manual/reference/debugging-cleanup/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/debugging-cleanup/SKILL.md
@@ -5,6 +5,7 @@ description: >
   cron jobs safely: scheduler fired, script ran, work landed, agent saw mail,
   worked launchd diagnosis, cleanup, and bash work footprint hygiene.
 version: 1.0.0
+last_changed_at: "2026-06-01T01:47:09-07:00"
 ---
 
 # Debugging and Cleanup Reference

--- a/src/lingtai/core/bash/manual/reference/notification-reminders/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/notification-reminders/SKILL.md
@@ -5,6 +5,7 @@ description: >
   `.notification/cron.json`: payload shape, atomic writer, shell example, and the
   rest checklist for agents leaving work pending.
 version: 1.0.0
+last_changed_at: "2026-06-20T13:05:49-07:00"
 ---
 
 # Notification Reminder Reference

--- a/src/lingtai/core/bash/manual/reference/scheduled-work/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/scheduled-work/SKILL.md
@@ -6,6 +6,7 @@ description: >
   script hygiene, macOS launchd, Linux systemd timers, crontab fallback, and the
   launchd process-tree reaping gotcha.
 version: 1.0.0
+last_changed_at: "2026-06-01T01:47:09-07:00"
 ---
 
 # Scheduled Work Reference

--- a/src/lingtai/core/daemon/manual/SKILL.md
+++ b/src/lingtai/core/daemon/manual/SKILL.md
@@ -7,6 +7,7 @@ description: >
   and clean up daemon footprint. Read this after dispatching daemon work that is
   slow, failed, timed out, exited 143 / SIGTERM, or needs backend-specific reasoning.
 version: 0.5.1
+last_changed_at: "2026-06-23T16:35:37-07:00"
 ---
 
 # Daemon Manual — Router

--- a/src/lingtai/core/daemon/manual/reference/cleanup/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cleanup/SKILL.md
@@ -5,6 +5,7 @@ description: >
   cleanup: what the manual does not cover, reclaim persistence, and safe cleanup
   of old daemon artifacts.
 version: 1.0.0
+last_changed_at: "2026-06-01T01:56:31-07:00"
 ---
 
 # Daemon Cleanup Reference

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -6,6 +6,7 @@ description: >
   backend_options flag passing, preset/capability inheritance, and Codex modal
   capabilities.
 version: 1.3.0
+last_changed_at: "2026-06-15T22:36:44-07:00"
 ---
 
 # Daemon CLI Backend Reference

--- a/src/lingtai/core/daemon/manual/reference/forensics/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/forensics/SKILL.md
@@ -6,6 +6,7 @@ description: >
   chat_history.jsonl, token_ledger.jsonl, events.jsonl, exit code 143 / SIGTERM,
   and how to inspect progress without guessing.
 version: 1.2.0
+last_changed_at: "2026-06-24T16:53:19-07:00"
 ---
 
 # Daemon Forensics Reference

--- a/src/lingtai/core/daemon/manual/reference/inspection/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/inspection/SKILL.md
@@ -5,6 +5,7 @@ description: >
   patterns, backend-specific polling notes, and setting reminders before resting
   while daemon work remains pending.
 version: 1.1.0
+last_changed_at: "2026-06-24T16:24:16-07:00"
 ---
 
 # Daemon Inspection Reference

--- a/src/lingtai/core/email/manual/SKILL.md
+++ b/src/lingtai/core/email/manual/SKILL.md
@@ -13,6 +13,7 @@ description: >
   skill (the lingtai-imap addon owns that surface).
 version: 1.0.0
 tags: [capabilities, email, communication]
+last_changed_at: "2026-06-20T13:05:49-07:00"
 ---
 
 # Email Manual — the internal `email` tool

--- a/src/lingtai/core/knowledge/manual/SKILL.md
+++ b/src/lingtai/core/knowledge/manual/SKILL.md
@@ -8,6 +8,7 @@ description: >
   need to create, organize, or load private knowledge, lay out a routing parent
   over related entries, or explain how knowledge differs from portable skills.
 version: 1.0.0
+last_changed_at: "2026-06-09T13:24:44-07:00"
 ---
 
 # The Knowledge Capability

--- a/src/lingtai/core/mcp/manual/SKILL.md
+++ b/src/lingtai/core/mcp/manual/SKILL.md
@@ -41,6 +41,7 @@ description: >
   internal logic all live in `lingtai-kernel-anatomy reference/mcp-protocol.md`.
   Read this for *what to do*; read anatomy for *how it works*.
 version: 3.2.0
+last_changed_at: "2026-06-24T16:26:32-07:00"
 ---
 
 # MCP Capability — How To Use It

--- a/src/lingtai/core/skills/ANATOMY.md
+++ b/src/lingtai/core/skills/ANATOMY.md
@@ -22,7 +22,7 @@ Skills capability — per-agent skill catalog and skill-manual surface. This is 
 ## Components
 
 - `skills/__init__.py` — the capability implementation. `get_description` (`__init__.py:296-297`), `get_schema` (`__init__.py:300-311`), `setup` (`__init__.py:314-348`), `_reconcile` (`__init__.py:205-289`), and scanner helpers (`__init__.py:53-198`).
-- `skills/manual/` — `skills-manual` skill documentation, template assets, and validator script.
+- `skills/manual/` — `skills-manual` skill documentation, template assets, and validator script. The validator can optionally require `last_changed_at` for LingTai-maintained skill bundles.
 
 ## Connections
 
@@ -49,3 +49,4 @@ The `skills` tool exposes one action:
 
 - The `.library/` directory name and `.library_shared/` convention are intentionally preserved in this rename-only change; they are storage compatibility names, not the user-facing capability name.
 - New callers should use `skills({"action":"info"})`; old `library({"action":"info"})` is not registered because private durable memory is now `knowledge` and `library` is not registered.
+- LingTai-maintained `SKILL.md` files carry `last_changed_at` in frontmatter, initialized from git history for metadata-only backfills and updated on substantive skill edits.

--- a/src/lingtai/core/skills/manual/SKILL.md
+++ b/src/lingtai/core/skills/manual/SKILL.md
@@ -35,6 +35,7 @@ description: >
   SKILL.md files document them. This is meta — how the skills *system*
   works, not what's *inside* it.
 version: 1.1.0
+last_changed_at: "2026-06-29T08:11:47Z"
 ---
 
 # The Skills Capability
@@ -89,12 +90,32 @@ Create a folder under `<agent>/.library/custom/<skill-name>/` with a `SKILL.md` 
 name: <skill-name>
 description: One-line description of what this skill does
 version: 1.0.0
+# Required for LingTai-maintained skills; optional for custom/external skills.
+last_changed_at: "2026-06-29T08:00:00Z"
 ---
 
 Full instructions in Markdown below...
 ```
 
-Required frontmatter: `name`, `description`. Optional: `version`, `author`, `tags`.
+Required frontmatter for ordinary custom/external skills: `name`,
+`description`. Optional for those skills: `version`, `author`, `tags`,
+`last_changed_at`.
+
+**LingTai-maintained skill metadata:** every skill bundle maintained inside a
+LingTai repository must also include `last_changed_at` in its YAML frontmatter.
+This applies to intrinsic capability manuals, standalone intrinsic skills, MCP
+manual bundles, TUI preset utility skills, and their nested reference
+`SKILL.md` files. Use an ISO 8601 timestamp with timezone, for example:
+
+```yaml
+last_changed_at: "2026-06-29T08:00:00Z"
+```
+
+For a historical backfill or metadata-only edit, derive the value from git
+history, e.g. `git log -1 --format=%cI -- path/to/SKILL.md`, so the field points
+to the latest meaningful skill-content change rather than the bookkeeping commit.
+For any substantive future edit to the skill body, update `last_changed_at` in
+the same commit.
 
 `tags` is a list of lowercase, hyphenated strings that aid discoverability and (eventually) tier filtering. Three useful axes:
 
@@ -144,6 +165,13 @@ python3 .library/intrinsic/capabilities/skills/scripts/validate.py \
 ```
 
 It checks: required frontmatter (`name`, `description`), unfilled `[PLACEHOLDER]` slots from the template, broken internal references (paths under `scripts/`, `assets/`, `references/` mentioned in `SKILL.md` that don't exist on disk), and `chmod +x` on Python scripts under `scripts/`. Exits 1 on any FAIL, 0 on PASS (warnings allowed). Run it after authoring and before `cp -r`'ing into `.library_shared/`.
+
+For LingTai-maintained skill bundles, require the timestamp field too:
+
+```
+python3 .library/intrinsic/capabilities/skills/scripts/validate.py \
+   --require-last-changed-at .library/custom/<skill-name>/
+```
 
 ### Self-test before publishing
 
@@ -248,9 +276,11 @@ find directly from the top-level catalog. Those should be normal skills under
 Nested child conventions:
 
 - Each child `reference/<topic>/SKILL.md` must have normal skill frontmatter:
-  `name` and `description` required; `version`/`tags` optional. `name` should be
-  unique within the parent and descriptive (`system-manual-sqlite-log-query`,
-  `daily-reflection-data-collection`), even though it is not globally cataloged.
+  `name` and `description` required; `version`/`tags` optional. If the parent
+  skill is maintained inside a LingTai repository, the child must also carry
+  `last_changed_at`. `name` should be unique within the parent and descriptive
+  (`system-manual-sqlite-log-query`, `daily-reflection-data-collection`), even
+  though it is not globally cataloged.
 - The child `description` and the parent catalog `description` should start with
   the fact that it is nested, name the parent, and give the trigger condition:
   `Nested system-manual reference for ...`.

--- a/src/lingtai/core/skills/manual/assets/skill-template.md
+++ b/src/lingtai/core/skills/manual/assets/skill-template.md
@@ -3,6 +3,7 @@ name: [SKILL_NAME]          # REQUIRED: lowercase-kebab-case, unique
 description: [ONE_LINE_DESCRIPTION]  # REQUIRED: What this skill does + when NOT to use it. Shown in catalog.
 version: 1.0.0              # Semantic versioning
 tags: [[optional, tags]]      # Optional: search/categorization tags
+# last_changed_at: "YYYY-MM-DDTHH:MM:SSZ"  # Required only for LingTai-maintained skills
 ---
 
 # [SKILL NAME]

--- a/src/lingtai/core/skills/manual/scripts/validate.py
+++ b/src/lingtai/core/skills/manual/scripts/validate.py
@@ -8,12 +8,14 @@ import os
 import sys
 import re
 import argparse
+from datetime import date, datetime
 from pathlib import Path
 
 import yaml
 
 
 PLACEHOLDER_RE = re.compile(r'\[[A-Z][A-Z_]*\]')
+ISO_TIMESTAMP_RE = re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$')
 
 
 def _parse_frontmatter(content: str) -> dict | None:
@@ -42,7 +44,29 @@ def _parse_frontmatter(content: str) -> dict | None:
     return data
 
 
-def validate_frontmatter(skill_path: Path) -> tuple[bool, list[str]]:
+def _format_timestamp(value) -> str:
+    """Return a frontmatter timestamp as a normalized string for validation."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if value is None:
+        return ""
+    return str(value).strip().strip('"\'')
+
+
+def _is_iso_timestamp(value: str) -> bool:
+    """Validate the LingTai skill timestamp convention."""
+    if not value or not ISO_TIMESTAMP_RE.match(value):
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
+
+
+def validate_frontmatter(skill_path: Path, *, require_last_changed_at: bool = False) -> tuple[bool, list[str]]:
     """Check frontmatter completeness and quality."""
     errors = []
     warnings = []
@@ -90,6 +114,14 @@ def validate_frontmatter(skill_path: Path) -> tuple[bool, list[str]]:
         # Check for unfilled placeholder
         if PLACEHOLDER_RE.search(desc_text):
             errors.append(f"Unfilled placeholder in description: {desc_text}")
+
+    if require_last_changed_at:
+        raw_changed = fm.get("last_changed_at") if fm else None
+        changed_text = _format_timestamp(raw_changed)
+        if not changed_text:
+            errors.append("Missing 'last_changed_at' field in frontmatter")
+        elif not _is_iso_timestamp(changed_text):
+            errors.append("Invalid 'last_changed_at' timestamp; use ISO 8601 like 2026-06-29T08:00:00Z")
 
     # Quality: description length (warn if > 500 chars — catalog is cluttered)
     if desc_text:
@@ -158,7 +190,7 @@ def validate_scripts(skill_path: Path) -> tuple[bool, list[str]]:
     return True, warnings  # non-executable is a warning, not an error
 
 
-def validate_skill(skill_path: str) -> bool:
+def validate_skill(skill_path: str, *, require_last_changed_at: bool = False) -> bool:
     """Validate a single skill directory."""
     skill_path = Path(skill_path)
 
@@ -173,7 +205,7 @@ def validate_skill(skill_path: str) -> bool:
     all_passed = True
 
     # 1. Frontmatter
-    passed, msgs = validate_frontmatter(skill_path)
+    passed, msgs = validate_frontmatter(skill_path, require_last_changed_at=require_last_changed_at)
     status = "PASS" if passed else "FAIL"
     print(f"  [{status}] Frontmatter")
     for m in msgs:
@@ -212,16 +244,21 @@ def validate_skill(skill_path: str) -> bool:
 def main():
     parser = argparse.ArgumentParser(description="Validate LingTai skill structure")
     parser.add_argument("skill", nargs="?", help="Skill directory path")
+    parser.add_argument(
+        "--require-last-changed-at",
+        action="store_true",
+        help="Require LingTai-maintained skills to include last_changed_at in frontmatter",
+    )
     args = parser.parse_args()
 
     if args.skill:
-        success = validate_skill(args.skill)
+        success = validate_skill(args.skill, require_last_changed_at=args.require_last_changed_at)
         sys.exit(0 if success else 1)
 
     # Validate current directory
     current = Path.cwd()
     if (current / "SKILL.md").exists():
-        success = validate_skill(current)
+        success = validate_skill(current, require_last_changed_at=args.require_last_changed_at)
         sys.exit(0 if success else 1)
     else:
         print("Usage: python validate.py <skill-directory>")

--- a/src/lingtai/intrinsic_skills/file-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/file-manual/SKILL.md
@@ -3,6 +3,7 @@ name: file-manual
 description: "Operational guide for LingTai's built-in file tools: read, write, edit, glob, and grep. Use when working with local text files, deciding whether to use file tools versus bash, handling large files, avoiding binary/image misuse, or reading non-UTF-8 text via explicit bash/Python/iconv instead of complicating the core read tool. Covers UTF-8 policy, safe write/edit discipline, search workflows, and examples for GBK/Shift-JIS/Latin-1 conversion."
 version: 0.1.0
 tags: [files, read, write, edit, grep, glob, encoding, utf-8]
+last_changed_at: "2026-05-26T03:24:43-07:00"
 ---
 
 # File Manual

--- a/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
@@ -9,6 +9,7 @@ description: >
   local checks without exposing secrets.
 version: 0.1.0
 tags: [doctor, diagnostics, mcp, addons, heartbeat, migration, recovery]
+last_changed_at: "2026-06-12T14:27:46-07:00"
 ---
 
 # LingTai Doctor

--- a/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
@@ -29,6 +29,7 @@ description: >
     5. If anatomy disagreed with code, update the anatomy before you leave
        the file. Reading and maintaining are the same act.
 version: 0.1.0
+last_changed_at: "2026-06-26T14:07:06-07:00"
 ---
 
 # LingTai Kernel Anatomy — the Convention

--- a/src/lingtai/intrinsic_skills/lingtai-repo-watch/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-repo-watch/SKILL.md
@@ -24,6 +24,7 @@ description: >
     4. Stop. Do not act on findings unless the caller asked for action.
        The digest is the deliverable.
 version: 0.1.0
+last_changed_at: "2026-05-12T23:30:27-07:00"
 ---
 
 # LingTai Repo Watch — the Routine

--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -3,6 +3,7 @@ name: psyche-manual
 description: |
   Router and operational guide for the psyche tool — molt, pad management, session journaling, and post-wipe recovery. Read this when: you are about to molt; you need to tend the four durable stores; you want guidance on writing a good summary or session journal; you wake up after a system-performed wipe with no summary; or you need to understand keep_tool_calls, keep_last, and pad.append. Routes consequential molt handoffs to assets/molt-template.md while keeping routine guidance compact.
 version: 1.1.0
+last_changed_at: "2026-06-28T02:02:37-07:00"
 ---
 
 # Psyche Manual

--- a/src/lingtai/intrinsic_skills/read-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/read-manual/SKILL.md
@@ -3,6 +3,7 @@ name: read-manual
 description: "Complete guide for the read tool: continuation workflow, next_offset pagination, line_truncated handling, runtime tool-result spill vs read-level pagination, 50k read default / 200k runtime hard cap, and when to use bash/grep/sed for truncated lines. Use when implementing complete file-read workflows, handling large files, or understanding cap and truncation semantics."
 version: 0.1.0
 tags: [read, files, continuation, truncation, cap, pagination]
+last_changed_at: "2026-06-27T02:45:37-07:00"
 ---
 
 # Read Manual

--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -21,6 +21,7 @@ description: >
   design, and the `system` tool actions.
 version: 1.3.0
 tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize, nudge, updates, runtime-checks]
+last_changed_at: "2026-06-23T23:50:45-07:00"
 ---
 
 # System Manual — Progressive Disclosure Router

--- a/src/lingtai/intrinsic_skills/system-manual/reference/goal-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/goal-manual/SKILL.md
@@ -6,6 +6,7 @@ description: >
   completion semantics.
 version: 0.2.0
 tags: [lingtai, goal, notifications, reminders]
+last_changed_at: "2026-06-20T13:05:49-07:00"
 ---
 
 # Goal Manual

--- a/src/lingtai/intrinsic_skills/system-manual/reference/notification-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/notification-manual/SKILL.md
@@ -9,6 +9,7 @@ description: >
   by system(action="summarize").
 version: 0.2.0
 tags: [lingtai, notifications, channels, dismiss, large-result, force, stale, nudge]
+last_changed_at: "2026-06-27T14:31:30-07:00"
 ---
 
 # Notification Manual

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -13,6 +13,7 @@ description: >
   guidance grows.
 version: 1.2.0
 tags: [lingtai, system-manual, procedures, progressive-disclosure, responsiveness, deliverables, issue-reporting]
+last_changed_at: "2026-06-27T15:15:34-07:00"
 ---
 
 # Procedures Manual

--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -9,6 +9,7 @@ description: >
   only when safe.
 version: 0.1.0
 tags: [lingtai, runtime, kernel, nudge, updates, refresh, editable, dev-mode]
+last_changed_at: "2026-06-23T23:50:45-07:00"
 ---
 
 # Runtime Update Checks

--- a/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
@@ -14,6 +14,7 @@ description: >
   companion scripts and assets as SQLite trace tooling grows.
 version: 1.2.0
 tags: [lingtai, system-manual, sqlite, log.sqlite, runtime-logs, trace, jsonl, daemon, trajectory, mining, event-log, improvement, pitfalls, observability, cheap-model]
+last_changed_at: "2026-06-24T23:45:17-07:00"
 ---
 
 # SQLite Log Query

--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -12,6 +12,7 @@ description: >
   its folder may carry scripts/assets as the substrate reference grows.
 version: 1.0.0
 tags: [lingtai, system-manual, substrate, runtime, lifecycle, communication, memory, notifications, mcp]
+last_changed_at: "2026-06-27T21:13:46-07:00"
 ---
 
 # Substrate Manual

--- a/src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: summarize-manual
-description: Detailed operational guide for system(action="summarize"): what tool-result summarization is, why it implements progressive disclosure, when to summarize urgently versus during idle cleanup, how to write good summaries, how to recover the original tool result by tool_call_id, and how summarize differs from molt.
+description: >-
+  Detailed operational guide for system(action="summarize"): what tool-result
+  summarization is, why it implements progressive disclosure, when to summarize
+  urgently versus during idle cleanup, how to write good summaries, how to
+  recover the original tool result by tool_call_id, and how summarize differs
+  from molt.
+last_changed_at: "2026-06-29T08:16:06Z"
 ---
 
 # Summarize Manual

--- a/src/lingtai/mcp_servers/cloud_mail/SKILL.md
+++ b/src/lingtai/mcp_servers/cloud_mail/SKILL.md
@@ -8,6 +8,7 @@ description: |
   external-email side-effect caveats. Pulled on demand via action='manual'; you
   do not need to call it before every send.
 version: 1.0.0
+last_changed_at: "2026-06-26T14:33:19-07:00"
 ---
 
 # Cloud Mail MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/feishu/SKILL.md
+++ b/src/lingtai/mcp_servers/feishu/SKILL.md
@@ -8,6 +8,7 @@ description: |
   Pulled on demand via action='manual'; you do not need to call it before every
   send.
 version: 1.0.0
+last_changed_at: "2026-06-26T14:33:19-07:00"
 ---
 
 # Feishu (Lark) MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/imap/SKILL.md
+++ b/src/lingtai/mcp_servers/imap/SKILL.md
@@ -9,6 +9,7 @@ description: |
   before sending). Pulled on demand via action='manual'; you do not need to call
   it before every send.
 version: 1.0.0
+last_changed_at: "2026-06-27T17:30:57-07:00"
 ---
 
 # IMAP/SMTP email MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -8,6 +8,7 @@ description: |
   and error surfacing. Pulled on demand via action='manual'; you do not need to
   call it before every send.
 version: 1.0.0
+last_changed_at: "2026-06-26T14:00:36-07:00"
 ---
 
 # Telegram MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -7,6 +7,7 @@ description: |
   contacts/accounts basics, and external-delivery side-effect caveats. Pulled on
   demand via action='manual'; you do not need to call it before every send.
 version: 1.0.0
+last_changed_at: "2026-06-26T14:33:19-07:00"
 ---
 
 # WeChat MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/whatsapp/SKILL.md
+++ b/src/lingtai/mcp_servers/whatsapp/SKILL.md
@@ -8,6 +8,7 @@ description: |
   external-delivery side-effect caveats. Pulled on demand via action='manual'; you
   do not need to call it before every send.
 version: 1.0.0
+last_changed_at: "2026-06-26T14:33:19-07:00"
 ---
 
 # WhatsApp MCP — usage manual (progressive disclosure)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+from datetime import date, datetime
 import json
 import sqlite3
 import time
@@ -12,6 +13,36 @@ from lingtai.agent import Agent
 from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
+
+
+def _parse_skill_frontmatter(skill_md: Path) -> dict:
+    content = skill_md.read_text(encoding="utf-8")
+    assert content.startswith("---\n"), f"missing frontmatter: {skill_md}"
+    end = content.find("\n---\n", 4)
+    assert end != -1, f"missing closing frontmatter delimiter: {skill_md}"
+    import yaml
+
+    data = yaml.safe_load(content[4:end])
+    assert isinstance(data, dict), f"frontmatter is not a mapping: {skill_md}"
+    return data
+
+
+def _timestamp_text(value) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return "" if value is None else str(value).strip().strip('"\'')
+
+
+def _assert_iso_timestamp(value, path: Path):
+    text = _timestamp_text(value)
+    assert text, f"missing last_changed_at: {path}"
+    datetime.fromisoformat(text.replace("Z", "+00:00"))
+    assert "T" in text, f"last_changed_at must include time: {path}"
+    assert text.endswith("Z") or "+" in text[10:] or "-" in text[10:], (
+        f"last_changed_at must include timezone: {path}"
+    )
 
 
 def _mk_agent(tmp_path: Path, skills_cfg: dict | None = None):
@@ -32,6 +63,42 @@ def _write_skill(folder: Path, name: str, desc: str = "test skill"):
     (folder / "SKILL.md").write_text(
         f"---\nname: {name}\ndescription: {desc}\n---\n\nBody of {name}.\n"
     )
+
+
+def test_lingtai_owned_skill_frontmatter_has_last_changed_at():
+    root = Path(__file__).resolve().parents[1]
+    skill_files = sorted((root / "src" / "lingtai").rglob("SKILL.md"))
+    assert skill_files, "expected LingTai-owned source skills"
+    for skill_md in skill_files:
+        fm = _parse_skill_frontmatter(skill_md)
+        _assert_iso_timestamp(fm.get("last_changed_at"), skill_md)
+
+
+def test_skills_validator_can_require_last_changed_at(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    validator_path = root / "src" / "lingtai" / "core" / "skills" / "manual" / "scripts" / "validate.py"
+    spec = importlib.util.spec_from_file_location("skill_validate", validator_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    skill = tmp_path / "skill"
+    _write_skill(skill, "demo-skill", "demo skill for validator")
+    passed, messages = module.validate_frontmatter(skill, require_last_changed_at=True)
+    assert not passed
+    assert any("last_changed_at" in msg for msg in messages)
+
+    (skill / "SKILL.md").write_text(
+        "---\n"
+        "name: demo-skill\n"
+        "description: demo skill for validator\n"
+        "last_changed_at: \"2026-06-29T08:00:00Z\"\n"
+        "---\n\n"
+        "Body.\n",
+        encoding="utf-8",
+    )
+    passed, messages = module.validate_frontmatter(skill, require_last_changed_at=True)
+    assert passed, messages
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- require `last_changed_at` metadata for LingTai-maintained skill bundles in `skills-manual`
- backfill `last_changed_at` on all 47 kernel-owned tracked `SKILL.md` files using git history for metadata-only entries
- add `--require-last-changed-at` validator support and tests for the timestamp convention
- fix the `summarize-manual` frontmatter description to valid YAML while adding its timestamp

## Timestamp source
- Metadata-only backfills use `git log -1 --format=%cI -- <path>`.
- Files substantively edited in this PR use the current edit timestamp.

## Validation
- `python3 -m py_compile src/lingtai/core/skills/manual/scripts/validate.py`
- custom all-`SKILL.md` timestamp/YAML parser: `47/47`
- `python3 src/lingtai/core/skills/manual/scripts/validate.py --require-last-changed-at src/lingtai/core/skills/manual`
- `python3 src/lingtai/core/skills/manual/scripts/validate.py --require-last-changed-at src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual`
- `git diff --check`
- `pytest tests/test_skills.py -q` → `25 passed`
- `python tools/check_anatomy_drift.py --check` → `No anatomy drift found across 38 file(s).`

## Local explainer
- `reports/skill-last-changed-at-pr-20260629.html`

## Scope note
This PR updates the canonical kernel `skills-manual` plus kernel-owned shipped skills. The manual now says TUI preset utility skills should follow the same convention too; those live in the separate `lingtai` repository and would need a separate PR if we want to backfill them immediately.
