### PR TITLE
docs(daemon): add Codex backend flag-discovery submanual

### DIFF
--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -3,16 +3,41 @@ name: daemon-cli-backends
 description: >
   Nested daemon-manual reference for daemon API details and CLI backends:
   daemon(action=list), claude-p/codex/opencode behavior,
-  backend_options flag passing, preset/capability inheritance, and Codex modal
-  capabilities.
-version: 1.4.0
-last_changed_at: "2026-06-30T00:00:00-07:00"
+  backend_options flag passing, preset/capability inheritance, and nested
+  per-backend flag-discovery references (Codex).
+version: 1.5.0
+last_changed_at: "2026-07-09T18:46:53-07:00"
 ---
 
 # Daemon CLI Backend Reference
 
 Nested daemon-manual reference. Open this when choosing a daemon backend,
 inspecting `daemon(action="list")`, or passing CLI flags through `backend_options`.
+
+## Nested reference catalog
+
+`daemon-cli-backends` owns these nested references. They are parent-owned
+drill-down files, not standalone top-level skills. Backend-specific pages live
+under `reference/backends/<backend>/`; each is a small flag-discovery and
+translation guide that routes to the installed CLI's live help, never a
+maintained flag catalog. Only backends with proven demand get a page.
+
+```yaml
+- name: daemon-backend-codex
+  location: reference/backends/codex/SKILL.md
+  description: |
+    Nested daemon-cli-backends reference for the Codex daemon backend's flag
+    surface. Read this only when a daemon task needs Codex-specific CLI flags
+    (model selection, reasoning effort, config overrides): it routes to the
+    installed CLI's live help via bash and shows how to translate that help
+    into generic `backend_options` (e.g. repeated `--config` overrides).
+```
+
+## Routing table
+
+| Need / keywords | Read |
+|---|---|
+| Codex-specific flags for a daemon task: model selection, reasoning effort (`model_reasoning_effort`, ultra), `--config` overrides; discover the installed Codex CLI's flags and translate them into `backend_options` | `reference/backends/codex/SKILL.md` |
 
 ## API note: `daemon(action="list")`
 
@@ -176,7 +201,11 @@ For CLI backends, each task may carry an optional `backend_options` JSON object
 that is converted to argv tokens and appended to the CLI command before the task
 prompt. This lets you reach the underlying CLI's flag surface (model selection,
 search/web access, effort levels, sandbox/policy switches, etc.) without the
-daemon needing to hard-code every flag.
+daemon needing to hard-code every flag. This is the default generic path for
+backend flags: one object may carry any number of keys, each converted
+independently in insertion order. For Codex-specific discovery and translation
+examples (e.g. reasoning effort via repeated `--config` overrides), read
+`reference/backends/codex/SKILL.md`.
 
 This is intentionally a passthrough, not a fixed table. Claude Code, Codex,
 OpenCode, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, and Cursor rev their flag

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/codex/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/codex/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: daemon-backend-codex
+description: >
+  Nested daemon-cli-backends reference for the Codex daemon backend's flag
+  surface. Read this only when a daemon task needs Codex-specific CLI flags
+  (model selection, reasoning effort, config overrides): it routes you to the
+  installed CLI's live help via bash and shows how to translate that help into
+  the generic `backend_options` mechanism. It is not a flag catalog.
+version: 0.1.0
+last_changed_at: "2026-07-09T18:55:23-07:00"
+---
+
+# Codex Daemon Backend — Flag Discovery Entrypoint
+
+This page is deliberately tiny: it only tells you where the knowledge lives.
+The Codex CLI revs its flags and accepted values between releases, so the
+installed CLI's own help output is the authority — not this page, and not any
+flag list LingTai could ship.
+
+## Discover flags from the installed CLI
+
+1. Load `bash-manual` (its nested `reference/bash-openai-codex/SKILL.md` has
+   broader Codex CLI context).
+2. Run, in bash: `codex --version`, `codex --help`, and `codex exec --help`.
+   The daemon backend wraps `codex exec`, so `codex exec --help` is the
+   relevant flag surface. These are local read-only commands; no session is
+   started.
+3. Translate the long flags you found into `backend_options` using the
+   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
+   (key→flag mapping, value handling, key safety, persistence). Nothing
+   Codex-specific is added to that contract here.
+
+## Example: reasoning effort via the generic `config` route
+
+Codex exposes most of its tunables as repeated `-c, --config <key=value>`
+overrides (see `codex exec --help` for the key=value syntax). Through
+`backend_options`, a list value repeats the flag once per item:
+
+```jsonc
+{
+  "backend": "codex",
+  "tasks": [{
+    "task": "Implement and validate the change.",
+    "tools": [],
+    "backend_options": {
+      "config": ["model_reasoning_effort=\"ultra\""]
+    }
+  }]
+}
+// argv: --config model_reasoning_effort="ultra"
+```
+
+The effort vocabulary belongs to the installed CLI and the selected model —
+LingTai does not validate, enumerate, or simulate effort levels. A value like
+`ultra` passes through and the CLI/model decides its semantics (or rejects
+it).
+
+## Harness boundary
+
+Codex currently declares no reserved-flag list at the validation layer, so
+nothing is refused for this backend beyond the generic key/value safety rules.
+Still, do not re-set harness-owned surfaces (`--json`, sandbox/approval
+bypass, or `mcp_servers.daemon_common.*` config keys): breaking them silently
+breaks progress/result extraction and completion enforcement.
+
+To debug what was actually sent, `daemon.json` records the raw
+`backend_options` object alongside the resolved `backend_argv` /
+`backend_harness_argv` token lists.

