### PR TITLE
Preserve pending sequential streaming tools

### DIFF
--- a/src/lingtai_kernel/llm/ANATOMY.md
+++ b/src/lingtai_kernel/llm/ANATOMY.md
@@ -35,7 +35,7 @@ Provider-agnostic LLM protocol layer. This folder defines the canonical chat log
   - `InterfaceEntry` is one role+content row with id, role, timestamp, provider metadata, model/provider, usage, and optional tool snapshot (`llm/interface.py:230-294`).
   - `ChatInterface` is the append-only source of truth for history (`llm/interface.py:296`). It appends system/user/assistant/tool-result entries (`llm/interface.py:522-660`), enforces/repairs tool-call pairing (`llm/interface.py:345-521`), removes strict synthetic pairs (`llm/interface.py:662-767`), prunes history (`llm/interface.py:857-930`), estimates tokens (`llm/interface.py:932-980`), and supports compaction summaries (`llm/interface.py:981-1057`).
 - `llm/service.py` — `LLMService` ABC: `model`, `provider`, `create_session()`, `generate()`, and `make_tool_result()` (`llm/service.py:16-70`).
-- `llm/streaming.py` — `StreamingAccumulator`, which gathers streaming text/thought/tool-call deltas and finalizes to `LLMResponse` (`llm/streaming.py:16-69`, `llm/streaming.py:145-170`). It supports sequential tool-call assembly (`llm/streaming.py:71-84`), index-keyed deltas (`llm/streaming.py:88-117`), atomic tool calls (`llm/streaming.py:121-126`), and `_finalize_tool()` (`llm/streaming.py:173-180`).
+- `llm/streaming.py` — `StreamingAccumulator`, which gathers streaming text/thought/tool-call deltas and finalizes to `LLMResponse` (`llm/streaming.py:19-69`, `llm/streaming.py:148-184`). It supports sequential tool-call assembly (`llm/streaming.py:72-87`), index-keyed deltas (`llm/streaming.py:89-120`), atomic tool calls (`llm/streaming.py:122-126`), and `_finalize_tool()` (`llm/streaming.py:187-201`).
 
 ## Connections
 
@@ -55,11 +55,11 @@ Provider-agnostic LLM protocol layer. This folder defines the canonical chat log
 ## State
 
 - **Ephemeral:** `ChatInterface._entries`, `_next_id`, current system/tools, and `_pending_system` live in memory for one session (`llm/interface.py:305-318`).
-- **Ephemeral:** `StreamingAccumulator` stores partial text, tool args, thoughts, and usage until `finalize()` (`llm/streaming.py:39-69`).
+- **Ephemeral:** `StreamingAccumulator` stores partial text, tool args, and thoughts until `finalize()` (`llm/streaming.py:42-52`, `llm/streaming.py:148-184`).
 - **Persistent writes:** none in this folder. `session.py` writes `history/chat_history.jsonl`; token/state persistence happens in sibling modules that consume these types.
 
 ## Notes
 
 - `add_system()` defers system/tool updates while the tail has unanswered tool calls so strict providers do not see a system entry between assistant tool calls and user tool results (`llm/interface.py:522-572`).
 - `close_pending_tool_calls()` closes unanswered tail tool calls by first accepting optional real recovered `ToolResultBlock`s from a recovery lookup and then synthesizing abort placeholders for any remaining misses (`llm/interface.py:445-521`, `llm/interface.py:99-186`).
-- `StreamingAccumulator` intentionally supports three provider styles in one place: sequential, index-keyed, and atomic tool calls (`llm/streaming.py:71-126`).
+- `StreamingAccumulator` intentionally supports three provider styles in one place: sequential, index-keyed, and atomic tool calls (`llm/streaming.py:72-126`).

--- a/src/lingtai_kernel/llm/streaming.py
+++ b/src/lingtai_kernel/llm/streaming.py
@@ -152,12 +152,23 @@ class StreamingAccumulator:
     ) -> LLMResponse:
         """Build the final LLMResponse from all accumulated deltas.
 
-        Any pending thought block is automatically closed.
+        Any pending thought block is automatically closed. Any pending
+        sequential tool call is also auto-finalized.
         Index-keyed tools are NOT auto-finalized — call finish_all_tools()
         explicitly before finalize() if using the index-keyed style.
         """
         # Close any open thought block
         self.finish_thought()
