### PR TITLE
fix(nudge): run kernel_version PyPI probe off the heartbeat thread (#730)

### DIFF
--- a/src/lingtai_kernel/base_agent/lifecycle.py
+++ b/src/lingtai_kernel/base_agent/lifecycle.py
@@ -517,7 +517,12 @@ def _heartbeat_loop(agent) -> None:
         # when something needs the agent's attention (e.g. a newer lingtai
         # wheel is installed on disk than the version this process imported).
         # Each check throttles itself; the dispatcher wraps individual calls
-        # so a misbehaving check cannot block the heartbeat loop. See
+        # in try/except so a check that *raises* cannot break the loop. That
+        # does NOT bound a check that is *slow*: this loop is the sole writer of
+        # `.agent.heartbeat`, and `handshake.is_alive` reads a tick older than
+        # 2.0s as dead. Invariant (#730): checks must never block on the
+        # network — long work is handed to a background thread and its result
+        # consumed on a later tick (see `nudge/kernel_version.py`). See
         # `nudge/ANATOMY.md`.
         try:
             from ..nudge import run_checks as _run_nudge_checks

--- a/src/lingtai_kernel/nudge/ANATOMY.md
+++ b/src/lingtai_kernel/nudge/ANATOMY.md
@@ -30,6 +30,16 @@ small additions (e.g. MCP version drift, addon updates).
 bad check never breaks the loop). It dispatches to each check's
 `check(agent) -> None` in order.
 
+**Invariant — checks must never block on the network (issue #730).** The
+heartbeat loop is the sole writer of `.agent.heartbeat`, and
+`handshake.is_alive` reads a tick older than 2.0s as *dead*. The try/except
+wrapper only protects against a check that *raises* — it does nothing for one
+that is *slow*, and latency inside any check is latency between heartbeat
+writes. A network probe on the heartbeat thread can therefore make a live agent
+read as dead (mail delivery, karma, cpr all gate on `is_alive`). Any check that
+needs the network must hand that work to a background daemon thread and consume
+the result on a later tick — see `kernel_version.py` for the pattern.
+
 ## File layout
 
 - `__init__.py` — dispatcher (`run_checks`), shared upsert/remove
@@ -43,7 +53,14 @@ bad check never breaks the loop). It dispatches to each check's
   package-index check for a newer kernel version and nudges the agent to read
   `system-manual -> reference/runtime-update-checks/SKILL.md` before asking the
   human whether to update. It stores daily throttle state in the hidden
-  `.notification/.nudge_state.json` helper file, which is not a channel.
+  `.notification/.nudge_state.json` helper file, which is not a channel. The
+  PyPI probe never runs on the heartbeat thread (see the invariant above): the
+  due `check()` spawns a daemon worker (`_start_fetch`) that writes only into a
+  process-local `_PendingFetch` slot, and a later probe (past the 60s fast gate)
+  consumes the result and emits/clears the nudge. All `.nudge_state.json` writes
+  stay on the heartbeat thread, keeping it the single writer; a wedged worker is
+  abandoned after `_FETCH_DEADLINE_SECONDS`. The nudge therefore surfaces up to
+  ~60s after the fetch completes rather than in the same tick.
 - `source_drift.py` — read-only process/source freshness check. It compares the
   startup runtime fingerprint with the current on-disk fingerprint and emits a
   low-priority refresh nudge only for non-dev/non-editable/non-source runtimes;

--- a/src/lingtai_kernel/nudge/kernel_version.py
+++ b/src/lingtai_kernel/nudge/kernel_version.py
@@ -16,21 +16,38 @@ Two related cases share one nudge ``kind``:
 
 Editable/source/dev installs are skipped for the package-update check: their
 source of truth is the checkout, not the package index.
