### PR TITLE
fix(karma): nirvana writes .suspend not .sleep

### DIFF
--- a/src/lingtai_kernel/intrinsics/system/karma.py
+++ b/src/lingtai_kernel/intrinsics/system/karma.py
@@ -189,7 +189,11 @@ def _nirvana(agent, args: dict) -> dict:
     address = args["address"]
     resolved = args["_resolved_address"]
     if is_alive(resolved):
-        (resolved / ".sleep").write_text("")
+        # Write .suspend (not .sleep) so the process actually shuts down.
+        # .sleep sets _asleep — heartbeat continues, is_alive() stays True,
+        # and the wait loop below would always time out.
+        # .suspend sets _shutdown — process terminates, heartbeat stops.
+        (resolved / ".suspend").write_text("")
         import time as _time
         deadline = _time.time() + 10.0
         while _time.time() < deadline:
@@ -198,7 +202,7 @@ def _nirvana(agent, args: dict) -> dict:
             _time.sleep(0.5)
         else:
             if is_alive(resolved):
-                return {"error": True, "message": f"Agent at {address} did not sleep within timeout"}
+                return {"error": True, "message": f"Agent at {address} did not shut down within timeout"}
     shutil.rmtree(resolved)
     agent._log("karma_nirvana", target=address)
     return {"status": "nirvana", "address": address}


### PR DESCRIPTION
## Summary

Fixes #621

`_nirvana()` wrote `.sleep` (same as `_lull()`), which puts the agent into ASLEEP state. In ASLEEP state, the heartbeat thread continues running, so `is_alive()` stays True. This means nirvana's 10-second wait loop always times out and `shutil.rmtree()` is never reached — **nirvana is completely broken**.

## Root cause

| Signal file | Effect | `is_alive()` after |
|---|---|---|
| `.sleep` | Sets `_asleep` — process survives, heartbeat continues | True (heartbeat fresh) |
| `.suspend` | Sets `_shutdown` — process terminates, heartbeat stops | False (heartbeat stale) |

`_nirvana()` needs the process to actually die so that `is_alive()` returns False, allowing the wait loop to break and proceed to `shutil.rmtree()`.

## Change

- Line 192: `.sleep` → `.suspend`
- Line 205: Updated error message from "did not sleep" to "did not shut down"
- Added explanatory comment documenting why `.suspend` is required

## Verification

Verified across 5 files in the kernel source (`base_agent/lifecycle.py`, `base_agent/__init__.py`, `intrinsics/system/karma.py`, `handshake.py`). Could not run tests locally (Python 3.9.6 lacks `X | None` type hint support), but the change is minimal and well-understood.