### PR TITLE
feat(bash): add last-resort async reminders

### DIFF
--- a/src/lingtai_kernel/base_agent/messaging.py
+++ b/src/lingtai_kernel/base_agent/messaging.py
@@ -121,7 +121,7 @@ def _enqueue_system_notification(
     from ..notifications import collect_notifications
     from ..notifications import submit as publish_notification
 
-    event_id = f"evt_{int(time.time()*1000):x}_{secrets.token_hex(2)}"
+    event_id = f"evt_{int(time.time()*1000):x}_{secrets.token_hex(8)}"
     received_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     lock = agent._system_notification_lock

--- a/src/tools/bash/ANATOMY.md
+++ b/src/tools/bash/ANATOMY.md
@@ -25,7 +25,7 @@ be explicitly opted into.
 
 ## Components
 
-- `bash/__init__.py` — the entire capability in a single file. `get_description`, `get_schema`, `setup`. Two core classes: `BashPolicy` for command filtering, `BashManager` for execution. Module-level result helpers: `_augment_command_result` (adds `ok`/`command_status`/`warning` fidelity fields), `_detect_failure_signature` (labels `python_traceback`/`missing_module`), `_broad_scan_hint` (timeout recipe for broad recursive walks).
+- `bash/__init__.py` — the entire capability in a single file. `get_description` (`__init__.py:175`), `get_schema` (`__init__.py:179-223`), `setup` (`__init__.py:822-860`). Two core classes: `BashPolicy` for command filtering (`__init__.py:227-315`), `BashManager` for execution (`__init__.py:318-819`). Module-level result helpers: `_augment_command_result` adds `ok`/`command_status`/`warning` fidelity fields (`__init__.py:121-173`), `_detect_failure_signature` labels `python_traceback`/`missing_module` (`__init__.py:64-78`), `_broad_scan_hint` returns timeout recipe text for broad recursive walks (`__init__.py:91-118`).
 - `bash/bash_policy.json` — default denylist policy shipped with the kernel. Denies destructive (`rm`, `rmdir`, `shred`, `dd`), privilege escalation (`sudo`, `su`, `doas`), permission changes (`chmod`, `chown`, `chgrp`), disk management (`mount`, `umount`, `mkfs`, `fdisk`), package managers (`apt`, `apt-get`, `yum`, `dnf`, `brew`), process control (`kill`, `killall`, `pkill`, `shutdown`, `reboot`, `systemctl`), network (`nc`, `ncat`), and code execution (`eval`, `exec`).
 
 ## Public API
@@ -39,13 +39,14 @@ The `bash` tool supports synchronous and asynchronous execution:
 | `working_dir`  | string   | Working directory for execution (default: agent's working dir) |
 | `action`       | string   | `run` (default), `poll`, or `cancel` |
 | `async`        | boolean  | If true, run in background and return job_id immediately (default: false) |
+| `reminder`     | number   | Top-level schema-required field; provider calls carry it for every action, but runtime consumes/validates it only for async `run` (default 1800) |
 | `job_id`       | string   | Job ID for `poll` and `cancel` actions |
 
 **Sync mode** (`async=false`, default): Returns `{status, exit_code, stdout, stderr, ok, command_status[, warning]}` once the command completes, or `{status: "error", message}` only when the shell itself could not run it (empty command, policy denial, timeout, spawn failure).
 
-**Async mode** (`async=true`): Returns `{status: "ok", job_id, pid, message}` immediately. Use `action="poll"` with the job_id to check status: returns `{status: "running", job_id, pid}` while running, or `{status: "done", exit_code, stdout, stderr, ok, command_status[, warning]}` once finished. Use `action="cancel"` to kill the process group.
+**Async mode** (`async=true`): Returns `{status: "ok", job_id, pid, message}` immediately. Use `action="poll"` with the job_id to check status: returns `{status: "running", job_id, pid}` while running, or `{status: "done", exit_code, stdout, stderr, ok, command_status[, warning]}` once finished. Use `action="cancel"` to kill the process group. Async run validates `reminder` as a finite non-negative number bounded by `threading.TIMEOUT_MAX` and defaults omitted direct calls to 1800 seconds (`__init__.py:385-408`, `__init__.py:436-441`).
 
-**Result fidelity — top-level `status` vs. inner command success.** The top-level `status` (`ok`/`done`) reflects only that the shell *spawned* the command; it stays `ok`/`done` even when the inner command exits nonzero. To make inner failures impossible to skim past *without* changing the `status` contract that downstream recovery/telemetry branch on (`tool_executor.py` enriches/logs/collects on `status == "error"`), `_augment_command_result` (`bash/__init__.py`) adds three additive, model-visible fields keyed off `exit_code`:
+**Result fidelity — top-level `status` vs. inner command success.** The top-level `status` (`ok`/`done`) reflects only that the shell *spawned* the command; it stays `ok`/`done` even when the inner command exits nonzero. To make inner failures impossible to skim past *without* changing the `status` contract that downstream recovery/telemetry branch on (`tool_executor.py` enriches/logs/collects on `status == "error"`), `_augment_command_result` (`__init__.py`) adds three additive, model-visible fields keyed off `exit_code`:
 
 - `ok` (bool) — `True` only when `exit_code == 0`.
 - `command_status` (str) — `"success"` or `"failed"`.
@@ -55,7 +56,7 @@ On a still-running poll there is no `exit_code`, so no fidelity fields are added
 
 **Timeout hint.** On a sync timeout whose command resembles a broad recursive scan (`find … -name/-path/-type`, `rglob(`, `os.walk(`, `glob('**…')` — `_broad_scan_hint`), the timeout `message` appends an `rg --files`-based recipe. The hint is advisory text only; it never blocks or rewrites the command.
 
-Job files are stored under `system/jobs/{job_id}/` (stdout.log, stderr.log, pid, status). Cleaned up automatically on poll-completion or cancel.
+Job files are stored under `system/jobs/{job_id}/` (stdout.log, stderr.log, pid, status). Cleaned up automatically on poll-completion or cancel. The process-exit watcher still writes single-slot `.notification/bash.json` with a bounded command preview (`__init__.py:651-700`); the last-resort reminder uses `.notification/system.json` multi-event append with stable `ref_id="bash.reminder:<job_id>"` so close-due jobs do not overwrite one another (`__init__.py:531-649`, `src/lingtai_kernel/base_agent/messaging.py:66-180`).
 
 ## Internal Module Layout
 
@@ -75,11 +76,14 @@ bash/__init__.py
   │   └── _extract_commands(command) — parses pipes, chains, subshells to extract all command names
   │
   ├── BashManager                    — execution manager
-  │   ├── __init__(policy, working_dir, max_output) — stores policy + config
+  │   ├── __init__(policy, working_dir, max_output, agent) — stores policy, config, notification locks
   │   ├── handle(args)               — dispatches to _handle_run / _handle_poll / _handle_cancel
   │   ├── _handle_run(args)          — validates + runs sync or async
   │   ├── _run_sync(command, cwd, timeout) — subprocess.run path; augments result + timeout hint
-  │   ├── _run_async(command, cwd)   — subprocess.Popen with start_new_session, returns job_id
+  │   ├── _run_async(command, cwd, reminder) — subprocess.Popen with start_new_session, returns job_id
+  │   ├── _run_reminder_timer(...)   — daemon-threaded last-resort poll reminder
+  │   ├── _claim_reminder_timer(...) — lock-owned terminal-vs-deadline claim
+  │   ├── _publish_async_reminder(job_id) — appends bash.reminder system event
   │   ├── _handle_poll(args)         — checks job status; augments completed result
   │   ├── _handle_cancel(args)       — SIGTERM to process group, cleanup
   │   └── _close_handles(job_id)     — closes open file handles for a job
@@ -96,6 +100,7 @@ bash/__init__.py
 - **Output truncation:** `max_output = 50_000` chars. Both stdout and stderr are truncated with a note showing total length.
 - **Subprocess isolation:** Commands run via `subprocess.run(shell=True, capture_output=True, text=True, timeout=...)` in the agent's working directory by default.
 - **Async subprocess:** Async commands use `subprocess.Popen(shell=True, start_new_session=True)` with stdout/stderr redirected to files under `system/jobs/{job_id}/`. `start_new_session=True` ensures the process gets its own session, enabling `os.killpg()` for clean cancellation.
+- **Async reminder lifecycle:** `_run_async()` arms one daemon timer per job (`__init__.py:512-541`). The timer and terminal handling share `_reminder_lock`: `_claim_reminder_timer()` atomically pops the pending reminder before publish, while terminal `poll -> done` / successful `cancel` suppress by popping first (`__init__.py:543-577`, `__init__.py:742-744`, `__init__.py:800-801`). Process exit and `.notification/bash.json` completion do not cancel the timer.
 - **Job lifecycle:** Jobs are created on async run, tracked via PID files, and cleaned up (directory deleted) after poll-completion or cancel. File handles are closed via `_close_handles()` to avoid resource leaks.
 - **Policy file location:** Default policy is `bash/bash_policy.json` (shipped with the kernel). Can be overridden via `policy_file` arg or bypassed with `yolo=True`.
 
@@ -103,6 +108,8 @@ bash/__init__.py
 
 - `lingtai.i18n` — `t()` for localized strings
 - `lingtai_kernel.base_agent.BaseAgent` — agent type (TYPE_CHECKING only)
+- `lingtai_kernel.base_agent.messaging._enqueue_system_notification` — canonical `.notification/system.json` multi-event append path when Bash is installed on an agent (`src/lingtai_kernel/base_agent/messaging.py:66-180`).
+- `lingtai_kernel.notifications.collect_notifications` / `submit` — direct-manager fallback for tests and programmatic BashManager use without a BaseAgent; protected by the agent's shared system lock when present, otherwise a module-global fallback lock (`__init__.py:605-649`).
 - `lingtai_kernel.trace_redaction.redact_text` — mechanical secret redaction for the stderr tail hoisted into `warning` (imported lazily inside `_redact_warning_tail`, fail-open).
 
 ## Composition

--- a/src/tools/bash/CONTRACT.md
+++ b/src/tools/bash/CONTRACT.md
@@ -54,15 +54,20 @@ does not stream output incrementally (async jobs are polled, not streamed).
 
 ## Tool surface
 
-`get_schema` requires nothing at the schema level (`required: []`); the handler
-enforces per-action requirements. `action` defaults to `run`.
+`get_schema` marks `reminder` required at the top schema level to satisfy the
+provider-facing required-option contract. Provider-validated sync `run`,
+`poll`, and `cancel` calls therefore also carry `reminder` on the wire, but the
+handler consumes and validates it only for async `run`; sync `run`, `poll`, and
+`cancel` ignore it. Direct async runtime calls that omit it still default to
+1800 seconds for compatibility. The handler enforces per-action requirements
+for `command` and `job_id`. `action` defaults to `run`.
 
 | Action | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|
-| `run` (sync) | `command` | `working_dir`, `timeout` (default 30), `summary` | `{status: "ok", exit_code, stdout, stderr, ok, command_status, warning?}` | `{status: "error", message}` — empty command, policy-denied, cwd outside sandbox, timeout (with broad-scan hint), or spawn failure |
-| `run` (async) | `command`, `async: true` | `working_dir`, `summary` | `{status: "ok", job_id, pid, message}` | `{status: "error", message}` — same validation errors, plus `Failed to start async job: ...` |
-| `poll` | `job_id` | — | running: `{status: "running", job_id, pid}`; finished: `{status: "done", exit_code, stdout, stderr, ok, command_status, warning?}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or `Job already finished (...)` |
-| `cancel` | `job_id` | — | `{status: "cancelled", job_id}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or `Job already finished (...)` |
+| `run` (sync) | Provider schema: `command`, `reminder`; runtime consumes `command` only | `working_dir`, `timeout` (default 30), `summary` | `{status: "ok", exit_code, stdout, stderr, ok, command_status, warning?}` | `{status: "error", message}` — empty command, policy-denied, cwd outside sandbox, timeout (with broad-scan hint), or spawn failure |
+| `run` (async) | Provider/runtime: `command`, `async: true`, `reminder` | `working_dir`, `summary` | `{status: "ok", job_id, pid, message}` | `{status: "error", message}` — same validation errors, invalid boolean/non-numeric/non-finite/negative/too-large `reminder`, plus `Failed to start async job: ...` |
+| `poll` | Provider schema: `job_id`, `reminder`; runtime consumes `job_id` only | — | running: `{status: "running", job_id, pid}`; finished: `{status: "done", exit_code, stdout, stderr, ok, command_status, warning?}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or `Job already finished (...)` |
+| `cancel` | Provider schema: `job_id`, `reminder`; runtime consumes `job_id` only | — | `{status: "cancelled", job_id}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or `Job already finished (...)` |
 
 Fidelity fields are additive and keyed off `exit_code`: `ok` is `True` only when
 `exit_code == 0`; `command_status` is `"success"`/`"failed"`; `warning` is
@@ -73,6 +78,13 @@ inner failure is surfaced through the additive fields, not by changing `status`.
 
 Unknown/invalid `job_id` values containing `/`, `\`, or `..` are rejected before
 any filesystem access (path-traversal guard).
+
+`reminder` is a finite non-negative number of seconds used only for async
+`run`; booleans, non-numeric values, non-finite values (`NaN`, `Infinity`),
+negative values, and values larger than `threading.TIMEOUT_MAX` are rejected
+because the timer backend cannot accept them safely. The schema default is 1800
+seconds. Direct runtime calls that omit it still get 1800 seconds, so older
+callers keep working even though providers see the field as required.
 
 ## State & storage
 
@@ -86,6 +98,7 @@ All paths are relative to the agent working directory (`<agent>/`):
   stdout.log    # streamed child stdout
   stderr.log    # streamed child stderr
 <agent>/.notification/bash.json   # written by the async watcher on job exit
+<agent>/.notification/system.json # appended by the last-resort async reminder
 ```
 
 `job_id` is `job-<8 hex>`. On `poll`-to-completion or `cancel`, the job
@@ -94,6 +107,17 @@ watcher thread writes `.notification/bash.json` atomically (`.tmp` + rename) whe
 the process exits, so completion reaches the agent through the same notification
 channel as email/soul/molt. `stdout`/`stderr` are truncated to `max_output`
 (default 50_000 chars) with a trailing `... (truncated, N chars total)` marker.
+
+Async run also arms a daemon-threaded last-resort reminder. When `reminder`
+seconds elapse, the deadline path atomically claims the job under the same
+reminder lock used by terminal handling. If terminal `poll -> done` or
+successful `cancel` popped the job first, the reminder is suppressed; if the
+deadline claims first, the reminder legitimately wins and Bash appends one
+`bash.reminder` event to `.notification/system.json` with stable
+`ref_id="bash.reminder:<job_id>"` and a poll instruction. The reminder is
+intentionally **not** cancelled just because the process exits or the normal
+`.notification/bash.json` completion notification was written: an unpolled
+completed job still needs the fallback.
 
 ## Cross-platform invariants
 
@@ -126,6 +150,11 @@ for cancellation correctness.
 | Warning-tail redaction fails open when the redactor is unavailable | `src/tools/bash/__init__.py` | `tests/test_bash_async.py::test_fail_open_returns_input_when_redactor_unavailable` |
 | Allowlist mode permits only listed commands; denylist blocks listed ones | `src/tools/bash/__init__.py` | `tests/test_layers_bash.py::test_allow_only`, `::test_deny_only`, `::test_pipe_awareness` |
 | Policy is enforced on async runs too | `src/tools/bash/__init__.py` | `tests/test_bash_async.py::test_policy_applies_to_async` |
+| Async `reminder` defaults to 1800 for omitted direct calls while schema marks it required | `src/tools/bash/__init__.py` | `tests/test_bash_async.py::test_schema_requires_reminder_with_runtime_default` |
+| Last-resort reminders survive process exit until terminal poll/cancel and append without overwriting close due jobs | `src/tools/bash/__init__.py` | `tests/test_bash_async.py::test_async_reminder_publishes_after_delay_even_if_process_exited_unpolled`, `::test_async_reminder_does_not_overwrite_close_due_jobs`, `::test_terminal_poll_suppresses_async_reminder`, `::test_successful_cancel_suppresses_async_reminder` |
+| Reminder validation rejects non-finite and backend-unsafe delays | `src/tools/bash/__init__.py` | `tests/test_bash_async.py::test_async_reminder_rejects_invalid_values` |
+| Deadline claim and terminal handling have deterministic lock-owned ordering | `src/tools/bash/__init__.py` | `tests/test_bash_async.py::test_terminal_pop_before_deadline_claim_suppresses_reminder`, `::test_deadline_claim_before_terminal_pop_publishes_once` |
+| Direct-manager fallback appends remain multi-event safe across managers | `src/tools/bash/__init__.py` | `tests/test_bash_async.py::test_direct_manager_fallback_is_shared_across_managers` |
 | `yolo=True` allows all commands | `src/tools/bash/__init__.py` | `tests/test_layers_bash.py::test_add_capability_bash_yolo` |
 
 ## Verification matrix
@@ -133,6 +162,7 @@ for cancellation correctness.
 | Invariant | Automated test | Manual check | Risk if broken |
 |---|---|---|---|
 | Async job lifecycle (start/poll/cancel) is correct | `tests/test_bash_async.py` | Run a `sleep 30` async job, poll it, then cancel it | Orphaned processes / zombies; agent cannot stop background work |
+| Async reminder does not overwrite a sibling reminder | `tests/test_bash_async.py::test_async_reminder_does_not_overwrite_close_due_jobs` | Start two async `sleep` jobs with short reminders and inspect `.notification/system.json` | Close-due fallback reminders are lost instead of being preserved as separate system events |
 | Cancel kills the whole process group | `tests/test_bash_async.py::test_cancel_kills_process` | Start a job that forks children, cancel it, confirm all die | Runaway child processes survive cancellation |
 | Policy allow/deny (incl. pipes/chains) is enforced | `tests/test_layers_bash.py` | Configure an allowlist, try a denied command, confirm refusal | Sandbox escape via unlisted or piped commands |
 | Inner command failure is surfaced despite `status: ok` | `tests/test_bash_async.py::test_nonzero_exit_is_flagged_failed_with_warning` | Run `python -c 'import nope'`, confirm `ok=false` + `warning` | Agents proceed on silent inner failures |

--- a/src/tools/bash/__init__.py
+++ b/src/tools/bash/__init__.py
@@ -11,6 +11,7 @@ Usage:
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import signal
@@ -27,6 +28,8 @@ if TYPE_CHECKING:
 PROVIDERS = {"providers": [], "default": "builtin"}
 
 _DEFAULT_POLICY_FILE = Path(__file__).parent / "bash_policy.json"
+_DEFAULT_ASYNC_REMINDER_SECONDS = 1800.0
+_SYSTEM_NOTIFICATION_FALLBACK_LOCK = threading.Lock()
 
 # Length of the stderr tail surfaced in the failure warning. Short on purpose:
 # the full stderr is already present in the result; the tail just makes the
@@ -201,6 +204,11 @@ def get_schema(lang: str = "en") -> dict:
                 "description": "Run command in background and return immediately with a job_id (default: false, only for action='run')",
                 "default": False,
             },
+            "reminder": {
+                "type": "number",
+                "description": "Last-resort async wake delay in seconds (default: 1800). For async run only: if the job has not been terminally polled or cancelled by then, publish a system notification reminding you to poll it.",
+                "default": _DEFAULT_ASYNC_REMINDER_SECONDS,
+            },
             "job_id": {
                 "type": "string",
                 "description": 'Job ID for poll/cancel actions (returned by async run)',
@@ -211,7 +219,7 @@ def get_schema(lang: str = "en") -> dict:
                 "default": False,
             },
         },
