### PR TITLE
feat(llm): add LingTai HTTP identity headers

### DIFF
--- a/src/lingtai/llm/ANATOMY.md
+++ b/src/lingtai/llm/ANATOMY.md
@@ -3,6 +3,7 @@ related_files:
   - src/lingtai/ANATOMY.md
   - src/lingtai/llm/__init__.py
   - src/lingtai/llm/_register.py
+  - src/lingtai/llm/identity_headers.py
   - src/lingtai/llm/anthropic/ANATOMY.md
   - src/lingtai/llm/api_gate.py
   - src/lingtai/llm/base.py
@@ -18,6 +19,7 @@ related_files:
   - src/lingtai/llm/service.py
   - src/lingtai_kernel/llm/ANATOMY.md
   - tests/test_codex_endpoint_pool.py
+  - tests/test_llm_identity_headers.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;
@@ -36,12 +38,13 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 20 | Re-exports kernel types (`ChatSession`, `LLMResponse`, `ToolCall`, `FunctionSchema`, `ChatInterface`) + `LLMAdapter` from `base.py`. Triggers `register_all_adapters()` on import. |
-| `_register.py` | 200 | Registers adapter factories for all providers with `LLMService.register_adapter()`. Module constant `CODEX_OFFICIAL_BASE_URL` is the Codex default endpoint. The `_codex` factory also forwards an optional `codex_base_urls` pool (+ `codex_molt_count` override) to the adapter. |
+| `_register.py` | 202 | Registers adapter factories for all providers with `LLMService.register_adapter()`. Module constant `CODEX_OFFICIAL_BASE_URL` is the Codex default endpoint. The `_codex` factory also forwards an optional `codex_base_urls` pool (+ `codex_molt_count` override) to the adapter. |
+| `identity_headers.py` | 53 | Shared non-secret LingTai HTTP identity/version header helper for SDK-backed LLM adapters. |
 | `claude_code/` | — | `claude-code` provider: drives the local `claude` CLI as a stateless reasoning core on a Claude subscription (`adapter.py`, `defaults.py`). |
 | `api_gate.py` | 112 | `APICallGate` — RPM rate limiter with deque timestamps, `ThreadPoolExecutor`, daemon gate thread |
 | `base.py` | 150 | `LLMAdapter` ABC (4 abstract methods), `_GatedSession` proxy |
 | `interface_converters.py` | 335 | Bidirectional converters: `to_*` / `from_*` for Anthropic, OpenAI, OpenAI Responses API, Gemini |
-| `service.py` | 430 | `LLMService` concrete class — adapter registry, session management, one-shot generation |
+| `service.py` | 454 | `LLMService` concrete class — adapter registry, session management, one-shot generation |
 
 ## Connections
 
@@ -53,7 +56,8 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 
 ## Composition
 
-- **Factory pattern** — `LLMService._adapter_registry` (class-level dict) maps provider name → `Callable[..., LLMAdapter]`. Each factory receives `(model, defaults, **kw)` and lazy-imports the adapter module.
+- **Factory pattern** — `LLMService._adapter_registry` (class-level dict) maps provider name → `Callable[..., LLMAdapter]`. Each factory receives `(model, defaults, **kw)` and lazy-imports the adapter module. HTTP-capable factories forward `default_headers` to SDK-backed adapters; `claude-code` deliberately drops them because the local CLI owns its own HTTP stack.
+- **HTTP identity headers** — `identity_headers.py:12-53` builds `X-LingTai-Client`, optional `X-LingTai-Version`, and optional `User-Agent: LingTai/<version>`, then merges them under caller/provider headers case-insensitively. OpenAI-compatible, Anthropic-compatible, and Gemini adapters consume this helper at SDK construction time.
 - **Adapter caching** — `LLMService._adapters` keyed by `(provider, base_url)` tuple (`service.py:141`). Double-checked locking via `_adapter_lock` (`service.py:142`).
 - **Session tracking** — `LLMService._sessions` dict maps `st_<12-hex>` session IDs to `ChatSession` instances (`service.py:144`). Untracked sessions get `session_id=""`.
 - **Gated sessions** — `_GatedSession` (`base.py:19`) proxies `send()` and `send_stream()` through `APICallGate.submit()`. Attribute writes land on the proxy; reads fall through to inner session via `__getattr__`.
@@ -67,7 +71,7 @@ LLM adapter layer — multi-provider support with adapter registry, base classes
 
 - **Class-level** — `LLMService._adapter_registry` (shared across all instances); `LLMAdapter._gate` (per-adapter instance).
 - **Instance-level** — `LLMService._adapters` cache; `LLMService._sessions` registry; `APICallGate._timestamps` deque for RPM window.
