### PR TITLE
feat(codex): add codex-pool provider

### DIFF
--- a/src/lingtai/auth/codex_pool.py
+++ b/src/lingtai/auth/codex_pool.py
@@ -97,7 +97,9 @@ def load_codex_auth_pool(pool_path: Path) -> list[dict]:
     account is dropped when:
       * ``enabled`` is explicitly ``False``;
       * ``path`` is missing / not a non-blank string;
-      * ``weight`` is missing, non-numeric, or not strictly positive.
+      * ``weight`` is present but non-numeric or not strictly positive. A
+        missing ``weight`` defaults to ``1`` (a hand-edited pool file may omit
+        it; the TUI always writes an explicit weight).
 
     A missing file, unreadable file, malformed JSON, or a non-dict / non-list
     structure yields ``[]`` (no exception) so the caller falls back cleanly.

--- a/src/lingtai/auth/codex_pool.py
+++ b/src/lingtai/auth/codex_pool.py
@@ -1,0 +1,232 @@
+"""Codex auth POOL selection (provider ``codex-pool``).
+
+This module load-balances a Codex agent across several existing Codex OAuth
+token files with a *sticky-per-agent-session* choice. It never touches provider
+``codex``: it only computes which ``codex-auth.json``-shaped token file the new
+``codex-pool`` provider should read, and the caller injects that as the ordinary
+``codex_auth_path`` so the existing Codex adapter / ``CodexTokenManager`` handle
+the token itself.
+
+Design constraints (Jason's spec):
+
+  * The pool file is NON-SECRET — it lists token *paths* and weights only. Token
+    contents are never read or logged here; we only stat/parse the pool file.
+  * Selection is weighted (cumulative weights, no giant list expansion) and
+    *sticky* within one agent wake/session: the seed is derived from the stable
+    ``codex_session_anchor`` plus the agent's ``.agent.json`` ``started_at`` and
+    deliberately EXCLUDES ``molt_count`` — an auth account must not rotate on a
+    molt (that is what the endpoint pool does, not this).
+  * Missing / empty / invalid pool -> return ``None`` so the caller falls back to
+    the legacy default Codex token path for the ``codex-pool`` provider.
+
+Public helpers:
+
+  * :func:`resolve_codex_tui_dir`      -> the ``~/.lingtai-tui`` base dir.
+  * :func:`resolve_codex_pool_path`    -> the pool file path (override-aware).
+  * :func:`load_codex_auth_pool`       -> validated list of enabled accounts.
+  * :func:`select_codex_pool_auth_path`-> chosen token path, or ``None``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+# Manifest / provider-defaults override for the pool file location. Parallels the
+# existing ``codex_auth_path`` naming used for a single token file.
+POOL_PATH_KEY = "codex_auth_pool_path"
+
+# Default pool file name inside the TUI dir.
+_DEFAULT_POOL_FILENAME = "codex-auth-pool.json"
+
+# Legacy single-token default, used as the fallback when the pool is unusable.
+_LEGACY_TOKEN_FILENAME = "codex-auth.json"
+
+
+def resolve_codex_tui_dir() -> Path:
+    """Return the LingTai TUI base directory (``$LINGTAI_TUI_DIR`` or default).
+
+    Relative account paths in the pool file resolve against this directory.
+    """
+    tui_dir = os.environ.get("LINGTAI_TUI_DIR", "~/.lingtai-tui")
+    return Path(tui_dir).expanduser()
+
+
+def resolve_codex_pool_path(defaults: dict | None = None) -> Path:
+    """Resolve the pool file path.
+
+    Priority:
+      1. An explicit, non-blank ``codex_auth_pool_path`` in provider defaults —
+         ``~``/absolute honored; a relative path resolves against the TUI dir.
+      2. ``$LINGTAI_TUI_DIR/codex-auth-pool.json`` (or ``~/.lingtai-tui/...``).
+
+    The path is non-secret; nothing here reads its contents.
+    """
+    tui_dir = resolve_codex_tui_dir()
+    override = (defaults or {}).get(POOL_PATH_KEY)
+    if isinstance(override, str) and override.strip():
+        return _resolve_relative_to_tui(override.strip(), tui_dir)
+    return tui_dir / _DEFAULT_POOL_FILENAME
+
+
+def legacy_codex_token_path() -> Path:
+    """The legacy single-token default (``<tui_dir>/codex-auth.json``).
+
+    Mirrors ``CodexTokenManager``'s own default so the ``codex-pool`` fallback
+    lands on exactly the same file the manager would have used with no path.
+    """
+    return resolve_codex_tui_dir() / _LEGACY_TOKEN_FILENAME
+
+
+def _resolve_relative_to_tui(raw: str, tui_dir: Path) -> Path:
+    """Resolve a pool ``path``: ``~``/absolute honored, else relative to TUI dir."""
+    if raw.startswith("~"):
+        return Path(raw).expanduser()
+    p = Path(raw)
+    if p.is_absolute():
+        return p
+    return tui_dir / p
+
+
+def load_codex_auth_pool(pool_path: Path) -> list[dict]:
+    """Parse the pool file into a list of validated, enabled accounts.
+
+    Each returned entry is ``{"path": <str>, "weight": <positive int>}``. An
+    account is dropped when:
+      * ``enabled`` is explicitly ``False``;
+      * ``path`` is missing / not a non-blank string;
+      * ``weight`` is missing, non-numeric, or not strictly positive.
+
+    A missing file, unreadable file, malformed JSON, or a non-dict / non-list
+    structure yields ``[]`` (no exception) so the caller falls back cleanly.
+    Token contents are never read here — only the pool file's own JSON.
+    """
+    try:
+        raw = json.loads(pool_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    if not isinstance(raw, dict):
+        return []
+    accounts = raw.get("accounts")
+    if not isinstance(accounts, list):
+        return []
+
+    valid: list[dict] = []
+    for acct in accounts:
+        if not isinstance(acct, dict):
+            continue
+        if acct.get("enabled", True) is False:
+            continue
+        path = acct.get("path")
+        if not isinstance(path, str) or not path.strip():
+            continue
+        weight = _coerce_weight(acct.get("weight", 1))
+        if weight is None:
+            continue
+        valid.append({"path": path.strip(), "weight": weight})
+    return valid
+
+
+def _coerce_weight(raw) -> int | None:
+    """Return a strictly-positive int weight, or ``None`` for invalid input.
+
+    Bools are rejected (``True``/``False`` are not meaningful weights). Floats
+    that are whole positive numbers are accepted (e.g. ``2.0`` -> ``2``).
+    """
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw if raw > 0 else None
+    if isinstance(raw, float):
+        if raw > 0 and raw.is_integer():
+            return int(raw)
+        return None
+    return None
+
+
+def _selection_seed(defaults: dict | None, tui_dir: Path) -> str:
+    """Build the stable per-agent-session selection seed.
+
+    Combines the ``codex_session_anchor`` with the agent's ``started_at`` (read
+    from ``<anchor-dir>/.agent.json``) so the choice is stable across requests
+    and molts within one wake and changes on a new agent session. Deliberately
+    EXCLUDES ``molt_count``. When ``started_at`` is unavailable, falls back to
+    ``agent_id`` -> ``address`` -> the anchor path itself.
+    """
+    d = defaults or {}
+    anchor = d.get("codex_session_anchor")
+    anchor_str = anchor if isinstance(anchor, str) and anchor else str(tui_dir)
+
+    session_marker = _read_started_at(anchor_str)
+    if session_marker is None:
+        for key in ("agent_id", "address"):
+            val = d.get(key)
+            if isinstance(val, str) and val:
+                session_marker = val
+                break
+    if session_marker is None:
+        session_marker = anchor_str
+
+    return f"{anchor_str}\0{session_marker}"
+
+
+def _read_started_at(anchor_str: str) -> str | None:
+    """Read ``started_at`` from ``<anchor-dir>/.agent.json``; ``None`` on failure.
+
+    The ``.agent.json`` sits next to the anchor (``init.json``). A missing /
+    malformed file or absent ``started_at`` yields ``None`` — no exception, no
+    token content touched.
+    """
+    try:
+        agent_json = Path(anchor_str).parent / ".agent.json"
+        data = json.loads(agent_json.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    val = data.get("started_at")
+    if val is None:
+        return None
+    return str(val)
+
+
+def _weighted_pick(accounts: list[dict], seed: str) -> dict:
+    """Deterministically pick one account by cumulative weight from ``seed``.
+
+    Hashes ``seed`` into a stable integer and maps it into ``[0, total_weight)``
+    via cumulative weights — no per-unit list expansion, so a huge weight stays
+    O(len(accounts)). The same seed + same accounts always picks the same one.
+    """
+    total = sum(a["weight"] for a in accounts)
+    digest = hashlib.sha256(seed.encode("utf-8")).digest()
+    point = int.from_bytes(digest[:8], "big") % total
+    cumulative = 0
+    for acct in accounts:
+        cumulative += acct["weight"]
+        if point < cumulative:
+            return acct
+    # Unreachable (point < total == final cumulative) — defensive fallback.
+    return accounts[-1]
+
+
+def select_codex_pool_auth_path(defaults: dict | None = None) -> str | None:
+    """Select the Codex token path for the ``codex-pool`` provider.
+
+    Returns the resolved token file path (a filesystem string) chosen stickily
+    for this agent session by weighted selection, or ``None`` when the pool file
+    is missing / has no valid enabled accounts — in which case the caller falls
+    back to the legacy default Codex token path.
+
+    Pure path computation: no token file is read and nothing secret is logged.
+    """
+    tui_dir = resolve_codex_tui_dir()
+    pool_path = resolve_codex_pool_path(defaults)
+    accounts = load_codex_auth_pool(pool_path)
+    if not accounts:
+        return None
+
+    seed = _selection_seed(defaults, tui_dir)
+    chosen = _weighted_pick(accounts, seed)
+    return str(_resolve_relative_to_tui(chosen["path"], tui_dir))

--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -1475,9 +1475,11 @@ class DaemonManager:
         """
         provider_key = str(provider).lower()
         bucket = dict(base_defaults or {})