+
+        if self._pending_tool is not None:
+            logger.warning(
+                "stream ended with pending sequential tool call; "
+                "auto-finalizing name=%r id=%r args_len=%d",
+                self._pending_tool["name"],
+                self._pending_tool["id"] or None,
+                len(self._pending_tool["args_json"]),
+            )
+            self.finish_tool()
 
         # Consolidate thoughts into a single entry if multiple deltas
         thoughts = self._thoughts
@@ -179,6 +190,12 @@ def _finalize_tool(pending: dict[str, str]) -> ToolCall:
     try:
         args = json.loads(args_json) if args_json else {}
     except json.JSONDecodeError:
-        logger.warning("streamed tool-call args JSON parse failed; defaulting to {}")
+        logger.warning(
+            "streamed tool-call args JSON parse failed; "
+            "name=%r id=%r args_len=%d; defaulting to args={}",
+            pending["name"],
+            pending["id"] or None,
+            len(args_json),
+        )
         args = {}
     return ToolCall(name=pending["name"], args=args, id=pending["id"] or None)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -64,15 +64,41 @@ def test_sequential_tool_empty_args():
     assert result.tool_calls[0].args == {}
 
 
+def test_finalize_auto_closes_pending_sequential_tool(caplog):
+    acc = StreamingAccumulator()
+    args_json = '{"path": "foo.py"}'
+    acc.start_tool(id="toolu_1", name="read_file")
+    acc.add_tool_args(args_json)
+
+    with caplog.at_level("WARNING", logger="lingtai_kernel.llm.streaming"):
+        result = acc.finalize()
+
+    assert len(result.tool_calls) == 1
+    tc = result.tool_calls[0]
+    assert tc.name == "read_file"
+    assert tc.args == {"path": "foo.py"}
+    assert tc.id == "toolu_1"
+    assert "pending sequential tool call" in caplog.text
+    assert "auto-finalizing" in caplog.text
+    assert "read_file" in caplog.text
+    assert "toolu_1" in caplog.text
+    assert f"args_len={len(args_json)}" in caplog.text
+
+
 def test_sequential_tool_malformed_json(caplog):
     acc = StreamingAccumulator()
+    args_json = "{not valid json"
     acc.start_tool(id="t1", name="broken")
-    acc.add_tool_args("{not valid json")
+    acc.add_tool_args(args_json)
     with caplog.at_level("WARNING", logger="lingtai_kernel.llm.streaming"):
         acc.finish_tool()
     result = acc.finalize()
     assert result.tool_calls[0].args == {}
-    assert "streamed tool-call args JSON parse failed; defaulting to {}" in caplog.text
+    assert "streamed tool-call args JSON parse failed" in caplog.text
+    assert "defaulting to args={}" in caplog.text
+    assert "broken" in caplog.text
+    assert "t1" in caplog.text
+    assert f"args_len={len(args_json)}" in caplog.text
 
 
 def test_finish_tool_noop_when_no_pending():
@@ -120,6 +146,15 @@ def test_index_keyed_late_id():
     acc.finish_all_tools()
     result = acc.finalize()
     assert result.tool_calls[0].id == "late_id"
+
+
+def test_finalize_does_not_auto_close_index_keyed_tools():
+    acc = StreamingAccumulator()
+    acc.add_tool_delta(0, id="call_1", name="search", args_delta='{"q": "hello"}')
+
+    result = acc.finalize()
+
+    assert result.tool_calls == []
 
 
 # -- Atomic tool calls (Gemini Interactions) --------------------------------

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -85,6 +85,66 @@ def test_finalize_auto_closes_pending_sequential_tool(caplog):
     assert f"args_len={len(args_json)}" in caplog.text
 
 
