### PR TITLE
Prioritize pseudo-agent outbox polling

### DIFF
--- a/src/lingtai_kernel/services/ANATOMY.md
+++ b/src/lingtai_kernel/services/ANATOMY.md
@@ -27,8 +27,8 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
   - `MailService` is the ABC for `send()`, `listen()`, `stop()`, and `address` (`services/mail.py:29`).
   - `FilesystemMailService` implements directory-based delivery (`services/mail.py:81`); its constructor takes `working_dir`, `mailbox_rel`, and optional pseudo-agent subscriptions (`services/mail.py:94`).
   - `send()` resolves peer/absolute addresses, checks `is_agent`/`is_alive`, generates ids through `intrinsics.email._new_mailbox_id`, copies attachments, and writes `message.json` atomically (`services/mail.py:131`, `services/mail.py:165`, `services/mail.py:199-206`).
-  - `listen()` starts a daemon polling thread (`services/mail.py:216`), snapshots existing inbox ids into `_seen` (`services/mail.py:224-227`), polls subscribed pseudo-agent outboxes before each own-inbox scan, and waits 0.5s between iterations (`services/mail.py:234-260`, `services/mail.py:265-387`).
-  - `stop()` sets the poll stop event and joins the thread (`services/mail.py:469-474`).
+  - `listen()` starts a daemon polling thread (`services/mail.py:216`), snapshots existing inbox ids into `_seen` (`services/mail.py:224-227`), polls subscribed pseudo-agent outboxes before each own-inbox scan (each phase isolated so a persistent OSError in one phase cannot skip the other), and waits 0.5s between iterations (`services/mail.py:233-264`, `services/mail.py:269-391`).
+  - `stop()` sets the poll stop event and joins the thread (`services/mail.py:473-477`).
 - `services/logging.py` — structured event log, token-ledger mirror, and additive SQLite trace query index. Agent event rows are stamped upstream with compact kernel runtime identity fields (`kernel_version`, `kernel_runtime_stamp`, `kernel_runtime`) before durable JSONL/SQLite persistence.
   - `LoggingService` is the ABC for `log(event)` and `close()`; `log()` may return optional storage metadata such as JSONL offsets (`services/logging.py:76`, `services/logging.py:83-89`).
   - `JSONLLoggingService` appends UTF-8 JSON lines with a lock and flush per write, returning `(source_file, source_offset)` metadata (`services/logging.py:95`, `services/logging.py:104-111`, `services/logging.py:119-130`).
@@ -60,7 +60,7 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
 
 ## Notes
 
-- Pseudo-agent outbox claiming is optimistic concurrency: pollers copy to inbox, race on outbox→sent rename, and losers delete their speculative copy and clear `_seen` (`services/mail.py:325-370`).
+- Pseudo-agent outbox claiming is optimistic concurrency: pollers copy to inbox, race on outbox→sent rename, and losers delete their speculative copy and clear `_seen` (`services/mail.py:329-374`).
 - The services package has two ABCs but mail and logging now differ in shape: mail still has one filesystem implementation, while logging composes the JSONL primary with optional derived indexes.
 - `get_events()` favors simplicity over hot-path performance: it re-opens and parses the whole JSONL file each call (`services/logging.py:153-168`).
 - SQLite is intentionally additive: JSONL remains the durable source of truth; rebuild requires the agent working-directory lock (offline/stopped agent), uses a temporary database and atomic replace, and checkpoints WAL before replacing so the final artifact is self-contained (`services/logging.py:845-959`).

--- a/src/lingtai_kernel/services/ANATOMY.md
+++ b/src/lingtai_kernel/services/ANATOMY.md
@@ -27,8 +27,8 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
   - `MailService` is the ABC for `send()`, `listen()`, `stop()`, and `address` (`services/mail.py:29`).
   - `FilesystemMailService` implements directory-based delivery (`services/mail.py:81`); its constructor takes `working_dir`, `mailbox_rel`, and optional pseudo-agent subscriptions (`services/mail.py:94`).
   - `send()` resolves peer/absolute addresses, checks `is_agent`/`is_alive`, generates ids through `intrinsics.email._new_mailbox_id`, copies attachments, and writes `message.json` atomically (`services/mail.py:131`, `services/mail.py:165`, `services/mail.py:199-206`).
