### PR TITLE
docs(daemon): add Cursor backend flag-discovery submanual

### DIFF
--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -5,9 +5,9 @@ description: >
   daemon(action=list), claude-p/codex/opencode behavior,
   backend_options flag passing, preset/capability inheritance, and nested
   per-backend references (Codex, OpenCode, claude-p, MiMo Code, Qwen Code,
-  and Kimi Code flag discovery, built-in LingTai knowledge entrypoint).
-version: 1.11.0
-last_changed_at: "2026-07-09T20:30:50-07:00"
+  Kimi Code, and Cursor flag discovery, built-in LingTai knowledge entrypoint).
+version: 1.12.0
+last_changed_at: "2026-07-09T20:34:39-07:00"
 ---
 
 # Daemon CLI Backend Reference
@@ -78,6 +78,14 @@ catalog. Only backends with proven demand get a page.
     installed CLI's live help via bash and shows how to translate that help
     into generic `backend_options`, plus the exact reserved harness flags,
     the run-private `mcp.json` loader, and the current ask/resume limitation.
+- name: daemon-backend-cursor
+  location: reference/backends/cursor/SKILL.md
+  description: |
+    Nested daemon-cli-backends reference for the Cursor daemon backend's flag
+    surface. Read this only when a daemon task needs Cursor-specific CLI
+    flags (model selection, output/tooling switches): it routes to the
+    installed `agent` CLI's live help via bash and shows how to translate
+    that help into generic `backend_options`.
 - name: daemon-backend-lingtai
   location: reference/backends/lingtai/SKILL.md
   description: |
@@ -99,6 +107,7 @@ catalog. Only backends with proven demand get a page.
 | MiMo Code-specific flags for a daemon task (`mimocode` / `mimo`): model selection, provider switches; discover the installed `mimo` CLI's flags (`mimo run --help`) and translate them into `backend_options` | `reference/backends/mimocode/SKILL.md` |
 | Qwen Code (`qwen-code` / `qwen`)-specific flags for a daemon task: model selection, provider tunables, reserved `--prompt`/`--yolo`/`--approval-mode` boundary, no-`ask` planning; discover the installed `qwen` CLI's flags and translate them into `backend_options` | `reference/backends/qwen-code/SKILL.md` |
 | Kimi Code (`kimicode` / `kimi`)-specific flags for a daemon task: model selection (`--model`), skills/workspace dirs; reserved harness flags, run-private `mcp.json` MCP loader, why `ask`/resume is unsupported; discover the installed Kimi CLI's flags and translate them into `backend_options` | `reference/backends/kimicode/SKILL.md` |
+| Cursor-specific flags for a daemon task: model selection, output/tooling switches; discover the installed Cursor Agent CLI's (`agent`) flags and translate them into `backend_options` | `reference/backends/cursor/SKILL.md` |
 | Built-in `lingtai` backend knowledge for a daemon task: confirm it has no CLI/`backend_options` flag surface; find the live authorities for preset selection/inspection, tools/skills/MCP inheritance, and the completion contract | `reference/backends/lingtai/SKILL.md` |
 
 ## API note: `daemon(action="list")`
