### PR TITLE
fix: make load_jsonc trailing-comma stripping string-aware (#725)

### DIFF
--- a/src/lingtai_kernel/config_resolve.py
+++ b/src/lingtai_kernel/config_resolve.py
@@ -9,34 +9,47 @@ from pathlib import Path
 
 # Module-level: pre-compiled regex for JSONC string literals (matches "..."
 # with escape sequences). Used by load_jsonc to skip over string contents
-# when stripping // comments.
+# when stripping // comments and trailing commas.
 _JSONC_STRING_RE = re.compile(r'"(?:[^"\\]|\\.)*"')
+
+
+def _clean_jsonc_chunk(chunk: str) -> str:
+    """Strip // comments and trailing commas from a non-string JSONC span.
+
+    Comments are stripped first so a trailing comma followed by a comment
+    (``,  // note`` then ``]`` on the next line) still collapses: the comma
+    regex's ``\\s*`` spans the newline left behind by comment removal.
+    """
+    chunk = re.sub(r'//[^\n]*', '', chunk)
+    return re.sub(r',\s*([}\]])', r'\1', chunk)
 
 
 def load_jsonc(path: str | Path) -> dict:
     """Load a JSON or JSONC file (strips // comments and trailing commas).
 
-    Comment stripping is string-aware: // inside a quoted JSON string value
-    is never treated as a comment (preserving URLs like "https://host/...").
+    Both normalisations are string-aware: // inside a quoted JSON string
+    value is never treated as a comment (preserving URLs like
+    "https://host/..."), and a ", ]" or ", }" inside a string value is never
+    mistaken for a trailing comma. String literals pass through verbatim.
     """
     text = Path(path).read_text(encoding="utf-8")
-    # Strip // comments only when not inside a JSON string.
+    # Apply JSONC cleanup only when not inside a JSON string.
     # Strategy: tokenise by alternating between string spans and non-string
-    # spans; within non-string spans, replace //...EOL with nothing.
+    # spans; clean only the non-string spans. A genuine trailing comma and
+    # its closing bracket can never be separated by a string literal (that
+    # would make the comma a normal separator), so per-chunk substitution is
+    # equivalent to a whole-text pass for all well-formed inputs.
     parts: list[str] = []
     pos = 0
     for m in _JSONC_STRING_RE.finditer(text):
-        # Non-string chunk before this string: strip comments
-        chunk = re.sub(r'//[^\n]*', '', text[pos:m.start()])
-        parts.append(chunk)
+        # Non-string chunk before this string: strip comments and commas
+        parts.append(_clean_jsonc_chunk(text[pos:m.start()]))
         # String literal: preserve verbatim
         parts.append(m.group())
         pos = m.end()
     # Trailing non-string chunk after last string
-    parts.append(re.sub(r'//[^\n]*', '', text[pos:]))
-    text = ''.join(parts)
-    text = re.sub(r',\s*([}\]])', r'\1', text)
-    return json.loads(text)
+    parts.append(_clean_jsonc_chunk(text[pos:]))
+    return json.loads(''.join(parts))
 
 
 def resolve_env(value: str | None, env_name: str | None) -> str | None:

--- a/tests/test_config_resolve_jsonc.py
+++ b/tests/test_config_resolve_jsonc.py
@@ -1,0 +1,53 @@
+"""Unit tests for load_jsonc — string-aware comment and trailing-comma handling."""
+
+from lingtai_kernel.config_resolve import load_jsonc
+
+
+def _load(tmp_path, body: str) -> dict:
+    p = tmp_path / "cfg.jsonc"
+    p.write_text(body, encoding="utf-8")
+    return load_jsonc(p)
+
+
+def test_load_jsonc_preserves_comma_bracket_inside_strings(tmp_path):
+    """Regression for #725: ", ]" / ", }" inside string values must survive."""
+    data = _load(tmp_path, '{"pattern": "a, ]b", "cmd": "x, }y"}')
+    assert data == {"pattern": "a, ]b", "cmd": "x, }y"}
+
+
+def test_load_jsonc_preserves_comma_whitespace_bracket_inside_strings(tmp_path):
+    """The \\s* span (including newlines) inside a string is untouched."""
+    body = '{"snippet": "end,\\n  ]"}'
+    data = _load(tmp_path, body)
+    assert data == {"snippet": "end,\n  ]"}
+
+
+def test_load_jsonc_still_strips_trailing_commas(tmp_path):
+    data = _load(tmp_path, '{"a": [1, 2, ], "b": {"c": 1, }, }')
+    assert data == {"a": [1, 2], "b": {"c": 1}}
+
+
+def test_load_jsonc_trailing_comma_before_comment(tmp_path):
+    """Comments strip before the comma pass, so ", // note\\n}" collapses."""
+    data = _load(tmp_path, '{"a": 1,  // note\n}')
+    assert data == {"a": 1}
+
+
+def test_load_jsonc_comment_and_comma_features_compose_with_strings(tmp_path):
+    body = '''{
+      "url": "https://host/x",  // comment after a URL value
+      "pattern": "match, ]end",
+      "list": [1, 2, ],
+    }'''
+    data = _load(tmp_path, body)
+    assert data == {
+        "url": "https://host/x",
+        "pattern": "match, ]end",
+        "list": [1, 2],
+    }
+
+
+def test_load_jsonc_escaped_quote_before_comma_bracket(tmp_path):
+    """Escaped quotes inside a string don't break the string tokenizer."""
+    data = _load(tmp_path, '{"v": "end \\", ]"}')
+    assert data == {"v": 'end ", ]'}


### PR DESCRIPTION
## Summary

`load_jsonc()` protected string literals from `//` comment stripping via its string tokenizer, but then ran the trailing-comma regex (`re.sub(r',\s*([}\]])', r'\1', text)`) over the reassembled text — string literals included. Any string value containing `, ]` or `, }` (with any whitespace, including newlines) was silently corrupted: `{"pattern": "a, ]b"}` loaded as `{'pattern': 'a]b'}` with no error. This affected every `load_jsonc` caller (preset loading and the `migrate/m0xx` modules, where rewrite-on-migrate could bake the corruption back to disk).

This PR moves both JSONC normalisations into a shared `_clean_jsonc_chunk` helper applied only to the non-string spans of the existing tokenizer, deletes the whole-text pass, and updates the docstring. Within each chunk, comments strip before the comma pass so `,  // note` followed by `]` on the next line still collapses. Genuine trailing commas are handled identically: in well-formed JSONC a real trailing comma and its closing bracket can never be separated by a string literal, so per-chunk substitution is equivalent for all legal inputs.

Closes #725

## Testing

Added `tests/test_config_resolve_jsonc.py` with direct unit coverage of `load_jsonc` (previously only exercised indirectly): the `, ]` / `, }` regression case, comma+newline+bracket inside a string, legitimate trailing-comma stripping, trailing comma before a `//` comment, a combined URL/comment/comma fixture, and an escaped-quote case.

Ran `pytest tests/test_config_resolve_jsonc.py tests/test_presets.py tests/test_kernel_migrate.py` — 111 passed.

## Caveats

Malformed inputs like `[1, "x" ]` with the comma actually dangling across a string were never legal; previously they could be silently patched, now they raise `json.JSONDecodeError` (arguably an improvement, noted in the issue's risk analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
