### PR TITLE
chore(release): bump kernel to 0.16.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.16.2"
+version = "0.16.3"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the canonical `lingtai` package version in `pyproject.toml` from `0.16.2` to `0.16.3`
- no runtime, tool, schema, documentation, or workflow changes

## Release context

This is the separate reviewable release-metadata PR after #843 landed and before the Release Captain locks the final public commit/tree tuple. The version remains proposed until tag/package absence and native-version symmetry are rechecked at S2/S3.

## Validation

- exact diff: one file, +1/-1; `git diff --check` PASS
- package-data wheel boundary: 4 passed
- `uv build`: 0.16.3 CPython 3.12 macOS ARM wheel + sdist built locally
- `twine check`: both PASS
- wheel and sdist metadata: Version 0.16.3
- wheel critical package assets: 5/5 present
- clean Python 3.12 install: distribution Version 0.16.3; critical installed assets 5/5 present
- privacy scan: 0 findings

The local artifacts are validation-only and will not be uploaded; final release artifacts are rebuilt only after the exact public tuple is locked and post-lock gates pass.
