### PR TITLE
fix(bash): persist async jobs across relaunches

### DIFF
--- a/reports/bash-async-relaunch-durability-20260713.html
+++ b/reports/bash-async-relaunch-durability-20260713.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Bash async relaunch durability — implementation and validation report</title>
+<style>
+  :root {
+    --ink:#172033; --muted:#637083; --paper:#f5f7fb; --card:#ffffff;
+    --line:#dfe5ee; --blue:#2458d3; --blue-soft:#eaf0ff;
+    --green:#16744b; --green-soft:#e8f7ef; --amber:#9a5b00; --amber-soft:#fff3dc;
+    --red:#a13c34; --red-soft:#fff0ee; --shadow:0 12px 34px rgba(27,42,72,.08);
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; color:var(--ink); background:var(--paper); font:15px/1.58 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+  main { width:min(1180px, calc(100% - 36px)); margin:34px auto 70px; }
+  .hero { padding:34px 38px; color:white; border-radius:20px; background:linear-gradient(135deg,#183c9a,#2f68e6 58%,#5c88ef); box-shadow:var(--shadow); }
+  .eyebrow { font-size:12px; font-weight:750; letter-spacing:.12em; text-transform:uppercase; opacity:.78; }
+  h1 { margin:8px 0 10px; font-size:clamp(30px,5vw,52px); line-height:1.08; letter-spacing:-.035em; }
+  .hero p { max-width:850px; margin:0; font-size:18px; opacity:.9; }
+  .meta { display:flex; flex-wrap:wrap; gap:9px; margin-top:22px; }
+  .pill { display:inline-flex; align-items:center; gap:7px; padding:7px 11px; border:1px solid rgba(255,255,255,.28); border-radius:999px; background:rgba(255,255,255,.12); font-size:13px; }
+  section { margin-top:22px; padding:27px 30px; border:1px solid var(--line); border-radius:18px; background:var(--card); box-shadow:var(--shadow); }
+  h2 { margin:0 0 14px; font-size:24px; letter-spacing:-.02em; }
+  h3 { margin:0 0 7px; font-size:16px; }
+  p { margin:7px 0; }
+  code { padding:.12em .35em; border-radius:5px; background:#edf1f7; font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; }
+  .lead { font-size:18px; }
+  .grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:13px; }
+  .metric { padding:17px; border:1px solid var(--line); border-radius:13px; background:#fbfcff; }
+  .metric strong { display:block; font-size:25px; line-height:1.15; }
+  .metric span { color:var(--muted); font-size:13px; }
+  .success { color:var(--green); }
+  .flow { display:grid; grid-template-columns:1fr 56px 1fr; align-items:stretch; gap:11px; }
+  .flow-card { padding:19px; border-radius:14px; border:1px solid var(--line); }
+  .flow-card.before { background:var(--red-soft); border-color:#f1ccc7; }
+  .flow-card.after { background:var(--green-soft); border-color:#c7e7d6; }
+  .arrow { display:grid; place-items:center; color:var(--blue); font-size:31px; font-weight:800; }
+  ol.chain { margin:12px 0 0; padding-left:22px; }
+  ol.chain li { margin:7px 0; }
+  table { width:100%; border-collapse:collapse; margin-top:10px; }
+  th,td { padding:12px 13px; border-bottom:1px solid var(--line); text-align:left; vertical-align:top; }
+  th { color:#45536a; background:#f7f9fc; font-size:12px; text-transform:uppercase; letter-spacing:.06em; }
+  tr:last-child td { border-bottom:0; }
+  .tag { display:inline-block; padding:3px 8px; border-radius:999px; font-size:12px; font-weight:700; }
+  .tag.green { color:var(--green); background:var(--green-soft); }
+  .tag.amber { color:var(--amber); background:var(--amber-soft); }
+  .note { padding:15px 17px; border-left:4px solid var(--blue); border-radius:8px; background:var(--blue-soft); }
+  .warning { border-left-color:var(--amber); background:var(--amber-soft); }
+  .paths { display:grid; grid-template-columns:1fr 1fr; gap:8px 18px; padding:0; list-style:none; }
+  .paths li { padding:9px 11px; border:1px solid var(--line); border-radius:9px; overflow-wrap:anywhere; font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px; }
+  footer { margin-top:22px; color:var(--muted); text-align:center; font-size:13px; }
+  @media (max-width:850px) { .grid{grid-template-columns:1fr 1fr}.flow{grid-template-columns:1fr}.arrow{transform:rotate(90deg)}.paths{grid-template-columns:1fr} }
+  @media (max-width:520px) { main{width:min(100% - 20px,1180px);margin-top:10px}.hero,section{padding:22px 19px;border-radius:14px}.grid{grid-template-columns:1fr} }
+</style>
+</head>
+<body>
+<main>
+  <header class="hero">
+    <div class="eyebrow">LingTai kernel · Bash capability · PR candidate</div>
+    <h1>Async jobs now outlive the agent that started them.</h1>
+    <p>A durable supervisor owns the child process, logs, cancellation, and exact exit status. A relaunched manager rehydrates the same job instead of guessing from an orphaned PID.</p>
+    <div class="meta">
+      <span class="pill">Live base <code>99deeafe</code></span>
+      <span class="pill">8 implementation/doc/test paths</span>
+      <span class="pill">No merge or release authorized</span>
+      <span class="pill">Report generated 2026-07-13</span>
+    </div>
+  </header>
+
+  <section>
+    <h2>Conclusion first</h2>
+    <p class="lead">The candidate closes the cross-refresh/relaunch ownership gap without pretending that a live PID is proof of process identity or exact exit status.</p>
+    <div class="grid">
+      <div class="metric"><strong class="success">114 passed</strong><span>Bash async + layer focused gate</span></div>
+      <div class="metric"><strong class="success">330 passed</strong><span>Anatomy, architecture, package, glossary, layers; 54 resources validated</span></div>
+      <div class="metric"><strong class="success">10 × 8</strong><span>Cancellation/start/handoff/suppression races, all green</span></div>
+      <div class="metric"><strong class="success">5109 passed</strong><span>Full source suite; 3 skipped, 5 failures exactly reproduced on clean base</span></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Before and after</h2>
+    <div class="flow">
+      <div class="flow-card before">
+        <h3>Before: manager-owned lifetime</h3>
+        <ol class="chain">
+          <li>Agent manager starts a child and keeps transient process handles.</li>
+          <li>Refresh/relaunch destroys the manager's in-memory ownership.</li>
+          <li>A later poll can see files or a PID, but cannot recover exact wait status.</li>
+          <li>Cancellation and reminders can race terminal truth or report premature success.</li>
+        </ol>
+      </div>
+      <div class="arrow">→</div>
+      <div class="flow-card after">
+        <h3>After: supervisor-owned lifetime</h3>
+        <ol class="chain">
+          <li>Manager atomically creates durable job state with a finite start lease and bounded successful-return handoff.</li>
+          <li>Supervisor claims and rechecks the start lease before <code>Popen</code>; parent reaping or later dead/expired proof closes every preclaim exit.</li>
+          <li>Supervisor owns <code>Popen</code>, logs, whole-group TERM→KILL quiescence, exact <code>wait()</code>, and terminal commit.</li>
+          <li>Any later manager rehydrates state; <code>status: ok</code> is permitted only while the return handoff still linearizes safely.</li>
+        </ol>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>Normative contracts locked by the patch</h2>
+    <table>
+      <thead><tr><th>Concern</th><th>Promise</th><th>Failure avoided</th></tr></thead>
+      <tbody>
+        <tr><td>Supervisor start</td><td>Initial state carries a tokenized finite lease; the supervisor claims it and rechecks under the state lock immediately before command spawn. The owning parent reaps an early exit; a fresh manager uses expired-lease or definitively-dead PID proof.</td><td>Preclaim death stranded forever in <code>launching</code>/<code>running</code>, duplicate spawn, and PID-reuse guessing.</td></tr>
+        <tr><td>Exact terminal truth</td><td>Only the supervisor holding the direct child unreaped commits the real wait result after logs close.</td><td>Fabricated <code>-1</code>, false failure, or poll-before-commit unknown.</td></tr>
+        <tr><td>Polling</td><td>Verified-live commands fast-path; otherwise poll waits for bounded supervisor commit before declaring explicit unrecoverable state.</td><td>Command PID exits a moment before supervisor persists the exit code.</td></tr>
+        <tr><td>Cancellation</td><td>The supervisor keeps the direct shell unreaped through TERM grace, KILLs the original process group, and reports <code>group_cancelled</code> only after no live non-zombie group member remains.</td><td>False “cancelled” after outer-shell exit while a TERM-ignoring descendant survives.</td></tr>
+        <tr><td>One terminal consumer</td><td>Terminal claim and reminder suppression are atomic under the durable state lock.</td><td>Two managers both consuming the same result.</td></tr>
+        <tr><td>Reminder timing</td><td>A bounded durable return handoff blocks the crash fallback before <code>Popen</code> and between durable <code>running</code> and successful return. <code>status: ok</code> requires the valid lock-owned transition; a post-expiry owner returns a pollable error with <code>job_id/pid</code>.</td><td>Premature reminder or false start success after fallback publication.</td></tr>
+        <tr><td>Completion wake</td><td>Exact completion suppresses pending/publishing/bounded-suppressing watchdogs; expired cancellation suppression recovers to pending. Bash completion owns the authoritative wake.</td><td>Stale reminder, permanent suppression after manager crash, and reminder/terminal races.</td></tr>
+        <tr><td>Legacy jobs</td><td>A live legacy PID stays conservatively running and uncancellable; after it dies, one poll returns explicit unknown status.</td><td>Signalling an unowned reused PID or inventing an exit code.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Validation receipts</h2>
+    <table>
+      <thead><tr><th>Gate</th><th>Exact result</th><th>Evidence</th></tr></thead>
+      <tbody>
+        <tr><td>Focused</td><td><span class="tag green">PASS</span> 114 tests in 18.66s</td><td><code>final-focused-20260713T1402Z/receipt.txt</code></td></tr>
+        <tr><td>Related contracts/docs</td><td><span class="tag green">PASS</span> 330 tests in 26.13s; 54 glossary resources validated</td><td><code>final-related-20260713T1402Z/receipt.txt</code></td></tr>
+        <tr><td>Race repetition</td><td><span class="tag green">PASS</span> 8 adversarial tests × 10 iterations</td><td><code>final-race-repeat-20260713T1404Z/receipt.txt</code></td></tr>
+        <tr><td>Full source suite</td><td><span class="tag amber">BASELINE ONLY</span> 5109 passed, 3 skipped, 5 failed in 225.64s; no Bash failures</td><td><code>final-full-source-20260713T1405Z/receipt.txt</code></td></tr>
+        <tr><td>Baseline comparison</td><td><span class="tag green">REPRODUCED</span> the same five failures on clean exact base <code>99deeafe</code></td><td><code>baseline-five-cleanbase-20260713T1415Z/receipt.txt</code></td></tr>
+      </tbody>
+    </table>
+    <div class="note warning">
+      <strong>Verified baseline failures, not candidate regressions.</strong>
+      Three Codex-focused tests fail because the intentionally empty scratch <code>HOME</code> has no <code>codex-auth.json</code>; the traversal-budget test sees <code>/tmp/</code> in the absolute task-scratch prefix; and the wheel sidecar smoke test installs a wheel without <code>lingtai/bin/</code>. Clean exact base <code>99deeafe</code> reproduces all five under the same confined environment.
+    </div>
+  </section>
+
+  <section>
+    <h2>Patch scope</h2>
+    <ul class="paths">
+      <li>src/lingtai/tools/bash/__init__.py</li>
+      <li>src/lingtai/tools/bash/_async_supervisor.py</li>
+      <li>src/lingtai/tools/bash/CONTRACT.md</li>
+      <li>src/lingtai/tools/bash/ANATOMY.md</li>
+      <li>src/lingtai/tools/bash/manual/SKILL.md</li>
+      <li>src/lingtai/tools/bash/glossary-zh.md</li>
+      <li>src/lingtai/tools/bash/glossary-wen.md</li>
+      <li>tests/test_bash_async.py</li>
+    </ul>
+    <p>The report itself is intentionally separate from the eight implementation/doc/test paths. The previous stale-base worktree and every failed/review/test artifact remain preserved; no cleanup or deletion was performed.</p>
+  </section>
+
+  <section>
+    <h2>Review focus</h2>
+    <div class="note">
+      The decisive questions are not style or line count. Review the state-machine linearization points: finite supervisor-start claim and pre-<code>Popen</code> recheck; owning-parent/fresh-manager recovery from preclaim death; exact terminal commit; poll's precommit wait; whole-group cancellation quiescence; atomic terminal consumption; bounded return-handoff success; and reminder publication versus cancellation/terminal suppression.
+    </div>
+    <p>External side effects remain gated: the candidate is not committed, pushed, merged, released, or installed by this report.</p>
+  </section>
+
+  <footer>Source: candidate worktree and preserved validation receipts under the task scratch root. This is a self-contained local report with no external scripts, fonts, or network requests.</footer>
+</main>
+</body>
+</html>

--- a/src/lingtai/tools/bash/ANATOMY.md
+++ b/src/lingtai/tools/bash/ANATOMY.md
@@ -2,7 +2,9 @@
 related_files:
   - src/lingtai/ANATOMY.md
   - src/lingtai/tools/bash/__init__.py
+  - src/lingtai/tools/bash/_async_supervisor.py
   - src/lingtai/tools/bash/bash_policy.json
+  - src/lingtai/tools/bash/CONTRACT.md
   - src/lingtai/tools/bash/manual/SKILL.md
   - tests/test_bash_async.py
   - tests/test_layers_bash.py
@@ -25,7 +27,8 @@ be explicitly opted into.
 
 ## Components
 
-- `bash/__init__.py` — the entire capability in a single file. `get_description` (`__init__.py:175`), `get_schema` (`__init__.py:179-223`), `setup` (`__init__.py:822-860`). Two core classes: `BashPolicy` for command filtering (`__init__.py:227-315`), `BashManager` for execution (`__init__.py:318-819`). Module-level result helpers: `_augment_command_result` adds `ok`/`command_status`/`warning` fidelity fields (`__init__.py:121-173`), `_detect_failure_signature` labels `python_traceback`/`missing_module` (`__init__.py:64-78`), `_broad_scan_hint` returns timeout recipe text for broad recursive walks (`__init__.py:91-118`).
+- `bash/__init__.py` — public schema/setup plus policy, sync execution, and durable async manager orchestration. `get_description` (`__init__.py:195`), `get_schema` (`__init__.py:199`), and `setup` (`__init__.py:1416`) define the public capability surface. `BashPolicy` owns command filtering (`__init__.py:247`); `BashManager` owns validation, sync execution, durable-state rehydration, notification publication, and poll/cancel consumption (`__init__.py:338`). `_augment_command_result` adds `ok`/`command_status`/`warning` fidelity fields (`__init__.py:141`).
+- `bash/_async_supervisor.py` — private detached process that owns command spawn/wait/log handles and atomically persists terminal truth. State writers begin at `_async_supervisor.py:72`, PID identity at `:169`, group liveness proof at `:205`, start-lease claiming at `:263`, durable cancellation/wait at `:334`, and the supervisor entry path at `:386`.
 - `bash/bash_policy.json` — default denylist policy shipped with the kernel. Denies destructive (`rm`, `rmdir`, `shred`, `dd`), privilege escalation (`sudo`, `su`, `doas`), permission changes (`chmod`, `chown`, `chgrp`), disk management (`mount`, `umount`, `mkfs`, `fdisk`), package managers (`apt`, `apt-get`, `yum`, `dnf`, `brew`), process control (`kill`, `killall`, `pkill`, `shutdown`, `reboot`, `systemctl`), network (`nc`, `ncat`), and code execution (`eval`, `exec`).
 
 ## Public API
@@ -44,7 +47,7 @@ The `bash` tool supports synchronous and asynchronous execution:
 
 **Sync mode** (`async=false`, default): Returns `{status, exit_code, stdout, stderr, ok, command_status[, warning]}` once the command completes, or `{status: "error", message}` only when the shell itself could not run it (empty command, policy denial, timeout, spawn failure).
 
-**Async mode** (`async=true`): Returns `{status: "ok", job_id, pid, message}` immediately. Use `action="poll"` with the job_id to check status: returns `{status: "running", job_id, pid}` while running, or `{status: "done", exit_code, stdout, stderr, ok, command_status[, warning]}` once finished. Use `action="cancel"` to kill the process group. Async run validates `reminder` as a finite non-negative number bounded by `threading.TIMEOUT_MAX` and defaults omitted direct calls to 1800 seconds (`__init__.py:385-408`, `__init__.py:436-441`).
+**Async mode** (`async=true`): Returns `{status: "ok", job_id, pid, message}` immediately. Initial durable state carries both a tokenized finite supervisor-start lease and a bounded `return_handoff`. The supervisor must claim/recheck the start lease before command `Popen`; the parent then atomically replaces the crash-fallback reminder deadline with `returned_at + reminder` and arms the return handoff before returning. `status: ok` requires winning that valid pending-to-armed transition (or exact completed/failed truth under the still-valid guard); a late owner after expiry returns a pollable error with `job_id`/`pid` instead of false success. Any rehydrated old timer defers while that handoff is pending. The detached supervisor owns the command `Popen`/`wait()` and atomically records `{cwd, started_at, finished_at, exit_status_known, exit_code}`. A fresh manager never consumes unknown merely because a command PID vanished: it waits/reloads while the recorded supervisor can still commit, marks unknown only after an expired start lease or a definitively gone supervisor, and otherwise returns recoverable `running`. Terminal poll is a conditional one-shot claim. `cancel` persists a request; the supervisor keeps the direct child unreaped through TERM grace, KILLs the original group, proves live-member quiescence, and commits exact terminal truth before cancellation can atomically consume/suppress the job. Async run validates `reminder` as a finite non-negative number bounded by `threading.TIMEOUT_MAX` and defaults omitted direct calls to 1800 seconds.
 
 **Result fidelity — top-level `status` vs. inner command success.** The top-level `status` (`ok`/`done`) reflects only that the shell *spawned* the command; it stays `ok`/`done` even when the inner command exits nonzero. To make inner failures impossible to skim past *without* changing the `status` contract that downstream recovery/telemetry branch on (`tool_executor.py` enriches/logs/collects on `status == "error"`), `_augment_command_result` (`__init__.py`) adds three additive, model-visible fields keyed off `exit_code`:
 
@@ -56,7 +59,7 @@ On a still-running poll there is no `exit_code`, so no fidelity fields are added
 
 **Timeout hint.** On a sync timeout whose command resembles a broad recursive scan (`find … -name/-path/-type`, `rglob(`, `os.walk(`, `glob('**…')` — `_broad_scan_hint`), the timeout `message` appends an `rg --files`-based recipe. The hint is advisory text only; it never blocks or rewrites the command.
 
-Job files are stored under `system/jobs/{job_id}/` (stdout.log, stderr.log, pid, status). Cleaned up automatically on poll-completion or cancel. The process-exit watcher still writes single-slot `.notification/bash.json` with a bounded command preview (`__init__.py:651-700`); the last-resort reminder uses `.notification/system.json` multi-event append with stable `ref_id="bash.reminder:<job_id>"` so close-due jobs do not overwrite one another (`__init__.py:531-649`, `src/lingtai/kernel/base_agent/messaging.py:66-180`).
+Job files are stored under `system/jobs/{job_id}/`, where new IDs use the full UUID4 hex form `job-<32 hex>` and only old `job-<8 hex>` names remain accepted for legacy reads. `state.json` is the atomically replaced source of truth; it carries command/cwd, supervisor-start and successful-return handoff leases, supervisor and command PID identities, lifecycle timestamps, terminal result, cancellation request, and completion/reminder publication state. `stdout.log` and `stderr.log` remain supervisor-owned. Directories intentionally remain as durable records; retention/compaction is future policy, not implicit deletion. A conditional terminal claim changes `terminal_polled` and reminder suppression in one write, so concurrent managers have one terminal consumer. Reminder state is a tokenized `pending → publishing → published` (or bounded `suppressing` / terminal `suppressed`) claim; a due timer defers while `return_handoff` remains pending, and the final sink write shares the state lock with suppression. Stable reminder/completion refs correlate and can dedupe only while their bounded/current sinks retain them; they do not make bounded system events or latest-only Bash completion delivery globally exactly-once. Both are separate from `.notification/cron.json` workflow reminders.
 
 ## Internal Module Layout
 
@@ -80,13 +83,17 @@ bash/__init__.py
   │   ├── handle(args)               — dispatches to _handle_run / _handle_poll / _handle_cancel
   │   ├── _handle_run(args)          — validates + runs sync or async
   │   ├── _run_sync(command, cwd, timeout) — subprocess.run path; augments result + timeout hint
-  │   ├── _run_async(command, cwd, reminder) — subprocess.Popen with start_new_session, returns job_id
-  │   ├── _run_reminder_timer(...)   — daemon-threaded last-resort poll reminder
-  │   ├── _claim_reminder_timer(...) — lock-owned terminal-vs-deadline claim
-  │   ├── _publish_async_reminder(job_id) — appends bash.reminder system event
-  │   ├── _handle_poll(args)         — checks job status; augments completed result
-  │   ├── _handle_cancel(args)       — SIGTERM to process group, cleanup
-  │   └── _close_handles(job_id)     — closes open file handles for a job
+  │   ├── _run_async(command, cwd, reminder) — writes initial state, starts/reaps private supervisor, returns command PID
+  │   ├── _rehydrate_async_jobs()    — resumes reminder/completion state at manager construction
+  │   ├── _run_reminder_timer(...)   — deadline worker; claim is durable rather than timer-local
+  │   ├── _publish_async_reminder(...) / _publish_completion_if_due(...) — stable-ref notifications
+  │   ├── _handle_poll(args)         — reads exact durable outcome or explicit unknown exit
+  │   └── _handle_cancel(args)       — verifies durable supervisor ownership, requests cancel, waits exact commit
+  │
+  ├── _async_supervisor.py           — private detached runner; owns command wait/logs/atomic terminal write
+  │   ├── write_initial_state/update_state — fsync + replace under POSIX state lock
+  │   ├── process_identity(...)       — Linux start ticks or POSIX lstart identity
+  │   └── supervise(job_dir)          — command spawn, wait, exact exit persistence
   │
   └── setup(agent, policy_file, yolo) — resolves policy, registers bash tool
 ```
@@ -99,9 +106,10 @@ bash/__init__.py
 - **Result fidelity is additive, never status-changing:** A completed command always returns top-level `status: "ok"`/`"done"` regardless of `exit_code`. The pass/fail signal lives in additive `ok`/`command_status`/`warning` fields. `status: "error"` is reserved for the shell failing to run the command at all (empty/denied command, timeout, spawn failure) — this preserves the `tool_executor` contract that branches on `status == "error"` for error enrichment, lifecycle logging, and `collected_errors`.
 - **Output truncation:** `max_output = 50_000` chars. Both stdout and stderr are truncated with a note showing total length.
 - **Subprocess isolation:** Commands run via `subprocess.run(shell=True, capture_output=True, text=True, timeout=...)` in the agent's working directory by default.
-- **Async subprocess:** Async commands use `subprocess.Popen(shell=True, start_new_session=True)` with stdout/stderr redirected to files under `system/jobs/{job_id}/`. `start_new_session=True` ensures the process gets its own session, enabling `os.killpg()` for clean cancellation.
-- **Async reminder lifecycle:** `_run_async()` arms one daemon timer per job (`__init__.py:512-541`). The timer and terminal handling share `_reminder_lock`: `_claim_reminder_timer()` atomically pops the pending reminder before publish, while terminal `poll -> done` / successful `cancel` suppress by popping first (`__init__.py:543-577`, `__init__.py:742-744`, `__init__.py:800-801`). Process exit and `.notification/bash.json` completion do not cancel the timer.
-- **Job lifecycle:** Jobs are created on async run, tracked via PID files, and cleaned up (directory deleted) after poll-completion or cancel. File handles are closed via `_close_handles()` to avoid resource leaks.
+- **Async supervisor:** A private detached runner must claim a tokenized finite start lease and recheck it under the state lock before `Popen(shell=True, start_new_session=True)`. It records its incarnation and command identity, owns the unreaped child and exact `wait()`, and atomically persists terminal truth. If it exits before terminal commit, its owning parent reaper or a later lease/dead-PID proof makes the job explicitly unrecoverable.
+- **Terminal truth, cancellation, and consumption:** A missing command PID is pending evidence while the recorded supervisor can still commit. Poll writes unrecoverable only after bounded start-lease or supervisor-loss proof. After a durable cancel request, the supervisor retains the direct shell unreaped through TERM grace, KILLs the original group, and reports success only after live non-zombie group quiescence. `terminal_polled` is a conditional atomic claim coupled to reminder suppression, so poll/cancel races have one consumer.
+- **Async reminder lifecycle:** Deadline, return handoff, and publication state live in `state.json`, not only a timer. Initial state provides a crash fallback plus a bounded pending-return guard; due claims defer until the successful-return mutation atomically writes `returned_at + reminder` and arms that guard. The returning manager reports success only if this still-valid lock transition wins (or exact completed/failed terminal truth already won under the valid guard); after expiry it returns a pollable recovery error. On guard expiry, a live job may use the fallback while an expired launch/dead supervisor becomes unrecoverable. Cancellation's durable `suppressing` state is bounded and returns to `pending` after crash/timeout. Final reminder publication is serialized with terminal suppression; exact completion suppresses stale pending/publishing/suppressing watchdogs and Bash completion owns the wake. Stable refs offer bounded/current-sink deduplication only, so crashes after sink write can still duplicate after retention/eviction.
+- **Job lifecycle:** Jobs remain durable records after terminal poll/confirmed cancellation; retention/compaction is future policy. New IDs are full UUID4 hex and collision-safe; old eight-hex IDs are legacy read compatibility. A live legacy PID remains conservatively running and uncancellable because its incarnation cannot be proved; after it dies, one poll returns explicit unknown exit status rather than fabricated `-1` failure.
 - **Policy file location:** Default policy is `bash/bash_policy.json` (shipped with the kernel). Can be overridden via `policy_file` arg or bypassed with `yolo=True`.
 
 ## Dependencies
@@ -109,12 +117,12 @@ bash/__init__.py
 - `lingtai.i18n` — `t()` for localized strings
 - `lingtai.kernel.base_agent.BaseAgent` — agent type (TYPE_CHECKING only)
 - `lingtai.kernel.base_agent.messaging._enqueue_system_notification` — canonical `.notification/system.json` multi-event append path when Bash is installed on an agent (`src/lingtai/kernel/base_agent/messaging.py:66-180`).
-- `lingtai.kernel.notifications.collect_notifications` / `submit` — direct-manager fallback for tests and programmatic BashManager use without a BaseAgent; protected by the agent's shared system lock when present, otherwise a module-global fallback lock (`__init__.py:605-649`).
+- `lingtai.kernel.notification_store.NotificationStore` — serialized compare/update ownership for direct-manager reminder appends and sink-idempotent Bash completion writes; injected through `agent._notification_store` (`__init__.py:937`, `:1012`).
 - `lingtai.kernel.trace_redaction.redact_text` — mechanical secret redaction for the stderr tail hoisted into `warning` (imported lazily inside `_redact_warning_tail`, fail-open).
 
 ## Composition
 
 - **Parent:** `src/lingtai/tools/` (tool package).
 - **Siblings:** `daemon/`, `avatar/`, `mcp/`, `knowledge/` (private durable memory), `skills/` (skill catalog).
-- **Manual:** `bash/manual/SKILL.md` — operational guide for agents (currently focused on scheduled / cron-driven work — when to schedule, the wake-by-mailbox-drop contract, hygiene rules, OS-specific recipes for launchd / systemd / crontab, and debugging walkthroughs).
+- **Manual:** `bash/manual/SKILL.md` — operational guide for agents covering async/poll/reminder durability plus scheduled / cron-driven work, wake-by-mailbox-drop, hygiene rules, OS-specific scheduler recipes, and debugging walkthroughs.
 - **Kernel hooks:** `setup()` is called during capability initialization; `BashManager.handle()` is registered as the `bash` tool handler.

--- a/src/lingtai/tools/bash/CONTRACT.md
+++ b/src/lingtai/tools/bash/CONTRACT.md
@@ -1,10 +1,12 @@
 ---
 name: bash-contract
 tool: bash
-contract_version: 1
+contract_version: 3
 related_files:
   - src/lingtai/tools/bash/__init__.py
+  - src/lingtai/tools/bash/_async_supervisor.py
   - src/lingtai/tools/bash/ANATOMY.md
+  - src/lingtai/tools/bash/manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -66,8 +68,8 @@ for `command` and `job_id`. `action` defaults to `run`.
 |---|---|---|---|---|
 | `run` (sync) | Provider schema: `command`, `reminder`; runtime consumes `command` only | `working_dir`, `timeout` (default 30), `summary` | `{status: "ok", exit_code, stdout, stderr, ok, command_status, warning?}` | `{status: "error", message}` — empty command, policy-denied, cwd outside sandbox, timeout (with broad-scan hint), or spawn failure |
 | `run` (async) | Provider/runtime: `command`, `async: true`, `reminder` | `working_dir`, `summary` | `{status: "ok", job_id, pid, message}` | `{status: "error", message}` — same validation errors, invalid boolean/non-numeric/non-finite/negative/too-large `reminder`, plus `Failed to start async job: ...` |
-| `poll` | Provider schema: `job_id`, `reminder`; runtime consumes `job_id` only | — | running: `{status: "running", job_id, pid}`; finished: `{status: "done", exit_code, stdout, stderr, ok, command_status, warning?}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or `Job already finished (...)` |
-| `cancel` | Provider schema: `job_id`, `reminder`; runtime consumes `job_id` only | — | `{status: "cancelled", job_id}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or `Job already finished (...)` |
+| `poll` | Provider schema: `job_id`, `reminder`; runtime consumes `job_id` only | — | running: `{status: "running", job_id, pid?}` while the recorded supervisor may still commit; known finished: `{status: "done", exit_status_known: true, exit_code, stdout, stderr, ok, command_status, warning?}`; unrecoverable/legacy terminal: `{status: "done", exit_status_known: false, exit_code: null, stdout, stderr}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or an already terminal-consumed job |
+| `cancel` | Provider schema: `job_id`, `reminder`; runtime consumes `job_id` only | — | `{status: "cancelled", job_id}` only after the supervisor has committed the held child's exact terminal status and cancellation atomically consumes/suppresses the job | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, terminal job, legacy job, or a durable cancellation request still awaiting a terminal commit (which remains pollable/remindable) |
 
 Fidelity fields are additive and keyed off `exit_code`: `ok` is `True` only when
 `exit_code == 0`; `command_status` is `"success"`/`"failed"`; `warning` is
@@ -92,32 +94,80 @@ All paths are relative to the agent working directory (`<agent>/`):
 
 ```text
 <agent>/system/jobs/<job_id>/
-  command       # the command string
-  status        # "running" (dir is removed once poll/cancel reaps the job)
-  pid           # child PID (also the process-group id; see below)
-  stdout.log    # streamed child stdout
-  stderr.log    # streamed child stderr
-<agent>/.notification/bash.json   # written by the async watcher on job exit
-<agent>/.notification/system.json # appended by the last-resort async reminder
+  state.json    # atomically replaced authoritative state (command, cwd, timestamps,
+                # start/return handoff leases, supervisor/command PID identities,
+                # terminal result, reminder and completion publication claims)
+  .state.lock   # POSIX lock serializing manager and supervisor state transitions
+  stdout.log    # streamed child stdout, owned/closed by the supervisor
+  stderr.log    # streamed child stderr, owned/closed by the supervisor
+  command/status/pid  # legacy layout read only for honest unknown-exit recovery
+<agent>/.notification/bash.json   # manager-published durable completion wake
+<agent>/.notification/system.json # stable-ref last-resort async reminder events
 ```
 
-`job_id` is `job-<8 hex>`. On `poll`-to-completion or `cancel`, the job
-directory is removed with `shutil.rmtree(..., ignore_errors=True)`. The async
-watcher thread writes `.notification/bash.json` atomically (`.tmp` + rename) when
-the process exits, so completion reaches the agent through the same notification
-channel as email/soul/molt. `stdout`/`stderr` are truncated to `max_output`
-(default 50_000 chars) with a trailing `... (truncated, N chars total)` marker.
+New retained IDs are `job-<32 lowercase hex>` (a full UUID4 hex value). The
+strict reader also accepts only the old `job-<8 lowercase hex>` form so existing
+legacy records remain addressable; all other names are rejected before path use.
+Async run uses collision-safe directory creation and first atomically records
+`state.json`, including a tokenized finite supervisor-start lease and a bounded
+`return_handoff` guard, before starting a detached private supervisor
+(`_async_supervisor.py`). The launching manager immediately records the observed
+supervisor PID/identity; the supervisor must claim the matching unexpired lease,
+recheck it under the state lock immediately before `Popen`, then records its own
+incarnation and the command PID. An expired/terminal lease cannot spawn a command.
+The supervisor owns the unreaped `Popen` and `wait()` and atomically records the
+exact wait status. If it exits before terminal commit, the owning parent reaper
+marks the state unrecoverable; after parent loss, an expired launch lease or a
+definitively absent recorded supervisor gives a fresh manager equivalent proof.
 
-Async run also arms a daemon-threaded last-resort reminder. When `reminder`
-seconds elapse, the deadline path atomically claims the job under the same
-reminder lock used by terminal handling. If terminal `poll -> done` or
-successful `cancel` popped the job first, the reminder is suppressed; if the
-deadline claims first, the reminder legitimately wins and Bash appends one
-`bash.reminder` event to `.notification/system.json` with stable
-`ref_id="bash.reminder:<job_id>"` and a poll instruction. The reminder is
-intentionally **not** cancelled just because the process exits or the normal
-`.notification/bash.json` completion notification was written: an unpolled
-completed job still needs the fallback.
+A missing command PID is never terminal proof while the recorded supervisor is
+live/identifiable or cannot yet be disproved: poll reloads for a bounded commit
+window and remains `running` if necessary. It records `unrecoverable` only after
+the bounded start lease expires or the recorded supervisor incarnation is
+definitively gone. Terminal poll and successful cancellation use one conditional
+state claim (`terminal_polled` was false and state was terminal); that same atomic
+write suppresses the reminder, so only one concurrent manager receives the
+terminal response. Job directories and logs remain durable records.
+`stdout`/`stderr` are truncated to `max_output` (default 50,000 chars) only when
+returned, with a trailing `... (truncated, N chars total)` marker.
+Retention/compaction limits for these records and logs are an explicit future
+policy; this feature does not delete them.
+
+`reminder.deadline_at`, its publication state, and `return_handoff` are durable.
+Initial state records a crash-safe reminder deadline before supervisor launch and
+marks the successful-return transition pending. A second manager whose old timer
+becomes due while that bounded guard is valid must defer and re-read durable
+state; it cannot publish the fallback before the first manager returns. The
+successful-return mutation atomically writes `returned_at + reminder` and marks
+the handoff armed, so neither the pre-`Popen` window nor the durable-`running`
+/pre-return window consumes the caller's requested interval. The call may report
+`status: ok` only when that lock-owned pending-to-armed transition wins before
+expiry, or when exact completed/failed terminal truth wins under the still-valid
+guard. A live owner resuming after expiry returns an explicit `status: error`
+containing the durable `job_id`/`pid` and pollable-recovery message; it cannot
+recall an already-published fallback and cannot falsely report start success. If
+the bounded handoff expires, a live running job retains the crash fallback; an
+expired start lease or definitively gone supervisor becomes unrecoverable and
+completion owns the wake instead.
+
+On every manager construction, a future non-terminal deadline is re-armed and an
+overdue/stale publishing claim is retried. Cancellation uses a bounded durable
+`suppressing` state: claims defer through the supervisor's commit window, then an
+expired suppression returns to `pending` if the manager died or cancellation did
+not commit. The final reminder-sink write and its acknowledgement are serialized
+with terminal suppression by the job-state lock: after suppression wins, a stale
+claim cannot publish. Exact supervisor terminal commit suppresses any
+`pending`/`publishing`/`suppressing` watchdog, and the Bash completion channel owns
+that wake-up; a reminder whose sink write linearized first may remain as
+historical evidence, but terminal state prevents a later retry. A crash after a
+sink write but before its acknowledgement can still retry while the job is
+non-terminal. Stable `ref_id="bash.reminder:<job_id>"` deduplicates only while the
+bounded/current system sink retains that reference; it is not a global exactly-once
+ledger. Completion `ref_id="bash.completion:<job_id>"` likewise avoids an immediate
+same-slot rewrite, but the latest-only `bash` sink can be overwritten by another
+completion before a crash retry. Completion/ref IDs are correlation aids, not
+durable delivery acknowledgements across bounded/latest-only sinks. This is Bash
+job state, not a `.notification/cron.json` workflow reminder.
 
 ## Cross-platform invariants
 
@@ -125,15 +175,27 @@ DOCUMENT ONLY — do not change these assumptions and do not propose Windows wor
 
 - Sync execution uses `subprocess.run(command, shell=True, ...)` — POSIX shell
   string semantics.
-- Async execution uses `subprocess.Popen(command, shell=True,
-  start_new_session=True, ...)`, making the child PID its own process-group
-  leader (pgid == pid).
-- `cancel` relies on that invariant: it sends `SIGTERM` to the whole group via
-  `os.killpg(os.getpgid(pid), signal.SIGTERM)`, then reaps the `Popen` handle if
-  held (2s wait, then `kill()`), avoiding zombies and orphaned children.
-- `poll` falls back to `os.waitpid(pid, os.WNOHANG)` / `os.kill(pid, 0)` when the
-  in-process `Popen` handle is not held (different manager instance, same PID
-  file).
+- The detached private supervisor uses `subprocess.Popen(command, shell=True,
+  start_new_session=True, ...)`, making the command PID its own process-group
+  leader (pgid == pid), while its durable `wait()` result survives a manager
+  relaunch.
+- Before reporting a command PID as running, Bash compares its persisted OS
+  process-start identity with the live PID (Linux boot-id/start ticks; POSIX
+  `ps lstart` fallback). A mismatch/unavailable observation is never terminal
+  evidence while the recorded supervisor may still commit.
+- `cancel` is a durable request, not a manager-side signal. The supervisor holds
+  the direct child `Popen` unreaped through the full group `SIGTERM` grace, then
+  targets the original group with `SIGKILL` even if the outer shell already
+  exited. It reports `group_cancelled` only after proving no live non-zombie group
+  member remains and preserves the direct child's exact wait status otherwise.
+  Keeping the group leader unreaped prevents its PID/pgid from being recycled
+  during that signal sequence. POSIX still cannot promise control of processes
+  which deliberately leave the command group.
+- A legacy directory without durable supervisor state cannot prove PID identity
+  and is therefore never signalable. While its recorded PID is live it remains
+  conservatively `running`/uncancellable; after that PID is gone, its explicit
+  unknown terminal response is one-shot via a legacy consumption marker and never
+  invents `-1` or a false `command_status: failed`.
 
 These POSIX process-group, signal, and `shell=True` assumptions are load-bearing
 for cancellation correctness.
@@ -151,10 +213,11 @@ for cancellation correctness.
 | Allowlist mode permits only listed commands; denylist blocks listed ones | `src/lingtai/tools/bash/__init__.py` | `tests/test_layers_bash.py::test_allow_only`, `::test_deny_only`, `::test_pipe_awareness` |
 | Policy is enforced on async runs too | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_policy_applies_to_async` |
 | Async `reminder` defaults to 1800 for omitted direct calls while schema marks it required | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_schema_requires_reminder_with_runtime_default` |
-| Last-resort reminders survive process exit until terminal poll/cancel and append without overwriting close due jobs | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_async_reminder_publishes_after_delay_even_if_process_exited_unpolled`, `::test_async_reminder_does_not_overwrite_close_due_jobs`, `::test_terminal_poll_suppresses_async_reminder`, `::test_successful_cancel_suppresses_async_reminder` |
+| Last-resort deadlines are measured from successful async return, and a bounded durable handoff blocks both pre-`Popen` and durable-`running` pre-return publication windows while retaining crash fallback | `src/lingtai/tools/bash/__init__.py`, `_async_supervisor.py` | `tests/test_bash_async.py::test_reminder_deadline_starts_at_successful_async_return`, `::test_return_handoff_blocks_fallback_while_parent_popen_is_delayed`, `::test_return_handoff_blocks_fallback_after_running_before_return_arm`, `::test_owner_resuming_after_handoff_expiry_cannot_report_start_success`, `::test_stale_pre_return_reminder_timer_defers_to_latest_deadline` |
+| Supervisor terminal truth, bounded start-lease recovery, parent-reaper/fresh-manager handling of an actual preclaim supervisor exit, PID identity refusal, and sink-idempotent completion wake survive manager loss | `src/lingtai/tools/bash/_async_supervisor.py`, `__init__.py` | `tests/test_bash_async.py::TestBashAsyncRelaunchDurability`, `::test_owned_parent_reaps_actual_supervisor_exit_before_start_claim`, `::test_fresh_manager_recovers_actual_preclaim_exit_after_owner_loss`, `::test_legacy_live_pid_remains_running_and_uncancellable` |
 | Reminder validation rejects non-finite and backend-unsafe delays | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_async_reminder_rejects_invalid_values` |
-| Deadline claim and terminal handling have deterministic lock-owned ordering | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_terminal_pop_before_deadline_claim_suppresses_reminder`, `::test_deadline_claim_before_terminal_pop_publishes_once` |
-| Direct-manager fallback appends remain multi-event safe across managers | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_direct_manager_fallback_is_shared_across_managers` |
+| Deadline claim, bounded cancellation suppression/recovery, and terminal handling have deterministic lock-owned ordering | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_terminal_pop_before_deadline_claim_suppresses_reminder`, `::test_deadline_claim_before_terminal_pop_publishes_once`, `::test_expired_suppressing_reminder_recovers_after_manager_crash` |
+| Direct-manager fallback appends remain multi-event safe across managers | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_direct_manager_fallback_is_serialized_by_shared_store` |
 | `yolo=True` allows all commands | `src/lingtai/tools/bash/__init__.py` | `tests/test_layers_bash.py::test_add_capability_bash_yolo` |
 
 ## Verification matrix

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -12,14 +12,25 @@ from __future__ import annotations
 
 import json
 import math
-import os
 import re
-import signal
+import secrets
 import subprocess
+import sys
 import threading
+import time
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from ._async_supervisor import (
+    load_state,
+    process_identity,
+    process_identity_matches,
+    process_is_alive,
+    publish_reminder_if_claimed,
+    update_state,
+    write_initial_state,
+)
 
 
 if TYPE_CHECKING:
@@ -29,6 +40,16 @@ PROVIDERS = {"providers": [], "default": "builtin"}
 
 _DEFAULT_POLICY_FILE = Path(__file__).parent / "bash_policy.json"
 _DEFAULT_ASYNC_REMINDER_SECONDS = 1800.0
+_SUPERVISOR_START_LEASE_SECONDS = 3.0
+# The parent may spend one start lease launching the supervisor and another
+# waiting for its durable PID before it can atomically arm the user-visible
+# reminder from the successful-return boundary.  During that bounded handoff,
+# another manager must not publish the earlier crash-fallback deadline.
+_RETURN_HANDOFF_LEASE_SECONDS = _SUPERVISOR_START_LEASE_SECONDS * 2
+_RETURN_HANDOFF_RECHECK_SECONDS = 0.05
+_SUPERVISOR_COMMIT_GRACE_SECONDS = 0.25
+_CANCEL_COMMIT_TIMEOUT_SECONDS = 3.0
+_JOB_ID_RE = re.compile(r"job-(?:[0-9a-f]{32}|[0-9a-f]{8})\Z")
 
 # Length of the stderr tail surfaced in the failure warning. Short on purpose:
 # the full stderr is already present in the result; the tail just makes the
@@ -205,7 +226,7 @@ def get_schema(lang: str = "en") -> dict:
             },
             "reminder": {
                 "type": "number",
-                "description": "Last-resort async wake delay in seconds (default: 1800). For async run only: if the job has not been terminally polled or cancelled by then, publish a system notification reminding you to poll it.",
+                "description": "Last-resort async wake delay in seconds (default: 1800). For async run only: if the job is still non-terminal when the durable deadline expires, publish a system notification reminding you to poll it; exact completion suppresses this stale watchdog and publishes the Bash completion wake instead.",
                 "default": _DEFAULT_ASYNC_REMINDER_SECONDS,
             },
             "job_id": {
@@ -315,7 +336,7 @@ class BashPolicy:
 
 
 class BashManager:
-    """Manages shell command execution for an agent."""
+    """Manages shell commands; async terminal truth belongs to a durable child."""
 
     def __init__(
         self,
@@ -331,9 +352,15 @@ class BashManager:
         self._jobs_dir: Path | None = None
         self._reminder_lock = threading.Lock()
         self._reminder_cancel_events: dict[str, threading.Event] = {}
+        self._completion_lock = threading.Lock()
+        self._completion_watchers: set[str] = set()
+        self._rehydrate_async_jobs()
+
+    def _jobs_path(self) -> Path:
+        return self._jobs_dir or Path(self._working_dir) / "system" / "jobs"
 
     def _ensure_jobs_dir(self) -> Path:
-        """Create and return the jobs directory (lazy init)."""
+        """Create and return the jobs directory (only for an async run)."""
         if self._jobs_dir is None:
             self._jobs_dir = Path(self._working_dir) / "system" / "jobs"
         self._jobs_dir.mkdir(parents=True, exist_ok=True)
@@ -373,11 +400,10 @@ class BashManager:
 
     @staticmethod
     def _validate_job_id(job_id: str) -> dict | None:
-        """Validate job_id is safe (no path traversal). Returns error dict or None."""
-        if not job_id:
+        """Accept only retained full UUID IDs and the old eight-hex legacy form."""
+        if not isinstance(job_id, str) or not job_id:
             return {"status": "error", "message": "job_id is required"}
-        # Reject path traversal attempts
-        if "/" in job_id or "\\" in job_id or ".." in job_id:
+        if _JOB_ID_RE.fullmatch(job_id) is None:
             return {"status": "error", "message": f"Invalid job_id: {job_id}"}
         return None
 
@@ -392,11 +418,7 @@ class BashManager:
             delay = float(value)
         except (TypeError, ValueError):
             return None, {"status": "error", "message": "reminder must be a finite non-negative number of seconds"}
-        if (
-            delay < 0
-            or not math.isfinite(delay)
-            or delay > threading.TIMEOUT_MAX
-        ):
+        if delay < 0 or not math.isfinite(delay) or delay > threading.TIMEOUT_MAX:
             return None, {
                 "status": "error",
                 "message": (
@@ -408,12 +430,10 @@ class BashManager:
 
     def handle(self, args: dict) -> dict:
         action = args.get("action", "run")
-
         if action == "poll":
             return self._handle_poll(args)
         if action == "cancel":
             return self._handle_cancel(args)
-        # action == "run"
         return self._handle_run(args)
 
     def _handle_run(self, args: dict) -> dict:
@@ -421,19 +441,13 @@ class BashManager:
         err = self._validate_command(command)
         if err:
             return err
-
-        # Treat an empty/whitespace-only working_dir the same as omitting it:
-        # run in the agent working directory rather than failing the sandbox
-        # check (models commonly pass working_dir="" to mean "default").
         cwd = args.get("working_dir") or self._working_dir
         if isinstance(cwd, str) and not cwd.strip():
             cwd = self._working_dir
         err = self._validate_working_dir(cwd)
         if err:
             return err
-
-        is_async = args.get("async", False)
-        if is_async:
+        if args.get("async", False):
             reminder, err = self._validate_reminder(args.get("reminder"))
             if err:
                 return err
@@ -441,142 +455,486 @@ class BashManager:
         return self._run_sync(command, cwd, args.get("timeout", 30))
 
     def _run_sync(self, command: str, cwd: str, timeout: float) -> dict:
-        """Synchronous execution — original behavior, unchanged."""
+        """Synchronous execution remains intentionally unchanged."""
         try:
             result = subprocess.run(
-                command,
-                shell=True,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                cwd=cwd,
+                command, shell=True, capture_output=True, text=True,
+                timeout=timeout, cwd=cwd,
             )
-            stdout = result.stdout
-            stderr = result.stderr
+            stdout, stderr = result.stdout, result.stderr
             if len(stdout) > self._max_output:
                 stdout = stdout[: self._max_output] + f"\n... (truncated, {len(result.stdout)} chars total)"
             if len(stderr) > self._max_output:
                 stderr = stderr[: self._max_output] + f"\n... (truncated, {len(result.stderr)} chars total)"
-
             return _augment_command_result({
-                "status": "ok",
-                "exit_code": result.returncode,
-                "stdout": stdout,
-                "stderr": stderr,
+                "status": "ok", "exit_code": result.returncode,
+                "stdout": stdout, "stderr": stderr,
             })
         except subprocess.TimeoutExpired:
             msg = f"Command timed out after {timeout}s"
             hint = _broad_scan_hint(command)
-            if hint:
-                msg = f"{msg}. {hint}"
-            return {"status": "error", "message": msg}
+            return {"status": "error", "message": f"{msg}. {hint}" if hint else msg}
         except Exception as e:
             return {"status": "error", "message": f"Command failed: {e}"}
 
-    def _run_async(self, command: str, cwd: str, reminder: float) -> dict:
-        """Start command in background, return job_id immediately."""
-        jobs_dir = self._ensure_jobs_dir()
-        job_id = f"job-{uuid.uuid4().hex[:8]}"
-        job_dir = jobs_dir / job_id
-        job_dir.mkdir()
+    @staticmethod
+    def _terminal(status: object) -> bool:
+        return status in {"completed", "unrecoverable"}
 
-        (job_dir / "command").write_text(command)
-        (job_dir / "status").write_text("running")
+    def _rehydrate_async_jobs(self) -> None:
+        """Restore deadline/completion publication work from durable job state."""
+        jobs_dir = self._jobs_path()
+        if not jobs_dir.is_dir():
+            return
+        for job_dir in jobs_dir.iterdir():
+            if not job_dir.is_dir() or _JOB_ID_RE.fullmatch(job_dir.name) is None:
+                continue
+            state = load_state(job_dir)
+            if state is None:
+                continue  # Legacy jobs remain readable by _handle_poll.
+            if not self._terminal(state.get("status")):
+                state = self._mark_unrecoverable_if_supervisor_gone(job_dir) or load_state(job_dir) or state
+            job_id = job_dir.name
+            reminder = state.get("reminder")
+            if self._terminal(state.get("status")):
+                # Completion owns the wake-up once terminal truth exists.  A
+                # watchdog saying the job "may still be running" is stale and
+                # must not be re-armed by a fresh manager.
+                def suppress_terminal_reminder(current: dict) -> dict:
+                    durable_reminder = current.get("reminder")
+                    if isinstance(durable_reminder, dict) and durable_reminder.get("state") in {
+                        "pending", "publishing", "suppressing"
+                    }:
+                        durable_reminder.update({
+                            "state": "suppressed",
+                            "suppressed_at": time.time(),
+                        })
+                        durable_reminder.pop("claim_token", None)
+                        durable_reminder.pop("suppressing_at", None)
+                        durable_reminder.pop("suppressing_until", None)
+                    return current
 
-        stdout_f = open(job_dir / "stdout.log", "w", encoding="utf-8")
-        stderr_f = open(job_dir / "stderr.log", "w", encoding="utf-8")
+                update_state(job_dir, suppress_terminal_reminder)
+                self._publish_completion_if_due(job_id, job_dir)
+            else:
+                if isinstance(reminder, dict) and reminder.get("state") in {"pending", "publishing", "suppressing"}:
+                    self._start_reminder_timer(job_id, job_dir)
+                self._start_completion_watcher(job_id, job_dir)
 
-        try:
-            proc = subprocess.Popen(
-                command,
-                shell=True,
-                stdout=stdout_f,
-                stderr=stderr_f,
-                cwd=cwd,
-                start_new_session=True,
-            )
-        except Exception as e:
-            stdout_f.close()
-            stderr_f.close()
-            # Clean up on launch failure
-            import shutil
-            shutil.rmtree(job_dir, ignore_errors=True)
-            return {"status": "error", "message": f"Failed to start async job: {e}"}
-
-        (job_dir / "pid").write_text(str(proc.pid))
-        # Store Popen + file handles in-process so we can reap and close them.
-        if not hasattr(self, "_open_handles"):
-            self._open_handles: dict[str, tuple] = {}
-        self._open_handles[job_id] = (proc, stdout_f, stderr_f)
-        self._start_reminder_timer(job_id, job_dir, reminder)
-
-        # Start background watcher — writes .notification/bash.json when
-        # the process exits, so the agent gets notified via the standard
-        # notification sync mechanism (same channel as email/soul/molt).
-        watcher = threading.Thread(
-            target=self._watch_async_job,
-            args=(job_id, command, proc, job_dir, stdout_f, stderr_f),
-            daemon=True,
-        )
-        watcher.start()
-
+    def _initial_async_state(self, job_id: str, command: str, cwd: str, reminder: float) -> dict:
+        now = time.time()
         return {
-            "status": "ok",
+            "version": 3,
             "job_id": job_id,
-            "pid": proc.pid,
-            "message": f'Job started. Use bash(action="poll", job_id="{job_id}") to check.',
+            "command": command,
+            "cwd": cwd,
+            "status": "launching",
+            "created_at": now,
+            "started_at": None,
+            "finished_at": None,
+            "pid": None,
+            "pid_identity": None,
+            "pid_start_time": None,
+            "process_group": None,
+            "supervisor_start_lease": {
+                "token": secrets.token_hex(16),
+                "deadline_at": now + _SUPERVISOR_START_LEASE_SECONDS,
+                "state": "pending",
+            },
+            "return_handoff": {
+                "state": "pending",
+                "deadline_at": now + _RETURN_HANDOFF_LEASE_SECONDS,
+            },
+            "exit_status_known": False,
+            "exit_code": None,
+            "terminal_polled": False,
+            "reminder": {
+                "deadline_at": now + reminder,
+                "state": "pending",
+                "ref_id": f"bash.reminder:{job_id}",
+            },
+            "completion": {
+                "state": "pending",
+                "ref_id": f"bash.completion:{job_id}",
+            },
         }
 
-    def _start_reminder_timer(self, job_id: str, job_dir: Path, delay: float) -> None:
-        """Arm the last-resort async poll reminder for a job."""
-        cancel_event = threading.Event()
-        with self._reminder_lock:
-            self._reminder_cancel_events[job_id] = cancel_event
-        timer = threading.Thread(
-            target=self._run_reminder_timer,
-            args=(job_id, job_dir, delay, cancel_event),
+    def _run_async(self, command: str, cwd: str, reminder: float) -> dict:
+        """Start a detached durable supervisor and return its command PID."""
+        jobs_dir = self._ensure_jobs_dir()
+        job_dir: Path | None = None
+        job_id = ""
+        # Retained records make collision handling a correctness requirement, not
+        # cleanup hygiene.  A full UUID has ample entropy; mkdir remains the
+        # collision-safe authority if a hostile or extraordinarily unlikely name
+        # is already present.
+        for _ in range(8):
+            candidate = f"job-{uuid.uuid4().hex}"
+            try:
+                candidate_dir = jobs_dir / candidate
+                candidate_dir.mkdir()
+            except FileExistsError:
+                continue
+            except OSError as exc:
+                return {"status": "error", "message": f"Failed to create async job: {exc}"}
+            job_id, job_dir = candidate, candidate_dir
+            break
+        if job_dir is None:
+            return {"status": "error", "message": "Failed to allocate a unique async job ID"}
+        initial_state = self._initial_async_state(job_id, command, cwd, reminder)
+        start_lease = initial_state["supervisor_start_lease"]
+        start_token = start_lease["token"]
+        try:
+            write_initial_state(job_dir, initial_state)
+        except Exception as exc:
+            return {"status": "error", "message": f"Failed to initialize async job: {exc}"}
+        try:
+            supervisor = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "lingtai.tools.bash._async_supervisor",
+                    str(job_dir),
+                    start_token,
+                ],
+                start_new_session=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception as exc:
+            def mark_failed(state: dict) -> dict:
+                state.update({
+                    "status": "unrecoverable", "finished_at": time.time(),
+                    "supervisor_error": f"cannot start supervisor: {exc}",
+                })
+                return state
+            update_state(job_dir, mark_failed)
+            return {"status": "error", "message": f"Failed to start async job: {exc}"}
+
+        # Record the launched supervisor PID from the owning parent even when an
+        # OS incarnation identity cannot be observed.  The child must still claim
+        # the matching durable lease before it can spawn the command.
+        supervisor_identity = process_identity(supervisor.pid)
+
+        def record_supervisor(state: dict) -> dict:
+            lease = state.get("supervisor_start_lease")
+            if (
+                self._terminal(state.get("status"))
+                or not isinstance(lease, dict)
+                or lease.get("token") != start_token
+            ):
+                return state
+            state["supervisor_pid"] = supervisor.pid
+            if supervisor_identity is not None:
+                state["supervisor_identity"] = supervisor_identity
+            return state
+
+        update_state(job_dir, record_supervisor)
+
+        # If this owned supervisor exits before a terminal commit, its parent has
+        # stronger evidence than any PID heuristic and closes the state itself.
+        threading.Thread(
+            target=self._reap_supervisor,
+            args=(supervisor, job_dir),
             daemon=True,
-        )
-        timer.start()
+        ).start()
+
+        deadline = time.monotonic() + _SUPERVISOR_START_LEASE_SECONDS
+        state = load_state(job_dir)
+        while time.monotonic() < deadline:
+            state = load_state(job_dir)
+            pid = state.get("pid") if state else None
+            if isinstance(pid, int):
+                # Preserve the historical/user-facing meaning of `reminder=N`:
+                # the caller gets N seconds after a successful async-start return,
+                # rather than losing supervisor-startup time from that interval.
+                # The initial deadline remains a crash-safe fallback if this
+                # manager disappears before reaching the return path.
+                return_armed = False
+
+                def arm_from_return(current: dict) -> dict:
+                    # This lock-owned mutation is the successful-return boundary.
+                    # Success is conditional on winning the still-valid handoff:
+                    # after expiry another manager is entitled to publish the
+                    # crash fallback, and that already-published event cannot be
+                    # recalled by a late owner.
+                    nonlocal return_armed
+                    returned_at = time.time()
+                    return_handoff = current.get("return_handoff")
+                    handoff_pending = (
+                        isinstance(return_handoff, dict)
+                        and return_handoff.get("state") == "pending"
+                    )
+                    handoff_deadline = (
+                        return_handoff.get("deadline_at")
+                        if isinstance(return_handoff, dict)
+                        else None
+                    )
+                    handoff_valid = (
+                        handoff_pending
+                        and isinstance(handoff_deadline, (int, float))
+                        and not isinstance(handoff_deadline, bool)
+                        and returned_at < float(handoff_deadline)
+                    )
+                    if self._terminal(current.get("status")):
+                        # A very short command may finish exactly before the start
+                        # call returns.  That is still a successful start only when
+                        # exact terminal truth won while the handoff was valid; its
+                        # terminal commit already suppressed the fallback reminder.
+                        if (
+                            handoff_valid
+                            and current.get("status") in {"completed", "failed"}
+                            and current.get("exit_status_known") is True
+                        ):
+                            return_handoff.update({
+                                "state": "completed_before_return",
+                                "returned_at": returned_at,
+                            })
+                            return_armed = True
+                        elif handoff_pending:
+                            return_handoff.update({
+                                "state": "aborted",
+                                "resolved_at": returned_at,
+                            })
+                        return current
+                    if not handoff_pending:
+                        return current
+                    if not handoff_valid:
+                        return_handoff.update({
+                            "state": "expired",
+                            "expired_at": returned_at,
+                        })
+                        return current
+                    durable_reminder = current.get("reminder")
+                    if not (
+                        isinstance(durable_reminder, dict)
+                        and durable_reminder.get("state") in {
+                            "pending", "publishing", "suppressing"
+                        }
+                    ):
+                        return current
+                    durable_reminder["deadline_at"] = returned_at + reminder
+                    # A pre-return publisher should have been deferred by the
+                    # handoff guard.  Recover conservatively if a stale claim from
+                    # an older implementation nevertheless exists.
+                    if durable_reminder.get("state") == "publishing":
+                        durable_reminder["state"] = "pending"
+                        durable_reminder.pop("claim_token", None)
+                        durable_reminder.pop("claimed_at", None)
+                    return_handoff.update({
+                        "state": "armed",
+                        "returned_at": returned_at,
+                    })
+                    return_armed = True
+                    return current
+
+                update_state(job_dir, arm_from_return)
+                self._start_reminder_timer(job_id, job_dir)
+                self._start_completion_watcher(job_id, job_dir)
+                if not return_armed:
+                    return {
+                        "status": "error",
+                        "job_id": job_id,
+                        "pid": pid,
+                        "message": (
+                            "Async job started, but its successful-return handoff "
+                            "expired or was superseded. The job remains pollable "
+                            "by job_id and its crash-fallback reminder remains authoritative."
+                        ),
+                    }
+                return {
+                    "status": "ok", "job_id": job_id, "pid": pid,
+                    "message": f'Job started. Use bash(action="poll", job_id="{job_id}") to check.',
+                }
+            if state and self._terminal(state.get("status")):
+                break
+            time.sleep(0.01)
+        self._mark_unrecoverable_if_supervisor_gone(job_dir)
+        return {"status": "error", "message": "Failed to start async job supervisor"}
+
+    def _reap_supervisor(self, supervisor: subprocess.Popen, job_dir: Path) -> None:
+        try:
+            returncode = supervisor.wait()
+        except Exception:
+            return
+
+        def close_abandoned_start(state: dict) -> dict:
+            if self._terminal(state.get("status")):
+                return state
+            state.update({
+                "status": "unrecoverable",
+                "exit_status_known": False,
+                "exit_code": None,
+                "finished_at": time.time(),
+                "supervisor_error": (
+                    f"owned supervisor exited with code {returncode} before terminal commit"
+                ),
+            })
+            return state
+
+        update_state(job_dir, close_abandoned_start)
+
+    def _start_reminder_timer(self, job_id: str, job_dir: Path, delay: float | None = None) -> None:
+        """Arm/re-arm the persisted deadline; a new manager can resume it."""
+        if delay is None:
+            state = load_state(job_dir)
+            reminder = state.get("reminder") if state else None
+            if not isinstance(reminder, dict) or not isinstance(reminder.get("deadline_at"), (int, float)):
+                return
+            delay = max(0.0, float(reminder["deadline_at"]) - time.time())
+        with self._reminder_lock:
+            if job_id in self._reminder_cancel_events:
+                return
+            cancel_event = threading.Event()
+            self._reminder_cancel_events[job_id] = cancel_event
+        threading.Thread(
+            target=self._run_reminder_timer,
+            args=(job_id, job_dir, delay, cancel_event), daemon=True,
+        ).start()
 
     def _run_reminder_timer(
-        self,
-        job_id: str,
-        job_dir: Path,
-        delay: float,
-        cancel_event: threading.Event,
+        self, job_id: str, job_dir: Path, delay: float, cancel_event: threading.Event,
     ) -> None:
-        """Publish one reminder unless terminal poll/cancel handles the job first."""
         if cancel_event.wait(delay):
             return
-        if not self._claim_reminder_timer(job_id, job_dir, cancel_event):
+        claim_token = self._claim_reminder_timer(job_id, job_dir, cancel_event)
+        if claim_token is None:
             return
-        self._publish_async_reminder(job_id)
+        # The helper retains the cross-manager state lock through the final
+        # pre-publish suppression check, sink write, and acknowledgement.  A
+        # terminal claim which wins that lock makes this stale token a no-op.
+        self._publish_claimed_reminder(job_id, job_dir, claim_token)
 
     def _claim_reminder_timer(
-        self,
-        job_id: str,
-        job_dir: Path,
-        cancel_event: threading.Event,
-    ) -> bool:
-        """Atomically claim the reminder deadline before publishing."""
+        self, job_id: str, job_dir: Path, cancel_event: threading.Event,
+    ) -> str | None:
+        """Claim only a currently due reminder; stale timers defer to durable truth."""
         with self._reminder_lock:
             current = self._reminder_cancel_events.get(job_id)
             if current is not cancel_event or cancel_event.is_set() or not job_dir.is_dir():
-                return False
+                return None
             self._reminder_cancel_events.pop(job_id, None)
             cancel_event.set()
-            return True
+        state = load_state(job_dir)
+        if state is None:  # Compatibility for the original private race tests.
+            return "legacy-private-race"
+        claim_token = uuid.uuid4().hex
+        claimed = False
+        defer_seconds: float | None = None
+
+        def claim(current_state: dict) -> dict:
+            nonlocal claimed, defer_seconds
+            reminder = current_state.get("reminder")
+            if not isinstance(reminder, dict) or reminder.get("state") in {
+                "suppressed", "published"
+            }:
+                return current_state
+            now = time.time()
+            if reminder.get("state") == "suppressing":
+                suppressing_until = reminder.get("suppressing_until")
+                if (
+                    isinstance(suppressing_until, (int, float))
+                    and not isinstance(suppressing_until, bool)
+                    and float(suppressing_until) > now
+                ):
+                    defer_seconds = float(suppressing_until) - now
+                    return current_state
+                reminder["state"] = "pending"
+                reminder.pop("suppressing_at", None)
+                reminder.pop("suppressing_until", None)
+
+            return_handoff = current_state.get("return_handoff")
+            if (
+                isinstance(return_handoff, dict)
+                and return_handoff.get("state") == "pending"
+            ):
+                handoff_deadline = return_handoff.get("deadline_at")
+                if (
+                    isinstance(handoff_deadline, (int, float))
+                    and not isinstance(handoff_deadline, bool)
+                    and float(handoff_deadline) > now
+                ):
+                    # The manager which owns the synchronous start response has not
+                    # yet durably moved the reminder to returned_at + delay.  Check
+                    # the cross-process state again soon rather than sleeping until
+                    # the whole lease expires, so a crash immediately after arming
+                    # still recovers close to the requested deadline.
+                    defer_seconds = min(
+                        float(handoff_deadline) - now,
+                        _RETURN_HANDOFF_RECHECK_SECONDS,
+                    )
+                    return current_state
+                return_handoff.update({"state": "expired", "expired_at": now})
+
+                # Once the bounded handoff fails, do not emit a misleading
+                # may-still-be-running reminder for a start which is already known
+                # to be unrecoverable.  The completion channel owns that wake-up.
+                lease_expired = self._supervisor_start_lease_expired(current_state)
+                supervisor_gone = self._supervisor_definitively_gone(current_state)
+                if lease_expired or supervisor_gone:
+                    reason = (
+                        "supervisor start lease expired before command spawn"
+                        if lease_expired
+                        else "recorded supervisor is definitively gone before terminal commit"
+                    )
+                    current_state.update({
+                        "status": "unrecoverable",
+                        "exit_status_known": False,
+                        "exit_code": None,
+                        "finished_at": now,
+                        "supervisor_error": reason,
+                    })
+                    reminder.update({"state": "suppressed", "suppressed_at": now})
+                    reminder.pop("claim_token", None)
+                    reminder.pop("claimed_at", None)
+                    return current_state
+
+            deadline_at = reminder.get("deadline_at")
+            if (
+                isinstance(deadline_at, (int, float))
+                and not isinstance(deadline_at, bool)
+                and float(deadline_at) > now
+            ):
+                # Another manager may have moved the crash-fallback deadline to
+                # the successful-return boundary after this timer was armed.
+                # Revert any stale publishing claim and let a fresh timer own the
+                # later durable deadline.
+                reminder["state"] = "pending"
+                reminder.pop("claim_token", None)
+                reminder.pop("claimed_at", None)
+                defer_seconds = float(deadline_at) - now
+                return current_state
+            # A stale ``publishing`` claim is recoverable after a crash.  Replacing
+            # its token makes concurrent rehydrators mutually exclusive at the
+            # final publication gate below.
+            reminder.update({
+                "state": "publishing",
+                "claimed_at": now,
+                "claim_token": claim_token,
+            })
+            claimed = True
+            return current_state
+
+        update_state(job_dir, claim)
+        if defer_seconds is not None:
+            self._start_reminder_timer(job_id, job_dir, defer_seconds)
+        return claim_token if claimed else None
+
+    def _publish_claimed_reminder(self, job_id: str, job_dir: Path, claim_token: str) -> bool:
+        if claim_token == "legacy-private-race":
+            return self._publish_async_reminder(job_id) is not False
+        return publish_reminder_if_claimed(
+            job_dir, claim_token, lambda: self._publish_async_reminder(job_id),
+        )
 
     def _cancel_reminder_timer(self, job_id: str) -> None:
-        """Suppress and forget a pending reminder after terminal poll/cancel."""
+        """Stop this manager's local deadline worker; durable suppression is a terminal claim."""
         with self._reminder_lock:
             cancel_event = self._reminder_cancel_events.pop(job_id, None)
         if cancel_event is not None:
             cancel_event.set()
 
-    def _publish_async_reminder(self, job_id: str) -> None:
-        """Append the last-resort reminder to the durable multi-event system channel."""
+    def _publish_async_reminder(self, job_id: str) -> bool:
         body = (
             f"Bash async job {job_id} may still be running. "
             f"Poll it with bash(action=\"poll\", job_id=\"{job_id}\")."
@@ -585,239 +943,475 @@ class BashManager:
         if hasattr(agent, "_enqueue_system_notification"):
             try:
                 agent._enqueue_system_notification(
-                    source="bash.reminder",
-                    ref_id=f"bash.reminder:{job_id}",
-                    body=body,
-                    skip_if_ref_id_exists=True,
+                    source="bash.reminder", ref_id=f"bash.reminder:{job_id}",
+                    body=body, skip_if_ref_id_exists=True,
                 )
-                return
+                return True
             except Exception:
                 pass
-        # Fallback: use the agent's store directly via compare_update_channel.
-        self._append_system_notification_fallback(
-            source="bash.reminder",
-            ref_id=f"bash.reminder:{job_id}",
-            body=body,
-        )
+        try:
+            self._append_system_notification_fallback(
+                source="bash.reminder", ref_id=f"bash.reminder:{job_id}", body=body,
+            )
+            return True
+        except Exception:
+            return False
 
     def _append_system_notification_fallback(
-        self,
-        *,
-        source: str,
-        ref_id: str,
-        body: str,
+        self, *, source: str, ref_id: str, body: str,
     ) -> str:
-        """Append a system event using the agent's serialized store.
-
-        Uses compare_update_channel so serialization is store-owned.
-        """
+        """Append a system event using the agent's serialized store."""
         import secrets
-        import time
         from datetime import datetime, timezone
-
         from lingtai.kernel.notification_store import UNCONDITIONAL
 
-        agent = self._agent
-        store = agent._notification_store
-
+        store = self._agent._notification_store
         event_id = f"evt_{int(time.time()*1000):x}_{secrets.token_hex(8)}"
         received_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-        def _mutator(current_payload: dict) -> tuple[dict | None, bool, str]:
+        def mutate(current_payload: dict) -> tuple[dict | None, bool, str]:
             current = current_payload if isinstance(current_payload, dict) else {}
             events = list(current.get("data", {}).get("events", []))
-            if any(isinstance(ev, dict) and ev.get("ref_id") == ref_id for ev in events):
+            if any(isinstance(event, dict) and event.get("ref_id") == ref_id for event in events):
                 return current_payload, False, ""
             events.append({
-                "event_id": event_id,
-                "source": source,
-                "ref_id": ref_id,
-                "body": body,
-                "at": received_at,
+                "event_id": event_id, "source": source, "ref_id": ref_id,
+                "body": body, "at": received_at,
             })
             events = events[-20:]
-            payload = {
-                "header": (
-                    f"{len(events)} system notification"
-                    f"{'s' if len(events) != 1 else ''}"
-                ),
-                "icon": "🔔",
-                "priority": "normal",
-                "published_at": received_at,
+            return ({
+                "header": f"{len(events)} system notification{'s' if len(events) != 1 else ''}",
+                "icon": "🔔", "priority": "normal", "published_at": received_at,
                 "data": {"events": events},
-            }
-            return payload, True, event_id
-
-        result = store.compare_update_channel("system", UNCONDITIONAL, _mutator)
+            }, True, event_id)
+        result = store.compare_update_channel("system", UNCONDITIONAL, mutate)
         return result.value if isinstance(result.value, str) else ""
 
-    def _watch_async_job(
-        self, job_id: str, command: str, proc: subprocess.Popen,
-        job_dir: Path, stdout_f, stderr_f,
-    ) -> None:
-        """Background thread: wait for async job, then write notification."""
-        try:
-            returncode = proc.wait()
-        except Exception:
-            returncode = -1
+    def _start_completion_watcher(self, job_id: str, job_dir: Path) -> None:
+        with self._completion_lock:
+            if job_id in self._completion_watchers:
+                return
+            self._completion_watchers.add(job_id)
+        threading.Thread(
+            target=self._watch_durable_job, args=(job_id, job_dir), daemon=True,
+        ).start()
 
-        # Close file handles
+    def _watch_durable_job(self, job_id: str, job_dir: Path) -> None:
         try:
-            stdout_f.close()
-            stderr_f.close()
-        except Exception:
-            pass
+            while True:
+                state = load_state(job_dir)
+                if state is None:
+                    return
+                if self._terminal(state.get("status")):
+                    self._publish_completion_if_due(job_id, job_dir)
+                    return
+                time.sleep(0.05)
+        finally:
+            with self._completion_lock:
+                self._completion_watchers.discard(job_id)
 
-        # Read stdout preview
-        stdout_preview = ""
-        try:
-            stdout_text = (job_dir / "stdout.log").read_text(encoding="utf-8", errors="replace")
-            stdout_preview = stdout_text[:200]
-        except Exception:
-            pass
+    def _publish_completion_if_due(self, job_id: str, job_dir: Path) -> None:
+        claimed = False
+        def claim(state: dict) -> dict:
+            nonlocal claimed
+            completion = state.get("completion")
+            if not self._terminal(state.get("status")) or not isinstance(completion, dict):
+                return state
+            if completion.get("state") == "published":
+                return state
+            completion["state"] = "publishing"
+            claimed = True
+            return state
+        state = update_state(job_dir, claim)
+        if not claimed or state is None:
+            return
+        if self._publish_async_completion(job_id, job_dir, state):
+            def published(current: dict) -> dict:
+                completion = current.get("completion")
+                if isinstance(completion, dict) and completion.get("state") == "publishing":
+                    completion["state"] = "published"
+                    completion["published_at"] = time.time()
+                return current
+            update_state(job_dir, published)
 
-        # Write notification to .notification/bash.json via the store.
+    def _publish_async_completion(self, job_id: str, job_dir: Path, state: dict) -> bool:
         try:
             from datetime import datetime, timezone
-            agent = self._agent
-            store = agent._notification_store
+            stdout, _ = self._read_logs(job_dir)
+            exit_code = state.get("exit_code") if state.get("exit_status_known") else None
             payload = {
-                "header": f"Job {job_id} completed (exit {returncode})",
-                "icon": "⚡",
-                "priority": "normal",
-                "published_at": datetime.now(timezone.utc).strftime(
-                    "%Y-%m-%dT%H:%M:%SZ"
-                ),
+                "header": f"Job {job_id} completed (exit {exit_code})",
+                "icon": "⚡", "priority": "normal",
+                "published_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "data": {
                     "job_id": job_id,
-                    "command": command[:200],
-                    "exit_code": returncode,
-                    "stdout_preview": stdout_preview,
+                    "command": str(state.get("command", ""))[:200],
+                    "exit_code": exit_code,
+                    "exit_status_known": bool(state.get("exit_status_known")),
+                    "stdout_preview": stdout[:200],
+                    "ref_id": f"bash.completion:{job_id}",
                 },
             }
+            store = self._agent._notification_store
+            if hasattr(store, "compare_update_channel"):
+                from lingtai.kernel.notification_store import UNCONDITIONAL
+
+                ref_id = f"bash.completion:{job_id}"
+
+                def mutate(current_payload: dict) -> tuple[dict | None, bool, bool]:
+                    current = current_payload if isinstance(current_payload, dict) else {}
+                    data = current.get("data")
+                    if isinstance(data, dict) and data.get("ref_id") == ref_id:
+                        return current_payload, False, True
+                    return payload, True, True
+
+                result = store.compare_update_channel("bash", UNCONDITIONAL, mutate)
+                return bool(result.value)
             store.publish("bash", payload)
+            return True
         except Exception:
-            pass  # Notification failure should not break the job
+            return False
 
-    def _handle_poll(self, args: dict) -> dict:
-        """Check status of an async job."""
-        job_id = args.get("job_id", "")
-        err = self._validate_job_id(job_id)
-        if err:
-            return err
-
-        jobs_dir = self._ensure_jobs_dir()
-        job_dir = jobs_dir / job_id
-        if not job_dir.is_dir():
-            return {"status": "error", "message": f"Job not found: {job_id}"}
-
-        status = (job_dir / "status").read_text(encoding="utf-8").strip()
-        if status != "running":
-            return {"status": "error", "message": f"Job already finished ({status})"}
-
-        pid = int((job_dir / "pid").read_text(encoding="utf-8").strip())
-
-        # Use Popen.poll() if we have the handle (same process), else os.waitpid
-        handles = getattr(self, "_open_handles", {})
-        entry = handles.get(job_id)
-        if entry:
-            proc = entry[0]
-            returncode = proc.poll()
-        else:
-            # Fallback: try waitpid (different manager instance, same PID file)
-            try:
-                wpid, wait_status = os.waitpid(pid, os.WNOHANG)
-                returncode = os.waitstatus_to_exitcode(wait_status) if wpid != 0 else None
-            except ChildProcessError:
-                # Not our child — check if alive via signal 0
-                try:
-                    os.kill(pid, 0)
-                    returncode = None  # still alive
-                except OSError:
-                    returncode = -1  # dead but we can't get the code
-
-        if returncode is None:
-            return {"status": "running", "job_id": job_id, "pid": pid}
-
-        # Process finished — close file handles, read output
-        self._cancel_reminder_timer(job_id)
-        self._close_handles(job_id)
-
-        stdout = (job_dir / "stdout.log").read_text(encoding="utf-8", errors="replace")
-        stderr = (job_dir / "stderr.log").read_text(encoding="utf-8", errors="replace")
-
+    def _read_logs(self, job_dir: Path) -> tuple[str, str]:
+        try:
+            stdout = (job_dir / "stdout.log").read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            stdout = ""
+        try:
+            stderr = (job_dir / "stderr.log").read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            stderr = ""
         if len(stdout) > self._max_output:
             stdout = stdout[: self._max_output] + f"\n... (truncated, {len(stdout)} chars total)"
         if len(stderr) > self._max_output:
             stderr = stderr[: self._max_output] + f"\n... (truncated, {len(stderr)} chars total)"
+        return stdout, stderr
 
-        # Clean up
-        import shutil
-        shutil.rmtree(job_dir, ignore_errors=True)
+    def _already_finished(self, state: dict) -> dict:
+        label = "cancelled" if state.get("terminal_consumed_by") == "cancel" else state.get("status")
+        return {"status": "error", "message": f"Job already finished ({label})"}
 
-        return _augment_command_result({
-            "status": "done",
-            "exit_code": returncode,
-            "stdout": stdout,
-            "stderr": stderr,
-        })
+    def _claim_terminal(self, job_dir: Path, consumer: str) -> dict | None:
+        """Atomically consume a terminal result and suppress its reminder.
 
-    def _handle_cancel(self, args: dict) -> dict:
-        """Kill an async job."""
+        The conditional state transition is the one-shot linearization point for
+        both poll and cancel.  Suppression belongs in this same durable write so
+        no successful terminal consumer can leave a later deadline publication.
+        """
+        claimed = False
+
+        def claim(current: dict) -> dict:
+            nonlocal claimed
+            if not self._terminal(current.get("status")) or current.get("terminal_polled"):
+                return current
+            now = time.time()
+            current.update({
+                "terminal_polled": True,
+                "terminal_polled_at": now,
+                "terminal_consumed_by": consumer,
+            })
+            reminder = current.get("reminder")
+            if isinstance(reminder, dict):
+                # Even a previously published reminder is terminally suppressed
+                # for future retries; its published_at remains historical evidence.
+                reminder.update({"state": "suppressed", "suppressed_at": now})
+                reminder.pop("claim_token", None)
+                reminder.pop("suppressing_at", None)
+                reminder.pop("suppressing_until", None)
+            claimed = True
+            return current
+
+        state = update_state(job_dir, claim)
+        return state if claimed else None
+
+    def _terminal_result(self, job_id: str, job_dir: Path) -> dict | None:
+        state = self._claim_terminal(job_dir, "poll")
+        if state is None:
+            return None
+        self._cancel_reminder_timer(job_id)
+        stdout, stderr = self._read_logs(job_dir)
+        if state.get("exit_status_known") and isinstance(state.get("exit_code"), int):
+            return _augment_command_result({
+                "status": "done", "exit_status_known": True,
+                "exit_code": state["exit_code"], "stdout": stdout, "stderr": stderr,
+            })
+        return {
+            "status": "done", "job_id": job_id, "exit_status_known": False,
+            "exit_code": None, "stdout": stdout, "stderr": stderr,
+            "message": "Async job terminated but its exit status is unavailable",
+        }
+
+    def _claim_legacy_terminal(self, job_dir: Path) -> bool:
+        """Preserve old unknown-exit one-shot behavior without creating an exit code."""
+        try:
+            marker = job_dir / ".legacy-terminal-polled"
+            with marker.open("x", encoding="utf-8") as handle:
+                handle.write(f"{time.time()}\n")
+            return True
+        except FileExistsError:
+            return False
+        except OSError:
+            return False
+
+    def _legacy_unknown(self, job_id: str, job_dir: Path, message: str | None = None) -> dict:
+        if not self._claim_legacy_terminal(job_dir):
+            return {"status": "error", "message": "Job already finished (legacy unknown)"}
+        stdout, stderr = self._read_logs(job_dir)
+        return {
+            "status": "done", "job_id": job_id, "exit_status_known": False,
+            "exit_code": None, "stdout": stdout, "stderr": stderr,
+            "message": message or "Legacy async job has no recoverable exit status",
+        }
+
+    def _handle_legacy_poll(self, job_id: str, job_dir: Path) -> dict:
+        if (job_dir / ".legacy-terminal-polled").exists():
+            return {"status": "error", "message": "Job already finished (legacy unknown)"}
+        try:
+            status = (job_dir / "status").read_text(encoding="utf-8").strip()
+            pid = int((job_dir / "pid").read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            return self._legacy_unknown(job_id, job_dir)
+        if status != "running" or not process_is_alive(pid):
+            return self._legacy_unknown(job_id, job_dir)
+        # A legacy record cannot prove the PID incarnation, so it is never safe
+        # to signal.  But a still-live PID is not evidence that the old command
+        # has terminated either: keep the job pollable instead of consuming a
+        # fabricated unknown terminal result while it may still be running.
+        return {
+            "status": "running",
+            "job_id": job_id,
+            "pid": pid,
+            "message": "Legacy async job may still be running; cancellation is unavailable without durable supervisor ownership",
+        }
+
+    @staticmethod
+    def _supervisor_start_lease_expired(state: dict) -> bool:
+        """Whether a version-3 job missed its bounded pre-command start lease."""
+        if state.get("status") != "launching":
+            return False
+        lease = state.get("supervisor_start_lease")
+        if not isinstance(lease, dict) or lease.get("state") not in {"pending", "claimed"}:
+            return False
+        deadline_at = lease.get("deadline_at")
+        return (
+            isinstance(deadline_at, (int, float))
+            and not isinstance(deadline_at, bool)
+            and time.time() >= float(deadline_at)
+        )
+
+    @staticmethod
+    def _supervisor_definitively_gone(state: dict) -> bool:
+        """True when a recorded PID is absent, or its saved incarnation mismatches."""
+        pid = state.get("supervisor_pid")
+        if not isinstance(pid, int):
+            return False
+        # PID absence is proof even when identity capture failed.  Identity remains
+        # necessary only to distinguish a still-live PID from a recycled process.
+        if not process_is_alive(pid):
+            return True
+        saved_identity = state.get("supervisor_identity")
+        if not isinstance(saved_identity, str):
+            return False
+        observed_identity = process_identity(pid)
+        # ``None`` is an observation failure, not proof that the supervisor died.
+        return observed_identity is not None and observed_identity != saved_identity
+
+    def _mark_unrecoverable_if_supervisor_gone(self, job_dir: Path) -> dict | None:
+        """Resolve a lost supervisor or expired start lease under the state lock."""
+        marked = False
+
+        def mark(current: dict) -> dict:
+            nonlocal marked
+            if self._terminal(current.get("status")):
+                return current
+            lease_expired = self._supervisor_start_lease_expired(current)
+            supervisor_gone = self._supervisor_definitively_gone(current)
+            if not lease_expired and not supervisor_gone:
+                return current
+            reason = (
+                "supervisor start lease expired before command spawn"
+                if lease_expired
+                else "recorded supervisor is definitively gone before terminal commit"
+            )
+            current.update({
+                "status": "unrecoverable",
+                "exit_status_known": False,
+                "exit_code": None,
+                "finished_at": time.time(),
+                "supervisor_error": reason,
+            })
+            marked = True
+            return current
+
+        state = update_state(job_dir, mark)
+        return state if marked else None
+
+    def _await_supervisor_commit(self, job_dir: Path, timeout: float) -> dict | None:
+        """Reload terminal truth while a supervisor or valid start lease can commit."""
+        deadline = time.monotonic() + timeout
+        state = load_state(job_dir)
+        while state is not None:
+            if self._terminal(state.get("status")):
+                return state
+            resolved = self._mark_unrecoverable_if_supervisor_gone(job_dir)
+            if resolved is not None:
+                return resolved
+            if time.monotonic() >= deadline:
+                return state
+            time.sleep(0.01)
+            state = load_state(job_dir)
+        return None
+
+    def _running_result(self, job_id: str, state: dict) -> dict:
+        pid = state.get("pid")
+        identity = state.get("pid_identity")
+        if isinstance(pid, int) and process_identity_matches(pid, identity) and process_is_alive(pid):
+            return {"status": "running", "job_id": job_id, "pid": pid}
+        return {
+            "status": "running",
+            "job_id": job_id,
+            "message": "Awaiting the durable supervisor terminal commit",
+        }
+
+    def _handle_poll(self, args: dict) -> dict:
         job_id = args.get("job_id", "")
         err = self._validate_job_id(job_id)
         if err:
             return err
-
-        jobs_dir = self._ensure_jobs_dir()
-        job_dir = jobs_dir / job_id
+        job_dir = self._jobs_path() / job_id
         if not job_dir.is_dir():
             return {"status": "error", "message": f"Job not found: {job_id}"}
+        state = load_state(job_dir)
+        if state is None:
+            return self._handle_legacy_poll(job_id, job_dir)
+        if state.get("terminal_polled"):
+            return self._already_finished(state)
+        if self._terminal(state.get("status")):
+            result = self._terminal_result(job_id, job_dir)
+            return result if result is not None else self._already_finished(load_state(job_dir) or state)
 
-        status = (job_dir / "status").read_text(encoding="utf-8").strip()
-        if status != "running":
-            return {"status": "error", "message": f"Job already finished ({status})"}
+        pid = state.get("pid")
+        identity = state.get("pid_identity")
+        if (
+            isinstance(pid, int)
+            and process_identity_matches(pid, identity)
+            and process_is_alive(pid)
+        ):
+            return {"status": "running", "job_id": job_id, "pid": pid}
 
-        pid = int((job_dir / "pid").read_text(encoding="utf-8").strip())
+        # A dead/mismatched command PID is not terminal evidence: its detached
+        # supervisor may have already obtained the exact wait result but not yet
+        # committed it.  Give that verified supervisor a bounded commit window.
+        state = self._await_supervisor_commit(job_dir, _SUPERVISOR_COMMIT_GRACE_SECONDS) or state
+        if state.get("terminal_polled"):
+            return self._already_finished(state)
+        if self._terminal(state.get("status")):
+            result = self._terminal_result(job_id, job_dir)
+            return result if result is not None else self._already_finished(load_state(job_dir) or state)
+        return self._running_result(job_id, state)
 
-        # Kill the entire process group (start_new_session=True makes pid the pgid)
-        try:
-            os.killpg(os.getpgid(pid), signal.SIGTERM)
-        except (ProcessLookupError, PermissionError, OSError):
-            pass  # Already dead
+    def _handle_cancel(self, args: dict) -> dict:
+        job_id = args.get("job_id", "")
+        err = self._validate_job_id(job_id)
+        if err:
+            return err
+        job_dir = self._jobs_path() / job_id
+        if not job_dir.is_dir():
+            return {"status": "error", "message": f"Job not found: {job_id}"}
+        state = load_state(job_dir)
+        if state is None:
+            return {"status": "error", "message": "Cannot cancel legacy async job without durable supervisor ownership"}
+        if self._terminal(state.get("status")) or state.get("terminal_polled"):
+            return self._already_finished(state)
+        if not (
+            isinstance(state.get("supervisor_pid"), int)
+            and isinstance(state.get("supervisor_identity"), str)
+        ):
+            return {
+                "status": "error",
+                "message": "Cannot cancel async job: durable supervisor identity is unavailable",
+            }
+        if self._supervisor_definitively_gone(state):
+            self._mark_unrecoverable_if_supervisor_gone(job_dir)
+            return {
+                "status": "error",
+                "message": "Cannot cancel async job: recorded supervisor identity is no longer live; poll for the durable terminal result",
+            }
 
-        # Reap via Popen if we have the handle, to avoid zombies
-        handles = getattr(self, "_open_handles", {})
-        entry = handles.get(job_id)
-        if entry:
-            proc = entry[0]
-            try:
-                proc.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
+        requested = False
 
-        self._close_handles(job_id)
+        def request_cancel(current: dict) -> dict:
+            nonlocal requested
+            if self._terminal(current.get("status")) or current.get("terminal_polled"):
+                return current
+            now = time.time()
+            if not current.get("cancel_requested_at"):
+                current["cancel_requested_at"] = now
+            reminder = current.get("reminder")
+            if isinstance(reminder, dict) and reminder.get("state") in {
+                "pending", "publishing"
+            }:
+                reminder.update({
+                    "state": "suppressing",
+                    "suppressing_at": now,
+                    "suppressing_until": now + _CANCEL_COMMIT_TIMEOUT_SECONDS,
+                })
+                reminder.pop("claim_token", None)
+                reminder.pop("claimed_at", None)
+            requested = True
+            return current
+
+        state = update_state(job_dir, request_cancel)
+        if not requested or state is None:
+            return self._already_finished(state or {})
         self._cancel_reminder_timer(job_id)
 
-        # Clean up
-        import shutil
-        shutil.rmtree(job_dir, ignore_errors=True)
+        # The detached supervisor owns the unreaped Popen and performs TERM/KILL.
+        # A manager only requests that protocol, then waits for its exact commit.
+        state = self._await_supervisor_commit(job_dir, _CANCEL_COMMIT_TIMEOUT_SECONDS)
+        if state is not None and state.get("status") == "completed":
+            if state.get("cancellation_outcome") != "group_cancelled":
+                return {
+                    "status": "error",
+                    "message": (
+                        "Cancellation did not confirm process-group termination; "
+                        "poll for the exact durable terminal result"
+                    ),
+                }
+            claimed = self._claim_terminal(job_dir, "cancel")
+            if claimed is not None:
+                self._cancel_reminder_timer(job_id)
+                return {"status": "cancelled", "job_id": job_id}
+            return self._already_finished(load_state(job_dir) or state)
+        if state is not None and state.get("terminal_polled"):
+            return self._already_finished(state)
+        reminder_restored = False
 
-        return {"status": "cancelled", "job_id": job_id}
+        def restore_reminder(current: dict) -> dict:
+            nonlocal reminder_restored
+            if self._terminal(current.get("status")):
+                return current
+            reminder = current.get("reminder")
+            if isinstance(reminder, dict) and reminder.get("state") == "suppressing":
+                reminder["state"] = "pending"
+                reminder.pop("suppressing_at", None)
+                reminder.pop("suppressing_until", None)
+                reminder_restored = True
+            return current
+
+        update_state(job_dir, restore_reminder)
+        if reminder_restored:
+            self._start_reminder_timer(job_id, job_dir)
+        return {
+            "status": "error",
+            "message": (
+                "Cancellation requested; awaiting supervisor terminal commit. "
+                "The job remains pollable and its reminder remains recoverable."
+            ),
+        }
 
     def _close_handles(self, job_id: str) -> None:
-        """Close open file handles for a job if we hold them."""
-        handles = getattr(self, "_open_handles", {})
-        entry = handles.pop(job_id, None)
-        if entry:
-            # entry is (Popen, stdout_file, stderr_file)
-            for fh in entry[1:]:
-                try:
-                    fh.close()
-                except Exception:
-                    pass
-
+        """Compatibility no-op: durable supervisors own and close their logs."""
+        return None
 
 def setup(
     agent: "BaseAgent",

--- a/src/lingtai/tools/bash/_async_supervisor.py
+++ b/src/lingtai/tools/bash/_async_supervisor.py
@@ -1,0 +1,526 @@
+"""Durable implementation details for Bash async jobs.
+
+This is intentionally private to the Bash capability.  The supervisor process
+owns ``wait()``; managers only consume the atomically persisted state, so an
+agent relaunch never has to infer an exit result from an unrelated PID.
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+try:  # Bash async jobs are POSIX-only because cancellation is process-group based.
+    import fcntl
+except ImportError:  # pragma: no cover - asserted by the Bash POSIX contract
+    fcntl = None  # type: ignore[assignment]
+
+
+_STATE_FILE = "state.json"
+_LOCK_FILE = ".state.lock"
+
+
+def state_path(job_dir: Path) -> Path:
+    return job_dir / _STATE_FILE
+
+
+def load_state(job_dir: Path) -> dict[str, Any] | None:
+    """Return a durable job state, or ``None`` for a legacy/broken job directory."""
+    try:
+        value = json.loads(state_path(job_dir).read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+@contextlib.contextmanager
+def _state_lock(job_dir: Path):
+    """Serialize read-modify-write state transitions across managers/runner."""
+    if fcntl is None:
+        raise RuntimeError("Bash async supervisor requires POSIX file locking")
+    lock = open(job_dir / _LOCK_FILE, "a", encoding="utf-8")
+    try:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+        lock.close()
+
+
+def _write_state_atomic(job_dir: Path, value: dict[str, Any]) -> None:
+    """Durably replace the one authoritative state document."""
+    fd, temporary = tempfile.mkstemp(prefix=".state-", suffix=".json", dir=job_dir)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(value, handle, sort_keys=True, separators=(",", ":"))
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, state_path(job_dir))
+    directory_fd = os.open(job_dir, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def write_initial_state(job_dir: Path, value: dict[str, Any]) -> None:
+    """Create the first state document before a supervisor is launched."""
+    with _state_lock(job_dir):
+        _write_state_atomic(job_dir, value)
+
+
+def update_state(
+    job_dir: Path, mutate: Callable[[dict[str, Any]], dict[str, Any] | None],
+) -> dict[str, Any] | None:
+    """Atomically apply ``mutate`` and return the resulting state.
+
+    ``None`` means this is not a readable durable job.  Mutators receive the
+    latest state under the same lock the independent supervisor uses.
+    """
+    with _state_lock(job_dir):
+        current = load_state(job_dir)
+        if current is None:
+            return None
+        updated = mutate(current)
+        if updated is None:
+            return current
+        _write_state_atomic(job_dir, updated)
+        return updated
+
+
+def publish_reminder_if_claimed(
+    job_dir: Path, claim_token: str, publish: Callable[[], object],
+) -> bool:
+    """Publish one reminder while holding its durable claim/suppression lock.
+
+    The external sink write and the ``publishing -> published`` acknowledgement
+    intentionally share the job-state lock.  A terminal consumer which wins the
+    same lock writes ``suppressed`` first, so a stale timer can no longer publish
+    after suppression.  A crash after the sink write but before this state write
+    remains possible and is deliberately recovered as a retry; bounded sinks do
+    not provide a global exactly-once acknowledgement.
+    """
+    with _state_lock(job_dir):
+        current = load_state(job_dir)
+        if current is None:
+            return False
+        reminder = current.get("reminder")
+        if not (
+            isinstance(reminder, dict)
+            and reminder.get("state") == "publishing"
+            and reminder.get("claim_token") == claim_token
+        ):
+            return False
+        try:
+            published = publish()
+        except Exception:
+            return False
+        if published is False:
+            return False
+        reminder["state"] = "published"
+        reminder["published_at"] = time.time()
+        _write_state_atomic(job_dir, current)
+        return True
+
+
+def _linux_process_identity(pid: int) -> str | None:
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+        end = raw.rfind(")")
+        # Fields after the final ')' begin at process-stat field 3.  starttime is
+        # field 22, hence index 19 in this suffix.
+        fields = raw[end + 2 :].split()
+        start_ticks = fields[19]
+        boot_id = Path("/proc/sys/kernel/random/boot_id").read_text(
+            encoding="utf-8"
+        ).strip()
+        return f"linux:{boot_id}:{start_ticks}"
+    except (OSError, IndexError, ValueError):
+        return None
+
+
+def _ps_process_identity(pid: int) -> str | None:
+    """Fallback for Darwin/BSD, whose procfs form is unavailable.
+
+    ``lstart`` is the operating system's process start timestamp; including the
+    parent PID makes an accidental same-second PID reuse even less plausible.
+    If it cannot be read, managers deliberately refuse to signal that PID.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "lstart=", "-o", "ppid=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    line = result.stdout.strip()
+    return f"ps:{line}" if result.returncode == 0 and line else None
+
+
+def process_identity(pid: int) -> str | None:
+    """Capture an OS start-time identity for a live PID, never PID alone."""
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return None
+    return _linux_process_identity(pid) or _ps_process_identity(pid)
+
+
+def process_identity_matches(pid: int, saved_identity: object) -> bool:
+    """True only when the PID is still the recorded process incarnation."""
+    return isinstance(saved_identity, str) and process_identity(pid) == saved_identity
+
+
+def process_is_alive(pid: int) -> bool:
+    """Whether a process can still make progress rather than merely occupy a PID.
+
+    Linux zombies still answer ``kill(pid, 0)`` but cannot write a terminal state;
+    treating them as alive would make a dead detached supervisor appear able to
+    commit forever.  Other POSIX systems retain the conservative ``kill`` check.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        # Permission or observation failures prove neither death nor PID absence.
+        return True
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+        end = raw.rfind(")")
+        return raw[end + 2 :].split(maxsplit=1)[0] != "Z"
+    except (OSError, IndexError, ValueError):
+        return True
+
+
+def process_group_exists(process_group: int) -> bool:
+    """Conservatively report whether the owned group has a live (non-zombie) member."""
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Darwin reports EPERM for a group containing only an unreaped zombie;
+        # fall through to the member-state proof below.
+        pass
+    except OSError:
+        # Other observation failures must never become false cancellation success.
+        return True
+
+    proc_root = Path("/proc")
+    if proc_root.is_dir():
+        try:
+            for entry in proc_root.iterdir():
+                if not entry.name.isdigit():
+                    continue
+                raw = (entry / "stat").read_text(encoding="utf-8")
+                end = raw.rfind(")")
+                fields = raw[end + 2 :].split()
+                if int(fields[2]) == process_group and fields[0] != "Z":
+                    return True
+            return False
+        except (OSError, IndexError, ValueError):
+            return True
+
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pgid=,state="],
+            capture_output=True,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+    if result.returncode != 0:
+        return True
+    for line in result.stdout.splitlines():
+        fields = line.split(None, 1)
+        if len(fields) == 2 and fields[0] == str(process_group):
+            if not fields[1].lstrip().startswith("Z"):
+                return True
+    return False
+
+
+def _lease_deadline(lease: object) -> float | None:
+    if not isinstance(lease, dict):
+        return None
+    value = lease.get("deadline_at")
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    return float(value)
+
+
+def _claim_supervisor_start(
+    job_dir: Path,
+    start_token: str,
+    supervisor_pid: int,
+    supervisor_identity: str | None,
+) -> bool:
+    """Claim the matching unexpired lease before any command process can exist."""
+    claimed = False
+
+    def mutate(state: dict[str, Any]) -> dict[str, Any]:
+        nonlocal claimed
+        now = time.time()
+        lease = state.get("supervisor_start_lease")
+        deadline = _lease_deadline(lease)
+        if (
+            state.get("status") in {"completed", "unrecoverable"}
+            or not isinstance(lease, dict)
+            or lease.get("token") != start_token
+            or lease.get("state") != "pending"
+        ):
+            return state
+        if deadline is None or now >= deadline:
+            state.update({
+                "status": "unrecoverable",
+                "exit_status_known": False,
+                "exit_code": None,
+                "finished_at": now,
+                "supervisor_error": "supervisor start lease expired before claim",
+            })
+            return state
+        state["supervisor_pid"] = supervisor_pid
+        if supervisor_identity is not None:
+            state["supervisor_identity"] = supervisor_identity
+        lease.update({
+            "state": "claimed",
+            "claimed_at": now,
+            "supervisor_pid": supervisor_pid,
+        })
+        claimed = True
+        return state
+
+    update_state(job_dir, mutate)
+    return claimed
+
+
+def _mark_launch_failure(job_dir: Path, message: str) -> None:
+    finished = time.time()
+
+    def mutate(state: dict[str, Any]) -> dict[str, Any]:
+        state.update({
+            "status": "unrecoverable",
+            "exit_status_known": False,
+            "exit_code": None,
+            "finished_at": finished,
+            "supervisor_error": message,
+        })
+        return state
+
+    update_state(job_dir, mutate)
+
+
+_CANCEL_POLL_SECONDS = 0.05
+_CANCEL_TERM_GRACE_SECONDS = 0.5
+_CANCEL_GROUP_QUIESCE_SECONDS = 1.0
+
+
+def _cancel_requested(job_dir: Path) -> bool:
+    state = load_state(job_dir)
+    return bool(state and state.get("cancel_requested_at"))
+
+
+def _wait_with_cancellation(
+    job_dir: Path, proc: subprocess.Popen,
+) -> tuple[int, str | None]:
+    """Return the direct wait status plus proof of any whole-group cancellation.
+
+    Once TERM is sent, the direct shell remains unreaped for the entire grace.  Its
+    PID therefore cannot be recycled while KILL targets the original process group,
+    even if that shell exits promptly and an ignored-TERM descendant survives.
+    """
+    while True:
+        if _cancel_requested(job_dir):
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                return proc.wait(), "natural_or_concurrent"
+            except OSError:
+                return proc.wait(), "unconfirmed"
+
+            grace_deadline = time.monotonic() + _CANCEL_TERM_GRACE_SECONDS
+            while True:
+                remaining = grace_deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                time.sleep(min(_CANCEL_POLL_SECONDS, remaining))
+
+            group_absent = False
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                group_absent = True
+            except OSError:
+                # Darwin can return EPERM when only already-dead/zombie members
+                # remain.  Confirm live-member absence before accepting that as
+                # quiescence; any live member keeps cancellation unconfirmed.
+                group_absent = not process_group_exists(proc.pid)
+                if not group_absent:
+                    return proc.wait(), "unconfirmed"
+
+            returncode = proc.wait()
+            if not group_absent:
+                quiesce_deadline = time.monotonic() + _CANCEL_GROUP_QUIESCE_SECONDS
+                while process_group_exists(proc.pid):
+                    if time.monotonic() >= quiesce_deadline:
+                        return returncode, "unconfirmed"
+                    time.sleep(_CANCEL_POLL_SECONDS)
+            return returncode, "group_cancelled"
+        try:
+            return proc.wait(timeout=_CANCEL_POLL_SECONDS), None
+        except subprocess.TimeoutExpired:
+            continue
+
+
+def supervise(job_dir: Path, start_token: str) -> int:
+    """Claim a bounded start lease, then persist one command's terminal truth."""
+    state = load_state(job_dir)
+    if state is None:
+        return 2
+    command = state.get("command")
+    cwd = state.get("cwd")
+    if not isinstance(command, str) or not isinstance(cwd, str):
+        _mark_launch_failure(job_dir, "durable state is missing command or cwd")
+        return 2
+
+    supervisor_pid = os.getpid()
+    supervisor_identity = process_identity(supervisor_pid)
+    if not _claim_supervisor_start(
+        job_dir, start_token, supervisor_pid, supervisor_identity
+    ):
+        return 2
+
+    try:
+        stdout = open(job_dir / "stdout.log", "x", encoding="utf-8")
+        stderr = open(job_dir / "stderr.log", "x", encoding="utf-8")
+    except OSError as exc:
+        _mark_launch_failure(job_dir, f"cannot open async log: {exc}")
+        return 2
+
+    proc: subprocess.Popen | None = None
+    with _state_lock(job_dir):
+        current = load_state(job_dir)
+        if current is not None:
+            lease = current.get("supervisor_start_lease")
+            deadline = _lease_deadline(lease)
+            valid = (
+                current.get("status") not in {"completed", "unrecoverable"}
+                and isinstance(lease, dict)
+                and lease.get("token") == start_token
+                and lease.get("state") == "claimed"
+                and lease.get("supervisor_pid") == supervisor_pid
+                and deadline is not None
+                and time.time() < deadline
+            )
+            if valid:
+                try:
+                    proc = subprocess.Popen(
+                        command,
+                        shell=True,
+                        stdout=stdout,
+                        stderr=stderr,
+                        cwd=cwd,
+                        start_new_session=True,
+                    )
+                except Exception as exc:
+                    current.update({
+                        "status": "unrecoverable",
+                        "exit_status_known": False,
+                        "exit_code": None,
+                        "finished_at": time.time(),
+                        "supervisor_error": f"cannot start async command: {exc}",
+                    })
+                else:
+                    started = time.time()
+                    identity = process_identity(proc.pid)
+                    current.update({
+                        "status": "running",
+                        "pid": proc.pid,
+                        "pid_identity": identity,
+                        "pid_start_time": identity,
+                        "started_at": started,
+                        "process_group": proc.pid,
+                    })
+                    lease.update({"state": "started", "started_at": started})
+                _write_state_atomic(job_dir, current)
+            elif (
+                current.get("status") not in {"completed", "unrecoverable"}
+                and isinstance(lease, dict)
+                and lease.get("token") == start_token
+                and deadline is not None
+                and time.time() >= deadline
+            ):
+                current.update({
+                    "status": "unrecoverable",
+                    "exit_status_known": False,
+                    "exit_code": None,
+                    "finished_at": time.time(),
+                    "supervisor_error": "supervisor start lease expired before command spawn",
+                })
+                _write_state_atomic(job_dir, current)
+
+    if proc is None:
+        stdout.close()
+        stderr.close()
+        return 2
+
+    try:
+        returncode, cancellation_outcome = _wait_with_cancellation(job_dir, proc)
+    except Exception as exc:  # pragma: no cover - defensive: wait normally cannot fail
+        stdout.close()
+        stderr.close()
+        _mark_launch_failure(job_dir, f"supervisor wait failed: {exc}")
+        return 2
+    stdout.close()
+    stderr.close()
+
+    finished = time.time()
+
+    def mark_completed(current: dict[str, Any]) -> dict[str, Any]:
+        # The held Popen's exact wait status is authoritative, including after a
+        # cancellation request.  Managers never synthesize a replacement result.
+        current.update({
+            "status": "completed",
+            "exit_status_known": True,
+            "exit_code": returncode,
+            "finished_at": finished,
+        })
+        if cancellation_outcome is not None:
+            current["cancellation_outcome"] = cancellation_outcome
+        # Completion owns the wake-up once exact terminal truth exists.  Serialize
+        # this state transition with reminder publication so a watchdog cannot
+        # later claim that an already-completed job may still be running.
+        reminder = current.get("reminder")
+        if isinstance(reminder, dict) and reminder.get("state") in {
+            "pending", "publishing", "suppressing"
+        }:
+            reminder.update({"state": "suppressed", "suppressed_at": finished})
+            reminder.pop("claim_token", None)
+            reminder.pop("suppressing_at", None)
+            reminder.pop("suppressing_until", None)
+        return current
+
+    update_state(job_dir, mark_completed)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 2:
+        return 2
+    return supervise(Path(args[0]), args[1])
+
+
+if __name__ == "__main__":  # pragma: no cover - invoked in the supervisor child
+    raise SystemExit(main())

--- a/src/lingtai/tools/bash/glossary-wen.md
+++ b/src/lingtai/tools/bash/glossary-wen.md
@@ -12,6 +12,6 @@ language: wen
 - `timeout`：超时秒数（默认：30，唯同步执行时生效）
 - `working_dir`：指令之工作目录（可选）。留空或传空字符串即用 agent 工作目录。须在 agent 工作目录沙箱之内；沙箱外路径会被拒。若需操作外部仓库/路径，请令 working_dir 保持为 agent 目录，并在 command 中显式 cd，如 cd /absolute/path && ...
 - `async`：后台运行指令，即返 job_id（默认：false，唯 action='run' 时生效）
-- `reminder`：异步兜底唤醒之延迟秒数（默认 1800）。顶层 schema 要求此字段，故经 provider 校验之同步 run、poll、cancel 亦携之；运行时唯异步 run 用且校验之，余动作忽略。任务届时若未被终态 poll 或 cancel，则发 system 通知，促其 poll。
+- `reminder`：异步兜底唤醒之延迟秒数（默认 1800）。顶层 schema 要求此字段，故经 provider 校验之同步 run、poll、cancel 亦携之；运行时唯异步 run 用且校验之，余动作忽略。初期之限，惟崩溃兜底；有界且持久之 return-handoff，禁次 manager 于首 manager 尚未毕成功返转之际先发旧限。惟守尚有效而原子书 `returned_at + reminder`（或精确成败已于有效守内落盘），方报启成；守既逾期，后复之 owner 携 `job_id/pid` 明告“犹可 poll”之误，且存崩溃兜底。终限届而任务仍非终态，方发 system 通知促 poll。取消中之持久 suppressing 亦有界，逾期可复告。若已得精确终态，则抑“或仍在行”之旧告，改由 Bash completion 唤醒。
 - `job_id`：异步任务之号，用于 poll/cancel（由异步 run 所返）
 - `summary`：可选。默认 false。设 true 时，此 tool 照常运行，原始结果完存于持久日志（可凭 tool_call_id 取回）；然结果入尔上下文前，先以尔 `reasoning` 字段所驱之 LLM 摘要代之——故 `reasoning` 当明言所欲存者。唯料输出甚巨（逾一万字符）且无需精确原文时，方设 true。需精确之行/文件/diff/stderr 原文者，留 false。摘要非权威；原始结果逾五十万字符，则不生摘要，尔得一拒辞，指向所存之原始结果。

--- a/src/lingtai/tools/bash/glossary-zh.md
+++ b/src/lingtai/tools/bash/glossary-zh.md
@@ -12,6 +12,6 @@ language: zh
 - `timeout`：超时秒数（默认：30，仅同步执行时生效）
 - `working_dir`：命令的工作目录（可选）。留空或传空字符串即使用 agent 工作目录。必须位于 agent 工作目录沙箱内；沙箱外路径会被拒绝。若要操作外部仓库/路径，请将 working_dir 保持为 agent 目录，并在 command 中显式 cd，例如 cd /absolute/path && ...
 - `async`：后台运行命令并立即返回 job_id（默认：false，仅 action='run' 时生效）
-- `reminder`：兜底异步唤醒延迟秒数（默认 1800）。顶层 schema 要求提供此字段，所以 provider 校验过的同步 run、poll、cancel 也会携带它；运行时只在异步 run 中使用并校验它，其他动作忽略。若任务届时尚未被终态 poll 或 cancel，则发布 system 通知提醒 poll。
+- `reminder`：兜底异步唤醒延迟秒数（默认 1800）。顶层 schema 要求提供此字段，所以 provider 校验过的同步 run、poll、cancel 也会携带它；运行时只在异步 run 中使用并校验它，其他动作忽略。初始期限仅作崩溃兜底；有界的持久 return-handoff 会阻止第二个 manager 在首个 manager 尚未完成成功返回转换时提前发布旧期限。只有在守卫仍有效时原子写入 `returned_at + reminder`（或精确完成/失败已在有效守卫内落盘）才返回成功；过期后恢复的 owner 会携 `job_id/pid` 返回“仍可 poll”的显式错误，且保留崩溃兜底。若最终到期时任务仍非终态，则发布 system 通知提醒 poll。取消期间的持久 suppressing 状态同样有界，超时后可恢复提醒。精确完成会抑制这条过时的“仍可能运行”提醒，改由 Bash completion 通知唤醒。
 - `job_id`：异步任务 ID，用于 poll/cancel（由异步 run 返回）
 - `summary`：可选。默认 false。为 true 时，该 tool 照常执行，原始结果会完整保存到持久日志（可按 tool_call_id 取回），但在结果进入你的上下文之前，会被一段由你的 `reasoning` 字段驱动的 LLM 生成摘要替换——所以请在 `reasoning` 中明确说明要保留什么。仅当预期输出很大（>10k 字符）且你不需要精确原文时才设为 true。需要精确的行/文件/diff/stderr 原文时请保持 false。摘要非权威；若原始结果超过 500,000 字符则不生成摘要，你会收到一条指向已保存原始结果的拒绝信息。

--- a/src/lingtai/tools/bash/manual/SKILL.md
+++ b/src/lingtai/tools/bash/manual/SKILL.md
@@ -11,8 +11,8 @@ description: >
   reminders, debugging silent jobs, and safe cleanup. Start here for any
   long-running agent CLI, time-driven recurring work ("every hour", "weekdays at
   9", "remind me later"), or when a scheduled job misbehaves.
-version: 1.6.1
-last_changed_at: "2026-06-24T14:38:03-07:00"
+version: 1.7.1
+last_changed_at: "2026-07-13T04:44:00-07:00"
 ---
 
 # Bash Manual — Router
@@ -209,17 +209,17 @@ reading the whole file when you only need recent events.
   ```text
   # Start the child agent in the background — returns immediately with a job_id:
   bash(async=true, reminder=1800, command="claude -p 'refactor the auth module' --output-format json")
-  # → {"status": "ok", "job_id": "job-a1b2c3d4", "pid": 4321}
+  # → {"status": "ok", "job_id": "job-a1b2c3d4e5f678901234567890abcdef", "pid": 4321}
 
   # Later turns: poll until done (handle mail/other work between polls):
-  bash(action="poll", job_id="job-a1b2c3d4", reminder=1800)
+  bash(action="poll", job_id="job-a1b2c3d4e5f678901234567890abcdef", reminder=1800)
   # → {"status": "running", …}   then eventually
   # → {"status": "done", "exit_code": 0, "ok": true, "command_status": "success", "stdout": "…", "stderr": "…"}
   #   On failure: {"status": "done", "exit_code": 1, "ok": false,
   #                "command_status": "failed", "warning": "command exited with code 1; …"}
 
   # Abandon it if needed:
-  bash(action="cancel", job_id="job-a1b2c3d4", reminder=1800)
+  bash(action="cancel", job_id="job-a1b2c3d4e5f678901234567890abcdef", reminder=1800)
   ```
 
 - **If repeated-call `_advisory` appears on `bash(action="poll")`, stop
@@ -237,20 +237,66 @@ reading the whole file when you only need recent events.
   and `cancel` also carry `reminder` because of that schema shape, but the field
   is meaningful and runtime-validated only for async `run`; sync commands,
   `poll`, and `cancel` ignore it.
-  When that delay expires, Bash publishes a `bash.reminder` event into
-  `.notification/system.json` unless the job has already been terminally polled
-  or cancelled. The normal completion notification still arrives through
-  `.notification/bash.json`; the reminder is separate and intentionally still
-  fires for an unpolled job even if the process already exited. Pick the delay
-  from the task's *expected* duration — not a fixed number; a 30 s scan and a
-  40 min build warrant different windows. When the reminder fires, health-check
-  rather than assume progress: poll the job, confirm the log is **growing**, the
-  PID/child is **alive** if still running, the output file/worktree shows
-  **progress**, and the job is not stuck on an interactive prompt or a
-  provider/model error. If there is no progress, do not keep waiting — cancel,
-  downgrade, or switch path, and report to the human. Use a separate
-  `.notification/cron.json` reminder or delayed self-email only for a broader
-  workflow wake that is not tied to one Bash async job.
+  The initial durable deadline is a crash fallback while the supervisor starts.
+  A bounded durable return-handoff guard prevents a relaunched/second manager from
+  publishing that fallback while the first manager is still before supervisor
+  `Popen`, or after the command is durably `running` but before async `run` has
+  completed its return transition. Successful `run` atomically resets the
+  deadline to `returned_at + reminder` and arms the guard, so startup latency does
+  not consume the interval you requested. Bash reports `status: ok` only when this
+  still-valid transition wins (or an exact completed/failed result already won
+  under the valid guard). If the owner resumes after expiry, it returns
+  `status: error` with the durable `job_id`/`pid` and an explicit "remains
+  pollable" recovery message rather than claiming false success. A live job keeps
+  the expired fallback; an expired launch or definitively dead supervisor becomes
+  explicit unrecoverable state instead.
+  If the job is still non-terminal when its final deadline expires, Bash publishes
+  a `bash.reminder` event into `.notification/system.json`.
+  The deadline and stable `bash.reminder:<job_id>` claim survive agent
+  stop/relaunch: Bash re-arms a future deadline or retries an overdue/stale claim.
+  Cancellation temporarily uses a bounded durable `suppressing` state; if the
+  manager crashes or the supervisor does not commit before it expires, reminder
+  publication becomes recoverable again. Exact supervisor terminal commit
+  suppresses a pending/publishing/suppressing `may still be running` watchdog and
+  publishes the authoritative completion wake through `.notification/bash.json`;
+  terminal poll and confirmed cancellation also suppress future reminder retries.
+  Final reminder publication and suppression are serialized, so a stale claim
+  that loses the job-state lock cannot publish. If the reminder sink write won
+  before terminal commit, that already-published event may remain as historical
+  evidence.
+  Do not treat either stable ref as a global exactly-once guarantee: a crash after
+  sink write before durable acknowledgement can retry after the bounded system
+  list evicts the reminder ref, while the latest-only Bash slot can be overwritten
+  by another completion. Pick the delay from the task's *expected* duration — not
+  a fixed number; a 30 s scan and a 40 min build warrant different windows. When
+  a reminder fires, health-check rather than assume progress: poll the job,
+  confirm the log is **growing**, the PID/child is **alive** if still running,
+  the output file/worktree shows **progress**, and the job is not stuck on an
+  interactive prompt or a provider/model error. If there is no progress, do not
+  keep waiting — cancel, downgrade, or switch path, and report to the human.
+  Use a separate `.notification/cron.json` reminder or delayed self-email only
+  for a broader workflow wake that is not tied to one Bash async job. Do not
+  conflate them: a Bash reminder belongs to one persisted `job_id`, while
+  `.notification/cron.json` is a separately scheduled workflow wake.
+
+- **Relaunch-safe status is still evidence, not PID guessing.** The launching
+  manager records the observed supervisor identity immediately; Bash's detached
+  supervisor confirms its incarnation and persists exact wait truth. A missing command PID
+  is not a terminal result while that supervisor may still commit: poll retries
+  briefly, then remains recoverably `running` unless the recorded supervisor is
+  definitively gone. A retained legacy job with a still-live recorded PID remains
+  conservatively `running` and uncancellable because Bash cannot prove that PID's
+  incarnation; after the PID dies, one poll may return `exit_status_known: false`
+  and `exit_code: null`. Unrecoverable durable state uses the same explicit unknown
+  shape. Bash never invents `-1` or calls that a command failure. Cancellation is
+  a durable request to the
+  supervisor that holds the unreaped child: it sends TERM, bounded KILL escalation
+  if needed, and the manager reports `cancelled` only after exact terminal commit.
+  A timeout/error leaves poll and the reminder available for recovery. Terminal
+  poll and successful cancel are atomic one-shot consumer actions; the durable
+  record remains for evidence, but any later poll/cancel returns `Job already
+  finished` instead of exposing a second result. New job IDs carry full UUID4 hex;
+  legacy eight-hex IDs are accepted only to read retained old records.
 
 - LingTai has no built-in recurring scheduler. Host schedulers wake agents by
   producing channel input, usually a mailbox-drop or notification file.

--- a/tests/test_bash_async.py
+++ b/tests/test_bash_async.py
@@ -1,5 +1,7 @@
 """Tests for async mode of the bash capability."""
 import json
+import subprocess
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -10,6 +12,7 @@ import pytest
 
 from tests._notification_store_helpers import notification_store_for, snapshot_notifications
 from lingtai.tools.bash import BashManager, BashPolicy, get_schema
+from lingtai.tools.bash import _async_supervisor
 
 
 class TestBashAsync:
@@ -143,7 +146,7 @@ class TestBashAsync:
         assert result["status"] == "error"
         assert "job_id is required" in result["message"]
 
-    # 8. double-poll after completion returns error (job already cleaned up)
+    # 8. double-poll after completion returns error (durable record is consumed)
     def test_double_poll_after_completion(self, tmp_path):
         mgr = self._make_manager(tmp_path)
         result = mgr.handle({"command": "echo done", "async": True})
@@ -151,24 +154,24 @@ class TestBashAsync:
 
         time.sleep(0.5)
 
-        # First poll — should succeed and clean up
+        # First poll succeeds and durably marks the terminal result consumed.
         poll1 = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
         assert poll1["status"] == "done"
 
-        # Second poll — job dir is gone
+        # The record remains for relaunch evidence, but the public result is one-shot.
         poll2 = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
         assert poll2["status"] == "error"
-        assert "not found" in poll2["message"].lower()
+        assert "already finished" in poll2["message"].lower()
 
     def test_poll_nonexistent_job(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"action": "poll", "command": "", "job_id": "job-doesnotexist"})
+        result = mgr.handle({"action": "poll", "command": "", "job_id": "job-ffffffffffffffffffffffffffffffff"})
         assert result["status"] == "error"
         assert "not found" in result["message"].lower()
 
     def test_cancel_nonexistent_job(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"action": "cancel", "command": "", "job_id": "job-doesnotexist"})
+        result = mgr.handle({"action": "cancel", "command": "", "job_id": "job-ffffffffffffffffffffffffffffffff"})
         assert result["status"] == "error"
         assert "not found" in result["message"].lower()
 
@@ -208,6 +211,31 @@ class TestBashAsync:
         assert result["status"] == "ok"
         mgr.handle({"action": "cancel", "command": "", "job_id": result["job_id"]})
 
+    def test_reminder_deadline_starts_at_successful_async_return(self, tmp_path, monkeypatch):
+        mgr = self._make_manager(tmp_path)
+        real_popen = subprocess.Popen
+        startup_delay = 0.2
+        reminder = 0.15
+
+        def delayed_supervisor_start(*args, **kwargs):
+            time.sleep(startup_delay)
+            return real_popen(*args, **kwargs)
+
+        monkeypatch.setattr("lingtai.tools.bash.subprocess.Popen", delayed_supervisor_start)
+        started = mgr.handle({"command": "sleep 5", "async": True, "reminder": reminder})
+        returned_at = time.time()
+        assert started["status"] == "ok"
+
+        state = json.loads(
+            (tmp_path / "system" / "jobs" / started["job_id"] / "state.json").read_text()
+        )
+        deadline = state["reminder"]["deadline_at"]
+        # The initial persisted deadline is only the crash fallback. A successful
+        # return gives the caller the requested interval after supervisor startup.
+        assert deadline - state["created_at"] >= startup_delay + reminder * 0.5
+        assert deadline - returned_at >= reminder * 0.5
+        mgr.handle({"action": "cancel", "job_id": started["job_id"]})
+
     @pytest.mark.parametrize(
         "value",
         [
@@ -227,21 +255,17 @@ class TestBashAsync:
         assert result["status"] == "error"
         assert "reminder" in result["message"]
 
-    def test_async_reminder_publishes_after_delay_even_if_process_exited_unpolled(self, tmp_path):
+    def test_completed_unpolled_job_uses_completion_wake_without_stale_reminder(self, tmp_path):
         mgr = self._make_manager(tmp_path)
         result = mgr.handle({"command": "echo finished", "async": True, "reminder": 0.05})
         job_id = result["job_id"]
 
         time.sleep(0.3)
 
-        events = snapshot_notifications(tmp_path)["system"]["data"]["events"]
-        assert len(events) == 1
-        event = events[0]
-        assert event["source"] == "bash.reminder"
-        assert event["ref_id"] == f"bash.reminder:{job_id}"
-        assert job_id in event["body"]
-        assert "poll" in event["body"]
-        assert "echo finished" not in event["body"]
+        notifications = snapshot_notifications(tmp_path)
+        assert "system" not in notifications
+        assert notifications["bash"]["data"]["job_id"] == job_id
+        assert notifications["bash"]["data"]["exit_code"] == 0
 
         poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
         assert poll["status"] == "done"
@@ -288,6 +312,9 @@ class TestBashAsync:
             "reminder": float("nan"),
         })
         assert cancel["status"] == "cancelled"
+        consumed = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        assert consumed["status"] == "error"
+        assert "cancelled" in consumed["message"].lower()
         time.sleep(0.3)
 
         assert "system" not in snapshot_notifications(tmp_path)
@@ -417,3 +444,921 @@ class TestBashAsync:
         assert second.startswith("evt_")
         assert first != second
         assert [len(event_id.rsplit("_", 1)[1]) for event_id in (first, second)] == [16, 16]
+
+
+class TestBashAsyncRelaunchDurability:
+    """Regression coverage for jobs surviving a fresh BashManager instance."""
+
+    @staticmethod
+    def _manager(tmp_path: Path) -> BashManager:
+        return BashManager(
+            policy=BashPolicy.yolo(),
+            working_dir=str(tmp_path),
+            agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path)),
+        )
+
+    @staticmethod
+    def _wait_for(predicate, timeout: float = 3.0) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            time.sleep(0.02)
+        raise AssertionError("timed out waiting for durable async state")
+
+    @staticmethod
+    def _durable_state(
+        tmp_path: Path,
+        job_id: str,
+        *,
+        status: str = "completed",
+        deadline: float | None = None,
+        pid: int | None = None,
+        pid_identity: str | None = None,
+    ) -> Path:
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        now = time.time()
+        (job_dir / "state.json").write_text(json.dumps({
+            "version": 1,
+            "job_id": job_id,
+            "command": "echo durable",
+            "cwd": str(tmp_path),
+            "status": status,
+            "created_at": now - 1,
+            "started_at": now - 1,
+            "finished_at": now if status == "completed" else None,
+            "pid": pid,
+            "pid_identity": pid_identity,
+            "pid_start_time": pid_identity,
+            "exit_status_known": status == "completed",
+            "exit_code": 0 if status == "completed" else None,
+            "terminal_polled": False,
+            "reminder": {
+                "deadline_at": deadline,
+                "state": "pending",
+                "ref_id": f"bash.reminder:{job_id}",
+            },
+            "completion": {
+                "state": "pending",
+                "ref_id": f"bash.completion:{job_id}",
+            },
+        }))
+        (job_dir / "stdout.log").write_text("durable output\n")
+        (job_dir / "stderr.log").write_text("")
+        return job_dir
+
+    @pytest.mark.parametrize("command, expected", [("exit 0", 0), ("exit 23", 23)])
+    def test_fresh_manager_recovers_exact_supervisor_exit_code(
+        self, tmp_path, command, expected
+    ):
+        first = self._manager(tmp_path)
+        started = first.handle({"command": command, "async": True, "reminder": 30})
+        job_id = started["job_id"]
+        job_dir = tmp_path / "system" / "jobs" / job_id
+
+        self._wait_for(lambda: (job_dir / "state.json").exists())
+        self._wait_for(
+            lambda: json.loads((job_dir / "state.json").read_text())["status"] == "completed"
+        )
+
+        # A new manager has no Popen handle and must use the supervisor's durable
+        # terminal result rather than inferring a false -1 failure from a dead PID.
+        relaunched = self._manager(tmp_path)
+        poll = relaunched.handle({"action": "poll", "job_id": job_id})
+        assert poll["status"] == "done"
+        assert poll["exit_status_known"] is True
+        assert poll["exit_code"] == expected
+        assert poll["ok"] is (expected == 0)
+
+    def test_supervisor_survives_actual_manager_process_exit(self, tmp_path):
+        launcher = """
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from tests._notification_store_helpers import notification_store_for
+from lingtai.tools.bash import BashManager, BashPolicy
+
+root = Path(sys.argv[1])
+manager = BashManager(
+    policy=BashPolicy.yolo(),
+    working_dir=str(root),
+    agent=SimpleNamespace(_notification_store=notification_store_for(root)),
+)
+print(json.dumps(manager.handle({
+    "command": "sleep 0.2; exit 17",
+    "async": True,
+    "reminder": 30,
+})), flush=True)
+"""
+        launched = subprocess.run(
+            [sys.executable, "-c", launcher, str(tmp_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        started = json.loads(launched.stdout.strip())
+        job_id = started["job_id"]
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        self._wait_for(
+            lambda: (job_dir / "state.json").exists()
+            and json.loads((job_dir / "state.json").read_text())["status"] == "completed"
+        )
+
+        relaunched = self._manager(tmp_path)
+        poll = relaunched.handle({"action": "poll", "job_id": job_id})
+        assert poll["status"] == "done"
+        assert poll["exit_status_known"] is True
+        assert poll["exit_code"] == 17
+        assert poll["ok"] is False
+
+    def test_rehydrate_future_and_overdue_reminders_publish_once(self, tmp_path):
+        future = "job-20000000000000000000000000000001"
+        overdue = "job-20000000000000000000000000000002"
+        self._durable_state(
+            tmp_path, future, status="running", deadline=time.time() + 0.12
+        )
+        self._durable_state(
+            tmp_path, overdue, status="running", deadline=time.time() - 1
+        )
+
+        self._manager(tmp_path)
+        self._wait_for(
+            lambda: len(
+                snapshot_notifications(tmp_path).get("system", {}).get("data", {}).get("events", [])
+            ) == 2
+        )
+        # A second rehydrate is a retry/relaunch, not a duplicate publication.
+        self._manager(tmp_path)
+        time.sleep(0.15)
+
+        events = snapshot_notifications(tmp_path)["system"]["data"]["events"]
+        assert {event["ref_id"] for event in events} == {
+            f"bash.reminder:{future}", f"bash.reminder:{overdue}"
+        }
+        assert len(events) == 2
+
+    def test_rehydrated_terminal_poll_and_cancel_suppress_reminders(self, tmp_path):
+        first = self._manager(tmp_path)
+        completed = first.handle({"command": "exit 0", "async": True, "reminder": 0.2})
+        cancelled = first.handle({"command": "sleep 5", "async": True, "reminder": 0.2})
+        completed_dir = tmp_path / "system" / "jobs" / completed["job_id"]
+
+        self._wait_for(
+            lambda: (completed_dir / "state.json").exists()
+            and json.loads((completed_dir / "state.json").read_text())["status"] == "completed"
+        )
+
+        relaunched = self._manager(tmp_path)
+        poll = relaunched.handle({"action": "poll", "job_id": completed["job_id"]})
+        assert poll["status"] == "done"
+        cancel = relaunched.handle({"action": "cancel", "job_id": cancelled["job_id"]})
+        assert cancel["status"] == "cancelled"
+
+        time.sleep(0.3)
+        assert "system" not in snapshot_notifications(tmp_path)
+
+    def test_legacy_dead_pid_is_explicitly_unknown_not_false_failure(self, tmp_path):
+        import subprocess
+
+        dead = subprocess.Popen(["sh", "-c", "exit 0"])
+        dead.wait()
+        job_id = "job-deadbeef"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        (job_dir / "command").write_text("exit 0")
+        (job_dir / "status").write_text("running")
+        (job_dir / "pid").write_text(str(dead.pid))
+        (job_dir / "stdout.log").write_text("")
+        (job_dir / "stderr.log").write_text("")
+
+        poll = self._manager(tmp_path).handle({"action": "poll", "job_id": job_id})
+        assert poll["status"] == "done"
+        assert poll["exit_status_known"] is False
+        assert poll["exit_code"] is None
+        assert "ok" not in poll
+        assert "command_status" not in poll
+
+    def test_legacy_live_pid_remains_running_and_uncancellable(self, tmp_path):
+        import os
+
+        proc = subprocess.Popen(["sh", "-c", "sleep 5"])
+        try:
+            job_id = "job-feedface"
+            job_dir = tmp_path / "system" / "jobs" / job_id
+            job_dir.mkdir(parents=True)
+            (job_dir / "command").write_text("sleep 5")
+            (job_dir / "status").write_text("running")
+            (job_dir / "pid").write_text(str(proc.pid))
+            (job_dir / "stdout.log").write_text("")
+            (job_dir / "stderr.log").write_text("")
+
+            manager = self._manager(tmp_path)
+            poll = manager.handle({"action": "poll", "job_id": job_id})
+            assert poll["status"] == "running"
+            assert poll["pid"] == proc.pid
+            assert "cancellation is unavailable" in poll["message"]
+
+            cancel = manager.handle({"action": "cancel", "job_id": job_id})
+            assert cancel["status"] == "error"
+            assert "legacy" in cancel["message"].lower()
+            os.kill(proc.pid, 0)
+        finally:
+            proc.terminate()
+            proc.wait(timeout=2)
+
+    def test_pid_identity_mismatch_refuses_process_group_signal(self, tmp_path):
+        import os
+        import subprocess
+
+        proc = subprocess.Popen(["sh", "-c", "sleep 5"], start_new_session=True)
+        try:
+            job_id = "job-11111111111111111111111111111111"
+            job_dir = self._durable_state(
+                tmp_path,
+                job_id,
+                status="running",
+                deadline=time.time() + 30,
+                pid=proc.pid,
+                pid_identity="not-the-saved-process",
+            )
+            # Compatibility files make sure an old manager would have signalled it.
+            (job_dir / "status").write_text("running")
+            (job_dir / "pid").write_text(str(proc.pid))
+
+            result = self._manager(tmp_path).handle({"action": "cancel", "job_id": job_id})
+            assert result["status"] == "error"
+            assert "identity" in result["message"].lower()
+            os.kill(proc.pid, 0)
+        finally:
+            proc.terminate()
+            proc.wait(timeout=2)
+
+    def test_rehydrated_completion_is_published_to_bash_notification_channel(self, tmp_path):
+        job_id = "job-20000000000000000000000000000003"
+        self._durable_state(tmp_path, job_id, deadline=time.time() + 30)
+
+        self._manager(tmp_path)
+        self._wait_for(lambda: "bash" in snapshot_notifications(tmp_path))
+        payload = snapshot_notifications(tmp_path)["bash"]
+        assert payload["data"]["job_id"] == job_id
+        assert payload["data"]["exit_code"] == 0
+        assert payload["data"]["ref_id"] == f"bash.completion:{job_id}"
+
+    def test_completion_retry_is_idempotent_at_notification_store(self, tmp_path):
+        class CountingStore:
+            def __init__(self):
+                self.current = {}
+                self.writes = 0
+
+            def compare_update_channel(self, channel, _expected, mutate):
+                payload, changed, value = mutate(self.current.get(channel))
+                if changed:
+                    self.current[channel] = payload
+                    self.writes += 1
+                return SimpleNamespace(value=value)
+
+        job_id = "job-20000000000000000000000000000004"
+        job_dir = self._durable_state(tmp_path, job_id, deadline=time.time() + 30)
+        store = CountingStore()
+        manager = BashManager(
+            policy=BashPolicy.yolo(),
+            working_dir=str(tmp_path),
+            agent=SimpleNamespace(_notification_store=store),
+        )
+        assert store.writes == 1
+
+        # Simulate a crash window where durable state is retried after the sink
+        # already contains the same stable completion reference.
+        state = json.loads((job_dir / "state.json").read_text())
+        assert manager._publish_async_completion(job_id, job_dir, state) is True
+        assert store.writes == 1
+
+
+class TestBashAsyncTerminalRaces:
+    """Deterministic coverage for durable terminal/cancellation linearization."""
+
+    @staticmethod
+    def _manager(tmp_path: Path) -> BashManager:
+        return BashManager(
+            policy=BashPolicy.yolo(),
+            working_dir=str(tmp_path),
+            agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path)),
+        )
+
+    @staticmethod
+    def _completed_job(tmp_path: Path, job_id: str) -> Path:
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        now = time.time()
+        _async_supervisor.write_initial_state(job_dir, {
+            "version": 2, "job_id": job_id, "command": "echo durable",
+            "cwd": str(tmp_path), "status": "completed", "created_at": now - 1,
+            "started_at": now - 1, "finished_at": now, "pid": None,
+            "pid_identity": None, "exit_status_known": True, "exit_code": 0,
+            "terminal_polled": False,
+            "reminder": {"deadline_at": now + 30, "state": "pending", "ref_id": f"bash.reminder:{job_id}"},
+            "completion": {"state": "pending", "ref_id": f"bash.completion:{job_id}"},
+        })
+        (job_dir / "stdout.log").write_text("durable output\n")
+        (job_dir / "stderr.log").write_text("")
+        return job_dir
+
+    def test_poll_does_not_consume_unknown_during_supervisor_precommit_window(
+        self, tmp_path, monkeypatch
+    ):
+        manager = self._manager(tmp_path)
+        job_id = "job-10000000000000000000000000000001"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        initial_state = manager._initial_async_state(job_id, "exit 23", str(tmp_path), 30)
+        _async_supervisor.write_initial_state(job_dir, initial_state)
+        start_token = initial_state["supervisor_start_lease"]["token"]
+        before_commit = threading.Event()
+        release_commit = threading.Event()
+        real_update_state = _async_supervisor.update_state
+
+        def paused_update(job_path, mutate):
+            if getattr(mutate, "__name__", "") == "mark_completed":
+                before_commit.set()
+                assert release_commit.wait(2)
+            return real_update_state(job_path, mutate)
+
+        monkeypatch.setattr(_async_supervisor, "update_state", paused_update)
+        worker = threading.Thread(
+            target=_async_supervisor.supervise, args=(job_dir, start_token)
+        )
+        worker.start()
+        assert before_commit.wait(2)
+
+        # The command has exited, but its live recorded supervisor is paused before
+        # the exact wait status commit.  This must remain recoverable, not consume
+        # an unknown terminal response.
+        pending = manager.handle({"action": "poll", "job_id": job_id})
+        assert pending["status"] == "running"
+        assert json.loads((job_dir / "state.json").read_text())["terminal_polled"] is False
+
+        release_commit.set()
+        worker.join(timeout=2)
+        assert not worker.is_alive()
+        terminal = manager.handle({"action": "poll", "job_id": job_id})
+        assert terminal["status"] == "done"
+        assert terminal["exit_status_known"] is True
+        assert terminal["exit_code"] == 23
+
+    def test_term_ignoring_group_is_killed_by_supervisor_before_cancelled(self, tmp_path):
+        manager = self._manager(tmp_path)
+        started = manager.handle({
+            "command": "trap '' TERM; while :; do sleep 1; done",
+            "async": True,
+            "reminder": 30,
+        })
+        began = time.monotonic()
+        cancelled = manager.handle({"action": "cancel", "job_id": started["job_id"]})
+        elapsed = time.monotonic() - began
+        assert cancelled == {"status": "cancelled", "job_id": started["job_id"]}
+        # The supervisor grants TERM a bounded interval before escalating to KILL.
+        assert elapsed >= 0.35
+        state = json.loads(
+            (tmp_path / "system" / "jobs" / started["job_id"] / "state.json").read_text()
+        )
+        assert state["status"] == "completed"
+        assert state["exit_status_known"] is True
+        assert state["terminal_polled"] is True
+        assert state["reminder"]["state"] == "suppressed"
+
+    def test_outer_shell_exit_does_not_leave_term_ignoring_descendant(self, tmp_path):
+        manager = self._manager(tmp_path)
+        started = manager.handle({
+            "command": (
+                "sh -c 'trap \"\" TERM; echo $$ > descendant.pid; "
+                ": > descendant.ready; while :; do sleep 1; done' & wait $!"
+            ),
+            "async": True,
+            "reminder": 30,
+        })
+        descendant_file = tmp_path / "descendant.pid"
+        descendant_ready = tmp_path / "descendant.ready"
+        deadline = time.monotonic() + 2
+        while not descendant_ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        # The child writes this acknowledgement only after installing its ignored-
+        # TERM trap, so cancellation necessarily exercises the intended survivor.
+        assert descendant_ready.exists()
+        assert descendant_file.exists()
+        descendant_pid = int(descendant_file.read_text().strip())
+
+        cancelled = manager.handle({"action": "cancel", "job_id": started["job_id"]})
+        assert cancelled == {"status": "cancelled", "job_id": started["job_id"]}
+        deadline = time.monotonic() + 2
+        while _async_supervisor.process_is_alive(descendant_pid) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert not _async_supervisor.process_is_alive(descendant_pid)
+        state = json.loads(
+            (tmp_path / "system" / "jobs" / started["job_id"] / "state.json").read_text()
+        )
+        assert state["exit_status_known"] is True
+        assert state["cancellation_outcome"] == "group_cancelled"
+
+    def test_owned_parent_reaper_terminalizes_early_supervisor_exit(self, tmp_path):
+        manager = self._manager(tmp_path)
+        job_id = "job-10000000000000000000000000000004"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        _async_supervisor.write_initial_state(
+            job_dir, manager._initial_async_state(job_id, "sleep 1", str(tmp_path), 30)
+        )
+
+        class ExitedSupervisor:
+            @staticmethod
+            def wait():
+                return 17
+
+        manager._reap_supervisor(ExitedSupervisor(), job_dir)
+        state = json.loads((job_dir / "state.json").read_text())
+        assert state["status"] == "unrecoverable"
+        assert state["exit_status_known"] is False
+        assert "exited with code 17" in state["supervisor_error"]
+
+    def test_owned_parent_reaps_actual_supervisor_exit_before_start_claim(
+        self, tmp_path, monkeypatch
+    ):
+        manager = self._manager(tmp_path)
+        real_popen = subprocess.Popen
+
+        def launch_with_wrong_start_token(args, *popen_args, **popen_kwargs):
+            actual_args = list(args)
+            if "lingtai.tools.bash._async_supervisor" in actual_args:
+                actual_args[-1] = "wrong-start-token"
+            return real_popen(actual_args, *popen_args, **popen_kwargs)
+
+        monkeypatch.setattr(
+            "lingtai.tools.bash.subprocess.Popen", launch_with_wrong_start_token
+        )
+        started = manager.handle({
+            "command": "echo must-not-run", "async": True, "reminder": 30,
+        })
+        assert started["status"] == "error"
+        job_dirs = list((tmp_path / "system" / "jobs").iterdir())
+        assert len(job_dirs) == 1
+        state = json.loads((job_dirs[0] / "state.json").read_text())
+        assert state["status"] == "unrecoverable"
+        assert state["pid"] is None
+        assert state["exit_status_known"] is False
+        assert "owned supervisor exited with code 2" in state["supervisor_error"]
+
+    def test_fresh_manager_recovers_actual_preclaim_exit_after_owner_loss(
+        self, tmp_path
+    ):
+        seed = self._manager(tmp_path)
+        job_id = "job-1000000000000000000000000000000b"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        state = seed._initial_async_state(job_id, "echo must-not-run", str(tmp_path), 30)
+        _async_supervisor.write_initial_state(job_dir, state)
+        wrong_token = "wrong-start-token"
+        supervisor = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "lingtai.tools.bash._async_supervisor",
+                str(job_dir),
+                wrong_token,
+            ],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        def record_without_identity(current):
+            current["supervisor_pid"] = supervisor.pid
+            return current
+
+        _async_supervisor.update_state(job_dir, record_without_identity)
+        assert supervisor.wait(timeout=2) == 2
+        self._manager(tmp_path)
+        recovered = json.loads((job_dir / "state.json").read_text())
+        assert recovered["status"] == "unrecoverable"
+        assert recovered["pid"] is None
+        assert recovered["exit_status_known"] is False
+        assert "definitively gone" in recovered["supervisor_error"]
+
+    def test_fresh_manager_proves_dead_supervisor_without_identity(self, tmp_path):
+        seed = self._manager(tmp_path)
+        job_id = "job-10000000000000000000000000000005"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        state = seed._initial_async_state(job_id, "sleep 1", str(tmp_path), 30)
+        state["supervisor_pid"] = 999_999_999
+        state["supervisor_start_lease"].update({
+            "state": "claimed", "supervisor_pid": 999_999_999,
+        })
+        _async_supervisor.write_initial_state(job_dir, state)
+
+        self._manager(tmp_path)
+        recovered = json.loads((job_dir / "state.json").read_text())
+        assert recovered["status"] == "unrecoverable"
+        assert "definitively gone" in recovered["supervisor_error"]
+
+    def test_fresh_manager_expires_unclaimed_supervisor_start_lease(self, tmp_path):
+        seed = self._manager(tmp_path)
+        job_id = "job-10000000000000000000000000000006"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        state = seed._initial_async_state(job_id, "sleep 1", str(tmp_path), 30)
+        state["supervisor_start_lease"]["deadline_at"] = time.time() - 1
+        _async_supervisor.write_initial_state(job_dir, state)
+
+        self._manager(tmp_path)
+        recovered = json.loads((job_dir / "state.json").read_text())
+        assert recovered["status"] == "unrecoverable"
+        assert "start lease expired" in recovered["supervisor_error"]
+
+    @pytest.mark.parametrize("terminal", [False, True])
+    def test_supervisor_refuses_expired_or_terminal_start_lease(
+        self, tmp_path, monkeypatch, terminal
+    ):
+        manager = self._manager(tmp_path)
+        job_id = (
+            "job-10000000000000000000000000000007"
+            if not terminal
+            else "job-10000000000000000000000000000008"
+        )
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        state = manager._initial_async_state(job_id, "echo forbidden", str(tmp_path), 30)
+        token = state["supervisor_start_lease"]["token"]
+        if terminal:
+            state.update({"status": "unrecoverable", "finished_at": time.time()})
+        else:
+            state["supervisor_start_lease"]["deadline_at"] = time.time() - 1
+        _async_supervisor.write_initial_state(job_dir, state)
+        monkeypatch.setattr(_async_supervisor, "process_identity", lambda pid: f"test:{pid}")
+        monkeypatch.setattr(
+            _async_supervisor.subprocess,
+            "Popen",
+            lambda *args, **kwargs: pytest.fail("expired/terminal supervisor spawned command"),
+        )
+
+        assert _async_supervisor.supervise(job_dir, token) == 2
+        recovered = json.loads((job_dir / "state.json").read_text())
+        assert recovered["status"] == "unrecoverable"
+
+    def test_stale_pre_return_reminder_timer_defers_to_latest_deadline(
+        self, tmp_path, monkeypatch
+    ):
+        manager = self._manager(tmp_path)
+        job_id = "job-10000000000000000000000000000009"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        state = manager._initial_async_state(job_id, "sleep 1", str(tmp_path), 30)
+        state["reminder"]["deadline_at"] = time.time() - 1
+        _async_supervisor.write_initial_state(job_dir, state)
+        captured = []
+
+        class CapturedThread:
+            def __init__(self, *, target, args, daemon):
+                captured.append((target, args, daemon))
+
+            def start(self):
+                return None
+
+        monkeypatch.setattr("lingtai.tools.bash.threading.Thread", CapturedThread)
+        published = []
+        monkeypatch.setattr(
+            manager, "_publish_async_reminder", lambda value: published.append(value) or True
+        )
+        manager._start_reminder_timer(job_id, job_dir)
+        assert len(captured) == 1
+
+        latest_deadline = time.time() + 30
+
+        def retime(current):
+            current["reminder"]["deadline_at"] = latest_deadline
+            return current
+
+        _async_supervisor.update_state(job_dir, retime)
+        target, args, _ = captured[0]
+        target(*args)
+
+        recovered = json.loads((job_dir / "state.json").read_text())
+        assert published == []
+        assert recovered["reminder"]["state"] == "pending"
+        assert recovered["reminder"]["deadline_at"] == latest_deadline
+        assert "claim_token" not in recovered["reminder"]
+        assert len(captured) == 2
+
+    def test_return_handoff_blocks_fallback_while_parent_popen_is_delayed(
+        self, tmp_path, monkeypatch
+    ):
+        manager_a = self._manager(tmp_path)
+        reminder = 0.08
+        parent_popen_entered = threading.Event()
+        release_parent_popen = threading.Event()
+        real_popen = subprocess.Popen
+
+        def gated_supervisor_popen(*args, **kwargs):
+            parent_popen_entered.set()
+            assert release_parent_popen.wait(2)
+            return real_popen(*args, **kwargs)
+
+        monkeypatch.setattr("lingtai.tools.bash.subprocess.Popen", gated_supervisor_popen)
+        published = []
+        monkeypatch.setattr(
+            BashManager,
+            "_publish_async_reminder",
+            lambda self, job_id: published.append(job_id) or True,
+        )
+        claim_attempted = threading.Event()
+        real_claim = BashManager._claim_reminder_timer
+
+        def observed_claim(manager, *args):
+            result = real_claim(manager, *args)
+            claim_attempted.set()
+            return result
+
+        monkeypatch.setattr(BashManager, "_claim_reminder_timer", observed_claim)
+        outcome = {}
+
+        def start_job():
+            outcome["result"] = manager_a.handle({
+                "command": "sleep 5", "async": True, "reminder": reminder,
+            })
+            outcome["returned_at"] = time.time()
+
+        starter = threading.Thread(target=start_job)
+        starter.start()
+        assert parent_popen_entered.wait(2)
+        job_dirs = list((tmp_path / "system" / "jobs").iterdir())
+        assert len(job_dirs) == 1
+        job_dir = job_dirs[0]
+
+        # A second manager rehydrates the old crash-fallback deadline while the
+        # first manager is still live but has not launched its supervisor.  Its
+        # due timer must observe the durable return handoff and defer.
+        self._manager(tmp_path)
+        assert claim_attempted.wait(2)
+        assert published == []
+        pending = json.loads((job_dir / "state.json").read_text())
+        assert pending["status"] == "launching"
+        assert pending["return_handoff"]["state"] == "pending"
+        assert pending["reminder"]["state"] == "pending"
+
+        release_parent_popen.set()
+        starter.join(timeout=2)
+        assert not starter.is_alive()
+        assert outcome["result"]["status"] == "ok"
+        armed = json.loads((job_dir / "state.json").read_text())
+        returned_at = armed["return_handoff"]["returned_at"]
+        assert armed["return_handoff"]["state"] == "armed"
+        assert armed["reminder"]["deadline_at"] == pytest.approx(
+            returned_at + reminder
+        )
+        assert returned_at <= outcome["returned_at"]
+        manager_a.handle({"action": "cancel", "job_id": outcome["result"]["job_id"]})
+
+    def test_return_handoff_blocks_fallback_after_running_before_return_arm(
+        self, tmp_path, monkeypatch
+    ):
+        manager_a = self._manager(tmp_path)
+        reminder = 0.05
+        before_return_arm = threading.Event()
+        release_return_arm = threading.Event()
+        real_update_state = _async_supervisor.update_state
+
+        def paused_manager_update(job_dir, mutate):
+            if getattr(mutate, "__name__", "") == "arm_from_return":
+                before_return_arm.set()
+                assert release_return_arm.wait(2)
+            return real_update_state(job_dir, mutate)
+
+        monkeypatch.setattr("lingtai.tools.bash.update_state", paused_manager_update)
+        published = []
+        monkeypatch.setattr(
+            BashManager,
+            "_publish_async_reminder",
+            lambda self, job_id: published.append(job_id) or True,
+        )
+        claim_attempted = threading.Event()
+        real_claim = BashManager._claim_reminder_timer
+
+        def observed_claim(manager, *args):
+            result = real_claim(manager, *args)
+            claim_attempted.set()
+            return result
+
+        monkeypatch.setattr(BashManager, "_claim_reminder_timer", observed_claim)
+        outcome = {}
+
+        def start_job():
+            outcome["result"] = manager_a.handle({
+                "command": "sleep 5", "async": True, "reminder": reminder,
+            })
+            outcome["returned_at"] = time.time()
+
+        starter = threading.Thread(target=start_job)
+        starter.start()
+        assert before_return_arm.wait(2)
+        job_dirs = list((tmp_path / "system" / "jobs").iterdir())
+        assert len(job_dirs) == 1
+        job_dir = job_dirs[0]
+        pre_arm = json.loads((job_dir / "state.json").read_text())
+        assert pre_arm["status"] == "running"
+        assert pre_arm["return_handoff"]["state"] == "pending"
+        sleep_for = pre_arm["reminder"]["deadline_at"] - time.time() + 0.02
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+
+        self._manager(tmp_path)
+        assert claim_attempted.wait(2)
+        assert published == []
+        still_pending = json.loads((job_dir / "state.json").read_text())
+        assert still_pending["return_handoff"]["state"] == "pending"
+        assert still_pending["reminder"]["state"] == "pending"
+
+        release_return_arm.set()
+        starter.join(timeout=2)
+        assert not starter.is_alive()
+        assert outcome["result"]["status"] == "ok"
+        armed = json.loads((job_dir / "state.json").read_text())
+        returned_at = armed["return_handoff"]["returned_at"]
+        assert armed["return_handoff"]["state"] == "armed"
+        assert armed["reminder"]["deadline_at"] == pytest.approx(
+            returned_at + reminder
+        )
+        assert returned_at <= outcome["returned_at"]
+        manager_a.handle({"action": "cancel", "job_id": outcome["result"]["job_id"]})
+
+    def test_owner_resuming_after_handoff_expiry_cannot_report_start_success(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "lingtai.tools.bash._RETURN_HANDOFF_LEASE_SECONDS", 0.2
+        )
+        manager_a = self._manager(tmp_path)
+        before_return_arm = threading.Event()
+        release_return_arm = threading.Event()
+        fallback_published = threading.Event()
+        real_update_state = _async_supervisor.update_state
+
+        def paused_manager_update(job_dir, mutate):
+            if getattr(mutate, "__name__", "") == "arm_from_return":
+                before_return_arm.set()
+                assert release_return_arm.wait(2)
+            return real_update_state(job_dir, mutate)
+
+        monkeypatch.setattr("lingtai.tools.bash.update_state", paused_manager_update)
+        published = []
+
+        def record_publish(manager, job_id):
+            published.append(job_id)
+            fallback_published.set()
+            return True
+
+        monkeypatch.setattr(BashManager, "_publish_async_reminder", record_publish)
+        outcome = {}
+
+        def start_job():
+            outcome["result"] = manager_a.handle({
+                "command": "sleep 5", "async": True, "reminder": 0.02,
+            })
+
+        starter = threading.Thread(target=start_job)
+        starter.start()
+        assert before_return_arm.wait(2)
+        job_dirs = list((tmp_path / "system" / "jobs").iterdir())
+        assert len(job_dirs) == 1
+        job_dir = job_dirs[0]
+        pre_expiry = json.loads((job_dir / "state.json").read_text())
+        assert pre_expiry["status"] == "running"
+        assert pre_expiry["return_handoff"]["state"] == "pending"
+
+        # B is now entitled to the bounded crash fallback because A has not
+        # completed its return transition before the durable handoff deadline.
+        self._manager(tmp_path)
+        try:
+            assert fallback_published.wait(2)
+            # The sink callback runs while the state lock is held; its event can
+            # become visible just before publishing -> published is fsynced.
+            publish_deadline = time.monotonic() + 2
+            while time.monotonic() < publish_deadline:
+                expired = json.loads((job_dir / "state.json").read_text())
+                if expired["reminder"]["state"] == "published":
+                    break
+                time.sleep(0.01)
+            assert expired["return_handoff"]["state"] == "expired"
+            assert expired["reminder"]["state"] == "published"
+        finally:
+            release_return_arm.set()
+            starter.join(timeout=2)
+        assert not starter.is_alive()
+        late = outcome["result"]
+        assert late["status"] == "error"
+        assert late["job_id"] == job_dir.name
+        assert isinstance(late["pid"], int)
+        assert "remains pollable" in late["message"]
+        final = json.loads((job_dir / "state.json").read_text())
+        assert final["return_handoff"]["state"] == "expired"
+        assert final["reminder"]["state"] == "published"
+        assert published == [job_dir.name]
+        manager_a.handle({"action": "cancel", "job_id": job_dir.name})
+
+    def test_expired_suppressing_reminder_recovers_after_manager_crash(
+        self, tmp_path, monkeypatch
+    ):
+        manager = self._manager(tmp_path)
+        job_id = "job-1000000000000000000000000000000a"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        state = manager._initial_async_state(job_id, "sleep 5", str(tmp_path), 30)
+        state.update({"status": "running", "pid": None})
+        state["return_handoff"].update({
+            "state": "armed", "returned_at": time.time() - 2,
+        })
+        state["reminder"].update({
+            "state": "suppressing",
+            "deadline_at": time.time() - 1,
+            "suppressing_at": time.time() - 2,
+            "suppressing_until": time.time() - 1,
+        })
+        _async_supervisor.write_initial_state(job_dir, state)
+        published = []
+        monkeypatch.setattr(
+            manager,
+            "_publish_async_reminder",
+            lambda value: published.append(value) or True,
+        )
+        cancel_event = threading.Event()
+        with manager._reminder_lock:
+            manager._reminder_cancel_events[job_id] = cancel_event
+
+        claim_token = manager._claim_reminder_timer(job_id, job_dir, cancel_event)
+        assert isinstance(claim_token, str)
+        assert manager._publish_claimed_reminder(job_id, job_dir, claim_token) is True
+        recovered = json.loads((job_dir / "state.json").read_text())
+        assert published == [job_id]
+        assert recovered["reminder"]["state"] == "published"
+        assert "suppressing_until" not in recovered["reminder"]
+
+    def test_concurrent_managers_have_one_terminal_consumer(self, tmp_path):
+        job_id = "job-10000000000000000000000000000002"
+        self._completed_job(tmp_path, job_id)
+        managers = [self._manager(tmp_path), self._manager(tmp_path)]
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(
+                lambda manager: manager.handle({"action": "poll", "job_id": job_id}),
+                managers,
+            ))
+
+        assert [result["status"] for result in results].count("done") == 1
+        assert [result["status"] for result in results].count("error") == 1
+
+    def test_terminal_suppression_wins_over_stale_reminder_publish(self, tmp_path, monkeypatch):
+        job_id = "job-10000000000000000000000000000003"
+        manager = self._manager(tmp_path)
+        # Create the terminal fixture after construction so rehydration cannot
+        # pre-suppress it; this test needs a stale claim acquired before poll wins.
+        job_dir = self._completed_job(tmp_path, job_id)
+
+        def make_due(current):
+            current["reminder"]["deadline_at"] = time.time() - 1
+            return current
+
+        _async_supervisor.update_state(job_dir, make_due)
+        cancel_event = threading.Event()
+        with manager._reminder_lock:
+            manager._reminder_cancel_events[job_id] = cancel_event
+        claim_token = manager._claim_reminder_timer(job_id, job_dir, cancel_event)
+        assert isinstance(claim_token, str)
+
+        published = []
+        monkeypatch.setattr(manager, "_publish_async_reminder", lambda value: published.append(value) or True)
+        assert manager._terminal_result(job_id, job_dir)["status"] == "done"
+        # The token was acquired before the terminal action, but final
+        # publication rechecks it under the same durable state lock.
+        assert manager._publish_claimed_reminder(job_id, job_dir, claim_token) is False
+        assert published == []
+        state = json.loads((job_dir / "state.json").read_text())
+        assert state["reminder"]["state"] == "suppressed"
+
+    def test_full_ids_are_strict_and_collision_safe(self, tmp_path, monkeypatch):
+        manager = self._manager(tmp_path)
+        existing = "a" * 32
+        replacement = "b" * 32
+        (tmp_path / "system" / "jobs" / f"job-{existing}").mkdir(parents=True)
+        values = iter((SimpleNamespace(hex=existing), SimpleNamespace(hex=replacement)))
+        monkeypatch.setattr("lingtai.tools.bash.uuid.uuid4", lambda: next(values))
+
+        started = manager.handle({"command": "exit 0", "async": True, "reminder": 30})
+        assert started["job_id"] == f"job-{replacement}"
+        assert len(started["job_id"]) == 36
+        assert manager._validate_job_id(started["job_id"]) is None
+        # The old eight-hex retained layout remains readable only as an explicit
+        # migration form; all other text, including traversal-shaped input, fails.
+        assert manager._validate_job_id("job-deadbeef") is None
+        for invalid in ("job-" + "c" * 31, "job-" + "C" * 32, "job-../escape"):
+            assert manager._validate_job_id(invalid)["status"] == "error"


### PR DESCRIPTION
## Summary

- move Bash async command ownership out of the agent process into a detached durable supervisor that owns `Popen`, logs, whole-process-group cancellation, `wait()`, and the exact terminal commit
- rehydrate versioned job records after manager/agent relaunch, with a finite tokenized start lease, process-incarnation checks, bounded successful-return handoff, and truthful legacy unknown-state handling
- serialize poll/cancel terminal claims with reminder/completion publication so refreshes and races cannot invent exit codes, report false start success, or emit stale duplicate wakes
- lock the contract with deterministic race regressions plus CONTRACT, ANATOMY, Bash manual, Simplified/Classical glossary, and a self-contained HTML report

## Root cause

Bash async previously kept the watcher, reminder timer, and direct `Popen`/wait-status handle only in the current agent process. A refresh or relaunch therefore destroyed all three while the command could continue running. The next manager could see a PID and log files, but could neither recover the real exit status nor rebuild the reminder safely.

This patch fixes the invariant at the owning layer: the detached supervisor, not the restartable manager, is the direct-child owner and durable source of terminal truth.

## Behavior contract

- the supervisor must claim and recheck an unexpired tokenized start lease under the state lock immediately before command spawn
- only the supervisor that owns the direct child may persist its actual wait status
- cancellation keeps the direct shell unreaped through TERM grace, KILLs the original process group, and reports `group_cancelled` only after no live non-zombie group member remains
- `status: ok` from async start requires the lock-owned valid return-handoff transition, or exact terminal truth while that guard remains valid; a late owner after fallback publication receives a pollable error with `job_id`/`pid`
- terminal consumption, reminder suppression/publication, and completion publication are durable conditional transitions with bounded crash recovery
- live legacy PID-only records remain conservatively running and uncancellable; dead legacy records return one explicit unknown result instead of a fabricated failure

## Non-goals

- no Windows implementation: the production mechanism is intentionally POSIX-only and documents its `fcntl`, process-group, signal, `/proc`/`ps` assumptions
- no job/log retention or compaction policy in this PR
- no merge, release, runtime refresh, or configuration change

## Validation

```text
PYTHONPATH=src python -m pytest -q \
  tests/test_bash_async.py tests/test_layers_bash.py
114 passed in 18.66s
```

```text
PYTHONPATH=src python -m pytest -q \
  tests/test_bash_async.py \
  tests/test_layers_bash.py \
  tests/test_anatomy_drift_checker.py \
  tests/test_architecture_documents.py \
  tests/test_kernel_package_move.py \
  tests/test_tools_package_data.py \
  tests/test_tools_package_move.py \
  tests/test_tool_glossary.py
330 passed in 26.13s
```

```text
# Eight load-bearing cancellation/start/handoff/suppression races,
# repeated with their exact node IDs for ten iterations
8 passed × 10 iterations
```

```text
PYTHONPATH=src python -m pytest -q
5109 passed, 3 skipped, 5 failed in 225.64s
```

The five full-suite failures are not candidate regressions: the same five node IDs and causes reproduce on a clean exact `99deeafe7fe1d28f90de61ca255838fcc6f206fa` base under the same confined empty-HOME/TMP environment. They are three missing scratch-HOME `codex-auth.json` failures, one absolute scratch-prefix `/tmp/` traversal assertion, and the existing installed-wheel `lingtai/bin/` sidecar assertion. No Bash test failed.

Additional gates:

```text
python -m lingtai.tools.glossary_validator --check
OK: 54 glossary resources across 18 packages validated.

git diff --check
PASS

clean-base git apply --check
PASS
```

The frozen nine-path patch SHA-256 was `cbeeebf18d34ab3022ce02aa4965a49721ed3871af7cbecd296d0ea21e3dcb6c`. A fresh independent adversarial Terra review of that exact frozen patch and its receipts returned PASS with no PR-blocking correctness, contract, test, evidence, or scope finding.

Detailed behavior and validation report: `reports/bash-async-relaunch-durability-20260713.html`.
