### PR TITLE
daemon: preflight required inputs before scheduling

### DIFF
--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -1075,7 +1075,9 @@ class DaemonManager:
             lines.append(f"- {path}")
         lines.append(
             "If any later becomes unreadable or does not contain the expected material, "
-            "call `finish(status=\"incomplete\", reason=...)`; do not substitute unrelated materials."
+            "report `incomplete` (call `finish(status=\"incomplete\", reason=...)` "
+            "when the finish tool is available; otherwise state incomplete in the final result); "
+            "do not substitute unrelated materials."
         )
         return "\n".join(lines)
 
@@ -1278,9 +1280,11 @@ class DaemonManager:
             "inspect its result in this run, then call `finish`. If the task "
             "specifies a required local input, file path, or brief and you "
             "cannot access it after direct resolution from the stated context "
-            "or working directory, fail closed: call "
-            "`finish(status=\"incomplete\", reason=...)` and report the "
-            "missing input. Do not broad-search for substitute evidence or "
+            "or working directory, fail closed: report `incomplete` "
+            "(call `finish(status=\"incomplete\", reason=...)` when the "
+            "finish tool is available; otherwise state incomplete in the final "
+            "result) and report the missing input. Do not broad-search for "
+            "substitute evidence or "
             "complete the task from unrelated materials unless the parent "
             "explicitly authorizes a fallback source."
         )

--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -651,6 +651,15 @@ def get_schema(lang: str = "en") -> dict:
                             "items": {"type": "object"},
                             "description": t(lang, "daemon.tasks.mcp"),
                         },
+                        "required_inputs": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional paths that must exist before this daemon is "
+                                "scheduled. Relative paths resolve against the parent "
+                                "agent working directory."
+                            ),
+                        },
                         "preset": {
                             "type": "string",
                             "description": t(lang, "daemon.tasks.preset"),
@@ -995,6 +1004,81 @@ class DaemonManager:
             handlers[name] = self._agent._intrinsics[name]
         return schemas, handlers
 
+
+    @staticmethod
+    def _resolve_required_input_path(raw_path: str, working_dir: Path) -> Path:
+        """Resolve one required input path relative to the parent agent cwd."""
+        p = Path(raw_path).expanduser()
+        if not p.is_absolute():
+            p = working_dir / p
+        return p.resolve(strict=False)
+
+    def _preflight_required_inputs(self, tasks: list[dict]) -> list[list[str]] | dict:
+        """Validate all per-task required_inputs before any run is created."""
+        normalized_by_task: list[list[str]] = []
+        for i, spec in enumerate(tasks):
+            raw_inputs = spec.get("required_inputs")
+            if raw_inputs is None:
+                normalized_by_task.append([])
+                continue
+            if not isinstance(raw_inputs, list):
+                return {
+                    "status": "error",
+                    "message": f"tasks[{i}].required_inputs must be an array of strings",
+                }
+            normalized: list[str] = []
+            for j, raw in enumerate(raw_inputs):
+                field = f"tasks[{i}].required_inputs[{j}]"
+                if not isinstance(raw, str):
+                    return {
+                        "status": "error",
+                        "message": f"{field} must be a non-empty string path",
+                    }
+                if not raw.strip():
+                    return {
+                        "status": "error",
+                        "message": f"{field} must be a non-empty string path",
+                    }
+                resolved = self._resolve_required_input_path(raw, self._agent._working_dir)
+                try:
+                    exists = resolved.exists()
+                    readable = os.access(resolved, os.R_OK)
+                except OSError as e:
+                    return {
+                        "status": "error",
+                        "message": f"{field} is invalid: {resolved}: {e}",
+                    }
+                if not exists:
+                    return {
+                        "status": "error",
+                        "message": f"{field} does not exist: {resolved}",
+                    }
+                if not readable:
+                    return {
+                        "status": "error",
+                        "message": f"{field} is not readable: {resolved}",
+                    }
+                normalized.append(str(resolved))
+            normalized_by_task.append(normalized)
+        return normalized_by_task
+
+    @staticmethod
+    def _render_required_inputs_block(required_inputs: list[str] | None) -> str | None:
+        """Render the validated input manifest shown to the daemon."""
+        if not required_inputs:
+            return None
+        lines = [
+            "## Required inputs validated by parent before launch",
+            "The parent verified these paths existed and were readable before scheduling this daemon:",
+        ]
+        for path in required_inputs:
+            lines.append(f"- {path}")
+        lines.append(
+            "If any later becomes unreadable or does not contain the expected material, "
+            "call `finish(status=\"incomplete\", reason=...)`; do not substitute unrelated materials."
+        )
+        return "\n".join(lines)
+
     @staticmethod
     def _resolve_task_skill_path(raw_path: str, working_dir: Path) -> Path:
         """Resolve one daemon task skill path to a concrete SKILL.md file."""
@@ -1191,7 +1275,14 @@ class DaemonManager:
             "contract, background-and-wait is invalid: do not start a background "
             "job and end your turn expecting a later notification or re-entry. "
             "Run required validation synchronously with an explicit timeout, "
-            "inspect its result in this run, then call `finish`."
+            "inspect its result in this run, then call `finish`. If the task "
+            "specifies a required local input, file path, or brief and you "
+            "cannot access it after direct resolution from the stated context "
+            "or working directory, fail closed: call "
+            "`finish(status=\"incomplete\", reason=...)` and report the "
+            "missing input. Do not broad-search for substitute evidence or "
+            "complete the task from unrelated materials unless the parent "
+            "explicitly authorizes a fallback source."
         )
 
     @staticmethod
