### PR TITLE
docs: codify repository design principles

### DIFF
--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -141,6 +141,13 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
    the same PR. A change affecting both updates the pair together.
 6. Orphans, missing targets, duplicate links, one-way pair links, and unpaired
    governed components are defects and MUST fail validation.
+7. A capability's manual is a navigation target linked from **both** owner twins:
+   the paired `ANATOMY.md` lists it in `related_files` as a route to the manual,
+   and the capability `CONTRACT.md` lists the same manual as its interface owner.
+   The normative both-edges requirement is owned by root
+   [`CONTRACT.md`](CONTRACT.md) `## Design principles` (principle 4); this anatomy
+   only names the navigation edge and does not restate that rule. A manual reached
+   from only one twin is a missing-edge defect.
 
 ## Components
 

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: component-contract-convention
-contract_version: 2
+contract_version: 3
 related_files:
   - ANATOMY.md
   - src/lingtai/kernel/event_journal/CONTRACT.md
@@ -25,6 +25,43 @@ maintenance: |
   convention change.
 ---
 # Component Contract Convention
+
+## Design principles
+
+These repository-wide design principles are normative for every capability,
+Contract, Anatomy, manual, and skill in this repository. Read and apply them
+before any change. They stay concise here by design: the deeper how and why live
+in the manuals and references they point to (progressive disclosure), not inline.
+
+1. **User-facing-only i18n, gated by human confirmation.** LingTai considers
+   internationalization only for genuinely *user-facing* surfaces. Existing
+   user-facing i18n is not disabled by this rule. Internal, code-level, or
+   agent-only surfaces MUST NOT acquire i18n by default. Before adding or
+   expanding i18n on any surface, an agent MUST ask the human to confirm that
+   i18n belongs there.
+2. **Progressive disclosure wherever possible.** Prefer a concise entry that
+   routes to depth over one exhaustive document, especially for agent-consumed
+   material for both coding agents and LingTai agents. Each layer states its rule
+   once and links onward instead of copying downstream detail upward.
+3. **Every capability is taught by a manual.** EVERY capability MUST have a
+   corresponding manual that explains what to do, how it works, and why it is
+   designed that way. The why and deeper detail MAY route through progressively
+   disclosed manual references rather than sitting inline. This does not blur the
+   layers: a Contract still defines the capability's obligations and behavior,
+   while its manual teaches the procedure to carry them out.
+4. **Manuals are discoverable from both owner twins.** ALL manuals MUST be
+   connected through the corresponding capability `CONTRACT.md` **and** its
+   paired/owning `ANATOMY.md` — both edges, not either one. Where those documents
+   carry a `related_files` schema, the manual (or its manual reference) MUST
+   appear in the `related_files` of both the capability Contract and its paired
+   Anatomy, so an agent descending either the interface graph or the navigation
+   graph reaches it. A missing Contract→manual edge or a missing Anatomy→manual
+   edge is a defect; global reachability through only one side does not satisfy
+   this rule.
+5. **The dev guide enforces these principles.** `dev-guide-skill/SKILL.md` MUST
+   strongly emphasize reading and applying this section before every development
+   task and route each change to the manual that teaches the capability it
+   touches.
 
 ## Purpose
 
@@ -219,8 +256,15 @@ order:
 3. `root_contract`: literal repo-relative path `CONTRACT.md`.
 4. `related_files`: non-empty duplicate-free list of repo-relative regular
    files. It includes the co-located paired `ANATOMY.md`, the Port, every
-   production Adapter, contract tests, public exports, and directly relevant
-   component contracts.
+   production Adapter, contract tests, public exports, directly relevant
+   component contracts, and — per Design principles 3 and 4 — the corresponding
+   manual(s) or manual reference for every capability the governed component
+   exposes. Every exposed capability MUST have such a manual (a component that
+   exposes no capability need not invent one, but no actual capability may opt
+   out). The paired `ANATOMY.md` MUST link the same manual(s) so both owner twins
+   carry the edge; the Contract lists the manual as the capability's interface
+   owner, while the Anatomy lists it as a navigation target, without copying the
+   manual's content into either.
 5. `maintenance`: the **canonical Maintenance block**, copied byte-for-byte
    from the single source of truth in this root contract's `## Template`
    section. Component authors MUST NOT paraphrase, reword, reindent, or
@@ -240,8 +284,8 @@ itself changes; that bump is a convention change that also bumps the root
 
 ## Body contract
 
-The root body headings are exactly the nine `##` sections in this file, in
-this order.
+The root body headings are exactly the ten `##` sections in this file, in
+this order, beginning with `## Design principles`.
 
 Every governed child body has these `##` headings, once and in this order:
 
