### PR TITLE
docs: make kernel README a runtime and SDK entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,142 +1,70 @@
 <div align="center">
 
-<img src="https://raw.githubusercontent.com/Lingtai-AI/lingtai/main/docs/assets/network-demo.gif" alt="Agent network growing — one soul spawning avatars that communicate and multiply" width="100%">
+# lingtai-kernel
 
-# 灵台 LingTai
-
-**Agent Genesis — an Agent OS that gifts life**
-
-> *灵台，心也。* Lingtai means soul.
->
-> *灵台者有持，而不知其所持，而不可持者也。*
-> *The soul holds something, yet knows not what it holds — and what it holds cannot be held.*
-> — Zhuangzi · Gengsang Chu (庄子 · 庚桑楚)
+**The Python runtime and SDK that powers LingTai agents.**
 
 [![PyPI](https://img.shields.io/pypi/v/lingtai?color=%237dab8f)](https://pypi.org/project/lingtai/)
 [![License](https://img.shields.io/github/license/Lingtai-AI/lingtai-kernel?color=%237dab8f)](LICENSE)
 [![Blog](https://img.shields.io/badge/blog-lingtai.ai-%23d4a853)](https://lingtai.ai)
 
-[lingtai.ai](https://lingtai.ai) · [简体中文](docs/readmes/README.zh.md) · [文言](docs/readmes/README.wen.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md)
+[English](README.md) · [简体中文](docs/readmes/README.zh.md) · [文言](docs/readmes/README.wen.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md)
 
 </div>
 
 ---
 
-<p align="center">This is the Python runtime and CLI for LingTai.</p>
-<p align="center">For the full experience with guided setup, use the <a href="https://github.com/Lingtai-AI/lingtai">TUI</a> instead — <code>brew install lingtai-ai/lingtai/lingtai-tui</code></p>
+This repository is the engine underneath the product, not the product itself.
 
-## Install
+**Looking for LingTai the product?** The [`Lingtai-AI/lingtai`](https://github.com/Lingtai-AI/lingtai)
+repository is the source of truth for the Digital Scientist — the lifelong, self-growing
+agent — including the guided installer, the TUI/Portal, and everyday workflows. Normal
+users should start there and let the installer manage this runtime for them. This
+repository is for developers who build on or contribute to the kernel; do not treat a
+bare `pip install` here as the normal installation path.
+
+## What this repository owns
+
+- **The agent runtime** — the core turn loop, lifecycle, tool dispatch, mailbox,
+  soul (inner voice), molt, and notification machinery that make an agent run.
+- **Two Python surfaces** — `lingtai.kernel`, the minimal runtime (`BaseAgent`,
+  intrinsics, the LLM protocol, mail, and logging), and `lingtai`, the
+  batteries-included runtime, CLI, and services that build `Agent(BaseAgent)` on top
+  of it and re-export the kernel's public API.
+- **The batteries** — the bundled built-in tools, the LLM adapters, the curated MCP
+  server implementations, the packaging (Python distribution plus the bundled Rust
+  search sidecar). These are ownership boundaries, not a feature list.
+
+## Developer quick start
+
+For **kernel development** — not the normal LingTai user installation path. Requires
+Python >= 3.11; use a local `.venv`.
 
 ```bash
-pip install lingtai
+git clone https://github.com/Lingtai-AI/lingtai-kernel.git
+cd lingtai-kernel
+uv venv --python 3.11
+uv pip install -e . pytest
+.venv/bin/python -m pytest
 ```
 
-## CLI
+## Architecture / developer entry points
 
-The `lingtai-agent` command is the agent runtime — it boots and runs individual agents.
+| Entry point | What it covers |
+|---|---|
+| [`ANATOMY.md`](ANATOMY.md) | Repository map — top-level layout and where each subsystem's anatomy begins. |
+| [`src/lingtai/kernel/ANATOMY.md`](src/lingtai/kernel/ANATOMY.md) | The core runtime: `BaseAgent`, turn/lifecycle, tool machinery, mail, LLM protocol. |
+| [`src/lingtai/ANATOMY.md`](src/lingtai/ANATOMY.md) | The `lingtai` package: `Agent(BaseAgent)`, capabilities, presets, CLI, public re-exports. |
+| [`src/lingtai/tools/ANATOMY.md`](src/lingtai/tools/ANATOMY.md) | The concrete built-in tools and the registry that composes them. |
+| [`src/lingtai/mcp_servers/ANATOMY.md`](src/lingtai/mcp_servers/ANATOMY.md) | The bundled MCP server implementations. |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Contribution workflow and repository navigation. |
+| [`docs/references/claude-code-guide.md`](docs/references/claude-code-guide.md) | The full repository guide — test commands, architecture notes, and conventions. |
 
-```bash
-# Boot an agent from its working directory
-lingtai-agent run /path/to/agent/
+## Security · Support · Acknowledgements
 
-# Check available capability providers
-lingtai-agent check-caps
-```
-
-Agents are typically managed by the [TUI](https://github.com/Lingtai-AI/lingtai), which handles initialization, lifecycle, and monitoring. The CLI is for scripting, custom agents, and programmatic use.
-
-## Architecture
-
-This repo contains both packages. The dependency is strictly one-directional:
-
-| Package | Role |
-|---------|------|
-| **`lingtai.kernel`** (`import lingtai.kernel`) | Minimal runtime — BaseAgent, intrinsics, LLM protocol, mail, logging. Zero hard dependencies. |
-| **`lingtai`** (`import lingtai`) | Batteries-included — Agent with 19 capabilities, 5 LLM adapters, MCP integration, addons. Re-exports the kernel's public API. |
-
-```
-BaseAgent              — kernel (intrinsics, sealed tool surface)
-    │
-Agent(BaseAgent)       — kernel + capabilities + domain tools
-    │
-CustomAgent(Agent)     — your domain logic
-```
-
-## Capabilities
-
-<table>
-<tr><th>Perception</th><th>Action</th><th>Cognition</th><th>Network</th></tr>
-<tr>
-<td>
-
-`vision` — image understanding
-`listen` — speech & music
-`web_search` — web search
-`web_read` — page extraction
-
-</td>
-<td>
-
-`file` — read/write/edit/glob/grep
-`bash` — shell with guardrails
-`talk` — text-to-speech
-`compose` — music generation
-`draw` — image generation
-`video` — video generation
-
-</td>
-<td>
-
-`psyche` — evolving identity
-`knowledge` — private durable knowledge
-`skills` — skill catalog
-`email` — full mailbox system
-
-</td>
-<td>
-
-`avatar` — spawn sub-agents (分身)
-`daemon` — parallel workers (神識)
-
-</td>
-</tr>
-</table>
-
-## LLM Support
-
-Anthropic, OpenAI, Gemini, MiniMax, or any OpenAI-compatible API (DeepSeek, Grok, Qwen, GLM, Kimi).
-
-## Agent = directory
-
-```
-/agents/wukong/
-  .agent.lock               ← exclusive lock (one process per directory)
-  .agent.heartbeat          ← liveness proof
-  .agent.json               ← manifest
-  system/
-    covenant.md             ← protected instructions (survive molts)
-    pad.md                  ← working notes
-  mailbox/
-    inbox/                  ← received messages
-    outbox/                 ← pending sends
-    sent/                   ← delivery audit trail
-  logs/
-    events.jsonl            ← structured event log
-```
-
-No `agent_id`. The path is the identity. Agents find each other by path, communicate by writing to each other's `mailbox/inbox/`.
-
-## Learn more
-
-Read the full manifesto at [lingtai.ai](https://lingtai.ai).
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution workflow and repository navigation entry points. For responsible disclosure, read [SECURITY.md](SECURITY.md); for help, read [SUPPORT.md](SUPPORT.md).
-
-## Acknowledgements
-
-See [docs/references/acknowledgements.md](docs/references/acknowledgements.md).
+For responsible disclosure, read [SECURITY.md](SECURITY.md); for help, read
+[SUPPORT.md](SUPPORT.md); for credits, read
+[docs/references/acknowledgements.md](docs/references/acknowledgements.md).
 
 ## License
 
@@ -144,6 +72,6 @@ Apache-2.0 — [Zesen Huang](https://github.com/huangzesen), 2025–2026
 
 <div align="center">
 
-[lingtai.ai](https://lingtai.ai) · [GitHub](https://github.com/Lingtai-AI/lingtai-kernel) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md) · [TUI](https://github.com/Lingtai-AI/lingtai)
+[lingtai.ai](https://lingtai.ai) · [LingTai (product)](https://github.com/Lingtai-AI/lingtai) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Support](SUPPORT.md)
 
 </div>

--- a/docs/readmes/README.wen.md
+++ b/docs/readmes/README.wen.md
@@ -1,85 +1,72 @@
-# 灵台内核
+<div align="center">
 
-> [English](../../README.md) | [中文](README.zh.md) | [文言](README.wen.md) | [贡献](../../CONTRIBUTING.md) | [安全](../../SECURITY.md) | [支持](../../SUPPORT.md)
+# lingtai-kernel 灵台内核
 
-> *灵台者有持，而不知其所持，而不可持者也。*
-> — 庄子·庚桑楚
+**驱 LingTai 器灵之 Python 运行时与 SDK。**
 
-器灵之最小内核 — 思、通、简、承器。
+[![PyPI](https://img.shields.io/pypi/v/lingtai?color=%237dab8f)](https://pypi.org/project/lingtai/)
+[![License](https://img.shields.io/github/license/Lingtai-AI/lingtai-kernel?color=%237dab8f)](../../LICENSE)
+[![Blog](https://img.shields.io/badge/blog-lingtai.ai-%23d4a853)](https://lingtai.ai)
 
-## 道
+[English](../../README.md) · [简体中文](README.zh.md) · [文言](README.wen.md) · [贡献](../../CONTRIBUTING.md) · [安全](../../SECURITY.md) · [支持](../../SUPPORT.md)
 
-**灵台，心也。** 庄子言灵台，谓其自然持守灵魂所需之一切，不自知其所持，亦不可强持之。
+</div>
 
-此框架中，器灵之灵台即其**工作目录**——磁盘之上一隅，简牍、盟约、名号、书信皆寄于此。目录即器灵。予内核以一目录、一语言服务，器灵即生；去其目录，器灵即灭。内核承载器灵之一切而不解其意——有持而不知其所持。
+---
 
-内核循 Unix 之道：
+此仓乃器物之下之枢机，非器物本身也。
 
-- **万物皆文卷。** 器灵之身份即其目录路径。无抽象之号——路径即地址、即锁、即真。
-- **内核定规矩，不定实现。** `LLMService` 与 `ChatSession` 皆抽象之约。何以实现——适配之器、密钥、流量之限——皆调用者之事。
-- **一灵一进程。** 独立之目录、独立之语言服务、独立之书信、独立之日志。器灵之间以文件系统传书通信，非共享内存。
-- **内核至简。** 思（LLM）、通（传书）、简（手简）、承器。能力、文卷读写、编排——皆在 [lingtai](https://github.com/Lingtai-AI/lingtai) 中。
+**欲得 LingTai 之器物者？** [`Lingtai-AI/lingtai`](https://github.com/Lingtai-AI/lingtai)
+一仓，乃「数字科学家」——终身而自长之器灵——叙事之所本，引导之装置、TUI/Portal 及日用诸流皆在焉。
+凡常之用者，宜自彼而始，任装置为汝掌此运行时。此仓所向，乃于内核之上有所构、或为内核效力之开发者也；
+勿以此间裸 `pip install` 为寻常安装之途。
 
-## 安装
+## 本仓所辖
+
+- **器灵之运行时** —— 使器灵得以运转之核心轮次之环、生灭、工具之派发、信箱、
+  soul（内心之声）、molt 与通知诸机也。
+- **两 Python 之面** —— 其一 `lingtai.kernel`，至简之运行时（`BaseAgent`、固有之能、
+  LLM 之约、书信、日志）；其二 `lingtai`，具足之运行时、CLI 与服务，于其上构
+  `Agent(BaseAgent)`，且重导内核公开之 API。
+- **配属之物** —— 所捆之内置工具、LLM 适配之器、精择之 MCP 服务器诸实现，暨其打包
+  （Python 发行之物与随附之 Rust 搜索 sidecar）。此皆所辖之界，非罗列之能也。
+
+## 开发者速启
+
+为**内核之开发**，非寻常 LingTai 用者安装之途也。须 Python >= 3.11；宜用本地之 `.venv`。
 
 ```bash
-pip install lingtai-kernel
+git clone https://github.com/Lingtai-AI/lingtai-kernel.git
+cd lingtai-kernel
+uv venv --python 3.11
+uv pip install -e . pytest
+.venv/bin/python -m pytest
 ```
 
-## 内核所含
+## 架构与开发者门径
 
-| 器 | 用 |
-|------|------|
-| **BaseAgent** | 内核之主——生灭、消息循环、器之派发 |
-| **四固有之器** | 传书（通信）、观己（生灭）、核心自治（简/名号）、灵魂（内心之声） |
-| **LLM 之约** | `LLMService` 抽象之约、`ChatSession` 抽象之约 |
-| **服务** | 文件系统传书、JSONL 日志 |
-| **工作目录** | 目录管理——锁、git、清单 |
+| 门径 | 所涵 |
+|---|---|
+| [`ANATOMY.md`](../../ANATOMY.md) | 仓之舆图——顶层之布局，暨各子系统解剖所始之处。 |
+| [`src/lingtai/kernel/ANATOMY.md`](../../src/lingtai/kernel/ANATOMY.md) | 核心之运行时：`BaseAgent`、轮次与生灭、工具之机、书信、LLM 之约。 |
+| [`src/lingtai/ANATOMY.md`](../../src/lingtai/ANATOMY.md) | `lingtai` 之包：`Agent(BaseAgent)`、诸能、预设、CLI、公开之重导。 |
+| [`src/lingtai/tools/ANATOMY.md`](../../src/lingtai/tools/ANATOMY.md) | 具体之内置工具，暨组合诸工具之注册表。 |
+| [`src/lingtai/mcp_servers/ANATOMY.md`](../../src/lingtai/mcp_servers/ANATOMY.md) | 随附之 MCP 服务器诸实现。 |
+| [`CONTRIBUTING.md`](../../CONTRIBUTING.md) | 效力之流程与仓之导览。 |
+| [`docs/references/claude-code-guide.md`](../references/claude-code-guide.md) | 全仓之指要——测试之命、架构之注与规约。 |
 
-## 内核不含
+## 安全 · 支持 · 谢忱
 
-能力、文卷读写、MCP、观象、游历、bash、化身、LLM 适配之器、流量之限——皆在 `lingtai` 中。
-
-## 速启
-
-```python
-from lingtai.kernel import BaseAgent
-
-# 调用者供语言服务（抽象之约的任何实现）
-agent = BaseAgent(
-    service=my_llm_service,
-    working_dir="/agents/alice",    # 灵台——灵魂所居
-    agent_name="alice",             # 真名（可不设）
-)
-
-agent.add_tool("hello", schema={...}, handler=lambda args: {"msg": "hi"})
-agent.start()
-agent.send("Say hello")
-agent.stop()
-```
-
-内核受一目录路径与一服务，不问其从何而来。
-
-## 灵台之制
-
-```
-/agents/alice/              ← 此路径即器灵
-  .agent.lock               ← 独占之锁
-  .agent.heartbeat          ← 存活之证
-  .agent.json               ← 清单
-  system/
-    covenant.md             ← 盟约
-    pad.md                  ← 简
-  mailbox/
-    inbox/                  ← 所收之书信
-    outbox/                 ← 待发之书信
-    sent/                   ← 已发之记录
-  logs/
-    events.jsonl            ← 事件日志
-```
-
-无需 `agent_id`。路径即身份。心跳证存活。锁证独占。
+责任之披露，阅 [SECURITY.md](../../SECURITY.md)；求助，阅
+[SUPPORT.md](../../SUPPORT.md)；谢忱，阅
+[docs/references/acknowledgements.md](../references/acknowledgements.md)。
 
 ## 许可
 
-Apache-2.0
+Apache-2.0 —— [Zesen Huang](https://github.com/huangzesen)，2025–2026
+
+<div align="center">
+
+[lingtai.ai](https://lingtai.ai) · [LingTai（器物）](https://github.com/Lingtai-AI/lingtai) · [贡献](../../CONTRIBUTING.md) · [安全](../../SECURITY.md) · [支持](../../SUPPORT.md)
+
+</div>

--- a/docs/readmes/README.zh.md
+++ b/docs/readmes/README.zh.md
@@ -1,85 +1,72 @@
+<div align="center">
+
 # lingtai-kernel 灵台内核
 
-> [English](../../README.md) | [中文](README.zh.md) | [文言](README.wen.md) | [贡献](../../CONTRIBUTING.md) | [安全](../../SECURITY.md) | [支持](../../SUPPORT.md)
+**驱动 LingTai 智能体的 Python 运行时与 SDK。**
 
-> *灵台者有持，而不知其所持，而不可持者也。*
-> — 庄子·庚桑楚
+[![PyPI](https://img.shields.io/pypi/v/lingtai?color=%237dab8f)](https://pypi.org/project/lingtai/)
+[![License](https://img.shields.io/github/license/Lingtai-AI/lingtai-kernel?color=%237dab8f)](../../LICENSE)
+[![Blog](https://img.shields.io/badge/blog-lingtai.ai-%23d4a853)](https://lingtai.ai)
 
-最小智能体内核 — 思考、通信、手记、承载工具。
+[English](../../README.md) · [简体中文](README.zh.md) · [文言](README.wen.md) · [贡献](../../CONTRIBUTING.md) · [安全](../../SECURITY.md) · [支持](../../SUPPORT.md)
 
-## 设计哲学
+</div>
 
-**灵台，心也。** 在庄子笔下，灵台是意识栖居之所：自然地承载灵魂所需的一切，却不自知其所承载，也无法被刻意掌控。
+---
 
-在本框架中，智能体的灵台就是它的**工作目录**——磁盘上的一个文件夹，手记、盟约、身份、信箱都在其中。目录即智能体。给内核一个文件夹和一个 LLM 服务，它便赋予智能体生命。拿走文件夹，智能体便不复存在。内核承载智能体的一切，但不解读其内容——正如庄子的灵台，有持而不知其所持。
+这个仓库是产品之下的引擎，而非产品本身。
 
-本内核遵循 Unix 设计哲学：
+**想要 LingTai 产品？** [`Lingtai-AI/lingtai`](https://github.com/Lingtai-AI/lingtai)
+仓库是「数字科学家」——那个终身、自我生长的智能体——的唯一叙事来源，包含引导式安装器、
+TUI/Portal 以及日常工作流。普通用户应从那里开始，让安装器为你管理本运行时。本仓库面向在
+内核之上构建或为内核贡献代码的开发者；请勿把这里的裸 `pip install` 当作常规安装路径。
 
-- **一切皆文件。** 智能体的身份就是其目录路径。没有抽象 ID——路径即地址、即锁、即真实。
-- **内核只定义协议，不定义实现。** `LLMService` 和 `ChatSession` 是抽象接口。如何实现——适配器、API 密钥、速率限制——是调用者的事。
-- **每个智能体都是独立进程。** 独立的目录、独立的 LLM 服务、独立的信箱、独立的日志。智能体之间通过文件系统信件通信，而非共享内存。
-- **内核是最小的。** 思考（LLM）、通信（信件）、手记（手记）、承载工具。能力、文件读写、编排——这些在 [lingtai](https://github.com/Lingtai-AI/lingtai) 中。
+## 本仓库所辖
 
-## 安装
+- **智能体运行时** —— 让智能体得以运转的核心轮次循环、生命周期、工具派发、信箱、
+  soul（内心之声）、molt 与通知机制。
+- **两个 Python 界面** —— `lingtai.kernel`，最小运行时（`BaseAgent`、内置固有能力、
+  LLM 协议、信件、日志）；以及 `lingtai`，开箱即用的运行时、CLI 与服务，在其之上构建
+  `Agent(BaseAgent)` 并重新导出内核的公开 API。
+- **配套组件** —— 捆绑的内置工具、LLM 适配器、精选的 MCP 服务器实现，以及打包
+  （Python 发行版与随附的 Rust 搜索 sidecar）。这些是所辖边界，而非功能清单。
+
+## 开发者快速开始
+
+用于**内核开发**，而非常规 LingTai 用户安装路径。需要 Python >= 3.11；请使用本地 `.venv`。
 
 ```bash
-pip install lingtai-kernel
+git clone https://github.com/Lingtai-AI/lingtai-kernel.git
+cd lingtai-kernel
+uv venv --python 3.11
+uv pip install -e . pytest
+.venv/bin/python -m pytest
 ```
 
-## 内核所含
+## 架构 / 开发者入口
 
-| 组件 | 用途 |
-|------|------|
-| **BaseAgent** | 内核调度器——生命周期、消息循环、工具派发 |
-| **四种内置工具** | mail（进程间通信）、system（生命周期）、psyche（手记/身份）、soul（内心声音） |
-| **LLM 协议** | `LLMService` 抽象基类、`ChatSession` 抽象基类、供应商无关类型 |
-| **服务** | 文件系统信件传输、JSONL 结构化日志 |
-| **WorkingDir** | 目录管理——锁、git、清单 |
+| 入口 | 涵盖内容 |
+|---|---|
+| [`ANATOMY.md`](../../ANATOMY.md) | 仓库地图——顶层布局，以及各子系统的解剖从何处开始。 |
+| [`src/lingtai/kernel/ANATOMY.md`](../../src/lingtai/kernel/ANATOMY.md) | 核心运行时：`BaseAgent`、轮次/生命周期、工具机制、信件、LLM 协议。 |
+| [`src/lingtai/ANATOMY.md`](../../src/lingtai/ANATOMY.md) | `lingtai` 包：`Agent(BaseAgent)`、能力、预设、CLI、公开重导出。 |
+| [`src/lingtai/tools/ANATOMY.md`](../../src/lingtai/tools/ANATOMY.md) | 具体的内置工具，以及组合它们的注册表。 |
+| [`src/lingtai/mcp_servers/ANATOMY.md`](../../src/lingtai/mcp_servers/ANATOMY.md) | 随附的 MCP 服务器实现。 |
+| [`CONTRIBUTING.md`](../../CONTRIBUTING.md) | 贡献流程与仓库导航。 |
+| [`docs/references/claude-code-guide.md`](../references/claude-code-guide.md) | 完整仓库指南——测试命令、架构说明与约定。 |
 
-## 内核不含
+## 安全 · 支持 · 致谢
 
-能力、文件读写、MCP、视觉、搜索、bash、化身、LLM 适配器、速率限制——这些在 `lingtai` 中。
-
-## 快速开始
-
-```python
-from lingtai.kernel import BaseAgent
-
-# 调用者提供 LLM 服务（抽象基类的任意实现）
-agent = BaseAgent(
-    service=my_llm_service,
-    working_dir="/agents/alice",    # 灵台——灵魂栖居之所
-    agent_name="alice",             # 可选的显示名称
-)
-
-agent.add_tool("hello", schema={...}, handler=lambda args: {"msg": "hi"})
-agent.start()
-agent.send("Say hello")
-agent.stop()
-```
-
-内核接收一个目录路径和一个服务，不关心它们如何创建。
-
-## 灵台之结构
-
-```
-/agents/alice/              ← 此路径即智能体
-  .agent.lock               ← 独占锁（每个目录只能运行一个进程）
-  .agent.heartbeat          ← 存活证明（定期更新）
-  .agent.json               ← 清单（名称、地址、配置）
-  system/
-    covenant.md             ← 受保护的指令（盟约）
-    pad.md                  ← 工作笔记（手记）
-  mailbox/
-    inbox/                  ← 收到的信件
-    outbox/                 ← 待发送
-    sent/                   ← 发送记录
-  logs/
-    events.jsonl            ← 结构化事件日志
-```
-
-无需 `agent_id`。路径即身份。心跳证明存活。锁证明独占。
+负责任披露请阅读 [SECURITY.md](../../SECURITY.md)；求助请阅读
+[SUPPORT.md](../../SUPPORT.md)；致谢请阅读
+[docs/references/acknowledgements.md](../references/acknowledgements.md)。
 
 ## 许可
 
-Apache-2.0
+Apache-2.0 —— [Zesen Huang](https://github.com/huangzesen)，2025–2026
+
+<div align="center">
+
+[lingtai.ai](https://lingtai.ai) · [LingTai（产品）](https://github.com/Lingtai-AI/lingtai) · [贡献](../../CONTRIBUTING.md) · [安全](../../SECURITY.md) · [支持](../../SUPPORT.md)
+
+</div>


### PR DESCRIPTION
## Why

The main [`Lingtai-AI/lingtai`](https://github.com/Lingtai-AI/lingtai) README is now the product narrative and normal-user source of truth. The kernel repository should be the concise runtime / SDK / developer entry rather than a second product landing page.

## What changed

- reduce the English, modern-Chinese, and Wen README set in lockstep
- redirect product users immediately to the main repository for the Digital Scientist narrative, installer, TUI/Portal, and everyday workflows
- replace product manifesto, user-install tutorial, capability matrices, LLM marketing, and agent-directory walkthroughs with stable repository ownership boundaries
- retain a developer-only Python 3.11+ `uv` / local `.venv` / pytest quick start
- route contributors to the current ANATOMY tree, `CONTRIBUTING.md`, security, support, acknowledgements, and license

## Validation

- `git diff --check origin/main...HEAD` — clean
- exact scope — only `README.md`, `docs/readmes/README.zh.md`, and `docs/readmes/README.wen.md`
- diff — 144 insertions / 242 deletions (net −98 lines)
- locale structure — 6 aligned headings, 2 code fences, and 1 architecture table in each locale
- links — 57 local targets, none missing; 6 unique external URLs, all HTTP 200
- source checks — Python requirement, pytest config, package boundaries, built-in tools, LLM adapters, MCP implementations, Rust sidecar, and architecture paths verified against current source
- review — Claude implementation verified as Opus 4.8; independent MiMo V2.5 review returned PASS WITH SUGGESTIONS, with both concision/parity suggestions applied
- runtime tests not run (documentation-only change)

## Coordination

Open PR #860 also edits the root README to add future repository-local developer entry points. This PR is based on current `main`; whichever PR lands second should rebase and preserve #860's valid new developer links inside this compact structure without restoring the removed product/user-install content.