### PR TITLE
fix(packaging): make sidecar wheels platlib compliant

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,10 +12,18 @@ jobs:
   build-wheels:
     name: Wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # Fail loud instead of hanging: cibuildwheel across three CPythons plus a
+    # QEMU-emulated aarch64 leg is the long pole, so give it a generous but
+    # bounded ceiling rather than the 6h GitHub default.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        # Four-platform coverage. macos-15-intel is the current GitHub-hosted
+        # Intel label (macos-13 was retired); macos-14 is Apple Silicon (arm64).
+        # cibuildwheel builds arch-specific macOS wheels (CIBW_ARCHS_MACOS=auto),
+        # so each runner yields its own native slice — no universal2.
+        os: [ubuntu-latest, macos-15-intel, macos-14, windows-latest]
 
     steps:
       - name: Check out repository
@@ -53,10 +61,6 @@ jobs:
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "python -m pytest {project}/tests/test_wheel_sidecar_smoke.py -q"
 
-      - name: Build source distribution
-        if: runner.os == 'Linux'
-        run: uv build --sdist --out-dir dist
-
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -64,8 +68,25 @@ jobs:
           path: ./wheelhouse/*.whl
           if-no-files-found: error
 
+  build-sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
+    # Independent of build-wheels so a wheel/auditwheel failure on any platform
+    # cannot suppress the source release. The sdist is source-only (setup.py's
+    # cargo hook fires only for bdist_wheel/build_py), so it needs no Rust.
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build source distribution
+        run: uv build --sdist --out-dir dist
+
       - name: Upload sdist artifact
-        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
           name: sdist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,6 +24,19 @@ jobs:
         # cibuildwheel builds arch-specific macOS wheels (CIBW_ARCHS_MACOS=auto),
         # so each runner yields its own native slice — no universal2.
         os: [ubuntu-latest, macos-15-intel, macos-14, windows-latest]
+        include:
+          # macOS deployment target must match the Rust sidecar's minimum OS, or
+          # delocate rejects the wheel ("Library dependencies do not satisfy
+          # target MacOS version"). rustc defaults to 10.12 on x86_64 and 11.0 on
+          # arm64, while CPython historically tags macOS wheels 10.9 — the
+          # mismatch is what broke the Intel leg. Pin the target per arch so the
+          # wheel *tag* and the *sidecar compile* agree; the value is exported
+          # into the build env below (CIBW_ENVIRONMENT_MACOS), which both raises
+          # the wheel's platform tag and reaches cargo via setup.py.
+          - os: macos-15-intel
+            macos_target: "10.12"
+          - os: macos-14
+            macos_target: "11.0"
 
     steps:
       - name: Check out repository
@@ -53,13 +66,64 @@ jobs:
           CIBW_ARCHS_MACOS: "auto"
           CIBW_ARCHS_LINUX: "auto64 aarch64"
           CIBW_ARCHS_WINDOWS: "AMD64"
+          # Consistent macOS floor for both the wheel platform tag and the cargo
+          # build of lingtai-search-sidecar (see matrix.include). Empty on
+          # non-macOS runners, where this *_MACOS override is ignored.
+          CIBW_ENVIRONMENT_MACOS: >-
+            MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos_target }}
+            LINGTAI_REQUIRE_RUST_BUILD=1
           CIBW_BEFORE_BUILD_LINUX: >-
             curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
           CIBW_ENVIRONMENT_LINUX: >-
             PATH="$HOME/.cargo/bin:$PATH"
             LINGTAI_REQUIRE_RUST_BUILD=1
-          CIBW_TEST_REQUIRES: "pytest"
-          CIBW_TEST_COMMAND: "python -m pytest {project}/tests/test_wheel_sidecar_smoke.py -q"
+          # NOTE: no CIBW_TEST_* here on purpose. cibuildwheel's built-in test
+          # phase always `pip install`s the wheel WITH its full runtime
+          # dependency tree (not configurable), which drags in faster-whisper →
+          # av (PyAV). In the manylinux2014 test container PyAV has only an sdist
+          # that needs FFmpeg pkg-config dev libs, so the smoke test failed
+          # during unrelated dependency installation even though the repaired
+          # wheel was valid. The sidecar is verified instead by the dependency-
+          # free `Verify built wheels` step below (pip install --no-deps).
+
+      # Pin a known interpreter so the verify step's `cp3XX` tag deterministically
+      # matches one of the built wheels (cp311/cp312/cp313) on every runner,
+      # rather than depending on the image's ambient `python`.
+      - name: Set up Python for wheel verification
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify built wheels carry a runnable sidecar
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          wheels=(./wheelhouse/*.whl)
+          if [ ${#wheels[@]} -eq 0 ]; then
+            echo "no wheels produced in ./wheelhouse" >&2
+            exit 1
+          fi
+          # `--auto` per wheel: the checker installs (--no-deps) and executes the
+          # sidecar when the wheel is compatible with this interpreter, else does
+          # the archive-layout check only (the QEMU aarch64 Linux wheel can't run
+          # on the x86_64 runner). Every wheel is checked; a real defect fails
+          # loud. See tests/test_wheel_sidecar_smoke.py for why this is
+          # dependency-free (the manylinux2014 PyAV/FFmpeg trap).
+          for w in "${wheels[@]}"; do
+            python tests/test_wheel_sidecar_smoke.py --auto "$w"
+          done
+          # Fail loud if NO produced wheel was compatible enough to run
+          # end-to-end here — a proof that is only ever archive-deep would be a
+          # weaker gate than intended.
+          python - "${wheels[@]}" <<'PY'
+          import sys
+          from tests.test_wheel_sidecar_smoke import wheel_runnable_here
+          from pathlib import Path
+          if not any(wheel_runnable_here(Path(w)) for w in sys.argv[1:]):
+              sys.exit("no produced wheel was runnable on this runner; "
+                       "install+run proof did not execute")
+          PY
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,20 @@ two extra steps into the standard ``setuptools.build_meta`` flow:
    idempotent — repeated invocations are cheap because cargo no-ops when
    nothing changed.
 
-2. **Mark the wheel as platform-specific.** Since the wheel ships a native
-   binary, ``bdist_wheel`` is overridden so ``root_is_pure=False`` and the
-   wheel filename carries the correct platform tag (e.g.
-   ``lingtai-0.10.10-cp311-cp311-macosx_14_0_arm64.whl``). The "is the
-   binary actually present?" check runs *after* ``_ensure_sidecar_built()``,
-   so soft-fallback builds (no cargo, ``LINGTAI_SKIP_RUST_BUILD=1``) still
-   produce a universal wheel and skip the platform tag.
+2. **Mark the wheel as platform-specific *and* platlib-compliant.** Since the
+   wheel ships a native binary, ``bdist_wheel`` is overridden so the
+   distribution reports ``has_ext_modules()`` *before* superclass layout
+   finalization. That single predicate drives the platform tag
+   (``root_is_pure=False`` → e.g.
+   ``lingtai-0.10.10-cp311-cp311-macosx_14_0_arm64.whl``) *and* the install
+   scheme, so every package — including the bundled binary under
+   ``lingtai/bin/`` — lands at the archive root (platlib) instead of under
+   ``<name>-<ver>.data/purelib/``. The latter placement is what auditwheel
+   rejects on Linux; see ``BdistWheelImpure`` and
+   ``tests/test_wheel_platlib_layout.py``. The sidecar-present check runs after
+   ``_ensure_sidecar_built()``, so soft-fallback builds (no cargo,
+   ``LINGTAI_SKIP_RUST_BUILD=1``) leave the distribution pure and produce a
+   universal ``py3-none-any`` wheel.
 
 Skip / fallback behavior:
 
@@ -194,23 +201,59 @@ class BuildPyWithSidecar(_build_py):
 if _bdist_wheel is not None:
 
     class BdistWheelImpure(_bdist_wheel):
-        """Force a platform-specific wheel when a native binary is bundled.
+        """Force a platform-specific, platlib-compliant wheel when a native
+        binary is bundled.
 
-        Why this needs ``finalize_options``: ``bdist_wheel`` decides the
-        wheel tag (``py3-none-any`` vs platform-specific) inside
-        ``get_tag``, which reads ``self.root_is_pure`` set during
-        ``finalize_options``. ``build_py`` runs *later*, so we have to
-        kick off the cargo build from here too — otherwise the file
-        existence check below would always be ``False`` on a fresh
-        checkout and we'd ship the binary inside a misleadingly
-        ``py3-none-any`` wheel (which pip won't even look at on a
-        machine with a different ABI).
+        The native/platlib decision must be made *before*
+        ``super().finalize_options()`` runs, because setuptools finalizes the
+        whole wheel layout off a single predicate — ``distribution.has_ext_modules()``:
+
+        * ``bdist_wheel.finalize_options`` recomputes ``root_is_pure`` as
+          ``not (has_ext_modules() or has_c_libraries())`` — this drives the
+          platform tag (``py3-none-any`` vs ``…-macosx_14_0_arm64``).
+        * ``bdist_wheel.run`` then routes the *purelib* scheme to the archive
+          root only when ``root_is_pure`` is true; when false it routes the
+          *platlib* scheme to the root and leaves purelib under
+          ``<name>-<ver>.data/purelib/``.
+        * The nested ``install`` command independently picks
+          ``install_lib = install_platlib if has_ext_modules() else install_purelib``.
+
+        Setting ``root_is_pure = False`` *after* the superclass has finalized
+        (the previous approach) fixed only the tag: ``has_ext_modules()`` stayed
+        false, so ``install`` still routed the pure-Python packages — and the
+        bundled binary under ``lingtai/bin/`` — through *purelib*, landing the
+        whole tree under ``<name>.data/purelib/``. auditwheel then rejects the
+        Linux wheel because the native ``lingtai-search-sidecar`` is not at
+        platlib. See ``tests/test_wheel_platlib_layout.py`` for the regression.
+
+        The fix makes ``has_ext_modules()`` report true *before* the superclass
+        reads it, so tag, run-layout, and install-routing all agree and every
+        package (binary included) lands at the archive root (platlib). We have
+        no ``ext_modules`` list, so ``build_ext`` still runs as a no-op — the
+        native binary is a prebuilt data payload, not a compiled extension.
+
+        ``build_py`` runs *later* than ``finalize_options``, so the cargo build
+        is kicked off here too; otherwise the sidecar-present check would always
+        be false on a fresh checkout and we would ship a misleadingly pure wheel.
+        The pure-Python fallback (``LINGTAI_SKIP_RUST_BUILD=1`` or no cargo) is
+        preserved: with no bundled binary, ``has_ext_modules()`` is left
+        untouched and the superclass produces the normal ``py3-none-any`` wheel.
         """
 
         def finalize_options(self) -> None:  # noqa: D401 - setuptools API
-            super().finalize_options()
             built = _ensure_sidecar_built()
             if built is not None:
+                # Report an ext-module distribution *before* the superclass
+                # finalizes layout, so root_is_pure, the run() install-scheme
+                # routing, and install_lib selection all pick platlib and place
+                # the bundled binary at the archive root — auditwheel-repairable.
+                self.distribution.has_ext_modules = lambda: True
+            super().finalize_options()
+            if built is not None:
+                # Belt-and-braces: the tag is derived from root_is_pure, which
+                # the has_ext_modules() override already forces false. Assert the
+                # invariant so a future setuptools refactor can't silently ship a
+                # pure-tagged wheel around a native binary.
                 self.root_is_pure = False
 
     cmdclass = {"build_py": BuildPyWithSidecar, "bdist_wheel": BdistWheelImpure}

--- a/tests/test_tools_package_data.py
+++ b/tests/test_tools_package_data.py
@@ -8,11 +8,12 @@ the tool code still installs (the consolidation blocker this test guards).
 
 Rather than grepping the config text, this test builds a real wheel and inspects
 the distribution manifest at the correct boundary — the archive that pip
-actually installs. Path handling is layout-aware: a pure-Python wheel places
-packages at the archive root (``tools/...``) while a platform wheel that bundles
-the Rust sidecar places pure-Python packages under
-``<name>-<ver>.data/purelib/tools/...``; both are normalized to the logical
-package path before assertion.
+actually installs. Both the pure-Python wheel (built here) and the native
+sidecar wheel place packages at the archive root (``tools/...``): the native
+wheel is platlib-compliant, so it does *not* bury packages under
+``<name>-<ver>.data/purelib/`` — that placement was the auditwheel release
+blocker fixed in ``setup.py`` and is guarded by
+``tests/test_wheel_platlib_layout.py``.
 """
 
 from __future__ import annotations
@@ -107,13 +108,24 @@ def _build_wheel(dest: Path) -> Path:
 
 
 def _logical(path: str) -> str:
-    """Normalize a wheel archive entry to its logical package path.
+    """Return a wheel archive entry's logical package path.
 
-    Strips a leading ``<name>-<ver>.data/purelib/`` prefix (platform wheels)
-    so entries compare against the same ``tools/...`` paths a pure wheel uses.
+    Both pure and native wheels now place packages at the archive root, so this
+    is effectively identity for ``tools/...`` entries. A ``*.data/{purelib,
+    platlib}/`` prefix is *not* normalized away — it is the auditwheel-rejected
+    layout the packaging fix eliminated. If one ever reappears it must surface as
+    a broken path, not be silently accepted; ``test_wheel_platlib_layout.py``
+    asserts the native wheel never produces one.
     """
     parts = path.split("/")
     for i, segment in enumerate(parts):
+        if segment.endswith(".data") and i + 1 < len(parts) and parts[i + 1] in ("purelib", "platlib"):
+            # Fail loud rather than normalize: this placement is the release
+            # blocker, not an acceptable alternate layout.
+            raise AssertionError(
+                "wheel entry under *.data/%s is the auditwheel-rejected layout: %r"
+                % (parts[i + 1], path)
+            )
         if segment == "tools":
             return "/".join(parts[i:])
     return path

--- a/tests/test_wheel_platlib_layout.py
+++ b/tests/test_wheel_platlib_layout.py
@@ -1,0 +1,189 @@
+"""Regression test: a native-sidecar wheel must be platlib-compliant.
+
+The release blocker this guards: cibuildwheel builds a Linux wheel that bundles
+the native ``lingtai-search-sidecar`` binary, then ``auditwheel repair`` rejects
+it because the binary (and every pure-Python package) lands under
+``<name>-<ver>.data/purelib/`` instead of at the archive root (platlib). That
+happened because ``setup.py`` set ``root_is_pure = False`` *after*
+``bdist_wheel.finalize_options`` had already finalized the install layout off
+``distribution.has_ext_modules()`` (still false) — fixing the wheel *tag* but not
+the *layout*. See ``setup.py::BdistWheelImpure``.
+
+These tests build a real wheel at the boundary pip/auditwheel actually consume —
+the ``.whl`` archive — and assert the corrected contract:
+
+* the native build (cargo present) is ``Root-Is-Purelib: false``, carries the
+  sidecar binary at ``lingtai/bin/…`` at the archive root, and places *no*
+  package under ``*.data/purelib`` / ``*.data/platlib``;
+* the pure fallback (``LINGTAI_SKIP_RUST_BUILD=1``, Rust-independent) is
+  ``Root-Is-Purelib: true``, ships no binary, and keeps packages at the root.
+
+The native test is skipped — not silently passed — when ``cargo`` is absent, so
+a Rust-less CI leg does not give a false green. The pure test always runs.
+
+This exercises the custom ``bdist_wheel`` layout end-to-end rather than asserting
+implementation internals (e.g. ``root_is_pure`` attribute state).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+BINARY_NAMES = ("lingtai-search-sidecar", "lingtai-search-sidecar.exe")
+
+
+def _build_wheel(dest: Path, *, skip_rust: bool) -> Path:
+    """Build one wheel into ``dest`` and return its path.
+
+    ``skip_rust`` toggles ``LINGTAI_SKIP_RUST_BUILD``: false forces a real
+    native build (cargo must be present), true forces the pure fallback. Build
+    isolation lets pip pick a setuptools that understands the PEP 639 license
+    expression, matching the release build.
+    """
+    env = dict(os.environ)
+    if skip_rust:
+        env["LINGTAI_SKIP_RUST_BUILD"] = "1"
+    else:
+        env.pop("LINGTAI_SKIP_RUST_BUILD", None)
+        # Fail loud if the toolchain silently degrades to a pure wheel: a native
+        # build that produced no binary would make the platlib assertions below
+        # vacuously pass. Mirrors the CI env in .github/workflows/wheels.yml.
+        env["LINGTAI_REQUIRE_RUST_BUILD"] = "1"
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "wheel", "--no-deps", "-w", str(dest), str(REPO_ROOT)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            "wheel build failed (skip_rust=%s, rc=%d):\n%s\n%s"
+            % (skip_rust, result.returncode, result.stdout, result.stderr)
+        )
+    wheels = sorted(dest.glob("*.whl"))
+    assert len(wheels) == 1, wheels
+    return wheels[0]
+
+
+def _wheel_metadata(wheel: Path) -> dict[str, str]:
+    """Return the parsed ``*.dist-info/WHEEL`` key/value fields."""
+    with zipfile.ZipFile(wheel) as zf:
+        wheel_meta = next(n for n in zf.namelist() if n.endswith(".dist-info/WHEEL"))
+        text = zf.read(wheel_meta).decode("utf-8")
+    fields: dict[str, str] = {}
+    for line in text.splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+def _archive_names(wheel: Path) -> list[str]:
+    with zipfile.ZipFile(wheel) as zf:
+        return zf.namelist()
+
+
+def _sidecar_entries(names: list[str]) -> list[str]:
+    return [n for n in names if Path(n).name in BINARY_NAMES]
+
+
+def _data_scheme_entries(names: list[str]) -> list[str]:
+    """Entries routed through the wheel ``.data`` install schemes.
+
+    A native, platlib-compliant wheel puts every package at the archive root, so
+    nothing may sit under ``<name>-<ver>.data/purelib/`` or ``.data/platlib/`` —
+    those are exactly the paths auditwheel refuses to relocate correctly.
+    """
+    hits = []
+    for n in names:
+        parts = n.split("/")
+        for i, seg in enumerate(parts[:-1]):
+            if seg.endswith(".data") and parts[i + 1] in ("purelib", "platlib"):
+                hits.append(n)
+                break
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Native wheel — requires the Rust toolchain; skipped (not passed) without it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("cargo") is None, reason="Rust toolchain is optional")
+def test_native_wheel_is_platlib_compliant(tmp_path: Path) -> None:
+    wheel = _build_wheel(tmp_path, skip_rust=False)
+
+    # 1. The sidecar must actually be present — a soft-fallback (no binary)
+    #    wheel would make the platlib assertions vacuously true.
+    names = _archive_names(wheel)
+    sidecars = _sidecar_entries(names)
+    assert sidecars, (
+        "native wheel is missing lingtai-search-sidecar; the platlib checks "
+        "below would be vacuous. Archive entries: %r" % names
+    )
+
+    # 2. It must be tagged as a platform wheel, not pure.
+    meta = _wheel_metadata(wheel)
+    assert meta.get("Root-Is-Purelib") == "false", (
+        "native wheel must be Root-Is-Purelib: false, got %r" % meta.get("Root-Is-Purelib")
+    )
+    assert meta.get("Tag", "").endswith(("-any",)) is False, (
+        "native wheel must carry a platform tag, got Tag: %r" % meta.get("Tag")
+    )
+
+    # 3. No package — the binary least of all — may live under *.data/purelib
+    #    or *.data/platlib; that placement is what auditwheel rejects.
+    misplaced = _data_scheme_entries(names)
+    assert not misplaced, (
+        "native wheel routes packages through *.data/{purelib,platlib}; "
+        "auditwheel cannot repair this. Misplaced entries: %r" % misplaced
+    )
+
+    # 4. Concretely, the sidecar binary must sit at the platlib root under
+    #    lingtai/bin/, exactly where importlib.resources resolves it.
+    assert any(s.startswith("lingtai/bin/") for s in sidecars), (
+        "sidecar not at platlib root lingtai/bin/; entries: %r" % sidecars
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure fallback — Rust-independent, always runs.
+# ---------------------------------------------------------------------------
+
+
+def test_pure_wheel_has_no_native_payload_and_root_layout(tmp_path: Path) -> None:
+    wheel = _build_wheel(tmp_path, skip_rust=True)
+
+    meta = _wheel_metadata(wheel)
+    assert meta.get("Root-Is-Purelib") == "true", (
+        "pure fallback wheel must be Root-Is-Purelib: true, got %r"
+        % meta.get("Root-Is-Purelib")
+    )
+    assert meta.get("Tag") == "py3-none-any", (
+        "pure fallback wheel must be py3-none-any, got %r" % meta.get("Tag")
+    )
+
+    names = _archive_names(wheel)
+    assert not _sidecar_entries(names), (
+        "pure fallback wheel must not bundle the native sidecar binary: %r"
+        % _sidecar_entries(names)
+    )
+    # A pure wheel keeps everything at the root too (purelib scheme → root).
+    assert not _data_scheme_entries(names), (
+        "pure wheel unexpectedly routes packages through *.data: %r"
+        % _data_scheme_entries(names)
+    )
+    assert "lingtai/__init__.py" in names, (
+        "pure wheel must place lingtai/ at the archive root; entries sample: %r"
+        % names[:20]
+    )

--- a/tests/test_wheel_sidecar_smoke.py
+++ b/tests/test_wheel_sidecar_smoke.py
@@ -1,55 +1,274 @@
-"""Smoke-test that an installed lingtai wheel carries and uses the Rust sidecar.
+"""Smoke-check that a built ``lingtai`` wheel carries a runnable Rust sidecar.
 
-This test is intended for cibuildwheel's ``CIBW_TEST_COMMAND``. It runs against
-an installed wheel inside cibuildwheel's test virtualenv, not against the source
-tree. When run from a source checkout, it skips rather than requiring a packaged
-binary in ``src/lingtai/bin``.
+Why this file is dependency-free
+--------------------------------
+
+cibuildwheel's built-in test phase always ``pip install``s the wheel *with its
+full runtime dependency tree* before running ``test-command``, and that is not
+configurable (see ``.github/workflows/wheels.yml``). For LingTai that tree pulls
+``faster-whisper → av`` (PyAV), whose only distribution for the old
+manylinux2014 test container is an sdist that needs FFmpeg ``pkg-config`` dev
+libraries — absent in the container. So the old ``import lingtai`` smoke test
+failed during *dependency installation*, never reaching the actual wheel, even
+though ``auditwheel repair`` had already produced a valid wheel.
+
+The wheel's own correctness does not depend on any of those runtime packages.
+This module therefore verifies the produced wheel *directly*, with **no import
+of the ``lingtai`` package** (whose ``__init__`` imports the heavy stack) and
+**without installing runtime dependencies**:
+
+1. ``pip install --no-deps <wheel>`` into a throwaway environment;
+2. locate ``lingtai/bin/lingtai-search-sidecar[.exe]`` under the install prefix
+   by path (never by importing the package);
+3. drive the binary with its JSON stdin protocol and assert a well-formed,
+   ``ok: true`` response — i.e. the native binary is present *and runnable* on
+   this platform/arch.
+
+Two entry points, one logic
+---------------------------
+
+* **CLI (used by CI):** ``python tests/test_wheel_sidecar_smoke.py <wheel.whl>``
+  runs the ``--no-deps`` install + run check against an already-built wheel. The
+  workflow calls this after cibuildwheel, once per host-arch wheel. Exit 0 on
+  success, non-zero with a diagnostic on failure.
+* **pytest (local/dev):** builds a real native wheel (skipped when ``cargo`` is
+  absent) and runs the same check, so the gate is exercised on macOS hosts too.
+
+Cross-arch wheels (e.g. the QEMU-emulated Linux ``aarch64`` wheel) cannot be
+*run* on an x86_64 host; ``verify_wheel_archive_only`` checks such a wheel's
+archive for the sidecar at the platlib root without executing it.
 """
 
 from __future__ import annotations
 
-import pathlib
+import argparse
+import json
+import shutil
+import subprocess
+import sys
 import tempfile
+import venv
+import zipfile
+from pathlib import Path
 
-import pytest
+# pytest is optional: CI invokes this file as a plain script (`python
+# tests/test_wheel_sidecar_smoke.py --auto <wheel>`) in an environment that has
+# no pytest and — deliberately — none of lingtai's runtime deps. Only the
+# collected test function needs pytest, and that path runs under pytest.
+try:
+    import pytest
+except ModuleNotFoundError:  # pragma: no cover - exercised in the CI verify step
+    pytest = None  # type: ignore[assignment]
 
-import lingtai
-from lingtai.services.file_io_sidecar import (
-    RustFileIOBackend,
-    default_file_io_service,
-    resolve_sidecar_binary,
-)
-
-
-def _is_source_tree_import() -> bool:
-    package_path = pathlib.Path(lingtai.__file__).resolve()
-    project_root = pathlib.Path(__file__).resolve().parents[1]
-    try:
-        package_path.relative_to(project_root / "src")
-    except ValueError:
-        return False
-    return True
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BINARY_NAMES = ("lingtai-search-sidecar", "lingtai-search-sidecar.exe")
 
 
-def test_installed_wheel_carries_and_uses_rust_sidecar() -> None:
-    if _is_source_tree_import():
-        pytest.skip("wheel sidecar smoke test requires an installed wheel")
+# ---------------------------------------------------------------------------
+# Archive-only check (works for any wheel, including non-host-arch ones)
+# ---------------------------------------------------------------------------
 
-    binary = resolve_sidecar_binary(skip_env=True, skip_dev_tree=True)
-    assert binary is not None, "packaged lingtai-search-sidecar was not found"
-    binary_path = pathlib.Path(binary)
-    assert binary_path.is_file(), binary
 
+def verify_wheel_archive_only(wheel: Path) -> None:
+    """Assert the wheel carries the sidecar at the platlib root (no execution).
+
+    Raises ``AssertionError`` if the binary is missing or is buried under a
+    ``*.data/{purelib,platlib}/`` scheme (the auditwheel-rejected layout).
+    """
+    with zipfile.ZipFile(wheel) as zf:
+        names = zf.namelist()
+    sidecars = [n for n in names if Path(n).name in BINARY_NAMES]
+    if not sidecars:
+        raise AssertionError(f"{wheel.name}: no lingtai-search-sidecar in archive")
+    for n in sidecars:
+        parts = n.split("/")
+        for i, seg in enumerate(parts[:-1]):
+            if seg.endswith(".data") and parts[i + 1] in ("purelib", "platlib"):
+                raise AssertionError(
+                    f"{wheel.name}: sidecar under *.data/{parts[i + 1]} "
+                    f"(auditwheel-rejected layout): {n}"
+                )
+    if not any(s.startswith("lingtai/bin/") for s in sidecars):
+        raise AssertionError(
+            f"{wheel.name}: sidecar not at platlib root lingtai/bin/: {sidecars}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Install (--no-deps) + run check (host-arch wheels only)
+# ---------------------------------------------------------------------------
+
+
+def _sidecar_in_prefix(prefix_purelib: str, prefix_platlib: str) -> Path | None:
+    """Find the installed sidecar under either install scheme, no import."""
+    for base in (prefix_platlib, prefix_purelib):
+        for name in BINARY_NAMES:
+            candidate = Path(base) / "lingtai" / "bin" / name
+            if candidate.is_file():
+                return candidate
+    return None
+
+
+def _drive_sidecar(binary: Path) -> None:
+    """Run the sidecar over its JSON stdin protocol and assert a good response."""
     with tempfile.TemporaryDirectory() as tmp:
-        root = pathlib.Path(tmp)
+        root = Path(tmp)
         target = root / "a.txt"
         target.write_text("hello native sidecar\n", encoding="utf-8")
 
-        service = default_file_io_service(str(root), backend="auto")
-        backend = getattr(service, "_backend", service)
-        assert isinstance(backend, RustFileIOBackend), type(backend)
+        request = json.dumps(
+            {"op": "glob", "root": str(root), "path": str(root), "pattern": "*.txt"}
+        )
+        proc = subprocess.run(
+            [str(binary)],
+            input=request,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, (
+            f"sidecar exited {proc.returncode}: {proc.stdout}\n{proc.stderr}"
+        )
+        response = json.loads(proc.stdout)
+        assert response.get("ok") is True, f"sidecar not ok: {proc.stdout}"
+        assert response.get("op") == "glob", response
+        got = [Path(p).resolve() for p in response.get("paths", [])]
+        assert got == [target.resolve()], f"unexpected glob result: {response}"
 
-        assert service.glob("*.txt") == [str(target.resolve())]
-        matches = service.grep("native", str(root))
-        got = [(pathlib.Path(m.path).resolve(), m.line_number, m.line) for m in matches]
-        assert got == [(target.resolve(), 1, "hello native sidecar")], got
+
+def wheel_runnable_here(wheel: Path) -> bool:
+    """True iff this wheel's tags are compatible with the running interpreter.
+
+    Uses the same tag machinery pip uses (``packaging.tags``), so a wheel built
+    for another OS/arch/ABI — e.g. the QEMU-emulated Linux ``aarch64`` wheel on
+    an x86_64 runner, or a ``cp313`` wheel under a ``cp312`` interpreter — is
+    correctly classified as not runnable here and gets the archive-only check
+    instead of a spurious install failure. ``packaging`` is available via pip's
+    vendored copy, which is always present in a pip-bearing environment.
+    """
+    try:
+        from packaging.tags import sys_tags
+        from packaging.utils import parse_wheel_filename
+    except ModuleNotFoundError:  # fall back to pip's vendored copy
+        from pip._vendor.packaging.tags import sys_tags  # type: ignore
+        from pip._vendor.packaging.utils import parse_wheel_filename  # type: ignore
+    _, _, _, tags = parse_wheel_filename(wheel.name)
+    return bool(set(tags) & set(sys_tags()))
+
+
+def verify_wheel_install_and_run(wheel: Path) -> None:
+    """``pip install --no-deps`` the wheel and run its sidecar. No lingtai import.
+
+    Creates a throwaway venv so the check is hermetic and never pulls the heavy
+    runtime dependency tree (the manylinux2014 PyAV/FFmpeg trap this reshape
+    exists to avoid).
+    """
+    # Archive contract first — fail loud before we even install.
+    verify_wheel_archive_only(wheel)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        env_dir = Path(tmp) / "venv"
+        venv.EnvBuilder(with_pip=True).create(env_dir)
+        bindir = "Scripts" if sys.platform == "win32" else "bin"
+        py = env_dir / bindir / ("python.exe" if sys.platform == "win32" else "python")
+
+        install = subprocess.run(
+            [str(py), "-m", "pip", "install", "--no-deps", "--quiet", str(wheel)],
+            capture_output=True,
+            text=True,
+        )
+        assert install.returncode == 0, (
+            f"--no-deps install failed:\n{install.stdout}\n{install.stderr}"
+        )
+
+        purelib = subprocess.run(
+            [str(py), "-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        platlib = subprocess.run(
+            [str(py), "-c", "import sysconfig; print(sysconfig.get_paths()['platlib'])"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        binary = _sidecar_in_prefix(purelib, platlib)
+        assert binary is not None, (
+            f"installed wheel has no lingtai/bin/ sidecar under {platlib} / {purelib}"
+        )
+        _drive_sidecar(binary)
+
+
+# ---------------------------------------------------------------------------
+# pytest entry point — build a native wheel locally and run the check
+# ---------------------------------------------------------------------------
+
+
+def _build_native_wheel(dest: Path) -> Path:
+    import os
+
+    env = dict(os.environ)
+    env.pop("LINGTAI_SKIP_RUST_BUILD", None)
+    env["LINGTAI_REQUIRE_RUST_BUILD"] = "1"  # fail loud if no binary is produced
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "wheel", "--no-deps", "-w", str(dest), str(REPO_ROOT)],
+        cwd=REPO_ROOT, env=env, capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            "native wheel build failed:\n%s\n%s" % (result.stdout, result.stderr)
+        )
+    wheels = sorted(dest.glob("*.whl"))
+    assert len(wheels) == 1, wheels
+    return wheels[0]
+
+
+if pytest is not None:  # only collected under pytest; CI runs this file scriptwise
+
+    @pytest.mark.skipif(
+        shutil.which("cargo") is None, reason="Rust toolchain is optional"
+    )
+    def test_native_wheel_ships_and_runs_sidecar(tmp_path: Path) -> None:
+        wheel = _build_native_wheel(tmp_path)
+        verify_wheel_install_and_run(wheel)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point — used by CI against an already-built wheel
+# ---------------------------------------------------------------------------
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path, help="path to the built .whl to verify")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--archive-only",
+        action="store_true",
+        help="only inspect the archive (for wheels whose arch differs from the host)",
+    )
+    mode.add_argument(
+        "--auto",
+        action="store_true",
+        help="install+run if the wheel is compatible with this interpreter, "
+        "else archive-only — the mode CI uses per produced wheel",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.wheel.is_file():
+        print(f"error: wheel not found: {args.wheel}", file=sys.stderr)
+        return 2
+    try:
+        archive_only = args.archive_only or (args.auto and not wheel_runnable_here(args.wheel))
+        if archive_only:
+            verify_wheel_archive_only(args.wheel)
+            print(f"OK (archive): {args.wheel.name} carries sidecar at platlib root")
+        else:
+            verify_wheel_install_and_run(args.wheel)
+            print(f"OK (install+run): {args.wheel.name} sidecar present and runnable")
+    except AssertionError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_wheel_sidecar_smoke.py
+++ b/tests/test_wheel_sidecar_smoke.py
@@ -43,6 +43,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import ntpath
+import posixpath
 import shutil
 import subprocess
 import sys
@@ -109,8 +111,83 @@ def _sidecar_in_prefix(prefix_purelib: str, prefix_platlib: str) -> Path | None:
     return None
 
 
+def _strip_extended_prefix(path: str) -> str:
+    """Drop a Windows extended-length / device path prefix if present.
+
+    The sidecar canonicalizes paths with Rust's ``Path::canonicalize``, which on
+    Windows yields verbatim ``\\\\?\\C:\\...`` paths, then normalizes separators to
+    ``/`` (``main.rs``: ``abs.to_string_lossy().replace('\\\\', "/")``). So a real
+    Windows glob hit looks like ``//?/C:/Users/.../a.txt``. That prefix is a
+    spelling artifact, not part of the file's identity — strip it before
+    comparison. POSIX paths are returned unchanged.
+    """
+    for prefix in ("\\\\?\\", "\\\\.\\", "//?/", "//./"):
+        if path.startswith(prefix):
+            return path[len(prefix):]
+    return path
+
+
+def _canonical_key(path: str) -> str:
+    """Spelling-independent identity key for a filesystem path.
+
+    Folds away the platform-specific spelling the sidecar emits — the Windows
+    extended-length prefix, ``/`` vs ``\\`` separators, and case-insensitive
+    volumes — so the same key falls out of ``//?/C:/Users/.../a.txt`` and
+    ``C:\\Users\\...\\A.TXT`` while a genuinely different file (other basename or
+    other directory) yields a different key. On POSIX it is an ordinary
+    case-sensitive normpath. This mirrors how the production integration test
+    compares glob output rather than reconstructing the path with
+    ``Path.resolve``, which does not equate these Windows spellings.
+    """
+    stripped = _strip_extended_prefix(path)
+    # A drive letter (``C:``) or a backslash means Windows path semantics;
+    # otherwise treat it as POSIX. ``normcase`` lowercases + unifies separators
+    # on Windows and is a no-op on POSIX; ``normpath`` collapses ``.``/``..``.
+    mod = ntpath if (ntpath.splitdrive(stripped)[0] or "\\" in stripped) else posixpath
+    return mod.normcase(mod.normpath(stripped))
+
+
+def _assert_glob_envelope_locates(response: dict, expected_key: str) -> None:
+    """Assert a ``glob`` envelope canonically located exactly ``expected_key``.
+
+    Encodes the canonical sidecar contract (``crates/lingtai-search-sidecar``):
+    a ``glob`` op returns its hits in ``paths`` (``matches`` is a grep-only
+    field and is legitimately empty here), each an absolute, canonicalized path
+    in the sidecar's platform spelling. The comparison is robust across POSIX
+    and the Windows ``//?/C:/...`` spelling but still demands the *exact* file —
+    an unrelated or missing path fails loud. ``expected_key`` is a
+    ``_canonical_key``; taking it (rather than a live ``Path``) lets the
+    Windows response shape be exercised deterministically off-Windows.
+    """
+    assert response.get("ok") is True, f"sidecar not ok: {response}"
+    assert response.get("backend") == "lingtai-search-sidecar", response
+    assert response.get("op") == "glob", response
+    # The walk must have actually traversed the tree (root + the one file).
+    assert response.get("visited", 0) >= 1, f"sidecar visited nothing: {response}"
+    # glob hits live in ``paths``; ``matches`` belongs to ``grep`` and is empty.
+    assert not response.get("matches"), f"glob unexpectedly set matches: {response}"
+    paths = response.get("paths") or []
+    got = {_canonical_key(p) for p in paths}
+    assert got == {expected_key}, (
+        f"glob did not return exactly the expected file.\n"
+        f"  expected key: {expected_key}\n"
+        f"  got keys:     {sorted(got)}\n"
+        f"  raw response: {response}"
+    )
+
+
+def _assert_glob_found_target(response: dict, target: Path) -> None:
+    """Assert a ``glob`` envelope located exactly ``target`` (live filesystem)."""
+    _assert_glob_envelope_locates(response, _canonical_key(str(target.resolve())))
+
+
 def _drive_sidecar(binary: Path) -> None:
-    """Run the sidecar over its JSON stdin protocol and assert a good response."""
+    """Run the sidecar over its JSON stdin protocol and assert a good response.
+
+    Proves the native binary launches, returns ``ok: true`` with the expected
+    backend/op, traverses the tree, and returns exactly the seeded test file —
+    across POSIX and Windows path spellings — then lets the tempdir clean up.
+    """
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         target = root / "a.txt"
@@ -130,10 +207,7 @@ def _drive_sidecar(binary: Path) -> None:
             f"sidecar exited {proc.returncode}: {proc.stdout}\n{proc.stderr}"
         )
         response = json.loads(proc.stdout)
-        assert response.get("ok") is True, f"sidecar not ok: {proc.stdout}"
-        assert response.get("op") == "glob", response
-        got = [Path(p).resolve() for p in response.get("paths", [])]
-        assert got == [target.resolve()], f"unexpected glob result: {response}"
+        _assert_glob_found_target(response, target)
 
 
 def wheel_runnable_here(wheel: Path) -> bool:
@@ -229,6 +303,122 @@ if pytest is not None:  # only collected under pytest; CI runs this file scriptw
     def test_native_wheel_ships_and_runs_sidecar(tmp_path: Path) -> None:
         wheel = _build_native_wheel(tmp_path)
         verify_wheel_install_and_run(wheel)
+
+    # -----------------------------------------------------------------------
+    # Deterministic regression for the Windows glob response shape.
+    #
+    # These run on any host (no Windows, no Rust). They pin the exact response
+    # shape from the failing Windows CI run (job 86408373017, run
+    # 29106557281): a successful ``glob`` whose hit is spelled with the
+    # extended-length ``//?/C:/...`` prefix and forward slashes, with an empty
+    # ``matches`` array. The pre-fix assertion compared ``Path(p).resolve()``
+    # against the local tempfile and failed on that spelling even though the
+    # sidecar had located the exact file.
+    # -----------------------------------------------------------------------
+
+    # The literal path from windows-latest.log line 804.
+    _WIN_GLOB_PATH = (
+        "//?/C:/Users/runneradmin/AppData/Local/Temp/tmpduegvy1z/a.txt"
+    )
+    _WIN_TARGET = "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\tmpduegvy1z\\a.txt"
+
+    def _win_response(paths: list[str]) -> dict:
+        # Mirrors the exact envelope fields the sidecar emitted on Windows.
+        return {
+            "ok": True,
+            "backend": "lingtai-search-sidecar",
+            "op": "glob",
+            "matches": [],
+            "paths": paths,
+            "visited": 2,
+            "files_skipped_size": 0,
+            "files_skipped_binary": 0,
+            "dirs_pruned": 0,
+            "elapsed_ms": 4,
+            "truncated_reason": None,
+            "error": None,
+        }
+
+    def test_canonical_key_folds_windows_extended_length_spelling() -> None:
+        # The //?/ + forward-slash spelling keys equal to the plain Windows path.
+        assert _canonical_key(_WIN_GLOB_PATH) == _canonical_key(_WIN_TARGET)
+        # Case-insensitive volume: an upper-cased expected path still matches.
+        assert _canonical_key(_WIN_GLOB_PATH) == _canonical_key(
+            "C:/USERS/runneradmin/AppData/Local/Temp/tmpduegvy1z/A.TXT"
+        )
+
+    def test_canonical_key_distinguishes_different_files() -> None:
+        # Same directory, different basename — must NOT collapse.
+        assert _canonical_key(_WIN_GLOB_PATH) != _canonical_key(
+            "//?/C:/Users/runneradmin/AppData/Local/Temp/tmpduegvy1z/b.txt"
+        )
+        # Same basename, different directory — must NOT collapse.
+        assert _canonical_key(_WIN_GLOB_PATH) != _canonical_key(
+            "//?/C:/Users/runneradmin/AppData/Local/Temp/OTHER/a.txt"
+        )
+        # POSIX pair sanity: distinct files differ, identical spelling matches.
+        assert _canonical_key("/tmp/x/a.txt") != _canonical_key("/tmp/x/b.txt")
+        assert _canonical_key("/tmp/x/a.txt") == _canonical_key("/tmp/x/a.txt")
+
+    def test_windows_glob_envelope_accepts_exact_file() -> None:
+        # The full envelope assertion accepts the real Windows response shape.
+        _assert_glob_envelope_locates(
+            _win_response([_WIN_GLOB_PATH]), _canonical_key(_WIN_TARGET)
+        )
+
+    def test_windows_glob_envelope_rejects_unrelated_file() -> None:
+        # A hit for a different file under the same temp dir must fail loud.
+        with pytest.raises(AssertionError):
+            _assert_glob_envelope_locates(
+                _win_response(
+                    ["//?/C:/Users/runneradmin/AppData/Local/Temp/tmpduegvy1z/b.txt"]
+                ),
+                _canonical_key(_WIN_TARGET),
+            )
+
+    def test_windows_glob_envelope_rejects_missing_and_extra_paths() -> None:
+        # Empty paths (found nothing) fails loud …
+        with pytest.raises(AssertionError):
+            _assert_glob_envelope_locates(
+                _win_response([]), _canonical_key(_WIN_TARGET)
+            )
+        # … and an extra unrelated hit alongside the right one also fails.
+        with pytest.raises(AssertionError):
+            _assert_glob_envelope_locates(
+                _win_response(
+                    [
+                        _WIN_GLOB_PATH,
+                        "//?/C:/Users/runneradmin/AppData/Local/Temp/tmpduegvy1z/b.txt",
+                    ]
+                ),
+                _canonical_key(_WIN_TARGET),
+            )
+
+    def test_glob_envelope_rejects_grep_style_and_not_ok() -> None:
+        # A glob envelope must not carry grep ``matches`` …
+        bad = _win_response([_WIN_GLOB_PATH])
+        bad["matches"] = [{"path": "a.txt", "line_number": 1, "line": "x"}]
+        with pytest.raises(AssertionError):
+            _assert_glob_envelope_locates(bad, _canonical_key(_WIN_TARGET))
+        # … and an ``ok: false`` envelope always fails loud.
+        not_ok = _win_response([_WIN_GLOB_PATH])
+        not_ok["ok"] = False
+        with pytest.raises(AssertionError):
+            _assert_glob_envelope_locates(not_ok, _canonical_key(_WIN_TARGET))
+
+    def test_posix_glob_envelope_accepts_forward_slash_path(tmp_path: Path) -> None:
+        # The POSIX shape still works through the same assertion.
+        target = tmp_path / "a.txt"
+        target.write_text("x", encoding="utf-8")
+        resp = {
+            "ok": True,
+            "backend": "lingtai-search-sidecar",
+            "op": "glob",
+            "matches": [],
+            "paths": [str(target.resolve())],
+            "visited": 2,
+        }
+        _assert_glob_found_target(resp, target)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The current release-trigger wheel workflow builds the Linux wheel, then `auditwheel repair` rejects it because the bundled native `lingtai-search-sidecar` sits under `<dist>.data/purelib/`. The previous `bdist_wheel` hook changed `root_is_pure` only after setuptools had already selected the install scheme, so the filename was platform-tagged but the payload still followed purelib routing.

The same workflow also used retired `macos-13`, had no bounded job timeout, and built the sdist only after the Linux wheel leg, so one auditwheel failure suppressed the source artifact.

## What changed

- decide native/platlib layout before `bdist_wheel.finalize_options()` by making `has_ext_modules()` report true only when the Rust sidecar was actually built;
- preserve the intentional `LINGTAI_SKIP_RUST_BUILD=1` / no-cargo universal-wheel fallback and stale sidecar cleanup;
- add a real built-wheel regression for native and pure layouts, and stop normalizing `.data/purelib` as acceptable;
- replace `macos-13` with `macos-15-intel`, retain `macos-14` arm64, split sdist into an independent job, and add 120/15 minute fail-loud bounds.

## Validation

- `tests/test_wheel_platlib_layout.py tests/test_tools_package_data.py`: **11 passed, 0 skipped** in 8.79s on Python 3.11.10 with cargo present;
- native wheel: `Root-Is-Purelib: false`, sidecar at root `lingtai/bin/`, no `.data/{purelib,platlib}` entries;
- pure fallback: `Root-Is-Purelib: true`, `py3-none-any`, no native payload;
- fresh installed-wheel sidecar smoke: **1 passed**;
- sdist build and `git diff --check`: passed;
- independent Claude Opus 4.8 review: **PASS, no blockers**;
- independent GLM-5.2 review using the synced LingTai taste criteria: **PASS, no blockers**.

`auditwheel` itself is Linux-only and was not claimed as a local macOS check. After merge, the release gate will dispatch `Build Python wheels` and require successful Ubuntu auditwheel repair, Intel macOS, ARM macOS, Windows, and independent sdist artifacts before a fresh generation-4 release lock. Generation 3 remains blocked and unpublished.
