### PR TITLE
fix(llm): normalize base_url trailing slash to prevent urljoin path stripping

### DIFF
--- a/src/lingtai/llm/service.py
+++ b/src/lingtai/llm/service.py
@@ -207,6 +207,24 @@ class LLMService(LLMServiceABC):
         self._provider = provider.lower()
         self._model = model
         self._context_window = context_window
+        # Normalize base_url: if it contains a path component (e.g.
+        # ``/api/coding``) but lacks a trailing slash, append one.
+        # Python's ``urljoin`` treats the last segment as a *file* when
+        # there is no trailing slash, silently stripping it:
+        #   urljoin('https://x.com/api/coding', '/v1/messages')
+        #   → 'https://x.com/v1/messages'   ← wrong!
+        # With a trailing slash the path is preserved:
+        #   urljoin('https://x.com/api/coding/', '/v1/messages')
+        #   → 'https://x.com/api/coding/v1/messages'
+        # This affects any provider whose endpoint sits behind a non-root
+        # path (Volcano Engine Ark, Azure OpenAI, etc.).
+        if (
+            base_url
+            and isinstance(base_url, str)
+            and "/" in base_url.split("://", 1)[-1]
+            and not base_url.endswith("/")
+        ):
+            base_url += "/"
         self._base_url = base_url
         self._key_resolver = key_resolver or (lambda p: os.environ.get(f"{p.upper()}_API_KEY"))
         self._provider_defaults = provider_defaults or {}

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -196,3 +196,61 @@ def test_direct_api_key_reaches_boot_adapter_unchanged(monkeypatch):
     assert len(calls) == 1
     assert calls[0]["api_key"] == "sk-direct"
     assert calls[0]["base_url"] == "https://proxy.example/v1"
+
+
+# ---------------------------------------------------------------------------
+# base_url trailing-slash normalization
+# ---------------------------------------------------------------------------
+
+class _FakeAdapter:
+    """Minimal adapter stub for testing LLMService construction."""
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _ensure_fake_adapter():
+    """Register a fake adapter if not already present."""
+    try:
+        LLMService.register_adapter("fake", lambda **kw: _FakeAdapter(**kw))
+    except Exception:
+        pass  # already registered
+
+
+def test_base_url_normalization_adds_trailing_slash():
+    """LLMService should append '/' to a base_url with a path component."""
+    _ensure_fake_adapter()
+    svc = LLMService(
+        provider="fake",
+        model="test",
+        base_url="https://ark.example.com/api/coding",
+    )
+    assert svc._base_url == "https://ark.example.com/api/coding/"
+
+
+def test_base_url_normalization_preserves_existing_slash():
+    """LLMService should not double-append '/' if already present."""
+    _ensure_fake_adapter()
+    svc = LLMService(
+        provider="fake",
+        model="test",
+        base_url="https://ark.example.com/api/coding/",
+    )
+    assert svc._base_url == "https://ark.example.com/api/coding/"
+
+
+def test_base_url_normalization_skips_root_urls():
+    """LLMService should not modify a base_url with no path component."""
+    _ensure_fake_adapter()
+    svc = LLMService(
+        provider="fake",
+        model="test",
+        base_url="https://api.example.com",
+    )
+    assert svc._base_url == "https://api.example.com"
+
+
+def test_base_url_normalization_handles_none():
+    """LLMService should accept base_url=None without error."""
+    _ensure_fake_adapter()
+    svc = LLMService(provider="fake", model="test", base_url=None)
+    assert svc._base_url is None


### PR DESCRIPTION
## Problem

When a preset's `base_url` contains a non-root path (e.g. `https://ark.cn-beijing.volces.com/api/coding`) but lacks a trailing slash, Python's `urljoin` treats the last segment as a *file* and silently strips it:

```python
urljoin('https://x.com/api/coding', '/v1/messages')
# → 'https://x.com/v1/messages'   ← /api/coding discarded!
```

This causes HTTP 404 for any provider whose endpoint sits behind a non-root path (Volcano Engine Ark, Azure OpenAI, etc.).

## Fix

In `LLMService.__init__`, detect `base_url`s with a path component but no trailing slash, and auto-append `/` before storing or passing to any adapter:

```python
if (base_url and isinstance(base_url, str)
    and "/" in base_url.split("://", 1)[-1]
    and not base_url.endswith("/")):
    base_url += "/"
```

This normalization runs once at construction time, before the value is stored or passed to any adapter. All downstream consumers (main adapter, on-demand adapters, cache keys) see the corrected URL.

## Tests

4 new test cases in `tests/test_llm_service.py`:

| Test | Input | Expected |
|---|---|---|
| `test_base_url_normalization_adds_trailing_slash` | `https://ark.example.com/api/coding` | `…/api/coding/` |
| `test_base_url_normalization_preserves_existing_slash` | `https://ark.example.com/api/coding/` | unchanged |
| `test_base_url_normalization_skips_root_urls` | `https://api.example.com` | unchanged |
| `test_base_url_normalization_handles_none` | `None` | `None` |