### PR TITLE
Deduplicate provider reasoning replay fallback

### DIFF
--- a/src/lingtai/llm/deepseek/ANATOMY.md
+++ b/src/lingtai/llm/deepseek/ANATOMY.md
@@ -22,25 +22,24 @@ DeepSeek adapter — thin OpenAI-compat wrapper that satisfies DeepSeek V4 think
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 0 | Empty |
-| `adapter.py` | ~130 | `DeepSeekAdapter`, `DeepSeekChatSession`, `_fallback_reasoning_for` |
+| `adapter.py` | ~100 | `DeepSeekAdapter`, `DeepSeekChatSession` |
 
 ### Classes
 
 - **`DeepSeekAdapter(OpenAIAdapter)`** — pinned to DeepSeek endpoint, sets `_session_class`; overrides `_default_prompt_cache_key` → `lingtai-deepseek:{model}:v1` (clean provider namespace for the default-on OpenAI-compatible prompt cache key; see `../openai/ANATOMY.md`).
-- **`DeepSeekChatSession(OpenAIChatSession)`** — overrides only `_build_messages`. Real reasoning round-trip is handled upstream by `interface_converters.to_openai`; this subclass only fills in a fallback when an assistant turn has no captured ThinkingBlock.
+- **`DeepSeekChatSession(OpenAIChatSession)`** — provider-named session class that sets `_requires_reasoning_content_after_tool_call = True`. Real reasoning round-trip is handled upstream by `interface_converters.to_openai`; shared `OpenAIChatSession` logic fills in a fallback when an assistant turn has no captured ThinkingBlock.
 
 ### Module-level
 
 | Symbol | Purpose |
 |--------|---------|
 | `_DEEPSEEK_BASE_URL` | `"https://api.deepseek.com"` |
-| `_fallback_reasoning_for` | Per-turn-unique reasoning stub for assistant turns lacking real reasoning (inlines tool name + call ids or content snippet + turn index) |
 
 ## Connections
 
 - **Inherits**: `OpenAIAdapter` / `OpenAIChatSession` from `../openai/adapter.py`.
 - **No additional imports**: Only `openai` SDK (inherited), no new external deps.
-- **Hook points used**: `_build_messages` (overridden on session), `_session_class` and `_default_prompt_cache_key` (overridden on adapter).
+- **Hook points used**: `_requires_reasoning_content_after_tool_call` (enabled on session), `_session_class` and `_default_prompt_cache_key` (overridden on adapter).
 
 ## Composition
 
@@ -53,11 +52,9 @@ DeepSeek adapter — thin OpenAI-compat wrapper that satisfies DeepSeek V4 think
 
 All other `LLMAdapter` methods (`create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`) are **inherited unchanged** from `OpenAIAdapter`.
 
-### ChatSession method overrides (`DeepSeekChatSession`)
+### ChatSession behavior (`DeepSeekChatSession`)
 
-| Method | Notes |
-|--------|-------|
-| `_build_messages` | Calls `super()._build_messages()` (which already emits real `reasoning_content` from any ThinkingBlock via `to_openai`). Then walks assistant messages: once any has `tool_calls`, all subsequent assistant messages without a non-empty `reasoning_content` get `_fallback_reasoning_for(msg, turn_idx)` filled in. |
+`DeepSeekChatSession` does not override methods. It enables the shared `OpenAIChatSession._build_messages()` fallback path: after `to_openai` emits any real `reasoning_content` from ThinkingBlocks, the shared post-pass walks assistant messages; once any has `tool_calls`, all subsequent assistant messages without a non-empty `reasoning_content` get a per-turn-unique stub.
 
 `send` and `send_stream` are no longer overridden — there's no placeholder-echo to strip.
 
@@ -67,7 +64,7 @@ Real reasoning is preserved end-to-end:
 
 1. **Capture** — `OpenAIChatSession._record_assistant_response` (non-streaming) and the streaming finalize path read `message.reasoning_content` (or `.reasoning` for OpenRouter) and append a `ThinkingBlock` to the assistant interface entry.
 2. **Replay** — `interface_converters.to_openai` emits the ThinkingBlock text back as `reasoning_content` on the wire.
