### PR TITLE
Extract shared daemon test helpers

### DIFF
--- a/tests/_daemon_helpers.py
+++ b/tests/_daemon_helpers.py
@@ -1,0 +1,133 @@
+"""Focused daemon test helpers.
+
+These keep repeated daemon test setup in one place without becoming a general
+test framework.  The helpers intentionally model the concrete shapes the daemon
+tests already use: a mock daemon-capable agent, a run directory, finite fake CLI
+processes, and in-memory daemon entries.
+"""
+from __future__ import annotations
+
+import threading
+from concurrent.futures import Future
+from pathlib import Path
+from typing import Any, Iterable
+from unittest.mock import MagicMock
+
+from lingtai.agent import Agent
+from lingtai.core.daemon.run_dir import DaemonRunDir
+from lingtai_kernel.config import AgentConfig
+
+
+def make_daemon_agent(
+    tmp_path: Path,
+    *,
+    capabilities: list[str] | None = None,
+    working_dir_name: str = "daemon-agent",
+) -> Agent:
+    """Create the minimal mock-service Agent used by daemon tests."""
+    svc = MagicMock()
+    svc.provider = "mock"
+    svc.model = "mock-model"
+    svc.create_session = MagicMock()
+    svc.make_tool_result = MagicMock()
+    return Agent(
+        svc,
+        working_dir=tmp_path / working_dir_name,
+        capabilities=capabilities or ["daemon"],
+        config=AgentConfig(),
+    )
+
+
+def make_daemon_run_dir(
+    agent: Agent | None = None,
+    *,
+    parent_working_dir: Path | None = None,
+    handle: str = "em-test",
+    task: str = "test task",
+    tools: Iterable[str] | None = ("file",),
+    model: str = "mock-model",
+    max_turns: int = 30,
+    timeout_s: float = 300.0,
+    parent_addr: str | None = None,
+    parent_pid: int = 12345,
+    system_prompt: str = "You are a daemon.",
+    backend: str = "lingtai",
+) -> DaemonRunDir:
+    """Create a DaemonRunDir with explicit, daemon-test-oriented defaults."""
+    if parent_working_dir is None:
+        if agent is None:
+            raise ValueError("make_daemon_run_dir requires agent or parent_working_dir")
+        parent_working_dir = agent._working_dir
+    parent_working_dir.mkdir(parents=True, exist_ok=True)
+
+    return DaemonRunDir(
+        parent_working_dir=parent_working_dir,
+        handle=handle,
+        task=task,
+        tools=list(tools or []),
+        model=model,
+        max_turns=max_turns,
+        timeout_s=timeout_s,
+        parent_addr=parent_addr or parent_working_dir.name,
+        parent_pid=parent_pid,
+        system_prompt=system_prompt,
+        backend=backend,
+    )
+
+
+class FiniteFakeProc:
+    """Minimal ``subprocess.Popen`` stand-in with finite stdout/stderr streams."""
+
+    def __init__(
+        self,
+        *,
+        stdout_lines: Iterable[str] = (),
+        stderr_lines: Iterable[str] = (),
+        returncode: int = 0,
+        pid: int = 0,
+    ) -> None:
+        self.stdout = iter(list(stdout_lines))
+        self.stderr = iter(list(stderr_lines))
+        self.returncode = returncode
+        self.pid = pid
+
+    def wait(self, timeout: float | None = None) -> int:
+        return self.returncode
+
+
+def completed_future(result: Any = None) -> Future[Any]:
+    future: Future[Any] = Future()
+    future.set_result(result)
+    return future
+
+
+def register_daemon_entry(
+    mgr: Any,
+    em_id: str,
+    run_dir: DaemonRunDir,
+    *,
+    future: Any | None = None,
+    task: str = "test task",
+    start_time: float = 0.0,
+    backend: str | None = None,
+    ask_in_flight: bool | None = None,
+    ask_future: Any | None = None,
+) -> dict[str, Any]:
+    """Register an in-memory daemon entry and return it for assertions."""
+    entry: dict[str, Any] = {
+        "future": future if future is not None else Future(),
+        "task": task,
+        "start_time": start_time,
+        "cancel_event": threading.Event(),
+        "timeout_event": threading.Event(),
+        "followup_buffer": "",
+        "followup_lock": threading.Lock(),
+        "run_dir": run_dir,
+    }
+    if backend is not None:
+        entry["backend"] = backend
+    if ask_in_flight is not None:
+        entry["ask_in_flight"] = ask_in_flight
+        entry["ask_future"] = ask_future
+    mgr._emanations[em_id] = entry
+    return entry

--- a/tests/test_daemon_backend_options.py
+++ b/tests/test_daemon_backend_options.py
@@ -12,17 +12,24 @@ Covers:
 from __future__ import annotations
 
 import json
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from lingtai_kernel.config import AgentConfig
 from lingtai.core.daemon import (
     _BACKEND_ALIASES,
     _backend_options_to_argv,
     _BACKEND_SCHEMA_ENUM,
     _BACKEND_SPECS,
     _normalize_backend,
+)
+from tests._daemon_helpers import (
+    FiniteFakeProc,
+    completed_future,
+    make_daemon_agent,
+    make_daemon_run_dir,
+    register_daemon_entry,
 )
 
 
@@ -124,27 +131,10 @@ def test_argv_rejects_non_dict_root():
 # ---------------------------------------------------------------------------
 
 
-def _make_agent(tmp_path):
-    """Minimal Agent with daemon capability and mock LLM service."""
-    from lingtai.agent import Agent
-    svc = MagicMock()
-    svc.provider = "mock"
-    svc.model = "mock-model"
-    svc.create_session = MagicMock()
-    svc.make_tool_result = MagicMock()
-    agent = Agent(
-        svc,
-        working_dir=tmp_path / "daemon-agent",
-        capabilities=["daemon"],
-        config=AgentConfig(),
-    )
-    return agent
-
-
 def test_emanate_cli_rejects_bad_backend_options(tmp_path):
     """A single invalid backend_options spec refuses the whole batch
     with a tool-level error mentioning the offending index."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     result = mgr.handle({
         "action": "emanate",
@@ -164,7 +154,7 @@ def test_emanate_cli_persists_resolved_options(tmp_path):
     """Successful CLI emanate writes backend_options + backend_argv into
     daemon.json so daemon(check) and the on-disk artifact can be
     reconstructed later."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     # Block the worker from actually invoking subprocess.Popen — we only
@@ -226,7 +216,7 @@ def test_emanate_cli_no_options_omits_fields(tmp_path):
     """When backend_options is absent, daemon.json should not carry the
     fields at all (avoids confusing readers into thinking an empty
     options object was passed)."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     captured: dict = {}
@@ -256,7 +246,7 @@ def test_emanate_cli_no_options_omits_fields(tmp_path):
 def test_lingtai_backend_ignores_backend_options(tmp_path):
     """The lingtai backend has no CLI process — backend_options must be
     silently ignored, never raised against the schema."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     # Force preset path off and mock create_session so the worker is a no-op.
