### PR TITLE
Write status snapshots atomically

### DIFF
--- a/docs/plans/2026-06-25-fsutil-migration.md
+++ b/docs/plans/2026-06-25-fsutil-migration.md
@@ -45,6 +45,7 @@ These are migration *candidates*, not a commitment to change every one.
 
 ### Stage 1 — riskiest crash-sensitive / model-visible state (do first)
 - [x] `workdir.py::WorkingDir.write_manifest` (`.agent.json`) — **migrated here**
+- [x] `base_agent/__init__.py::_write_status_snapshot` (`.status.json`) — migrated with byte-parity coverage
 - [ ] `workdir.py::write_resolved_manifest` (`manifest.resolved.json`, trailing newline → pass explicit newline or keep inline)
 - [ ] notification files (`.notification/*.json`)
 - [ ] `intrinsics/email/primitives.py` message/`message.json` writes (currently direct `write_text`; some non-contact paths can escape non-ASCII)

--- a/docs/plans/2026-06-25-fsutil-migration.md
+++ b/docs/plans/2026-06-25-fsutil-migration.md
@@ -45,7 +45,7 @@ These are migration *candidates*, not a commitment to change every one.
 
 ### Stage 1 — riskiest crash-sensitive / model-visible state (do first)
 - [x] `workdir.py::WorkingDir.write_manifest` (`.agent.json`) — **migrated here**
-- [x] `base_agent/__init__.py::_write_status_snapshot` (`.status.json`) — migrated with byte-parity coverage
+- [x] `base_agent/__init__.py::_write_status_snapshot` (`.status.json`) — migrated with byte-parity coverage and opt-in existing-mode retention
 - [ ] `workdir.py::write_resolved_manifest` (`manifest.resolved.json`, trailing newline → pass explicit newline or keep inline)
 - [ ] notification files (`.notification/*.json`)
 - [ ] `intrinsics/email/primitives.py` message/`message.json` writes (currently direct `write_text`; some non-contact paths can escape non-ASCII)

--- a/src/lingtai_kernel/_fsutil.py
+++ b/src/lingtai_kernel/_fsutil.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -79,6 +80,7 @@ def atomic_write_text(
     *,
     encoding: str = "utf-8",
     fsync: bool = False,
+    preserve_existing_mode: bool = False,
 ) -> Path:
     """Atomically write ``text`` to ``path``.
 
@@ -92,11 +94,22 @@ def atomic_write_text(
     fsyncs the *file content* only, not the parent directory, so the rename
     metadata is not guaranteed durable across a power loss; that is stronger
     than the default and sufficient for the current opt-out callers.
+
+    ``preserve_existing_mode`` is also opt-in.  When True and the target
+    exists, its permission bits are applied to the new temp file before the
+    replace.  A missing target still inherits the process umask, and the
+    default False preserves the existing behaviour for other callers.
     """
     target = Path(path)
     target.parent.mkdir(parents=True, exist_ok=True)
     tmp = _unique_tmp(target)
     try:
+        existing_mode = None
+        if preserve_existing_mode:
+            try:
+                existing_mode = stat.S_IMODE(target.stat().st_mode)
+            except FileNotFoundError:
+                pass
         # "x" (exclusive create) guarantees we never write into a temp file
         # another writer already created; combined with the uuid4 name this
         # makes concurrent same-target writes collision-free.
