### PR TITLE
fix(daemon): derive no-preset runs from effective preset

### DIFF
--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -1147,6 +1147,42 @@ class DaemonManager:
         )
         return {key: llm[key] for key in keys if key in llm}
 
+    def _implicit_parent_preset_llm(self) -> dict:
+        """Materialize the parent service into an implicit/effective preset.
+
+        A LingTai daemon always runs from an effective preset. When a task does
+        not name one, the parent agent's existing LLM configuration *is* the
+        implicit preset: same provider/model/base_url, the credential the parent
+        actually built its boot adapter with (``parent_service.api_key``), and
+        the parent's own provider-defaults bucket carried through unchanged.
+
+        This deliberately does NOT run fallback key resolution for the daemon's
+        primary key — the parent already resolved that at boot, so the daemon
+        inherits the same effective key directly rather than re-deriving it from
+        a guessed ``{PROVIDER}_API_KEY`` env slot. The parent's ``key_resolver``
+        is still carried so on-demand adapters for *other* providers behave like
+        the parent's; it is never consulted for this preset's primary key.
+
+        Extra non-manifest fields (``key_resolver``, ``context_window``, and the
+        verbatim ``_provider_defaults`` bucket) ride along so the shared preset
+        construction path in ``_run_emanation`` can mirror the parent service.
+        The api_key is never logged or persisted.
+        """
+        parent_service = self._agent.service
+        provider = str(getattr(parent_service, "provider", "")).lower()
+        parent_defaults = getattr(parent_service, "_provider_defaults", {}) or {}
+        return {
+            "provider": parent_service.provider,
+            "model": parent_service.model,
+            "api_key": getattr(parent_service, "api_key", None),
+            "base_url": getattr(parent_service, "_base_url", None),
+            "key_resolver": getattr(parent_service, "_key_resolver", None),
+            "context_window": getattr(parent_service, "_context_window", 1_000_000),
+            # Parent provider defaults carried verbatim (not re-derived through
+            # the manifest key list) so any provider-specific field survives.
+            "_provider_defaults": dict(parent_defaults.get(provider, {})),
+        }
+
     def _build_tool_surface(
         self,
         requested: list[str],
@@ -1456,10 +1492,14 @@ class DaemonManager:
         mark_timeout instead of mark_cancelled. None is allowed for direct-call
         tests and the cancellation defaults to "cancelled" semantics.
 
-        preset_llm: if provided, a dict with keys provider/model/api_key_env/
-        base_url (and optionally api_key) resolved from the preset. A dedicated
-        LLMService is constructed for this emanation instead of reusing
-        self._agent.service.
+        preset_llm: the per-task preset's ``manifest.llm`` block when the task
+        explicitly named a preset (keys provider/model/api_key_env/base_url and
+        optionally api_key). When the task omits ``preset``, the parent agent's
+        existing LLM configuration is used as an implicit/effective preset (see
+        ``_implicit_parent_preset_llm``). Either way a dedicated daemon-scoped
+        LLMService is built from the effective preset — the daemon never reuses
+        ``self._agent.service`` directly and never runs provider-name env-var
+        fallback resolution for its primary key.
         """
         def _exit_cancelled() -> str:
             if timeout_event is not None and timeout_event.is_set():
@@ -1471,60 +1511,49 @@ class DaemonManager:
         if cancel_event.is_set():
             return _exit_cancelled()
 
-        if preset_llm:
-            # Build a dedicated LLM service for this emanation from the preset.
-            from lingtai.llm.service import LLMService
-            from lingtai_kernel.config_resolve import resolve_env
-            api_key = resolve_env(preset_llm.get("api_key"), preset_llm.get("api_key_env"))
-            service = LLMService(
-                provider=preset_llm["provider"],
-                model=preset_llm["model"],
-                api_key=api_key,
-                base_url=preset_llm.get("base_url"),
-                provider_defaults=self._daemon_provider_defaults(
-                    preset_llm["provider"],
-                    self._llm_defaults_from_manifest(preset_llm),
-                    run_dir,
-                ),
-            )
-            effective_model = preset_llm["model"]
+        # A LingTai daemon always runs from an effective preset: the task's
+        # explicit preset if it supplied one, otherwise the parent agent's
+        # current LLM configuration synthesized into an implicit preset. Both
+        # flow through the same daemon-scoped service construction below.
+        effective_preset_llm = preset_llm or self._implicit_parent_preset_llm()
+
+        from lingtai.llm.service import LLMService
+        from lingtai_kernel.config_resolve import resolve_env
+
+        provider = effective_preset_llm["provider"]
+        effective_model = effective_preset_llm["model"]
+        # Primary key: the preset's direct api_key (resolved from its api_key_env
+        # only, never a guessed provider-name slot). For the implicit preset this
+        # is the parent's already-resolved effective key. Never logged/persisted.
+        api_key = resolve_env(
+            effective_preset_llm.get("api_key"),
+            effective_preset_llm.get("api_key_env"),
+        )
+        # Base provider defaults: the implicit preset carries the parent bucket
+        # verbatim; an explicit preset derives them from its manifest.llm fields.
+        # Codex daemons additionally get a per-run cache anchor (set inside
+        # _daemon_provider_defaults) so they don't collide with the parent slot.
+        if "_provider_defaults" in effective_preset_llm:
+            base_defaults = effective_preset_llm["_provider_defaults"]
         else:
-            # No preset: build a fresh daemon-scoped service mirroring the parent
-            # service rather than reusing ``self._agent.service``. Every provider
-            # keeps the parent's provider defaults; Codex additionally gets a
-            # per-run cache anchor (and drops any fixed session id) so this run
-            # gets its own session_id/thread_id/prompt_cache_key triple instead
-            # of colliding with the parent agent's cache slot.
-            from lingtai.llm.service import LLMService
-            parent_service = self._agent.service
-            parent_provider = str(getattr(parent_service, "provider", "")).lower()
-            parent_defaults = getattr(parent_service, "_provider_defaults", {}) or {}
-            parent_key_resolver = getattr(parent_service, "_key_resolver", None)
-            # Prefer the parent's *effective* api_key (the credential it actually
-            # built its boot adapter with) over re-deriving it through the
-            # resolver. The default resolver only reads the canonical
-            # ``{PROVIDER}_API_KEY``, so a parent whose key came from a
-            # noncanonical env slot (e.g. provider=custom + api_key_env=LLM_API_KEY,
-            # or MIMO_1_API_KEY) would otherwise be lost here, leaving the daemon
-            # without a key. The resolver is still passed through below for
-            # on-demand adapters of *other* providers. Never logged.
-            parent_api_key = getattr(parent_service, "api_key", None)
-            if parent_api_key is None and callable(parent_key_resolver):
-                parent_api_key = parent_key_resolver(parent_provider)
-            service = LLMService(
-                provider=parent_service.provider,
-                model=parent_service.model,
-                api_key=parent_api_key,
-                base_url=getattr(parent_service, "_base_url", None),
-                key_resolver=parent_key_resolver,
-                provider_defaults=self._daemon_provider_defaults(
-                    parent_provider,
-                    parent_defaults.get(parent_provider, {}),
-                    run_dir,
-                ),
-                context_window=getattr(parent_service, "_context_window", 1_000_000),
-            )
-            effective_model = parent_service.model
+            base_defaults = self._llm_defaults_from_manifest(effective_preset_llm)
+        service_kwargs = {
+            "provider": provider,
+            "model": effective_model,
+            "api_key": api_key,
+            "base_url": effective_preset_llm.get("base_url"),
+            "provider_defaults": self._daemon_provider_defaults(
+                provider, base_defaults, run_dir,
+            ),
+        }
+        # Implicit-preset-only pass-throughs that mirror the parent service:
+        # the key_resolver (for on-demand adapters of *other* providers — never
+        # the primary key) and the parent's context window.
+        if "key_resolver" in effective_preset_llm:
+            service_kwargs["key_resolver"] = effective_preset_llm["key_resolver"]
+        if "context_window" in effective_preset_llm:
+            service_kwargs["context_window"] = effective_preset_llm["context_window"]
+        service = LLMService(**service_kwargs)
 
         session = service.create_session(
             system_prompt=run_dir.prompt_path.read_text(encoding="utf-8"),

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2852,3 +2852,174 @@ def test_daemon_provider_defaults_preserves_codex_auth_path(tmp_path):
     assert out["codex"]["codex_session_anchor"] == str(
         (run_dir.path / "daemon.json").resolve()
     )
+
+
+def _capturing_fake_service(captured, text="daemon done"):
+    """Build a FakeService class that records its init kwargs into *captured*."""
+    class FakeService:
+        def __init__(self, **kwargs):
+            captured["init"] = kwargs
+            self.model = kwargs["model"]
+            self.provider = kwargs["provider"]
+
+        def create_session(self, **kwargs):
+            mock_session = MagicMock()
+            mock_response = MagicMock()
+            mock_response.text = text
+            mock_response.tool_calls = []
+            mock_response.usage = MagicMock(
+                input_tokens=0, output_tokens=0,
+                thinking_tokens=0, cached_tokens=0,
+            )
+            mock_session.send = MagicMock(return_value=mock_response)
+            return mock_session
+
+    return FakeService
+
+
+def test_run_emanation_no_preset_uses_parent_api_key_without_resolver(
+    tmp_path, monkeypatch
+):
+    """No-preset daemon uses the implicit parent preset's direct api_key.
+
+    Jason's effective-preset design: a daemon with no explicit preset runs from
+    the parent's existing LLM configuration as an implicit preset. The parent's
+    already-resolved ``api_key`` is used directly; the daemon execution layer
+    must NOT call the parent's ``_key_resolver`` to derive the primary key — not
+    even when the parent's direct api_key is ``None`` (the prior bespoke
+    fallback resolver path that this change removes). Make the resolver raise so
+    any primary-key resolution attempt fails the test.
+    """
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    agent.service.provider = "custom"
+    agent.service.model = "glm-5.1"
+    agent.service._base_url = "https://proxy.example/v1"
+    agent.service._context_window = 200000
+
+    def exploding_resolver(provider):
+        raise AssertionError(
+            "daemon must not call parent _key_resolver for the primary key"
+        )
+
+    agent.service._key_resolver = exploding_resolver
+    # No direct api_key on the parent: the old bespoke no-preset branch would
+    # fall back to calling the resolver here. The effective-preset path must not.
+    agent.service._api_key = None
+    agent.service.api_key = None
+    agent.service._provider_defaults = {"custom": {"api_compat": "openai"}}
+
+    captured = {}
+    import lingtai.llm.service as service_mod
+    monkeypatch.setattr(service_mod, "LLMService", _capturing_fake_service(captured))
+
+    mgr = agent.get_capability("daemon")
+    cancel = threading.Event()
+    em_id = "em-implicit"
+    schemas, dispatch = mgr._build_tool_surface(["file"])
+    run_dir = _make_run_dir(agent, em_id=em_id)
+    mgr._emanations[em_id] = {
+        "followup_buffer": "",
+        "followup_lock": threading.Lock(),
+        "run_dir": run_dir,
+    }
+
+    # The resolver raising would surface as an exception here if consulted for
+    # the primary key.
+    result = mgr._run_emanation(em_id, run_dir, schemas, dispatch, "x", cancel)
+
+    assert result == "daemon done"
+    agent.service.create_session.assert_not_called()
+    # Primary key is the parent's direct effective key (None here) — no resolver
+    # fallback. The old branch would have raised by calling the resolver.
+    assert captured["init"]["api_key"] is None
+    # The resolver is still carried for on-demand adapters of *other* providers,
+    # but was never invoked (it would have raised).
+    assert captured["init"]["key_resolver"] is exploding_resolver
+
+
+def test_run_emanation_no_preset_preserves_parent_provider_defaults(
+    tmp_path, monkeypatch
+):
+    """Implicit preset path carries the parent provider_defaults bucket verbatim.
+
+    Includes a field outside the manifest allowlist (``codex_base_urls``) to
+    prove the implicit path forwards the parent bucket directly rather than
+    re-deriving it through ``_llm_defaults_from_manifest``.
+    """
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    agent.service.provider = "custom"
+    agent.service.model = "glm-5.1"
+    agent.service._base_url = "https://proxy.example/v1"
+    agent.service._context_window = 200000
+    agent.service._key_resolver = lambda provider: "token"
+    agent.service._api_key = "sk-effective"
+    agent.service.api_key = "sk-effective"
+    agent.service._provider_defaults = {
+        "custom": {
+            "api_compat": "openai",
+            "max_rpm": 9,
+            "default_headers": {"x-test": "1"},
+            # Outside the _llm_defaults_from_manifest allowlist on purpose.
+            "codex_base_urls": ["https://a.example", "https://b.example"],
+        }
+    }
+
+    captured = {}
+    import lingtai.llm.service as service_mod
+    monkeypatch.setattr(service_mod, "LLMService", _capturing_fake_service(captured))
+
+    mgr = agent.get_capability("daemon")
+    cancel = threading.Event()
+    em_id = "em-defaults"
+    schemas, dispatch = mgr._build_tool_surface(["file"])
+    run_dir = _make_run_dir(agent, em_id=em_id)
+    mgr._emanations[em_id] = {
+        "followup_buffer": "",
+        "followup_lock": threading.Lock(),
+        "run_dir": run_dir,
+    }
+
+    result = mgr._run_emanation(em_id, run_dir, schemas, dispatch, "x", cancel)
+
+    assert result == "daemon done"
+    # The whole parent bucket survives — including codex_base_urls, which the
+    # manifest allowlist would have dropped (no Codex anchor for non-codex).
+    assert captured["init"]["provider_defaults"] == {
+        "custom": {
+            "api_compat": "openai",
+            "max_rpm": 9,
+            "default_headers": {"x-test": "1"},
+            "codex_base_urls": ["https://a.example", "https://b.example"],
+        }
+    }
+
+
+def test_implicit_parent_preset_llm_does_not_resolve_primary_key(tmp_path):
+    """``_implicit_parent_preset_llm`` reads the parent's effective key directly.
+
+    It must not invoke the parent ``_key_resolver`` to synthesize the implicit
+    preset's primary key — the parent already resolved it at boot.
+    """
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    agent.service.provider = "anthropic"
+    agent.service.model = "claude-opus-4-8"
+    agent.service._base_url = "https://api.anthropic.com"
+    agent.service._context_window = 200000
+    agent.service.api_key = "sk-effective"
+
+    def exploding_resolver(provider):
+        raise AssertionError("must not resolve the primary key here")
+
+    agent.service._key_resolver = exploding_resolver
+    agent.service._provider_defaults = {"anthropic": {"max_rpm": 5}}
+
+    mgr = agent.get_capability("daemon")
+    preset = mgr._implicit_parent_preset_llm()
+
+    assert preset["provider"] == "anthropic"
+    assert preset["model"] == "claude-opus-4-8"
+    assert preset["api_key"] == "sk-effective"
+    assert preset["base_url"] == "https://api.anthropic.com"
+    assert preset["context_window"] == 200000
+    assert preset["key_resolver"] is exploding_resolver
+    assert preset["_provider_defaults"] == {"max_rpm": 5}


### PR DESCRIPTION
## Summary\n- materialize no-preset LingTai daemon runs from the parent effective LLM config\n- route explicit and implicit preset runs through the same service-construction path\n- stop using the parent key resolver as a primary-key fallback for no-preset daemons\n\n## Validation\n- git diff --check -- .\n- python -m pytest tests/test_daemon.py tests/test_llm_service.py -q