### PR TITLE
fix(whatsapp): dedup inbound webhook replays by stable wamid (#733)

### DIFF
--- a/src/lingtai/mcp_servers/whatsapp/SKILL.md
+++ b/src/lingtai/mcp_servers/whatsapp/SKILL.md
@@ -7,8 +7,8 @@ description: |
   check/read/search, media attachments, contacts/accounts/status basics, and
   external-delivery side-effect caveats. Pulled on demand via action='manual'; you
   do not need to call it before every send.
-version: 1.0.0
-last_changed_at: "2026-06-26T14:33:19-07:00"
+version: 1.1.0
+last_changed_at: "2026-07-06T00:00:00-07:00"
 ---
 
 # WhatsApp MCP — usage manual (progressive disclosure)
@@ -49,6 +49,18 @@ bridge).
 - `read`: read messages from one conversation (`wa_id`; optional `limit`,
   `mark_read`).
 - `search`: regex search over message text (`query`).
+
+## WAKE / REPLAY / DUPLICATE-REPLY DISCIPLINE
+
+- Reply once per inbound `message_id` (the compound `account:wa_id:wamid`).
+  Before sending after a refresh, molt, or recovery, use `read` to reconcile the
+  merged inbox+sent view and avoid duplicate replies.
+- Meta's webhook delivery is at-least-once: it re-delivers the same payload
+  (same upstream `wamid`) whenever it does not get a timely HTTP 200. The MCP
+  deduplicates these by the stable `wamid` and suppresses the duplicate inbox
+  landing and wake, so a single user message is not counted twice. If you are
+  investigating inflated unread counts, confirm the runtime version/state before
+  assuming the MCP lost or doubled a message.
 
 ## CONTACTS / ACCOUNTS / STATUS
 

--- a/src/lingtai/mcp_servers/whatsapp/manager.py
+++ b/src/lingtai/mcp_servers/whatsapp/manager.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
 import re
+import tempfile
 import threading
 from datetime import datetime, timezone
 from importlib import resources
@@ -21,6 +24,16 @@ def _load_notification_header_template() -> str:
 
 
 _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()
+
+log = logging.getLogger(__name__)
+
+# Max number of stable inbound signatures retained in the replay-guard index
+# (inbox_seen.json). Meta re-delivers a webhook whenever it does not get a
+# timely HTTP 200, repeating the same wamid; a retry window is far smaller than
+# 5000 inbound messages, so this bounds the state file while never forgetting a
+# message inside the replay horizon. Mirrors the WeChat manager's guard so both
+# channel addons use one dedup idiom.
+SEEN_KEYS_MAX = 5000
 
 # Bundled usage manual (skill format) — SKILL.md ships in this package folder.
 # action='manual' reads the full body; the YAML frontmatter name/description are
@@ -83,6 +96,16 @@ class WhatsAppManager:
         self.config_source = config_source
         self._last_verified_at = _utcnow()
         self._contacts_lock = threading.Lock()
+        # Inbound replay guard. Meta's webhook delivery is at-least-once, and
+        # the receiving server is threaded, so the original delivery and a
+        # retry (identical wamid) can arrive concurrently. This lock-protected
+        # seen-set keyed on the stable upstream wamid suppresses the duplicate
+        # landing + wake. Persisted to inbox_seen.json so the guard survives a
+        # restart/refresh.
+        self._seen_lock = threading.Lock()
+        self._seen_keys: dict[str, str] = {}   # stable_key -> first local dir name
+        self._seen_order: list[str] = []       # FIFO for bounded eviction
+        self._load_seen()
 
     def _account_alias(self, alias: str | None) -> str:
         if alias:
@@ -137,12 +160,97 @@ class WhatsAppManager:
             raise ValueError("message_id must be account:wa_id:wamid")
         return parts[0], parts[1], parts[2]
 
