### PR TITLE
fix(wechat): sanitize filename in download_media to prevent path traversal

### DIFF
--- a/src/lingtai/mcp_servers/wechat/media.py
+++ b/src/lingtai/mcp_servers/wechat/media.py
@@ -240,7 +240,9 @@ async def download_media(
     if not url:
         raise ValueError("CDN media has no full_url")
 
-    dest_path = dest_dir / filename
+    # Sanitize: use basename only to prevent path traversal via sender-controlled filenames
+    safe_name = Path(filename).name or "file"
+    dest_path = dest_dir / safe_name
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, timeout=60.0)
         resp.raise_for_status()


### PR DESCRIPTION
## Problem

WeChat MCP addon uses sender-controlled `file_name` from inbound file messages as the local filename when downloading CDN content. The filename was passed directly to `dest_dir / filename` without sanitizing `..` or absolute path components.

A malicious WeChat user who can send a file to the bot could craft a `file_name` like `../../init.json` to write CDN-downloaded content to arbitrary paths relative to the media directory.

Image, voice, and video downloads are not affected — they use UUID-generated filenames. Only the FILE message type used the raw sender-controlled filename.

## Fix

Use `Path(filename).name` (basename only) to strip path components before joining with `dest_dir`. Falls back to `"file"` if the basename is empty.

## Testing

The fix is a 3-line change to `download_media()` in `src/lingtai/mcp_servers/wechat/media.py`. Existing tests for image/voice/video download paths (which use UUID filenames) are unaffected. A regression test for crafted filenames should be added separately.

Related issue: inbound WeChat file attachment path traversal (issue pending review loop).