### PR TITLE
Share addon skill and identity helpers

### DIFF
--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -5,6 +5,7 @@ related_files:
   - src/lingtai/core/mcp/ANATOMY.md
   - src/lingtai/mcp_catalog.json
   - src/lingtai/mcp_servers/__init__.py
+  - src/lingtai/mcp_servers/_identity.py
   - src/lingtai/mcp_servers/_skill.py
   - src/lingtai/mcp_servers/cloud_mail/manager.py
   - src/lingtai/mcp_servers/feishu/manager.py
@@ -31,16 +32,16 @@ Curated MCP server package implementations shipped inside the `lingtai` Python d
 | File / folder | Role |
 |---|---|
 | `_skill.py` | Shared bundled-skill helper: re-exports the kernel-owned `split_frontmatter` from `lingtai_kernel._frontmatter` (one impl shared with the prompt-section catalog; kernel never imports the wrapper), `load_skill()` loads package `SKILL.md`, `manual_action_description()` injects frontmatter into the schema, and `manual_payload()` returns the manual body + absolute path without sidecar lists (`_skill.py:36-82`). |
-| `telegram/` | Telegram MCP. It predates `_skill.py` and keeps an inline SKILL.md loader/manual payload with the same minimal contract (`telegram/manager.py:40-118`, `telegram/manager.py:1616-1633`). |
-| `imap/`, `feishu/`, `wechat/`, `whatsapp/`, `cloud_mail/` | Curated MCPs using `_skill.py` for their `action="manual"` payloads (`imap/manager.py:322-333`, `feishu/manager.py:454-466`, `wechat/manager.py:504-516`, `whatsapp/manager.py:174-186`, `cloud_mail/manager.py:213-225`). |
+| `_identity.py` | Shared public-identity envelope/path/write helper for curated messaging MCPs: builds the `lingtai.mcp.identity.v1` document, computes `system/mcp_identities/<name>.json`, and performs the newline-terminated atomic JSON write. Provider-specific account fields and redaction stay in each provider. |
+| `telegram/`, `imap/`, `feishu/`, `wechat/`, `whatsapp/`, `cloud_mail/` | Curated MCPs using `_skill.py` for their `action="manual"` payloads (`telegram/manager.py`, `imap/manager.py`, `feishu/manager.py`, `wechat/manager.py`, `whatsapp/manager.py`, `cloud_mail/manager.py`). Messaging MCPs with runtime account identity also delegate their identity envelope/path/write policy to `_identity.py`. |
 | Per-package `SKILL.md` | The human/agent-facing bundled manual. If a manual has sidecars, the sidecar inventory and relative paths live in this markdown, not in the tool payload. |
 | `pyproject.toml` package-data entries | Ships every curated MCP `SKILL.md`; `reference/**/*` and `assets/**/*` are also packaged for future sidecar files (`pyproject.toml:81-86`). |
 
 ## Connections
 
 - Catalog/script launchers (`pyproject.toml:43-49`) start these servers as subprocess MCPs; agents activate them through the generic MCP capability (`src/lingtai/core/mcp/ANATOMY.md`).
-- Manager schemas include `manual` in each action enum and use either `_skill.manual_action_description()` or Telegram's inline equivalent to advertise the bundled skill without loading the full body into the resident schema (`_skill.py:44-58`, `telegram/manager.py:111-124`).
-- Tests pin the manual contract and package-data sidecar support in `tests/test_mcp_skill_manuals.py` and Telegram's legacy path in `tests/test_telegram_rich_formatting.py`.
+- Manager schemas include `manual` in each action enum and use `_skill.manual_action_description()` to advertise the bundled skill without loading the full body into the resident schema.
+- Tests pin the manual contract, package-data sidecar support, and Telegram parity in `tests/test_mcp_skill_manuals.py` and `tests/test_telegram_rich_formatting.py`.
 
 ## Composition
 
@@ -48,10 +49,9 @@ Parent: `src/lingtai/` wrapper package (`src/lingtai/ANATOMY.md`). Sibling wrapp
 
 ## State
 
