### PR TITLE
Surface Codex quota diagnostics in AED events

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -3164,6 +3164,116 @@ class CodexResponsesSession(OpenAIResponsesSession):
         per_full = incremental_count / full_count
         return f"1:{per_full:.1f}".replace(".0", "")
 
+    # -- Codex quota / usage-limit diagnostics --------------------------------
+
+    # Rate-limit response headers the Codex backend may include.  Values are
+    # safe to log (they are numeric durations/tokens, never secrets).
+    _RATE_LIMIT_HEADER_KEYS = (
+        "x-ratelimit-limit-requests",
+        "x-ratelimit-limit-tokens",
+        "x-ratelimit-remaining-requests",
+        "x-ratelimit-remaining-tokens",
+        "x-ratelimit-reset-requests",
+        "x-ratelimit-reset-tokens",
+        "retry-after",
+    )
+
+    # Message fragments that identify a quota / usage-limit condition in the
+    # Codex (ChatGPT-OAuth) error body.  Only the match is recorded, not the
+    # full message.
+    _QUOTA_MESSAGE_FRAGMENTS = (
+        "usage limit",
+        "quota",
+        "rate limit",
+        "too many requests",
+        "too many tokens",
+        "token limit",
+        "exceeded",
+        "exhausted",
+        "insufficient",
+    )
+
+    @staticmethod
+    def _codex_quota_diagnostics(exc: BaseException) -> dict[str, Any]:
+        """Extract safe, non-secret diagnostic metadata from a Codex API error.
+
+        Returns a small dict of **scalars only** — status codes, error codes,
+        header counts, boolean flags, truncated message fragments.  No prompt,
+        token, header value, OAuth secret, or response-body content is
+        included.  Designed to be safe for ``events.jsonl`` / ``logger`` /
+        ``UsageMetadata.extra`` / exception attribute attachment.
+
+        The caller attaches the returned dict to
+        ``exc._codex_quota_diagnostics`` so downstream logging (``turn.py``
+        AED) can include it in ``agent._log()`` events without the kernel
+        needing to understand Codex-specific exception shapes.
+        """
+        diag: dict[str, Any] = {
+            "error_type": type(exc).__name__,
+        }
+
+        # HTTP status code (openai SDK attaches it to all API errors).
+        status = getattr(exc, "status_code", None)
+        if isinstance(status, int):
+            diag["status_code"] = status
+
+        # Error code from the body's ``error.code`` field (openai SDK exposes
+        # ``body`` as a dict on API errors).
+        try:
+            body = getattr(exc, "body", None)
+            if isinstance(body, dict):
+                err = body.get("error")
+                if isinstance(err, dict):
+                    code = err.get("code")
+                    if isinstance(code, str) and code:
+                        diag["error_code"] = code[:80]
+                    err_type = err.get("type")
+                    if isinstance(err_type, str) and err_type:
+                        diag["error_body_type"] = err_type[:80]
+        except Exception:
+            pass
+
+        # Rate-limit headers (safe: numeric values, not secrets).
+        try:
+            response = getattr(exc, "response", None)
+            if response is not None:
+                headers = getattr(response, "headers", None)
+                if headers is not None:
+                    rl: dict[str, str] = {}
+                    for key in CodexResponsesSession._RATE_LIMIT_HEADER_KEYS:
+                        val = headers.get(key)
+                        if val is not None:
+                            rl[key] = str(val)[:80]
+                    if rl:
+                        diag["rate_limit_headers"] = rl
+        except Exception:
+            pass
+
+        # Quota / usage-limit message match (fragment only, not the full text).
+        msg = (str(exc) or "").lower()
+        matched = [
+            frag
+            for frag in CodexResponsesSession._QUOTA_MESSAGE_FRAGMENTS
+            if frag in msg
+        ]
+        if matched:
+            diag["quota_message_fragments"] = matched
+
+        # Whether this looks like a quota / usage-limit error.
+        diag["is_quota"] = bool(
+            isinstance(exc, openai.RateLimitError)
+            or matched
+            or (isinstance(status, int) and status == 429)
+        )
+
+        # Whether this looks like an auth-lane failure.
+        diag["is_auth_error"] = bool(
+            isinstance(exc, (openai.AuthenticationError, openai.PermissionDeniedError))
+            or (isinstance(status, int) and status in (401, 403))
+        )
+
+        return diag
+
     @staticmethod
     def _ws_maintenance_hint(
         *,
@@ -3769,11 +3879,30 @@ class CodexResponsesSession(OpenAIResponsesSession):
                                 ws_diag=(self._ws_last_diag if self._continuation_enabled else None),
                             ),
                         )
