### PR TITLE
docs: add LICC notification contract

### DIFF
--- a/src/lingtai/core/mcp/ANATOMY.md
+++ b/src/lingtai/core/mcp/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md
   - src/lingtai/ANATOMY.md
   - src/lingtai/core/mcp/__init__.py
   - src/lingtai/core/mcp/inbox.py
@@ -25,6 +26,8 @@ via file operations from the agent (`write`, `edit`).
 Also includes the **LICC v1 (LingTai Inbox Callback Contract)** — a
 filesystem-based inbox that lets out-of-process MCP servers push events into
 the agent's inbox.
+
+The model-visible notification projection for LICC events is governed by `src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md`; touching `inbox.py`, `licc.py`, or curated human-message producer metadata must re-check that contract.
 
 ## Components
 
@@ -145,6 +148,7 @@ mcp/licc.py  (client-side producer; mirrors inbox.py's consumer)
 - **LICC client is best-effort, path-safe, and receiver-validating:** `push_inbox_event` never raises into the calling MCP. Missing agent dir / mcp name (neither arg nor env var set), invalid MCP names, unsafe explicit event IDs, or payload fields rejected by `validate_event` → `False` no-op; filesystem/serialization errors → `False`. Failure logs are terse and never echo `body`/`subject`/`metadata` (which may carry user content or secrets). Producer and consumer share the contract constants and validation because `licc.py` imports them from `inbox.py` — they cannot drift.
 - **LICC dead-letter:** Invalid events (parse errors, missing fields, unknown version, dispatch failures) are moved to `.dead/` with a `.error.json` sidecar. Dead-letters are never auto-deleted.
 - **LICC bounded work:** `MAX_EVENTS_PER_CYCLE = 100` per MCP per sweep prevents pathological backlog from blocking the poller.
+- **LICC notification projection contract:** raw `.notification/mcp.<name>.json` previews are only the producer mirror; once a producer has a persistent context lane, model-visible `_meta.notifications` must be reduced to a minimal identity hook and content must move to `_meta.notification_persistent` (see `src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md`).
 - **LICC notification shape (post-#37 + previews):** The coalesced notification carries the MCP name, event count, plus a `previews` list — one entry per consumed event with `{"from": <sender>, "subject": <subject>, "preview": <body[:_PREVIEW_FIELD_CAP]>}` and, **when the event opts in via `metadata`**, optional IM/chat scalars `conversation_ref`, `message_ref`, `platform` (each capped at `_PREVIEW_META_FIELD_CAP = 200` chars). Only well-formed non-empty string metadata values are copied; non-string/empty/unknown keys are silently ignored, so legacy events without metadata produce the identical preview shape as before. The body snippet is hard-truncated at `_PREVIEW_FIELD_CAP` (10000 chars); `from` and `subject` pass through uncapped (sender bounded by upstream construction; subject already validated `<= 200` chars by `validate_event`). Full message **bodies** are still NOT inlined — those stay behind the `<mcp>(action="check"/"read")` tool result. The original issue #37 invariant (no body duplication → no agent re-processing loop) is preserved; previews exist purely to let the agent triage which MCPs/messages deserve a read call. Multiple events from the same MCP in one sweep are coalesced into a single summary; `wake` is the OR of all per-event `wake` flags. Preview list length is naturally bounded by `MAX_EVENTS_PER_CYCLE` (100).
 - **LICC uses `.notification/` filesystem-as-protocol:** `_dispatch_summary` publishes via `notifications.submit` to `.notification/mcp.<mcp_name>.json` instead of posting to the legacy inbox queue. This unifies MCP events with all other notification producers (email, soul, system events) in the kernel's `_sync_notifications` wire injection path.
 - **Pure presentation:** The capability never writes to the registry file. It only reads and renders.

--- a/src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md
+++ b/src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md
@@ -1,0 +1,278 @@
+---
+name: licc-notification-contract
+description: >
+  Contract for LICC/MCP notification events and their model-visible projection
+  into _meta.notifications and _meta.notification_persistent.
+status: active
+contract_version: 1
+last_changed_at: "2026-07-06"
+related_files:
+  - src/lingtai/core/mcp/ANATOMY.md
+  - src/lingtai/core/mcp/inbox.py
+  - src/lingtai/core/mcp/licc.py
+  - src/lingtai/mcp_servers/ANATOMY.md
+  - src/lingtai/mcp_servers/telegram/manager.py
+  - src/lingtai_kernel/ANATOMY.md
+  - src/lingtai_kernel/base_agent/ANATOMY.md
+  - src/lingtai_kernel/base_agent/__init__.py
+  - src/lingtai_kernel/base_agent/messaging.py
+  - src/lingtai_kernel/base_agent/turn.py
+  - src/lingtai_kernel/intrinsics/notification/ANATOMY.md
+  - src/lingtai_kernel/intrinsics/notification/__init__.py
+  - src/lingtai_kernel/meta_block.py
+  - src/lingtai_kernel/notifications.py
+  - tests/test_licc_notification_contract_doc.py
+  - tests/test_mcp_inbox.py
+  - tests/test_meta_block.py
+  - tests/test_notification_sync.py
+  - tests/test_telegram_notification_read_state.py
+review_triggers:
+  - src/lingtai/core/mcp/inbox.py
+  - src/lingtai/core/mcp/licc.py
+  - src/lingtai/mcp_servers/telegram/manager.py
+  - src/lingtai/mcp_servers/imap/manager.py
+  - src/lingtai/mcp_servers/feishu/manager.py
+  - src/lingtai/mcp_servers/wechat/manager.py
+  - src/lingtai/mcp_servers/whatsapp/manager.py
+  - src/lingtai/mcp_servers/cloud_mail/manager.py
+  - src/lingtai_kernel/base_agent/__init__.py
+  - src/lingtai_kernel/base_agent/messaging.py
+  - src/lingtai_kernel/base_agent/turn.py
+  - src/lingtai_kernel/intrinsics/email/
+  - src/lingtai_kernel/intrinsics/notification/
+  - src/lingtai_kernel/meta_block.py
+  - src/lingtai_kernel/notifications.py
+maintenance: |
+  Keep this file in the same maintenance graph as the ANATOMY.md files listed
+  under related_files. If any review_triggers path changes notification event
+  identity, preview/body placement, persistent context, dismissal semantics, or
+  producer/source-of-truth boundaries, re-read this contract in the same change
+  and either update it or explicitly state in the PR why no contract update was
+  needed.
+---
+# LICC Notification Contract
+
+> **Maintenance trigger:** any change to a path listed in `review_triggers` must
+> re-check this contract in the same change. The PR should either update this
+> document or say why the notification contract still holds.
+
+## What this is
+
+This document is the cross-module contract for **LICC notification events** and
+how they become model-visible notification metadata. It is intentionally
+anatomy-style: it maps the moving parts, cites the code that owns them, names the
+state boundary, and gives future agents a checklist for deciding whether a
+change must also update the contract.
+
+Scope:
+
+- LICC v1 producer/consumer files under `.mcp_inbox/`.
+- Coalesced `.notification/mcp.<server>.json` files produced from LICC events.
+- The `_meta.notifications` high-attention hook visible to the agent.
+- The `_meta.notification_persistent` communication-context lane when a producer
+  has one (currently Telegram).
+- Producer-owned read/reply/dismiss state that remains the source of truth.
+
+Non-scope: the low-level Telegram Bot API, IMAP protocol semantics, frontend UI
+rendering, and unrelated notification producers such as `soul` or `goal` except
+where they share the `.notification/` filesystem protocol.
+
+## Components
+
+1. **LICC event file (producer -> kernel inbox).** Out-of-process MCPs write one
+   JSON event to `<agent_dir>/.mcp_inbox/<mcp_name>/<event_id>.json`; the event
+   schema is `licc_version`, `from`, `subject`, `body`, optional `metadata`,
+   `wake`, and `received_at` (`src/lingtai/core/mcp/inbox.py:58-116`). The
+   canonical producer helper is `push_inbox_event(...)`, which validates the
+   payload and writes atomically through `.json.tmp` + `fsync` + `os.replace`
+   (`src/lingtai/core/mcp/licc.py:80-145`).
+2. **LICC inbox consumer (kernel inbox -> `.notification`).** `MCPInboxPoller`
+   validates/coalesces events per MCP, extracts bounded preview metadata, and
+   publishes one `.notification/mcp.<name>.json` per sweep
+   (`src/lingtai/core/mcp/inbox.py:183-219`,
+   `src/lingtai/core/mcp/inbox.py:320-391`).
+3. **Notification filesystem envelope.** `notifications.submit` is the standard
+   envelope builder (`header`, `icon`, `priority`, `published_at`, optional
+   `instructions`, and producer-owned `data`) and `notifications.publish` writes
+   it atomically (`src/lingtai_kernel/notifications.py:260-275`,
+   `src/lingtai_kernel/notifications.py:1054-1087`).
+4. **Model-visible transient hook.** `_meta.notifications` is sparse and
+   update-driven. `attach_active_notifications` attaches or moves the canonical
+   payload only on first appearance, material change, or deliberate
+   `notification(action="check")` (`src/lingtai_kernel/meta_block.py:2453-2584`).
+   For Telegram, `sanitize_telegram_notification_after_persistent` reduces
+   `_meta.notifications.mcp.telegram.data` to stable `message_ids` only; content,
+   sender/subject, routing details, counts, and summaries must not remain in the
+   transient lane (`src/lingtai_kernel/meta_block.py:2163-2192`).
+5. **Model-visible persistent communication context.** When structured Telegram
+   metadata is available, `build_notification_persistent_payload` emits
+   `_meta.notification_persistent.mcp.telegram` with `messages`, `events`,
+   `previous_block`, comments, and full out-of-window reply targets
+   (`src/lingtai_kernel/meta_block.py:1956-2085`). The Telegram MCP supplies the
+   structured `recent_messages`, `latest_incoming`, and `referenced_messages`
+   metadata (`src/lingtai/mcp_servers/telegram/manager.py:904-1040`).
+6. **Producer source of truth.** Notification files are mirrors/hooks, not the
+   authoritative mailbox/chat store. Producer tools own real state changes and
+   side effects. Email is the current built-in mirror example: unread mail state
+   is rendered into `.notification/email.json`, and read/dismiss/reply actions
+   live on the email tool (`src/lingtai_kernel/base_agent/messaging.py:60-130`).
+
+## Connections
+
+The flow is:
+
+```text
+MCP/server state
+  -> LICC event file (.mcp_inbox/<mcp>/<event>.json)
+  -> MCPInboxPoller coalesced notification (.notification/mcp.<mcp>.json)
+  -> BaseAgent notification sync (IDLE synthetic notification check, or ACTIVE
+     sparse _meta attachment)
+  -> _meta.notifications high-attention hook
+  -> optional _meta.notification_persistent communication context
+  -> producer tool read/reply/dismiss for exact data and state changes
+```
+
+The transient and persistent lanes have different jobs:
+
+| Lane | Job | Must not become |
+|---|---|---|
+| `.notification/<channel>.json` | Producer-owned live mirror/hook that wakes the agent and carries enough structured data for the kernel projection. | A durable arrival log. |
+| `_meta.notifications.<channel>` | High-attention hook saying "this producer needs handling" and carrying only the minimal identity needed to correlate/dismiss. | A second copy of chat/mail content when a persistent lane exists. |
+| `_meta.notification_persistent...` | Context lane for conversation content, routing hooks, and continuity comments that should survive sparse notification movement. | A dismiss/action channel or producer source of truth. |
+| Producer tool/store | Exact read/reply/dismiss state and external side effects. | A passive mirror inferred from `_meta`. |
+
+## Contract rules
+
+### 1. Stable event identity is required
+
+Human-message producers MUST expose stable IDs for the actionable event. Telegram
+uses compound message IDs; after PR #705 the transient hook carries them as
+`data.message_ids` and nothing else. Email migration should use the analogous
+`data.email_ids` shape when email content moves to a persistent lane.
+
+### 2. Content has one model-visible home
+
+When a producer has a persistent context lane, message content and routing context
+MUST be moved there, not duplicated into `_meta.notifications`. For Telegram that
+means:
+
+```json
+"_meta": {
+  "notifications": {
+    "mcp.telegram": {
+      "header": "Telegram event",
+      "data": {"message_ids": ["mimo-1:6859932159:6281"]},
+      "instructions": "High-attention Telegram hook: use notification_persistent for content/context; when handled, dismiss this notification."
+    }
+  },
+  "notification_persistent": {
+    "mcp": {
+      "telegram": {"messages": [...], "events": [...], "previous_block": {...}}
+    }
+  }
+}
+```
+
+The transient hook may keep generic notification scaffolding (`header`, `icon`,
+`priority`, `published_at`) but not body text, previews, sender/subject,
+conversation refs, platform/routing refs, counts, summaries, or explanatory
+`content_moved_to` fields when the key path already identifies the producer and
+the persistent lane is conventional.
+
+### 3. Bounded previews are transitional unless no persistent lane exists
+
+Generic LICC notifications still publish bounded `data.previews` in the
+producer-owned `.notification/mcp.<name>.json` envelope. That raw file is an
+internal mirror and may be used by the kernel to build a persistent lane. Once a
+specific human-message producer has a persistent lane, the model-visible
+transient projection MUST sanitize those previews away. For producers that have
+not yet been migrated, bounded previews are tolerated as a transitional triage
+surface; adding a persistent lane turns on the move-not-duplicate rule.
+
+### 4. Persistent blocks are context, not unread state
+
+`_meta.notification_persistent` can remain in history after the transient hook is
+handled. It is a communication-context lane, not a notification action channel.
+Do not dismiss it, do not mutate producer state from it, and do not treat its
+presence as proof that there is still an unhandled event. Telegram persistent
+blocks must keep `previous_block` hooks so later deltas can point at earlier
+context without re-sending all history.
+
+### 5. Producer tools own side effects and clearing
+
+The producer tool remains the source of truth for exact reads, replies, and
+state-clearing side effects. Generic notification dismissal only clears the
+notification mirror/hook; it must not be used to pretend producer state changed.
+For source-of-truth mirrors (email today), prefer producer-specific
+`read`/`dismiss` verbs. For content-free LICC hooks whose event was handled via
+the producer tool, generic `notification.dismiss_channel("mcp.<name>")` may clear
+the high-attention hook.
+
+### 6. Secret and volume boundaries are part of the contract
+
+Producer metadata copied into `.notification` or `_meta.notification_persistent`
+MUST be bounded and secret-safe. The MCP inbox copies only allowlisted scalar IM
+metadata and bounded JSON-safe structured fields (`src/lingtai/core/mcp/inbox.py:183-219`).
+Curated MCPs that add new structured metadata must update this contract and tests
+before the new field becomes model-visible.
+
+## State
+
+Persistent/on-disk state involved in this contract:
+
+- `.mcp_inbox/<mcp_name>/<event_id>.json` — transient LICC inbox file, consumed
+  and deleted by the poller after successful dispatch; invalid files move to
+  `.dead/`.
+- `.notification/mcp.<name>.json` — producer-owned live mirror. One file per
+  channel, overwritten or cleared as current producer state changes.
+- Producer stores such as Telegram inbox/sent JSON and email mailbox state —
+  authoritative source for exact read/reply/dismiss semantics.
+- Chat history/tool results — where `_meta.notifications` and
+  `_meta.notification_persistent` blocks are recorded for the model and replay.
+
+In-memory state involved in this contract:
+
+- `agent._notification_live_holder` and `_notification_payload_signature` control
+  sparse movement of the transient notification payload.
+- `agent._notification_persistent_telegram_message_ids` and
+  `_notification_persistent_telegram_last_tool_id` track which Telegram messages
+  have already been delivered into the current provider context.
+
+## Review triggers
+
+Re-check this contract whenever a change touches any of these areas:
+
+- LICC schema, validation, atomic write, or dead-letter handling:
+  `src/lingtai/core/mcp/inbox.py`, `src/lingtai/core/mcp/licc.py`.
+- `.notification` helper semantics, channel allowlists, publish/clear/dismiss,
+  or generic-dismiss guards: `src/lingtai_kernel/notifications.py` and
+  `src/lingtai_kernel/intrinsics/notification/`.
+- Notification injection, sparse live-holder movement, `notification_guidance`,
+  `_meta.notifications`, `_meta.notification_persistent`, or sanitizer logic:
+  `src/lingtai_kernel/meta_block.py`, `src/lingtai_kernel/base_agent/__init__.py`,
+  and `src/lingtai_kernel/base_agent/turn.py`.
+- Built-in producers that create notification mirrors or human-message metadata:
+  `src/lingtai_kernel/base_agent/messaging.py`, `src/lingtai_kernel/intrinsics/email/`,
+  and curated messaging MCP managers under `src/lingtai/mcp_servers/`.
+- Tests that lock notification shape, Telegram persistent context, MCP inbox
+  delivery, or email notification behavior.
+
+## Current implementation status
+
+- **Telegram:** compliant with the content split. Transient
+  `_meta.notifications.mcp.telegram` is an identity-only high-attention hook;
+  content/context lives in `_meta.notification_persistent.mcp.telegram`.
+- **Generic LICC/MCP:** still publishes bounded previews into the raw
+  `.notification/mcp.<name>.json` mirror. That is allowed until the producer has
+  a persistent context lane.
+- **Email:** not yet migrated to the identity-only/persistent split. It remains a
+  source-of-truth mirror over unread mail and should be the next producer checked
+  against this contract.
+
+## Notes
+
+This contract deliberately separates **attention** from **context** from
+**authority**. The agent needs an attention hook to wake and decide what to do,
+context to understand human messages without re-reading every time, and producer
+tools to perform real state changes. Mixing those three was the source of the
+Telegram transient-content regressions that PRs #700, #704, and #705 resolved.

--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md
   - pyproject.toml
   - src/lingtai/ANATOMY.md
   - src/lingtai/core/mcp/ANATOMY.md
@@ -55,5 +56,6 @@ The package itself is mostly code + packaged manuals. Runtime state is per-agent
 
 ## Notes
 
+- **Notification contract:** curated messaging MCPs that change structured notification metadata (`recent_messages`, `latest_incoming`, `referenced_messages`, stable IDs, routing hooks, or preview/body placement) must check `src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md` in the same change.
 - **Manual sidecar minimal contract:** `action="manual"` returns the main `SKILL.md` body, parsed metadata, and the main `SKILL.md` absolute `path` only. Concrete `assets/` and `reference/` lists MUST NOT be returned as structured tool fields; `SKILL.md` is the single source of truth for what sidecars exist and how to follow their relative paths.
 - **Packaging discipline:** when adding manual sidecars, put their relative paths in `SKILL.md` and keep the package-data globs for `reference/**/*` / `assets/**/*` so wheels contain them (`pyproject.toml:81-86`).

--- a/src/lingtai_kernel/ANATOMY.md
+++ b/src/lingtai_kernel/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md
   - ANATOMY.md
   - MANIFEST.in
   - pyproject.toml
@@ -120,6 +121,8 @@ The kernel root holds the coordinator (`base_agent/`) plus a flat collection of 
 - The wrapper layer registers LLM adapters into `llm.service` at import time, registers capabilities into `Agent` (which subclasses `BaseAgent`), and provides MCP, FileIO, Vision, Search, and the CLI.
 
 ## Notifications — the `.notification/` filesystem-as-protocol
+
+> **Contract:** changes to LICC/MCP notification event identity, `.notification` envelopes, `_meta.notifications`, `_meta.notification_persistent`, or producer read/dismiss authority must check `src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md` in the same change. The contract names the attention/context/authority split and its review-trigger paths.
 
 Out-of-band events — mail arrival, soul-flow firings, daemon emanations, MCP webhook events, kernel-internal alerts — surface as one **live notification payload holder** at a time. When the agent is IDLE/ASLEEP, the holder is a synthetic `(ToolCallBlock, ToolResultBlock)` pair of shape `notification(action="check")` whose result carries the canonical JSON union of all currently-active producer files. When the agent is ACTIVE and has just produced an ordinary dict-shaped tool result, the holder is the same canonical `notifications` + `notification_guidance` payload attached under `_meta` — but **sparsely / update-driven**, mirroring the `agent_meta` cadence: the payload attaches on first appearance and re-attaches to a newer ACTIVE result only when it **materially changes** (or on a deliberate `notification(action=check)` read). While the payload is unchanged it stays on its existing holder and is NOT chased onto every newest ordinary tool result (`meta_block.attach_active_notifications`, `base_agent/turn.py`). Older holders remain in history only as skeletons/placeholders once a newer holder takes over.
 

--- a/src/lingtai_kernel/base_agent/ANATOMY.md
+++ b/src/lingtai_kernel/base_agent/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md
   - src/lingtai/agent.py
   - src/lingtai_kernel/ANATOMY.md
   - src/lingtai_kernel/base_agent/__init__.py
@@ -70,6 +71,7 @@ Generic agent kernel. Single class `BaseAgent` with methods distributed across 6
 
 ## Notes
 
+- **LICC notification contract:** changes to notification sync, live-holder movement, `_meta.notifications`, `_meta.notification_persistent`, Telegram persistent delivery state, or producer authority/dismissal boundaries must check `src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md` in the same change.
 - **`__init__.py` is large.** This is intentional — the constructor, properties, state machine, hooks, cross-cutting infrastructure (`_save_chat_history`, `_log`, notification sync, legacy tc_inbox drain), and pass-through stubs all live here. The package is not "thin shell + 6 leaves"; the remaining code is genuinely cross-cutting or bound to the class definition.
 - **Pass-through pattern.** Each extracted method becomes a 2-line stub in `__init__.py` (lazy import + call). This preserves the `BaseAgent` class interface while the implementation lives in submodules. The `self` → `agent` conversion is mechanical but `_heartbeat_loop` (~264 lines, 15+ cross-cluster calls) deserves extra-careful review.
 - **Subclass overrides stay on `__init__.py`.** `_activate_preset`, `_activate_default_preset`, `_build_launch_cmd`, `_pre_request`, `_post_request`, `_on_tool_result_hook`, `_cpr_agent` are all overridden by the `Agent` subclass in the wrapper package. They must remain as methods on `BaseAgent`.

--- a/src/lingtai_kernel/intrinsics/notification/ANATOMY.md
+++ b/src/lingtai_kernel/intrinsics/notification/ANATOMY.md
@@ -1,5 +1,6 @@
 ---
 related_files:
+  - src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md
   - src/lingtai_kernel/intrinsics/ANATOMY.md
   - src/lingtai_kernel/intrinsics/notification/__init__.py
   - src/lingtai_kernel/intrinsics/notification/schema.py
@@ -55,6 +56,7 @@ it remains a `system` action (context hygiene, not a notification verb).
 
 ## Notes
 
+- **Contract link:** notification tool verbs clear the high-attention hook/mirror, not producer source-of-truth state. Changes to dismiss/read semantics must check `src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md`.
 - **No `system` compatibility:** `system(action="notification"|"dismiss")` no longer exist. The notification tool is the sole agent-callable surface for these verbs. The kernel still *synthesizes* a notification delivery tool-call pair for IDLE/ASLEEP delivery — now shaped as `notification(action="check")` (`base_agent/__init__.py:1369-1382`), byte-shape-identical to a voluntary `check` so the LLM cannot tell a kernel-injected read from one it issued; the `_synthesized: true` body flag is the only marker. That synthesis is kernel plumbing, not an agent-callable operation.
 - **Atomic, not aggregate:** dismissal is split by target (`channel` / `event_id` / `ref_id`) so the API states exactly what is being cleared. `dismiss_channel` refuses `event_id`/`ref_id`; `dismiss_event`/`dismiss_ref` require their target id.
 - **Large-result escape hatch (legacy):** The kernel no longer produces `large_tool_result` reminders — large results are ranked under `_meta.agent_meta.current_tool_result_chars` and compacted via `system(action="summarize")`. Any `large_tool_result` event still present (persisted before this change, or pre-molt) can be discharged two ways: a successful `system(action="summarize")` of its `tool_call_id` clears it, or an atomic notification dismissal acknowledges and removes the reminder surface (including stale/pre-molt refs) without deleting or mutating the original tool result. Acknowledged refs persist in the ack store so they are not re-surfaced. Regression-anchored by `tests/test_notification_tool.py`, `tests/test_system_dismiss.py`, and `tests/test_large_result_rescan.py`.

--- a/tests/test_licc_notification_contract_doc.py
+++ b/tests/test_licc_notification_contract_doc.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md"
+DOC_REL = "src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md"
+REQUIRED_ANATOMIES = [
+    "src/lingtai_kernel/ANATOMY.md",
+    "src/lingtai_kernel/base_agent/ANATOMY.md",
+    "src/lingtai_kernel/intrinsics/notification/ANATOMY.md",
+    "src/lingtai/core/mcp/ANATOMY.md",
+    "src/lingtai/mcp_servers/ANATOMY.md",
+]
+REQUIRED_TRIGGERS = [
+    "src/lingtai/core/mcp/inbox.py",
+    "src/lingtai/core/mcp/licc.py",
+    "src/lingtai_kernel/meta_block.py",
+    "src/lingtai_kernel/notifications.py",
+    "src/lingtai_kernel/base_agent/__init__.py",
+    "src/lingtai_kernel/base_agent/turn.py",
+    "src/lingtai_kernel/base_agent/messaging.py",
+    "src/lingtai/mcp_servers/telegram/manager.py",
+    "src/lingtai_kernel/intrinsics/email/",
+    "src/lingtai_kernel/intrinsics/notification/",
+]
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} must start with YAML frontmatter"
+    _blank, frontmatter, _body = text.split("---", 2)
+    return yaml.safe_load(frontmatter) or {}
+
+
+def test_licc_notification_contract_frontmatter_lists_review_triggers():
+    meta = _frontmatter(DOC)
+    assert meta["name"] == "licc-notification-contract"
+    assert meta["status"] == "active"
+    related = set(meta["related_files"])
+    triggers = set(meta["review_triggers"])
+    for anatomy in REQUIRED_ANATOMIES:
+        assert anatomy in related
+    for trigger in REQUIRED_TRIGGERS:
+        assert trigger in triggers
+    for rel in related:
+        assert (ROOT / rel).exists(), rel
+
+
+def test_licc_notification_contract_is_linked_from_relevant_anatomies():
+    for rel in REQUIRED_ANATOMIES:
+        path = ROOT / rel
+        meta = _frontmatter(path)
+        assert DOC_REL in meta.get("related_files", []), rel
+        body = path.read_text(encoding="utf-8")
+        assert "LICC_NOTIFICATION_CONTRACT.md" in body, rel


### PR DESCRIPTION
## Summary
- add a code-near `src/lingtai/core/mcp/LICC_NOTIFICATION_CONTRACT.md` with YAML frontmatter, related files, and review triggers
- link the contract from the kernel/MCP/notification ANATOMY graph so notification-shape changes must re-check it
- add a small durability test that verifies the contract frontmatter and ANATOMY backlinks

## Validation
- `python -m pytest -q tests/test_licc_notification_contract_doc.py`
- `git diff --check origin/main...HEAD`
- `python tools/check_anatomy_drift.py --check`
