### PR TITLE
fix(daemon): expose Codex auth lane in quota diagnostics

### DIFF
--- a/src/lingtai/core/daemon/__init__.py
+++ b/src/lingtai/core/daemon/__init__.py
@@ -36,6 +36,7 @@ from lingtai_kernel._fsutil import atomic_write_json
 from lingtai_kernel.llm.base import FunctionSchema
 from lingtai_kernel.loop_guard import LoopGuard
 from lingtai_kernel.meta_block import build_meta
+import lingtai_kernel.provider_quota as _provider_quota
 from lingtai_kernel.tool_executor import ToolExecutor
 from .run_dir import DaemonRunDir
 from .claude_interactive import ClaudeInteractiveError, run_claude_interactive
@@ -58,6 +59,17 @@ _DAEMON_COMPLETION_FILE = "daemon_completion.json"
 _DAEMON_CLAUDE_MCP_CONFIG_FILE = "claude-mcp-config.json"
 _DAEMON_COMPLETION_STATUSES = {"done", "failed", "incomplete"}
 _SOURCE_ROOT = Path(__file__).resolve().parents[3]
+
+# Compatibility aliases: tests and existing callers import these private daemon
+# helpers directly. Keep the names stable while the implementation lives in the
+# shared provider_quota module.
+_daemon_codex_auth_path_diagnostic = _provider_quota.codex_auth_path_diagnostic
+_daemon_exception_headers = _provider_quota.exception_headers
+_daemon_exception_payload = _provider_quota.exception_payload
+_daemon_parse_retry_after_seconds = _provider_quota.parse_retry_after_seconds
+_daemon_path_label = _provider_quota.path_label
+_daemon_quota_error_extra = _provider_quota.quota_error_extra
+_daemon_status_code = _provider_quota.status_code
 
 
 # Tools emanations can never use (no recursion, no spawning, no identity mutation)
@@ -881,6 +893,17 @@ class DaemonManager:
             max_workers=max(1, max_emanations),
             thread_name_prefix="daemon-cli-ask",
         )
+        # Provider-level daemon quota backoff. Populated when a LingTai daemon
+        # fails before/at the first provider call with a structured quota error,
+        # then consulted by later LingTai daemon dispatches so we do not keep
+        # launching short-lived runs that are guaranteed to hit the same window.
+        self._daemon_provider_quota_backoff: dict[str, dict] = {}
+        self._daemon_provider_quota_lock = threading.Lock()
+        # Serializes daemon runs that intentionally share the parent Codex
+        # cache-affinity/session identity. This avoids concurrent writes through
+        # one upstream session/thread id while still letting non-Codex and fresh
+        # Codex daemons run in parallel.
+        self._codex_parent_affinity_lock = threading.Lock()
         self._reap_dead_parent_daemon_records()
 
     def _reap_dead_parent_daemon_records(self) -> None:
@@ -1146,6 +1169,70 @@ class DaemonManager:
             "registrations. Secret env/header values are redacted in this prompt.\n"
             f"{body}"
         )
+
+    @staticmethod
+    def _provider_key(provider: str | None) -> str:
+        return str(provider or "").strip().lower()
+
+    def _daemon_task_provider_key(self, resolved: dict | None) -> str:
+        if resolved is not None:
+            return self._provider_key(resolved.get("llm", {}).get("provider"))
+        service = getattr(self._agent, "service", None)
+        return self._provider_key(getattr(service, "provider", None))
+
+    def _active_daemon_provider_quota_backoff(self, provider: str | None) -> dict | None:
+        key = self._provider_key(provider)
+        if not key:
+            return None
+        now = time.time()
+        with self._daemon_provider_quota_lock:
+            info = self._daemon_provider_quota_backoff.get(key)
+            if not info:
+                return None
+            until = info.get("backoff_until")
+            if isinstance(until, (int, float)) and until > now:
+                out = dict(info)
+                out["retry_after_seconds"] = max(int(until - now), 0)
+                return out
+            self._daemon_provider_quota_backoff.pop(key, None)
+        return None
+
+    def _remember_daemon_provider_quota_backoff(
+        self, provider: str | None, error_extra: dict | None
+    ) -> None:
+        key = self._provider_key(provider)
+        quota = (error_extra or {}).get("quota")
+        if not key or not isinstance(quota, dict):
+            return
+        now = time.time()
+        until: float | None = None
+        resets_at = quota.get("resets_at")
+        if isinstance(resets_at, (int, float)):
+            until = float(resets_at)
+        retry_after = quota.get("retry_after_seconds") or quota.get("resets_in_seconds")
+        if isinstance(retry_after, (int, float)):
+            until = max(until or 0.0, now + float(retry_after))
+        if until is None or until <= now:
+            # Short safety valve for generic 429s without reset metadata.
+            until = now + 60.0
+
+        info = {
+            "provider": key,
+            "backoff_until": until,
+            "error_type": quota.get("error_type"),
+            "plan_type": quota.get("plan_type"),
+        }
+        if isinstance(resets_at, (int, float)):
+            info["resets_at"] = int(resets_at)
+        if quota.get("resets_at_iso"):
+            info["resets_at_iso"] = quota.get("resets_at_iso")
+        for field in ("codex_auth_path_source", "codex_auth_path_label"):
+            if quota.get(field):
+                info[field] = quota.get(field)
+        with self._daemon_provider_quota_lock:
+            existing = self._daemon_provider_quota_backoff.get(key)
+            if not existing or float(existing.get("backoff_until", 0)) < until:
+                self._daemon_provider_quota_backoff[key] = info
 
     @staticmethod
     def _completion_file(run_dir: DaemonRunDir) -> Path:
@@ -1462,25 +1549,57 @@ class DaemonManager:
         provider: str,
         base_defaults: dict | None,
         run_dir,
+        *,
+        codex_session_mode: str = "fresh",
     ) -> dict | None:
         """Return provider defaults for a daemon-scoped LLM service.
 
         Daemon-scoped services preserve the parent/preset provider defaults for
         every provider, so a non-Codex daemon keeps the same adapter behavior as
-        its parent. Codex is the one exception: the normal Codex agent path uses
-        the agent's resolved ``init.json`` path as its cache-affinity anchor, but
-        a LingTai daemon is a disposable run, so Codex daemon calls need a per-run
-        anchor rather than the parent agent's anchor; otherwise parent and child
-        traffic collide in one REST cache slot.
+        its parent. Codex needs an explicit daemon session policy:
+
+        * ``fresh`` keeps the historical per-run daemon anchor, isolating parent
+          and child cache/session affinity.
+        * ``parent_affinity`` preserves the parent Codex anchor when available,
+          so a daemon that uses the same provider/model/account can continue
+          through the already-warm parent session identity instead of opening a
+          brand-new Codex session/thread id.
+
+        The chosen policy is recorded in daemon.json.session for diagnostics.
         """
         provider_key = str(provider).lower()
         bucket = dict(base_defaults or {})
+        # Internal feature flag consumed by daemon construction, not forwarded to
+        # provider adapters. Without it, Codex daemon runs keep historical fresh
+        # per-daemon affinity even when the parent has an anchor.
+        bucket.pop("codex_daemon_session_mode", None)
         if provider_key in ("codex", "codex-pool", "codex_pool"):
