### PR TITLE
fix(llm_utils): disambiguate worker-raised TimeoutError from an unsettled future (#738)

### DIFF
--- a/src/lingtai_kernel/llm_utils.py
+++ b/src/lingtai_kernel/llm_utils.py
@@ -63,6 +63,18 @@ def _send(
         try:
             return future.result(timeout=wait)
         except TimeoutError:
+            # On Python >= 3.11 (this repo's floor) concurrent.futures.TimeoutError,
+            # socket.timeout and asyncio.TimeoutError are all the builtin
+            # TimeoutError, so this clause fires for BOTH "result() gave up
+            # waiting" and "the worker itself raised a TimeoutError". Ask the
+            # future which one it was (#738): a done future never blocks, so if
+            # the worker settled we surface its real outcome immediately instead
+            # of busy-looping "not responding" and later escalating to a false
+            # WorkerStillRunningError. future.result(timeout=0) re-raises the
+            # worker's exception (common case) or returns the value (benign race
+            # where the future settled just after our wait expired).
+            if future.done():
+                return future.result(timeout=0)
             elapsed = time.monotonic() - t0
             if elapsed >= retry_timeout:
                 _wait_for_worker_settle(future, elapsed, agent_name)
@@ -84,10 +96,21 @@ def _wait_for_worker_settle(future: Future, elapsed: float, agent_name: str) -> 
     If the worker is still running after the grace period, raise a distinct
     WorkerStillRunningError. AED must not treat this as an ordinary timeout
     because the provider worker may still mutate the shared ChatInterface.
+
+    Note: ``except TimeoutError`` alone is ambiguous on Python >= 3.11 — the
+    worker may have *settled* by raising its own TimeoutError (socket.timeout,
+    asyncio.TimeoutError, or a hand-raised builtin), which is not the same as
+    result() giving up. ``future.done()`` is the discriminator (#738).
     """
     try:
         future.result(timeout=_WORKER_SETTLE_GRACE)
     except TimeoutError:
+        if future.done():
+            # The worker settled with its own TimeoutError, not result()
+            # giving up. Its except-block already ran drop_trailing, so this
+            # is safe — treat it exactly like the except Exception branch
+            # below and let the caller raise its ordinary watchdog TimeoutError.
+            return
         _logger.error(
             "[%s] LLM worker thread still running after %.0fs + %.0fs grace — "
             "interface state may be inconsistent. Refusing AED retry.",

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -231,3 +231,66 @@ def test_send_with_timeout_raises_worker_still_running_when_worker_never_settles
     finally:
         blocker.set()
         pool.shutdown(wait=True)
+
+
+# --- Regression tests for #738: worker-raised TimeoutError must not be
+# misread as "future not settled". On Python >= 3.11 (this repo's floor)
+# concurrent.futures.TimeoutError, socket.timeout and asyncio.TimeoutError are
+# all aliases of the builtin TimeoutError, so `except TimeoutError` alone cannot
+# tell "Future.result gave up waiting" apart from "the worker raised a
+# TimeoutError". The discriminator is future.done().
+
+
+def test_wait_for_worker_settle_returns_when_worker_raised_timeout():
+    """A future that settled with the worker's own TimeoutError (e.g. a raw
+    socket.timeout bubbling out of the HTTP layer) is DONE — its except-block
+    already ran drop_trailing. _wait_for_worker_settle must treat it like any
+    other settled worker error (return, let the caller raise its ordinary
+    watchdog TimeoutError), NOT escalate to WorkerStillRunningError. See #738.
+    """
+    future: Future = Future()
+    # socket.timeout / asyncio.TimeoutError are the builtin TimeoutError on >=3.11.
+    future.set_exception(TimeoutError("worker socket timeout"))
+
+    # Must return None and must NOT raise WorkerStillRunningError.
+    assert _wait_for_worker_settle(future, elapsed=10.0, agent_name="t") is None
+
+
+def test_send_surfaces_worker_timeout_immediately_without_spam(caplog):
+    """When the worker settles with a builtin TimeoutError early in the
+    retry_timeout budget, _send must surface it promptly as a plain
+    TimeoutError (not WorkerStillRunningError) instead of busy-looping and
+    spamming "not responding" warnings for the rest of the budget. See #738.
+    """
+    import logging
+    import threading
+    import time as _time
+
+    pool = ThreadPoolExecutor(max_workers=1)
+    blocker = threading.Event()
+    # Worker sleeps a beat, then raises a builtin TimeoutError (socket.timeout).
+    chat = _FakeChat(blocker, raises=TimeoutError("worker HTTP timeout"))
+    blocker.set()  # let the worker settle immediately
+
+    t_start = _time.monotonic()
+    with caplog.at_level(logging.WARNING):
+        try:
+            with pytest.raises(TimeoutError) as exc:
+                # Generous retry_timeout: a busy-loop would take ~this long and
+                # spam warnings; the fix must return well before it.
+                send_with_timeout(
+                    chat=chat, message="hi",
+                    timeout_pool=pool, retry_timeout=30.0,
+                    agent_name="test", logger=None,
+                )
+        finally:
+            pool.shutdown(wait=True)
+    elapsed = _time.monotonic() - t_start
+
+    # Surfaced as an ordinary worker exception, NOT the poison signal.
+    assert not isinstance(exc.value, WorkerStillRunningError)
+    # Promptly — proving the hot loop is gone (nowhere near the 30s budget).
+    assert elapsed < 5.0, f"_send busy-looped for {elapsed:.1f}s"
+    # No warning spam for a worker that already finished.
+    spam = [r for r in caplog.records if "not responding" in r.getMessage()]
+    assert len(spam) <= 1, f"expected no warning spam, got {len(spam)}"


### PR DESCRIPTION
## Summary

- Fix the LLM send watchdog in `src/lingtai_kernel/llm_utils.py` to disambiguate a worker-raised `TimeoutError` from an unsettled future by consulting `future.done()`, instead of inferring "not settled yet" purely from `except TimeoutError`.
- In `_send`: when the future is done, surface its real outcome immediately via `future.result(timeout=0)` (re-raises the worker's exception in the common case, or returns the value on a benign settle-during-race).
- In `_wait_for_worker_settle`: when the future is done, treat it like the existing `except Exception` branch (return; the caller raises its ordinary watchdog `TimeoutError`), reserving `WorkerStillRunningError` for a genuinely still-alive worker.
- Add two failing-first regression tests to `tests/test_llm_utils.py`.

## Root cause

On Python >= 3.11 (this repo's floor, `pyproject.toml` `requires-python = ">=3.11"`), `concurrent.futures.TimeoutError`, `socket.timeout` and `asyncio.TimeoutError` are all aliases of the builtin `TimeoutError`. Verified on the running interpreter:

```
$ python3 -c "import concurrent.futures, socket, asyncio; print(concurrent.futures.TimeoutError is TimeoutError, socket.timeout is TimeoutError, asyncio.TimeoutError is TimeoutError)"
True True True
```

`Future.result(timeout=...)` raises the builtin `TimeoutError` when it gives up waiting — but `except TimeoutError:` equally catches the case where the future **is done** and `Future.result` re-raised a worker-raised `TimeoutError` (a done future never blocks, so it re-raises instantly). Provider adapters re-raise worker exceptions verbatim after running `drop_trailing`, so a raw `socket.timeout` arrives at `_send` unwrapped. Result: `_send` busy-looped one "LLM API not responding" warning per iteration (no wait) until `retry_timeout` expired, then `_wait_for_worker_settle` raised a spurious `WorkerStillRunningError` — the poison signal — even though the worker had finished and its cleanup had run. Downstream AED (`base_agent/turn.py`) then took a full outage (interface poisoned, agent ASLEEP, forced refresh) for a transient timeout that should have been an ordinary in-process retry. This is fixed at the owning layer (the watchdog that owns "has the future settled?"); the poison path in `turn.py`/`worker_recovery` is untouched and only stops receiving false positives. `WorkerStillRunningError` still fires for a genuinely still-alive worker, restoring its documented invariant.

## Non-goals

- Not restructuring the loop onto `concurrent.futures.wait()` (a larger rewrite for the same behavior); the `done()` check is the minimal, obviously-correct diff.
- No public-surface, schema, config-flag, or i18n change (the touched log strings are diagnostic, not i18n-keyed). No ANATOMY.md re-anchor needed: no `file:line` citation points into the touched functions.

## Validation

Environment: worktree off `origin/main` (ab294c9f), Python 3.14 venv with pytest 9.0.3, `PYTHONPATH=src` so imports resolve to the worktree.

Failing-first (new tests against pre-fix code) — reproduces the bug: warning spam, ~33 s hot loop, spurious `WorkerStillRunningError`:

```
$ python -m pytest tests/test_llm_utils.py -q -k "worker_raised_timeout or surfaces_worker_timeout"
WARNING  lingtai:llm_utils.py:70 [test] LLM API not responding after 30s...
... (dozens of identical warnings) ...
ERROR    lingtai:llm_utils.py:91 [test] LLM worker thread still running after 30s + 5s grace — ... Refusing AED retry.
FAILED tests/test_llm_utils.py::test_wait_for_worker_settle_returns_when_worker_raised_timeout
FAILED tests/test_llm_utils.py::test_send_surfaces_worker_timeout_immediately_without_spam
2 failed, 8 deselected in 32.78s
```

After the fix — full module suite (2 new + 8 pre-existing; note the run drops from ~33 s to 0.40 s, confirming the hot loop is gone):

```
$ python -m pytest tests/test_llm_utils.py -q
..........                                                               [100%]
10 passed in 0.40s
```

Poison path untouched — AED recovery suite:

```
$ python -m pytest tests/test_aed_recovery.py -q
..........                                                               [100%]
10 passed in 0.14s
```

`git diff --check`: clean.

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
