### PR TITLE
fix(file-io): normalize Windows glob separators

### DIFF
--- a/src/lingtai/services/ANATOMY.md
+++ b/src/lingtai/services/ANATOMY.md
@@ -29,7 +29,7 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 | File | LOC | Role |
 |---|---|---|
 | `__init__.py` | 1 | Docstring-only package marker |
-| `file_io.py` | 530 | `FileIOService` facade contract + `FileIOBackend`/`LocalFileIOBackend` — backs read/edit/write/glob/grep. `grep` accepts an optional basename `glob_filter` that prunes the candidate set before stat/read |
+| `file_io.py` | 556 | `FileIOService` facade contract + `FileIOBackend`/`LocalFileIOBackend` — backs read/edit/write/glob/grep. `glob` normalizes the native path separator to `/` (`_to_forward_slashes`) so forward-slash patterns match Windows backslash rel-paths. `grep` accepts an optional basename `glob_filter` that prunes the candidate set before stat/read |
 | `file_io_sidecar.py` | 698 | Rust-backed grep/glob: `RustFileIOBackend`, `SidecarAdapter`, `SidecarError`, plus the `resolve_sidecar_binary` resolver and the `default_file_io_service` factory used by `Agent.__init__`. `grep`'s `glob_filter` is applied as a Python-side basename post-filter (the sidecar wire protocol carries no glob field yet) |
 | `mail.py` | 4 | Re-exports `MailService`, `FilesystemMailService` from `lingtai_kernel.services.mail` |
 | `mcp.py` | 510 | `MCPClient` (stdio) + `HTTPMCPClient` (streamable HTTP) — async-to-sync MCP bridges |

--- a/src/lingtai/services/file_io.py
+++ b/src/lingtai/services/file_io.py
@@ -88,6 +88,26 @@ DEFAULT_MAX_VISITED: int = 20_000
 DEFAULT_MAX_FILE_BYTES: int = 4 * 1024 * 1024  # 4 MiB
 
 