-        "required": [],  # command required only for action=run; job_id for poll/cancel
+        "required": ["reminder"],  # command/job_id are enforced per action; handler defaults omitted reminder for runtime compatibility
     }
 
 
@@ -315,11 +323,15 @@ class BashManager:
         policy: BashPolicy,
         working_dir: str,
         max_output: int = 50_000,
+        agent: "BaseAgent | None" = None,
     ):
         self._policy = policy
         self._working_dir = working_dir
         self._max_output = max_output
+        self._agent = agent
         self._jobs_dir: Path | None = None
+        self._reminder_lock = threading.Lock()
+        self._reminder_cancel_events: dict[str, threading.Event] = {}
 
     def _ensure_jobs_dir(self) -> Path:
         """Create and return the jobs directory (lazy init)."""
@@ -370,6 +382,31 @@ class BashManager:
             return {"status": "error", "message": f"Invalid job_id: {job_id}"}
         return None
 
+    @staticmethod
+    def _validate_reminder(value) -> tuple[float | None, dict | None]:
+        """Validate async reminder delay, defaulting omitted values for runtime compatibility."""
+        if value is None:
+            return _DEFAULT_ASYNC_REMINDER_SECONDS, None
+        if isinstance(value, bool):
+            return None, {"status": "error", "message": "reminder must be a finite non-negative number of seconds"}
+        try:
+            delay = float(value)
+        except (TypeError, ValueError):
+            return None, {"status": "error", "message": "reminder must be a finite non-negative number of seconds"}
+        if (
+            delay < 0
+            or not math.isfinite(delay)
+            or delay > threading.TIMEOUT_MAX
+        ):
+            return None, {
+                "status": "error",
+                "message": (
+                    "reminder must be a finite non-negative number of seconds "
+                    f"not greater than {threading.TIMEOUT_MAX}"
+                ),
+            }
+        return delay, None
+
     def handle(self, args: dict) -> dict:
         action = args.get("action", "run")
 
