### PR TITLE
Reuse daemon process and test helpers

### DIFF
--- a/src/lingtai/core/daemon/claude_interactive.py
+++ b/src/lingtai/core/daemon/claude_interactive.py
@@ -28,13 +28,13 @@ import queue
 import re
 import select
 import shlex
-import signal
 import subprocess
 import threading
 import time
 from typing import Callable
 
 from .run_dir import DaemonRunDir
+from .runtime import kill_process_group
 
 
 @dataclass(slots=True)
@@ -584,25 +584,6 @@ class ClaudeInteractiveBridge:
         self._prompt_sent = True
         self._write_state(claude_interactive_prompt_sent=True)
 
-    def _kill_process_group(self, proc: subprocess.Popen) -> None:
-        try:
-            os.killpg(proc.pid, signal.SIGTERM)
-        except (ProcessLookupError, OSError):
-            pass
-        try:
-            proc.wait(timeout=2)
-            return
-        except subprocess.TimeoutExpired:
-            pass
-        try:
-            os.killpg(proc.pid, signal.SIGKILL)
-        except (ProcessLookupError, OSError):
-            pass
-        try:
-            proc.wait(timeout=1)
-        except subprocess.TimeoutExpired:  # pragma: no cover - defensive
-            pass
-
     def _command(self, settings_json: str) -> list[str]:
         cmd = ["claude"]
         if self.resume_session_id:
@@ -663,7 +644,7 @@ class ClaudeInteractiveBridge:
             with self.raw_pty_log_path.open("ab") as raw_log:
                 while True:
                     if self.cancel_event.is_set():
-                        self._kill_process_group(proc)
+                        kill_process_group(proc, term_timeout=2.0, kill_timeout=1.0)
                         break
 
                     self._handle_hook_events(master_fd)
@@ -682,7 +663,7 @@ class ClaudeInteractiveBridge:
                             self._respond_to_terminal_probes(master_fd, data)
                             self._handle_auth_or_trust_prompt(master_fd, data)
                             if self._prompt_warning:
-                                self._kill_process_group(proc)
+                                kill_process_group(proc, term_timeout=2.0, kill_timeout=1.0)
                                 break
 
                     # After Stop, Claude's turn is complete.  Give the process a
@@ -692,7 +673,7 @@ class ClaudeInteractiveBridge:
                         if proc.poll() is not None:
                             break
                         if time.monotonic() - stop_seen_at > 0.25:
-                            self._kill_process_group(proc)
+                            kill_process_group(proc, term_timeout=2.0, kill_timeout=1.0)
                             break
 
                     # A fast fake (and occasionally a fast real failure) can
@@ -712,7 +693,7 @@ class ClaudeInteractiveBridge:
                 try:
                     proc.wait(timeout=1)
                 except subprocess.TimeoutExpired:
-                    self._kill_process_group(proc)
+                    kill_process_group(proc, term_timeout=2.0, kill_timeout=1.0)
         finally:
             self._hook_done.set()
             # Wake the nonblocking FIFO reader if it is sitting in select/read.