-            # Daemon traffic must use the daemon run identity so it gets its own
-            # cache slot, not the parent agent's anchor. ``codex-pool`` reuses the
-            # Codex adapter and also seeds its sticky auth-pool choice off this
-            # anchor, so a daemon run selects independently of its parent.
-            bucket["codex_session_anchor"] = self._daemon_codex_session_anchor(run_dir)
+            requested_mode = str(codex_session_mode or "fresh").lower()
+            parent_anchor = bucket.get("codex_session_anchor")
+            if requested_mode in {"parent_affinity", "fork_parent", "share_parent_affinity"} and parent_anchor:
+                anchor = str(parent_anchor)
+                source = "parent"
+                mode = "parent_affinity"
+                bucket["codex_session_anchor"] = anchor
+            else:
+                anchor = self._daemon_codex_session_anchor(run_dir)
+                source = "daemon"
+                mode = "fresh"
+                # Historical behavior: daemon traffic gets its own cache/session
+                # identity, seeded from daemon.json.
+                bucket["codex_session_anchor"] = anchor
+            try:
+                run_dir.set_session_metadata(
+                    provider=provider_key,
+                    session_mode=mode,
+                    codex_session_anchor_source=source,
+                    codex_session_anchor=anchor,
+                    **_daemon_codex_auth_path_diagnostic(bucket),
+                )
+            except Exception:
+                # Session metadata is diagnostic only; never let it break run
+                # construction before the real provider call.
+                pass
         if not bucket:
             return None
         return {provider_key: bucket}
@@ -1493,6 +1612,7 @@ class DaemonManager:
             "base_url",
             "codex_auth_path",
             "codex_auth_pool_path",
+            "codex_daemon_session_mode",
             "codex_session_anchor",
             "codex_thread_salt",
             "compact_threshold",
@@ -1870,12 +1990,46 @@ class DaemonManager:
         )
         # Base provider defaults: the implicit preset carries the parent bucket
         # verbatim; an explicit preset derives them from its manifest.llm fields.
-        # Codex daemons additionally get a per-run cache anchor (set inside
-        # _daemon_provider_defaults) so they don't collide with the parent slot.
+        # Codex daemons default to a per-run cache/session anchor for isolation.
+        # A deliberate codex_daemon_session_mode=parent_affinity feature flag can
+        # opt into sharing the parent anchor for A/B experiments when the daemon
+        # uses the same Codex provider/model/account as the live parent.
         if "_provider_defaults" in effective_preset_llm:
             base_defaults = effective_preset_llm["_provider_defaults"]
         else:
             base_defaults = self._llm_defaults_from_manifest(effective_preset_llm)
+
+        base_defaults = dict(base_defaults or {})
+        raw_codex_session_mode = base_defaults.pop(
+            "codex_daemon_session_mode",
+            effective_preset_llm.get("codex_daemon_session_mode", "fresh"),
+        )
+        codex_session_mode = str(raw_codex_session_mode or "fresh").lower()
+        parent_affinity_modes = {"parent_affinity", "fork_parent", "share_parent_affinity"}
+        provider_key = self._provider_key(provider)
+        if provider_key in ("codex", "codex-pool", "codex_pool"):
+            parent_service = getattr(self._agent, "service", None)
+            parent_provider = self._provider_key(getattr(parent_service, "provider", None))
+            parent_model = getattr(parent_service, "model", None)
+            parent_api_key = getattr(parent_service, "api_key", None) or getattr(parent_service, "_api_key", None)
+            same_parent_identity = (
+                parent_provider == provider_key
+                and parent_model == effective_model
+                and parent_api_key == api_key
+            )
+            parent_defaults = getattr(parent_service, "_provider_defaults", {}) or {}
+            parent_bucket = dict(parent_defaults.get(provider_key) or {})
+            parent_anchor = parent_bucket.get("codex_session_anchor")
+            if codex_session_mode not in parent_affinity_modes:
+                codex_session_mode = "fresh"
+            elif same_parent_identity and parent_anchor:
+                codex_session_mode = "parent_affinity"
+                base_defaults.setdefault("codex_session_anchor", parent_anchor)
+                if parent_bucket.get("codex_thread_salt") and "codex_thread_salt" not in base_defaults:
+                    base_defaults["codex_thread_salt"] = parent_bucket["codex_thread_salt"]
+            else:
+                codex_session_mode = "fresh"
+
         service_kwargs = {
             "provider": provider,
             "model": effective_model,
@@ -1883,6 +2037,7 @@ class DaemonManager:
             "base_url": effective_preset_llm.get("base_url"),
             "provider_defaults": self._daemon_provider_defaults(
                 provider, base_defaults, run_dir,
+                codex_session_mode=codex_session_mode,
             ),
         }
         # Implicit-preset-only pass-throughs that mirror the parent service:
@@ -1903,6 +2058,11 @@ class DaemonManager:
         )
 
         endpoint = getattr(service, "_base_url", None)
+
+        parent_affinity_locked = False
+        if codex_session_mode == "parent_affinity":
+            self._codex_parent_affinity_lock.acquire()
+            parent_affinity_locked = True
 
         intrinsic_tool_names = set(self._daemon_intrinsic_surface()[1])
 
@@ -2019,9 +2179,16 @@ class DaemonManager:
             run_dir.mark_done(text)
             return text
         except Exception as e:
-            run_dir.mark_failed(e)
+            session_metadata = (run_dir.state_snapshot().get("session") or {})
+            error_extra = _daemon_quota_error_extra(
+                e, provider=provider, service=service, session_metadata=session_metadata
+            )
+            self._remember_daemon_provider_quota_backoff(provider, error_extra)
+            run_dir.mark_failed(e, error_extra=error_extra)
             raise
         finally:
+            if parent_affinity_locked:
+                self._codex_parent_affinity_lock.release()
             self._close_task_mcp_clients(mcp_clients)
 
     def _find_claude_session_id(self, em_id: str) -> str | None:
@@ -2792,6 +2959,22 @@ class DaemonManager:
                 "preset_schemas": preset_schemas,
                 "preset_handlers": preset_handlers,
             })
+
+        for resolved in resolved_presets:
+            provider_key = self._daemon_task_provider_key(resolved)
+            backoff = self._active_daemon_provider_quota_backoff(provider_key)
+            if backoff:
+                retry_after = backoff.get("retry_after_seconds")
+                reset = backoff.get("resets_at_iso") or backoff.get("resets_at")
+                message = (
+                    f"provider {provider_key!r} daemon quota backoff is active"
+                )
+                if reset:
+                    message += f" until {reset}"
+                if retry_after is not None:
+                    message += f" (retry after ~{retry_after}s)"
+                message += "; choose another preset/backend or wait before retrying"
+                return {"status": "error", "message": message, "quota": backoff}
 
         cancel_event = threading.Event()
         # Separate event so the watchdog can distinguish timeout from manual

--- a/src/lingtai/core/daemon/run_dir.py
+++ b/src/lingtai/core/daemon/run_dir.py
@@ -123,6 +123,7 @@ class DaemonRunDir:
             "preset_provider": preset_provider,
             "preset_model": preset_model,
             "backend": backend,
+            "session": None,
             "claude_session_id": None,
         }
 
@@ -188,6 +189,23 @@ class DaemonRunDir:
     def state_snapshot(self) -> dict:
         """Return a shallow copy of the current daemon.json state."""
         return dict(self._state)
