### PR TITLE
Extract file tool workdir path helper

### DIFF
--- a/src/lingtai/core/_file_paths.py
+++ b/src/lingtai/core/_file_paths.py
@@ -1,0 +1,19 @@
+"""Shared path helpers for built-in file tool wrappers."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lingtai_kernel.base_agent import BaseAgent
+
+
+def resolve_workdir_path(agent: "BaseAgent", path: str | Path) -> str | Path:
+    """Resolve relative tool paths against the agent workdir.
+
+    Absolute paths pass through unchanged to preserve the file tools' historical
+    string/path behavior and error messages.
+    """
+    if not Path(path).is_absolute():
+        return str(agent._working_dir / path)
+    return path

--- a/src/lingtai/core/edit/__init__.py
+++ b/src/lingtai/core/edit/__init__.py
@@ -4,10 +4,10 @@ Usage: Agent(capabilities=["edit"]) or capabilities=["file"]
 """
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...i18n import t
+from .._file_paths import resolve_workdir_path
 
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
@@ -39,8 +39,7 @@ def setup(agent: "BaseAgent") -> None:
         path = args.get("file_path", "")
         if not path:
             return {"status": "error", "message": "file_path is required"}
-        if not Path(path).is_absolute():
-            path = str(agent._working_dir / path)
+        path = resolve_workdir_path(agent, path)
         old = args.get("old_string", "")
         new = args.get("new_string", "")
         replace_all = args.get("replace_all", False)

--- a/src/lingtai/core/glob/__init__.py
+++ b/src/lingtai/core/glob/__init__.py
@@ -4,10 +4,10 @@ Usage: Agent(capabilities=["glob"]) or capabilities=["file"]
 """
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...i18n import t
+from .._file_paths import resolve_workdir_path
 
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
@@ -38,8 +38,7 @@ def setup(agent: "BaseAgent") -> None:
         if not pattern:
             return {"status": "error", "message": "pattern is required"}
         search_dir = args.get("path", str(agent._working_dir))
-        if not Path(search_dir).is_absolute():
-            search_dir = str(agent._working_dir / search_dir)
+        search_dir = resolve_workdir_path(agent, search_dir)
         try:
             matches = agent._file_io.glob(pattern, root=search_dir)
             result: dict = {"matches": matches, "count": len(matches)}

--- a/src/lingtai/core/grep/__init__.py
+++ b/src/lingtai/core/grep/__init__.py
@@ -4,10 +4,10 @@ Usage: Agent(capabilities=["grep"]) or capabilities=["file"]
 """
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ...i18n import t
+from .._file_paths import resolve_workdir_path
 
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
@@ -40,8 +40,7 @@ def setup(agent: "BaseAgent") -> None:
         if not pattern:
             return {"status": "error", "message": "pattern is required"}
         search_path = args.get("path", str(agent._working_dir))
-        if not Path(search_path).is_absolute():
-            search_path = str(agent._working_dir / search_path)
+        search_path = resolve_workdir_path(agent, search_path)
         max_matches = args.get("max_matches", 200)
         glob_filter = args.get("glob", "*")
         try:

--- a/src/lingtai/core/read/__init__.py
+++ b/src/lingtai/core/read/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from lingtai_kernel.tool_result_artifacts import PREVENTIVE_MAX_CHARS
 
 from ...i18n import t
+from .._file_paths import resolve_workdir_path
 
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
@@ -132,8 +133,7 @@ def setup(agent: "BaseAgent") -> None:
         path = args.get("file_path", "")
         if not path:
             return {"status": "error", "message": "file_path is required"}
-        if not Path(path).is_absolute():
-            path = str(agent._working_dir / path)
+        path = resolve_workdir_path(agent, path)
         offset = args.get("offset", 1)
         limit = args.get("limit", 2000)
         max_chars = args.get("max_chars")

--- a/src/lingtai/core/write/__init__.py
+++ b/src/lingtai/core/write/__init__.py
@@ -4,10 +4,10 @@ Usage: Agent(capabilities=["write"]) or capabilities=["file"]
 """
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ...i18n import t
+from .._file_paths import resolve_workdir_path
 
 if TYPE_CHECKING:
     from lingtai_kernel.base_agent import BaseAgent
@@ -38,8 +38,7 @@ def setup(agent: "BaseAgent") -> None:
         content = args.get("content", "")
         if not path:
             return {"status": "error", "message": "file_path is required"}
-        if not Path(path).is_absolute():
-            path = str(agent._working_dir / path)
+        path = resolve_workdir_path(agent, path)
         try:
             agent._file_io.write(path, content)
             return {"status": "ok", "path": path, "bytes": len(content.encode("utf-8"))}

--- a/tests/test_layers_file.py
+++ b/tests/test_layers_file.py
@@ -121,6 +121,42 @@ def test_grep_via_capability(tmp_path):
     agent.stop(timeout=1.0)
 
 
+def test_file_capability_relative_paths_resolve_under_workdir(tmp_path):
+    """Relative file tool paths are rooted under the agent working directory."""
+    agent = Agent(
+        service=make_mock_service(), agent_name="test", working_dir=tmp_path / "test",
+        capabilities=["file"],
+    )
+    target = agent.working_dir / "nested" / "target.py"
+    try:
+        write_result = agent._tool_handlers["write"](
+            {"file_path": "nested/target.py", "content": "needle\nold\n"}
+        )
+        assert write_result == {
+            "status": "ok",
+            "path": str(target),
+            "bytes": len("needle\nold\n".encode("utf-8")),
+        }
+        assert target.read_text() == "needle\nold\n"
+
+        read_result = agent._tool_handlers["read"]({"file_path": "nested/target.py"})
+        assert "needle" in read_result["content"]
+
+        edit_result = agent._tool_handlers["edit"](
+            {"file_path": "nested/target.py", "old_string": "old", "new_string": "new"}
+        )
+        assert edit_result["status"] == "ok"
+        assert target.read_text() == "needle\nnew\n"
+
+        glob_result = agent._tool_handlers["glob"]({"pattern": "*.py", "path": "nested"})
+        assert str(target) in glob_result["matches"]
+
+        grep_result = agent._tool_handlers["grep"]({"pattern": "needle", "path": "nested"})
+        assert any(match["file"] == str(target) for match in grep_result["matches"])
+    finally:
+        agent.stop(timeout=1.0)
+
+
 def test_base_agent_has_no_file_intrinsics(tmp_path):
     """BaseAgent should NOT have file intrinsics after phase 2."""
     from lingtai_kernel.base_agent import BaseAgent


### PR DESCRIPTION
## Summary

- add a private shared helper for file-tool workdir-relative path resolution
- use it from the built-in read/write/edit/glob/grep wrappers
- add regression coverage that all five wrappers resolve relative paths under the agent workdir

## Why

The built-in file tools repeated the same `Path(path).is_absolute()` / `agent._working_dir / path` logic in several wrappers. This extracts that logic without changing normalization, containment, default-path, or error-message behavior.

## Validation

- `python -m pytest tests/test_layers_file.py -q` → 17 passed
- implementation sweep: focused file-tool tests → 121 passed, 1 skipped
- `git diff --check canonical/main...HEAD`
- independent GLM and Claude Code cold reviews: no blockers
