### PR TITLE
fix: snapshot adapter cache in get_adapter fast-path scan (#739)

### DIFF
--- a/src/lingtai/llm/service.py
+++ b/src/lingtai/llm/service.py
@@ -299,9 +299,14 @@ class LLMService(LLMServiceABC):
         # Fast path — no lock needed for reads of an already-cached adapter
         if cache_key in self._adapters:
             return self._adapters[cache_key]
-        # When no base_url specified, find any cached adapter for this provider
+        # When no base_url specified, find any cached adapter for this provider.
+        # This scan runs WITHOUT self._adapter_lock, while the slow path below
+        # inserts into self._adapters under that lock. Iterating the live dict
+        # here would raise "RuntimeError: dictionary changed size during
+        # iteration" if a concurrent insert lands mid-scan, so iterate over an
+        # atomic snapshot (list(...) materializes in one C-level step) instead.
         if base_url is None:
-            for (p, _url), adapter in self._adapters.items():
+            for (p, _url), adapter in list(self._adapters.items()):
                 if p == provider:
                     return adapter
 

--- a/tests/test_llm_service_adapter_cache.py
+++ b/tests/test_llm_service_adapter_cache.py
@@ -1,0 +1,118 @@
+"""Regression tests for LLMService adapter-cache concurrency.
+
+Lingtai-AI/lingtai-kernel#739: ``LLMService.get_adapter`` has a lock-free
+"fast path" that, when the caller passes no ``base_url``, scans the whole
+``self._adapters`` dict looking for any adapter whose provider matches. That
+scan runs without ``self._adapter_lock``, while the slow path inside the lock
+does ``self._adapters[cache_key] = adapter``. In CPython, iterating a dict
+while another thread inserts into it raises
+``RuntimeError: dictionary changed size during iteration`` — surfacing as a
+spurious, unexplained LLM failure right when several threads race to warm the
+cache. The fix scans a snapshot so a concurrent insert can no longer interleave
+with the iteration.
+"""
+from __future__ import annotations
+
+import threading
+
+from lingtai.llm.service import LLMService
+
+
+def _register_opaque_adapter(provider: str) -> None:
+    """Register a hermetic adapter factory returning a fresh opaque object."""
+    LLMService.register_adapter(provider, lambda **kwargs: object())
+
+
+def test_get_adapter_scan_race_with_concurrent_insert():
+    """The base_url=None fast-path scan must not crash on a concurrent insert.
+
+    Pre-fix, a reader iterating ``self._adapters.items()`` without the lock
+    while a writer inserts a new key raises
+    ``RuntimeError: dictionary changed size during iteration``. This test
+    hammers that race: many readers scan for provider "a" (no base_url) while
+    writers create adapters for fresh ("b", base_url) keys.
+    """
+    _register_opaque_adapter("z")
+    _register_opaque_adapter("b")
+
+    svc = LLMService(
+        provider="z",
+        model="m",
+        api_key="sk-z",
+        key_resolver=lambda p: "sk-key",
+    )
+    # Remove the boot ("z", None) entry: with a ("z", None) key present the
+    # exact-key fast path (service.py:288) returns immediately and never
+    # reaches the scan. The scan at service.py:291-294 only runs when there is
+    # NO (provider, None) key but there IS a (provider, other_url) entry, so we
+    # seed the lone match under an explicit base_url.
+    del svc._adapters[("z", None)]
+    for i in range(3000):
+        svc._adapters[("b", f"http://filler/{i}")] = object()
+    # Put the single matching entry LAST so the scan must traverse the whole
+    # dict (past the churning region) before it can return.
+    seeded_z = object()
+    svc._adapters[("z", "http://only")] = seeded_z
+
+    errors: list[BaseException] = []
+    stop = threading.Event()
+    barrier = threading.Barrier(4)
+
+    def reader():
+        barrier.wait()
+        try:
+            while not stop.is_set():
+                svc.get_adapter("z")  # base_url=None -> full dict scan
+        except BaseException as exc:  # noqa: BLE001 - capture RuntimeError race
+            errors.append(exc)
+
+    def writer():
+        barrier.wait()
+        try:
+            i = 0
+            while not stop.is_set():
+                # Model the slow-path insert at service.py:320: a write into
+                # the same dict the lock-free readers are scanning, under the
+                # real lock the production writer holds. The reader does NOT
+                # take that lock, so its scan is unprotected. Growing the dict
+                # (net insert) changes its size mid-scan, which is exactly the
+                # condition CPython raises "dictionary changed size during
+                # iteration" for.
+                with svc._adapter_lock:
+                    svc._adapters[("b", f"http://churn/{i}")] = object()
+                i += 1
+                if i % 500 == 0:
+                    # Periodically prune so memory stays bounded across the run.
+                    with svc._adapter_lock:
+                        for j in range(i - 500, i):
+                            svc._adapters.pop(("b", f"http://churn/{j}"), None)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=reader) for _ in range(3)] + [
+        threading.Thread(target=writer) for _ in range(1)
+    ]
+    for t in threads:
+        t.start()
+    # Let the race run briefly, then stop.
+    stop_timer = threading.Timer(1.5, stop.set)
+    stop_timer.start()
+    for t in threads:
+        t.join(timeout=5)
+    stop.set()
+    stop_timer.cancel()
+
+    assert not errors, f"get_adapter raced on concurrent insert: {errors!r}"
+
+
+def test_get_adapter_base_url_none_still_matches_provider():
+    """The snapshot scan still returns a cached adapter for the provider."""
+    _register_opaque_adapter("a")
+    svc = LLMService(
+        provider="a",
+        model="m",
+        api_key="sk-a",
+        key_resolver=lambda p: "sk-key",
+    )
+    seeded = svc._adapters[("a", None)]
+    assert svc.get_adapter("a") is seeded


