### PR TITLE
Extract addon load_config helper

### DIFF
--- a/src/lingtai/mcp_servers/_config.py
+++ b/src/lingtai/mcp_servers/_config.py
@@ -1,0 +1,60 @@
+"""Shared config loading helpers for curated MCP server wrappers.
+
+These helpers factor out the common env-var to path to strict-JSON sequence
+used by the simple addon loaders. Each addon keeps its public ``load_config()``
+wrapper and return type.
+
+WeChat is intentionally not a client: it has a two-candidate compatibility
+resolver, status diagnostics, and a second credentials file.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+__all__ = ["resolve_config_path", "load_config_file"]
+
+
+def resolve_config_path(
+    env_name: str,
+    *,
+    label: str,
+    missing_env_msg: str | None = None,
+) -> Path:
+    """Resolve the config path named by ``env_name``.
+
+    Relative paths resolve against ``LINGTAI_AGENT_DIR`` or the current working
+    directory when that env var is unset.
+    """
+    raw = os.environ.get(env_name)
+    if not raw:
+        raise ValueError(
+            missing_env_msg
+            or f"{env_name} env var not set — point it at your {label} "
+            "config JSON file"
+        )
+
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        base = Path(os.environ.get("LINGTAI_AGENT_DIR", os.getcwd()))
+        path = base / path
+    if not path.is_file():
+        raise FileNotFoundError(f"{label} config not found: {path}")
+    return path
+
+
+def load_config_file(
+    env_name: str,
+    *,
+    label: str,
+    missing_env_msg: str | None = None,
+) -> tuple[dict[str, Any], Path]:
+    """Resolve and load a strict JSON config file."""
+    path = resolve_config_path(
+        env_name,
+        label=label,
+        missing_env_msg=missing_env_msg,
+    )
+    return json.loads(path.read_text(encoding="utf-8")), path

--- a/src/lingtai/mcp_servers/cloud_mail/server.py
+++ b/src/lingtai/mcp_servers/cloud_mail/server.py
@@ -44,6 +44,7 @@ import mcp.types as types
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 
+from .. import _config
 from .licc import push_inbox_event
 from .manager import CloudMailManager, DESCRIPTION, SCHEMA
 
@@ -70,19 +71,7 @@ def load_config() -> dict:
     Path is resolved relative to LINGTAI_AGENT_DIR (or cwd as fallback)
     when not absolute. Plaintext only — no *_env indirection.
     """
-    config_path_raw = os.environ.get(CONFIG_ENV)
-    if not config_path_raw:
-        raise ValueError(
-            f"{CONFIG_ENV} env var not set — point it at your Cloud Mail "
-            "config JSON file"
-        )
-    config_path = Path(config_path_raw).expanduser()
-    if not config_path.is_absolute():
-        base = Path(os.environ.get("LINGTAI_AGENT_DIR", os.getcwd()))
-        config_path = base / config_path
-    if not config_path.is_file():
-        raise FileNotFoundError(f"Cloud Mail config not found: {config_path}")
-    return json.loads(config_path.read_text(encoding="utf-8"))
+    return _config.load_config_file(CONFIG_ENV, label="Cloud Mail")[0]
 
 
 def accounts_from_config(cfg: dict) -> list[dict]:

--- a/src/lingtai/mcp_servers/feishu/server.py
+++ b/src/lingtai/mcp_servers/feishu/server.py
@@ -39,6 +39,7 @@ import mcp.types as types
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 
+from .. import _config
 from .licc import push_inbox_event
 from .manager import FeishuManager, SCHEMA, DESCRIPTION
 from .service import FeishuService
