### PR TITLE
feat: add NoKV workbench MCP example

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -769,6 +769,26 @@ class Agent(BaseAgent):
         self._mcp_inbox_poller = MCPInboxPoller(self)
         self._mcp_inbox_poller.start()
 
+    def _expand_agent_placeholders(self, value):
+        """Substitute per-agent placeholders in an MCP launch string.
+
+        Lets a single shared MCP registry template scope each agent to its own
+        namespace without per-agent hand-editing — e.g. a NoKV workbench root
+        ``--workbench-root /agents/{agent_id}/wb``. ``{agent_id}`` and
+        ``{agent_address}`` resolve to the agent's stable working-dir name (its
+        address); ``{agent_dir}`` resolves to the absolute working directory.
+        Non-string values and strings without a placeholder pass through
+        unchanged, so ordinary MCP args are never touched.
+        """
+        if not isinstance(value, str) or "{" not in value:
+            return value
+        agent_id = self._working_dir.name
+        return (
+            value.replace("{agent_id}", agent_id)
+            .replace("{agent_address}", agent_id)
+            .replace("{agent_dir}", str(self._working_dir))
+        )
+
     def connect_mcp(
         self,
         command: str,
@@ -786,6 +806,14 @@ class Agent(BaseAgent):
             List of registered tool names.
         """
         from .services.mcp import MCPClient
+
+        # Expand per-agent placeholders (e.g. {agent_id}) so a shared registry
+        # template gives each agent its own scope. See _expand_agent_placeholders.
+        command = self._expand_agent_placeholders(command)
+        if args:
+            args = [self._expand_agent_placeholders(a) for a in args]
+        if env:
+            env = {k: self._expand_agent_placeholders(v) for k, v in env.items()}
 
         client = MCPClient(command=command, args=args, env=env)
         client.start()

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -4,9 +4,10 @@ description: >
   Thin routing manual for NoKV-controlled workbenches. Use when an agent is
   asked to persist task inputs, scripts, outputs, logs, provenance, or run
   manifests through the `workbench_*` MCP tools instead of ordinary local
-  file writes. Covers MCP registration, directory layout, commit discipline,
-  segmented logs, and snapshot references.
-version: 0.1.0
+  file writes. Covers MCP registration, directory layout, append and edit
+  discipline, conditional reads, cross-workbench queries, commit discipline,
+  and snapshot references.
+version: 0.2.0
 tags: [nokv, mcp, workbench, artifacts, provenance, snapshots]
 ---
 
@@ -42,7 +43,8 @@ Activate it from `init.json`:
 Keep the global NoKV flags before `mcp`, and set them to the same metadata
 server and object-store bucket used by the running NoKV service. If your
 deployment uses a non-default S3/RustFS endpoint or credentials, add the
-matching `--s3-*` flags here as well.
+matching `--s3-*` flags here as well. Developer deployment steps live in
+`assets/PREFLIGHT.md`, not here.
 
 ### Per-agent root (tenant isolation)
 
@@ -66,32 +68,6 @@ provenance is explicit; the committed `run_manifest.json` also embeds the full
 
 The MCP tools are intentionally prefixed with `workbench_` so they do not replace
 LingTai's local `read`, `write`, `edit`, `grep`, or `glob` tools.
-
-## TUI runtime preflight
-
-Before installing a workbench-enabled LingTai branch into the TUI runtime,
-check the runtime package version:
-
-```bash
-~/.lingtai-tui/runtime/venv/bin/python - <<'PY'
-import importlib.metadata as md
-print(md.version("lingtai"))
-PY
-```
-
-Do not install a source branch that is older than the runtime package already
-used by TUI. Rebase or cherry-pick this workbench skill onto the matching or
-newer upstream LingTai release, build/install that branch, then verify that the
-runtime can see the skill:
-
-```bash
-~/.lingtai-tui/runtime/venv/bin/python - <<'PY'
-from pathlib import Path
-import lingtai.intrinsic_skills as skills
-root = Path(skills.__file__).parent
-print((root / "nokv-workbench" / "SKILL.md").exists())
-PY
-```
 
 ## Layout
 
@@ -136,15 +112,26 @@ with `workbench_create`.
    that section: use `section="outputs", path="spectrum.csv"`, not
    `path="outputs/spectrum.csv"`.
 
-3. For logs, write segmented files rather than appending:
+3. Grow logs and journals with `workbench_append` — one file per stream,
+   appended record by record:
 
-```text
-logs/agent_trace/000001.log
-logs/tool_calls/000001.jsonl
-logs/tool_calls/000002.jsonl
+```json
+{"id":"spedas-task-001","section":"logs","path":"tool_calls.jsonl","text":"{\"tool\":\"bash\",\"status\":\"ok\"}\n"}
 ```
 
-4. Commit only after required outputs are present:
+   Append creates the file if it does not exist. Concurrent appends to the
+   same file are retried automatically with backoff; under sustained
+   contention a conflict error can still surface — retry the append once
+   before treating it as a coordination bug. Do not re-upload a growing file
+   with `put_file replace=true`, and do not hand-number segment files — both
+   are obsolete workarounds.
+
+4. Make small in-place changes with `workbench_edit` (same semantics as the
+   local `edit` tool: `old_string` must match exactly once unless
+   `replace_all=true`; the error texts match too). Reserve
+   `put_file replace=true` for whole-file replacement.
+
+5. Commit only after required outputs are present:
 
 ```json
 {
@@ -154,7 +141,7 @@ logs/tool_calls/000002.jsonl
     "inputs": ["input/event.json", "input/dataset-ref.json"],
     "scripts": ["scripts/analysis.py"],
     "outputs": ["outputs/plot_001.png", "outputs/spectrum.csv"],
-    "logs": ["logs/tool_calls/000001.jsonl"],
+    "logs": ["logs/tool_calls.jsonl"],
     "provenance": "metadata/provenance.json"
   }
 }
@@ -163,35 +150,75 @@ logs/tool_calls/000002.jsonl
 `workbench_commit` publishes `metadata/run_manifest.json`. In v0 this file
 is the completion marker. A workbench without it is not complete.
 
-5. Snapshot the committed workbench with `workbench_snapshot` and cite the
+6. Snapshot the committed workbench with `workbench_snapshot` and cite the
 returned `snapshot_id` and `read_version` in final reports or handoff notes.
 
 ## Concurrency
 
 For the MVP, use a parent-created workbench and child-filled files:
 
-- The parent agent creates the workbench, assigns disjoint section-relative
-  paths, validates outputs, commits, and snapshots.
+- The parent agent creates the workbench, assigns section-relative paths,
+  validates outputs, commits, and snapshots.
 - Child or daemon agents only write the paths assigned by the parent. They do
   not create, commit, snapshot, or write `metadata/run_manifest.json`.
-- Assign disjoint prefixes such as `outputs/agent-a/` and `logs/agent-a/`.
-- Do not let two agents write the same file path. Same-path writes with
-  `replace=false` intentionally fail with an exists conflict; treat that as a
-  coordination bug, not a reason to bypass with `replace=true`.
+- Multiple writers may `workbench_append` to the same log file — appends are
+  serialized by the server with automatic retry. Everything else stays
+  disjoint: assign prefixes such as `outputs/agent-a/` and never let two
+  agents `put_file` or `edit` the same path. Same-path `put_file` with
+  `replace=false` intentionally fails with an exists conflict; treat that as
+  a coordination bug, not a reason to bypass with `replace=true`.
 
 ## Read and search
 
-Use `workbench_find` to query across workbenches. By default it returns
-compact committed-state and manifest summaries rather than full manifest
-bodies. Pass `include_manifest=true` only when the full
-`metadata/run_manifest.json` envelope is needed.
+Reading inside one workbench:
 
-Use `workbench_list`, `workbench_stat`, `workbench_read`, and
-`workbench_grep` for content inside one workbench. Query tools return
-flat `section`, `relative_path`, and `path` fields so follow-up calls can reuse
-`section` and `relative_path` directly. NoKV grep is a case-insensitive
-literal substring search, not regex. Use LingTai's local `grep` for local
-workdir text and NoKV grep for workbench artifacts.
+- `workbench_read` pages structured records (JSON, text lines) with
+  `cursor`/`offset`/`limit` (limit up to 300 records). For polling or
+  re-checking a file you already read, pass
+  `if_none_match: <generation from the previous response>` — an unchanged
+  file returns a tiny `not_modified` response instead of the full body.
+  Exception: right after a context molt, read without `if_none_match`; you
+  need the content back, not a not-modified marker.
+- Files larger than the structured limit: use `format="bytes"` with
+  `offset`/`limit` ranges (bytes come back base64-encoded), or
+  `workbench_grep` to locate lines first.
+- Record shape depends on content type: `.json` files parse into JSON
+  records; `.jsonl`, `.log`, and other text files come back as `text_lines`
+  records whose `value.text` holds the raw line — parse it yourself when the
+  line is JSON.
+- `workbench_grep` searches file bodies for case-insensitive **literal**
+  substrings (not regex). Pass several alternatives at once with
+  `patterns: ["营养", "食谱", "recipe"]` (OR semantics); a single `pattern`
+  containing `|` is split into alternatives automatically. Filter files with
+  `glob` (basename match, `*` and `?`, CJK-safe, e.g. `"*.md"`). `limit`
+  accepts up to 300 matches. Narrow with `section`/`glob` first; huge result
+  sets get compacted out of your context later.
+
+Searching across workbenches:
+
+- `workbench_find` answers "which workbenches are committed / mention X in
+  the manifest". It returns compact committed-state and manifest summaries;
+  pass `include_manifest=true` only when the full
+  `metadata/run_manifest.json` envelope is needed.
+- `workbench_search` answers path- and metadata-level queries: predicates
+  over the built-in fields with sort, projection, and facets. Omit `id` to
+  search every workbench under your root; matches come back with
+  `workbench_id`, `section`, and `relative_path`. Built-in queryable fields
+  (no index registration needed): `path`, `name`, `kind`, `size_bytes`,
+  `body.content_type`, `body.producer`, `body.manifest_id`. A single
+  `workbench_search` with `facets: ["body.content_type"]` replaces a
+  list-then-stat sweep.
+- `workbench_aggregate` computes count/sum/avg/min/max with `group_by` over
+  the same fields. `workbench_catalog` lists the queryable fields; until
+  custom indexes exist it always returns the built-in set above, so calling
+  it is rarely necessary.
+- **Content search stays with `workbench_grep`** — `workbench_search`
+  matches paths and metadata, not file contents.
+
+Query tools return flat `section`, `relative_path`, and `path` fields so
+follow-up calls can reuse `section` and `relative_path` directly. Use
+LingTai's local `grep` for local workdir text and NoKV tools for workbench
+artifacts.
 
 ## Commit checklist
 
@@ -201,5 +228,5 @@ Before calling `workbench_commit`, verify:
 - `scripts/` has code or notebooks needed to reproduce the result.
 - `outputs/` has the requested deliverables.
 - `metadata/provenance.json` exists when provenance is required.
-- `logs/` contains evidence segments rather than one append-only file.
+- `logs/` contains the evidence streams (appended files are fine).
 - The manifest lists relative paths inside the workbench sections.

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -62,9 +62,10 @@ the agent's absolute working directory. The same registry line therefore works
 verbatim for every agent — no per-agent editing. This is path-scoped isolation
 enforced by the NoKV MCP (an agent's tools can only address paths under its own
 root); it is not a server-side ACL, which matches LingTai's local trust model.
-Record the owner in each run manifest (e.g. `"owner": "{agent_id}"`) so the
-provenance is explicit; the committed `run_manifest.json` also embeds the full
-`workbench_path`, which already contains the owning agent id.
+Record the resolved owner in each run manifest (for example, `"owner": "scout"`
+for agent `scout`) so provenance is explicit. Do not expect placeholders to expand
+inside committed run manifests; the committed `run_manifest.json` also embeds the
+full `workbench_path`, which already contains the owning agent id.
 
 The MCP tools are intentionally prefixed with `workbench_` so they do not replace
 LingTai's local `read`, `write`, `edit`, `grep`, or `glob` tools.

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: nokv-workbench
+description: >
+  Thin routing manual for NoKV-controlled workbenches. Use when an agent is
+  asked to persist task inputs, scripts, outputs, logs, provenance, or run
+  manifests through the `nokv_workbench_*` MCP tools instead of ordinary local
+  file writes. Covers MCP registration, directory layout, commit discipline,
+  segmented logs, and snapshot references.
+version: 0.1.0
+tags: [nokv, mcp, workbench, artifacts, provenance, snapshots]
+---
+
+# NoKV Workbench
+
+Use this skill when a task must write durable artifacts through NoKV rather
+than the local LingTai workdir. The authoritative control surface is the NoKV
+MCP server started in workbench profile. This skill is only the operating
+manual.
+
+## MCP registration
+
+Register the MCP with a per-agent `mcp_registry.jsonl` line like:
+
+```json
+{"name":"nokv-workbench","summary":"NoKV-controlled workbench artifact namespace.","transport":"stdio","command":"/path/to/nokv","args":["mcp","--profile","workbench","--workbench-root","/workbenches"],"source":"local-nokv"}
+```
+
+Activate it from `init.json`:
+
+```json
+{
+  "mcp": {
+    "nokv-workbench": {
+      "type": "stdio",
+      "command": "/path/to/nokv",
+      "args": ["mcp", "--profile", "workbench", "--workbench-root", "/workbenches"]
+    }
+  }
+}
+```
+
+The MCP tools are intentionally prefixed with `nokv_` so they do not replace
+LingTai's local `read`, `write`, `edit`, `grep`, or `glob` tools.
+
+## Layout
+
+Each workbench id maps to `/workbenches/<id>/` with these sections:
+
+```text
+input/
+scripts/
+outputs/
+logs/
+metadata/
+```
+
+Use the sections consistently:
+
+| Section | Contents |
+|---|---|
+| `input` | task event payloads, dataset references, parameters |
+| `scripts` | analysis code, notebooks, reproducibility scripts |
+| `outputs` | plots, CSVs, derived datasets, reports |
+| `logs` | agent-facing trace excerpts and tool-call evidence |
+| `metadata` | provenance, run manifests, audit references |
+
+Do not write LingTai runtime state here. `.agent.lock`, heartbeat files,
+mailbox, `.notification/`, `.mcp_inbox/`, and `logs/events.jsonl` stay in the
+local LingTai workdir.
+
+## Workflow
+
+1. Create the workbench:
+
+```json
+{"id":"spedas-task-001"}
+```
+
+with `nokv_workbench_create`.
+
+2. Write inputs, scripts, outputs, and evidence with
+   `nokv_workbench_put_file`. Pass `replace=true` only when intentionally
+   replacing a prior artifact.
+
+3. For logs, write segmented files rather than appending:
+
+```text
+logs/agent_trace/000001.log
+logs/tool_calls/000001.jsonl
+logs/tool_calls/000002.jsonl
+```
+
+4. Commit only after required outputs are present:
+
+```json
+{
+  "id": "spedas-task-001",
+  "manifest": {
+    "task": "spedas-task-001",
+    "inputs": ["input/event.json", "input/dataset-ref.json"],
+    "scripts": ["scripts/analysis.py"],
+    "outputs": ["outputs/plot_001.png", "outputs/spectrum.csv"],
+    "logs": ["logs/tool_calls/000001.jsonl"],
+    "provenance": "metadata/provenance.json"
+  }
+}
+```
+
+`nokv_workbench_commit` publishes `metadata/run_manifest.json`. In v0 this file
+is the completion marker. A workbench without it is not complete.
+
+5. Snapshot the committed workbench with `nokv_workbench_snapshot` and cite the
+returned `snapshot_id` and `read_version` in final reports or handoff notes.
+
+## Read and search
+
+Use `nokv_workbench_list`, `nokv_workbench_stat`, `nokv_workbench_read`, and
+`nokv_workbench_grep` for NoKV workbench content. NoKV grep is a
+case-insensitive literal substring search, not regex. Use LingTai's local
+`grep` for local workdir text and NoKV grep for workbench artifacts.
+
+## Commit checklist
+
+Before calling `nokv_workbench_commit`, verify:
+
+- `input/` has the task event and dataset references.
+- `scripts/` has code or notebooks needed to reproduce the result.
+- `outputs/` has the requested deliverables.
+- `metadata/provenance.json` exists when provenance is required.
+- `logs/` contains evidence segments rather than one append-only file.
+- The manifest lists relative paths inside the workbench sections.

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -189,7 +189,8 @@ Reading inside one workbench:
 - `workbench_grep` searches file bodies for case-insensitive **literal**
   substrings (not regex). Pass several alternatives at once with
   `patterns: ["营养", "食谱", "recipe"]` (OR semantics); a single `pattern`
-  containing `|` is split into alternatives automatically. Filter files with
+  containing `|` is split into alternatives automatically. At most 16
+  alternatives per call — batch synonyms accordingly. Filter files with
   `glob` (basename match, `*` and `?`, CJK-safe, e.g. `"*.md"`). `limit`
   accepts up to 300 matches. Narrow with `section`/`glob` first; huge result
   sets get compacted out of your context later.
@@ -215,8 +216,11 @@ Searching across workbenches:
 - **Content search stays with `workbench_grep`** — `workbench_search`
   matches paths and metadata, not file contents.
 
-Query tools return flat `section`, `relative_path`, and `path` fields so
-follow-up calls can reuse `section` and `relative_path` directly. Use
+`workbench_search`, `workbench_grep`, `workbench_list`, `workbench_stat`,
+and `workbench_read` return flat `section`, `relative_path`, and `path`
+fields so follow-up calls can reuse `section` and `relative_path` directly
+(`workbench_find` returns manifest summaries and `workbench_aggregate`
+returns grouped values — neither carries per-file path fields). Use
 LingTai's local `grep` for local workdir text and NoKV tools for workbench
 artifacts.
 

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -114,10 +114,17 @@ returned `snapshot_id` and `read_version` in final reports or handoff notes.
 
 ## Read and search
 
+Use `nokv_workbench_find` to query across workbenches. By default it returns
+compact committed-state and manifest summaries rather than full manifest
+bodies. Pass `include_manifest=true` only when the full
+`metadata/run_manifest.json` envelope is needed.
+
 Use `nokv_workbench_list`, `nokv_workbench_stat`, `nokv_workbench_read`, and
-`nokv_workbench_grep` for NoKV workbench content. NoKV grep is a
-case-insensitive literal substring search, not regex. Use LingTai's local
-`grep` for local workdir text and NoKV grep for workbench artifacts.
+`nokv_workbench_grep` for content inside one workbench. Query tools return
+flat `section`, `relative_path`, and `path` fields so follow-up calls can reuse
+`section` and `relative_path` directly. NoKV grep is a case-insensitive
+literal substring search, not regex. Use LingTai's local `grep` for local
+workdir text and NoKV grep for workbench artifacts.
 
 ## Commit checklist
 

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -3,7 +3,7 @@ name: nokv-workbench
 description: >
   Thin routing manual for NoKV-controlled workbenches. Use when an agent is
   asked to persist task inputs, scripts, outputs, logs, provenance, or run
-  manifests through the `nokv_workbench_*` MCP tools instead of ordinary local
+  manifests through the `workbench_*` MCP tools instead of ordinary local
   file writes. Covers MCP registration, directory layout, commit discipline,
   segmented logs, and snapshot references.
 version: 0.1.0
@@ -22,7 +22,7 @@ manual.
 Register the MCP with a per-agent `mcp_registry.jsonl` line like:
 
 ```json
-{"name":"nokv-workbench","summary":"NoKV-controlled workbench artifact namespace.","transport":"stdio","command":"/path/to/nokv","args":["mcp","--profile","workbench","--workbench-root","/workbenches"],"source":"local-nokv"}
+{"name":"nokv-workbench","summary":"NoKV-controlled workbench artifact namespace.","transport":"stdio","command":"/path/to/nokv","args":["--server-bind","127.0.0.1:7777","--object-backend","rustfs","--s3-bucket","nokv-lingtai-workbench","mcp","--profile","workbench","--workbench-root","/agents/{agent_id}/wb"],"source":"local-nokv"}
 ```
 
 Activate it from `init.json`:
@@ -33,18 +33,70 @@ Activate it from `init.json`:
     "nokv-workbench": {
       "type": "stdio",
       "command": "/path/to/nokv",
-      "args": ["mcp", "--profile", "workbench", "--workbench-root", "/workbenches"]
+      "args": ["--server-bind", "127.0.0.1:7777", "--object-backend", "rustfs", "--s3-bucket", "nokv-lingtai-workbench", "mcp", "--profile", "workbench", "--workbench-root", "/agents/{agent_id}/wb"]
     }
   }
 }
 ```
 
-The MCP tools are intentionally prefixed with `nokv_` so they do not replace
+Keep the global NoKV flags before `mcp`, and set them to the same metadata
+server and object-store bucket used by the running NoKV service. If your
+deployment uses a non-default S3/RustFS endpoint or credentials, add the
+matching `--s3-*` flags here as well.
+
+### Per-agent root (tenant isolation)
+
+Each agent gets its own workbench root so agents cannot see or clobber each
+other's workbenches on a shared NoKV server. Use the `{agent_id}` placeholder
+in `--workbench-root`; LingTai expands it at MCP launch to the agent's stable
+address (its `.lingtai/<agent>` directory name):
+
+```
+--workbench-root /agents/{agent_id}/wb   ->   /agents/scout/wb   (for agent "scout")
+```
+
+`{agent_address}` is an alias for the same value, and `{agent_dir}` expands to
+the agent's absolute working directory. The same registry line therefore works
+verbatim for every agent — no per-agent editing. This is path-scoped isolation
+enforced by the NoKV MCP (an agent's tools can only address paths under its own
+root); it is not a server-side ACL, which matches LingTai's local trust model.
+Record the owner in each run manifest (e.g. `"owner": "{agent_id}"`) so the
+provenance is explicit; the committed `run_manifest.json` also embeds the full
+`workbench_path`, which already contains the owning agent id.
+
+The MCP tools are intentionally prefixed with `workbench_` so they do not replace
 LingTai's local `read`, `write`, `edit`, `grep`, or `glob` tools.
+
+## TUI runtime preflight
+
+Before installing a workbench-enabled LingTai branch into the TUI runtime,
+check the runtime package version:
+
+```bash
+~/.lingtai-tui/runtime/venv/bin/python - <<'PY'
+import importlib.metadata as md
+print(md.version("lingtai"))
+PY
+```
+
+Do not install a source branch that is older than the runtime package already
+used by TUI. Rebase or cherry-pick this workbench skill onto the matching or
+newer upstream LingTai release, build/install that branch, then verify that the
+runtime can see the skill:
+
+```bash
+~/.lingtai-tui/runtime/venv/bin/python - <<'PY'
+from pathlib import Path
+import lingtai.intrinsic_skills as skills
+root = Path(skills.__file__).parent
+print((root / "nokv-workbench" / "SKILL.md").exists())
+PY
+```
 
 ## Layout
 
-Each workbench id maps to `/workbenches/<id>/` with these sections:
+Each workbench id maps to `<workbench-root>/<id>/` (with the per-agent root
+above, `/agents/<agent_id>/wb/<id>/`) with these sections:
 
 ```text
 input/
@@ -76,11 +128,13 @@ local LingTai workdir.
 {"id":"spedas-task-001"}
 ```
 
-with `nokv_workbench_create`.
+with `workbench_create`.
 
 2. Write inputs, scripts, outputs, and evidence with
-   `nokv_workbench_put_file`. Pass `replace=true` only when intentionally
-   replacing a prior artifact.
+   `workbench_put_file`. Pass `replace=true` only when intentionally
+   replacing a prior artifact. When `section` is set, `path` is relative to
+   that section: use `section="outputs", path="spectrum.csv"`, not
+   `path="outputs/spectrum.csv"`.
 
 3. For logs, write segmented files rather than appending:
 
@@ -106,21 +160,34 @@ logs/tool_calls/000002.jsonl
 }
 ```
 
-`nokv_workbench_commit` publishes `metadata/run_manifest.json`. In v0 this file
+`workbench_commit` publishes `metadata/run_manifest.json`. In v0 this file
 is the completion marker. A workbench without it is not complete.
 
-5. Snapshot the committed workbench with `nokv_workbench_snapshot` and cite the
+5. Snapshot the committed workbench with `workbench_snapshot` and cite the
 returned `snapshot_id` and `read_version` in final reports or handoff notes.
+
+## Concurrency
+
+For the MVP, use a parent-created workbench and child-filled files:
+
+- The parent agent creates the workbench, assigns disjoint section-relative
+  paths, validates outputs, commits, and snapshots.
+- Child or daemon agents only write the paths assigned by the parent. They do
+  not create, commit, snapshot, or write `metadata/run_manifest.json`.
+- Assign disjoint prefixes such as `outputs/agent-a/` and `logs/agent-a/`.
+- Do not let two agents write the same file path. Same-path writes with
+  `replace=false` intentionally fail with an exists conflict; treat that as a
+  coordination bug, not a reason to bypass with `replace=true`.
 
 ## Read and search
 
-Use `nokv_workbench_find` to query across workbenches. By default it returns
+Use `workbench_find` to query across workbenches. By default it returns
 compact committed-state and manifest summaries rather than full manifest
 bodies. Pass `include_manifest=true` only when the full
 `metadata/run_manifest.json` envelope is needed.
 
-Use `nokv_workbench_list`, `nokv_workbench_stat`, `nokv_workbench_read`, and
-`nokv_workbench_grep` for content inside one workbench. Query tools return
+Use `workbench_list`, `workbench_stat`, `workbench_read`, and
+`workbench_grep` for content inside one workbench. Query tools return
 flat `section`, `relative_path`, and `path` fields so follow-up calls can reuse
 `section` and `relative_path` directly. NoKV grep is a case-insensitive
 literal substring search, not regex. Use LingTai's local `grep` for local
@@ -128,7 +195,7 @@ workdir text and NoKV grep for workbench artifacts.
 
 ## Commit checklist
 
-Before calling `nokv_workbench_commit`, verify:
+Before calling `workbench_commit`, verify:
 
 - `input/` has the task event and dataset references.
 - `scripts/` has code or notebooks needed to reproduce the result.

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
@@ -1,0 +1,35 @@
+# TUI runtime preflight (developer-facing)
+
+This is deployment guidance for developers installing a workbench-enabled
+LingTai branch into the TUI runtime. It is not agent-facing instruction and
+is deliberately kept out of SKILL.md.
+
+Check the runtime package version first:
+
+```bash
+~/.lingtai-tui/runtime/venv/bin/python - <<'PY'
+import importlib.metadata as md
+print(md.version("lingtai"))
+PY
+```
+
+Do not install a source branch that is older than the runtime package already
+used by TUI. Rebase or cherry-pick the workbench skill onto the matching or
+newer upstream LingTai release, build/install that branch, then verify that
+the runtime can see the skill:
+
+```bash
+~/.lingtai-tui/runtime/venv/bin/python - <<'PY'
+from pathlib import Path
+import lingtai.intrinsic_skills as skills
+root = Path(skills.__file__).parent
+print((root / "nokv-workbench" / "SKILL.md").exists())
+PY
+```
+
+Tool-surface note: the 14-tool surface documented in SKILL.md (including
+workbench_append / workbench_edit / workbench_search / workbench_aggregate /
+workbench_catalog and conditional reads) requires a NoKV build that ships the
+specialized workbench MCP. Older 9-tool NoKV servers still work with this
+skill; the extra tools are simply absent from tools/list and the SKILL
+sections about them do not apply.

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/init-snippet.json
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/init-snippet.json
@@ -1,0 +1,15 @@
+{
+  "mcp": {
+    "nokv-workbench": {
+      "type": "stdio",
+      "command": "/path/to/nokv",
+      "args": [
+        "mcp",
+        "--profile",
+        "workbench",
+        "--workbench-root",
+        "/workbenches"
+      ]
+    }
+  }
+}

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/init-snippet.json
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/init-snippet.json
@@ -4,11 +4,17 @@
       "type": "stdio",
       "command": "/path/to/nokv",
       "args": [
+        "--server-bind",
+        "127.0.0.1:7777",
+        "--object-backend",
+        "rustfs",
+        "--s3-bucket",
+        "nokv-lingtai-workbench",
         "mcp",
         "--profile",
         "workbench",
         "--workbench-root",
-        "/workbenches"
+        "/agents/{agent_id}/wb"
       ]
     }
   }

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/mcp_registry.example.jsonl
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/mcp_registry.example.jsonl
@@ -1,0 +1,1 @@
+{"name":"nokv-workbench","summary":"NoKV-controlled workbench artifact namespace.","transport":"stdio","command":"/path/to/nokv","args":["mcp","--profile","workbench","--workbench-root","/workbenches"],"source":"local-nokv"}

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/mcp_registry.example.jsonl
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/mcp_registry.example.jsonl
@@ -1,1 +1,1 @@
-{"name":"nokv-workbench","summary":"NoKV-controlled workbench artifact namespace.","transport":"stdio","command":"/path/to/nokv","args":["mcp","--profile","workbench","--workbench-root","/workbenches"],"source":"local-nokv"}
+{"name":"nokv-workbench","summary":"NoKV-controlled workbench artifact namespace.","transport":"stdio","command":"/path/to/nokv","args":["--server-bind","127.0.0.1:7777","--object-backend","rustfs","--s3-bucket","nokv-lingtai-workbench","mcp","--profile","workbench","--workbench-root","/agents/{agent_id}/wb"],"source":"local-nokv"}

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -140,6 +140,31 @@ def test_validator_rejects_long_summary():
     assert "summary too long" in err
 
 
+def test_nokv_workbench_registry_example_is_valid():
+    skill_root = Path("src/lingtai/intrinsic_skills/nokv-workbench")
+    registry_path = skill_root / "assets" / "mcp_registry.example.jsonl"
+    init_path = skill_root / "assets" / "init-snippet.json"
+
+    record = json.loads(registry_path.read_text(encoding="utf-8").strip())
+    ok, err = validate_record(record)
+    assert ok, err
+    assert record["name"] == "nokv-workbench"
+    assert record["transport"] == "stdio"
+    assert record["args"] == [
+        "mcp",
+        "--profile",
+        "workbench",
+        "--workbench-root",
+        "/workbenches",
+    ]
+
+    init = json.loads(init_path.read_text(encoding="utf-8"))
+    spec = init["mcp"]["nokv-workbench"]
+    assert spec["type"] == "stdio"
+    assert spec["command"] == record["command"]
+    assert spec["args"] == record["args"]
+
+
 # ---------------------------------------------------------------------------
 # Decompression
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -151,11 +151,17 @@ def test_nokv_workbench_registry_example_is_valid():
     assert record["name"] == "nokv-workbench"
     assert record["transport"] == "stdio"
     assert record["args"] == [
+        "--server-bind",
+        "127.0.0.1:7777",
+        "--object-backend",
+        "rustfs",
+        "--s3-bucket",
+        "nokv-lingtai-workbench",
         "mcp",
         "--profile",
         "workbench",
         "--workbench-root",
-        "/workbenches",
+        "/agents/{agent_id}/wb",
     ]
 
     init = json.loads(init_path.read_text(encoding="utf-8"))
@@ -163,6 +169,20 @@ def test_nokv_workbench_registry_example_is_valid():
     assert spec["type"] == "stdio"
     assert spec["command"] == record["command"]
     assert spec["args"] == record["args"]
+
+
+def test_expand_agent_placeholders_scopes_workbench_root(tmp_path):
+    # Per-agent root injection: a shared registry template resolves to a root
+    # unique to each agent, so agents cannot address each other's workbenches.
+    agent, workdir = _mk_agent(tmp_path)  # workdir.name == "agent"
+    assert agent._expand_agent_placeholders("/agents/{agent_id}/wb") == "/agents/agent/wb"
+    # {agent_address} is an alias for the stable working-dir name.
+    assert agent._expand_agent_placeholders("/agents/{agent_address}/wb") == "/agents/agent/wb"
+    # {agent_dir} expands to the absolute working directory.
+    assert agent._expand_agent_placeholders("{agent_dir}/x") == f"{workdir}/x"
+    # Strings without a placeholder and non-strings pass through untouched.
+    assert agent._expand_agent_placeholders("--profile") == "--profile"
+    assert agent._expand_agent_placeholders(None) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -139,6 +139,18 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert "reference/cli-backends/SKILL.md" in daemon_body
         assert "reference/cleanup/SKILL.md" in daemon_body
 
+        nokv_md = (
+            workdir / ".library" / "intrinsic" / "capabilities" / "nokv-workbench" / "SKILL.md"
+        )
+        assert nokv_md.is_file()
+        nokv_body = nokv_md.read_text(encoding="utf-8")
+        assert "name: nokv-workbench" in nokv_body
+        assert "nokv_workbench_commit" in nokv_body
+        assert "metadata/run_manifest.json" in nokv_body
+        assert (
+            nokv_md.parent / "assets" / "mcp_registry.example.jsonl"
+        ).is_file()
+
         daemon_reference_dir = daemon_md.parent / "reference"
         for reference_name in ("forensics", "inspection", "cli-backends", "cleanup"):
             daemon_reference = daemon_reference_dir / reference_name / "SKILL.md"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -145,8 +145,8 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert nokv_md.is_file()
         nokv_body = nokv_md.read_text(encoding="utf-8")
         assert "name: nokv-workbench" in nokv_body
-        assert "nokv_workbench_find" in nokv_body
-        assert "nokv_workbench_commit" in nokv_body
+        assert "workbench_find" in nokv_body
+        assert "workbench_commit" in nokv_body
         assert "metadata/run_manifest.json" in nokv_body
         assert (
             nokv_md.parent / "assets" / "mcp_registry.example.jsonl"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -145,6 +145,7 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert nokv_md.is_file()
         nokv_body = nokv_md.read_text(encoding="utf-8")
         assert "name: nokv-workbench" in nokv_body
+        assert "nokv_workbench_find" in nokv_body
         assert "nokv_workbench_commit" in nokv_body
         assert "metadata/run_manifest.json" in nokv_body
         assert (


### PR DESCRIPTION
## Summary

- add the `nokv-workbench` intrinsic skill as a concrete downstream example for NoKV-backed workbench artifacts
- document the NoKV MCP registration contract, including global NoKV flags before `mcp`, `workbench_*` tool names, and section-relative paths
- expand `{agent_id}`, `{agent_address}`, and `{agent_dir}` placeholders when LingTai launches MCP servers so a shared registry template can scope workbench roots per agent

## Context

This PR is intended as an example for LingTai developers showing the kernel-side adaptation needed for the NoKV workbench MCP surface. It depends on the NoKV workbench MCP branch/PR: https://github.com/NoKV-Lab/NoKV/pull/387

## Validation

- `uv run --with pytest --with mcp pytest tests/test_mcp_capability.py tests/test_skills.py -q`
- `git diff --check`
