### PR TITLE
fix: merge shipped translations in register_strings() instead of masking them (#735)

### DIFF
--- a/src/lingtai_kernel/i18n/__init__.py
+++ b/src/lingtai_kernel/i18n/__init__.py
@@ -16,6 +16,8 @@ import json
 from pathlib import Path
 
 _DIR = Path(__file__).parent
+# Invariant: an entry for `lang` means the shipped `<lang>.json` (if any)
+# has already been merged in. All writes must go through _load().
 _CACHE: dict[str, dict[str, str]] = {}
 
 
@@ -35,9 +37,12 @@ def register_strings(lang: str, strings: dict[str, str]) -> None:
 
     Called by lingtai to inject non-English translations into the
     kernel's cache so that kernel-level t() calls resolve correctly.
-    Merges into any existing entries for the language.
+    Loads the kernel-shipped table for `lang` first (if any) so that
+    registration merges into it rather than masking it, regardless of
+    whether register_strings() or t() runs first. Registered strings
+    override shipped ones on key collision.
     """
-    table = _CACHE.setdefault(lang, {})
+    table = _load(lang)
     table.update(strings)
 
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,5 +1,8 @@
 """Tests for lingtai_kernel.i18n."""
-from lingtai_kernel.i18n import t
+import pytest
+
+import lingtai_kernel.i18n
+from lingtai_kernel.i18n import register_strings, t
 
 
 class TestT:
@@ -105,3 +108,44 @@ class TestFallbackToEnglish:
     def test_wen_falls_back_for_tool_reasoning_schema(self):
         result = t("wen", "tool.reasoning_description")
         assert result == t("en", "tool.reasoning_description")
+
+
+class TestRegisterStrings:
+    """register_strings() must merge into the shipped table, not mask it."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_caches(self):
+        """Reset both i18n caches so ordering can be controlled per test."""
+        import lingtai.i18n
+
+        lingtai_kernel.i18n._CACHE.clear()
+        lingtai.i18n._CACHE.clear()
+        yield
+        lingtai_kernel.i18n._CACHE.clear()
+        lingtai.i18n._CACHE.clear()
+
+    def test_register_strings_before_t_keeps_shipped_translations(self):
+        register_strings("zh", {"custom.key": "自定义"})
+        assert t("zh", "system.context_unknown") == "未知"
+        assert t("zh", "custom.key") == "自定义"
+
+    def test_register_strings_overrides_shipped_key(self):
+        register_strings("zh", {"system.context_unknown": "OVERRIDE"})
+        assert t("zh", "system.context_unknown") == "OVERRIDE"
+
+    def test_register_strings_for_unshipped_language(self):
+        register_strings("xx", {"system.context_unknown": "XX"})
+        assert t("xx", "system.context_unknown") == "XX"
+        # Unregistered keys still fall back to English.
+        assert t("xx", "system.stuck_revive", ts="T", err_desc="E") == t(
+            "en", "system.stuck_revive", ts="T", err_desc="E"
+        )
+
+    @pytest.mark.parametrize("lang", ["zh", "wen"])
+    def test_lingtai_t_first_does_not_mask_kernel_translations(self, lang):
+        """lingtai.i18n.t() first (via _sync_to_kernel) must not mask
+        the kernel-shipped table for that language."""
+        import lingtai.i18n
+
+        lingtai.i18n.t(lang, "read.description")
+        assert t(lang, "system.context_unknown") == "未知"


### PR DESCRIPTION
## Summary

`lingtai_kernel.i18n.register_strings()` seeded the language cache with `_CACHE.setdefault(lang, {})`, so if it ran before the first kernel `t(lang, ...)` call for a language, `_load()` later treated the language as already cached and never read the kernel-shipped `zh.json` / `wen.json`. Since `lingtai.i18n.t()` calls `register_strings()` as a side effect of its first load per language, a lingtai-first call order silently downgraded all 26 kernel-shipped `zh` strings (and all `wen` strings) to English for the lifetime of the process.

Fix: `register_strings()` now merges into `_load(lang)` so the shipped table is loaded first. Registered strings still override shipped ones on key collision, and the non-shipped-language path is unchanged (`_load()` returns and caches an empty dict). Also documented the `_CACHE` invariant: an entry for `lang` means the shipped `<lang>.json` (if any) has been merged in.

Closes #735

## Testing

- Reproduced the bug on `main` in a fresh interpreter (`lingtai.i18n.t("zh", ...)` first, then `lingtai_kernel.i18n.t("zh", "system.context_unknown")` returned `"unavailable"`); after the fix it returns `"未知"`.
- Added regression tests in `tests/test_i18n.py` (`TestRegisterStrings`): register-before-t keeps shipped translations, registered strings override shipped keys, unshipped-language path unchanged with English fallback, and the cross-package lingtai-first ordering for both `zh` and `wen`.
- `python -m pytest tests/test_i18n.py -x -q` — 28 passed.

## Caveats

- The new cross-package ordering tests clear both modules' caches in an autouse fixture (module-level caches otherwise make ordering untestable) and restore-clear on teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