-3. **Fallback** — `DeepSeekChatSession._build_messages` fills in `_fallback_reasoning_for` only on assistant turns that lack real reasoning (typically: rehydrated history from before this fix, or turns where the provider returned no reasoning text). The fallback inlines tool names + call ids (or content snippet for plain-text post-tool turns) plus a turn index, which is byte-different per turn by construction.
+3. **Fallback** — `DeepSeekChatSession` enables the shared `OpenAIChatSession` fallback only on assistant turns that lack real reasoning (typically: rehydrated history from before this fix, or turns where the provider returned no reasoning text). The fallback inlines tool names + call ids (or content snippet for plain-text post-tool turns) plus a turn index, which is byte-different per turn by construction.
 
 ### Why per-turn-unique matters
 
@@ -92,7 +89,7 @@ Replacing the placeholder with anything per-turn-byte-unique drives the empty ra
 
 ## Notes
 
-- **Minimal footprint**: ~130 LOC, ~25 lines of unique logic.
+- **Minimal footprint**: provider-specific endpoint/cache-key wiring only; reasoning fallback mechanics live in `OpenAIChatSession` and are shared with MiMo.
 - **No `defaults.py`**: DeepSeek adapter is not registered via the `DEFAULTS` config pattern — likely invoked directly by `LLMService`.
 - **Pre-fix history compatibility**: rehydrated chat_history.jsonl entries that lack ThinkingBlocks (written before this fix shipped) get the per-turn-unique fallback automatically; no migration needed.
 - Git history: 4 commits on the original placeholder approach (afc7ddc → a9382dc → 23599ca → 86c2a3d), then issue-#9 rewrite to preserve real reasoning end-to-end.

