### PR TITLE
fix(telegram): surface document download failures

### DIFF
--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -7,8 +7,8 @@ description: |
   messages, reply vs send, read/check/search, parse_mode/entities, chat_action, dynamic slash commands,
   and error surfacing. Pulled on demand via action='manual'; you do not need to
   call it before every send.
-version: 1.1.0
-last_changed_at: "2026-07-02T15:34:00-07:00"
+version: 1.1.1
+last_changed_at: "2026-07-10T14:24:00-07:00"
 ---
 
 # Telegram MCP — usage manual (progressive disclosure)
@@ -136,5 +136,14 @@ Important behavior notes:
   failure (e.g. missing `chat_id`, unreadable `media.path`, bad `parse_mode`).
   Check for the `'error'` key and surface or act on it rather than assuming the
   message was delivered.
+- The hosted Telegram Bot API limits `getFile` downloads to 20 MB. If an inbound
+  document cannot be downloaded, `read` retains its available Telegram metadata
+  without a local path, adds a safe bounded provider reason in `download_error`,
+  and includes actionable resend/alternate-transfer guidance in the message text.
+  For the hosted size error, ask for parts no larger than 20 MB or another transfer
+  method. No reply is sent to the Telegram user automatically.
+- Telegram's upstream local Bot API server can download files without that limit,
+  but this addon currently uses the official hosted endpoints and does not expose
+  local-server configuration or support.
 - A duplicate identical send returns `{'status': 'blocked'}`; treat that as
   'already sent', not as a transient error to retry.

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -56,6 +56,38 @@ _COMPOUND_ID_RE = re.compile(r"#([^\s:#]+:-?\d+:\d+)\b")
 _CONVERSATION_PREVIEW_MESSAGES = 20
 # Keep 20 structured Telegram messages below the MCP inbox structured metadata cap.
 _STRUCTURED_MESSAGE_TEXT_CAP = 500
+_DOCUMENT_DOWNLOAD_REASON_CAP = 200
+_TELEGRAM_API_ERROR_PREFIX = "Telegram API error: "
+
+
+def _safe_document_download_reason(exc: Exception) -> str:
+    """Return a bounded provider reason without retaining arbitrary exception text."""
+    detail = str(exc)
+    if detail.startswith(_TELEGRAM_API_ERROR_PREFIX):
+        description = " ".join(detail[len(_TELEGRAM_API_ERROR_PREFIX):].split())
+        if description:
+            return description[:_DOCUMENT_DOWNLOAD_REASON_CAP]
+
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+    exc_class = type(exc).__name__
+    if isinstance(status, int) and not isinstance(status, bool):
+        return f"{exc_class} (HTTP {status})"
+    return exc_class
+
+
+def _document_download_failure_notice(reason: str) -> str:
+    if reason.casefold() == "bad request: file is too big":
+        guidance = (
+            "Ask the sender to split the document into parts no larger than 20 MB "
+            "or use another transfer method."
+        )
+    else:
+        guidance = (
+            "Ask the sender to resend the document or use another transfer method."
+        )
+    return f"[Document download failed: {reason}. {guidance}]"
 
 
 def _looks_like_compound_id(value: str) -> bool:
@@ -653,14 +685,27 @@ class TelegramManager:
         file_id = None
         media_type = None
         media_meta: dict = {}
+        document_meta: dict = {}
 
         if tg_msg.get("photo"):
             # Photos come as array of sizes — take the largest
             file_id = tg_msg["photo"][-1]["file_id"]
             media_type = "photo"
         elif tg_msg.get("document"):
-            file_id = tg_msg["document"]["file_id"]
+            document = tg_msg["document"]
+            file_id = document["file_id"]
             media_type = "document"
+            document_meta = {
+                key: document[key]
+                for key in (
+                    "file_name",
+                    "file_size",
+                    "file_id",
+                    "file_unique_id",
+                    "mime_type",
+                )
+                if document.get(key) is not None
+            }
         elif tg_msg.get("voice"):
             # Voice messages: .oga format, typically short recordings
             file_id = tg_msg["voice"]["file_id"]
@@ -697,10 +742,28 @@ class TelegramManager:
                 "size": len(data),
                 **media_meta,
             }
