### PR TITLE
Share provider vision and search helpers

### DIFF
--- a/src/lingtai/capabilities/web_search/__init__.py
+++ b/src/lingtai/capabilities/web_search/__init__.py
@@ -113,8 +113,10 @@ def setup(
         if provider == "duckduckgo":
             search_service = create_search_service("duckduckgo")
         else:
-            from .._media_host import resolve_media_host
-            extra_kwargs: dict = {"api_host": resolve_media_host(agent)}
+            extra_kwargs: dict[str, Any] = {}
+            if provider == "minimax":
+                from .._media_host import resolve_media_host
+                extra_kwargs["api_host"] = resolve_media_host(agent)
             if provider == "zhipu":
                 from .._zhipu_mode import resolve_z_ai_mode
                 extra_kwargs["z_ai_mode"] = resolve_z_ai_mode(agent)

--- a/src/lingtai/services/vision/__init__.py
+++ b/src/lingtai/services/vision/__init__.py
@@ -11,6 +11,7 @@ Usage:
 """
 from __future__ import annotations
 
+import base64
 from abc import ABC, abstractmethod
 
 
@@ -58,6 +59,24 @@ def _read_image(image_path: str) -> tuple[bytes, str]:
     image_bytes = path.read_bytes()
     mime_type = _MIME_BY_EXT.get(path.suffix.lower(), "image/png")
     return image_bytes, mime_type
+
+
+def _image_url_messages(image_path: str, prompt: str | None = None) -> list[dict[str, object]]:
+    """Build OpenAI-compatible chat messages for image_url vision providers."""
+    image_bytes, mime_type = _read_image(image_path)
+    question = prompt or "Describe this image."
+
+    b64 = base64.b64encode(image_bytes).decode("utf-8")
+    data_url = f"data:{mime_type};base64,{b64}"
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": data_url}},
+                {"type": "text", "text": question},
+            ],
+        }
+    ]
 
 
 def create_vision_service(provider: str, *, api_key: str | None = None, **kwargs) -> VisionService:

--- a/src/lingtai/services/vision/mimo.py
+++ b/src/lingtai/services/vision/mimo.py
@@ -16,9 +16,7 @@ identical. This service wraps that with a sane MiMo-specific default.
 """
 from __future__ import annotations
 
-import base64
-
-from . import VisionService, _read_image
+from . import VisionService, _image_url_messages
 
 
 _MIMO_BASE_URL = "https://api.xiaomimimo.com/v1"
@@ -51,23 +49,9 @@ class MiMoVisionService(VisionService):
 
     def analyze_image(self, image_path: str, prompt: str | None = None) -> str:
         """Analyze an image using MiMo's vision-capable models."""
-        image_bytes, mime_type = _read_image(image_path)
-        question = prompt or "Describe this image."
-
-        b64 = base64.b64encode(image_bytes).decode("utf-8")
-        data_url = f"data:{mime_type};base64,{b64}"
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "image_url", "image_url": {"url": data_url}},
-                    {"type": "text", "text": question},
-                ],
-            }
-        ]
         raw = self._client.chat.completions.create(
             model=self._model,
-            messages=messages,
+            messages=_image_url_messages(image_path, prompt),
             max_completion_tokens=self._max_tokens,
         )
         if raw.choices:

--- a/src/lingtai/services/vision/openai.py
+++ b/src/lingtai/services/vision/openai.py
@@ -1,9 +1,7 @@
 """OpenAI vision service — standalone image analysis via OpenAI's multimodal API."""
 from __future__ import annotations
 
-import base64
-
-from . import VisionService, _read_image
+from . import VisionService, _image_url_messages
 
 
 class OpenAIVisionService(VisionService):
@@ -32,23 +30,9 @@ class OpenAIVisionService(VisionService):
 
     def analyze_image(self, image_path: str, prompt: str | None = None) -> str:
         """Analyze an image using OpenAI's vision capabilities."""
-        image_bytes, mime_type = _read_image(image_path)
-        question = prompt or "Describe this image."
-
-        b64 = base64.b64encode(image_bytes).decode("utf-8")
-        data_url = f"data:{mime_type};base64,{b64}"
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "image_url", "image_url": {"url": data_url}},
-                    {"type": "text", "text": question},
-                ],
-            }
-        ]
         raw = self._client.chat.completions.create(
             model=self._model,
-            messages=messages,
+            messages=_image_url_messages(image_path, prompt),
             max_tokens=self._max_tokens,
         )
         if not hasattr(raw, "choices"):

