### PR TITLE
fix(wechat): support Windows poller lock

### DIFF
--- a/src/lingtai/mcp_servers/wechat/lockfile.py
+++ b/src/lingtai/mcp_servers/wechat/lockfile.py
@@ -12,10 +12,14 @@ the iLink account from the addon's perspective). The lockfile path is
 deterministic across processes/working-dirs on the same machine, so a
 second poller for the same account on the same host is reliably refused.
 
-Platform note: this module is POSIX-only. ``acquire()`` raises
-``UnsupportedPlatformError`` if ``fcntl`` is unavailable (e.g. on Windows)
-rather than silently no-opping, since a silent no-op would leave issue #83
-unresolved while pretending the lock had been taken.
+Platform note: the lock primitive differs by OS but the safety model does
+not. On POSIX we take an exclusive ``fcntl.flock``; on native Windows (where
+``fcntl`` is absent) we take a non-blocking exclusive ``msvcrt.locking``
+byte-range lock over the same lockfile. Either way a second poller for the
+same account on the same host is reliably refused. ``acquire()`` only raises
+``UnsupportedPlatformError`` when *neither* primitive is available, since a
+silent no-op would leave issue #83 unresolved while pretending the lock had
+been taken.
 """
 from __future__ import annotations
 
@@ -26,6 +30,12 @@ from pathlib import Path
 from typing import IO
 
 log = logging.getLogger(__name__)
+
+# msvcrt.locking locks/unlocks a byte range starting at the current file
+# position. We lock a single byte at offset 0 — the range need not contain
+# data, and locking one byte is enough to serialize acquirers. Kept as a
+# module constant so acquire()/release() agree on the range.
+_WINDOWS_LOCK_BYTES = 1
 
 
 class PollerLockBusy(RuntimeError):
@@ -52,16 +62,21 @@ def lock_path(bot_token: str) -> Path:
 
 
 class AccountLock:
-    """fcntl-based exclusive lock per iLink account.
+    """Exclusive OS lock per iLink account.
 
-    Held for the lifetime of the poller. Releases automatically when the
-    process exits (kernel drops the flock), so a hard kill leaves no stale
-    state requiring cleanup.
+    On POSIX the primitive is ``fcntl.flock``; on native Windows it is a
+    non-blocking ``msvcrt.locking`` byte-range lock. Held for the lifetime of
+    the poller. Both primitives release automatically when the process exits
+    (the kernel drops the lock), so a hard kill leaves no stale state
+    requiring cleanup.
     """
 
     def __init__(self, bot_token: str) -> None:
         self._path = lock_path(bot_token)
         self._fh: IO[str] | None = None
+        # Which primitive currently holds the lock, so release() unlocks with
+        # the matching call. None until acquire() succeeds.
+        self._primitive: str | None = None
 
     @property
     def path(self) -> Path:
@@ -72,18 +87,9 @@ class AccountLock:
 
         Raises:
             PollerLockBusy: if another process already holds the lock.
