### PR TITLE
docs(telegram): add long-work Task Card watcher guidance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,11 +109,12 @@ lingtai = [
 ]
 "lingtai.mcp_servers.telegram" = ["notification_header.md", "SKILL.md", "reference/**/*", "assets/**/*"]
 # The Telegram-owned programmable Task Card unit is its own subpackage, so its
-# manual and architecture documents are NOT covered by the parent telegram glob
-# above (package-data globs do not recurse into subpackages). Ship the nested
-# SKILL.md manual plus the paired ANATOMY.md/CONTRACT.md explicitly, or the wheel
-# installs the code and silently drops the manual/contract.
-"lingtai.mcp_servers.telegram.task_card" = ["SKILL.md", "ANATOMY.md", "CONTRACT.md"]
+# manual, architecture documents, and renderer template assets are NOT covered by
+# the parent telegram glob above (package-data globs do not recurse into
+# subpackages). Ship the nested SKILL.md manual plus the paired
+# ANATOMY.md/CONTRACT.md and the assets/ renderer templates explicitly, or the
+# wheel installs the code and silently drops the manual/contract/templates.
+"lingtai.mcp_servers.telegram.task_card" = ["SKILL.md", "ANATOMY.md", "CONTRACT.md", "assets/**/*"]
 "lingtai.mcp_servers.feishu" = ["notification_header.md", "SKILL.md", "reference/**/*", "assets/**/*"]
 "lingtai.mcp_servers.wechat" = ["notification_header.md", "SKILL.md", "reference/**/*", "assets/**/*"]
 "lingtai.mcp_servers.whatsapp" = ["notification_header.md", "SKILL.md", "reference/**/*", "assets/**/*"]

--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -5,10 +5,12 @@ description: |
   you need detail beyond the one-line action descriptions: media.type='document'
   vs 'photo' for charts/reports/generated artifacts, placeholder/live-status
   messages, reply vs send, read/check/search, parse_mode/entities, chat_action, dynamic slash commands,
-  the programmable Task Card (task_card tool), and error surfacing. Pulled on
-  demand via action='manual'; you do not need to call it before every send.
-version: 1.4.0
-last_changed_at: "2026-07-12T20:45:00-07:00"
+  the programmable Task Card (task_card tool) — including the default to add a
+  human-visible watcher for long-running bash-async/daemon work — and error
+  surfacing. Pulled on demand via action='manual'; you do not need to call it
+  before every send.
+version: 1.5.1
+last_changed_at: "2026-07-13T12:15:00-07:00"
 ---
 
 # Telegram MCP — usage manual (progressive disclosure)
@@ -195,16 +197,26 @@ Important behavior notes:
 
 ## PROGRAMMABLE TASK CARD (`task_card` tool)
 
+- **Default during Telegram-originated turns: when you launch a meaningful
+  long-running `bash(async=true)` job or daemon task and then go idle to await it,
+  create a human-visible programmable Task Card watcher for it** so the person
+  watching Telegram sees the latest reported snapshot instead of a silent gap
+  (you refresh that snapshot after launch, after meaningful polls/checks, and at
+  the terminal result). Two ready, copy-and-adapt renderer templates cover exactly
+  these two cases (`render_bash_async.py` and `render_daemon.py`); the full manual
+  below routes to them and explains how to copy an asset into your working
+  directory. Skip the watcher only for quick or invisible jobs.
 - The resident Task Card has two independent slots: the **automatic** tool-activity
   slot (managed for you, described under **TASKCARD STATE**) and a **programmable**
   slot you drive with the separate public `task_card` tool. With both present, the
   programmable block appears under a `— WATCH —` header; updating one slot never
   disturbs the other.
-- You bind live state to the programmable slot by supplying a small **Python
-  renderer** file inside your working directory whose stdout is exactly one Task
-  Card JSON object (`title` string, `lines` array of ≤20 strings, `footer` string;
-  at least one present). Telegram never runs your code — the controller runs the
-  renderer as a subprocess and forwards only the validated data.
+- You surface your latest reported snapshot on the programmable slot by supplying
+  a small **Python renderer** file inside your working directory whose stdout is
+  exactly one Task Card JSON object (`title` string, `lines` array of ≤20 strings,
+  `footer` string; at least one present). Telegram never runs your code — the
+  controller runs the renderer as a subprocess and forwards only the validated
+  data.
 - Actions: `start` (validate + run once, then watch on an interval; returns a
   `watch_id`), `inspect` (state + last valid frame), `retry` (re-run now), `stop`
   (end the watch, clear only the programmable frame; renderer files are never
@@ -212,10 +224,13 @@ Important behavior notes:
   failures keep the last valid frame and raise a deduped fail-loud system wake.
 - `/taskcard off` hides delivery of **both** slots (see **TASKCARD STATE**) while
   the renderer, watches, and last-valid bookkeeping keep running.
-- **Full manual (renderer contract, a safe runnable example, and the full
-  start|inspect|retry|stop walkthrough):** follow the relative path
-  `task_card/SKILL.md` from this manual's directory (the co-located Programmable
-  Task Card manual).
+- **Full manual (renderer contract, the two ready bash-async/daemon renderer
+  templates, the snapshot truthfulness model, and the full start|inspect|retry|stop
+  walkthrough):** follow the relative path `task_card/SKILL.md` from this manual's
+  directory (the co-located Programmable Task Card manual). Starting a watch drives
+  the programmable slot of the `TelegramManager`-owned single resident card,
+  reusing the tracked resident or creating its one resident if none exists yet; it
+  does not start another manager or a second card.
 
 ## ERROR SURFACING
 

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -69,12 +69,13 @@ Normative promises live in the paired [`CONTRACT.md`](CONTRACT.md).
 
 ## Connections
 
-- Composition root: `Agent._maybe_setup_task_card_controller` calls `setup`
-  only after the newly rebuilt reverse-route map contains Telegram; it
-  re-registers the same controller after a full refresh clears the public tool
-  surface or a colliding MCP overwrites it, verifying the handler binding and
-  owned schema rather than a name/count alone (`src/lingtai/agent.py:975`,
-  `src/lingtai/agent.py:1330`).
+- Composition root: `Agent._maybe_setup_task_card_controller`
+  (`src/lingtai/agent.py:1001-1042`) calls `setup` only after the newly rebuilt
+  reverse-route map contains Telegram; it re-registers the same controller after a
+  full refresh clears the public tool surface or a colliding MCP overwrites it,
+  verifying the handler binding and owned schema rather than a name/count alone. It
+  runs at the end of each MCP-connect path that may add the Telegram route
+  (`src/lingtai/agent.py:998`, `src/lingtai/agent.py:1099`).
 - Renderer: `_run_renderer` runs `sys.executable <renderer>` with the agent
   workdir as `cwd`; `_validate_renderer_path` confines the path to that workdir.
 - Reverse channel: `_project` calls the private `_lingtai_telegram_task_card`

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -70,12 +70,13 @@ Normative promises live in the paired [`CONTRACT.md`](CONTRACT.md).
 ## Connections
 
 - Composition root: `Agent._maybe_setup_task_card_controller`
-  (`src/lingtai/agent.py:1001-1042`) calls `setup` only after the newly rebuilt
+  (`src/lingtai/agent.py:1023-1064`; `setup` call at
+  `src/lingtai/agent.py:1064`) calls `setup` only after the newly rebuilt
   reverse-route map contains Telegram; it re-registers the same controller after a
   full refresh clears the public tool surface or a colliding MCP overwrites it,
   verifying the handler binding and owned schema rather than a name/count alone. It
   runs at the end of each MCP-connect path that may add the Telegram route
-  (`src/lingtai/agent.py:998`, `src/lingtai/agent.py:1099`).
+  (`src/lingtai/agent.py:1020`, `src/lingtai/agent.py:1121`).
 - Renderer: `_run_renderer` runs `sys.executable <renderer>` with the agent
   workdir as `cwd`; `_validate_renderer_path` confines the path to that workdir.
 - Reverse channel: `_project` calls the private `_lingtai_telegram_task_card`

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -7,6 +7,8 @@ related_files:
   - src/lingtai/mcp_servers/telegram/task_card/interface.py
   - src/lingtai/mcp_servers/telegram/task_card/controller.py
   - src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+  - src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py
+  - src/lingtai/mcp_servers/telegram/task_card/assets/render_daemon.py
   - src/lingtai/mcp_servers/telegram/manager.py
   - src/lingtai/agent.py
 maintenance: |
@@ -99,14 +101,23 @@ Normative promises live in the paired [`CONTRACT.md`](CONTRACT.md).
   [`src/lingtai/kernel/base_agent/ANATOMY.md`](../../../kernel/base_agent/ANATOMY.md);
   render/compose/persistence in `src/lingtai/mcp_servers/telegram/manager.py`.
 - **Manual:** [`SKILL.md`](SKILL.md).
+- **Manual assets:** [`assets/render_bash_async.py`](assets/render_bash_async.py)
+  and [`assets/render_daemon.py`](assets/render_daemon.py) — the two co-located,
+  stdlib-only renderer templates the manual routes agents to (bash-async job and
+  daemon task). They read an orchestrator-owned working-dir state snapshot and
+  print one bounded Task Card object; they are packaged skill assets, not runtime
+  code (the controller never imports them — it runs the agent's own working-dir
+  copy as a subprocess).
 
 ## State
 
 The controller holds only in-memory per-watch state (`_watches`, threads,
-last-valid frames, error epochs). It writes no files and deletes none — renderer
-files are the agent's own. Durable Task Card state (resident message id per
-account+chat, composed slots, the `/taskcard` delivery boolean) is owned by the
-Telegram adapter, not here (see `src/lingtai/mcp_servers/ANATOMY.md`).
+last-valid frames, error epochs). It writes no files and deletes none — the
+renderer files it runs are the agent's own working-dir copies (the shipped
+`assets/` templates are read-only starting points the agent copies and adapts).
+Durable Task Card state (resident message id per account+chat, composed slots,
+the `/taskcard` delivery boolean) is owned by the Telegram adapter, not here
+(see `src/lingtai/mcp_servers/ANATOMY.md`).
 
 ## Notes
 

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -8,6 +8,8 @@ related_files:
   - src/lingtai/mcp_servers/telegram/task_card/controller.py
   - src/lingtai/mcp_servers/telegram/task_card/__init__.py
   - src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+  - src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py
+  - src/lingtai/mcp_servers/telegram/task_card/assets/render_daemon.py
   - src/lingtai/mcp_servers/telegram/manager.py
   - src/lingtai/mcp_servers/telegram/account.py
   - src/lingtai/mcp_servers/telegram/server.py
@@ -16,6 +18,7 @@ related_files:
   - tests/test_task_card_controller.py
   - tests/test_telegram_task_card_programmable.py
   - tests/test_telegram_task_card_toggle.py
+  - tests/test_telegram_task_card_templates.py
   - tests/test_mcp_skill_manuals.py
   - tests/test_telegram_task_card_singleton.py
   - tests/test_telegram_task_card_last_message.py
@@ -281,11 +284,22 @@ partial, `old_resident_deleted` preserved
 `tests/test_telegram_account_last_message_id.py` locks the int-only,
 edit/delete-immune, non-persisted last-message high-water.
 
-Packaging traceability: `pyproject.toml`
-(`[tool.setuptools.package-data]."lingtai.mcp_servers.telegram.task_card"` ships
-`SKILL.md`, `ANATOMY.md`, `CONTRACT.md`) is verified by
-`tests/test_mcp_skill_manuals.py`, so this governed nested unit's docs ship in
-built wheels/sdists and cannot silently drop on a future ownership move.
+Packaging traceability: `tests/test_mcp_skill_manuals.py` checks that
+`pyproject.toml`
+(`[tool.setuptools.package-data]."lingtai.mcp_servers.telegram.task_card"`)
+**declares** `SKILL.md`, `ANATOMY.md`, `CONTRACT.md`, and the `assets/**/*`
+renderer templates. The test asserts the package-data declaration only — it does
+not build or inspect a wheel/sdist — so it guards against the declaration silently
+dropping this governed nested unit's docs/assets on a future ownership move, which
+is why the entry is required rather than relying on the (non-recursing) parent
+`telegram` glob. `tests/test_telegram_task_card_templates.py` locks the two
+renderer template assets themselves: both entry-point manuals, asset shape
+(stdlib-only, documented schema), and executable behavior through the real
+`TaskCardController._run_renderer` — including snapshot truthfulness (no
+`starting`/`running` without a recorded identity plus an allow-listed state) and
+the byte/type/range bounds (oversize file, container-valued fields, giant
+integers, non-finite floats, wrong types, and hostile strings all degrade to an
+explicit awaiting frame or are clipped, never fabricated).
 
 Verification commands (repo venv):
 
@@ -296,7 +310,8 @@ Verification commands (repo venv):
   tests/test_telegram_task_card_singleton.py \
   tests/test_telegram_task_card_last_message.py \
   tests/test_telegram_account_last_message_id.py \
