### PR TITLE
docs(daemon): add MiMo Code backend flag-discovery submanual

### DIFF
--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Nested daemon-manual reference for daemon API details and CLI backends:
   daemon(action=list), claude-p/codex/opencode behavior,
   backend_options flag passing, preset/capability inheritance, and nested
-  per-backend flag-discovery references (Codex, OpenCode, claude-p).
-version: 1.7.0
-last_changed_at: "2026-07-09T19:47:33-07:00"
+  per-backend flag-discovery references (Codex, OpenCode, claude-p, MiMo Code).
+version: 1.8.0
+last_changed_at: "2026-07-09T19:56:24-07:00"
 ---
 
 # Daemon CLI Backend Reference
@@ -48,6 +48,14 @@ maintained flag catalog. Only backends with proven demand get a page.
     restrictions): it routes to the installed CLI's live help via bash and
     shows how to translate that help into generic `backend_options` (e.g.
     underscore keys becoming dashed long flags like `--fallback-model`).
+- name: daemon-backend-mimocode
+  location: reference/backends/mimocode/SKILL.md
+  description: |
+    Nested daemon-cli-backends reference for the MiMo Code (`mimocode` /
+    `mimo`) daemon backend's flag surface. Read this only when a daemon task
+    needs MiMo-specific CLI flags (model selection, provider switches): it
+    routes to the installed CLI's live help via bash (`mimo run --help`) and
+    shows how to translate that help into generic `backend_options`.
 ```
 
 ## Routing table
@@ -57,6 +65,7 @@ maintained flag catalog. Only backends with proven demand get a page.
 | Codex-specific flags for a daemon task: model selection, reasoning effort (`model_reasoning_effort`, ultra), `--config` overrides; discover the installed Codex CLI's flags and translate them into `backend_options` | `reference/backends/codex/SKILL.md` |
 | OpenCode-specific flags for a daemon task: model selection (`--model provider/model`), reasoning variant (`--variant`), agent choice; discover the installed OpenCode CLI's flags and translate them into `backend_options` | `reference/backends/opencode/SKILL.md` |
 | Claude Code-specific flags for a `claude-p` / `claude-code` daemon task: model selection, `--fallback-model`, tool restrictions; reserved/harness-owned flag boundary, resume and auth-env behavior; discover the installed Claude CLI's flags and translate them into `backend_options` | `reference/backends/claude-p/SKILL.md` |
+| MiMo Code-specific flags for a daemon task (`mimocode` / `mimo`): model selection, provider switches; discover the installed `mimo` CLI's flags (`mimo run --help`) and translate them into `backend_options` | `reference/backends/mimocode/SKILL.md` |
 
 ## API note: `daemon(action="list")`
 
@@ -228,7 +237,9 @@ examples (e.g. reasoning effort via repeated `--config` overrides), read
 `--model provider/model`, `--variant`), read
 `reference/backends/opencode/SKILL.md`. For Claude Code-specific discovery and
 the `claude-p` harness boundary (reserved flags, MCP config, resume, auth-env
-hygiene), read `reference/backends/claude-p/SKILL.md`.
+hygiene), read `reference/backends/claude-p/SKILL.md`. For MiMo Code
+(`mimocode` / `mimo`) discovery and translation, read
+`reference/backends/mimocode/SKILL.md`.
 
 This is intentionally a passthrough, not a fixed table. Claude Code, Codex,
 OpenCode, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, and Cursor rev their flag

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: daemon-backend-mimocode
+description: >
+  Nested daemon-cli-backends reference for the MiMo Code (`mimocode` / `mimo`)
+  daemon backend's flag surface. Read this only when a daemon task needs
+  MiMo-specific CLI flags (model selection, provider switches): it routes you
+  to the installed CLI's live help via bash and shows how to translate that
+  help into the generic `backend_options` mechanism. It is not a flag catalog.
+version: 0.1.0
+last_changed_at: "2026-07-09T19:22:58-07:00"
+---
+
+# MiMo Code Daemon Backend — Flag Discovery Entrypoint
+
+This page is deliberately tiny: it only tells you where the knowledge lives.
+The MiMo Code CLI (npm package `@mimo-ai/cli`, binary `mimo`) revs its flags
+and accepted values between releases, so the installed CLI's own help output
+is the authority — not this page, and not any flag list LingTai could ship.
+
+## Backend identity and spawn shape
+
+`mimo` is a short alias: the daemon canonicalizes it to `mimocode`, and
+persisted daemon entries use the canonical name. The backend spawns
+`mimo run --format json <prompt>`; converted `backend_options` tokens sit
+between the harness flags and the trailing prompt positional.
+
+## Discover flags from the installed CLI
+
+1. Load `bash-manual` (its nested `reference/bash-mimocode/SKILL.md` has
+   broader MiMo Code CLI context).
+2. Run, in bash: `mimo --version`, `mimo --help`, and `mimo run --help`.
+   The daemon backend wraps `mimo run`, so `mimo run --help` is the relevant
+   flag surface. These are local read-only commands; no session is started.
+3. Translate the long flags you found into `backend_options` using the
+   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
+   (key→flag mapping, value handling, key safety, persistence). Nothing
+   MiMo-specific is added to that contract here.
+
+## Example: model selection via the generic route
+
+```jsonc
+{
+  "backend": "mimo",  // canonicalizes to "mimocode"
+  "tasks": [{
+    "task": "Implement and validate the change.",
+    "tools": [],
+    "backend_options": {
+      "model": "mimo-auto"
+    }
+  }]
+}
+// spawned argv: mimo run --format json --model mimo-auto <prompt>
+```
+
+The flag/value vocabulary belongs to the installed CLI — LingTai does not
+validate, enumerate, or simulate it. A value passes through and the CLI
+decides its semantics (or rejects it).
+
+## Harness boundary
+
+`mimocode` shares the OpenCode-family reserved list: `--format` is
+harness-owned (daemon progress/result extraction depends on `--format json`
+JSONL events), and passing it in `backend_options` refuses the whole batch
+before any process is spawned. Session resume is also harness-owned:
+`daemon(action="ask")` asynchronously runs
+`mimo run --session <mimocode_session_id> --format json <message>`, with the
+session id captured from the first session-shaped JSON event into
+`daemon.json`. Do not re-set `--session` through `backend_options`.
+
+Per-run `daemon_common` MCP injection is not wired for `mimocode` yet, so the
+MCP completion contract is not enforced on this backend; parent MCP
+registrations reach the run as prompt catalog only. Output parsing uses the
+permissive OpenCode-family JSONL parser — non-JSON stdout lines are still
+recorded as `cli_output`, never silently dropped.
+
+To debug what was actually sent, `daemon.json` records the raw
+`backend_options` object alongside the resolved `backend_argv` /
+`backend_harness_argv` token lists.

--- a/tests/test_daemon_mimocode_submanual.py
+++ b/tests/test_daemon_mimocode_submanual.py
@@ -1,0 +1,107 @@
+"""Docs/routing contract for the MiMo Code daemon-backend submanual.
+
+The MiMo Code child under the daemon CLI-backend router is a small
+progressive-disclosure entrypoint: it routes agents to the installed CLI's
+live help (via bash) and shows how to translate that help into the generic
+``backend_options`` mechanism. It must never grow into a maintained flag
+catalog. The runtime behavior itself (alias canonicalization, argv placement,
+reserved ``--format``, session capture) is covered by
+``tests/test_daemon_backend_options.py`` (see e.g.
+``test_mimocode_alias_dispatches_to_canonical_backend``,
+``test_mimocode_cmd_appends_backend_argv_before_prompt``) and is not
+re-tested here.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTER = ROOT / "src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md"
+CHILD = (
+    ROOT
+    / "src/lingtai/core/daemon/manual/reference/cli-backends"
+    / "reference/backends/mimocode/SKILL.md"
+)
+CHILD_LOCATION = "reference/backends/mimocode/SKILL.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} must start with YAML frontmatter"
+    _blank, frontmatter, _body = text.split("---", 2)
+    return yaml.safe_load(frontmatter) or {}
+
+
+def _body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.split("---", 2)[2]
+
+
+def test_router_has_yaml_catalog_entry_for_mimocode_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Nested reference catalog" in text
+    catalog_section = text.split("## Nested reference catalog", 1)[1]
+    match = re.search(r"```yaml\n(.*?)```", catalog_section, re.DOTALL)
+    assert match, "nested reference catalog must be a fenced YAML block"
+    entries = yaml.safe_load(match.group(1))
+    mimocode_entries = [e for e in entries if e.get("location") == CHILD_LOCATION]
+    assert len(mimocode_entries) == 1
+    assert mimocode_entries[0]["name"] == "daemon-backend-mimocode"
+    assert mimocode_entries[0]["description"].strip()
+
+
+def test_router_routing_table_points_to_mimocode_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Routing table" in text
+    table_rows = [
+        line for line in text.splitlines()
+        if line.startswith("|") and CHILD_LOCATION in line
+    ]
+    assert table_rows, "routing table must map MiMo flag needs to the child"
+
+
+def test_mimocode_child_frontmatter_and_location():
+    assert CHILD.is_file()
+    meta = _frontmatter(CHILD)
+    assert meta["name"] == "daemon-backend-mimocode"
+    assert meta["description"].strip()
+    assert meta["last_changed_at"]
+
+
+def test_mimocode_child_routes_to_live_help_and_generic_backend_options():
+    body = _body(CHILD)
+    # Live installed help is the authority — the child must send agents there.
+    for phrase in (
+        "bash-manual",
+        "mimo --version",
+        "mimo --help",
+        "mimo run --help",
+    ):
+        assert phrase in body, phrase
+    # Translation goes through the existing generic mechanism.
+    assert "backend_options" in body
+    # The CLI owns the value vocabulary; no LingTai-side enum.
+    assert "not\nvalidate, enumerate, or simulate" in body or (
+        "not validate, enumerate, or simulate" in " ".join(body.split())
+    )
+
+
+def test_mimocode_child_states_verified_backend_contract():
+    body = _body(CHILD)
+    # Canonical name / alias, exact spawn shape, reserved harness flag, and
+    # current MCP status — all verified against src/lingtai/core/daemon.
+    assert "canonicalizes it to `mimocode`" in body
+    assert "mimo run --format json <prompt>" in body
+    assert "`--format`" in body
+    assert "mimo run --session <mimocode_session_id> --format json" in body
+    assert "not wired for `mimocode` yet" in body
+
+
+def test_mimocode_child_stays_tiny_not_a_flag_catalog():
+    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    assert line_count <= 90, (
+        "the MiMo Code backend submanual is a tiny entrypoint to live CLI "
+        f"help; {line_count} lines suggests it is growing into a flag catalog"
+    )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -255,33 +255,16 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         for reference_name in ("forensics", "inspection", "cli-backends", "cleanup"):
             daemon_reference = daemon_reference_dir / reference_name / "SKILL.md"
             assert daemon_reference.is_file()
-        codex_backend_reference = (
-            daemon_reference_dir
-            / "cli-backends"
-            / "reference"
-            / "backends"
-            / "codex"
-            / "SKILL.md"
-        )
-        assert codex_backend_reference.is_file()
-        opencode_backend_reference = (
-            daemon_reference_dir
-            / "cli-backends"
-            / "reference"
-            / "backends"
-            / "opencode"
-            / "SKILL.md"
-        )
-        assert opencode_backend_reference.is_file()
-        claude_p_backend_reference = (
-            daemon_reference_dir
-            / "cli-backends"
-            / "reference"
-            / "backends"
-            / "claude-p"
-            / "SKILL.md"
-        )
-        assert claude_p_backend_reference.is_file()
+        for backend_name in ("codex", "opencode", "claude-p", "mimocode"):
+            backend_reference = (
+                daemon_reference_dir
+                / "cli-backends"
+                / "reference"
+                / "backends"
+                / backend_name
+                / "SKILL.md"
+            )
+            assert backend_reference.is_file()
         assert "Nested daemon-manual reference" in (
             daemon_reference_dir / "forensics" / "SKILL.md"
         ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add a 78-line progressive-disclosure entrypoint for `mimocode` / `mimo` daemon backend flags instead of maintaining a copied CLI-help catalog
- route agents to the installed `mimo --help`, the matching bash-manual reference, and the shared generic `backend_options` translation contract
- document source-verified alias/spawn order, output/session ownership, prompt-only MCP context, stream parsing, and persisted argv/session artifacts
- add focused routing/install/size tests; no runtime, schema, config, or i18n surface

## Rebase

Rebased mechanically onto Claude-p PR #831's merge commit `7ac35de8`. The two expected shared conflicts preserved all upstream Codex + OpenCode + Claude-p catalog/routing/install rows and appended the MiMo rows. Parent range-diff inspection confirmed the 78-line child is byte-identical to the GLM-reviewed original and the remaining conflict resolution is cumulative router/test bookkeeping only.

## Validation

- cumulative Codex/OpenCode/Claude-p/MiMo submanual + install suite — **52 passed**
- generic backend-options/contract/manifest/validator/anatomy unit suite — **103 passed**
- skill validator passed for both `reference/cli-backends` and the new `reference/backends/mimocode` child
- anatomy checker — no drift across **40 files**
- `git diff --check origin/main...HEAD` — passed
- exact four-file diff, range-diff, human-only identity, clean worktree, no AI trailer, and no worktree/derived Claude memory writes verified

## Review

Independent GLM-5.2 review of the semantic patch: **APPROVE**, with alias/canonicalization, spawn ordering, reserved/session flags, prompt-only MCP behavior, parser/artifact claims, and tests checked against current source and no blockers.

Implements the small knowledge-entrypoint shape Jason confirmed in the current backend rollout; mirrors the merged siblings without introducing a static flag catalog.
