### PR TITLE
Expose daemon backend options schema

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -965,10 +965,9 @@ def _scrub_responses_schema(node: Any) -> Any:
          type-establishing key (see `_SCHEMA_KIND_KEYS`) gets `type:
          "string"`. This covers the nested `secondary.args.*` fields LingTai
          emits with only a description.
-      3. `{"type": "object"}` with neither `properties` nor
-         `additionalProperties` -> an empty `properties: {}` is added. An
-         empty `properties` map is accepted, while an explicit
-         `additionalProperties` schema already defines the object's values.
+      3. `{"type": "object"}` with no `properties` key (a free-form object,
+         e.g. `daemon`'s `tasks[].backend_options`) -> an empty
+         `properties: {}` is added. An empty `properties` map is accepted.
 
     `enum`/`anyOf`/`allOf` are left untouched (the backend accepts them
     nested). Walks dicts and lists so all fixes apply at any depth.
@@ -987,13 +986,8 @@ def _scrub_responses_schema(node: Any) -> Any:
         # empty {} or {"required": [...]} that aren't value descriptors.
         if "description" in out and not any(k in out for k in _SCHEMA_KIND_KEYS):
             out["type"] = "string"
-        # A typed object with no shape is rejected; give it an empty map.
-        # Preserve explicitly typed free-form values via additionalProperties.
-        if (
-            out.get("type") == "object"
-            and "properties" not in out
-            and "additionalProperties" not in out
-        ):
+        # A typed object with no `properties` is rejected; give it an empty map.
+        if out.get("type") == "object" and "properties" not in out:
             out["properties"] = {}
         return out
     if isinstance(node, list):

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -965,9 +965,10 @@ def _scrub_responses_schema(node: Any) -> Any:
          type-establishing key (see `_SCHEMA_KIND_KEYS`) gets `type:
          "string"`. This covers the nested `secondary.args.*` fields LingTai
          emits with only a description.
-      3. `{"type": "object"}` with no `properties` key (a free-form object,
-         e.g. `daemon`'s `tasks[].backend_options`) -> an empty
-         `properties: {}` is added. An empty `properties` map is accepted.
+      3. `{"type": "object"}` with neither `properties` nor
+         `additionalProperties` -> an empty `properties: {}` is added. An
+         empty `properties` map is accepted, while an explicit
+         `additionalProperties` schema already defines the object's values.
 
     `enum`/`anyOf`/`allOf` are left untouched (the backend accepts them
     nested). Walks dicts and lists so all fixes apply at any depth.
@@ -986,8 +987,13 @@ def _scrub_responses_schema(node: Any) -> Any:
         # empty {} or {"required": [...]} that aren't value descriptors.
         if "description" in out and not any(k in out for k in _SCHEMA_KIND_KEYS):
             out["type"] = "string"
-        # A typed object with no `properties` is rejected; give it an empty map.
-        if out.get("type") == "object" and "properties" not in out:
+        # A typed object with no shape is rejected; give it an empty map.
+        # Preserve explicitly typed free-form values via additionalProperties.
+        if (
+            out.get("type") == "object"
+            and "properties" not in out
+            and "additionalProperties" not in out
+        ):
             out["properties"] = {}
         return out
     if isinstance(node, list):

--- a/src/tools/daemon/__init__.py
+++ b/src/tools/daemon/__init__.py
@@ -701,6 +701,25 @@ def get_schema(lang: str = "en") -> dict:
                         },
                         "backend_options": {
                             "type": "object",
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {"type": "boolean"},
+                                    {"type": "string"},
+                                    {"type": "integer"},
+                                    {"type": "number"},
+                                    {"type": "null"},
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "anyOf": [
+                                                {"type": "string"},
+                                                {"type": "integer"},
+                                                {"type": "number"},
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
                             "description": 'Optional free-form CLI options for \'claude-code\' / \'codex\' / \'opencode\' / \'mimocode\' / \'qwen-code\' / \'oh-my-pi\' / \'kimicode\' / \'cursor\' backends ONLY (ignored by lingtai). JSON object mapping flag names to values: true → flag only (e.g. {"search": true} → --search); string/int/float → \'--flag <value>\'; list of scalars → \'--flag <v1> --flag <v2>\'; false/null omits the flag. Underscores in keys become dashes; nested objects and unsafe keys are rejected. Applies only when starting the emanation (not to `ask`). Discover supported flags by running \'claude --help\', \'codex exec --help\', \'opencode run --help\', \'mimo run --help\', \'qwen --help\', \'omp --help\', \'kimi --help\', or \'agent --help\' in bash — the CLI\'s flag list changes between versions; this field is intentionally a passthrough rather than a fixed list. See daemon-manual.',
                         },
                         "system_prompt": {

--- a/tests/test_daemon_backend_options.py
+++ b/tests/test_daemon_backend_options.py
@@ -54,6 +54,9 @@ def test_argv_bool_false_and_null_are_omitted():
 
 
 def test_argv_string_int_float():
+    out = _backend_options_to_argv({"config": "model_reasoning_effort=ultra"})
+    assert out == ["--config", "model_reasoning_effort=ultra"]
+
     out = _backend_options_to_argv({"model": "gpt-5"})
     assert out == ["--model", "gpt-5"]
 
@@ -180,9 +183,7 @@ def test_emanate_cli_persists_resolved_options(tmp_path):
                 "task": "Refactor auth.",
                 "tools": [],
                 "backend_options": {
-                    "effort": "high",
-                    "model": "claude-opus-4-7",
-                    "search": True,
+                    "config": "model_reasoning_effort=ultra",
                 },
             }],
         })