@@ -277,7 +286,8 @@ hygiene), read `reference/backends/claude-p/SKILL.md`. For MiMo Code
 translation (e.g. model selection, reserved headless flags), read
 `reference/backends/qwen-code/SKILL.md`. For Kimi Code-specific discovery and
 translation (model selection, exact reserved flags, the run-private `mcp.json`
-loader), read `reference/backends/kimicode/SKILL.md`.
+loader), read `reference/backends/kimicode/SKILL.md`. For Cursor (binary `agent`), read
+`reference/backends/cursor/SKILL.md`.
 
 This is intentionally a passthrough, not a fixed table. Claude Code, Codex,
 OpenCode, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, and Cursor rev their flag

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: daemon-backend-cursor
+description: >
+  Nested daemon-cli-backends reference for the Cursor daemon backend's flag
+  surface. Read this only when a daemon task needs Cursor-specific CLI flags
+  (model selection, output/tooling switches): it routes you to the installed
+  CLI's live help via bash and shows how to translate that help into the
+  generic `backend_options` mechanism. It is not a flag catalog.
+version: 0.1.0
+last_changed_at: "2026-07-09T19:23:56-07:00"
+---
+
+# Cursor Daemon Backend — Flag Discovery Entrypoint
+
+This page is deliberately tiny: it only tells you where the knowledge lives.
+The Cursor Agent CLI revs its flags and accepted values between releases, so
+the installed CLI's own help output is the authority — not this page, and not
+any flag list LingTai could ship.
+
+## Discover flags from the installed CLI
+
+1. Load `bash-manual` (its nested `reference/bash-cursor-agent/SKILL.md` has
+   broader Cursor Agent CLI context).
+2. Run, in bash: `agent --version` and `agent --help`. The daemon backend
+   spawns the root `agent` binary directly, with no subcommand —
+   `agent -p --force --output-format stream-json <prompt>` — so root-level
+   help is the relevant flag surface; open `agent <subcommand> --help` only
+   if the root help routes a flag you need through a subcommand. These are
+   local read-only commands; no session is started. The CLI may require
+   macOS keychain access even for `--help`; if it errors before printing
+   help, unlock the login keychain and retry.
+3. Translate the long flags you found into `backend_options` using the
+   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
+   (key→flag mapping, value handling, key safety, persistence). Nothing
+   Cursor-specific is added to that contract here.
+
+## Example: model selection via the generic route
+
+`backend_options` keys become long flags, inserted after the harness-owned
+flags and before the task prompt:
+
+```jsonc
+{
+  "backend": "cursor",
+  "tasks": [{
+    "task": "Implement and validate the change.",
+    "tools": [],
+    "backend_options": {
+      "model": "opus"
+    }
+  }]
+}
+// argv: --model opus
+```
+
+The flag and model vocabulary belong to the installed CLI — LingTai does
+not validate, enumerate, or simulate them. Confirm `--model` and its
+accepted values in your installed `agent --help` before relying on this;
+an unknown flag or value is the CLI's error, not the daemon's.
+
+## Harness boundary
+
+Cursor currently declares no reserved-flag list at the validation layer, so
+nothing is refused for this backend beyond the generic key/value safety
+rules. Still, do not re-set harness-owned surfaces: `-p` (non-interactive
+print mode), `--force` (allows file modifications in print mode),
+`--output-format stream-json` (one JSON event per stdout line — the daemon's
+progress/result parser and the session-id capture depend on it), and
+`--resume` (owned by `daemon(action='ask')` follow-ups, which replay the
+captured session id).
+
+Session and completion behavior, source-verified: the first stream event
+carrying a session-id-shaped field is stored in `daemon.json` as
+`cursor_session_id`; `ask` resumes with
+`agent -p --force --resume <cursor_session_id> --output-format stream-json
+<message>` (async, one follow-up in flight per session). Per-run MCP
+injection — including the `daemon_common` completion MCP — is not wired for
+this backend yet, so there are no MCP loader flags to collide with and no
+`finish` contract: success comes from the stream's final result event and
+the process exit code.
+
+`backend_options` is honored only at `emanate` time; `ask` follow-ups reuse
+the session without re-passing it. To debug what was actually sent,
+`daemon.json` records the raw `backend_options` object alongside the
+resolved `backend_argv` token list.