@@ -576,19 +577,7 @@ def load_config() -> dict:
     Path is resolved relative to LINGTAI_AGENT_DIR (or cwd as fallback)
     if not absolute. Plaintext only — no *_env indirection.
     """
-    config_path_raw = os.environ.get("LINGTAI_FEISHU_CONFIG")
-    if not config_path_raw:
-        raise ValueError(
-            "LINGTAI_FEISHU_CONFIG env var not set — point it at your "
-            "Feishu config JSON file"
-        )
-    config_path = Path(config_path_raw).expanduser()
-    if not config_path.is_absolute():
-        base = Path(os.environ.get("LINGTAI_AGENT_DIR", os.getcwd()))
-        config_path = base / config_path
-    if not config_path.is_file():
-        raise FileNotFoundError(f"Feishu config not found: {config_path}")
-    return json.loads(config_path.read_text(encoding="utf-8"))
+    return _config.load_config_file("LINGTAI_FEISHU_CONFIG", label="Feishu")[0]
 
 
 def _accounts_from_config(cfg: dict) -> list[dict]:

--- a/src/lingtai/mcp_servers/imap/server.py
+++ b/src/lingtai/mcp_servers/imap/server.py
@@ -44,6 +44,7 @@ from mcp.server import Server
 from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.stdio import stdio_server
 
+from .. import _config
 from ._migrate import migrate_legacy_state
 from .bridge import FilesystemMailBridge
 from .licc import push_inbox_event
@@ -475,19 +476,7 @@ def load_config() -> dict:
     Path is resolved relative to LINGTAI_AGENT_DIR (or cwd as fallback)
     if not absolute. Plaintext only — no *_env indirection.
     """
-    config_path_raw = os.environ.get("LINGTAI_IMAP_CONFIG")
-    if not config_path_raw:
-        raise ValueError(
-            "LINGTAI_IMAP_CONFIG env var not set — point it at your IMAP "
-            "config JSON file"
-        )
-    config_path = Path(config_path_raw).expanduser()
-    if not config_path.is_absolute():
-        base = Path(os.environ.get("LINGTAI_AGENT_DIR", os.getcwd()))
-        config_path = base / config_path
-    if not config_path.is_file():
-        raise FileNotFoundError(f"IMAP config not found: {config_path}")
-    return json.loads(config_path.read_text(encoding="utf-8"))
+    return _config.load_config_file("LINGTAI_IMAP_CONFIG", label="IMAP")[0]
 
 
 def _accounts_from_config(cfg: dict) -> list[dict]:

--- a/src/lingtai/mcp_servers/telegram/server.py
+++ b/src/lingtai/mcp_servers/telegram/server.py
@@ -42,6 +42,7 @@ import mcp.types as types
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 
+from .. import _config
 from .licc import push_inbox_event
 from .manager import TelegramManager, SCHEMA, DESCRIPTION
 from .service import TelegramService