-- **Provider defaults** — `LLMService._provider_defaults` dict injected at construction (`service.py:140`). Drives model, base_url, max_rpm, api_compat, the Codex per-agent identity (`codex_session_anchor`/`codex_thread_salt`), Codex token-file selection (`codex_auth_path`), the optional Codex endpoint pool (`codex_base_urls`; direct host/test defaults may also pass `codex_molt_count`), and OpenAI Responses `compact_threshold` settings. Build it from `manifest.llm` via `build_provider_defaults_from_manifest_llm()` (`service.py:66`) — opt-in safelists ensure adapter-consulted manifest fields propagate: `_PROVIDER_DEFAULTS_PASS_THROUGH_KEYS` skips `None` values such as `api_compat`, while `_PROVIDER_DEFAULTS_PRESERVE_NONE_KEYS` preserves explicit `None` for settings like `compact_threshold` where `null` means “disable”. Both `cli.py:_load_init` and `agent.py:_setup_from_init` use this helper to stay in sync.
+- **Provider defaults** — `LLMService._provider_defaults` dict injected at construction (`service.py:140`). Drives model, base_url, max_rpm, api_compat, `default_headers` (caller/provider headers preserved under the shared LingTai identity defaults), the Codex per-agent identity (`codex_session_anchor`/`codex_thread_salt`), Codex token-file selection (`codex_auth_path`), the optional Codex endpoint pool (`codex_base_urls`; direct host/test defaults may also pass `codex_molt_count`), and OpenAI Responses `compact_threshold` settings. Build it from `manifest.llm` via `build_provider_defaults_from_manifest_llm()` (`service.py:66`) — opt-in safelists ensure adapter-consulted manifest fields propagate: `_PROVIDER_DEFAULTS_PASS_THROUGH_KEYS` skips `None` values such as `api_compat`, while `_PROVIDER_DEFAULTS_PRESERVE_NONE_KEYS` preserves explicit `None` for settings like `compact_threshold` where `null` means “disable”. Both `cli.py:_load_init` and `agent.py:_setup_from_init` use this helper to stay in sync.
 - **Key resolution** — `LLMService._key_resolver` callable (`service.py:94`); defaults to `os.environ.get(f"{PROVIDER}_API_KEY")`.
 
 ## Notes

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -17,13 +17,15 @@ CODEX_OFFICIAL_BASE_URL = "https://chatgpt.com/backend-api/codex"
 def register_all_adapters() -> None:
     from lingtai.llm.service import LLMService
 
-    def _gemini(*, model=None, defaults=None, api_key=None, max_rpm=0, **_kw):
+    def _gemini(*, model=None, defaults=None, api_key=None, max_rpm=0, **kw):
         from .gemini.adapter import GeminiAdapter
-        kw: dict = {}
-        if api_key is not None: kw["api_key"] = api_key
-        if max_rpm > 0: kw["max_rpm"] = max_rpm
-        if model: kw["default_model"] = model
-        return GeminiAdapter(**kw)
+        adapter_kw: dict = {}
+        if api_key is not None: adapter_kw["api_key"] = api_key
+        if max_rpm > 0: adapter_kw["max_rpm"] = max_rpm
+        if model: adapter_kw["default_model"] = model
+        if kw.get("default_headers") is not None:
+            adapter_kw["default_headers"] = kw["default_headers"]
+        return GeminiAdapter(**adapter_kw)
 
     def _anthropic(*, model=None, defaults=None, **kw):
         from .anthropic.adapter import AnthropicAdapter

--- a/src/lingtai/llm/anthropic/ANATOMY.md
+++ b/src/lingtai/llm/anthropic/ANATOMY.md
@@ -22,12 +22,12 @@ Anthropic Claude adapter — Messages API with prompt caching, tool use, and ext
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 3 | Re-exports `AnthropicAdapter`, `AnthropicChatSession` |
-| `adapter.py` | 829 | Adapter + session + helpers |
+| `adapter.py` | 832 | Adapter + session + helpers |
 | `defaults.py` | 6 | `DEFAULTS` dict: `api_key_env=ANTHROPIC_API_KEY`, `model=claude-sonnet-4-20250514` |
 
 ### Classes
 
-- **`AnthropicAdapter(LLMAdapter)`** — `adapter.py:652` — wraps `anthropic.Anthropic` SDK.
+- **`AnthropicAdapter(LLMAdapter)`** — `adapter.py:653` — wraps `anthropic.Anthropic` SDK and supplies merged LingTai identity/version default headers.
 - **`AnthropicChatSession(ChatSession)`** — `adapter.py:279` — per-session state, owns `ChatInterface`.
 
 ### Helper functions (module-level)
@@ -57,10 +57,10 @@ Anthropic Claude adapter — Messages API with prompt caching, tool use, and ext
 
 | Method | Line | Notes |
 |--------|------|-------|
-| `create_chat` | 696 | Builds tools, tool_choice, thinking config; wraps in `_GatedSession` via `_wrap_with_gate` |
-| `generate` | 765 | One-shot via `self._client.messages.create`; gated by `_gated_call` |
-| `make_tool_result_message` | 810 | Returns canonical `ToolResultBlock` with `toolu_` prefix ID |
-| `is_quota_error` | 820 | `isinstance(exc, anthropic.RateLimitError)` |
+| `create_chat` | 699 | Builds tools, tool_choice, thinking config; wraps in `_GatedSession` via `_wrap_with_gate` |
+| `generate` | 768 | One-shot via `self._client.messages.create`; gated by `_gated_call` |
+| `make_tool_result_message` | 813 | Returns canonical `ToolResultBlock` with `toolu_` prefix ID |
+| `is_quota_error` | 823 | `isinstance(exc, anthropic.RateLimitError)` |
 
 ### ChatSession method overrides (`AnthropicChatSession`)
 
@@ -107,7 +107,7 @@ Anthropic Claude adapter — Messages API with prompt caching, tool use, and ext
 
 ## State
 
-- `AnthropicAdapter`: holds `_client` (SDK instance), `_client_kwargs` (for session reset), `_gate` (rate limiter).
+- `AnthropicAdapter`: holds `_client` (SDK instance), `_client_kwargs` (for session reset), `_gate` (rate limiter). Constructor merges LingTai HTTP identity headers under caller/provider `default_headers` before building the SDK client.
 - `AnthropicChatSession`: holds `_client`, `_model`, `_system` (list of cached blocks), `_interface` (ChatInterface), `_tools`, `_tool_choice`, `_extra_kwargs`, `_client_kwargs`, `_context_window`, `_request_timeout`.
 
 ### Usage normalization (`adapter.py:163-173`)

--- a/src/lingtai/llm/anthropic/adapter.py
+++ b/src/lingtai/llm/anthropic/adapter.py
@@ -50,6 +50,7 @@ from lingtai.llm.base import LLMAdapter
 from lingtai_kernel.llm.interface import ChatInterface
 from ..interface_converters import to_anthropic
 from lingtai_kernel.llm.streaming import StreamingAccumulator
