### PR TITLE
fix: clean release diff whitespace

### DIFF
--- a/src/lingtai/mcp_servers/daemon_common/__init__.py
+++ b/src/lingtai/mcp_servers/daemon_common/__init__.py
@@ -1,2 +1,1 @@
 """Common daemon MCP server used by LingTai daemon backends."""
-

--- a/src/lingtai/mcp_servers/daemon_common/__main__.py
+++ b/src/lingtai/mcp_servers/daemon_common/__main__.py
@@ -11,4 +11,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -2053,4 +2053,3 @@ class BaseAgent:
         may still reference it) but is intentionally inert.
         """
         return None
-


### PR DESCRIPTION
## Summary
- remove three blank-at-EOF lines that made `git diff --check v0.15.3..HEAD` fail during the post-#641 release validation gate
- no runtime behavior changes

## Validation
- `git diff --check`
- `git diff --check v0.15.3..HEAD`

Dev-2 reported this as a release-hygiene blocker candidate after functional validation passed; this PR clears the hygiene gate before the kernel release flow continues.