### PR TITLE
fix: use atomic_write_text for chat_history.jsonl writes

### DIFF
--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -42,6 +42,7 @@ from ..meta_block import (
 from ..session import SessionManager
 from ..tc_inbox import TCInbox
 from ..token_ledger import append_token_entry
+from .._fsutil import atomic_write_text
 from ..trace_redaction import redact_for_trajectory
 from ..runtime_identity import runtime_identity_event_fields
 
@@ -1937,7 +1938,7 @@ class BaseAgent:
             if state and state.get("messages"):
                 redacted_messages = redact_for_trajectory(state["messages"])
                 lines = [json.dumps(entry, ensure_ascii=False) for entry in redacted_messages]
-                (history_dir / "chat_history.jsonl").write_text("\n".join(lines) + "\n")
+                atomic_write_text(history_dir / "chat_history.jsonl", "\n".join(lines) + "\n")
         except Exception as e:
             logger.warning(f"[{self.agent_name}] Failed to save chat history: {e}")
         # Update .agent.json with current state

--- a/src/lingtai_kernel/tool_result_artifacts.py
+++ b/src/lingtai_kernel/tool_result_artifacts.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .workdir import workdir_layout
+from ._fsutil import atomic_write_text
 
 # Stable, namespaced literal stamped into every manifest produced by this
 # module.  Detectors require it for new manifests; older manifests that
@@ -197,7 +198,7 @@ def spill_oversized_result(
         try:
             spill_dir.mkdir(parents=True, exist_ok=True)
             spill_path = spill_dir / filename
-            spill_path.write_text(serialized_text, encoding="utf-8")
+            atomic_write_text(spill_path, serialized_text)
             spill_path_str = str(spill_path.relative_to(wd))
             spill_path_abs = str(spill_path.resolve())
         except OSError as exc:
@@ -488,8 +489,8 @@ def mark_expired_spill_manifests(working_dir: Path | str) -> int:
         new_lines.append(_json.dumps(entry, ensure_ascii=False, default=str))
 
     if changed:
-        history_path.write_text(
+        atomic_write_text(
+            history_path,
             "\n".join(new_lines) + ("\n" if new_lines else ""),
-            encoding="utf-8",
         )
     return expired_count


### PR DESCRIPTION
## Problem

`chat_history.jsonl` — the agent's primary conversation store — was written using plain `Path.write_text()` in multiple locations. This is **not crash-atomic**: a process crash (OOM, SIGKILL, power loss, disk full) during the write leaves the file truncated or empty.

## Fix

Replace `Path.write_text()` with `atomic_write_text()` from `_fsutil.py` in three locations:

1. **`base_agent/__init__.py:1940`** (`_save_chat_history`) — the dominant writer, called ~20 times per agent lifecycle. Uses plain `write_text` to rewrite the entire `chat_history.jsonl`.
2. **`tool_result_artifacts.py:200`** (`spill_oversized_result`) — spill sidecar file write.
3. **`tool_result_artifacts.py:491`** (`mark_expired_spill_manifests`) — boot/refresh rewrite of `chat_history.jsonl`.

`atomic_write_text` uses a uuid4-named temp file + `os.replace`, which is atomic on POSIX (rename syscall). The helper was already adopted in `run_dir.py`, `token_ledger.py`, `notifications.py`, and other modules — these sites were an oversight.

## Changes

- 2 files changed, +6 insertions, -4 deletions
- No behavioral change — same encoding, same content, just crash-safe writes

Closes #649.
