### PR TITLE
fix(telegram): surface latest unread incoming in check

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -203,7 +203,10 @@ SCHEMA = {
                 "For charts, reports, generated artifacts, and other files the user should open intact, prefer media.type='document'; use media.type='photo' only when an inline Telegram photo preview is desired, because photo previews may crop, compress, or display poorly for text-heavy graphics. "
                 "If chat_action is set and no text/media is provided, sends a typing "
                 "indicator (auto-expires after 5s) instead of a message. "
-                "check: list recent conversations with unread counts (optional account). "
+                "check: list recent conversations with unread counts (optional account); "
+                "when unread>0 each conversation also carries latest_unread_incoming "
+                "(the latest unread incoming message from the inbox folder), distinct "
+                "from last_from/last_text which may be the bot's own reply. "
                 "read: read messages from a chat (chat_id; optional limit). "
                 "reply: reply to a specific message (message_id from read results, text; optional parse_mode/entities). "
                 "search: search messages (query; optional account, chat_id). "
@@ -1499,8 +1502,16 @@ class TelegramManager:
 
     def _check(self, args: dict) -> dict:
         account = self._resolve_account(args)
+        # Tag folder provenance: an inbox record is an incoming (human) message,
+        # a sent record is the bot's own outgoing message. The merged list loses
+        # the folder, so remember it here to surface unread *incoming* messages
+        # below (see Lingtai-AI/lingtai#470).
         inbox = self._list_messages(account, "inbox")
+        for m in inbox:
+            m["_incoming"] = True
         sent = self._list_messages(account, "sent")
+        for m in sent:
+            m["_incoming"] = False
         messages = inbox + sent
         messages.sort(key=lambda m: m.get("date", ""), reverse=True)
         read_ids = self._read_ids(account)
@@ -1525,10 +1536,28 @@ class TelegramManager:
                     "last_date": msg.get("date", ""),
                     "total": 0,
                     "unread": 0,
+                    "latest_unread_incoming": None,
                 }
             conversations[cid]["total"] += 1
-            if msg.get("id") and msg["id"] not in read_ids:
+            is_unread = bool(msg.get("id")) and msg["id"] not in read_ids
+            if is_unread:
                 conversations[cid]["unread"] += 1
