### PR TITLE
fix: probe real host for schemeless preset base_url (#741)

### DIFF
--- a/src/lingtai_kernel/preset_connectivity.py
+++ b/src/lingtai_kernel/preset_connectivity.py
@@ -84,6 +84,39 @@ def _resolve_url(provider: str | None, base_url: str | None) -> str | None:
     return None
 
 
+def _parse_probe_target(url: str) -> tuple[str, int] | None:
+    """Parse ``url`` into a ``(host, port)`` tuple for a TCP probe.
+
+    Guards against two surprising ``urlparse`` behaviors that otherwise make
+    the probe silently resolve to localhost (``getaddrinfo(None, ...)``):
+
+    - ``urlparse("api.openai.com")`` -> ``scheme=''``, ``hostname=None`` (the
+      whole string lands in ``path``).
+    - ``urlparse("myhost:8080")`` -> ``scheme='myhost'``, ``hostname=None`` (the
+      host is swallowed as a scheme).
+
+    A schemeless URL is normalized to https before parsing — matching every
+    ``_PROVIDER_DEFAULT_URLS`` entry and the realistic intent of an API base
+    URL — so ``api.openai.com`` probes ``(api.openai.com, 443)`` and
+    ``myhost:8080`` probes ``(myhost, 8080)``. The scheme test must be
+    ``"://" not in url`` rather than ``parsed.scheme == ""`` precisely because
+    the ``myhost:8080`` case yields a non-empty bogus scheme.
+
+    Returns ``None`` (never a localhost fallback) when no hostname can be
+    extracted or the port is non-numeric, so the caller can fail loud.
+    """
+    if "://" not in url:
+        url = f"https://{url}"
+    parsed = urlparse(url)
+    if not parsed.hostname:
+        return None
+    try:
+        port = parsed.port  # raises ValueError on e.g. "host:notaport"
+    except ValueError:
+        return None
+    return parsed.hostname, port or (443 if parsed.scheme == "https" else 80)
+
+
 def check_connectivity(
     provider: str | None,
     base_url: str | None,
@@ -98,6 +131,11 @@ def check_connectivity(
          "checked_at": "<ISO timestamp>",
          "latency_ms": int (only on ok),
          "error": str | None}
+
+    A schemeless base_url (e.g. ``api.openai.com`` or ``myhost:8080``) is
+    probed as https on its real host — never silently against localhost. A
+    base_url with no extractable host yields ``"unreachable"`` with an
+    ``invalid base_url`` error rather than a misleading loopback probe.
     """
     # Local CLI-login providers (e.g. claude-code) have no network
     # endpoint and no API key — they authenticate through a local CLI/login
@@ -143,9 +181,15 @@ def check_connectivity(
             "error": f"no base_url and no default URL for provider {provider!r}",
         }
 
-    parsed = urlparse(url)
-    host = parsed.hostname
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    target = _parse_probe_target(url)
+    if target is None:
+        return {
+            "status": "unreachable",
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+            "latency_ms": None,
+            "error": f"invalid base_url {url!r}: cannot determine host to probe",
+        }
+    host, port = target
 
     try:
         latency_ms = _probe_host(host, port, _PROBE_TIMEOUT_S)

--- a/tests/test_preset_connectivity.py
+++ b/tests/test_preset_connectivity.py
@@ -181,6 +181,106 @@ def test_check_many_empty_list_returns_empty():
 
 
 # ---------------------------------------------------------------------------
+# Schemeless / malformed base_url (issue #741)
+#
+# urlparse() has two surprising behaviors that made check_connectivity()
+# silently probe localhost instead of the configured endpoint:
+#   urlparse("api.openai.com") -> scheme='',      hostname=None
+#   urlparse("myhost:8080")    -> scheme='myhost', hostname=None, port=None
+# With hostname=None, socket.create_connection((None, 80)) resolves to
+# loopback — a false "ok" if anything local listens, or a misleading
+# "unreachable". These tests pin the corrected behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_schemeless_base_url_probed_as_https(monkeypatch):
+    """A bare hostname base_url is probed as https on the real host, not localhost."""
+    monkeypatch.setenv("MOCK_KEY", "sk-test")
+    from lingtai_kernel import preset_connectivity
+    captured = {}
+    def fake_probe(host, port, timeout):
+        captured["host"] = host
+        captured["port"] = port
+        return 7
+    with patch.object(preset_connectivity, "_probe_host", side_effect=fake_probe):
+        result = preset_connectivity.check_connectivity(
+            provider=None,
+            base_url="api.openai.com",
+            api_key_env="MOCK_KEY",
+        )
+    assert captured["host"] == "api.openai.com"
+    assert captured["port"] == 443
+    assert result["status"] == "ok"
+
+
+def test_schemeless_host_port_base_url_keeps_port(monkeypatch):
+    """A schemeless host:port base_url probes that host and port (the
+    urlparse scheme-swallowing case), not localhost:80."""
+    monkeypatch.setenv("MOCK_KEY", "sk-test")
+    from lingtai_kernel import preset_connectivity
+    captured = {}
+    def fake_probe(host, port, timeout):
+        captured["host"] = host
+        captured["port"] = port
+        return 3
+    with patch.object(preset_connectivity, "_probe_host", side_effect=fake_probe):
+        result = preset_connectivity.check_connectivity(
+            provider=None,
+            base_url="myhost:8080",
+            api_key_env="MOCK_KEY",
+        )
+    assert captured["host"] == "myhost"
+    assert captured["port"] == 8080
+    assert result["status"] == "ok"
+
+
+@pytest.mark.parametrize("bad_url", ["https://", "http://host:notaport"])
+def test_invalid_base_url_reports_error_without_probing(monkeypatch, bad_url):
+    """A base_url with no extractable host fails loud with an
+    'invalid base_url' error and never probes (no silent localhost fallback)."""
+    monkeypatch.setenv("MOCK_KEY", "sk-test")
+    from lingtai_kernel import preset_connectivity
+    with patch.object(preset_connectivity, "_probe_host") as probe:
+        result = preset_connectivity.check_connectivity(
+            provider=None,
+            base_url=bad_url,
+            api_key_env="MOCK_KEY",
+        )
+        probe.assert_not_called()
+    assert result["status"] == "unreachable"
+    assert "invalid base_url" in (result.get("error") or "")
+
+
+def test_http_scheme_still_defaults_to_port_80(monkeypatch):
+    """Regression guard: explicit http:// with no port still probes port 80 —
+    the schemeless normalization must not disturb explicit-scheme handling."""
+    monkeypatch.setenv("MOCK_KEY", "sk-test")
+    from lingtai_kernel import preset_connectivity
+    captured = {}
+    def fake_probe(host, port, timeout):
+        captured["host"] = host
+        captured["port"] = port
+        return 1
+    with patch.object(preset_connectivity, "_probe_host", side_effect=fake_probe):
+        preset_connectivity.check_connectivity(
+            provider=None,
+            base_url="http://myhost",
+            api_key_env="MOCK_KEY",
+        )
+    assert captured["host"] == "myhost"
+    assert captured["port"] == 80
+
+
+def test_urlparse_schemeless_assumptions():
+    """stdlib canary: if urlparse's schemeless semantics change, surface it
+    here rather than as a silent regression in the probe target."""
+    from urllib.parse import urlparse
+    assert urlparse("api.openai.com").hostname is None
+    assert urlparse("myhost:8080").hostname is None
+    assert urlparse("myhost:8080").scheme == "myhost"
+
+
+# ---------------------------------------------------------------------------
 # Local CLI-login providers (e.g. claude-code)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`check_connectivity()` parsed a preset's `base_url` with `urlparse()` and passed `parsed.hostname` straight to `socket.create_connection()`, with no guard on `hostname is None`. For a schemeless `base_url` — `api.openai.com` or `myhost:8080`, both natural to type in a hand-authored manifest — `urlparse` returns `hostname=None` (the string lands in `path`, or the host is swallowed as a bogus scheme). `create_connection((None, 80))` then resolves to **loopback** via `getaddrinfo(None, ...)`, so the probe silently tested `localhost:80` instead of the configured endpoint:

- **False positive:** anything listening locally on port 80 makes the preset report `"ok"` with a tiny `latency_ms` — the agent confidently swaps into a preset whose real endpoint may be down. Exactly the failure the module's no-caching design exists to prevent.
- **Misleading negative:** with nothing local, the user gets `"unreachable"` / `Connection refused`, which reads as "the API host refused me" and sends them debugging firewalls instead of a missing `https://`.
- The `http://host:notaport` case even let a `ValueError` from `parsed.port` escape `check_connectivity` entirely.

The happy path never exercised this: every `_PROVIDER_DEFAULT_URLS` entry carries an `https://` scheme, and no test passed a schemeless `base_url`. The gap only opened for explicit hand-authored `base_url` values — the self-hosted/proxy case where bare `host:port` strings are written.

**Fix at the owning layer** (the probe-target derivation in `preset_connectivity.py`): a new `_parse_probe_target()` normalizes a schemeless URL to `https` before parsing (the scheme test is `"://" not in url`, not `scheme == ""`, because `myhost:8080` yields a non-empty bogus scheme), catches the non-numeric-port `ValueError`, and returns `None` — **never a localhost fallback** — when no host can be extracted. `check_connectivity` then fails loud with an explicit `invalid base_url` `"unreachable"` result. The return schema is unchanged, so `check_many()` and `intrinsics/system/preset.py` need no changes; well-formed `http(s)://` URLs take exactly the same path as before (`http://host` → port 80 preserved).

Non-goals: load-time `base_url` validation in the manifest loader (a compatible future addition; this probe-time guard is the minimal correct fix and also protects other `check_many` callers). No new config flags or opt-outs.

## Validation

Failing-first (against unmodified code):

```
$ .venv/bin/python -m pytest tests/test_preset_connectivity.py -q \
    -k "schemeless or invalid_base_url or http_scheme or urlparse_schemeless"
FAILED tests/test_preset_connectivity.py::test_schemeless_base_url_probed_as_https
FAILED tests/test_preset_connectivity.py::test_schemeless_host_port_base_url_keeps_port
FAILED tests/test_preset_connectivity.py::test_invalid_base_url_reports_error_without_probing[https://]
FAILED tests/test_preset_connectivity.py::test_invalid_base_url_reports_error_without_probing[http://host:notaport]
4 failed, 2 passed, 15 deselected in 0.18s
```

(The `http://host:notaport` failure was a raw `ValueError` escaping `check_connectivity` — a bonus bug the fix closes.)

After the fix — full file plus related preset suites:

```
$ .venv/bin/python -m pytest tests/test_preset_connectivity.py -q
21 passed in 0.86s

$ .venv/bin/python -m pytest tests/test_presets.py tests/test_activate_preset.py -q
78 passed in 0.21s

$ git diff --check
(no output)
```

Closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)