-        if provider_key == "codex":
+        if provider_key in ("codex", "codex-pool", "codex_pool"):
             # Daemon traffic must use the daemon run identity so it gets its own
-            # cache slot, not the parent agent's anchor.
+            # cache slot, not the parent agent's anchor. ``codex-pool`` reuses the
+            # Codex adapter and also seeds its sticky auth-pool choice off this
+            # anchor, so a daemon run selects independently of its parent.
             bucket["codex_session_anchor"] = self._daemon_codex_session_anchor(run_dir)
         if not bucket:
             return None
@@ -1490,6 +1492,7 @@ class DaemonManager:
             "api_compat",
             "base_url",
             "codex_auth_path",
+            "codex_auth_pool_path",
             "codex_session_anchor",
             "codex_thread_salt",
             "compact_threshold",

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -158,6 +158,26 @@ def register_all_adapters() -> None:
 
     LLMService.register_adapter("codex", _codex)
 
+    def _codex_pool(*, model=None, defaults=None, **kw):
+        # ``codex-pool``: same request/adapter/refresh logic as ``codex`` — we
+        # only pick WHICH Codex OAuth token file to read and inject it as the
+        # ordinary ``codex_auth_path``, then delegate to ``_codex``. The choice is
+        # sticky per agent session (weighted across the non-secret pool file); a
+        # missing/empty/invalid pool returns None here, so defaults pass through
+        # unchanged and ``CodexTokenManager`` uses its legacy default token path.
+        # Provider ``codex`` is never affected — it does not read the pool file.
+        from lingtai.auth.codex_pool import select_codex_pool_auth_path
+        selected = select_codex_pool_auth_path(defaults)
+        if selected:
+            defaults = dict(defaults or {})
+            defaults["codex_auth_path"] = selected
+        return _codex(model=model, defaults=defaults, **kw)
+
+    # Register both spellings: LLMService does no dash/underscore normalization,
+    # and a saved ``codex_pool`` preset must build the same provider.
+    for name in ("codex-pool", "codex_pool"):
+        LLMService.register_adapter(name, _codex_pool)
+
     def _claude_code(*, model=None, defaults=None, **kw):
         # Drive the local `claude` CLI as the agent brain on a Claude
         # subscription. The CLI owns auth (stored OAuth / CLAUDE_CODE_OAUTH_TOKEN),

