### PR TITLE
fix(init): recognize supported AED manifest fields

### DIFF
--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -90,6 +90,16 @@ MANIFEST_OPTIONAL: dict[str, type | tuple[type, ...]] = {
     # meta_block.build_molt_context. See MANIFEST_LEGACY_IGNORED below.
     "max_turns": int,
     "max_rpm": int,
+    # Max AED (agent-environment-defibrillation) retry attempts per inbox
+    # message turn (see turn.py). Hydrated into AgentConfig.max_aed_attempts by
+    # agent.build_agent_config; AgentConfig clamps it to >= 1 (issue #654), so
+    # the (int) type here only rejects non-int types like str/float.
+    "max_aed_attempts": int,
+    # Max seconds an agent may remain STUCK before the AED subsystem
+    # transitions it to ASLEEP (see lifecycle.py). Hydrated into
+    # AgentConfig.aed_timeout by agent.build_agent_config (default 360.0);
+    # accepts integer or float seconds.
+    "aed_timeout": (int, float),
     # Soft per-molt/session cache-miss token budget. Positive int; default
     # 1_000_000 lives in AgentConfig.cache_miss_budget. The range check
     # (reject bool and <= 0) is enforced explicitly in validate_init below —

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -134,6 +134,48 @@ def test_cache_miss_budget_rejects_bool():
         validate_init(data)
 
 
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("max_aed_attempts", 5),
+        ("aed_timeout", 120),
+        ("aed_timeout", 360.0),
+    ],
+)
+def test_aed_manifest_fields_accept_valid_values_without_warning(field, value):
+    """Both AED manifest fields — max_aed_attempts (int) and aed_timeout
+    (int/float seconds) — are hydrated into AgentConfig by
+    agent.build_agent_config and consumed by the AED subsystem, so init_schema
+    must recognize them as known optional fields: a valid value must not warn
+    as 'unknown field' (issue #612).
+    """
+    data = _valid_init()
+    data["manifest"][field] = value
+
+    warnings = validate_init(data)
+
+    assert not any(field in w for w in warnings), (
+        f"valid manifest.{field} should not warn, got: {warnings}"
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("max_aed_attempts", "five"),
+        ("aed_timeout", "soon"),
+    ],
+)
+def test_aed_manifest_fields_reject_wrong_type(field, value):
+    """Each AED field must raise when given a value of the wrong type:
+    max_aed_attempts is int; aed_timeout is int or float seconds."""
+    data = _valid_init()
+    data["manifest"][field] = value
+
+    with pytest.raises(ValueError, match=rf"manifest\.{field}"):
+        validate_init(data)
+
+
 def test_wrong_type_capabilities():
     data = _valid_init()
     data["manifest"]["capabilities"] = ["file", "bash"]


### PR DESCRIPTION
## Summary

- register the already-supported `manifest.max_aed_attempts` and `manifest.aed_timeout` fields in the typed init schema
- keep existing `AgentConfig` defaults, numeric-bool rejection, retry clamping, and AED runtime behavior unchanged
- add focused regression coverage for valid integer/float values and path-specific wrong-type failures

## Root cause

Historical commit `9697eb57` exposed both AED settings through `build_agent_config`, and the runtime already consumes them, but neither key was added to `MANIFEST_OPTIONAL`. As a result, valid configuration emitted unknown-field warnings and bypassed schema type checking even though it was hydrated at runtime.

This is an owning-schema correction, not a new setting or AED behavior change.

## Validation

- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_init_schema.py -k 'aed_manifest' -q` — **5 passed**
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_init_schema.py -q` — **94 passed**
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_agent_config_hydration.py -q` — **18 passed**
- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_aed_recovery.py -q` — **10 passed**
- full suite — **3,868 passed, 4 skipped, 1 failed** in 304.59s
  - the sole failure is the pre-existing `substrate.md` prompt-catalog `related_files` assertion for `~/.lingtai-tui/runtime/venv`
  - the same targeted failure reproduces on a clean detached worktree at the exact starting base `b7676eee`
- `tools/check_anatomy_drift.py --check` — **no drift across 40 files**
- `git diff --check` — clean
- rebased onto current `origin/main@59d9afc9`; the intervening change touched no relevant file and the reviewed diff SHA-256 remained unchanged
- independent GLM-5.2 review — **APPROVE — no blockers**

## Scope / non-goals

- no AED retry/timeout algorithm or default change
- no new range or bool policy
- no compatibility alias for legacy top-level `prompt` (its warning is intentional and separately tested)
- no migration, feature flag, dependency, or anatomy change

Closes #612