-The package itself is mostly code + packaged manuals. Runtime state is per-agent and server-specific: e.g. message caches, contacts, inbox replay guards, or credential-derived identities live under the agent workdir or `.secrets/`, not in `src/lingtai/mcp_servers/`. The shared manual helper has no persistent state.
+The package itself is mostly code + packaged manuals. Runtime state is per-agent and server-specific: e.g. message caches, contacts, inbox replay guards, or credential-derived identities live under the agent workdir or `.secrets/`, not in `src/lingtai/mcp_servers/`. The shared manual and identity helpers have no persistent state of their own.
 
 ## Notes
 
 - **Manual sidecar minimal contract:** `action="manual"` returns the main `SKILL.md` body, parsed metadata, and the main `SKILL.md` absolute `path` only. Concrete `assets/` and `reference/` lists MUST NOT be returned as structured tool fields; `SKILL.md` is the single source of truth for what sidecars exist and how to follow their relative paths.
 - **Packaging discipline:** when adding manual sidecars, put their relative paths in `SKILL.md` and keep the package-data globs for `reference/**/*` / `assets/**/*` so wheels contain them (`pyproject.toml:81-86`).
-- **Telegram exception:** Telegram still has an inline copy of the helper logic for historical reasons; keep its comments/tests aligned with `_skill.py` until it is deliberately migrated.

--- a/src/lingtai/mcp_servers/_identity.py
+++ b/src/lingtai/mcp_servers/_identity.py
@@ -1,0 +1,67 @@
+"""Shared public-identity helpers for curated messaging MCP servers."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+IDENTITY_SCHEMA = "lingtai.mcp.identity.v1"
+
+__all__ = [
+    "IDENTITY_SCHEMA",
+    "identity_payload",
+    "identity_path",
+    "write_identity_file",
+]
+
+
+def identity_payload(
+    mcp_name: str,
+    accounts: list[dict[str, Any]],
+    *,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Build the non-secret MCP identity document for a curated provider."""
+    payload: dict[str, Any] = {
+        "schema": IDENTITY_SCHEMA,
+        "mcp": mcp_name,
+        "generated_at": generated_at or datetime.now(timezone.utc).isoformat(),
+        "accounts": accounts,
+    }
+    verified = [
+        a.get("last_verified_at") for a in accounts if a.get("last_verified_at")
+    ]
+    if verified:
+        payload["last_verified_at"] = max(str(v) for v in verified)
+    return payload
+
+
+def identity_path(working_dir: str | Path, mcp_name: str) -> Path:
+    return Path(working_dir) / "system" / "mcp_identities" / f"{mcp_name}.json"
+
+
+def write_identity_file(path: str | Path, payload: dict[str, Any]) -> Path:
+    """Atomically write public, non-secret MCP identity metadata."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+    return path

--- a/src/lingtai/mcp_servers/_skill.py
+++ b/src/lingtai/mcp_servers/_skill.py
@@ -6,10 +6,7 @@ body on demand (progressive disclosure), while the frontmatter ``name`` +
 ``description`` are injected into the tool schema's ``manual`` action line as a
 catalog entry. This module factors out the tiny frontmatter parser, the loader,
 the schema catalog line, and the ``action='manual'`` payload so every MCP can
-share one understandable implementation instead of copying Telegram's.
-
-The original Telegram MCP keeps its own inline copy of this logic for historical
-reasons; new/curated MCPs use this shared helper.
+share one understandable implementation.
 """
 
 from __future__ import annotations

--- a/src/lingtai/mcp_servers/feishu/service.py
+++ b/src/lingtai/mcp_servers/feishu/service.py
@@ -8,12 +8,10 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import tempfile
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from .. import _identity
 from .account import FeishuAccount
 
 logger = logging.getLogger(__name__)
@@ -77,45 +75,16 @@ class FeishuService:
 
     def identity_payload(self) -> dict[str, Any]:
         """Build the non-secret MCP identity document for this service."""
-        now = datetime.now(timezone.utc).isoformat()
-        accounts = self.account_details()
-        verified = [
-            a.get("last_verified_at") for a in accounts if a.get("last_verified_at")
-        ]
-        payload: dict[str, Any] = {
-            "schema": "lingtai.mcp.identity.v1",
-            "mcp": "feishu",
-            "generated_at": now,
-            "accounts": accounts,
-        }
-        if verified:
-            payload["last_verified_at"] = max(str(v) for v in verified)
-        return payload
+        return _identity.identity_payload("feishu", self.account_details())
 
     def identity_path(self) -> Path:
-        return self._working_dir / "system" / "mcp_identities" / "feishu.json"
+        return _identity.identity_path(self._working_dir, "feishu")
 
     def write_identity_file(self) -> Path:
         """Atomically write public, non-secret MCP identity metadata."""
