### PR TITLE
feat(nokv-workbench): add checkpoint restore workflow

### DIFF
--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -189,7 +189,7 @@ the checkpoint by `name` or `snapshot_id`.
 Do not rely on a `snapshot_id` you remembered in a note — that note is exactly
 what goes stale. `workbench_snapshot_list {"id":"spedas-task-001"}` enumerates
 every checkpoint of the workbench with its `name`, `snapshot_id`,
-`lease_expires_at`, and lifecycle `status` (`alive`, `expired`, or `reaped`).
+`lease_expires_at`, and lifecycle `state` (`alive`, `expired`, or `reaped`).
 Use it to see what is still restorable before you try to read history.
 
 ### Read history with at_snapshot
@@ -238,9 +238,9 @@ read this manifest and the required outputs before handing work to another
 agent. The source workbench remains at its current state throughout the
 restore.
 
-Do not request an in-place rollback from normal agent workflows. In-place
-replacement is an operator-only recovery action because it temporarily fences
-writes and invalidates the entire target subtree.
+Do not request an in-place rollback from normal agent workflows. The Workbench
+contract exposed to agents supports restore-to-fork only; operator recovery
+APIs are outside this skill.
 
 ### Handle structured checkpoint errors
 
@@ -254,7 +254,7 @@ message:
 | `SnapshotRootMismatch` | Stop. The checkpoint belongs to another workbench root; never substitute or copy its id. |
 | `SnapshotBindingChanged` | Refresh the MCP/workbench resolution and retry once because the root binding changed during the operation. |
 | `SnapshotRenewContended` | Retry renewal with bounded backoff; the lease in the error response is not authoritative. |
-| `RestoreInProgress` | Back off and retry the blocked write after the operator restore reaches a terminal state. |
+| `RestoreInProgress` | Retry the exact restore-to-fork request with bounded backoff; the same operation is still preparing or cleaning staged state. |
 | `RestoreDestinationConflict` | Choose a new empty `destination_id`, unless this was an exact retry of the same restore operation. |
 | `RestoreResourceLimit` | Do not retry unchanged. Reduce the restore subtree or metadata payload reported in `details`, then create a new checkpoint and destination if needed. |
 

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -230,10 +230,13 @@ it returns the existing restored workbench instead of creating a second fork.
 Using the same destination with a different checkpoint is a conflict.
 
 The restored workbench contains the files visible at the checkpoint, is
-independently writable, and records `restored_from` provenance. It does not
-inherit the source's checkpoint aliases. After success, read the destination's
-manifest and required outputs before handing work to another agent. The source
-workbench remains at its current state throughout the restore.
+independently writable, and writes `metadata/restore_manifest.json`. Its
+`restored_from` object binds `workbench_id`, absolute source `path`, and
+`snapshot_id`; the manifest also records the deterministic `operation_id`. The
+destination does not inherit the source's checkpoint aliases. After success,
+read this manifest and the required outputs before handing work to another
+agent. The source workbench remains at its current state throughout the
+restore.
 
 Do not request an in-place rollback from normal agent workflows. In-place
 replacement is an operator-only recovery action because it temporarily fences
@@ -253,6 +256,7 @@ message:
 | `SnapshotRenewContended` | Retry renewal with bounded backoff; the lease in the error response is not authoritative. |
 | `RestoreInProgress` | Back off and retry the blocked write after the operator restore reaches a terminal state. |
 | `RestoreDestinationConflict` | Choose a new empty `destination_id`, unless this was an exact retry of the same restore operation. |
+| `RestoreResourceLimit` | Do not retry unchanged. Reduce the restore subtree or metadata payload reported in `details`, then create a new checkpoint and destination if needed. |
 
 Honor the returned `retryable` flag when it is stricter than this table. A
 failed renew never changes the locally recorded expiry; use the authoritative

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -7,10 +7,10 @@ description: >
   manifests through the `workbench_*` MCP tools instead of ordinary local
   file writes. Covers MCP registration, directory layout, append and edit
   discipline, conditional reads, cross-workbench queries, commit discipline,
-  and leased checkpoint snapshots with naming, renewal, discovery, and
-  point-in-time history reads.
-version: 0.3.0
-tags: [nokv, mcp, workbench, artifacts, provenance, snapshots, checkpoints, leases]
+  leased checkpoint snapshots with naming, renewal, discovery, point-in-time
+  reads, and safe restore-to-fork recovery.
+version: 0.4.0
+tags: [nokv, mcp, workbench, artifacts, provenance, snapshots, checkpoints, leases, restore]
 related_files:
 - src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
 - src/lingtai/intrinsic_skills/nokv-workbench/assets/init-snippet.json
