### PR TITLE
docs(daemon): add built-in LingTai backend knowledge-entrypoint submanual

### DIFF
--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -4,9 +4,10 @@ description: >
   Nested daemon-manual reference for daemon API details and CLI backends:
   daemon(action=list), claude-p/codex/opencode behavior,
   backend_options flag passing, preset/capability inheritance, and nested
-  per-backend flag-discovery references (Codex, OpenCode, claude-p, MiMo Code).
-version: 1.8.0
-last_changed_at: "2026-07-09T19:56:24-07:00"
+  per-backend references (Codex, OpenCode, claude-p, and MiMo Code flag
+  discovery, built-in LingTai knowledge entrypoint).
+version: 1.9.0
+last_changed_at: "2026-07-09T20:06:40-07:00"
 ---
 
 # Daemon CLI Backend Reference
@@ -18,9 +19,12 @@ inspecting `daemon(action="list")`, or passing CLI flags through `backend_option
 
 `daemon-cli-backends` owns these nested references. They are parent-owned
 drill-down files, not standalone top-level skills. Backend-specific pages live
-under `reference/backends/<backend>/`; each is a small flag-discovery and
-translation guide that routes to the installed CLI's live help, never a
-maintained flag catalog. Only backends with proven demand get a page.
+under `reference/backends/<backend>/` — despite this router's historical
+`cli-backends` path, the built-in `lingtai` backend's page lives here too.
+Each page is a small knowledge entrypoint that routes to the current
+authority — a CLI backend's installed live help, or the built-in backend's
+live manuals/preset/contract sources — never a maintained flag or rules
+catalog. Only backends with proven demand get a page.
 
 ```yaml
 - name: daemon-backend-codex
@@ -56,6 +60,15 @@ maintained flag catalog. Only backends with proven demand get a page.
     needs MiMo-specific CLI flags (model selection, provider switches): it
     routes to the installed CLI's live help via bash (`mimo run --help`) and
     shows how to translate that help into generic `backend_options`.