--- a/src/lingtai/llm/service.py
+++ b/src/lingtai/llm/service.py
@@ -96,6 +96,11 @@ _PROVIDER_DEFAULTS_PASS_THROUGH_KEYS = (
     "codex_session_anchor",
     "codex_thread_salt",
     "codex_auth_path",
+    # Optional Codex AUTH pool (provider ``codex-pool``). Points at the non-secret
+    # pool file that lists token paths + weights; the ``codex-pool`` factory picks
+    # one token file stickily per agent session. Absent -> legacy default token
+    # path. Never read by provider ``codex``.
+    "codex_auth_pool_path",
     # Optional Codex endpoint pool (molt-boundary shuffle). A manifest ``llm``
     # block may carry ``codex_base_urls`` (list/tuple or comma/newline string);
     # the adapter chooses one endpoint at request time without changing
@@ -103,6 +108,13 @@ _PROVIDER_DEFAULTS_PASS_THROUGH_KEYS = (
     "codex_base_urls",
 )
 _PROVIDER_DEFAULTS_PRESERVE_NONE_KEYS = ("compact_threshold",)
+
+# Providers that get the automatic per-agent ``codex_session_anchor`` (the
+# resolved ``init.json`` path). ``codex-pool`` reuses the Codex adapter and needs
+# the same anchor both for cache-affinity headers and as the sticky auth-pool
+# selection seed. Both spellings of the pool provider are included since
+# LLMService does no dash/underscore normalization.
+_CODEX_ANCHOR_PROVIDERS = ("codex", "codex-pool", "codex_pool")
 
 
 def build_provider_defaults_from_manifest_llm(
@@ -153,7 +165,7 @@ def build_provider_defaults_from_manifest_llm(
     # value shared by session_id, thread_id, and prompt_cache_key. A
     # manifest-supplied ``codex_session_anchor`` (handled above) takes precedence;
     # we only fill the gap. No token ledger / molt time is consulted.
-    if provider_key == "codex" and working_dir is not None:
+    if provider_key in _CODEX_ANCHOR_PROVIDERS and working_dir is not None:
         per_provider.setdefault(
             "codex_session_anchor",
             str((working_dir / "init.json").resolve()),

--- a/tests/test_codex_pool.py
+++ b/tests/test_codex_pool.py
@@ -1,0 +1,357 @@
+"""Tests for the ``codex-pool`` auth pool provider.
+
+``codex-pool`` load-balances a Codex agent across several existing Codex OAuth
+token files with a *sticky-per-agent-session* weighted choice, WITHOUT changing
+provider ``codex``. These tests exercise:
+
+  * pool file resolution (default location + ``codex_auth_pool_path`` override,
+    ``$LINGTAI_TUI_DIR`` honored);
+  * schema validation (disabled / blank-path / bad-weight accounts dropped);
+  * weighted selection landing on the higher-weight account;
+  * stickiness — same anchor + same ``.agent.json`` ``started_at`` -> same path
+    across repeated selection AND across ``molt_count`` changes;
+  * seed sensitivity — changing ``started_at`` can change the selection;
+  * fallback to the legacy default token path when the pool is unusable;
+  * provider ``codex`` is unaffected and never reads the pool file;
+  * the ``codex-pool`` factory injects the selected path as ``codex_auth_path``
+    into the reused Codex adapter / ``CodexTokenManager``.
+
+No network calls: ``CodexTokenManager`` is mocked where an adapter is built, and
+all token/pool files are real temp files. No token contents are read or logged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import lingtai  # noqa: F401  (registers adapters / loads service module)
+from lingtai.auth import codex_pool
+from lingtai.llm.service import LLMService
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tui_dir(tmp_path, monkeypatch):
+    """A temp TUI dir wired via ``LINGTAI_TUI_DIR``."""
+    d = tmp_path / "tui"
+    d.mkdir()
+    monkeypatch.setenv("LINGTAI_TUI_DIR", str(d))
+    return d
+
+
+def _write_pool(tui_dir: Path, accounts, *, version=1, name="codex-auth-pool.json"):
+    path = tui_dir / name
+    path.write_text(json.dumps({"version": version, "accounts": accounts}), encoding="utf-8")
+    return path
+
+
+def _anchor_with_started_at(dir_: Path, started_at, *, molt_count=0) -> str:
+    """Write ``<dir>/.agent.json`` and return the anchor (``init.json`` path)."""
+    dir_.mkdir(parents=True, exist_ok=True)
+    payload = {"molt_count": molt_count}
+    if started_at is not None:
+        payload["started_at"] = started_at
+    (dir_ / ".agent.json").write_text(json.dumps(payload), encoding="utf-8")
+    return str(dir_ / "init.json")
+
+
+def _mock_mgr():
+    mgr = mock.patch("lingtai.auth.codex.CodexTokenManager")
+    cls = mgr.start()
+    cls.return_value.get_access_token.return_value = "fake-token"
+    cls.return_value.get_account_id.return_value = None
+    return mgr, cls
+
+
+# --------------------------------------------------------------------------
+# Pool file resolution
+# --------------------------------------------------------------------------
+
+
+def test_resolve_pool_path_default_uses_tui_dir(tui_dir):
+    assert codex_pool.resolve_codex_pool_path() == tui_dir / "codex-auth-pool.json"
+
+
+def test_resolve_pool_path_override_relative_to_tui(tui_dir):
+    defaults = {"codex_auth_pool_path": "pools/custom.json"}
+    assert codex_pool.resolve_codex_pool_path(defaults) == tui_dir / "pools/custom.json"
+
+
+def test_resolve_pool_path_override_absolute(tui_dir, tmp_path):
+    abs_path = tmp_path / "elsewhere" / "pool.json"
+    defaults = {"codex_auth_pool_path": str(abs_path)}
+    assert codex_pool.resolve_codex_pool_path(defaults) == abs_path
+
+
+def test_resolve_pool_path_override_tilde(tui_dir):
+    defaults = {"codex_auth_pool_path": "~/custom-pool.json"}
+    assert codex_pool.resolve_codex_pool_path(defaults) == Path("~/custom-pool.json").expanduser()
+
+
+# --------------------------------------------------------------------------
+# Schema validation
+# --------------------------------------------------------------------------
+
+
+def test_load_pool_filters_invalid_accounts(tui_dir):
+    pool = _write_pool(tui_dir, [
+        {"path": "a.json", "weight": 1},
+        {"path": "b.json", "weight": 2, "enabled": True},
+        {"path": "disabled.json", "weight": 5, "enabled": False},
+        {"path": "  ", "weight": 1},               # blank path
+        {"path": "zero.json", "weight": 0},         # non-positive
+        {"path": "neg.json", "weight": -3},         # negative
+        {"path": "bad.json", "weight": "lots"},     # non-numeric
+        {"path": "boolw.json", "weight": True},     # bool rejected
+        {"weight": 1},                              # missing path
+        "not-a-dict",
+    ])
+    accounts = codex_pool.load_codex_auth_pool(pool)
+    assert accounts == [
+        {"path": "a.json", "weight": 1},
+        {"path": "b.json", "weight": 2},
+    ]
+
+
+def test_load_pool_missing_file_returns_empty(tui_dir):
+    assert codex_pool.load_codex_auth_pool(tui_dir / "nope.json") == []
+
+
+def test_load_pool_malformed_json_returns_empty(tui_dir):
+    p = tui_dir / "codex-auth-pool.json"
+    p.write_text("{not json", encoding="utf-8")
+    assert codex_pool.load_codex_auth_pool(p) == []
+
+
+def test_load_pool_non_dict_root_returns_empty(tui_dir):
+    p = tui_dir / "codex-auth-pool.json"
+    p.write_text(json.dumps([{"path": "a.json", "weight": 1}]), encoding="utf-8")
+    assert codex_pool.load_codex_auth_pool(p) == []
+
+
+def test_load_pool_accepts_whole_float_weight(tui_dir):
+    pool = _write_pool(tui_dir, [{"path": "a.json", "weight": 2.0}])
+    assert codex_pool.load_codex_auth_pool(pool) == [{"path": "a.json", "weight": 2}]
+
+
+# --------------------------------------------------------------------------
+# Weighted selection + path resolution
+# --------------------------------------------------------------------------
+
+
+def test_selection_resolves_relative_and_absolute(tui_dir, tmp_path):
+    _write_pool(tui_dir, [{"path": "codex-auth/work.json", "weight": 1}])
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    chosen = codex_pool.select_codex_pool_auth_path({"codex_session_anchor": anchor})
+    assert chosen == str(tui_dir / "codex-auth/work.json")
+
+
+def test_selection_honors_absolute_account_path(tui_dir, tmp_path):
+    abs_token = tmp_path / "custom" / "codex-token.json"
+    _write_pool(tui_dir, [{"path": str(abs_token), "weight": 1}])
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    chosen = codex_pool.select_codex_pool_auth_path({"codex_session_anchor": anchor})
+    assert chosen == str(abs_token)
+
+
+def test_weighted_selection_favors_heavier_account(tui_dir, tmp_path):
+    """Across many distinct seeds the heavy-weighted account wins the majority."""
+    _write_pool(tui_dir, [
+        {"path": "light.json", "weight": 1},
+        {"path": "heavy.json", "weight": 9},
+    ])
+    heavy = 0
+    total = 200
+    for i in range(total):
+        anchor = _anchor_with_started_at(tui_dir / f"agent{i}", f"start-{i}")
+        chosen = codex_pool.select_codex_pool_auth_path({"codex_session_anchor": anchor})
+        if chosen == str(tui_dir / "heavy.json"):
+            heavy += 1
+    # weight 9/10 -> expect a large majority; a loose bound keeps this stable.
+    assert heavy > total * 0.7
+
+
+# --------------------------------------------------------------------------
+# Stickiness
+# --------------------------------------------------------------------------
+
+
+def test_sticky_same_anchor_and_started_at(tui_dir, tmp_path):
+    _write_pool(tui_dir, [
+        {"path": "a.json", "weight": 1},
+        {"path": "b.json", "weight": 1},
+        {"path": "c.json", "weight": 1},
+    ])
+    anchor = _anchor_with_started_at(tmp_path / "agent", "2026-07-04T00:00:00Z")
+    defaults = {"codex_session_anchor": anchor}
+    first = codex_pool.select_codex_pool_auth_path(defaults)
+    for _ in range(5):
+        assert codex_pool.select_codex_pool_auth_path(defaults) == first
+
+
+def test_sticky_across_molt_count_changes(tui_dir, tmp_path):
+    """molt_count must NOT affect auth-pool selection."""
+    _write_pool(tui_dir, [
+        {"path": "a.json", "weight": 1},
+        {"path": "b.json", "weight": 1},
+        {"path": "c.json", "weight": 1},
+    ])
+    agent_dir = tmp_path / "agent"
+    anchor = _anchor_with_started_at(agent_dir, "fixed-start", molt_count=0)
+    defaults = {"codex_session_anchor": anchor}
+    first = codex_pool.select_codex_pool_auth_path(defaults)
+    for molt in (1, 2, 7, 42):
+        _anchor_with_started_at(agent_dir, "fixed-start", molt_count=molt)
+        assert codex_pool.select_codex_pool_auth_path(defaults) == first
+
+
+def test_started_at_change_can_change_selection(tui_dir, tmp_path):
+    """Different ``started_at`` produces a different seed; at least one differs."""
+    _write_pool(tui_dir, [
+        {"path": "a.json", "weight": 1},
+        {"path": "b.json", "weight": 1},
+        {"path": "c.json", "weight": 1},
+        {"path": "d.json", "weight": 1},
+    ])
+    agent_dir = tmp_path / "agent"
+    anchor = _anchor_with_started_at(agent_dir, "start-A")
+    defaults = {"codex_session_anchor": anchor}
+    base = codex_pool.select_codex_pool_auth_path(defaults)
+    seen_change = False
+    for i in range(20):
+        _anchor_with_started_at(agent_dir, f"start-{i}")
+        if codex_pool.select_codex_pool_auth_path(defaults) != base:
+            seen_change = True
+            break
+    assert seen_change
+
+
+def test_seed_fallback_agent_id_when_no_started_at(tui_dir, tmp_path):
+    """No ``started_at`` -> agent_id seeds the (still deterministic) choice."""
+    _write_pool(tui_dir, [
+        {"path": "a.json", "weight": 1},
+        {"path": "b.json", "weight": 1},
+    ])
+    anchor = _anchor_with_started_at(tmp_path / "agent", None)  # no started_at
+    defaults = {"codex_session_anchor": anchor, "agent_id": "agent-123"}
+    first = codex_pool.select_codex_pool_auth_path(defaults)
+    assert first is not None
+    # Deterministic across repeats.
+    assert codex_pool.select_codex_pool_auth_path(defaults) == first
+
+
+# --------------------------------------------------------------------------
+# Fallback when pool unusable
+# --------------------------------------------------------------------------
+
+
+def test_missing_pool_returns_none(tui_dir, tmp_path):
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    assert codex_pool.select_codex_pool_auth_path({"codex_session_anchor": anchor}) is None
+
+
+def test_empty_accounts_returns_none(tui_dir, tmp_path):
+    _write_pool(tui_dir, [])
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    assert codex_pool.select_codex_pool_auth_path({"codex_session_anchor": anchor}) is None
+
+
+def test_all_invalid_accounts_returns_none(tui_dir, tmp_path):
+    _write_pool(tui_dir, [
+        {"path": "x.json", "weight": 0},
+        {"path": "  ", "weight": 1},
+        {"path": "y.json", "enabled": False, "weight": 3},
+    ])
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    assert codex_pool.select_codex_pool_auth_path({"codex_session_anchor": anchor}) is None
+
+
+# --------------------------------------------------------------------------
+# Factory integration: codex-pool injects codex_auth_path into the reused adapter
+# --------------------------------------------------------------------------
+
+
+def _codex_pool_adapter(provider, defaults):
+    svc = LLMService(
+        provider=provider, model="gpt-5.5",
+        provider_defaults={provider: defaults},
+    )
+    return svc.get_adapter(provider)
+
+
+def test_codex_pool_factory_injects_selected_path(tui_dir, tmp_path):
+    token = tui_dir / "work.json"
+    _write_pool(tui_dir, [{"path": "work.json", "weight": 1}])
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    mgr, cls = _mock_mgr()
+    try:
+        _codex_pool_adapter("codex-pool", {"codex_session_anchor": anchor})
+        # The reused CodexTokenManager is constructed with the pool-selected path.
+        cls.assert_called_with(token_path=str(token))
+    finally:
+        mgr.stop()
+
+
+def test_codex_pool_alias_underscore_registered(tui_dir, tmp_path):
+    _write_pool(tui_dir, [{"path": "work.json", "weight": 1}])
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    mgr, cls = _mock_mgr()
+    try:
+        _codex_pool_adapter("codex_pool", {"codex_session_anchor": anchor})
+        cls.assert_called_with(token_path=str(tui_dir / "work.json"))
+    finally:
+        mgr.stop()
+
+
+def test_codex_pool_missing_pool_falls_back_to_default_path(tui_dir, tmp_path):
+    """No pool file -> factory injects no path -> manager uses legacy default."""
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    mgr, cls = _mock_mgr()
+    try:
+        _codex_pool_adapter("codex-pool", {"codex_session_anchor": anchor})
+        # No token_path kwarg -> CodexTokenManager() legacy default behavior.
+        cls.assert_called_with()
+    finally:
+        mgr.stop()
+
+
+# --------------------------------------------------------------------------
+# Provider ``codex`` is unchanged and never reads the pool file
+# --------------------------------------------------------------------------
+
+
+def test_codex_provider_ignores_pool_file(tui_dir, tmp_path):
+    """A populated pool file must NOT affect provider ``codex``."""
+    _write_pool(tui_dir, [{"path": "work.json", "weight": 1}])
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    mgr, cls = _mock_mgr()
+    try:
+        _codex_pool_adapter("codex", {"codex_session_anchor": anchor})
+        # codex with no codex_auth_path -> legacy default (no token_path kwarg).
+        cls.assert_called_with()
+    finally:
+        mgr.stop()
+
+
+def test_codex_provider_honors_explicit_auth_path(tui_dir, tmp_path):
+    """Existing ``codex_auth_path`` behavior is unchanged."""
+    explicit = str(tmp_path / "explicit.json")
+    _write_pool(tui_dir, [{"path": "work.json", "weight": 1}])
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    mgr, cls = _mock_mgr()
+    try:
+        _codex_pool_adapter("codex", {
+            "codex_session_anchor": anchor,
+            "codex_auth_path": explicit,
+        })
+        cls.assert_called_with(token_path=explicit)
+    finally:
+        mgr.stop()

--- a/tests/test_codex_pool.py
+++ b/tests/test_codex_pool.py
@@ -142,6 +142,24 @@ def test_load_pool_accepts_whole_float_weight(tui_dir):
     assert codex_pool.load_codex_auth_pool(pool) == [{"path": "a.json", "weight": 2}]
 
 
+def test_load_pool_missing_weight_defaults_to_one(tui_dir):
+    """A hand-edited account with a path but no ``weight`` is kept at weight 1.
+
+    The TUI always writes an explicit weight, but the parser must not drop a
+    path-only account — a missing weight defaults to 1 (GLM review C1).
+    """
+    pool = _write_pool(tui_dir, [{"path": "only-path.json"}])
+    assert codex_pool.load_codex_auth_pool(pool) == [{"path": "only-path.json", "weight": 1}]
+
+
+def test_missing_weight_account_is_selectable(tui_dir, tmp_path):
+    """A sole path-only (weight-defaulted) account is actually selected."""
+    _write_pool(tui_dir, [{"path": "only-path.json"}])
+    anchor = _anchor_with_started_at(tmp_path / "agent", "t0")
+    chosen = codex_pool.select_codex_pool_auth_path({"codex_session_anchor": anchor})
+    assert chosen == str(tui_dir / "only-path.json")
+
+
 # --------------------------------------------------------------------------
 # Weighted selection + path resolution
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add a new `codex-pool` / `codex_pool` provider that load-balances across existing Codex OAuth token files without changing the existing `codex` provider
- add non-secret `codex-auth-pool.json` loading and weighted, sticky-per-agent-session account selection (`codex_session_anchor` + `.agent.json.started_at`, not `molt_count`)
- pass through `codex_auth_pool_path` and treat `codex-pool` like Codex for session anchors / daemon provider defaults

## Notes

The existing `codex` provider still uses `codex_auth_path` / legacy `~/.lingtai-tui/codex-auth.json` behavior. The new provider selects one token path and delegates to the existing Codex adapter / `CodexTokenManager` by injecting `codex_auth_path` internally.

## Tests

- `pytest tests/test_codex_pool.py tests/test_llm_service.py -q` — 37 passed
- `pytest tests/test_codex_pool.py tests/test_codex_endpoint_pool.py tests/test_codex_endpoint_override.py tests/test_codex_prompt_cache_key.py -q` — 97 passed

Generated with Claude Code; reviewed and tested by mimo-1.
