### PR TITLE
docs(daemon): add Qwen Code backend flag-discovery submanual

### DIFF
--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -4,10 +4,10 @@ description: >
   Nested daemon-manual reference for daemon API details and CLI backends:
   daemon(action=list), claude-p/codex/opencode behavior,
   backend_options flag passing, preset/capability inheritance, and nested
-  per-backend references (Codex, OpenCode, claude-p, and MiMo Code flag
-  discovery, built-in LingTai knowledge entrypoint).
-version: 1.9.0
-last_changed_at: "2026-07-09T20:06:40-07:00"
+  per-backend references (Codex, OpenCode, claude-p, MiMo Code, and Qwen
+  Code flag discovery, built-in LingTai knowledge entrypoint).
+version: 1.10.0
+last_changed_at: "2026-07-09T20:15:31-07:00"
 ---
 
 # Daemon CLI Backend Reference
@@ -60,6 +60,15 @@ catalog. Only backends with proven demand get a page.
     needs MiMo-specific CLI flags (model selection, provider switches): it
     routes to the installed CLI's live help via bash (`mimo run --help`) and
     shows how to translate that help into generic `backend_options`.
+- name: daemon-backend-qwen-code
+  location: reference/backends/qwen-code/SKILL.md
+  description: |
+    Nested daemon-cli-backends reference for the Qwen Code (`qwen-code` /
+    `qwen`) daemon backend's flag surface. Read this only when a daemon task
+    needs Qwen-specific CLI flags (model selection, provider tunables): it
+    routes to the installed CLI's live help via bash and shows how to
+    translate that help into generic `backend_options`, plus the backend's
+    reserved-flag and no-resume boundaries.
 - name: daemon-backend-lingtai
   location: reference/backends/lingtai/SKILL.md
   description: |
@@ -79,6 +88,7 @@ catalog. Only backends with proven demand get a page.
 | OpenCode-specific flags for a daemon task: model selection (`--model provider/model`), reasoning variant (`--variant`), agent choice; discover the installed OpenCode CLI's flags and translate them into `backend_options` | `reference/backends/opencode/SKILL.md` |
 | Claude Code-specific flags for a `claude-p` / `claude-code` daemon task: model selection, `--fallback-model`, tool restrictions; reserved/harness-owned flag boundary, resume and auth-env behavior; discover the installed Claude CLI's flags and translate them into `backend_options` | `reference/backends/claude-p/SKILL.md` |
 | MiMo Code-specific flags for a daemon task (`mimocode` / `mimo`): model selection, provider switches; discover the installed `mimo` CLI's flags (`mimo run --help`) and translate them into `backend_options` | `reference/backends/mimocode/SKILL.md` |
+| Qwen Code (`qwen-code` / `qwen`)-specific flags for a daemon task: model selection, provider tunables, reserved `--prompt`/`--yolo`/`--approval-mode` boundary, no-`ask` planning; discover the installed `qwen` CLI's flags and translate them into `backend_options` | `reference/backends/qwen-code/SKILL.md` |
 | Built-in `lingtai` backend knowledge for a daemon task: confirm it has no CLI/`backend_options` flag surface; find the live authorities for preset selection/inspection, tools/skills/MCP inheritance, and the completion contract | `reference/backends/lingtai/SKILL.md` |
 
 ## API note: `daemon(action="list")`
@@ -253,7 +263,9 @@ examples (e.g. reasoning effort via repeated `--config` overrides), read
 the `claude-p` harness boundary (reserved flags, MCP config, resume, auth-env
 hygiene), read `reference/backends/claude-p/SKILL.md`. For MiMo Code
 (`mimocode` / `mimo`) discovery and translation, read