-        except Exception as e:
-            import logging
-            logging.getLogger(__name__).warning(
-                "Failed to download media: %s", e,
+        except Exception as exc:
+            if media_type != "document":
+                logging.getLogger(__name__).warning(
+                    "Failed to download media: %s", exc,
+                )
+                return
+
+            reason = _safe_document_download_reason(exc)
+            payload["media"] = {
+                "type": "document",
+                **document_meta,
+                "download_error": reason,
+            }
+            failure_notice = _document_download_failure_notice(reason)
+            existing_text = str(payload.get("text") or "")
+            payload["text"] = (
+                f"{existing_text}\n\n{failure_notice}" if existing_text else failure_notice
+            )
+            log.warning(
+                "Failed to download inbound Telegram document (%s); "
+                "preserved metadata without path",
+                reason,
             )
 
     # ------------------------------------------------------------------

--- a/src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
+++ b/src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
@@ -120,7 +120,8 @@ where they share the `.notification/` filesystem protocol.
 5. **Model-visible persistent communication context.** When structured IM metadata is available, `build_notification_persistent_payload` emits `_meta.notification_persistent.mcp.<channel>` with `messages`, `events`, and comments through the shared `_ImPersistentLane` machinery. Delta lanes (Telegram, WeChat, Feishu) also carry `previous_block`; WhatsApp is snapshot/no-previous-block because the producer sends the current bounded conversation window per event. Telegram additionally carries full out-of-window reply targets under `referenced_messages`. For built-in email it emits `_meta.notification_persistent.email` with `email_ids` plus full unread email bodies for the current unread snapshot (ordinary sends are capped at 50,000 characters so the notification layer does not truncate)
    (`src/lingtai_kernel/meta_block.py:1857-2489`). The Telegram MCP supplies the
    structured `recent_messages`, `latest_incoming`, and `referenced_messages`
-   metadata (`src/lingtai/mcp_servers/telegram/manager.py:904-1040`); the WeChat
+   metadata (`src/lingtai/mcp_servers/telegram/manager.py:967-1007`,
+   `src/lingtai/mcp_servers/telegram/manager.py:1063-1102`); the WeChat
    MCP supplies `recent_messages` and `latest_incoming` built from its merged
    inbox+sent preview window with per-message text bounded at 500 chars
    (`src/lingtai/mcp_servers/wechat/manager.py:835-956`); Feishu supplies the

--- a/tests/test_telegram_inbound_media_download_failure.py
+++ b/tests/test_telegram_inbound_media_download_failure.py
@@ -1,0 +1,292 @@
+"""Regression coverage for Telegram inbound document download failures."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from lingtai.mcp_servers.telegram import manager as telegram_manager
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+
+
+class _FakeAccount:
+    alias = "main"
+
+    def __init__(
+        self,
+        *,
+        download: tuple[str, bytes] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self._download = download
+        self._error = error
+        self.requested_file_ids: list[str] = []
+        self.sent_messages: list[tuple[int, str]] = []
+
+    def get_file(self, file_id: str) -> tuple[str, bytes]:
+        self.requested_file_ids.append(file_id)
+        if self._error is not None:
+            raise self._error
+        assert self._download is not None
+        return self._download
+
+    def send_message(self, chat_id: int, text: str, **_kwargs: Any) -> dict[str, Any]:
+        self.sent_messages.append((chat_id, text))
+        return {"message_id": 9001, "chat": {"id": chat_id}, "text": text}
+
+    def set_message_reaction(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class _FakeService:
+    def __init__(self, account: _FakeAccount) -> None:
+        self.default_account = account
+
+    def get_account(self, _alias: str) -> _FakeAccount:
+        return self.default_account
+
+
+def _document_update(*, caption: str | None = None) -> dict[str, Any]:
+    message: dict[str, Any] = {
+        "message_id": 53,
+        "date": 1781600000,
+        "from": {"id": 1, "username": "alice"},
+        "chat": {"id": 123, "type": "private"},
+        "document": {
+            "file_name": "report.zip",
+            "file_size": 25 * 1024 * 1024,
+            "file_id": "document-file-id",
+            "mime_type": "application/zip",
+        },
+    }
+    if caption is not None:
+        message["caption"] = caption
+    return {"message": message}
+
+
+def _receive(
+    tmp_path: Path,
+    monkeypatch: Any,
+    account: _FakeAccount,
+    update: dict[str, Any],
+) -> tuple[TelegramManager, list[dict[str, Any]]]:
+    inbound_events: list[dict[str, Any]] = []
+    manager = TelegramManager(
+        _FakeService(account),
+        working_dir=tmp_path,
+        on_inbound=inbound_events.append,
+    )
+    monkeypatch.setattr(telegram_manager._typing_manager, "start_typing", lambda *_args: None)
+    manager.on_incoming("main", update)
+    return manager, inbound_events
+
+
+def _read_latest(manager: TelegramManager) -> dict[str, Any]:
+    result = manager._read({"account": "main", "chat_id": 123, "limit": 1})
+    assert result["status"] == "ok"
+    return result["messages"][0]
+
+
+def test_hosted_size_error_is_visible_actionable_and_raw_only(
+    tmp_path: Path,
+    monkeypatch: Any,
+    caplog: Any,
+) -> None:
+    reason = "Bad Request: file is too big"
+    account = _FakeAccount(error=RuntimeError(f"Telegram API error: {reason}"))
+    caplog.set_level(logging.WARNING)
+
+    manager, inbound_events = _receive(
+        tmp_path, monkeypatch, account, _document_update()
+    )
+    message = _read_latest(manager)
+
+    assert message["media"] == {
+        "type": "document",
+        "file_name": "report.zip",
+        "file_size": 25 * 1024 * 1024,
+        "file_id": "document-file-id",
+        "mime_type": "application/zip",
+        "download_error": reason,
+    }
+    assert "path" not in message["media"]
+    assert not list(
+        (tmp_path / "telegram" / "main" / "inbox").glob("*/attachments/*")
+    )
+    assert reason in message["text"]
+    assert "parts no larger than 20 MB" in message["text"]
+    assert "another transfer method" in message["text"]
+
+    assert account.requested_file_ids == ["document-file-id"]
+    assert account.sent_messages == []
+    assert len(inbound_events) == 1
+    event = inbound_events[0]
+    latest = event["metadata"]["latest_incoming"]
+    assert event["metadata"]["has_media"] is True
+    assert reason in event["body"]
+    assert "parts no larger than 20 MB" in latest["text"]
+    assert latest["media"] == {
+        "type": "document",
+        "mime_type": "application/zip",
+    }
+    assert {"file_name", "file_size", "file_id"}.isdisjoint(latest["media"])
+    assert reason in caplog.text
+
+
+def test_failed_document_preserves_caption_as_exact_prefix(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    caption = "  important  \n"
+    account = _FakeAccount(error=OSError("disk detail must not be retained"))
+
+    manager, _events = _receive(
+        tmp_path, monkeypatch, account, _document_update(caption=caption)
+    )
+    message = _read_latest(manager)
+
+    assert message["media"]["download_error"] == "OSError"
+    assert message["text"].startswith(caption + "\n\n[")
+    assert message["text"][: len(caption)] == caption
+    assert "resend the document" in message["text"]
+    assert "another transfer method" in message["text"]
+
+
+def test_arbitrary_exception_text_and_token_url_are_not_retained(
+    tmp_path: Path,
+    monkeypatch: Any,
+    caplog: Any,
+) -> None:
+    secret_url = "https://api.telegram.org/file/bot123456:SECRET/private/report.zip"
+    account = _FakeAccount(error=RuntimeError(f"GET {secret_url} timed out"))
+    caplog.set_level(logging.WARNING)
+
+    manager, inbound_events = _receive(
+        tmp_path, monkeypatch, account, _document_update()
+    )
+    message = _read_latest(manager)
+    persisted = next((tmp_path / "telegram" / "main" / "inbox").glob("*/message.json"))
+    observable_output = json.dumps(
+        {
+            "stored": json.loads(persisted.read_text(encoding="utf-8")),
+            "read": message,
+            "events": inbound_events,
+            "logs": caplog.text,
+        }
+    )
+
+    assert message["media"]["download_error"] == "RuntimeError"
+    assert "RuntimeError" in message["text"]
+    assert "RuntimeError" in caplog.text
+    assert secret_url not in observable_output
+    assert "SECRET" not in observable_output
+
+
+def test_provider_reason_is_whitespace_normalized_and_bounded(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    description = "  provider\n\treason  " + ("detail " * 80)
+    normalized = " ".join(description.split())
+    account = _FakeAccount(
+        error=RuntimeError(f"Telegram API error: {description}")
+    )
+
+    manager, _events = _receive(
+        tmp_path, monkeypatch, account, _document_update()
+    )
+    reason = _read_latest(manager)["media"]["download_error"]
+
+    assert reason == normalized[:200]
+    assert len(reason) == 200
+    assert "\n" not in reason
+    assert "\t" not in reason
+
+
+def test_http_exception_exposes_only_class_and_numeric_status(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    secret_url = "https://api.telegram.org/file/bot123456:SECRET/private/report.zip"
+
+    class HTTPStatusError(RuntimeError):
+        def __init__(self) -> None:
+            super().__init__(f"413 response from {secret_url}")
+            self.response = SimpleNamespace(status_code=413)
+
+    account = _FakeAccount(error=HTTPStatusError())
+    manager, inbound_events = _receive(
+        tmp_path, monkeypatch, account, _document_update()
+    )
+    message = _read_latest(manager)
+    observable_output = json.dumps({"read": message, "events": inbound_events})
+
+    assert message["media"]["download_error"] == "HTTPStatusError (HTTP 413)"
+    assert secret_url not in observable_output
+    assert "SECRET" not in observable_output
+
+
+def test_successful_inbound_document_keeps_existing_shape_path_bytes_and_caption(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    caption = "  keep this caption byte-for-byte  \n"
+    data = b"existing-success-bytes\x00\xff"
+    account = _FakeAccount(download=("telegram-report.zip", data))
+
+    manager, inbound_events = _receive(
+        tmp_path, monkeypatch, account, _document_update(caption=caption)
+    )
+    message = _read_latest(manager)
+    media = message["media"]
+    path = Path(media["path"])
+
+    assert message["text"] == caption
+    assert media == {
+        "type": "document",
+        "filename": "telegram-report.zip",
+        "path": str(path),
+        "size": len(data),
+    }
+    assert path.name == "telegram-report.zip"
+    assert path.parent.name == "attachments"
+    assert path.is_relative_to(tmp_path / "telegram" / "main" / "inbox")
+    assert path.read_bytes() == data
+    assert inbound_events[0]["metadata"]["latest_incoming"]["text"] == caption.replace(
+        "\n", " "
+    )
+
+
+def test_non_document_download_failure_keeps_pre_existing_media_and_text_behavior(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    caption = "photo caption"
+    account = _FakeAccount(error=RuntimeError("photo unavailable"))
+    update = {
+        "message": {
+            "message_id": 53,
+            "date": 1781600000,
+            "from": {"id": 1, "username": "alice"},
+            "chat": {"id": 123, "type": "private"},
+            "caption": caption,
+            "photo": [
+                {
+                    "file_id": "photo-file-id",
+                    "file_size": 4096,
+                    "width": 320,
+                    "height": 240,
+                }
+            ],
+        }
+    }
+
+    manager, inbound_events = _receive(tmp_path, monkeypatch, account, update)
+    message = _read_latest(manager)
+
+    assert message["media"] is None
+    assert message["text"] == caption
+    assert inbound_events[0]["metadata"]["has_media"] is False
+    assert inbound_events[0]["metadata"]["latest_incoming"]["text"] == caption


### PR DESCRIPTION
## Summary

- preserve available inbound Telegram document metadata and captions when download or local persistence fails
- surface a bounded, provider-safe `download_error` plus actionable resend guidance instead of storing a silent empty message
- document the hosted Bot API's 20 MB `getFile` limit and the addon's current lack of Local Bot API endpoint support
- add hermetic regressions for oversized files, caption fidelity, redaction, bounded reasons, HTTP status, successful documents, and non-document compatibility

## Root cause

The addon received a valid Telegram `document`, but constructed `payload["media"]` only after `getFile` and the local write both succeeded. Any exception was swallowed before structured media state existed, so a real inbound document could be persisted as `text=""` and `media=null`.

For the reproduced incident, Telegram's hosted `getFile` call returned HTTP 400 with `Bad Request: file is too big`. Telegram documents a 20 MB hosted download ceiling: https://core.telegram.org/bots/api#getfile

## Non-goals

- no Local Bot API server deployment or endpoint configuration
- no automatic failure reply to the Telegram sender
- no behavior change for successful media downloads or failed photo/voice/audio downloads
- no runtime refresh, release, or production configuration change

## Validation

```text
python -m pytest -q tests/test_telegram_inbound_media_download_failure.py
7 passed in 0.44s

pytest -q tests/test_telegram_notification_read_state.py tests/test_telegram_rich_formatting.py tests/test_telegram_inbound_media_download_failure.py
43 passed in 4.47s

PYTHONDONTWRITEBYTECODE=1 uv run --offline pytest -p no:cacheprovider -q tests/test_telegram*.py tests/test_mcp_inbox.py tests/test_meta_block.py tests/test_mcp_skill_manuals.py
273 passed, 1 warning in 5.92s (unrelated third-party google.genai.types deprecation warning)

ruff check src/lingtai/mcp_servers/telegram/manager.py tests/test_telegram_inbound_media_download_failure.py
All checks passed!

git diff --check
passed
```

A fresh independent read-only Codex review of the final uncommitted diff returned **READY** with no blocking findings. Added-line privacy scanning found no private paths, human chat IDs, or real credential markers; the two token-bearing URLs in the new test are explicitly fake fixtures used to prove redaction.

## Authorization and attribution

Authorized by Jason on Telegram on 2026-07-10. Implementation and review were AI-assisted by OpenAI Codex via LingTai; human direction and merge authority remain with Jason.
