### PR TITLE
fix(daemon): expose config backend option to responses

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -1025,7 +1025,7 @@ def _scrub_responses_schema(node: Any) -> Any:
          "string"`. This covers the nested `secondary.args.*` fields LingTai
          emits with only a description.
       3. `{"type": "object"}` with no `properties` key (a free-form object,
-         e.g. `daemon`'s `tasks[].backend_options`) -> an empty
+         e.g. entries in `daemon`'s `tasks[].mcp` array) -> an empty
          `properties: {}` is added. An empty `properties` map is accepted.
 
     `enum`/`anyOf`/`allOf` are left untouched (the backend accepts them

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -1089,6 +1089,34 @@ def get_description(lang: str = "en") -> str:
     return 'Daemon (神識) — delegate work to ephemeral subagents for context isolation. Each is a disposable LLM session sharing your working directory, retaining no memory after completion. Use for noisy work where you only need the conclusion. Results truncated to ~2000 chars — instruct the emanation to write detailed output to a file. Actions: emanate (dispatch), list (status), ask (follow-up), check (inspect recent events), reclaim (kill all), manual (return the installed daemon-manual skill). Every terminal outcome is push-notified exactly once — done, failed, cancelled, or timed out — so after you dispatch you can safely go idle and wait for the notification; do not poll for "is it done". The notification carries the daemon id, terminal status, task summary, and the result/error path; act on it with daemon(action="check", id=...). LingTai daemons also receive compact; compact(action="manual") is read-only procedures, while explicit compact(action="run", _reason="...") is the repeatable sole-call context reset; action is required. Before using this tool, read the `daemon-manual` skill — it covers inspection patterns, polling cadence, preset/capability inheritance, and compact procedures; no exceptions.'
 
 
+def _backend_option_value_schema() -> dict:
+    """Return a fresh JSON schema for one generic CLI option value.
+
+    ``backend_options`` remains an open-ended argv passthrough.  A factory keeps
+    its explicit provider-visible properties and ``additionalProperties`` on
+    the same validation contract without sharing mutable schema nodes.
+    """
+    return {
+        "anyOf": [
+            {"type": "boolean"},
+            {"type": "string"},
+            {"type": "integer"},
+            {"type": "number"},
+            {"type": "null"},
+            {
+                "type": "array",
+                "items": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "number"},
+                    ],
+                },
+            },
+        ],
+    }
+
+
 def get_schema(lang: str = "en") -> dict:
     return {
         "type": "object",
@@ -1121,25 +1149,18 @@ def get_schema(lang: str = "en") -> dict:
                         },
                         "backend_options": {
                             "type": "object",
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {"type": "boolean"},
-                                    {"type": "string"},
-                                    {"type": "integer"},
-                                    {"type": "number"},
-                                    {"type": "null"},
-                                    {
-                                        "type": "array",
-                                        "items": {
-                                            "anyOf": [
-                                                {"type": "string"},
-                                                {"type": "integer"},
-                                                {"type": "number"},
-                                            ],
-                                        },
-                                    },
-                                ],
+                            "properties": {
+                                "config": {
+                                    **_backend_option_value_schema(),
+                                    "description": (
+                                        "Explicitly declared so constrained tool-schema "
+                                        "providers can generate repeated --config overrides; "
+                                        "uses the same scalar/list contract as generic "
+                                        "backend_options."
+                                    ),
+                                },
                             },
+                            "additionalProperties": _backend_option_value_schema(),
                             "description": 'Optional free-form CLI options for \'claude-code\' / \'codex\' / \'opencode\' / \'mimocode\' / \'qwen-code\' / \'oh-my-pi\' / \'kimicode\' / \'cursor\' backends ONLY (ignored by lingtai). JSON object mapping flag names to values: true → flag only (e.g. {"search": true} → --search); string/int/float → \'--flag <value>\'; list of scalars → \'--flag <v1> --flag <v2>\'; false/null omits the flag. Underscores in keys become dashes; nested objects and unsafe keys are rejected. Applies only when starting the emanation (not to `ask`). Discover supported flags by running \'claude --help\', \'codex exec --help\', \'opencode run --help\', \'mimo run --help\', \'qwen --help\', \'omp --help\', \'kimi --help\', or \'agent --help\' in bash — the CLI\'s flag list changes between versions; this field is intentionally a passthrough rather than a fixed list. See daemon-manual.',
                         },
                         "prompt": {

--- a/tests/test_daemon_backend_options.py
+++ b/tests/test_daemon_backend_options.py
@@ -445,8 +445,14 @@ def test_schema_includes_backend_options():
     schema = get_schema("en")
     task_props = schema["properties"]["tasks"]["items"]["properties"]
     assert "backend_options" in task_props
-    assert task_props["backend_options"]["type"] == "object"
-    passthrough = task_props["backend_options"]["additionalProperties"]
+    backend_options = task_props["backend_options"]
+    assert backend_options["type"] == "object"
+    passthrough = backend_options["additionalProperties"]
+    assert set(backend_options["properties"]) == {"config"}
+    config = backend_options["properties"]["config"]
+    assert config is not passthrough
+    assert config["anyOf"] == passthrough["anyOf"]
+    assert "constrained tool-schema providers" in config["description"]
     alternatives = passthrough["anyOf"]
     assert {item.get("type") for item in alternatives} == {
         "boolean", "string", "integer", "number", "null", "array",

--- a/tests/test_wire_tool_description.py
+++ b/tests/test_wire_tool_description.py
@@ -146,7 +146,9 @@ def test_openai_responses_preserves_daemon_backend_options_passthrough_schema():
     ]["backend_options"]
 
     assert "additionalProperties" in backend_options
-    assert backend_options["properties"] == {}
+    assert set(backend_options["properties"]) == {"config"}
+    config = backend_options["properties"]["config"]
+    assert config["anyOf"] == backend_options["additionalProperties"]["anyOf"]
     assert any(
         option == {"type": "string"}
         for option in backend_options["additionalProperties"]["anyOf"]


### PR DESCRIPTION
## Summary

- explicitly expose `tasks[].backend_options.config` in the daemon tool schema so constrained Responses providers can generate the key
- preserve the existing typed `additionalProperties` contract, keeping #849's generic CLI-option passthrough open-ended
- cover both the canonical daemon schema and the transformed OpenAI Responses wire schema with regressions
- repair the Responses scrub docstring example made stale by the new explicit property; scrub behavior is unchanged

## Problem

#849 added the runtime passthrough from `backend_options` to backend CLI arguments. The provider-facing schema, however, described `backend_options` only with `additionalProperties`.

The Codex Responses compatibility scrub adds `properties: {}` to object schemas that lack an explicit `properties` key because the endpoint rejects that original free-form shape. Under constrained tool generation, that transformed schema could express only an empty `backend_options` object, so values such as:

```json
{"config": ["model_reasoning_effort=\"ultra\""]}
```

never reached the already-correct runtime argument conversion.

## Implementation

`_backend_option_value_schema()` returns a fresh copy of the existing safe scalar/list option-value contract. `backend_options.properties.config` and `backend_options.additionalProperties` each receive an independent copy of that same contract. This makes `config` nameable to constrained providers without enumerating or narrowing other backend flags.

Follow-up to #849.

## Validation

- `PYTHONPATH=src PYTHONDONTWRITEBYTECODE=1 $LINGTAI_RUNTIME_PYTHON -m pytest -q -p no:cacheprovider tests/test_daemon_backend_options.py tests/test_wire_tool_description.py tests/test_tool_glossary.py tests/test_daemon_codex_submanual.py tests/test_daemon_opencode_submanual.py` — **231 passed**
- `git diff --check` — passed
- scoped daemon and OpenAI anatomy drift checks — passed; no cited symbol moved and no anatomy update was required
- exact-final-HEAD Claude Opus/max review — **PASS** (full diff and cited code traced, scrub/runtime/schema assertions verified, `git diff --check` clean; no blocking findings)
- exact-final-HEAD Codex ultra review — **PASS** (18 focused tests, full 8-test wire file, Draft 7 schema validation, and direct schema-flow probes; no blocking findings)

Ruff was unavailable in the active runtime and is not claimed as run.

## Scope

No runtime argument conversion, persistence, logging, global Codex configuration, adapter behavior, or unrelated daemon routing is changed.
