### PR TITLE
docs(daemon): add Kimi Code backend flag-discovery submanual

### DIFF
--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -4,10 +4,10 @@ description: >
   Nested daemon-manual reference for daemon API details and CLI backends:
   daemon(action=list), claude-p/codex/opencode behavior,
   backend_options flag passing, preset/capability inheritance, and nested
-  per-backend references (Codex, OpenCode, claude-p, MiMo Code, and Qwen
-  Code flag discovery, built-in LingTai knowledge entrypoint).
-version: 1.10.0
-last_changed_at: "2026-07-09T20:15:31-07:00"
+  per-backend references (Codex, OpenCode, claude-p, MiMo Code, Qwen Code,
+  and Kimi Code flag discovery, built-in LingTai knowledge entrypoint).
+version: 1.11.0
+last_changed_at: "2026-07-09T20:30:50-07:00"
 ---
 
 # Daemon CLI Backend Reference
@@ -69,6 +69,15 @@ catalog. Only backends with proven demand get a page.
     routes to the installed CLI's live help via bash and shows how to
     translate that help into generic `backend_options`, plus the backend's
     reserved-flag and no-resume boundaries.
+- name: daemon-backend-kimicode
+  location: reference/backends/kimicode/SKILL.md
+  description: |
+    Nested daemon-cli-backends reference for the Kimi Code daemon backend's
+    flag surface. Read this only when a daemon task needs Kimi-specific CLI
+    flags (model selection, skills/workspace directories): it routes to the
+    installed CLI's live help via bash and shows how to translate that help
+    into generic `backend_options`, plus the exact reserved harness flags,
+    the run-private `mcp.json` loader, and the current ask/resume limitation.
 - name: daemon-backend-lingtai
   location: reference/backends/lingtai/SKILL.md
   description: |
@@ -89,6 +98,7 @@ catalog. Only backends with proven demand get a page.
 | Claude Code-specific flags for a `claude-p` / `claude-code` daemon task: model selection, `--fallback-model`, tool restrictions; reserved/harness-owned flag boundary, resume and auth-env behavior; discover the installed Claude CLI's flags and translate them into `backend_options` | `reference/backends/claude-p/SKILL.md` |
 | MiMo Code-specific flags for a daemon task (`mimocode` / `mimo`): model selection, provider switches; discover the installed `mimo` CLI's flags (`mimo run --help`) and translate them into `backend_options` | `reference/backends/mimocode/SKILL.md` |
 | Qwen Code (`qwen-code` / `qwen`)-specific flags for a daemon task: model selection, provider tunables, reserved `--prompt`/`--yolo`/`--approval-mode` boundary, no-`ask` planning; discover the installed `qwen` CLI's flags and translate them into `backend_options` | `reference/backends/qwen-code/SKILL.md` |
+| Kimi Code (`kimicode` / `kimi`)-specific flags for a daemon task: model selection (`--model`), skills/workspace dirs; reserved harness flags, run-private `mcp.json` MCP loader, why `ask`/resume is unsupported; discover the installed Kimi CLI's flags and translate them into `backend_options` | `reference/backends/kimicode/SKILL.md` |
 | Built-in `lingtai` backend knowledge for a daemon task: confirm it has no CLI/`backend_options` flag surface; find the live authorities for preset selection/inspection, tools/skills/MCP inheritance, and the completion contract | `reference/backends/lingtai/SKILL.md` |
 
 ## API note: `daemon(action="list")`
@@ -265,7 +275,9 @@ hygiene), read `reference/backends/claude-p/SKILL.md`. For MiMo Code
 (`mimocode` / `mimo`) discovery and translation, read
 `reference/backends/mimocode/SKILL.md`. For Qwen Code–specific discovery and
 translation (e.g. model selection, reserved headless flags), read