-        path = self.identity_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(
-            dir=str(path.parent),
-            prefix=f".{path.name}.",
-            suffix=".tmp",
+        return _identity.write_identity_file(
+            self.identity_path(), self.identity_payload()
         )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(self.identity_payload(), f, indent=2, ensure_ascii=False)
-                f.write("\n")
-            os.replace(tmp, path)
-        except Exception:
-            try:
-                os.unlink(tmp)
-            except FileNotFoundError:
-                pass
-            raise
-        return path
 
     def _contact_count(self, alias: str) -> int | None:
         contacts_path = self._working_dir / "feishu" / alias / "contacts.json"

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -25,6 +25,8 @@ from uuid import uuid4
 import logging
 import threading
 
+from .. import _skill
+
 if TYPE_CHECKING:
     from .service import TelegramService
 
@@ -44,84 +46,8 @@ def _load_notification_header_template() -> str:
 # catalog entry, while the full body stays behind action='manual'.
 # ---------------------------------------------------------------------------
 
-_SKILL_FILENAME = "SKILL.md"
-
-
-def _split_frontmatter(text: str) -> tuple[dict[str, str], str]:
-    """Split a SKILL.md into (frontmatter dict, body markdown).
-
-    Tiny dependency-free parser for the leading ``---`` YAML block. Handles the
-    flat ``key: value`` and ``key: |``/``key: >`` block-scalar forms used by our
-    skill frontmatter; it does not attempt to be a general YAML parser. Returns
-    an empty mapping and the original text when no frontmatter is present.
-    """
-    if not text.startswith("---"):
-        return {}, text
-    lines = text.splitlines(keepends=True)
-    # lines[0] is the opening '---'; find the closing fence.
-    end = None
-    for i in range(1, len(lines)):
-        if lines[i].rstrip("\n").strip() == "---":
-            end = i
-            break
-    if end is None:
-        return {}, text
-
-    fm_lines = [ln.rstrip("\n") for ln in lines[1:end]]
-    body = "".join(lines[end + 1:]).lstrip("\n")
-
-    meta: dict[str, str] = {}
-    key: str | None = None
-    block_parts: list[str] = []
-
-    def _flush() -> None:
-        if key is not None:
-            meta[key] = " ".join(" ".join(block_parts).split())
-
-    for raw in fm_lines:
-        if key is not None and (raw.startswith((" ", "\t")) or not raw.strip()):
-            # Continuation line of a block scalar (key: | / key: >).
-            block_parts.append(raw.strip())
-            continue
-        if ":" in raw and not raw.startswith((" ", "\t")):
-            _flush()
-            k, _, v = raw.partition(":")
-            key = k.strip()
-            block_parts = []
-            v = v.strip()
-            if v in ("|", ">", "|-", ">-", "|+", ">+"):
-                # Block scalar — value continues on indented lines below.
-                continue
-            block_parts.append(v.strip("'\""))
-    _flush()
-    return meta, body
-
-
-def _load_skill() -> tuple[dict[str, str], str, str]:
-    """Load the bundled SKILL.md → (frontmatter, body, path)."""
-    resource = resources.files(__package__).joinpath(_SKILL_FILENAME)
-    text = resource.read_text(encoding="utf-8")
-    frontmatter, body = _split_frontmatter(text)
-    return frontmatter, body, str(resource)
-
-
-_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _load_skill()
-
-
-def _manual_action_description() -> str:
-    """Build the schema 'manual' action line from the skill frontmatter.
-
-    Injects the skill name + description (the frontmatter/catalog entry) so the
-    tool schema advertises the skill while the full body stays progressive-
-    disclosure behind action='manual'.
-    """
-    name = _SKILL_FRONTMATTER.get("name", "telegram-mcp-manual")
-    description = _SKILL_FRONTMATTER.get("description", "")
-    return (
-        f"manual: progressive-disclosure usage manual (skill '{name}') — "
-        "call this (no other args) to pull the full bundled SKILL.md. "
-        f"{description}"
-    ).strip()
+_SKILL_NAME = "telegram-mcp-manual"
+_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _skill.load_skill(__package__)
 
 
 _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()
@@ -285,7 +211,7 @@ SCHEMA = {
                 "To receive messages from that user, their Telegram user ID must also be in allowed_users. "
                 "remove_contact: remove a contact (alias or chat_id). "
                 "accounts: list configured bot accounts. "
-                + _manual_action_description()
+                + _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME)
             ),
         },
         "account": {
@@ -1623,11 +1549,6 @@ class TelegramManager:
     # tool-side list; do not add assets/references fields here.
 
     def _manual(self) -> dict:
-        return {
-            "status": "ok",
-            "action": "manual",
-            "skill": _SKILL_FRONTMATTER.get("name", "telegram-mcp-manual"),
-            "metadata": dict(_SKILL_FRONTMATTER),
-            "path": _SKILL_PATH,
-            "manual": _SKILL_BODY,
-        }
+        return _skill.manual_payload(
+            _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
+        )

--- a/src/lingtai/mcp_servers/telegram/service.py
+++ b/src/lingtai/mcp_servers/telegram/service.py
@@ -8,12 +8,10 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import tempfile
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from .. import _identity
 from .account import TelegramAccount
 
 logger = logging.getLogger(__name__)
@@ -78,43 +76,16 @@ class TelegramService:
 
     def identity_payload(self) -> dict[str, Any]:
         """Build the non-secret MCP identity document for this service."""
-        now = datetime.now(timezone.utc).isoformat()
-        accounts = self.account_details()
-        verified = [a.get("last_verified_at") for a in accounts if a.get("last_verified_at")]
-        payload: dict[str, Any] = {
-            "schema": "lingtai.mcp.identity.v1",
-            "mcp": "telegram",
-            "generated_at": now,
-            "accounts": accounts,
-        }
-        if verified:
-            payload["last_verified_at"] = max(str(v) for v in verified)
-        return payload
+        return _identity.identity_payload("telegram", self.account_details())
 
     def identity_path(self) -> Path:
-        return self._working_dir / "system" / "mcp_identities" / "telegram.json"
+        return _identity.identity_path(self._working_dir, "telegram")
 
     def write_identity_file(self) -> Path:
         """Atomically write public, non-secret MCP identity metadata."""
-        path = self.identity_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(
-            dir=str(path.parent),
-            prefix=f".{path.name}.",
-            suffix=".tmp",
+        return _identity.write_identity_file(
+            self.identity_path(), self.identity_payload()
         )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(self.identity_payload(), f, indent=2, ensure_ascii=False)
-                f.write("\n")
-            os.replace(tmp, path)
-        except Exception:
-            try:
-                os.unlink(tmp)
-            except FileNotFoundError:
-                pass
-            raise
-        return path
 
     def _contact_count(self, alias: str) -> int | None:
         contacts_path = self._working_dir / "telegram" / alias / "contacts.json"

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -25,7 +25,7 @@ from .types import (
 from . import api
 from . import media as media_mod
 from .lockfile import AccountLock, PollerLockBusy
-from .. import _skill
+from .. import _identity, _skill
 
 if TYPE_CHECKING:
     pass
@@ -766,45 +766,16 @@ class WechatManager:
 
     def identity_payload(self) -> dict[str, Any]:
         """Build the non-secret MCP identity document for this service."""
-        now = datetime.now(timezone.utc).isoformat()
-        accounts = self.account_details()
-        verified = [
-            a.get("last_verified_at") for a in accounts if a.get("last_verified_at")
-        ]
-        payload: dict[str, Any] = {
-            "schema": "lingtai.mcp.identity.v1",
-            "mcp": "wechat",
-            "generated_at": now,
-            "accounts": accounts,
-        }
-        if verified:
-            payload["last_verified_at"] = max(str(v) for v in verified)
-        return payload
+        return _identity.identity_payload("wechat", self.account_details())
 
     def identity_path(self) -> Path:
-        return self._working_dir / "system" / "mcp_identities" / "wechat.json"
+        return _identity.identity_path(self._working_dir, "wechat")
 
     def write_identity_file(self) -> Path:
         """Atomically write public, non-secret MCP identity metadata."""
-        path = self.identity_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(
-            dir=str(path.parent),
-            prefix=f".{path.name}.",
-            suffix=".tmp",
+        return _identity.write_identity_file(
+            self.identity_path(), self.identity_payload()
         )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(self.identity_payload(), f, indent=2, ensure_ascii=False)
-                f.write("\n")
-            os.replace(tmp, path)
-        except Exception:
-            try:
-                os.unlink(tmp)
-            except FileNotFoundError:
-                pass
-            raise
-        return path
 
     # ── Helpers ─────────────────────────────────────────────────
 

--- a/src/lingtai/mcp_servers/whatsapp/manager.py
+++ b/src/lingtai/mcp_servers/whatsapp/manager.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 import json
-import os
 import re
-import tempfile
 import threading
 from datetime import datetime, timezone
 from importlib import resources
@@ -15,7 +13,7 @@ from uuid import uuid4
 from .client import WhatsAppClient
 from .redaction import redact_account
 from .webhook import extract_events
-from .. import _skill
+from .. import _identity, _skill
 
 
 def _load_notification_header_template() -> str:
@@ -361,44 +359,18 @@ class WhatsAppManager:
 
     def identity_payload(self) -> dict[str, Any]:
         """Build the non-secret MCP identity document for this service."""
-        accounts = self.account_details()
-        verified = [
-            a.get("last_verified_at") for a in accounts if a.get("last_verified_at")
-        ]
-        payload: dict[str, Any] = {
-            "schema": "lingtai.mcp.identity.v1",
-            "mcp": "whatsapp",
-            "generated_at": _utcnow(),
-            "accounts": accounts,
-        }
-        if verified:
-            payload["last_verified_at"] = max(str(v) for v in verified)
-        return payload
+        return _identity.identity_payload(
+            "whatsapp", self.account_details(), generated_at=_utcnow()
+        )
 
     def identity_path(self) -> Path:
-        return self.working_dir / "system" / "mcp_identities" / "whatsapp.json"
+        return _identity.identity_path(self.working_dir, "whatsapp")
 
     def write_identity_file(self) -> Path:
         """Atomically write public, non-secret MCP identity metadata."""
-        path = self.identity_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(
-            dir=str(path.parent),
-            prefix=f".{path.name}.",
-            suffix=".tmp",
+        return _identity.write_identity_file(
+            self.identity_path(), self.identity_payload()
         )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(self.identity_payload(), f, indent=2, ensure_ascii=False)
-                f.write("\n")
-            os.replace(tmp, path)
-        except Exception:
-            try:
-                os.unlink(tmp)
-            except FileNotFoundError:
-                pass
-            raise
-        return path
 
     def ingest_webhook(self, alias: str, payload: dict[str, Any]) -> list[dict[str, Any]]:
         events = extract_events(payload)

--- a/tests/test_mcp_identity_discovery.py
+++ b/tests/test_mcp_identity_discovery.py
@@ -15,6 +15,7 @@ a (hypothetical) malformed identity file on disk contains them.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -24,6 +25,11 @@ from lingtai.core.mcp import (
     IDENTITY_SAFE_ACCOUNT_KEYS,
     read_identities,
 )
+from lingtai.mcp_servers import _identity
+from lingtai.mcp_servers.feishu.service import FeishuService
+from lingtai.mcp_servers.telegram.service import TelegramService
+from lingtai.mcp_servers.wechat.manager import WechatManager
+from lingtai.mcp_servers.whatsapp.manager import WhatsAppManager
 from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
 
@@ -68,6 +74,78 @@ def _mk_agent(tmp_path: Path, *, addons=None):
         capabilities={"mcp": {}},
         addons=addons,
     ), workdir
+
+
+def _provider_with_accounts(
+    cls, workdir_attr: str, workdir: Path, accounts: list[dict]
+):
+    provider = object.__new__(cls)
+    setattr(provider, workdir_attr, workdir)
+    provider.account_details = lambda: accounts
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Producer helpers used by curated messaging addons
+# ---------------------------------------------------------------------------
+
+def test_shared_identity_payload_top_level_keys_and_last_verified_at():
+    accounts = [
+        {"alias": "older", "last_verified_at": "2026-06-24T09:59:00+00:00"},
+        {"alias": "newer", "last_verified_at": "2026-06-24T10:01:00+00:00"},
+        {"alias": "unverified"},
+    ]
+
+    assert _identity.identity_payload(
+        "telegram",
+        accounts,
+        generated_at="2026-06-24T10:05:00+00:00",
+    ) == {
+        "schema": "lingtai.mcp.identity.v1",
+        "mcp": "telegram",
+        "generated_at": "2026-06-24T10:05:00+00:00",
+        "accounts": accounts,
+        "last_verified_at": "2026-06-24T10:01:00+00:00",
+    }
+
+
+@pytest.mark.parametrize(
+    ("cls", "workdir_attr", "name"),
+    [
+        (TelegramService, "_working_dir", "telegram"),
+        (FeishuService, "_working_dir", "feishu"),
+        (WechatManager, "_working_dir", "wechat"),
+        (WhatsAppManager, "working_dir", "whatsapp"),
+    ],
+)
+def test_curated_identity_provider_methods_keep_payload_path_and_write_contract(
+    tmp_path, cls, workdir_attr, name
+):
+    accounts = [
+        {"alias": "main", "last_verified_at": "2026-06-24T09:59:00+00:00"},
+        {"alias": "ops", "last_verified_at": "2026-06-24T10:02:00+00:00"},
+    ]
+    provider = _provider_with_accounts(cls, workdir_attr, tmp_path, accounts)
+
+    payload = provider.identity_payload()
+    assert payload["schema"] == "lingtai.mcp.identity.v1"
+    assert payload["mcp"] == name
+    assert payload["accounts"] is accounts
+    assert payload["last_verified_at"] == "2026-06-24T10:02:00+00:00"
+    datetime.fromisoformat(payload["generated_at"])
+
+    expected_path = tmp_path / "system" / "mcp_identities" / f"{name}.json"
+    assert provider.identity_path() == expected_path
+
+    written_path = provider.write_identity_file()
+    assert written_path == expected_path
+    text = written_path.read_text(encoding="utf-8")
+    assert text.endswith("\n")
+    written = json.loads(text)
+    assert written["schema"] == "lingtai.mcp.identity.v1"
+    assert written["mcp"] == name
+    assert written["accounts"] == accounts
+    assert written["last_verified_at"] == "2026-06-24T10:02:00+00:00"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_skill_manuals.py
+++ b/tests/test_mcp_skill_manuals.py
@@ -3,8 +3,7 @@
 Each curated MCP ships a standard skill file (``SKILL.md``: YAML frontmatter +
 markdown body) in its package folder, exposes an ``action='manual'`` that returns
 the full body plus parsed metadata, and injects the frontmatter name/description
-into its tool schema as a progressive-disclosure catalog entry. This mirrors the
-Telegram MCP pattern (covered by tests/test_telegram_rich_formatting.py).
+into its tool schema as a progressive-disclosure catalog entry.
 
 The ``manual`` action is account-independent and reads only module-level
 constants, so we call it on a bare instance (``object.__new__``) without standing
@@ -19,6 +18,7 @@ import pytest
 
 from lingtai.mcp_servers import _skill
 
+from lingtai.mcp_servers.telegram import manager as telegram_mgr
 from lingtai.mcp_servers.feishu import manager as feishu_mgr
 from lingtai.mcp_servers.wechat import manager as wechat_mgr
 from lingtai.mcp_servers.imap import manager as imap_mgr
@@ -28,6 +28,7 @@ from lingtai.mcp_servers.whatsapp import manager as whatsapp_mgr
 
 # (module, package-folder name, manual-method name, expected skill name)
 _CASES = [
+    (telegram_mgr, "telegram", "_manual", "telegram-mcp-manual"),
     (feishu_mgr, "feishu", "_manual", "feishu-mcp-manual"),
     (wechat_mgr, "wechat", "_handle_manual", "wechat-mcp-manual"),
     (imap_mgr, "imap", "_manual", "imap-mcp-manual"),
@@ -36,6 +37,7 @@ _CASES = [
 ]
 
 _MANAGER_CLS = {
+    "telegram": "TelegramManager",
     "feishu": "FeishuManager",
     "wechat": "WechatManager",
     "imap": "IMAPMailManager",


### PR DESCRIPTION
## Summary
- Add shared addon helpers for bundled skill/manual rendering and identity-file payload construction.
- Keep Telegram, Feishu, WeChat, and WhatsApp public wrappers intact while delegating common internals.
- Preserve redaction/projection behavior and output envelopes.

## Why
The addon entry points had repeated manual/identity helper logic. Sharing the internal implementation reduces duplicated code without changing the public addon APIs.

## Validation
- Focused addon/manual/identity tests passed (`106 passed`).
- `python -m compileall` on changed addon modules
- `git diff --check canonical/main...HEAD`
- Independent Claude Code and GLM reviews found no blockers.