--- a/src/lingtai/core/daemon/runtime.py
+++ b/src/lingtai/core/daemon/runtime.py
@@ -26,12 +26,17 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from .run_dir import DaemonRunDir
 
 
-def kill_process_group(proc: subprocess.Popen) -> None:
+def kill_process_group(
+    proc: subprocess.Popen,
+    *,
+    term_timeout: float = 5.0,
+    kill_timeout: float = 3.0,
+) -> None:
     """Terminate the entire process group for *proc*, then force-kill if needed.
 
     Requires *proc* to have been started with ``start_new_session=True`` so
     that its PGID equals its own PID.  Sends SIGTERM to the group, waits up
-    to 5 seconds, then escalates to SIGKILL for any survivors.
+    to ``term_timeout`` seconds, then escalates to SIGKILL for any survivors.
 
     Uses ``proc.pid`` directly as the PGID (since ``start_new_session=True``
     guarantees PGID == PID) to avoid a ``getpgid`` round-trip that could
@@ -47,14 +52,14 @@ def kill_process_group(proc: subprocess.Popen) -> None:
     except (ProcessLookupError, OSError):
         pass
     try:
-        proc.wait(timeout=5)
+        proc.wait(timeout=term_timeout)
     except subprocess.TimeoutExpired:
         try:
             os.killpg(pgid, signal.SIGKILL)
         except (ProcessLookupError, OSError):
             pass
         try:
-            proc.wait(timeout=3)
+            proc.wait(timeout=kill_timeout)
         except subprocess.TimeoutExpired:
             pass
 

--- a/tests/_daemon_helpers.py
+++ b/tests/_daemon_helpers.py
@@ -20,8 +20,8 @@ from lingtai_kernel.config import AgentConfig
 
 def make_daemon_agent(
     tmp_path: Path,
+    capabilities: Any | None = None,
     *,
-    capabilities: list[str] | None = None,
     working_dir_name: str = "daemon-agent",
 ) -> Agent:
     """Create the minimal mock-service Agent used by daemon tests."""
@@ -43,6 +43,7 @@ def make_daemon_run_dir(
     *,
     parent_working_dir: Path | None = None,
     handle: str = "em-test",
+    em_id: str | None = None,
     task: str = "test task",
     tools: Iterable[str] | None = ("file",),
     model: str = "mock-model",
@@ -52,8 +53,11 @@ def make_daemon_run_dir(
     parent_pid: int = 12345,
     system_prompt: str = "You are a daemon.",
     backend: str = "lingtai",
+    call_parameters: dict[str, Any] | None = None,
 ) -> DaemonRunDir:
     """Create a DaemonRunDir with explicit, daemon-test-oriented defaults."""
+    if em_id is not None:
+        handle = em_id
     if parent_working_dir is None:
         if agent is None:
             raise ValueError("make_daemon_run_dir requires agent or parent_working_dir")
@@ -72,6 +76,7 @@ def make_daemon_run_dir(
         parent_pid=parent_pid,
         system_prompt=system_prompt,
         backend=backend,
+        call_parameters=call_parameters,
     )
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -12,49 +12,8 @@ from lingtai_kernel.config import AgentConfig
 from lingtai_kernel.llm.base import FunctionSchema, ToolCall
 from lingtai_kernel.tool_call_guard import GuardDecision, ToolCallGuard
 
-
-def _make_agent(tmp_path, capabilities=None):
-    """Create a minimal Agent with mock LLM service."""
-    from lingtai.agent import Agent
-    svc = MagicMock()
-    svc.provider = "mock"
-    svc.model = "mock-model"
-    svc.create_session = MagicMock()
-    svc.make_tool_result = MagicMock()
-    agent = Agent(
-        svc,
-        working_dir=tmp_path / "daemon-agent",
-        capabilities=capabilities or ["daemon"],
-        config=AgentConfig(),
-    )
-    return agent
-
-
-def _make_run_dir(
-    agent,
-    em_id="em-test",
-    *,
-    task="test task",
-    tools=None,
-    system_prompt="You are a daemon.",
-    call_parameters=None,
-):
-    """Helper: build a DaemonRunDir matching the new _run_emanation signature."""
-    from lingtai.core.daemon.run_dir import DaemonRunDir
-    tools = ["file"] if tools is None else tools
-    return DaemonRunDir(
-        parent_working_dir=agent._working_dir,
-        handle=em_id,
-        task=task,
-        tools=tools,
-        model="mock-model",
-        max_turns=30,
-        timeout_s=300.0,
-        parent_addr=agent._working_dir.name,
-        parent_pid=12345,
-        system_prompt=system_prompt,
-        call_parameters=call_parameters,
-    )
+from tests._daemon_helpers import make_daemon_agent as _make_agent
+from tests._daemon_helpers import make_daemon_run_dir as _make_run_dir
 
 
 def _reuse_parent_service(monkeypatch, agent):

--- a/tests/test_daemon_check_historical.py
+++ b/tests/test_daemon_check_historical.py
@@ -14,24 +14,8 @@ fresh manager (empty registry, simulating post-refresh) and assert that
 erroring.
 """
 import json