@@ -289,7 +279,7 @@ def test_unknown_backend_falls_back_to_lingtai_path(tmp_path):
     Unknown backend strings are not CLI backends; they route to the in-process
     LingTai worker and therefore do not store a CLI ``backend`` field.
     """
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured: dict = {}
 
@@ -324,28 +314,17 @@ def test_unknown_backend_falls_back_to_lingtai_path(tmp_path):
 def test_claude_code_cmd_appends_backend_argv_before_task(tmp_path):
     """The Claude Code runner must put backend_argv after the required
     infrastructure flags and immediately before the task positional."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     captured_cmd: list[list[str]] = []
 
-    class FakeProc:
-        def __init__(self):
-            self.stdout = iter([])
-            self.stderr = iter([])
-            self.returncode = 0
-            self.pid = 0
-
-        def wait(self, timeout=None):
-            return 0
-
     def fake_popen(cmd, *args, **kwargs):
         captured_cmd.append(list(cmd))
-        return FakeProc()
+        return FiniteFakeProc()
 
-    from lingtai.core.daemon.run_dir import DaemonRunDir
-    run_dir = DaemonRunDir(
-        parent_working_dir=agent._working_dir,
+    run_dir = make_daemon_run_dir(
+        agent,
         handle="em-test",
         task="dummy task",
         tools=[],
@@ -358,9 +337,8 @@ def test_claude_code_cmd_appends_backend_argv_before_task(tmp_path):
         backend="claude-code",
     )
 
-    import threading as _t
-    cancel = _t.Event()
-    timeout = _t.Event()
+    cancel = threading.Event()
+    timeout = threading.Event()
 
     with patch("lingtai.core.daemon.subprocess.Popen", side_effect=fake_popen):
         mgr._run_claude_code_emanation(
@@ -390,28 +368,17 @@ def test_claude_code_cmd_appends_backend_argv_before_task(tmp_path):
 
 
 def test_codex_cmd_appends_backend_argv_before_task(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     captured_cmd: list[list[str]] = []
 
-    class FakeProc:
-        def __init__(self):
-            self.stdout = iter([])
-            self.stderr = iter([])
-            self.returncode = 0
-            self.pid = 0
-
-        def wait(self, timeout=None):
-            return 0
-
     def fake_popen(cmd, *args, **kwargs):
         captured_cmd.append(list(cmd))
-        return FakeProc()
+        return FiniteFakeProc()
 
-    from lingtai.core.daemon.run_dir import DaemonRunDir
-    run_dir = DaemonRunDir(
-        parent_working_dir=agent._working_dir,
+    run_dir = make_daemon_run_dir(
+        agent,
         handle="em-codex",
         task="dummy",
         tools=[],
@@ -424,9 +391,8 @@ def test_codex_cmd_appends_backend_argv_before_task(tmp_path):
         backend="codex",
     )
 
-    import threading as _t
-    cancel = _t.Event()
-    timeout = _t.Event()
+    cancel = threading.Event()
+    timeout = threading.Event()
 
     # Codex needs a `turn.completed` event to consider the run successful;
     # feed a minimal valid stream.
@@ -436,15 +402,11 @@ def test_codex_cmd_appends_backend_argv_before_task(tmp_path):
         '{"type":"turn.completed"}\n',
     ]
 
-    class StreamingFakeProc(FakeProc):
-        def __init__(self):
-            super().__init__()
-            self.stdout = iter(fake_stdout_lines)
-            self.stderr = iter([])
-
     with patch("lingtai.core.daemon.subprocess.Popen",
                side_effect=lambda cmd, *a, **kw: (captured_cmd.append(list(cmd))
-                                                  or StreamingFakeProc())):
+                                                  or FiniteFakeProc(
+                                                      stdout_lines=fake_stdout_lines,
+                                                  ))):
         mgr._run_codex_emanation(
             "em-codex", run_dir, "Find the breaking change.",
             cancel, timeout,
@@ -535,7 +497,7 @@ def test_schema_includes_mimocode_and_qwen_code_backends():
 
 
 def test_mimocode_alias_dispatches_to_canonical_backend(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured: dict = {}
 
@@ -563,7 +525,7 @@ def test_mimocode_alias_dispatches_to_canonical_backend(tmp_path):
 
 
 def test_cli_contexts_keep_per_task_argv_and_passive_mcp(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured: dict[str, dict] = {}
 
@@ -625,26 +587,12 @@ def test_cli_contexts_keep_per_task_argv_and_passive_mcp(tmp_path):
 
 
 def test_mimocode_cmd_appends_backend_argv_before_prompt(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured_cmd: list[list[str]] = []
 
-    class FakeProc:
-        def __init__(self):
-            self.stdout = iter([
-                '{"type":"session.created","sessionID":"sess-mimo"}\n',
-                '{"type":"message.completed","text":"done"}\n',
-            ])
-            self.stderr = iter([])
-            self.returncode = 0
-            self.pid = 0
-
-        def wait(self, timeout=None):
-            return 0
-
-    from lingtai.core.daemon.run_dir import DaemonRunDir
-    run_dir = DaemonRunDir(
-        parent_working_dir=agent._working_dir,
+    run_dir = make_daemon_run_dir(
+        agent,
         handle="em-mimo",
         task="dummy",
         tools=[],
@@ -656,14 +604,19 @@ def test_mimocode_cmd_appends_backend_argv_before_prompt(tmp_path):
         system_prompt="[stub]",
         backend="mimocode",
     )
+    stdout_lines = [
+        '{"type":"session.created","sessionID":"sess-mimo"}\n',
+        '{"type":"message.completed","text":"done"}\n',
+    ]
 
-    import threading as _t
     with patch("lingtai.core.daemon.subprocess.Popen",
                side_effect=lambda cmd, *a, **kw: (captured_cmd.append(list(cmd))
-                                                  or FakeProc())):
+                                                  or FiniteFakeProc(
+                                                      stdout_lines=stdout_lines,
+                                                  ))):
         mgr._run_mimocode_emanation(
             "em-mimo", run_dir, "Refactor with MiMo.",
-            _t.Event(), _t.Event(),
+            threading.Event(), threading.Event(),
             backend_argv=["--model", "mimo-auto", "--agent", "build"],
         )
 
@@ -675,23 +628,12 @@ def test_mimocode_cmd_appends_backend_argv_before_prompt(tmp_path):
 
 
 def test_qwen_code_cmd_appends_backend_argv_before_prompt(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured_cmd: list[list[str]] = []
 
-    class FakeProc:
-        def __init__(self):
-            self.stdout = iter(["qwen done\n"])
-            self.stderr = iter([])
-            self.returncode = 0
-            self.pid = 0
-
-        def wait(self, timeout=None):
-            return 0
-
-    from lingtai.core.daemon.run_dir import DaemonRunDir
-    run_dir = DaemonRunDir(
-        parent_working_dir=agent._working_dir,
+    run_dir = make_daemon_run_dir(
+        agent,
         handle="em-qwen",
         task="dummy",
         tools=[],
@@ -704,13 +646,14 @@ def test_qwen_code_cmd_appends_backend_argv_before_prompt(tmp_path):
         backend="qwen-code",
     )
 
-    import threading as _t
     with patch("lingtai.core.daemon.subprocess.Popen",
                side_effect=lambda cmd, *a, **kw: (captured_cmd.append(list(cmd))
-                                                  or FakeProc())):
+                                                  or FiniteFakeProc(
+                                                      stdout_lines=["qwen done\n"],
+                                                  ))):
         mgr._run_qwen_code_emanation(
             "em-qwen", run_dir, "Refactor with Qwen.",
-            _t.Event(), _t.Event(),
+            threading.Event(), threading.Event(),
             backend_argv=["--model", "qwen3-coder-plus"],
         )
 
@@ -723,7 +666,7 @@ def test_qwen_code_cmd_appends_backend_argv_before_prompt(tmp_path):
 
 
 def test_qwen_code_rejects_harness_owned_backend_options(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     result = mgr.handle({
@@ -739,7 +682,7 @@ def test_qwen_code_rejects_harness_owned_backend_options(tmp_path):
 
 
 def test_qwen_code_ask_is_explicitly_unsupported(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     def fake_run(em_id, run_dir, task, cancel_event, timeout_event, backend_argv=None):
@@ -781,7 +724,7 @@ def test_schema_includes_oh_my_pi_backend():
 
 @pytest.mark.parametrize("backend", ["omp", "oh-my-pi"])
 def test_oh_my_pi_alias_and_canonical_dispatch_to_backend(tmp_path, backend):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured: dict = {}
 
@@ -809,31 +752,21 @@ def test_oh_my_pi_alias_and_canonical_dispatch_to_backend(tmp_path, backend):
 
 
 def test_oh_my_pi_cmd_includes_mode_json_and_session_id_from_header(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured_cmd: list[list[str]] = []
 
-    class FakeProc:
-        def __init__(self):
-            # Oh-My-Pi JSON mode: a `type:session` header (bare top-level id)
-            # followed by agent events.
-            self.stdout = iter([
-                '{"type":"session","id":"omp-sess-1","cwd":"/tmp"}\n',
-                # Event ids that arrive after the session header must not
-                # overwrite the resumable session id.
-                '{"type":"session.updated","id":"not-the-session-id"}\n',
-                '{"type":"message.completed","text":"all done"}\n',
-            ])
-            self.stderr = iter([])
-            self.returncode = 0
-            self.pid = 0
-
-        def wait(self, timeout=None):
-            return 0
-
-    from lingtai.core.daemon.run_dir import DaemonRunDir
-    run_dir = DaemonRunDir(
-        parent_working_dir=agent._working_dir,
+    # Oh-My-Pi JSON mode: a `type:session` header (bare top-level id)
+    # followed by agent events.
+    stdout_lines = [
+        '{"type":"session","id":"omp-sess-1","cwd":"/tmp"}\n',
+        # Event ids that arrive after the session header must not overwrite
+        # the resumable session id.
+        '{"type":"session.updated","id":"not-the-session-id"}\n',
+        '{"type":"message.completed","text":"all done"}\n',
+    ]
+    run_dir = make_daemon_run_dir(
+        agent,
         handle="em-omp",
         task="dummy",
         tools=[],
@@ -846,13 +779,14 @@ def test_oh_my_pi_cmd_includes_mode_json_and_session_id_from_header(tmp_path):
         backend="oh-my-pi",
     )
 
-    import threading as _t
     with patch("lingtai.core.daemon.subprocess.Popen",
                side_effect=lambda cmd, *a, **kw: (captured_cmd.append(list(cmd))
-                                                  or FakeProc())):
+                                                  or FiniteFakeProc(
+                                                      stdout_lines=stdout_lines,
+                                                  ))):
         mgr._run_oh_my_pi_emanation(
             "em-omp", run_dir, "Refactor with Oh-My-Pi.",
-            _t.Event(), _t.Event(),
+            threading.Event(), threading.Event(),
             backend_argv=["--provider", "anthropic", "--model", "claude-x"],
         )
 
@@ -867,23 +801,12 @@ def test_oh_my_pi_cmd_includes_mode_json_and_session_id_from_header(tmp_path):
 
 
 def test_oh_my_pi_ask_resume_uses_session_flag(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured_cmd: list[list[str]] = []
 
-    class FakeProc:
-        def __init__(self):
-            self.stdout = iter(['{"type":"message.completed","text":"resumed"}\n'])
-            self.stderr = iter([])
-            self.returncode = 0
-            self.pid = 0
-
-        def wait(self, timeout=None):
-            return 0
-
-    from lingtai.core.daemon.run_dir import DaemonRunDir
-    run_dir = DaemonRunDir(
-        parent_working_dir=agent._working_dir,
+    run_dir = make_daemon_run_dir(
+        agent,
         handle="em-omp-ask",
         task="dummy",
         tools=[],
@@ -898,29 +821,24 @@ def test_oh_my_pi_ask_resume_uses_session_flag(tmp_path):
     run_dir._state["oh_my_pi_session_id"] = "omp-sess-9"
     run_dir._atomic_write_json(run_dir.daemon_json_path, run_dir._state)
 
-    import threading as _t
-    from concurrent.futures import Future
-    done = Future()
-    done.set_result("[fake done]")
-    entry = {
-        "run_dir": run_dir,
-        "task": "x",
-        "start_time": 0,
-        "cancel_event": _t.Event(),
-        "timeout_event": _t.Event(),
-        "followup_buffer": "",
-        "backend": "oh-my-pi",
-        "future": done,
-        "followup_lock": _t.Lock(),
-        "ask_in_flight": False,
-        "ask_future": None,
-    }
     em_id = "em-omp-ask"
-    mgr._emanations[em_id] = entry
+    entry = register_daemon_entry(
+        mgr,
+        em_id,
+        run_dir,
+        future=completed_future("[fake done]"),
+        task="x",
+        backend="oh-my-pi",
+        ask_in_flight=False,
+    )
 
     with patch("lingtai.core.daemon.subprocess.Popen",
                side_effect=lambda cmd, *a, **kw: (captured_cmd.append(list(cmd))
-                                                  or FakeProc())):
+                                                  or FiniteFakeProc(
+                                                      stdout_lines=[
+                                                          '{"type":"message.completed","text":"resumed"}\n',
+                                                      ],
+                                                  ))):
         resp = mgr.handle({"action": "ask", "id": em_id, "message": "keep going"})
         # ask is async; wait for the ask worker to finish before asserting.
         fut = entry.get("ask_future")
@@ -936,15 +854,11 @@ def test_oh_my_pi_ask_resume_uses_session_flag(tmp_path):
 
 
 def test_oh_my_pi_ask_before_session_id_returns_initializing_error(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
-    from concurrent.futures import Future
-    import threading as _t
-    from lingtai.core.daemon.run_dir import DaemonRunDir
-
-    run_dir = DaemonRunDir(
-        parent_working_dir=agent._working_dir,
+    run_dir = make_daemon_run_dir(
+        agent,
         handle="em-omp-no-session",
         task="dummy",
         tools=[],
@@ -956,22 +870,16 @@ def test_oh_my_pi_ask_before_session_id_returns_initializing_error(tmp_path):
         system_prompt="[stub]",
         backend="oh-my-pi",
     )
-    done = Future()
-    done.set_result("[fake done]")
     em_id = "em-omp-no-session"
-    mgr._emanations[em_id] = {
-        "run_dir": run_dir,
-        "task": "x",
-        "start_time": 0,
-        "cancel_event": _t.Event(),
-        "timeout_event": _t.Event(),
-        "followup_buffer": "",
-        "backend": "oh-my-pi",
-        "future": done,
-        "followup_lock": _t.Lock(),
-        "ask_in_flight": False,
-        "ask_future": None,
-    }
+    register_daemon_entry(
+        mgr,
+        em_id,
+        run_dir,
+        future=completed_future("[fake done]"),
+        task="x",
+        backend="oh-my-pi",
+        ask_in_flight=False,
+    )
 
     resp = mgr.handle({"action": "ask", "id": em_id, "message": "continue"})
 
@@ -981,7 +889,7 @@ def test_oh_my_pi_ask_before_session_id_returns_initializing_error(tmp_path):
 
 
 def test_oh_my_pi_rejects_harness_owned_backend_options(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     for flag, key, value in (

--- a/tests/test_daemon_check.py
+++ b/tests/test_daemon_check.py
@@ -1,56 +1,15 @@
 """Tests for daemon(action='check') — read-only event-tail surface."""
-import threading
-from unittest.mock import MagicMock
 
-from lingtai_kernel.config import AgentConfig
-
-
-def _make_agent(tmp_path, capabilities=None):
-    from lingtai.agent import Agent
-    svc = MagicMock()
-    svc.provider = "mock"
-    svc.model = "mock-model"
-    svc.create_session = MagicMock()
-    svc.make_tool_result = MagicMock()
-    return Agent(
-        svc,
-        working_dir=tmp_path / "daemon-agent",
-        capabilities=capabilities or ["daemon"],
-        config=AgentConfig(),
-    )
-
-
-def _make_run_dir(agent, em_id="em-test"):
-    from lingtai.core.daemon.run_dir import DaemonRunDir
-    return DaemonRunDir(
-        parent_working_dir=agent._working_dir,
-        handle=em_id,
-        task="test task",
-        tools=["file"],
-        model="mock-model",
-        max_turns=30,
-        timeout_s=300.0,
-        parent_addr=agent._working_dir.name,
-        parent_pid=12345,
-        system_prompt="You are a daemon.",
-    )
-
-
-def _register(mgr, em_id, run_dir, future=None):
-    mgr._emanations[em_id] = {
-        "future": future or MagicMock(done=MagicMock(return_value=False)),
-        "task": "test task",
-        "start_time": 0.0,
-        "cancel_event": threading.Event(),
-        "timeout_event": threading.Event(),
-        "followup_buffer": "",
-        "followup_lock": threading.Lock(),
-        "run_dir": run_dir,
-    }
+from tests._daemon_helpers import (
+    completed_future,
+    make_daemon_agent,
+    make_daemon_run_dir,
+    register_daemon_entry,
+)
 
 
 def test_check_unknown_id_returns_error(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     out = mgr.handle({"action": "check", "id": "em-999"})
     assert out["status"] == "error"
@@ -58,10 +17,10 @@ def test_check_unknown_id_returns_error(tmp_path):
 
 
 def test_check_running_emanation_returns_state_and_events(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
-    rd = _make_run_dir(agent, "em-1")
-    _register(mgr, "em-1", rd)
+    rd = make_daemon_run_dir(agent, handle="em-1")
+    register_daemon_entry(mgr, "em-1", rd)
 
     # Constructor already wrote daemon_start event. Add a couple more.
     rd.set_current_tool("read", {"file_path": "/tmp/x"})
@@ -81,10 +40,10 @@ def test_check_running_emanation_returns_state_and_events(tmp_path):
 
 
 def test_check_respects_last_parameter(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
-    rd = _make_run_dir(agent, "em-2")
-    _register(mgr, "em-2", rd)
+    rd = make_daemon_run_dir(agent, handle="em-2")
+    register_daemon_entry(mgr, "em-2", rd)
 
     # Generate ~10 events
     for i in range(5):
@@ -100,10 +59,10 @@ def test_check_respects_last_parameter(tmp_path):
 
 
 def test_check_truncate_limits_string_fields(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
-    rd = _make_run_dir(agent, "em-3")
-    _register(mgr, "em-3", rd)
+    rd = make_daemon_run_dir(agent, handle="em-3")
+    register_daemon_entry(mgr, "em-3", rd)
 
     # Inject an event with a very long args_preview
     rd.set_current_tool("bash", {"cmd": "x" * 2000})
@@ -119,10 +78,10 @@ def test_check_truncate_limits_string_fields(tmp_path):
 
 
 def test_check_truncate_zero_disables(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
-    rd = _make_run_dir(agent, "em-4")
-    _register(mgr, "em-4", rd)
+    rd = make_daemon_run_dir(agent, handle="em-4")
+    register_daemon_entry(mgr, "em-4", rd)
     rd.set_current_tool("bash", {"cmd": "x" * 100})
 
     out = mgr.handle({"action": "check", "id": "em-4", "truncate": 0})
@@ -137,10 +96,12 @@ def test_check_truncate_zero_disables(tmp_path):
 
 
 def test_check_includes_terminal_event_for_done_emanation(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
-    rd = _make_run_dir(agent, "em-5")
-    _register(mgr, "em-5", rd, future=MagicMock(done=MagicMock(return_value=True)))
+    rd = make_daemon_run_dir(agent, handle="em-5")
+    register_daemon_entry(
+        mgr, "em-5", rd, future=completed_future("[fake done]"),
+    )
 
     rd.mark_done("final report text")
 
@@ -158,12 +119,12 @@ def test_check_includes_terminal_event_for_done_emanation(tmp_path):
 
 
 def test_check_includes_cli_progress_fields(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
-    rd = _make_run_dir(agent, "em-cli")
+    rd = make_daemon_run_dir(agent, handle="em-cli")
     rd._state["backend"] = "codex"
     rd._atomic_write_json(rd.daemon_json_path, rd._state)
-    _register(mgr, "em-cli", rd)
+    register_daemon_entry(mgr, "em-cli", rd)
 
     rd.record_cli_output("phase 1 complete", stream="combined")
 
@@ -177,10 +138,12 @@ def test_check_includes_cli_progress_fields(tmp_path):
 
 
 def test_check_includes_failure_error(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
-    rd = _make_run_dir(agent, "em-fail")
-    _register(mgr, "em-fail", rd, future=MagicMock(done=MagicMock(return_value=True)))
+    rd = make_daemon_run_dir(agent, handle="em-fail")
+    register_daemon_entry(
+        mgr, "em-fail", rd, future=completed_future("[fake done]"),
+    )
 
     rd.mark_failed(RuntimeError("boom"))
 
@@ -191,10 +154,10 @@ def test_check_includes_failure_error(tmp_path):
     assert out["finished_at"] is not None
 
 def test_check_default_last_is_20(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
-    rd = _make_run_dir(agent, "em-6")
-    _register(mgr, "em-6", rd)
+    rd = make_daemon_run_dir(agent, handle="em-6")
+    register_daemon_entry(mgr, "em-6", rd)
 
     # Generate 30 events (15 tool_call + tool_result pairs)
     for i in range(15):
@@ -209,7 +172,7 @@ def test_check_default_last_is_20(tmp_path):
 
 def test_check_rejects_non_numeric_last(tmp_path):
     """Non-numeric `last` must return a clean error, not raise."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     out = mgr.handle({"action": "check", "id": "em-x", "last": "twenty"})
     assert out["status"] == "error"
@@ -217,7 +180,7 @@ def test_check_rejects_non_numeric_last(tmp_path):
 
 
 def test_check_rejects_non_numeric_truncate(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     out = mgr.handle({"action": "check", "id": "em-x", "truncate": "tons"})
     assert out["status"] == "error"
@@ -225,7 +188,7 @@ def test_check_rejects_non_numeric_truncate(tmp_path):
 
 
 def test_check_rejects_zero_or_negative_last(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     out = mgr.handle({"action": "check", "id": "em-x", "last": 0})
     assert out["status"] == "error"
@@ -235,7 +198,7 @@ def test_check_rejects_zero_or_negative_last(tmp_path):
 
 
 def test_check_rejects_negative_truncate(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     out = mgr.handle({"action": "check", "id": "em-x", "truncate": -10})
     assert out["status"] == "error"
@@ -246,10 +209,10 @@ def test_check_caps_last_at_max(tmp_path):
     """last is capped at _CHECK_LAST_MAX so events.jsonl can't be slurped
     unboundedly (readlines() would otherwise read the whole file)."""
     from lingtai.core.daemon import DaemonManager
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
-    rd = _make_run_dir(agent, "em-cap")
-    _register(mgr, "em-cap", rd)
+    rd = make_daemon_run_dir(agent, handle="em-cap")
+    register_daemon_entry(mgr, "em-cap", rd)
 
     # Asking for a huge value still works but only returns up to the cap.
     out = mgr.handle({"action": "check", "id": "em-cap", "last": 10**9})

--- a/tests/test_daemon_claude_interactive_backend.py
+++ b/tests/test_daemon_claude_interactive_backend.py
@@ -7,35 +7,18 @@ import subprocess
 from pathlib import Path
 import textwrap
 import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-from lingtai.agent import Agent
 from lingtai.core.daemon import get_schema
 from lingtai.core.daemon.claude_interactive import ClaudeInteractiveError, run_claude_interactive
-from lingtai.core.daemon.run_dir import DaemonRunDir
-from lingtai_kernel.config import AgentConfig
+from tests._daemon_helpers import make_daemon_agent, make_daemon_run_dir
 
 
-def _make_agent(tmp_path: Path) -> Agent:
-    svc = MagicMock()
-    svc.provider = "mock"
-    svc.model = "mock-model"
-    svc.create_session = MagicMock()
-    svc.make_tool_result = MagicMock()
-    return Agent(
-        svc,
-        working_dir=tmp_path / "daemon-agent",
-        capabilities=["daemon"],
-        config=AgentConfig(),
-    )
-
-
-def _make_run_dir(tmp_path: Path, *, backend: str = "claude") -> DaemonRunDir:
+def _make_run_dir(tmp_path: Path, *, backend: str = "claude"):
     parent = tmp_path / "daemon-agent"
-    parent.mkdir(parents=True, exist_ok=True)
-    return DaemonRunDir(
+    return make_daemon_run_dir(
         parent_working_dir=parent,
         handle="em-1",
         task="interactive task",
@@ -162,7 +145,7 @@ def test_schema_hides_interactive_claude_backends_keeps_print_mode():
 
 
 def test_emanate_claude_dispatches_interactive_runner(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured = {}
 
@@ -197,7 +180,7 @@ def test_emanate_claude_dispatches_interactive_runner(tmp_path):
 
 
 def test_emanate_claude_p_dispatches_legacy_print_runner(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured = {}
 
@@ -232,7 +215,7 @@ def test_emanate_claude_p_dispatches_legacy_print_runner(tmp_path):
 def test_claude_backend_ids_are_preserved_while_sharing_runners(
     tmp_path, backend, expected_runner,
 ):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured = {}
 
@@ -272,7 +255,7 @@ def test_claude_backend_ids_are_preserved_while_sharing_runners(
 
 
 def test_claude_reserved_backend_options_are_rejected(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     result = mgr.handle({
@@ -291,7 +274,7 @@ def test_claude_reserved_backend_options_are_rejected(tmp_path):
 
 
 def test_claude_interactive_system_prompt_backend_option_is_rejected(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     result = mgr.handle({

--- a/tests/test_daemon_cursor_backend.py
+++ b/tests/test_daemon_cursor_backend.py
@@ -11,12 +11,16 @@ from __future__ import annotations
 
 import json
 import threading
-from concurrent.futures import Future
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from lingtai_kernel.config import AgentConfig
 from lingtai.core.daemon import DaemonManager
-from lingtai.core.daemon.run_dir import DaemonRunDir
+from tests._daemon_helpers import (
+    FiniteFakeProc,
+    completed_future,
+    make_daemon_agent,
+    make_daemon_run_dir,
+    register_daemon_entry,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -24,25 +28,9 @@ from lingtai.core.daemon.run_dir import DaemonRunDir
 # ---------------------------------------------------------------------------
 
 
-def _make_agent(tmp_path):
-    from lingtai.agent import Agent
-
-    svc = MagicMock()
-    svc.provider = "mock"
-    svc.model = "mock-model"
-    svc.create_session = MagicMock()
-    svc.make_tool_result = MagicMock()
-    return Agent(
-        svc,
-        working_dir=tmp_path / "daemon-agent",
-        capabilities=["daemon"],
-        config=AgentConfig(),
-    )
-
-
 def _make_run_dir(agent, *, handle="em-cursor"):
-    return DaemonRunDir(
-        parent_working_dir=agent._working_dir,
+    return make_daemon_run_dir(
+        agent,
         handle=handle,
         task="dummy task",
         tools=[],
@@ -54,17 +42,6 @@ def _make_run_dir(agent, *, handle="em-cursor"):
         system_prompt="[stub]",
         backend="cursor",
     )
-
-
-class _FakeProc:
-    def __init__(self, stdout_lines=(), stderr_lines=(), returncode=0):
-        self.stdout = iter(list(stdout_lines))
-        self.stderr = iter(list(stderr_lines))
-        self.returncode = returncode
-        self.pid = 0
-
-    def wait(self, timeout=None):
-        return self.returncode
 
 
 # ---------------------------------------------------------------------------
@@ -113,13 +90,13 @@ def test_cursor_documented_result_event_extracts_session_and_text():
 
 
 def test_cursor_emanate_cmd_uses_agent_print_stream_json(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured: list[list[str]] = []
 
     def fake_popen(cmd, *args, **kwargs):
         captured.append(list(cmd))
-        return _FakeProc()
+        return FiniteFakeProc()
 
     run_dir = _make_run_dir(agent, handle="em-cur-cmd")
     cancel = threading.Event()
@@ -139,13 +116,13 @@ def test_cursor_emanate_cmd_uses_agent_print_stream_json(tmp_path):
 
 
 def test_cursor_emanate_appends_backend_argv_before_prompt(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured: list[list[str]] = []
 
     def fake_popen(cmd, *args, **kwargs):
         captured.append(list(cmd))
-        return _FakeProc()
+        return FiniteFakeProc()
 
     run_dir = _make_run_dir(agent, handle="em-cur-opts")
     cancel = threading.Event()
@@ -166,7 +143,7 @@ def test_cursor_emanate_appends_backend_argv_before_prompt(tmp_path):
 
 
 def test_cursor_emanate_persists_session_id_and_final_result(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     stdout_lines = [
@@ -176,7 +153,7 @@ def test_cursor_emanate_persists_session_id_and_final_result(tmp_path):
     ]
 
     def fake_popen(cmd, *args, **kwargs):
-        return _FakeProc(stdout_lines=stdout_lines)
+        return FiniteFakeProc(stdout_lines=stdout_lines)
 
     run_dir = _make_run_dir(agent, handle="em-cur-sid")
     cancel = threading.Event()
@@ -194,7 +171,7 @@ def test_cursor_emanate_persists_session_id_and_final_result(tmp_path):
 
 
 def test_cursor_emanate_marks_error_result_failed(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     stdout_lines = [
@@ -202,7 +179,7 @@ def test_cursor_emanate_marks_error_result_failed(tmp_path):
     ]
 
     def fake_popen(cmd, *args, **kwargs):
-        return _FakeProc(stdout_lines=stdout_lines)
+        return FiniteFakeProc(stdout_lines=stdout_lines)
 
     run_dir = _make_run_dir(agent, handle="em-cur-error")
     cancel = threading.Event()
@@ -225,7 +202,7 @@ def test_cursor_emanate_marks_error_result_failed(tmp_path):
 
 
 def test_emanate_cursor_routes_to_cli_handler(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured: dict = {}
 
@@ -264,29 +241,23 @@ def test_emanate_cursor_routes_to_cli_handler(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _register_cursor_entry(mgr, agent, run_dir, em_id="em-cur-resume"):
-    fut = Future()
-    fut.set_result("[fake done]")
-    mgr._emanations[em_id] = {
-        "future": fut,
-        "task": "x",
-        "start_time": 0,
-        "cancel_event": threading.Event(),
-        "timeout_event": threading.Event(),
-        "followup_buffer": "",
-        "followup_lock": threading.Lock(),
-        "run_dir": run_dir,
-        "backend": "cursor",
-        "ask_in_flight": False,
-        "ask_future": None,
-    }
+def _register_cursor_entry(mgr, run_dir, em_id="em-cur-resume"):
+    return register_daemon_entry(
+        mgr,
+        em_id,
+        run_dir,
+        future=completed_future("[fake done]"),
+        task="x",
+        backend="cursor",
+        ask_in_flight=False,
+    )
 
 
 def test_ask_cursor_errors_when_no_session_id(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     run_dir = _make_run_dir(agent, handle="em-cur-noresume")
-    _register_cursor_entry(mgr, agent, run_dir, em_id="em-cur-noresume")
+    _register_cursor_entry(mgr, run_dir, em_id="em-cur-noresume")
 
     result = mgr.handle({
         "action": "ask",
@@ -300,20 +271,20 @@ def test_ask_cursor_errors_when_no_session_id(tmp_path):
 
 
 def test_ask_cursor_resumes_with_captured_session_id(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     captured_cmd: list[list[str]] = []
 
     def fake_popen(cmd, *args, **kwargs):
         captured_cmd.append(list(cmd))
-        return _FakeProc(stdout_lines=[
+        return FiniteFakeProc(stdout_lines=[
             '{"type":"result","subtype":"success","result":"follow-up done"}\n',
         ])
 
     run_dir = _make_run_dir(agent, handle="em-cur-resume")
     run_dir._state["cursor_session_id"] = "cursor-resumable-123"
     run_dir._atomic_write_json(run_dir.daemon_json_path, run_dir._state)
-    _register_cursor_entry(mgr, agent, run_dir, em_id="em-cur-resume")
+    _register_cursor_entry(mgr, run_dir, em_id="em-cur-resume")
 
     with patch("lingtai.core.daemon.subprocess.Popen", side_effect=fake_popen):
         result = mgr.handle({
@@ -339,18 +310,18 @@ def test_ask_cursor_resumes_with_captured_session_id(tmp_path):
 
 
 def test_ask_cursor_error_result_publishes_failure(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     def fake_popen(cmd, *args, **kwargs):
-        return _FakeProc(stdout_lines=[
+        return FiniteFakeProc(stdout_lines=[
             '{"type":"result","subtype":"error","is_error":true,"result":"resume failed"}\n',
         ])
 
     run_dir = _make_run_dir(agent, handle="em-cur-resume-error")
     run_dir._state["cursor_session_id"] = "cursor-resumable-error"
     run_dir._atomic_write_json(run_dir.daemon_json_path, run_dir._state)
-    _register_cursor_entry(mgr, agent, run_dir, em_id="em-cur-resume-error")
+    _register_cursor_entry(mgr, run_dir, em_id="em-cur-resume-error")
 
     with patch("lingtai.core.daemon.subprocess.Popen", side_effect=fake_popen):
         result = mgr.handle({
@@ -370,12 +341,12 @@ def test_ask_cursor_error_result_publishes_failure(tmp_path):
 
 
 def test_ask_cursor_concurrent_returns_busy(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
     run_dir = _make_run_dir(agent, handle="em-cur-busy")
     run_dir._state["cursor_session_id"] = "cursor-busy-1"
     run_dir._atomic_write_json(run_dir.daemon_json_path, run_dir._state)
-    _register_cursor_entry(mgr, agent, run_dir, em_id="em-cur-busy")
+    _register_cursor_entry(mgr, run_dir, em_id="em-cur-busy")
     mgr._emanations["em-cur-busy"]["ask_in_flight"] = True
 
     result = mgr._handle_ask("em-cur-busy", "second concurrent ask")

--- a/tests/test_daemon_opencode_backend.py
+++ b/tests/test_daemon_opencode_backend.py
@@ -22,13 +22,18 @@ from __future__ import annotations
 
 import json
 import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-from lingtai_kernel.config import AgentConfig
 from lingtai.core.daemon import DaemonManager
-from lingtai.core.daemon.run_dir import DaemonRunDir
+from tests._daemon_helpers import (
+    FiniteFakeProc,
+    completed_future,
+    make_daemon_agent,
+    make_daemon_run_dir,
+    register_daemon_entry,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -36,26 +41,9 @@ from lingtai.core.daemon.run_dir import DaemonRunDir
 # ---------------------------------------------------------------------------
 
 
-def _make_agent(tmp_path):
-    """Minimal Agent with daemon capability and a mock LLM service."""
-    from lingtai.agent import Agent
-
-    svc = MagicMock()
-    svc.provider = "mock"
-    svc.model = "mock-model"
-    svc.create_session = MagicMock()
-    svc.make_tool_result = MagicMock()
-    return Agent(
-        svc,
-        working_dir=tmp_path / "daemon-agent",
-        capabilities=["daemon"],
-        config=AgentConfig(),
-    )
-
-
 def _make_run_dir(agent, *, handle="em-test"):
-    return DaemonRunDir(
-        parent_working_dir=agent._working_dir,
+    return make_daemon_run_dir(
+        agent,
         handle=handle,
         task="dummy task",
         tools=[],
@@ -67,19 +55,6 @@ def _make_run_dir(agent, *, handle="em-test"):
         system_prompt="[stub]",
         backend="opencode",
     )
-
-
-class _FakeProc:
-    """Minimal subprocess.Popen stand-in for opencode."""
-
-    def __init__(self, stdout_lines=(), stderr_lines=(), returncode=0):
-        self.stdout = iter(list(stdout_lines))
-        self.stderr = iter(list(stderr_lines))
-        self.returncode = returncode
-        self.pid = 0
-
-    def wait(self, timeout=None):
-        return self.returncode
 
 
 # ---------------------------------------------------------------------------
@@ -157,14 +132,14 @@ def test_text_extraction_returns_empty_for_purely_structural_events():
 
 
 def test_opencode_emanate_cmd_includes_run_and_format_json(tmp_path):
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     captured: list[list[str]] = []
 
     def fake_popen(cmd, *args, **kwargs):
         captured.append(list(cmd))
-        return _FakeProc()
+        return FiniteFakeProc()
 
     run_dir = _make_run_dir(agent, handle="em-oc")
     cancel = threading.Event()
@@ -193,14 +168,14 @@ def test_opencode_emanate_cmd_includes_run_and_format_json(tmp_path):
 
 def test_opencode_emanate_appends_backend_argv_before_prompt(tmp_path):
     """backend_options tokens must sit between --format json and the prompt."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     captured: list[list[str]] = []
 
     def fake_popen(cmd, *args, **kwargs):
         captured.append(list(cmd))
-        return _FakeProc()
+        return FiniteFakeProc()
 
     run_dir = _make_run_dir(agent, handle="em-oc-opts")
     cancel = threading.Event()
@@ -230,7 +205,7 @@ def test_opencode_emanate_persists_session_id_from_first_event(tmp_path):
     """The first JSON event carrying a session-id-shaped field is stored
     in daemon.json so daemon(ask) can resume from the moment the
     emanation returns."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     stdout_lines = [
@@ -241,7 +216,7 @@ def test_opencode_emanate_persists_session_id_from_first_event(tmp_path):
     ]
 
     def fake_popen(cmd, *args, **kwargs):
-        return _FakeProc(stdout_lines=stdout_lines)
+        return FiniteFakeProc(stdout_lines=stdout_lines)
 
     run_dir = _make_run_dir(agent, handle="em-oc-sid")
     cancel = threading.Event()
@@ -264,7 +239,7 @@ def test_opencode_emanate_handles_non_json_lines_gracefully(tmp_path):
     """Banners / progress lines that aren't JSON should be recorded as
     cli_output, not crash the parser. The terminal text from a later
     JSON event still wins."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     stdout_lines = [
@@ -275,7 +250,7 @@ def test_opencode_emanate_handles_non_json_lines_gracefully(tmp_path):
     ]
 
     def fake_popen(cmd, *args, **kwargs):
-        return _FakeProc(stdout_lines=stdout_lines)
+        return FiniteFakeProc(stdout_lines=stdout_lines)
 
     run_dir = _make_run_dir(agent, handle="em-oc-mixed")
     cancel = threading.Event()
@@ -296,11 +271,11 @@ def test_opencode_emanate_uses_no_output_sentinel_when_silent(tmp_path):
     """A process that exits 0 with no JSON events and no stderr is
     surfaced as the explicit [no output] sentinel — not as an empty
     string that the agent has to interpret."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     def fake_popen(cmd, *args, **kwargs):
-        return _FakeProc(stdout_lines=[], stderr_lines=[], returncode=0)
+        return FiniteFakeProc(stdout_lines=[], stderr_lines=[], returncode=0)
 
     run_dir = _make_run_dir(agent, handle="em-oc-silent")
     cancel = threading.Event()
@@ -318,14 +293,14 @@ def test_opencode_emanate_uses_no_output_sentinel_when_silent(tmp_path):
 def test_opencode_emanate_raises_when_returncode_nonzero(tmp_path):
     """Non-zero exit → mark_failed + raise, with the stderr tail in the
     error message so the parent can see what went wrong."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     stdout_lines = ['{"type":"text","text":"partial"}\n']
     stderr_lines = ['auth: invalid token\n', 'exit 1\n']
 
     def fake_popen(cmd, *args, **kwargs):
-        return _FakeProc(
+        return FiniteFakeProc(
             stdout_lines=stdout_lines, stderr_lines=stderr_lines, returncode=1,
         )
 
@@ -343,7 +318,7 @@ def test_opencode_emanate_raises_when_returncode_nonzero(tmp_path):
 
 def test_opencode_emanate_missing_cli_raises_runtime_error(tmp_path):
     """FileNotFoundError → mark_failed + RuntimeError naming opencode."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     def fake_popen(cmd, *args, **kwargs):
@@ -370,7 +345,7 @@ def test_emanate_opencode_routes_to_cli_handler(tmp_path):
     """`emanate` with backend='opencode' must go through
     `_handle_emanate_cli` (which skips preset resolution) and ultimately
     submit `_run_opencode_emanation` to the pool."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     captured: dict = {}
@@ -414,28 +389,21 @@ def test_emanate_opencode_routes_to_cli_handler(tmp_path):
 def test_ask_opencode_errors_when_no_session_id(tmp_path):
     """ask before the emanation captured a session id → clear error
     pointing the agent at the (still-initializing) state, not a hang."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     # Register a fake opencode emanation entry with a run_dir but no
     # opencode_session_id yet.
-    from concurrent.futures import Future
     run_dir = _make_run_dir(agent, handle="em-oc-noresume")
-    fut = Future()
-    fut.set_result("[fake done]")
-    mgr._emanations["em-oc-noresume"] = {
-        "future": fut,
-        "task": "x",
-        "start_time": 0,
-        "cancel_event": threading.Event(),
-        "timeout_event": threading.Event(),
-        "followup_buffer": "",
-        "followup_lock": threading.Lock(),
-        "run_dir": run_dir,
-        "backend": "opencode",
-        "ask_in_flight": False,
-        "ask_future": None,
-    }
+    register_daemon_entry(
+        mgr,
+        "em-oc-noresume",
+        run_dir,
+        future=completed_future("[fake done]"),
+        task="x",
+        backend="opencode",
+        ask_in_flight=False,
+    )
 
     result = mgr.handle({
         "action": "ask",
@@ -451,7 +419,7 @@ def test_ask_opencode_resumes_with_captured_session_id(tmp_path):
     """When opencode_session_id is present, ask spawns
     `opencode run --session <id> --format json <message>` and returns
     {"status":"sent","async":true} synchronously."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
     captured_cmd: list[list[str]] = []
@@ -460,29 +428,22 @@ def test_ask_opencode_resumes_with_captured_session_id(tmp_path):
         captured_cmd.append(list(cmd))
         # Return an empty-stream proc — the ask worker will see EOF and
         # complete cleanly via the deadline branch.
-        return _FakeProc()
+        return FiniteFakeProc()
 
-    from concurrent.futures import Future
     run_dir = _make_run_dir(agent, handle="em-oc-resume")
     # Pre-seed the session id as if a prior emanation captured it.
     run_dir._state["opencode_session_id"] = "oc-resumable-123"
     run_dir._atomic_write_json(run_dir.daemon_json_path, run_dir._state)
 
-    fut = Future()
-    fut.set_result("[fake done]")
-    mgr._emanations["em-oc-resume"] = {
-        "future": fut,
-        "task": "x",
-        "start_time": 0,
-        "cancel_event": threading.Event(),
-        "timeout_event": threading.Event(),
-        "followup_buffer": "",
-        "followup_lock": threading.Lock(),
-        "run_dir": run_dir,
-        "backend": "opencode",
-        "ask_in_flight": False,
-        "ask_future": None,
-    }
+    register_daemon_entry(
+        mgr,
+        "em-oc-resume",
+        run_dir,
+        future=completed_future("[fake done]"),
+        task="x",
+        backend="opencode",
+        ask_in_flight=False,
+    )
 
     with patch("lingtai.core.daemon.subprocess.Popen", side_effect=fake_popen):
         result = mgr.handle({
@@ -520,29 +481,22 @@ def test_ask_opencode_concurrent_returns_busy(tmp_path):
     still streaming must return ``status='busy'`` (the resumed CLI
     serializes per session and a second spawn would interleave or
     error)."""
-    agent = _make_agent(tmp_path)
+    agent = make_daemon_agent(tmp_path)
     mgr = agent.get_capability("daemon")
 
-    from concurrent.futures import Future
     run_dir = _make_run_dir(agent, handle="em-oc-busy")
     run_dir._state["opencode_session_id"] = "oc-busy-1"
     run_dir._atomic_write_json(run_dir.daemon_json_path, run_dir._state)
 
-    fut = Future()
-    fut.set_result("[fake done]")
-    mgr._emanations["em-oc-busy"] = {
-        "future": fut,
-        "task": "x",
-        "start_time": 0,
-        "cancel_event": threading.Event(),
-        "timeout_event": threading.Event(),
-        "followup_buffer": "",
-        "followup_lock": threading.Lock(),
-        "run_dir": run_dir,
-        "backend": "opencode",
-        "ask_in_flight": True,  # pretend an ask is already in flight
-        "ask_future": None,
-    }
+    register_daemon_entry(
+        mgr,
+        "em-oc-busy",
+        run_dir,
+        future=completed_future("[fake done]"),
+        task="x",
+        backend="opencode",
+        ask_in_flight=True,  # pretend an ask is already in flight
+    )
 
     result = mgr._handle_ask("em-oc-busy", "second concurrent ask")
     assert result["status"] == "busy"


### PR DESCRIPTION
## Summary
- Add `tests/_daemon_helpers.py` with shared daemon-test setup helpers for lightweight agents, run directories, finite fake processes, completed futures, and manager entries.
- Migrate repeated setup in daemon check/backend tests to those helpers.
- Keep the change test-only: no production daemon runtime behavior is touched.

## Why
The daemon backend/check tests repeated the same local setup patterns across several files. That made backend tests noisy and increased the risk that future tests would subtly diverge in fake process, run-directory, or manager-entry setup. This PR extracts only the shared test scaffolding that was already repeated and leaves the production daemon code unchanged.

## Non-goals
- No production `src/` changes.
- No broad pytest fixture framework.
- No stderr-drainer or daemon ask/runtime behavior cleanup.

## Validation
Ran in a local no-deps editable test environment because full dependency resolution on this macOS/x86_64 host is blocked by the known `onnxruntime` wheel availability issue.

- `python -m pytest tests/test_daemon_check.py tests/test_daemon_opencode_backend.py tests/test_daemon_cursor_backend.py tests/test_daemon_claude_interactive_backend.py tests/test_daemon_backend_options.py` → 115 passed
- `python -m pytest tests/test_daemon*.py` → 372 passed
- `git diff --check canonical/main...HEAD` → passed