@@ -298,6 +342,14 @@ every production Adapter, contract tests, public exports, and related component
 contracts that own the boundary. Contract-to-contract links are reciprocal when
 either contract depends on the other's normative rules. Unrelated children do
 not link to each other or copy each other's promises.
+
+Every capability's corresponding manual — required to exist by Design principle 3
+— carries that manual on **both** owner twins per Design principle 4: the
+capability `CONTRACT.md` `related_files` lists it as the interface owner, and the
+paired `ANATOMY.md` `related_files` lists the same manual as a navigation target.
+Missing either edge is a defect. The two jobs stay distinct — Contract owns the
+promise, Anatomy owns the route — and neither twin copies the manual's procedural
+content.
 
 ## Maintenance contract
 
@@ -364,6 +416,7 @@ related_files:
   - <repo-relative Port file>
   - <repo-relative production Adapter file>
   - <repo-relative contract-test file>
+  - <repo-relative capability manual or manual reference>
 maintenance: |
   <!-- CANONICAL-MAINTENANCE v2 BEGIN -->
   This component contract is governed by the root CONTRACT.md. Keep

--- a/dev-guide-skill/SKILL.md
+++ b/dev-guide-skill/SKILL.md
@@ -14,6 +14,14 @@ Read this skill before every development task in this repository. It owns the
 **workflow**, not the architecture facts or interface promises. Follow its links
 instead of copying the root documents into this file.
 
+Above all, the root [`CONTRACT.md`](../CONTRACT.md) `## Design principles`
+section is mandatory reading, and you MUST apply those principles to every
+change: gate any new or expanded i18n on explicit human confirmation, prefer
+progressive disclosure, ensure every capability you touch is taught by a manual
+(what/how/why), and keep that manual discoverable from **both** the corresponding
+`CONTRACT.md` and its paired `ANATOMY.md` (`related_files` on both twins) — one
+edge alone is a defect.
+
 ## First establish the task and baseline
 
 1. Re-read the latest human or maintainer instruction. Separate the requested
@@ -36,7 +44,11 @@ Use progressive disclosure in this order:
    the nearest child
    anatomy until cited code answers where the relevant files, connections,
    composition, and state live.
-2. Read root [`CONTRACT.md`](../CONTRACT.md). If the component is
+2. Read root [`CONTRACT.md`](../CONTRACT.md), **beginning with its
+   `## Design principles` section, and apply those principles to every change**
+   (i18n gate, progressive disclosure, every-capability-has-a-manual, and manual
+   discoverability from both the corresponding Contract and Anatomy). If the
+   component is
    governed, read its
    paired local contract before changing its interface or expected behavior.
 3. Read the cited code and narrow tests. Anatomy is navigation, not evidence in

--- a/tests/test_architecture_documents.py
+++ b/tests/test_architecture_documents.py
@@ -230,7 +230,7 @@ def test_root_architecture_documents_are_reciprocal_and_well_formed() -> None:
         "maintenance",
     ]
     assert contract_meta["name"] == "component-contract-convention"
-    assert contract_meta["contract_version"] == 2
+    assert contract_meta["contract_version"] == 3
 
     _assert_related_files(anatomy_meta)
     _assert_related_files(contract_meta)
@@ -281,6 +281,11 @@ def test_root_anatomy_defines_the_distributed_navigation_system() -> None:
         "single source for governed-component",
         "mutual progressive",
         "fail-loud mismatch reports",
+        # Navigation counterpart of Design principle 4: a capability manual is a
+        # graph target linked from BOTH owner twins, with the normative rule
+        # routed back to root CONTRACT.md `## Design principles`.
+        "navigation target linked from **both** owner twins",
+        "both-edges requirement is owned by root",
     ]:
         assert anchor in body
 
@@ -289,6 +294,7 @@ def test_root_contract_defines_the_distributed_interface_system() -> None:
     _, body = _read_document(ROOT_CONTRACT)
 
     assert _heading_order(body) == [
+        "## Design principles",
         "## Purpose",
         "## Architecture foundation",
         "## Behavior",
@@ -332,6 +338,54 @@ def test_root_contract_defines_the_distributed_interface_system() -> None:
         "suggested action",
     ]:
         assert anchor in body