-  tests/test_telegram_task_card_in_place.py
+  tests/test_telegram_task_card_in_place.py \
+  tests/test_telegram_task_card_templates.py
 .venv/bin/python -m pytest -q tests/test_architecture_documents.py \
   tests/test_mcp_skill_manuals.py
 ```

--- a/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
@@ -9,7 +9,7 @@ description: |
   templates (bash async, daemon) shipped as skill assets, the
   start | inspect | retry | stop lifecycle, path/timeout/validation rules,
   fail-loud error wakes, and how the /taskcard toggle interacts.
-last_changed_at: "2026-07-13T12:15:00-07:00"
+last_changed_at: "2026-07-13T15:00:00-07:00"
 ---
 
 # Programmable Telegram Task Card — manual (what / how / why)
@@ -194,6 +194,23 @@ driver that forwards validated frames.
   is the only content on the card, stopping
   shows a stable `— WATCH STOPPED —` marker (an empty Telegram message is not
   allowed) and leaves the resident message reusable. Pass the `watch_id`.
+
+### Terminal cleanup: stop a finished watch
+
+A watcher does not end itself — the renderer is passive and has no `watch_id`, so
+**you** must stop it when the work finishes. When your job reaches a terminal
+state — bash `status` `done`/`failed`/`cancelled`, or daemon `state`
+`done`/`failed`/`cancelled`/`timeout` (learned from the terminal bash
+`bash(action="poll")` or the terminal `daemon` notification/`daemon(action="check")`)
+— record that terminal snapshot, then **immediately call
+`task_card(action="stop", watch_id="<watch_id>")`** (the `watch_id` that
+`task_card(action="start", ...)` returned) to quiesce the watcher and clear the
+programmable slot so the completed card does not stay resident. The two shipped
+templates surface this by rendering the footer
+`terminal snapshot — stop/clear this watch now` on a terminal snapshot. If it
+returns a retryable `stop_failed`, **call the same `task_card(action="stop", ...)`
+again** — do not restart or duplicate the watch. Non-terminal states
+(`starting`/`running`) stay resident and keep updating.
 
 ### When a watch fails
 

--- a/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
@@ -121,13 +121,40 @@ malformed:
 
 - **`render_bash_async.py`** — for a `bash(async=true)` job. Reads
   `task_card_state.json`. Requires `job_id` (str) + `status` (str, one of
-  `starting|running|done|failed|cancelled`); also surfaces optional `title`,
-  `exit_code` (int), `stage`, `updated_at`, `note`.
+  `starting|running|done|failed|cancelled|unknown`); also surfaces optional
+  `title`, `exit_code` (int), `stage`, `updated_at`, `note`. Here `status` is a
+  **display state you derive from the sanctioned poll/cancel result**, not the raw
+  top-level bash `status` (which is always `done` on completion — see the mapping
+  under **Deriving the bash display state** below).
 - **`render_daemon.py`** — for a daemon task (emanation). Reads
   `daemon_card_state.json`. Requires `id` (str) + `state` (str, one of
   `running|done|failed|cancelled|timeout`); also surfaces optional `title`,
   `current`, `elapsed_s` (finite number), `last_activity`, `health`
   (`alive|stalled|unknown`), `updated_at`, `note`.
+
+**Deriving the bash display state.** The bash `status` you record is a **display
+state derived from the sanctioned action result**, not the raw top-level bash
+`status`. Bash's terminal `bash(action="poll")` is **always** top-level
+`status: "done"` — a nonzero inner command does **not** make it a top-level
+`"failed"`; the pass/fail signal is in the additive fidelity fields
+(`exit_status_known`, `exit_code`, `ok`, `command_status`). Map the result:
+
+| `bash` result | record `status` |
+|---|---|
+| `{"status": "running", ...}` | `running` (resident) |
+| `{"status": "done", "exit_status_known": true, "exit_code": 0, "ok": true, "command_status": "success"}` | `done` (terminal) |
+| `{"status": "done", "exit_status_known": true, "exit_code": <nonzero>, "ok": false, "command_status": "failed"}` | `failed` (terminal) |
+| `{"status": "done", "exit_status_known": false, "exit_code": null, ...}` | `unknown` (terminal) |
+| `bash(action="cancel")` → `{"status": "cancelled", ...}` | `cancelled` (terminal) |
+
+So a nonzero completion is recorded `failed` (never `done` by copying the raw
+top-level `status`), and an exit-status-unavailable terminal completion is
+recorded `unknown` — a distinct **terminal** state that reports the exit status is
+unavailable and claims **neither** success **nor** failure (Bash never invents
+`-1` or a false `command_status: "failed"` for it, so neither does the card). Copy
+`exit_code` only when `exit_status_known` is true; omit it for `unknown`. All four
+terminal display states (`done`, `failed`, `cancelled`, `unknown`) render the
+stop/clear footer and require the same terminal closeout below.
 
 **Locate and copy the asset.** The asset lives next to this manual under
 `task_card/assets/`. Resolve it relative to the **absolute manual path** that the
@@ -199,14 +226,17 @@ driver that forwards validated frames.
 
 A watcher does not end itself — the renderer is passive and has no `watch_id`, so
 **you** must stop it when the work finishes. When your job reaches a terminal
-state — bash `status` `done`/`failed`/`cancelled`, or daemon `state`
-`done`/`failed`/`cancelled`/`timeout` (learned from the terminal bash
-`bash(action="poll")` or the terminal `daemon` notification/`daemon(action="check")`)
-— record that terminal snapshot, then **immediately call
-`task_card(action="stop", watch_id="<watch_id>")`** (the `watch_id` that
-`task_card(action="start", ...)` returned) to quiesce the watcher and clear the
-programmable slot so the completed card does not stay resident. The two shipped
-templates surface this by rendering the footer
+display state — bash `status` `done`/`failed`/`cancelled`/`unknown`, or daemon
+`state` `done`/`failed`/`cancelled`/`timeout` (learned from the terminal bash
+`bash(action="poll")`/`bash(action="cancel")` or the terminal `daemon`
+notification/`daemon(action="check")`) — record that terminal snapshot, then
+**immediately call `task_card(action="stop", watch_id="<watch_id>")`** (the
+`watch_id` that `task_card(action="start", ...)` returned) to quiesce the watcher
+and clear the programmable slot so the completed card does not stay resident. The
+bash `unknown` display state (a terminal poll whose `exit_status_known` is
+`false`) is terminal too — it reports the exit status is unavailable, claims
+neither success nor failure, and must still be stopped/cleared, not left resident.
+The two shipped templates surface this by rendering the footer
 `terminal snapshot — stop/clear this watch now` on a terminal snapshot. If it
 returns a retryable `stop_failed`, **call the same `task_card(action="stop", ...)`
 again** — do not restart or duplicate the watch. Non-terminal states

--- a/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
@@ -2,21 +2,35 @@
 name: telegram-task-card-manual
 description: |
   Manual for the programmable Telegram Task Card (`task_card` tool). Read this to
-  bind live state — a bash async job, a build, a countdown — to the resident
-  Telegram Task Card by supplying a small Python renderer whose stdout is one
-  Task Card JSON object. Covers the renderer contract, a safe runnable example,
-  the start | inspect | retry | stop lifecycle, path/timeout/validation rules,
+  surface your latest reported state snapshot — a bash async job, a daemon task,
+  a build — on the resident Telegram Task Card by supplying a small Python
+  renderer whose stdout is one Task Card JSON object. Covers the renderer
+  contract, the snapshot truthfulness model, the two co-located renderer
+  templates (bash async, daemon) shipped as skill assets, the
+  start | inspect | retry | stop lifecycle, path/timeout/validation rules,
   fail-loud error wakes, and how the /taskcard toggle interacts.
-last_changed_at: "2026-07-13T00:45:00-07:00"
+last_changed_at: "2026-07-13T12:15:00-07:00"
 ---
 
 # Programmable Telegram Task Card — manual (what / how / why)
 
-The `task_card` tool lets you attach your own live view to Telegram's one tracked
-resident Task Card. You write a small Python **renderer** file under your working
-directory; the controller runs it on an interval and projects its output onto the
-Task Card's **programmable** slot, side by side with the automatic tool-activity
-slot. The one tracked resident target carries both slots.
+The `task_card` tool lets you surface your own **latest reported snapshot** on
+Telegram's one tracked resident Task Card. You write a small Python **renderer**
+file under your working directory; the controller runs it on an interval and
+projects its output onto the Task Card's **programmable** slot, side by side with
+the automatic tool-activity slot. The one tracked resident target carries both
+slots. The renderer reflects a state snapshot you keep current — it is not an
+autonomous progress feed.
+
+## When to reach for this
+
+During a **Telegram-originated turn**, when you launch a meaningful
+**long-running `bash(async=true)` job or daemon task** and then go idle to await
+its result, add a human-visible programmable Task Card watcher so the human
+watching Telegram sees the latest reported snapshot instead of a silent gap. Two
+ready templates cover exactly these two cases — see **Two ready templates** below.
+This is the default for long, human-visible background work; skip it only for
+quick or invisible jobs.
 
 ## WHAT it is
 
@@ -60,36 +74,84 @@ Secrets are redacted at the render boundary by the Telegram manager, and raw
 renderer output never appears in error wakes — but keep secrets out of the card
 anyway; it is a progress view, not a data channel.
 
-### A safe runnable example
+### The state source: read a snapshot file you own, not tool internals
 
-Save this as `render_card.py` in your working directory. It reads a plain status
-file your long-running job updates and prints one Task Card object:
+The renderer receives **no arguments** and runs with your working directory as
+its cwd, so it locates state by a fixed relative path. Point it at a small
+**state snapshot file that you (the orchestrator) keep truthful** — not at a
+tool's private internals:
 
-```python
-# render_card.py — prints exactly one Task Card JSON object to stdout.
-import json
-import pathlib
+- A `bash(async=true)` job's own state under `system/jobs/<job_id>/` is **private
+  to the Bash capability**, and `bash(action="poll")` is a **one-shot, consuming**
+  read (the first terminal poll marks the job consumed). A passive renderer must
+  not touch either.
+- A daemon run's `daemons/<id>/daemon.json` is a **versioned forensic** artifact,
+  not a stable machine API; the sanctioned surface is `daemon(action="check",
+  id=...)`, which is read-only and safe to poll.
 
-status_file = pathlib.Path("job_status.txt")  # relative to the working dir
-state = status_file.read_text().strip() if status_file.exists() else "starting"
+So the honest pattern is: **you** own a tiny JSON snapshot in the working
+directory and rewrite it from your own turn — right after the launch returns your
+`job_id`/`id`, after each **meaningful** `poll` / `check`, and at the **terminal**
+result or completion notification. The renderer shows only the **latest reported
+snapshot** — the frame it prints reflects what you last recorded, not autonomous
+job progress. It never invents or introspects tool state.
 
-print(json.dumps({
-    "title": "Nightly backup",
-    "lines": [
-        f"stage: {state}",
-        "host: db-primary",
-    ],
-    "footer": "auto-refreshing",
-}))
-```
+**Truthfulness contract (both templates enforce this):** a live/terminal card is
+shown **only** when the snapshot carries both a nonempty **identity** (`job_id`
+for bash, `id` for daemon) **and** an exact allow-listed **state** string. A
+missing file, non-JSON, non-object, missing identity/state, an unknown state, or
+a wrong-typed field renders an explicit `awaiting orchestrator update` frame —
+never a fabricated `starting`/`running`. So an empty or half-written snapshot can
+never claim progress.
+
+Write the snapshot **completely** each time: build the whole JSON object in
+memory and write it in one operation. Writing to a temporary file in the same
+directory and then `os.replace`-ing it over the snapshot makes the update atomic,
+so the renderer never reads a partially written object. Keep secrets and raw log
+bodies out of the snapshot — the card is a progress view, not a data channel. The
+manager also redacts at the render boundary, but that cannot rescue a snapshot you
+fill with secrets in violation of the schema.
+
+### Two ready templates (locate, copy, adapt, bind)
+
+Two co-located, stdlib-only renderer templates implement exactly this pattern.
+Each prints exactly one bounded Task Card object, enforces the truthfulness
+contract above, and stays valid even when the snapshot is missing, partial, or
+malformed:
+
+- **`render_bash_async.py`** — for a `bash(async=true)` job. Reads
+  `task_card_state.json`. Requires `job_id` (str) + `status` (str, one of
+  `starting|running|done|failed|cancelled`); also surfaces optional `title`,
+  `exit_code` (int), `stage`, `updated_at`, `note`.
+- **`render_daemon.py`** — for a daemon task (emanation). Reads
+  `daemon_card_state.json`. Requires `id` (str) + `state` (str, one of
+  `running|done|failed|cancelled|timeout`); also surfaces optional `title`,
+  `current`, `elapsed_s` (finite number), `last_activity`, `health`
+  (`alive|stalled|unknown`), `updated_at`, `note`.
+
+**Locate and copy the asset.** The asset lives next to this manual under
+`task_card/assets/`. Resolve it relative to the **absolute manual path** that the
+Telegram `manual` action returns (`telegram(action='manual')` → its `path`; this
+manual sits at `task_card/SKILL.md` beside that directory), then **copy it into
+your working directory** — the controller confines `renderer_path` to the agent
+working directory, so the renderer must physically live there. Do not reference
+the source-tree or installed-package path directly. Rename the copy per job if you
+run several, and adapt only its `STATE_FILE` and labels; each file's docstring
+documents its full snapshot schema and orchestrator update points.
 
 Then bind it:
 
 ```json
