### PR TITLE
fix(daemon): allow codex-pool presets

### DIFF
--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from lingtai_kernel.config import THINKING_LEVELS
+from lingtai_kernel.config import THINKING_LEVELS, THINKING_PROVIDERS
 
 log = logging.getLogger(__name__)
 
@@ -334,10 +334,11 @@ def validate_init(data: dict) -> list[str]:
                 "manifest.llm.compact_threshold: expected positive int or null"
             )
     if "thinking" in llm:
-        if llm["provider"].lower() != "codex":
+        if llm["provider"].lower() not in THINKING_PROVIDERS:
             raise ValueError(
                 "manifest.llm.thinking is currently supported only for "
-                "the Codex provider (provider='codex')"
+                "the Codex providers "
+                f"({', '.join(THINKING_PROVIDERS)})"
             )
         thinking = llm["thinking"]
         if not isinstance(thinking, str) or thinking not in THINKING_LEVELS:

--- a/src/lingtai_kernel/config.py
+++ b/src/lingtai_kernel/config.py
@@ -6,6 +6,12 @@ from dataclasses import dataclass, field
 
 THINKING_LEVELS = ("low", "medium", "high", "xhigh")
 
+# Providers that accept manifest.llm.thinking. ``codex-pool`` reuses the Codex
+# adapter (both dash/underscore spellings), so it is thinking-compatible; every
+# other provider rejects the field. Kept here next to THINKING_LEVELS so the
+# preset validator and init-schema validator share one source of truth.
+THINKING_PROVIDERS = ("codex", "codex-pool", "codex_pool")
+
 # Molt context-pressure thresholds are kernel-fixed runtime constants — NOT
 # agent-configurable. An agent must not be able to raise its own molt
 # thresholds (or defeat them entirely) to avoid molting under pressure, so the

--- a/src/lingtai_kernel/presets.py
+++ b/src/lingtai_kernel/presets.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from .config import THINKING_LEVELS
+from .config import THINKING_LEVELS, THINKING_PROVIDERS
 
 log = logging.getLogger(__name__)
 
@@ -310,10 +310,11 @@ def load_preset(
         )
     if "thinking" in llm:
         provider = llm.get("provider")
-        if not isinstance(provider, str) or provider.lower() != "codex":
+        if not isinstance(provider, str) or provider.lower() not in THINKING_PROVIDERS:
             raise ValueError(
                 f"preset {name!r} ({p}): manifest.llm.thinking is currently "
-                "supported only for the Codex provider (provider='codex')"
+                "supported only for the Codex providers "
+                f"({', '.join(THINKING_PROVIDERS)})"
             )
         thinking = llm["thinking"]
         if not isinstance(thinking, str) or thinking not in THINKING_LEVELS:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -3001,6 +3001,46 @@ def test_daemon_provider_defaults_preserves_codex_auth_path(tmp_path):
     )
 
 
+def _assert_codex_pool_daemon_defaults(provider, tmp_path):
+    """codex-pool daemon defaults keep the pool path, re-anchor to daemon.json.
+
+    ``codex-pool`` reuses the Codex adapter and also seeds its sticky auth-pool
+    choice off the anchor, so a daemon run must keep the non-secret
+    ``codex_auth_pool_path`` while getting its own per-run anchor (its own cache
+    slot and an independent pool selection from the parent).
+    """
+    from types import SimpleNamespace
+
+    from lingtai.core.daemon import DaemonManager
+
+    run_dir = SimpleNamespace(path=tmp_path / "run")
+    mgr = DaemonManager.__new__(DaemonManager)
+    out = DaemonManager._daemon_provider_defaults(
+        mgr,
+        provider,
+        {
+            "codex_auth_pool_path": "/home/alice/.lingtai-tui/codex-auth-pool.json",
+            "codex_session_anchor": "/agents/alice/init.json",
+        },
+        run_dir,
+    )
+    assert out[provider]["codex_auth_pool_path"] == (
+        "/home/alice/.lingtai-tui/codex-auth-pool.json"
+    )
+    # The per-run daemon anchor replaces the parent agent's anchor.
+    assert out[provider]["codex_session_anchor"] == str(
+        (run_dir.path / "daemon.json").resolve()
+    )
+
+
+def test_daemon_provider_defaults_codex_pool_dash(tmp_path):
+    _assert_codex_pool_daemon_defaults("codex-pool", tmp_path)
+
+
+def test_daemon_provider_defaults_codex_pool_underscore(tmp_path):
+    _assert_codex_pool_daemon_defaults("codex_pool", tmp_path)
+
+
 def _capturing_fake_service(captured, text="daemon done"):
     """Build a FakeService class that records its init kwargs into *captured*."""
     class FakeService:

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -212,6 +212,15 @@ def test_llm_thinking_rejected_for_non_codex_provider(value):
         validate_init(data)
 
 
+@pytest.mark.parametrize("provider", ["codex-pool", "codex_pool"])
+def test_llm_thinking_accepted_for_codex_pool(provider):
+    """codex-pool reuses the Codex adapter, so thinking is Codex-compatible."""
+    data = _valid_init()
+    data["manifest"]["llm"]["provider"] = provider
+    data["manifest"]["llm"]["thinking"] = "xhigh"
+    validate_init(data)
+
+
 # --- addons (list of curated MCP names; mcp capability handles the rest) ---
 
 

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -380,6 +380,25 @@ def test_load_preset_rejects_thinking_for_non_codex_provider(tmp_path, value):
         load_preset(str(f))
 
 
+@pytest.mark.parametrize("provider", ["codex-pool", "codex_pool"])
+def test_load_preset_accepts_thinking_for_codex_pool(tmp_path, provider):
+    """A saved/builtin-style codex-pool preset may carry thinking."""
+    p = {
+        "name": "pool",
+        "description": _DESC,
+        "manifest": {
+            "llm": {"provider": provider, "model": "gpt-5.5", "thinking": "xhigh"},
+            "capabilities": {},
+        },
+    }
+    f = tmp_path / "pool.json"
+    f.write_text(json.dumps(p))
+
+    loaded = load_preset(str(f))
+
+    assert loaded["manifest"]["llm"]["thinking"] == "xhigh"
+
+
 def test_preset_context_limit_reads_from_llm_block():
     manifest = {
         "llm": {"provider": "x", "model": "y", "context_limit": 16384},


### PR DESCRIPTION
## Summary
- Allow `manifest.llm.thinking` for Codex Pool provider spellings (`codex-pool`, `codex_pool`) in kernel preset/init validation.
- Keep the existing `codex` behavior unchanged while making the TUI-generated Codex Pool preset valid for agent refresh, `system.presets`, and daemon `tasks[].preset` usage.
- Pin daemon provider defaults so `codex-pool` daemon runs preserve `codex_auth_pool_path` while replacing `codex_session_anchor` with the daemon run anchor.

## Stack
- Follow-up stacked on #697 (`feat/codex-pool-adapter-20260705`).
- Requested after #697/#544 to cover the daemon preset path.

## Validation
- `python -m pytest tests/test_init_schema.py tests/test_presets.py tests/test_daemon.py -q` → 237 passed
- `python -m pytest tests/test_codex_pool.py -q` → 26 passed
- `git diff --check` → pass

## Notes
- No token contents are read or logged; tests use fabricated non-secret paths only.
- No merge performed.
