### PR TITLE
fix(doctor): keep diagnostics running on malformed state

### DIFF
--- a/src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -350,9 +351,14 @@ def collect_lifecycle(report: Report) -> dict[str, Any]:
 
     if agent_err:
         sec.add("FAIL", ".agent.json unavailable", f"Could not read .agent.json: {agent_err}")
+    elif not isinstance(agent_json, dict):
+        sec.add(
+            "FAIL",
+            ".agent.json malformed",
+            f".agent.json parsed as {type(agent_json).__name__}, expected a JSON object.",
+        )
     else:
         fields = {}
-        assert isinstance(agent_json, dict)
         for key in (
             "name",
             "id",
@@ -371,8 +377,13 @@ def collect_lifecycle(report: Report) -> dict[str, Any]:
 
     if status_err:
         sec.add("WARN", ".status.json unavailable", f"Could not read .status.json: {status_err}")
+    elif not isinstance(status_json, dict):
+        sec.add(
+            "WARN",
+            ".status.json malformed",
+            f".status.json parsed as {type(status_json).__name__}, expected a JSON object.",
+        )
     else:
-        assert isinstance(status_json, dict)
         fields = {
             k: status_json.get(k)
             for k in ("state", "status", "current_time", "no_progress_seconds", "context", "context_usage")
@@ -767,14 +778,35 @@ def try_addon_imports(sec: Section, python_commands: list[str], modules: set[str
     python = next((cmd for cmd in python_commands if Path(cmd).exists() and os.access(cmd, os.X_OK)), sys.executable)
     results: list[dict[str, Any]] = []
     for module in sorted(modules):
-        proc = subprocess.run(
-            [python, "-c", f"import {module}; print('ok')"],
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=10,
-            check=False,
-        )
+        try:
+            proc = subprocess.run(
+                [python, "-c", f"import {module}; print('ok')"],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=10,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            results.append(
+                {
+                    "module": module,
+                    "ok": False,
+                    "python": python,
+                    "error": ["import probe timed out after 10s"],
+                }
+            )
+            continue
+        except OSError as exc:
+            results.append(
+                {
+                    "module": module,
+                    "ok": False,
+                    "python": python,
+                    "error": [f"{type(exc).__name__}: {exc}"],
+                }
+            )
+            continue
         ok = proc.returncode == 0
         results.append({"module": module, "ok": ok, "python": python, "error": "" if ok else proc.stderr.strip().splitlines()[-1:]})
     severity = "OK" if all(item["ok"] for item in results) else "WARN"

--- a/tests/test_lingtai_doctor.py
+++ b/tests/test_lingtai_doctor.py
@@ -1,14 +1,25 @@
 """Tests for the intrinsic lingtai-doctor script."""
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
+import typing
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCTOR = ROOT / "src" / "lingtai" / "intrinsic_skills" / "lingtai-doctor" / "scripts" / "doctor.py"
+
+
+def load_doctor_module():
+    spec = importlib.util.spec_from_file_location("lingtai_doctor", DOCTOR)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_lingtai_doctor_self_test_passes():
@@ -57,3 +68,52 @@ def test_lingtai_doctor_json_redacts_env_secrets(tmp_path):
     data = json.loads(proc.stdout)
     assert data["severity"] == "FAIL"
     assert any(section["name"] == "mcp/addons" for section in data["sections"])
+
+
+def test_lingtai_doctor_reports_non_object_lifecycle_json(tmp_path):
+    agent = tmp_path / "agent"
+    agent.mkdir()
+    (agent / ".agent.json").write_text("[]", encoding="utf-8")
+    (agent / ".status.json").write_text('"idle"', encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, "-O", str(DOCTOR), "--agent-dir", str(agent), "--json"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert proc.returncode == 1
+    assert not proc.stderr
+    lifecycle = next(
+        section for section in json.loads(proc.stdout)["sections"]
+        if section["name"] == "lifecycle"
+    )
+    findings = {finding["title"]: finding for finding in lifecycle["findings"]}
+    assert "list" in findings[".agent.json malformed"]["detail"]
+    assert "str" in findings[".status.json malformed"]["detail"]
+
+
+def test_lingtai_doctor_addon_timeout_becomes_warning(monkeypatch):
+    doctor = load_doctor_module()
+    section = doctor.Section("mcp/addons")
+
+    def time_out(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(doctor.subprocess, "run", time_out)
+
+    assert doctor.try_addon_imports(section, [], {"example.addon"}) == ["example.addon"]
+    assert section.severity == "WARN"
+    assert section.findings[0].data["imports"][0]["error"] == [
+        "import probe timed out after 10s"
+    ]
+
+
+def test_lingtai_doctor_type_hints_resolve():
+    doctor = load_doctor_module()
+
+    hints = typing.get_type_hints(doctor.newest_mtime)
+
+    assert hints["paths"] == doctor.Iterable[Path]


### PR DESCRIPTION
## Summary

- import `Iterable` so runtime type-hint resolution does not fail
- replace assertion-based crashes on malformed-but-valid JSON shapes with structured diagnostic findings
- catch addon probe `subprocess.TimeoutExpired` errors and continue the remaining checks
- add focused regressions for all three keep-going failure modes

## Validation

- `PYTHONPATH=src python -m pytest -q tests/test_lingtai_doctor.py` — **5 passed**
- `git diff --check canonical/main...HEAD` — passed
- independent read-only review — **PASS**, no blockers

## Risk

The doctor now reports these failures instead of terminating early. The change is confined to diagnostic error handling and preserves successful probe behavior.

Fixes #748
