### PR TITLE
docs(daemon): add OpenCode backend flag-discovery submanual

### DIFF
--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Nested daemon-manual reference for daemon API details and CLI backends:
   daemon(action=list), claude-p/codex/opencode behavior,
   backend_options flag passing, preset/capability inheritance, and nested
-  per-backend flag-discovery references (Codex).
-version: 1.5.0
-last_changed_at: "2026-07-09T18:46:53-07:00"
+  per-backend flag-discovery references (Codex, OpenCode).
+version: 1.6.0
+last_changed_at: "2026-07-09T19:22:21-07:00"
 ---
 
 # Daemon CLI Backend Reference
@@ -31,6 +31,14 @@ maintained flag catalog. Only backends with proven demand get a page.
     (model selection, reasoning effort, config overrides): it routes to the
     installed CLI's live help via bash and shows how to translate that help
     into generic `backend_options` (e.g. repeated `--config` overrides).
+- name: daemon-backend-opencode
+  location: reference/backends/opencode/SKILL.md
+  description: |
+    Nested daemon-cli-backends reference for the OpenCode daemon backend's
+    flag surface. Read this only when a daemon task needs OpenCode-specific
+    CLI flags (model selection, reasoning variants, agent choice): it routes
+    to the installed CLI's live help via bash and shows how to translate that
+    help into generic `backend_options` (e.g. `--model provider/model`).
 ```
 
 ## Routing table
@@ -38,6 +46,7 @@ maintained flag catalog. Only backends with proven demand get a page.
 | Need / keywords | Read |
 |---|---|
 | Codex-specific flags for a daemon task: model selection, reasoning effort (`model_reasoning_effort`, ultra), `--config` overrides; discover the installed Codex CLI's flags and translate them into `backend_options` | `reference/backends/codex/SKILL.md` |
+| OpenCode-specific flags for a daemon task: model selection (`--model provider/model`), reasoning variant (`--variant`), agent choice; discover the installed OpenCode CLI's flags and translate them into `backend_options` | `reference/backends/opencode/SKILL.md` |
 
 ## API note: `daemon(action="list")`
 
@@ -205,7 +214,9 @@ daemon needing to hard-code every flag. This is the default generic path for
 backend flags: one object may carry any number of keys, each converted
 independently in insertion order. For Codex-specific discovery and translation
 examples (e.g. reasoning effort via repeated `--config` overrides), read
-`reference/backends/codex/SKILL.md`.
+`reference/backends/codex/SKILL.md`. For OpenCode-specific examples (e.g.
+`--model provider/model`, `--variant`), read
+`reference/backends/opencode/SKILL.md`.
 
 This is intentionally a passthrough, not a fixed table. Claude Code, Codex,
 OpenCode, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, and Cursor rev their flag

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: daemon-backend-opencode
+description: >
+  Nested daemon-cli-backends reference for the OpenCode daemon backend's flag
+  surface. Read this only when a daemon task needs OpenCode-specific CLI flags
+  (model selection, provider-specific reasoning variants, agent choice): it
+  routes you to the installed CLI's live help via bash and shows how to
+  translate that help into the generic `backend_options` mechanism. It is not
+  a flag catalog.
+version: 0.1.0
+last_changed_at: "2026-07-09T19:22:21-07:00"
+---
+
+# OpenCode Daemon Backend — Flag Discovery Entrypoint
+
+This page is deliberately tiny: it only tells you where the knowledge lives.
+The OpenCode CLI revs its flags and accepted values between releases, so the
+installed CLI's own help output is the authority — not this page, and not any
+flag list LingTai could ship.
+
+## Discover flags from the installed CLI
+
+1. Load `bash-manual` (its nested `reference/bash-opencode/SKILL.md` has
+   broader OpenCode CLI context: providers, agents, config files).
+2. Run, in bash: `opencode --version`, `opencode --help`, and
+   `opencode run --help`. The daemon backend wraps `opencode run`, so
+   `opencode run --help` is the relevant flag surface. These are local
+   read-only commands; no session is started.
+3. Translate the long flags you found into `backend_options` using the
+   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
+   (key→flag mapping, value handling, key safety, persistence). Nothing
+   OpenCode-specific is added to that contract here.
+
+## Example: model and reasoning variant
+
+OpenCode selects models as `provider/model` via `-m, --model`, and exposes
+provider-specific reasoning effort as `--variant` (see `opencode run --help`
+for both). Through `backend_options`, plain scalars become `--flag <value>`:
+
+```jsonc
+{
+  "backend": "opencode",
+  "tasks": [{
+    "task": "Implement and validate the change.",
+    "tools": [],
+    "backend_options": {
+      "model": "anthropic/claude-sonnet-4-5",
+      "variant": "high"
+    }
+  }]
+}
+// argv: --model anthropic/claude-sonnet-4-5 --variant high
+```
+
+The model and variant vocabularies belong to the installed CLI and the
+selected provider — LingTai does not validate, enumerate, or simulate them. A
+value passes through and the CLI/provider decides its semantics (or rejects
+it).
+
+## Harness boundary
+
+OpenCode reserves `--format` at the validation layer: the daemon owns
+`opencode run --format json` so its per-line JSON event parsing keeps working,
+and passing `--format` in `backend_options` refuses the whole batch before
+spawn. Beyond that, do not re-set harness-owned surfaces: session flags
+(`--session` / `--continue`) belong to `daemon(action="ask")` resume
+(`opencode run --session <opencode_session_id> --format json ...`), and the
+completion MCP is injected through the `OPENCODE_CONFIG_CONTENT` environment
+variable — not argv — so breaking either silently breaks progress/result
+extraction and completion enforcement.
+
+To debug what was actually sent, `daemon.json` records the raw
+`backend_options` object alongside the resolved `backend_argv` /
+`backend_harness_argv` token lists. For OpenCode, `backend_harness_argv`
+holds a sentinel token pair that the runner converts into the
+`OPENCODE_CONFIG_CONTENT` environment variable rather than real argv flags.

--- a/tests/test_daemon_opencode_submanual.py
+++ b/tests/test_daemon_opencode_submanual.py
@@ -1,0 +1,102 @@
+"""Docs/routing contract for the OpenCode daemon-backend submanual.
+
+The OpenCode child under the daemon CLI-backend router is a small
+progressive-disclosure entrypoint: it routes agents to the installed CLI's
+live help (via bash) and shows how to translate that help into the generic
+``backend_options`` mechanism. It must never grow into a maintained flag
+catalog. The generic conversion behavior itself is covered by
+``tests/test_daemon_backend_options.py`` and the reserved ``--format``
+refusal by the backend-options validation tests; neither is re-tested here.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTER = ROOT / "src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md"
+CHILD = (
+    ROOT
+    / "src/lingtai/core/daemon/manual/reference/cli-backends"
+    / "reference/backends/opencode/SKILL.md"
+)
+CHILD_LOCATION = "reference/backends/opencode/SKILL.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} must start with YAML frontmatter"
+    _blank, frontmatter, _body = text.split("---", 2)
+    return yaml.safe_load(frontmatter) or {}
+
+
+def _body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.split("---", 2)[2]
+
+
+def test_router_has_yaml_catalog_entry_for_opencode_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Nested reference catalog" in text
+    catalog_section = text.split("## Nested reference catalog", 1)[1]
+    match = re.search(r"```yaml\n(.*?)```", catalog_section, re.DOTALL)
+    assert match, "nested reference catalog must be a fenced YAML block"
+    entries = yaml.safe_load(match.group(1))
+    opencode_entries = [e for e in entries if e.get("location") == CHILD_LOCATION]
+    assert len(opencode_entries) == 1
+    assert opencode_entries[0]["name"] == "daemon-backend-opencode"
+    assert opencode_entries[0]["description"].strip()
+
+
+def test_router_routing_table_points_to_opencode_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Routing table" in text
+    table_rows = [
+        line for line in text.splitlines()
+        if line.startswith("|") and CHILD_LOCATION in line
+    ]
+    assert table_rows, "routing table must map OpenCode flag needs to the child"
+
+
+def test_opencode_child_frontmatter_and_location():
+    assert CHILD.is_file()
+    meta = _frontmatter(CHILD)
+    assert meta["name"] == "daemon-backend-opencode"
+    assert meta["description"].strip()
+    assert meta["last_changed_at"]
+
+
+def test_opencode_child_routes_to_live_help_and_generic_backend_options():
+    body = _body(CHILD)
+    # Live installed help is the authority — the child must send agents there.
+    for phrase in (
+        "bash-manual",
+        "opencode --version",
+        "opencode --help",
+        "opencode run --help",
+    ):
+        assert phrase in body, phrase
+    # Translation goes through the existing generic mechanism, and the
+    # high-value model/variant example uses plain scalar conversion.
+    assert "backend_options" in body
+    assert "--model anthropic/claude-sonnet-4-5 --variant high" in body
+    # The CLI/provider owns the value vocabulary; no LingTai-side enum.
+    assert "not validate, enumerate, or simulate" in body
+
+
+def test_opencode_child_states_reserved_format_flag_and_mcp_env():
+    body = _body(CHILD)
+    # `--format` is source-reserved (_OPENCODE_FAMILY_RESERVED_BACKEND_FLAGS);
+    # the completion MCP rides the OPENCODE_CONFIG_CONTENT environment
+    # variable, not argv. The child must state both harness boundaries.
+    assert "`--format`" in body
+    assert "OPENCODE_CONFIG_CONTENT" in body
+
+
+def test_opencode_child_stays_tiny_not_a_flag_catalog():
+    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    assert line_count <= 90, (
+        "the OpenCode backend submanual is a tiny entrypoint to live CLI help; "
+        f"{line_count} lines suggests it is growing into a flag catalog"
+    )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -264,6 +264,15 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
             / "SKILL.md"
         )
         assert codex_backend_reference.is_file()
+        opencode_backend_reference = (
+            daemon_reference_dir
+            / "cli-backends"
+            / "reference"
+            / "backends"
+            / "opencode"
+            / "SKILL.md"
+        )
+        assert opencode_backend_reference.is_file()
         assert "Nested daemon-manual reference" in (
             daemon_reference_dir / "forensics" / "SKILL.md"
         ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add a 76-line progressive-disclosure entrypoint for OpenCode daemon backend flags instead of maintaining a copied/generated help catalog
- route agents to the installed `opencode` version/help and the shared generic `backend_options` translation contract
- document the source-verified harness boundaries: reserved `--format`, ask/resume session ownership, completion MCP injection through `OPENCODE_CONFIG_CONTENT`, and persisted argv artifacts
- add focused routing/install/size tests; no runtime, schema, config, or i18n surface

## Validation

- `python -m pytest tests/test_daemon_opencode_submanual.py tests/test_skills.py -q` — **35 passed**
- `python -m pytest tests/test_daemon_backend_options.py tests/test_daemon_opencode_backend.py -q` — **94 passed**
- `python src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check` — passed across 40 files
- skill validator passed for both `reference/cli-backends` and the new `reference/backends/opencode` child
- `git diff --check origin/main...HEAD` — passed

## Review

Independent GLM-5.2 review: **APPROVE**, with every harness/session/MCP/artifact claim checked against current source and no blockers.

Implements the small knowledge-entrypoint shape Jason confirmed in the current backend rollout; mirrors the merged Codex sibling without introducing a static flag catalog.
