### PR TITLE
fix(imap): gate send bookkeeping on the delivery result (#734)

### DIFF
--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -498,7 +498,15 @@ class IMAPMailManager:
             attachments=attachments or None,
         )
 
-        # Track last sent message per recipient for duplicate detection
+        if err is not None:
+            # send_email returns an error string (it does not raise) on a failed
+            # delivery. A failed send must not count toward the duplicate block,
+            # or two transient SMTP failures would exhaust the free passes and
+            # lock out the retry that would have succeeded.
+            return {"status": "error", "error": err}
+
+        # Track last sent message per recipient for duplicate detection —
+        # only successful deliveries count.
         for addr in to_list:
             prev = self._last_sent.get(addr)
             if prev is not None and prev[0] == message_text:
@@ -508,10 +516,7 @@ class IMAPMailManager:
 
         log.info("imap_sent to=%s subject=%r", to_list, subject)
 
-        if err is None:
-            return {"status": "delivered", "to": to_list}
-        else:
-            return {"status": "error", "error": err}
+        return {"status": "delivered", "to": to_list}
 
     def _check(self, args: dict, account: "IMAPAccount") -> dict:
         # Empty/whitespace-only folder is treated like omitted → default INBOX.
@@ -627,16 +632,19 @@ class IMAPMailManager:
             references=references or None,
         )
 
-        # Mark as answered
+        if err is not None:
+            # The reply never went out; do not mark the original answered, or a
+            # filter/human client using \Answered to find mail still needing a
+            # response would treat this thread as handled (dropped correspondence).
+            return {"status": "error", "error": err}
+
+        # Mark the original message answered only after a successful send.
         target.store_flags(folder, uid, ["\\Answered"])
 
         log.info("imap_sent_reply to=%s subject=%r in_reply_to=%s",
                  reply_to, subject, email_id)
 
-        if err is None:
-            return {"status": "delivered", "to": [reply_to], "in_reply_to": email_id}
-        else:
-            return {"status": "error", "error": err}
+        return {"status": "delivered", "to": [reply_to], "in_reply_to": email_id}
 
     def _search(self, args: dict, account: "IMAPAccount") -> dict:
         query = args.get("query", "")

