### PR TITLE
Fix #662: Ensure .inquiry.taken is cleaned up on _run_inquiry failure

### DIFF
--- a/src/lingtai_kernel/base_agent/lifecycle.py
+++ b/src/lingtai_kernel/base_agent/lifecycle.py
@@ -442,11 +442,13 @@ def _heartbeat_loop(agent) -> None:
                         source, question = "human", content.strip()
                     if question:
                         def _inquiry_done(q: str, s: str, tf) -> None:
-                            _run_inquiry(agent, q, source=s)
                             try:
-                                tf.unlink()
-                            except OSError:
-                                pass
+                                _run_inquiry(agent, q, source=s)
+                            finally:
+                                try:
+                                    tf.unlink()
+                                except OSError:
+                                    pass
                         threading.Thread(
                             target=_inquiry_done,
                             args=(question, source, taken_file),


### PR DESCRIPTION
## Problem

The `_inquiry_done` closure in `lifecycle.py` did not use try/finally around `_run_inquiry`. If `_run_inquiry` raised (LLM error, context overflow), the cleanup `tf.unlink()` never executed, orphaning `.inquiry.taken` permanently and blocking all future inquiries.

## Fix

Wrap `_run_inquiry` in `try/finally` so `tf.unlink()` always runs.

Fixes #662.