### PR DESCRIPTION
## Summary

`LLMService.get_adapter` (`src/lingtai/llm/service.py`) has a lock-free fast path that, when the caller passes no `base_url`, scans `self._adapters.items()` for any cached adapter whose provider matches. That scan runs **without** `self._adapter_lock`, while the slow path below inserts `self._adapters[cache_key] = adapter` under that lock from another thread. In CPython, a concurrent insert landing mid-iteration raises `RuntimeError: dictionary changed size during iteration`, which propagates to the caller as a spurious, unexplained LLM failure — exactly when several threads race to warm the cache (e.g. `core/daemon/__init__.py` calls `service.get_adapter(provider)` with no `base_url` while agent/capability threads warm a second provider on the same shared `LLMService`).

**Root cause:** iterating a live dict that another thread may mutate. **Fix at the owning layer, smallest honest scope:** iterate over an atomic snapshot — `list(self._adapters.items())` materializes in one C-level step, so no concurrent insert can interleave with the scan. Point reads stay lock-free; the slow-path double-check scan is already protected by the lock and is unchanged.

**Non-goals (deliberately out of scope):** the issue also proposed a `_find_provider_adapter` helper with a 3-tier deterministic preference rule (prefer the `(provider, None)` entry, then the configured default `base_url`, then sorted-key tie-break) for *which* adapter a `base_url=None` call returns when multiple base_urls are cached for one provider. Today that ordering is unspecified — the issue itself notes "previously unspecified, so no documented contract is broken." Changing it is a behavior change with a different review/risk profile and a new abstraction, not part of this crash fix, so it is left out. This PR changes behavior only in that `get_adapter` no longer raises the spurious `RuntimeError`.

## Validation

Failing-first regression test (`tests/test_llm_service_adapter_cache.py`), run against the unfixed code — reproduces the exact `RuntimeError` from the issue:

```
$ PYTHONPATH=src .venv/bin/python -m pytest tests/test_llm_service_adapter_cache.py::test_get_adapter_scan_race_with_concurrent_insert -x -q
>       assert not errors, f"get_adapter raced on concurrent insert: {errors!r}"
E       AssertionError: get_adapter raced on concurrent insert: [RuntimeError('dictionary changed size during iteration'), RuntimeError('dictionary changed size during iteration'), RuntimeError('dictionary changed size during iteration')]
tests/test_llm_service_adapter_cache.py:105: AssertionError
1 failed in 1.60s
```

After the one-line snapshot fix — passes, and stable across repeats:

```
$ PYTHONPATH=src .venv/bin/python -m pytest tests/test_llm_service_adapter_cache.py -x -q
..                                                                       [100%]
2 passed in 1.61s

$ for i in 1 2 3; do PYTHONPATH=src .venv/bin/python -m pytest tests/test_llm_service_adapter_cache.py::test_get_adapter_scan_race_with_concurrent_insert -q | tail -1; done
1 passed in 1.59s
1 passed in 1.58s
1 passed in 1.62s
```

Existing service tests for the touched module — unaffected:

```
$ PYTHONPATH=src .venv/bin/python -m pytest tests/test_llm_service.py tests/test_services_integration.py -q
..............sss                                                        [100%]
14 passed, 3 skipped in 1.53s
```

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)