@@ -194,9 +195,7 @@ def test_emanate_cli_persists_resolved_options(tmp_path):
         fut.result(timeout=5)
 
     user_argv = [
-        "--effort", "high",
-        "--model", "claude-opus-4-7",
-        "--search",
+        "--config", "model_reasoning_effort=ultra",
     ]
     assert captured["backend_argv"][:len(user_argv)] == user_argv
     assert "--mcp-config" in captured["backend_argv"]
@@ -204,9 +203,7 @@ def test_emanate_cli_persists_resolved_options(tmp_path):
     state = captured["daemon_json_state"]
     assert state["backend"] == "claude-code"
     assert state["backend_options"] == {
-        "effort": "high",
-        "model": "claude-opus-4-7",
-        "search": True,
+        "config": "model_reasoning_effort=ultra",
     }
     assert state["backend_argv"] == user_argv
     assert "--mcp-config" in state["backend_harness_argv"]
@@ -436,6 +433,21 @@ def test_schema_includes_backend_options():
     task_props = schema["properties"]["tasks"]["items"]["properties"]
     assert "backend_options" in task_props
     assert task_props["backend_options"]["type"] == "object"
+    passthrough = task_props["backend_options"]["additionalProperties"]
+    alternatives = passthrough["anyOf"]
+    assert {item.get("type") for item in alternatives} == {
+        "boolean", "string", "integer", "number", "null", "array",
+    }
+    array_schema = next(item for item in alternatives if item.get("type") == "array")
+    assert {item["type"] for item in array_schema["items"]["anyOf"]} == {
+        "string", "integer", "number",
+    }
+    # Nested objects and booleans in lists are intentionally not representable.
+    assert all(item.get("type") != "object" for item in alternatives)
+    assert all(
+        item["type"] != "boolean"
+        for item in array_schema["items"]["anyOf"]
+    )
     # The free-form description should mention discovery via --help so
     # agents know not to expect a fixed list here.
     assert "--help" in task_props["backend_options"]["description"]

--- a/tests/test_wire_tool_description.py
+++ b/tests/test_wire_tool_description.py
@@ -132,6 +132,25 @@ def test_openai_responses_wire_description():
     assert schemas[0].description == FULL_DESCRIPTION
 
 
+def test_openai_responses_preserves_daemon_backend_options_passthrough_schema():
+    from lingtai.llm.openai.adapter import _build_responses_tools
+    from tools.daemon import get_schema
+
+    tools = _build_responses_tools([
+        FunctionSchema(name="daemon", description="daemon", parameters=get_schema())
+    ])
+    backend_options = tools[0]["parameters"]["properties"]["tasks"]["items"][
+        "properties"
+    ]["backend_options"]
+
+    assert "additionalProperties" in backend_options
+    assert "properties" not in backend_options
+    assert any(
+        option == {"type": "string"}
+        for option in backend_options["additionalProperties"]["anyOf"]
+    )
+
+
 def test_anthropic_wire_description_and_cache_control():
     from lingtai.llm.anthropic.adapter import _build_tools
 

--- a/tests/test_wire_tool_description.py
+++ b/tests/test_wire_tool_description.py
@@ -144,7 +144,7 @@ def test_openai_responses_preserves_daemon_backend_options_passthrough_schema():
     ]["backend_options"]
 
     assert "additionalProperties" in backend_options
-    assert "properties" not in backend_options
+    assert backend_options["properties"] == {}
     assert any(
         option == {"type": "string"}
         for option in backend_options["additionalProperties"]["anyOf"]


### PR DESCRIPTION
## Summary

- add a typed `additionalProperties` contract to the daemon `backend_options` schema so provider structured-tool schemas can carry free-form CLI flags
- cover `backend_options.config` passthrough into Codex CLI argv/persisted daemon metadata
- assert Responses tool-schema construction preserves the free-form option schema while keeping the existing object normalization shape

## Why

`backend_options` is documented as a free-form passthrough for CLI daemon backends, for example:

```json
{"config": "model_reasoning_effort=ultra"}
```

The runtime argv conversion already accepted that value and would emit:

```text
--config model_reasoning_effort=ultra
```

But the tool schema described `backend_options` only as a bare object. After provider schema normalization, that object could become effectively keyless for structured tool calls, so the model had no usable schema path for emitting keys such as `config`.

## Changes

- Defines scalar/array `additionalProperties` for `tasks[].backend_options`, matching the documented passthrough value types accepted by daemon argv conversion.
- Adds explicit test coverage for `backend_options.config` and the resulting Codex backend argv.
- Adds a wire-schema regression that checks `backend_options.additionalProperties` survives Responses tool construction.
- Leaves the OpenAI Responses object scrubber behavior otherwise unchanged: `properties: {}` may coexist with `additionalProperties`, which keeps this near the existing accepted provider schema shape.

## Non-goals

- Does not redesign `tasks[].mcp[]`; one-run MCP registration schemas need a separate stdio/http registration contract.
- Does not change daemon runtime argv validation beyond exposing the already-supported option shape to providers.
- Does not add a live provider smoke test.

## Validation

- `python3 -m py_compile src/tools/daemon/__init__.py src/lingtai/llm/openai/adapter.py tests/test_daemon_backend_options.py tests/test_wire_tool_description.py`
- `git diff --check canonical/main...HEAD`
- `uv run --offline --no-project --with pytest --with-editable . python -m pytest tests/test_daemon_backend_options.py tests/test_wire_tool_description.py -q` → `66 passed`

`tools/check_anatomy_drift.py` is absent in this checkout.
