### PR TITLE
Fix #654: Clamp max_aed_attempts to prevent infinite AED retry loop

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -769,7 +769,7 @@ def _run_loop(agent) -> None:
                         f"[{agent.agent_name}] AED attempt {aed_attempts}/{agent._config.max_aed_attempts}: {err_desc}",
                     )
 
-                    if aed_attempts == agent._config.max_aed_attempts:
+                    if aed_attempts >= agent._config.max_aed_attempts:
                         if not agent._preset_fallback_attempted and agent._can_fallback_preset():
                             agent._preset_fallback_attempted = True
                             agent._log("preset_auto_fallback",

--- a/src/lingtai_kernel/config.py
+++ b/src/lingtai_kernel/config.py
@@ -104,3 +104,11 @@ class AgentConfig:
     soul_voice: str = "inner"  # consultation prompt profile — "inner" (terse, "you are the soul, speak as inner voice"), "observer" (structured stepped-back hook framing), or "custom" (use soul_voice_prompt). One unified prompt per profile; the per-fire cue text differentiates insights (current diary) vs past (future-self diary).
     soul_voice_prompt: str = ""  # custom voice prompt — only used when soul_voice == "custom". Set/cleared by the agent via soul(action="voice", set="custom", prompt="..."). Length-capped at SOUL_VOICE_PROMPT_MAX in soul.py.
     snapshot_interval: float | None = None  # seconds between git snapshots; None = off
+
+    def __post_init__(self):
+        # Clamp max_aed_attempts to at least 1.  A value of 0 or negative
+        # causes the AED retry loop in turn.py to spin forever: aed_attempts
+        # starts at 1 (incremented before the equality check) and never equals
+        # 0 or a negative max.  See issue #654.
+        if self.max_aed_attempts < 1:
+            self.max_aed_attempts = 1


### PR DESCRIPTION
## Problem

When `max_aed_attempts` is set to 0 or a negative value, the AED (Agent Error Detection) retry loop in `turn.py` spins **infinitely**.

Root cause: `aed_attempts` is initialized to 0 and incremented to 1 *before* the termination check on line 772:

```python
aed_attempts += 1          # now 1
if aed_attempts == agent._config.max_aed_attempts:  # 1 == 0 → never True
    ...break / sleep...
```

The equality test (`==`) never matches when `max_aed_attempts` is 0 or negative, so the agent never reaches the ASLEEP/exhaustion path — it retries forever, consuming API quota and never recovering.

## Fix

Two-layer defense:

1. **`config.py` — `__post_init__` clamp**: `max_aed_attempts` is clamped to at least 1 at construction time, preventing misconfiguration at the source.

2. **`turn.py` — `==` → `>=`**: Even if the config clamp is bypassed (e.g., runtime mutation of `_config`), the comparison terminates correctly because `aed_attempts` (starting at 1) will always be `>=` any non-positive `max_aed_attempts`.

## Testing

```python
AgentConfig()                     # → max_aed_attempts = 3 ✓
AgentConfig(max_aed_attempts=0)   # → clamped to 1 ✓
AgentConfig(max_aed_attempts=-5)  # → clamped to 1 ✓
AgentConfig(max_aed_attempts=10)  # → stays 10 ✓
```

Fixes #654.