-  - `listen()` starts a daemon polling thread (`services/mail.py:216`), snapshots existing inbox ids into `_seen` (`services/mail.py:224-227`), scans every 0.5s (`services/mail.py:256`), and also claims subscribed pseudo-agent outbox messages (`services/mail.py:250-253`, `services/mail.py:261-368`).
-  - `stop()` sets the poll stop event and joins the thread (`services/mail.py:370-374`).
+  - `listen()` starts a daemon polling thread (`services/mail.py:216`), snapshots existing inbox ids into `_seen` (`services/mail.py:224-227`), polls subscribed pseudo-agent outboxes before each own-inbox scan, and waits 0.5s between iterations (`services/mail.py:234-260`, `services/mail.py:265-387`).
+  - `stop()` sets the poll stop event and joins the thread (`services/mail.py:469-474`).
 - `services/logging.py` — structured event log, token-ledger mirror, and additive SQLite trace query index. Agent event rows are stamped upstream with compact kernel runtime identity fields (`kernel_version`, `kernel_runtime_stamp`, `kernel_runtime`) before durable JSONL/SQLite persistence.
   - `LoggingService` is the ABC for `log(event)` and `close()`; `log()` may return optional storage metadata such as JSONL offsets (`services/logging.py:76`, `services/logging.py:83-89`).
   - `JSONLLoggingService` appends UTF-8 JSON lines with a lock and flush per write, returning `(source_file, source_offset)` metadata (`services/logging.py:95`, `services/logging.py:104-111`, `services/logging.py:119-130`).
@@ -60,7 +60,7 @@ Kernel-side service ABCs and implementations. Services back cross-cutting kernel
 
 ## Notes
 
-- Pseudo-agent outbox claiming is optimistic concurrency: pollers copy to inbox, race on outbox→sent rename, and losers delete their speculative copy and clear `_seen` (`services/mail.py:326-354`).
+- Pseudo-agent outbox claiming is optimistic concurrency: pollers copy to inbox, race on outbox→sent rename, and losers delete their speculative copy and clear `_seen` (`services/mail.py:325-370`).
 - The services package has two ABCs but mail and logging now differ in shape: mail still has one filesystem implementation, while logging composes the JSONL primary with optional derived indexes.
 - `get_events()` favors simplicity over hot-path performance: it re-opens and parses the whole JSONL file each call (`services/logging.py:153-168`).
 - SQLite is intentionally additive: JSONL remains the durable source of truth; rebuild requires the agent working-directory lock (offline/stopped agent), uses a temporary database and atomic replace, and checkpoints WAL before replacing so the final artifact is self-contained (`services/logging.py:845-959`).

--- a/src/lingtai_kernel/services/mail.py
+++ b/src/lingtai_kernel/services/mail.py
@@ -230,14 +230,19 @@ class FilesystemMailService(MailService):
 
         def _poll_loop() -> None:
             while not self._poll_stop.is_set():
+                # Phase 1 — subscribed pseudo-agent outboxes. Poll these
+                # before historical own-inbox scans so urgent human/TUI
+                # wake mail cannot starve behind old inbox entries. Isolated
+                # from Phase 2 so a persistent OSError here cannot skip the
+                # same tick's own-inbox scan.
                 try:
-                    # Phase 1 — subscribed pseudo-agent outboxes. Poll these
-                    # before historical own-inbox scans so urgent human/TUI
-                    # wake mail cannot starve behind old inbox entries.
                     for pseudo_dir in self._pseudo_agent_dirs:
                         self._poll_pseudo_outbox(pseudo_dir, on_message)
+                except OSError:
+                    pass
 
-                    # Phase 2 — own inbox.
+                # Phase 2 — own inbox.
+                try:
                     if self._inbox_dir.is_dir():
                         for entry in self._inbox_dir.iterdir():
                             # _seen only holds handled directory names or
@@ -254,7 +259,6 @@ class FilesystemMailService(MailService):
                                 except (json.JSONDecodeError, OSError):
                                     pass
                                 self._seen.add(entry.name)
-
                 except OSError:
                     pass
                 self._poll_stop.wait(0.5)

--- a/src/lingtai_kernel/services/mail.py
+++ b/src/lingtai_kernel/services/mail.py
@@ -231,12 +231,20 @@ class FilesystemMailService(MailService):
         def _poll_loop() -> None:
             while not self._poll_stop.is_set():
                 try:
