### PR TITLE
fix: confine pad/email paths to working directory (#624)

### DIFF
--- a/src/lingtai_kernel/intrinsics/email/manager.py
+++ b/src/lingtai_kernel/intrinsics/email/manager.py
@@ -272,7 +272,22 @@ class EmailManager:
             base_payload["cc"] = cc
         attachments = args.get("attachments", [])
         if attachments:
-            base_payload["attachments"] = attachments
+            # Confinement: only allow attachment paths within the agent's
+            # working directory (issue #624).
+            working_dir = self._agent._working_dir.resolve()
+            safe_attachments: list[str] = []
+            for att_path in attachments:
+                ap = Path(att_path)
+                if ap.is_absolute():
+                    candidate = ap.resolve()
+                else:
+                    candidate = (working_dir / ap).resolve()
+                try:
+                    candidate.relative_to(working_dir)
+                except ValueError:
+                    return {"error": f"Attachment path escapes working directory: {att_path!r}"}
+                safe_attachments.append(str(candidate))
+            base_payload["attachments"] = safe_attachments
 
         deliver_at = datetime.now(timezone.utc) + timedelta(seconds=delay)
         all_recipients = to_list + cc + bcc

--- a/src/lingtai_kernel/intrinsics/psyche/_pad.py
+++ b/src/lingtai_kernel/intrinsics/psyche/_pad.py
@@ -40,9 +40,24 @@ def _save_append_list(agent, files: list[str]) -> None:
 
 
 def _resolve_path(agent, fpath: str) -> Path:
+    """Resolve a file path, confining it to the agent's working directory.
+
+    Rejects absolute paths and ``../`` traversals that escape the working
+    directory, preventing sandbox breakout via pad append/edit (issue #624).
+    """
+    working_dir = agent._working_dir.resolve()
     if os.path.isabs(fpath):
-        return Path(fpath)
-    return agent._working_dir / fpath
+        candidate = Path(fpath).resolve()
+    else:
+        candidate = (working_dir / fpath).resolve()
+    try:
+        candidate.relative_to(working_dir)
+    except ValueError:
+        raise ValueError(
+            f"Path escapes working directory: {fpath!r}. "
+            "Only paths within the agent working directory are allowed."
+        )
+    return candidate
 
 
 def _read_append_content(agent, files: list[str]) -> tuple[str, list[str]]:
@@ -50,7 +65,11 @@ def _read_append_content(agent, files: list[str]) -> tuple[str, list[str]]:
     parts: list[str] = []
     not_found: list[str] = []
     for fpath in files:
-        resolved = _resolve_path(agent, fpath)
+        try:
+            resolved = _resolve_path(agent, fpath)
+        except ValueError:
+            not_found.append(fpath)
+            continue
         if not resolved.is_file():
             not_found.append(fpath)
             continue
@@ -95,10 +114,10 @@ def _pad_edit(agent, args: dict) -> dict:
 
     not_found: list[str] = []
     for i, fpath in enumerate(files, start=1):
-        if os.path.isabs(fpath):
-            resolved = Path(fpath)
-        else:
-            resolved = agent._working_dir / fpath
+        try:
+            resolved = _resolve_path(agent, fpath)
+        except ValueError as e:
+            return {"error": str(e)}
         if not resolved.is_file():
             not_found.append(fpath)
             continue
@@ -183,7 +202,10 @@ def _pad_append(agent, args: dict) -> dict:
     not_found: list[str] = []
     not_text: list[str] = []
     for fpath in files:
-        resolved = _resolve_path(agent, fpath)
+        try:
+            resolved = _resolve_path(agent, fpath)
+        except ValueError as e:
+            return {"error": str(e)}
         if not resolved.is_file():
             not_found.append(fpath)
         elif not _is_text_file(resolved):


### PR DESCRIPTION
## Summary

Fixes path traversal vulnerability in pad append/edit and email attachments (#624).

## Changes

### `_pad.py` — pad path confinement
- `_resolve_path()`: now resolves and verifies that all paths (both absolute and relative) are within the agent's working directory. Rejects `../` traversals and absolute paths that escape the sandbox.
- `_pad_edit()`: uses `_resolve_path()` for file imports instead of duplicating unsafe absolute-path logic.
- `_read_append_content()` and `_pad_append()`: handle `ValueError` from confined `_resolve_path` gracefully.

### `email/manager.py` — attachment path confinement
- `_send()`: validates all attachment paths are within the sender's working directory before including them in the payload. Prevents exfiltration of arbitrary files (e.g. `~/.secrets/telegram.json`, `~/.ssh/id_rsa`) via email attachments.

## Attack Vector Prevented

Before: `psyche({object: "pad", action: "append", files: ["/Users/operator/.ssh/id_rsa"]})` would read the private key and inject it permanently into the system prompt.

After: Returns `{"error": "Path escapes working directory: '/Users/operator/.ssh/id_rsa'. Only paths within the agent working directory are allowed."}`

## Testing

- Both files pass `ast.parse()` syntax check.
- Path confinement uses `Path.resolve()` + `relative_to()` — the standard Python path containment pattern.
- Graceful error handling preserves existing behavior for valid paths.

Fixes #624