--- a/src/lingtai/services/websearch/__init__.py
+++ b/src/lingtai/services/websearch/__init__.py
@@ -51,7 +51,7 @@ def create_search_service(
     api_key: str | None = None,
     model: str | None = None,
     api_host: str | None = None,
-    **kwargs,
+    z_ai_mode: str = "ZAI",
 ) -> SearchService:
     """Factory — create a SearchService for the given provider.
 
@@ -60,6 +60,8 @@ def create_search_service(
                   ``"openai"``, ``"gemini"``, ``"minimax"``).
         api_key: API key for the provider (required for all except duckduckgo).
         model: Optional model override.
+        api_host: MiniMax MCP host, required by the MiniMax provider.
+        z_ai_mode: Zhipu/Z.AI endpoint mode for the Zhipu provider.
 
     Returns:
         A configured SearchService instance.
@@ -108,7 +110,7 @@ def create_search_service(
 
     if name == "zhipu":
         from .zhipu import ZhipuSearchService
-        return ZhipuSearchService(api_key=_require_key(), z_ai_mode=kwargs.get("z_ai_mode", "ZAI"))
+        return ZhipuSearchService(api_key=_require_key(), z_ai_mode=z_ai_mode)
 
     raise ValueError(
         f"Unknown web search provider: {provider!r}. "

--- a/tests/_chat_completion_helpers.py
+++ b/tests/_chat_completion_helpers.py
@@ -1,0 +1,29 @@
+"""Shared fake ChatCompletion builders for provider adapter tests."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def make_raw_response(*, content=None, reasoning_content=None, tool_calls=None):
+    """Build a minimal fake OpenAI ChatCompletion-like object."""
+    msg = SimpleNamespace(
+        content=content,
+        reasoning_content=reasoning_content,
+        tool_calls=tool_calls or [],
+    )
+    choice = SimpleNamespace(message=msg)
+    return SimpleNamespace(
+        choices=[choice],
+        usage=SimpleNamespace(
+            prompt_tokens=100,
+            completion_tokens=50,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=10),
+        ),
+    )
+
+
+def make_tool_call(id_, name, args_json="{}"):
+    return SimpleNamespace(
+        id=id_,
+        function=SimpleNamespace(name=name, arguments=args_json),
+    )

--- a/tests/test_deepseek_adapter.py
+++ b/tests/test_deepseek_adapter.py
@@ -18,7 +18,6 @@ this design.
 """
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from lingtai.llm.deepseek.adapter import DeepSeekAdapter, DeepSeekChatSession
@@ -29,31 +28,10 @@ from lingtai_kernel.llm.interface import (
     ToolCallBlock,
     ToolResultBlock,
 )
-
-
-def _make_raw_response(*, content=None, reasoning_content=None, tool_calls=None):
-    """Build a minimal fake OpenAI ChatCompletion-like object."""
-    msg = SimpleNamespace(
-        content=content,
-        reasoning_content=reasoning_content,
-        tool_calls=tool_calls or [],
-    )
-    choice = SimpleNamespace(message=msg)
-    return SimpleNamespace(
-        choices=[choice],
-        usage=SimpleNamespace(
-            prompt_tokens=100,
-            completion_tokens=50,
-            completion_tokens_details=SimpleNamespace(reasoning_tokens=10),
-        ),
-    )
-
-
-def _make_tool_call(id_, name, args_json="{}"):
-    return SimpleNamespace(
-        id=id_,
-        function=SimpleNamespace(name=name, arguments=args_json),
-    )
+from tests._chat_completion_helpers import (
+    make_raw_response as _make_raw_response,
+    make_tool_call as _make_tool_call,
+)
 
 
 def _build_session(client, iface=None):

--- a/tests/test_mimo_adapter.py
+++ b/tests/test_mimo_adapter.py
@@ -14,7 +14,6 @@ placeholder would re-trigger MiMo's verbatim-thinking loop pathology.
 """
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from lingtai.llm.mimo.adapter import MimoAdapter, MimoChatSession
@@ -25,30 +24,10 @@ from lingtai_kernel.llm.interface import (
     ToolCallBlock,
     ToolResultBlock,
 )