--- a/tests/test_daemon_cursor_submanual.py
+++ b/tests/test_daemon_cursor_submanual.py
@@ -1,0 +1,98 @@
+"""Docs/routing contract for the Cursor daemon-backend submanual.
+
+The Cursor child under the daemon CLI-backend router is a small
+progressive-disclosure entrypoint: it routes agents to the installed `agent`
+CLI's live help (via bash) and shows how to translate that help into the
+generic ``backend_options`` mechanism. It must never grow into a maintained
+flag catalog. The generic conversion behavior itself is covered by
+``tests/test_daemon_backend_options.py`` and the Cursor runner/ask behavior
+by ``tests/test_daemon_cursor_backend.py``; neither is re-tested here.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTER = ROOT / "src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md"
+CHILD = (
+    ROOT
+    / "src/lingtai/core/daemon/manual/reference/cli-backends"
+    / "reference/backends/cursor/SKILL.md"
+)
+CHILD_LOCATION = "reference/backends/cursor/SKILL.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} must start with YAML frontmatter"
+    _blank, frontmatter, _body = text.split("---", 2)
+    return yaml.safe_load(frontmatter) or {}
+
+
+def _body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.split("---", 2)[2]
+
+
+def test_router_has_yaml_catalog_entry_for_cursor_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Nested reference catalog" in text
+    catalog_section = text.split("## Nested reference catalog", 1)[1]
+    match = re.search(r"```yaml\n(.*?)```", catalog_section, re.DOTALL)
+    assert match, "nested reference catalog must be a fenced YAML block"
+    entries = yaml.safe_load(match.group(1))
+    cursor_entries = [e for e in entries if e.get("location") == CHILD_LOCATION]
+    assert len(cursor_entries) == 1
+    assert cursor_entries[0]["name"] == "daemon-backend-cursor"
+    assert cursor_entries[0]["description"].strip()
+
+
+def test_router_routing_table_points_to_cursor_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Routing table" in text
+    table_rows = [
+        line for line in text.splitlines()
+        if line.startswith("|") and CHILD_LOCATION in line
+    ]
+    assert table_rows, "routing table must map Cursor flag needs to the child"
+
+
+def test_cursor_child_frontmatter_and_location():
+    assert CHILD.is_file()
+    meta = _frontmatter(CHILD)
+    assert meta["name"] == "daemon-backend-cursor"
+    assert meta["description"].strip()
+    assert meta["last_changed_at"]
+
+
+def test_cursor_child_routes_to_live_help_and_generic_backend_options():
+    body = _body(CHILD)
+    # Live installed help is the authority — the child must send agents there.
+    for phrase in (
+        "bash-manual",
+        "reference/bash-cursor-agent/SKILL.md",
+        "agent --version",
+        "agent --help",
+    ):
+        assert phrase in body, phrase
+    # The harness-owned spawn shape and session/resume contract stay stated
+    # exactly as the runner implements them.
+    assert "agent -p --force --output-format stream-json" in body
+    assert "cursor_session_id" in body
+    assert "--resume" in body
+    # Translation goes through the existing generic mechanism only.
+    assert "backend_options" in body
+    # The CLI/model owns the value vocabulary; no LingTai-side enum.
+    assert "not validate, enumerate, or simulate" in body
+    # MCP wiring status must be stated, not implied.
+    assert "not wired" in body
+
+
+def test_cursor_child_stays_tiny_not_a_flag_catalog():
+    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    assert line_count <= 90, (
+        "the Cursor backend submanual is a tiny entrypoint to live CLI help; "
+        f"{line_count} lines suggests it is growing into a flag catalog"
+    )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -262,6 +262,7 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
             "mimocode",
             "qwen-code",
             "kimicode",
+            "cursor",
             "lingtai",
         ):
             backend_reference = (


### PR DESCRIPTION
## Summary

- add a tiny progressive-disclosure entrypoint for Cursor Agent daemon flags
- route agents to installed `agent --version` / `agent --help` and the generic `backend_options` contract instead of maintaining a flag catalog
- document the source-backed harness/session boundary: spawn shape, empty reserved set, async resume, stream capture, and MCP-not-wired status
- add deterministic routing/install/size tests; no runtime, schema, or i18n surface

## Product contract

This follows Jason's final direction: the backend child stays a small knowledge entrypoint, with one useful example and live CLI help as the authority. It does not generate or maintain a static flag list.

## Validation

- independent original GLM-5.2 review: **APPROVE**
- GLM mechanical incremental rebase onto Kimi #835: **complete**
- complete parent gate (all 8 submanuals + generic/runtime/install + Cursor runtime): **257 passed**
- router + Cursor child skill validators: **passed**
- anatomy drift checker: **40 files, no drift**
- exact full-patch/range-diff/byte-identity/diff/identity/cleanliness checks: **passed**

## Scope

One backend per PR. Four files only: CLI-backend router, Cursor child, Cursor docs contract test, and hard-copy install assertion.