@@ -1776,6 +1867,7 @@ class DaemonManager:
         task: str,
         schemas: list[FunctionSchema],
         system_prompt: str | None = None,
+        required_inputs: list[str] | None = None,
     ) -> str:
         """Build the system prompt for an emanation."""
         lines = [
@@ -1811,6 +1903,11 @@ class DaemonManager:
                 "approval guard."
             )
             lines.append(system_prompt)
+
+        required_inputs_block = self._render_required_inputs_block(required_inputs)
+        if required_inputs_block:
+            lines.append("")
+            lines.append(required_inputs_block)
 
         lines.append("")
         lines.append("Your task:")
@@ -2718,6 +2815,10 @@ class DaemonManager:
         else:
             effective_timeout = self._timeout
 
+        required_inputs_by_task = self._preflight_required_inputs(tasks)
+        if isinstance(required_inputs_by_task, dict):
+            return required_inputs_by_task
+
         # Clear completed emanations and stale pools.
         # Keep completed CLI emanations (backend != lingtai) so that `ask`
         # can still route to `_handle_ask_cli` / `_handle_ask_codex` /
@@ -2736,6 +2837,7 @@ class DaemonManager:
                 tasks, backend=backend,
                 effective_max_turns=effective_max_turns,
                 effective_timeout=effective_timeout,
+                required_inputs_by_task=required_inputs_by_task,
             )
 
         # Pre-flight: resolve any per-task presets BEFORE scheduling.
@@ -2859,6 +2961,7 @@ class DaemonManager:
                         "skills": spec.get("skills", []),
                         "mcp": [],
                         "system_prompt": task_system_prompt,
+                        "required_inputs": required_inputs_by_task[i],
                     },
                     log_callback=self._log,
                     preset_name=resolved["name"] if resolved else None,
