### PR TITLE
chore: bump version to 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.15.3"
+version = "0.16.0"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump kernel/PyPI package version to `0.16.0` for the authorized release flow

## Release gate context
- post-#641 three-dev validation completed after cleanup #642
- release-range `git diff --check v0.15.3..HEAD` is clean on current main
- v0.16.0 tag and PyPI version were checked as unused before this bump

## Validation
- `git diff --check`

Additional release validation (`pytest`, `python -m build`, `twine check`) will run from this release worktree before merge/publish.