+def test_finalize_auto_closes_pending_sequential_tool_with_malformed_json(caplog):
+    acc = StreamingAccumulator()
+    args_json = '{"path":'
+    acc.start_tool(id="toolu_bad", name="read_file")
+    acc.add_tool_args(args_json)
+
+    with caplog.at_level("WARNING", logger="lingtai_kernel.llm.streaming"):
+        result = acc.finalize()
+
+    assert len(result.tool_calls) == 1
+    tc = result.tool_calls[0]
+    assert tc.name == "read_file"
+    assert tc.id == "toolu_bad"
+    assert tc.args == {}
+    assert "pending sequential tool call" in caplog.text
+    assert "auto-finalizing" in caplog.text
+    assert "streamed tool-call args JSON parse failed" in caplog.text
+    assert "defaulting to args={}" in caplog.text
+    assert "read_file" in caplog.text
+    assert "toolu_bad" in caplog.text
+    assert f"args_len={len(args_json)}" in caplog.text
+
+
+def test_finalize_after_finished_sequential_tool_emits_no_pending_warning(caplog):
+    acc = StreamingAccumulator()
+    acc.start_tool(id="toolu_1", name="read_file")
+    acc.add_tool_args('{"path": "foo.py"}')
+    acc.finish_tool()
+
+    with caplog.at_level("WARNING", logger="lingtai_kernel.llm.streaming"):
+        result = acc.finalize()
+
+    assert len(result.tool_calls) == 1
+    assert "pending sequential tool call" not in caplog.text
+
+
+def test_finalize_preserves_finished_then_pending_tool_order_and_is_idempotent(caplog):
+    acc = StreamingAccumulator()
+    acc.start_tool(id="toolu_1", name="read_file")
+    acc.add_tool_args('{"path": "foo.py"}')
+    acc.finish_tool()
+    acc.start_tool(id="toolu_2", name="write_file")
+    acc.add_tool_args('{"path": "bar.py"}')
+
+    with caplog.at_level("WARNING", logger="lingtai_kernel.llm.streaming"):
+        first_result = acc.finalize()
+
+    assert [tc.id for tc in first_result.tool_calls] == ["toolu_1", "toolu_2"]
+    assert [tc.name for tc in first_result.tool_calls] == ["read_file", "write_file"]
+    assert "pending sequential tool call" in caplog.text
+    assert "toolu_2" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level("WARNING", logger="lingtai_kernel.llm.streaming"):
+        second_result = acc.finalize()
+
+    assert [tc.id for tc in second_result.tool_calls] == ["toolu_1", "toolu_2"]
+    assert "pending sequential tool call" not in caplog.text
+
+
 def test_sequential_tool_malformed_json(caplog):
     acc = StreamingAccumulator()
     args_json = "{not valid json"


### PR DESCRIPTION
Fixes #753.

## Summary

- Preserve a pending sequential streaming tool call when `StreamingAccumulator.finalize()` is reached before the provider sends the normal tool-close event.
- Keep the index-keyed tool path unchanged: callers still must use `finish_all_tools()` before `finalize()`.
- Improve warning diagnostics for abnormal sequential-tool finalization and malformed tool-argument JSON without logging raw tool arguments.
- Add regression coverage for valid pending tools, truncated/malformed pending tools, happy-path no-warning behavior, ordering/idempotency, and index-keyed non-auto-finalization.

## Why

Sequential streaming adapters can receive a tool start/name/id and argument deltas before the stream ends or omits the normal close event. Before this change, `finalize()` closed unfinished thoughts but did not close `_pending_tool`, so the already-started tool call could disappear from `LLMResponse.tool_calls` with little diagnostic signal.

This is worse than returning a malformed-but-visible tool call: downstream pairing/recovery code cannot reason about a tool call that vanished before it became part of the response.

## What changed

- `StreamingAccumulator.finalize()` now checks for `self._pending_tool` after `finish_thought()` and calls the existing `finish_tool()` path before constructing the final `LLMResponse`.
- The abnormal finalize path logs a warning with tool name, id, and accumulated-argument length.
- `_finalize_tool()` now includes tool name, id, and argument length in JSON parse-failure warnings.
- The warnings intentionally log `args_len`, not a raw argument snippet. The original issue plan suggested a short raw snippet, but streamed tool arguments may contain user content, file contents, messages, or credentials; length + tool identity gives correlation value without copying payloads into logs.
- `llm/ANATOMY.md` line citations were updated for the touched streaming code.

## Non-goals

- No adapter changes.
- No `LLMResponse` / `ToolCall` schema changes.
- No auto-finalization for index-keyed tools; that contract remains explicit through `finish_all_tools()`.
- No raw streamed argument payloads in warnings.

## Review notes

Independent Claude Code and GLM-5.2 reviews both returned `approve-with-nits` with no blockers. Their shared main nit was to add regression coverage for the composition of auto-finalize + malformed/truncated JSON, plus happy-path warning silence and ordering/idempotency. Those nits are addressed by the second test-only commit.

## Validation

- `python3 -m py_compile src/lingtai_kernel/llm/streaming.py tests/test_streaming.py` — passed
- `uv run --no-project --with pytest python -m pytest tests/test_streaming.py -q` — `26 passed`
- `git diff --check canonical/main...HEAD` — passed
- `python3 tools/check_anatomy_drift.py --check` — still reports one pre-existing/unrelated drift item: `src/lingtai/llm/anthropic/ANATOMY.md` cites `adapter.py:827` while that file has 823 lines. The touched `src/lingtai_kernel/llm/ANATOMY.md` citations were updated and reviewed.
