### PR TITLE
docs(daemon): add Oh-My-Pi backend flag-discovery submanual

### DIFF
--- a/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md
@@ -5,9 +5,9 @@ description: >
   daemon(action=list), claude-p/codex/opencode behavior,
   backend_options flag passing, preset/capability inheritance, and nested
   per-backend references (Codex, OpenCode, claude-p, MiMo Code, Qwen Code,
-  Kimi Code, and Cursor flag discovery, built-in LingTai knowledge entrypoint).
-version: 1.12.0
-last_changed_at: "2026-07-09T20:34:39-07:00"
+  Kimi Code, Cursor, and Oh-My-Pi flag discovery, built-in LingTai knowledge entrypoint).
+version: 1.13.0
+last_changed_at: "2026-07-09T19:24:35-07:00"
 ---
 
 # Daemon CLI Backend Reference
@@ -86,6 +86,15 @@ catalog. Only backends with proven demand get a page.
     flags (model selection, output/tooling switches): it routes to the
     installed `agent` CLI's live help via bash and shows how to translate
     that help into generic `backend_options`.
+- name: daemon-backend-oh-my-pi
+  location: reference/backends/oh-my-pi/SKILL.md
+  description: |
+    Nested daemon-cli-backends reference for the Oh-My-Pi (`omp`) daemon
+    backend's flag surface. Read this only when a daemon task needs
+    Oh-My-Pi-specific CLI flags (model selection, tool or provider
+    switches): it routes to the installed CLI's live help via bash, lists
+    the exact harness-reserved flags, and shows how to translate that help
+    into generic `backend_options`.
 - name: daemon-backend-lingtai
   location: reference/backends/lingtai/SKILL.md
   description: |
@@ -108,6 +117,7 @@ catalog. Only backends with proven demand get a page.
 | Qwen Code (`qwen-code` / `qwen`)-specific flags for a daemon task: model selection, provider tunables, reserved `--prompt`/`--yolo`/`--approval-mode` boundary, no-`ask` planning; discover the installed `qwen` CLI's flags and translate them into `backend_options` | `reference/backends/qwen-code/SKILL.md` |
 | Kimi Code (`kimicode` / `kimi`)-specific flags for a daemon task: model selection (`--model`), skills/workspace dirs; reserved harness flags, run-private `mcp.json` MCP loader, why `ask`/resume is unsupported; discover the installed Kimi CLI's flags and translate them into `backend_options` | `reference/backends/kimicode/SKILL.md` |
 | Cursor-specific flags for a daemon task: model selection, output/tooling switches; discover the installed Cursor Agent CLI's (`agent`) flags and translate them into `backend_options` | `reference/backends/cursor/SKILL.md` |
+| Oh-My-Pi (`omp`)-specific flags for a daemon task: model selection, tool/provider switches, the harness-reserved mode/approval/session flags; discover the installed `omp` CLI's flags and translate them into `backend_options` | `reference/backends/oh-my-pi/SKILL.md` |
 | Built-in `lingtai` backend knowledge for a daemon task: confirm it has no CLI/`backend_options` flag surface; find the live authorities for preset selection/inspection, tools/skills/MCP inheritance, and the completion contract | `reference/backends/lingtai/SKILL.md` |
 
 ## API note: `daemon(action="list")`

