### PR TITLE
fix(preset): skip env-var check when inline api_key is present

### DIFF
--- a/src/lingtai_kernel/intrinsics/system/preset.py
+++ b/src/lingtai_kernel/intrinsics/system/preset.py
@@ -264,10 +264,15 @@ def _presets(agent, args: dict) -> dict:
             },
             "capabilities": pm.get("capabilities", {}),
         })
+        # If the preset has an inline api_key, skip the env-var credential
+        # check — the key is already embedded and does not need an env var.
+        api_key_env = llm.get("api_key_env")
+        if llm.get("api_key"):
+            api_key_env = None
         connectivity_specs.append({
             "provider": llm.get("provider"),
             "base_url": llm.get("base_url"),
-            "api_key_env": llm.get("api_key_env"),
+            "api_key_env": api_key_env,
         })
 
     # Probe all presets in parallel — fresh each call.


### PR DESCRIPTION
## Summary

Fix preset connectivity status for presets that store the LLM API key inline.

When a preset has `llm.api_key` set, the `/setup` / `system(action="presets")` connectivity check should not require `llm.api_key_env` to also be present in the process environment. The inline key is already sufficient credential material.

## What changed

In `src/lingtai_kernel/intrinsics/system/preset.py`, the connectivity spec now passes `api_key_env=None` when `llm.api_key` is present. This avoids a false `no_credentials` result from `check_connectivity()`.

## Validation

- Ran `python3 -m compileall -q src/lingtai_kernel/intrinsics/system/preset.py`
- Confirmed diff is limited to connectivity spec construction

## Related issue

Closes #582
