### PR TITLE
chore(release): bump kernel to 0.16.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.16.3"
+version = "0.16.4"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the canonical `pyproject.toml` package version from `0.16.3` to `0.16.4`
- prepare the current completed kernel state for the coordinated TUI/Portal v0.10.7 release

## Validation

- parsed `pyproject.toml` with `tomllib` and asserted project name `lingtai`, version `0.16.4`, and `setuptools.build_meta` backend
- exact scope is one file / one line
- `git diff --check`
- branch is rebased onto current `main` (`c363008e593d6a183ef3f792822f5b9ead60b350`); stable patch-id is unchanged from the pre-drift bump

Requested by the maintainer as part of the coordinated kernel v0.16.4 / TUI v0.10.7 release.