### PR TITLE
fix(workdir): gitignore .secrets/ and lifecycle signals

### DIFF
--- a/src/lingtai_kernel/workdir.py
+++ b/src/lingtai_kernel/workdir.py
@@ -308,7 +308,19 @@ class WorkingDir:
             )
 
             gitignore = self._path / ".gitignore"
-            gitignore.write_text("")
+            # Exclude secrets and transient lifecycle files from git tracking.
+            # Without this, snapshot()'s `git add -A` would commit .secrets/
+            # (MCP addon credentials such as bot tokens) to git history.
+            gitignore.write_text(
+                "# Secrets — MCP addon credentials (bot tokens, API keys)\n"
+                ".secrets/\n"
+                "\n"
+                "# Transient lifecycle signal files\n"
+                ".sleep\n"
+                ".suspend\n"
+                ".agent.heartbeat\n"
+                ".timemachine.pid\n"
+            )
 
             system_dir = self._path / "system"
             system_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary

Fixes #627

`init_git()` created an empty `.gitignore`, and `snapshot()` uses `git add -A`. This caused `.secrets/` (MCP addon credentials — bot tokens, API keys, passwords) to be committed to git history.

## Change

Initialize `.gitignore` with entries for:
- `.secrets/` — MCP addon credentials
- `.sleep` — ASLEEP lifecycle signal
- `.suspend` — SUSPENDED lifecycle signal
- `.agent.heartbeat` — heartbeat file (changes every second)
- `.timemachine.pid` — time machine process ID

## Verification

- Change is content-only (string initialization); no logic changes
- Could not run tests locally (Python 3.9.6 lacks `X | None` type hint support, Python 3.13 lacks pytest)
- The change is trivial enough for visual review

## Note for existing agents

Existing agent directories still have `.secrets/` tracked in git. They need:

```bash
git rm --cached -r .secrets/
echo '.secrets/' >> .gitignore
git commit -m 'security: stop tracking .secrets/'
```

Git history scrubbing may also be needed for already-committed secrets.