### PR TITLE
Fix #663: Remove undefined logger reference in meta_block.py

### DIFF
--- a/src/lingtai_kernel/meta_block.py
+++ b/src/lingtai_kernel/meta_block.py
@@ -288,7 +288,6 @@ def dynamic_adapter_comment(agent: AgentState) -> Mapping[str, Any] | None:
         try:
             comment = comment_fn()
         except Exception:
-            logger.debug("llm_dynamic_adapter_comment_failed", exc_info=True)
             comment = None
         if comment:
             if not isinstance(comment, Mapping):


### PR DESCRIPTION
## Problem

`dynamic_adapter_comment()` in `meta_block.py` referenced `logger.debug()` in its exception handler, but `logger` was never imported or defined anywhere in the file. When the adapter raised an exception, the intended graceful-degradation path crashed with `NameError` instead of falling through to `comment = None`.

## Fix

Removed the `logger.debug()` call to match the sibling pattern used by `static_adapter_comment` and `adapter_comment`, which both use bare `except Exception` without logging.

One line removed. No new code added.

Fixes #663.