-`reference/backends/mimocode/SKILL.md`.
+`reference/backends/mimocode/SKILL.md`. For Qwen Code–specific discovery and
+translation (e.g. model selection, reserved headless flags), read
+`reference/backends/qwen-code/SKILL.md`.
 
 This is intentionally a passthrough, not a fixed table. Claude Code, Codex,
 OpenCode, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, and Cursor rev their flag

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: daemon-backend-qwen-code
+description: >
+  Nested daemon-cli-backends reference for the Qwen Code (`qwen-code` /
+  `qwen`) daemon backend's flag surface. Read this only when a daemon task
+  needs Qwen-specific CLI flags (model selection, provider tunables): it
+  routes you to the installed CLI's live help via bash and shows how to
+  translate that help into the generic `backend_options` mechanism. It is
+  not a flag catalog.
+version: 0.1.0
+last_changed_at: "2026-07-09T19:22:18-07:00"
+---
+
+# Qwen Code Daemon Backend — Flag Discovery Entrypoint
+
+This page is deliberately tiny: it only tells you where the knowledge lives.
+The Qwen Code CLI (npm package `@qwen-code/qwen-code`, binary `qwen`) revs its
+flags and accepted values between releases, so the installed CLI's own help
+output is the authority — not this page, and not any flag list LingTai could
+ship. The alias `qwen` canonicalizes to the `qwen-code` backend id.
+
+## Discover flags from the installed CLI
+
+1. Load `bash-manual` (its nested `reference/bash-qwen-code/SKILL.md` has
+   broader Qwen Code CLI context).
+2. Run, in bash: `qwen --version` and `qwen --help`. The daemon backend wraps
+   the top-level `qwen` binary directly — it spawns
+   `qwen --yolo <backend_argv...> -p <prompt>`, no subcommand — so
+   `qwen --help` is the whole relevant flag surface. These are local
+   read-only commands; no session is started.
+3. Translate the long flags you found into `backend_options` using the
+   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
+   (key→flag mapping, value handling, key safety, persistence). Nothing
+   Qwen-specific is added to that contract here.
+
+## Example: model selection via the generic route
+
+Your options land between the harness-owned `--yolo` and the final
+`-p <prompt>` (argv placement is pinned by
+`tests/test_daemon_backend_options.py::test_qwen_code_cmd_appends_backend_argv_before_prompt`):
+
+```jsonc
+{
+  "backend": "qwen",
+  "tasks": [{
+    "task": "Implement and validate the change.",
+    "tools": [],
+    "backend_options": {
+      "model": "qwen3-coder-plus"
+    }
+  }]
+}
+// argv: qwen --yolo --model qwen3-coder-plus -p <prompt>
+```
+
+The model vocabulary belongs to the installed CLI and the configured
+provider — LingTai does not validate, enumerate, or simulate model names. A
+value passes through and the CLI/provider decides its semantics (or rejects
+it).
+
+## Harness boundary
+
+Qwen Code reserves `--prompt`/`-p`, `--yolo`/`-y`, and `--approval-mode`:
+they drive LingTai's non-interactive headless harness, and passing any of
+them in `backend_options` refuses the whole batch before spawn. Beyond that,
+do not re-point harness-owned surfaces: the daemon writes a per-run
+`<run>/qwen-daemon-settings.json` (carrying `mcpServers.daemon_common` plus
+parent stdio MCP registrations) and injects it via the
+`QWEN_CODE_SYSTEM_SETTINGS_PATH` environment variable — overriding settings
+paths silently breaks completion enforcement.
+
+Plan flags at emanate time: `daemon(action='ask')` is intentionally
+unsupported for this backend (no stable headless resume contract), so there
+is no later chance to adjust a running session. Output parsing is verbatim
+text — Qwen Code headless mode has no machine-readable event stream here, so
+stdout/stderr are recorded as-is and the result is the final stdout text;
+the `daemon_common` `finish(status="done")` call is still required for
+success.
+
+To debug what was actually sent, `daemon.json` records the raw
+`backend_options` object alongside the resolved `backend_argv` /
+`backend_harness_argv` token lists.