+    # ── Inbound replay / idempotency guard ─────────────────────
+    #
+    # Mirrors the WeChat manager's guard (SEEN_KEYS_MAX, inbox_seen.json,
+    # _stable_key/_is_replay/_record_seen, store-then-record ordering) so both
+    # channel addons behave identically under upstream redelivery.
+
+    def _seen_path(self) -> Path:
+        return self.root / "inbox_seen.json"
+
+    @staticmethod
+    def _atomic_write(path: Path, content: str) -> None:
+        """Write content to path atomically via tempfile + os.replace."""
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    def _load_seen(self) -> None:
+        p = self._seen_path()
+        if not p.is_file():
+            return
+        try:
+            seen = json.loads(p.read_text(encoding="utf-8"))
+            self._seen_keys = dict(seen.get("keys", {}))
+            self._seen_order = [k for k in seen.get("order", []) if k in self._seen_keys]
+        except (ValueError, AttributeError) as e:
+            # Corrupt index degrades to "no guard", never crashes construction.
+            log.warning("Failed to load WhatsApp inbox_seen.json (ignoring): %s", e)
+            self._seen_keys = {}
+            self._seen_order = []
+
+    def _save_seen(self) -> None:
+        with self._seen_lock:
+            payload = {
+                "version": 1,
+                "order": list(self._seen_order),
+                "keys": dict(self._seen_keys),
+            }
+        self._atomic_write(self._seen_path(), json.dumps(payload, ensure_ascii=False))
+
+    @staticmethod
+    def _stable_key(alias: str, ev: dict[str, Any]) -> str | None:
+        """Derive a replay-resistant signature for an inbound event.
+
+        Meta assigns a globally stable ``wamid`` (``ev['message_id']``) to every
+        message and repeats it verbatim on every retry, so it is the stable key.
+        Namespace by ``alias`` and ``wa_id`` as cheap insurance against any id
+        collision across accounts/senders. Returns ``None`` when no upstream
+        wamid is present — such an event has no stable identity, so it is never
+        deduped (better a rare duplicate than dropping a real message).
+        """
+        wamid = ev.get("message_id")
+        if not wamid:
+            return None
+        wa_id = ev.get("wa_id") or "unknown"
+        return f"{alias}|{wa_id}|mid:{wamid}"
+
+    def _is_replay(self, key: str) -> bool:
+        """True if this stable key was already landed (replay guard hit)."""
+        with self._seen_lock:
+            return key in self._seen_keys
+
+    def _record_seen(self, key: str, local_id: str) -> None:
+        """Persist that ``key`` was landed under ``local_id`` (atomic)."""
+        with self._seen_lock:
+            if key in self._seen_keys:
+                return
+            self._seen_keys[key] = local_id
+            self._seen_order.append(key)
+            # Evict oldest beyond the window to bound the state file.
+            while len(self._seen_order) > SEEN_KEYS_MAX:
+                evicted = self._seen_order.pop(0)
+                self._seen_keys.pop(evicted, None)
+        self._save_seen()
+
     def _store_message(self, alias: str, folder: str, msg: dict[str, Any]) -> dict[str, Any]:
         d = self._account_dir(alias) / folder / str(uuid4())
         d.mkdir(parents=True, exist_ok=True)
         msg = dict(msg)
         msg.setdefault("stored_at", _utcnow())
         (d / "message.json").write_text(json.dumps(msg, ensure_ascii=False, indent=2), encoding="utf-8")
+        # Expose the local directory name so the inbound replay guard can record
+        # which landing a stable key maps to (traceability for suppressed dupes).
+        msg["_local_id"] = d.name
         return msg
 
     def _iter_messages(self, alias: str, folder: str | None = None) -> list[dict[str, Any]]:
@@ -377,9 +485,23 @@ class WhatsAppManager:
         for ev in events:
             if ev.get("kind") == "message":
                 wa_id = ev.get("wa_id") or "unknown"
+                # Compute the stable key from the event BEFORE the local-uuid4
+                # placeholder below, so a genuine wamid keys the guard while a
+                # placeholder never does (None => always land, never dedup).
+                stable_key = self._stable_key(alias, ev)
+                if stable_key is not None and self._is_replay(stable_key):
+                    log.info("WhatsApp inbound replay suppressed: %s", stable_key)
+                    continue  # no new inbox entry, no LICC wake
                 wamid = ev.get("message_id") or f"local-{uuid4()}"