+
+    def set_session_metadata(self, **fields) -> None:
+        """Persist bounded daemon LLM session metadata under daemon.json.session."""
+        clean = {key: value for key, value in fields.items() if value is not None}
+        if not clean:
+            return
+
+        def _write():
+            session = dict(self._state.get("session") or {})
+            session.update(clean)
+            self._state["session"] = session
+            self._atomic_write_json(self.daemon_json_path, self._state)
+            event = {"event": "daemon_session", "ts": self._now_iso()}
+            event.update(clean)
+            self._append_jsonl(self.events_path, event)
+
+        self._safe("set_session_metadata", _write)
 
     def set_session_id(self, key: str, value: str, *, overwrite: bool = True) -> bool:
         """Persist a backend resume id into daemon.json under *key*.
@@ -799,8 +817,15 @@ class DaemonRunDir:
         # failure can't undo the terminal transition above.
         self.write_manifest()
 
-    def mark_failed(self, exc: BaseException) -> None:
-        """Exception in run loop. Sets state=failed, error.{type, message}.
+    def mark_failed(
+        self, exc: BaseException, *, error_extra: dict | None = None
+    ) -> None:
+        """Exception in run loop. Sets state=failed and error metadata.
+
+        The stable fields remain ``error.{type,message}``. Callers that can
+        classify a backend failure may pass ``error_extra`` to persist bounded,
+        structured diagnostics (for example provider quota reset metadata) in
+        both daemon.json and the terminal daemon_error event.
 
         Defensive: a user-defined exception's `__str__` may itself raise
         (TypeError, AttributeError, ...). _safe only catches OSError, so we
@@ -810,27 +835,31 @@ class DaemonRunDir:
             msg = str(exc)
         except Exception:
             msg = f"<unrenderable {type(exc).__name__}>"
+        extra = dict(error_extra or {})
 
         def _write():
             self._state["state"] = "failed"
             self._state["finished_at"] = self._now_iso()
             self._state["elapsed_s"] = self._now_secs()
             self._state["current_tool"] = None
-            self._state["error"] = {
+            error = {
                 "type": type(exc).__name__,
                 "message": msg,
             }
+            if extra:
+                error.update(extra)
+            self._state["error"] = error
             self._atomic_write_json(self.daemon_json_path, self._state)
-            self._append_jsonl(
-                self.events_path,
-                {
-                    "event": "daemon_error",
-                    "exception": type(exc).__name__,
-                    "message": msg,
-                    "elapsed_s": self._state["elapsed_s"],
-                    "ts": self._now_iso(),
-                },
-            )
+            event = {
+                "event": "daemon_error",
+                "exception": type(exc).__name__,
+                "message": msg,
+                "elapsed_s": self._state["elapsed_s"],
+                "ts": self._now_iso(),
+            }
+            if extra:
+                event["error_extra"] = extra
+            self._append_jsonl(self.events_path, event)
         self._safe("mark_failed", _write)
         self.write_manifest()
 

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -17,6 +17,7 @@ from ..safety_limits import (
 )
 from ..tool_executor import ToolExecutor
 from ..tool_result_artifacts import CompactionStats, compact_oversized_history
+from ..provider_quota import codex_auth_path_diagnostic, quota_error_extra
 from ..meta_block import (
     attach_active_notifications,
     attach_active_runtime,
@@ -1283,7 +1284,111 @@ def _make_tool_executor(agent, guard: LoopGuard) -> ToolExecutor:
         ),
         reconstruction_event_fn=lambda: build_reconstruction_tool_meta(agent),
         summarizer_fn=_build_apriori_summarizer_fn(agent),
+        summary_quota_error_extra_fn=_build_apriori_quota_error_extra_fn(agent),
+        summary_quota_backoff_fn=lambda: _active_apriori_summary_quota_backoff(agent),
     )
+
+
+def _apriori_summary_quota_key(provider: str | None) -> str:
+    return str(provider or "").lower() or "default"
+
+
+def _active_apriori_summary_quota_backoff(agent) -> dict | None:
+    service = getattr(agent, "service", None)
+    config = getattr(agent, "_config", None)
+    provider = getattr(config, "provider", None) or getattr(service, "provider", None)
+    key = _apriori_summary_quota_key(provider)
+    backoffs = getattr(agent, "_apriori_summary_provider_quota_backoff", None)
+    if not isinstance(backoffs, dict):
+        return None
+    info = backoffs.get(key)
+    if not isinstance(info, dict):
+        return None
+    until = info.get("backoff_until")
+    if isinstance(until, (int, float)) and until > time.time():
+        quota = {k: v for k, v in info.items() if k != "backoff_until"}
+        if quota.get("retry_after_seconds") is None:
+            quota["retry_after_seconds"] = max(int(until - time.time()), 0)
+        return {"quota": quota}
+    backoffs.pop(key, None)
+    return None
+
+
+def _remember_apriori_summary_quota_backoff(
+    agent, provider: str | None, error_extra: dict | None
+) -> None:
+    quota = (error_extra or {}).get("quota")
+    if not isinstance(quota, dict):
+        return
+    resets_at = quota.get("resets_at")
+    until = None
+    if isinstance(resets_at, (int, float)):
+        until = float(resets_at)
+    retry_after = quota.get("retry_after_seconds") or quota.get("resets_in_seconds")
+    if until is None and isinstance(retry_after, (int, float)):
+        until = time.time() + max(float(retry_after), 0.0)
+    if until is None:
+        return
+
+    key = _apriori_summary_quota_key(provider)
+    backoffs = getattr(agent, "_apriori_summary_provider_quota_backoff", None)
+    if not isinstance(backoffs, dict):
+        backoffs = {}
+        setattr(agent, "_apriori_summary_provider_quota_backoff", backoffs)
+
+    info = {
+        k: v
+        for k, v in quota.items()
+        if k
+        in {
+            "provider",
+            "error_type",
+            "status_code",
+            "plan_type",
+            "resets_at",
+            "resets_at_iso",
+            "resets_in_seconds",
+            "retry_after_seconds",
+            "codex_auth_path_source",
+            "codex_auth_path_label",
+            "limit_reason",
+        }
+    }
+    info["provider"] = provider
+    info["backoff_until"] = until
+    existing = backoffs.get(key)
+    if not isinstance(existing, dict) or until >= float(existing.get("backoff_until", 0)):
+        backoffs[key] = info
+
+
+def _build_apriori_quota_error_extra_fn(agent):
+    """Build quota diagnostics for internal a-priori one-shot provider errors."""
+    service = getattr(agent, "service", None)
+    config = getattr(agent, "_config", None)
+    provider = getattr(config, "provider", None) or getattr(service, "provider", None)
+    defaults = None
+    try:
+        all_defaults = getattr(service, "_provider_defaults", None)
+        if isinstance(all_defaults, dict) and provider is not None:
+            defaults = all_defaults.get(str(provider).lower())
+    except Exception:
+        defaults = None
+
+    session_metadata = None
+    if str(provider or "").lower() in {"codex", "codex-pool", "codex_pool"}:
+        session_metadata = codex_auth_path_diagnostic(defaults)
+
+    def _quota_error_extra(exc: BaseException) -> dict | None:
+        extra = quota_error_extra(
+            exc,
+            provider=provider,
+            service=service,
+            session_metadata=session_metadata,
+        )
+        _remember_apriori_summary_quota_backoff(agent, provider, extra)
+        return extra
+
+    return _quota_error_extra
 
 
 def _record_apriori_summary_usage(agent, response, tool_name, tool_call_id) -> None:

--- a/src/lingtai_kernel/provider_quota.py
+++ b/src/lingtai_kernel/provider_quota.py
@@ -1,0 +1,247 @@
+"""Shared non-secret provider quota diagnostics."""
+from __future__ import annotations
+
+import ast
+import hashlib
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+import time
+
+
+def exception_payload(exc: BaseException) -> dict | None:
+    """Best-effort extraction of a provider error payload."""
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        return body
+
+    response = getattr(exc, "response", None)
+    if response is not None:
+        try:
+            parsed = response.json()
+            if isinstance(parsed, dict):
+                return parsed
+        except Exception:
+            pass
+
+    try:
+        rendered = str(exc)
+    except Exception:
+        return None
+    start = rendered.find("{'error'")
+    if start < 0:
+        start = rendered.find('{"error"')
+    if start < 0:
+        return None
+    try:
+        parsed = ast.literal_eval(rendered[start:])
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+QUOTA_HEADER_ALLOWLIST = {
+    "retry-after",
+    "x-request-id",
+    "x-ratelimit-limit-requests",
+    "x-ratelimit-limit-tokens",
+    "x-ratelimit-remaining-requests",
+    "x-ratelimit-remaining-tokens",
+    "x-ratelimit-reset-requests",
+    "x-ratelimit-reset-tokens",
+    "openai-processing-ms",
+    "x-should-retry",
+    "x-stainless-retry-count",
+    "cf-ray",
+}
+
+
+def exception_headers(exc: BaseException) -> dict[str, str]:
+    """Return a bounded allowlisted header snapshot for provider errors."""
+    candidates = []
+    headers = getattr(exc, "headers", None)
+    if headers is not None:
+        candidates.append(headers)
+    response = getattr(exc, "response", None)
+    if response is not None:
+        headers = getattr(response, "headers", None)
+        if headers is not None:
+            candidates.append(headers)
+
+    out: dict[str, str] = {}
+    for candidate in candidates:
+        try:
+            items = candidate.items()
+        except Exception:
+            continue
+        for raw_key, raw_value in items:
+            key = str(raw_key).lower()
+            if key not in QUOTA_HEADER_ALLOWLIST:
+                continue
+            if raw_value is None:
+                continue
+            out[key] = str(raw_value)[:300]
+    return out
+
+
+def status_code(exc: BaseException) -> int | None:
+    for obj in (exc, getattr(exc, "response", None)):
+        if obj is None:
+            continue
+        status = getattr(obj, "status_code", None)
+        if status is None:
+            continue
+        try:
+            return int(status)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def parse_retry_after_seconds(value: object) -> int | None:
+    if value is None:
+        return None
+    rendered = str(value).strip()
+    if not rendered:
+        return None
+    try:
+        return max(int(float(rendered)), 0)
+    except (TypeError, ValueError):
+        pass
+    try:
+        dt = parsedate_to_datetime(rendered)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return max(int(dt.timestamp() - time.time()), 0)
+    except Exception:
+        return None
+
+
+def path_label(value: str | None) -> str | None:
+    """Return a non-secret, human-usable path label for diagnostics."""
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    try:
+        expanded = Path(raw).expanduser()
+        home = Path.home()
+        try:
+            rel = expanded.resolve(strict=False).relative_to(home.resolve(strict=False))
+            return "~/" + rel.as_posix()
+        except ValueError:
+            if expanded.is_absolute():
+                digest = hashlib.sha256(str(expanded).encode("utf-8")).hexdigest()[:8]
+                name = expanded.name or "path"
+                return f"external:{name}:{digest}"
+            return raw
+    except Exception:
+        return raw
+
+
+def codex_auth_path_diagnostic(defaults: dict | None) -> dict:
+    """Return non-secret Codex auth-lane diagnostics."""
+    bucket = defaults or {}
+    raw = bucket.get("codex_auth_path") if isinstance(bucket, dict) else None
+    label = path_label(raw) if raw else "~/.lingtai-tui/codex-auth.json"
+    return {
+        "codex_auth_path_source": "explicit" if raw else "implicit_default",
+        "codex_auth_path_label": label,
+    }
+
+
+def quota_error_extra(
+    exc: BaseException,
+    *,
+    provider: str | None = None,
+    service=None,
+    session_metadata: dict | None = None,
+) -> dict | None:
+    """Return bounded structured metadata for provider quota/rate-limit errors."""
+    adapter_says_quota = False
+    if service is not None:
+        try:
+            adapter = (
+                service.get_adapter(provider)
+                if provider
+                else service.get_adapter(service.provider)
+            )
+            adapter_says_quota = bool(adapter.is_quota_error(exc))
+        except Exception:
+            adapter_says_quota = False
+
+    payload = exception_payload(exc)
+    err = payload.get("error") if isinstance(payload, dict) else None
+    if not isinstance(err, dict):
+        err = {}
+
+    try:
+        rendered = str(exc)
+    except Exception:
+        rendered = ""
+    code_status = status_code(exc)
+    headers = exception_headers(exc)
+    error_type = err.get("type")
+    code = err.get("code")
+    message = err.get("message")
+    rendered_lower = rendered.lower()
+    looks_quota = (
+        adapter_says_quota
+        or code_status == 429
+        or error_type in {"usage_limit_reached", "rate_limit_exceeded"}
+        or code in {"usage_limit_reached", "rate_limit_exceeded", "account_stream_cap"}
+        or "usage_limit" in rendered_lower
+        or "rate limit" in rendered_lower
+        or "account_stream_cap" in rendered_lower
+        or "429" in rendered
+    )
+    if not looks_quota:
+        return None
+
+    quota: dict = {
+        "provider": provider,
+        "error_type": error_type or code or type(exc).__name__,
+    }
+    if code_status is not None:
+        quota["status_code"] = code_status
+    if message:
+        quota["message"] = str(message)[:300]
+    for key in ("code", "param", "plan_type", "eligible_promo"):
+        if key in err:
+            quota[key] = err.get(key)
+    for key in ("resets_at", "resets_in_seconds"):
+        if key in err and err.get(key) is not None:
+            try:
+                quota[key] = int(err[key])
+            except (TypeError, ValueError):
+                quota[key] = err[key]
+    if headers:
+        quota["headers"] = headers
+    if (
+        code == "account_stream_cap"
+        or error_type == "account_stream_cap"
+        or "account_stream_cap" in rendered_lower
+    ):
+        quota["limit_reason"] = "account_stream_cap"
+    if isinstance(quota.get("resets_at"), int):
+        try:
+            quota["resets_at_iso"] = datetime.fromtimestamp(
+                quota["resets_at"], tz=timezone.utc
+            ).isoformat()
+        except (OverflowError, OSError, ValueError):
+            pass
+    if isinstance(quota.get("resets_in_seconds"), int):
+        quota["retry_after_seconds"] = max(quota["resets_in_seconds"], 0)
+    else:
+        retry_after = parse_retry_after_seconds(headers.get("retry-after"))
+        if retry_after is not None:
+            quota["retry_after_seconds"] = retry_after
+
+    if str(provider or "").lower() in {"codex", "codex-pool", "codex_pool"}:
+        session = session_metadata or {}
+        for key in ("codex_auth_path_source", "codex_auth_path_label"):
+            value = session.get(key) if isinstance(session, dict) else None
+            if value:
+                quota[key] = value
+    return {"quota": quota}

--- a/src/lingtai_kernel/tool_executor.py
+++ b/src/lingtai_kernel/tool_executor.py
@@ -90,6 +90,8 @@ class ToolExecutor:
         summarize_notification_threshold: int | None = None,
         reconstruction_event_fn: Callable[[], dict | None] | None = None,
         summarizer_fn: Callable[[str, str, str, str | None], str] | None = None,
+        summary_quota_error_extra_fn: Callable[[BaseException], dict | None] | None = None,
+        summary_quota_backoff_fn: Callable[[], dict | None] | None = None,
     ) -> None:
         self._dispatch_fn = dispatch_fn
         self._make_tool_result_fn = make_tool_result_fn
@@ -119,6 +121,8 @@ class ToolExecutor:
         # ``summary=true`` fails closed to a summary-layer error (the raw is
         # never dumped into context); see ``maybe_summarize_result``.
         self._summarizer_fn = summarizer_fn
+        self._summary_quota_error_extra_fn = summary_quota_error_extra_fn
+        self._summary_quota_backoff_fn = summary_quota_backoff_fn
         # Dedup memory for the current sustained-pressure molt EMISSION EVENT.
         # The reminder text is permanent (restamped on every tool result while
         # active), so the ``context_pressure_current_molt_reminder_emitted`` event
@@ -772,6 +776,8 @@ class ToolExecutor:
             tool_call_id=tool_call_id,
             summarizer_fn=self._summarizer_fn,
             logger_fn=self._log,
+            quota_error_extra_fn=self._summary_quota_error_extra_fn,
+            quota_backoff_fn=self._summary_quota_backoff_fn,
         )
 
     def _build_result_message(

--- a/src/lingtai_kernel/tool_result_summary.py
+++ b/src/lingtai_kernel/tool_result_summary.py
@@ -306,6 +306,7 @@ def build_summary_error(
     error: str,
     summary_input_chars: int = 0,
     summary_input_truncated: bool = False,
+    error_extra: dict | None = None,
 ) -> dict:
     """Build the error dict when the summarizer call fails.
 