-
-
-def _make_raw_response(*, content=None, reasoning_content=None, tool_calls=None):
-    msg = SimpleNamespace(
-        content=content,
-        reasoning_content=reasoning_content,
-        tool_calls=tool_calls or [],
-    )
-    choice = SimpleNamespace(message=msg)
-    return SimpleNamespace(
-        choices=[choice],
-        usage=SimpleNamespace(
-            prompt_tokens=100,
-            completion_tokens=50,
-            completion_tokens_details=SimpleNamespace(reasoning_tokens=10),
-        ),
-    )
-
-
-def _make_tool_call(id_, name, args_json="{}"):
-    return SimpleNamespace(
-        id=id_,
-        function=SimpleNamespace(name=name, arguments=args_json),
-    )
+from tests._chat_completion_helpers import (
+    make_raw_response as _make_raw_response,
+    make_tool_call as _make_tool_call,
+)
 
 
 def _build_session(client, iface=None):

--- a/tests/test_vision_services.py
+++ b/tests/test_vision_services.py
@@ -21,6 +21,20 @@ def _make_openai_service(monkeypatch, raw_response):
     return OpenAIVisionService(api_key="sk-test", model="gpt-4o", base_url="http://127.0.0.1:34891")
 
 
+def _make_mimo_service(monkeypatch, raw_response):
+    """Build a MiMoVisionService whose client returns `raw_response`."""
+    completions = MagicMock()
+    completions.create.return_value = raw_response
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    openai_cls = MagicMock(return_value=client)
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=openai_cls))
+
+    from lingtai.services.vision.mimo import MiMoVisionService
+
+    svc = MiMoVisionService(api_key="sk-test", model="mimo-v2.5")
+    return svc, completions
+
+
 def test_openai_vision_raises_clear_error_on_string_response(monkeypatch, tmp_path):
     """Bug G: a raw `str` body (proxy served HTML/non-JSON) raises a clear RuntimeError.
 
@@ -68,6 +82,39 @@ def test_openai_vision_returns_content_on_valid_response(monkeypatch, tmp_path):
     svc = _make_openai_service(monkeypatch, raw)
 
     assert svc.analyze_image(str(img)) == "a candlestick chart"
+
+
+def test_mimo_vision_returns_content_on_valid_response(monkeypatch, tmp_path):
+    """A well-formed MiMo ChatCompletion returns its message content."""
+    img = tmp_path / "chart.png"
+    img.write_bytes(b"\x89PNG fake")
+
+    message = SimpleNamespace(content="a candlestick chart")
+    choice = SimpleNamespace(message=message)
+    raw = SimpleNamespace(choices=[choice])
+    svc, completions = _make_mimo_service(monkeypatch, raw)
+
+    assert svc.analyze_image(str(img), prompt="what is shown?") == "a candlestick chart"
+    kwargs = completions.create.call_args.kwargs
+    assert kwargs["model"] == "mimo-v2.5"
+    assert kwargs["max_completion_tokens"] == 1024
+    content = kwargs["messages"][0]["content"]
+    assert content[0]["type"] == "image_url"
+    assert content[0]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert content[1] == {"type": "text", "text": "what is shown?"}
+
+
+def test_mimo_vision_returns_empty_string_on_empty_choices(monkeypatch, tmp_path):
+    """Empty MiMo choices keep the existing empty-string behavior."""
+    img = tmp_path / "chart.png"
+    img.write_bytes(b"\x89PNG fake")
+
+    svc, completions = _make_mimo_service(monkeypatch, SimpleNamespace(choices=[]))
+
+    assert svc.analyze_image(str(img)) == ""
+    content = completions.create.call_args.kwargs["messages"][0]["content"]
+    assert content[0]["type"] == "image_url"
+    assert content[1] == {"type": "text", "text": "Describe this image."}
 
 
 def test_anthropic_vision_service_accepts_base_url(monkeypatch):

--- a/tests/test_web_search_capability.py
+++ b/tests/test_web_search_capability.py
@@ -88,6 +88,34 @@ def test_create_search_service_unknown():
         create_search_service("nonexistent", api_key="key")
 
 
+def test_create_search_service_minimax_passes_api_host():
+    """Factory should pass api_host only to the MiniMax service."""
+    with patch("lingtai.services.websearch.minimax.MiniMaxSearchService") as mock_cls:
+        svc = create_search_service(
+            "minimax",
+            api_key="sk-test",
+            api_host="https://mini.example",
+        )
+
+    assert svc is mock_cls.return_value
+    mock_cls.assert_called_once_with(api_key="sk-test", api_host="https://mini.example")
+
+
+def test_create_search_service_zhipu_passes_explicit_mode():
+    """Factory should pass the explicit Zhipu endpoint mode."""
+    with patch("lingtai.services.websearch.zhipu.ZhipuSearchService") as mock_cls:
+        svc = create_search_service("zhipu", api_key="sk-test", z_ai_mode="ZHIPU")
+
+    assert svc is mock_cls.return_value
+    mock_cls.assert_called_once_with(api_key="sk-test", z_ai_mode="ZHIPU")
+
+
+def test_create_search_service_rejects_unknown_kwargs():
+    """The factory API is intentionally narrow; provider kwargs must be explicit."""
+    with pytest.raises(TypeError):
+        create_search_service("zhipu", api_key="sk-test", unknown=True)
+
+
 def test_web_search_with_provider_kwarg(tmp_path):
     """web_search capability with provider= should create service via factory."""
     agent = Agent(
@@ -133,6 +161,67 @@ def test_web_search_setup_api_key_env_overrides_raw_key(monkeypatch):
         )
 
     assert mock_factory.call_args.kwargs["api_key"] == "sk-from-env"
+
+
+def test_web_search_setup_omits_api_host_for_gemini():
+    """Gemini search ignores api_host, so setup should not resolve or pass it."""
+    agent = MagicMock()
+    agent._config.language = "en"
+
+    with (
+        patch("lingtai.capabilities.web_search.create_search_service") as mock_factory,
+        patch("lingtai.capabilities._media_host.resolve_media_host") as mock_media_host,
+    ):
+        mock_factory.return_value = MagicMock(spec=SearchService)
+        setup(agent, provider="gemini", api_key="sk-test")
+
+    assert mock_factory.call_args.args == ("gemini",)
+    assert mock_factory.call_args.kwargs["api_key"] == "sk-test"
+    assert "api_host" not in mock_factory.call_args.kwargs
+    mock_media_host.assert_not_called()
+
+
+def test_web_search_setup_passes_api_host_for_minimax():
+    """MiniMax search still receives the resolved MCP host."""
+    agent = MagicMock()
+    agent._config.language = "en"
+
+    with (
+        patch("lingtai.capabilities.web_search.create_search_service") as mock_factory,
+        patch(
+            "lingtai.capabilities._media_host.resolve_media_host",
+            return_value="https://mini.example",
+        ) as mock_media_host,
+    ):
+        mock_factory.return_value = MagicMock(spec=SearchService)
+        setup(agent, provider="minimax", api_key="sk-test")
+
+    assert mock_factory.call_args.args == ("minimax",)
+    assert mock_factory.call_args.kwargs["api_host"] == "https://mini.example"
+    mock_media_host.assert_called_once_with(agent)
+
+
+def test_web_search_setup_passes_zhipu_mode_without_api_host():
+    """Zhipu search receives z_ai_mode but not the MiniMax api_host."""
+    agent = MagicMock()
+    agent._config.language = "en"
+
+    with (
+        patch("lingtai.capabilities.web_search.create_search_service") as mock_factory,
+        patch(
+            "lingtai.capabilities._zhipu_mode.resolve_z_ai_mode",
+            return_value="ZHIPU",
+        ) as mock_z_mode,
+        patch("lingtai.capabilities._media_host.resolve_media_host") as mock_media_host,
+    ):
+        mock_factory.return_value = MagicMock(spec=SearchService)
+        setup(agent, provider="zhipu", api_key="sk-test")
+
+    assert mock_factory.call_args.args == ("zhipu",)
+    assert mock_factory.call_args.kwargs["z_ai_mode"] == "ZHIPU"
+    assert "api_host" not in mock_factory.call_args.kwargs
+    mock_z_mode.assert_called_once_with(agent)
+    mock_media_host.assert_not_called()
 
 
 def test_inherited_web_search_env_key_registers(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Share OpenAI/MiMo vision message construction while keeping provider-specific response handling separate.
- Narrow web-search provider kwargs to the supported provider surfaces.
- Share DeepSeek/MiMo reasoning test fixture setup without reviving the closed provider fallback dedupe.

## Why
The duplicated message/test setup could be shared safely, but provider-specific response guards and reasoning fallback behavior should remain separate. This PR keeps that boundary explicit.

## Validation
- Focused provider/vision/search tests passed (`70 passed` + targeted preset inheritance tests `4 passed`).
- Additional targeted review suite passed (`47 passed`).
- `git diff --check canonical/main...HEAD`
- Independent Claude Code and GLM reviews found no blockers.
