### PR TITLE
fix: preserve pre-request hooks through API gates

### DIFF
--- a/src/lingtai/llm/base.py
+++ b/src/lingtai/llm/base.py
@@ -37,6 +37,20 @@ class _GatedSession:
     def interface(self):
         return self._inner.interface
 
+    @property
+    def pre_request_hook(self):
+        # Named getter/setter so the hook lives on the inner adapter — the
+        # object whose send() reads ``self.pre_request_hook`` before the API
+        # call. A plain write would land in the proxy __dict__ and leave the
+        # inner's hook None, so the kernel drain hook would silently never
+        # fire under rate gating. The proxy never invokes the hook itself;
+        # the inner adapter continues to own request timing.
+        return self._inner.pre_request_hook
+
+    @pre_request_hook.setter
+    def pre_request_hook(self, hook):
+        self._inner.pre_request_hook = hook
+
     def send(self, message):
         return self._gate.submit(lambda: self._inner.send(message))
 

--- a/tests/test_max_rpm_plumbing.py
+++ b/tests/test_max_rpm_plumbing.py
@@ -154,11 +154,28 @@ def test_gated_session_routes_send_through_gate():
     a = _StubAdapter()
     a._setup_gate(60)
     inner = MagicMock()
-    inner.send.return_value = "response"
+    inner.pre_request_hook = None
+    inner.session_id = "inner-sess"
+    # Model a real adapter: read the (inner) hook and fire it once at send.
+    inner.send.side_effect = lambda m: (
+        inner.pre_request_hook(inner.interface), "response")[1]
     wrapped = a._wrap_with_gate(inner)
-    result = wrapped.send("hi")
+
+    fired = []
+    wrapped.pre_request_hook = lambda iface: fired.append(iface)
+    # The named slot delegates to the inner (the object whose send reads it),
+    # never landing in the proxy __dict__.
+    assert wrapped.pre_request_hook is inner.pre_request_hook
+    assert "pre_request_hook" not in wrapped.__dict__
+    # Unrelated metadata writes stay proxy-local; inner identity is untouched.
+    wrapped.session_id = "proxy-sess"
+
+    result = wrapped.send("hi")  # drive the real gate
     assert result == "response"
     inner.send.assert_called_once_with("hi")
+    assert fired == [inner.interface]
+    assert wrapped.session_id == "proxy-sess"
+    assert inner.session_id == "inner-sess"
     a._gate.shutdown()
 
 

--- a/tests/test_tc_inbox_mid_turn_drain.py
+++ b/tests/test_tc_inbox_mid_turn_drain.py
@@ -39,6 +39,8 @@ from lingtai.kernel.llm.interface import (
     ToolResultBlock,
 )
 from lingtai.kernel.tc_inbox import InvoluntaryToolCall, TCInbox
+from lingtai.llm.api_gate import APICallGate
+from lingtai.llm.base import _GatedSession
 
 
 # ---------------------------------------------------------------------------
@@ -307,6 +309,38 @@ class TestInstallDrainHook:
         # be callable.
         assert callable(first)
         assert callable(second)
+
+    def test_install_through_gate_proxy_drains_at_inner_send(self, tmp_path):
+        """Composition: install on a real _GatedSession, then a gated send.
+        The hook must reach the inner (which reads it at send), so the mid-turn
+        drain fires under rate gating instead of landing dead on the proxy."""
+        agent = BaseAgent(
+            intrinsics=_TEST_INTRINSICS,
+            service=make_mock_service(),
+            agent_name="gate-hook-test",
+            working_dir=tmp_path / "gate-hook-test",
+        )
+        iface = ChatInterface()
+        iface.add_user_message("hello")
+        inner = MagicMock(spec_set=["pre_request_hook", "interface", "send"])
+        inner.pre_request_hook = None
+        inner.interface = iface
+        inner.send.side_effect = lambda m: (
+            inner.pre_request_hook(inner.interface), "response")[1]
+        gate = APICallGate(60)
+        agent._chat = _GatedSession(inner, gate)
+
+        agent._tc_inbox.enqueue(_mail_pair("gated1"))
+        agent._install_drain_hook()
+        assert agent._chat.send([]) == "response"  # drive the real gate
+        inner.send.assert_called_once_with([])
+        assert len(agent._tc_inbox) == 0
+        drained = [
+            b.id for e in iface.entries for b in e.content
+            if isinstance(b, ToolCallBlock) and b.name == "system"
+        ]
+        assert drained == ["sn_gated1"]
+        gate.shutdown()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- forward `_GatedSession.pre_request_hook` writes to the wrapped `ChatSession`, so rate-gated sessions preserve the existing inner request-boundary callback contract;
- keep every unrelated assignment proxy-local rather than adding generic `__setattr__` forwarding;
- lock the behavior through the real API gate and through `BaseAgent._install_drain_hook`, including one exact TCInbox assistant/tool-result pair.

This PR is stacked on #863 and should not merge before its base PR.

## Scope

- production: `src/lingtai/llm/base.py` only;
- tests: two existing focused modules only;
- 14 production insertions and 53 focused-test insertions;
- no provider, gate-timing, identity, wire-conversion, Contract, Anatomy, or root-link changes.

## Failing-first evidence

With the repaired focused tests in place and only the named property temporarily removed via `Edit`, the two new/extended cases failed for the intended storage defect: the inner hook remained `None`, so the direct callback and BaseAgent drain did not reach the inner request boundary. The property was then restored exactly and all required suites passed.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider tests/test_max_rpm_plumbing.py tests/test_tc_inbox_mid_turn_drain.py` — **25 passed**
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider tests/contracts/llm_conversation_input` — **182 passed**
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider tests/test_codex_prompt_cache_key.py tests/test_codex_ws_session.py` — **119 passed**
- broader targeted API-gate/registry/service/Claude-Code adapter set — **52 passed**
- all nine validated modules together — **378 passed**
- `git diff --check` — clean
- independent GPT-5.6-sol re-review — **APPROVE**
- reviewed diff SHA-256 (`git diff --no-ext-diff --binary | shasum -a 256`): `f7384bd710ead76464a3d9c9c4c38415d4e6d7bc6b64212eb27aba8f343d43d4`

## Non-goals

This PR does not add a Model/Conversation Port, change provider implementations, convert Gemini Chat history, broaden proxy attribute forwarding, or add architectural documentation. It is the smallest production correction needed before later boundary extraction.