-                    # Phase 1 — own inbox.
+                    # Phase 1 — subscribed pseudo-agent outboxes. Poll these
+                    # before historical own-inbox scans so urgent human/TUI
+                    # wake mail cannot starve behind old inbox entries.
+                    for pseudo_dir in self._pseudo_agent_dirs:
+                        self._poll_pseudo_outbox(pseudo_dir, on_message)
+
+                    # Phase 2 — own inbox.
                     if self._inbox_dir.is_dir():
                         for entry in self._inbox_dir.iterdir():
-                            if not entry.is_dir():
-                                continue
+                            # _seen only holds handled directory names or
+                            # pseudo-claim UUIDs, so skip before the stat.
                             if entry.name in self._seen:
+                                continue
+                            if not entry.is_dir():
                                 continue
                             msg_file = entry / "message.json"
                             if msg_file.is_file():
@@ -247,10 +255,6 @@ class FilesystemMailService(MailService):
                                     pass
                                 self._seen.add(entry.name)
 
-                    # Phase 2 — subscribed pseudo-agent outboxes. Claim
-                    # messages addressed to self via atomic rename outbox→sent.
-                    for pseudo_dir in self._pseudo_agent_dirs:
-                        self._poll_pseudo_outbox(pseudo_dir, on_message)
                 except OSError:
                     pass
                 self._poll_stop.wait(0.5)
@@ -272,8 +276,9 @@ class FilesystemMailService(MailService):
           1. Atomically rename ``<pseudo_dir>/mailbox/outbox/<uuid>/`` to a
              temporary claim directory under ``sent``. Only one poller can win
              this claim.
-          2. Pre-mark the UUID in ``_seen`` so Phase 1 won't re-dispatch it
-             after we place a copy in own inbox.
+          2. Pre-mark the UUID in ``_seen`` so the own-inbox scan in this
+             tick, and later ticks, won't re-dispatch it after we place a copy
+             in own inbox.
           3. Write ``message.json`` atomically into
              ``<self>/mailbox/inbox/<uuid>/``. This makes the wake signal
              truthful: by the time ``on_message`` fires, the message really is
@@ -329,9 +334,9 @@ class FilesystemMailService(MailService):
             except OSError:
                 continue
 
-            # Pre-mark BEFORE placing the file so Phase 1's own-inbox scan
-            # on the next tick doesn't treat this UUID as a new arrival and
-            # double-dispatch. Removed on rollback.
+            # Pre-mark BEFORE placing the file so the same poll iteration's
+            # own-inbox scan, and later ticks, do not double-dispatch it.
+            # Removed on rollback.
             self._seen.add(uuid_name)
 
             # Step 1: write the payload to own inbox (tmp -> rename).

--- a/tests/test_filesystem_mail.py
+++ b/tests/test_filesystem_mail.py
@@ -368,6 +368,155 @@ def test_pseudo_agent_outbox_pickup(tmp_path):
     assert received[0]["message"] == "hello from human"
 
 