+from lingtai.llm.identity_headers import merge_lingtai_identity_headers
 
 
 # ---------------------------------------------------------------------------
@@ -660,11 +661,13 @@ class AnthropicAdapter(LLMAdapter):
         base_url: str | None = None,
         timeout_ms: int = 300_000,
         max_rpm: int = 0,
+        default_headers: dict | None = None,
     ):
         self._base_url = base_url
         kwargs: dict[str, Any] = {
             "api_key": api_key,
             "timeout": timeout_ms / 1000.0,
+            "default_headers": merge_lingtai_identity_headers(default_headers),
         }
         if base_url:
             kwargs["base_url"] = base_url

--- a/src/lingtai/llm/custom/ANATOMY.md
+++ b/src/lingtai/llm/custom/ANATOMY.md
@@ -22,7 +22,7 @@ Custom adapter — factory for named provider aliases routing to OpenAI, Anthrop
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 3 | Re-exports `create_custom_adapter`, `DEFAULTS` |
-| `adapter.py` | 48 | `create_custom_adapter()` factory function |
+| `adapter.py` | 51 | `create_custom_adapter()` factory function |
 | `defaults.py` | 6 | `DEFAULTS` dict: `api_compat=openai`, `base_url=None`, `api_key_env=CUSTOM_API_KEY`, `model=""` |
 
 ## Connections
@@ -47,7 +47,7 @@ Parameters:
 - `api_key: str | None` — passed through to chosen adapter.
 - `api_compat: str` — selects backend (`"openai"`, `"anthropic"`, `"gemini"`).
 - `base_url: str | None` — provider endpoint URL.
-- `default_headers: dict | None` — forwarded only to the OpenAI-compatible path; Anthropic/Gemini branches drop it for now.
+- `default_headers: dict | None` — forwarded to all compat paths that expose SDK HTTP header configuration (OpenAI-, Anthropic-, and Gemini-compatible).
 - `**kwargs` — forwarded to adapter constructor (`timeout_ms`, `max_rpm`, etc.).
 
 ### No class of its own

--- a/src/lingtai/llm/custom/adapter.py
+++ b/src/lingtai/llm/custom/adapter.py
@@ -26,17 +26,20 @@ def create_custom_adapter(
 ) -> LLMAdapter:
     """Factory: creates adapter based on api_compat.
 
-    ``default_headers`` is forwarded to the underlying SDK client when it
-    is supported (currently only the OpenAI-compat path). Other api_compat
-    branches silently drop it for now — extend here when needed.
+    ``default_headers`` is forwarded to the underlying SDK client for all
+    compat paths that expose HTTP header configuration.
     """
     if api_compat == "gemini":
         from ..gemini.adapter import GeminiAdapter
+        if default_headers is not None:
+            kwargs["default_headers"] = default_headers
         return GeminiAdapter(api_key=api_key, **kwargs)
     elif api_compat == "anthropic":
         if not base_url:
             raise ValueError("Anthropic-compat provider requires a base_url")
         from ..anthropic.adapter import AnthropicAdapter
+        if default_headers is not None:
+            kwargs["default_headers"] = default_headers
         return AnthropicAdapter(api_key=api_key, base_url=base_url, **kwargs)
     else:
         if not base_url:

--- a/src/lingtai/llm/deepseek/ANATOMY.md
+++ b/src/lingtai/llm/deepseek/ANATOMY.md
@@ -22,7 +22,7 @@ DeepSeek adapter — thin OpenAI-compat wrapper that satisfies DeepSeek V4 think
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 0 | Empty |
-| `adapter.py` | ~130 | `DeepSeekAdapter`, `DeepSeekChatSession`, `_fallback_reasoning_for` |
+| `adapter.py` | 133 | `DeepSeekAdapter`, `DeepSeekChatSession`, `_fallback_reasoning_for` |
 
 ### Classes
 
@@ -48,7 +48,7 @@ DeepSeek adapter — thin OpenAI-compat wrapper that satisfies DeepSeek V4 think
 
 | Method | Notes |
 |--------|-------|
-| `__init__` | Calls `super().__init__()` with `base_url=base_url or _DEEPSEEK_BASE_URL` |
+| `__init__` | Calls `super().__init__()` with `base_url=base_url or _DEEPSEEK_BASE_URL` and forwards `default_headers` so OpenAIAdapter adds LingTai identity/version headers |
 | `_session_class` | Set to `DeepSeekChatSession` (parent's `create_chat` uses this) |
 
 All other `LLMAdapter` methods (`create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`) are **inherited unchanged** from `OpenAIAdapter`.

--- a/src/lingtai/llm/deepseek/adapter.py
+++ b/src/lingtai/llm/deepseek/adapter.py
@@ -122,10 +122,12 @@ class DeepSeekAdapter(OpenAIAdapter):
         base_url: str | None = None,
         timeout_ms: int = 300_000,
         max_rpm: int = 0,
+        default_headers: dict | None = None,
     ):
         super().__init__(
             api_key=api_key,
             base_url=base_url or _DEEPSEEK_BASE_URL,
             timeout_ms=timeout_ms,
             max_rpm=max_rpm,
+            default_headers=default_headers,
         )

--- a/src/lingtai/llm/gemini/ANATOMY.md
+++ b/src/lingtai/llm/gemini/ANATOMY.md
@@ -22,12 +22,12 @@ Gemini adapter — `google-genai` SDK with Chat API and Interactions API, thinki
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 3 | Re-exports `GeminiAdapter`, `GeminiChatSession`, `InteractionsChatSession` |
-| `adapter.py` | 908 | Adapter + 2 session classes + helpers |
+| `adapter.py` | 913 | Adapter + 2 session classes + helpers |
 | `defaults.py` | 4 | `DEFAULTS` dict: `api_key_env=GEMINI_API_KEY`, `model=gemini-3-flash-preview` |
 
 ### Classes
 