+- name: daemon-backend-lingtai
+  location: reference/backends/lingtai/SKILL.md
+  description: |
+    Nested daemon-cli-backends reference for the built-in `lingtai` daemon
+    backend (the in-process ChatSession default). Read this when routing a
+    daemon task to the built-in backend: it has no external CLI and no
+    `backend_options` flag surface; the page routes to the live authorities
+    for preset selection/inspection, tools/skills/MCP inheritance, and the
+    daemon completion contract.
 ```
 
 ## Routing table
@@ -66,6 +79,7 @@ maintained flag catalog. Only backends with proven demand get a page.
 | OpenCode-specific flags for a daemon task: model selection (`--model provider/model`), reasoning variant (`--variant`), agent choice; discover the installed OpenCode CLI's flags and translate them into `backend_options` | `reference/backends/opencode/SKILL.md` |
 | Claude Code-specific flags for a `claude-p` / `claude-code` daemon task: model selection, `--fallback-model`, tool restrictions; reserved/harness-owned flag boundary, resume and auth-env behavior; discover the installed Claude CLI's flags and translate them into `backend_options` | `reference/backends/claude-p/SKILL.md` |
 | MiMo Code-specific flags for a daemon task (`mimocode` / `mimo`): model selection, provider switches; discover the installed `mimo` CLI's flags (`mimo run --help`) and translate them into `backend_options` | `reference/backends/mimocode/SKILL.md` |
+| Built-in `lingtai` backend knowledge for a daemon task: confirm it has no CLI/`backend_options` flag surface; find the live authorities for preset selection/inspection, tools/skills/MCP inheritance, and the completion contract | `reference/backends/lingtai/SKILL.md` |
 
 ## API note: `daemon(action="list")`
 

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/lingtai/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/lingtai/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: daemon-backend-lingtai
+description: >
+  Nested daemon-cli-backends reference for the built-in `lingtai` daemon
+  backend (the in-process ChatSession default). Read this when routing a
+  daemon task to the built-in backend: it has no external CLI and no
+  `backend_options` flag surface; this page routes you to the live
+  authorities for preset selection/inspection, tools/skills/MCP inheritance,
+  and the daemon completion contract. It is not a rules catalog.
+version: 0.1.0
+last_changed_at: "2026-07-09T19:22:26-07:00"
+---
+
+# LingTai Daemon Backend — Knowledge Entrypoint
+
+This page is deliberately tiny: it only tells you where the knowledge lives.
+`backend="lingtai"` is the built-in default — an in-process ChatSession run
+loop, not a wrapped external CLI. There is no installed binary whose help
+output could be consulted, and `backend_options` is ignored (there is no CLI
+process to forward argv to), so this backend has no flag surface to discover
+or translate. Its behavior is owned by live LingTai configuration, manuals,
+and source — route to the current authority instead of memorizing snapshots.
+
+## Where the knowledge lives
+
+1. **Task shape and behavior contract** — the `daemon-manual` router
+   (`manual/SKILL.md`): `task` vs `system_prompt` vs `tools` vs `skills` vs
+   `mcp` semantics, and the shared parent `reference/cli-backends/SKILL.md`
+   ("LingTai backend tool surface") for how this backend curates tools.
+2. **Preset selection and inspection** — run `system(action="presets")` for
+   the live tier/connectivity/capability listing (guidance:
+   `system-manual` → `reference/substrate-manual/SKILL.md`). A per-task
+   `preset` must be a `.json`/`.jsonc` path exactly as returned by that
+   listing; an unloadable or unreachable preset refuses the whole batch at
+   emanate time. Omit `preset` to inherit the parent's regular (non-MCP)
+   tool surface.
+3. **Tools/skills/MCP inheritance** — parent MCP tools are **not**
+   auto-inherited: pass full one-run `mcp` registrations per task. `skills`
+   entries become a compact prompt catalog (paths, not pasted bodies).
+   `email` is daemon-eligible but opt-in via `tools`. Details live in the
+   parent router's "LingTai backend tool surface" section.
+4. **Completion contract** — the built-in `daemon_common` MCP is added
+   automatically and `finish(status="done")` is the only terminal-success
+   signal. The maintainer-facing architecture invariants are
+   `src/lingtai/core/daemon/DAEMON_CONTRACT.md`; the current tool schema
+   description is the caller-facing authority.
+
+## Example: explicit preset, tools, skills, and MCP
+
+```jsonc
+{
+  "action": "emanate",
+  "backend": "lingtai",
+  "tasks": [{
+    "task": "Summarize reports/audit.md into reports/audit-summary.md.",
+    "tools": ["file"],
+    "preset": "~/.lingtai-tui/presets/saved/cheap.json",
+    "skills": ["src/lingtai/core/daemon/manual"],
+    "mcp": [{"name": "local-docs", "transport": "stdio",
+             "command": "python", "args": ["-m", "local_docs_mcp"]}]
+  }]
+}
+```
+
+Every field above resolves live: the preset path comes from
+`system(action="presets")`, skill paths resolve against the parent working
+directory, and the MCP registration is started as a task-scoped client whose
+tools appear only for this run (secret `env`/`headers` values are redacted
+in prompts).
+
+## Harness boundary
+
+There is nothing to tune at the process-spawn layer: no reserved flags, no
+argv, no `backend_argv`/`backend_harness_argv` in `daemon.json`. Model and
+tool shape are chosen through `preset`; behavior is guided through
+`system_prompt`; capability comes from `tools`/`skills`/`mcp`. LingTai-backend
+tool calls still pass the kernel ToolExecutor/ToolCallGuard gate — a daemon
+run does not bypass normal execution policy.

--- a/tests/test_daemon_lingtai_submanual.py
+++ b/tests/test_daemon_lingtai_submanual.py
@@ -1,0 +1,123 @@
+"""Docs/routing contract for the built-in LingTai daemon-backend submanual.
+
+The LingTai child under the daemon backend router is the built-in sibling of
+the Codex flag-discovery page: a small progressive-disclosure knowledge
+entrypoint. Unlike CLI backend pages it discloses *knowledge routing*, not
+flags — `backend="lingtai"` is the in-process ChatSession default with no
+external CLI and no `backend_options` surface, so the page must route agents
+to the live authorities (daemon-manual router, `system(action="presets")`
+preset inspection, tools/skills/MCP inheritance rules, DAEMON_CONTRACT.md)
+and must never grow into a duplicated rules catalog or invent a flag
+surface. Runtime behavior itself is covered by ``tests/test_daemon.py`` and
+``tests/test_daemon_backend_options.py`` and is not re-tested here.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTER = ROOT / "src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md"
+CHILD = (
+    ROOT
+    / "src/lingtai/core/daemon/manual/reference/cli-backends"
+    / "reference/backends/lingtai/SKILL.md"
+)
+CHILD_LOCATION = "reference/backends/lingtai/SKILL.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} must start with YAML frontmatter"
+    _blank, frontmatter, _body = text.split("---", 2)
+    return yaml.safe_load(frontmatter) or {}
+
+
+def _body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.split("---", 2)[2]
+
+
+def test_router_has_yaml_catalog_entry_for_lingtai_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Nested reference catalog" in text
+    catalog_section = text.split("## Nested reference catalog", 1)[1]
+    match = re.search(r"```yaml\n(.*?)```", catalog_section, re.DOTALL)
+    assert match, "nested reference catalog must be a fenced YAML block"
+    entries = yaml.safe_load(match.group(1))
+    lingtai_entries = [e for e in entries if e.get("location") == CHILD_LOCATION]
+    assert len(lingtai_entries) == 1
+    assert lingtai_entries[0]["name"] == "daemon-backend-lingtai"
+    assert lingtai_entries[0]["description"].strip()
+
+
+def test_router_admits_builtin_sibling_without_moving():
+    # The router keeps its historical cli-backends path but must say the
+    # built-in backend's page lives under it too.
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "historical" in text
+    assert ROUTER.parent.name == "cli-backends", "router must not be renamed/moved"
+
+
+def test_router_routing_table_points_to_lingtai_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Routing table" in text
+    table_rows = [
+        line for line in text.splitlines()
+        if line.startswith("|") and CHILD_LOCATION in line
+    ]
+    assert table_rows, "routing table must map built-in backend needs to the child"
+
+
+def test_lingtai_child_frontmatter_and_location():
+    assert CHILD.is_file()
+    meta = _frontmatter(CHILD)
+    assert meta["name"] == "daemon-backend-lingtai"
+    assert meta["description"].strip()
+    assert meta["last_changed_at"]
+
+
+def test_lingtai_child_routes_to_live_authorities():
+    body = _body(CHILD)
+    # The page routes to current authorities instead of restating rules.
+    for phrase in (
+        "daemon-manual",
+        'system(action="presets")',
+        "reference/substrate-manual/SKILL.md",
+        "DAEMON_CONTRACT.md",
+        "auto-inherited",
+        "one-run `mcp` registrations",
+        "daemon_common",
+        'finish(status="done")',
+    ):
+        assert phrase in body, phrase
+
+
+def test_lingtai_child_declares_no_cli_flag_surface():
+    body = _body(CHILD)
+    # Built-in backend: no wrapped CLI, and backend_options is ignored.
+    assert "in-process" in body
+    assert "`backend_options` is ignored" in body
+    assert "no flag surface" in body
+    # No invented per-run argv artifacts for this backend.
+    assert "no reserved flags" in body
+
+
+def test_lingtai_child_has_exactly_one_example_with_explicit_surface():
+    body = _body(CHILD)
+    fences = re.findall(r"```jsonc?\n(.*?)```", body, re.DOTALL)
+    assert len(fences) == 1, "the child carries exactly one compact example"
+    example = fences[0]
+    assert '"backend": "lingtai"' in example
+    for field in ('"preset"', '"tools"', '"skills"', '"mcp"'):
+        assert field in example, field
+    assert '"backend_options"' not in example
+
+
+def test_lingtai_child_stays_tiny_not_a_rules_catalog():
+    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    assert line_count <= 90, (
+        "the LingTai backend submanual is a tiny entrypoint to live authorities; "
+        f"{line_count} lines suggests it is growing into a duplicated rules catalog"
+    )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -255,7 +255,7 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         for reference_name in ("forensics", "inspection", "cli-backends", "cleanup"):
             daemon_reference = daemon_reference_dir / reference_name / "SKILL.md"
             assert daemon_reference.is_file()
-        for backend_name in ("codex", "opencode", "claude-p", "mimocode"):
+        for backend_name in ("codex", "opencode", "claude-p", "mimocode", "lingtai"):
             backend_reference = (
                 daemon_reference_dir
                 / "cli-backends"


### PR DESCRIPTION
## Summary

- add a 78-line progressive-disclosure knowledge entrypoint for the built-in `lingtai` daemon backend
- make the historical CLI-backends router explicitly admit the built-in sibling while routing agents to live preset/manual/tool/skill/MCP/contract authorities rather than inventing a CLI surface
- document the source-verified boundaries: in-process ChatSession, ignored `backend_options`, preset validation/inheritance, task-scoped MCP, `daemon_common` completion, and no CLI argv artifacts
- add focused routing/install/size tests; no runtime, schema, config, or i18n surface

## Rebase

Rebased mechanically onto MiMo PR #832's merge commit `06f1dc99`. The two expected shared conflicts preserved all upstream Codex + OpenCode + Claude-p + MiMo catalog/routing/install rows and appended the LingTai rows. Parent range-diff inspection confirmed the 78-line child/focused test remain byte-identical to the GLM-reviewed semantic patch; the remaining changes are cumulative router/install bookkeeping only.

## Validation

- cumulative five-backend submanual suite — **31 passed**
- skills/install + daemon contract + MCP manual + backend-options + validator/anatomy unit suite — **141 passed**
- skill validator passed for both `reference/cli-backends` and the new `reference/backends/lingtai` child
- anatomy checker — no drift across **40 files**
- `git diff --check origin/main...HEAD` — passed
- exact four-file diff, range-diff, human-only identity, clean worktree, no AI trailer, and no worktree/derived Claude memory writes verified

## Review

Clean replacement GLM-5.2 review after the earlier provider-only 429: **APPROVE**. The reviewer verified the ignored `backend_options` behavior, preset/tool/skill/MCP inheritance, `daemon_common` finish semantics, artifacts/ask behavior, and live-authority routing against current source with no blockers.

Implements the small knowledge-entrypoint shape Jason confirmed in the current backend rollout; it deliberately adds no CLI/help catalog for the in-process backend.