-`reference/backends/qwen-code/SKILL.md`.
+`reference/backends/qwen-code/SKILL.md`. For Kimi Code-specific discovery and
+translation (model selection, exact reserved flags, the run-private `mcp.json`
+loader), read `reference/backends/kimicode/SKILL.md`.
 
 This is intentionally a passthrough, not a fixed table. Claude Code, Codex,
 OpenCode, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, and Cursor rev their flag

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: daemon-backend-kimicode
+description: >
+  Nested daemon-cli-backends reference for the Kimi Code daemon backend's flag
+  surface. Read this only when a daemon task needs Kimi-specific CLI flags
+  (model selection, skills/workspace directories): it routes you to the
+  installed CLI's live help via bash and shows how to translate that help into
+  the generic `backend_options` mechanism. It is not a flag catalog.
+version: 0.1.0
+last_changed_at: "2026-07-09T19:22:52-07:00"
+---
+
+# Kimi Code Daemon Backend — Flag Discovery Entrypoint
+
+This page is deliberately tiny: it only tells you where the knowledge lives.
+The Kimi Code CLI revs its flags and accepted values between releases, so the
+installed CLI's own help output is the authority — not this page, and not any
+flag list LingTai could ship. `kimi` is the accepted short alias; persisted
+daemon entries use the canonical backend name `kimicode`.
+
+## Discover flags from the installed CLI
+
+1. Load `bash-manual` (its nested `reference/bash-kimicode/SKILL.md` has
+   broader Kimi Code CLI context: per-run environment contract, MCP config
+   evidence, validation checklist).
+2. Run, in bash: `kimi --version` and `kimi --help`. The daemon backend wraps
+   the top-level one-shot mode (`kimi --prompt <prompt> --output-format
+   text`), so the top-level help is the relevant flag surface — there is no
+   `exec`-style wrapper subcommand. Run `kimi <subcommand> --help` only when a
+   task actually needs one of the listed subcommands. These are local
+   read-only commands; no session is started.
+3. Translate the long flags you found into `backend_options` using the
+   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
+   (key→flag mapping, value handling, key safety, persistence). Nothing
+   Kimi-specific is added to that contract here.
+
+## Example: model selection
+
+`kimi --help` lists `-m, --model <model>` for per-invocation model choice.
+Through `backend_options`, a string value becomes `--flag <value>`:
+
+```jsonc
+{
+  "backend": "kimicode",   // or the accepted alias "kimi"
+  "tasks": [{
+    "task": "Implement and validate the change.",
+    "tools": [],
+    "backend_options": {
+      "model": "kimi-for-coding"
+    }
+  }]
+}
+// argv: kimi --model kimi-for-coding --prompt <prompt> --output-format text
+```
+
+The model vocabulary belongs to the installed CLI and its provider
+configuration — LingTai does not validate, enumerate, or simulate model
+names. A value passes through and the CLI decides its semantics (or rejects
+it).
+
+## Harness boundary
+
+Kimi Code declares a reserved-flag list at the validation layer; passing any
+of these in `backend_options` refuses the whole batch before spawn:
+`--prompt` / `-p`, `--output-format`, `--yolo` / `-y`, `--session` / `-S`,
+`--continue` / `-c`. LingTai owns `--prompt` and `--output-format` (they
+drive the non-interactive text-capture harness), forbids `--yolo` (the CLI
+refuses `--prompt` combined with `--yolo`), and reserves the
+session/continue flags because resume is not wired for this backend: no
+stable machine-readable session-id output was verified, so
+`daemon(action="ask")` returns an explicit unsupported-backend error — start
+a new kimicode emanation instead.
+
+Free-form options are inserted between `kimi` and the owned flags (the
+prompt travels via `--prompt`, never as a trailing positional). Output is
+plain text, not a JSON event stream: stdout is recorded verbatim, line by
+line, as `cli_output` events, no session id is captured, and the joined
+stdout becomes the result. The run-private MCP loader is not argv-based —
+the daemon writes `daemon_common` plus parent stdio and HTTP registrations
+to `<run>/kimi-code-home/mcp.json` (path recorded in `daemon.json` under
+`backend_harness_files.kimicode_mcp_config`); secret env/header values stay
+out of prompts and logs. To debug what was actually sent, `daemon.json`
+records the raw `backend_options` object alongside the resolved
+`backend_argv` token list.

