### PR TITLE
Use fsutil helpers for persistence writes

### DIFF
--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -31,6 +31,7 @@ from ...i18n import t
 if TYPE_CHECKING:
     from ...agent import Agent
 
+from lingtai_kernel._fsutil import atomic_write_json
 from lingtai_kernel.llm.base import FunctionSchema
 from lingtai_kernel.loop_guard import LoopGuard
 from lingtai_kernel.meta_block import build_meta
@@ -791,15 +792,8 @@ class DaemonManager:
                     f"{parent_pid} is no longer alive after daemon manager startup."
                 ),
             }
-            tmp_path = daemon_json_path.with_suffix(
-                daemon_json_path.suffix + ".tmp"
-            )
             try:
-                tmp_path.write_text(
-                    json.dumps(state, indent=2, ensure_ascii=False),
-                    encoding="utf-8",
-                )
-                os.replace(tmp_path, daemon_json_path)
+                atomic_write_json(daemon_json_path, state, ensure_ascii=False, indent=2)
             except OSError:
                 continue
 
@@ -2902,9 +2896,7 @@ class DaemonManager:
 
     @staticmethod
     def _atomic_write_daemon_json(path: Path, state: dict) -> None:
-        tmp_path = path.with_suffix(path.suffix + ".tmp")
-        tmp_path.write_text(json.dumps(state, indent=2, ensure_ascii=False), encoding="utf-8")
-        os.replace(tmp_path, path)
+        atomic_write_json(path, state, ensure_ascii=False, indent=2)
 
     @staticmethod
     def _looks_like_daemon_run_dir(run_path: Path) -> bool:

--- a/src/lingtai/core/daemon/run_dir.py
+++ b/src/lingtai/core/daemon/run_dir.py
@@ -9,12 +9,12 @@ without itself touching the filesystem.
 from __future__ import annotations
 
 import json
-import os
 import secrets
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from lingtai_kernel._fsutil import append_jsonl, atomic_write_json
 from lingtai_kernel.token_ledger import append_token_entry
 
 
@@ -228,15 +228,12 @@ class DaemonRunDir:
         return round(time.monotonic() - self._started_monotonic, 3)
 
     def _atomic_write_json(self, path: Path, data: dict) -> None:
-        """Write JSON to a tempfile then os.replace — readers never see partial state."""
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
-        os.replace(tmp, path)
+        """Write JSON atomically — readers never see partial state."""
+        atomic_write_json(path, data, ensure_ascii=False, indent=2)
 
     def _append_jsonl(self, path: Path, entry: dict) -> None:
-        """Append one JSON line. Single-writer per file — POSIX O_APPEND atomic for sub-PIPE_BUF lines."""
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        """Append one JSON line."""
+        append_jsonl(path, entry, ensure_ascii=False)
 
     def _safe(self, op: str, fn) -> None:
         """Run `fn`; swallow OSError (best-effort policy for mutation writes).

--- a/src/lingtai_kernel/notifications.py
+++ b/src/lingtai_kernel/notifications.py
@@ -25,6 +25,7 @@ import re
 from datetime import datetime, timezone
 from pathlib import Path
 
+from ._fsutil import atomic_write_json
 from .workdir import workdir_layout
 
 
@@ -133,9 +134,7 @@ def save_large_result_acks(workdir: Path, ref_ids: set[str]) -> None:
             pass
         return
     ack_path.parent.mkdir(exist_ok=True)
-    tmp = ack_path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(sorted(ref_ids), ensure_ascii=False), encoding="utf-8")
-    tmp.rename(ack_path)
+    atomic_write_json(ack_path, sorted(ref_ids), ensure_ascii=False, indent=None)
 
 
 def ack_large_result_refs(workdir: Path, ref_ids: set[str]) -> None:
@@ -292,9 +291,7 @@ def publish(workdir: Path, tool_name: str, payload: dict) -> None:
     notif_dir = layout.notification_dir
     notif_dir.mkdir(exist_ok=True)
     target = layout.notification_file(tool_name)
-    tmp = target.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
-    tmp.rename(target)
+    atomic_write_json(target, payload, ensure_ascii=False, indent=None)
 
 
 def clear(workdir: Path, tool_name: str) -> None:

--- a/src/lingtai_kernel/token_ledger.py
+++ b/src/lingtai_kernel/token_ledger.py
@@ -42,9 +42,10 @@ same immutable log.
 """
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from pathlib import Path
+
+from ._fsutil import append_jsonl, iter_jsonl_records
 
 
 def _mirror_token_entry_to_sqlite(path: Path, entry: dict, source_offset: int) -> None:
@@ -131,7 +132,6 @@ def append_token_entry(
     attribution.
     """
     path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
     entry: dict = {}
     if extra:
         entry.update(extra)
@@ -146,11 +146,7 @@ def append_token_entry(
         entry["model"] = model
     if endpoint is not None:
         entry["endpoint"] = endpoint
-    payload = (json.dumps(entry) + "\n").encode("utf-8")
-    with open(path, "ab") as f:
-        source_offset = f.tell()
-        f.write(payload)
-        f.flush()
+    source_offset = append_jsonl(path, entry)
     _mirror_token_entry_to_sqlite(path, entry, source_offset)
 
 
@@ -174,17 +170,9 @@ def count_main_api_calls(path: Path | str) -> int:
 
     Returns 0 if the file is missing.
     """
-    path = Path(path)
-    if not path.is_file():
-        return 0
     n = 0
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            entry = json.loads(line)
-        except json.JSONDecodeError:
+    for entry in iter_jsonl_records(path):
+        if not isinstance(entry, dict):
             continue
         if entry.get("source") == "main":
             n += 1
@@ -223,7 +211,6 @@ def sum_token_ledger(path: Path | str, *, scope: str = "all") -> dict:
         raise ValueError(
             f"unknown scope {scope!r}; expected 'all' or 'main_agent'"
         )
-    path = Path(path)
     totals = {
         "input_tokens": 0,
         "output_tokens": 0,
@@ -231,15 +218,8 @@ def sum_token_ledger(path: Path | str, *, scope: str = "all") -> dict:
         "cached_tokens": 0,
         "api_calls": 0,
     }
-    if not path.is_file():
-        return totals
-    for line in path.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            entry = json.loads(line)
-        except json.JSONDecodeError:
+    for entry in iter_jsonl_records(path):
+        if not isinstance(entry, dict):
             continue
         if scope == "main_agent" and is_daemon_entry(entry):
             continue

--- a/tests/test_daemon_run_dir.py
+++ b/tests/test_daemon_run_dir.py
@@ -75,6 +75,25 @@ def test_initial_daemon_json_fields(tmp_path):
     assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", data["started_at"])
 
 
+def test_daemon_json_preserves_legacy_json_bytes(tmp_path):
+    rd = _make_run_dir(tmp_path, task="\u7814\u7a76\u7075\u53f0")
+
+    raw = rd.daemon_json_path.read_bytes()
+    data = json.loads(raw)
+    assert raw == json.dumps(data, indent=2, ensure_ascii=False).encode("utf-8")
+    assert not raw.endswith(b"\n")
+    assert "\u7814\u7a76\u7075\u53f0".encode("utf-8") in raw
+
+
+def test_daemon_jsonl_preserves_legacy_utf8_bytes(tmp_path):
+    rd = _make_run_dir(tmp_path)
+    entry = {"event": "note", "text": "\u7075\u53f0"}
+
+    rd._append_jsonl(rd.events_path, entry)
+
+    line = rd.events_path.read_text(encoding="utf-8").splitlines()[-1]
+    assert line == json.dumps(entry, ensure_ascii=False)
+    assert "\u7075\u53f0" in line
 
 
 def test_initial_daemon_json_records_group_id(tmp_path):

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -34,6 +34,7 @@ from lingtai_kernel.notifications import (
     collect_notifications,
     publish,
     clear,
+    save_large_result_acks,
 )
 
 
@@ -119,7 +120,30 @@ def test_publish_atomic_no_tmp_residue(tmp_path: Path) -> None:
     publish(tmp_path, "email", {"x": 1})
     notif_dir = tmp_path / ".notification"
     assert (notif_dir / "email.json").is_file()
-    assert not (notif_dir / "email.json.tmp").exists()
+    leftover = [p for p in notif_dir.iterdir() if p.name.endswith(".tmp")]
+    assert leftover == []
+
+
+def test_publish_preserves_compact_json_bytes(tmp_path: Path) -> None:
+    payload = {"message": "\u7075\u53f0", "count": 1}
+    publish(tmp_path, "email", payload)
+
+    raw = (tmp_path / ".notification" / "email.json").read_bytes()
+    assert raw == json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    assert not raw.endswith(b"\n")
+
+
+def test_large_result_acks_preserve_compact_json_bytes(tmp_path: Path) -> None:
+    ref_ids = {"ref-\u7075", "ref-a"}
+    save_large_result_acks(tmp_path, ref_ids)
+
+    raw = (tmp_path / ".notification" / "large_result_acks.json").read_bytes()
+    assert raw == json.dumps(sorted(ref_ids), ensure_ascii=False).encode("utf-8")
+    assert not raw.endswith(b"\n")
+    leftover = [
+        p for p in (tmp_path / ".notification").iterdir() if p.name.endswith(".tmp")
+    ]
+    assert leftover == []
 
 
 def test_clear_idempotent(tmp_path: Path) -> None:
@@ -156,7 +180,7 @@ def test_concurrent_publish_atomicity(tmp_path: Path) -> None:
 
     # No .tmp residue.
     notif_dir = tmp_path / ".notification"
-    leftover = list(notif_dir.glob("*.tmp"))
+    leftover = [p for p in notif_dir.iterdir() if p.name.endswith(".tmp")]
     assert leftover == [], f"Stale tmp files: {leftover}"
 
 

--- a/tests/test_token_ledger.py
+++ b/tests/test_token_ledger.py
@@ -13,6 +13,7 @@ from lingtai_kernel.services.logging import (
 )
 from lingtai_kernel.token_ledger import (
     append_token_entry,
+    count_main_api_calls,
     is_daemon_entry,
     sum_token_ledger,
 )
@@ -64,6 +65,39 @@ def test_sum_ignores_corrupt_lines(tmp_path):
     }
 
 
