### PR TITLE
docs(notifications): document persistent Telegram/email hooks

### DIFF
--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -539,7 +539,9 @@ class BaseAgent:
         # until the first active payload, and reset to ``None`` whenever
         # notifications go empty so a later reappearance attaches afresh.
         self._notification_payload_signature: str | None = None
-        # Telegram-only persistent communication-context lane.  These IDs track
+        # Telegram delivery state for the persistent communication-context
+        # lane (shared with email, which snapshots and needs no tracker;
+        # see meta_block.build_notification_persistent_payload).  These IDs track
         # which Telegram messages have already been emitted in
         # `_meta.notification_persistent.mcp.telegram.messages` for the current
         # provider-visible context, so later deliveries can be deltas with a

--- a/src/lingtai_kernel/meta_block.py
+++ b/src/lingtai_kernel/meta_block.py
@@ -681,7 +681,9 @@ def build_meta_readme() -> dict:
             "notification contents as the result body."
         ),
         NOTIFICATION_PERSISTENT_KEY: (
-            "Sparse communication-context lane, currently Telegram-only. Carries "
+            "Sparse communication-context lane, currently carrying Telegram "
+            f"(under {NOTIFICATION_PERSISTENT_TELEGRAM_PATH}) and built-in "
+            f"email (under {NOTIFICATION_PERSISTENT_EMAIL_PATH}). For Telegram it carries "
             "structured recent/new Telegram messages under "
             f"{NOTIFICATION_PERSISTENT_TELEGRAM_PATH}.messages, Telegram "
             "event/routing hooks under `.events`, and a previous_block hook "
@@ -700,7 +702,11 @@ def build_meta_readme() -> dict:
             "ephemeral _meta.notifications.mcp.telegram lane is only a short "
             "high-attention hook carrying message_ids, not a holder for message "
             "text, sender/subject, routing refs, counts, or content-location "
-            "pointers. It is not a "
+            "pointers. For email it carries the current unread snapshot "
+            f"under {NOTIFICATION_PERSISTENT_EMAIL_PATH} (email_ids plus full "
+            "unread bodies), while the ephemeral _meta.notifications.email lane "
+            "is reduced to an email_ids identity hook; the email tool/store "
+            "remains the source of truth for mailbox actions. It is not a "
             "notification/action/dismiss channel and is not part of the formal "
             "tool-result payload; older blocks intentionally remain in history "
             "so later deltas can refer to them via their previous_block hook."

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -325,6 +325,20 @@ def test_build_meta_readme_documents_always_on_session_cache_miss_telemetry():
     assert "reconstruct" in lowered
 
 
+def test_build_meta_readme_notification_persistent_documents_both_channels():
+    """The resident notification_persistent readme must name both current
+    channels — Telegram and email — at their exact dotted paths. Locks the
+    post-#707 state: the lane is no longer Telegram-only, and each channel's
+    transient lane is described as a reduced identity hook."""
+    doc = build_meta_readme()[meta_block.NOTIFICATION_PERSISTENT_KEY]
+    assert meta_block.NOTIFICATION_PERSISTENT_TELEGRAM_PATH in doc
+    assert meta_block.NOTIFICATION_PERSISTENT_EMAIL_PATH in doc
+    assert "Telegram-only" not in doc
+    # Both transient lanes are described by their identity-hook field.
+    assert "message_ids" in doc
+    assert "email_ids" in doc
+
+
 def test_build_guidance_with_meta_readme_keeps_section_shape_without_packaged_guidance():
     guidance = build_guidance_with_meta_readme({})
 
@@ -2725,6 +2739,53 @@ def test_sanitize_telegram_notification_after_persistent_is_noop_without_telegra
     meta_block.sanitize_telegram_notification_after_persistent(payload)
     assert payload["notifications"]["email"]["data"]["previews"][0]["preview"] == "x"
     meta_block.sanitize_telegram_notification_after_persistent({})
+
+
+def test_sanitize_telegram_notification_locks_transient_hook_shape():
+    """Exact-shape lock for the transient Telegram hook (LICC contract).
+
+    After sanitize, the model-visible ephemeral entry must consist of the
+    canonical identity hook (header / data.message_ids / instructions) plus
+    the untouched generic notification scaffolding (icon / priority /
+    published_at) — nothing else. Any new content-bearing field in the hook
+    must show up here as a deliberate diff.
+    """
+    notification_payload = {
+        "notifications": {
+            "mcp.telegram": {
+                "header": "1 new Telegram event",
+                "icon": "💬",
+                "priority": "normal",
+                "published_at": "2026-07-06T10:00:00Z",
+                "instructions": "producer-authored read-the-preview guidance",
+                "data": {
+                    "count": 1,
+                    "previews": [
+                        {
+                            "from": "Jason",
+                            "subject": "telegram message",
+                            "preview": "durable body text",
+                            "message_ref": "main:123:7",
+                        }
+                    ],
+                },
+            }
+        }
+    }
+
+    meta_block.sanitize_telegram_notification_after_persistent(notification_payload)
+
+    assert notification_payload["notifications"]["mcp.telegram"] == {
+        "icon": "💬",
+        "priority": "normal",
+        "published_at": "2026-07-06T10:00:00Z",
+        "header": "Telegram event",
+        "data": {"message_ids": ["main:123:7"]},
+        "instructions": (
+            "High-attention Telegram hook: use notification_persistent for "
+            "content/context; when handled, dismiss this notification."
+        ),
+    }
 
 
 def test_attach_active_notifications_uses_canonical_mcp_payload(tmp_path):


### PR DESCRIPTION
## Summary
- update the resident `_meta.notification_persistent` readme text to reflect the post-#707 state: Telegram and built-in email both use the persistent lane
- fix the matching stale BaseAgent comment so it no longer says the persistent communication context lane is Telegram-only
- add regression tests that lock the documented Telegram/email persistent paths and the compact transient Telegram identity-hook shape

## Context
Follow-up to #707 (`Move email notification context to persistent lane`). Telegram was already behaviorally aligned with the LICC notification contract; this PR locks the contract with documentation and tests instead of changing runtime behavior.

## Validation
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/pytest tests/test_meta_block.py -q` (Claude) → 168 passed
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/pytest tests/test_telegram_notification_read_state.py tests/test_messaging_notification_format.py tests/test_notification_sync.py tests/test_licc_notification_contract_doc.py tests/test_notification_tool.py -q` (Claude) → 116 passed
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/pytest tests/test_mcp_inbox.py -q` (Claude) → 31 passed
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/pytest tests/test_meta_block.py::test_build_meta_readme_notification_persistent_documents_both_channels tests/test_meta_block.py::test_sanitize_telegram_notification_locks_transient_hook_shape tests/test_meta_block.py::test_attach_active_notifications_uses_canonical_mcp_payload -q` (parent spot-check) → 3 passed
- `git diff --check HEAD~1..HEAD` → clean

## Review
- Claude primary author report: `reports/telegram-persistent-notification-claude-20260706.md`
- GLM independent review: `VERDICT: OK_TO_PR` in `reports/telegram-persistent-notification-glm-review-20260706.md`
