### PR TITLE
docs(bash): add Windows Task Scheduler guidance

### DIFF
--- a/src/lingtai/core/bash/manual/SKILL.md
+++ b/src/lingtai/core/bash/manual/SKILL.md
@@ -4,15 +4,16 @@ description: >
   **Read this before running long-lived agent/coding CLIs (`claude -p`,
   `codex exec`, `opencode run`, Cursor Agent, Gemini CLI, Aider, Goose,
   OpenHands, Crush, or similar harnesses), or before setting up cron,
-  launchd, systemd timers, crontab jobs, or scheduled reminders.** Router for
+  launchd, systemd timers, crontab jobs, native Windows Task Scheduler
+  (`schtasks.exe` / `Register-ScheduledTask`), or scheduled reminders.** Router for
   Bash-related operational depth beyond the bash tool schema: async + poll
   discipline for long-running child agents, host-scheduler setup, LingTai
   wake-by-mailbox-drop, script hygiene, one-shot `.notification/cron.json`
   reminders, debugging silent jobs, and safe cleanup. Start here for any
   long-running agent CLI, time-driven recurring work ("every hour", "weekdays at
   9", "remind me later"), or when a scheduled job misbehaves.
-version: 1.6.1
-last_changed_at: "2026-06-24T14:38:03-07:00"
+version: 1.6.2
+last_changed_at: "2026-07-09T00:00:00-07:00"
 ---
 
 # Bash Manual — Router
@@ -37,8 +38,9 @@ files, not standalone top-level skills.
   description: |
     Cron-driven scheduled work: when to use host schedulers, the LingTai
     wake-by-mailbox-drop contract, prompt boundaries, script hygiene, macOS
-    launchd, Linux systemd timers, crontab fallback, and the launchd
-    process-tree reaping gotcha.
+    launchd, Linux systemd timers, crontab fallback, the launchd process-tree
+    reaping gotcha, and native Windows Task Scheduler (PowerShell wrapper,
+    schtasks.exe, Register-ScheduledTask).
 - name: bash-notification-reminders
   location: reference/notification-reminders/SKILL.md
   description: |
@@ -126,7 +128,7 @@ files, not standalone top-level skills.
 | Need / keywords | Read |
 |---|---|
 | Running a long-running agent/coding CLI as a sub-process: `claude -p`, `codex exec`, `opencode run`, Cursor Agent, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, Gemini CLI, Aider, Goose, OpenHands, Crush; "run an agent in the background"; avoid blocking the turn | `reference/bash-claude-code/SKILL.md`, `reference/bash-openai-codex/SKILL.md`, `reference/bash-opencode/SKILL.md`, or the matching `reference/bash-*/SKILL.md`; keep the core async/poll rules below resident |
-| Human asks for time-driven recurring work: "every hour", "daily", "weekdays at 9", "write/check/send on a schedule"; choose cron vs event watcher; create launchd/systemd/crontab wiring; understand wake-by-mailbox-drop; write scheduler prompt/script hygiene | `reference/scheduled-work/SKILL.md` |
+| Human asks for time-driven recurring work: "every hour", "daily", "weekdays at 9", "write/check/send on a schedule"; choose cron vs event watcher; create launchd/systemd/crontab wiring, or **Windows Task Scheduler** (`schtasks.exe` / `Register-ScheduledTask`, PowerShell `.ps1` wrapper); understand wake-by-mailbox-drop; write scheduler prompt/script hygiene | `reference/scheduled-work/SKILL.md` |
 | Need a one-shot reminder or wakeup nudge while work is pending; `.notification/cron.json`; atomic reminder writer; rest checklist | `reference/notification-reminders/SKILL.md` |
 | Scheduled job is silent, fires twice, exits immediately, gets killed by launchd, fails to deliver mail, or must be retired/cleaned up | `reference/debugging-cleanup/SKILL.md` |
 
@@ -246,10 +248,13 @@ reading the whole file when you only need recent events.
   rule exists to catch.
 
 - LingTai has no built-in recurring scheduler. Host schedulers wake agents by
-  producing channel input, usually a mailbox-drop or notification file.
+  producing channel input, usually a mailbox-drop or notification file. On
+  native Windows the host scheduler is **Task Scheduler** (`schtasks.exe` /
+  `Register-ScheduledTask`), not POSIX cron/launchd/systemd — route
+  Windows time-driven work through the same scheduled-work reference.
 - Prefer event watchers/webhooks when an external event is the real trigger;
-  prefer cron/launchd/systemd only when time is the trigger or polling is truly
-  the right tradeoff.
+  prefer cron/launchd/systemd/Task Scheduler only when time is the trigger or
+  polling is truly the right tradeoff.
 - Scheduler scripts must be idempotent, audited, logged, absolute-path based,
   and explicit about how they wake the agent.
 - On macOS, remember launchd process-tree reaping; use the documented

--- a/src/lingtai/core/bash/manual/reference/scheduled-work/SKILL.md
+++ b/src/lingtai/core/bash/manual/reference/scheduled-work/SKILL.md
@@ -3,10 +3,11 @@ name: bash-scheduled-work
 description: >
   Nested bash-manual reference for cron-driven scheduled work: when to use host
   schedulers, the LingTai wake-by-mailbox-drop contract, prompt boundaries,
-  script hygiene, macOS launchd, Linux systemd timers, crontab fallback, and the
-  launchd process-tree reaping gotcha.
-version: 1.0.0
-last_changed_at: "2026-06-01T01:47:09-07:00"
+  script hygiene, macOS launchd, Linux systemd timers, crontab fallback, the
+  launchd process-tree reaping gotcha, and native Windows Task Scheduler
+  (PowerShell wrapper, schtasks.exe, Register-ScheduledTask, debugging).
+version: 1.1.0
+last_changed_at: "2026-07-09T00:00:00-07:00"
 ---
 
 # Scheduled Work Reference
@@ -357,3 +358,183 @@ Add a line:
 ```
 
 5 fields: `minute hour day-of-month month day-of-week`. The default `PATH` for crontab is even sparser than launchd's — set `PATH=` at the top of the crontab file or use absolute paths everywhere in the script.
+
+## Windows — Task Scheduler
+
+On native Windows there is no cron, launchd, or systemd. The host scheduler is
+**Task Scheduler** (`schtasks.exe`, or the PowerShell `*-ScheduledTask` cmdlets).
+Everything above still holds: LingTai has **no built-in scheduler** and does
+**not** register Task Scheduler entries for you. A scheduled task wakes you the
+same way every other producer does — by dropping a `message.json` into the human
+outbox (see [the wake-by-mailbox-drop contract](#the-wake-by-mailbox-drop-contract))
+and optionally creating/updating `.refresh` for prompt pickup. Task Scheduler is
+just another thing that can write that file on a wall clock.
+
+### Prefer a PowerShell wrapper, not a raw `/TR` command
+
+The single most important rule on Windows: **schedule a small `.ps1` wrapper, not
+an inline command.** `schtasks /TR` quoting is famously brittle — nested quotes,
+spaces in paths, and `&`/`|` characters all get mangled by the double layer of
+`cmd.exe` and Task Scheduler parsing, and failures are silent. A wrapper script
+sidesteps all of it and gives you one editable place for working directory,
+environment, logging, and the actual command. It also matches how the `bash`
+tool already runs on Windows — commands execute through
+`powershell.exe -NoProfile -NonInteractive -Command`, so a PowerShell wrapper is
+the native shape, not an extra dependency.
+
+`C:\Users\you\.lingtai-tui\cron\my-job.ps1`:
+
+```powershell
+#Requires -Version 5
+$ErrorActionPreference = 'Stop'        # the PowerShell analogue of set -euo pipefail
+
+# --- working directory ---
+Set-Location 'C:\Users\you\work\my-project'
+
+# --- logging (append; ISO 8601 with offset; never trust the task's stdout) ---
+$LogFile = 'C:\Users\you\.lingtai-tui\cron\my-job.log'
+function Log($msg) { "{0} {1}" -f (Get-Date -Format 'o'), $msg | Out-File -FilePath $LogFile -Append -Encoding utf8 }
+Log '[fire] starting cycle'
+
+# --- environment / PATH / venv (Task Scheduler starts with a sparse env) ---
+$env:PATH = 'C:\Program Files\Git\cmd;' + $env:PATH
+$Python   = 'C:\Users\you\.lingtai-tui\runtime\venv\Scripts\python.exe'   # absolute, not "python"
+
+# --- idempotency guard (safe to fire twice in the same hour) ---
+$Mark = Join-Path $env:TEMP ('my-job-' + (Get-Date -Format 'yyyyMMdd-HH'))
+if (Test-Path $Mark) { Log '[skip] already ran this hour'; exit 0 }
+
+# --- the actual work: drop mail / run the LingTai or project command ---
+& $Python 'C:\Users\you\.lingtai-tui\scripts\drop_mail.py' --subject 'hourly' --body '...'
+if ($LASTEXITCODE -ne 0) { Log "[err] drop_mail exited $LASTEXITCODE"; exit $LASTEXITCODE }
+
+New-Item -ItemType File -Path $Mark -Force | Out-Null
+Log '[done] cycle complete'
+```
+
+The hygiene rules from earlier map directly: `$ErrorActionPreference = 'Stop'`
+for `set -euo pipefail`, `Get-Date -Format 'o'` for `date -Iseconds`, absolute
+binary paths because the task's `PATH` is sparse, an append-only log because the
+task's own stdout is discarded, and a marker-file idempotency guard. Check
+`$LASTEXITCODE` after each external command — PowerShell does **not** abort on a
+native command's nonzero exit even under `Stop`.
+
+### Register the wrapper — `schtasks.exe`
+
+```powershell
+# Create: run the wrapper every day at 09:00. Note -File, -NoProfile,
+# -ExecutionPolicy Bypass so the task does not depend on the machine policy.
+schtasks /Create /TN "LingTai\my-job" /SC DAILY /ST 09:00 /F `
+  /TR "powershell.exe -NoProfile -ExecutionPolicy Bypass -File `"C:\Users\you\.lingtai-tui\cron\my-job.ps1`""
+
+schtasks /Query /TN "LingTai\my-job" /V /FO LIST   # inspect: Last Run Time, Last Result, Next Run Time
+schtasks /Run   /TN "LingTai\my-job"               # fire once now, for testing
+schtasks /Delete /TN "LingTai\my-job" /F           # retire it
+```
+
+Always pass explicit `/SC` (schedule kind) and, for time-driven kinds, `/ST`
+(start time) — the defaults are surprising. `/SC HOURLY`, `/SC MINUTE /MO 15`
+(every 15 minutes), `/SC ONCE /ST 14:30` (one-shot today), and `/SC ONSTART` are
+the common ones. Even wrapping a single `.ps1`, note that `/TR` still needs the
+inner quotes escaped (`` `" `` in PowerShell); this is exactly the brittleness
+the wrapper minimizes — keep the `/TR` value to just the `powershell.exe … -File
+<path>` invocation and put everything else inside the script.
+
+### Register the wrapper — PowerShell cmdlets
+
+Equivalent, and easier to quote correctly for anything non-trivial:
+
+```powershell
+$Action  = New-ScheduledTaskAction -Execute 'powershell.exe' `
+  -Argument '-NoProfile -ExecutionPolicy Bypass -File "C:\Users\you\.lingtai-tui\cron\my-job.ps1"'
+$Trigger = New-ScheduledTaskTrigger -Daily -At 9am
+# Run whether or not the user is logged on; -WakeToRun if the box may be asleep.
+$Settings = New-ScheduledTaskSettingsSet -StartWhenAvailable
+Register-ScheduledTask -TaskName 'my-job' -TaskPath '\LingTai\' `
+  -Action $Action -Trigger $Trigger -Settings $Settings -Description 'LingTai hourly mail-drop'
+
+Get-ScheduledTask       -TaskName 'my-job' -TaskPath '\LingTai\'
+Get-ScheduledTaskInfo   -TaskName 'my-job' -TaskPath '\LingTai\'   # LastRunTime, LastTaskResult, NextRunTime
+Start-ScheduledTask     -TaskName 'my-job' -TaskPath '\LingTai\'   # fire once now
+Unregister-ScheduledTask -TaskName 'my-job' -TaskPath '\LingTai\' -Confirm:$false
+```
+
+`-StartWhenAvailable` is the Windows analogue of systemd's `Persistent=true` /
+launchd catch-up: it runs a missed fire once the machine is available again. Drop
+it when catch-up firings are unwanted (same caveat as the launchd/systemd
+sections — don't post three backed-up poems after a weekend outage).
+
+### One-shot vs recurring, and self-mail
+
+- **Recurring** → `/SC DAILY|HOURLY|MINUTE|WEEKLY` or `New-ScheduledTaskTrigger
+  -Daily|-Weekly`. This is the wake-by-mailbox-drop path: the wrapper drops mail
+  every fire.
+- **One-shot** → `/SC ONCE /ST <time>` or `-Once -At <time>`. But if you only
+  need a *single* future nudge to yourself, you usually do **not** want Task
+  Scheduler at all — a `.notification/cron.json` reminder is lighter and needs no
+  host registration. See the `bash-notification-reminders` reference.
+- **Self-mail / wake-by-mailbox-drop** is unchanged from the contract above: the
+  wrapper writes `human/mailbox/outbox/<uuid>/message.json` (use
+  `via: "schtasks-cron"` in the `identity` block so scheduled mail is
+  distinguishable in your audit log) and, for prompt pickup, creates/updates
+  `.refresh`. **The `.agent.lock` anti-pattern applies verbatim on Windows** —
+  never poll for, remove, or race the lock from a scheduled script; drop mail,
+  create/update `.refresh`, and exit.
+
+### How Windows differs from cron / launchd / systemd
+
+- **No `PATH`/env inheritance from your interactive shell.** Task Scheduler runs
+  with a minimal environment, often as a different logon session. Set `PATH`,
+  activate the venv (`…\Scripts\python.exe`), and use absolute paths inside the
+  wrapper — do not assume your profile ran.
+- **Account and session matter.** "Run only when user is logged on" vs "Run
+  whether user is logged on or not" changes which session (and which credential)
+  the task uses, and whether it has a desktop. LingTai mail-drop work needs no
+  desktop; prefer whichever account owns the project directory and can write the
+  mailbox.
+- **Execution policy can block the script.** A default `Restricted` policy
+  refuses to run `.ps1`. Passing `-ExecutionPolicy Bypass` on the invocation
+  (as above) is the least-surprising fix and is scoped to that one process; do
+  not change the machine-wide policy for a scheduler.
+- **No double-fork reaping gotcha.** The launchd process-tree reaping problem
+  does not apply. If the wrapper must launch a process that outlives the task,
+  start it detached (`Start-Process`), but for the standard drop-mail-and-exit
+  pattern nothing special is needed — the kernel's `.refresh` watcher owns
+  relaunch, exactly as on POSIX.
+
+### Debugging a silent Windows task
+
+Walk this in order when a scheduled task appears not to run:
+
+1. **Did it fire?** `Get-ScheduledTaskInfo -TaskName … -TaskPath …` →
+   `LastRunTime` and `NextRunTime`. Or `schtasks /Query /TN … /V /FO LIST`. If
+   `LastRunTime` is older than expected, the trigger didn't fire (machine asleep
+   without `-StartWhenAvailable`, task disabled, clock skew).
+2. **Last Run Result / history.** `LastTaskResult` is a Win32/HRESULT code:
+   `0` = success, `0x41301` = still running, `0x1` = generic script failure,
+   `0x2` = file not found (usually a bad `-File` path or a missing binary). Turn
+   on **"All Tasks History"** in `taskschd.msc` (it's off by default) or read the
+   `Microsoft-Windows-TaskScheduler/Operational` event log for the full trace.
+3. **Working directory.** Task Scheduler does not default to your project dir;
+   confirm the wrapper's `Set-Location` ran and points where you expect.
+4. **Execution policy.** If the task result is a policy error, the `-File`
+   invocation is missing `-ExecutionPolicy Bypass`.
+5. **PATH / venv.** A "command not found" in the wrapper log means the sparse
+   task `PATH` didn't include Git/Python — use absolute paths.
+6. **Account / session.** A task set to "run only when logged on" silently does
+   nothing while you're logged out. Check the task's configured account.
+7. **The wrapper log.** Because the task's own stdout is discarded, your
+   append-only `$LogFile` is the source of truth — read it, not the Task
+   Scheduler summary alone.
+
+When you print any of this for a human, **do not echo secrets** (tokens, mail
+bodies, credentials). The redaction discipline from the hygiene rules applies to
+Windows logs too.
+
+### Retiring a Windows task
+
+Reverse of setup: `Unregister-ScheduledTask` (or `schtasks /Delete /TN … /F`),
+verify with `Get-ScheduledTask`, then delete the wrapper `.ps1` and its log (or
+archive if the human wants the history). Don't delete the wrapper while the task
+is still registered — a fire against a missing `-File` just logs noisy `0x2`
+errors.


### PR DESCRIPTION
## Summary
- add a native Windows Task Scheduler section to the bash scheduled-work reference
- document the PowerShell wrapper pattern, `schtasks.exe`, `Register-ScheduledTask`, one-shot vs recurring guidance, self-mail / `.refresh` routing, debugging, and retirement
- update the parent `bash-manual` router so Windows scheduling keywords route to the nested scheduled-work reference

## Taste / scope check
- Checked `lingtai-taste`: docs-only owning-layer/routing fix, no fake automation claim, no new public runtime surface.
- Kept progressive disclosure: parent router only routes; the scheduled-work reference owns examples/details.
- Left `system-manual` untouched after checking its existing generic `Bash/cron/host scheduling details → bash-manual` route; adding a Windows-specific duplicate row would be surface creep.

## Validation
- `git diff --check` → clean
- `python3 src/lingtai/core/skills/manual/scripts/validate.py src/lingtai/core/bash/manual --require-last-changed-at` → PASS, with pre-existing/advisory description-length warning
- `python3 src/lingtai/core/skills/manual/scripts/validate.py src/lingtai/core/bash/manual/reference/scheduled-work --require-last-changed-at` → frontmatter PASS; directory-structure FAIL only on pre-existing illustrative `scripts/my-job.*` references from existing POSIX examples
- Verified this PR adds no new `scripts/my-job.*` references (`git diff --unified=0 ... | grep '^+' | grep 'scripts/my-job'` → none); base already has 7 such occurrences
