### PR TITLE
fix(telegram): surface boot exception via status action instead of stderr (#711)

### DIFF
--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -138,3 +138,11 @@ Important behavior notes:
   message was delivered.
 - A duplicate identical send returns `{'status': 'blocked'}`; treat that as
   'already sent', not as a transient error to retry.
+- If a call fails with `Telegram manager not initialized — server boot failed`,
+  the addon could not initialize at launch (most often a missing
+  `LINGTAI_TELEGRAM_CONFIG`, an unreadable config file, or an invalid bot
+  token). Call `telegram action=status`: it works even while the manager is
+  dead and returns the captured `boot_error` (the underlying exception) plus a
+  redacted config summary, so you can act on the real cause instead of a
+  restart. Fix the config, then `system(action="refresh")` to re-launch the
+  addon.

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -196,7 +196,7 @@ SCHEMA = {
                 "send", "check", "read", "reply", "search",
                 "delete", "edit",
                 "contacts", "add_contact", "remove_contact",
-                "accounts", "manual",
+                "accounts", "status", "manual",
             ],
             "description": (
                 "send: send message to a chat (chat_id, text; optional media, reply_markup, placeholder, chat_action, parse_mode/entities). "
@@ -214,6 +214,9 @@ SCHEMA = {
                 "To receive messages from that user, their Telegram user ID must also be in allowed_users. "
                 "remove_contact: remove a contact (alias or chat_id). "
                 "accounts: list configured bot accounts. "
+                "status: report addon health (manager/service state, redacted "
+                "config summary) and, when boot failed, the inline boot_error "
+                "exception; safe to call even when the manager is dead. "
                 + _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME)
             ),
         },
@@ -329,6 +332,8 @@ DESCRIPTION = (
     "'delete'/'edit' to modify bot messages. "
     "'contacts' to manage saved contacts. "
     "'accounts' to list configured bot accounts. "
+    "'status' to check addon health and read the inline boot_error when the "
+    "manager failed to initialize (works even when the manager is dead). "
     "Voice messages are automatically transcribed using Whisper (local) and delivered as text. "
     "Rich feedback: automatic typing indicators, emoji reactions (👀 seen, ✅ done), "
     "and progress messages for long-running tasks."

--- a/src/lingtai/mcp_servers/telegram/server.py
+++ b/src/lingtai/mcp_servers/telegram/server.py
@@ -344,6 +344,15 @@ the allow-list is reloaded.
 def _troubleshooting_markdown() -> str:
     return """# lingtai-telegram troubleshooting
 
+## `Telegram manager not initialized — server boot failed`
+
+The addon failed to initialize at launch, so no message can be sent or received
+until it is fixed. Call `telegram action=status`: unlike the other actions it
+answers even while the manager is dead, and it returns the captured `boot_error`
+(the underlying exception, e.g. a missing config path or invalid token) plus a
+redacted config summary. Fix the reported cause, then `system(action="refresh")`
+to re-launch the addon. You do not need to read the server's stderr.
+
 ## `LINGTAI_TELEGRAM_CONFIG env var not set`
 
 Set `LINGTAI_TELEGRAM_CONFIG` to the config JSON path. Relative paths resolve
@@ -665,9 +674,56 @@ def build_manager() -> tuple[TelegramManager, Path]:
 # MCP server
 # ---------------------------------------------------------------------------
 
-def build_server(manager: TelegramManager | None) -> Server:
+async def _dispatch_tool_call(
+    manager: TelegramManager | None,
+    boot_error: str | None,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Route one ``telegram`` tool call to a result dict.
+
+    The ``status`` action is handled here rather than in TelegramManager
+    because it must answer even when eager boot failed and ``manager`` is
+    None — that is precisely the case an agent needs diagnosed. When boot
+    failed, the caught exception is surfaced inline as ``boot_error`` so the
+    agent can act on it (issue #711: the old message told the agent to "check
+    stderr", which an agent cannot read).
+    """
+    if arguments.get("action") == "status":
+        payload = _safe_status_payload(manager)
+        # The boot exception is the single most actionable field for a dead
+        # manager; carry it inline instead of stranding it on stderr.
+        payload["boot_error"] = boot_error
+        return payload
+    if manager is None:
+        detail = boot_error or (
+            "underlying exception was not captured (most often missing "
+            "LINGTAI_TELEGRAM_CONFIG or invalid bot token)"
+        )
+        return {
+            "status": "error",
+            "error": (
+                "Telegram manager not initialized — server boot failed: "
+                f"{detail}. Call telegram action=status for the full boot "
+                "diagnostic."
+            ),
+        }
+    try:
+        return await asyncio.to_thread(manager.handle, arguments)
+    except Exception as e:
+        return {
+            "status": "error",
+            "error": str(e),
+            "error_type": type(e).__name__,
+        }
+
+
+def build_server(
+    manager: TelegramManager | None, boot_error: str | None = None,
+) -> Server:
     """Construct the MCP server. ``manager`` is None when eager start
-    failed; in that case every tool call returns an error explaining why."""
+    failed; in that case ``boot_error`` carries the captured exception so
+    ``telegram action=status`` can surface it, and every other tool call
+    returns an error pointing the agent at that status action."""
     server: Server = Server("lingtai-telegram", instructions=_SERVER_INSTRUCTIONS)
 
     @server.list_resources()
@@ -707,24 +763,7 @@ def build_server(manager: TelegramManager | None) -> Server:
     ) -> list[types.TextContent]:
         if name != "telegram":
             raise ValueError(f"unknown tool: {name!r}")
-        if manager is None:
-            result = {
-                "status": "error",
-                "error": (
-                    "Telegram manager not initialized — server boot failed. "
-                    "Check stderr for the underlying exception (most often "
-                    "missing LINGTAI_TELEGRAM_CONFIG or invalid bot token)."
-                ),
-            }
-        else:
-            try:
-                result = await asyncio.to_thread(manager.handle, arguments)
-            except Exception as e:
-                result = {
-                    "status": "error",
-                    "error": str(e),
-                    "error_type": type(e).__name__,
-                }
+        result = await _dispatch_tool_call(manager, boot_error, arguments)
         return [types.TextContent(
             type="text", text=json.dumps(result, ensure_ascii=False),
         )]
@@ -741,6 +780,7 @@ async def serve() -> None:
     so inbound messages flow before the host expects them."""
     manager: TelegramManager | None = None
     service_started = False
+    boot_error: str | None = None
     try:
         manager, _wd = build_manager()
         # The service starts the per-account poll threads.
@@ -752,8 +792,11 @@ async def serve() -> None:
             "eager start failed; tool calls will return errors until fixed: %s", e,
         )
         manager = None