-            UnsupportedPlatformError: if ``fcntl`` is not available (Windows).
+            UnsupportedPlatformError: if neither ``fcntl`` (POSIX) nor
+                ``msvcrt`` (Windows) is available.
         """
-        try:
-            import fcntl
-        except ImportError as exc:  # pragma: no cover — non-POSIX (Windows)
-            raise UnsupportedPlatformError(
-                "lingtai-wechat's poller lock requires fcntl (POSIX). "
-                "Running on this platform without a lock would silently "
-                "re-introduce the duplicate-poller race (GH #83). If you "
-                "need Windows support, please open an issue."
-            ) from exc
-
         # Open without truncating: a losing contender used to wipe the
         # holder's PID entry between holder-write and contender-read, which
         # made the PollerLockBusy diagnostic unreliable. Create-if-missing
@@ -91,17 +97,80 @@ class AccountLock:
         fd = os.open(self._path, os.O_RDWR | os.O_CREAT, 0o600)
         fh = os.fdopen(fd, "r+", encoding="utf-8")
         try:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError as exc:
-            existing_pid = _read_existing_pid_fh(fh)
+            primitive = self._take_lock(fh)
+        except Exception:
             fh.close()
-            pid_str = existing_pid or "unknown"
-            # Concrete remediation hints — after an upgrade, the most common
-            # reason this fires is that another LingTai project still has
-            # its old lingtai-wechat MCP running and we can't tell the user
-            # which project it belongs to from this side of the lock.
-            remediation: list[str] = []
-            if existing_pid and existing_pid.isdigit():
+            raise
+
+        # Only write the PID *after* the lock is acquired, so contenders
+        # never observe a half-truncated empty file.
+        fh.seek(0)
+        fh.truncate()
+        fh.write(str(os.getpid()))
+        fh.flush()
+        os.fsync(fh.fileno())
+        self._fh = fh
+        self._primitive = primitive
+        log.info("Acquired WeChat poller lock for account at %s", self._path)
+
+    def _take_lock(self, fh: IO[str]) -> str:
+        """Take the OS lock on ``fh``; return the primitive name used.
+
+        The file is left open on success (the caller keeps it) and closed by
+        the caller on any raise.
+        """
+        try:
+            import fcntl
+        except ImportError:
+            fcntl = None  # type: ignore[assignment]
+        if fcntl is not None:
+            try:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as exc:
+                raise self._busy(fh, posix=True) from exc
+            return "fcntl"
+
+        try:
+            import msvcrt
+        except ImportError as exc:  # pragma: no cover — neither POSIX nor NT
+            raise UnsupportedPlatformError(
+                "lingtai-wechat's poller lock requires fcntl (POSIX) or "
+                "msvcrt (Windows); neither is available on this platform. "
+                "Running without a lock would silently re-introduce the "
+                "duplicate-poller race (GH #83). Please open an issue."
+            ) from exc
+
+        # msvcrt.locking locks a byte range starting at the current file
+        # position, so seek to the stable offset first. LK_NBLCK is the
+        # non-blocking exclusive variant; it raises OSError on contention.
+        fh.seek(0)
+        try:
+            msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, _WINDOWS_LOCK_BYTES)
+        except OSError as exc:
+            if _is_windows_lock_busy(exc):
+                raise self._busy(fh, posix=False) from exc
+            # A different OS error (permissions, bad handle, …) must surface
+            # as itself rather than be mislabeled as a duplicate poller.
+            raise
+        return "msvcrt"
+
+    def _busy(self, fh: IO[str], *, posix: bool) -> PollerLockBusy:
+        """Build the PollerLockBusy for a losing contender and close ``fh``.
+
+        The contender reads the holder's PID from its own already-open handle
+        (no re-open race). If the OS denies that read — Windows may refuse a
+        read on a range the holder locked — we fall back to ``unknown``.
+        """
+        existing_pid = _read_existing_pid_fh(fh)
+        fh.close()
+        pid_str = existing_pid or "unknown"
+        # Concrete remediation hints — after an upgrade, the most common
+        # reason this fires is that another LingTai project still has its old
+        # lingtai-wechat MCP running and we can't tell the user which project
+        # it belongs to from this side of the lock.
+        remediation: list[str] = []
+        if existing_pid and existing_pid.isdigit():
+            if posix:
                 remediation.append(
                     f"  Inspect the holder:  ps -p {existing_pid} -o pid,command"
                 )
@@ -113,40 +182,51 @@ class AccountLock:
                 )
             else:
                 remediation.append(
-                    "  Find pollers:   pgrep -af 'lingtai-wechat|lingtai.mcp_servers.wechat'"
+                    f"  Inspect the holder:  Get-Process -Id {existing_pid}   "
+                    f"(or: tasklist /FI \"PID eq {existing_pid}\")"
                 )
                 remediation.append(
-                    "  Lockfile is held but no PID recorded — most likely a "
-                    "pre-upgrade poller that predates the lockfile. Stop it "
-                    "from the project that launched it."
+                    f"  Stop it gracefully:  Stop-Process -Id {existing_pid}"
                 )
-            raise PollerLockBusy(
-                f"Another lingtai-wechat poller is already running for this "
-                f"iLink account.\n"
-                f"  Lockfile:    {self._path}\n"
-                f"  Holder PID:  {pid_str}\n"
-                f"Stop the other poller before starting this one:\n"
-                + "\n".join(remediation)
-                + "\n(See lingtai-wechat README → Troubleshooting → "
-                "\"multiple pollers after upgrade\".)"
-            ) from exc
-
-        # Only write the PID *after* the lock is acquired, so contenders
-        # never observe a half-truncated empty file.
-        fh.seek(0)
-        fh.truncate()
-        fh.write(str(os.getpid()))
-        fh.flush()
-        os.fsync(fh.fileno())
-        self._fh = fh
-        log.info("Acquired WeChat poller lock for account at %s", self._path)
+        else:
+            if posix:
+                remediation.append(
+                    "  Find pollers:   pgrep -af 'lingtai-wechat|lingtai.mcp_servers.wechat'"
+                )
+            else:
+                remediation.append(
+                    "  Find pollers:   Get-CimInstance Win32_Process -Filter "
+                    '"Name = \'python.exe\'" | Select-Object ProcessId,CommandLine'
+                )
+            remediation.append(
+                "  Lockfile is held but no PID recorded — most likely a "
+                "pre-upgrade poller that predates the lockfile. Stop it "
+                "from the project that launched it."
+            )
+        return PollerLockBusy(
+            f"Another lingtai-wechat poller is already running for this "
+            f"iLink account.\n"
+            f"  Lockfile:    {self._path}\n"
+            f"  Holder PID:  {pid_str}\n"
+            f"Stop the other poller before starting this one:\n"
+            + "\n".join(remediation)
+            + "\n(See lingtai-wechat README → Troubleshooting → "
+            "\"multiple pollers after upgrade\".)"
+        )
 
     def release(self) -> None:
         if self._fh is None:
             return
         try:
-            import fcntl
-            fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+            if self._primitive == "fcntl":
+                import fcntl
+                fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+            elif self._primitive == "msvcrt":
+                import msvcrt
+                self._fh.seek(0)
+                msvcrt.locking(
+                    self._fh.fileno(), msvcrt.LK_UNLCK, _WINDOWS_LOCK_BYTES
+                )
         except Exception:
             pass
         try:
@@ -154,8 +234,38 @@ class AccountLock:
         except Exception:
             pass
         self._fh = None
-        # Leave the lockfile on disk (its presence + flock state is what
+        self._primitive = None
+        # Leave the lockfile on disk (its presence + lock state is what
         # matters); removing it would race with a concurrent acquire().
+
+
+def _is_windows_lock_busy(exc: OSError) -> bool:
+    """Whether an ``msvcrt.locking`` OSError means "already locked".
+
+    On a lock violation ``msvcrt.locking`` raises OSError with ``errno`` set
+    to ``EACCES`` (13) or ``EDEADLOCK`` (36) — the two values the Windows CRT
+    maps a lock contention to. When present, the Windows ``winerror`` is
+    ``ERROR_LOCK_VIOLATION`` (33) or ``ERROR_SHARING_VIOLATION`` (32). Any
+    other error (bad handle, permission, disk) is *not* contention and must
+    surface as itself so we never mislabel a real failure as a duplicate
+    poller.
+
+    The errno constant is named ``EDEADLOCK`` on the Windows Python build but
+    ``EDEADLK`` elsewhere, so we accept either spelling to keep this classifier
+    testable on POSIX. ``winerror`` only exists on Windows OSErrors.
+    """
+    import errno
+
+    busy_errnos = {errno.EACCES}
+    for name in ("EDEADLOCK", "EDEADLK"):
+        value = getattr(errno, name, None)
+        if value is not None:
+            busy_errnos.add(value)
+    if exc.errno in busy_errnos:
+        return True
+    winerror = getattr(exc, "winerror", None)
+    # 32 = ERROR_SHARING_VIOLATION, 33 = ERROR_LOCK_VIOLATION.
+    return winerror in (32, 33)
 
 
 def _read_existing_pid_fh(fh: IO[str]) -> str | None:

--- a/tests/test_wechat_lockfile.py
+++ b/tests/test_wechat_lockfile.py
@@ -1,0 +1,258 @@
+"""Regression tests for the WeChat per-account poller lock.
+
+The lock prevents the duplicate-poller race (GH #83) by taking an exclusive
+OS lock on a per-account lockfile. It uses ``fcntl.flock`` on POSIX and
+``msvcrt.locking`` on native Windows, and must fail loud (never silently
+no-op) when neither primitive exists.
+
+These tests run on POSIX. The Windows branch is exercised by injecting a fake
+``msvcrt`` module into ``sys.modules`` and hiding ``fcntl``, so no real
+Windows host is needed for unit coverage.
+"""
+from __future__ import annotations
+
+import errno
+import os
+import types
+
+import pytest
+
+from lingtai.mcp_servers.wechat import lockfile as lockfile_mod
+from lingtai.mcp_servers.wechat.lockfile import (
+    AccountLock,
+    PollerLockBusy,
+    UnsupportedPlatformError,
+    _WINDOWS_LOCK_BYTES,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_lock_dir(tmp_path, monkeypatch):
+    """Point the lockfile dir at a per-test tmp dir so runs don't collide."""
+    monkeypatch.setattr(
+        lockfile_mod, "_lock_dir", lambda: tmp_path, raising=True
+    )
+    return tmp_path
+
+
+# --------------------------------------------------------------------------
+# POSIX behavior (unchanged) — fcntl.flock is the real primitive here.
+# --------------------------------------------------------------------------
+
+
+def test_posix_acquire_writes_pid_after_lock():
+    lock = AccountLock("token-a")
+    lock.acquire()
+    try:
+        assert lock.path.read_text().strip() == str(os.getpid())
+    finally:
+        lock.release()
+
+
+def test_posix_second_acquire_is_busy_with_pid_and_posix_hints():
+    first = AccountLock("token-b")
+    first.acquire()
+    try:
+        second = AccountLock("token-b")
+        with pytest.raises(PollerLockBusy) as exc_info:
+            second.acquire()
+    finally:
+        first.release()
+    msg = str(exc_info.value)
+    assert str(os.getpid()) in msg
+    # POSIX remediation hints, not Windows ones.
+    assert "kill -TERM" in msg
+    assert "ps -p" in msg
+    assert "Stop-Process" not in msg
+
+
+def test_posix_release_allows_reacquire():
+    first = AccountLock("token-c")
+    first.acquire()
+    first.release()
+    # A fresh holder must be able to take the lock once released.
+    second = AccountLock("token-c")
+    second.acquire()
+    try:
+        assert second.path.read_text().strip()
+    finally:
+        second.release()
+
+
+# --------------------------------------------------------------------------
+# Windows branch — faked msvcrt, fcntl hidden.
+# --------------------------------------------------------------------------
+
+
+class _FakeMsvcrt(types.ModuleType):
+    """Minimal stand-in for the ``msvcrt`` module.
+
+    Models a byte-range lock on the underlying *file* (keyed by inode, like
+    the real CRT) rather than the raw fd — two different fds on the same
+    lockfile must conflict, which is the whole point of the lock. A second
+    LK_NBLCK on an already-locked file raises OSError like the real CRT.
+    """
+
+    LK_NBLCK = 2
+    LK_UNLCK = 0
+
+    def __init__(self, busy_error=None):
+        super().__init__("msvcrt")
+        self._locked: set[int] = set()  # inode numbers
+        self.calls: list[tuple[int, int, int]] = []
+        self._busy_error = busy_error
+
+    def _inode(self, fd):
+        import os as _os
+
+        return _os.fstat(fd).st_ino
+
+    def locking(self, fd, mode, nbytes):
+        self.calls.append((fd, mode, nbytes))
+        key = self._inode(fd)
+        if mode == self.LK_NBLCK:
+            if key in self._locked:
+                # EDEADLK is the POSIX spelling of the Windows CRT's
+                # EDEADLOCK, which is what a lock violation surfaces as.
+                raise self._busy_error or OSError(
+                    errno.EDEADLK, "lock violation"
+                )
+            self._locked.add(key)
+        elif mode == self.LK_UNLCK:
+            self._locked.discard(key)
+
+
+def _force_windows(monkeypatch, fake_msvcrt):
+    """Make the lockfile module take the Windows branch on this POSIX host."""
+
+    real_import = __builtins__["__import__"] if isinstance(
+        __builtins__, dict
+    ) else __builtins__.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "fcntl":
+            raise ImportError("no fcntl on this fake-Windows host")
+        if name == "msvcrt":
+            return fake_msvcrt
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+
+def test_windows_acquire_takes_msvcrt_lock_and_writes_pid(monkeypatch):
+    fake = _FakeMsvcrt()
+    _force_windows(monkeypatch, fake)
+
+    lock = AccountLock("win-token")
+    lock.acquire()
+    try:
+        # Actually locked via LK_NBLCK, not a silent no-op.
+        assert any(
+            mode == fake.LK_NBLCK and nbytes == _WINDOWS_LOCK_BYTES
+            for _, mode, nbytes in fake.calls
+        )
+        assert lock.path.read_text().strip() == str(os.getpid())
+    finally:
+        lock.release()
+
+
+def test_windows_second_acquire_is_busy_with_windows_hints(monkeypatch):
+    fake = _FakeMsvcrt()
+    _force_windows(monkeypatch, fake)
+
+    first = AccountLock("win-busy")
+    first.acquire()
+    try:
+        second = AccountLock("win-busy")
+        with pytest.raises(PollerLockBusy) as exc_info:
+            second.acquire()
+    finally:
+        first.release()
+    msg = str(exc_info.value)
+    assert str(os.getpid()) in msg
+    # Windows-specific remediation, not POSIX.
+    assert "Stop-Process" in msg
+    assert "Get-Process" in msg or "tasklist" in msg
+    assert "kill -TERM" not in msg
+
+
+def test_windows_release_unlocks_and_allows_reacquire(monkeypatch):
+    fake = _FakeMsvcrt()
+    _force_windows(monkeypatch, fake)
+
+    first = AccountLock("win-release")
+    first.acquire()
+    first.release()
+    # release() must issue LK_UNLCK over the same byte range.
+    assert (
+        first._fh is None
+    )  # handle dropped
+    assert any(
+        mode == fake.LK_UNLCK and nbytes == _WINDOWS_LOCK_BYTES
+        for _, mode, nbytes in fake.calls
+    )
+    # A fresh acquirer succeeds because the range was actually released.
+    second = AccountLock("win-release")
+    second.acquire()
+    second.release()
+
+
+def test_windows_sharing_violation_winerror_is_busy(monkeypatch):
+    err = OSError()
+    err.winerror = 33  # ERROR_LOCK_VIOLATION, no errno set
+    fake = _FakeMsvcrt(busy_error=err)
+    _force_windows(monkeypatch, fake)
+
+    first = AccountLock("win-winerror")
+    first.acquire()
+    try:
+        second = AccountLock("win-winerror")
+        with pytest.raises(PollerLockBusy):
+            second.acquire()
+    finally:
+        first.release()
+
+
+def test_windows_non_lock_oserror_surfaces_unlabeled(monkeypatch):
+    # A permission error (EPERM) is not contention: it must propagate as
+    # itself, never be relabeled PollerLockBusy.
+    boom = OSError(errno.EPERM, "operation not permitted")
+    fake = _FakeMsvcrt(busy_error=boom)
+    _force_windows(monkeypatch, fake)
+
+    first = AccountLock("win-boom")
+    first.acquire()
+    try:
+        second = AccountLock("win-boom")
+        with pytest.raises(OSError) as exc_info:
+            second.acquire()
+        assert not isinstance(exc_info.value, PollerLockBusy)
+        assert exc_info.value.errno == errno.EPERM
+    finally:
+        first.release()
+
+
+def test_neither_primitive_raises_unsupported(monkeypatch):
+    real_import = __builtins__["__import__"] if isinstance(
+        __builtins__, dict
+    ) else __builtins__.__import__
+
+    def no_lock_import(name, *args, **kwargs):
+        if name in ("fcntl", "msvcrt"):
+            raise ImportError(f"no {name} on this fake host")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", no_lock_import)
+
+    lock = AccountLock("no-primitive")
+    with pytest.raises(UnsupportedPlatformError) as exc_info:
+        lock.acquire()
+    # Must be explicit that it did not silently no-op.
+    assert "#83" in str(exc_info.value)
+
+
+def test_classifier_treats_eaccess_and_edeadlock_as_busy():
+    assert lockfile_mod._is_windows_lock_busy(OSError(errno.EACCES, "x"))
+    assert lockfile_mod._is_windows_lock_busy(OSError(errno.EDEADLK, "x"))
+    other = OSError(errno.ENOENT, "x")
+    assert not lockfile_mod._is_windows_lock_busy(other)


### PR DESCRIPTION
## Summary
- add native-Windows `msvcrt.locking` support to the in-kernel WeChat per-account poller lock
- preserve existing POSIX `fcntl.flock` behavior, lockfile key/path, PID-write-after-lock, and fail-loud duplicate-poller semantics
- add focused POSIX-runnable regression tests for POSIX lock behavior, fake-Windows lock/acquire/release/busy paths, unsupported-platform behavior, and Windows lock-error classification

## Taste / scope check
- Checked `lingtai-taste`: owning-layer fix in `src/lingtai/mcp_servers/wechat/lockfile.py`, no config flag, no fake support/no silent no-op.
- Verified maintained WeChat MCP source is in-kernel under `src/lingtai/mcp_servers/wechat/`, not the old standalone repo.
- No config/media/replay/lifecycle/daemon/docs/support-status changes.

## Validation
- `PYTHONPATH=src python -m py_compile src/lingtai/mcp_servers/wechat/lockfile.py tests/test_wechat_lockfile.py` → clean
- `PYTHONPATH=src python -m pytest tests/test_wechat_lockfile.py tests/test_wechat_config_resolution.py tests/test_wechat_inbound_replay.py -q` → 27 passed
- `PYTHONPATH=src python -m pytest tests/ -q -k 'wechat and lock'` → 16 passed, 3924 deselected
- `PYTHONPATH=src python -m pytest tests/test_wechat*.py -q` → 59 passed
- `git diff --check` → clean
- `rg -n "lockfile\.py" src tests -g 'ANATOMY.md' || true` → no anatomy citations, so no anatomy update needed

## Caveat
- No real native-Windows runner exercises the actual CRT `msvcrt` path here. The Windows branch is covered through a fake `msvcrt` module via patched import, including `LK_NBLCK`, `LK_UNLCK`, busy/error classification, and release/reacquire behavior. If a future Windows/Python build reports a different lock-violation error code, the code fails loud as a normal `OSError` rather than silently allowing duplicate pollers.