-        except Exception:
+        except Exception as exc:
             # Revert the trailing user entry we just added so the next retry
             # doesn't double-record it. Mirrors OpenAIChatSession.send's
             # error path. ToolResultBlock entries also revert — the executor
             # will re-supply them when AED rebuilds the loop.
+            #
+            # Codex quota / usage-limit diagnostics: extract safe metadata
+            # from the error and attach it to the exception so downstream
+            # logging (turn.py AED → agent._log → events.jsonl) can include
+            # it without understanding Codex-specific exception shapes.
+            try:
+                diag = self._codex_quota_diagnostics(exc)
+                if diag.get("is_quota") or diag.get("is_auth_error"):
+                    logger.warning(
+                        "Codex quota/auth diagnostics: %s",
+                        json.dumps(diag, ensure_ascii=False, default=str),
+                    )
+                # Attach to the exception for downstream structured logging.
+                # turn.py can read ``exc._codex_quota_diagnostics`` and
+                # include it in ``agent._log()`` calls.  No-attribute access
+                # is harmless — the kernel already handles missing attributes.
+                exc._codex_quota_diagnostics = diag  # type: ignore[attr-defined]
+            except Exception:
+                pass  # diagnostics must never mask the real error
             self._interface.drop_trailing(lambda e: e.role == "user")
             raise
 
@@ -4147,3 +4276,19 @@ class CodexOpenAIAdapter(OpenAIAdapter):
             base_url=self.base_url,
             api_key=self._client_kwargs.get("api_key"),
         )
+
+    def is_quota_error(self, exc: Exception) -> bool:
+        """Check if the exception is a Codex quota / rate-limit / usage-limit error.
+
+        Extends the parent ``openai.RateLimitError`` check to also match
+        Codex-specific usage-limit messages that may arrive as 403 or other
+        status codes.  Uses the same ``_codex_quota_diagnostics`` helper the
+        session error path uses, so the detection logic is in one place.
+        """
+        if super().is_quota_error(exc):
+            return True
+        try:
+            diag = CodexResponsesSession._codex_quota_diagnostics(exc)
+            return bool(diag.get("is_quota"))
+        except Exception:
+            return False

--- a/src/lingtai_kernel/base_agent/turn.py
+++ b/src/lingtai_kernel/base_agent/turn.py
@@ -157,6 +157,25 @@ def _is_transient_provider_error(exc: Exception) -> bool:
     return any(fragment in msg for fragment in _TRANSIENT_MSG_FRAGMENTS)
 
 
+def _exception_event_fields(
+    exc: Exception,
+    err_desc: str,
+    *,
+    error_limit: int | None = 300,
+) -> dict:
+    """Return AED event fields, including optional provider diagnostics.
+
+    Codex quota diagnostics are attached by the Codex adapter to the raised
+    exception.  The run loop is the bridge into ``events.jsonl``; keep this
+    additive and inert for exceptions without the namespaced attribute.
+    """
+    fields = {"error": err_desc if error_limit is None else err_desc[:error_limit]}
+    diagnostics = getattr(exc, "_codex_quota_diagnostics", None)
+    if isinstance(diagnostics, dict):
+        fields["codex_quota_diagnostics"] = diagnostics
+    return fields
+
+
 def _tool_call_summary(tool_calls) -> dict:
     calls = list(tool_calls or [])
     return {
@@ -704,11 +723,9 @@ def _run_loop(agent) -> None:
                     # _handle_message — see TODO below.
                     over_window = _is_over_window_error(e)
                     if over_window:
-                        agent._log(
-                            "aed_over_window_detected",
-                            error=err_desc[:300],
-                            exception=type(e).__name__,
-                        )
+                        over_window_fields = _exception_event_fields(e, err_desc)
+                        over_window_fields["exception"] = type(e).__name__
+                        agent._log("aed_over_window_detected", **over_window_fields)
 
                     if not over_window and _is_transient_provider_error(e):
                         if transient_attempts < _TRANSIENT_AED_RETRY_LIMIT:
@@ -728,7 +745,7 @@ def _run_loop(agent) -> None:
                                 attempt=transient_attempts,
                                 max_attempts=_TRANSIENT_AED_RETRY_LIMIT,
                                 backoff_s=backoff_s,
-                                error=err_desc[:300],
+                                **_exception_event_fields(e, err_desc),
                             )
                             logger.warning(
                                 f"[{agent.agent_name}] AED transient retry "
@@ -741,7 +758,7 @@ def _run_loop(agent) -> None:
                         agent._log(
                             "aed_transient_exhausted",
                             attempts=transient_attempts,
-                            error=err_desc[:300],
+                            **_exception_event_fields(e, err_desc),
                         )
                     # TODO(issue #144 follow-up): add a hard pre-send gate
                     # in _handle_message that runs retroactive compaction
@@ -764,7 +781,11 @@ def _run_loop(agent) -> None:
                         )
 
                     agent._set_state(AgentState.STUCK, reason=f"AED attempt {aed_attempts}: {err_desc}")