+                # messages iterate newest-first, so the first unread incoming
+                # message we see per chat is the latest unread incoming message
+                # from the inbox folder.
+                if msg.get("_incoming") and conversations[cid]["latest_unread_incoming"] is None:
+                    conversations[cid]["latest_unread_incoming"] = {
+                        "id": msg.get("id"),
+                        "from": msg.get("from"),
+                        "text": (msg.get("text") or "")[:100],
+                        "date": msg.get("date", ""),
+                    }
+
+        # Drop the placeholder key when there is nothing unread/incoming to show,
+        # so the preview only carries latest_unread_incoming when it is real.
+        for conv in conversations.values():
+            if conv["latest_unread_incoming"] is None:
+                conv.pop("latest_unread_incoming")
 
         return {
             "status": "ok",

--- a/tests/test_telegram_check_unread_surface.py
+++ b/tests/test_telegram_check_unread_surface.py
@@ -1,0 +1,118 @@
+"""Regression test for Lingtai-AI/lingtai#470.
+
+`telegram.check` must surface an actionable *unread incoming* human message
+when unread > 0, instead of only previewing whatever message is newest overall
+(which is often the bot's own last reply).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+
+
+class _FakeAccount:
+    alias = "main"
+
+    def get_account(self, _alias: str) -> "_FakeAccount":
+        return self
+
+
+class _FakeService:
+    default_account = _FakeAccount()
+
+    def get_account(self, _alias: str) -> _FakeAccount:
+        return self.default_account
+
+
+def _manager(workdir: Path) -> TelegramManager:
+    return TelegramManager(
+        _FakeService(),
+        working_dir=workdir,
+        on_inbound=lambda _event: None,
+    )
+
+
+def _write_message(
+    workdir: Path,
+    folder: str,
+    record: dict[str, Any],
+    *,
+    account: str = "main",
+) -> None:
+    msg_dir = workdir / "telegram" / account / folder / record["id"].replace(":", "-")
+    msg_dir.mkdir(parents=True, exist_ok=True)
+    (msg_dir / "message.json").write_text(json.dumps(record), encoding="utf-8")
+
+
+def test_check_surfaces_unread_incoming_when_bot_replied_last(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    manager = _manager(workdir)
+    chat_id = 123
+
+    # Incoming human message (unread), then a NEWER outgoing bot reply.
+    _write_message(
+        workdir,
+        "inbox",
+        {
+            "id": f"main:{chat_id}:53",
+            "from": {"username": "alice", "is_bot": False},
+            "chat": {"id": chat_id, "type": "private"},
+            "date": "2026-06-30T09:00:00Z",
+            "text": "please clean up the extra files",
+        },
+    )
+    _write_message(
+        workdir,
+        "sent",
+        {
+            "id": f"main:{chat_id}:54",
+            "to": {"chat_id": chat_id},
+            "from": {"is_bot": True},
+            "date": "2026-06-30T09:01:00Z",
+            "text": "记住了：你不喜欢电脑里有多余东西",
+        },
+    )
+
+    result = manager.handle({"action": "check"})
+    assert result["status"] == "ok"
+    conv = next(c for c in result["messages"] if c["chat_id"] == chat_id)
+
+    # last_* still reflects newest-overall (the bot's own reply) — unchanged.
+    assert conv["last_from"].get("is_bot") is True
+    assert conv["unread"] >= 1
+
+    # The fix: an actionable unread incoming preview is now exposed.
+    lui = conv["latest_unread_incoming"]
+    assert lui is not None
+    assert lui["id"] == f"main:{chat_id}:53"
+    assert lui["text"] == "please clean up the extra files"
+    assert lui["from"].get("is_bot") is False
+
+
+def test_check_omits_unread_incoming_when_nothing_unread(tmp_path: Path) -> None:
+    workdir = tmp_path / "agent"
+    manager = _manager(workdir)
+    chat_id = 200
+
+    _write_message(
+        workdir,
+        "inbox",
+        {
+            "id": f"main:{chat_id}:10",
+            "from": {"username": "bob", "is_bot": False},
+            "chat": {"id": chat_id, "type": "private"},
+            "date": "2026-06-30T08:00:00Z",
+            "text": "hi",
+        },
+    )
+    # Mark it read so the conversation has zero unread.
+    manager._mark_read("main", [f"main:{chat_id}:10"])
+
+    result = manager.handle({"action": "check"})
+    conv = next(c for c in result["messages"] if c["chat_id"] == chat_id)
+    assert conv["unread"] == 0
+    # No placeholder key when there is nothing actionable to surface.
+    assert "latest_unread_incoming" not in conv


### PR DESCRIPTION
## Summary
- Add `latest_unread_incoming` to Telegram MCP `check` conversation rows when an unread incoming message exists in the inbox folder.
- Preserve existing `last_from` / `last_text`, unread counts, ordering, and read-state behavior; the new field only exposes the latest actionable incoming text that can otherwise be hidden by a later bot reply.
- Add regression coverage for present/absent unread incoming cases and keep the Telegram help text honest about "incoming" (not guaranteed human provenance).

Refs Lingtai-AI/lingtai#470.

## Validation
- `PYTHONPATH=src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_telegram_check_unread_surface.py tests/test_telegram_notification_read_state.py tests/test_telegram_rich_formatting.py -q` → 38 passed
- Batch 4 review chain: Claude implementation + Codex/Kimi/GLM review; Codex/Kimi final recheck pass for #470.

## Notes
This PR is in the kernel/SDK repo because the maintained Telegram MCP implementation lives here; the tracked issue is in `Lingtai-AI/lingtai`. No merge/close is performed by this PR.
