### PR TITLE
fix: treat naive Z-suffix timestamps as UTC in retention _parse_iso (#729)

### DIFF
--- a/src/lingtai_kernel/maintenance/retention.py
+++ b/src/lingtai_kernel/maintenance/retention.py
@@ -770,9 +770,11 @@ def _parse_iso(value: object) -> datetime | None:
     for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%z"):
         try:
             parsed = datetime.strptime(value, fmt)
-            return parsed.astimezone(timezone.utc)
         except ValueError:
             continue
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
     return None
 
 

--- a/tests/test_retention_report.py
+++ b/tests/test_retention_report.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
 from lingtai_kernel.maintenance import RetentionOptions, TargetError, report_to_dict, scan_retention
+from lingtai_kernel.maintenance.retention import _parse_iso
 
 
 NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
@@ -251,6 +253,67 @@ def test_symlink_candidate_is_skipped(tmp_path):
     assert data["classes"]["sent_mail"]["candidates"] == 0
     assert data["classes"]["sent_mail"]["skipped"] == 1
     assert data["skipped"][0]["reason"] == "symlink"
+
+
+@pytest.fixture
+def set_tz(monkeypatch):
+    if not hasattr(time, "tzset"):
+        pytest.skip("time.tzset is unavailable on this platform")
+
+    def _set(tz: str) -> None:
+        monkeypatch.setenv("TZ", tz)
+        time.tzset()
+
+    yield _set
+    monkeypatch.undo()
+    time.tzset()
+
+
+@pytest.mark.parametrize("tz", ["UTC", "Asia/Shanghai", "America/Los_Angeles"])
+def test_parse_iso_z_suffix_is_utc_regardless_of_local_tz(set_tz, tz):
+    set_tz(tz)
+
+    assert _parse_iso("2026-06-05T12:00:00Z") == datetime(
+        2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc
+    )
+
+
+def test_parse_iso_explicit_offset_normalized_to_utc():
+    assert _parse_iso("2026-06-05T20:00:00+08:00") == datetime(
+        2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.parametrize("value", [None, 123, "garbage", "2026-06-05"])
+def test_parse_iso_rejects_non_conforming_values(value):
+    assert _parse_iso(value) is None
+
+
+@pytest.mark.parametrize("tz", ["Asia/Shanghai", "America/Los_Angeles"])
+def test_daemon_finished_at_near_cutoff_not_shifted_by_host_tz(tmp_path, set_tz, tz):
+    set_tz(tz)
+    agent = _agent(tmp_path)
+    _daemon(agent, finished_at=NOW - timedelta(days=30) + timedelta(hours=4))
+
+    data = _report(agent)
+
+    assert data["classes"]["terminal_daemon_run"]["candidates"] == 0
+    reasons = {item["reason"] for item in data["protected"]}
+    assert "newer_than_cutoff" in reasons
+
+
+def test_daemon_age_fields_match_finished_at(tmp_path, set_tz):
+    set_tz("Asia/Shanghai")
+    agent = _agent(tmp_path)
+    finished_at = NOW - timedelta(days=60)
+    _daemon(agent, finished_at=finished_at)
+
+    data = _report(agent)
+
+    candidate = data["candidates"][0]
+    assert candidate["age_source"] == "daemon_finished_at"
+    assert candidate["timestamp"] == finished_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert candidate["age_days"] == pytest.approx(60.0)
 
 
 def test_json_report_is_deterministic(tmp_path):


### PR DESCRIPTION
## Summary

`_parse_iso` in `src/lingtai_kernel/maintenance/retention.py` parsed the daemon `finished_at` format `%Y-%m-%dT%H:%M:%SZ` into a naive `datetime` and then called `.astimezone(timezone.utc)`, which interprets a naive value as host-local time. The daemon writer always emits UTC "Z" strings, so every `daemon_finished_at`-sourced run-dir age in retention reports was shifted by the host's UTC offset — flipping run dirs near the `older_than_days` boundary to false candidates (east of UTC) or false `newer_than_cutoff` protections (west of UTC), and skewing the reported `age_seconds`/`age_days`/`timestamp` fields.

The fix stamps naive parses with `tzinfo=timezone.utc` (matching the writer contract in `DaemonRunDir._now_iso` and the sibling `_parse_mail_id_time` / `_parse_run_id_time` helpers) and keeps `astimezone(timezone.utc)` normalization only for aware parses from the `%z` format. Read-side only; no schema, report shape, or reason-string changes.

Closes #729

## Testing

- Added to `tests/test_retention_report.py`:
  - `test_parse_iso_z_suffix_is_utc_regardless_of_local_tz` (parametrized over `UTC`, `Asia/Shanghai`, `America/Los_Angeles` via a `TZ` + `time.tzset` fixture, skipped where `tzset` is unavailable)
  - `test_parse_iso_explicit_offset_normalized_to_utc`
  - `test_parse_iso_rejects_non_conforming_values` (`None`, `123`, `"garbage"`, date-only)
  - `test_daemon_finished_at_near_cutoff_not_shifted_by_host_tz` (integration: terminal run 4h inside the 30-day window stays `newer_than_cutoff` under non-UTC TZ)
  - `test_daemon_age_fields_match_finished_at` (timestamp round-trips and `age_days` is exact under `Asia/Shanghai`)
- `python -m pytest tests/test_retention_report.py -q`: 28 passed.
- Verified the new TZ-sensitive tests fail against the unfixed code (4 failures with the fix stashed) and pass with it.
- Audited `astimezone(timezone.utc)` call sites under `src/`; the only other user-facing site (`src/lingtai/mcp_servers/telegram/account.py`) already guards naive values with `tzinfo is None` → `replace`.

## Caveats

- The `America/Los_Angeles` case of the near-cutoff integration test also passes pre-fix (west-of-UTC skew errs toward protection); the `Asia/Shanghai` case is the regression guard for the candidate-flip direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
