### PR TITLE
fix: preserve Telegram Task Card registration on refresh

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -983,15 +983,37 @@ class Agent(BaseAgent):
         ``lingtai.mcp_servers.telegram.task_card``, not in ``lingtai.tools``, so it
         carries no glossary package. This method is only the Composition Root: it
         detects the Telegram route and invokes the Telegram-owned ``setup``.
-        Idempotent: a no-op after the first registration and when no Telegram
-        client is present, so reconnects/reconciles never double-register.
+        Idempotent: a no-op when the current controller owns the public handler
+        and its exact schema, and when no Telegram client is present. A full
+        refresh clears those public registries but retains active controller
+        watches, so reconnect re-registers that same controller rather than
+        starting a second manager.
         """
-        if hasattr(self, "_task_card_controller"):
-            return
         if "telegram" not in getattr(self, "_mcp_clients_by_tool", {}):
             return
-        from .mcp_servers.telegram.task_card import setup as _setup_task_card
-        self._task_card_controller = _setup_task_card(self)
+        from .mcp_servers.telegram.task_card import (
+            get_description as _get_task_card_description,
+            get_schema as _get_task_card_schema,
+            setup as _setup_task_card,
+        )
+
+        controller = getattr(self, "_task_card_controller", None)
+        if controller is not None:
+            schemas = [
+                schema for schema in self._tool_schemas if schema.name == "task_card"
+            ]
+            handler = self._tool_handlers.get("task_card")
+            has_public_registration = (
+                getattr(handler, "__self__", None) is controller
+                and len(schemas) == 1
+                and schemas[0].description == _get_task_card_description()
+                and schemas[0].parameters == _get_task_card_schema()
+                and schemas[0].system_prompt == ""
+                and schemas[0].glossary_package is None
+            )
+            if has_public_registration:
+                return
+        self._task_card_controller = _setup_task_card(self, controller=controller)
 
     def connect_mcp_http(
         self,
@@ -1315,6 +1337,10 @@ class Agent(BaseAgent):
             except Exception:
                 pass
         self._mcp_clients = []
+        # Reverse routes belong to the closed clients above. Rebuild this mapping
+        # only from successfully connected clients during the following MCP load;
+        # a retained Task Card controller must never select a prior runtime route.
+        self._mcp_clients_by_tool = {}
 
         self._sealed = False
         self._tool_handlers.clear()

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -58,7 +58,9 @@ Normative promises live in the paired [`CONTRACT.md`](CONTRACT.md).
 - `_Watch` — per-watch in-memory state: thread, last-valid frame + timestamp,
   sticky `stopping`, `finalized` handshake flag, deduped error/epoch bookkeeping
   (`controller.py:118`).
-- `setup(agent)` — registers the `task_card` tool with `glossary_package=None`
+- `setup(agent, controller=...)` — registers the controller-bound `task_card`
+  handler and its schema with `glossary_package=None`, reusing an existing
+  controller when a full Agent refresh rebuilds the public tool registries
   (`controller.py:821`).
 - `TelegramTaskCardAgent` — the narrow host Protocol the controller depends on
   instead of the concrete `Agent` (`interface.py:23`).
@@ -66,7 +68,11 @@ Normative promises live in the paired [`CONTRACT.md`](CONTRACT.md).
 ## Connections
 
 - Composition root: `Agent._maybe_setup_task_card_controller` calls `setup`
-  once a Telegram MCP client exists (`src/lingtai/agent.py:977`).
+  only after the newly rebuilt reverse-route map contains Telegram; it
+  re-registers the same controller after a full refresh clears the public tool
+  surface or a colliding MCP overwrites it, verifying the handler binding and
+  owned schema rather than a name/count alone (`src/lingtai/agent.py:975`,
+  `src/lingtai/agent.py:1330`).
 - Renderer: `_run_renderer` runs `sys.executable <renderer>` with the agent
   workdir as `cwd`; `_validate_renderer_path` confines the path to that workdir.
 - Reverse channel: `_project` calls the private `_lingtai_telegram_task_card`

--- a/src/lingtai/mcp_servers/telegram/task_card/controller.py
+++ b/src/lingtai/mcp_servers/telegram/task_card/controller.py
@@ -818,13 +818,19 @@ class TaskCardController:
                 watch.thread.join(timeout=_JOIN_TIMEOUT_S)
 
 
-def setup(agent: TelegramTaskCardAgent) -> TaskCardController:
+def setup(
+    agent: TelegramTaskCardAgent,
+    *,
+    controller: TaskCardController | None = None,
+) -> TaskCardController:
     """Register the public ``task_card`` controller tool on *agent*.
 
     Telegram MCP-owned (it drives the Telegram-owned reverse channel), so it adds
     no ``lingtai.tools`` package and no glossary obligation (``glossary_package=None``).
