### PR TITLE
Add runtime venv environment marker

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -30,6 +30,7 @@ related_files:
   - tests/test_cli.py
   - tests/test_deep_refresh.py
   - tests/test_kernel_migrate.py
+  - tests/test_venv_resolve.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;
@@ -54,7 +55,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 | `network.py` | Read-only network topology crawler — avatar/contact/mail edge discovery |
 | `presets.py` | Compatibility shim re-exporting the kernel preset library (`lingtai_kernel.presets`) |
 | `init_schema.py` | `validate_init()` plus `strip_deprecated()` — strict schema for active init.json fields, simple deprecated-field cleanup, and known-but-inactive legacy fields migrated by `lingtai_kernel.migrate` |
-| `venv_resolve.py` | Python venv resolution — init.json → global runtime → auto-create |
+| `venv_resolve.py` | Python venv resolution — explicit `init.json` venv → global runtime → auto-create, plus kernel-owned `.lingtai-env.json` marker check/stamp semantics for TUI and kernel callers |
 | `intrinsic_skills/__init__.py` | Standalone skill bundles (docs-only) copied into `.library/intrinsic/` |
 | `mcp_servers/` | Curated MCP server implementations shipped in the `lingtai` distribution and launched by `mcp_catalog.json` via `python -m lingtai.mcp_servers.<name>`; see `mcp_servers/ANATOMY.md` for the bundled `SKILL.md` manual-action and sidecar packaging contract. Stateful curated servers may own per-agent sidecars: the WeChat manager checkpoints `wechat/state.json` cursor progress and `wechat/inbox_seen.json` replay guards in `mcp_servers/wechat/manager.py:266` and `mcp_servers/wechat/manager.py:912`. |
 
@@ -70,7 +71,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **`network.py`**: `build_network` :306 · `_discover_agents` :143 · `_build_avatar_edges` :168
 
-**`venv_resolve.py`**: `resolve_venv` :19 · `venv_python` :40
+**`venv_resolve.py`**: `resolve_venv` :74 · `venv_python` :101 · `_is_default_runtime_dir` :108 · `_test_venv` :118 · `_env_marker_status` :298 · `_env_marker_status_detail` :303 · `_remove_mismatched_managed_venv` :353 · `_env_marker_main` :362
 
 > Config-resolution helpers (`load_jsonc`/`resolve_env`/`resolve_paths`/`_resolve_capabilities`) and preset-connectivity probing (`check_connectivity`/`check_many`) live in the kernel — import directly from `lingtai_kernel.config_resolve` / `lingtai_kernel.preset_connectivity`. The former wrapper-side compatibility shims were removed (no back-compat shims per repo policy).
 
