### PR TITLE
test: ignore external paths in prompt crawl checks

### DIFF
--- a/tests/test_prompt_catalog.py
+++ b/tests/test_prompt_catalog.py
@@ -58,11 +58,22 @@ _PROMPT_SOURCE_GRAPH = {
 
 
 def _mentioned_file_paths(body: str) -> list[str]:
-    """Return file paths explicitly mentioned in Markdown body backticks."""
+    """Return repo-relative source/document paths mentioned in body backticks.
+
+    The prompt-source crawl graph (`related_files`) is a graph of repo-relative
+    prompt/guidance/reference sources. Body backticks also carry non-source
+    references that must never become crawl links: test paths (`tests/...`) and
+    external runtime locations that live outside the repo — home-directory paths
+    (`~/.lingtai-tui/runtime/venv`) and absolute paths (`/usr/...`). Those are
+    filtered here so the graph invariant only enforces real repo-relative
+    sources.
+    """
     paths: list[str] = []
     for match in _FILE_PATH_IN_BACKTICKS.finditer(body):
         value = match.group(1).strip()
         if value.startswith("tests/"):
+            continue
+        if value.startswith(("~/", "~", "/")):
             continue
         if "/" in value or any(
             suffix in value
@@ -118,6 +129,42 @@ def _prompt_source_path_for_section(name: str) -> str:
 
 def _prompt_source_path_for_guidance(filename: str) -> str:
     return f"{_GUIDANCE_CATALOG_DIR}/{filename}"
+
+
+# ---------------------------------------------------------------------------
+# Body path detection for the crawl-graph invariant
+# ---------------------------------------------------------------------------
+
+
+def test_mentioned_file_paths_ignores_external_runtime_paths():
+    """External home/absolute runtime paths are not prompt-source crawl links.
+
+    `substrate.md` documents the TUI runtime venv `~/.lingtai-tui/runtime/venv`;
+    it lives outside the repo and must never be added to `related_files`. Only
+    repo-relative source/document references feed the crawl-graph invariant.
+    """
+    body = (
+        "Prefer `LINGTAI_RUNTIME_PYTHON`; TUI runs point it into the runtime venv "
+        "(for example `~/.lingtai-tui/runtime/venv` on macOS/Linux). See "
+        "`reference/substrate-manual/SKILL.md` for the full model. Absolute paths "
+        "like `/usr/local/bin/python` are external too.\n"
+    )
+    mentioned = _mentioned_file_paths(body)
+    assert "~/.lingtai-tui/runtime/venv" not in mentioned
+    assert "/usr/local/bin/python" not in mentioned
+    # A real repo-relative document reference is still detected and enforced.
+    assert "reference/substrate-manual/SKILL.md" in mentioned
+
+
+def test_mentioned_file_paths_detects_repo_relative_sources():
+    """Repo-relative paths — including placeholder segments — stay enforced."""
+    body = (
+        "See `src/lingtai/prompts/principle/principle.md` and the journal at "
+        "`knowledge/session-journal/<YYYY-MM-DD>-<slug>/KNOWLEDGE.md`.\n"
+    )
+    mentioned = _mentioned_file_paths(body)
+    assert "src/lingtai/prompts/principle/principle.md" in mentioned
+    assert "knowledge/session-journal/<YYYY-MM-DD>-<slug>/KNOWLEDGE.md" in mentioned
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- keep prompt `related_files` as a source/document crawl graph by ignoring backticked home and POSIX-absolute runtime paths in the test-local detector
- preserve detection and enforcement for real repo-relative source/document references
- add failing-first regression coverage for the documented runtime venv path plus positive repo-relative controls

## Why

The release full suite exposed one deterministic failure after `substrate.md` documented the actual TUI-managed runtime venv at `~/.lingtai-tui/runtime/venv`. The test helper treated every backticked slash-containing value as a required prompt-source inner link.

Adding that runtime directory to `related_files` would contradict the established prompt-frontmatter contract from #555: `related_files` is a maintained source crawl graph, not a runtime-dependency inventory. This patch narrows only the test helper's input set; product behavior, prompt prose, frontmatter, and crawl enforcement remain unchanged.

## Validation

- `git diff --check`
- `PYTHONPATH=src pytest -q tests/test_prompt_catalog.py` -> `22 passed`
- former failing parameter + both new regressions -> `3 passed`
- full kernel suite -> `4181 passed, 4 skipped in 332.54s`
- independent GLM-5.2 review -> `PASS`, no blockers

## Scope

Only `tests/test_prompt_catalog.py` changes. No production code, prompt body/frontmatter, version, package/lock, release workflow, docs, locale, or ANATOMY changes.

Implementation candidate was produced with Claude Code using explicitly verified `claude-opus-4-8`, then independently reviewed and revalidated by the release captain.