--- a/tests/test_daemon_kimicode_submanual.py
+++ b/tests/test_daemon_kimicode_submanual.py
@@ -1,0 +1,118 @@
+"""Docs/routing contract for the Kimi Code daemon-backend submanual.
+
+The Kimi Code child under the daemon CLI-backend router is a small
+progressive-disclosure entrypoint: it routes agents to the installed CLI's
+live help (via bash) and shows how to translate that help into the generic
+``backend_options`` mechanism. It must never grow into a maintained flag
+catalog. The generic conversion behavior and the kimicode runner/reserved
+flag enforcement themselves are covered by
+``tests/test_daemon_backend_options.py`` (see e.g.
+``test_kimicode_alias_and_canonical_dispatch_to_backend``,
+``test_kimicode_cmd_appends_backend_argv_before_owned_flags``,
+``test_kimicode_rejects_harness_owned_backend_options``,
+``test_kimicode_writes_run_private_mcp_json_for_common_and_parent_mcp``,
+``test_kimicode_ask_is_explicitly_unsupported``) and are not re-tested here.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+from lingtai.core.daemon import (
+    _BACKEND_ALIASES,
+    _KIMICODE_RESERVED_BACKEND_FLAGS,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTER = ROOT / "src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md"
+CHILD = (
+    ROOT
+    / "src/lingtai/core/daemon/manual/reference/cli-backends"
+    / "reference/backends/kimicode/SKILL.md"
+)
+CHILD_LOCATION = "reference/backends/kimicode/SKILL.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} must start with YAML frontmatter"
+    _blank, frontmatter, _body = text.split("---", 2)
+    return yaml.safe_load(frontmatter) or {}
+
+
+def _body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.split("---", 2)[2]
+
+
+def test_router_has_yaml_catalog_entry_for_kimicode_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Nested reference catalog" in text
+    catalog_section = text.split("## Nested reference catalog", 1)[1]
+    match = re.search(r"```yaml\n(.*?)```", catalog_section, re.DOTALL)
+    assert match, "nested reference catalog must be a fenced YAML block"
+    entries = yaml.safe_load(match.group(1))
+    kimicode_entries = [e for e in entries if e.get("location") == CHILD_LOCATION]
+    assert len(kimicode_entries) == 1
+    assert kimicode_entries[0]["name"] == "daemon-backend-kimicode"
+    assert kimicode_entries[0]["description"].strip()
+
+
+def test_router_routing_table_points_to_kimicode_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Routing table" in text
+    table_rows = [
+        line for line in text.splitlines()
+        if line.startswith("|") and CHILD_LOCATION in line
+    ]
+    assert table_rows, "routing table must map Kimi flag needs to the child"
+
+
+def test_kimicode_child_frontmatter_and_location():
+    assert CHILD.is_file()
+    meta = _frontmatter(CHILD)
+    assert meta["name"] == "daemon-backend-kimicode"
+    assert meta["description"].strip()
+    assert meta["last_changed_at"]
+
+
+def test_kimicode_child_routes_to_live_help_and_generic_backend_options():
+    body = _body(CHILD)
+    # Live installed help is the authority — the child must send agents there.
+    for phrase in (
+        "bash-manual",
+        "reference/bash-kimicode/SKILL.md",
+        "kimi --version",
+        "kimi --help",
+    ):
+        assert phrase in body, phrase
+    # Translation goes through the existing generic mechanism, and the
+    # high-value model-selection example uses a plain string option.
+    assert "backend_options" in body
+    assert '"model": "kimi-for-coding"' in body
+    # The CLI/provider owns the value vocabulary; no LingTai-side enum.
+    assert "not validate, enumerate, or simulate" in body
+
+
+def test_kimicode_child_names_canonical_alias_and_limitations():
+    body = _body(CHILD)
+    # Canonical/alias naming matches the backend alias table.
+    assert _BACKEND_ALIASES["kimi"] == "kimicode"
+    assert "kimicode" in body and '"kimi"' in body
+    # Every source-reserved harness flag is documented, exactly.
+    for flag in _KIMICODE_RESERVED_BACKEND_FLAGS:
+        assert f"`{flag}`" in body, flag
+    # Current limitations and MCP wiring stated as they are implemented.
+    assert 'daemon(action="ask")' in body
+    assert "unsupported" in body
+    assert "kimi-code-home/mcp.json" in body
+    assert "backend_harness_files.kimicode_mcp_config" in body
+
+
+def test_kimicode_child_stays_tiny_not_a_flag_catalog():
+    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    assert line_count <= 90, (
+        "the Kimi Code backend submanual is a tiny entrypoint to live CLI "
+        f"help; {line_count} lines suggests it is growing into a flag catalog"
+    )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -261,6 +261,7 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
             "claude-p",
             "mimocode",
             "qwen-code",
+            "kimicode",
             "lingtai",
         ):
             backend_reference = (


### PR DESCRIPTION
## Summary

- add a tiny progressive-disclosure entrypoint for Kimi Code daemon flags
- route agents to installed `kimi --version` / `kimi --help` and the generic `backend_options` contract instead of maintaining a flag catalog
- document the source-backed harness boundary: reserved flags, unsupported ask/resume, run-private `mcp.json`, and plain-text capture
- add deterministic routing/install/size tests; no runtime, schema, or i18n surface

## Product contract

This follows Jason's final direction: the backend child stays a small knowledge entrypoint, with one useful example and live CLI help as the authority. It does not generate or maintain a static flag list.

## Validation

- independent GLM-5.2 review: **APPROVE**
- cumulative backend submanual suite: **43 passed**
- generic daemon/runtime/install gate: **197 passed**
- router + Kimi child skill validators: **passed**
- anatomy drift checker: **40 files, no drift**
- `git diff --check`, exact range-diff, identity, and clean-worktree checks: **passed**

## Scope

One backend per PR. Four files only: CLI-backend router, Kimi child, Kimi docs contract test, and hard-copy install assertion.
