### PR TITLE
fix: resolve meta block type annotations

### DIFF
--- a/src/lingtai/kernel/meta_block.py
+++ b/src/lingtai/kernel/meta_block.py
@@ -53,7 +53,7 @@ import json as _json
 import time as _time
 import copy as _copy
 from collections.abc import Mapping
-from typing import NamedTuple
+from typing import Any, Dict, NamedTuple
 
 from .config import (
     CONTEXT_PRESSURE_HIGH_RATIO,
@@ -464,7 +464,7 @@ def static_adapter_comment(agent):
         return None
 
 
-def dynamic_adapter_comment(agent: AgentState) -> Mapping[str, Any] | None:
+def dynamic_adapter_comment(agent: object) -> Mapping[str, Any] | None:
     """Return adapter-owned dynamic tail state for ``_meta.agent_meta``.
 
     Adapters that can separate static guidance from dynamic runtime state should

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import re
 from types import SimpleNamespace
+from typing import get_type_hints
 
 import pytest
 import lingtai.kernel.meta_block as meta_block
@@ -35,6 +36,20 @@ from lingtai.kernel.meta_block import (
     validate_runtime_guidance,
 )
 from lingtai.kernel.llm.interface import ToolResultBlock
+
+
+@pytest.mark.parametrize(
+    "helper",
+    [
+        dynamic_adapter_comment,
+        slim_adapter_comment_for_tail,
+        meta_block.build_meta_readme_section,
+        build_guidance_with_meta_readme,
+    ],
+)
+def test_helper_type_hints_are_runtime_resolvable(helper):
+    """Public helper annotations must resolve without caller-supplied globals."""
+    assert get_type_hints(helper)
 
 
 def _fake_agent(*, time_awareness: bool = True, timezone_awareness: bool = True):


### PR DESCRIPTION
## Summary

- replace the undefined `AgentState` annotation with `object`, matching the helper's duck-typed use of agent instances
- import `Any` and `Dict` so the existing postponed annotations can be resolved at runtime
- add a regression test that resolves type hints for all four affected helpers

## Validation

- `.venv/bin/python -m pytest tests/test_meta_block.py -q` — **181 passed**
- `git diff --check canonical/main...HEAD` — passed
- independent read-only review — **PASS**, no blockers

## Risk

This is annotation-only production code plus a focused regression test; runtime control flow is unchanged.

Fixes #752
