### PR TITLE
fix(logging): guard jsonl close race

### DIFF
--- a/src/lingtai_kernel/services/logging.py
+++ b/src/lingtai_kernel/services/logging.py
@@ -144,6 +144,11 @@ class JSONLLoggingService(LoggingService):
         line = json.dumps(event, ensure_ascii=self._ensure_ascii, default=str)
         payload = (line + "\n").encode("utf-8")
         with self._lock:
+            # Re-check under the lock: a concurrent close() (or one triggered
+            # during serialization above) may have closed the file after the
+            # pre-lock check. Never write/tell/flush a closed file.
+            if self._closed:
+                return None
             source_offset = self._file.tell()
             self._file.write(payload)
             self._file.flush()
@@ -166,9 +171,10 @@ class JSONLLoggingService(LoggingService):
             return events
 
     def close(self) -> None:
-        if not self._closed:
-            self._closed = True
-            self._file.close()
+        with self._lock:
+            if not self._closed:
+                self._closed = True
+                self._file.close()
 
 
 class SQLiteEventIndex:

--- a/tests/test_services_logging.py
+++ b/tests/test_services_logging.py
@@ -56,6 +56,31 @@ class TestJSONLLoggingService:
         svc.log({"type": "test"})  # should not raise
         assert log_file.read_text().strip() == ""
 
+    def test_close_during_log_serialization_is_noop(self, tmp_path):
+        """A close() that lands after the pre-lock _closed check must not make
+        log() write to (or tell/flush) an already-closed file.
+
+        This reproduces the close/log interleaving deterministically: log()
+        serializes the event with ``default=str`` before taking the write lock,
+        so an object whose ``__str__`` closes the service closes the file inside
+        that window. Without lock-guarded close/write, log() then touches a
+        closed file and raises ValueError.
+        """
+        log_file = tmp_path / "test.jsonl"
+        svc = JSONLLoggingService(log_file)
+
+        class ClosesOnStr:
+            def __str__(self) -> str:
+                svc.close()
+                return "closed-during-serialization"
+
+        result = svc.log({"type": "test", "trigger": ClosesOnStr()})
+
+        # The service closed mid-log, so nothing should have been written and
+        # the call must report "not written" rather than raise.
+        assert result is None
+        assert log_file.read_text() == ""
+
     def test_creates_parent_dirs(self, tmp_path):
         """Parent directories are created if they don't exist."""
         log_file = tmp_path / "nested" / "dir" / "test.jsonl"


### PR DESCRIPTION
## Summary

Fixes #671 by making `JSONLLoggingService` serialize close/log access through the existing lock:

- `log()` re-checks `_closed` while holding `_lock` before touching the file handle.
- `close()` now acquires `_lock` before setting `_closed` and closing the file.
- Added a deterministic regression test that closes the service during `log()` serialization to reproduce the previous closed-file write path.

## Bug confirmation

Before the production fix, the new regression failed exactly on the issue path:

```text
src/lingtai_kernel/services/logging.py:147: ValueError
E           ValueError: I/O operation on closed file
```

Command used for the pre-fix check:

```bash
python -m pytest tests/test_services_logging.py::TestJSONLLoggingService::test_close_during_log_serialization_is_noop -q
```

## Validation

```bash
python -m pytest tests/test_services_logging.py::TestJSONLLoggingService::test_close_during_log_serialization_is_noop -q
# 1 passed in 0.05s

python -m pytest tests/test_services_logging.py -q
# 34 passed in 0.24s

git diff --check
# no output
```

## Notes

This is intentionally narrow: no unrelated refactors and no ANATOMY updates because no symbol/file shape changed.
