### PR TITLE
fix(process): resolve absolute path aliases when matching agents

### DIFF
--- a/src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import argparse
 import getpass
 import json
+import ntpath
 import os
 import platform
+import posixpath
 import shutil
 import subprocess
 import sys
@@ -44,6 +46,18 @@ ADDON_MODULES = {
 }
 
 
+def _is_absolute_anywhere(path: str) -> bool:
+    """True if ``path`` is absolute under POSIX or Windows path syntax.
+
+    ``ps command=`` text can carry either OS's path shape regardless of the
+    OS this matcher happens to run on (e.g. Windows-shaped test fixtures
+    exercised on POSIX CI), so relative-vs-absolute must be judged
+    syntactically rather than via ``os.path.isabs``, which only knows the
+    host OS's own convention.
+    """
+    return posixpath.isabs(path) or ntpath.isabs(path)
+
+
 def match_agent_run(cmdline: str, working_dir: str) -> str | None:
     """Return the launch form if ``cmdline`` is an agent run for ``working_dir``.
 
@@ -58,8 +72,20 @@ def match_agent_run(cmdline: str, working_dir: str) -> str | None:
     Program anchoring accepts both path separators: Windows process tables
     report backslash program paths, and a backslash immediately before the
     program name is as much a path anchor there as ``/`` is on POSIX.
+
+    Relative ``<dir>`` arguments are intentionally unsupported. Symlink
+    aliases are resolved with ``realpath`` only when ``working_dir`` is
+    absolute on the host OS; a foreign-OS-shaped path (e.g. a Windows
+    ``C:\\...`` path observed while running on POSIX) falls back to plain
+    ``normpath`` equality, since ``realpath`` would otherwise resolve it
+    against the wrong filesystem convention.
     """