@@ -398,7 +435,10 @@ class BashManager:
 
         is_async = args.get("async", False)
         if is_async:
-            return self._run_async(command, cwd)
+            reminder, err = self._validate_reminder(args.get("reminder"))
+            if err:
+                return err
+            return self._run_async(command, cwd, reminder)
         return self._run_sync(command, cwd, args.get("timeout", 30))
 
     def _run_sync(self, command: str, cwd: str, timeout: float) -> dict:
@@ -434,7 +474,7 @@ class BashManager:
         except Exception as e:
             return {"status": "error", "message": f"Command failed: {e}"}
 
-    def _run_async(self, command: str, cwd: str) -> dict:
+    def _run_async(self, command: str, cwd: str, reminder: float) -> dict:
         """Start command in background, return job_id immediately."""
         jobs_dir = self._ensure_jobs_dir()
         job_id = f"job-{uuid.uuid4().hex[:8]}"
@@ -469,6 +509,7 @@ class BashManager:
         if not hasattr(self, "_open_handles"):
             self._open_handles: dict[str, tuple] = {}
         self._open_handles[job_id] = (proc, stdout_f, stderr_f)
+        self._start_reminder_timer(job_id, job_dir, reminder)
 
         # Start background watcher — writes .notification/bash.json when
         # the process exits, so the agent gets notified via the standard