-{"action": "start", "renderer_path": "render_card.py", "interval_s": 5}
+{"action": "start", "renderer_path": "render_bash_async.py", "interval_s": 5}
 ```
 
-As your job rewrites `job_status.txt`, the card's programmable slot follows it.
+As you rewrite the snapshot, the card's programmable slot follows the latest
+reported snapshot. Starting a watch **drives the programmable slot of the
+`TelegramManager`-owned single resident Task Card**; the manager reuses the one
+resident card it already tracks, or **creates its single resident** if none is
+tracked yet — it never starts a second manager or a second card. `TelegramManager`
+stays the one render/compose/persistence/transport owner; the controller is a thin
+driver that forwards validated frames.
 
 ### The lifecycle: start | inspect | retry | stop
 
@@ -183,7 +245,11 @@ old card is visible; read the current `taskcard` value.
 ## Reaching this manual
 
 This manual is co-located with the unit at
-`src/lingtai/mcp_servers/telegram/task_card/SKILL.md`. From the Telegram MCP
-manual (`telegram(action='manual')`), the **Programmable Task Card** section
-routes here. The paired `CONTRACT.md` states the interface promise and `ANATOMY.md`
-maps the structure.
+`src/lingtai/mcp_servers/telegram/task_card/SKILL.md` in the source tree. From the
+Telegram MCP manual (`telegram(action='manual')`), the **Programmable Task Card**
+section routes here. The two renderer templates ship as co-located skill assets
+under `task_card/assets/` (`render_bash_async.py`, `render_daemon.py`); resolve
+them relative to the absolute manual `path` the `manual` action returns and copy
+one into your working directory, as **Two ready templates** describes — that path,
+not any fixed source-tree location, is the usable one. The paired `CONTRACT.md`
+states the interface promise and `ANATOMY.md` maps the structure.

--- a/src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py
+++ b/src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py
@@ -35,35 +35,62 @@ renders an explicit "awaiting orchestrator update" frame — never a fabricated
 
     {
       "job_id":   "job-a1b2...",             # REQUIRED str: the id bash(async=true) returned
-      "status":   "running",                 # REQUIRED str: starting|running|done|failed|cancelled
+      "status":   "running",                 # REQUIRED str: starting|running|done|failed|cancelled|unknown
       "title":    "Refactor auth module",    # optional str headline
-      "exit_code": 0,                        # optional int, once a terminal poll is recorded
+      "exit_code": 0,                        # optional int, once a terminal poll reports a known exit code
       "stage":    "tests passing",           # optional str progress note
       "updated_at": "2026-07-13T10:30:00Z",  # optional str (ISO-8601 UTC of your last write)
       "note":     "3/5 modules done"         # optional str extra one-liner
     }
 
+`status` is a DISPLAY STATE you derive from the sanctioned action result — it is
+NOT the raw top-level `status` of the poll. Bash's terminal poll is ALWAYS
+top-level `status: "done"`: a nonzero inner command does not change it to a
+top-level `"failed"`. Read the additive fidelity fields and map them:
+
+    bash(action="poll") result                              -> record status=
+    ----------------------------------------------------------  ---------------
+    {"status": "running", ...}                                  "running"
+    {"status": "done", "exit_status_known": true,               "done"
+        "exit_code": 0, "ok": true, "command_status": "success"}
+    {"status": "done", "exit_status_known": true,               "failed"
+        "exit_code": <nonzero>, "ok": false,
+        "command_status": "failed"}
+    {"status": "done", "exit_status_known": false,              "unknown"
+        "exit_code": null, ...}
+    bash(action="cancel") -> {"status": "cancelled", ...}       "cancelled"
+
+So a nonzero completion is recorded `failed` (never `done`), and an
+exit-status-unknown terminal completion is recorded `unknown` — a distinct
+TERMINAL state that reports the exit status is unavailable and claims NEITHER
+success NOR failure (Bash itself never invents `-1` or a false
+`command_status: "failed"` for it, so neither may this card). Only copy the exit
+code into `exit_code` when `exit_status_known` is true; for `unknown` leave it
+out. Update the snapshot from your turn on each meaningful poll and at the
+terminal result. Write it COMPLETELY each time — build the full JSON in memory
+and write it in one call (an atomic temp-file-plus-`os.replace` in the same
+directory avoids a reader seeing a half-written file) — so the renderer never
+parses a partial object.
+
 Only the primitive types above are accepted; containers, booleans in numeric
 fields, non-finite/oversized numbers, and wrong types are ignored, not
-stringified. Update it from your turn, e.g. after a poll:
-    bash(action="poll", job_id="job-a1b2...")  ->  {"status":"done","exit_code":0,...}
-then write status="done" and exit_code=0. Write the snapshot COMPLETELY each
-time — build the full JSON in memory and write it in one call (an atomic
-temp-file-plus-`os.replace` in the same directory avoids a reader seeing a
-half-written file) — so the renderer never parses a partial object.
+stringified.
 
 Terminal cleanup — you MUST stop the watcher yourself
 -----------------------------------------------------
 This renderer is PASSIVE: it only prints title/lines/footer and has no
 `watch_id` and no tool access, so it CANNOT stop the watch or clear the card by
-itself. When the job reaches a terminal status (`done`, `failed`, or
-`cancelled`) — which you learn from the terminal `bash(action="poll")` result —
-record that terminal snapshot, then IMMEDIATELY call
+itself. When the job reaches a terminal status (`done`, `failed`, `cancelled`,
+or `unknown` — the exit-status-unavailable terminal) — which you learn from the
+terminal `bash(action="poll")` or `bash(action="cancel")` result — record that
+terminal snapshot, then IMMEDIATELY call
 `task_card(action="stop", watch_id="<watch_id>")` (the `watch_id` that
 `task_card(action="start", ...)` returned) to quiesce the watcher and clear the
-programmable slot so the finished card does not stay resident. If it returns a
-retryable `stop_failed`, call the SAME `task_card(action="stop", ...)` again — do
-not restart or duplicate the watch. A terminal snapshot's footer says
+programmable slot so the finished card does not stay resident. This is required
+for `unknown` too: an unavailable exit status is still terminal and must be
+stopped/cleared, not left resident. If it returns a retryable `stop_failed`,
+call the SAME `task_card(action="stop", ...)` again — do not restart or
+duplicate the watch. A terminal snapshot's footer says
 `terminal snapshot — stop/clear this watch now` as your reminder. Non-terminal
 statuses (`starting`, `running`) stay resident and keep updating.
 
@@ -89,23 +116,32 @@ _MAX_LINES = 20  # controller rejects more than 20 lines; stay well under it.
 _MAX_STR = 120  # clip any single rendered value to this many characters.
 _MAX_INT = 10**9  # ignore an exit_code outside this sane magnitude.
 
-# The only accepted job states, mapped to a small status glyph.
+# The only accepted display states, mapped to a small status glyph. These are
+# DISPLAY states the orchestrator derives from the sanctioned poll/cancel result
+# (see the module docstring), not the raw top-level bash ``status``. ``unknown``
+# is the exit-status-unavailable terminal: it claims neither success nor failure.
 _STATUS_GLYPH = {
     "starting": "…",
     "running": "▶",
     "done": "✓",
     "failed": "✗",
     "cancelled": "⊘",
+    "unknown": "?",
 }
 
-# Terminal statuses: the job has finished (successfully or not). When the
-# snapshot records one of these, the work is over and the watcher should be
-# quiesced. The renderer is PASSIVE — it cannot stop itself — so it asks the
-# orchestrator, in the footer, to call
-# ``task_card(action="stop", watch_id="<watch_id>")``. ``starting`` and
+# Terminal display states: the job has finished (successfully, unsuccessfully, or
+# with an unavailable exit status) or was cancelled. When the snapshot records one
+# of these, the work is over and the watcher should be quiesced. The renderer is
+# PASSIVE — it cannot stop itself — so it asks the orchestrator, in the footer, to
+# call ``task_card(action="stop", watch_id="<watch_id>")``. ``unknown`` is
+# terminal too: an unavailable exit status still ends the job. ``starting`` and
 # ``running`` are non-terminal.
-_TERMINAL_STATUSES = {"done", "failed", "cancelled"}
+_TERMINAL_STATUSES = {"done", "failed", "cancelled", "unknown"}
 _TERMINAL_FOOTER = "terminal snapshot — stop/clear this watch now"
+
+# For the exit-status-unavailable terminal, the body line must state that the exit
+# status is unavailable and imply NEITHER success NOR failure.
+_UNKNOWN_OUTCOME_LINE = "exit status unavailable — outcome unknown"
 
 _UNAVAILABLE_TITLE = "Async job"
 _AWAITING = "no snapshot yet — awaiting orchestrator update"
@@ -179,9 +215,15 @@ def _build_card(state: dict) -> dict:
 
     lines = [f"{_STATUS_GLYPH[status]} status: {status}", f"job: {job_id}"]
 
-    exit_code = _clean_int(state.get("exit_code"))
-    if exit_code is not None:
-        lines.append(f"exit: {exit_code}")
+    if status == "unknown":
+        # Exit-status-unavailable terminal: state it plainly and do NOT surface an
+        # exit code even if the snapshot carries one, so the card cannot imply a
+        # known success/failure the poll never established.
+        lines.append(_UNKNOWN_OUTCOME_LINE)
+    else:
+        exit_code = _clean_int(state.get("exit_code"))
+        if exit_code is not None:
+            lines.append(f"exit: {exit_code}")
 
     stage = _clean_str(state.get("stage"))
     if stage:

--- a/src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py
+++ b/src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py
@@ -52,6 +52,21 @@ time — build the full JSON in memory and write it in one call (an atomic
 temp-file-plus-`os.replace` in the same directory avoids a reader seeing a
 half-written file) — so the renderer never parses a partial object.
 
+Terminal cleanup — you MUST stop the watcher yourself
+-----------------------------------------------------
+This renderer is PASSIVE: it only prints title/lines/footer and has no
+`watch_id` and no tool access, so it CANNOT stop the watch or clear the card by
+itself. When the job reaches a terminal status (`done`, `failed`, or
+`cancelled`) — which you learn from the terminal `bash(action="poll")` result —
+record that terminal snapshot, then IMMEDIATELY call
+`task_card(action="stop", watch_id="<watch_id>")` (the `watch_id` that
+`task_card(action="start", ...)` returned) to quiesce the watcher and clear the
+programmable slot so the finished card does not stay resident. If it returns a
+retryable `stop_failed`, call the SAME `task_card(action="stop", ...)` again — do
+not restart or duplicate the watch. A terminal snapshot's footer says
+`terminal snapshot — stop/clear this watch now` as your reminder. Non-terminal
+statuses (`starting`, `running`) stay resident and keep updating.
+
 Safety: stdlib-only; reads at most a few KiB of the snapshot; accepts only the
 allow-listed primitive fields; strips control characters; clips every string;
 caps the line count; and prints a valid bounded card on any missing/partial/
@@ -82,6 +97,15 @@ _STATUS_GLYPH = {
     "failed": "✗",
     "cancelled": "⊘",
 }
+
+# Terminal statuses: the job has finished (successfully or not). When the
+# snapshot records one of these, the work is over and the watcher should be
+# quiesced. The renderer is PASSIVE — it cannot stop itself — so it asks the
+# orchestrator, in the footer, to call
+# ``task_card(action="stop", watch_id="<watch_id>")``. ``starting`` and
+# ``running`` are non-terminal.
+_TERMINAL_STATUSES = {"done", "failed", "cancelled"}
+_TERMINAL_FOOTER = "terminal snapshot — stop/clear this watch now"
 
 _UNAVAILABLE_TITLE = "Async job"
 _AWAITING = "no snapshot yet — awaiting orchestrator update"
@@ -167,12 +191,18 @@ def _build_card(state: dict) -> dict:
     if note:
         lines.append(note)
 
-    updated_at = _clean_str(state.get("updated_at"), 40)
-    footer = (
-        f"snapshot as of {updated_at}; awaiting next check"
-        if updated_at
-        else "awaiting next orchestrator update"
-    )
+    if status in _TERMINAL_STATUSES:
+        # The job has finished: ask the orchestrator to stop the watcher now so the
+        # completed card does not stay resident. A non-terminal status keeps the
+        # awaiting-next-check footer.
+        footer = _TERMINAL_FOOTER
+    else:
+        updated_at = _clean_str(state.get("updated_at"), 40)
+        footer = (
+            f"snapshot as of {updated_at}; awaiting next check"
+            if updated_at
+            else "awaiting next orchestrator update"
+        )
 
     title = _clean_str(state.get("title")) or _UNAVAILABLE_TITLE
     return {"title": title, "lines": lines[:_MAX_LINES], "footer": footer}

--- a/src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py
+++ b/src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Task Card renderer TEMPLATE for a long-running `bash(async=true)` job.
+
+Locate this asset relative to the ABSOLUTE manual path that Telegram's
+`manual` action returns (its directory has `task_card/assets/`), then COPY it
+into your working directory — the controller confines `renderer_path` to the
+agent working directory, so the renderer must live there. Rename it per job if
+you run more than one. Then bind it with the `task_card` tool:
+
+    {"action": "start", "renderer_path": "render_bash_async.py", "interval_s": 5}
+
+The controller runs this file with the runtime interpreter, capturing stdout;
+it MUST print exactly one Task Card JSON object and exit 0. It receives no
+command-line arguments and runs with your working directory as the process cwd,
+so it locates its state by the fixed relative path `STATE_FILE` below.
+
+WHY it reads a snapshot file, not bash internals
+-------------------------------------------------
+The bash async job's own on-disk state under `system/jobs/<job_id>/` is PRIVATE
+to the Bash capability, and `bash(action="poll")` is a one-shot, consuming read
+(the first terminal poll marks the job consumed). A passive renderer must not
+touch either. Instead, YOU — the orchestrator — own a tiny snapshot file and
+keep it truthful: write it right after `bash(async=true)` returns your `job_id`,
+and rewrite it after each meaningful poll and at the terminal result. The
+renderer shows only the LATEST REPORTED SNAPSHOT; it never invents job state and
+never claims progress you have not recorded.
+
+Snapshot schema (`task_card_state.json`)
+----------------------------------------
+An active/terminal card is shown ONLY when both a nonempty string `job_id` AND an
+allow-listed string `status` are present. Any other shape (missing file, non-JSON,
+non-object, missing identity/status, an unknown status, or a wrong-typed field)
+renders an explicit "awaiting orchestrator update" frame — never a fabricated
+`starting`/`running`.
+
+    {
+      "job_id":   "job-a1b2...",             # REQUIRED str: the id bash(async=true) returned
+      "status":   "running",                 # REQUIRED str: starting|running|done|failed|cancelled
+      "title":    "Refactor auth module",    # optional str headline
+      "exit_code": 0,                        # optional int, once a terminal poll is recorded
+      "stage":    "tests passing",           # optional str progress note
+      "updated_at": "2026-07-13T10:30:00Z",  # optional str (ISO-8601 UTC of your last write)
+      "note":     "3/5 modules done"         # optional str extra one-liner
+    }
+
+Only the primitive types above are accepted; containers, booleans in numeric
+fields, non-finite/oversized numbers, and wrong types are ignored, not
+stringified. Update it from your turn, e.g. after a poll:
+    bash(action="poll", job_id="job-a1b2...")  ->  {"status":"done","exit_code":0,...}
+then write status="done" and exit_code=0. Write the snapshot COMPLETELY each
+time — build the full JSON in memory and write it in one call (an atomic
+temp-file-plus-`os.replace` in the same directory avoids a reader seeing a
+half-written file) — so the renderer never parses a partial object.
+
+Safety: stdlib-only; reads at most a few KiB of the snapshot; accepts only the
+allow-listed primitive fields; strips control characters; clips every string;
+caps the line count; and prints a valid bounded card on any missing/partial/
+malformed input. Keep secrets and raw log bodies OUT of the snapshot — the card
+is a progress view, not a data channel. The manager also redacts at the render
+boundary, but that cannot save a snapshot you fill with secrets in violation of
+this schema.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+# Relative to your working directory (the renderer's cwd). Rename per job if you
+# run several async jobs so each watcher reads its own snapshot.
+STATE_FILE = "task_card_state.json"
+
+_MAX_BYTES = 8192  # read at most this many bytes; a bigger snapshot is "unavailable".
+_MAX_LINES = 20  # controller rejects more than 20 lines; stay well under it.
+_MAX_STR = 120  # clip any single rendered value to this many characters.
+_MAX_INT = 10**9  # ignore an exit_code outside this sane magnitude.
+
+# The only accepted job states, mapped to a small status glyph.
+_STATUS_GLYPH = {
+    "starting": "…",
+    "running": "▶",
+    "done": "✓",
+    "failed": "✗",
+    "cancelled": "⊘",
+}
+
+_UNAVAILABLE_TITLE = "Async job"
+_AWAITING = "no snapshot yet — awaiting orchestrator update"
+_INCOMPLETE = "snapshot incomplete — awaiting orchestrator update"
+
+
+def _clean_str(value: object, limit: int = _MAX_STR) -> str | None:
+    """Return a bounded, single-line string ONLY for real ``str`` input.
+
+    Non-strings (containers, numbers, ``None``) return ``None`` — they are never
+    stringified. Control characters are stripped so a field cannot break the card.
+    """
+    if not isinstance(value, str):
+        return None
+    text = "".join(ch for ch in value if ch == " " or ch.isprintable()).strip()
+    if not text:
+        return None
+    if len(text) > limit:
+        text = text[: limit - 1] + "…"
+    return text
+
+
+def _clean_int(value: object) -> int | None:
+    """Accept only a real, sanely bounded, non-boolean ``int``."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    if -_MAX_INT <= value <= _MAX_INT:
+        return value
+    return None
+
+
+def _load_state() -> dict:
+    """Read at most ``_MAX_BYTES`` and parse one JSON object. Any problem (missing,
+    oversize, non-JSON, non-object) yields an empty dict so the renderer degrades
+    to an explicit awaiting frame instead of crashing or fabricating state."""
+    try:
+        with pathlib.Path(STATE_FILE).open("rb") as fh:
+            raw = fh.read(_MAX_BYTES + 1)
+    except OSError:
+        return {}
+    if len(raw) > _MAX_BYTES:  # oversize: refuse rather than parse an unbounded blob.
+        return {}
+    # ValueError covers malformed JSON; RecursionError covers a deeply nested (but
+    # sub-cap) payload whose parse exceeds the interpreter's recursion limit. Both
+    # degrade to the awaiting frame. We deliberately do NOT catch BaseException, so
+    # unrelated programmer errors still surface.
+    try:
+        data = json.loads(raw.decode("utf-8", "replace"))
+    except (ValueError, RecursionError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _unavailable(message: str) -> dict:
+    """A stable, honest frame that never claims progress."""
+    return {"title": _UNAVAILABLE_TITLE, "lines": [message], "footer": "awaiting orchestrator update"}
+
+
+def _build_card(state: dict) -> dict:
+    if not state:
+        return _unavailable(_AWAITING)
+
+    # Truthfulness gate: only a recorded identity AND an EXACT allow-listed status
+    # may show an active/terminal card. The status is matched verbatim (no case or
+    # whitespace normalization), so `RUNNING` or ` running ` is rejected — the
+    # documented schema is exact lowercase. Anything else is explicitly incomplete.
+    job_id = _clean_str(state.get("job_id"), 64)
+    status = state.get("status")
+    if not job_id or not isinstance(status, str) or status not in _STATUS_GLYPH:
+        return _unavailable(_INCOMPLETE)
+
+    lines = [f"{_STATUS_GLYPH[status]} status: {status}", f"job: {job_id}"]
+
+    exit_code = _clean_int(state.get("exit_code"))
+    if exit_code is not None:
+        lines.append(f"exit: {exit_code}")
+
+    stage = _clean_str(state.get("stage"))
+    if stage:
+        lines.append(f"stage: {stage}")
+
+    note = _clean_str(state.get("note"))
+    if note:
+        lines.append(note)
+
+    updated_at = _clean_str(state.get("updated_at"), 40)
+    footer = (
+        f"snapshot as of {updated_at}; awaiting next check"
+        if updated_at
+        else "awaiting next orchestrator update"
+    )
+
+    title = _clean_str(state.get("title")) or _UNAVAILABLE_TITLE
+    return {"title": title, "lines": lines[:_MAX_LINES], "footer": footer}
+
+
+def main() -> None:
+    print(json.dumps(_build_card(_load_state())))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lingtai/mcp_servers/telegram/task_card/assets/render_daemon.py
+++ b/src/lingtai/mcp_servers/telegram/task_card/assets/render_daemon.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Task Card renderer TEMPLATE for a long-running daemon task (an emanation).
+
+Locate this asset relative to the ABSOLUTE manual path that Telegram's
+`manual` action returns (its directory has `task_card/assets/`), then COPY it
+into your working directory — the controller confines `renderer_path` to the
+agent working directory, so the renderer must live there. Rename it per daemon
+if you run more than one. Then bind it with the `task_card` tool:
+
+    {"action": "start", "renderer_path": "render_daemon.py", "interval_s": 10}
+
+The controller runs this file with the runtime interpreter, capturing stdout;
+it MUST print exactly one Task Card JSON object and exit 0. It receives no
+command-line arguments and runs with your working directory as the process cwd,
+so it locates its state by the fixed relative path `STATE_FILE` below.
+
+WHY it reads a snapshot file, not daemon internals
+--------------------------------------------------
+A daemon run's `daemons/<id>/daemon.json` is a documented but VERSIONED FORENSIC
+artifact, not a stable machine-readable API; the sanctioned agent-facing surface
+is `daemon(action="check", id=...)`, which is read-only and safe to poll. Rather
+than couple a passive renderer to internal `data_version`-gated fields, YOU — the
+orchestrator — own a tiny snapshot file and keep it truthful: write it right
+after `daemon(emanate)` returns your `id`, and rewrite it from each meaningful
+`daemon(check)` result and at the terminal push-notification. The renderer shows
+only the LATEST REPORTED SNAPSHOT; it never introspects daemon internals and
+never claims activity you have not recorded.
+
+Snapshot schema (`daemon_card_state.json`)
+------------------------------------------
+An active/terminal card is shown ONLY when both a nonempty string `id` AND an
+allow-listed string `state` are present. Any other shape (missing file, non-JSON,
+non-object, missing identity/state, an unknown state, or a wrong-typed field)
+renders an explicit "awaiting orchestrator update" frame — never a fabricated
+`running`.
+
+    {
+      "id":        "em-a1b2",               # REQUIRED str: the id daemon(emanate) returned
+      "state":     "running",               # REQUIRED str: running|done|failed|cancelled|timeout
+      "title":     "Nightly synthesis",     # optional str headline
+      "current":   "grep",                  # optional str: what it is doing now (e.g. current_tool)
+      "elapsed_s": 312,                     # optional finite number: wall-clock seconds so far
+      "last_activity": "2026-07-13T10:29:00Z",  # optional str: last_output_at / last event time
+      "health":    "alive",                 # optional str verdict: alive|stalled|unknown
+      "updated_at": "2026-07-13T10:30:00Z", # optional str (ISO-8601 UTC of your last write)
+      "note":      "phase 2/3"              # optional str extra one-liner
+    }
+
+Only the primitive types above are accepted; containers, booleans in numeric
+fields, non-finite (NaN/Infinity) or oversized numbers, and wrong types are
+ignored, not stringified. Update it from your turn. `daemon(check, id="em-a1b2")`
+returns state, elapsed_s, current_tool, last_output_at, result_preview, ...; copy
+the non-secret ones you want to surface. A daemon is 'stalled' only if it is still
+`running` but its activity has not advanced across checks minutes apart — decide
+that verdict yourself and record it as `health`. Write the snapshot COMPLETELY
+each time — build the full JSON in memory and write it in one call (an atomic
+temp-file-plus-`os.replace` in the same directory avoids a reader seeing a
+half-written file) — so the renderer never parses a partial object.
+
+Safety: stdlib-only; reads at most a few KiB of the snapshot; accepts only the
+allow-listed primitive fields; strips control characters; clips every string;
+caps the line count; and prints a valid bounded card on any missing/partial/
+malformed input. Keep secrets and raw output OUT of the snapshot — the card is a
+progress view, not a data channel. The manager also redacts at the render
+boundary, but that cannot save a snapshot you fill with secrets in violation of
+this schema.
+"""
+from __future__ import annotations
+
+import json
+import math
+import pathlib
+
+# Relative to your working directory (the renderer's cwd). Rename per daemon if
+# you run several so each watcher reads its own snapshot.
+STATE_FILE = "daemon_card_state.json"
+
+_MAX_BYTES = 8192  # read at most this many bytes; a bigger snapshot is "unavailable".
+_MAX_LINES = 20  # controller rejects more than 20 lines; stay well under it.
+_MAX_STR = 120  # clip any single rendered value to this many characters.
+_MAX_ELAPSED = 10**9  # ignore an elapsed_s outside this sane magnitude (~31 years).
+
+# The only accepted emanation states, mapped to a small status glyph.
+_STATE_GLYPH = {
+    "running": "▶",
+    "done": "✓",
+    "failed": "✗",
+    "cancelled": "⊘",
+    "timeout": "⏳",
+}
+
+# The only accepted health verdicts YOU record after comparing checks.
+_HEALTH_GLYPH = {
+    "alive": "♥",
+    "stalled": "!",
+    "unknown": "?",
+}
+
+_UNAVAILABLE_TITLE = "Daemon task"
+_AWAITING = "no snapshot yet — awaiting orchestrator update"
+_INCOMPLETE = "snapshot incomplete — awaiting orchestrator update"
+
+
+def _clean_str(value: object, limit: int = _MAX_STR) -> str | None:
+    """Return a bounded, single-line string ONLY for real ``str`` input.
+
+    Non-strings (containers, numbers, ``None``) return ``None`` — they are never
+    stringified. Control characters are stripped so a field cannot break the card.
+    """
+    if not isinstance(value, str):
+        return None
+    text = "".join(ch for ch in value if ch == " " or ch.isprintable()).strip()
+    if not text:
+        return None
+    if len(text) > limit:
+        text = text[: limit - 1] + "…"
+    return text
+
+
+def _elapsed(value: object) -> str | None:
+    """Render elapsed seconds as a short m/s label for a FINITE, sanely bounded,
+    non-boolean number only. NaN/Infinity, giant, negative, and wrong types are
+    rejected (return ``None``).
+
+    An ``int`` is range-checked by INTEGER comparison first — never converted to
+    float — so an arbitrarily large integer (e.g. 401 digits, still under the byte
+    cap) is rejected without raising ``OverflowError``. ``math.isfinite`` is used
+    only for the ``float`` branch, where NaN/Infinity are the concern."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        if not 0 <= value <= _MAX_ELAPSED:
+            return None
+        total = value
+    elif isinstance(value, float):
+        if not math.isfinite(value) or not 0 <= value <= _MAX_ELAPSED:
+            return None
+        total = int(value)
+    else:
+        return None
+    minutes, seconds = divmod(total, 60)
+    return f"{minutes}m{seconds:02d}s" if minutes else f"{seconds}s"
+
+
+def _load_state() -> dict:
+    """Read at most ``_MAX_BYTES`` and parse one JSON object. Any problem (missing,
+    oversize, non-JSON, non-object) yields an empty dict so the renderer degrades
+    to an explicit awaiting frame instead of crashing or fabricating state."""
+    try:
+        with pathlib.Path(STATE_FILE).open("rb") as fh:
+            raw = fh.read(_MAX_BYTES + 1)
+    except OSError:
+        return {}
+    if len(raw) > _MAX_BYTES:  # oversize: refuse rather than parse an unbounded blob.
+        return {}
+    # ValueError covers malformed JSON; RecursionError covers a deeply nested (but
+    # sub-cap) payload whose parse exceeds the interpreter's recursion limit. Both
+    # degrade to the awaiting frame. We deliberately do NOT catch BaseException, so
+    # unrelated programmer errors still surface.
+    try:
+        data = json.loads(raw.decode("utf-8", "replace"))
+    except (ValueError, RecursionError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _unavailable(message: str) -> dict:
+    """A stable, honest frame that never claims activity."""
+    return {"title": _UNAVAILABLE_TITLE, "lines": [message], "footer": "awaiting orchestrator update"}
+
+
+def _build_card(state: dict) -> dict:
+    if not state:
+        return _unavailable(_AWAITING)
+
+    # Truthfulness gate: only a recorded identity AND an EXACT allow-listed state
+    # may show an active/terminal card. The state is matched verbatim (no case or
+    # whitespace normalization), so `RUNNING` or ` running ` is rejected — the
+    # documented schema is exact lowercase. Anything else is explicitly incomplete.
+    ident = _clean_str(state.get("id"), 64)
+    run_state = state.get("state")
+    if not ident or not isinstance(run_state, str) or run_state not in _STATE_GLYPH:
+        return _unavailable(_INCOMPLETE)
+
+    lines = [f"{_STATE_GLYPH[run_state]} state: {run_state}", f"id: {ident}"]
+
+    health = state.get("health")
+    if isinstance(health, str) and health in _HEALTH_GLYPH:
+        lines.append(f"{_HEALTH_GLYPH[health]} health: {health}")
+
+    current = _clean_str(state.get("current"), 64)
+    if current:
+        lines.append(f"doing: {current}")
+
+    elapsed = _elapsed(state.get("elapsed_s"))
+    if elapsed is not None:
+        lines.append(f"elapsed: {elapsed}")
+
+    last_activity = _clean_str(state.get("last_activity"), 40)
+    if last_activity:
+        lines.append(f"last activity: {last_activity}")
+
+    note = _clean_str(state.get("note"))
+    if note:
+        lines.append(note)
+
+    updated_at = _clean_str(state.get("updated_at"), 40)
+    footer = (
+        f"snapshot as of {updated_at}; awaiting next check"
+        if updated_at
+        else "awaiting next orchestrator update"
+    )
+
+    title = _clean_str(state.get("title")) or _UNAVAILABLE_TITLE
+    return {"title": title, "lines": lines[:_MAX_LINES], "footer": footer}
+
+
+def main() -> None:
+    print(json.dumps(_build_card(_load_state())))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lingtai/mcp_servers/telegram/task_card/assets/render_daemon.py
+++ b/src/lingtai/mcp_servers/telegram/task_card/assets/render_daemon.py
@@ -57,6 +57,21 @@ each time — build the full JSON in memory and write it in one call (an atomic
 temp-file-plus-`os.replace` in the same directory avoids a reader seeing a
 half-written file) — so the renderer never parses a partial object.
 
+Terminal cleanup — you MUST stop the watcher yourself
+-----------------------------------------------------
+This renderer is PASSIVE: it only prints title/lines/footer and has no
+`watch_id` and no tool access, so it CANNOT stop the watch or clear the card by
+itself. When the daemon reaches a terminal state (`done`, `failed`, `cancelled`,
+or `timeout`) — which you learn from the terminal `daemon` notification or a
+terminal `daemon(check)` result — record that terminal snapshot, then
+IMMEDIATELY call `task_card(action="stop", watch_id="<watch_id>")` (the
+`watch_id` that `task_card(action="start", ...)` returned) to quiesce the watcher
+and clear the programmable slot so the finished card does not stay resident. If
+it returns a retryable `stop_failed`, call the SAME `task_card(action="stop", ...)`
+again — do not restart or duplicate the watch. A terminal snapshot's footer says
+`terminal snapshot — stop/clear this watch now` as your reminder. Non-terminal
+states (`running`) stay resident and keep updating.
+
 Safety: stdlib-only; reads at most a few KiB of the snapshot; accepts only the
 allow-listed primitive fields; strips control characters; clips every string;
 caps the line count; and prints a valid bounded card on any missing/partial/
@@ -88,6 +103,15 @@ _STATE_GLYPH = {
     "cancelled": "⊘",
     "timeout": "⏳",
 }
+
+# Terminal states: the daemon has finished (successfully or not). When the
+# snapshot records one of these, the work is over and the watcher should be
+# quiesced. The renderer is PASSIVE — it cannot stop itself — so it asks the
+# orchestrator, in the footer, to call
+# ``task_card(action="stop", watch_id="<watch_id>")``. Only ``running`` is
+# non-terminal.
+_TERMINAL_STATES = {"done", "failed", "cancelled", "timeout"}
+_TERMINAL_FOOTER = "terminal snapshot — stop/clear this watch now"
 
 # The only accepted health verdicts YOU record after comparing checks.
 _HEALTH_GLYPH = {
@@ -204,12 +228,18 @@ def _build_card(state: dict) -> dict:
     if note:
         lines.append(note)
 
-    updated_at = _clean_str(state.get("updated_at"), 40)
-    footer = (
-        f"snapshot as of {updated_at}; awaiting next check"
-        if updated_at
-        else "awaiting next orchestrator update"
-    )
+    if run_state in _TERMINAL_STATES:
+        # The daemon has finished: ask the orchestrator to stop the watcher now so
+        # the completed card does not stay resident. A non-terminal state keeps the
+        # awaiting-next-check footer.
+        footer = _TERMINAL_FOOTER
+    else:
+        updated_at = _clean_str(state.get("updated_at"), 40)
+        footer = (
+            f"snapshot as of {updated_at}; awaiting next check"
+            if updated_at
+            else "awaiting next orchestrator update"
+        )
 
     title = _clean_str(state.get("title")) or _UNAVAILABLE_TITLE
     return {"title": title, "lines": lines[:_MAX_LINES], "footer": footer}

--- a/tests/test_mcp_skill_manuals.py
+++ b/tests/test_mcp_skill_manuals.py
@@ -182,6 +182,10 @@ def test_telegram_task_card_subpackage_ships_manual_and_architecture_docs():
     entries = package_data["lingtai.mcp_servers.telegram.task_card"]
     for document in ("SKILL.md", "ANATOMY.md", "CONTRACT.md"):
         assert document in entries, document
+    # The renderer template assets the manual routes agents to are shipped by an
+    # explicit assets glob (same reason as the docs: the parent telegram glob does
+    # not recurse into this subpackage), so they cannot silently drop from wheels.
+    assert "assets/**/*" in entries
     # The nested unit is a real subpackage, so the parent glob cannot cover it:
     # a bare ``SKILL.md`` in the parent entry only matches ``telegram/SKILL.md``.
     assert (

--- a/tests/test_telegram_task_card_templates.py
+++ b/tests/test_telegram_task_card_templates.py
@@ -92,18 +92,22 @@ _FULL_STATE = {
     },
 }
 
-# The allow-listed states each template may render as live/terminal.
+# The allow-listed display states each template may render as live/terminal. For
+# bash these are DISPLAY states the orchestrator derives from the sanctioned
+# poll/cancel result (see _BASH_RESULT_TO_DISPLAY_STATE below), not raw bash
+# statuses; `unknown` is the exit-status-unavailable terminal.
 _ALLOWED_STATES = {
-    "render_bash_async.py": ["starting", "running", "done", "failed", "cancelled"],
+    "render_bash_async.py": ["starting", "running", "done", "failed", "cancelled", "unknown"],
     "render_daemon.py": ["running", "done", "failed", "cancelled", "timeout"],
 }
 
 # Terminal states: the work has finished, so the terminal snapshot's footer must
 # request that the orchestrator stop/clear the watcher (the passive renderer
 # cannot stop itself). Non-terminal states are the remaining allow-listed states —
-# derived, not hand-maintained, so the two lists cannot drift apart.
+# derived, not hand-maintained, so the two lists cannot drift apart. The bash
+# `unknown` display state is terminal (an unavailable exit status still ends the job).
 _TERMINAL_STATES = {
-    "render_bash_async.py": ["done", "failed", "cancelled"],
+    "render_bash_async.py": ["done", "failed", "cancelled", "unknown"],
     "render_daemon.py": ["done", "failed", "cancelled", "timeout"],
 }
 _NON_TERMINAL_STATES = {
@@ -451,6 +455,184 @@ def test_non_terminal_state_footer_stays_resident_awaiting(asset, state_file, id
         footer = frame.get("footer", "")
         assert "awaiting next orchestrator update" in footer, (st, footer)
         assert _TERMINAL_FOOTER_MARKER not in footer, (st, footer)
+
+
+# =========================================================================
+# B1: the bash display state is a mapping from the REAL public Bash result
+# =========================================================================
+#
+# The bash `status` an orchestrator records is a DISPLAY state derived from the
+# sanctioned `bash(action="poll")` / `bash(action="cancel")` result — NOT the raw
+# top-level bash `status`, which is ALWAYS "done" on completion (a nonzero inner
+# command is signalled by the additive `exit_status_known`/`exit_code`/`ok`/
+# `command_status` fields, never by a top-level "failed"). These fixtures are the
+# real public result shapes documented in src/lingtai/tools/bash/CONTRACT.md and
+# render them through the real controller so the public-result -> display-state
+# mapping is executable and locked, not hand-authored renderer states.
+
+# Representative REAL `bash` result shapes (see bash/CONTRACT.md §Tool surface).
+_BASH_RESULT_RUNNING = {"status": "running", "job_id": "job-a1b2", "pid": 4321}
+_BASH_RESULT_DONE_ZERO = {
+    "status": "done", "exit_status_known": True, "exit_code": 0,
+    "ok": True, "command_status": "success", "stdout": "all green\n", "stderr": "",
+}
+_BASH_RESULT_DONE_NONZERO = {
+    "status": "done", "exit_status_known": True, "exit_code": 1,
+    "ok": False, "command_status": "failed", "stdout": "", "stderr": "boom\n",
+    "warning": "command exited with code 1; …",
+}
+_BASH_RESULT_DONE_UNKNOWN = {
+    "status": "done", "job_id": "job-a1b2", "exit_status_known": False,
+    "exit_code": None, "stdout": "", "stderr": "",
+    "message": "Async job terminated but its exit status is unavailable",
+}
+_BASH_RESULT_CANCELLED = {"status": "cancelled", "job_id": "job-a1b2"}
+
+
+def _bash_result_to_display_state(result: dict) -> str:
+    """The exact poll/cancel-result -> recorded `status` mapping the bash manual and
+    the render_bash_async.py docstring instruct the orchestrator to perform. This is
+    the SAME procedure a real orchestrator follows (not a test-only shortcut): branch
+    on the additive fidelity fields, never on a top-level "failed" (bash never emits
+    one)."""
+    top = result.get("status")
+    if top == "running":
+        return "running"
+    if top == "cancelled":
+        return "cancelled"
+    assert top == "done", f"unexpected top-level bash status: {top!r}"
+    if not result.get("exit_status_known"):
+        return "unknown"  # exit_status_known is false -> exit status unavailable
+    return "done" if result.get("exit_code") == 0 else "failed"
+
+
+# (real bash result, expected display state, is-terminal)
+_BASH_RESULT_CASES = [
+    (_BASH_RESULT_RUNNING, "running", False),
+    (_BASH_RESULT_DONE_ZERO, "done", True),
+    (_BASH_RESULT_DONE_NONZERO, "failed", True),
+    (_BASH_RESULT_CANCELLED, "cancelled", True),
+    (_BASH_RESULT_DONE_UNKNOWN, "unknown", True),
+]
+_BASH_RESULT_IDS = ["running", "done-zero", "done-nonzero", "cancelled", "done-unknown"]
+
+
+def _snapshot_from_bash_result(result: dict) -> dict:
+    """Build the orchestrator-owned snapshot from a real bash result exactly as the
+    manual documents: derive the display `status`, and copy `exit_code` ONLY when the
+    exit status is known (omit it for `unknown`)."""
+    status = _bash_result_to_display_state(result)
+    snapshot = {"job_id": "job-a1b2", "status": status}
+    if status in ("done", "failed") and result.get("exit_status_known"):
+        snapshot["exit_code"] = result["exit_code"]
+    return snapshot
+
+
+@pytest.mark.parametrize("result,expected_state,is_terminal", _BASH_RESULT_CASES, ids=_BASH_RESULT_IDS)
+def test_bash_result_maps_to_expected_display_state(result, expected_state, is_terminal, workdir):
+    """A real bash poll/cancel result, mapped as documented and rendered through the
+    real controller, produces the expected truthful live/terminal card — proving a
+    nonzero completion renders `failed` (not `done`) and every terminal display
+    state renders the stop/clear footer."""
+    snapshot = _snapshot_from_bash_result(result)
+    assert snapshot["status"] == expected_state  # the documented mapping held
+    frame = _render("render_bash_async.py", workdir, "task_card_state.json", snapshot)
+    _assert_live(frame, "job-a1b2", expected_state)
+    footer = frame.get("footer", "")
+    if is_terminal:
+        assert _TERMINAL_FOOTER_MARKER in footer, (expected_state, footer)
+    else:
+        assert _TERMINAL_FOOTER_MARKER not in footer, (expected_state, footer)
+        assert "awaiting next" in footer, (expected_state, footer)
+
+
+def test_bash_done_nonzero_is_failed_not_done(workdir):
+    """The Terra B1 core case: a terminal poll is top-level `status: "done"` even on
+    a nonzero inner command, so copying the raw top-level status would fabricate
+    success. The documented mapping records `failed`, and the rendered card shows
+    `failed` (never a `done` glyph/label) plus the terminal stop footer."""
+    snapshot = _snapshot_from_bash_result(_BASH_RESULT_DONE_NONZERO)
+    frame = _render("render_bash_async.py", workdir, "task_card_state.json", snapshot)
+    _assert_live(frame, "job-a1b2", "failed")
+    body = _body(frame)
+    assert "status: failed" in body, body
+    assert "status: done" not in body, body  # the raw top-level status is NOT copied
+    assert "exit: 1" in body, body
+    assert _TERMINAL_FOOTER_MARKER in frame.get("footer", "")
+
+
+def test_bash_exit_status_unknown_is_terminal_unknown_outcome(workdir):
+    """`{"status": "done", "exit_status_known": false, "exit_code": null}` maps to the
+    distinct terminal `unknown` display state. Its text must say the exit status is
+    unavailable and imply NEITHER success NOR failure; it must NOT surface a success
+    glyph, a failure glyph, or an exit code; and it is TERMINAL, so its footer still
+    requires the exact stop closeout."""
+    snapshot = _snapshot_from_bash_result(_BASH_RESULT_DONE_UNKNOWN)
+    assert snapshot["status"] == "unknown"
+    assert "exit_code" not in snapshot  # unknown exit status is NOT recorded as a code
+    frame = _render("render_bash_async.py", workdir, "task_card_state.json", snapshot)
+    _assert_live(frame, "job-a1b2", "unknown")
+    body = _body(frame).lower()
+    # States plainly that the exit status is unavailable / outcome unknown.
+    assert "unavailable" in body and "unknown" in body, body
+    # Neither success nor failure is implied: no done/success or failed wording,
+    # and no exit code leaks in.
+    assert "success" not in body, body
+    assert "failed" not in body and "failure" not in body, body
+    assert "exit:" not in body, body
+    # Terminal: the stop/clear footer is required even though the outcome is unknown.
+    footer = frame.get("footer", "")
+    assert _TERMINAL_FOOTER_MARKER in footer, footer
+    assert "awaiting next" not in footer, footer
+
+
+def test_bash_exit_status_unknown_does_not_surface_stray_exit_code(workdir):
+    """Even if a snapshot mistakenly carries an exit_code alongside `unknown` (which
+    the mapping says to omit), the renderer must NOT surface it — an unavailable exit
+    status can never be dressed up as a known outcome."""
+    frame = _render(
+        "render_bash_async.py",
+        workdir,
+        "task_card_state.json",
+        {"job_id": "job-a1b2", "status": "unknown", "exit_code": 0},
+    )
+    _assert_live(frame, "job-a1b2", "unknown")
+    body = _body(frame)
+    assert "exit: 0" not in body and "exit:" not in body, body
+    assert _TERMINAL_FOOTER_MARKER in frame.get("footer", "")
+
+
+def test_nested_manual_documents_bash_display_state_mapping():
+    """The nested manual must make the poll-result -> display-state mapping explicit:
+    the derived-display-state framing, all four terminal display states (including
+    the exit-status-unavailable `unknown`), and that a nonzero completion is `failed`
+    rather than a copied top-level `done`."""
+    text = _NESTED_SKILL.read_text(encoding="utf-8")
+    lowered = text.lower()
+    assert "display state" in lowered
+    assert "exit_status_known" in text
+    assert "command_status" in text
+    # The unknown/exit-status-unavailable terminal is documented as terminal.
+    assert "unknown" in lowered
+    assert "exit status is unavailable" in lowered or "exit-status-unavailable" in lowered
+    # A nonzero completion is failed, not a raw copied done.
+    assert "`failed`" in text and "never" in lowered
+
+
+def test_bash_template_docstring_documents_display_state_mapping():
+    """render_bash_async.py's own docstring must document the derived display state,
+    the additive fidelity fields it maps from, and the terminal `unknown` outcome —
+    so an agent copying the asset learns the mapping from the file itself."""
+    source = (_ASSETS_DIR / "render_bash_async.py").read_text(encoding="utf-8")
+    normalized = " ".join(source.split())
+    lowered = normalized.lower()
+    assert "display state" in lowered
+    assert "exit_status_known" in normalized
+    assert "command_status" in normalized
+    assert "unknown" in lowered
+    # It states the unavailable-exit-status terminal claims neither success nor failure.
+    assert "unavailable" in lowered
+    assert "neither success" in lowered or ("claims neither" in lowered)
 
 
 # -- truthfulness: no fabricated progress ----------------------------------

--- a/tests/test_telegram_task_card_templates.py
+++ b/tests/test_telegram_task_card_templates.py
@@ -98,6 +98,25 @@ _ALLOWED_STATES = {
     "render_daemon.py": ["running", "done", "failed", "cancelled", "timeout"],
 }
 
+# Terminal states: the work has finished, so the terminal snapshot's footer must
+# request that the orchestrator stop/clear the watcher (the passive renderer
+# cannot stop itself). Non-terminal states are the remaining allow-listed states —
+# derived, not hand-maintained, so the two lists cannot drift apart.
+_TERMINAL_STATES = {
+    "render_bash_async.py": ["done", "failed", "cancelled"],
+    "render_daemon.py": ["done", "failed", "cancelled", "timeout"],
+}
+_NON_TERMINAL_STATES = {
+    asset: [s for s in _ALLOWED_STATES[asset] if s not in _TERMINAL_STATES[asset]]
+    for asset in _ALLOWED_STATES
+}
+
+# The exact model-facing stop call the templates/manual must teach (action-based,
+# like bash(action="poll") / daemon(action="check")) and the terminal footer text.
+_STOP_CALL = 'task_card(action="stop", watch_id="<watch_id>")'
+_TERMINAL_FOOTER_TEXT = "terminal snapshot — stop/clear this watch now"
+_TERMINAL_FOOTER_MARKER = "stop/clear this watch"
+
 
 # =========================================================================
 # 1. Two-entry-point human contract (bound concepts, not loose substrings)
@@ -216,6 +235,35 @@ def test_nested_manual_binds_watcher_default_in_when_to_reach_section():
     assert "live progress" not in section
 
 
+def test_nested_manual_binds_terminal_cleanup_in_its_own_section():
+    """The nested manual must lock the terminal-cleanup workflow in its own
+    section: a finished watch is stopped by the orchestrator (the renderer is
+    passive) via the exact action-based stop call, every terminal state is named,
+    a retryable stop_failed is retried with the same call (not restarted), and
+    non-terminal states stay resident. This is the core behavioral promise of this
+    change, so a regression that drops it must fail here."""
+    section = _section(
+        _NESTED_SKILL.read_text(encoding="utf-8"),
+        "### Terminal cleanup: stop a finished watch",
+    ).lower()
+    # The renderer cannot end itself; the orchestrator must stop it with the exact
+    # action-based tool call (no method-style pseudo-invocation).
+    assert "passive" in section
+    assert _STOP_CALL.lower() in section
+    assert "stop(watch_id)" not in section  # no bare/method-style pseudo-call
+    # Every terminal state is named (bash + daemon), plus the terminal footer cue.
+    for terminal in ("done", "failed", "cancelled", "timeout"):
+        assert terminal in section, terminal
+    assert _TERMINAL_FOOTER_TEXT.lower() in section
+    # Retryable stop_failed is retried with the SAME stop call, never restarted.
+    assert "stop_failed" in section
+    assert "same" in section
+    assert "restart" in section or "duplicate" in section
+    # Non-terminal states stay resident.
+    assert "starting" in section and "running" in section
+    assert "resident" in section
+
+
 # =========================================================================
 # 4. Asset shape / packaging
 # =========================================================================
@@ -242,6 +290,21 @@ def test_template_asset_exists_and_is_stdlib_only(asset, state_file, _id, _state
     assert state_file in source
     assert "STATE_FILE" in source
     assert "_MAX_BYTES" in source
+
+    # Documents the terminal-cleanup workflow with the EXACT action-based stop
+    # call (no method-style pseudo-invocation): the passive renderer cannot stop
+    # itself, so the orchestrator calls task_card(action="stop", ...) on a terminal
+    # state and retries the same call (never restart) on a retryable stop_failed.
+    # Whitespace is normalized so the concepts bind regardless of line wrapping.
+    normalized = " ".join(source.split())
+    lowered = normalized.lower()
+    assert _STOP_CALL in normalized
+    assert "task_card.stop(" not in normalized  # no method-style pseudo-call
+    assert "cannot stop" in lowered
+    assert "stop_failed" in normalized
+    # The retry guidance points at the SAME stop call, not a restart.
+    assert "call the same" in lowered
+    assert '`task_card(action="stop", ...)` again' in normalized
 
 
 # =========================================================================
@@ -339,6 +402,55 @@ def test_every_allowlisted_state_renders_when_identity_present(asset, state_file
     for st in _ALLOWED_STATES[asset]:
         frame = _render(asset, workdir, state_file, {id_key: "the-id", state_key: st})
         _assert_live(frame, "the-id", st)
+
+
+# -- terminal cleanup: finished work must request stopping the watcher ------
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_terminal_state_footer_requests_stop_and_clear(asset, state_file, id_key, state_key, workdir):
+    """A terminal snapshot (finished work) must render a live card whose FOOTER
+    asks the orchestrator to stop/clear the watcher — the passive renderer cannot
+    stop itself, so this footer is the human/orchestrator cue that the completed
+    card should not stay resident. The updated_at path is used to prove the
+    terminal footer wins over the ordinary 'snapshot as of …' footer."""
+    for st in _TERMINAL_STATES[asset]:
+        frame = _render(
+            asset,
+            workdir,
+            state_file,
+            {id_key: "the-id", state_key: st, "updated_at": "2026-07-13T10:30:00Z"},
+        )
+        _assert_live(frame, "the-id", st)  # still a truthful live/terminal card
+        footer = frame.get("footer", "")
+        assert _TERMINAL_FOOTER_MARKER in footer, (st, footer)
+        # The terminal footer replaces the awaiting-next semantics entirely.
+        assert "awaiting next" not in footer, (st, footer)
+        assert "snapshot as of" not in footer, (st, footer)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_non_terminal_state_footer_stays_resident_awaiting(asset, state_file, id_key, state_key, workdir):
+    """A non-terminal snapshot (still running) must keep the awaiting-next footer
+    and MUST NOT request a stop — the watch stays resident and keeps updating."""
+    for st in _NON_TERMINAL_STATES[asset]:
+        # With updated_at: the 'snapshot as of …; awaiting next check' footer.
+        frame = _render(
+            asset,
+            workdir,
+            state_file,
+            {id_key: "the-id", state_key: st, "updated_at": "2026-07-13T10:30:00Z"},
+        )
+        _assert_live(frame, "the-id", st)
+        footer = frame.get("footer", "")
+        assert "awaiting next" in footer, (st, footer)
+        assert _TERMINAL_FOOTER_MARKER not in footer, (st, footer)
+
+        # Without updated_at: the bare 'awaiting next orchestrator update' footer.
+        frame = _render(asset, workdir, state_file, {id_key: "the-id", state_key: st})
+        footer = frame.get("footer", "")
+        assert "awaiting next orchestrator update" in footer, (st, footer)
+        assert _TERMINAL_FOOTER_MARKER not in footer, (st, footer)
 
 
 # -- truthfulness: no fabricated progress ----------------------------------

--- a/tests/test_telegram_task_card_templates.py
+++ b/tests/test_telegram_task_card_templates.py
@@ -1,0 +1,528 @@
+"""Tests for the two co-located programmable Task Card renderer template assets
+(bash-async + daemon) and the two-entry-point human contract that routes to them.
+
+These bind four properties, not merely valid Task Card JSON:
+
+1. **The two-entry-point human contract.** The top-level Telegram manual (an agent
+   may load only this one) expresses, *bound together in the programmable-Task-Card
+   section*, the default that a Telegram-originated turn's meaningful long-running
+   bash-async/daemon work should normally get a human-visible watcher, plus a route
+   to the nested manual/assets. The nested manual binds the snapshot model, both
+   copyable template names, and the start|inspect|retry|stop / single-resident
+   lifecycle.
+2. **Snapshot truthfulness (semantic).** Running each template through the real
+   ``TaskCardController._run_renderer``, a snapshot missing its identity, missing or
+   carrying an unknown/wrong-typed state, malformed, non-object, or empty must
+   render an explicit *awaiting* frame and MUST NOT claim ``starting``/``running``
+   or any live state. A live/terminal state is shown only with a recorded identity
+   plus an allow-listed state.
+3. **Bounds and type safety.** An oversize state file, container-valued fields,
+   giant integers, non-finite floats, booleans in numeric fields, and hostile
+   long strings never crash the renderer and never fabricate progress — they
+   degrade to the awaiting frame or are clipped within the Task Card bounds.
+4. **Asset shape/packaging.** Both files exist beside the manual, are stdlib-only,
+   and document their snapshot schema.
+
+No Telegram or network: ``_run_renderer`` runs the renderer as a subprocess and
+validates its stdout; the reverse channel is never called.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import re
+import shutil
+import threading
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.telegram.task_card import TaskCardController
+
+_TASK_CARD_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "src/lingtai/mcp_servers/telegram/task_card"
+)
+_ASSETS_DIR = _TASK_CARD_DIR / "assets"
+_NESTED_SKILL = _TASK_CARD_DIR / "SKILL.md"
+_TOP_SKILL = _TASK_CARD_DIR.parent / "SKILL.md"
+
+# (asset filename, its documented state-snapshot filename, identity key, state key)
+_BASH = ("render_bash_async.py", "task_card_state.json", "job_id", "status")
+_DAEMON = ("render_daemon.py", "daemon_card_state.json", "id", "state")
+_TEMPLATES = [_BASH, _DAEMON]
+_IDS = [t[0] for t in _TEMPLATES]
+
+# stdlib modules the templates are allowed to import — nothing third-party.
+_STDLIB_ALLOWED = {"__future__", "json", "math", "pathlib"}
+
+_MAX_LINES = 20  # controller's hard line cap (controller._MAX_LINES).
+
+# The explicit, honest "no usable snapshot" marker both templates emit. Its
+# presence (and the absence of any live-state label) is how we assert no fabricated
+# progress without pinning exact prose.
+_AWAITING_MARKER = "awaiting orchestrator update"
+
+# Live-state labels a template prints ONLY when identity + allow-listed state are
+# both present. If any of these appear on a partial/unknown snapshot, the renderer
+# has fabricated state.
+_LIVE_LABELS = ("status:", "state:")
+
+# A full, valid snapshot per template (identity + allow-listed state + extras).
+_FULL_STATE = {
+    "render_bash_async.py": {
+        "title": "Refactor auth module",
+        "job_id": "job-a1b2c3d4e5f6",
+        "status": "running",
+        "exit_code": 0,
+        "stage": "tests passing",
+        "updated_at": "2026-07-13T10:30:00Z",
+        "note": "3/5 modules",
+    },
+    "render_daemon.py": {
+        "title": "Nightly synthesis",
+        "id": "em-a1b2",
+        "state": "running",
+        "current": "grep",
+        "elapsed_s": 312,
+        "last_activity": "2026-07-13T10:29:00Z",
+        "health": "alive",
+        "updated_at": "2026-07-13T10:30:00Z",
+        "note": "phase 2/3",
+    },
+}
+
+# The allow-listed states each template may render as live/terminal.
+_ALLOWED_STATES = {
+    "render_bash_async.py": ["starting", "running", "done", "failed", "cancelled"],
+    "render_daemon.py": ["running", "done", "failed", "cancelled", "timeout"],
+}
+
+
+# =========================================================================
+# 1. Two-entry-point human contract (bound concepts, not loose substrings)
+# =========================================================================
+
+
+def _section(text: str, header: str) -> str:
+    """Return the body of the markdown section starting at ``header`` up to the
+    next same-or-higher-level header, so an assertion binds to the intended
+    section rather than to the whole document."""
+    lines = text.splitlines()
+    start = next((i for i, ln in enumerate(lines) if ln.strip() == header), None)
+    assert start is not None, f"section not found: {header!r}"
+    level = len(header) - len(header.lstrip("#"))
+    body: list[str] = []
+    for ln in lines[start + 1:]:
+        stripped = ln.lstrip("#")
+        this_level = len(ln) - len(stripped)
+        if ln.startswith("#") and this_level <= level:
+            break
+        body.append(ln)
+    return "\n".join(body)
+
+
+def test_top_level_manual_binds_watcher_default_in_taskcard_section():
+    """An agent loading ONLY the top-level Telegram manual must find, together in
+    the programmable Task Card section, the Telegram-originated + meaningful +
+    long-running qualification, the human-visible watcher default, both work kinds,
+    and a route onward to the templates. Binding them to one section (not scanning
+    the whole file) means a regression that weakens the advice fails here."""
+    section = _section(
+        _TOP_SKILL.read_text(encoding="utf-8"),
+        "## PROGRAMMABLE TASK CARD (`task_card` tool)",
+    ).lower()
+    # The default/trigger, all in the same section.
+    assert "default" in section
+    assert "telegram-originated turn" in section
+    assert "meaningful" in section and "long-running" in section
+    assert "human-visible" in section
+    assert "watcher" in section
+    # Both kinds of long-running work.
+    assert "bash(async=true)" in section
+    assert "daemon" in section
+    # Route onward to the concrete templates + nested manual.
+    assert "render_bash_async.py" in section and "render_daemon.py" in section
+    assert "task_card/skill.md" in section
+    # Truthful framing: snapshot, not an autonomous live feed.
+    assert "snapshot" in section
+    assert "live progress" not in section
+
+
+def test_nested_manual_binds_snapshot_model_templates_and_lifecycle():
+    """The nested manual must bind the snapshot model, both copyable template
+    names, the truthfulness rule, and the start|inspect|retry|stop / single-resident
+    lifecycle."""
+    text = _NESTED_SKILL.read_text(encoding="utf-8")
+    lowered = text.lower()
+
+    # Both copyable templates named, with the snapshot files they read.
+    assert "render_bash_async.py" in text and "render_daemon.py" in text
+    assert "task_card_state.json" in text and "daemon_card_state.json" in text
+
+    # The snapshot / latest-reported model (not autonomous live progress).
+    assert "latest reported snapshot" in lowered
+    assert "snapshot" in lowered
+
+    # The truthfulness rule is stated: identity + allow-listed state required,
+    # else an awaiting frame; never fabricated starting/running.
+    assert "identity" in lowered
+    assert "awaiting orchestrator update" in lowered
+    assert "never" in lowered and ("fabricat" in lowered or "invent" in lowered)
+
+    # Copy-into-workdir guidance resolved from the manual path (not a fixed
+    # source/installed path), because the controller confines renderer_path.
+    assert "manual" in lowered and "working directory" in lowered
+    assert "confine" in lowered
+
+    # Full lifecycle, in its lifecycle section.
+    lifecycle = _section(text, "### The lifecycle: start | inspect | retry | stop").lower()
+    for action in ("start", "inspect", "retry", "stop"):
+        assert action in lifecycle
+
+    # Single-resident manager, no second manager/card.
+    assert "single resident" in lowered
+    assert "does not start another manager" in lowered or (
+        "never starts a second manager" in lowered
+    ) or ("not start another manager" in lowered)
+
+
+def test_nested_manual_binds_watcher_default_in_when_to_reach_section():
+    """The nested manual must independently lock the watcher-default advisory in
+    its own ``When to reach for this`` section — not only the top-level manual and
+    not only nested asset/lifecycle wording. Binding these concepts to that section
+    means the encouragement cannot be silently removed or weakened to optional
+    while this test keeps passing."""
+    section = _section(
+        _NESTED_SKILL.read_text(encoding="utf-8"),
+        "## When to reach for this",
+    ).lower()
+    # The Telegram-originated + meaningful + long-running qualification.
+    assert "telegram-originated turn" in section
+    assert "meaningful" in section and "long-running" in section
+    # Both kinds of long-running work.
+    assert "bash(async=true)" in section
+    assert "daemon" in section
+    # A human-visible watcher is the recommended response.
+    assert "human-visible" in section
+    assert "watcher" in section
+    # It is a default, with an explicit skip qualification (not merely optional).
+    assert "default" in section
+    assert "skip" in section
+    # Routed to / related to the snapshot + template workflow.
+    assert "snapshot" in section
+    assert "two ready templates" in section
+    # Honest framing, not an autonomous live feed.
+    assert "live progress" not in section
+
+
+# =========================================================================
+# 4. Asset shape / packaging
+# =========================================================================
+
+
+@pytest.mark.parametrize("asset,state_file,_id,_state", _TEMPLATES, ids=_IDS)
+def test_template_asset_exists_and_is_stdlib_only(asset, state_file, _id, _state):
+    path = _ASSETS_DIR / asset
+    assert path.is_file(), path
+    source = path.read_text(encoding="utf-8")
+
+    tree = ast.parse(source)
+    imported_roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported_roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                imported_roots.add(node.module.split(".")[0])
+    assert imported_roots <= _STDLIB_ALLOWED, imported_roots
+
+    # Documents the snapshot file, the STATE_FILE hook, and a byte bound.
+    assert state_file in source
+    assert "STATE_FILE" in source
+    assert "_MAX_BYTES" in source
+
+
+# =========================================================================
+# Executable behavior through the real controller
+# =========================================================================
+
+
+class _FakeAgent:
+    """Minimal host for ``TaskCardController._run_renderer`` — no reverse channel
+    is exercised by rendering, so a client map is unnecessary here."""
+
+    def __init__(self, working_dir: Path) -> None:
+        self._working_dir = str(working_dir)
+        self._mcp_clients_by_tool: dict = {}
+        self._telegram_task_card_context = {"account": "acct", "chat_id": 42}
+        self._shutdown = threading.Event()
+
+    def _enqueue_system_notification(self, **_kwargs):
+        return "notif-id"
+
+    def add_tool(self, *_a, **_k):
+        pass
+
+
+@pytest.fixture
+def workdir(tmp_path):
+    return tmp_path
+
+
+def _render(asset: str, workdir: Path, state_file: str | None = None, state=None) -> dict:
+    """Copy the real asset into ``workdir``, optionally write a snapshot, and run
+    it through the real controller. Returns the validated frame dict."""
+    dest = workdir / asset
+    shutil.copy(_ASSETS_DIR / asset, dest)
+    if state is not None:
+        (workdir / state_file).write_text(
+            state if isinstance(state, str) else json.dumps(state)
+        )
+    ctrl = TaskCardController(_FakeAgent(workdir))
+    try:
+        return ctrl._run_renderer(dest, 10.0)
+    finally:
+        ctrl.shutdown_for_agent_stop()
+
+
+def _assert_valid_bounded_frame(frame: dict) -> None:
+    assert isinstance(frame, dict)
+    assert frame.get("title") or frame.get("footer") or frame.get("lines")
+    lines = frame.get("lines", [])
+    assert isinstance(lines, list)
+    assert len(lines) <= _MAX_LINES
+    assert all(isinstance(x, str) for x in lines)
+    if frame.get("title") is not None:
+        assert isinstance(frame["title"], str)
+    if frame.get("footer") is not None:
+        assert isinstance(frame["footer"], str)
+
+
+def _body(frame: dict) -> str:
+    return " ".join(frame.get("lines", []))
+
+
+def _assert_awaiting(frame: dict) -> None:
+    """The frame is the honest 'no usable snapshot' frame: it carries the awaiting
+    marker and NO live-state label — so it cannot be read as progress."""
+    _assert_valid_bounded_frame(frame)
+    body = _body(frame)
+    assert _AWAITING_MARKER in body, body
+    for label in _LIVE_LABELS:
+        assert label not in body, f"awaiting frame leaked a live label: {body!r}"
+
+
+def _assert_live(frame: dict, identity: str, state: str) -> None:
+    """The frame shows the recorded identity and the allow-listed state, and is
+    NOT an awaiting frame."""
+    _assert_valid_bounded_frame(frame)
+    body = _body(frame)
+    assert _AWAITING_MARKER not in body, body
+    assert identity in body, body
+    assert state in body, body
+
+
+# -- happy paths -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_full_snapshot_renders_true_identity_and_state(asset, state_file, id_key, state_key, workdir):
+    state = _FULL_STATE[asset]
+    frame = _render(asset, workdir, state_file, state)
+    _assert_live(frame, state[id_key], state[state_key])
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_every_allowlisted_state_renders_when_identity_present(asset, state_file, id_key, state_key, workdir):
+    for st in _ALLOWED_STATES[asset]:
+        frame = _render(asset, workdir, state_file, {id_key: "the-id", state_key: st})
+        _assert_live(frame, "the-id", st)
+
+
+# -- truthfulness: no fabricated progress ----------------------------------
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_missing_file_is_awaiting_not_progress(asset, state_file, id_key, state_key, workdir):
+    _assert_awaiting(_render(asset, workdir))
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_partial_snapshot_only_title_is_awaiting_not_starting(asset, state_file, id_key, state_key, workdir):
+    """The EXACT Terra case: {"title": "..."} must NOT render starting/running."""
+    frame = _render(asset, workdir, state_file, {"title": "only title"})
+    _assert_awaiting(frame)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_state_without_identity_is_awaiting(asset, state_file, id_key, state_key, workdir):
+    frame = _render(asset, workdir, state_file, {state_key: "running"})
+    _assert_awaiting(frame)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_identity_without_state_is_awaiting(asset, state_file, id_key, state_key, workdir):
+    frame = _render(asset, workdir, state_file, {id_key: "the-id"})
+    _assert_awaiting(frame)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_unknown_state_is_awaiting_not_rendered_verbatim(asset, state_file, id_key, state_key, workdir):
+    frame = _render(asset, workdir, state_file, {id_key: "the-id", state_key: "totally-made-up"})
+    _assert_awaiting(frame)
+    assert "totally-made-up" not in _body(frame)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+@pytest.mark.parametrize(
+    "variant", ["RUNNING", "Running", "running ", " running", " running ", "RuNnInG"],
+    ids=["upper", "title", "trailing-ws", "leading-ws", "surrounding-ws", "mixed"],
+)
+def test_case_or_whitespace_mutated_state_is_awaiting_not_live(asset, state_file, id_key, state_key, variant, workdir):
+    """The allow-list is EXACT lowercase: a case- or whitespace-mutated state
+    (e.g. ``RUNNING``) is schema-invalid and must render the awaiting frame, never
+    a normalized live ``running`` frame."""
+    frame = _render(asset, workdir, state_file, {id_key: "the-id", state_key: variant})
+    # _assert_awaiting already rejects any live status:/state: label; additionally
+    # confirm the mutated token was not normalized/echoed into the card at all.
+    _assert_awaiting(frame)
+    assert variant.strip() not in _body(frame)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_wrong_typed_identity_or_state_is_awaiting(asset, state_file, id_key, state_key, workdir):
+    for bad in ({id_key: 12345, state_key: "running"}, {id_key: "the-id", state_key: ["running"]}):
+        _assert_awaiting(_render(asset, workdir, state_file, bad))
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+@pytest.mark.parametrize(
+    "bad",
+    ["{not valid json", "[1, 2, 3]", '"a bare string"', "42", "", "{}"],
+    ids=["malformed", "array", "string", "number", "empty", "empty-object"],
+)
+def test_malformed_or_nonobject_snapshot_is_awaiting(asset, state_file, id_key, state_key, bad, workdir):
+    _assert_awaiting(_render(asset, workdir, state_file, bad))
+
+
+# -- bounds and type safety ------------------------------------------------
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_oversize_state_file_is_awaiting_not_parsed(asset, state_file, id_key, state_key, workdir):
+    """A snapshot larger than the byte cap is refused before parsing (so a huge
+    file cannot be read/parsed/stringified every tick), yielding an awaiting frame
+    even though it contains a valid identity + state."""
+    huge = {id_key: "the-id", state_key: "running", "note": "A" * 50000}
+    frame = _render(asset, workdir, state_file, huge)
+    _assert_awaiting(frame)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_container_valued_optional_fields_are_dropped_not_stringified(asset, state_file, id_key, state_key, workdir):
+    """Container-valued optional fields must be ignored, never stringified, while a
+    valid identity + state still render."""
+    state = {
+        id_key: "the-id",
+        state_key: "running",
+        "title": {"nested": "object"},
+        "stage": ["a", "b"],
+        "current": {"x": 1},
+        "note": [1, 2, 3],
+        "last_activity": {"t": 1},
+    }
+    frame = _render(asset, workdir, state_file, state)
+    _assert_live(frame, "the-id", "running")
+    body = _body(frame)
+    # No Python container repr leaked into the card.
+    for token in ("{", "}", "[", "]", "'"):
+        assert token not in body, f"container leaked into card: {body!r}"
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_giant_integer_numeric_fields_are_dropped(asset, state_file, id_key, state_key, workdir):
+    giant = 10 ** 40
+    state = {id_key: "the-id", state_key: "running", "exit_code": giant, "elapsed_s": giant}
+    frame = _render(asset, workdir, state_file, state)
+    _assert_live(frame, "the-id", "running")
+    assert str(giant) not in _body(frame)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_401_digit_integer_under_byte_cap_does_not_error(asset, state_file, id_key, state_key, workdir):
+    """A 401-digit integer is a valid JSON number that fits well under the 8 KiB
+    byte cap, so it reaches the numeric field. It must be rejected by an INTEGER
+    range check — never converted to float (``math.isfinite``/``float(int)`` raises
+    ``OverflowError`` for it) — so the renderer still emits a controller-valid
+    bounded frame with a valid identity + state, not an error."""
+    big = int("9" * 401)
+    assert len(str(big)) == 401
+    raw = (
+        '{"%s": "the-id", "%s": "running", "exit_code": %s, "elapsed_s": %s}'
+        % (id_key, state_key, big, big)
+    )
+    assert len(raw) < 8192  # stays below the byte cap so it reaches the numeric field
+    frame = _render(asset, workdir, state_file, raw)
+    _assert_live(frame, "the-id", "running")
+    assert str(big) not in _body(frame)  # the giant number is dropped, not rendered
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_deeply_nested_json_under_byte_cap_degrades_to_awaiting(asset, state_file, id_key, state_key, workdir):
+    """A deeply nested (but sub-cap) JSON payload makes ``json.loads`` exceed the
+    interpreter recursion limit (``RecursionError``, a ``RuntimeError`` — not a
+    ``ValueError``). The renderer must degrade to a controller-valid bounded
+    awaiting frame, not crash with a nonzero exit."""
+    depth = 1100
+    raw = "[" * depth + "]" * depth
+    assert len(raw) < 8192  # fits under the byte cap, so it reaches json.loads
+    frame = _render(asset, workdir, state_file, raw)
+    _assert_awaiting(frame)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+@pytest.mark.parametrize("token", ["NaN", "Infinity", "-Infinity"], ids=["nan", "inf", "neg-inf"])
+def test_non_finite_numeric_fields_do_not_crash(asset, state_file, id_key, state_key, token, workdir):
+    """json.loads accepts NaN/Infinity; the renderer must reject them for numeric
+    fields without crashing (a crash → nonzero exit → controller error, no watch)."""
+    raw = (
+        '{"%s": "the-id", "%s": "running", "exit_code": %s, "elapsed_s": %s}'
+        % (id_key, state_key, token, token)
+    )
+    frame = _render(asset, workdir, state_file, raw)
+    _assert_live(frame, "the-id", "running")
+    assert token.lstrip("-") not in _body(frame)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_boolean_in_numeric_field_is_dropped(asset, state_file, id_key, state_key, workdir):
+    state = {id_key: "the-id", state_key: "running", "exit_code": True, "elapsed_s": True}
+    frame = _render(asset, workdir, state_file, state)
+    _assert_live(frame, "the-id", "running")
+    body = _body(frame)
+    assert "exit: True" not in body and "elapsed: True" not in body
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_hostile_long_strings_and_control_chars_stay_bounded(asset, state_file, id_key, state_key, workdir):
+    """A long-but-in-byte-budget string field is clipped and its control
+    characters stripped; the frame stays within the Task Card bounds and a valid
+    identity + state still render. (Kept under ``_MAX_BYTES`` so this exercises the
+    per-field clip, not the oversize-file guard, which is covered separately.)"""
+    state = {
+        id_key: "the-id",
+        state_key: "running",
+        # One long field (well over the 120-char clip, well under the byte cap)
+        # plus embedded control characters.
+        "title": "x" * 2000 + "\n\r\tinjected\x00",
+    }
+    frame = _render(asset, workdir, state_file, state)
+    _assert_live(frame, "the-id", "running")
+    for line in frame["lines"]:
+        assert len(line) <= 200, len(line)
+    assert len(frame.get("title", "")) <= 200
+    assert len(frame.get("footer", "")) <= 200
+    # Control characters were stripped from displayed values.
+    assert not re.search(r"[\n\r\t\x00]", _body(frame) + frame.get("title", ""))


### PR DESCRIPTION
## Summary

- make the top-level Telegram manual and nested programmable Task Card skill strongly recommend a human-visible watcher for meaningful long-running `bash(async=true)` and daemon work started from Telegram
- add two copyable stdlib renderer assets backed by small orchestrator-owned snapshots, with truthful incomplete-state fallbacks, bounded parsing/fields, and the existing `start` / `inspect` / `retry` / `stop` lifecycle
- package and document the assets at the Telegram-owned Task Card surface, with focused semantic, hostile-input, packaging-declaration, and architecture tests

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src ../../.venv/bin/python -m pytest -q -p no:cacheprovider tests/test_task_card_controller.py tests/test_telegram_task_card_programmable.py tests/test_telegram_task_card_toggle.py tests/test_telegram_task_card_singleton.py tests/test_telegram_task_card_last_message.py tests/test_telegram_account_last_message_id.py tests/test_telegram_task_card_in_place.py tests/test_telegram_task_card_templates.py tests/test_mcp_skill_manuals.py tests/test_skills.py tests/test_telegram_rich_formatting.py tests/test_architecture_documents.py` — **336 passed**
- `PYTHONDONTWRITEBYTECODE=1 ../../.venv/bin/python -m py_compile src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py src/lingtai/mcp_servers/telegram/task_card/assets/render_daemon.py`
- `git diff --check bb411e816f5cf79811b3782c4ede55da82637159`
- final independent Terra review: **APPROVE**; reviewer independently ran **115 focused tests** plus **17 former-blocker tests**

## Review notes

- guidance/assets only: no new runtime mechanism, tool, flag, config surface, API, or cross-channel abstraction
- renderers do not inspect Bash private registries, consume `poll`, or read daemon forensic artifacts; the orchestrator refreshes a bounded snapshot after launch, meaningful checks, and terminal state
- `TelegramManager` remains the sole owner of its one resident Task Card; the programmable renderer supplies only the programmable slot
- package validation intentionally proves the `assets/**/*` declaration, not wheel/sdist archive membership