-                msg = {"id": self._compound(alias, wa_id, wamid), "wa_id": wa_id, "message_id": wamid, "text": ev.get("text"), "type": ev.get("type"), "direction": "incoming", "metadata": ev.get("metadata"), "timestamp": ev.get("timestamp"), "stored_at": _utcnow()}
-                self._store_message(alias, "inbox", msg)
+                msg = {"id": self._compound(alias, wa_id, wamid), "wa_id": wa_id, "message_id": wamid, "text": ev.get("text"), "type": ev.get("type"), "direction": "incoming", "metadata": ev.get("metadata"), "timestamp": ev.get("timestamp"), "stable_key": stable_key, "stored_at": _utcnow()}
+                stored = self._store_message(alias, "inbox", msg)
+                # Record the seen key only AFTER the inbox write succeeds: a
+                # crash mid-write must not mark a message seen without landing
+                # it. Recording before on_inbound loses at most one wake for a
+                # message that IS in the inbox (benign) rather than risking a
+                # double-wake on crash. Matches the WeChat ordering.
+                if stable_key is not None:
+                    self._record_seen(stable_key, stored["_local_id"])
                 if self.on_inbound:
                     header = _NOTIFICATION_HEADER_TEMPLATE.format(channel="WhatsApp").rstrip("\n")
                     message_body = ev.get("text") or f"[{ev.get('type')}]"