--- a/tests/test_daemon_codex_submanual.py
+++ b/tests/test_daemon_codex_submanual.py
@@ -1,0 +1,96 @@
+"""Docs/routing contract for the Codex daemon-backend submanual.
+
+The Codex child under the daemon CLI-backend router is a small
+progressive-disclosure entrypoint: it routes agents to the installed CLI's
+live help (via bash) and shows how to translate that help into the generic
+``backend_options`` mechanism. It must never grow into a maintained flag
+catalog. The generic conversion behavior itself is covered by
+``tests/test_daemon_backend_options.py`` (see e.g.
+``test_argv_list_repeats_flag``, ``test_argv_mixed_options_preserve_key_order``,
+``test_argv_underscore_key_becomes_dash``,
+``test_codex_cmd_appends_backend_argv_before_task``,
+``test_emanate_cli_persists_resolved_options``) and is not re-tested here.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTER = ROOT / "src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md"
+CHILD = (
+    ROOT
+    / "src/lingtai/core/daemon/manual/reference/cli-backends"
+    / "reference/backends/codex/SKILL.md"
+)
+CHILD_LOCATION = "reference/backends/codex/SKILL.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} must start with YAML frontmatter"
+    _blank, frontmatter, _body = text.split("---", 2)
+    return yaml.safe_load(frontmatter) or {}
+
+
+def _body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.split("---", 2)[2]
+
+
+def test_router_has_yaml_catalog_entry_for_codex_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Nested reference catalog" in text
+    catalog_section = text.split("## Nested reference catalog", 1)[1]
+    match = re.search(r"```yaml\n(.*?)```", catalog_section, re.DOTALL)
+    assert match, "nested reference catalog must be a fenced YAML block"
+    entries = yaml.safe_load(match.group(1))
+    codex_entries = [e for e in entries if e.get("location") == CHILD_LOCATION]
+    assert len(codex_entries) == 1
+    assert codex_entries[0]["name"] == "daemon-backend-codex"
+    assert codex_entries[0]["description"].strip()
+
+
+def test_router_routing_table_points_to_codex_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Routing table" in text
+    table_rows = [
+        line for line in text.splitlines()
+        if line.startswith("|") and CHILD_LOCATION in line
+    ]
+    assert table_rows, "routing table must map Codex flag needs to the child"
+
+
+def test_codex_child_frontmatter_and_location():
+    assert CHILD.is_file()
+    meta = _frontmatter(CHILD)
+    assert meta["name"] == "daemon-backend-codex"
+    assert meta["description"].strip()
+    assert meta["last_changed_at"]
+
+
+def test_codex_child_routes_to_live_help_and_generic_backend_options():
+    body = _body(CHILD)
+    # Live installed help is the authority — the child must send agents there.
+    for phrase in (
+        "bash-manual",
+        "codex --version",
+        "codex --help",
+        "codex exec --help",
+    ):
+        assert phrase in body, phrase
+    # Translation goes through the existing generic mechanism, and the
+    # high-value reasoning-effort example uses the generic config route.
+    assert "backend_options" in body
+    assert 'model_reasoning_effort=\\"ultra\\"' in body
+    # The CLI/model owns the value vocabulary; no LingTai-side enum.
+    assert "not validate, enumerate, or simulate" in body
+
+
+def test_codex_child_stays_tiny_not_a_flag_catalog():
+    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    assert line_count <= 90, (
+        "the Codex backend submanual is a tiny entrypoint to live CLI help; "
+        f"{line_count} lines suggests it is growing into a flag catalog"
+    )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -255,6 +255,15 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         for reference_name in ("forensics", "inspection", "cli-backends", "cleanup"):
             daemon_reference = daemon_reference_dir / reference_name / "SKILL.md"
             assert daemon_reference.is_file()
+        codex_backend_reference = (
+            daemon_reference_dir
+            / "cli-backends"
+            / "reference"
+            / "backends"
+            / "codex"
+            / "SKILL.md"
+        )
+        assert codex_backend_reference.is_file()
         assert "Nested daemon-manual reference" in (
             daemon_reference_dir / "forensics" / "SKILL.md"
         ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add the first nested daemon backend submanual for Codex as a **tiny knowledge entrypoint**, not a maintained flag catalog
- route agents to `bash-manual` plus the installed `codex --version` / `codex --help` / `codex exec --help`, then back to the shared generic `backend_options` conversion rules
- retain one high-value reasoning-effort example through repeated generic `--config`, plus a short harness/debugging boundary
- add deterministic routing/frontmatter/install tests and a `<=90`-line guard

## Product shape

This deliberately adds **no** first-class Codex effort field, runtime/schema/i18n surface, generated help body, or other backend stub. The installed CLI remains the authority; the submanual only tells an agent where to learn and how to apply what it finds safely.

## Credit

This extracts the useful direction from @TZZheng's #826: the Codex reasoning-effort need and `ultra` pass-through semantics. It uses the existing generic mechanism instead of modifying the contributor branch or shipping a provider-specific runtime field.

## Validation

- `96 passed` — Codex submanual contract, daemon contract docs, generic backend options, and intrinsic skill installation
- child and router skill validators: all checks passed
- anatomy drift checker: no drift across 40 files
- `git diff HEAD^ --check`: clean
- independent GLM review: APPROVE