-    target = os.path.normpath(working_dir)
+    host_absolute = os.path.isabs(working_dir)
+    target = (
+        os.path.realpath(os.path.normpath(working_dir))
+        if host_absolute
+        else os.path.normpath(working_dir)
+    )
     for token, label, program_anchored in (
         (" -m lingtai run ", "module", False),
         ("lingtai-agent run ", "console", True),
@@ -69,8 +95,14 @@ def match_agent_run(cmdline: str, working_dir: str) -> str | None:
         while idx != -1:
             if (not program_anchored) or idx == 0 or cmdline[idx - 1] in ("/", "\\"):
                 tail = cmdline[idx + len(token):].strip()
-                if tail and os.path.normpath(tail) == target:
-                    return label
+                if tail and _is_absolute_anywhere(tail):
+                    resolved = (
+                        os.path.realpath(os.path.normpath(tail))
+                        if host_absolute
+                        else os.path.normpath(tail)
+                    )
+                    if resolved == target:
+                        return label
             idx = cmdline.find(token, idx + 1)
     return None
 

--- a/src/lingtai/kernel/process_match.py
+++ b/src/lingtai/kernel/process_match.py
@@ -1,7 +1,21 @@
 """Process-command matcher for LingTai agent runs."""
 from __future__ import annotations
 
+import ntpath
 import os
+import posixpath
+
+
+def _is_absolute_anywhere(path: str) -> bool:
+    """True if ``path`` is absolute under POSIX or Windows path syntax.
+
+    ``ps command=`` text can carry either OS's path shape regardless of the
+    OS this matcher happens to run on (e.g. Windows-shaped test fixtures
+    exercised on POSIX CI), so relative-vs-absolute must be judged
+    syntactically rather than via ``os.path.isabs``, which only knows the
+    host OS's own convention.
+    """
+    return posixpath.isabs(path) or ntpath.isabs(path)
 
 
 def match_agent_run(cmdline: str, working_dir: str) -> str | None:
@@ -21,8 +35,20 @@ def match_agent_run(cmdline: str, working_dir: str) -> str | None:
     and a backslash immediately before the program name is as much a path
     anchor there as ``/`` is on POSIX. ``os.path.normpath`` on each platform
     normalizes the trailing directory the same way for the equality check.
+
+    Relative ``<dir>`` arguments are intentionally unsupported. Symlink
+    aliases are resolved with ``realpath`` only when ``working_dir`` is
+    absolute on the host OS; a foreign-OS-shaped path (e.g. a Windows
+    ``C:\\...`` path observed while running on POSIX) falls back to plain
+    ``normpath`` equality, since ``realpath`` would otherwise resolve it
+    against the wrong filesystem convention.
     """
-    target = os.path.normpath(working_dir)
+    host_absolute = os.path.isabs(working_dir)
+    target = (
+        os.path.realpath(os.path.normpath(working_dir))
+        if host_absolute
+        else os.path.normpath(working_dir)
+    )
     for token, label, program_anchored in (
         (" -m lingtai run ", "module", False),
         ("lingtai-agent run ", "console", True),
@@ -32,7 +58,13 @@ def match_agent_run(cmdline: str, working_dir: str) -> str | None:
         while idx != -1:
             if (not program_anchored) or idx == 0 or cmdline[idx - 1] in ("/", "\\"):
                 tail = cmdline[idx + len(token):].strip()
-                if tail and os.path.normpath(tail) == target:
-                    return label
+                if tail and _is_absolute_anywhere(tail):
+                    resolved = (
+                        os.path.realpath(os.path.normpath(tail))
+                        if host_absolute
+                        else os.path.normpath(tail)
+                    )
+                    if resolved == target:
+                        return label
             idx = cmdline.find(token, idx + 1)
     return None

--- a/tests/test_process_match.py
+++ b/tests/test_process_match.py
@@ -45,6 +45,12 @@ MATCH_CASES = [
     ("/usr/local/bin/lingtai-agent run /a/foobar", "/a/foo", None),
     ("/v/bin/python -m lingtai run /a/foo/", "/a/foo", "module"),
     ("/usr/local/bin/lingtai-agent run /a/foo/", "/a/foo", "console"),
+    ("/v/bin/python -m lingtai run /a/elsewhere/../foo", "/a/foo", "module"),
+    ("/usr/local/bin/lingtai-agent run /a/elsewhere/../foo", "/a/foo", "console"),
+    ("/usr/local/bin/lingtai run /a/elsewhere/../foo", "/a/foo", "legacy"),
+    ("python -m lingtai run agent", "agent", None),
+    ("lingtai-agent run agent", "agent", None),
+    ("lingtai run agent", "agent", None),
     ("grep lingtai run /a/foo", "/a/foo", None),
     ("grep lingtai-agent run /a/foo", "/a/foo", None),
     ("tail -f /var/log/x lingtai run /a/foo", "/a/foo", None),
@@ -107,6 +113,25 @@ def test_refresh_watcher_imports_canonical_match_agent_run(tmp_path):
 
     assert "from lingtai.kernel.process_match import match_agent_run" in script
     assert "def match_agent_run" not in script
+
+
+def test_all_matcher_copies_resolve_absolute_symlink_alias(tmp_path):
+    real_dir = tmp_path / "real-agent"
+    real_dir.mkdir()
+    alias_dir = tmp_path / "agent-alias"
+    alias_dir.symlink_to(real_dir, target_is_directory=True)
+
+    doctor = _load_doctor_module()
+    matchers = (match_agent_run, doctor.match_agent_run)
+    commands = (
+        f"python -m lingtai run {alias_dir}",
+        f"lingtai-agent run {alias_dir}",
+        f"lingtai run {alias_dir}",
+    )
+
+    for matcher in matchers:
+        for command, expected in zip(commands, ("module", "console", "legacy")):
+            assert matcher(command, str(real_dir)) == expected
 
 
 def test_cli_duplicate_process_detects_console_script(tmp_path):


### PR DESCRIPTION
## Summary

- canonicalize absolute run directories with `realpath` in the kernel matcher, doctor copy, and embedded lifecycle watcher copy
- preserve the existing contract that relative run-directory arguments are not matched
- extend the cross-copy test matrix with symlink aliases

## Validation

- `PYTHONPATH=src python -m pytest -q tests/test_process_match.py` — **30 passed**
- `git diff --check canonical/main...HEAD` — passed
- independent read-only review — **PASS**, no blockers

A broader diagnostic run reported **47 passed, 2 failed** in pre-existing refresh-watcher retry/fixture assertions outside the changed matcher behavior; the dedicated matcher matrix and symlink coverage passed.

## Risk

`realpath` intentionally changes only absolute-path alias handling. Relative process arguments remain rejected because their working directory cannot be recovered safely from the process listing.

Fixes #764
