### PR TITLE
Fix Telegram reply target persistence

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -1192,6 +1192,13 @@ class TelegramManager:
 
         acct = self._service.get_account(account)
         reply_to = args.get("_reply_to_message_id")
+        if reply_to is None:
+            reply_to = args.get("reply_to_message_id")
+        if reply_to is None and args.get("message_id"):
+            try:
+                _account, _chat_id, reply_to = self._parse_compound_id(str(args["message_id"]))
+            except Exception:
+                reply_to = None
 
         # Placeholder mode: fire a typing action before sending so the user
         # sees "is typing…" alongside the placeholder text. Best-effort —
@@ -1256,6 +1263,7 @@ class TelegramManager:
             "text": text,
             "media": media,
             "reply_markup": reply_markup,
+            "reply_to_message_id": reply_to,
             "parse_mode": self._normalize_parse_mode(args.get("parse_mode")),
             "entities": args.get("entities"),
             "caption_entities": args.get("caption_entities"),

--- a/tests/test_telegram_notification_read_state.py
+++ b/tests/test_telegram_notification_read_state.py
@@ -123,6 +123,28 @@ def test_incoming_event_populates_generic_notification_refs(tmp_path: Path) -> N
     assert metadata["message_ref"] == "main:123:53"
 
 
+def test_incoming_reply_persists_reply_to_message_id(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+
+    manager.on_incoming("main", {
+        "message": {
+            "message_id": 54,
+            "date": 1781600000,
+            "from": {"id": 1, "username": "alice"},
+            "chat": {"id": 123, "type": "private"},
+            "text": "reply from human",
+            "reply_to_message": {"message_id": 53},
+        }
+    })
+
+    read_result = manager._read({"account": "main", "chat_id": 123, "limit": 1})
+    assert read_result["status"] == "ok"
+    assert read_result["messages"][0]["id"] == "main:123:54"
+    assert read_result["messages"][0]["reply_to_message_id"] == 53
+    assert read_result["messages"][0]["_direction"] == "incoming"
+
+
+
 def test_callback_query_incoming_does_not_publish_non_unique_message_ref(tmp_path: Path) -> None:
     workdir = tmp_path / "agent"
     inbound_events: list[dict[str, Any]] = []

--- a/tests/test_telegram_rich_formatting.py
+++ b/tests/test_telegram_rich_formatting.py
@@ -242,6 +242,60 @@ def test_send_passes_parse_mode_entities_and_link_preview(tmp_path):
     )]
 
 
+def test_reply_persists_reply_to_message_id_in_sent_record(tmp_path):
+    manager, account = _manager(tmp_path)
+
+    result = manager._reply({
+        "message_id": "mybot:123:456",
+        "text": "reply text",
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls[0][0] == "send_message"
+    assert account.calls[0][1] == 123
+    assert account.calls[0][4] == 456
+
+    read_result = manager._read({"account": "mybot", "chat_id": 123, "limit": 1})
+    assert read_result["status"] == "ok"
+    assert read_result["messages"][0]["id"] == "mybot:123:111"
+    assert read_result["messages"][0]["reply_to_message_id"] == 456
+    assert read_result["messages"][0]["_direction"] == "outgoing"
+
+
+def test_send_accepts_public_reply_target_fields(tmp_path):
+    manager, account = _manager(tmp_path)
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "text": "reply text",
+        "message_id": "mybot:123:456",
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls[0][4] == 456
+
+    read_result = manager._read({"account": "mybot", "chat_id": 123, "limit": 1})
+    assert read_result["messages"][0]["reply_to_message_id"] == 456
+
+
+def test_send_accepts_raw_reply_to_message_id(tmp_path):
+    manager, account = _manager(tmp_path)
+
+    result = manager._send({
+        "account": "mybot",
+        "chat_id": 123,
+        "text": "reply text",
+        "reply_to_message_id": 456,
+    })
+
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls[0][4] == 456
+
+    read_result = manager._read({"account": "mybot", "chat_id": 123, "limit": 1})
+    assert read_result["messages"][0]["reply_to_message_id"] == 456
+
+
 def test_send_without_formatting_is_unchanged(tmp_path):
     """Backward compatibility: a plain send forwards no formatting kwargs."""
     manager, account = _manager(tmp_path)


### PR DESCRIPTION
## Summary
- persist `reply_to_message_id` in Telegram sent records when `telegram.reply()` sends through `_send`
- add an incoming reply regression test that preserves Telegram `reply_to_message.message_id`
- add an outgoing reply regression test that verifies `_read` returns the reply target after `telegram.reply()`

## Why
Jason asked to first validate the lower-level Telegram capability before restructuring `_meta.notification_persistent.telegram`: direct messages should read with `reply_to_message_id == null`, while replies in both directions should read with the replied-to Telegram message id.

## Validation
- `python -m py_compile src/lingtai/mcp_servers/telegram/manager.py`
- `git diff --check origin/main...HEAD`
- `pytest -q tests/test_mcp_inbox.py tests/test_telegram_notification_read_state.py tests/test_telegram_rich_formatting.py -q`