--- a/tests/test_daemon_qwen_code_submanual.py
+++ b/tests/test_daemon_qwen_code_submanual.py
@@ -1,0 +1,110 @@
+"""Docs/routing contract for the Qwen Code daemon-backend submanual.
+
+The Qwen Code child under the daemon CLI-backend router is a small
+progressive-disclosure entrypoint: it routes agents to the installed CLI's
+live help (via bash) and shows how to translate that help into the generic
+``backend_options`` mechanism. It must never grow into a maintained flag
+catalog. The runtime behavior it documents is covered elsewhere and is not
+re-tested here: generic conversion and qwen argv placement in
+``tests/test_daemon_backend_options.py`` (see
+``test_qwen_code_cmd_appends_backend_argv_before_prompt``,
+``test_qwen_code_rejects_harness_owned_backend_options``,
+``test_qwen_code_ask_is_explicitly_unsupported``).
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTER = ROOT / "src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md"
+CHILD = (
+    ROOT
+    / "src/lingtai/core/daemon/manual/reference/cli-backends"
+    / "reference/backends/qwen-code/SKILL.md"
+)
+CHILD_LOCATION = "reference/backends/qwen-code/SKILL.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} must start with YAML frontmatter"
+    _blank, frontmatter, _body = text.split("---", 2)
+    return yaml.safe_load(frontmatter) or {}
+
+
+def _body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.split("---", 2)[2]
+
+
+def test_router_has_yaml_catalog_entry_for_qwen_code_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Nested reference catalog" in text
+    catalog_section = text.split("## Nested reference catalog", 1)[1]
+    match = re.search(r"```yaml\n(.*?)```", catalog_section, re.DOTALL)
+    assert match, "nested reference catalog must be a fenced YAML block"
+    entries = yaml.safe_load(match.group(1))
+    qwen_entries = [e for e in entries if e.get("location") == CHILD_LOCATION]
+    assert len(qwen_entries) == 1
+    assert qwen_entries[0]["name"] == "daemon-backend-qwen-code"
+    assert qwen_entries[0]["description"].strip()
+
+
+def test_router_routing_table_points_to_qwen_code_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Routing table" in text
+    table_rows = [
+        line for line in text.splitlines()
+        if line.startswith("|") and CHILD_LOCATION in line
+    ]
+    assert table_rows, "routing table must map Qwen Code flag needs to the child"
+
+
+def test_qwen_code_child_frontmatter_and_location():
+    assert CHILD.is_file()
+    meta = _frontmatter(CHILD)
+    assert meta["name"] == "daemon-backend-qwen-code"
+    assert meta["description"].strip()
+    assert meta["last_changed_at"]
+
+
+def test_qwen_code_child_routes_to_live_help_and_generic_backend_options():
+    body = _body(CHILD)
+    # Live installed help is the authority — the child must send agents there.
+    # The daemon wraps the top-level `qwen` binary (no subcommand), so only
+    # top-level help is cited.
+    for phrase in (
+        "bash-manual",
+        "qwen --version",
+        "qwen --help",
+        "no subcommand",
+    ):
+        assert phrase in body, phrase
+    # Translation goes through the existing generic mechanism, and the
+    # high-value model-selection example matches the tested argv placement.
+    assert "backend_options" in body
+    assert "qwen3-coder-plus" in body
+    assert "qwen --yolo --model qwen3-coder-plus -p <prompt>" in body
+    # The CLI/provider owns the value vocabulary; no LingTai-side enum.
+    assert "not validate, enumerate, or simulate" in body
+
+
+def test_qwen_code_child_states_harness_boundaries():
+    body = _body(CHILD)
+    # Reserved headless flags are named so agents don't burn a batch on them.
+    for phrase in ("--prompt", "--yolo", "--approval-mode"):
+        assert phrase in body, phrase
+    # Per-run MCP settings injection and the no-resume planning consequence.
+    assert "QWEN_CODE_SYSTEM_SETTINGS_PATH" in body
+    assert "qwen-daemon-settings.json" in body
+    assert "daemon(action='ask')" in body
+
+
+def test_qwen_code_child_stays_tiny_not_a_flag_catalog():
+    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    assert line_count <= 90, (
+        "the Qwen Code backend submanual is a tiny entrypoint to live CLI "
+        f"help; {line_count} lines suggests it is growing into a flag catalog"
+    )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -255,7 +255,14 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         for reference_name in ("forensics", "inspection", "cli-backends", "cleanup"):
             daemon_reference = daemon_reference_dir / reference_name / "SKILL.md"
             assert daemon_reference.is_file()
-        for backend_name in ("codex", "opencode", "claude-p", "mimocode", "lingtai"):
+        for backend_name in (
+            "codex",
+            "opencode",
+            "claude-p",
+            "mimocode",
+            "qwen-code",
+            "lingtai",
+        ):
             backend_reference = (
                 daemon_reference_dir
                 / "cli-backends"


### PR DESCRIPTION
## Summary

- add an 82-line progressive-disclosure entrypoint for `qwen-code` / `qwen` daemon backend flags instead of maintaining a copied CLI-help catalog
- route agents to the installed top-level `qwen --help`, the matching bash-manual reference, and the shared generic `backend_options` translation contract
- document source-verified alias/spawn order, enforced headless reserved flags, unsupported `ask`/resume boundary, stdio MCP settings injection, verbatim output parsing, and persisted argv artifacts
- add focused routing/install/size tests; no runtime, schema, config, or i18n surface

## Rebase

Rebased mechanically onto built-in LingTai PR #833's merge commit `9c06e4ed`. Expected shared conflicts preserved all upstream Codex + OpenCode + Claude-p + MiMo + LingTai catalog/routing/install rows and appended Qwen. Parent range-diff confirmed the 82-line child/focused test are byte-identical to the replacement-GLM-reviewed semantic patch; remaining changes are cumulative router/install bookkeeping only.

## Validation

- cumulative six-backend submanual suite — **37 passed**
- skills/install + daemon contract + MCP manual + backend-options + validator/anatomy unit suite — **141 passed**
- skill validator passed for both `reference/cli-backends` and the new `reference/backends/qwen-code` child
- anatomy checker — no drift across **40 files**
- `git diff --check origin/main...HEAD` — passed
- exact four-file diff, range-diff, human-only identity, clean worktree, no AI trailer, and no worktree/derived Claude memory writes verified

## Review

Clean replacement GLM-5.2 review after the earlier provider-only 429: **APPROVE**. The reviewer verified aliasing, exact `qwen --yolo <opts> -p <prompt>` ordering, the enforced reserved set, unsupported `ask`, stdio-only MCP behavior, parser/artifact claims, and tests against current source with no blockers.

Implements the small knowledge-entrypoint shape Jason confirmed; it deliberately carries no static flag catalog.