+
+
+def test_root_contract_states_the_design_principles_first() -> None:
+    _, body = _read_document(ROOT_CONTRACT)
+
+    # The design-principles section is the very first body section.
+    assert _heading_order(body)[0] == "## Design principles"
+    assert body.index("## Design principles") < body.index("## Purpose")
+
+    # Each of the five normative principles is present and cannot silently
+    # regress: i18n gate, progressive disclosure, every-capability-has-a-manual
+    # (with the Contract-vs-manual distinction), the both-owner-twins manual
+    # discoverability rule, and dev-guide enforcement.
+    for anchor in [
+        "User-facing-only i18n, gated by human confirmation",
+        "MUST ask the human to confirm",
+        "Progressive disclosure wherever possible",
+        "agent-consumed",
+        "Every capability is taught by a manual",
+        "what to do, how it works, and why it is",
+        "a Contract still defines the capability's obligations",
+        "The dev guide enforces these principles",
+    ]:
+        assert anchor in body
+
+    # Principle 4 requires BOTH owner edges — the corresponding capability
+    # CONTRACT.md AND its paired ANATOMY.md — not general reachability via one
+    # side. Lock the literal both-edges wording so it cannot regress to "either".
+    for anchor in [
+        "Manuals are discoverable from both owner twins",
+        "both edges, not either one",
+        "global reachability through only one side does not satisfy",
+    ]:
+        assert anchor in body
+    # The detailed frontmatter and link-semantics rules carry the same both-twins
+    # requirement (manual on the capability Contract and its paired Anatomy).
+    assert "MUST link the same manual(s) so both owner twins" in body
+    assert "Missing either edge is a defect" in body
+
+    # Principle 3 makes the manual MANDATORY for every capability. The detailed
+    # frontmatter and link-semantics rules must state that obligation without
+    # optional/conditional escape hatches, and must not regress to "when the
+    # capability has any" / "a capability that has a manual" optionality.
+    assert "for every capability the governed component" in body
+    assert "Every exposed capability MUST have such a manual" in body
+    assert "Every capability's corresponding manual" in body
+    assert "when the capability has any" not in body
+    assert "a capability that has a manual" not in body
 
 
 def test_governed_child_contracts_have_reciprocal_anatomy_pairs() -> None:
@@ -528,6 +582,13 @@ def test_public_and_agent_entry_points_route_to_the_local_network() -> None:
         "CANONICAL-MAINTENANCE v<N> BEGIN",
         "Stop and report that diagnostic",
         "Do not\n   silently normalize, hand-edit, or auto-fix",
+        # The dev guide must strongly route to and enforce the root
+        # design-principles section (root CONTRACT.md `## Design principles`),
+        # including the both-twins manual-discoverability rule.
+        "Design principles",
+        "apply those principles to every change",
+        "mandatory reading",
+        "discoverable from **both** the corresponding",
     ]:
         assert anchor in dev_skill
     assert "repository’s dev guide skill" in contributing
@@ -587,6 +648,14 @@ def test_real_child_template_carries_the_canonical_block() -> None:
         "template-example", "CONTRACT.md#Template", template_meta["maintenance"]
     )
     assert report is None, report
+    # Per Design principles 3 and 4, the canonical child template must teach a
+    # capability manual / manual-reference related_files slot so a copied child
+    # carries the required Contract->manual edge; the terminology matches the
+    # Frontmatter contract ("manual or manual reference").
+    assert (
+        "<repo-relative capability manual or manual reference>"
+        in template_meta["related_files"]
+    )
 
 
 def test_byte_identical_child_passes() -> None:


### PR DESCRIPTION
## Summary

- add a first-body, normative `## Design principles` section to the root contract
- gate new or expanded i18n to genuinely user-facing surfaces with explicit human confirmation
- require progressive disclosure for agent-consumed material
- require every exposed capability to have a manual covering what/how/why
- require every capability manual to be discoverable from both its corresponding Contract and paired Anatomy
- make the repository-local dev guide route every change through these principles

## Contract mechanics

- bump the root contract convention from v2 to v3 and update the exact root heading schema
- add the manual edge to child frontmatter rules, link semantics, root Anatomy navigation rules, and the governed-child template
- preserve the canonical Maintenance block at v2 because its bytes did not change
- add focused regression anchors for section order, all five principles, mandatory manual existence, both-owner edges, the child template slot, and dev-guide routing

## Validation

- `python -m pytest -q tests/test_architecture_documents.py` — **23 passed**
- `python -m pytest -q tests/test_validate_skill.py tests/test_skills.py` — **48 passed**
- semantic positive/negative guards for mandatory manual wording — passed
- `git diff --check` — clean

## Review

- implemented and corrected with explicit Claude Opus 4.8; no Fable fallback
- independent DeepSeek V4 Pro review: **PASS / no blockers**
- accepted the review's child-template manual-slot suggestion, then reran the final validation above

## Out of scope

- no repository-wide migration of existing capabilities/manual graphs in this principles PR
- no Task Card ownership/manual relocation
- no canonical Maintenance v3 churn
