### PR TITLE
Reuse requested tool expansion helper

### DIFF
--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -1251,17 +1251,7 @@ class DaemonManager:
         ``preset_surface`` is None, the parent's currently registered regular
         capability surface is used, again plus only task-scoped MCP tools.
         """
-        from ...capabilities import _GROUPS
-
-        # Expand groups and filter blacklist
-        tool_names: set[str] = set()
-        for name in requested:
-            if name in EMANATION_BLACKLIST:
-                continue
-            if name in _GROUPS:
-                tool_names.update(_GROUPS[name])
-            else:
-                tool_names.add(name)
+        tool_names = self._expand_requested_tools(requested)
 
         intrinsic_schemas, intrinsic_handlers = self._daemon_intrinsic_surface()
         tool_names |= set(intrinsic_schemas)


### PR DESCRIPTION
## Summary
- Make `_build_tool_surface()` reuse the existing `_expand_requested_tools(requested)` helper.
- Remove the duplicated requested-tool group expansion / blacklist loop from the daemon tool-surface path.

## Why
The helper already centralizes this expansion logic. Reusing it keeps one source of truth and avoids future drift without changing tool execution behavior.

## Validation
- Focused daemon/tool-surface tests passed (`117 passed`).
- `git diff --check canonical/main...HEAD`
- Independent Claude Code and GLM reviews found no blockers.
