### PR TITLE
Log malformed streamed tool-call args fallback

### DIFF
--- a/src/lingtai_kernel/llm/streaming.py
+++ b/src/lingtai_kernel/llm/streaming.py
@@ -8,9 +8,12 @@ feeds deltas through the accumulator's methods, then calls finalize().
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from .base import LLMResponse, ToolCall, UsageMetadata
+
+logger = logging.getLogger(__name__)
 
 
 class StreamingAccumulator:
@@ -176,5 +179,6 @@ def _finalize_tool(pending: dict[str, str]) -> ToolCall:
     try:
         args = json.loads(args_json) if args_json else {}
     except json.JSONDecodeError:
+        logger.warning("streamed tool-call args JSON parse failed; defaulting to {}")
         args = {}
     return ToolCall(name=pending["name"], args=args, id=pending["id"] or None)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -64,13 +64,15 @@ def test_sequential_tool_empty_args():
     assert result.tool_calls[0].args == {}
 
 
-def test_sequential_tool_malformed_json():
+def test_sequential_tool_malformed_json(caplog):
     acc = StreamingAccumulator()
     acc.start_tool(id="t1", name="broken")
     acc.add_tool_args("{not valid json")
-    acc.finish_tool()
+    with caplog.at_level("WARNING", logger="lingtai_kernel.llm.streaming"):
+        acc.finish_tool()
     result = acc.finalize()
     assert result.tool_calls[0].args == {}
+    assert "streamed tool-call args JSON parse failed; defaulting to {}" in caplog.text
 
 
 def test_finish_tool_noop_when_no_pending():


### PR DESCRIPTION
## Summary
- add a module logger in `lingtai_kernel.llm.streaming`
- warn when malformed streamed tool-call args JSON falls back to `{}`
- extend the malformed JSON streaming test with `caplog` so the warning is covered while preserving existing fallback behavior

Closes #652.

## Validation
- `git diff --check`
- `python -m pytest tests/test_streaming.py -q` (21 passed)

## Notes
- Behavior is unchanged: malformed streamed tool-call args still default to `{}`.
- The warning does not include raw tool arguments, avoiding accidental argument/secret exposure in logs.
- No ANATOMY update is needed because this is a local observability/logging change and does not alter the `llm/streaming.py` structural role or cited entrypoints.