--- a/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/oh-my-pi/SKILL.md
+++ b/src/lingtai/core/daemon/manual/reference/cli-backends/reference/backends/oh-my-pi/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: daemon-backend-oh-my-pi
+description: >
+  Nested daemon-cli-backends reference for the Oh-My-Pi (`omp`) daemon
+  backend's flag surface. Read this only when a daemon task needs
+  Oh-My-Pi-specific CLI flags (model selection, tool or provider switches):
+  it routes you to the installed CLI's live help via bash and shows how to
+  translate that help into the generic `backend_options` mechanism. It is
+  not a flag catalog.
+version: 0.1.0
+last_changed_at: "2026-07-09T19:24:35-07:00"
+---
+
+# Oh-My-Pi Daemon Backend — Flag Discovery Entrypoint
+
+This page is deliberately tiny: it only tells you where the knowledge lives.
+The Oh-My-Pi CLI (npm package `@oh-my-pi/pi-coding-agent`, binary `omp`) revs
+its flags and accepted values between releases, so the installed CLI's own
+help output is the authority — not this page, and not any flag list LingTai
+could ship. `omp` is an accepted backend alias that canonicalizes to
+`oh-my-pi`; persisted daemon entries use the canonical name.
+
+## Discover flags from the installed CLI
+
+1. Load `bash-manual` (its nested `reference/bash-oh-my-pi/SKILL.md` has
+   broader Oh-My-Pi CLI context).
+2. Run, in bash: `omp --version` and `omp --help`. The daemon backend wraps
+   the root `omp` invocation (no subcommand), so the root help is the
+   relevant flag surface. These are local read-only commands; no session is
+   started. Run `omp <command> --help` only on demand for a subcommand the
+   installed root help itself lists — subcommands are outside the daemon
+   wrapper.
+3. Translate the long flags you found into `backend_options` using the
+   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
+   (key→flag mapping, value handling, key safety, persistence). Nothing
+   Oh-My-Pi-specific is added to that contract here.
+
+## Example: model selection
+
+```jsonc
+{
+  "backend": "oh-my-pi",
+  "tasks": [{
+    "task": "Implement and validate the change.",
+    "tools": [],
+    "backend_options": {
+      "model": "<model id from the installed CLI>"
+    }
+  }]
+}
+// argv: --model <model id from the installed CLI>
+```
+
+The model vocabulary belongs to the installed CLI and its configured
+providers — LingTai does not validate, enumerate, or simulate model ids. Use
+the CLI's own discovery surface (root `--help`) and
+pass the id through; the CLI decides its semantics (or rejects it).
+
+## Harness boundary: reserved flags
+
+The daemon owns Oh-My-Pi's non-interactive JSON harness
+(`omp --mode json --approval-mode yolo <task>`). `backend_options` refuses
+exactly these reserved flags before spawn (one bad key refuses the whole
+batch):
+
+`--mode`, `--print`, `--auto-approve`, `--yolo`, `--approval-mode`,
+`--session`, `--resume`, `--continue`, `--no-session`, `--session-dir`
+
+Keys are written without leading dashes, and underscores become dashes, so
+`{"approval_mode": "write"}` targets `--approval-mode` and is refused.
+Overriding these would break JSON event capture, re-enable interactive
+prompting, or hijack session ownership.
+
+## Session, ask, and MCP status
+
+- The first `type:session` JSON header line carries the resumable session id;
+  the OpenCode-family parser stores it as `oh_my_pi_session_id` in
+  `daemon.json`.
+- `ask` is async and resumes via
+  `omp --mode json --approval-mode yolo --session <id> <message>`;
+  emanate-time `backend_options` persist for the session and are not
+  re-passed.
+- Per-run `daemon_common` MCP injection is **not wired yet** for this backend
+  (pending source evidence of an accepted config/env path), so the MCP
+  `finish` completion contract does not apply here — and `backend_options`
+  is not the place to hand-wire MCP.
+- To debug what was actually sent, `daemon.json` records the raw
+  `backend_options` object alongside the resolved `backend_argv` /
+  `backend_harness_argv` token lists.

