### PR TITLE
docs: clarify live runtime venv checks

### DIFF
--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -218,6 +218,9 @@ def run(working_dir: Path) -> None:
     # Resolve venv and store on agent for CPR/avatar to use
     from lingtai.venv_resolve import resolve_venv
     venv_dir = resolve_venv(data)
+    # Expose the live runtime interpreter to bash/tools in a platform-neutral way.
+    os.environ["LINGTAI_RUNTIME_PYTHON"] = sys.executable
+    os.environ["LINGTAI_RUNTIME_VENV"] = str(venv_dir)
     # Write back to init.json if not already set (self-sufficient)
     if not data.get("venv_path") or data["venv_path"] != str(venv_dir):
         data["venv_path"] = str(venv_dir)

--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -90,7 +90,9 @@ editable install, a source checkout, or a dev/local version. In those modes the
 source of truth is usually the local checkout and git state, not the package
 index. Diagnose with:
 
-- the Python executable used by the agent runtime;
+- the Python executable used by the agent runtime — prefer the platform-neutral
+  `LINGTAI_RUNTIME_PYTHON` environment variable when available, and otherwise
+  trust the live process over a convenient shell `python` or conda env;
 - `lingtai.__version__`, `lingtai.__file__`, and `lingtai_kernel.__file__`;
 - installed distribution metadata, especially `direct_url.json` with
   `dir_info.editable: true`;
@@ -102,10 +104,16 @@ new commits, install packages, or publish anything.
 
 ## Quick manual check
 