@@ -602,19 +603,7 @@ def load_config() -> dict:
     Path is resolved relative to LINGTAI_AGENT_DIR (or cwd as fallback)
     if not absolute. Plaintext only — no *_env indirection.
     """
-    config_path_raw = os.environ.get("LINGTAI_TELEGRAM_CONFIG")
-    if not config_path_raw:
-        raise ValueError(
-            "LINGTAI_TELEGRAM_CONFIG env var not set — point it at your "
-            "Telegram config JSON file"
-        )
-    config_path = Path(config_path_raw).expanduser()
-    if not config_path.is_absolute():
-        base = Path(os.environ.get("LINGTAI_AGENT_DIR", os.getcwd()))
-        config_path = base / config_path
-    if not config_path.is_file():
-        raise FileNotFoundError(f"Telegram config not found: {config_path}")
-    return json.loads(config_path.read_text(encoding="utf-8"))
+    return _config.load_config_file("LINGTAI_TELEGRAM_CONFIG", label="Telegram")[0]
 
 
 def _accounts_from_config(cfg: dict) -> list[dict]:

--- a/src/lingtai/mcp_servers/whatsapp/server.py
+++ b/src/lingtai/mcp_servers/whatsapp/server.py
@@ -12,6 +12,7 @@ import mcp.types as types
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 
+from .. import _config
 from .licc import push_inbox_event
 from .manager import WhatsAppManager, SCHEMA, DESCRIPTION
 from .resources import resource_text
@@ -26,15 +27,11 @@ _SERVER_INSTRUCTIONS = (
 
 
 def load_config() -> tuple[dict[str, Any], Path]:
-    raw = os.environ.get("LINGTAI_WHATSAPP_CONFIG")
-    if not raw:
-        raise ValueError("LINGTAI_WHATSAPP_CONFIG env var not set")
-    path = Path(raw).expanduser()
-    if not path.is_absolute():
-        path = Path(os.environ.get("LINGTAI_AGENT_DIR", os.getcwd())) / path
-    if not path.is_file():
-        raise FileNotFoundError(f"WhatsApp config not found: {path}")
-    return json.loads(path.read_text(encoding="utf-8")), path
+    return _config.load_config_file(
+        "LINGTAI_WHATSAPP_CONFIG",
+        label="WhatsApp",
+        missing_env_msg="LINGTAI_WHATSAPP_CONFIG env var not set",
+    )
 
 
 def _accounts_from_config(cfg: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/test_mcp_config_helper.py
+++ b/tests/test_mcp_config_helper.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers import _config
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_resolve_config_path_relative_to_agent_dir(tmp_path, monkeypatch):
+    config_path = _write_json(tmp_path / "configs" / "addon.json", {"ok": True})
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path))
+    monkeypatch.setenv("LINGTAI_TEST_CONFIG", "configs/addon.json")
+
+    assert (
+        _config.resolve_config_path("LINGTAI_TEST_CONFIG", label="Test")
+        == config_path
+    )
+
+
+def test_resolve_config_path_absolute_passes_through(tmp_path, monkeypatch):
+    config_path = _write_json(tmp_path / "absolute.json", {"ok": True})
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path / "ignored"))
+    monkeypatch.setenv("LINGTAI_TEST_CONFIG", str(config_path))
+
+    assert (
+        _config.resolve_config_path("LINGTAI_TEST_CONFIG", label="Test")
+        == config_path
+    )
+
+
+def test_resolve_config_path_cwd_fallback(tmp_path, monkeypatch):
+    config_path = _write_json(tmp_path / "cwd.json", {"ok": True})
+    monkeypatch.delenv("LINGTAI_AGENT_DIR", raising=False)
+    monkeypatch.setenv("LINGTAI_TEST_CONFIG", "cwd.json")
+    monkeypatch.chdir(tmp_path)
+
+    assert (
+        _config.resolve_config_path("LINGTAI_TEST_CONFIG", label="Test")
+        == config_path
+    )
+
+
+def test_resolve_config_path_expands_home(tmp_path, monkeypatch):
+    config_path = _write_json(tmp_path / "home.json", {"ok": True})
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path / "ignored"))
+    monkeypatch.setenv("LINGTAI_TEST_CONFIG", "~/home.json")
+
+    assert (
+        _config.resolve_config_path("LINGTAI_TEST_CONFIG", label="Test")
+        == config_path
+    )
+
+
+def test_resolve_config_path_missing_env_default_message(monkeypatch):
+    monkeypatch.delenv("LINGTAI_TEST_CONFIG", raising=False)
+
+    with pytest.raises(ValueError) as excinfo:
+        _config.resolve_config_path("LINGTAI_TEST_CONFIG", label="Test")
+
+    assert (
+        str(excinfo.value)
+        == "LINGTAI_TEST_CONFIG env var not set — point it at your Test "
+        "config JSON file"
+    )
+
+
+def test_resolve_config_path_missing_env_override(monkeypatch):
+    monkeypatch.delenv("LINGTAI_TEST_CONFIG", raising=False)
+
+    with pytest.raises(ValueError) as excinfo:
+        _config.resolve_config_path(
+            "LINGTAI_TEST_CONFIG",
+            label="Test",
+            missing_env_msg="custom missing message",
+        )
+
+    assert str(excinfo.value) == "custom missing message"
+
+
+def test_resolve_config_path_missing_file_message(tmp_path, monkeypatch):
+    expected = tmp_path / "missing.json"
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path))
+    monkeypatch.setenv("LINGTAI_TEST_CONFIG", "missing.json")
+
+    with pytest.raises(FileNotFoundError) as excinfo:
+        _config.resolve_config_path("LINGTAI_TEST_CONFIG", label="Test")
+
+    assert str(excinfo.value) == f"Test config not found: {expected}"
+
+
+def test_load_config_file_returns_parsed_dict_and_path(tmp_path, monkeypatch):
+    payload = {"accounts": [{"alias": "a"}]}
+    config_path = _write_json(tmp_path / "addon.json", payload)
+    monkeypatch.setenv("LINGTAI_TEST_CONFIG", str(config_path))
+
+    assert _config.load_config_file("LINGTAI_TEST_CONFIG", label="Test") == (
+        payload,
+        config_path,
+    )
+
+
+@pytest.mark.parametrize(
+    ("module_name", "env_name", "label", "missing_env_msg", "returns_path"),
+    [
+        (
+            "lingtai.mcp_servers.imap.server",
+            "LINGTAI_IMAP_CONFIG",
+            "IMAP",
+            "LINGTAI_IMAP_CONFIG env var not set — point it at your IMAP "
+            "config JSON file",
+            False,
+        ),
+        (
+            "lingtai.mcp_servers.feishu.server",
+            "LINGTAI_FEISHU_CONFIG",
+            "Feishu",
+            "LINGTAI_FEISHU_CONFIG env var not set — point it at your "
+            "Feishu config JSON file",
+            False,
+        ),
+        (
+            "lingtai.mcp_servers.telegram.server",
+            "LINGTAI_TELEGRAM_CONFIG",
+            "Telegram",
+            "LINGTAI_TELEGRAM_CONFIG env var not set — point it at your "
+            "Telegram config JSON file",
+            False,
+        ),
+        (
+            "lingtai.mcp_servers.cloud_mail.server",
+            "LINGTAI_CLOUD_MAIL_CONFIG",
+            "Cloud Mail",
+            "LINGTAI_CLOUD_MAIL_CONFIG env var not set — point it at your "
+            "Cloud Mail config JSON file",
+            False,
+        ),
+        (
+            "lingtai.mcp_servers.whatsapp.server",
+            "LINGTAI_WHATSAPP_CONFIG",
+            "WhatsApp",
+            "LINGTAI_WHATSAPP_CONFIG env var not set",
+            True,
+        ),
+    ],
+)
+def test_addon_load_config_preserves_messages_and_return_shape(
+    tmp_path,
+    monkeypatch,
+    module_name,
+    env_name,
+    label,
+    missing_env_msg,
+    returns_path,
+):
+    module = importlib.import_module(module_name)
+    payload = {"accounts": [{"alias": "a"}]}
+    config_path = _write_json(tmp_path / "config.json", payload)
+
+    monkeypatch.delenv(env_name, raising=False)
+    with pytest.raises(ValueError) as excinfo:
+        module.load_config()
+    assert str(excinfo.value) == missing_env_msg
+
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path))
+    monkeypatch.setenv(env_name, "missing.json")
+    with pytest.raises(FileNotFoundError) as excinfo:
+        module.load_config()
+    assert (
+        str(excinfo.value)
+        == f"{label} config not found: {tmp_path / 'missing.json'}"
+    )
+
+    monkeypatch.setenv(env_name, "config.json")
+    loaded = module.load_config()
+    if returns_path:
+        assert loaded == (payload, config_path)
+    else:
+        assert loaded == payload


### PR DESCRIPTION
## Summary
- Add a shared internal MCP server config-loading helper for addon `load_config()` implementations.
- Refactor IMAP, Feishu, Telegram, Cloud Mail, and WhatsApp config wrappers to use the helper while preserving their public wrapper names, return shapes, config env behavior, and error messages.
- Leave WeChat config handling untouched and add parity coverage for the shared helper and touched addon wrappers.

## Why
Several addon modules duplicated nearly identical environment/file JSON config loading. Centralizing the common logic reduces drift while keeping each addon's public boundary stable.

## Validation
- Pre-open gate: fetched `canonical/main` at `5742d68d53b2132d0a43f2c7b8f932301509e9c4`; branch was one commit ahead, worktree clean, and `git diff --check canonical/main...HEAD` passed.
- Compile check passed for the new helper and test file.
- Focused validation covering helper/parity, Cloud Mail, WeChat config resolution, IMAP, and Telegram suites: `84 passed`.
- Independent Claude Code review reran helper/parity tests (`13 passed`) and touched-addon suites (`69 passed`).
- Independent GLM and Claude Code reviews found no blockers.

Full-project pytest was not run because the project dependency graph selects `onnxruntime==1.27.0`, which has no macOS x86_64 wheel in this environment. The focused suite covers the shared helper, the touched addon wrappers, and adjacent config behavior.