--- a/tests/test_daemon_oh_my_pi_submanual.py
+++ b/tests/test_daemon_oh_my_pi_submanual.py
@@ -1,0 +1,126 @@
+"""Docs/routing contract for the Oh-My-Pi daemon-backend submanual.
+
+The Oh-My-Pi child under the daemon CLI-backend router is a small
+progressive-disclosure entrypoint: it routes agents to the installed CLI's
+live help (via bash) and shows how to translate that help into the generic
+``backend_options`` mechanism. It must never grow into a maintained flag
+catalog. The generic conversion behavior itself is covered by
+``tests/test_daemon_backend_options.py`` (see e.g.
+``test_oh_my_pi_rejects_harness_owned_backend_options``,
+``test_oh_my_pi_cmd_includes_mode_json_and_session_id_from_header``,
+``test_oh_my_pi_ask_resume_uses_session_flag``) and is not re-tested here.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+from lingtai.core.daemon import (
+    _BACKEND_ALIASES,
+    _OH_MY_PI_RESERVED_BACKEND_FLAGS,
+    _cli_backend_loads_common_mcp,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTER = ROOT / "src/lingtai/core/daemon/manual/reference/cli-backends/SKILL.md"
+CHILD = (
+    ROOT
+    / "src/lingtai/core/daemon/manual/reference/cli-backends"
+    / "reference/backends/oh-my-pi/SKILL.md"
+)
+CHILD_LOCATION = "reference/backends/oh-my-pi/SKILL.md"
+
+
+def _frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} must start with YAML frontmatter"
+    _blank, frontmatter, _body = text.split("---", 2)
+    return yaml.safe_load(frontmatter) or {}
+
+
+def _body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.split("---", 2)[2]
+
+
+def test_router_has_yaml_catalog_entry_for_oh_my_pi_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Nested reference catalog" in text
+    catalog_section = text.split("## Nested reference catalog", 1)[1]
+    match = re.search(r"```yaml\n(.*?)```", catalog_section, re.DOTALL)
+    assert match, "nested reference catalog must be a fenced YAML block"
+    entries = yaml.safe_load(match.group(1))
+    omp_entries = [e for e in entries if e.get("location") == CHILD_LOCATION]
+    assert len(omp_entries) == 1
+    assert omp_entries[0]["name"] == "daemon-backend-oh-my-pi"
+    assert omp_entries[0]["description"].strip()
+
+
+def test_router_routing_table_points_to_oh_my_pi_child():
+    text = ROUTER.read_text(encoding="utf-8")
+    assert "## Routing table" in text
+    table_rows = [
+        line for line in text.splitlines()
+        if line.startswith("|") and CHILD_LOCATION in line
+    ]
+    assert table_rows, "routing table must map Oh-My-Pi flag needs to the child"
+
+
+def test_oh_my_pi_child_frontmatter_and_location():
+    assert CHILD.is_file()
+    meta = _frontmatter(CHILD)
+    assert meta["name"] == "daemon-backend-oh-my-pi"
+    assert meta["description"].strip()
+    assert meta["last_changed_at"]
+
+
+def test_oh_my_pi_child_routes_to_live_help_and_generic_backend_options():
+    body = _body(CHILD)
+    # Live installed help is the authority — the child must send agents there,
+    # and only to source-proven subcommand help on demand.
+    for phrase in (
+        "bash-manual",
+        "omp --version",
+        "omp --help",
+        "omp <command> --help",
+    ):
+        assert phrase in body, phrase
+    # Translation goes through the existing generic mechanism, and the
+    # high-value model-selection example uses the plain long-flag route.
+    assert "backend_options" in body
+    assert "--model" in body
+    # The CLI/providers own the value vocabulary; no LingTai-side enum.
+    assert "not validate, enumerate, or simulate" in body
+
+
+def test_oh_my_pi_child_documents_alias_and_exact_reserved_flags():
+    body = _body(CHILD)
+    # Alias contract matches source.
+    assert _BACKEND_ALIASES["omp"] == "oh-my-pi"
+    assert "canonicalizes to" in body
+    # Every harness-reserved flag from source appears verbatim; no stale
+    # extras are claimed as reserved beyond the documented harness argv.
+    for flag in _OH_MY_PI_RESERVED_BACKEND_FLAGS:
+        assert f"`{flag}`" in body, flag
+    documented = set(re.findall(r"`(--[a-z-]+)`", body))
+    non_reserved_mentions = {
+        "--mode", "--approval-mode", "--session",  # documented harness argv
+        "--model", "--help",  # example + discovery surfaces
+    }
+    assert documented - _OH_MY_PI_RESERVED_BACKEND_FLAGS <= non_reserved_mentions
+
+
+def test_oh_my_pi_child_mcp_status_matches_source():
+    # Source truth: oh-my-pi does not load the per-run daemon_common MCP yet.
+    assert not _cli_backend_loads_common_mcp("oh-my-pi")
+    body = _body(CHILD)
+    assert "not wired yet" in body
+
+
+def test_oh_my_pi_child_stays_tiny_not_a_flag_catalog():
+    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    assert line_count <= 90, (
+        "the Oh-My-Pi backend submanual is a tiny entrypoint to live CLI help; "
+        f"{line_count} lines suggests it is growing into a flag catalog"
+    )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -263,6 +263,7 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
             "qwen-code",
             "kimicode",
             "cursor",
+            "oh-my-pi",
             "lingtai",
         ):
             backend_reference = (


### PR DESCRIPTION
## Summary

- add a tiny progressive-disclosure entrypoint for Oh-My-Pi (`omp`) daemon flags
- route agents to installed `omp --version` / `omp --help` and the generic `backend_options` contract instead of maintaining a flag catalog
- document the source-backed harness/session boundary: alias, reserved flags, async resume, parser/debug surfaces, and MCP-not-wired status
- add deterministic routing/install/size tests; no runtime, schema, or i18n surface

## Product contract

This follows Jason's final direction: the child is 89 lines with one useful example; installed help owns CLI flag/model vocabulary. The earlier version-specific `--list-models` parenthetical and test allowlist mention were removed after an independent provenance review.

## Validation

- original independent GLM review: **APPROVE**
- independent provenance review: **REPHRASE**, applied exactly as two removals
- final fresh independent GLM review after the fix: **APPROVE**
- parent complete gate (all 9 submanuals + generic/runtime/install): **252 passed**
- router + Oh-My-Pi child skill validators: **passed**
- anatomy drift checker: **40 files, no drift**
- exact full-patch/range-diff/original-diff/no-stale-flag/diff/identity/cleanliness checks: **passed**

## Scope

One backend per PR. Four files only: CLI-backend router, Oh-My-Pi child, docs contract test, and hard-copy install assertion. OMP is immediately before built-in LingTai in catalog/routing/install order.

Non-blocking metadata note from final review: router `last_changed_at` uses the OMP author's original timestamp and is earlier than the preceding rebased version; version 1.13.0 and all validators/tests are correct, and timestamp monotonicity is not a contract.
