### PR TITLE
Warn on nested init schema typos

### DIFF
--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -126,6 +126,40 @@ MANIFEST_KNOWN: set[str] = (
     set(MANIFEST_REQUIRED) | set(MANIFEST_OPTIONAL) | MANIFEST_LEGACY_IGNORED
 )
 
+NoneType = type(None)
+
+SOUL_OPTIONAL: dict[str, type | tuple[type, ...]] = {
+    "delay": (int, float),
+    "consultation_past_count": int,
+    "voice": str,
+    "voice_prompt": str,
+}
+SOUL_KNOWN: set[str] = set(SOUL_OPTIONAL)
+
+LLM_REQUIRED: dict[str, type | tuple[type, ...]] = {
+    "provider": str,
+    "model": str,
+}
+LLM_OPTIONAL: dict[str, type | tuple[type, ...]] = {
+    "api_key": (str, NoneType),
+    "api_key_env": str,
+    "base_url": (str, NoneType),
+    "compact_threshold": (int, NoneType),
+}
+LLM_SPECIAL_KNOWN: set[str] = {"thinking"}
+LLM_PASS_THROUGH_KNOWN: set[str] = {
+    "api_compat",
+    "codex_session_anchor",
+    "codex_thread_salt",
+    "codex_auth_path",
+    "codex_auth_pool_path",
+    "codex_base_urls",
+    "default_headers",
+}
+LLM_KNOWN: set[str] = (
+    set(LLM_REQUIRED) | set(LLM_OPTIONAL) | LLM_SPECIAL_KNOWN | LLM_PASS_THROUGH_KNOWN
+)
+
 
 def strip_deprecated(data: dict) -> list[str]:
     """Remove deprecated top-level fields from *data* in-place.
@@ -307,24 +341,14 @@ def validate_init(data: dict) -> list[str]:
 
     soul = manifest.get("soul")
     if soul is not None:
-        _optional_keys(soul, {
-            "delay": (int, float),
-            "consultation_past_count": int,
-            "voice": str,
-            "voice_prompt": str,
-        }, prefix="manifest.soul")
+        _optional_keys(soul, SOUL_OPTIONAL, prefix="manifest.soul")
+        for key in soul:
+            if key not in SOUL_KNOWN:
+                warnings.append(f"unknown field in manifest.soul: {key}")
 
     llm = manifest["llm"]
-    _require_keys(llm, {
-        "provider": str,
-        "model": str,
-    }, prefix="manifest.llm")
-    _optional_keys(llm, {
-        "api_key": (str, type(None)),
-        "api_key_env": str,
-        "base_url": (str, type(None)),
-        "compact_threshold": (int, type(None)),
-    }, prefix="manifest.llm")
+    _require_keys(llm, LLM_REQUIRED, prefix="manifest.llm")
+    _optional_keys(llm, LLM_OPTIONAL, prefix="manifest.llm")
     if "compact_threshold" in llm:
         compact_threshold = llm["compact_threshold"]
         if isinstance(compact_threshold, bool):
@@ -346,6 +370,9 @@ def validate_init(data: dict) -> list[str]:
                 "manifest.llm.thinking: expected one of "
                 f"{', '.join(THINKING_LEVELS)}"
             )
+    for key in llm:
+        if key not in LLM_KNOWN:
+            warnings.append(f"unknown field in manifest.llm: {key}")
 
     # If api_key_env is set without api_key, env_file must be provided
     if llm.get("api_key_env") and not llm.get("api_key"):

--- a/src/lingtai/llm/anthropic/ANATOMY.md
+++ b/src/lingtai/llm/anthropic/ANATOMY.md
@@ -22,7 +22,7 @@ Anthropic Claude adapter — Messages API with prompt caching, tool use, and ext
 | File | LOC | Role |
 |------|-----|------|
 | `__init__.py` | 3 | Re-exports `AnthropicAdapter`, `AnthropicChatSession` |
-| `adapter.py` | 832 | Adapter + session + helpers |
+| `adapter.py` | 823 | Adapter + session + helpers |
 | `defaults.py` | 6 | `DEFAULTS` dict: `api_key_env=ANTHROPIC_API_KEY`, `model=claude-sonnet-4-20250514` |
 
 ### Classes
@@ -122,7 +122,7 @@ Both `send` and `send_stream` revert the interface on API error via `interface.d
 
 - **Strict alternation**: Anthropic rejects consecutive same-role messages. `_ensure_alternation()` at `adapter.py:201` merges them by combining content lists.
 - **JSON schema enforcement**: Implemented as a synthetic tool with `tool_choice: {"type": "tool", "name": ...}` (`adapter.py:726-737`).
-- **`client` property**: Escape hatch to raw SDK at `adapter.py:827`.
+- **`client` property**: Escape hatch to raw SDK at `adapter.py:820`.
 - **MiniMax inheritance**: `MiniMaxAdapter` subclasses `AnthropicAdapter` directly, overriding only `__init__` to set `base_url`. Inherits the pre-request hook automatically.
 - **`send(None)` contract** (`f596ec1`): both `send` and `send_stream` accept `None` as the "continue from wire" signal — caller has already pre-staged the canonical interface (e.g. `BaseAgent._inject_notification_pair` spliced a synthesized `notification(action="check")` `(call, result)` pair). The input-dispatch ladder tests `if message is None: pass` first; the error-path `drop_trailing(lambda e: e.role == "user")` is guarded with `if message is not None` so an API failure during a `send(None)` cannot corrupt the pre-staged pair. Driven from `base_agent/turn.py:_handle_tc_wake`. From the LLM's viewpoint, the wake is indistinguishable from the agent voluntarily calling the tool itself.
 - **Pre-request hook** (`f46b346`, dormant after notification redesign): both `send` and `send_stream` fire `self.pre_request_hook(self._interface)` after committing the message but before the API call. Historically used for mid-turn tc_inbox drain (canonical-interface regime, same-turn delivery). Post-`fadbabf`/`d2da97e` the hook still fires but the queue is always empty — ACTIVE notifications now defer to the post-turn IDLE synthetic-pair path rather than mutating tool results at send time. Phase 3 will remove the hook. See root `ANATOMY.md` "Notifications".

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -186,6 +186,54 @@ def test_api_key_env_wrong_type():
         validate_init(data)
 
 
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("api_key_evn", "ANTHROPIC_API_KEY"),
+        ("base-url", "https://example.test/v1"),
+        ("context_limit", 200_000),
+        ("max_rpm", 60),
+    ],
+)
+def test_unknown_manifest_llm_fields_warn(key, value):
+    data = _valid_init()
+    data["manifest"]["llm"][key] = value
+
+    warnings = validate_init(data)
+
+    assert f"unknown field in manifest.llm: {key}" in warnings
+
+
+def test_unknown_manifest_soul_field_warns():
+    data = _valid_init()
+    data["manifest"]["soul"]["voice_promt"] = "speak plainly"
+
+    warnings = validate_init(data)
+
+    assert "unknown field in manifest.soul: voice_promt" in warnings
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("api_compat", "anthropic"),
+        ("default_headers", {"x-test": "1"}),
+        ("codex_session_anchor", "/agents/alice/init.json"),
+        ("codex_thread_salt", "alice"),
+        ("codex_auth_path", "/tokens/alice/codex-auth.json"),
+        ("codex_auth_pool_path", "/tokens/codex-pool.json"),
+        ("codex_base_urls", ["https://codex-a.example.test/v1"]),
+    ],
+)
+def test_known_manifest_llm_pass_through_fields_do_not_warn(key, value):
+    data = _valid_init()
+    data["manifest"]["llm"][key] = value
+
+    warnings = validate_init(data)
+
+    assert all(f"unknown field in manifest.llm: {key}" != w for w in warnings)
+
+
 @pytest.mark.parametrize("value", ["none", "minimal", "low", "medium", "high", "xhigh"])
 def test_llm_thinking_valid_values(value):
     data = _valid_init()
@@ -219,6 +267,16 @@ def test_llm_thinking_accepted_for_codex_pool(provider):
     data["manifest"]["llm"]["provider"] = provider
     data["manifest"]["llm"]["thinking"] = "xhigh"
     validate_init(data)
+
+
+def test_llm_thinking_known_field_does_not_warn():
+    data = _valid_init()
+    data["manifest"]["llm"]["provider"] = "codex"
+    data["manifest"]["llm"]["thinking"] = "high"
+
+    warnings = validate_init(data)
+
+    assert "unknown field in manifest.llm: thinking" not in warnings
 
 
 # --- addons (list of curated MCP names; mcp capability handles the rest) ---
@@ -435,6 +493,48 @@ def test_top_optional_fields_all_in_known():
         f"Fields in TOP_OPTIONAL but not in TOP_KNOWN "
         f"(would trigger unknown-field warning): {sorted(missing)}"
     )
+
+
+def test_llm_known_fields_compose_from_schema_sets():
+    from lingtai.init_schema import (
+        LLM_KNOWN,
+        LLM_OPTIONAL,
+        LLM_PASS_THROUGH_KNOWN,
+        LLM_REQUIRED,
+        LLM_SPECIAL_KNOWN,
+    )
+
+    expected = (
+        set(LLM_REQUIRED)
+        | set(LLM_OPTIONAL)
+        | LLM_SPECIAL_KNOWN
+        | LLM_PASS_THROUGH_KNOWN
+    )
+    assert LLM_KNOWN == expected
+
+
+def test_soul_optional_fields_all_in_known():
+    from lingtai.init_schema import SOUL_KNOWN, SOUL_OPTIONAL
+
+    missing = set(SOUL_OPTIONAL) - SOUL_KNOWN
+    assert not missing, (
+        f"Fields in SOUL_OPTIONAL but not in SOUL_KNOWN "
+        f"(would trigger unknown-field warning): {sorted(missing)}"
+    )
+
+
+def test_provider_default_manifest_llm_keys_are_known():
+    from lingtai.init_schema import LLM_KNOWN, LLM_OPTIONAL
+    from lingtai.llm import service as llm_service
+
+    pass_through = set(llm_service._PROVIDER_DEFAULTS_PASS_THROUGH_KEYS) | {
+        "default_headers"
+    }
+    preserve_none = set(llm_service._PROVIDER_DEFAULTS_PRESERVE_NONE_KEYS)
+
+    assert pass_through <= LLM_KNOWN
+    assert preserve_none <= set(LLM_OPTIONAL)
+    assert preserve_none <= LLM_KNOWN
 
 
 def test_manifest_accepts_pseudo_agent_subscriptions():


### PR DESCRIPTION
## Summary

Fixes #760 by making `validate_init()` warn on typos inside nested `manifest.llm` and `manifest.soul` blocks instead of silently accepting them.

The active init schema already warned for unknown top-level, `manifest`, and `manifest.preset` keys, but `_optional_keys()` only type-checked known nested keys. That meant mistakes such as `manifest.llm.api_key_evn`, `manifest.llm.base-url`, or `manifest.soul.voice_promt` validated cleanly and failed later in less obvious ways.

## What changed

- Added module-level schema/known-key constants for raw active-init `manifest.llm` and `manifest.soul`.
- Added warning-only loops for unknown nested keys:
  - `unknown field in manifest.llm: <key>`
  - `unknown field in manifest.soul: <key>`
- Kept existing type and value validation behavior, including the special handling for Codex `thinking`.
- Treated runtime-honored LLM pass-through/default keys as known without adding new type checks (`api_compat`, Codex session/auth/base-url fields, and `default_headers`).
- Kept active-init `context_limit` and `max_rpm` at manifest root: raw `manifest.llm.context_limit` / `manifest.llm.max_rpm` now warn because those hand-placed keys are ignored in active init files. Preset files remain a separate domain and are materialized to active init before validation.
- Updated the stale Anthropic ANATOMY line/citation that otherwise caused the required anatomy drift check to fail; this is a narrow documentation correction only.

## Validation

- `python3 -m py_compile src/lingtai/init_schema.py tests/test_init_schema.py`
- `PYTHONPATH=/private/tmp/lingtai-kernel-issue-760-init-schema-nested-warnings-20260708/src <repo-venv>/python -m pytest tests/test_init_schema.py -q` → 89 passed
- `PYTHONPATH=/private/tmp/lingtai-kernel-issue-760-init-schema-nested-warnings-20260708/src <repo-venv>/python -m pytest tests/test_init_schema_procedures.py tests/test_llm_service.py tests/test_openai_compact_threshold.py -q` → 53 passed
- `python3 tools/check_anatomy_drift.py --check` → no drift
- `git diff --check canonical/main...HEAD`

Independent review daemons also approved the branch:

- Codex: APPROVE, no blockers or nits.
- Claude Code: APPROVE-WITH-NITS, no blockers.
- GLM: APPROVE-WITH-NITS, no blockers.