@@ -2886,7 +2989,10 @@ class DaemonManager:
                     mcp_surface=(mcp_schemas, mcp_handlers),
                 )
                 system_prompt = self._build_emanation_prompt(
-                    spec["task"], schemas, system_prompt=task_context
+                    spec["task"],
+                    schemas,
+                    system_prompt=task_context,
+                    required_inputs=required_inputs_by_task[i],
                 )
                 run_dir.prompt_path.write_text(system_prompt, encoding="utf-8")
                 run_dir._state["call_parameters"]["mcp"] = [
@@ -2955,6 +3061,7 @@ class DaemonManager:
         backend: str,
         effective_max_turns: int,
         effective_timeout: float,
+        required_inputs_by_task: list[list[str]],
     ) -> dict:
         """Dispatch emanations via an external CLI backend.
 
@@ -3029,6 +3136,13 @@ class DaemonManager:
             )
             if _cli_backend_loads_common_mcp(backend):
                 task_context = self._append_daemon_common_context(task_context)
+            required_inputs_block = self._render_required_inputs_block(
+                required_inputs_by_task[len(ids) - 1]
+            )
+            if required_inputs_block:
+                task_context = "\n\n".join(
+                    part for part in (task_context, required_inputs_block) if part
+                )
             if task_context:
                 system_prompt += (
                     "\n\nParent-provided daemon context (oneshot):\n"
@@ -3055,6 +3169,7 @@ class DaemonManager:
                         "mcp": [],
                         "system_prompt": context.system_prompt,
                         "backend_options": backend_options,
+                        "required_inputs": required_inputs_by_task[len(ids) - 1],
                     },
                     log_callback=self._log,
                     backend=backend,
@@ -3076,6 +3191,13 @@ class DaemonManager:
                 if _cli_backend_loads_common_mcp(backend):
                     task_context = self._append_daemon_common_context(task_context)
                 system_prompt = f"[{backend} backend — task delegated to external CLI]"
+                required_inputs_block = self._render_required_inputs_block(
+                    required_inputs_by_task[len(ids) - 1]
+                )
+                if required_inputs_block:
+                    task_context = "\n\n".join(
+                        part for part in (task_context, required_inputs_block) if part
+                    )
                 if task_context:
                     system_prompt += (
                         "\n\nParent-provided daemon context (oneshot):\n"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -363,6 +363,9 @@ def test_daemon_schema_accepts_task_system_prompt_and_skills():
     assert "mcp" in task_props
     assert task_props["mcp"]["type"] == "array"
     assert task_props["mcp"]["items"]["type"] == "object"
+    assert "required_inputs" in task_props
+    assert task_props["required_inputs"]["type"] == "array"
+    assert task_props["required_inputs"]["items"]["type"] == "string"
     assert "custom_system_prompt" not in task_props
 
 
@@ -476,6 +479,177 @@ def test_build_emanation_prompt_includes_oneshot_system_prompt(tmp_path):
     assert prompt.index("Only inspect Python files") < prompt.index("Your task:")
 
 
+
+
+
+def test_daemon_common_context_requires_fail_closed_for_missing_required_inputs(tmp_path):
+    """Default daemon completion contract rejects substituting unrelated evidence."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    context = mgr._daemon_common_context()
+
+    assert "required local input, file path, or brief" in context
+    assert "fail closed" in context
+    assert "finish(status=\"incomplete\", reason=...)" in context
+    assert "Do not broad-search for substitute evidence" in context
+
+
+def test_build_emanation_prompt_carries_missing_input_fail_closed_contract(tmp_path):
+    """LingTai daemon prompts include the default fail-closed completion context."""
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    schemas, _ = mgr._build_tool_surface(["file"])
+    context = mgr._append_daemon_common_context(None)
+
+    prompt = mgr._build_emanation_prompt(
+        "Use work/audit/missing_brief.md as the required brief.",
+        schemas,
+        system_prompt=context,
+    )
+
+    assert "Use work/audit/missing_brief.md as the required brief." in prompt
+    assert "fail closed" in prompt
+    assert "Do not broad-search for substitute evidence" in prompt
+    assert prompt.index("fail closed") < prompt.index("Your task:")
+
+def test_build_emanation_prompt_lists_required_inputs_before_task(tmp_path):
+    """Validated required inputs render as a compact no-substitution block."""
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    schemas, _ = mgr._build_tool_surface(["file"])
+    required = [str((agent._working_dir / "brief.md").resolve())]
+
+    prompt = mgr._build_emanation_prompt(
+        "Review the brief.", schemas, required_inputs=required
+    )
+
+    assert "## Required inputs validated by parent before launch" in prompt
+    assert required[0] in prompt
+    assert "finish(status=\"incomplete\", reason=...)" in prompt
+    assert "do not substitute unrelated materials" in prompt
+    assert prompt.index("## Required inputs") < prompt.index("Your task:")
+
+
+def test_required_inputs_relative_path_normalizes_into_run_params_and_prompt(tmp_path, monkeypatch):
+    """Relative required input paths resolve against the parent agent working dir."""
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    brief = agent._working_dir / "brief.md"
+    brief.parent.mkdir(parents=True, exist_ok=True)
+    brief.write_text("brief", encoding="utf-8")
+    normalized = str(brief.resolve())
+
+    def fake_run(em_id, run_dir, *args, **kwargs):
+        run_dir.mark_done("ok")
+        return "ok"
+
+    monkeypatch.setattr(mgr, "_run_emanation", fake_run)
+    result = mgr.handle({
+        "action": "emanate",
+        "tasks": [{
+            "task": "Review the brief.",
+            "tools": ["file"],
+            "required_inputs": ["brief.md"],
+        }],
+    })
+
+    assert result["status"] == "dispatched"
+    em_id = result["ids"][0]
+    mgr._emanations[em_id]["future"].result(timeout=5)
+    run_dir = mgr._emanations[em_id]["run_dir"]
+    data = json.loads(run_dir.daemon_json_path.read_text(encoding="utf-8"))
+    prompt = run_dir.prompt_path.read_text(encoding="utf-8")
+    assert data["call_parameters"]["required_inputs"] == [normalized]
+    assert normalized in prompt
+    assert "do not substitute unrelated materials" in prompt
+
+
+def test_required_inputs_missing_preflight_refuses_without_run_creation(tmp_path):
+    """A missing required input is a tool-level error before scheduling."""
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+
+    result = mgr.handle({
+        "action": "emanate",
+        "tasks": [{
+            "task": "Review the missing brief.",
+            "tools": ["file"],
+            "required_inputs": ["missing.md"],
+        }],
+    })
+
+    assert result["status"] == "error"
+    assert "tasks[0].required_inputs[0]" in result["message"]
+    assert "does not exist" in result["message"]
+    assert mgr._emanations == {}
+    assert not (agent._working_dir / "daemons").exists()
+
+
+def test_required_inputs_batch_refuses_whole_batch_before_scheduling(tmp_path):
+    """One bad required input refuses the entire daemon batch."""
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    ok = agent._working_dir / "ok.md"
+    ok.parent.mkdir(parents=True, exist_ok=True)
+    ok.write_text("ok", encoding="utf-8")
+
+    result = mgr.handle({
+        "action": "emanate",
+        "tasks": [
+            {"task": "A", "tools": ["file"], "required_inputs": ["ok.md"]},
+            {"task": "B", "tools": ["file"], "required_inputs": ["missing.md"]},
+        ],
+    })
+
+    assert result["status"] == "error"
+    assert "tasks[1].required_inputs[0]" in result["message"]
+    assert mgr._emanations == {}
+    assert not (agent._working_dir / "daemons").exists()
+
+
+def test_cli_backend_missing_required_input_refuses_before_spawn(tmp_path, monkeypatch):
+    """CLI backends share required-input preflight before runner scheduling."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    def should_not_spawn(*args, **kwargs):  # pragma: no cover - defensive
+        raise AssertionError("CLI runner should not be scheduled")
+
+    monkeypatch.setattr(mgr, "_run_codex_emanation", should_not_spawn)
+    result = mgr.handle({
+        "action": "emanate",
+        "backend": "codex",
+        "tasks": [{
+            "task": "Review missing input.",
+            "tools": [],
+            "required_inputs": ["missing.md"],
+        }],
+    })
+
+    assert result["status"] == "error"
+    assert "tasks[0].required_inputs[0]" in result["message"]
+    assert mgr._emanations == {}
+    assert not (agent._working_dir / "daemons").exists()
+
+
+def test_required_inputs_reject_invalid_shapes(tmp_path):
+    """required_inputs accepts only arrays of non-empty string paths."""
+    agent = _make_agent(tmp_path, ["daemon"])
+    mgr = agent.get_capability("daemon")
+
+    cases = [
+        ({"required_inputs": "brief.md"}, "tasks[0].required_inputs"),
+        ({"required_inputs": [""]}, "tasks[0].required_inputs[0]"),
+        ({"required_inputs": [None]}, "tasks[0].required_inputs[0]"),
+    ]
+    for extra, expected in cases:
+        spec = {"task": "x", "tools": []}
+        spec.update(extra)
+        result = mgr.handle({"action": "emanate", "tasks": [spec]})
+        assert result["status"] == "error"
+        assert expected in result["message"]
+        assert mgr._emanations == {}
 
 
 def test_task_system_prompt_allows_blank_string(tmp_path):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -492,6 +492,8 @@ def test_daemon_common_context_requires_fail_closed_for_missing_required_inputs(
     assert "required local input, file path, or brief" in context
     assert "fail closed" in context
     assert "finish(status=\"incomplete\", reason=...)" in context
+    assert "when the finish tool is available" in context
+    assert "otherwise state incomplete in the final result" in context
     assert "Do not broad-search for substitute evidence" in context
 
 
@@ -527,6 +529,8 @@ def test_build_emanation_prompt_lists_required_inputs_before_task(tmp_path):
     assert "## Required inputs validated by parent before launch" in prompt
     assert required[0] in prompt
     assert "finish(status=\"incomplete\", reason=...)" in prompt
+    assert "when the finish tool is available" in prompt
+    assert "otherwise state incomplete in the final result" in prompt
     assert "do not substitute unrelated materials" in prompt
     assert prompt.index("## Required inputs") < prompt.index("Your task:")
 


### PR DESCRIPTION
## Summary

- add optional per-task `required_inputs: string[]` support to `daemon(action="emanate")`
- preflight required inputs before creating LingTai/CLI run directories or scheduling workers
- resolve relative required-input paths against the parent agent working directory and persist normalized paths in `daemon.json` `call_parameters`
- render a required-input block into daemon prompts so a later unreadable/mismatched required input becomes `finish(status="incomplete")`, not evidence substitution

## Why

When the parent agent knows that a local brief/artifact is required, a daemon should fail closed if that input cannot be resolved. Without an explicit manifest, a daemon can drift to a semantically similar but unrelated file and still finish `done`, producing false success.

This PR adds the first small hard gate: opt-in required-input preflight before launch. Prompt guidance remains secondary; the launch-time preflight is the hard boundary.

## Boundaries

- does not parse free-text task prose for paths
- does not ban relative paths; relative paths are resolved against the parent agent working directory
- does not add a provenance/audit framework or object/kind schema
- does not guarantee semantic use after launch; it prevents missing/unreadable declared inputs from launching silently

## Tests

- `python -m pytest tests/test_daemon.py -k 'required_inputs or fail_closed or schema_accepts_task_system_prompt_and_skills' -q`
- `python -m pytest tests/test_daemon.py -q`
- `python -m pytest tests/test_daemon*.py -q`
- `python -m py_compile src/lingtai/core/daemon/__init__.py tests/test_daemon.py`
- `git diff --check`