+def test_pseudo_agent_outbox_polled_before_blocking_inbox_scan(tmp_path):
+    """Pseudo-agent outbox delivery should not wait behind an own-inbox scan."""
+    import json
+    import threading
+    from lingtai_kernel.services.mail import FilesystemMailService
+
+    base = tmp_path
+    pseudo_dir = base / "human"
+    my_dir = base / "agent_a"
+    pseudo_dir.mkdir()
+    my_dir.mkdir()
+    real_inbox = my_dir / "mailbox" / "inbox"
+    real_inbox.mkdir(parents=True)
+
+    outbox_dir = pseudo_dir / "mailbox" / "outbox"
+    msg_dir = outbox_dir / "msg-priority"
+    msg_dir.mkdir(parents=True)
+    msg = {
+        "id": "msg-priority",
+        "_mailbox_id": "msg-priority",
+        "from": "human",
+        "to": ["agent_a"],
+        "subject": "wake",
+        "message": "wake from human",
+        "type": "normal",
+        "received_at": "2026-07-08T10:00:00.000Z",
+    }
+    (msg_dir / "message.json").write_text(json.dumps(msg))
+
+    own_scan_started = threading.Event()
+    release_own_scan = threading.Event()
+
+    class BlockingInboxDir:
+        def __init__(self, path):
+            self.path = path
+            self.iterdir_calls = 0
+
+        def is_dir(self):
+            return self.path.is_dir()
+
+        def iterdir(self):
+            self.iterdir_calls += 1
+            if self.iterdir_calls == 1:
+                return iter(())
+            own_scan_started.set()
+            release_own_scan.wait(timeout=5.0)
+            return self.path.iterdir()
+
+        def __truediv__(self, child):
+            return self.path / child
+
+    received: list[dict] = []
+    received_event = threading.Event()
+
+    def on_message(payload: dict) -> None:
+        received.append(payload)
+        received_event.set()
+
+    svc = FilesystemMailService(
+        working_dir=my_dir,
+        pseudo_agent_subscriptions=["../human"],
+    )
+    svc._inbox_dir = BlockingInboxDir(real_inbox)
+    svc.listen(on_message=on_message)
+    try:
+        assert own_scan_started.wait(timeout=3.0), "own-inbox scan never started"
+        assert received_event.is_set(), (
+            "pseudo-agent outbox message was not dispatched before the "
+            "own-inbox scan blocked"
+        )
+        assert (real_inbox / "msg-priority" / "message.json").is_file()
+        assert (pseudo_dir / "mailbox" / "sent" / "msg-priority").is_dir()
+        assert not msg_dir.exists()
+    finally:
+        release_own_scan.set()
+        svc.stop()
+
+    assert len(received) == 1
+    assert received[0]["message"] == "wake from human"
+
+
+def test_seen_inbox_entries_skip_stat_before_is_dir(tmp_path):
+    """Already-seen inbox names should not pay an is_dir/stat call each tick."""
+    import threading
+    from lingtai_kernel.services.mail import FilesystemMailService
+
+    agent_dir = _make_agent_dir(tmp_path, "agent_a")
+    real_inbox = agent_dir / "mailbox" / "inbox"
+    real_inbox.mkdir(parents=True)
+
+    stat_attempted = threading.Event()
+    scan_finished = threading.Event()
+
+    class SeenEntry:
+        name = "already-seen"
+
+        def is_dir(self):
+            stat_attempted.set()
+            return True
+
+    seen_entry = SeenEntry()
+
+    class SeenEntries:
+        def __init__(self):
+            self.yielded = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.yielded:
+                scan_finished.set()
+                raise StopIteration
+            self.yielded = True
+            return seen_entry
+
+    class SeenInboxDir:
+        def __init__(self, path):
+            self.path = path
+            self.iterdir_calls = 0
+
+        def is_dir(self):
+            return self.path.is_dir()
+
+        def iterdir(self):
+            self.iterdir_calls += 1
+            if self.iterdir_calls == 1:
+                return iter(())
+            return SeenEntries()
+
+        def __truediv__(self, child):
+            return self.path / child
+
+    received: list[dict] = []
+    svc = FilesystemMailService(working_dir=agent_dir)
+    svc._seen.add("already-seen")
+    svc._inbox_dir = SeenInboxDir(real_inbox)
+    svc.listen(on_message=lambda p: received.append(p))
+    try:
+        assert scan_finished.wait(timeout=3.0), "own-inbox scan did not complete"
+        assert not stat_attempted.is_set(), (
+            "already-seen entries should be skipped before entry.is_dir()"
+        )
+    finally:
+        svc.stop()
+
+    assert received == []
+
+
 def test_runtime_probe_ack_from_pseudo_agent_outbox(tmp_path):
     """Explicit runtime probes get a structured ack from the real poller."""
     import json

--- a/tests/test_filesystem_mail.py
+++ b/tests/test_filesystem_mail.py
@@ -517,6 +517,63 @@ def test_seen_inbox_entries_skip_stat_before_is_dir(tmp_path):
     assert received == []
 
 