+
+Cadence note (issue #730): ``check(agent)`` runs on the heartbeat thread — the
+sole writer of ``.agent.heartbeat``, whose freshness ``handshake.is_alive``
+gates network-wide (a tick older than 2.0s reads as *dead*). Nothing on that
+thread may block on the network. The daily PyPI probe therefore runs on a
+short-lived daemon worker thread: the due ``check()`` spawns the worker and
+returns immediately, and a *later* probe (past the 60s fast gate) consumes the
+result and emits/clears the nudge. Consequence: the package-update nudge
+surfaces up to one fast interval (~60s) after the fetch completes rather than in
+the same tick — acceptable for an at-most-daily advisory. All persistent-state
+reads/writes stay on the heartbeat thread; the worker only produces a value.
 """
 
 from __future__ import annotations
 
 import json
 import re
+import threading
 import time
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 _FAST_INTERVAL_SECONDS = 60.0
 _REMOTE_TIMEOUT_SECONDS = 3.0
+# Hard ceiling for how long a spawned fetch worker may stay in flight before a
+# later probe abandons its slot and records a timeout. Bounds the damage from a
+# wedged DNS lookup (urllib's socket timeout does not reliably cover
+# getaddrinfo), so a stuck worker can never pin the single-flight slot forever.
+_FETCH_DEADLINE_SECONDS = 30.0
 _PYPI_JSON_URL = "https://pypi.org/pypi/lingtai/json"
 _STATE_FILE = Path(".notification") / ".nudge_state.json"
 _KIND = "kernel_version"
@@ -148,23 +165,60 @@ def check(agent) -> None:
         _save_persistent_state(agent, persistent)
 
     today = _today_utc()
-    if not _remote_check_due(kernel_state, info.installed_version, today):
+    _handle_remote_check(agent, info, kernel_state, persistent, today)
+
+
+def _handle_remote_check(agent, info, kernel_state, persistent, today) -> None:
+    """Drive the async PyPI probe without ever blocking the heartbeat thread.
+
+    State machine over the process-local fetch slot (:func:`_fetch_slot`):
+
+    * no fetch in flight and a remote check is due -> spawn a worker and return
+      immediately (the heartbeat tick completes at once);
+    * a fetch in flight that has not finished -> return, unless it has exceeded
+      ``_FETCH_DEADLINE_SECONDS``, in which case abandon the slot and record a
+      timeout so the day is not retried in a tight loop;
+    * a finished fetch -> consume its result/error here, on the heartbeat
+      thread, and emit/clear the nudge exactly as the synchronous path did.
+    """
+
+    pending = _fetch_slot(agent)
+
+    if pending is None:
+        if _remote_check_due(kernel_state, info.installed_version, today):
+            _start_fetch(agent)
         return
 
-    try:
-        latest = _fetch_latest_version()
-    except Exception as e:
+    if not pending.done.is_set():
+        if time.time() - pending.started_ts > _FETCH_DEADLINE_SECONDS:
+            _clear_fetch_slot(agent)
+            kernel_state.update(
+                {
+                    "last_remote_check_date": today,
+                    "checked_installed_version": info.installed_version,
+                    "last_error": "fetch timed out",
+                }
+            )
+            _save_persistent_state(agent, persistent)
+            _log(agent, "kernel_version_update_check_error", error="fetch timed out")
+        return
+
+    # Worker finished — consume its result on the heartbeat thread.
+    _clear_fetch_slot(agent)
+
+    if pending.error is not None:
         kernel_state.update(
             {
                 "last_remote_check_date": today,
                 "checked_installed_version": info.installed_version,
-                "last_error": str(e)[:200],
+                "last_error": pending.error,
             }
         )
         _save_persistent_state(agent, persistent)
-        _log(agent, "kernel_version_update_check_error", error=str(e)[:200])
+        _log(agent, "kernel_version_update_check_error", error=pending.error)
         return
 
+    latest = pending.result or ""
     kernel_state.update(
         {
             "last_remote_check_date": today,
@@ -173,6 +227,8 @@ def check(agent) -> None:
             "last_error": None,
         }
     )
+
+    from . import remove, upsert
 
     if _is_newer(latest, info.installed_version):
         kernel_state["emitted_for_latest"] = latest
@@ -287,6 +343,56 @@ def _remote_check_due(kernel_state: dict[str, Any], installed_version: str, toda
         kernel_state.get("last_remote_check_date") != today
         or kernel_state.get("checked_installed_version") != installed_version
     )
+
+
+@dataclass
+class _PendingFetch:
+    """Process-local slot for one in-flight PyPI probe (issue #730).
+
+    Lives as ``agent._nudge_kernel_fetch``; never persisted. The worker thread
+    writes only ``result``/``error`` and sets ``done`` as the publication
+    barrier — it must not touch ``.nudge_state.json`` or the notification files,
+    preserving the heartbeat thread as the single writer of that state.
+    """
+
+    started_ts: float
+    thread: threading.Thread | None = None
+    result: str | None = None  # written only by the worker
+    error: str | None = None  # written only by the worker
+    done: threading.Event = field(default_factory=threading.Event)
+
+
+def _fetch_slot(agent) -> _PendingFetch | None:
+    return getattr(agent, "_nudge_kernel_fetch", None)
+
+
+def _clear_fetch_slot(agent) -> None:
+    agent._nudge_kernel_fetch = None
+
+
+def _start_fetch(agent) -> None:
+    """Spawn a daemon worker that fetches the latest version off-thread.
+
+    Single-flight: callers must ensure no slot exists first. An abandoned or
+    wedged worker is a daemon holding no locks/files beyond its socket, so it
+    dies on interpreter exit and never blocks shutdown.
+    """
+
+    pending = _PendingFetch(started_ts=time.time())
+
+    def _worker() -> None:
+        try:
+            pending.result = _fetch_latest_version()
+        except Exception as e:  # pragma: no cover - error path exercised via monkeypatch
+            pending.error = str(e)[:200]
+        finally:
+            pending.done.set()
+
+    pending.thread = threading.Thread(
+        target=_worker, name="nudge-kernel-version-fetch", daemon=True
+    )
+    agent._nudge_kernel_fetch = pending
+    pending.thread.start()
 
 
 def _fetch_latest_version() -> str:

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -243,6 +243,61 @@ class TestSuspendFile:
         assert agent._shutdown.is_set()
 
 
+class TestHeartbeatNeverBlocksOnNetwork:
+    """Issue #730: the daily PyPI probe must not stall the heartbeat tick past
+    the ``handshake.is_alive`` threshold. The heartbeat thread is the sole
+    writer of ``.agent.heartbeat`` and a slow-but-successful fetch used to block
+    it for the full 3s socket timeout — long enough to read as dead."""
+
+    def test_slow_kernel_version_fetch_does_not_stall_heartbeat(self, tmp_path, monkeypatch):
+        from lingtai_kernel import BaseAgent, AgentState
+        from lingtai_kernel.handshake import is_alive
+        from lingtai_kernel.nudge import kernel_version as kv
+
+        # Force the daily remote check to be due, on a real (non-dev) runtime.
+        monkeypatch.setattr(
+            kv,
+            "_runtime_info",
+            lambda: kv._RuntimeInfo(
+                running_version="0.14.1",
+                installed_version="0.14.1",
+                dev_reason=None,
+            ),
+        )
+        monkeypatch.setattr(kv, "_remote_check_due", lambda *a, **k: True)
+
+        # A slow-but-successful fetch: 3s is longer than the 2.0s is_alive
+        # threshold. On the old synchronous path this blocked the tick.
+        def _slow_fetch():
+            time.sleep(3.0)
+            return "0.14.1"
+
+        monkeypatch.setattr(kv, "_fetch_latest_version", _slow_fetch)
+
+        agent = BaseAgent(
+            service=make_mock_service(),
+            agent_name="test",
+            working_dir=tmp_path / "test_agent",
+        )
+        hb_file = agent._working_dir / ".agent.heartbeat"
+        agent._start_heartbeat()
+        agent._set_state(AgentState.ACTIVE, reason="test")
+        try:
+            # Sample liveness across the window a slow fetch would have stalled.
+            deadline = time.monotonic() + 2.5
+            samples = []
+            while time.monotonic() < deadline:
+                samples.append(is_alive(agent._working_dir))
+                time.sleep(0.25)
+        finally:
+            agent._stop_heartbeat()
+
+        assert samples, "expected liveness samples"
+        assert all(samples), "heartbeat went stale during the slow fetch (#730)"
+        # And the fetch really did run off-thread — the ticks stayed fresh.
+        assert hb_file.exists() is False  # stopped -> file removed
+
+
 class TestSelfSleep:
 
     def test_self_sleep_no_karma_required(self, tmp_path):

--- a/tests/test_kernel_version_nudge.py
+++ b/tests/test_kernel_version_nudge.py
@@ -1,4 +1,6 @@
 import json
+import threading
+import time
 
 from lingtai_kernel.notifications import collect_notifications
 from lingtai_kernel.nudge import upsert
@@ -25,6 +27,26 @@ def _entries(workdir):
 
 def _reset_fast_gate(agent):
     agent._nudge_kernel_version_state["last_probe_ts"] = 0.0
+
+
+def _await_fetch(agent, timeout=2.0):
+    """Block the test (never the heartbeat) until the in-flight fetch finishes."""
+    pending = kv._fetch_slot(agent)
+    assert pending is not None, "expected a fetch to be in flight"
+    assert pending.done.wait(timeout), "worker thread did not finish"
+
+
+def _drain_remote_fetch(agent):
+    """Drive the async remote check to completion.
+
+    The first due ``check()`` only spawns the worker; a later probe (past the
+    fast gate) consumes the result. Tests that patch ``_fetch_latest_version``
+    to return promptly use this to observe the emitted nudge synchronously.
+    """
+    kv.check(agent)
+    _await_fetch(agent)
+    _reset_fast_gate(agent)
+    kv.check(agent)
 
 
 def test_installed_runtime_refresh_nudge_does_not_hit_remote(tmp_path, monkeypatch):
@@ -194,7 +216,7 @@ def test_remote_update_check_is_daily_and_persistent(tmp_path, monkeypatch):
 
     monkeypatch.setattr(kv, "_fetch_latest_version", latest)
 
-    kv.check(agent)
+    _drain_remote_fetch(agent)
 
     entries = _entries(tmp_path)
     assert len(entries) == 1
@@ -265,9 +287,163 @@ def test_current_remote_version_clears_existing_kernel_nudge(tmp_path, monkeypat
     monkeypatch.setattr(kv, "_today_utc", lambda: "2026-06-24")
     monkeypatch.setattr(kv, "_fetch_latest_version", lambda: "0.14.1")
 
-    kv.check(agent)
+    _drain_remote_fetch(agent)
 
     assert "nudge" not in collect_notifications(tmp_path)
     state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
     assert state["kernel_version"]["latest_seen"] == "0.14.1"
     assert state["kernel_version"]["emitted_for_latest"] is None
+
+
+def _remote_agent(tmp_path, monkeypatch):
+    agent = _Agent(tmp_path)
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo(
+            running_version="0.14.1",
+            installed_version="0.14.1",
+            dev_reason=None,
+        ),
+    )
+    monkeypatch.setattr(kv, "_today_utc", lambda: "2026-06-24")
+    return agent
+
+
+def test_check_does_not_block_on_slow_fetch(tmp_path, monkeypatch):
+    # Regression for #730: the heartbeat thread is the sole writer of
+    # .agent.heartbeat and is_alive treats a >2s-old tick as dead. A slow
+    # PyPI probe on the heartbeat thread stalls the tick past that threshold.
+    # check() must hand the network work to a worker thread and return at once.
+    agent = _remote_agent(tmp_path, monkeypatch)
+
+    release = threading.Event()
+
+    def _slow_fetch():
+        release.wait(5.0)
+        return "0.14.2"
+
+    monkeypatch.setattr(kv, "_fetch_latest_version", _slow_fetch)
+
+    start = time.monotonic()
+    kv.check(agent)
+    elapsed = time.monotonic() - start
+
+    try:
+        assert elapsed < 0.5, f"check() blocked on the fetch for {elapsed:.2f}s"
+        # No state or nudge emitted yet — the worker is still running.
+        assert _entries(tmp_path) == []
+        assert not (tmp_path / ".notification" / ".nudge_state.json").exists()
+    finally:
+        release.set()
+        _await_fetch(agent)
+
+
+def test_fetch_result_consumed_on_later_probe(tmp_path, monkeypatch):
+    agent = _remote_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(kv, "_fetch_latest_version", lambda: "0.14.2")
+
+    # First due probe only spawns the worker; no nudge yet.
+    kv.check(agent)
+    assert _entries(tmp_path) == []
+    _await_fetch(agent)
+
+    # A later probe (past the fast gate) consumes the result and emits.
+    _reset_fast_gate(agent)
+    kv.check(agent)
+
+    entries = _entries(tmp_path)
+    assert len(entries) == 1
+    assert entries[0]["source"] == "pypi-json"
+    assert entries[0]["latest"] == "0.14.2"
+    state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
+    assert state["kernel_version"]["latest_seen"] == "0.14.2"
+    assert state["kernel_version"]["last_remote_check_date"] == "2026-06-24"
+    assert kv._fetch_slot(agent) is None
+
+
+def test_fetch_error_recorded_asynchronously(tmp_path, monkeypatch):
+    agent = _remote_agent(tmp_path, monkeypatch)
+
+    def _boom():
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(kv, "_fetch_latest_version", _boom)
+
+    kv.check(agent)
+    _await_fetch(agent)
+    _reset_fast_gate(agent)
+    kv.check(agent)
+
+    state = json.loads((tmp_path / ".notification" / ".nudge_state.json").read_text())
+    ks = state["kernel_version"]
+    # The day is recorded so the failed probe is not retried in a tight loop.
+    assert ks["last_remote_check_date"] == "2026-06-24"
+    assert "network down" in ks["last_error"]
+    assert any(e == "kernel_version_update_check_error" for e, _ in agent.logs)
+    assert kv._fetch_slot(agent) is None
+
+
+def test_single_flight(tmp_path, monkeypatch):
+    agent = _remote_agent(tmp_path, monkeypatch)
+
+    starts = {"n": 0}
+    release = threading.Event()
+
+    def _slow_fetch():
+        starts["n"] += 1
+        release.wait(5.0)
+        return "0.14.2"
+
+    monkeypatch.setattr(kv, "_fetch_latest_version", _slow_fetch)
+
+    try:
+        kv.check(agent)
+        first_slot = kv._fetch_slot(agent)
+        assert first_slot is not None
+
+        # Repeated due probes while a fetch is in flight spawn no second worker.
+        for _ in range(3):
+            _reset_fast_gate(agent)
+            kv.check(agent)
+            assert kv._fetch_slot(agent) is first_slot
+    finally:
+        release.set()
+        _await_fetch(agent)
+
+    assert starts["n"] == 1
+
+
+def test_fetch_deadline_abandons_stuck_worker(tmp_path, monkeypatch):
+    agent = _remote_agent(tmp_path, monkeypatch)
+
+    release = threading.Event()
+
+    def _wedged_fetch():
+        release.wait(30.0)  # never released within the test window
+        return "0.14.2"
+
+    monkeypatch.setattr(kv, "_fetch_latest_version", _wedged_fetch)
+
+    now = [1_000_000.0]
+    monkeypatch.setattr(kv.time, "time", lambda: now[0])
+
+    kv.check(agent)
+    slot = kv._fetch_slot(agent)
+    assert slot is not None
+
+    # Advance past the abandon deadline; the next probe reclaims the slot.
+    now[0] += kv._FETCH_DEADLINE_SECONDS + 1.0
+    _reset_fast_gate(agent)
+    kv.check(agent)
+
+    try:
+        assert kv._fetch_slot(agent) is None
+        state = json.loads(
+            (tmp_path / ".notification" / ".nudge_state.json").read_text()
+        )
+        ks = state["kernel_version"]
+        assert ks["last_remote_check_date"] == "2026-06-24"
+        assert "timed out" in ks["last_error"]
+    finally:
+        release.set()


### PR DESCRIPTION
## Summary

**Root cause.** The heartbeat loop (`base_agent/lifecycle.py:_heartbeat_loop`) is the sole writer of `.agent.heartbeat`, and `handshake.is_alive` (`handshake.py:43`) treats a tick older than the default `threshold=2.0`s as *dead* — a verdict that gates real behavior (`services/mail.py:161` delivery, and karma sleep/suspend/cpr). That same loop runs nudge checks inline, and `kernel_version.check()` called `_fetch_latest_version()` **synchronously**: a blocking `urllib` GET to PyPI with a `3.0`s socket timeout (DNS not reliably bounded). Once per UTC day per agent, a slow-but-successful fetch stalled the heartbeat tick past the 2.0s threshold, so a healthy idle agent briefly read as dead and mail/karma/cpr drew the wrong conclusion. The dispatcher's `try/except` (`nudge/__init__.py:_run_one`) only guards a check that *raises*, never one that is *slow*.

**Fix, at the owning layer.** A network probe has no business on the single-writer heartbeat thread. Rather than weaken the network-wide liveness threshold (which would still lose to DNS stalls), the fix makes the fetch asynchronous inside the nudge that owns the I/O:

- The due `check()` spawns a short-lived daemon worker (`_start_fetch`) that writes only into a process-local `_PendingFetch` slot and returns immediately — the tick completes at once.
- A later probe (past the existing 60s fast gate) consumes the result **on the heartbeat thread** via `_handle_remote_check` and emits/clears the nudge exactly as the synchronous path did.
- **Single-flight:** no second worker spawns while a slot exists; a wedged worker (e.g. hung `getaddrinfo`) is abandoned after `_FETCH_DEADLINE_SECONDS = 30.0` with a recorded `"fetch timed out"` so the day is not retried in a tight loop.
- All `.nudge_state.json` writes stay on the heartbeat thread, preserving the single-writer property; the worker only produces a value.

**Trade-off / non-goal.** The at-most-daily advisory nudge now surfaces up to ~60s after the fetch completes rather than in the same tick — acceptable, documented in the module docstring and `nudge/ANATOMY.md`. `.nudge_state.json` keys are unchanged; no migration. Moving *all* post-tick housekeeping off the heartbeat thread (Alternative B in the issue) is a larger structural change with its own races and is a deliberate non-goal here — this PR fixes the only network-touching check (`source_drift` and `goal` are local-only).

The previously-incorrect lifecycle comment ("a misbehaving check cannot block the loop") and `nudge/ANATOMY.md` now state the real invariant: **checks must never block on the network; long work goes to a background thread.**

## Validation

All commands run in a worktree off `origin/main` (`ab294c9f`) with the repo venv.

Failing-first — new regression tests fail on unmodified `kernel_version.py`:

```
$ git show origin/main:src/lingtai_kernel/nudge/kernel_version.py > src/lingtai_kernel/nudge/kernel_version.py  # temporarily
$ python -m pytest tests/test_heartbeat.py::TestHeartbeatNeverBlocksOnNetwork -q
>       assert all(samples), "heartbeat went stale during the slow fetch (#730)"
E       AssertionError: heartbeat went stale during the slow fetch (#730)
1 failed in 4.17s

$ python -m pytest tests/test_kernel_version_nudge.py -q   # (also with original source)
7 failed, 5 passed in 40.32s   # note the 40s: check() blocked on the slow fetch
```

After the fix (source restored):

```
$ python -m pytest tests/test_kernel_version_nudge.py tests/test_heartbeat.py -q
..........................                                               [100%]
26 passed in 26.63s
```

The async unit tests alone drop from 40s (blocked) to 0.08s (non-blocking):

```
$ python -m pytest tests/test_kernel_version_nudge.py -q
............                                                             [100%]
12 passed in 0.08s
```

New tests: `test_check_does_not_block_on_slow_fetch` (returns <0.5s while a 5s fetch runs), `test_fetch_result_consumed_on_later_probe`, `test_fetch_error_recorded_asynchronously`, `test_single_flight`, `test_fetch_deadline_abandons_stuck_worker`, and end-to-end `TestHeartbeatNeverBlocksOnNetwork::test_slow_kernel_version_fetch_does_not_stall_heartbeat` (drives the real `_heartbeat_loop` with a 3s fetch and asserts `is_alive` stays true throughout).

```
$ git diff --check   # clean
```

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)
