### PR TITLE
docs(prompts): add adapt-from-evidence principle

### DIFF
--- a/src/lingtai/prompts/principle/principle.md
+++ b/src/lingtai/prompts/principle/principle.md
@@ -57,6 +57,7 @@ The original LingTai principles are part of this section, not disposable decorat
 
 - **Act on need.** Move toward the human or peer's actual need; use the smallest adequate body (tool, daemon, avatar, MCP, knowledge, or skill) and report back where the need arrived.
 - **Master tools and learn without cease.** When a tool, domain, or workflow is unfamiliar, study the relevant manual or evidence instead of guessing; turn reusable lessons into skills and private facts into knowledge.
+- **Adapt from evidence.** If observation shows a behavior was wasteful, wrong, or useless, do not merely continue or apologize: change course and preserve the lesson in the right memory layer (pad, character, knowledge, or skills) so one stumble becomes better future judgment.
 - **Together, not alone.** Ask peers for help when they have the better capability, help them when they ask, and keep network topology knowledge durable.
 - **Shed the chaff, keep the grain.** Conversation is temporary; preserve current work in pad, durable facts in knowledge, reusable procedures in skills, and identity-shaping lessons in character.
 - **Communication is channel-bound.** Humans and peers reach the agent through communication channels such as Telegram, email, or MCP inboxes. Always reply on the channel where the message arrived. Do not answer a channel message in plain text output: text output is diary/private scratch, not a communications channel.

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -190,6 +190,7 @@ def test_packaged_principle_owns_static_progressive_and_token_efficiency_rules()
     assert "`procedures` is how to act" in prompt
     assert "`substrate` is the working model" in prompt
     assert "Reference manuals are why" in prompt
+    assert "Adapt from evidence" in prompt
     assert "Token efficiency principle:" in prompt
     assert "the current session's active context is carried into every provider request" in prompt
     assert "summarize consumed tool results" in prompt

--- a/tests/test_prompt_catalog.py
+++ b/tests/test_prompt_catalog.py
@@ -200,6 +200,7 @@ def test_principle_body_starts_with_system_prompt_map_and_lingtai_principles():
         assert f"| `{section}` |" in body
     assert "## LingTai operating principles" in body
     assert "Act on need" in body
+    assert "Adapt from evidence" in body
     assert "text output is diary/private scratch" in body
     assert "Always reply on the channel where the message arrived" in body
     assert "Mechanical runtime facts" in body


### PR DESCRIPTION
## Summary
- add a high-level `Adapt from evidence` principle to the kernel-owned principle prompt layer
- frame wasteful/wrong/useless observed behavior as a signal to change course and persist the lesson into the right memory layer
- add prompt/catalog assertions so the packaged principle keeps carrying the new guidance

## Validation
- `uv run --no-progress pytest tests/test_prompt.py tests/test_prompt_catalog.py -q` → 35 passed
- `git diff --check`
