### PR TITLE
docs(daemon): add claude-p backend flag-discovery submanual

### DIFF
--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Nested daemon-manual reference for daemon API details and CLI backends:
   daemon(action=list), claude-p/codex/opencode behavior,
   backend_options flag passing, preset/capability inheritance, and nested
-  per-backend flag-discovery references (Codex, OpenCode).
-version: 1.6.0
-last_changed_at: "2026-07-09T19:22:21-07:00"
+  per-backend flag-discovery references (Codex, OpenCode, claude-p).
+version: 1.7.0
+last_changed_at: "2026-07-09T19:47:33-07:00"
 ---
 
 # Daemon CLI Backend Reference
@@ -39,6 +39,15 @@ maintained flag catalog. Only backends with proven demand get a page.
     CLI flags (model selection, reasoning variants, agent choice): it routes
     to the installed CLI's live help via bash and shows how to translate that
     help into generic `backend_options` (e.g. `--model provider/model`).
+- name: daemon-backend-claude-p
+  location: reference/backends/claude-p/SKILL.md
+  description: |
+    Nested daemon-cli-backends reference for the claude-p (alias claude-code)
+    daemon backend's flag surface. Read this only when a daemon task needs
+    Claude Code-specific CLI flags (model selection, fallback model, tool
+    restrictions): it routes to the installed CLI's live help via bash and
+    shows how to translate that help into generic `backend_options` (e.g.
+    underscore keys becoming dashed long flags like `--fallback-model`).
 ```
 
 ## Routing table
@@ -47,6 +56,7 @@ maintained flag catalog. Only backends with proven demand get a page.
 |---|---|
 | Codex-specific flags for a daemon task: model selection, reasoning effort (`model_reasoning_effort`, ultra), `--config` overrides; discover the installed Codex CLI's flags and translate them into `backend_options` | `reference/backends/codex/SKILL.md` |
 | OpenCode-specific flags for a daemon task: model selection (`--model provider/model`), reasoning variant (`--variant`), agent choice; discover the installed OpenCode CLI's flags and translate them into `backend_options` | `reference/backends/opencode/SKILL.md` |
+| Claude Code-specific flags for a `claude-p` / `claude-code` daemon task: model selection, `--fallback-model`, tool restrictions; reserved/harness-owned flag boundary, resume and auth-env behavior; discover the installed Claude CLI's flags and translate them into `backend_options` | `reference/backends/claude-p/SKILL.md` |
 
 ## API note: `daemon(action="list")`
 
@@ -216,7 +226,9 @@ independently in insertion order. For Codex-specific discovery and translation
 examples (e.g. reasoning effort via repeated `--config` overrides), read
 `reference/backends/codex/SKILL.md`. For OpenCode-specific examples (e.g.
 `--model provider/model`, `--variant`), read
-`reference/backends/opencode/SKILL.md`.
+`reference/backends/opencode/SKILL.md`. For Claude Code-specific discovery and
+the `claude-p` harness boundary (reserved flags, MCP config, resume, auth-env
+hygiene), read `reference/backends/claude-p/SKILL.md`.
 
 This is intentionally a passthrough, not a fixed table. Claude Code, Codex,
 OpenCode, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, and Cursor rev their flag

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: daemon-backend-claude-p
+description: >
+  Nested daemon-cli-backends reference for the claude-p (alias claude-code)
+  daemon backend's flag surface. Read this only when a daemon task needs
+  Claude Code-specific CLI flags (model selection, fallback model, tool
+  restrictions): it routes you to the installed CLI's live help via bash and
+  shows how to translate that help into the generic `backend_options`
+  mechanism. It is not a flag catalog.
+version: 0.1.0
+last_changed_at: "2026-07-09T19:22:27-07:00"
+---
+
+# claude-p Daemon Backend — Flag Discovery Entrypoint
+
+This page is deliberately tiny: it only tells you where the knowledge lives.
+The Claude Code CLI revs its flags and accepted values between releases, so
+the installed CLI's own help output is the authority — not this page, and not
+any flag list LingTai could ship. `claude-p` is the canonical print-mode
+backend id; `claude-code` is a compatibility alias that resolves to the same
+runner and the same reserved-flag set.
+
+## Discover flags from the installed CLI
+
+1. Load `bash-manual` (its nested `reference/bash-claude-code/SKILL.md` has
+   broader Claude Code CLI context).
+2. Run, in bash: `claude --version` and `claude --help`. The daemon backend
+   wraps `claude --print`, so the print-mode flags in `claude --help` are the
+   relevant surface. These are local read-only commands; no session is
+   started.
+3. Translate the long flags you found into `backend_options` using the
+   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
+   (key→flag mapping, value handling, key safety, persistence). Nothing
+   Claude-specific is added to that contract here.
+
+## Example: automatic fallback model for a long print run
+
+Through `backend_options`, an underscore key becomes a dashed long flag:
+
+```jsonc
+{
+  "backend": "claude-p",
+  "tasks": [{
+    "task": "Implement and validate the change.",
+    "tools": [],
+    "backend_options": {
+      "fallback_model": "claude-sonnet-5"
+    }
+  }]
+}
+// argv: --fallback-model claude-sonnet-5
+```
+
+The model-name vocabulary belongs to the installed CLI and the provider
+account — LingTai does not validate, enumerate, or simulate model names. A
+value passes through and the CLI decides its semantics (or rejects it).
+
+## Harness boundary
+
+The harness spawns `claude --print --dangerously-skip-permissions
+--output-format stream-json --verbose --name <em_id>`, then your
+`backend_options` argv, then harness-owned MCP flags, with the task prompt as
+the trailing positional argument. Validation therefore refuses the
+harness-owned flags `--settings`, `--print`, `--output-format`,
+`--mcp-config`, and `--strict-mcp-config` in `backend_options` before spawn:
+breaking stream-json output or the per-run MCP config silently breaks
+progress/result extraction and completion enforcement.
+
+Related run-scoped behavior you should not fight through flags:
+
+- MCP: the harness writes stdio registrations (including `daemon_common`) to
+  the run's `claude-mcp-config.json` and appends `--mcp-config <path>
+  --strict-mcp-config` itself as `backend_harness_argv`.
+- Resume: `daemon(action="ask")` runs `claude --resume <claude_session_id>
+  --print ...` against the session id persisted to
+  `daemon.json.claude_session_id`; `backend_options` are not re-passed on
+  ask — emanate-time flags persist for the session's life.
+- Auth-env hygiene: the spawn environment strips `ANTHROPIC_API_KEY`,
+  `ANTHROPIC_AUTH_TOKEN`, and `CLAUDE_CODE_OAUTH_TOKEN` so the CLI's own
+  OAuth credentials win; do not re-inject auth overrides via flags.
+
+To debug what was actually sent, `daemon.json` records the raw
+`backend_options` object alongside the resolved `backend_argv` /
+`backend_harness_argv` token lists.

--- a/tests/test_daemon_claude_p_submanual.py
+++ b/tests/test_daemon_claude_p_submanual.py
@@ -1,0 +1,122 @@
+"""Docs/routing contract for the claude-p daemon-backend submanual.
+
+The claude-p child under the daemon CLI-backend router is a small
+progressive-disclosure entrypoint: it routes agents to the installed CLI's
+live help (via bash) and shows how to translate that help into the generic
+``backend_options`` mechanism. It must never grow into a maintained flag
+catalog. The generic conversion behavior itself is covered by
+``tests/test_daemon_backend_options.py`` (see e.g.
+``test_argv_underscore_key_becomes_dash``,
+``test_argv_mixed_options_preserve_key_order``,
+``test_claude_code_cmd_appends_backend_argv_before_task``,
+``test_emanate_cli_rejects_bad_backend_options``,
+``test_emanate_cli_persists_resolved_options``) and is not re-tested here.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTER = ROOT / "src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md"
+CHILD = (
+    ROOT
+    / "src/lingtai/core/daemon/manual/reference/cli-backends"
+    / "reference/backends/claude-p/SKILL.md"
+)
+CHILD_LOCATION = "reference/backends/claude-p/SKILL.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} must start with YAML frontmatter"
+    _blank, frontmatter, _body = text.split("---", 2)
+    return yaml.safe_load(frontmatter) or {}
+
+
+def _body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.split("---", 2)[2]
+
+
+def test_router_has_yaml_catalog_entry_for_claude_p_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Nested reference catalog" in text
+    catalog_section = text.split("## Nested reference catalog", 1)[1]
+    match = re.search(r"```yaml\n(.*?)```", catalog_section, re.DOTALL)
+    assert match, "nested reference catalog must be a fenced YAML block"
+    entries = yaml.safe_load(match.group(1))
+    claude_p_entries = [e for e in entries if e.get("location") == CHILD_LOCATION]
+    assert len(claude_p_entries) == 1
+    assert claude_p_entries[0]["name"] == "daemon-backend-claude-p"
+    assert claude_p_entries[0]["description"].strip()
+
+
+def test_router_routing_table_points_to_claude_p_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Routing table" in text
+    table_rows = [
+        line for line in text.splitlines()
+        if line.startswith("|") and CHILD_LOCATION in line
+    ]
+    assert table_rows, "routing table must map Claude Code flag needs to the child"
+
+
+def test_claude_p_child_frontmatter_and_location():
+    assert CHILD.is_file()
+    meta = _frontmatter(CHILD)
+    assert meta["name"] == "daemon-backend-claude-p"
+    assert meta["description"].strip()
+    assert meta["last_changed_at"]
+
+
+def test_claude_p_child_routes_to_live_help_and_generic_backend_options():
+    body = _body(CHILD)
+    # Live installed help is the authority — the child must send agents there.
+    for phrase in (
+        "bash-manual",
+        "claude --version",
+        "claude --help",
+    ):
+        assert phrase in body, phrase
+    # Translation goes through the existing generic mechanism, and the
+    # high-value fallback-model example uses the underscore→dash rule.
+    assert "backend_options" in body
+    assert '"fallback_model"' in body
+    assert "--fallback-model" in body
+    # The CLI/provider owns the value vocabulary; no LingTai-side enum.
+    assert "not validate, enumerate, or simulate" in body
+
+
+def test_claude_p_child_states_alias_and_harness_boundary():
+    body = _body(CHILD)
+    # The alias relationship is part of the source contract.
+    assert "claude-code" in body
+    assert "compatibility alias" in body
+    # Source-verified harness-owned flags refused in backend_options
+    # (_CLAUDE_COMMON_RESERVED_BACKEND_FLAGS).
+    for flag in (
+        "--settings",
+        "--print",
+        "--output-format",
+        "--mcp-config",
+        "--strict-mcp-config",
+    ):
+        assert flag in body, flag
+    # Resume + auth-env hygiene are stated, not re-specified.
+    assert "claude_session_id" in body
+    for env_var in (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ):
+        assert env_var in body, env_var
+
+
+def test_claude_p_child_stays_tiny_not_a_flag_catalog():
+    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    assert line_count <= 90, (
+        "the claude-p backend submanual is a tiny entrypoint to live CLI help; "
+        f"{line_count} lines suggests it is growing into a flag catalog"
+    )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -273,6 +273,15 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
             / "SKILL.md"
         )
         assert opencode_backend_reference.is_file()
+        claude_p_backend_reference = (
+            daemon_reference_dir
+            / "cli-backends"
+            / "reference"
+            / "backends"
+            / "claude-p"
+            / "SKILL.md"
+        )
+        assert claude_p_backend_reference.is_file()
         assert "Nested daemon-manual reference" in (
             daemon_reference_dir / "forensics" / "SKILL.md"
         ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add an 84-line progressive-disclosure entrypoint for `claude-p` / `claude-code` daemon backend flags instead of maintaining a copied CLI-help catalog
- route agents to the installed `claude --help`, the matching bash-manual reference, and the shared generic `backend_options` translation contract
- document source-verified harness boundaries: reserved print/stream/MCP flags, run-private MCP config, resume session ownership, auth-environment hygiene, and persisted argv artifacts
- add focused routing/install/size tests; no runtime, schema, config, or i18n surface

## Rebase

Rebased mechanically onto OpenCode PR #830's merge commit `a8ba9d1e`. The two expected shared conflicts preserved all upstream Codex + OpenCode catalog/routing/install rows and appended the Claude-p rows. Parent range-diff inspection found no semantic change to the child/test patch beyond those cumulative main additions.

## Validation

- cumulative Claude-p/Codex/OpenCode submanual + install suite — **46 passed**
- generic backend-options/contract/manifest/validator/anatomy unit suite — **103 passed**
- skill validator passed for both `reference/cli-backends` and the new `reference/backends/claude-p` child
- anatomy checker — no drift across **40 files**
- `git diff --check origin/main...HEAD` — passed
- exact four-file diff, human-only identity, clean worktree, no AI trailer, and no worktree/derived Claude memory writes verified

## Review

Independent GLM-5.2 review of the semantic patch: **APPROVE**, with the alias, spawn order, reserved flags, MCP, resume, auth-env, and artifact claims checked against current source and no blockers.

Implements the small knowledge-entrypoint shape Jason confirmed in the current backend rollout; mirrors the merged Codex/OpenCode siblings without introducing a static flag catalog.