-from unittest.mock import MagicMock
 
-from lingtai_kernel.config import AgentConfig
-
-
-def _make_agent(tmp_path, capabilities=None):
-    from lingtai.agent import Agent
-    svc = MagicMock()
-    svc.provider = "mock"
-    svc.model = "mock-model"
-    svc.create_session = MagicMock()
-    svc.make_tool_result = MagicMock()
-    return Agent(
-        svc,
-        working_dir=tmp_path / "daemon-agent",
-        capabilities=capabilities or ["daemon"],
-        config=AgentConfig(),
-    )
+from tests._daemon_helpers import make_daemon_agent as _make_agent
 
 
 def _make_completed_run_dir(agent, em_id="em-5", result="final report text"):

--- a/tests/test_daemon_per_batch_limits.py
+++ b/tests/test_daemon_per_batch_limits.py
@@ -2,22 +2,7 @@
 import threading
 from unittest.mock import MagicMock, patch
 
-from lingtai_kernel.config import AgentConfig
-
-
-def _make_agent(tmp_path, capabilities=None):
-    from lingtai.agent import Agent
-    svc = MagicMock()
-    svc.provider = "mock"
-    svc.model = "mock-model"
-    svc.create_session = MagicMock()
-    svc.make_tool_result = MagicMock()
-    return Agent(
-        svc,
-        working_dir=tmp_path / "daemon-agent",
-        capabilities=capabilities or ["daemon"],
-        config=AgentConfig(),
-    )
+from tests._daemon_helpers import make_daemon_agent as _make_agent
 
 
 def _stub_emanate_internals(mgr):

--- a/tests/test_daemon_runtime_helpers.py
+++ b/tests/test_daemon_runtime_helpers.py
@@ -5,6 +5,7 @@ fakes — no real subprocesses, no LLM mocks, no DaemonManager. The integrated
 behavior (closure -> helper swap inside the backend runners) is covered by the
 existing ``tests/test_daemon.py`` cancellation/timeout tests.
 """
+import subprocess
 import threading
 
 from lingtai.core.daemon import runtime
@@ -35,6 +36,37 @@ class _FakeProc:
 
     def __init__(self, stderr_lines):
         self.stderr = iter(stderr_lines)
+
+
+class _TimeoutThenExitProc:
+    """Popen stand-in that forces TERM->KILL escalation once."""
+
+    pid = 4242
+
+    def __init__(self):
+        self.wait_timeouts: list[float] = []
+
+    def wait(self, timeout):
+        self.wait_timeouts.append(timeout)
+        if len(self.wait_timeouts) == 1:
+            raise subprocess.TimeoutExpired(cmd="fake", timeout=timeout)
+        return 0
+
+
+# --------------------------------------------------------------------------
+# kill_process_group
+# --------------------------------------------------------------------------
+
+
+def test_kill_process_group_uses_configured_timeouts(monkeypatch):
+    proc = _TimeoutThenExitProc()
+    signals: list[tuple[int, int]] = []
+    monkeypatch.setattr(runtime.os, "killpg", lambda pgid, sig: signals.append((pgid, sig)))
+
+    runtime.kill_process_group(proc, term_timeout=2.0, kill_timeout=1.0)
+
+    assert signals == [(4242, runtime.signal.SIGTERM), (4242, runtime.signal.SIGKILL)]
+    assert proc.wait_timeouts == [2.0, 1.0]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reuse the shared process-group cleanup helper in the interactive Claude bridge.
- Preserve existing timeout defaults and termination behavior.
- Consolidate repeated daemon test-factory setup.

## Why
The daemon bridge and tests carried duplicated process-cleanup and fixture setup logic. This keeps cleanup semantics centralized while leaving daemon ask dispatch and JSONL/check-side work out of scope.

## Validation
- Focused daemon/bridge tests passed (`128 passed`).
- Additional daemon bridge checks passed in review.
- `git diff --check canonical/main...HEAD`
- Independent Claude Code and GLM reviews found no blockers.