@@ -166,9 +166,10 @@ The response adds `name`, `lease_expires_at` (the reap deadline), and an
 gets only the 1-hour default lease** — never hand a raw-CLI snapshot to a
 handoff.
 
-**Name your checkpoints.** `name` is a stable alias you can renew, list, and
-read by, instead of memorizing an opaque `snapshot_id`. The name is the durable
-handle; the id is for pinning an exact version.
+**Name your checkpoints.** `name` is a workbench-scoped alias you can renew,
+list, read, and restore by instead of memorizing an opaque `snapshot_id`. The
+alias remains useful only while the checkpoint lease is live; it is not an
+archive or an independent durability guarantee.
 
 In final reports or handoff notes, cite the checkpoint `name`, its
 `snapshot_id`, and the returned `lease_expires_at` so a later reader knows both
@@ -202,13 +203,46 @@ that checkpoint** instead of its current state:
 ```
 
 Historical `workbench_read` serves the checkpoint's bytes/text-lines. Reading a
-checkpoint whose lease has expired now fails **loudly** — an explicit error that
-tells you to `workbench_snapshot_renew` (if a grace window remains) or re-mint —
-rather than silently returning current state or empty data.
+checkpoint whose lease has expired fails **loudly**. Expiry is terminal:
+expired checkpoints cannot be renewed, even if the background collector has not
+yet removed the pin. Re-mint from the current committed state when that is still
+useful; NoKV never revives a checkpoint whose historical records may already
+have been reclaimed.
+
+## Restore to a new workbench
+
+Use `workbench_restore` when you need to continue from a live checkpoint. The
+safe default is **restore-to-fork**: it creates a new workbench and never
+overwrites the source workbench.
+
+```json
+{
+  "id": "spedas-task-001",
+  "at_snapshot": "final-v1",
+  "destination_id": "spedas-task-001-restored"
+}
+```
+
+The destination must not already contain unrelated work. A successful response
+identifies the source checkpoint, destination path, and deterministic restore
+operation. Repeating the same source, checkpoint, and destination is idempotent:
+it returns the existing restored workbench instead of creating a second fork.
+Using the same destination with a different checkpoint is a conflict.
+
+The restored workbench contains the files visible at the checkpoint, is
+independently writable, and records `restored_from` provenance. It does not
+inherit the source's checkpoint aliases. After success, read the destination's
+manifest and required outputs before handing work to another agent. The source
+workbench remains at its current state throughout the restore.
+
+Do not request an in-place rollback from normal agent workflows. In-place
+replacement is an operator-only recovery action because it temporarily fences
+writes and invalidates the entire target subtree.
 
 ### Expired is not the same as data lost
 
-An expired checkpoint loses only the **point-in-time view**, not your work. The
+An expired checkpoint loses only the **point-in-time view**, not your current
+work. The
 workbench's committed files stay put: after `workbench_commit`, the current
 artifacts remain reachable with `workbench_read`, `workbench_list`, and
 `workbench_stat` (no `at_snapshot`). Only the frozen historical view needs a

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -239,6 +239,25 @@ Do not request an in-place rollback from normal agent workflows. In-place
 replacement is an operator-only recovery action because it temporarily fences
 writes and invalidates the entire target subtree.
 
+### Handle structured checkpoint errors
+
+Checkpoint and restore failures use a structured MCP error with `code`,
+`message`, `retryable`, and `details`. Branch on `code`; do not parse the human
+message:
+
+| Code | Agent action |
+|---|---|
+| `SnapshotLeaseExpired` | Do not retry or attempt revival. Mint a new checkpoint from current state when appropriate. |
+| `SnapshotRootMismatch` | Stop. The checkpoint belongs to another workbench root; never substitute or copy its id. |
+| `SnapshotBindingChanged` | Refresh the MCP/workbench resolution and retry once because the root binding changed during the operation. |
+| `SnapshotRenewContended` | Retry renewal with bounded backoff; the lease in the error response is not authoritative. |
+| `RestoreInProgress` | Back off and retry the blocked write after the operator restore reaches a terminal state. |
+| `RestoreDestinationConflict` | Choose a new empty `destination_id`, unless this was an exact retry of the same restore operation. |
+
+Honor the returned `retryable` flag when it is stricter than this table. A
+failed renew never changes the locally recorded expiry; use the authoritative
+pin returned by a successful renew or refresh with `workbench_snapshot_list`.
+
 ### Expired is not the same as data lost
 
 An expired checkpoint loses only the **point-in-time view**, not your current

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
@@ -38,7 +38,7 @@ Tool-surface note: parts of the SKILL.md surface depend on the NoKV build. An
 older server still works with this skill — the newer tools and parameters are
 simply absent from tools/list, and the SKILL sections about them do not apply.
 
-- **17-tool workbench MCP** (workbench_append / workbench_edit /
+- **17-tool surface** (workbench_append / workbench_edit /
   workbench_search / workbench_aggregate / workbench_catalog, conditional
   reads, and workbench_restore) requires a build shipping the specialized
   workbench MCP; older 9-tool NoKV servers lack it.
@@ -54,11 +54,13 @@ simply absent from tools/list, and the SKILL sections about them do not apply.
   the restore workflow against an older surface and silently downgrade
   checkpoint guarantees. Verify that `workbench_restore` requires `id`,
   `at_snapshot`, and `destination_id`; its `at_snapshot` schema must accept
-  only a checkpoint name or non-negative numeric snapshot id and must reject
-  `null`. Expired checkpoints must return a structured error and must not be
+  only a checkpoint name or non-negative numeric snapshot id and must reject `null`.
+  Expired checkpoints must return a structured error and must not be
   described as renewable within a grace period.
 
-Run the checked-in NoKV/LingTai live acceptance harness before deploying a new
-pair of builds that includes workbench_restore. It must exercise the real
-RustFS service, NoKV metadata server, workbench MCP subprocess, and LingTai
-MCPClient; unit-only schema checks are not a deployment acceptance substitute.
+Run the checked-in NoKV/LingTai live acceptance harness with `--profile full --require-all`
+before deploying a new pair of builds that includes workbench_restore. It must
+exercise the real RustFS service, NoKV metadata server, workbench MCP subprocess,
+LingTai Agent MCP registration/retry handler, and the MCPClient created from the
+resolved per-agent launch config; unit-only schema checks are not a deployment
+acceptance substitute.

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
@@ -53,9 +53,10 @@ simply absent from tools/list, and the SKILL sections about them do not apply.
   `workbench_restore` tool or schema field as a failed preflight — do not run
   the restore workflow against an older surface and silently downgrade
   checkpoint guarantees. Verify that `workbench_restore` requires `id`,
-  `at_snapshot`, and `destination_id`. Expired checkpoints must return a
-  structured error and must not be described as renewable within a grace
-  period.
+  `at_snapshot`, and `destination_id`; its `at_snapshot` schema must accept
+  only a checkpoint name or non-negative numeric snapshot id and must reject
+  `null`. Expired checkpoints must return a structured error and must not be
+  described as renewable within a grace period.
 
 Run the checked-in NoKV/LingTai live acceptance harness before deploying a new
 pair of builds that includes workbench_restore. It must exercise the real

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
@@ -38,13 +38,26 @@ Tool-surface note: parts of the SKILL.md surface depend on the NoKV build. An
 older server still works with this skill — the newer tools and parameters are
 simply absent from tools/list, and the SKILL sections about them do not apply.
 
-- **16-tool workbench MCP** (workbench_append / workbench_edit /
-  workbench_search / workbench_aggregate / workbench_catalog and conditional
-  reads) requires a build shipping the specialized workbench MCP; older 9-tool
-  NoKV servers lack it.
+- **17-tool workbench MCP** (workbench_append / workbench_edit /
+  workbench_search / workbench_aggregate / workbench_catalog, conditional
+  reads, and workbench_restore) requires a build shipping the specialized
+  workbench MCP; older 9-tool NoKV servers lack it.
 - **Checkpoint lifecycle** (workbench_snapshot_renew, workbench_snapshot_list,
   the workbench_snapshot `name`/`ttl_days` parameters and its
   `lease_expires_at`/`expiry_warning` output, and the `at_snapshot` parameter
   on workbench_read / workbench_list / workbench_stat) requires a build
   shipping Phase 1 snapshot leasing. Without it, snapshots fall back to the
   legacy 1-hour lease with no renewal path.
+- **Restore-to-fork** (workbench_restore) requires a build with strict
+  terminal expiry and root-bound snapshot operations. Treat a missing
+  `workbench_restore` tool or schema field as a failed preflight — do not run
+  the restore workflow against an older surface and silently downgrade
+  checkpoint guarantees. Verify that `workbench_restore` requires `id`,
+  `at_snapshot`, and `destination_id`. Expired checkpoints must return a
+  structured error and must not be described as renewable within a grace
+  period.
+
+Run the checked-in NoKV/LingTai live acceptance harness before deploying a new
+pair of builds that includes workbench_restore. It must exercise the real
+RustFS service, NoKV metadata server, workbench MCP subprocess, and LingTai
+MCPClient; unit-only schema checks are not a deployment acceptance substitute.

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -181,6 +181,8 @@ def test_nokv_workbench_skill_documents_strict_restore_contract():
     assert "workbench_restore" in skill
     assert '"destination_id"' in skill
     assert "restore-to-fork" in skill
+    assert "metadata/restore_manifest.json" in skill
+    assert "`restored_from` object" in skill
     assert "expired checkpoints cannot be renewed" in skill
     assert "grace window" not in skill
     assert "17-tool surface" in preflight
@@ -192,8 +194,10 @@ def test_nokv_workbench_skill_documents_strict_restore_contract():
         "SnapshotRenewContended",
         "RestoreInProgress",
         "RestoreDestinationConflict",
+        "RestoreResourceLimit",
     ):
         assert code in skill
+    assert "must reject `null`" in preflight
     assert "Branch on `code`" in skill
 
 

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -172,6 +172,21 @@ def test_nokv_workbench_registry_example_is_valid():
     assert spec["args"] == record["args"]
 
 
+def test_nokv_workbench_skill_documents_strict_restore_contract():
+    skill_root = Path("src/lingtai/intrinsic_skills/nokv-workbench")
+    skill = (skill_root / "SKILL.md").read_text(encoding="utf-8")
+    preflight = (skill_root / "assets" / "PREFLIGHT.md").read_text(encoding="utf-8")
+
+    assert "version: 0.4.0" in skill
+    assert "workbench_restore" in skill
+    assert '"destination_id"' in skill
+    assert "restore-to-fork" in skill
+    assert "expired checkpoints cannot be renewed" in skill
+    assert "grace window" not in skill
+    assert "17-tool surface" in preflight
+    assert "workbench_restore" in preflight
+
+
 def test_expand_agent_placeholders_scopes_workbench_root(tmp_path):
     # Per-agent root injection: a shared registry template resolves to a root
     # unique to each agent, so agents cannot address each other's workbenches.
@@ -184,6 +199,67 @@ def test_expand_agent_placeholders_scopes_workbench_root(tmp_path):
     # Strings without a placeholder and non-strings pass through untouched.
     assert agent._expand_agent_placeholders("--profile") == "--profile"
     assert agent._expand_agent_placeholders(None) is None
+
+
+def test_nokv_workbench_root_stays_resolved_after_mcp_retry(tmp_path, monkeypatch):
+    from lingtai.services import mcp as mcp_service
+
+    workdir = tmp_path / "agent"
+    workdir.mkdir(parents=True)
+    (workdir / "mcp_registry.jsonl").write_text(json.dumps({
+        "name": "nokv-workbench",
+        "summary": "test",
+        "transport": "stdio",
+        "command": "/bin/true",
+        "args": [],
+        "source": "test",
+    }) + "\n")
+    (workdir / "init.json").write_text(json.dumps({
+        "mcp": {
+            "nokv-workbench": {
+                "type": "stdio",
+                "command": "/bin/true",
+                "args": ["--workbench-root", "/agents/{agent_id}/wb"],
+            },
+        },
+    }))
+
+    created = []
+
+    class CapturingMCPClient:
+        def __init__(self, command, args=None, env=None):
+            self.command = command
+            self.args = list(args or [])
+            self.env = dict(env or {})
+            self.closed = False
+            self.connected = bool(created)
+            created.append(self)
+
+        def start(self):
+            return None
+
+        def list_tools(self, timeout=10):
+            return []
+
+        def is_connected(self):
+            return self.connected and not self.closed
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(mcp_service, "MCPClient", CapturingMCPClient)
+
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=workdir,
+        capabilities={"mcp": {}},
+    )
+    assert created[0].args == ["--workbench-root", "/agents/agent/wb"]
+
+    report = agent._retry_failed_mcps()
+    assert report["recovered"] == ["nokv-workbench"]
+    assert created[1].args == ["--workbench-root", "/agents/agent/wb"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -11,9 +11,6 @@ import json
 import re
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
-
-import pytest
 
 from lingtai.agent import Agent
 from lingtai.services.mcp_registry import (
@@ -181,12 +178,21 @@ def test_nokv_workbench_skill_documents_strict_restore_contract():
     assert "workbench_restore" in skill
     assert '"destination_id"' in skill
     assert "restore-to-fork" in skill
+    assert "Retry the exact restore-to-fork request" in skill
     assert "metadata/restore_manifest.json" in skill
     assert "`restored_from` object" in skill
     assert "expired checkpoints cannot be renewed" in skill
     assert "grace window" not in skill
+    assert "temporarily fences writes" not in skill
+    assert "invalidates the entire target subtree" not in skill
+    assert "blocked write after the operator restore" not in skill
+    assert "lifecycle `state` (`alive`, `expired`, or `reaped`)" in skill
+    assert "lifecycle `status`" not in skill
     assert "17-tool surface" in preflight
     assert "workbench_restore" in preflight
+    assert "--profile full --require-all" in preflight
+    assert "Agent MCP registration/retry handler" in preflight
+    assert "resolved per-agent launch config" in preflight
     for code in (
         "SnapshotLeaseExpired",
         "SnapshotRootMismatch",

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -185,6 +185,16 @@ def test_nokv_workbench_skill_documents_strict_restore_contract():
     assert "grace window" not in skill
     assert "17-tool surface" in preflight
     assert "workbench_restore" in preflight
+    for code in (
+        "SnapshotLeaseExpired",
+        "SnapshotRootMismatch",
+        "SnapshotBindingChanged",
+        "SnapshotRenewContended",
+        "RestoreInProgress",
+        "RestoreDestinationConflict",
+    ):
+        assert code in skill
+    assert "Branch on `code`" in skill
 
 
 def test_expand_agent_placeholders_scopes_workbench_root(tmp_path):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -256,8 +256,11 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert "version: 0.4.0" in nokv_body
         assert "workbench_restore" in nokv_body
         assert "restore-to-fork" in nokv_body
+        assert "metadata/restore_manifest.json" in nokv_body
+        assert "`restored_from` object" in nokv_body
         assert "SnapshotLeaseExpired" in nokv_body
         assert "RestoreDestinationConflict" in nokv_body
+        assert "RestoreResourceLimit" in nokv_body
         assert "metadata/run_manifest.json" in nokv_body
         assert (
             nokv_md.parent / "assets" / "mcp_registry.example.jsonl"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -256,6 +256,8 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert "version: 0.4.0" in nokv_body
         assert "workbench_restore" in nokv_body
         assert "restore-to-fork" in nokv_body
+        assert "SnapshotLeaseExpired" in nokv_body
+        assert "RestoreDestinationConflict" in nokv_body
         assert "metadata/run_manifest.json" in nokv_body
         assert (
             nokv_md.parent / "assets" / "mcp_registry.example.jsonl"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -253,6 +253,9 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert "name: nokv-workbench" in nokv_body
         assert "workbench_find" in nokv_body
         assert "workbench_commit" in nokv_body
+        assert "version: 0.4.0" in nokv_body
+        assert "workbench_restore" in nokv_body
+        assert "restore-to-fork" in nokv_body
         assert "metadata/run_manifest.json" in nokv_body
         assert (
             nokv_md.parent / "assets" / "mcp_registry.example.jsonl"


### PR DESCRIPTION
## Summary

- update the intrinsic NoKV Workbench skill to checkpoint and restore contract v0.4
- document terminal snapshot expiry, renew behavior, root-bound typed errors, and checkpoint registry handling
- add the restore-to-fork workflow with deterministic retry guidance and restore_manifest.json verification
- tighten PREFLIGHT around the 17-tool Workbench surface, per-agent placeholder expansion, MCP registration, and full live acceptance
- add capability and skill regression tests

## Scope

This skill exposes restore-to-fork to agents. It does not promise or request in-place rollback, write fencing, SubtreeReplaced invalidation, or any FUSE behavior.

RestoreInProgress is documented as an in-flight restore-to-fork preparation or cleanup state. Agents retry the exact restore with bounded backoff.

NoKV implementation dependency: https://github.com/NoKV-Lab/NoKV/pull/403

## Validation

- uv run pytest -q tests/test_mcp_capability.py tests/test_skills.py: 58 passed
- uv run ruff check tests/test_mcp_capability.py
- git diff --check

The checked-in cross-repository full live E2E was rerun after rebasing this branch onto current upstream main. All 11 scenarios passed with real RustFS, nokv serve, the 17-tool Workbench MCP profile, and two LingTai agents.