@@ -115,3 +116,4 @@ Parent: `src/lingtai/` under `lingtai-kernel/src/` alongside `lingtai_kernel/` (
 - **AgentConfig hydration:** `_setup_from_init` :1137 rebuilds runtime config via `build_agent_config`, overlaying explicit init.json values onto `lingtai_kernel.config.AgentConfig` defaults. `manifest.cache_miss_budget` overlays `AgentConfig.cache_miss_budget` (default 1,000,000). Legacy `max_turns` and `molt_*` manifest values remain deliberately ignored.
 - **Addon decompression** runs BEFORE capability setup so `mcp` capability sees populated `mcp_registry.jsonl` on first reconcile (`Agent.__init__` :33, `_setup_from_init` :989).
 - **MCP retry contract (issue #34):** `_load_mcp_from_workdir` :376 records every registered init.json mcp entry into `self._mcp_init_specs` (name → `{cfg, source, client}`). `_retry_failed_mcps` :524 walks this dict, closes any dead client (`is_connected()` False), respawns with the original config, and reports `{retried, recovered, still_failed, healthy}`. `system(action="refresh")` calls it via `intrinsics/system/preset.py:_refresh` before `_perform_refresh` so the documented "fix config → refresh" recovery path works without full process restart.
+- **Runtime venv markers:** `venv_resolve.py` accepts legacy managed venvs without `.lingtai-env.json` if `import lingtai` succeeds, then stamps the marker best-effort. Marker read/parse/probe failures are `error`, not `mismatch`, and never delete the managed runtime. A valid marker that proves a different OS/arch/Python environment is a confirmed mismatch: explicit `init.venv_path` candidates are rejected but left on disk, while only the managed global runtime venv (`~/.lingtai-tui/runtime/venv/`) may be removed before auto-create. The TUI calls this same logic through `python -m lingtai.venv_resolve env-marker {check,stamp} --venv <path>`.

--- a/src/lingtai/venv_resolve.py
+++ b/src/lingtai/venv_resolve.py
@@ -7,13 +7,68 @@ Resolution order:
 """
 from __future__ import annotations
 
+import json
 import os
+import platform
+import shutil
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
 
 
 _DEFAULT_RUNTIME_DIR = Path.home() / ".lingtai-tui" / "runtime" / "venv"
+_ENV_MARKER_FILE = ".lingtai-env.json"
+_ENV_MARKER_SCHEMA = "lingtai.runtime-env"
+_ENV_MARKER_SCHEMA_VERSION = 1
+_LINGTAI_ENV_VERSION = 1
+_MARKER_MISSING = "missing"
+_MARKER_MATCH = "match"
+_MARKER_MISMATCH = "mismatch"
+_MARKER_ERROR = "error"
+
+_PYTHON_ENV_PROBE = r"""
+import json
+import platform
+import sys
+import sysconfig
+
+def _goos():
+    if sys.platform == "win32":
+        return "windows"
+    if sys.platform == "darwin":
+        return "darwin"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return sys.platform
+
+def _goarch():
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        return "amd64"
+    if machine in ("aarch64", "arm64"):
+        return "arm64"
+    if machine in ("i386", "i686", "x86"):
+        return "386"
+    if machine.startswith("arm"):
+        return "arm"
+    return machine
+
+print(json.dumps({
+    "os": _goos(),
+    "arch": _goarch(),
+    "python": {
+        "sys_platform": sys.platform,
+        "machine": platform.machine(),
+        "sysconfig_platform": sysconfig.get_platform(),
+        "implementation": platform.python_implementation(),
+        "version": platform.python_version(),
+        "version_major": sys.version_info.major,
+        "version_minor": sys.version_info.minor,
+        "version_micro": sys.version_info.micro,
+    },
+}, sort_keys=True))
+"""
 
 
 def resolve_venv(init_data: dict | None = None) -> Path:
@@ -24,15 +79,21 @@ def resolve_venv(init_data: dict | None = None) -> Path:
     """
     # 1. init.json venv_path
     if init_data and init_data.get("venv_path"):
-        venv = Path(init_data["venv_path"])
-        if _test_venv(venv):
-            return venv
+        venv = Path(init_data["venv_path"]).expanduser()
+        # cli.run writes the managed runtime path into init.json. Keep that path
+        # on the managed branch so marker mismatches can self-heal by recreating it.
+        if not _is_default_runtime_dir(venv):
+            ok, detail = _test_venv_detail(venv, warn_marker_error=True)
+            if ok:
+                return venv
+            raise RuntimeError(f"Configured venv_path is not usable: {venv}: {detail}")
 
     # 2. ~/.lingtai-tui/runtime/venv/
     if _test_venv(_DEFAULT_RUNTIME_DIR):
         return _DEFAULT_RUNTIME_DIR
 
     # 3. Auto-create
+    _remove_mismatched_managed_venv(_DEFAULT_RUNTIME_DIR)
     _create_venv(_DEFAULT_RUNTIME_DIR)
     return _DEFAULT_RUNTIME_DIR
 
@@ -44,19 +105,52 @@ def venv_python(venv_dir: Path) -> str:
     return str(venv_dir / "bin" / "python")
 
 
+def _is_default_runtime_dir(venv_dir: Path) -> bool:
+    try:
+        return (
+            venv_dir.expanduser().resolve(strict=False)
+            == _DEFAULT_RUNTIME_DIR.expanduser().resolve(strict=False)
+        )
+    except OSError:
+        return venv_dir.expanduser() == _DEFAULT_RUNTIME_DIR.expanduser()
+
+
 def _test_venv(venv_dir: Path) -> bool:
     """Test that a venv exists and has lingtai importable."""
+    ok, _detail = _test_venv_detail(venv_dir, warn_marker_error=False)
+    return ok
+
+
+def _test_venv_detail(venv_dir: Path, *, warn_marker_error: bool) -> tuple[bool, str]:
+    """Return whether a venv is usable plus a short failure reason."""
     python = venv_python(venv_dir)
     if not os.path.isfile(python):
-        return False
+        return False, f"python executable missing at {python}"
+    marker_status, marker_detail = _env_marker_status_detail(venv_dir)
+    if marker_status == _MARKER_MISMATCH:
+        return False, marker_detail or "environment marker mismatch"
     try:
         result = subprocess.run(
             [python, "-c", "import lingtai"],
             capture_output=True, timeout=10,
         )
-        return result.returncode == 0
-    except (OSError, subprocess.TimeoutExpired):
-        return False
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            return False, detail or "import lingtai failed"
+        if warn_marker_error and marker_status == _MARKER_ERROR:
+            detail = marker_detail or "environment marker could not be verified"
+            print(
+                "warning: configured venv_path environment marker could not be "
+                f"verified; using venv after import check: {detail}",
+                file=sys.stderr,
+            )
+        if marker_status == _MARKER_MISSING:
+            _write_env_marker_best_effort(venv_dir)
+        return True, ""
+    except OSError as exc:
+        return False, str(exc)
+    except subprocess.TimeoutExpired:
+        return False, "import lingtai timed out"
 
 
 def _create_venv(venv_dir: Path) -> None:
@@ -88,12 +182,12 @@ def _create_venv(venv_dir: Path) -> None:
         [pip, "install", "lingtai"],
         check=True,
     )
+    _write_env_marker_best_effort(venv_dir)
     print("Runtime ready.", file=sys.stderr)
 
 
 def _find_python() -> str | None:
     """Find a Python ≥ 3.11 on the system."""
-    import shutil
     for name in ("python3", "python"):
         path = shutil.which(name)
         if path:
@@ -108,3 +202,199 @@ def _find_python() -> str | None:
             except (OSError, subprocess.TimeoutExpired):
                 continue
     return None
+
+
+def _marker_path(venv_dir: Path) -> Path:
+    return venv_dir / _ENV_MARKER_FILE
+
+
+def _goos() -> str:
+    if sys.platform == "win32":
+        return "windows"
+    if sys.platform == "darwin":
+        return "darwin"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return sys.platform
+
+
+def _goarch(machine: str | None = None) -> str:
+    value = (machine or platform.machine()).lower()
+    if value in ("x86_64", "amd64"):
+        return "amd64"
+    if value in ("aarch64", "arm64"):
+        return "arm64"
+    if value in ("i386", "i686", "x86"):
+        return "386"
+    if value.startswith("arm"):
+        return "arm"
+    return value
+
+
+def _current_process_env_marker() -> dict:
+    return {
+        "schema": _ENV_MARKER_SCHEMA,
+        "schema_version": _ENV_MARKER_SCHEMA_VERSION,
+        "lingtai_env_version": _LINGTAI_ENV_VERSION,
+        "os": _goos(),
+        "arch": _goarch(),
+        "python": {
+            "sys_platform": sys.platform,
+            "machine": platform.machine(),
+            "sysconfig_platform": sysconfig.get_platform(),
+            "implementation": platform.python_implementation(),
+            "version": platform.python_version(),
+            "version_major": sys.version_info.major,
+            "version_minor": sys.version_info.minor,
+            "version_micro": sys.version_info.micro,
+        },
+    }
+
+
+def _current_venv_env_marker(venv_dir: Path) -> dict:
+    result = subprocess.run(
+        [venv_python(venv_dir), "-c", _PYTHON_ENV_PROBE],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(detail or "environment marker probe failed")
+    marker = json.loads(result.stdout)
+    marker["schema"] = _ENV_MARKER_SCHEMA
+    marker["schema_version"] = _ENV_MARKER_SCHEMA_VERSION
+    marker["lingtai_env_version"] = _LINGTAI_ENV_VERSION
+    return marker
+
+
+def _env_marker_matches(marker: dict, current: dict | None = None) -> bool:
+    current = current or _current_process_env_marker()
+    if marker.get("schema") != _ENV_MARKER_SCHEMA:
+        return False
+    if marker.get("schema_version") != _ENV_MARKER_SCHEMA_VERSION:
+        return False
+    if marker.get("lingtai_env_version") != _LINGTAI_ENV_VERSION:
+        return False
+    if marker.get("os") != current.get("os"):
+        return False
+    if marker.get("arch") != current.get("arch"):
+        return False
+    python = marker.get("python") or {}
+    current_python = current.get("python") or {}
+    for key in (
+        "sys_platform",
+        "machine",
+        "sysconfig_platform",
+        "implementation",
+        "version_major",
+        "version_minor",
+    ):
+        if python.get(key) != current_python.get(key):
+            return False
+    return True
+
+
+def _env_marker_status(venv_dir: Path) -> str:
+    status, _detail = _env_marker_status_detail(venv_dir)
+    return status
+
+
+def _env_marker_status_detail(venv_dir: Path) -> tuple[str, str]:
+    try:
+        raw = _marker_path(venv_dir).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return _MARKER_MISSING, ""
+    except OSError as exc:
+        return _MARKER_ERROR, f"cannot read environment marker: {exc}"
+    try:
+        marker = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return _MARKER_ERROR, f"invalid environment marker JSON: {exc}"
+    if marker.get("schema") != _ENV_MARKER_SCHEMA:
+        return _MARKER_ERROR, "unsupported environment marker schema"
+    if marker.get("schema_version") != _ENV_MARKER_SCHEMA_VERSION:
+        return _MARKER_ERROR, "unsupported environment marker schema_version"
+    if marker.get("lingtai_env_version") != _LINGTAI_ENV_VERSION:
+        return _MARKER_ERROR, "unsupported environment marker version"
+    if marker.get("os") != _goos() or marker.get("arch") != _goarch():
+        return _MARKER_MISMATCH, "environment marker platform does not match this host"
+    try:
+        current = _current_venv_env_marker(venv_dir)
+    except OSError as exc:
+        return _MARKER_ERROR, f"environment marker probe failed: {exc}"
+    except subprocess.TimeoutExpired:
+        return _MARKER_ERROR, "environment marker probe timed out"
+    except RuntimeError as exc:
+        return _MARKER_ERROR, f"environment marker probe failed: {exc}"
+    except json.JSONDecodeError as exc:
+        return _MARKER_ERROR, f"environment marker probe returned invalid JSON: {exc}"
+    if _env_marker_matches(marker, current):
+        return _MARKER_MATCH, ""
+    return _MARKER_MISMATCH, "environment marker Python identity does not match this venv"
+
+
+def _write_env_marker(venv_dir: Path) -> None:
+    marker = _current_venv_env_marker(venv_dir)
+    venv_dir.mkdir(parents=True, exist_ok=True)
+    _marker_path(venv_dir).write_text(
+        json.dumps(marker, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_env_marker_best_effort(venv_dir: Path) -> None:
+    try:
+        _write_env_marker(venv_dir)
+    except (OSError, subprocess.TimeoutExpired, RuntimeError, json.JSONDecodeError):
+        return
+
+
+def _remove_mismatched_managed_venv(venv_dir: Path) -> None:
+    if _env_marker_status(venv_dir) == _MARKER_MISMATCH:
+        shutil.rmtree(venv_dir)
+
+
+def _print_env_marker_payload(payload: dict) -> None:
+    print(json.dumps(payload, sort_keys=True))
+
+
+def _env_marker_main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) < 2 or args[0] != "env-marker":
+        print("usage: python -m lingtai.venv_resolve env-marker {check,stamp} --venv PATH", file=sys.stderr)
+        return 2
+    action = args[1]
+    try:
+        venv_index = args.index("--venv")
+        venv_dir = Path(args[venv_index + 1])
+    except (ValueError, IndexError):
+        print("missing --venv PATH", file=sys.stderr)
+        return 2
+
+    if action == "check":
+        status, detail = _env_marker_status_detail(venv_dir)
+        payload = {"status": status}
+        if detail:
+            payload["detail"] = detail
+        _print_env_marker_payload(payload)
+        return 0
+    if action == "stamp":
+        try:
+            _write_env_marker(venv_dir)
+        except (OSError, subprocess.TimeoutExpired, RuntimeError, json.JSONDecodeError) as exc:
+            _print_env_marker_payload({
+                "status": _MARKER_ERROR,
+                "detail": str(exc),
+                "stamp_status": "failed",
+            })
+            return 0
+        _print_env_marker_payload({"status": _MARKER_MATCH, "stamp_status": "stamped"})
+        return 0
+
+    print(f"unknown env-marker action: {action}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_env_marker_main())

--- a/tests/test_venv_resolve.py
+++ b/tests/test_venv_resolve.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from lingtai import venv_resolve
+
+
+def _write_python_executable(venv: Path) -> None:
+    python = Path(venv_resolve.venv_python(venv))
+    python.parent.mkdir(parents=True, exist_ok=True)
+    python.write_text("#!/bin/sh\n", encoding="utf-8")
+    python.chmod(0o755)
+
+
+def _write_marker(venv: Path, marker: dict) -> None:
+    venv.mkdir(parents=True, exist_ok=True)
+    (venv / ".lingtai-env.json").write_text(
+        json.dumps(marker),
+        encoding="utf-8",
+    )
+
+
+def test_env_marker_missing_is_legacy(tmp_path: Path) -> None:
+    assert venv_resolve._env_marker_status(tmp_path / "venv") == "missing"
+
+
+def test_env_marker_detects_platform_mismatch(tmp_path: Path) -> None:
+    marker = venv_resolve._current_process_env_marker()
+    marker["os"] = "other-os"
+    venv = tmp_path / "venv"
+    _write_marker(venv, marker)
+
+    assert venv_resolve._env_marker_status(venv) == "mismatch"
+
+
+def test_env_marker_invalid_json_is_error_not_mismatch(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    venv.mkdir()
+    (venv / ".lingtai-env.json").write_text("{", encoding="utf-8")
+
+    assert venv_resolve._env_marker_status(venv) == "error"
+
+
+def test_env_marker_probe_timeout_is_error_not_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    venv = tmp_path / "venv"
+    _write_python_executable(venv)
+    _write_marker(venv, venv_resolve._current_process_env_marker())
+
+    def timeout_run(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="python", timeout=10)
+
+    monkeypatch.setattr(venv_resolve.subprocess, "run", timeout_run)
+
+    assert venv_resolve._env_marker_status(venv) == "error"
+
+
+def test_test_venv_rejects_mismatched_marker_without_deleting_explicit_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    venv = tmp_path / "explicit"
+    _write_python_executable(venv)
+    marker = venv_resolve._current_process_env_marker()
+    marker["arch"] = "other-arch"
+    _write_marker(venv, marker)
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("mismatched marker should be rejected before import")
+
+    monkeypatch.setattr(venv_resolve.subprocess, "run", fail_run)
+
+    assert not venv_resolve._test_venv(venv)
+    assert venv.exists()
+
+
+def test_resolve_explicit_mismatched_marker_raises_without_deleting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    venv = tmp_path / "explicit"
+    _write_python_executable(venv)
+    marker = venv_resolve._current_process_env_marker()
+    marker["arch"] = "other-arch"
+    _write_marker(venv, marker)
+    (venv / "sentinel").write_text("keep", encoding="utf-8")
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("mismatched explicit venv should be rejected before import")
+
+    monkeypatch.setattr(venv_resolve.subprocess, "run", fail_run)
+
+    with pytest.raises(RuntimeError, match="Configured venv_path is not usable"):
+        venv_resolve.resolve_venv({"venv_path": str(venv)})
+
+    assert (venv / "sentinel").is_file()
+
+
+def test_resolve_explicit_marker_error_accepts_importable_venv_without_deleting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    venv = tmp_path / "explicit"
+    _write_python_executable(venv)
+    (venv / "sentinel").write_text("keep", encoding="utf-8")
+    (venv / ".lingtai-env.json").write_text("{", encoding="utf-8")
+
+    def fake_run(args, **_kwargs):
+        assert args[2] == "import lingtai"
+        return subprocess.CompletedProcess(args, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(venv_resolve.subprocess, "run", fake_run)
+
+    assert venv_resolve.resolve_venv({"venv_path": str(venv)}) == venv
+    assert (venv / "sentinel").is_file()
+    assert "warning: configured venv_path environment marker" in capsys.readouterr().err
+
+
+def test_resolve_written_back_default_runtime_self_heals_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    managed = tmp_path / "runtime" / "venv"
+    monkeypatch.setattr(venv_resolve, "_DEFAULT_RUNTIME_DIR", managed)
+    _write_python_executable(managed)
+    marker = venv_resolve._current_process_env_marker()
+    marker["arch"] = "other-arch"
+    _write_marker(managed, marker)
+    (managed / "sentinel").write_text("stale", encoding="utf-8")
+    created: list[Path] = []
+
+    def fake_create_venv(venv_dir: Path) -> None:
+        created.append(venv_dir)
+        venv_dir.mkdir(parents=True, exist_ok=True)
+        (venv_dir / "created").write_text("yes", encoding="utf-8")
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("mismatched marker should be rejected before import")
+
+    monkeypatch.setattr(venv_resolve, "_create_venv", fake_create_venv)
+    monkeypatch.setattr(venv_resolve.subprocess, "run", fail_run)
+
+    assert venv_resolve.resolve_venv({"venv_path": str(managed)}) == managed
+    assert created == [managed]
+    assert not (managed / "sentinel").exists()
+    assert (managed / "created").is_file()
+
+
+def test_resolve_written_back_default_runtime_recreates_unusable_marker_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    managed = tmp_path / "runtime" / "venv"
+    monkeypatch.setattr(venv_resolve, "_DEFAULT_RUNTIME_DIR", managed)
+    _write_python_executable(managed)
+    (managed / "sentinel").write_text("keep", encoding="utf-8")
+    (managed / ".lingtai-env.json").write_text("{", encoding="utf-8")
+    created: list[Path] = []
+
+    def fake_run(args, **_kwargs):
+        assert args[2] == "import lingtai"
+        return subprocess.CompletedProcess(args, 1, stdout=b"", stderr=b"broken")
+
+    def fake_create_venv(venv_dir: Path) -> None:
+        created.append(venv_dir)
+        (venv_dir / "created").write_text("yes", encoding="utf-8")
+
+    monkeypatch.setattr(venv_resolve, "_create_venv", fake_create_venv)
+    monkeypatch.setattr(venv_resolve.subprocess, "run", fake_run)
+
+    assert venv_resolve.resolve_venv({"venv_path": str(managed)}) == managed
+    assert created == [managed]
+    assert (managed / "sentinel").is_file()
+    assert (managed / "created").is_file()
+
+
+def test_remove_mismatched_managed_venv(tmp_path: Path) -> None:
+    venv = tmp_path / "managed"
+    _write_python_executable(venv)
+    marker = venv_resolve._current_process_env_marker()
+    marker["arch"] = "other-arch"
+    _write_marker(venv, marker)
+    (venv / "sentinel").write_text("stale", encoding="utf-8")
+
+    venv_resolve._remove_mismatched_managed_venv(venv)
+
+    assert not venv.exists()
+
+
+def test_remove_marker_error_does_not_delete_managed_venv(tmp_path: Path) -> None:
+    venv = tmp_path / "managed"
+    _write_python_executable(venv)
+    (venv / "sentinel").write_text("keep", encoding="utf-8")
+    (venv / ".lingtai-env.json").write_text("{", encoding="utf-8")
+
+    venv_resolve._remove_mismatched_managed_venv(venv)
+
+    assert (venv / "sentinel").is_file()
+
+
+def test_test_venv_accepts_legacy_and_writes_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    venv = tmp_path / "legacy"
+    _write_python_executable(venv)
+    marker = venv_resolve._current_process_env_marker()
+
+    def fake_run(args, **kwargs):
+        script = args[2]
+        if script == "import lingtai":
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if "sysconfig.get_platform" in script:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                stdout=json.dumps(
+                    {
+                        "os": marker["os"],
+                        "arch": marker["arch"],
+                        "python": marker["python"],
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected subprocess: {args!r}")
+
+    monkeypatch.setattr(venv_resolve.subprocess, "run", fake_run)
+
+    assert venv_resolve._test_venv(venv)
+    assert (venv / ".lingtai-env.json").is_file()


### PR DESCRIPTION
## Summary

Adds an environment/platform marker for managed runtime virtual environments so a venv copied across machines, operating systems, architectures, or Python runtime versions can be detected before it is reused.

The kernel owns the marker semantics:

- marker file: `.lingtai-env.json`
- schema: `lingtai.runtime-env` v1
- status evaluation: `missing`, `match`, `mismatch`, `error`
- CLI surface for callers such as the TUI:
  - `python -m lingtai.venv_resolve env-marker check --venv <path>`
  - `python -m lingtai.venv_resolve env-marker stamp --venv <path>`

## Behavior

- A confirmed marker mismatch on the managed runtime can trigger managed venv recreation.
- Marker read/parse/probe errors are treated as inconclusive, not as mismatch.
- Explicit non-default `init.venv_path` is never deleted.
- Explicit non-default `init.venv_path` still rejects confirmed marker mismatch, but marker errors fall through to the normal `import lingtai` usability check; if import succeeds, the venv is accepted with a warning.
- If the default managed runtime path has been written back into `init.json`, it is still treated as managed so headless boots retain self-heal/recreate behavior after migration.
- Legacy missing markers are accepted after a successful import and are stamped best-effort.

## Validation

- `python -m pytest tests/test_venv_resolve.py tests/test_cli.py` — 38 passed
- `python3 -m py_compile src/lingtai/venv_resolve.py tests/test_venv_resolve.py tests/test_cli.py`
- `git diff --check canonical/main...HEAD`
- Independent Claude review after the D1/D2 follow-up: `NO_BLOCKERS`

## Companion change

Companion TUI PR: https://github.com/Lingtai-AI/lingtai/pull/528

The companion TUI PR calls this kernel-owned marker check from the Go runtime manager instead of duplicating marker schema/platform comparison logic in Go.

## Notes

Remaining possible follow-ups are intentionally not folded into this PR: subprocess-level tests for the new `env-marker` CLI surface, richer doctor branch coverage, and extra context around `rmtree` failures during managed-vend cleanup.