-- **`GeminiAdapter(LLMAdapter)`** — `adapter.py:686` — wraps `genai.Client`.
+- **`GeminiAdapter(LLMAdapter)`** — `adapter.py:687` — wraps `genai.Client` and passes LingTai identity/version headers through `types.HttpOptions(headers=...)`.
 - **`GeminiChatSession(ChatSession)`** — `adapter.py:139` — Chat API session (used for `json_schema` mode).
 - **`InteractionsChatSession(ChatSession)`** — `adapter.py:342` — Interactions API session (server-side history, primary path).
 
@@ -50,6 +50,7 @@ Gemini adapter — `google-genai` SDK with Chat API and Interactions API, thinki
 - **Imports from `lingtai`**: `LLMAdapter` ABC, `to_gemini` converter (lazy in `create_chat`)
 - **External**: `google.genai`, `google.genai.errors`, `google.genai.types`
 - **No inheritance from other adapters** (standalone implementation)
+- **HTTP identity**: `GeminiAdapter.__init__` uses `types.HttpOptions(headers=merge_lingtai_identity_headers(..., user_agent=False))`, sending `X-LingTai-*` headers while leaving the SDK-owned lowercase `user-agent` untouched.
 
 ## Composition
 
@@ -57,10 +58,10 @@ Gemini adapter — `google-genai` SDK with Chat API and Interactions API, thinki
 
 | Method | Line | Notes |
 |--------|------|-------|
-| `create_chat` | 706 | Routes to Interactions API (default) or Chat API (json_schema mode); wraps in `_GatedSession` |
-| `generate` | 851 | One-shot via `client.models.generate_content`; gated |
-| `make_tool_result_message` | 883 | Returns `ToolResultBlock` with `id=tool_call_id or tool_name` |
-| `is_quota_error` | 893 | `ClientError` with code 429 or `RESOURCE_EXHAUSTED` in message |
+| `create_chat` | 711 | Routes to Interactions API (default) or Chat API (json_schema mode); wraps in `_GatedSession` |
+| `generate` | 856 | One-shot via `client.models.generate_content`; gated |
+| `make_tool_result_message` | 888 | Returns `ToolResultBlock` with `id=tool_call_id or tool_name` |
+| `is_quota_error` | 898 | `ClientError` with code 429 or `RESOURCE_EXHAUSTED` in message |
 
 ### Dual session architecture
 

--- a/src/lingtai/llm/gemini/adapter.py
+++ b/src/lingtai/llm/gemini/adapter.py
@@ -26,6 +26,7 @@ from lingtai_kernel.llm.interface import ToolResultBlock
 from lingtai.llm.base import LLMAdapter
 from lingtai_kernel.llm.interface import ChatInterface
 from lingtai_kernel.llm.streaming import StreamingAccumulator
+from lingtai.llm.identity_headers import merge_lingtai_identity_headers
 
 logger = get_logger()
 
