### PR TITLE
fix(aed): tolerate missing usage on empty LLM response

### DIFF
--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -1558,12 +1558,13 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
                     _diag["finish_reason"] = getattr(
                         choices[0], "finish_reason", None
                     )
+            usage = getattr(response, "usage", None)
             agent._log(
                 "empty_llm_response",
                 ledger_source=ledger_source,
                 in_tool_loop=in_tool_loop,
-                output_tokens=response.usage.output_tokens,
-                thinking_tokens=response.usage.thinking_tokens,
+                output_tokens=getattr(usage, "output_tokens", 0) or 0,
+                thinking_tokens=getattr(usage, "thinking_tokens", 0) or 0,
                 api_call_id=getattr(response, "api_call_id", None),
                 **_diag,
             )

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -335,6 +335,41 @@ def test_empty_llm_response_error_carries_provider_diagnostics():
     )
 
 
+
+
+def test_empty_llm_response_allows_missing_usage_metadata():
+    logs: list[tuple[str, dict]] = []
+    agent = SimpleNamespace(
+        _cancel_event=threading.Event(),
+        _executor=SimpleNamespace(guard=SimpleNamespace()),
+        _log=lambda event, **fields: logs.append((event, fields)),
+    )
+    response = LLMResponse(
+        text="",
+        tool_calls=[],
+        thoughts=[],
+        usage=None,
+        raw=None,
+        api_call_id="api_no_usage",
+    )
+
+    with pytest.raises(turn.EmptyLLMResponseError) as excinfo:
+        turn._process_response(agent, response, ledger_source="tc_wake")
+
+    assert excinfo.value.api_call_id == "api_no_usage"
+    assert logs == [
+        (
+            "empty_llm_response",
+            {
+                "ledger_source": "tc_wake",
+                "in_tool_loop": False,
+                "output_tokens": 0,
+                "thinking_tokens": 0,
+                "api_call_id": "api_no_usage",
+            },
+        )
+    ]
+
 def test_tc_wake_error_logs_empty_response_diagnostics(tmp_path):
     from lingtai_kernel.llm.interface import ChatInterface, ToolCallBlock, ToolResultBlock
     from lingtai_kernel.message import _make_message, MSG_TC_WAKE


### PR DESCRIPTION
## Summary

Fixes the empty-LLM-response diagnostics path so a provider response with `usage=None` still raises the intended `EmptyLLMResponseError` instead of masking it with `AttributeError` while logging diagnostic fields.

Changes:

- guard `response.usage` with `getattr(response, "usage", None)` before logging token counts;
- default missing `output_tokens` / `thinking_tokens` to `0`;
- add a regression test for an empty response with `usage=None`.

Fixes #658.

## Accuracy check

Before the code fix, the new regression failed exactly as reported:

- `tests/test_aed_recovery.py::test_empty_llm_response_allows_missing_usage_metadata`
- failure: `AttributeError: 'NoneType' object has no attribute 'output_tokens'` at `src/lingtai_kernel/base_agent/turn.py:1565`

## Validation

- `python -m pytest tests/test_aed_recovery.py::test_empty_llm_response_allows_missing_usage_metadata -q` → passed after fix
- `python -m pytest tests/test_aed_recovery.py -k 'empty_llm_response or tc_wake_error_logs_empty_response_diagnostics' -q` → `4 passed, 6 deselected`
- `python -m pytest tests/test_aed_recovery.py -q` → `10 passed`
- `git diff --check`