-                    agent._log("aed_attempt", attempt=aed_attempts, error=err_desc)
+                    agent._log(
+                        "aed_attempt",
+                        attempt=aed_attempts,
+                        **_exception_event_fields(e, err_desc, error_limit=None),
+                    )
                     logger.warning(
                         f"[{agent.agent_name}] AED attempt {aed_attempts}/{agent._config.max_aed_attempts}: {err_desc}",
                     )
@@ -784,7 +805,11 @@ def _run_loop(agent) -> None:
                                 agent._perform_refresh()
                                 return
 
-                        agent._log("aed_exhausted", attempts=aed_attempts, error=err_desc)
+                        agent._log(
+                            "aed_exhausted",
+                            attempts=aed_attempts,
+                            **_exception_event_fields(e, err_desc, error_limit=None),
+                        )
                         sleep_state = AgentState.ASLEEP
                         agent._asleep.set()
                         break

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -272,6 +272,58 @@ def test_structural_error_skips_transient_retry(tmp_path, monkeypatch):
     assert any(name == "aed_attempt" and fields["attempt"] == 1 for name, fields in agent._logs)
 
 
+def test_aed_events_propagate_codex_quota_diagnostics(tmp_path, monkeypatch):
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 1
+    diagnostics = {
+        "provider": "codex",
+        "status_code": 429,
+        "error_code": "rate_limit_exceeded",
+        "matched_fragments": ["usage limit"],
+    }
+
+    class QuotaError(Exception):
+        status_code = 429
+
+    quota_error = QuotaError("usage limit reached")
+    quota_error._codex_quota_diagnostics = diagnostics
+
+    def fake_handle(_agent, _msg):
+        raise quota_error
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+
+    import lingtai_kernel.intrinsics.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    aed_attempt = next(fields for name, fields in agent._logs if name == "aed_attempt")
+    aed_exhausted = next(fields for name, fields in agent._logs if name == "aed_exhausted")
+    assert aed_attempt["error"] == "usage limit reached"
+    assert aed_attempt["codex_quota_diagnostics"] == diagnostics
+    assert aed_exhausted["codex_quota_diagnostics"] == diagnostics
+
+
+def test_aed_events_omit_codex_quota_diagnostics_without_attribute(tmp_path, monkeypatch):
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 1
+
+    def fake_handle(_agent, _msg):
+        raise ValueError("bad schema")
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+
+    import lingtai_kernel.intrinsics.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    for name, fields in agent._logs:
+        if name in {"aed_attempt", "aed_exhausted"}:
+            assert "codex_quota_diagnostics" not in fields
+
+
 def test_empty_llm_response_is_classified_transient():
     err = turn.EmptyLLMResponseError(ledger_source="main", in_tool_loop=False)
     assert turn._is_transient_provider_error(err) is True