@@ -320,7 +321,7 @@ def build_summary_error(
     paths); they default to ``0``/``False`` for paths where no LLM call was made
     (e.g. no summarizer wired).
     """
-    return {
+    payload = {
         "artifact": APRIORI_SUMMARY_MARKER,
         "summary_kind": "apriori_error",
         "status": "summary_unavailable",
@@ -340,6 +341,40 @@ def build_summary_error(
         ),
         "retrieval_hint": _retrieval_hint(tool_call_id),
     }
+    if isinstance(error_extra, dict):
+        payload.update(error_extra)
+    return payload
+
+
+def build_quota_backoff_refusal(
+    *,
+    tool_name: str,
+    tool_call_id: str | None,
+    original_visible_chars: int,
+    error_extra: dict,
+) -> dict:
+    """Build the refusal dict when an internal summary provider is in backoff."""
+    return {
+        "artifact": APRIORI_SUMMARY_MARKER,
+        "summary_kind": "apriori_quota_backoff_refused",
+        "status": "summary_unavailable",
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "canonical": False,
+        "raw_preserved": True,
+        "original_visible_chars": original_visible_chars,
+        "summary_input_chars": 0,
+        "summary_input_truncated": False,
+        "raw_locator": _raw_locator(tool_call_id),
+        "message": (
+            "summary=true was requested, but an internal summary provider quota "
+            "backoff is active, so the summary was NOT generated and the raw "
+            "result was deliberately NOT placed into your context. The full "
+            "original is preserved."
+        ),
+        "retrieval_hint": _retrieval_hint(tool_call_id),
+        **error_extra,
+    }
 
 
 def maybe_summarize_result(
@@ -350,6 +385,8 @@ def maybe_summarize_result(
     tool_call_id: str | None,
     summarizer_fn: Callable[[str, str, str, str | None], str] | None,
     logger_fn: Callable[..., None] | None = None,
+    quota_error_extra_fn: Callable[[BaseException], dict | None] | None = None,
+    quota_backoff_fn: Callable[[], dict | None] | None = None,
 ) -> Any:
     """Return a summary replacement for *result* when ``summary=true``, else *result*.
 