@@ -105,6 +118,8 @@ def atomic_write_text(
             if fsync:
                 f.flush()
                 os.fsync(f.fileno())
+        if existing_mode is not None:
+            tmp.chmod(existing_mode)
         os.replace(str(tmp), str(target))
     except BaseException:
         # Best-effort cleanup so a failed write does not leave temp litter.
@@ -125,6 +140,7 @@ def atomic_write_json(
     sort_keys: bool = False,
     default: Optional[Callable[[Any], Any]] = None,
     fsync: bool = False,
+    preserve_existing_mode: bool = False,
 ) -> Path:
     """Atomically write ``obj`` as JSON to ``path``.
 
@@ -132,6 +148,9 @@ def atomic_write_json(
     the kernel's dominant model-visible JSON convention.  Serialization happens
     *before* the file is touched, so a non-serializable ``obj`` raises without
     leaving a temp file or clobbering the target.
+
+    ``preserve_existing_mode`` is forwarded to :func:`atomic_write_text` and
+    remains disabled by default.
     """
     text = json.dumps(
         obj,
@@ -140,7 +159,13 @@ def atomic_write_json(
         sort_keys=sort_keys,
         default=default,
     )
-    return atomic_write_text(path, text, encoding="utf-8", fsync=fsync)
+    return atomic_write_text(
+        path,
+        text,
+        encoding="utf-8",
+        fsync=fsync,
+        preserve_existing_mode=preserve_existing_mode,
+    )
 
 
 def read_json(

--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -1998,7 +1998,11 @@ class BaseAgent:
     def _write_status_snapshot(self) -> None:
         """Write .status.json — live runtime snapshot consumed by TUI/portal."""
         try:
-            atomic_write_json(self._working_dir / ".status.json", self.status())
+            atomic_write_json(
+                self._working_dir / ".status.json",
+                self.status(),
+                preserve_existing_mode=True,
+            )
         except Exception as e:
             logger.warning(f"[{self.agent_name}] Failed to write .status.json: {e}")
 

--- a/src/lingtai_kernel/base_agent/__init__.py
+++ b/src/lingtai_kernel/base_agent/__init__.py
@@ -50,7 +50,7 @@ from ..meta_block import (
 from ..session import SessionManager
 from ..tc_inbox import TCInbox
 from ..token_ledger import append_token_entry
-from .._fsutil import atomic_write_text
+from .._fsutil import atomic_write_json, atomic_write_text
 from ..trace_redaction import redact_for_trajectory
 from ..runtime_identity import runtime_identity_event_fields
 
@@ -1998,10 +1998,7 @@ class BaseAgent:
     def _write_status_snapshot(self) -> None:
         """Write .status.json — live runtime snapshot consumed by TUI/portal."""
         try:
-            (self._working_dir / ".status.json").write_text(
-                json.dumps(self.status(), ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
+            atomic_write_json(self._working_dir / ".status.json", self.status())
         except Exception as e:
             logger.warning(f"[{self.agent_name}] Failed to write .status.json: {e}")
 

--- a/tests/test_fsutil.py
+++ b/tests/test_fsutil.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import stat
 
 import pytest
 
@@ -30,6 +31,31 @@ def test_atomic_write_text_overwrites_existing(tmp_path):
     target.write_text("old")
     _fsutil.atomic_write_text(target, "new")
     assert target.read_text() == "new"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode bits required")
+def test_atomic_write_text_preserves_existing_mode_when_requested(tmp_path):
+    target = tmp_path / "a.txt"
+    target.write_text("old")
+    target.chmod(0o600)
+
+    _fsutil.atomic_write_text(target, "new", preserve_existing_mode=True)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode bits required")
+def test_atomic_write_text_default_still_uses_umask_for_replacement(tmp_path):
+    target = tmp_path / "a.txt"
+    target.write_text("old")
+    target.chmod(0o600)
+    old_umask = os.umask(0o022)
+    try:
+        _fsutil.atomic_write_text(target, "new")
+    finally:
+        os.umask(old_umask)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
 
 
 def test_atomic_write_temp_is_sibling_of_target(tmp_path, monkeypatch):

--- a/tests/test_status_snapshot.py
+++ b/tests/test_status_snapshot.py
@@ -1,0 +1,64 @@
+"""Regression tests for the BaseAgent ``.status.json`` write call site."""
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import lingtai_kernel.base_agent as base_agent_module
+from lingtai_kernel import _fsutil
+from lingtai_kernel.base_agent import BaseAgent
+
+
+def test_status_snapshot_atomically_replaces_with_legacy_bytes(tmp_path, monkeypatch):
+    payload = {"identity": {"name": "灵台"}, "runtime": {"state": "idle"}}
+    agent = SimpleNamespace(
+        _working_dir=tmp_path,
+        agent_name="test",
+        status=lambda: payload,
+    )
+    replacements = []
+    real_replace = _fsutil.os.replace
+
+    def spy_replace(src, dst):
+        replacements.append((src, dst))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(_fsutil.os, "replace", spy_replace)
+
+    BaseAgent._write_status_snapshot(agent)
+
+    target = tmp_path / ".status.json"
+    assert len(replacements) == 1
+    temp_path, replaced_target = map(Path, replacements[0])
+    assert temp_path.parent == target.parent
+    assert temp_path != target
+    assert replaced_target == target
+    expected = json.dumps(payload, ensure_ascii=False, indent=2).encode("utf-8")
+    assert target.read_bytes() == expected
+    assert not expected.endswith(b"\n")
+    assert list(tmp_path.iterdir()) == [target]
+
+
+def test_status_snapshot_write_failure_warns_and_preserves_prior_bytes(
+    tmp_path, monkeypatch, caplog
+):
+    target = tmp_path / ".status.json"
+    prior_bytes = b'{"keep": true}'
+    target.write_bytes(prior_bytes)
+    agent = SimpleNamespace(
+        _working_dir=tmp_path,
+        agent_name="test",
+        status=lambda: {"replacement": True},
+    )
+
+    def fail_write(*args, **kwargs):
+        raise OSError("representative write failure")
+
+    monkeypatch.setattr(base_agent_module, "atomic_write_json", fail_write)
+
+    with caplog.at_level(logging.WARNING):
+        BaseAgent._write_status_snapshot(agent)
+
+    assert "[test] Failed to write .status.json: representative write failure" in caplog.text
+    assert target.read_bytes() == prior_bytes

--- a/tests/test_status_snapshot.py
+++ b/tests/test_status_snapshot.py
@@ -2,10 +2,13 @@
 
 import json
 import logging
+import os
+import stat
 from pathlib import Path
 from types import SimpleNamespace
 
 import lingtai_kernel.base_agent as base_agent_module
+import pytest
 from lingtai_kernel import _fsutil
 from lingtai_kernel.base_agent import BaseAgent
 
@@ -62,3 +65,36 @@ def test_status_snapshot_write_failure_warns_and_preserves_prior_bytes(
 
     assert "[test] Failed to write .status.json: representative write failure" in caplog.text
     assert target.read_bytes() == prior_bytes
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode bits required")
+def test_status_snapshot_preserves_existing_mode(tmp_path):
+    target = tmp_path / ".status.json"
+    target.write_text('{"old": true}')
+    target.chmod(0o600)
+    agent = SimpleNamespace(
+        _working_dir=tmp_path,
+        agent_name="test",
+        status=lambda: {"replacement": True},
+    )
+
+    BaseAgent._write_status_snapshot(agent)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode bits required")
+def test_status_snapshot_first_creation_inherits_umask(tmp_path):
+    target = tmp_path / ".status.json"
+    agent = SimpleNamespace(
+        _working_dir=tmp_path,
+        agent_name="test",
+        status=lambda: {"created": True},
+    )
+    old_umask = os.umask(0o027)
+    try:
+        BaseAgent._write_status_snapshot(agent)
+    finally:
+        os.umask(old_umask)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640


### PR DESCRIPTION
Closes #743

## Summary

Write the agent `.status.json` snapshot through the existing atomic filesystem helper instead of truncating and rewriting the live file in place.

This prevents TUI and portal readers from observing a partially written JSON document while preserving the snapshot's existing bytes, lifecycle cadence, and best-effort warning boundary.

## Why

`BaseAgent._write_status_snapshot()` previously called `Path.write_text()` directly. That truncates the target before the replacement JSON has been fully written, so concurrent readers can briefly see an empty or incomplete document and fail to decode it.

A first-pass conversion to sibling-temp + `os.replace()` exposed an additional compatibility concern: replacing the inode can reset an operator-hardened existing mode such as `0600` to the process-umask default. The final implementation preserves the existing target's permission bits for status snapshots while leaving first-creation and all unrelated atomic-write callers unchanged.

## Changes

- Route `.status.json` writes through `atomic_write_json()`.
- Add a default-off `preserve_existing_mode` option to `atomic_write_text()` and `atomic_write_json()`.
  - When enabled and the target exists, copy `stat.S_IMODE()` permission bits to the completed sibling temp before `os.replace()`.
  - When the target is absent, retain the helper's existing umask-derived creation mode.
  - Keep the default disabled so other callers preserve their current behavior.
- Keep the existing status writer's error contract: failures are logged as warnings and do not escape the lifecycle path.
- Mark `.status.json` complete in the staged fsutil migration checklist.
- Add deterministic helper and call-site regressions for atomic replacement, exact legacy bytes, prior-target preservation on failure, existing-mode retention, first-creation umask behavior, and unchanged helper defaults.

## Compatibility and non-goals

The JSON payload remains UTF-8, pretty-printed with two-space indentation, non-ASCII preserving, and without a trailing newline. The change does not alter status schema, write cadence, readers, lifecycle behavior, locking, or `fsync` policy.

The mode opt-in preserves permission bits only. Ownership, ACLs, extended attributes, filesystem flags, inode identity, and symlink semantics are outside this scoped fix.

## Validation

- `PYTHONPATH=src python -m pytest -q tests/test_status_snapshot.py tests/test_fsutil.py` — **37 passed**
- `PYTHONPATH=src python -m pytest -q tests/test_active_stuck_watchdog.py tests/test_heartbeat.py tests/test_time_awareness_status.py tests/test_lifecycle_daemon_shutdown.py` — **32 passed**
- Independent mode probes confirmed an existing `0600` snapshot remains `0600`, while first creation under umask `0027` produces `0640`.
- `python -m py_compile` on the changed Python files — passed
- `git diff --check` — passed
- Kernel anatomy drift checker — no drift across 38 files
