### PR TITLE
Clarify manual rebuild hint threshold

### DIFF
--- a/src/lingtai_kernel/meta_block.py
+++ b/src/lingtai_kernel/meta_block.py
@@ -939,7 +939,8 @@ def build_context_rebuild_hint(agent, usage: float) -> str | None:
     return (
         "context now above 75%, you are allowed to rebuild context via "
         "system(action='summarize', rebuild_only=true) or summarize already-"
-        "digested results; see meta_guidance for details."
+        "digested results; forced rebuild will be triggered at 95% context; "
+        "see meta_guidance for details."
     )
 
 

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -3052,5 +3052,6 @@ def test_build_context_rebuild_hint_stamps_after_high_ratio():
     assert hint is not None
     assert "context now above 75%" in hint
     assert "rebuild_only=true" in hint
+    assert "forced rebuild will be triggered at 95% context" in hint
     assert "meta_guidance" in hint
     assert build_context_rebuild_hint(SimpleNamespace(_intrinsics=set()), 0.90) is None


### PR DESCRIPTION
## Summary
- add Jason's requested sentence to the 75% manual context rebuild hint: `forced rebuild will be triggered at 95% context`
- cover the emitted hint wording in `tests/test_meta_block.py`

## Validation
- `python -m py_compile src/lingtai_kernel/meta_block.py`
- `python -m pytest -q tests/test_meta_block.py -q`
- `git diff --check`