--- a/tests/test_whatsapp_inbound_replay.py
+++ b/tests/test_whatsapp_inbound_replay.py
@@ -1,0 +1,217 @@
+"""Regression tests for inbound WhatsApp webhook replay / dedup.
+
+Bug: ``WhatsAppManager.ingest_webhook`` landed every inbound ``message`` event
+under a fresh ``uuid4()`` directory and fired ``on_inbound(..., wake=True)``
+unconditionally, keyed by nothing stable. Meta's webhook delivery is
+at-least-once (it re-delivers the same payload — same ``messages[].id`` /
+wamid — whenever it does not receive a timely HTTP 200), so a single user
+message landed in the inbox multiple times and woke the agent repeatedly.
+
+These tests pin the idempotency guard that suppresses such replays by the
+stable upstream wamid while preserving genuinely new messages, mirroring the
+WeChat manager's ``inbox_seen.json`` guard.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lingtai.mcp_servers.whatsapp import manager as wa_manager
+from lingtai.mcp_servers.whatsapp.manager import WhatsAppManager
+
+
+def _manager(tmp_path: Path, events: list[dict]) -> WhatsAppManager:
+    return WhatsAppManager(
+        accounts_config=[{
+            "alias": "biz",
+            "phone_number_id": "PNID123",
+            "access_token": "test-token",
+        }],
+        working_dir=tmp_path,
+        on_inbound=events.append,
+    )
+
+
+def _payload(*, wamid: str | None, wa_id: str = "15551230000", text: str = "hi") -> dict:
+    """A Meta-shaped inbound-message webhook payload."""
+    message: dict = {"from": wa_id, "timestamp": "1700000000", "type": "text",
+                     "text": {"body": text}}
+    if wamid is not None:
+        message["id"] = wamid
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [{
+            "id": "WABA1",
+            "changes": [{
+                "field": "messages",
+                "value": {
+                    "messaging_product": "whatsapp",
+                    "metadata": {"phone_number_id": "PNID123"},
+                    "messages": [message],
+                },
+            }],
+        }],
+    }
+
+
+def _inbox_count(tmp_path: Path, alias: str = "biz") -> int:
+    inbox = tmp_path / "whatsapp" / alias / "inbox"
+    if not inbox.exists():
+        return 0
+    return sum(1 for d in inbox.iterdir() if (d / "message.json").is_file())
+
+
+# ── Replay suppression (the bug) ──────────────────────────────────────────
+
+def test_duplicate_webhook_delivery_lands_once(tmp_path):
+    """Same wamid delivered twice (Meta retry) lands ONCE and wakes ONCE,
+    even though a fresh local UUID would otherwise be minted each time."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+
+    ev1 = mgr.ingest_webhook("biz", _payload(wamid="wamid.AAAA"))
+    ev2 = mgr.ingest_webhook("biz", _payload(wamid="wamid.AAAA"))
+
+    assert _inbox_count(tmp_path) == 1, "replay must not create a 2nd inbox entry"
+    assert len(events) == 1, "replay must not trigger a 2nd LICC wake"
+    # Return value (extracted events) is unchanged on the suppressed call.
+    assert len(ev1) == 1 and len(ev2) == 1
+
+
+def test_seen_state_survives_restart(tmp_path):
+    """The guard is durable: a fresh manager over the same working_dir loads
+    inbox_seen.json and still suppresses the replay."""
+    events1: list[dict] = []
+    mgr1 = _manager(tmp_path, events1)
+    mgr1.ingest_webhook("biz", _payload(wamid="wamid.PERSIST"))
+    assert (tmp_path / "whatsapp" / "inbox_seen.json").is_file()
+
+    events2: list[dict] = []
+    mgr2 = _manager(tmp_path, events2)  # == relaunch after refresh
+    mgr2.ingest_webhook("biz", _payload(wamid="wamid.PERSIST"))
+
+    assert _inbox_count(tmp_path) == 1
+    assert events2 == [], "replay after relaunch must not re-wake the host"
+
+
+# ── Genuine messages must NOT be dropped ──────────────────────────────────
+
+def test_distinct_wamids_both_land(tmp_path):
+    """Two payloads differing only in wamid both land and both wake."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+
+    mgr.ingest_webhook("biz", _payload(wamid="wamid.1", text="ok"))
+    mgr.ingest_webhook("biz", _payload(wamid="wamid.2", text="ok"))
+
+    assert _inbox_count(tmp_path) == 2
+    assert len(events) == 2
+
+
+def test_same_text_different_wamids_not_deduped(tmp_path):
+    """Identical text + wa_id but different wamids are two real messages
+    (guards against over-aggressive content-based keying)."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+
+    mgr.ingest_webhook("biz", _payload(wamid="wamid.a", text="same words"))
+    mgr.ingest_webhook("biz", _payload(wamid="wamid.b", text="same words"))
+
+    assert _inbox_count(tmp_path) == 2
+    assert len(events) == 2
+
+
+def test_missing_message_id_never_suppressed(tmp_path):
+    """An event with no upstream wamid has no stable identity, so it is never
+    deduped — both deliveries land (better a rare dup than a dropped message)."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+
+    mgr.ingest_webhook("biz", _payload(wamid=None, text="no id"))
+    mgr.ingest_webhook("biz", _payload(wamid=None, text="no id"))
+
+    assert _inbox_count(tmp_path) == 2
+    assert len(events) == 2
+
+
+# ── Eviction / ordering ───────────────────────────────────────────────────
+
+def test_seen_keys_fifo_eviction(tmp_path, monkeypatch):
+    """Beyond SEEN_KEYS_MAX the oldest key is evicted, so replaying the oldest
+    lands again while replaying the newest is still suppressed."""
+    monkeypatch.setattr(wa_manager, "SEEN_KEYS_MAX", 3)
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+
+    for n in range(1, 5):  # 4 distinct messages, window is 3
+        mgr.ingest_webhook("biz", _payload(wamid=f"wamid.{n}", text=f"m{n}"))
+    assert _inbox_count(tmp_path) == 4
+
+    # wamid.1 was evicted -> replaying it lands again.
+    mgr.ingest_webhook("biz", _payload(wamid="wamid.1", text="m1"))
+    assert _inbox_count(tmp_path) == 5
+
+    # wamid.4 is still in the window -> replay suppressed.
+    before = len(events)
+    mgr.ingest_webhook("biz", _payload(wamid="wamid.4", text="m4"))
+    assert _inbox_count(tmp_path) == 5
+    assert len(events) == before
+
+
+def test_record_after_store_ordering(tmp_path):
+    """If _store_message raises, the key is NOT recorded, so a later
+    successful ingest of the same payload still lands the message."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+
+    orig_store = mgr._store_message
+    boom = {"fail": True}
+
+    def flaky(alias, folder, msg):
+        if boom["fail"]:
+            raise RuntimeError("disk full")
+        return orig_store(alias, folder, msg)
+
+    mgr._store_message = flaky  # type: ignore[method-assign]
+
+    try:
+        mgr.ingest_webhook("biz", _payload(wamid="wamid.CRASH"))
+    except RuntimeError:
+        pass
+    assert _inbox_count(tmp_path) == 0
+    assert events == []
+
+    boom["fail"] = False
+    mgr.ingest_webhook("biz", _payload(wamid="wamid.CRASH"))
+    assert _inbox_count(tmp_path) == 1, "key must not have been recorded on the failed store"
+    assert len(events) == 1
+
+
+# ── Corruption tolerance ──────────────────────────────────────────────────
+
+def test_corrupt_seen_file_degrades_gracefully(tmp_path):
+    """A corrupt inbox_seen.json must not crash construction; the guard resets
+    to empty and ingest still works."""
+    (tmp_path / "whatsapp").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "whatsapp" / "inbox_seen.json").write_text("{not json", encoding="utf-8")
+
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)  # must not raise
+    mgr.ingest_webhook("biz", _payload(wamid="wamid.OK"))
+
+    assert _inbox_count(tmp_path) == 1
+    assert len(events) == 1
+
+
+# ── Provenance ────────────────────────────────────────────────────────────
+
+def test_landed_message_records_stable_key_provenance(tmp_path):
+    """The landed message.json carries stable_key so a suppressed duplicate is
+    always traceable to its original landing (no silent loss)."""
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+    mgr.ingest_webhook("biz", _payload(wamid="wamid.TRACE", wa_id="15551239999"))
+
+    inbox = tmp_path / "whatsapp" / "biz" / "inbox"
+    data = json.loads((next(inbox.iterdir()) / "message.json").read_text(encoding="utf-8"))
+    assert data["stable_key"] == "biz|15551239999|mid:wamid.TRACE"


