### PR TITLE
fix(codex): self-heal encrypted reasoning replays

### DIFF
--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -39,7 +39,7 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | `OpenAIChatSession` | 492–1003 | Chat Completions session with context overflow auto-recovery; sends optional `prompt_cache_key` |
 | `OpenAIResponsesSession` | 1006–1204 | Responses API session with server-side `previous_response_id` chaining, optional `context_management` compaction, and optional `prompt_cache_key` |
 | `OpenAIAdapter` | 1207–1520 | `LLMAdapter` implementation; dispatches to Completions or Responses path; receives injected `compact_threshold`; derives the default `prompt_cache_key` via `_default_prompt_cache_key` / `_resolve_prompt_cache_key` |
-| `CodexResponsesSession` | `adapter.py:1641` | Responses session for ChatGPT-backed Codex running the `full`/`incremental` additive continuation state machine over a selectable transport (REST default, WebSocket opt-in): `store=false` always, encrypted reasoning include, cache-affinity headers, honest client/account identity, and honest Codex metadata envelope. |
+| `CodexResponsesSession` | `adapter.py:2223` | Responses session for ChatGPT-backed Codex running the `full`/`incremental` additive continuation state machine over a selectable transport (REST default, WebSocket opt-in): `store=false` always, encrypted reasoning include/replay, encrypted-reasoning self-heal, cache-affinity headers, honest client/account identity, and honest Codex metadata envelope. |
 | `CodexOpenAIAdapter` | `adapter.py:2017` | Codex provider specialization: forces Responses mode, derives stable per-agent cache/session ids plus a LingTai installation id from the configured anchor, and wires account/metadata hints into Codex sessions. |
 
 ### adapter.py helpers
@@ -124,13 +124,21 @@ Flow:
      wire delta, and never sends `previous_response_id`.
    - WebSocket (`codex_ws`): `full` sends the full input; `incremental` sends the
      strict-additive delta plus `previous_response_id`.
-5. After success: record the assistant response into the interface and recompute
+5. If Codex rejects a full replay with `The encrypted content for item ... could
+   not be verified`, treat it as stale raw reasoning state: `_strip_codex_encrypted_reasoning_items`
+   (`adapter.py:3242-3286`) removes replay-only `encrypted_content` anchors from
+   `ThinkingBlock.provider_data`, `_reset_ws_epoch` (`adapter.py:2856-2885`) clears
+   stale baselines/response-id state, and the adapter retries the same visible
+   transcript once as `rest_full_self_heal` / `stateless_full_self_heal`
+   (`adapter.py:3556-3640`). Summary text, assistant text, and tool calls remain
+   in the canonical interface; only the opaque provider blob is dropped.
+6. After success: record the assistant response into the interface and recompute
    the converter-stable delta baseline (`_ws_record_baseline_from_interface`) so the
    next turn can strict-prefix-match and stay incremental.
 **Usage metadata axes:** `UsageMetadata.extra` carries `codex_transport`
 (`rest`/`websocket`), `codex_transfer_mode` (`full`/`incremental`), and the
 transport-qualified `codex_request_mode` (`rest_full` / `rest_incremental` /
-`ws_full` / `ws_incremental` / `rest_full_fallback`), plus the safe delta-decision
+`ws_full` / `ws_incremental` / `rest_full_fallback` / `rest_full_self_heal` / `stateless_full_self_heal`), plus the safe delta-decision
 diagnostic (`codex_ws_delta_reason` and counts — never prompt/secret content). The
 WS-named `codex_ws_*` diagnostic keys are reused on REST (transport-neutral
 metadata); `codex_request_mode` never reads `ws_*` on a REST request.