--- a/tests/test_codex_quota_diagnostics.py
+++ b/tests/test_codex_quota_diagnostics.py
@@ -1,0 +1,217 @@
+"""Tests for Codex adapter quota / usage-limit diagnostics.
+
+These tests verify that ``CodexResponsesSession._codex_quota_diagnostics``
+correctly extracts safe, non-secret diagnostic metadata from various Codex API
+error shapes, and that ``CodexOpenAIAdapter.is_quota_error`` extends the base
+``openai.RateLimitError`` check to cover Codex-specific usage-limit messages.
+
+All tests are pure and offline — no network, no secrets, no real SDK clients.
+"""
+
+from __future__ import annotations
+
+import pytest
+import openai
+
+from lingtai.llm.openai.adapter import (
+    CodexOpenAIAdapter,
+    CodexResponsesSession,
+)
+
+
+# ---------------------------------------------------------------------------
+# _codex_quota_diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestCodexQuotaDiagnostics:
+    """Unit tests for ``CodexResponsesSession._codex_quota_diagnostics``."""
+
+    def test_rate_limit_error(self):
+        """Standard openai.RateLimitError (429) is flagged as quota."""
+        exc = openai.RateLimitError(
+            message="Rate limit exceeded",
+            response=_fake_httpx_response(429, headers={
+                "x-ratelimit-remaining-requests": "0",
+                "x-ratelimit-reset-requests": "60s",
+            }),
+            body={"error": {"code": "rate_limit_exceeded", "type": "rate_limit"}},
+        )
+        diag = CodexResponsesSession._codex_quota_diagnostics(exc)
+        assert diag["is_quota"] is True
+        assert diag["is_auth_error"] is False
+        assert diag["status_code"] == 429
+        assert diag["error_type"] == "RateLimitError"
+        assert diag.get("error_code") == "rate_limit_exceeded"
+        assert "rate limit" in diag.get("quota_message_fragments", [])
+
+    def test_auth_error_401(self):
+        """401 AuthenticationError is flagged as auth error."""
+        exc = openai.AuthenticationError(
+            message="Invalid API key",
+            response=_fake_httpx_response(401),
+            body={"error": {"code": "invalid_api_key", "type": "auth"}},
+        )
+        diag = CodexResponsesSession._codex_quota_diagnostics(exc)
+        assert diag["is_auth_error"] is True
+        assert diag["status_code"] == 401
+        assert diag["error_type"] == "AuthenticationError"
+
+    def test_permission_denied_with_usage_limit(self):
+        """403 PermissionDeniedError with 'usage limit' is flagged as quota."""
+        exc = openai.PermissionDeniedError(
+            message="You have exceeded your usage limit for this period",
+            response=_fake_httpx_response(403),
+            body={"error": {"code": "usage_limit_exceeded", "type": "permission"}},
+        )
+        diag = CodexResponsesSession._codex_quota_diagnostics(exc)
+        assert diag["is_quota"] is True
+        assert diag["is_auth_error"] is True  # 403 is also auth
+        assert "usage limit" in diag.get("quota_message_fragments", [])
+
+    def test_bad_request_not_quota(self):
+        """400 BadRequestError is neither quota nor auth."""
+        exc = openai.BadRequestError(
+            message="Invalid request",
+            response=_fake_httpx_response(400),
+            body={"error": {"code": "invalid_request", "type": "bad_request"}},
+        )
+        diag = CodexResponsesSession._codex_quota_diagnostics(exc)
+        assert diag["is_quota"] is False
+        assert diag["is_auth_error"] is False
+
+    def test_server_error_not_quota(self):
+        """500 InternalServerError is neither quota nor auth."""
+        exc = openai.InternalServerError(
+            message="Internal server error",
+            response=_fake_httpx_response(500),
+            body={"error": {"code": "server_error", "type": "server"}},
+        )
+        diag = CodexResponsesSession._codex_quota_diagnostics(exc)
+        assert diag["is_quota"] is False
+        assert diag["is_auth_error"] is False
+
+    def test_generic_exception(self):
+        """A plain non-SDK exception is handled gracefully."""
+        exc = RuntimeError("some error")
+        diag = CodexResponsesSession._codex_quota_diagnostics(exc)
+        assert diag["error_type"] == "RuntimeError"
+        assert diag["is_quota"] is False
+        assert diag["is_auth_error"] is False
+
+    def test_no_secret_leakage(self):
+        """Diagnostic dict contains only safe scalar keys."""
+        exc = openai.RateLimitError(
+            message="Rate limit exceeded with sentinel SHOULD_NOT_LEAK",
+            response=_fake_httpx_response(429, headers={
+                "x-ratelimit-remaining-requests": "0",
+                "authorization": "SHOULD_NOT_LEAK_AUTH_HEADER",
+            }),
+            body={"error": {"code": "rate_limit_exceeded", "type": "rate_limit"}},
+        )
+        diag = CodexResponsesSession._codex_quota_diagnostics(exc)
+        # The diagnostic dict must NOT contain the full message or headers
+        diag_str = str(diag)
+        assert "SHOULD_NOT_LEAK" not in diag_str
+        # authorization is not a tracked rate-limit header
+        assert "authorization" not in diag_str.lower()
+
+    def test_rate_limit_headers_extracted(self):
+        """Rate-limit headers are included when present."""
+        exc = openai.RateLimitError(
+            message="Too many requests",
+            response=_fake_httpx_response(429, headers={
+                "x-ratelimit-limit-requests": "100",
+                "x-ratelimit-remaining-requests": "0",
+                "x-ratelimit-reset-requests": "60s",
+                "retry-after": "30",
+            }),
+            body={},
+        )
+        diag = CodexResponsesSession._codex_quota_diagnostics(exc)
+        rl = diag.get("rate_limit_headers", {})
+        assert rl.get("x-ratelimit-limit-requests") == "100"
+        assert rl.get("x-ratelimit-remaining-requests") == "0"
+        assert rl.get("retry-after") == "30"
+
+    def test_quota_fragments_detected(self):
+        """Various quota-related message fragments are detected."""
+        fragments = [
+            "usage limit exceeded",
+            "quota exceeded",
+            "rate limit hit",
+            "too many requests",
+            "insufficient quota",
+        ]
+        for msg in fragments:
+            exc = Exception(msg)
+            diag = CodexResponsesSession._codex_quota_diagnostics(exc)
+            assert diag["is_quota"] is True, f"Expected is_quota for: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# CodexOpenAIAdapter.is_quota_error
+# ---------------------------------------------------------------------------
+
+
+class TestCodexOpenAIAdapterIsQuotaError:
+    """Test that ``CodexOpenAIAdapter.is_quota_error`` extends the base check."""
+
+    def test_standard_rate_limit_error(self):
+        """openai.RateLimitError is detected as quota."""
+        adapter = _make_bare_codex_adapter()
+        exc = openai.RateLimitError(
+            message="Rate limit",
+            response=_fake_httpx_response(429),
+            body={},
+        )
+        assert adapter.is_quota_error(exc) is True
+
+    def test_codex_usage_limit_message(self):
+        """Codex 'usage limit' in a 403 is detected as quota."""
+        adapter = _make_bare_codex_adapter()
+        exc = openai.PermissionDeniedError(
+            message="You have exceeded your usage limit",
+            response=_fake_httpx_response(403),
+            body={},
+        )
+        assert adapter.is_quota_error(exc) is True
+
+    def test_non_quota_error(self):
+        """A generic error is not detected as quota."""
+        adapter = _make_bare_codex_adapter()
+        exc = openai.BadRequestError(
+            message="Invalid request",
+            response=_fake_httpx_response(400),
+            body={},
+        )
+        assert adapter.is_quota_error(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_httpx_response(status_code: int, headers: dict | None = None):
+    """Build a minimal fake httpx.Response for openai SDK error construction."""
+    import httpx
+
+    _headers = {"content-type": "application/json"}
+    if headers:
+        _headers.update(headers)
+    return httpx.Response(
+        status_code=status_code,
+        headers=_headers,
+        content=b"{}",
+        request=httpx.Request("POST", "https://chatgpt.com/backend-api/codex/responses"),
+    )
+
+
+def _make_bare_codex_adapter() -> CodexOpenAIAdapter:
+    """Build a CodexOpenAIAdapter with a dummy API key (no network)."""
+    return CodexOpenAIAdapter(
+        api_key="test-dummy-key-not-real",
+        use_responses=True,
+        force_responses=True,
+    )


### PR DESCRIPTION
## Summary

This PR surfaces Codex quota/rate-limit diagnostics all the way into AED event metadata / `events.jsonl`.

It includes two small pieces:

1. Codex adapter diagnostics
   - classify quota/rate-limit shaped Codex API errors;
   - extract only scalar, non-secret metadata such as status code, error code/type, request id, and rate-limit timing/header values;
   - attach the diagnostics to the raised exception as a namespaced attribute.

2. Minimal runtime event propagation
   - add a tiny AED event-field helper in `turn.py`;
   - merge `codex_quota_diagnostics` into AED log events when the exception carries the namespaced diagnostics dict;
   - preserve the no-attribute / non-Codex path.

## Scope / non-goals

- No retry behavior changes.
- No auth/session/backoff behavior changes.
- No raw response bodies, authorization headers, API keys, or token-shaped secrets are logged.
- This is intentionally framed as Codex adapter diagnostics plus minimal runtime event propagation, not as a pure adapter-only change.

Note: the adapter-level `is_quota_error` hook is present for interface completeness, but the production event propagation path in this PR is the exception-attached diagnostics consumed by AED logging.

## Validation

```text
python -m compileall -q src/lingtai_kernel/base_agent/turn.py tests/test_aed_recovery.py
```

```text
python -m pytest tests/test_aed_recovery.py tests/test_codex_quota_diagnostics.py tests/test_adapter_registry.py -q
# 29 passed
```

```text
python -m pytest tests/test_codex_ws_tool_result_freeze.py tests/test_codex_endpoint_pool.py tests/test_codex_raw_reasoning_replay.py tests/test_codex_prompt_cache_key.py -q
# 86 passed on rerun
```

Final selected validation after the last amend:

```text
python -m pytest tests/test_aed_recovery.py tests/test_codex_quota_diagnostics.py tests/test_adapter_registry.py tests/test_codex_ws_tool_result_freeze.py tests/test_codex_endpoint_pool.py tests/test_codex_raw_reasoning_replay.py tests/test_codex_prompt_cache_key.py -q
# 115 passed in 2.21s
```