--- a/src/lingtai/llm/deepseek/adapter.py
+++ b/src/lingtai/llm/deepseek/adapter.py
@@ -27,16 +27,17 @@ caused DeepSeek's cache fast-path to collapse onto the placeholder
 string, producing empty responses (issue #9). Real per-turn reasoning
 is byte-different by construction and avoids the collapse.
 
-The only remaining responsibility of this adapter is the **fallback**:
-if an assistant turn replayed from history has no captured ThinkingBlock
-(e.g. chat_history.jsonl entries written before this fix shipped, or
-entries where the provider returned no reasoning text at all), inject a
-per-turn-unique stub so DeepSeek's field-presence validator is satisfied
-without re-introducing the cache-collapse pattern.
+The only provider-specific responsibility here is opting into the shared
+fallback: if an assistant turn replayed from history has no captured
+ThinkingBlock (e.g. chat_history.jsonl entries written before this fix
+shipped, or entries where the provider returned no reasoning text at all),
+``OpenAIChatSession`` injects a per-turn-unique stub so DeepSeek's
+field-presence validator is satisfied without re-introducing the
+cache-collapse pattern.
 
-Everything else inherits from ``OpenAIAdapter`` / ``OpenAIChatSession``
-unchanged via the ``_build_messages`` and ``_session_class`` hook points
-on the parent.
+Everything else inherits from ``OpenAIAdapter`` / ``OpenAIChatSession``:
+``_session_class`` selects the DeepSeek session subclass, while message
+building remains in the shared parent implementation.
 """
 
 from __future__ import annotations
@@ -47,60 +48,17 @@ from ..openai.adapter import OpenAIAdapter, OpenAIChatSession
 _DEEPSEEK_BASE_URL = "https://api.deepseek.com"
 
 
-def _fallback_reasoning_for(msg: dict, turn_idx: int) -> str:
-    """Build a per-turn-unique reasoning stub for an assistant message.
-
-    Used only when an assistant turn carries no real reasoning_content
-    (typically: history entries that predate the ThinkingBlock-preservation
-    fix, or turns where the provider returned no reasoning text). The
-    string must be byte-different per turn — a constant placeholder
-    triggers DeepSeek's cache fast-path to collapse onto it and emit
-    empty responses (issue #9).
-
-    DeepSeek validates field presence, not content, so any non-empty
-    string is accepted. We inline tool names and the call ids to keep
-    the stub naturally unique per turn.
-    """
-    tool_calls = msg.get("tool_calls") or []
-    if tool_calls:
-        names = ",".join(
-            (tc.get("function", {}) or {}).get("name", "") for tc in tool_calls
-        )
-        ids = ",".join(tc.get("id", "") for tc in tool_calls)
-        return f"call {names} [{ids}] (turn {turn_idx})"
-    # Plain-text post-tool-call turn — content is per-turn unique by nature.
-    content = msg.get("content") or ""
-    snippet = content[:64].replace("\n", " ")
-    return f"reply [{snippet}] (turn {turn_idx})"
-
-
 class DeepSeekChatSession(OpenAIChatSession):
     """Chat session that satisfies DeepSeek's reasoning_content round-trip contract.
 
     Real reasoning_content is emitted by ``interface_converters.to_openai``
     when the canonical interface has a ThinkingBlock on the assistant turn.
-    This subclass only injects a per-turn-unique fallback on assistant
-    turns that lack one — typically rehydrated history entries from before
-    the fix shipped.
+    This subclass opts into OpenAIChatSession's per-turn-unique fallback on
+    assistant turns that lack one — typically rehydrated history entries from
+    before the fix shipped.
     """
 
-    def _build_messages(self) -> list[dict]:
-        messages = super()._build_messages()
-        # Field-presence requirement only kicks in once thinking mode has
-        # been invoked by an assistant tool_call. Earlier plain-text turns
-        # must NOT carry reasoning_content — DeepSeek rejects that.
-        seen_tool_call = False
-        turn_idx = 0
-        for msg in messages:
-            if msg.get("role") != "assistant":
-                continue
-            if msg.get("tool_calls"):
-                seen_tool_call = True
-            if seen_tool_call:
-                turn_idx += 1
-                if not msg.get("reasoning_content"):
-                    msg["reasoning_content"] = _fallback_reasoning_for(msg, turn_idx)
-        return messages
+    _requires_reasoning_content_after_tool_call = True
 
 
 class DeepSeekAdapter(OpenAIAdapter):

--- a/src/lingtai/llm/mimo/adapter.py
+++ b/src/lingtai/llm/mimo/adapter.py
@@ -12,40 +12,20 @@ assistant turn as a workaround for a model loop: when the *same* thinking
 block was echoed back unchanged on every turn, MiMo treated it as
 authoritative and parroted it verbatim, eventually tripping the 120s LLM
 hang watchdog. Real per-turn reasoning from ``ThinkingBlock``s is
-byte-different by construction (and so is the per-turn-unique fallback
-below), which avoids that pathology while satisfying the protocol.
+byte-different by construction (and so is the shared per-turn-unique
+fallback), which avoids that pathology while satisfying the protocol.
 
 Real reasoning is preserved end-to-end now: ``OpenAIChatSession`` captures
 ``reasoning_content`` into a ``ThinkingBlock`` on each assistant turn, and
 ``interface_converters.to_openai`` emits the block back as
-``reasoning_content`` on replay. This adapter only injects a per-turn-unique
-fallback for rehydrated/historical assistant turns that have no captured
-``ThinkingBlock`` (e.g. ``chat_history.jsonl`` entries written before this
-fix, or turns where the provider returned no reasoning text).
+``reasoning_content`` on replay. This adapter only opts into the shared
+per-turn-unique fallback for rehydrated/historical assistant turns that have
+no captured ``ThinkingBlock`` (e.g. ``chat_history.jsonl`` entries written
+before this fix, or turns where the provider returned no reasoning text).
 """
 from __future__ import annotations
 
 from ..openai.adapter import OpenAIAdapter, OpenAIChatSession
-
-
-def _fallback_reasoning_for(msg: dict, turn_idx: int) -> str:
-    """Build a per-turn-unique reasoning stub for an assistant message.
-
-    The string must be byte-different per turn — a constant placeholder
-    re-introduces the original loop pathology (model echoes the same
-    thinking block back). Inlining tool names, call ids, and a content
-    snippet keeps the stub naturally unique per turn.
-    """
-    tool_calls = msg.get("tool_calls") or []
-    if tool_calls:
-        names = ",".join(
-            (tc.get("function", {}) or {}).get("name", "") for tc in tool_calls
-        )
-        ids = ",".join(tc.get("id", "") for tc in tool_calls)
-        return f"call {names} [{ids}] (turn {turn_idx})"
-    content = msg.get("content") or ""
-    snippet = content[:64].replace("\n", " ")
-    return f"reply [{snippet}] (turn {turn_idx})"
 
 
 class MimoChatSession(OpenAIChatSession):
@@ -53,24 +33,12 @@ class MimoChatSession(OpenAIChatSession):
 
     Real ``reasoning_content`` produced by ``interface_converters.to_openai``
     from captured ``ThinkingBlock``s is preserved verbatim. Assistant turns
-    after the first tool_call that lack a ThinkingBlock get a per-turn-unique
-    fallback. Pre-tool-call plain-text assistant turns are left alone.
+    after the first tool_call that lack a ThinkingBlock opt into
+    OpenAIChatSession's per-turn-unique fallback. Pre-tool-call plain-text
+    assistant turns are left alone.
     """
 
-    def _build_messages(self) -> list[dict]:
-        messages = super()._build_messages()
-        seen_tool_call = False
-        turn_idx = 0
-        for msg in messages:
-            if msg.get("role") != "assistant":
-                continue
-            if msg.get("tool_calls"):
-                seen_tool_call = True
-            if seen_tool_call:
-                turn_idx += 1
-                if not msg.get("reasoning_content"):
-                    msg["reasoning_content"] = _fallback_reasoning_for(msg, turn_idx)
-        return messages
+    _requires_reasoning_content_after_tool_call = True
 
 
 class MimoAdapter(OpenAIAdapter):

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -191,7 +191,8 @@ When a Codex session has a stable LingTai session/thread identity, `CodexRespons
 - **`CodexResponsesSession._current_id`** — the single per-agent affinity id (the hash of the agent path + current molt count) handed to this session, used byte-identically for `_prompt_cache_key` / `_session_id` / `_thread_id`. Set once per session at construction — a NEW session is built for each `create_chat`, and the adapter resolves the molt-current id at that point, so a molt-advanced id reaches the next session without any in-session mutation (no rotation, no epoch, no clock).
 - **Codex Responses trace** — opt-in diagnostics write JSONL metadata to `logs/codex_responses_trace.jsonl` when `LINGTAI_CODEX_RESPONSES_TRACE=1` (override path with `LINGTAI_CODEX_RESPONSES_TRACE_PATH`). Default off; stores event/item shapes, lengths/hashes, usage, and accumulator counts, not raw content.
 - **`OpenAIAdapter._client`** — shared `openai.OpenAI` instance. `_client_kwargs` stored for session `reset()`.
-- **`OpenAIAdapter._session_class`** — class var, subclasses override (e.g. DeepSeek and MiMo inject `reasoning_content` round-trip fallbacks).
+- **`OpenAIChatSession._requires_reasoning_content_after_tool_call`** — opt-in provider flag used by DeepSeek and MiMo. When true, `_build_messages()` fills missing assistant `reasoning_content` after the first assistant tool-call turn using a per-turn-unique fallback; real ThinkingBlock-sourced reasoning is preserved verbatim.
+- **`OpenAIAdapter._session_class`** — class var, subclasses override (e.g. DeepSeek and MiMo select provider-named chat session classes).
 
 ## Notes
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1180,6 +1180,8 @@ class OpenAIChatSession(ChatSession):
     Uses ChatInterface as the single source of truth.
     """
 
+    _requires_reasoning_content_after_tool_call = False
+
     def __init__(
         self,
         client: openai.OpenAI,
@@ -1223,12 +1225,56 @@ class OpenAIChatSession(ChatSession):
         """Return the message list to send to the API.
 
         Default: the canonical OpenAI serialization of the current
-        interface. Subclasses override to mutate or wrap — e.g. the
-        DeepSeek session injects ``reasoning_content`` onto assistant
-        turns that carry tool calls, which DeepSeek V4 thinking mode
-        requires for the round-trip.
+        interface. Some OpenAI-compatible providers require
+        ``reasoning_content`` on assistant turns after thinking mode is
+        invoked by tool calls; subclasses opt into that fallback with
+        ``_requires_reasoning_content_after_tool_call``.
         """
-        return to_openai(self._interface)
+        messages = to_openai(self._interface)
+        if self._requires_reasoning_content_after_tool_call:
+            self._inject_reasoning_content_fallbacks(messages)
+        return messages
+
+    @staticmethod
+    def _inject_reasoning_content_fallbacks(messages: list[dict]) -> None:
+        """Fill missing assistant ``reasoning_content`` after the first tool call.
+
+        Real reasoning_content is emitted by ``interface_converters.to_openai``
+        when the canonical interface has a ThinkingBlock on the assistant turn.
+        This fallback only covers older rehydrated history or provider turns
+        where no reasoning text was returned. The injected string must be
+        byte-different per turn: DeepSeek cache fast-paths and MiMo thinking
+        replay both behave badly with a constant placeholder.
+        """
+        seen_tool_call = False
+        turn_idx = 0
+        for msg in messages:
+            if msg.get("role") != "assistant":
+                continue
+            if msg.get("tool_calls"):
+                seen_tool_call = True
+            if seen_tool_call:
+                turn_idx += 1
+                if not msg.get("reasoning_content"):
+                    msg["reasoning_content"] = (
+                        OpenAIChatSession._fallback_reasoning_content_for(
+                            msg, turn_idx
+                        )
+                    )
+
+    @staticmethod
+    def _fallback_reasoning_content_for(msg: dict, turn_idx: int) -> str:
+        """Build a per-turn-unique reasoning stub for an assistant message."""
+        tool_calls = msg.get("tool_calls") or []
+        if tool_calls:
+            names = ",".join(
+                (tc.get("function", {}) or {}).get("name", "") for tc in tool_calls
+            )
+            ids = ",".join(tc.get("id", "") for tc in tool_calls)
+            return f"call {names} [{ids}] (turn {turn_idx})"
+        content = msg.get("content") or ""
+        snippet = content[:64].replace("\n", " ")
+        return f"reply [{snippet}] (turn {turn_idx})"
 
     @staticmethod
     def _is_context_overflow_error(exc: Exception) -> bool:


### PR DESCRIPTION
## Summary

- move duplicated DeepSeek/MiMo reasoning replay fallback logic into `OpenAIChatSession`
- keep the fallback opt-in for DeepSeek and MiMo only
- preserve public provider session class names/import paths and provider behavior
- polish provider comments/docs after review feedback

## Why

DeepSeek and MiMo carried byte-identical logic that reconstructs `reasoning_content` stubs after tool-call turns. Keeping the shared replay fallback in the OpenAI-compatible base session makes the behavior easier to reason about while leaving it disabled for providers that do not opt in.

## Validation

- `uv run --no-sync --with-editable . --with pytest --with openai --with httpx pytest tests/test_deepseek_adapter.py tests/test_mimo_adapter.py -q` → 22 passed
- implementation sweep: DeepSeek/MiMo/prompt-cache/chat-interface invariant tests → 65 passed; adapter registry tests → 6 passed
- reviewer sweep: focused provider tests → 71 passed; broader LLM sweep including zhipu/codex/openai → 396 passed
- `git diff --check canonical/main...HEAD`
- independent GLM and Claude Code cold reviews: no blockers