### PR DESCRIPTION
## Summary

- **Root cause:** `WhatsAppManager.ingest_webhook` landed every inbound `message` event under a fresh `uuid4()` directory and fired `on_inbound(..., wake=True)` unconditionally, keyed by nothing stable — even though every event carries a globally stable upstream `wamid` (`ev["message_id"]`). Meta's webhook delivery is at-least-once: it re-delivers the same payload (identical `wamid`) whenever it does not receive a timely HTTP 200 (slow host, tunnel hiccup, non-200 response), and the receiving `ThreadingHTTPServer` can run the original and a retry concurrently. Every redelivery produced a duplicate inbox entry and a duplicate agent wake for a message that may already have been read and replied to.
- **Fix at the owning layer (the ingest boundary):** added a lock-protected, persisted replay guard mirroring the WeChat manager's existing `inbox_seen.json` guard, so both channel addons use one dedup idiom rather than two. `ingest_webhook` computes the stable `(alias, wa_id, wamid)` key from the event *before* the `local-<uuid4>` placeholder, skips both the store and the wake on a replay, and records the key only **after** `_store_message` succeeds (store-then-record — a crash mid-write cannot mark a message seen without landing it; recording before `on_inbound` loses at most one benign wake for a message that is in the inbox, matching WeChat's ordering).
- State persists atomically to `whatsapp/inbox_seen.json` (`{"version":1,"order":[...],"keys":{...}}`) with a bounded FIFO (`SEEN_KEYS_MAX = 5000`) and degrades to an empty guard on a missing/corrupt file (never crashes construction). Events with no upstream wamid have no stable identity and are never deduped (better a rare duplicate than a dropped real message).
- **Non-goals:** no new config flag / opt-out; no shared cross-channel dedup helper (WeChat's `_stable_key` is protocol-specific, so extraction would couple two diverging providers — deliberately kept as a mirrored idiom). Responding HTTP 200 before ingest to shrink the retry window is a separate latency concern and is left out.

Docs: added a "WAKE / REPLAY / DUPLICATE-REPLY DISCIPLINE" section to the WhatsApp `SKILL.md` (mirroring WeChat's), bumped the manual `version`/`last_changed_at`.

## Validation

Failing-first: with the new test file in place but the `manager.py` fix stashed (unpatched `ingest_webhook`), the dedup regressions fail while the "genuine messages both land" cases pass:

```
$ git stash push -- src/lingtai/mcp_servers/whatsapp/manager.py
$ python -m pytest tests/test_whatsapp_inbound_replay.py -q
FAILED tests/test_whatsapp_inbound_replay.py::test_duplicate_webhook_delivery_lands_once
FAILED tests/test_whatsapp_inbound_replay.py::test_seen_state_survives_restart
FAILED tests/test_whatsapp_inbound_replay.py::test_seen_keys_fifo_eviction
FAILED tests/test_whatsapp_inbound_replay.py::test_landed_message_records_stable_key_provenance
4 failed, 5 passed in 0.35s
```

After restoring the fix:

```
$ python -m pytest tests/test_whatsapp_inbound_replay.py -q
.........                                                                [100%]
9 passed in 0.36s
```

Targeted existing coverage for the touched module (every test that imports the WhatsApp package, plus the WeChat replay guard it mirrors):

```
$ python -m pytest tests/ -k "whatsapp or wechat" -q
70 passed, 3672 deselected in 6.05s

$ python -m pytest <all tests importing mcp_servers.whatsapp> -q
89 passed in 1.25s
```

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)
