### PR TITLE
fix: sanitize attachment filenames before writing to disk in IMAP read action (#726)

### DIFF
--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -68,6 +68,35 @@ def _opt_str(value: object) -> str | None:
     return value
 
 
+def _safe_attachment_name(filename: str) -> str:
+    """Reduce a sender-controlled filename to a safe basename.
+
+    Attachment filenames come straight from the MIME headers of inbound
+    mail, so they can contain ``..`` traversal segments or be absolute
+    paths (a ``pathlib`` join with an absolute right-hand side discards
+    the left side entirely). Strip all directory components — normalizing
+    ``\\`` to ``/`` first so Windows-style separators cannot survive on
+    POSIX — and fall back to ``"attachment"`` for empty or degenerate
+    dot names.
+    """
+    name = Path(filename.replace("\\", "/")).name
+    if name in ("", ".", ".."):
+        return "attachment"
+    return name
+
+
+def _dedupe_name(name: str, seen: set[str]) -> str:
+    """Suffix ``name`` with ``' (1)'``, ``' (2)'``, ... before the extension
+    until it no longer collides with an entry in ``seen``."""
+    if name not in seen:
+        return name
+    stem, suffix = Path(name).stem, Path(name).suffix
+    counter = 1
+    while f"{stem} ({counter}){suffix}" in seen:
+        counter += 1
+    return f"{stem} ({counter}){suffix}"
+
+
 # ---------------------------------------------------------------------------
 # Tool schema
 # ---------------------------------------------------------------------------
@@ -543,14 +572,23 @@ class IMAPMailManager:
             )
             persist_dir.mkdir(parents=True, exist_ok=True)
 
-            # Save attachments to disk
+            # Save attachments to disk. Filenames are sender-controlled:
+            # sanitize to a basename (path traversal) and dedupe within the
+            # message so duplicate names do not silently overwrite each other.
+            # Re-reads overwrite the same files, keeping reads idempotent.
             attachments_raw = data.get("attachments_raw", [])
             saved_attachments: list[dict] = []
+            seen_names: set[str] = set()
             for att in attachments_raw:
-                att_path = persist_dir / att["filename"]
+                safe_name = _dedupe_name(
+                    _safe_attachment_name(att["filename"]), seen_names
+                )
+                seen_names.add(safe_name)
+                att_path = persist_dir / safe_name
                 att_path.write_bytes(att["data"])
                 saved_attachments.append({
-                    "filename": att["filename"],
+                    "filename": safe_name,
+                    "original_filename": att["filename"],
                     "content_type": att["content_type"],
                     "size": len(att["data"]),
                     "path": str(att_path),

--- a/tests/test_imap_read_attachment_sanitization.py
+++ b/tests/test_imap_read_attachment_sanitization.py
@@ -1,0 +1,193 @@
+"""Regression tests: sanitize sender-controlled attachment filenames on read.
+
+An inbound email's MIME filename is attacker-controlled; without sanitization
+a name like ``../../evil.txt`` (or an absolute path, which a pathlib join
+replaces entirely) escapes the ``imap/{address}/{folder}/{uid}/`` persist dir.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.imap.manager import (
+    IMAPMailManager,
+    _dedupe_name,
+    _safe_attachment_name,
+)
+
+
+class FakeAccount:
+    address = "me@example.com"
+
+    def __init__(self, attachments_raw: list[dict]) -> None:
+        self._attachments_raw = attachments_raw
+
+    def fetch_full(self, folder: str, uid: str) -> dict:
+        return {
+            "from": "Sender <sender@example.com>",
+            "from_address": "sender@example.com",
+            "subject": "Hello",
+            "body": "See attached.",
+            "attachments_raw": self._attachments_raw,
+        }
+
+
+class FakeService:
+    def __init__(self, account: FakeAccount) -> None:
+        self.default_account = account
+        self._account = account
+
+    def get_account(self, address: str | None):
+        return self._account
+
+
+def _read(tmp_path: Path, attachments_raw: list[dict]) -> tuple[dict, Path]:
+    manager = IMAPMailManager(
+        FakeService(FakeAccount(attachments_raw)),
+        working_dir=tmp_path,
+        tcp_alias="/tmp/imap-bridge",
+        on_inbound=lambda payload: None,
+    )
+    result = manager.handle({
+        "action": "read",
+        "email_id": "me@example.com:INBOX:42",
+    })
+    persist_dir = tmp_path / "imap" / "me@example.com" / "INBOX" / "42"
+    return result, persist_dir
+
+
+def _all_files(root: Path) -> set[Path]:
+    return {p for p in root.rglob("*") if p.is_file()}
+
+
+# ---------------------------------------------------------------------------
+# _safe_attachment_name unit tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("raw,expected", [
+    ("report.pdf", "report.pdf"),
+    ("../../../evil.txt", "evil.txt"),
+    ("/tmp/evil.txt", "evil.txt"),
+    ("C:\\evil.txt", "evil.txt"),
+    ("..\\..\\evil.txt", "evil.txt"),
+    ("nested/dir/file.txt", "file.txt"),
+    ("", "attachment"),
+    (".", "attachment"),
+    ("..", "attachment"),
+    ("../", "attachment"),
+    (".bashrc", ".bashrc"),
+])
+def test_safe_attachment_name(raw: str, expected: str):
+    assert _safe_attachment_name(raw) == expected
+
+
+def test_dedupe_name_suffixes_before_extension():
+    assert _dedupe_name("report.pdf", set()) == "report.pdf"
+    assert _dedupe_name("report.pdf", {"report.pdf"}) == "report (1).pdf"
+    assert _dedupe_name(
+        "report.pdf", {"report.pdf", "report (1).pdf"}
+    ) == "report (2).pdf"
+    assert _dedupe_name("attachment", {"attachment"}) == "attachment (1)"
+
+
+# ---------------------------------------------------------------------------
+# _read integration tests
+# ---------------------------------------------------------------------------
+
+def test_traversal_filename_is_confined(tmp_path: Path):
+    result, persist_dir = _read(tmp_path, [{
+        "filename": "../../../evil.txt",
+        "content_type": "text/plain",
+        "data": b"payload",
+    }])
+
+    assert result["status"] == "ok"
+    assert (persist_dir / "evil.txt").read_bytes() == b"payload"
+    # Nothing escaped the persist dir.
+    for f in _all_files(tmp_path):
+        assert f.is_relative_to(persist_dir)
+    saved = result["emails"][0]["attachments"][0]
+    assert saved["path"] == str(persist_dir / "evil.txt")
+
+
+def test_absolute_filename_is_confined(tmp_path: Path):
+    result, persist_dir = _read(tmp_path, [{
+        "filename": "/tmp/evil.txt",
+        "content_type": "text/plain",
+        "data": b"abs",
+    }])
+
+    assert result["status"] == "ok"
+    assert (persist_dir / "evil.txt").read_bytes() == b"abs"
+    assert not Path("/tmp/evil.txt").exists() or Path(
+        "/tmp/evil.txt"
+    ).read_bytes() != b"abs"
+
+
+def test_backslash_traversal_is_confined(tmp_path: Path):
+    result, persist_dir = _read(tmp_path, [{
+        "filename": "..\\..\\evil.txt",
+        "content_type": "text/plain",
+        "data": b"win",
+    }])
+
+    assert result["status"] == "ok"
+    assert (persist_dir / "evil.txt").read_bytes() == b"win"
+    for f in _all_files(tmp_path):
+        assert f.is_relative_to(persist_dir)
+
+
+def test_empty_and_dot_filenames_fall_back(tmp_path: Path):
+    result, persist_dir = _read(tmp_path, [
+        {"filename": "", "content_type": "text/plain", "data": b"a"},
+        {"filename": ".", "content_type": "text/plain", "data": b"b"},
+        {"filename": "..", "content_type": "text/plain", "data": b"c"},
+        {"filename": "../", "content_type": "text/plain", "data": b"d"},
+    ])
+
+    assert result["status"] == "ok"
+    assert (persist_dir / "attachment").read_bytes() == b"a"
+    assert (persist_dir / "attachment (1)").read_bytes() == b"b"
+    assert (persist_dir / "attachment (2)").read_bytes() == b"c"
+    assert (persist_dir / "attachment (3)").read_bytes() == b"d"
+
+
+def test_duplicate_filenames_do_not_overwrite(tmp_path: Path):
+    result, persist_dir = _read(tmp_path, [
+        {"filename": "report.pdf", "content_type": "application/pdf",
+         "data": b"first"},
+        {"filename": "report.pdf", "content_type": "application/pdf",
+         "data": b"second"},
+    ])
+
+    assert result["status"] == "ok"
+    assert (persist_dir / "report.pdf").read_bytes() == b"first"
+    assert (persist_dir / "report (1).pdf").read_bytes() == b"second"
+
+
+def test_subdirectory_filename_does_not_error(tmp_path: Path):
+    # Regression: 'nested/dir/file.txt' used to raise FileNotFoundError
+    # (parent dir missing) and abort the whole read call.
+    result, persist_dir = _read(tmp_path, [{
+        "filename": "nested/dir/file.txt",
+        "content_type": "text/plain",
+        "data": b"deep",
+    }])
+
+    assert result["status"] == "ok"
+    assert (persist_dir / "file.txt").read_bytes() == b"deep"
+
+
+def test_saved_metadata_reflects_disk_name(tmp_path: Path):
+    result, persist_dir = _read(tmp_path, [{
+        "filename": "../../../evil.txt",
+        "content_type": "text/plain",
+        "data": b"meta",
+    }])
+
+    saved = result["emails"][0]["attachments"][0]
+    assert saved["filename"] == Path(saved["path"]).name == "evil.txt"
+    assert saved["original_filename"] == "../../../evil.txt"
+    assert saved["size"] == 4
+    assert saved["content_type"] == "text/plain"


### PR DESCRIPTION
## Summary

`IMAPMailManager._read` wrote email attachments to disk using the sender-controlled MIME filename verbatim (`persist_dir / att["filename"]`). A filename containing `..` segments escaped the `imap/{address}/{folder}/{uid}/` persist directory, and an absolute filename replaced it entirely (pathlib join semantics), letting any inbound email write attacker-controlled bytes anywhere the agent process can write.

Changes in `src/lingtai/mcp_servers/imap/manager.py`:

- `_safe_attachment_name` helper: strips all directory components (normalizing `\` to `/` first so Windows-style traversal cannot survive on POSIX) and falls back to `"attachment"` for empty/degenerate dot names — same pattern already used by the wechat and telegram sinks.
- `_dedupe_name` helper: suffixes ` (1)`, ` (2)`, ... before the extension so duplicate attachment names within one message no longer silently overwrite each other. Dedupe is per-`_read`-call, so re-reading the same email overwrites the same files (idempotent, no `report (1).pdf` churn).
- `saved_attachments` now reports the actual on-disk name in `filename` (consistent with `path`) and preserves the raw sender string as `original_filename`.
- Side effect fix: filenames with subdirectory components (`nested/dir/file.txt`) no longer abort the whole `read` call with `FileNotFoundError`.

No migration needed; only newly read emails go through the new path.

Closes #726

## Testing

Added `tests/test_imap_read_attachment_sanitization.py`: unit tests for both helpers (traversal, absolute, backslash, empty/dot inputs) plus `_read` integration tests using a fake account/service and `tmp_path` (confinement walk of the working dir, dedupe payload integrity, subdirectory regression, metadata consistency).

Ran `pytest tests/test_imap_read_attachment_sanitization.py tests/test_imap_reply_attachments.py tests/test_imap_empty_args.py` with the repo venv: 33 passed.

## Caveats

- The issue suggests back-porting the backslash normalization to `wechat/media.py` in a follow-up; not done here to keep this PR focused on the IMAP sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
