### PR TITLE
fix(telegram): exclude the bot's own replies from check unread counts (#715)

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -1508,6 +1508,10 @@ class TelegramManager:
         # Group by chat_id for conversation view
         conversations: dict[int, dict] = {}
         for msg in messages:
+            # Sent records carry a ``to`` target; inbox records carry ``chat``.
+            # This is the same direction test ``_read`` uses via ``_direction``.
+            outgoing = isinstance(msg.get("to"), dict)
+
             # Extract chat_id from inbox-style or sent-style records
             chat = msg.get("chat")
             if isinstance(chat, dict):
@@ -1527,7 +1531,10 @@ class TelegramManager:
                     "unread": 0,
                 }
             conversations[cid]["total"] += 1
-            if msg.get("id") and msg["id"] not in read_ids:
+            # Unread counts incoming messages only — outgoing ones are things
+            # the agent already produced, so counting them would inflate the
+            # counter with the bot's own replies and it could never drain.
+            if not outgoing and msg.get("id") and msg["id"] not in read_ids:
                 conversations[cid]["unread"] += 1
 
         return {

--- a/tests/test_telegram_check_unread.py
+++ b/tests/test_telegram_check_unread.py
@@ -1,0 +1,133 @@
+"""Regression tests for Telegram ``check`` unread accounting.
+
+The bot's own outgoing replies live in ``sent/`` and must never be counted
+as unread by ``check`` — otherwise the counter is inflated by messages the
+agent already produced and can never drain (issue #715).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+
+
+class _FakeAccount:
+    alias = "main"
+
+    def send_message(self, chat_id: int, text: str, **_kwargs: Any) -> dict[str, Any]:
+        return {"message_id": 9001, "chat": {"id": chat_id}, "text": text}
+
+    def set_message_reaction(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def send_chat_action(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class _FakeService:
+    default_account = _FakeAccount()
+
+    def get_account(self, _alias: str) -> _FakeAccount:
+        return self.default_account
+
+
+def _manager(workdir: Path) -> TelegramManager:
+    return TelegramManager(
+        _FakeService(),
+        working_dir=workdir,
+        on_inbound=lambda _event: None,
+    )
+
+
+def _write_inbox_message(
+    workdir: Path,
+    *,
+    account: str = "main",
+    chat_id: int = 123,
+    message_id: int = 53,
+    text: str = "hello",
+) -> str:
+    compound_id = f"{account}:{chat_id}:{message_id}"
+    msg_dir = workdir / "telegram" / account / "inbox" / f"uuid-{chat_id}-{message_id}"
+    msg_dir.mkdir(parents=True, exist_ok=True)
+    (msg_dir / "message.json").write_text(
+        json.dumps(
+            {
+                "id": compound_id,
+                "from": {"username": "alice"},
+                "chat": {"id": chat_id, "type": "private"},
+                "date": "2026-05-21T23:53:00Z",
+                "text": text,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return compound_id
+
+
+def _write_sent_message(
+    workdir: Path,
+    *,
+    account: str = "main",
+    chat_id: int = 123,
+    message_id: int = 900,
+    text: str = "on it",
+    date: str = "2026-05-21T23:54:00Z",
+) -> str:
+    compound_id = f"{account}:{chat_id}:{message_id}"
+    msg_dir = workdir / "telegram" / account / "sent" / f"uuid-sent-{message_id}"
+    msg_dir.mkdir(parents=True, exist_ok=True)
+    (msg_dir / "message.json").write_text(
+        json.dumps(
+            {
+                "id": compound_id,
+                "to": {"chat_id": chat_id},
+                "date": date,
+                "text": text,
+                "status": "sent",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return compound_id
+
+
+def _conversation(result: dict, chat_id: int) -> dict:
+    for conv in result["messages"]:
+        if conv["chat_id"] == chat_id:
+            return conv
+    raise AssertionError(f"no conversation for chat_id={chat_id}: {result}")
+
+
+def test_check_does_not_count_outgoing_replies_as_unread(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    # One incoming message that has already been read...
+    incoming_id = _write_inbox_message(workdir)
+    _manager(workdir)._mark_read("main", [incoming_id])
+    # ...and several of the bot's own replies in the same chat.
+    for i in range(5):
+        _write_sent_message(workdir, message_id=900 + i)
+
+    result = _manager(workdir).handle({"action": "check", "account": "main"})
+
+    conv = _conversation(result, 123)
+    # 1 incoming + 5 outgoing all appear in the conversation view...
+    assert conv["total"] == 6
+    # ...but the read incoming and every outgoing reply drain to zero unread.
+    assert conv["unread"] == 0
+
+
+def test_check_counts_only_unread_incoming(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    _write_inbox_message(workdir, message_id=53, text="first")
+    _write_inbox_message(workdir, message_id=54, text="second")
+    _write_sent_message(workdir, message_id=900)
+
+    result = _manager(workdir).handle({"action": "check", "account": "main"})
+
+    conv = _conversation(result, 123)
+    assert conv["total"] == 3
+    # Two unread incoming; the outgoing reply is not counted.
+    assert conv["unread"] == 2


### PR DESCRIPTION
## Summary

- **Root cause:** `TelegramManager._check` builds the conversation view from `inbox + sent` and increments `unread` for any message id not in `read.json`. `_send` persists every outgoing reply with a compound id but never records it in `read.json`, so the bot's own replies were counted as unread indefinitely. This is why chats whose last message is the bot's own reply still reported large, monotonically climbing `unread` counts (issue #715, causes observed across 8 networks).
- **Fix, at the owning layer:** count only *incoming* messages toward `unread`. Direction is decided by the same test `_read` already uses — a sent record carries a `to` target, an inbox record carries `chat`/`from`. This ports the WeChat manager's existing, intentional behavior (`_handle_check`: "Unread counts incoming messages only — outgoing ones are things the agent already produced") to Telegram, so the two addons now agree.
- Outgoing replies still appear in the conversation `total` and in `read` output; they simply no longer inflate `unread`.

### Non-goals (deliberately out of scope)

Issue #715 bundles three further enhancements that are separate behavior/surface changes, not part of this defect, and are intentionally **not** in this PR:
- a per-chat last-read watermark so a large *incoming* backlog fully drains past the `read` `limit` (cause #2 in the report);
- a new `mark_read` action;
- a `last_incoming_date` field in `check` output.

Because cause #2 (the read-`limit` drain for genuinely-unread incoming backlogs) remains, this is a partial fix.

## Validation

Environment: repo `.venv` (pytest 9.0.3, py3.11), run against the worktree source via `PYTHONPATH=<worktree>/src`.

Failing-first (fix stashed, so `_check` still counts outgoing):

```
$ python -m pytest tests/test_telegram_check_unread.py -x -q
F
>       assert conv["unread"] == 0
E       assert 5 == 0
tests/test_telegram_check_unread.py:119: AssertionError
1 failed in 0.32s
```

After the fix — new regression test plus the existing Telegram suites:

```
$ python -m pytest tests/test_telegram_check_unread.py -q
..                                                                       [100%]
2 passed in 0.30s

$ python -m pytest tests/test_telegram_notification_read_state.py \
      tests/test_telegram_rich_formatting.py \
      tests/test_telegram_check_unread.py -q
......................................                                   [100%]
38 passed in 0.49s
```

Partial fix for #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)