-Use a short local Python probe when the nudge payload is ambiguous:
+Use a short local Python probe when the nudge payload is ambiguous. Prefer the
+same interpreter used by the running agent. `LINGTAI_RUNTIME_PYTHON` is the
+platform-neutral path exposed by the runtime when available; if it is absent,
+choose the platform-specific TUI venv Python (`$HOME/.lingtai-tui/runtime/venv/bin/python`
+on macOS/Linux, `%USERPROFILE%\.lingtai-tui\runtime\venv\Scripts\python.exe`
+on Windows):
 
 ```bash
-python - <<'PY'
+PYTHON=${LINGTAI_RUNTIME_PYTHON:-$HOME/.lingtai-tui/runtime/venv/bin/python}
+"$PYTHON" - <<'PY'
 import importlib.metadata as md
 import sys
 import lingtai, lingtai_kernel

--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -80,8 +80,14 @@ General guidance:
 
 Use after changing `init.json`, MCP registry, presets, prompt sections, or
 installed capabilities. Refresh preserves identity and conversation while
-rebuilding the runtime surface. If a new MCP/tool still does not appear after
-refresh, inspect registry/config health before retrying.
+rebuilding the runtime surface. For runtime/version checks, inspect the live
+agent interpreter and imports — prefer `LINGTAI_RUNTIME_PYTHON` when available,
+then confirm `lingtai.__file__` and `lingtai_kernel.__file__` — rather than a
+convenient shell `python`, conda env, or unrelated checkout. TUI-managed runs
+normally expose that interpreter from their runtime venv (for example
+`~/.lingtai-tui/runtime/venv` on macOS/Linux; Windows uses the corresponding
+`Scripts\python.exe` inside the venv). If a new MCP/tool still does not appear
+after refresh, inspect registry/config health before retrying.
 
 Refresh is also the **emergency** context-reconstruction path: reach for it when
 context is broken or stale, or when an immediate provider-side rebuild is urgently

--- a/src/lingtai/prompts/substrate/substrate.md
+++ b/src/lingtai/prompts/substrate/substrate.md
@@ -49,6 +49,15 @@ Choose the smallest durable form that fits: bash for commands, daemon for
 throwaway parallel work, avatar for persistent ownership, MCP for external
 services, knowledge for private facts, skills for reusable know-how.
 
+Runtime/version checks must inspect the interpreter that actually runs the
+agent. Prefer the platform-neutral `LINGTAI_RUNTIME_PYTHON` environment variable
+when available; TUI-managed runs normally point it into their runtime venv (for
+example `~/.lingtai-tui/runtime/venv` on macOS/Linux) and should confirm the
+module files it imports (`lingtai.__file__`, `lingtai_kernel.__file__`). Do not
+infer freshness from a convenient shell `python`, conda env, or checkout;
+`refresh` reloads the current on-disk/runtime surface but does not fetch or
+switch code by itself.
+
 ## II · Life states
 
 Agents are ACTIVE, IDLE, STUCK, ASLEEP, or SUSPENDED. The key operational split:

--- a/tests/test_cli_runtime_env.py
+++ b/tests/test_cli_runtime_env.py
@@ -1,0 +1,61 @@
+import os
+import sys
+from pathlib import Path
+
+from lingtai import cli
+
+
+class _Flag:
+    def __init__(self):
+        self.was_set = False
+
+    def set(self):
+        self.was_set = True
+
+
+class _Shutdown:
+    def wait(self):
+        return None
+
+
+class _FakeAgent:
+    def __init__(self):
+        self._asleep = _Flag()
+        self._shutdown = _Shutdown()
+        self._state = None
+        self._venv_path = None
+        self.started = False
+        self.stopped = False
+
+    def start(self):
+        self.started = True
+
+    def stop(self, timeout=10.0):
+        self.stopped = True
+
+
+def test_run_exports_live_runtime_python_env(monkeypatch, tmp_path):
+    runtime_venv = tmp_path / "runtime-venv"
+    agent = _FakeAgent()
+
+    monkeypatch.setattr(cli, "_check_duplicate_process", lambda working_dir: None)
+    monkeypatch.setattr(cli, "_clean_signal_files", lambda working_dir: None)
+    monkeypatch.setattr(cli, "_install_signal_handlers", lambda working_dir, agent: None)
+    monkeypatch.setattr(cli, "load_init", lambda working_dir: {})
+    monkeypatch.setattr(cli, "build_agent", lambda data, working_dir: agent)
+
+    import lingtai.venv_resolve as venv_resolve
+
+    monkeypatch.setattr(venv_resolve, "resolve_venv", lambda data: runtime_venv)
+    monkeypatch.setenv("LINGTAI_RUNTIME_PYTHON", "stale-python")
+    monkeypatch.setenv("LINGTAI_RUNTIME_VENV", "stale-venv")
+
+    cli.run(tmp_path)
+
+    assert os.environ["LINGTAI_RUNTIME_PYTHON"] == sys.executable
+    assert os.environ["LINGTAI_RUNTIME_VENV"] == str(runtime_venv)
+    assert agent._venv_path == str(runtime_venv)
+    assert agent._asleep.was_set
+    assert agent.started
+    assert agent.stopped
+    assert (tmp_path / "init.json").is_file()


### PR DESCRIPTION
## Summary
- expose the live runtime interpreter to child tools as `LINGTAI_RUNTIME_PYTHON` and the resolved runtime venv as `LINGTAI_RUNTIME_VENV`
- clarify in resident substrate that runtime/version checks should use the live interpreter/env var and imported module files, not a convenient shell Python, conda env, or unrelated checkout
- add the same platform-neutral env-var guidance to the expanded substrate refresh docs and runtime-update checks, with macOS/Linux and Windows venv paths only as fallbacks/examples

## Validation
- `git diff --check`
- `PYTHONPATH=src /Users/huangzesen/anaconda3/bin/python -m pytest -q tests/test_cli_runtime_env.py tests/test_venv_resolve.py` (13 passed)
- targeted `rg` check for the new `runtime/venv` / `LINGTAI_RUNTIME_PYTHON` wording in the touched docs

Prompted by a live-runtime self-check incident where conda/imported checkouts were misleading and the real agent process used the TUI-managed runtime venv.
