### PR TITLE
fix(trace): redact additional credential key names

### DIFF
--- a/src/lingtai_kernel/trace_redaction.py
+++ b/src/lingtai_kernel/trace_redaction.py
@@ -40,7 +40,9 @@ _TOKEN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
 _KEY_NAME = (
     r"api[_-]?key|secret|token|password|passwd|pwd|credential|credentials|"
     r"bot[_-]?token|email[_-]?password|app[_-]?secret|client[_-]?secret|"
-    r"access[_-]?token|refresh[_-]?token|auth[_-]?token"
+    r"access[_-]?token|refresh[_-]?token|auth[_-]?token|"
+    r"private[_-]?key|signing[_-]?key|pem|certificate|cert|"
+    r"connection[_-]?string|dsn|database[_-]?url"
 )
 _JSON_QUOTED_ASSIGNMENT_RE = re.compile(
     rf"(?i)(([\"'])\b(?:{_KEY_NAME})\b\2\s*:\s*)([\"'])([^\"']{{8,}})(\3)"

--- a/tests/test_trace_redaction.py
+++ b/tests/test_trace_redaction.py
@@ -69,6 +69,54 @@ def test_redact_text_json_style_quoted_secret_assignment():
     assert '"safe":"ordinary"' in redacted
 
 
+def test_redact_for_trajectory_redacts_credential_key_names():
+    event = {
+        "type": "tool_result",
+        "tool_args": {
+            "private_key": "MIIEvQIBADANBgkq",
+            "signing_key": "whsec_abcdef123456",
+            "pem": "-----BEGIN PRIVATE KEY-----",
+            "certificate": "MIIDdzCCAl-gAwIB",
+            "cert": "MIIDdzCCAl-gAwIB",
+            "connection_string": "Server=db;User=sa;Pwd=hunter2;",
+            "dsn": "https://abc123@o0.ingest.sentry.io/1",
+            "database_url": "postgres://user:hunter2@host/db",
+            "database-url": "postgres://user:hunter2@host/db",
+        },
+    }
+    redacted = redact_for_trajectory(event)
+    for key in event["tool_args"]:
+        assert redacted["tool_args"][key] == "<REDACTED:secret>", key
+
+
+def test_redact_text_credential_key_assignments():
+    secret = "postgres://user:hunter2@host/db"
+    keys = (
+        "private_key", "private-key", "signing_key", "signing-key",
+        "pem", "certificate", "cert",
+        "connection_string", "connection-string",
+        "dsn", "database_url", "database-url",
+    )
+    for key in keys:
+        for raw in (f"{key}={secret}", f"{key}='{secret}'", f'{{"{key}":"{secret}"}}'):
+            redacted = redact_text(raw)
+            assert secret not in redacted, raw
+            assert "<REDACTED:secret>" in redacted, raw
+    # Key and formatting survive; only the value is removed.
+    assert redact_text(f'{{"database_url":"{secret}"}}') == '{"database_url":"<REDACTED:secret>"}'
+
+
+def test_credential_key_near_words_are_not_redacted():
+    # Substring near-words must not trigger key-name redaction.
+    prose = "concert=ticket-code-42 dsname=analytics-source certainty=extremely-high"
+    assert redact_text(prose) == prose
+    # Prose mentions without an assignment stay untouched.
+    prose2 = "the certificate expired and the pem file was rotated"
+    assert redact_text(prose2) == prose2
+    # client_id is a public identifier (OAuth2), deliberately not redacted.
+    event = {"tool_args": {"client_id": "public-client-identifier"}}
+    assert redact_for_trajectory(event)["tool_args"]["client_id"] == "public-client-identifier"
+
 
 def test_save_chat_history_redacts_persisted_copy_without_mutation(tmp_path):
     svc = MagicMock()


### PR DESCRIPTION
## Summary

- extend the existing trace-redaction key-name primitive with eight credential-bearing identifiers from #670
- preserve underscore/hyphen variants without adding a new redaction path or configuration surface
- add structured and text-assignment regression coverage, including false-positive and explicit non-goal cases

## Validation

- `python -m pytest -q tests/test_trace_redaction.py` — 9 passed
- `python -m pytest -q tests/test_trace_redaction.py tests/test_layers_bash.py tests/test_perform_refresh_handshake.py tests/test_aed_recovery.py` — 86 passed
- `git diff --check` — clean
- full `python -m pytest -q` — 3845 passed, 4 skipped, 1 unrelated pre-existing failure
  - failing node: `tests/test_prompt_catalog.py::test_packaged_section_sources_carry_frontmatter[substrate.md]`
  - the exact node also fails on a temporary clean detached `origin/main` worktree at `2a376f5b`
- independent GLM-5.2 review — approved with no blocking findings

## Scope

This intentionally does not add free-text PEM-block scanning, bare `key` / `auth` matching, `client_id` redaction, a new abstraction, or an anatomy update. The existing anatomy remains accurate because the owning component and persistence flow are unchanged.

Fixes #670