@@ -233,7 +241,7 @@ In-flight Responses/Codex sessions therefore have a **no-op `update_system_promp
 
 - **CC streaming** (`send_stream`, line 622) — `stream=True, stream_options={include_usage: True}`. Uses `StreamingAccumulator` for text + tool deltas. Reasoning deltas captured from `delta.reasoning` or `delta.reasoning_content` (OpenRouter compatibility, lines 726-733). Overflow recovery wraps the stream open + first chunk (lines 668-690).
 - **Responses streaming** (`send_stream`, line 891) — event types: `response.reasoning_summary_text.delta/done` (summary thoughts only), `response.output_text.delta`, `response.function_call_arguments.delta`, `response.output_item.added/done`, `response.completed`.
-- **Codex streaming** — forces `stream=True` even on `send()`. Runs the `full`/`incremental` planner per request over the selected transport (REST default / WebSocket opt-in): REST carries the whole converted interface in both modes; WebSocket carries the whole interface for `full` and delta + `previous_response_id` for `incremental`. Captured summary thoughts are persisted as ThinkingBlocks so `to_responses_input` replays reasoning items before function calls. Optional diagnostics (`LINGTAI_CODEX_RESPONSES_TRACE=1`) append safe per-event metadata to `logs/codex_responses_trace.jsonl` without changing accumulator/persistence behavior.
+- **Codex streaming** — forces `stream=True` even on `send()`. Runs the `full`/`incremental` planner per request over the selected transport (REST default / WebSocket opt-in): REST carries the whole converted interface in both modes; WebSocket carries the whole interface for `full` and delta + `previous_response_id` for `incremental`. Captured summary thoughts and raw encrypted reasoning items are persisted as ThinkingBlocks so `to_responses_input` replays reasoning items before function calls; if Codex later rejects a raw encrypted item as unverifiable, the adapter strips only that opaque replay state and retries once with summary/plain transcript. Optional diagnostics (`LINGTAI_CODEX_RESPONSES_TRACE=1`) append safe per-event metadata to `logs/codex_responses_trace.jsonl` without changing accumulator/persistence behavior.
 
 ### Authentication paths
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -56,6 +56,29 @@ _CODEX_RESPONSES_TRACE_FILE = "codex_responses_trace.jsonl"
 _AUTO_PROMPT_CACHE_KEY = object()
 
 
+def _is_codex_unverifiable_encrypted_content_error(exc: BaseException) -> bool:
+    """Return True for Codex 400s caused by stale encrypted reasoning blobs.
+
+    The ChatGPT Codex Responses endpoint may reject a replayed reasoning item
+    with messages like ``The encrypted content for item rs_... could not be
+    verified``.  That is a narrow history-state failure: the opaque encrypted
+    reasoning blob is no longer accepted, but the visible transcript can usually
+    continue if we fall back to summary/plain replay.
+    """
+
+    parts = [str(exc)]
+    for attr in ("message", "body"):
+        value = getattr(exc, attr, None)
+        if value is None:
+            continue
+        if isinstance(value, (dict, list)):
+            parts.append(json.dumps(value, default=str, ensure_ascii=False))
+        else:
+            parts.append(str(value))
+    text = "\n".join(parts).lower()
+    return "encrypted content" in text and "could not be verified" in text
+
+
 # Codex REST cache-affinity headers (issue #378). The official Codex client
 # sends ``session_id`` / ``thread_id`` headers on its
 # ``/backend-api/codex/responses`` calls; a probe showed they materially
@@ -3215,6 +3238,51 @@ class CodexResponsesSession(OpenAIResponsesSession):
     def adapter_comment(self):
         """Legacy compatibility hook; Codex adapter comments are disabled."""
         return None
+
+    def _strip_codex_encrypted_reasoning_items(self) -> int:
+        """Remove replay-only encrypted reasoning blobs from canonical history.
+
+        Codex encrypted reasoning items are opaque provider state.  When the
+        backend says one cannot be verified, replaying the same blobs will fail
+        forever (AED loops).  Keep the assistant transcript/tool calls intact and
+        preserve any summary text, but drop the raw encrypted replay anchors so
+        ``to_responses_input`` emits summary_text-only reasoning or omits empty
+        thought blocks.
+        """
+
+        stripped = 0
+        for entry in self._interface.entries:
+            if entry.role != "assistant":
+                continue
+            for block in entry.content:
+                if not isinstance(block, ThinkingBlock):
+                    continue
+                provider_data = block.provider_data
+                if not isinstance(provider_data, dict):
+                    continue
+                raw_item = provider_data.get("openai_responses_reasoning_item")
+                encrypted_content = (
+                    raw_item.get("encrypted_content")
+                    if isinstance(raw_item, dict)
+                    else None
+                )
+                if not (
+                    isinstance(raw_item, dict)
+                    and raw_item.get("type") == "reasoning"
+                    and isinstance(encrypted_content, str)
+                    and encrypted_content
+                    and encrypted_content != "<REDACTED:secret>"
+                ):
+                    continue
+                provider_data.pop("openai_responses_reasoning_item", None)
+                stripped += 1
+        if stripped:
+            # Baselines/previous_response_id chains may still contain the removed
+            # raw reasoning items.  Rebase the next request from sanitized local
+            # history instead of trying to continue the poisoned epoch.
+            self._reset_ws_epoch("encrypted_reasoning_self_heal")
+        return stripped
+
     def reset_provider_turn_state(self) -> None:
         self.reset_ws_turn()
 
@@ -3488,42 +3556,88 @@ class CodexResponsesSession(OpenAIResponsesSession):
                     stream = self._client.responses.create(**kwargs)
                 except Exception as exc:
                     if not (previous_response_id or request_store):
-                        # No continuation was in flight (first full turn): a real
-                        # error, not a recoverable incremental rejection.
-                        if rest_continuation:
-                            self._ws_session.last_request = rest_prev_last_request
-                            self._ws_session.last_response = rest_prev_last_response
-                            self._ws_pending_baseline_input = None
-                        raise
-                    fallback_error_type = type(exc).__name__
-                    fallback_error_message = str(exc)
-                    logger.info(
-                        "Codex incremental Responses request failed; falling back to full replay store=false: %s: %s",
-                        fallback_error_type,
-                        fallback_error_message[:240],
-                    )
-                    # Safe fallback for any future REST stateful variant that
-                    # carries continuation state on the wire: re-send the FULL input
-                    # with no ``previous_response_id`` and ``store=false``. Current
-                    # REST incremental is already a full-input/cache-epoch request,
-                    # so ordinary REST errors are allowed to surface instead of being
-                    # hidden by an identical retry. The reason rides into the token
-                    # ledger via ``codex_fallback_error_type`` / ``codex_request_mode``.
-                    fallback_kwargs = dict(kwargs)
-                    fallback_kwargs["input"] = full_replay_input_items
-                    fallback_kwargs["store"] = False
-                    fallback_kwargs.pop("previous_response_id", None)
-                    request_mode = "rest_full_fallback" if self._transport == "rest" else "stateless_full_fallback"
-                    previous_response_id = None
-                    request_store = False
-                    if rest_continuation:
-                        # Re-park the baseline against the FULL request we actually
-                        # sent, so the next turn can still chain off this full turn.
-                        self._ws_session.last_request = self._ws_frame_request(
-                            fallback_kwargs, full_replay_input_items
+                        # No continuation was in flight (first full turn): usually a
+                        # real error, not a recoverable incremental rejection.  The
+                        # Codex encrypted-reasoning verifier is the narrow exception:
+                        # a stale opaque reasoning blob can brick every replay until
+                        # it is removed from local history, while visible transcript
+                        # text/tool calls remain valid.
+                        if _is_codex_unverifiable_encrypted_content_error(exc):
+                            stripped_reasoning_items = self._strip_codex_encrypted_reasoning_items()
+                            if stripped_reasoning_items:
+                                fallback_error_type = type(exc).__name__
+                                fallback_error_message = str(exc)
+                                logger.info(
+                                    "Codex encrypted reasoning replay failed; stripped %s raw reasoning item(s) and retrying full replay",
+                                    stripped_reasoning_items,
+                                )
+                                retry_full_replay_input_items = self._frozen_responses_input(
+                                    self._interface
+                                )
+                                retry_full_replay_input_items.extend(prebuilt_items)
+                                retry_kwargs = dict(kwargs)
+                                retry_kwargs["input"] = retry_full_replay_input_items
+                                retry_kwargs["store"] = False
+                                retry_kwargs.pop("previous_response_id", None)
+                                request_mode = (
+                                    "rest_full_self_heal"
+                                    if self._transport == "rest"
+                                    else "stateless_full_self_heal"
+                                )
+                                previous_response_id = None
+                                request_store = False
+                                full_replay_input_items = retry_full_replay_input_items
+                                if rest_continuation:
+                                    self._ws_session.last_request = self._ws_frame_request(
+                                        retry_kwargs, retry_full_replay_input_items
+                                    )
+                                    self._ws_pending_baseline_input = list(
+                                        retry_full_replay_input_items
+                                    )
+                                    continuation_turn_recorded = True
+                                stream = self._client.responses.create(**retry_kwargs)
+                            else:
+                                if rest_continuation:
+                                    self._ws_session.last_request = rest_prev_last_request
+                                    self._ws_session.last_response = rest_prev_last_response
+                                    self._ws_pending_baseline_input = None
+                                raise
+                        else:
+                            if rest_continuation:
+                                self._ws_session.last_request = rest_prev_last_request
+                                self._ws_session.last_response = rest_prev_last_response
+                                self._ws_pending_baseline_input = None
+                            raise
+                    else:
+                        fallback_error_type = type(exc).__name__
+                        fallback_error_message = str(exc)
+                        logger.info(
+                            "Codex incremental Responses request failed; falling back to full replay store=false: %s: %s",
+                            fallback_error_type,
+                            fallback_error_message[:240],
                         )
-                        self._ws_pending_baseline_input = list(full_replay_input_items)
-                    stream = self._client.responses.create(**fallback_kwargs)
+                        # Safe fallback for any future REST stateful variant that
+                        # carries continuation state on the wire: re-send the FULL input
+                        # with no ``previous_response_id`` and ``store=false``. Current
+                        # REST incremental is already a full-input/cache-epoch request,
+                        # so ordinary REST errors are allowed to surface instead of being
+                        # hidden by an identical retry. The reason rides into the token
+                        # ledger via ``codex_fallback_error_type`` / ``codex_request_mode``.
+                        fallback_kwargs = dict(kwargs)
+                        fallback_kwargs["input"] = full_replay_input_items
+                        fallback_kwargs["store"] = False
+                        fallback_kwargs.pop("previous_response_id", None)
+                        request_mode = "rest_full_fallback" if self._transport == "rest" else "stateless_full_fallback"
+                        previous_response_id = None
+                        request_store = False
+                        if rest_continuation:
+                            # Re-park the baseline against the FULL request we actually
+                            # sent, so the next turn can still chain off this full turn.
+                            self._ws_session.last_request = self._ws_frame_request(
+                                fallback_kwargs, full_replay_input_items
+                            )
+                            self._ws_pending_baseline_input = list(full_replay_input_items)
+                        stream = self._client.responses.create(**fallback_kwargs)
             for event in stream:
                 thoughts_before = acc.thoughts
                 pending_thought_chars_before = len("".join(acc._thought_parts))

--- a/tests/test_codex_prompt_cache_key.py
+++ b/tests/test_codex_prompt_cache_key.py
@@ -24,6 +24,7 @@ from lingtai.llm.openai.adapter import (
     _lingtai_user_agent,
 )
 from lingtai_kernel.llm.base import FunctionSchema
+from lingtai_kernel.llm.interface import TextBlock, ThinkingBlock
 
 
 # NOTE: these HTTP-path prompt-cache tests build Codex sessions WITHOUT an
@@ -56,6 +57,24 @@ class FakeResponses:
 class FakeClient:
     def __init__(self, events: list[Event]):
         self.responses = FakeResponses(events)
+
+
+class FailOnceResponses:
+    def __init__(self, events: list[Event], error: Exception):
+        self.events = events
+        self.error = error
+        self.kwargs: list[dict] = []
+
+    def create(self, **kwargs):
+        self.kwargs.append(kwargs)
+        if len(self.kwargs) == 1:
+            raise self.error
+        return iter(self.events)
+
+
+class FailOnceClient:
+    def __init__(self, events: list[Event], error: Exception):
+        self.responses = FailOnceResponses(events, error)
 
 
 def _usage() -> SimpleNamespace:
@@ -210,6 +229,78 @@ def test_codex_prompt_cache_key_is_stable_across_requests():
 
     keys = [kw["prompt_cache_key"] for kw in session._client.responses.kwargs]
     assert keys == ["lingtai-codex:gpt-5.5:v1", "lingtai-codex:gpt-5.5:v1"]
+
+
+def test_codex_self_heals_unverifiable_encrypted_reasoning_replay():
+    """A stale Codex encrypted reasoning blob is stripped and retried once.
+
+    The visible assistant transcript remains replayable: raw encrypted provider
+    state is removed, but the summary text survives as summary_text reasoning.
+    """
+
+    error = RuntimeError(
+        "Error code: 400 - {'error': {'message': 'The encrypted content for "
+        "item rs_bad could not be verified. Reason: Encrypted content could "
+        "not be decrypted.'}}"
+    )
+    session = CodexResponsesSession(
+        client=FailOnceClient([_completed()], error),
+        model="gpt-5.5",
+        instructions="system",
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+    )
+    session._interface.add_user_message("prior user")
+    session._interface.add_assistant_message(
+        [
+            ThinkingBlock(
+                text="safe summary",
+                provider_data={
+                    "openai_responses_reasoning_item": {
+                        "type": "reasoning",
+                        "id": "rs_bad",
+                        "summary": [{"type": "summary_text", "text": "safe summary"}],
+                        "encrypted_content": "opaque-broken-ciphertext",
+                    }
+                },
+            ),
+            TextBlock(text="visible answer"),
+        ],
+        model="gpt-5.5",
+        provider="codex",
+    )
+
+    response = session.send("continue")
+
+    assert len(session._client.responses.kwargs) == 2
+    first_input = session._client.responses.kwargs[0]["input"]
+    second_input = session._client.responses.kwargs[1]["input"]
+    assert any(
+        item.get("type") == "reasoning"
+        and item.get("encrypted_content") == "opaque-broken-ciphertext"
+        for item in first_input
+    )
+    assert not any(
+        item.get("type") == "reasoning" and "encrypted_content" in item
+        for item in second_input
+    )
+    assert any(
+        item.get("type") == "reasoning"
+        and item.get("summary") == [{"type": "summary_text", "text": "safe summary"}]
+        for item in second_input
+    )
+    assert any(
+        item.get("role") == "assistant" and item.get("content") == "visible answer"
+        for item in second_input
+    )
+    prior_assistant = [e for e in session._interface.entries if e.role == "assistant"][0]
+    prior_thinking = next(
+        block for block in prior_assistant.content if isinstance(block, ThinkingBlock)
+    )
+    assert "openai_responses_reasoning_item" not in prior_thinking.provider_data
+    assert response.usage.extra["codex_request_mode"] == "rest_full_self_heal"
+    assert response.usage.extra["codex_fallback_error_type"] == "RuntimeError"
 
 
 def test_lone_prompt_cache_key_stays_body_only_no_headers():


### PR DESCRIPTION
## Summary
- detect the specific Codex/OpenAI encrypted-reasoning verifier failure (`encrypted content` + `could not be verified`)
- strip only replay-only raw encrypted reasoning blobs from `ThinkingBlock.provider_data`, preserving summary text, visible assistant text, and tool calls
- reset the Codex continuation epoch and retry the sanitized full replay once as `rest_full_self_heal` / `stateless_full_self_heal`
- document the new failure-recovery flow in the OpenAI/Codex anatomy

## Context
Jason hit a dev1 AED exhaustion loop where every retry failed with:

> The encrypted content for item rs_... could not be verified

The dev1 process and heartbeat were healthy; the bad state was the replayed Codex encrypted reasoning item in local/provider history. A normal CPR/wait would not fix it.

## Validation
- `python3 -m py_compile src/lingtai/llm/openai/adapter.py tests/test_codex_prompt_cache_key.py`
- `PYTHONPATH=src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m py_compile src/lingtai/llm/openai/adapter.py tests/test_codex_prompt_cache_key.py`
- `PYTHONPATH=src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_codex_prompt_cache_key.py -k 'self_heals_unverifiable_encrypted_reasoning_replay or prompt_cache_key_is_stable_across_requests' -q`
- `PYTHONPATH=src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_codex_prompt_cache_key.py tests/test_codex_ws_delta.py -q`
- `PYTHONPATH=src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_codex_prompt_cache_key.py tests/test_codex_raw_reasoning_replay.py tests/test_codex_ws_delta.py tests/test_codex_ws_session.py tests/test_codex_ws_tool_result_freeze.py tests/test_openai_responses_streaming.py tests/test_tool_result_restore_after_continuation_failure.py -q`
- `PYTHONPATH=src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_codex_endpoint_override.py tests/test_codex_endpoint_pool.py tests/unit/auth/test_codex_auth.py -q`
- `git diff --check`

Full `PYTHONPATH=src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q` was attempted but timed out after 300s, so it is not counted as passing validation.

## Local report
`/Users/huangzesen/work/projects/lingtai-dev/dev-2/.lingtai/mimo-1/reports/codex-encrypted-selfheal-20260630.html`