+    A refresh may retain an active controller while rebuilding the sealed public
+    tool surface; in that case the Composition Root supplies it for re-registration.
     """
-    mgr = TaskCardController(agent)
+    mgr = controller if controller is not None else TaskCardController(agent)
     agent.add_tool(
         "task_card",
         schema=get_schema(),

--- a/tests/test_deep_refresh.py
+++ b/tests/test_deep_refresh.py
@@ -917,3 +917,332 @@ def test_refresh_watcher_receives_parent_captured_runtime_identity(tmp_path):
         "runtime_identity_event_fields",
     }.isdisjoint(names | attributes | imported_symbols)
     agent._workdir_lease.release()
+
+
+def test_deep_refresh_re_registers_telegram_task_card_without_leaking_watcher(
+    tmp_path, monkeypatch
+):
+    """The real reconstruct path reconnects Telegram and exposes one public
+    ``task_card`` tool again while reusing the existing controller and watcher.
+
+    This exercises ``_setup_from_init`` -> ``_load_mcp_from_workdir`` ->
+    ``connect_mcp`` rather than mocking the task-card composition helper. The
+    MCP transport is local/fake only so the regression has no subprocess or
+    network dependency.
+    """
+    from lingtai.agent import Agent
+    from lingtai.kernel.config import AgentConfig
+    from lingtai.services import mcp as mcp_module
+
+    class _FakeTelegramMCPClient:
+        instances: list["_FakeTelegramMCPClient"] = []
+
+        def __init__(self, command, args=None, env=None):
+            self.command = command
+            self.args = args
+            self.env = env
+            self.closed = False
+            self.calls: list[tuple[str, dict]] = []
+            type(self).instances.append(self)
+
+        def start(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+        def list_tools(self):
+            return [{
+                "name": "telegram",
+                "schema": {
+                    "type": "object",
+                    "properties": {"action": {"type": "string"}},
+                    "required": ["action"],
+                },
+                "description": "fake Telegram MCP tool",
+            }]
+
+        def call_tool(self, name, args, timeout=None):
+            assert name == "_lingtai_telegram_task_card"
+            assert args["channel"] == "programmable"
+            self.calls.append((name, dict(args)))
+            return {"status": "ok", "message_id": "acct:42:100"}
+
+    monkeypatch.setattr(mcp_module, "MCPClient", _FakeTelegramMCPClient)
+    (tmp_path / "init.json").write_text(json.dumps(_make_init()))
+    mcp_dir = tmp_path / "mcp"
+    mcp_dir.mkdir()
+    (mcp_dir / "servers.json").write_text(json.dumps({
+        "telegram": {"command": "fake-telegram"},
+    }))
+
+    service = MagicMock()
+    service.provider = "openai"
+    service.model = "gpt-4o"
+    service._base_url = None
+    agent = Agent(
+        service,
+        agent_name="test-agent",
+        working_dir=tmp_path,
+        config=AgentConfig(),
+    )
+    old_controller = None
+    try:
+        old_controller = agent._task_card_controller
+        assert [s.name for s in agent._build_tool_schemas()].count("task_card") == 1
+        assert list(agent._tool_handlers).count("task_card") == 1
+
+        agent._telegram_task_card_context = {"account": "acct", "chat_id": 42}
+        renderer = tmp_path / "task-card-renderer.py"
+        renderer.write_text(
+            "import json; print(json.dumps({'title': 'refresh'}))",
+            encoding="utf-8",
+        )
+        started = agent._tool_handlers["task_card"]({
+            "action": "start", "renderer_path": str(renderer), "interval_s": 3600,
+        })
+        old_watch = old_controller._watches[started["watch_id"]]
+        assert old_watch.thread is not None and old_watch.thread.is_alive()
+
+        agent._setup_from_init()
+
+        # The provider-facing schema is rebuilt from the same public tool
+        # registration as dispatch, not merely retained in a mock helper.
+        assert "task_card" in agent._tool_handlers
+        assert getattr(agent._tool_handlers["task_card"], "__self__", None) is old_controller
+        assert [s.name for s in agent._build_tool_schemas()].count("task_card") == 1
+        assert [s.name for s in agent._tool_schemas].count("task_card") == 1
+
+        # Full reconstruction closes the old MCP, but the controller is agent
+        # state rather than client state: reuse it so its active watcher survives
+        # and later projects through the freshly connected Telegram client.
+        assert _FakeTelegramMCPClient.instances[0].closed is True
+        assert old_watch.thread.is_alive()
+        assert agent._task_card_controller is old_controller
+        assert len(_FakeTelegramMCPClient.instances) == 2
+        agent._tool_handlers["task_card"]({
+            "action": "retry", "watch_id": started["watch_id"],
+        })
+        assert _FakeTelegramMCPClient.instances[1].calls
+
+        agent._maybe_setup_task_card_controller()
+        assert agent._task_card_controller is old_controller
+        assert list(agent._tool_handlers).count("task_card") == 1
+        assert [s.name for s in agent._tool_schemas].count("task_card") == 1
+    finally:
+        for controller in (old_controller, getattr(agent, "_task_card_controller", None)):
+            if controller is not None:
+                controller.shutdown_for_agent_stop(reason="test_cleanup")
+        agent._workdir_lease.release()
+
+
+def test_deep_refresh_drops_removed_telegram_route_before_unrelated_mcp_load(
+    tmp_path, monkeypatch
+):
+    """A full reconstruction never reuses a closed Telegram reverse route.
+
+    The retained controller/watch policy is deliberately narrow: removing Telegram
+    does not stop watches here, but it must leave them without a route rather than
+    recreate a public tool or project through the closed client.
+    """
+    from lingtai.agent import Agent
+    from lingtai.kernel.config import AgentConfig
+    from lingtai.services import mcp as mcp_module
+
+    class _FakeMCPClient:
+        instances: list["_FakeMCPClient"] = []
+
+        def __init__(self, command, args=None, env=None):
+            self.command = command
+            self.args = args
+            self.env = env
+            self.closed = False
+            self.calls: list[tuple[str, dict]] = []
+            type(self).instances.append(self)
+
+        def start(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+        def list_tools(self):
+            if self.command == "fake-telegram":
+                return [{
+                    "name": "telegram",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"action": {"type": "string"}},
+                        "required": ["action"],
+                    },
+                    "description": "fake Telegram MCP tool",
+                }]
+            assert self.command == "fake-unrelated"
+            return [{
+                "name": "unrelated",
+                "schema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+                "description": "fake unrelated MCP tool",
+            }]
+
+        def call_tool(self, name, args, timeout=None):
+            self.calls.append((name, dict(args)))
+            assert self.command == "fake-telegram"
+            assert name == "_lingtai_telegram_task_card"
+            return {"status": "ok", "message_id": "acct:42:100"}
+
+    monkeypatch.setattr(mcp_module, "MCPClient", _FakeMCPClient)
+    (tmp_path / "init.json").write_text(json.dumps(_make_init()))
+    mcp_dir = tmp_path / "mcp"
+    mcp_dir.mkdir()
+    servers_path = mcp_dir / "servers.json"
+    servers_path.write_text(json.dumps({"telegram": {"command": "fake-telegram"}}))
+
+    service = MagicMock()
+    service.provider = "openai"
+    service.model = "gpt-4o"
+    service._base_url = None
+    agent = Agent(
+        service,
+        agent_name="test-agent",
+        working_dir=tmp_path,
+        config=AgentConfig(),
+    )
+    old_controller = None
+    try:
+        old_controller = agent._task_card_controller
+        agent._telegram_task_card_context = {"account": "acct", "chat_id": 42}
+        renderer = tmp_path / "task-card-renderer.py"
+        renderer.write_text(
+            "import json; print(json.dumps({'title': 'removed-route'}))",
+            encoding="utf-8",
+        )
+        started = agent._tool_handlers["task_card"]({
+            "action": "start", "renderer_path": str(renderer), "interval_s": 3600,
+        })
+        watch = old_controller._watches[started["watch_id"]]
+        old_telegram = _FakeMCPClient.instances[0]
+        calls_before_refresh = len(old_telegram.calls)
+
+        # Remove Telegram while retaining an unrelated MCP. Its connection still
+        # invokes the real composition-root hook during reconstruction.
+        servers_path.write_text(
+            json.dumps({"unrelated": {"command": "fake-unrelated"}})
+        )
+        agent._setup_from_init()
+
+        assert old_telegram.closed is True
+        assert len(_FakeMCPClient.instances) == 2
+        unrelated = _FakeMCPClient.instances[1]
+        assert agent._mcp_clients_by_tool == {"unrelated": unrelated}
+        assert "telegram" not in agent._mcp_clients_by_tool
+        assert "task_card" not in agent._tool_handlers
+        assert all(schema.name != "task_card" for schema in agent._tool_schemas)
+        assert all(schema.name != "task_card" for schema in agent._build_tool_schemas())
+
+        # The retained watch fails closed against the absent route. It must not
+        # select the closed Telegram client or the unrelated MCP client.
+        assert old_controller._project(watch, "update", {"title": "no route"}) == {
+            "status": "error"
+        }
+        assert len(old_telegram.calls) == calls_before_refresh
+        assert unrelated.calls == []
+    finally:
+        for controller in (old_controller, getattr(agent, "_task_card_controller", None)):
+            if controller is not None:
+                controller.shutdown_for_agent_stop(reason="test_cleanup")
+        agent._workdir_lease.release()
+
+
+def test_telegram_registration_reclaims_foreign_task_card_on_collision_and_reconnect(
+    tmp_path, monkeypatch
+):
+    """Telegram-owned registration wins over a colliding MCP tool in either order."""
+    from lingtai.agent import Agent
+    from lingtai.kernel.config import AgentConfig
+    from lingtai.mcp_servers.telegram.task_card import get_description, get_schema
+    from lingtai.services import mcp as mcp_module
+
+    class _FakeMCPClient:
+        instances: list["_FakeMCPClient"] = []
+
+        def __init__(self, command, args=None, env=None):
+            self.command = command
+            self.args = args
+            self.env = env
+            type(self).instances.append(self)
+
+        def start(self):
+            pass
+
+        def close(self):
+            pass
+
+        def list_tools(self):
+            if self.command == "fake-foreign":
+                return [{
+                    "name": "task_card",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"foreign": {"type": "string"}},
+                        "required": ["foreign"],
+                    },
+                    "description": "foreign task card",
+                }]
+            assert self.command == "fake-telegram"
+            return [{
+                "name": "telegram",
+                "schema": {
+                    "type": "object",
+                    "properties": {"action": {"type": "string"}},
+                    "required": ["action"],
+                },
+                "description": "fake Telegram MCP tool",
+            }]
+
+        def call_tool(self, name, args, timeout=None):
+            raise AssertionError("registration test must not dispatch an MCP tool")
+
+    monkeypatch.setattr(mcp_module, "MCPClient", _FakeMCPClient)
+    (tmp_path / "init.json").write_text(json.dumps(_make_init()))
+    service = MagicMock()
+    service.provider = "openai"
+    service.model = "gpt-4o"
+    service._base_url = None
+    agent = Agent(
+        service,
+        agent_name="test-agent",
+        working_dir=tmp_path,
+        config=AgentConfig(),
+    )
+    try:
+        # A foreign MCP may claim the public name before Telegram connects.
+        agent.connect_mcp(command="fake-foreign")
+        foreign_handler = agent._tool_handlers["task_card"]
+        assert not hasattr(agent, "_task_card_controller")
+
+        agent.connect_mcp(command="fake-telegram")
+        controller = agent._task_card_controller
+        schema = [s for s in agent._tool_schemas if s.name == "task_card"]
+        assert getattr(agent._tool_handlers["task_card"], "__self__", None) is controller
+        assert agent._tool_handlers["task_card"] is not foreign_handler
+        assert len(schema) == 1
+        assert schema[0].parameters == get_schema()
+        assert schema[0].description == get_description()
+
+        # A later foreign collision must be reclaimed immediately; a Telegram
+        # reconnect must preserve the same controller and exact public surface.
+        agent.connect_mcp(command="fake-foreign")
+        agent.connect_mcp(command="fake-telegram")
+        schema = [s for s in agent._tool_schemas if s.name == "task_card"]
+        assert agent._task_card_controller is controller
+        assert getattr(agent._tool_handlers["task_card"], "__self__", None) is controller
+        assert len(schema) == 1
+        assert schema[0].parameters == get_schema()
+        assert schema[0].description == get_description()
+        assert agent._mcp_clients_by_tool["telegram"] is _FakeMCPClient.instances[-1]
+    finally:
+        agent._workdir_lease.release()

--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -128,15 +128,30 @@ def test_description_routes_to_the_telegram_manual():
 def test_wiring_registers_only_with_telegram_and_is_idempotent():
     """The composition-root hook registers ``task_card`` exactly once, and only
     when a Telegram reverse channel is present."""
+    from types import SimpleNamespace
+
     from lingtai.agent import Agent
 
     class _Stub:
         def __init__(self, telegram):
             self._mcp_clients_by_tool = {"telegram": object()} if telegram else {}
+            self._tool_handlers: dict = {}
+            self._tool_schemas: list = []
             self.added: list = []
 
-        def add_tool(self, name, **_):
+        def add_tool(self, name, **kwargs):
             self.added.append(name)
+            self._tool_handlers[name] = kwargs["handler"]
+            self._tool_schemas = [s for s in self._tool_schemas if s.name != name]
+            self._tool_schemas.append(
+                SimpleNamespace(
+                    name=name,
+                    description=kwargs["description"],
+                    parameters=kwargs["schema"],
+                    system_prompt=kwargs.get("system_prompt", ""),
+                    glossary_package=kwargs["glossary_package"],
+                )
+            )
 
     no_tg = _Stub(telegram=False)
     Agent._maybe_setup_task_card_controller(no_tg)
@@ -147,6 +162,8 @@ def test_wiring_registers_only_with_telegram_and_is_idempotent():
     Agent._maybe_setup_task_card_controller(tg)
     assert tg.added == ["task_card"]
     assert hasattr(tg, "_task_card_controller")
+    assert getattr(tg._tool_handlers["task_card"], "__self__", None) is tg._task_card_controller
+    assert tg._tool_schemas[0].parameters == get_schema()
     Agent._maybe_setup_task_card_controller(tg)  # idempotent
     assert tg.added == ["task_card"]
 


### PR DESCRIPTION
## Summary

Follow-up to #898's live activation test.

- rebuild the MCP reverse-route map during deep refresh so closed/removed Telegram clients cannot gate public Task Card registration
- preserve the existing Task Card controller/watch while restoring exactly one controller-owned public `task_card` handler/schema after a valid Telegram reconnect
- reclaim foreign `task_card` handler/schema collisions without creating a second controller
- add real `_setup_from_init()` regressions for successful reconnect, Telegram removal with an unrelated MCP, and foreign collision/reconnect ordering
- update the Telegram Task Card Anatomy; the existing Contract already promises Telegram-gated ownership and is unchanged

## Root cause

`Agent._setup_from_init()` cleared public tool handlers/schemas but retained both the Task Card controller and the old tool→MCP-client reverse map. The old attribute-only idempotence guard then skipped public re-registration, while a removed or failed Telegram reconnect could still leave a closed Telegram route visible.

The fix resets the reverse map before MCP reload and treats registration as idempotent only when the current handler is bound to the retained controller and the singleton schema matches the Telegram-owned Task Card schema.

## Validation

- `305 passed` — deep refresh, Task Card, Agent/MCP, and architecture-document suites
- `5084 passed, 3 skipped, 1 failed` — complete `tests/` suite on current `main`
  - sole failure: `tests/test_wheel_sidecar_smoke.py::test_native_wheel_ships_and_runs_sidecar`
  - the locally built native wheel installs without `lingtai/bin/`; this is the same known environment/native-sidecar failure reproduced before this diff and during #898 validation
- failing-first blocker regressions: `2 failed` before the remediation, then passed after the production fix
- final focused lifecycle/collision review: `3 passed`; HTTP/stdio mapping: `3 passed`; MCP retry recovery: `1 passed`
- `tests/test_architecture_documents.py`: `25 passed`
- Anatomy drift checker: no drift across 45 files
- `git diff --check`: passed
- no tracked deletions

## Review

- implementation candidate: Terra, after the default Claude Opus weekly quota was exhausted
- first independent Terra review: **BLOCK**, identifying stale closed-client routing and foreign-handler ownership gaps
- remediated both blockers with failing-first regressions
- final independent Terra re-review: **APPROVE**, no suggestions

## Scope note

This PR intentionally does not define a new product policy for retained watches after Telegram is removed. They fail closed without projecting through a stale or unrelated client; pause/shutdown/report behavior remains a separate decision.