--- a/tests/test_imap_send_result_gating.py
+++ b/tests/test_imap_send_result_gating.py
@@ -1,0 +1,132 @@
+"""Regression tests: IMAP send/reply bookkeeping must gate on the send result.
+
+`IMAPAccount.send_email` returns an error string (not None) on failure instead
+of raising, so the manager must inspect the return value before recording any
+post-send state. Two bugs are covered here:
+
+  * `_send` recorded the duplicate-detection counter unconditionally, so a
+    failed delivery still counted toward the two-free-passes block and could
+    lock out the retry that would have succeeded.
+  * `_reply` set the original message's `\\Answered` flag unconditionally, so a
+    failed reply still marked the source mail answered — a success envelope
+    that outruns the real result.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lingtai.mcp_servers.imap.manager import IMAPMailManager
+
+
+class FakeAccount:
+    address = "me@example.com"
+
+    def __init__(self, send_results: list[str | None]) -> None:
+        # Successive return values for send_email: an error string means the
+        # delivery failed; None means it succeeded.
+        self._send_results = list(send_results)
+        self.send_calls = 0
+        self.stored_flags: list[tuple[str, str, list[str]]] = []
+
+    def fetch_full(self, folder: str, uid: str) -> dict:
+        return {
+            "from": "Sender <sender@example.com>",
+            "from_address": "sender@example.com",
+            "subject": "Question",
+            "message_id": "<orig@example.com>",
+            "references": "<parent@example.com>",
+        }
+
+    def send_email(self, **kwargs):
+        result = self._send_results[self.send_calls]
+        self.send_calls += 1
+        return result
+
+    def store_flags(self, folder: str, uid: str, flags: list[str]) -> bool:
+        self.stored_flags.append((folder, uid, flags))
+        return True
+
+
+class FakeService:
+    def __init__(self, account: FakeAccount) -> None:
+        self.default_account = account
+        self._account = account
+
+    def get_account(self, address: str | None):
+        return self._account
+
+
+def _manager(account: FakeAccount) -> IMAPMailManager:
+    return IMAPMailManager(
+        FakeService(account),
+        working_dir=Path("/tmp/imap-send-result-workdir"),
+        tcp_alias="/tmp/imap-bridge",
+        on_inbound=lambda payload: None,
+    )
+
+
+def _send(mgr: IMAPMailManager, message: str) -> dict:
+    return mgr.handle({
+        "action": "send",
+        "address": "peer@example.com",
+        "subject": "hi",
+        "message": message,
+    })
+
+
+def test_failed_send_does_not_count_toward_duplicate_block():
+    # Two failed delivery attempts, then a success. Failed sends must not
+    # consume the two free passes, so the third (successful) send must deliver.
+    account = FakeAccount(send_results=["smtp: temporary failure", "smtp: temporary failure", None])
+    mgr = _manager(account)
+
+    first = _send(mgr, "please retry")
+    assert first["status"] == "error"
+    second = _send(mgr, "please retry")
+    assert second["status"] == "error"
+
+    third = _send(mgr, "please retry")
+    assert third["status"] == "delivered"
+    assert third["to"] == ["peer@example.com"]
+
+
+def test_two_successful_identical_sends_then_block():
+    # Successful identical sends still count and the third is blocked.
+    account = FakeAccount(send_results=[None, None, None])
+    mgr = _manager(account)
+
+    assert _send(mgr, "Done.")["status"] == "delivered"
+    assert _send(mgr, "Done.")["status"] == "delivered"
+
+    blocked = _send(mgr, "Done.")
+    assert blocked["status"] == "blocked"
+    assert "peer@example.com" in blocked["warning"]
+
+
+def test_reply_failure_does_not_mark_answered():
+    account = FakeAccount(send_results=["smtp: connection reset"])
+    mgr = _manager(account)
+
+    result = mgr.handle({
+        "action": "reply",
+        "email_id": "me@example.com:INBOX:42",
+        "message": "here is my reply",
+    })
+
+    assert result["status"] == "error"
+    # The original message must NOT be flagged answered when the reply failed.
+    assert account.stored_flags == []
+
+
+def test_reply_success_marks_answered():
+    account = FakeAccount(send_results=[None])
+    mgr = _manager(account)
+
+    result = mgr.handle({
+        "action": "reply",
+        "email_id": "me@example.com:INBOX:42",
+        "message": "here is my reply",
+    })
+
+    assert result["status"] == "delivered"
+    assert account.stored_flags == [("INBOX", "42", ["\\Answered"])]


### PR DESCRIPTION
## Summary

`IMAPAccount.send_email` returns an error string (`str | None`) on a failed delivery rather than raising (`src/lingtai/mcp_servers/imap/account.py`), so the IMAP manager must inspect that return value before recording any post-send state. Two paths recorded state *before* the check, producing a "success envelope that outruns the real result":

- **`_send` counted failed sends toward the duplicate block.** The per-recipient duplicate-detection counter was updated before `err` was inspected, so a failed delivery still consumed one of the two free passes. Two transient SMTP failures (greylisting, auth hiccup, connection reset) exhausted the free passes and blocked the *third* attempt — the one that would have succeeded — as a "repetitive loop", punishing exactly the retry a sensible agent performs after a delivery error. The counter now increments only after a confirmed successful send. A failed send also no longer emits the misleading `imap_sent` log line.

- **`_reply` marked the original `\Answered` even when the reply failed.** `store_flags(folder, uid, ["\\Answered"])` ran unconditionally, before the `err` check. If the reply send failed, the source message was still flagged answered, so any filter or human mail client that uses `\Answered` to find mail still needing a response treats the thread as handled — a silent correctness bug with real-world consequences (dropped correspondence). The flag is now set only after a successful send.

Both fixes live at the owning layer (`IMAPMailManager`, `src/lingtai/mcp_servers/imap/manager.py`) and are one concern: gate post-send bookkeeping on the actual delivery result. Response shapes and the existing `blocked` warning text are unchanged, so there are no user-facing string or locale changes; the tracker state is private in-memory per-process, so no migration is needed.

### Non-goals (why this is a partial fix)

The issue also proposes fixing the never-reset / never-expire duplicate counters in the **Telegram** and **Feishu** managers (permanent block + unbounded dict growth) and converging all channels onto a **new shared time-windowed `DuplicateSendGuard` abstraction**. Those are deliberately left out:

- Changing Telegram/Feishu from a per-`(account, chat, text)` counter to a per-destination-last-text counter with a time window is a **behavior/policy change** to the loop-detection contract, not a correctness bug — and the kernel already carries a live, deliberate decision that duplicate detection should be **advisory-only, never blocking** (`src/lingtai_kernel/loop_guard.py`: *"Duplicate calls are advisory-only: execute the tool… Execution was NOT blocked; the tool still ran"*). Whether the channel guards should hard-block at all is a maintainer call, not something to redesign unilaterally.
- Introducing `_dup_guard.py` to deduplicate five divergent implementations is a new shared surface whose primary benefit is deduplication itself; that carries its own review bar. It should ride the policy decision above rather than land as a bugfix.

This PR ships the unambiguous correctness slice; the redesign is left for #734 to decide.

## Validation

Environment: `python3` = `/Users/huangzesen/anaconda3/bin/python3`, pytest 9.0.3.

Failing-first — new regression tests against unmodified `manager.py` (the two bug-exposing tests fail, the two control tests pass):

```
$ python3 -m pytest tests/test_imap_send_result_gating.py -q
...
tests/test_imap_send_result_gating.py:89: AssertionError
    assert third["status"] == "delivered"
    AssertionError: assert 'blocked' == 'delivered'
...
FAILED tests/test_imap_send_result_gating.py::test_failed_send_does_not_count_toward_duplicate_block
FAILED tests/test_imap_send_result_gating.py::test_reply_failure_does_not_mark_answered
2 failed, 2 passed in 0.41s
```

After the fix — new tests plus the existing IMAP suites:

```
$ python3 -m pytest tests/test_imap_send_result_gating.py tests/test_imap_reply_attachments.py tests/test_imap_empty_args.py -q
..................                                                       [100%]
18 passed in 0.44s
```

Broader mail/email regression check (no regressions):

```
$ python3 -m pytest tests/ -q -k "imap or email"
137 passed, 3600 deselected in 20.52s
```

`git diff --check` is clean; only `src/lingtai/mcp_servers/imap/manager.py` and the new `tests/test_imap_send_result_gating.py` are touched.

Partial fix for #734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