@@ -393,6 +430,24 @@ def maybe_summarize_result(
             except Exception:
                 pass
 
+    def _quota_error_extra(exc: BaseException) -> dict | None:
+        if quota_error_extra_fn is None:
+            return None
+        try:
+            extra = quota_error_extra_fn(exc)
+            return extra if isinstance(extra, dict) else None
+        except Exception:
+            return None
+
+    def _quota_backoff() -> dict | None:
+        if quota_backoff_fn is None:
+            return None
+        try:
+            extra = quota_backoff_fn()
+            return extra if isinstance(extra, dict) else None
+        except Exception:
+            return None
+
     # Fail closed when no summarizer is available. ``summary=true`` is a request
     # NOT to place the raw result into context; if we cannot summarize, we must
     # not silently fall back to dumping the raw payload. The raw is already
@@ -425,6 +480,19 @@ def maybe_summarize_result(
             original_visible_chars=original_visible_chars,
         )
 
+    quota_backoff = _quota_backoff()
+    if quota_backoff:
+        _log(
+            "apriori_summary_quota_backoff_refused",
+            original_visible_chars=original_visible_chars,
+        )
+        return build_quota_backoff_refusal(
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            original_visible_chars=original_visible_chars,
+            error_extra=quota_backoff,
+        )
+
     reason = ""
     if isinstance(args, dict):
         reason = args.get("_reasoning") or ""
@@ -454,6 +522,7 @@ def maybe_summarize_result(
             error=f"{type(exc).__name__}: {exc}",
             summary_input_chars=summary_input_chars,
             summary_input_truncated=summary_input_truncated,
+            error_extra=_quota_error_extra(exc),
         )
 
     if not isinstance(summary_text, str) or not summary_text.strip():

--- a/tests/test_apriori_summary_executor.py
+++ b/tests/test_apriori_summary_executor.py
@@ -24,7 +24,15 @@ from lingtai_kernel.tool_result_summary import (
 )
 
 
-def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
+def _make_executor(
+    *,
+    dispatch_fn,
+    summarizer_fn,
+    events,
+    tmp_path,
+    summary_quota_error_extra_fn=None,
+    summary_quota_backoff_fn=None,
+):
     """Construct a ToolExecutor that records durable log events into *events*."""
 
     def logger_fn(event_type, **fields):
@@ -43,6 +51,8 @@ def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
         logger_fn=logger_fn,
         working_dir=tmp_path,
         summarizer_fn=summarizer_fn,
+        summary_quota_error_extra_fn=summary_quota_error_extra_fn,
+        summary_quota_backoff_fn=summary_quota_backoff_fn,
     )
 
 
@@ -287,6 +297,142 @@ class _AgentStub:
 
     def _log(self, *a, **k):
         pass
