### PR TITLE
Return mail edges for non-node correspondents

### DIFF
--- a/src/lingtai/ANATOMY.md
+++ b/src/lingtai/ANATOMY.md
@@ -70,7 +70,7 @@ PyPI wrapper package — `Agent(BaseAgent)` with composable capabilities, preset
 
 **`init_schema.py`**: `DEPRECATED_TOP_FIELDS` :41 (plain deprecated top-level fields stripped by `strip_deprecated`), `LEGACY_MIGRATED_TOP_FIELDS` :60 (legacy fields removed by version-controlled agent migrations and known only as inactive schema), `validate_init` :146, `TOP_OPTIONAL` :15, `MANIFEST_OPTIONAL` :79; `manifest.llm.compact_threshold` is validated as positive int or null in the LLM block, and `manifest.cache_miss_budget` (the soft cache-miss token budget) is validated as a positive int — bool and `<= 0` rejected — with a clear `manifest.cache_miss_budget` error path (:295-306).
 
-**`network.py`**: `build_network` :306 · `_discover_agents` :143 · `_build_avatar_edges` :168
+**`network.py`**: `build_network` :310 · `_discover_agents` :147 · `_build_avatar_edges` :172
 
 **`venv_resolve.py`**: `resolve_venv` :74 · `venv_python` :101 · `_is_default_runtime_dir` :108 · `_test_venv` :118 · `_env_marker_status` :298 · `_env_marker_status_detail` :303 · `_remove_mismatched_managed_venv` :353 · `_env_marker_main` :362
 

--- a/src/lingtai/network.py
+++ b/src/lingtai/network.py
@@ -94,9 +94,13 @@ class AgentNetwork:
         return [e for e in self.contact_edges if e.owner_address == address]
 
     def mail_of(self, address: str) -> list[MailEdge]:
-        """Return all mail edges where *address* is sender or recipient."""
-        if address not in self.nodes:
-            return []
+        """Return mail edges whose endpoints exactly equal *address*.
+
+        Accepts any address string, not just a discovered node. Matching uses
+        exact string equality against ``MailEdge.sender`` or
+        ``MailEdge.recipient``; useful values include node addresses,
+        ``../human``, and dead/external correspondents.
+        """
         return [e for e in self.mail_edges
                 if e.sender == address or e.recipient == address]
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -353,6 +353,64 @@ def test_mail_of(tmp_path):
     assert alice_mail[0].sender == alice_addr
 
 
+def test_mail_of_human_sender_and_recipient(tmp_path):
+    agent_addr = _write_manifest(tmp_path / "agent", "agent")
+    human_addr = "../human"
+    _write_mail(tmp_path / "agent", "inbox", [
+        {
+            "from": human_addr,
+            "to": [agent_addr],
+            "subject": "question",
+            "received_at": "2026-03-20T10:00:00Z",
+        },
+    ])
+    _write_mail(tmp_path / "agent", "sent", [
+        {
+            "from": agent_addr,
+            "to": [human_addr],
+            "subject": "answer",
+            "sent_at": "2026-03-20T11:00:00Z",
+        },
+    ])
+
+    net = build_network(tmp_path)
+
+    assert human_addr not in net.nodes
+    assert {(e.sender, e.recipient) for e in net.mail_of(human_addr)} == {
+        (human_addr, agent_addr),
+        (agent_addr, human_addr),
+    }
+
+
+def test_mail_of_external_non_node_correspondent(tmp_path):
+    agent_addr = _write_manifest(tmp_path / "agent", "agent")
+    external_addr = "dead@example.test"
+    _write_mail(tmp_path / "agent", "inbox", [
+        {
+            "from": external_addr,
+            "to": [agent_addr],
+            "subject": "old inbound",
+            "received_at": "2026-03-20T10:00:00Z",
+        },
+    ])
+    _write_mail(tmp_path / "agent", "sent", [
+        {
+            "from": agent_addr,
+            "to": [external_addr],
+            "subject": "old outbound",
+            "sent_at": "2026-03-20T11:00:00Z",
+        },
+    ])
+
+    net = build_network(tmp_path)
+
+    assert external_addr not in net.nodes
+    assert {(e.sender, e.recipient) for e in net.mail_of(external_addr)} == {
+        (external_addr, agent_addr),
+        (agent_addr, external_addr),
+    }
+
+
 def test_mail_of_unknown_agent(tmp_path):
     net = build_network(tmp_path)
     assert net.mail_of("unknown") == []


### PR DESCRIPTION
Fixes #747.

## Summary

`AgentNetwork.mail_of()` previously returned `[]` before checking any mail edges whenever the requested address was not present in `network.nodes`. That hid valid mail edges for non-node correspondents such as the `../human` pseudo-agent or external/dead addresses, even though the mail-edge builder already records sender and recipient strings verbatim.

This PR removes that node-membership gate and documents that `mail_of()` matches by exact address string. If no mail edge mentions the requested address, it still naturally returns `[]`.

## What changed

- Removes the `address in self.nodes` precondition from `AgentNetwork.mail_of()`.
- Expands the `mail_of()` docstring to clarify exact-string lookup for nodes, `../human`, and external/dead correspondents.
- Adds focused tests for non-node correspondents in both sender and recipient positions, while preserving the unknown-address empty result.
- Updates `src/lingtai/ANATOMY.md` line citations shifted by the network.py edit.

## Non-goals

- No ghost `AgentNode` creation for non-node correspondents.
- No address normalization or fuzzy matching.
- No schema, parser, CLI, or network-builder behavior changes outside the `mail_of()` lookup helper.

## Validation

- `python3 -m py_compile src/lingtai/network.py tests/test_network.py`
- `uv run --no-project --with pytest --with-editable . python -m pytest tests/test_network.py -q` → `20 passed`
- `git diff --check canonical/main...HEAD`
- `python3 tools/check_anatomy_drift.py --check` still reports only the pre-existing unrelated `src/lingtai/llm/anthropic/ANATOMY.md` citation drift.

## Review

Codex, Claude Code, and GLM independently reviewed the implementation. Codex and Claude approved with no blockers or nits; GLM approved with only optional nonblocking test-organization suggestions.