+def _to_forward_slashes(text: str, sep: str) -> str:
+    """Return ``text`` with the native path separator ``sep`` rewritten to ``/``.
+
+    Agent-facing glob patterns use ``/`` as the path separator (the
+    ``**/*.py`` contract), but ``os.path.relpath`` yields the native
+    separator — ``\\`` on Windows. ``fnmatch`` does not treat ``\\`` and
+    ``/`` as equivalent, so a forward-slash pattern would never match a
+    backslash rel-path on Windows. Normalizing both the pattern and the
+    rel-path to ``/`` for the match keeps glob behavior identical across
+    platforms. ``sep`` is passed explicitly (defaulting to ``os.sep`` at
+    the call site) so the separator being normalized is a parameter, not a
+    hidden platform global — which also makes the logic unit-testable on
+    POSIX. On POSIX (``sep == "/"``) this is a no-op, so a literal ``\\``
+    in a filename is preserved.
+    """
+    if sep == "/":
+        return text
+    return text.replace(sep, "/")
+
+
 class FileIOService(ABC):
     """Abstract file I/O service.
 
@@ -326,6 +346,10 @@ class LocalFileIOBackend(FileIOBackend):
 
         self.last_traversal = TraversalStats()
         search_root = Path(root) if root else (self._root or Path("."))
+        # Normalize the pattern's separators to ``/`` once, matching the
+        # rel-path normalization below (see ``_to_forward_slashes``). The
+        # returned paths keep their native form; only the match form changes.
+        match_pattern = _to_forward_slashes(pattern, os.sep)
         results: list[str] = []
         for path in self._walk_files(
             search_root,
@@ -340,7 +364,9 @@ class LocalFileIOBackend(FileIOBackend):
             except ValueError:
                 # cross-volume on Windows — fall back to absolute.
                 rel = str(path)
-            if fnmatch.fnmatch(rel, pattern):
+            # Match on the forward-slash form so ``/`` patterns match the
+            # native-separator rel-path on Windows.
+            if fnmatch.fnmatch(_to_forward_slashes(rel, os.sep), match_pattern):
                 results.append(str(path))
                 if max_results is not None and len(results) >= max_results:
                     self.last_traversal.truncated_reason = (

--- a/tests/test_services_file_io.py
+++ b/tests/test_services_file_io.py
@@ -214,6 +214,87 @@ class TestTraversalBudgets:
         assert any(".git" in r for r in results)
 
 
+class TestGlobSeparatorNormalization:
+    """Forward-slash glob patterns must match native-separator paths.
+
+    Agents write patterns with ``/`` (the ``src/*.py`` / ``**/*.py``
+    contract). On Windows, ``os.path.relpath`` produces ``\\``-separated
+    rel-paths, and ``fnmatch`` does not treat ``\\`` and ``/`` as
+    equivalent — so without normalization a ``/`` pattern would match
+    nothing on Windows. These tests pin the normalization at both the
+    unit level (``_to_forward_slashes``, POSIX-safe) and the integration
+    level (``glob`` with a simulated Windows separator).
+    """
+
+    def test_to_forward_slashes_rewrites_backslash_sep(self):
+        # Simulated Windows: native sep is backslash.
+        assert file_io._to_forward_slashes("src\\main.py", "\\") == "src/main.py"
+        assert file_io._to_forward_slashes("a\\b\\c.py", "\\") == "a/b/c.py"
+
+    def test_to_forward_slashes_noop_on_posix(self):
+        # POSIX: sep is already "/", so nothing changes — a literal
+        # backslash in a filename is preserved (not treated as a sep).
+        assert file_io._to_forward_slashes("weird\\name.py", "/") == "weird\\name.py"
+        assert file_io._to_forward_slashes("src/main.py", "/") == "src/main.py"
+
+    def test_glob_forward_slash_pattern_matches_windows_separators(
+        self, svc, tmp_dir, monkeypatch
+    ):
+        # Regression: emulate Windows by making the module see ``\`` as the
+        # native separator and ``os.path.relpath`` emit backslash rel-paths.
+        # ``os.walk`` still runs over the real POSIX tree, so we translate
+        # its ``/`` output to ``\`` in the fake relpath to mimic Windows.
+        svc.write("src/main.py", "# main")
+        svc.write("src/utils.py", "# utils")
+        svc.write("tests/test.py", "# test")
+
+        real_relpath = os.path.relpath
+
+        def win_relpath(path, start):
+            return real_relpath(path, start).replace("/", "\\")
+
+        # ``glob`` does ``import os`` locally, so it sees the real ``os``
+        # singleton — patch that directly to emulate Windows.
+        monkeypatch.setattr(os, "sep", "\\")
+        monkeypatch.setattr(os.path, "relpath", win_relpath)
+
+        # Forward-slash pattern must still match the backslash rel-paths.
+        results = svc.glob("src/*.py")
+        assert len(results) == 2
+        assert all(r.endswith(".py") for r in results)
+
+    def test_glob_backslash_pattern_matches_windows_separators(
+        self, svc, tmp_dir, monkeypatch
+    ):
+        # A pattern that itself uses ``\`` (as a Windows agent might paste)
+        # is normalized the same way, so both slash styles behave alike.
+        svc.write("src/main.py", "# main")
+        svc.write("tests/test.py", "# test")
+
+        real_relpath = os.path.relpath
+
+        def win_relpath(path, start):
+            return real_relpath(path, start).replace("/", "\\")
+
+        # ``glob`` does ``import os`` locally, so it sees the real ``os``
+        # singleton — patch that directly to emulate Windows.
+        monkeypatch.setattr(os, "sep", "\\")
+        monkeypatch.setattr(os.path, "relpath", win_relpath)
+
+        results = svc.glob("src\\*.py")
+        assert len(results) == 1
+        assert results[0].endswith("main.py")
+
+    def test_glob_forward_slash_pattern_still_works_on_posix(self, svc, tmp_dir):
+        # Guard the POSIX contract: normalization must not regress the
+        # native ``/`` case.
+        svc.write("src/main.py", "# main")
+        svc.write("src/utils.py", "# utils")
+        svc.write("tests/test.py", "# test")
+        results = svc.glob("src/*.py")
+        assert len(results) == 2
+
+
 class TestGrepGlobFilter:
     """``glob_filter`` prunes the candidate set *before* stat / read.
 


### PR DESCRIPTION
## Summary
- normalize `LocalFileIOBackend.glob` matching by converting the native separator to `/` for the pattern and relative path match form
- preserve existing returned path contract, sorting, exclusions, traversal budgets, and POSIX literal-backslash behavior
- add POSIX-runnable Windows-separator regression tests plus a services anatomy breadcrumb update

## Taste / scope check
- Checked `lingtai-taste`: root-cause/owning-layer fix, smallest honest scope, no new public surface or config flag.
- Deliberately leaves Rust sidecar behavior out of scope: its `rel_to()` already converts backslashes to `/` before glob matching, and a deeper sidecar/protocol change would be a separate PR.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_services_file_io.py tests/test_layers_file.py tests/test_file_io_sidecar.py -q` → 95 passed
- `PYTHONPATH=src python -m pytest tests/ -q -k 'glob or file_io'` → 86 passed, 3844 deselected
- `git diff --check` → clean
- `PYTHONPATH=src python tools/check_anatomy_drift.py --check` → one known unrelated pre-existing drift in `src/lingtai/llm/anthropic/ANATOMY.md` (`adapter.py:827 > 823`); touched services anatomy is clean