+def test_pseudo_outbox_oserror_does_not_skip_own_inbox_scan(tmp_path):
+    """A persistent OSError from pseudo-outbox polling must not skip the same
+    tick's own-inbox scan. Regression: before per-phase isolation the poll loop
+    wrapped both phases in one ``except OSError`` block, so a pseudo-outbox
+    error starved own-inbox delivery for the whole tick.
+    """
+    import threading
+    from lingtai_kernel.services.mail import FilesystemMailService
+
+    agent_dir = _make_agent_dir(tmp_path, "agent_a")
+    real_inbox = agent_dir / "mailbox" / "inbox"
+    real_inbox.mkdir(parents=True, exist_ok=True)
+
+    # A subscribed pseudo-agent dir exists so the poll loop actually enters
+    # Phase 1 every tick.
+    pseudo_dir = tmp_path / "human"
+    pseudo_dir.mkdir()
+    (pseudo_dir / "mailbox").mkdir()
+
+    svc = FilesystemMailService(
+        working_dir=agent_dir,
+        pseudo_agent_subscriptions=["../human"],
+    )
+
+    # Force Phase 1 to raise a persistent OSError every tick.
+    def _always_oserror(*args, **kwargs):
+        raise OSError("simulated persistent pseudo-outbox failure")
+
+    svc._poll_pseudo_outbox = _always_oserror
+
+    received: list[dict] = []
+    received_event = threading.Event()
+
+    def on_message(payload: dict) -> None:
+        received.append(payload)
+        received_event.set()
+
+    svc.listen(on_message=on_message)
+    try:
+        # Drop a fresh own-inbox message AFTER listen() snapshotted _seen, so
+        # it is a genuine new arrival the Phase 2 scan must pick up.
+        msg_dir = real_inbox / "own-msg"
+        msg_dir.mkdir()
+        (msg_dir / "message.json").write_text(
+            json.dumps({"message": "own-inbox wake", "subject": "x"})
+        )
+        assert received_event.wait(timeout=3.0), (
+            "own-inbox message was not delivered while pseudo-outbox polling "
+            "raised a persistent OSError"
+        )
+    finally:
+        svc.stop()
+
+    assert len(received) == 1
+    assert received[0]["message"] == "own-inbox wake"
+
+
 def test_runtime_probe_ack_from_pseudo_agent_outbox(tmp_path):
     """Explicit runtime probes get a structured ack from the real poller."""
     import json


### PR DESCRIPTION
## Summary

Refs Lingtai-AI/lingtai#591 by prioritizing pseudo-agent outbox polling in the filesystem mail listener.

The previous listener scanned the agent's own inbox before subscribed pseudo-agent outboxes. On agents with large historical inbox directories, pseudo-agent outbox delivery could wait behind a full own-inbox scan even when the pseudo-agent had already dropped wake mail. This patch keeps the existing startup snapshot semantics, but changes each poll tick so pseudo-agent outboxes are drained before the own-inbox scan starts.

## Changes

- Poll subscribed pseudo-agent outboxes before scanning the agent's own inbox inside `FilesystemMailService.listen()`.
- Check `_seen` before `entry.is_dir()` in the own-inbox loop so already-handled inbox names avoid repeated per-entry stat work.
- Update the pseudo-outbox pre-marking comment/docstring to describe same-tick duplicate prevention.
- Add focused regressions for pseudo-outbox priority ahead of a blocking own-inbox scan and for the `_seen`-before-stat optimization.
- Refresh the mail service ANATOMY notes for the new phase order.

## Non-goals

- No send-staging, attachment, dead-letter, telemetry, time-slicing, protocol, or broader error-handling changes.
- No change to the synchronous startup snapshot in `listen()`; first startup snapshot latency is preserved intentionally.

## Adjacent work / rebase note

This is adjacent to open kernel PRs #773 and #786, which touch nearby mail listener/send code. They are not duplicates. If those branches land first, preserve this PR's pseudo-outbox-before-own-inbox ordering during rebase; #786 in particular rewrites the own-inbox scan and currently uses the old ordering.

## Validation

- `git diff --check canonical/main...HEAD`
- `python3 -m py_compile src/lingtai_kernel/services/mail.py tests/test_filesystem_mail.py`
- `uv run --no-project --with pytest --with-editable . python -m pytest tests/test_filesystem_mail.py -q -k "pseudo_agent_outbox or polled_before or seen"` — 6 passed
- `uv run --no-project --with pytest --with-editable . python -m pytest tests/test_filesystem_mail.py tests/test_services_mail.py -q` — 33 passed
- `uv run --no-project --with pytest --with-editable . python -m pytest tests/test_three_agent_email.py -q` — 5 passed
- `python3 tools/check_anatomy_drift.py --check` — fails only the known unrelated baseline `src/lingtai/llm/anthropic/ANATOMY.md` citation (`adapter.py:827 > 823`)

Independent reviews: Codex, Claude Code, and GLM all approved with nonblocking nits and no blockers.