@@ -486,6 +527,126 @@ class BashManager:
             "pid": proc.pid,
             "message": f'Job started. Use bash(action="poll", job_id="{job_id}") to check.',
         }
+
+    def _start_reminder_timer(self, job_id: str, job_dir: Path, delay: float) -> None:
+        """Arm the last-resort async poll reminder for a job."""
+        cancel_event = threading.Event()
+        with self._reminder_lock:
+            self._reminder_cancel_events[job_id] = cancel_event
+        timer = threading.Thread(
+            target=self._run_reminder_timer,
+            args=(job_id, job_dir, delay, cancel_event),
+            daemon=True,
+        )
+        timer.start()
+
+    def _run_reminder_timer(
+        self,
+        job_id: str,
+        job_dir: Path,
+        delay: float,
+        cancel_event: threading.Event,
+    ) -> None:
+        """Publish one reminder unless terminal poll/cancel handles the job first."""
+        if cancel_event.wait(delay):
+            return
+        if not self._claim_reminder_timer(job_id, job_dir, cancel_event):
+            return
+        self._publish_async_reminder(job_id)
+
+    def _claim_reminder_timer(
+        self,
+        job_id: str,
+        job_dir: Path,
+        cancel_event: threading.Event,
+    ) -> bool:
+        """Atomically claim the reminder deadline before publishing."""
+        with self._reminder_lock:
+            current = self._reminder_cancel_events.get(job_id)
+            if current is not cancel_event or cancel_event.is_set() or not job_dir.is_dir():
+                return False
+            self._reminder_cancel_events.pop(job_id, None)
+            cancel_event.set()
+            return True
+
+    def _cancel_reminder_timer(self, job_id: str) -> None:
+        """Suppress and forget a pending reminder after terminal poll/cancel."""
+        with self._reminder_lock:
+            cancel_event = self._reminder_cancel_events.pop(job_id, None)
+        if cancel_event is not None:
+            cancel_event.set()
+
+    def _publish_async_reminder(self, job_id: str) -> None:
+        """Append the last-resort reminder to the durable multi-event system channel."""
+        body = (
+            f"Bash async job {job_id} may still be running. "
+            f"Poll it with bash(action=\"poll\", job_id=\"{job_id}\")."
+        )
+        agent = self._agent
+        if agent is not None and hasattr(agent, "_enqueue_system_notification"):
+            try:
+                agent._enqueue_system_notification(
+                    source="bash.reminder",
+                    ref_id=f"bash.reminder:{job_id}",
+                    body=body,
+                    skip_if_ref_id_exists=True,
+                )
+                return
+            except Exception:
+                pass
+        fallback_lock = getattr(agent, "_system_notification_lock", None)
+        self._append_system_notification_fallback(
+            source="bash.reminder",
+            ref_id=f"bash.reminder:{job_id}",
+            body=body,
+            lock=fallback_lock,
+        )
+
+    def _append_system_notification_fallback(
+        self,
+        *,
+        source: str,
+        ref_id: str,
+        body: str,
+        lock: threading.Lock | None = None,
+    ) -> str:
+        """Small direct-manager equivalent of BaseAgent._enqueue_system_notification."""
+        import secrets
+        import time
+        from datetime import datetime, timezone
+
+        from lingtai_kernel.notifications import collect_notifications
+        from lingtai_kernel.notifications import submit as publish_notification
+
+        event_id = f"evt_{int(time.time()*1000):x}_{secrets.token_hex(8)}"
+        received_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        actual_lock = lock or _SYSTEM_NOTIFICATION_FALLBACK_LOCK
+        with actual_lock:
+            current = collect_notifications(Path(self._working_dir)).get("system", {})
+            events = list(current.get("data", {}).get("events", []))
+            if any(isinstance(ev, dict) and ev.get("ref_id") == ref_id for ev in events):
+                return ""
+            events.append({
+                "event_id": event_id,
+                "source": source,
+                "ref_id": ref_id,
+                "body": body,
+                "at": received_at,
+            })
+            events = events[-20:]
+            publish_notification(
+                Path(self._working_dir),
+                "system",
+                header=(
+                    f"{len(events)} system notification"
+                    f"{'s' if len(events) != 1 else ''}"
+                ),
+                icon="🔔",
+                priority="normal",
+                data={"events": events},
+            )
+        return event_id
 
     def _watch_async_job(
         self, job_id: str, command: str, proc: subprocess.Popen,
@@ -579,6 +740,7 @@ class BashManager:
             return {"status": "running", "job_id": job_id, "pid": pid}
 
         # Process finished — close file handles, read output
+        self._cancel_reminder_timer(job_id)
         self._close_handles(job_id)
 
         stdout = (job_dir / "stdout.log").read_text(encoding="utf-8", errors="replace")
@@ -636,6 +798,7 @@ class BashManager:
                 proc.wait()
 
         self._close_handles(job_id)
+        self._cancel_reminder_timer(job_id)
 
         # Clean up
         import shutil
@@ -685,6 +848,7 @@ def setup(
     mgr = BashManager(
         policy=policy,
         working_dir=str(agent._working_dir),
+        agent=agent,
     )
     # Build description with policy rules
     desc = get_description()

--- a/src/tools/bash/glossary-wen.md
+++ b/src/tools/bash/glossary-wen.md
@@ -12,5 +12,6 @@ language: wen
 - `timeout`：超时秒数（默认：30，唯同步执行时生效）
 - `working_dir`：指令之工作目录（可选）。留空或传空字符串即用 agent 工作目录。须在 agent 工作目录沙箱之内；沙箱外路径会被拒。若需操作外部仓库/路径，请令 working_dir 保持为 agent 目录，并在 command 中显式 cd，如 cd /absolute/path && ...
 - `async`：后台运行指令，即返 job_id（默认：false，唯 action='run' 时生效）
+- `reminder`：异步兜底唤醒之延迟秒数（默认 1800）。顶层 schema 要求此字段，故经 provider 校验之同步 run、poll、cancel 亦携之；运行时唯异步 run 用且校验之，余动作忽略。任务届时若未被终态 poll 或 cancel，则发 system 通知，促其 poll。
 - `job_id`：异步任务之号，用于 poll/cancel（由异步 run 所返）
 - `summary`：可选。默认 false。设 true 时，此 tool 照常运行，原始结果完存于持久日志（可凭 tool_call_id 取回）；然结果入尔上下文前，先以尔 `reasoning` 字段所驱之 LLM 摘要代之——故 `reasoning` 当明言所欲存者。唯料输出甚巨（逾一万字符）且无需精确原文时，方设 true。需精确之行/文件/diff/stderr 原文者，留 false。摘要非权威；原始结果逾五十万字符，则不生摘要，尔得一拒辞，指向所存之原始结果。

--- a/src/tools/bash/glossary-zh.md
+++ b/src/tools/bash/glossary-zh.md
@@ -12,5 +12,6 @@ language: zh
 - `timeout`：超时秒数（默认：30，仅同步执行时生效）
 - `working_dir`：命令的工作目录（可选）。留空或传空字符串即使用 agent 工作目录。必须位于 agent 工作目录沙箱内；沙箱外路径会被拒绝。若要操作外部仓库/路径，请将 working_dir 保持为 agent 目录，并在 command 中显式 cd，例如 cd /absolute/path && ...
 - `async`：后台运行命令并立即返回 job_id（默认：false，仅 action='run' 时生效）
+- `reminder`：兜底异步唤醒延迟秒数（默认 1800）。顶层 schema 要求提供此字段，所以 provider 校验过的同步 run、poll、cancel 也会携带它；运行时只在异步 run 中使用并校验它，其他动作忽略。若任务届时尚未被终态 poll 或 cancel，则发布 system 通知提醒 poll。
 - `job_id`：异步任务 ID，用于 poll/cancel（由异步 run 返回）
 - `summary`：可选。默认 false。为 true 时，该 tool 照常执行，原始结果会完整保存到持久日志（可按 tool_call_id 取回），但在结果进入你的上下文之前，会被一段由你的 `reasoning` 字段驱动的 LLM 生成摘要替换——所以请在 `reasoning` 中明确说明要保留什么。仅当预期输出很大（>10k 字符）且你不需要精确原文时才设为 true。需要精确的行/文件/diff/stderr 原文时请保持 false。摘要非权威；若原始结果超过 500,000 字符则不生成摘要，你会收到一条指向已保存原始结果的拒绝信息。

--- a/src/tools/bash/manual/SKILL.md
+++ b/src/tools/bash/manual/SKILL.md
@@ -7,7 +7,7 @@ description: >
   launchd, systemd timers, crontab jobs, or scheduled reminders.** Router for
   Bash-related operational depth beyond the bash tool schema: async + poll
   discipline for long-running child agents, host-scheduler setup, LingTai
-  wake-by-mailbox-drop, script hygiene, one-shot `.notification/cron.json`
+  wake-by-mailbox-drop, built-in async last-resort reminders, script hygiene, one-shot `.notification/cron.json`
   reminders, debugging silent jobs, and safe cleanup. Start here for any
   long-running agent CLI, time-driven recurring work ("every hour", "weekdays at
   9", "remind me later"), or when a scheduled job misbehaves.
@@ -19,7 +19,7 @@ last_changed_at: "2026-06-24T14:38:03-07:00"
 
 The `bash` tool schema covers one-off command execution. This manual routes to
 operational depth that is too long for the schema: host scheduling, mailbox-drop
-wakeups, reminder files, debugging, and cleanup.
+wakeups, async last-resort reminders, reminder files, debugging, and cleanup.
 
 For ordinary short, deterministic one-off shell commands, use the tool schema
 synchronously. For anything involving time, recurring work, external schedulers,
@@ -208,18 +208,18 @@ reading the whole file when you only need recent events.
 
   ```text
   # Start the child agent in the background — returns immediately with a job_id:
-  bash(async=true, command="claude -p 'refactor the auth module' --output-format json")
-  # → {"status": "ok", "job_id": "ab12…", "pid": 4321}
+  bash(async=true, reminder=1800, command="claude -p 'refactor the auth module' --output-format json")
+  # → {"status": "ok", "job_id": "job-a1b2c3d4", "pid": 4321}
 
   # Later turns: poll until done (handle mail/other work between polls):
-  bash(action="poll", job_id="ab12…")
+  bash(action="poll", job_id="job-a1b2c3d4", reminder=1800)
   # → {"status": "running", …}   then eventually
   # → {"status": "done", "exit_code": 0, "ok": true, "command_status": "success", "stdout": "…", "stderr": "…"}
   #   On failure: {"status": "done", "exit_code": 1, "ok": false,
   #                "command_status": "failed", "warning": "command exited with code 1; …"}
 
   # Abandon it if needed:
-  bash(action="cancel", job_id="ab12…")
+  bash(action="cancel", job_id="job-a1b2c3d4", reminder=1800)
   ```
 
 - **If repeated-call `_advisory` appears on `bash(action="poll")`, stop
@@ -230,20 +230,27 @@ reading the whole file when you only need recent events.
   a completion notification arrives, the reminder fires, or you have a concrete
   reason to expect new state.
 
-- **Idle care: never hand a launched async job entirely to its completion
-  notification.** Once you start a long-running agent/coding CLI with
-  `bash(async=true)` (or any child sub-process), do not go fully IDLE relying
-  only on the completion/IDLE signal. Before resting, arm **at least one**
-  self-wake (a `.notification/cron.json` reminder or an internal delayed
-  self-email). Pick the delay from the task's *expected* duration — not a fixed
-  number; a 30 s scan and a 40 min build warrant different windows. When the
-  wake fires, health-check rather than assume progress: confirm the log is
-  **growing**, the PID/child is **alive**, the output file/worktree shows
+- **Idle care: set an async `reminder` that matches the expected duration.**
+  Every `bash(async=true)` call has a last-resort `reminder` delay, required in
+  the top-level provider schema and defaulted by the runtime to 1800 seconds
+  when omitted by older direct callers. Provider-facing sync commands, `poll`,
+  and `cancel` also carry `reminder` because of that schema shape, but the field
+  is meaningful and runtime-validated only for async `run`; sync commands,
+  `poll`, and `cancel` ignore it.
+  When that delay expires, Bash publishes a `bash.reminder` event into
+  `.notification/system.json` unless the job has already been terminally polled
+  or cancelled. The normal completion notification still arrives through
+  `.notification/bash.json`; the reminder is separate and intentionally still
+  fires for an unpolled job even if the process already exited. Pick the delay
+  from the task's *expected* duration — not a fixed number; a 30 s scan and a
+  40 min build warrant different windows. When the reminder fires, health-check
+  rather than assume progress: poll the job, confirm the log is **growing**, the
+  PID/child is **alive** if still running, the output file/worktree shows
   **progress**, and the job is not stuck on an interactive prompt or a
   provider/model error. If there is no progress, do not keep waiting — cancel,
-  downgrade, or switch path, and report to the human. A job that exits
-  immediately or sits silent past its expected window is the failure mode this
-  rule exists to catch.
+  downgrade, or switch path, and report to the human. Use a separate
+  `.notification/cron.json` reminder or delayed self-email only for a broader
+  workflow wake that is not tied to one Bash async job.
 
 - LingTai has no built-in recurring scheduler. Host schedulers wake agents by
   producing channel input, usually a mailbox-drop or notification file.

--- a/tests/test_bash_async.py
+++ b/tests/test_bash_async.py
@@ -1,11 +1,15 @@
 """Tests for async mode of the bash capability."""
 import json
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
 
-from tools.bash import BashManager, BashPolicy
+from lingtai_kernel.notifications import collect_notifications
+from tools.bash import BashManager, BashPolicy, get_schema
 
 
 class TestBashAsync:
@@ -172,6 +176,13 @@ class TestBashAsync:
         assert result["exit_code"] == 0
         assert "sync-test" in result["stdout"]
 
+    def test_sync_ignores_reminder_field(self, tmp_path):
+        mgr = self._make_manager(tmp_path)
+        result = mgr.handle({"command": "echo sync-test", "reminder": float("nan")})
+        assert result["status"] == "ok"
+        assert result["exit_code"] == 0
+        assert "sync-test" in result["stdout"]
+
     def test_async_stderr_captured(self, tmp_path):
         mgr = self._make_manager(tmp_path)
         result = mgr.handle({"command": "echo err >&2", "async": True})
@@ -182,3 +193,220 @@ class TestBashAsync:
         poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
         assert poll["status"] == "done"
         assert "err" in poll["stderr"]
+
+    def test_schema_requires_reminder_with_runtime_default(self, tmp_path):
+        schema = get_schema()
+        assert "reminder" in schema["required"]
+        assert schema["properties"]["reminder"]["default"] == 1800.0
+
+        mgr = self._make_manager(tmp_path)
+        result = mgr.handle({"command": "echo compat", "async": True})
+        assert result["status"] == "ok"
+        mgr.handle({"action": "cancel", "command": "", "job_id": result["job_id"]})
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            -1,
+            "soon",
+            object(),
+            True,
+            float("nan"),
+            float("inf"),
+            -float("inf"),
+            threading.TIMEOUT_MAX + 1,
+        ],
+    )
+    def test_async_reminder_rejects_invalid_values(self, tmp_path, value):
+        mgr = self._make_manager(tmp_path)
+        result = mgr.handle({"command": "echo nope", "async": True, "reminder": value})
+        assert result["status"] == "error"
+        assert "reminder" in result["message"]
+
+    def test_async_reminder_publishes_after_delay_even_if_process_exited_unpolled(self, tmp_path):
+        mgr = self._make_manager(tmp_path)
+        result = mgr.handle({"command": "echo finished", "async": True, "reminder": 0.05})
+        job_id = result["job_id"]
+
+        time.sleep(0.3)
+
+        events = collect_notifications(tmp_path)["system"]["data"]["events"]
+        assert len(events) == 1
+        event = events[0]
+        assert event["source"] == "bash.reminder"
+        assert event["ref_id"] == f"bash.reminder:{job_id}"
+        assert job_id in event["body"]
+        assert "poll" in event["body"]
+        assert "echo finished" not in event["body"]
+
+        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        assert poll["status"] == "done"
+
+    def test_async_reminder_does_not_overwrite_close_due_jobs(self, tmp_path):
+        mgr = self._make_manager(tmp_path)
+        first = mgr.handle({"command": "sleep 1", "async": True, "reminder": 0.05})
+        second = mgr.handle({"command": "sleep 1", "async": True, "reminder": 0.05})
+        job_ids = {first["job_id"], second["job_id"]}
+
+        time.sleep(0.3)
+
+        events = collect_notifications(tmp_path)["system"]["data"]["events"]
+        assert len(events) == 2
+        assert {event["ref_id"] for event in events} == {
+            f"bash.reminder:{job_id}" for job_id in job_ids
+        }
+        assert len({event["event_id"] for event in events}) == 2
+
+        for job_id in job_ids:
+            mgr.handle({"action": "cancel", "command": "", "job_id": job_id})
+
+    def test_terminal_poll_suppresses_async_reminder(self, tmp_path):
+        mgr = self._make_manager(tmp_path)
+        result = mgr.handle({"command": "echo handled", "async": True, "reminder": 0.3})
+        job_id = result["job_id"]
+
+        time.sleep(0.1)
+        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        assert poll["status"] == "done"
+        time.sleep(0.3)
+
+        assert "system" not in collect_notifications(tmp_path)
+
+    def test_successful_cancel_suppresses_async_reminder(self, tmp_path):
+        mgr = self._make_manager(tmp_path)
+        result = mgr.handle({"command": "sleep 5", "async": True, "reminder": 0.2})
+        job_id = result["job_id"]
+
+        cancel = mgr.handle({
+            "action": "cancel",
+            "command": "",
+            "job_id": job_id,
+            "reminder": float("nan"),
+        })
+        assert cancel["status"] == "cancelled"
+        time.sleep(0.3)
+
+        assert "system" not in collect_notifications(tmp_path)
+
+    def test_poll_ignores_reminder_field(self, tmp_path):
+        mgr = self._make_manager(tmp_path)
+        result = mgr.handle({"command": "sleep 5", "async": True, "reminder": 10})
+        job_id = result["job_id"]
+
+        poll = mgr.handle({
+            "action": "poll",
+            "command": "",
+            "job_id": job_id,
+            "reminder": float("nan"),
+        })
+        assert poll["status"] == "running"
+
+        mgr.handle({"action": "cancel", "command": "", "job_id": job_id})
+
+    def test_terminal_pop_before_deadline_claim_suppresses_reminder(self, tmp_path, monkeypatch):
+        mgr = self._make_manager(tmp_path)
+        job_id = "job-race-terminal"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        cancel_event = threading.Event()
+        with mgr._reminder_lock:
+            mgr._reminder_cancel_events[job_id] = cancel_event
+
+        published = []
+        monkeypatch.setattr(mgr, "_publish_async_reminder", published.append)
+
+        mgr._cancel_reminder_timer(job_id)
+        mgr._run_reminder_timer(job_id, job_dir, 0, cancel_event)
+
+        assert published == []
+        assert job_id not in mgr._reminder_cancel_events
+
+    def test_deadline_claim_before_terminal_pop_publishes_once(self, tmp_path, monkeypatch):
+        mgr = self._make_manager(tmp_path)
+        job_id = "job-race-deadline"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        cancel_event = threading.Event()
+        with mgr._reminder_lock:
+            mgr._reminder_cancel_events[job_id] = cancel_event
+
+        published = []
+
+        def fake_publish(claimed_job_id):
+            published.append(claimed_job_id)
+            mgr._cancel_reminder_timer(claimed_job_id)
+
+        monkeypatch.setattr(mgr, "_publish_async_reminder", fake_publish)
+
+        mgr._run_reminder_timer(job_id, job_dir, 0, cancel_event)
+
+        assert published == [job_id]
+        assert job_id not in mgr._reminder_cancel_events
+
+    def test_agent_exception_fallback_uses_agent_system_lock(self, tmp_path, monkeypatch):
+        agent_lock = threading.Lock()
+        agent = SimpleNamespace(_system_notification_lock=agent_lock)
+
+        def failing_enqueue(**_kwargs):
+            raise RuntimeError("boom")
+
+        agent._enqueue_system_notification = failing_enqueue
+        mgr = BashManager(policy=BashPolicy.yolo(), working_dir=str(tmp_path), agent=agent)
+
+        seen = {}
+
+        def fake_fallback(**kwargs):
+            seen.update(kwargs)
+
+        monkeypatch.setattr(mgr, "_append_system_notification_fallback", fake_fallback)
+
+        mgr._publish_async_reminder("job-fallback")
+
+        assert seen["lock"] is agent_lock
+
+    def test_direct_manager_fallback_is_shared_across_managers(self, tmp_path):
+        first = self._make_manager(tmp_path)
+        second = self._make_manager(tmp_path)
+        managers = [first, second]
+        n_events = 20
+
+        def worker(i: int) -> None:
+            managers[i % 2]._append_system_notification_fallback(
+                source="bash.reminder",
+                ref_id=f"bash.reminder:job-{i}",
+                body=f"poll job-{i}",
+            )
+
+        with ThreadPoolExecutor(max_workers=n_events) as pool:
+            list(pool.map(worker, range(n_events)))
+
+        events = collect_notifications(tmp_path)["system"]["data"]["events"]
+        assert len(events) == n_events
+        assert {event["ref_id"] for event in events} == {
+            f"bash.reminder:job-{i}" for i in range(n_events)
+        }
+        assert len({event["event_id"] for event in events}) == n_events
+
+    def test_direct_manager_fallback_event_ids_keep_entropy_with_fixed_millisecond(
+        self, tmp_path, monkeypatch
+    ):
+        mgr = self._make_manager(tmp_path)
+        suffixes = iter(("a" * 16, "b" * 16))
+        monkeypatch.setattr("time.time", lambda: 1234.567)
+        monkeypatch.setattr("secrets.token_hex", lambda n: next(suffixes))
+
+        first = mgr._append_system_notification_fallback(
+            source="bash.reminder",
+            ref_id="bash.reminder:job-a",
+            body="poll job-a",
+        )
+        second = mgr._append_system_notification_fallback(
+            source="bash.reminder",
+            ref_id="bash.reminder:job-b",
+            body="poll job-b",
+        )
+
+        assert first.startswith("evt_")
+        assert second.startswith("evt_")
+        assert first != second
+        assert [len(event_id.rsplit("_", 1)[1]) for event_id in (first, second)] == [16, 16]

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -368,6 +368,30 @@ def test_system_publish_appends_event(tmp_path: Path) -> None:
     assert events[0]["event_id"] != events[1]["event_id"]
 
 
+def test_system_event_ids_keep_entropy_with_fixed_millisecond(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Same-millisecond events keep enough random suffix to avoid collisions."""
+    from lingtai_kernel.base_agent import messaging
+
+    suffixes = iter(("0" * 16, "1" * 16))
+    monkeypatch.setattr("time.time", lambda: 1234.567)
+    monkeypatch.setattr("secrets.token_hex", lambda n: next(suffixes))
+
+    agent = _ProducerStubAgent(_working_dir=tmp_path)
+    first = messaging._enqueue_system_notification(
+        agent, source="daemon", ref_id="ref_1", body="event 1"
+    )
+    second = messaging._enqueue_system_notification(
+        agent, source="daemon", ref_id="ref_2", body="event 2"
+    )
+
+    assert first.startswith("evt_")
+    assert second.startswith("evt_")
+    assert first != second
+    assert [len(event_id.rsplit("_", 1)[1]) for event_id in (first, second)] == [16, 16]
+
+
 def test_system_publish_caps_at_20(tmp_path: Path) -> None:
     """25 sequential calls keep only the 20 most recent events."""
     from lingtai_kernel.base_agent import messaging


### PR DESCRIPTION
## Summary

- require a provider-facing `reminder` option for Bash calls, with a runtime-compatible 1800-second default consumed only by async `run`
- arm one last-resort timer per async job and append a `bash.reminder` event to the multi-event system notification channel unless terminal `poll` or `cancel` wins first
- keep process-exit completion notifications separate, so an exited-but-unpolled job still gets the fallback wake
- harden system notification event IDs from 16 to 64 random bits after same-millisecond concurrency exposed a real collision flake
- document the provider/runtime distinction, lifecycle, validation bounds, and notification ownership

## Motivation

A read-only machine-wide audit found a strict lower bound of 54 completed Bash async jobs that crossed IDLE/ASLEEP without job-specific Bash delivery; 9 remained unhandled for at least 30 minutes. The fallback closes the long-tail wake gap without replacing normal completion delivery.

## Behavior

- schema: `reminder` is required and defaults to `1800`
- async `run`: validates a finite non-negative value up to `threading.TIMEOUT_MAX`
- sync `run`, `poll`, `cancel`: ignore the field at runtime
- terminal `poll -> done` / successful `cancel`: suppress a pending reminder
- process exit alone: does not suppress the reminder
- simultaneous reminders: append separate `system.json` events keyed by `bash.reminder:<job_id>`

## Validation

- `148 passed` — `tests/test_bash_async.py tests/test_layers_bash.py tests/test_notification_sync.py`
- glossary validator: 54 resources across 18 packages
- anatomy drift checker: 38 files, no drift
- `git diff --check`

The default Anaconda pytest executable segfaulted before collection in the local environment; the authoritative run used `/opt/homebrew/bin/python3`.