+
+
+class _ProviderQuotaError(Exception):
+    status_code = 429
+    body = {
+        "error": {
+            "type": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+            "plan_type": "pro",
+            "resets_at": 1783393160,
+            "resets_in_seconds": 1,
+        }
+    }
+
+
+def test_summary_true_provider_429_carries_quota_and_codex_auth_lane(tmp_path):
+    """Internal a-priori summary provider 429s expose non-secret diagnostics."""
+    raw = {"stdout": "RAWMARKER-" + "x" * 100}
+    events = []
+    service = _SessionService()
+    service._provider_defaults = {"codex": {}}
+    agent = _AgentStub(service, provider="codex")
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        raise _ProviderQuotaError("quota")
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+        summary_quota_error_extra_fn=turn._build_apriori_quota_error_extra_fn(agent),
+    )
+    results, _, _ = ex.execute(
+        [ToolCall(name="bash", args={"command": "x", "summary": True}, id="t429")]
+    )
+
+    content = _wire_content(results[0])
+    assert isinstance(content, dict)
+    assert content["artifact"] == APRIORI_SUMMARY_MARKER
+    assert content["status"] == "summary_unavailable"
+    assert "RAWMARKER" not in str(content)
+
+    quota = content["quota"]
+    assert quota["provider"] == "codex"
+    assert quota["error_type"] == "usage_limit_reached"
+    assert quota["status_code"] == 429
+    assert quota["plan_type"] == "pro"
+    assert quota["resets_at"] == 1783393160
+    assert quota["resets_at_iso"].endswith("+00:00")
+    assert quota["retry_after_seconds"] == 1
+    assert quota["codex_auth_path_source"] == "implicit_default"
+    assert quota["codex_auth_path_label"] == "~/.lingtai-tui/codex-auth.json"
+    assert agent._apriori_summary_provider_quota_backoff["codex"]["resets_at"] == 1783393160
+
+
+def test_summary_true_provider_429_carries_explicit_codex_auth_lane(tmp_path):
+    """Explicit Codex auth paths are labeled but never expanded to secrets."""
+    raw = {"stdout": "RAWMARKER-" + "x" * 100}
+    events = []
+    service = _SessionService()
+    service._provider_defaults = {
+        "codex": {"codex_auth_path": "~/.lingtai-tui/codex-auth/codex.json"}
+    }
+    agent = _AgentStub(service, provider="codex")
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        raise _ProviderQuotaError("quota")
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+        summary_quota_error_extra_fn=turn._build_apriori_quota_error_extra_fn(agent),
+    )
+    results, _, _ = ex.execute(
+        [ToolCall(name="bash", args={"command": "x", "summary": True}, id="texplicit")]
+    )
+
+    content = _wire_content(results[0])
+    assert "RAWMARKER" not in str(content)
+    quota = content["quota"]
+    assert quota["codex_auth_path_source"] == "explicit"
+    assert quota["codex_auth_path_label"] == "~/.lingtai-tui/codex-auth/codex.json"
+
+
+def test_summary_true_active_quota_backoff_skips_internal_summary_call(tmp_path):
+    raw = {"stdout": "RAWMARKER-" + "x" * 100}
+    events = []
+    service = _SessionService()
+    service._provider_defaults = {"codex": {}}
+    agent = _AgentStub(service, provider="codex")
+    agent._apriori_summary_provider_quota_backoff = {
+        "codex": {
+            "provider": "codex",
+            "error_type": "usage_limit_reached",
+            "status_code": 429,
+            "plan_type": "pro",
+            "resets_at": 1783393160,
+            "resets_at_iso": "2026-07-07T02:59:20+00:00",
+            "codex_auth_path_source": "implicit_default",
+            "codex_auth_path_label": "~/.lingtai-tui/codex-auth.json",
+            "backoff_until": 1783393160,
+        }
+    }
+    called = {"n": 0}
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        called["n"] += 1
+        return "should not run"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+        summary_quota_backoff_fn=lambda: turn._active_apriori_summary_quota_backoff(agent),
+    )
+    results, _, _ = ex.execute(
+        [ToolCall(name="bash", args={"command": "x", "summary": True}, id="tbackoff")]
+    )
+
+    content = _wire_content(results[0])
+    assert called["n"] == 0
+    assert content["artifact"] == APRIORI_SUMMARY_MARKER
+    assert content["summary_kind"] == "apriori_quota_backoff_refused"
+    assert content["status"] == "summary_unavailable"
+    assert "RAWMARKER" not in str(content)
+    quota = content["quota"]
+    assert quota["provider"] == "codex"
+    assert quota["plan_type"] == "pro"
+    assert quota["resets_at"] == 1783393160
+    assert quota["resets_at_iso"].endswith("+00:00")
+    assert quota["codex_auth_path_source"] == "implicit_default"
+    assert quota["codex_auth_path_label"] == "~/.lingtai-tui/codex-auth.json"
 
 
 def test_summarizer_factory_none_without_session_gateway():

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2,6 +2,7 @@
 """Tests for the daemon (神識) capability — subagent system."""
 import json
 import os
+import pytest
 import queue
 import re
 import threading
@@ -663,8 +664,7 @@ def test_run_emanation_returns_text(tmp_path, monkeypatch):
 
 
 
-def test_run_emanation_codex_parent_gets_daemon_cache_anchor(tmp_path, monkeypatch):
-    """Builtin Codex daemon runs get a per-run cache anchor, not parent service."""
+def _run_builtin_codex_daemon_and_capture(tmp_path, monkeypatch, *, provider_defaults_extra=None, send_side_effect=None):
     agent = _make_agent(tmp_path, ["file", "daemon"])
     agent.service.provider = "codex"
     agent.service.model = "gpt-5.5"