+def test_token_ledger_readers_skip_non_dict_records(tmp_path):
+    """Shared JSONL iteration can yield non-dicts; ledger readers ignore them."""
+    path = tmp_path / "token_ledger.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                "[1, 2, 3]",
+                json.dumps(
+                    {
+                        "source": "main",
+                        "input": 5,
+                        "output": 3,
+                        "thinking": 2,
+                        "cached": 1,
+                    }
+                ),
+                "not json",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert count_main_api_calls(path) == 1
+    assert sum_token_ledger(path) == {
+        "input_tokens": 5,
+        "output_tokens": 3,
+        "thinking_tokens": 2,
+        "cached_tokens": 1,
+        "api_calls": 1,
+    }
+
+
 def test_append_creates_parent_dirs(tmp_path):
     """append_token_entry creates parent directories if missing."""
     path = tmp_path / "logs" / "token_ledger.jsonl"
@@ -74,6 +108,29 @@ def test_append_creates_parent_dirs(tmp_path):
     entry = json.loads(lines[0])
     assert entry["input"] == 100
     assert "ts" in entry
+
+
+def test_append_token_entry_preserves_legacy_jsonl_bytes(tmp_path):
+    """Token ledger rows remain compact ASCII-escaped JSON plus one newline."""
+    path = tmp_path / "token_ledger.jsonl"
+    append_token_entry(
+        path,
+        input=1,
+        output=2,
+        thinking=3,
+        cached=4,
+        model="\u6a21\u578b-\u7075\u53f0",
+        endpoint="https://\u4f8b\u5b50.example",
+        extra={"source": "main"},
+    )
+
+    raw = path.read_bytes()
+    assert raw.endswith(b"\n")
+    line = raw.decode("utf-8").removesuffix("\n")
+    entry = json.loads(line)
+    assert line == json.dumps(entry)
+    assert "\\u7075\\u53f0" in line
+    assert "\u7075\u53f0" not in line
 
 
 def test_append_standard_token_ledger_mirrors_to_sqlite(tmp_path):


### PR DESCRIPTION
## Summary
- Move selected persistence write paths onto the shared filesystem-state helpers.
- Cover token-ledger JSONL, daemon run-dir JSON/JSONL, and notification atomic-write behavior.
- Leave contacts, SQLite offset parsing, and mailbox persistence out of scope.

## Why
These paths were reimplementing small persistence details independently. Using the shared helpers reduces drift while preserving byte formats, offset behavior, compact JSON output, and notification temp-file filtering.

## Validation
- `python -m py_compile` on changed modules
- `python -m pytest tests/test_token_ledger.py tests/test_daemon_run_dir.py tests/test_notification_sync.py tests/test_fsutil.py tests/test_daemon_manifest.py tests/test_services_logging.py` (`226 passed`)
- `git diff --check canonical/main...HEAD`
- Independent Claude Code and GLM reviews found no blockers.