@@ -687,10 +688,14 @@ class GeminiAdapter(LLMAdapter):
     """Adapter that wraps all ``google-genai`` SDK calls."""
 
     def __init__(self, api_key: str, timeout_ms: int = 300_000, max_rpm: int = 0,
-                 default_model: str = "gemini-3-flash-preview"):
+                 default_model: str = "gemini-3-flash-preview",
+                 default_headers: dict | None = None):
         self._client = genai.Client(
             api_key=api_key,
             http_options=types.HttpOptions(
+                # google-genai appends its own lowercase user-agent internally;
+                # use explicit LingTai X-headers here to avoid duplicate UA keys.
+                headers=merge_lingtai_identity_headers(default_headers, user_agent=False),
                 timeout=timeout_ms,
                 retry_options=types.HttpRetryOptions(),
             ),

--- a/src/lingtai/llm/identity_headers.py
+++ b/src/lingtai/llm/identity_headers.py
@@ -1,0 +1,53 @@
+"""Shared LingTai HTTP identity headers for LLM provider adapters."""
+
+from __future__ import annotations
+
+import importlib.metadata as metadata
+
+
+_PACKAGE_NAME = "lingtai"
+_CLIENT_NAME = "LingTai"
+
+
+def lingtai_version() -> str | None:
+    """Return the installed LingTai package version, if package metadata exists."""
+    try:
+        return metadata.version(_PACKAGE_NAME)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def lingtai_user_agent() -> str:
+    """Return the honest LingTai User-Agent token."""
+    installed_version = lingtai_version()
+    if installed_version:
+        return f"{_CLIENT_NAME}/{installed_version}"
+    return _CLIENT_NAME
+
+
+def lingtai_identity_headers(*, user_agent: bool = True) -> dict[str, str]:
+    """Return default non-secret LingTai identity/version headers."""
+    headers = {"X-LingTai-Client": _CLIENT_NAME}
+    if user_agent:
+        headers["User-Agent"] = lingtai_user_agent()
+    installed_version = lingtai_version()
+    if installed_version:
+        headers["X-LingTai-Version"] = installed_version
+    return headers
+
+
+def merge_lingtai_identity_headers(
+    headers: dict | None = None, *, user_agent: bool = True
+) -> dict[str, str]:
+    """Merge LingTai identity headers under caller-supplied headers.
+
+    Header names are compared case-insensitively, while caller spelling and
+    values are preserved. This keeps provider/user headers authoritative.
+    """
+    caller_headers = dict(headers or {})
+    merged = dict(caller_headers)
+    caller_names = {str(name).lower() for name in caller_headers}
+    for name, value in lingtai_identity_headers(user_agent=user_agent).items():
+        if name.lower() not in caller_names:
+            merged[name] = value
+    return merged

--- a/src/lingtai/llm/minimax/ANATOMY.md
+++ b/src/lingtai/llm/minimax/ANATOMY.md
@@ -24,7 +24,7 @@ MiniMax adapter — inherits Anthropic-compatible endpoint, adds MCP client fact
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 4 | Re-exports `MiniMaxAdapter`, `get_minimax_mcp_client` |
-| `adapter.py` | 21 | `MiniMaxAdapter(AnthropicAdapter)` — thin subclass |
+| `adapter.py` | 27 | `MiniMaxAdapter(AnthropicAdapter)` — thin subclass |
 | `mcp_client.py` | 153 | Singleton MCP client factory for MiniMax MCP server (vision/compose/draw/talk) |
 | `defaults.py` | 7 | `DEFAULTS` dict: `api_compat=anthropic`, `base_url=https://api.minimax.io/anthropic`, `api_key_env=MINIMAX_API_KEY`, `model=MiniMax-M2.7-highspeed`, `max_rpm=120` |
 
@@ -43,7 +43,7 @@ Only override is `__init__`:
 
 | Override | Line | What changes |
 |----------|------|-------------|
-| `__init__` | 15 | Sets `base_url` to `https://api.minimax.io/anthropic` (or custom), calls `super().__init__()`, re-calls `_setup_gate(max_rpm=120)` |
+| `__init__` | 15 | Sets `base_url` to `https://api.minimax.io/anthropic` (or custom), forwards `default_headers`, calls `super().__init__()`, re-calls `_setup_gate(max_rpm=120)` |
 
 All other methods (`create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`, `send`, `send_stream`, etc.) are **inherited unchanged** from `AnthropicAdapter` / `AnthropicChatSession`.
 

--- a/src/lingtai/llm/minimax/adapter.py
+++ b/src/lingtai/llm/minimax/adapter.py
@@ -15,7 +15,13 @@ class MiniMaxAdapter(AnthropicAdapter):
     def __init__(
         self, api_key: str, *, base_url: str | None = None,
         max_rpm: int = 120, timeout_ms: int = 300_000,
+        default_headers: dict | None = None,
     ):
         effective_url = base_url or "https://api.minimax.io/anthropic"
-        super().__init__(api_key=api_key, base_url=effective_url, timeout_ms=timeout_ms)
+        super().__init__(
+            api_key=api_key,
+            base_url=effective_url,
+            timeout_ms=timeout_ms,
+            default_headers=default_headers,
+        )
         self._setup_gate(max_rpm)

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -5,6 +5,7 @@ related_files:
   - src/lingtai/llm/ANATOMY.md
   - src/lingtai/llm/_register.py
   - src/lingtai/llm/interface_converters.py
+  - src/lingtai/llm/identity_headers.py
   - src/lingtai/llm/openai/__init__.py
   - src/lingtai/llm/openai/adapter.py
   - src/lingtai/llm/openai/codex_ws.py
@@ -49,7 +50,7 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | `_base_url_namespace()` | 102–116 | Stable namespace token for an OpenAI-compatible `base_url` (URL host, or short hash fallback) used in the default `prompt_cache_key` |
 | `_codex_session_id()` | ~106–122 | Derive the 8-char Codex cache-affinity id (issue #378): `sha256(f"{anchor}\0{molt_count}").hexdigest()[:8]`, lowercase hex, where `anchor` MUST be a per-agent identity (the resolved `init.json` path) and `molt_count` is the agent's current molt count. The same value is used byte-identically for `session_id`, `thread_id`, and the default `prompt_cache_key` on the root/main path. No time/epoch — stable across restarts WITHIN a molt segment, and intentionally changes at each molt boundary |
 | `_codex_installation_id()` | `adapter.py:154` | Derives a UUID-shaped, non-secret LingTai installation id for Codex `client_metadata` from the same local anchor/id; never reuses `~/.codex/installation_id`. |
-| `_codex_identity_headers()` | ~150–205 | Builds Codex client identity headers (`originator`, `User-Agent`): default requests identify as LingTai, while the official Codex CLI-shaped identity remains an explicit local diagnostic opt-in. | `adapter.py:140`, `adapter.py:153`, `adapter.py:178`, `adapter.py:214` |
+| `_codex_identity_headers()` | ~259–268 | Builds Codex client identity headers (`originator`, `User-Agent`): default requests identify as LingTai via the shared `llm/identity_headers.py` User-Agent helper, while the official Codex CLI-shaped identity remains an explicit local diagnostic opt-in. | `adapter.py:259`, `adapter.py:268`, `identity_headers.py:20` |
 | `_validate_compact_threshold()` | 69–83 | Validates/normalizes OpenAI Responses auto-compaction threshold; positive `int` or explicit `None` (disable) only |
 | `_codex_responses_trace_path()` / `_codex_responses_trace_record()` | 63–157 | Opt-in Codex Responses stream diagnostic trace helpers; safe metadata only, default off |
 | `_build_http_timeout()` | 159–173 | `httpx.Timeout` per-phase caps (connect≤30s, read≤60s, pool=10s) |
@@ -176,7 +177,7 @@ Stable HTTP headers (`session_id` / `thread_id`, underscore spelling to match Co
 
 ### Codex client-identity headers (`originator` / `User-Agent`)
 
-The default request identity is explicit LingTai: `_CODEX_ORIGINATOR = "lingtai"` and `User-Agent: LingTai/<version>`. `_CODEX_IMPERSONATE_OFFICIAL_CLI` is reserved for explicit local protocol comparisons and switches both `originator` and `User-Agent` to the official Codex CLI-shaped values only when enabled; account-selection headers remain independent of this identity choice. `adapter.py:140`, `adapter.py:153`, `adapter.py:178`, `adapter.py:214`, `tests/test_codex_prompt_cache_key.py:113`, `tests/test_codex_prompt_cache_key.py:590`
+The default request identity is explicit LingTai: `_CODEX_ORIGINATOR = "lingtai"` and `User-Agent: LingTai/<version>`, with the version token resolved through the shared LLM HTTP identity helper (`../identity_headers.py:20`). `_CODEX_IMPERSONATE_OFFICIAL_CLI` is reserved for explicit local protocol comparisons and switches both `originator` and `User-Agent` to the official Codex CLI-shaped values only when enabled; account-selection headers remain independent of this identity choice. `adapter.py:140`, `adapter.py:153`, `adapter.py:178`, `adapter.py:214`, `tests/test_codex_prompt_cache_key.py:113`, `tests/test_codex_prompt_cache_key.py:590`
 
 ### Codex `ChatGPT-Account-ID` header (the user's own account id)
 
@@ -198,7 +199,7 @@ When a Codex session has a stable LingTai session/thread identity, `CodexRespons
 - **`CodexResponsesSession._response_id`** — transient debug aid only; never threaded into next request (line 1538).
 - **`CodexResponsesSession._current_id`** — the single per-agent affinity id (the hash of the agent path + current molt count) handed to this session, used byte-identically for `_prompt_cache_key` / `_session_id` / `_thread_id`. Set once per session at construction — a NEW session is built for each `create_chat`, and the adapter resolves the molt-current id at that point, so a molt-advanced id reaches the next session without any in-session mutation (no rotation, no epoch, no clock).
 - **Codex Responses trace** — opt-in diagnostics write JSONL metadata to `logs/codex_responses_trace.jsonl` when `LINGTAI_CODEX_RESPONSES_TRACE=1` (override path with `LINGTAI_CODEX_RESPONSES_TRACE_PATH`). Default off; stores event/item shapes, lengths/hashes, usage, and accumulator counts, not raw content.
-- **`OpenAIAdapter._client`** — shared `openai.OpenAI` instance. `_client_kwargs` stored for session `reset()`.
+- **`OpenAIAdapter._client`** — shared `openai.OpenAI` instance. `_client_kwargs` stored for session `reset()`. Constructor passes `default_headers=merge_lingtai_identity_headers(...)` (`adapter.py:1974`), so OpenAI-compatible HTTP requests carry non-secret LingTai identity/version headers unless a caller/provider header overrides them case-insensitively.
 - **`OpenAIAdapter._session_class`** — class var, subclasses override (e.g. DeepSeek and MiMo inject `reasoning_content` round-trip fallbacks).
 
 ## Notes

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -41,6 +41,7 @@ from lingtai.llm.base import LLMAdapter
 from lingtai_kernel.llm.interface import ChatInterface, TextBlock, ThinkingBlock, ToolCallBlock
 from ..interface_converters import to_openai, to_responses_input
 from lingtai_kernel.llm.streaming import StreamingAccumulator
+from lingtai.llm.identity_headers import lingtai_user_agent, merge_lingtai_identity_headers
 
 logger = get_logger()
 
@@ -237,9 +238,7 @@ def _lingtai_user_agent() -> str:
     if _CODEX_IMPERSONATE_OFFICIAL_CLI:
         return _codex_cli_user_agent()
     try:
-        from importlib.metadata import version
-
-        return f"LingTai/{version('lingtai')}"
+        return lingtai_user_agent()
     except Exception:
         return "LingTai"
 
@@ -1972,8 +1971,7 @@ class OpenAIAdapter(LLMAdapter):
         if base_url:
             kwargs["base_url"] = base_url
         kwargs["timeout"] = timeout_ms / 1000.0  # openai SDK uses seconds
-        if default_headers:
-            kwargs["default_headers"] = dict(default_headers)
+        kwargs["default_headers"] = merge_lingtai_identity_headers(default_headers)
         self._client_kwargs = dict(kwargs)  # store for session reset
         self._client = openai.OpenAI(**kwargs)
         self._setup_gate(max_rpm)

--- a/src/lingtai/llm/openrouter/ANATOMY.md
+++ b/src/lingtai/llm/openrouter/ANATOMY.md
@@ -22,7 +22,7 @@ OpenRouter adapter — thin OpenAI-compat shim pinned to `openrouter.ai/api/v1`,
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 0 | Empty |
-| `adapter.py` | 48 | `OpenRouterAdapter(OpenAIAdapter)` — one override |
+| `adapter.py` | 50 | `OpenRouterAdapter(OpenAIAdapter)` — one override |
 
 ### Class
 
@@ -40,7 +40,7 @@ OpenRouter adapter — thin OpenAI-compat shim pinned to `openrouter.ai/api/v1`,
 
 | Method | Line | Notes |
 |--------|------|-------|
-| `__init__` | 28 | Calls `super().__init__()` with `base_url=base_url or _OPENROUTER_BASE_URL` |
+| `__init__` | 28 | Calls `super().__init__()` with `base_url=base_url or _OPENROUTER_BASE_URL` and forwards `default_headers` for LingTai identity/version headers |
 | `_adapter_extra_body` | 45 | Returns `{"reasoning": {"include": False}}` — tells OpenRouter to omit reasoning text from responses |
 
 All other methods (`create_chat`, `generate`, `make_tool_result_message`, `is_quota_error`, `send`, `send_stream`) are **inherited unchanged** from `OpenAIAdapter` / `OpenAIChatSession`.
@@ -55,7 +55,7 @@ No additional state beyond what `OpenAIAdapter` provides.
 
 ## Notes
 
-- **48 LOC total** — one of the thinnest adapters.
+- **50 LOC total** — one of the thinnest adapters.
 - **Same pattern as DeepSeek**: subclass `OpenAIAdapter`, override `__init__` for base URL, optionally override `_adapter_extra_body`.
 - **Reasoning exclusion**: Unlike DeepSeek (which needs `reasoning_content` round-trip), OpenRouter explicitly opts **out** of reasoning text. The OpenAI response parser already reads both `reasoning_content` and `reasoning` field names if present.
 - Git history: 2 commits.

--- a/src/lingtai/llm/openrouter/adapter.py
+++ b/src/lingtai/llm/openrouter/adapter.py
@@ -32,6 +32,7 @@ class OpenRouterAdapter(OpenAIAdapter):
         base_url: str | None = None,
         timeout_ms: int = 300_000,
         max_rpm: int = 0,
+        default_headers: dict | None = None,
     ):
         # Allow base_url override for staging / self-hosted proxies, but
         # default to the public OpenRouter endpoint.
@@ -40,6 +41,7 @@ class OpenRouterAdapter(OpenAIAdapter):
             base_url=base_url or _OPENROUTER_BASE_URL,
             timeout_ms=timeout_ms,
             max_rpm=max_rpm,
+            default_headers=default_headers,
         )
 
     def _adapter_extra_body(self) -> dict:

--- a/tests/test_llm_identity_headers.py
+++ b/tests/test_llm_identity_headers.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from lingtai.llm.identity_headers import merge_lingtai_identity_headers
+
+
+def test_identity_header_merge_preserves_caller_headers(monkeypatch):
+    monkeypatch.setattr("lingtai.llm.identity_headers.lingtai_version", lambda: "9.8.7")
+
+    headers = merge_lingtai_identity_headers(
+        {"user-agent": "Caller/1", "X-LingTai-Version": "caller-version", "X-Test": "1"}
+    )
+
+    assert headers["user-agent"] == "Caller/1"
+    assert headers["X-LingTai-Version"] == "caller-version"
+    assert headers["X-Test"] == "1"
+    assert "User-Agent" not in headers
+    assert headers["X-LingTai-Client"] == "LingTai"
+
+
+def test_identity_header_merge_can_skip_user_agent(monkeypatch):
+    monkeypatch.setattr("lingtai.llm.identity_headers.lingtai_version", lambda: "9.8.7")
+
+    headers = merge_lingtai_identity_headers(user_agent=False)
+
+    assert "User-Agent" not in headers
+    assert headers["X-LingTai-Client"] == "LingTai"
+    assert headers["X-LingTai-Version"] == "9.8.7"
+
+
+def test_openai_adapter_builds_client_with_identity_headers(monkeypatch):
+    from lingtai.llm.openai import adapter as mod
+
+    captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(mod.openai, "OpenAI", FakeOpenAI)
+    monkeypatch.setattr("lingtai.llm.identity_headers.lingtai_version", lambda: "9.8.7")
+
+    mod.OpenAIAdapter(api_key="sk-test", default_headers={"X-Test": "1"})
+
+    headers = captured["default_headers"]
+    assert headers["User-Agent"] == "LingTai/9.8.7"
+    assert headers["X-LingTai-Client"] == "LingTai"
+    assert headers["X-LingTai-Version"] == "9.8.7"
+    assert headers["X-Test"] == "1"
+
+
+def test_anthropic_adapter_builds_client_with_identity_headers(monkeypatch):
+    from lingtai.llm.anthropic import adapter as mod
+
+    captured = {}
+
+    class FakeAnthropic:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(mod.anthropic, "Anthropic", FakeAnthropic)
+    monkeypatch.setattr("lingtai.llm.identity_headers.lingtai_version", lambda: "9.8.7")
+
+    mod.AnthropicAdapter(api_key="sk-test", default_headers={"X-Test": "1"})
+
+    headers = captured["default_headers"]
+    assert headers["User-Agent"] == "LingTai/9.8.7"
+    assert headers["X-LingTai-Client"] == "LingTai"
+    assert headers["X-LingTai-Version"] == "9.8.7"
+    assert headers["X-Test"] == "1"
+
+
+def test_gemini_adapter_builds_client_with_identity_headers(monkeypatch):
+    from lingtai.llm.gemini import adapter as mod
+
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(mod.genai, "Client", FakeClient)
+    monkeypatch.setattr("lingtai.llm.identity_headers.lingtai_version", lambda: "9.8.7")
+
+    mod.GeminiAdapter(api_key="sk-test", default_headers={"X-Test": "1"})
+
+    headers = captured["http_options"].headers
+    assert "User-Agent" not in headers
+    assert headers["X-LingTai-Client"] == "LingTai"
+    assert headers["X-LingTai-Version"] == "9.8.7"
+    assert headers["X-Test"] == "1"
+
+
+def test_openai_compatible_subclasses_forward_identity_headers(monkeypatch):
+    from lingtai.llm.openai import adapter as openai_mod
+    from lingtai.llm.deepseek.adapter import DeepSeekAdapter
+    from lingtai.llm.mimo.adapter import MimoAdapter
+    from lingtai.llm.openrouter.adapter import OpenRouterAdapter
+    from lingtai.llm.zhipu.adapter import ZhipuAdapter
+
+    captured = []
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.append(kwargs)
+
+    monkeypatch.setattr(openai_mod.openai, "OpenAI", FakeOpenAI)
+    monkeypatch.setattr("lingtai.llm.identity_headers.lingtai_version", lambda: "9.8.7")
+
+    for adapter_cls in (DeepSeekAdapter, MimoAdapter, OpenRouterAdapter, ZhipuAdapter):
+        adapter_cls(api_key="sk-test", default_headers={"X-Test": "1"})
+        headers = captured[-1]["default_headers"]
+        assert headers["User-Agent"] == "LingTai/9.8.7"
+        assert headers["X-LingTai-Client"] == "LingTai"
+        assert headers["X-LingTai-Version"] == "9.8.7"
+        assert headers["X-Test"] == "1"
+
+
+def test_minimax_adapter_forwards_identity_headers(monkeypatch):
+    from lingtai.llm.anthropic import adapter as anthropic_mod
+    from lingtai.llm.minimax.adapter import MiniMaxAdapter
+
+    captured = {}
+
+    class FakeAnthropic:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(anthropic_mod.anthropic, "Anthropic", FakeAnthropic)
+    monkeypatch.setattr("lingtai.llm.identity_headers.lingtai_version", lambda: "9.8.7")
+
+    MiniMaxAdapter(api_key="sk-test", default_headers={"X-Test": "1"})
+
+    headers = captured["default_headers"]
+    assert headers["User-Agent"] == "LingTai/9.8.7"
+    assert headers["X-LingTai-Client"] == "LingTai"
+    assert headers["X-LingTai-Version"] == "9.8.7"
+    assert headers["X-Test"] == "1"
+
+
+def test_custom_adapter_forwards_identity_headers_to_all_compat_paths(monkeypatch):
+    from lingtai.llm.anthropic import adapter as anthropic_mod
+    from lingtai.llm.custom.adapter import create_custom_adapter
+    from lingtai.llm.gemini import adapter as gemini_mod
+    from lingtai.llm.openai import adapter as openai_mod
+
+    openai_captured = {}
+    anthropic_captured = {}
+    gemini_captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            openai_captured.update(kwargs)
+
+    class FakeAnthropic:
+        def __init__(self, **kwargs):
+            anthropic_captured.update(kwargs)
+
+    class FakeGeminiClient:
+        def __init__(self, **kwargs):
+            gemini_captured.update(kwargs)
+
+    monkeypatch.setattr(openai_mod.openai, "OpenAI", FakeOpenAI)
+    monkeypatch.setattr(anthropic_mod.anthropic, "Anthropic", FakeAnthropic)
+    monkeypatch.setattr(gemini_mod.genai, "Client", FakeGeminiClient)
+    monkeypatch.setattr("lingtai.llm.identity_headers.lingtai_version", lambda: "9.8.7")
+
+    create_custom_adapter(
+        api_compat="openai",
+        api_key="sk-test",
+        base_url="https://example.invalid/openai",
+        default_headers={"X-Test": "openai"},
+    )
+    assert openai_captured["default_headers"]["X-LingTai-Version"] == "9.8.7"
+    assert openai_captured["default_headers"]["X-Test"] == "openai"
+
+    create_custom_adapter(
+        api_compat="anthropic",
+        api_key="sk-test",
+        base_url="https://example.invalid/anthropic",
+        default_headers={"X-Test": "anthropic"},
+    )
+    assert anthropic_captured["default_headers"]["X-LingTai-Version"] == "9.8.7"
+    assert anthropic_captured["default_headers"]["X-Test"] == "anthropic"
+
+    create_custom_adapter(
+        api_compat="gemini",
+        api_key="sk-test",
+        default_headers={"X-Test": "gemini"},
+    )
+    gemini_headers = gemini_captured["http_options"].headers
+    assert "User-Agent" not in gemini_headers
+    assert gemini_headers["X-LingTai-Client"] == "LingTai"
+    assert gemini_headers["X-LingTai-Version"] == "9.8.7"
+    assert gemini_headers["X-Test"] == "gemini"


### PR DESCRIPTION
## Summary
- add shared `lingtai.llm.identity_headers` helpers for non-secret LingTai HTTP identity/version headers
- wire merged identity headers into OpenAI-compatible, Anthropic-compatible, Gemini, MiniMax, DeepSeek, OpenRouter, and custom compat adapters
- keep `claude_code`/`claude-p` CLI backend out of scope because the CLI owns its HTTP stack
- update LLM ANATOMY files and add regression coverage for helper behavior and adapter forwarding

## Behavior
- Adds `X-LingTai-Client: LingTai` to adapter-owned HTTP requests.
- Adds `X-LingTai-Version: <installed package version>` when package metadata is available.
- Adds `User-Agent: LingTai/<version>` for SDKs where we own/safely set User-Agent.
- Gemini uses `X-LingTai-*` only because google-genai appends its own lowercase user-agent internally.
- Caller/provider `default_headers` remain authoritative via case-insensitive merge; existing custom headers are preserved.

## Validation
- `PYTHONPATH=src .venv/bin/python -m py_compile src/lingtai/llm/identity_headers.py src/lingtai/llm/openai/adapter.py src/lingtai/llm/openrouter/adapter.py src/lingtai/llm/deepseek/adapter.py src/lingtai/llm/anthropic/adapter.py src/lingtai/llm/gemini/adapter.py src/lingtai/llm/minimax/adapter.py src/lingtai/llm/custom/adapter.py src/lingtai/llm/_register.py tests/test_llm_identity_headers.py`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_llm_identity_headers.py tests/test_llm_adapter_timeouts.py tests/test_codex_prompt_cache_key.py tests/test_openai_prompt_cache_key.py tests/test_deepseek_adapter.py tests/test_zhipu_merge_consecutive.py -q` → `102 passed`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_llm_service.py tests/test_adapter_registry.py tests/test_daemon.py -k 'default_headers or provider_defaults or adapter_registry' -q` → `13 passed, 97 deselected`
- `.venv/bin/python tools/check_anatomy_drift.py --root src/lingtai/llm --check` → `No anatomy drift found across 8 file(s).`
- `git diff --check`

## Notes
- No live provider calls were made.
- This PR intentionally does not force identity headers into local CLI backends such as `claude-p`; those tools own their own HTTP requests.