@@ -673,12 +673,13 @@ def test_run_emanation_codex_parent_gets_daemon_cache_anchor(tmp_path, monkeypat
     agent.service._key_resolver = lambda provider: "token"
     agent.service._api_key = "token"
     agent.service.api_key = "token"
-    agent.service._provider_defaults = {
-        "codex": {
-            "max_rpm": 7,
-            "codex_session_anchor": str((agent._working_dir / "init.json").resolve()),
-        }
+    codex_defaults = {
+        "max_rpm": 7,
+        "codex_session_anchor": str((agent._working_dir / "init.json").resolve()),
     }
+    if provider_defaults_extra:
+        codex_defaults.update(provider_defaults_extra)
+    agent.service._provider_defaults = {"codex": codex_defaults}
 
     captured = {}
 
@@ -700,7 +701,10 @@ def test_run_emanation_codex_parent_gets_daemon_cache_anchor(tmp_path, monkeypat
                 thinking_tokens=0,
                 cached_tokens=0,
             )
-            mock_session.send = MagicMock(return_value=mock_response)
+            if send_side_effect is not None:
+                mock_session.send = MagicMock(side_effect=send_side_effect)
+            else:
+                mock_session.send = MagicMock(return_value=mock_response)
             return mock_session
 
     import lingtai.llm.service as service_mod
@@ -717,7 +721,21 @@ def test_run_emanation_codex_parent_gets_daemon_cache_anchor(tmp_path, monkeypat
         "run_dir": run_dir,
     }
 
-    result = mgr._run_emanation(em_id, run_dir, schemas, dispatch, "x", cancel)
+    try:
+        result = mgr._run_emanation(em_id, run_dir, schemas, dispatch, "x", cancel)
+    except Exception as exc:
+        if send_side_effect is None:
+            raise
+        captured["exception"] = exc
+        result = None
+    return agent, run_dir, captured, result
+
+
+def test_run_emanation_codex_parent_defaults_to_fresh_daemon_anchor(tmp_path, monkeypatch):
+    """Builtin Codex daemon runs default to an isolated per-daemon anchor."""
+    agent, run_dir, captured, result = _run_builtin_codex_daemon_and_capture(
+        tmp_path, monkeypatch
+    )
 
     assert result == "daemon done"
     agent.service.create_session.assert_not_called()
@@ -727,7 +745,63 @@ def test_run_emanation_codex_parent_gets_daemon_cache_anchor(tmp_path, monkeypat
     assert captured["init"]["context_window"] == 123456
     defaults = captured["init"]["provider_defaults"]
     assert defaults["codex"]["max_rpm"] == 7
-    assert defaults["codex"]["codex_session_anchor"] == str((run_dir.path / "daemon.json").resolve())
+    assert defaults["codex"]["codex_session_anchor"] == str(run_dir.daemon_json_path.resolve())
+    assert "codex_daemon_session_mode" not in defaults["codex"]
+    state = json.loads(run_dir.daemon_json_path.read_text(encoding="utf-8"))
+    assert state["session"]["session_mode"] == "fresh"
+    assert state["session"]["codex_session_anchor_source"] == "daemon"
+
+
+def test_run_emanation_codex_quota_error_records_auth_path_on_real_failure(tmp_path, monkeypatch):
+    """The real emanation failure path persists auth-lane labels on 429s."""
+
+    class FakeQuotaError(Exception):
+        status_code = 429
+        body = {
+            "error": {
+                "type": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+                "plan_type": "pro",
+                "resets_at": int(time.time()) + 120,
+            }
+        }
+
+    agent, run_dir, captured, _result = _run_builtin_codex_daemon_and_capture(
+        tmp_path,
+        monkeypatch,
+        provider_defaults_extra={
+            "codex_auth_path": "~/.lingtai-tui/codex-auth/codex.json"
+        },
+        send_side_effect=FakeQuotaError("quota"),
+    )
+
+    assert isinstance(captured["exception"], FakeQuotaError)
+    state = json.loads(run_dir.daemon_json_path.read_text(encoding="utf-8"))
+    quota = state["error"]["quota"]
+    assert quota["codex_auth_path_source"] == "explicit"
+    assert quota["codex_auth_path_label"] == "~/.lingtai-tui/codex-auth/codex.json"
+    backoff = agent.get_capability("daemon")._active_daemon_provider_quota_backoff("codex")
+    assert backoff["codex_auth_path_label"] == "~/.lingtai-tui/codex-auth/codex.json"
+
+
+
+def test_run_emanation_codex_parent_affinity_requires_feature_flag(tmp_path, monkeypatch):
+    """Parent affinity is opt-in for A/B experiments, not the default."""
+    agent, run_dir, captured, result = _run_builtin_codex_daemon_and_capture(
+        tmp_path,
+        monkeypatch,
+        provider_defaults_extra={"codex_daemon_session_mode": "parent_affinity"},
+    )
+
+    assert result == "daemon done"
+    agent.service.create_session.assert_not_called()
+    defaults = captured["init"]["provider_defaults"]
+    assert defaults["codex"]["max_rpm"] == 7
+    assert defaults["codex"]["codex_session_anchor"] == str((agent._working_dir / "init.json").resolve())
+    assert "codex_daemon_session_mode" not in defaults["codex"]
+    state = json.loads(run_dir.daemon_json_path.read_text(encoding="utf-8"))
+    assert state["session"]["session_mode"] == "parent_affinity"
+    assert state["session"]["codex_session_anchor_source"] == "parent"
 
 
 def test_run_emanation_non_codex_parent_builds_fresh_daemon_service(tmp_path, monkeypatch):
@@ -2999,6 +3073,63 @@ def test_daemon_provider_defaults_preserves_codex_auth_path(tmp_path):
     assert out["codex"]["codex_session_anchor"] == str(
         (run_dir.path / "daemon.json").resolve()
     )
+
+
+def test_daemon_provider_defaults_records_codex_auth_path_metadata(tmp_path):
+    """Codex daemon session diagnostics identify the auth lane without tokens."""
+    from lingtai.core.daemon import DaemonManager
+
+    class FakeRunDir:
+        def __init__(self, path):
+            self.path = path
+            self.metadata = {}
+
+        def set_session_metadata(self, **fields):
+            self.metadata.update(fields)
+
+    run_dir = FakeRunDir(tmp_path / "run")
+    mgr = DaemonManager.__new__(DaemonManager)
+
+    out = DaemonManager._daemon_provider_defaults(
+        mgr,
+        "codex",
+        {
+            "codex_auth_path": "~/.lingtai-tui/codex-auth/codex.json",
+            "codex_session_anchor": "/agents/alice/init.json",
+        },
+        run_dir,
+    )
+
+    assert out["codex"]["codex_auth_path"] == "~/.lingtai-tui/codex-auth/codex.json"
+    assert run_dir.metadata["codex_auth_path_source"] == "explicit"
+    assert run_dir.metadata["codex_auth_path_label"] == "~/.lingtai-tui/codex-auth/codex.json"
+
+
+def test_daemon_provider_defaults_records_implicit_codex_auth_path_metadata(tmp_path):
+    """Absence of codex_auth_path is diagnosable as the implicit REST lane."""
+    from lingtai.core.daemon import DaemonManager
+
+    class FakeRunDir:
+        def __init__(self, path):
+            self.path = path
+            self.metadata = {}
+
+        def set_session_metadata(self, **fields):
+            self.metadata.update(fields)
+
+    run_dir = FakeRunDir(tmp_path / "run")
+    mgr = DaemonManager.__new__(DaemonManager)
+
+    out = DaemonManager._daemon_provider_defaults(
+        mgr,
+        "codex",
+        {"codex_session_anchor": "/agents/alice/init.json"},
+        run_dir,
+    )
+
+    assert "codex_auth_path" not in out["codex"]
+    assert run_dir.metadata["codex_auth_path_source"] == "implicit_default"
+    assert run_dir.metadata["codex_auth_path_label"] == "~/.lingtai-tui/codex-auth.json"
 
 
 def _assert_codex_pool_daemon_defaults(provider, tmp_path):

--- a/tests/test_daemon_quota_error.py
+++ b/tests/test_daemon_quota_error.py
@@ -1,0 +1,172 @@
+import threading
+import time
+
+from lingtai.core.daemon import DaemonManager, _daemon_path_label, _daemon_quota_error_extra
+
+
+class FakeQuotaError(Exception):
+    status_code = 429
+    body = {
+        "error": {
+            "type": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+            "plan_type": "pro",
+            "resets_at": 1783393160,
+            "resets_in_seconds": 170117,
+            "eligible_promo": None,
+        }
+    }
+
+
+def test_daemon_quota_error_extra_extracts_openai_body():
+    meta = _daemon_quota_error_extra(FakeQuotaError("boom"), provider="codex")
+
+    quota = meta["quota"]
+    assert quota["provider"] == "codex"
+    assert quota["status_code"] == 429
+    assert quota["error_type"] == "usage_limit_reached"
+    assert quota["plan_type"] == "pro"
+    assert quota["resets_at"] == 1783393160
+    assert quota["resets_in_seconds"] == 170117
+    assert quota["retry_after_seconds"] == 170117
+    assert quota["resets_at_iso"].endswith("+00:00")
+
+
+def test_daemon_quota_error_extra_includes_codex_auth_path_label():
+    meta = _daemon_quota_error_extra(
+        FakeQuotaError("boom"),
+        provider="codex",
+        session_metadata={
+            "codex_auth_path_source": "explicit",
+            "codex_auth_path_label": "~/.lingtai-tui/codex-auth/codex.json",
+        },
+    )
+
+    quota = meta["quota"]
+    assert quota["codex_auth_path_source"] == "explicit"
+    assert quota["codex_auth_path_label"] == "~/.lingtai-tui/codex-auth/codex.json"
+
+
+def test_daemon_path_label_collapses_home_and_fingerprints_external_absolute(tmp_path):
+    home_label = _daemon_path_label("~/.lingtai-tui/codex-auth/codex.json")
+    assert home_label == "~/.lingtai-tui/codex-auth/codex.json"
+
+    external = tmp_path / "secrets" / "codex.json"
+    label = _daemon_path_label(str(external))
+    assert label.startswith("external:codex.json:")
+    assert str(tmp_path) not in label
+
+
+
+
+class StringOnlyQuotaError(Exception):
+    def __str__(self):
+        return (
+            "Error code: 429 - {'error': {'type': 'usage_limit_reached', "
+            "'message': 'The usage limit has been reached', 'plan_type': 'pro', "
+            "'resets_at': 1783393160, 'resets_in_seconds': 170117}}"
+        )
+
+
+def test_daemon_quota_error_extra_parses_string_payload():
+    meta = _daemon_quota_error_extra(StringOnlyQuotaError(), provider="codex")
+
+    quota = meta["quota"]
+    assert quota["error_type"] == "usage_limit_reached"
+    assert quota["resets_at"] == 1783393160
+
+
+class FakeResponse:
+    status_code = 429
+    headers = {
+        "Retry-After": "17",
+        "X-Request-Id": "req_123",
+        "X-RateLimit-Reset-Requests": "3m12s",
+        "Authorization": "Bearer should-not-leak",
+    }
+
+    def json(self):
+        raise ValueError("no json")
+
+
+class HeaderOnlyQuotaError(Exception):
+    response = FakeResponse()
+
+    def __str__(self):
+        return "Error code: 429 - rate limit"
+
+
+def test_daemon_quota_error_extra_extracts_allowlisted_headers():
+    meta = _daemon_quota_error_extra(HeaderOnlyQuotaError(), provider="codex")
+
+    quota = meta["quota"]
+    assert quota["status_code"] == 429
+    assert quota["retry_after_seconds"] == 17
+    assert quota["headers"] == {
+        "retry-after": "17",
+        "x-request-id": "req_123",
+        "x-ratelimit-reset-requests": "3m12s",
+    }
+    assert "authorization" not in quota["headers"]
+
+
+class AccountStreamCapError(Exception):
+    status_code = 429
+    body = {
+        "error": {
+            "type": "rate_limit_exceeded",
+            "code": "account_stream_cap",
+            "message": "Too many concurrent streams for this account",
+        }
+    }
+
+
+def test_daemon_quota_error_extra_classifies_account_stream_cap():
+    meta = _daemon_quota_error_extra(AccountStreamCapError(), provider="codex")
+
+    quota = meta["quota"]
+    assert quota["status_code"] == 429
+    assert quota["error_type"] == "rate_limit_exceeded"
+    assert quota["code"] == "account_stream_cap"
+    assert quota["limit_reason"] == "account_stream_cap"
+
+
+def test_daemon_quota_error_extra_ignores_non_quota_error():
+    assert _daemon_quota_error_extra(ValueError("plain boom"), provider="mimo") is None
+
+
+def test_daemon_manager_records_provider_quota_backoff():
+    manager = object.__new__(DaemonManager)
+    manager._daemon_provider_quota_backoff = {}
+    manager._daemon_provider_quota_lock = threading.Lock()
+    reset = int(time.time()) + 120
+
+    manager._remember_daemon_provider_quota_backoff(
+        "codex",
+        {
+            "quota": {
+                "error_type": "usage_limit_reached",
+                "plan_type": "pro",
+                "resets_at": reset,
+                "resets_at_iso": "2026-07-07T00:00:00+00:00",
+            }
+        },
+    )
+
+    backoff = manager._active_daemon_provider_quota_backoff("codex")
+    assert backoff["provider"] == "codex"
+    assert backoff["error_type"] == "usage_limit_reached"
+    assert backoff["plan_type"] == "pro"
+    assert backoff["resets_at"] == reset
+    assert backoff["retry_after_seconds"] > 0
+
+
+def test_daemon_manager_ignores_expired_provider_quota_backoff():
+    manager = object.__new__(DaemonManager)
+    manager._daemon_provider_quota_backoff = {
+        "codex": {"provider": "codex", "backoff_until": time.time() - 1}
+    }
+    manager._daemon_provider_quota_lock = threading.Lock()
+
+    assert manager._active_daemon_provider_quota_backoff("codex") is None
+    assert manager._daemon_provider_quota_backoff == {}

--- a/tests/test_daemon_run_dir.py
+++ b/tests/test_daemon_run_dir.py
@@ -507,6 +507,27 @@ def test_mark_failed_logs_event(tmp_path):
     assert last["exception"] == "ValueError"
 
 
+def test_mark_failed_records_structured_error_extra(tmp_path):
+    rd = _make_run_dir(tmp_path)
+    rd.mark_failed(
+        RuntimeError("quota hit"),
+        error_extra={
+            "quota": {
+                "provider": "codex",
+                "error_type": "usage_limit_reached",
+                "resets_at": 1783393160,
+            }
+        },
+    )
+    data = json.loads(rd.daemon_json_path.read_text())
+    assert data["error"]["type"] == "RuntimeError"
+    assert data["error"]["message"] == "quota hit"
+    assert data["error"]["quota"]["provider"] == "codex"
+    assert data["error"]["quota"]["resets_at"] == 1783393160
+    last = json.loads(rd.events_path.read_text().splitlines()[-1])
+    assert last["error_extra"]["quota"]["error_type"] == "usage_limit_reached"
+
+
 def test_mark_cancelled_writes_state(tmp_path):
     rd = _make_run_dir(tmp_path)
     rd.mark_cancelled()


### PR DESCRIPTION
## Summary

- add structured quota metadata for daemon provider 429 / usage-limit errors
- record non-secret Codex auth-lane diagnostics in daemon session metadata:
  - `codex_auth_path_source` (`explicit` / `implicit_default`)
  - `codex_auth_path_label` (home-collapsed label such as `~/.lingtai-tui/codex-auth/codex.json`)
- propagate those labels into quota error metadata and provider quota backoff so future failures distinguish CLI/default REST/preset REST auth lanes without exposing token contents
- keep Codex daemon session policy default `fresh`; parent-affinity remains feature-flagged, not silently enabled

## Why

During investigation of GPT/Codex daemon 429 failures, direct `codex exec` and some REST probes succeeded while default `backend=lingtai` Codex daemons failed. The missing diagnostic was the auth lane: Codex CLI (`~/.codex`), LingTai REST implicit default (`~/.lingtai-tui/codex-auth.json`), and preset-specific REST (`codex_auth_path`) are different lanes. Without recording the selected `codex_auth_path` label, daemon 429 artifacts can make different lanes look like one account/quota problem.

This PR records only a path label/source, never token contents.

## Validation

- `git diff --check`
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/pytest tests/test_daemon_quota_error.py tests/test_daemon.py -k 'codex_auth_path or quota_error_extra or provider_quota_backoff' tests/test_daemon_run_dir.py::test_mark_failed_records_structured_error_extra -q`
  - `12 passed, 93 deselected`
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/pytest tests/test_daemon.py tests/test_daemon_run_dir.py tests/test_daemon_quota_error.py -q`
  - `169 passed`

## Secret hygiene

No token/password/auth file contents are read or logged. Paths under the current home directory are collapsed to `~/...`.