+        # Capture the exception so telegram action=status can surface it
+        # inline (issue #711); the agent host cannot read our stderr.
+        boot_error = f"{type(e).__name__}: {e}"
 
-    server = build_server(manager)
+    server = build_server(manager, boot_error=boot_error)
     try:
         async with stdio_server() as (read_stream, write_stream):
             await server.run(

--- a/tests/test_telegram_boot_status.py
+++ b/tests/test_telegram_boot_status.py
@@ -1,0 +1,85 @@
+"""Regression tests for Telegram addon dead-on-boot diagnostics (issue #711).
+
+When eager boot fails the manager is None and every tool call used to return a
+static "check stderr" message — unactionable for an agent that cannot read the
+server's stderr, leaving the human channel permanently and opaquely dead. These
+tests pin the contract that the captured boot exception is surfaced inline
+through ``telegram action=status`` and that the dead-manager error for other
+actions cites the cause and points the agent at that status action.
+
+They drive the real registered MCP ``CallToolRequest`` handler so the whole
+dead-on-boot path is exercised end to end.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import mcp.types as types
+
+from lingtai.mcp_servers.telegram.server import (
+    _dispatch_tool_call,
+    build_server,
+)
+
+
+def _call(manager, boot_error, arguments) -> dict:
+    """Invoke the real telegram tool handler and return the decoded result."""
+    server = build_server(manager, boot_error=boot_error)
+    handler = server.request_handlers[types.CallToolRequest]
+    request = types.CallToolRequest(
+        method="tools/call",
+        params=types.CallToolRequestParams(name="telegram", arguments=arguments),
+    )
+    result = asyncio.run(handler(request))
+    return json.loads(result.root.content[0].text)
+
+
+def test_status_action_surfaces_boot_error_when_manager_dead():
+    """A dead manager still answers status with the captured boot exception."""
+    boot_error = "FileNotFoundError: Telegram config not found: /old/linux/path.json"
+
+    result = _call(None, boot_error, {"action": "status"})
+
+    # The actionable exception must be inline, not stranded on stderr.
+    assert result["boot_error"] == boot_error
+    assert result["manager_initialized"] is False
+    assert result["status"] == "degraded"
+
+
+def test_dead_manager_nonstatus_error_points_at_status_not_stderr():
+    """Non-status calls on a dead manager cite the boot cause and status action,
+    never the old unreadable 'check stderr' instruction."""
+    boot_error = "ValueError: LINGTAI_TELEGRAM_CONFIG env var not set"
+
+    result = _call(None, boot_error, {"action": "send"})
+
+    assert result["status"] == "error"
+    assert "check stderr" not in result["error"].lower()
+    assert boot_error in result["error"]
+    assert "action=status" in result["error"]
+
+
+def test_status_action_carries_none_boot_error_when_boot_succeeded():
+    """When boot succeeded there is no boot exception; boot_error is None."""
+
+    class _StubService:
+        _running = True
+
+    class _StubManager:
+        _service = _StubService()
+
+    result = _call(_StubManager(), None, {"action": "status"})
+
+    assert result["boot_error"] is None
+    assert result["manager_initialized"] is True
+    assert result["status"] == "ok"
+
+
+def test_dispatch_status_is_handled_before_manager_guard():
+    """Unit-level: status is answered by the server even with no boot_error,
+    independent of the manager, so it never falls through to 'unknown action'."""
+    result = asyncio.run(_dispatch_tool_call(None, None, {"action": "status"}))
+
+    assert "boot_error" in result
+    assert result["manager_initialized"] is False


### PR DESCRIPTION
## Summary

- Fix the Telegram addon's **permanent dead-on-boot** state (issue #711, symptom 1): the boot exception is now captured and surfaced inline instead of being logged to a stderr the agent cannot read.
- Add a `telegram action=status` action, handled at the server dispatch layer **before** the manager-is-None guard, so it answers even when eager boot failed — exactly the case an agent needs diagnosed. It returns the existing redacted `_safe_status_payload` plus an inline `boot_error` carrying the underlying exception.
- Rewrite the dead-manager error for all other actions to cite the captured cause and point at `telegram action=status`, replacing the unactionable "Check stderr for the underlying exception".
- Docs in lockstep: SKILL.md ERROR SURFACING note and the `lingtai://docs/troubleshooting` resource both explain the new status-based recovery flow (`fix config` then `system(action="refresh")`).

## Root cause

`serve()` caught the eager-start exception, logged it, and set `manager = None`, discarding the exception. `build_server`'s tool handler then returned a static "check stderr" message for every call. The agent host has no access to the server subprocess's stderr, so the primary human-communication channel was permanently and opaquely dead with a diagnostic the agent could not act on. The fix belongs at the server layer because that is the only layer that observes the boot failure — when boot fails the manager object does not exist, so this cannot live in `TelegramManager.handle`.

## Non-goals (deliberately out of scope — separate concerns)

Issue #711 bundles five lifecycle problems. This PR takes the smallest honest slice: making the dead-on-boot state **diagnosable and actionable**. It intentionally does **not** include:

- **Lazy re-init on next send** — an auto-recovery/self-heal behavior change; the taste here is to fail loud and let the operator refresh, not silently resurrect. Needs its own design justification.
- **`allow_user` action with hot reload** — a new mutation surface that writes the token-bearing config file; separate one-concern PR.
- **Send pre-flight (caption truncation / parse-mode auto-retry)** — silently altering or suppressing the agent's payload is a behavior change, not a diagnostics fix; the raw API error is already truthful.
- **Relative config paths in `init.json`** — lives in a different layer (agent init/migration).

Filing these as follow-ups keeps each behavior change reviewable on its own risk profile.

## Validation

Test framework note: the worktree's package resolves via the shared editable venv, so tests are run with the worktree `src/` explicitly on `PYTHONPATH`.

Failing-first — observed the pre-fix behavior directly (stashing the fix):

```
$ git stash push -- .../telegram/server.py .../telegram/manager.py
$ PYTHONPATH=.../src python3 -c "... build_server(None) ; drive CallToolRequest ..."
status -> Input validation error: 'status' is not one of ['send', 'check', 'read', 'reply', 'search', 'delete', 'edit', 'contacts', 'add_contact', 'remove_contact', 'accounts', 'manual']
send   -> {"status": "error", "error": "Telegram manager not initialized — server boot failed. Check stderr for the underlying exception (most often missing LINGTAI_TELEGRAM_CONFIG or invalid bot token)."}
```

Pre-fix `status` is rejected by the schema and `send` returns the unreadable "check stderr" message — the regression the new tests pin.

New regression test (post-fix):

```
$ PYTHONPATH=.../src python3 -m pytest tests/test_telegram_boot_status.py -x -q
....                                                                     [100%]
4 passed in 0.32s
```

Touched-module + adjacent suites (no regressions):

```
$ PYTHONPATH=.../src python3 -m pytest \
    tests/test_telegram_boot_status.py \
    tests/test_telegram_notification_read_state.py \
    tests/test_telegram_rich_formatting.py \
    tests/test_mcp_skill_manuals.py -q
..............................................................           [100%]
62 passed in 0.59s

$ PYTHONPATH=.../src python3 -m pytest tests/test_tool_executor.py tests/test_system_summarize.py -q
............................................................................................ [100%]
92 passed in 1.20s
```

`git diff --check`: clean.

Partial fix for #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)
