### PR TITLE
docs(telegram): require terminal watcher cleanup

### DIFF
--- a/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
@@ -9,7 +9,7 @@ description: |
   templates (bash async, daemon) shipped as skill assets, the
   start | inspect | retry | stop lifecycle, path/timeout/validation rules,
   fail-loud error wakes, and how the /taskcard toggle interacts.
-last_changed_at: "2026-07-13T12:15:00-07:00"
+last_changed_at: "2026-07-13T15:00:00-07:00"
 ---
 
 # Programmable Telegram Task Card — manual (what / how / why)
@@ -194,6 +194,23 @@ driver that forwards validated frames.
   is the only content on the card, stopping
   shows a stable `— WATCH STOPPED —` marker (an empty Telegram message is not
   allowed) and leaves the resident message reusable. Pass the `watch_id`.
+
+### Terminal cleanup: stop a finished watch
+
+A watcher does not end itself — the renderer is passive and has no `watch_id`, so
+**you** must stop it when the work finishes. When your job reaches a terminal
+state — bash `status` `done`/`failed`/`cancelled`, or daemon `state`
+`done`/`failed`/`cancelled`/`timeout` (learned from the terminal bash
+`bash(action="poll")` or the terminal `daemon` notification/`daemon(action="check")`)
+— record that terminal snapshot, then **immediately call
+`task_card(action="stop", watch_id="<watch_id>")`** (the `watch_id` that
+`task_card(action="start", ...)` returned) to quiesce the watcher and clear the
+programmable slot so the completed card does not stay resident. The two shipped
+templates surface this by rendering the footer
+`terminal snapshot — stop/clear this watch now` on a terminal snapshot. If it
+returns a retryable `stop_failed`, **call the same `task_card(action="stop", ...)`
+again** — do not restart or duplicate the watch. Non-terminal states
+(`starting`/`running`) stay resident and keep updating.
 
 ### When a watch fails
 

--- a/src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py
+++ b/src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py
@@ -52,6 +52,21 @@ time — build the full JSON in memory and write it in one call (an atomic
 temp-file-plus-`os.replace` in the same directory avoids a reader seeing a
 half-written file) — so the renderer never parses a partial object.
 
+Terminal cleanup — you MUST stop the watcher yourself
+-----------------------------------------------------
+This renderer is PASSIVE: it only prints title/lines/footer and has no
+`watch_id` and no tool access, so it CANNOT stop the watch or clear the card by
+itself. When the job reaches a terminal status (`done`, `failed`, or
+`cancelled`) — which you learn from the terminal `bash(action="poll")` result —
+record that terminal snapshot, then IMMEDIATELY call
+`task_card(action="stop", watch_id="<watch_id>")` (the `watch_id` that
+`task_card(action="start", ...)` returned) to quiesce the watcher and clear the
+programmable slot so the finished card does not stay resident. If it returns a
+retryable `stop_failed`, call the SAME `task_card(action="stop", ...)` again — do
+not restart or duplicate the watch. A terminal snapshot's footer says
+`terminal snapshot — stop/clear this watch now` as your reminder. Non-terminal
+statuses (`starting`, `running`) stay resident and keep updating.
+
 Safety: stdlib-only; reads at most a few KiB of the snapshot; accepts only the
 allow-listed primitive fields; strips control characters; clips every string;
 caps the line count; and prints a valid bounded card on any missing/partial/
@@ -82,6 +97,15 @@ _STATUS_GLYPH = {
     "failed": "✗",
     "cancelled": "⊘",
 }
+
+# Terminal statuses: the job has finished (successfully or not). When the
+# snapshot records one of these, the work is over and the watcher should be
+# quiesced. The renderer is PASSIVE — it cannot stop itself — so it asks the
+# orchestrator, in the footer, to call
+# ``task_card(action="stop", watch_id="<watch_id>")``. ``starting`` and
+# ``running`` are non-terminal.
+_TERMINAL_STATUSES = {"done", "failed", "cancelled"}
+_TERMINAL_FOOTER = "terminal snapshot — stop/clear this watch now"
 
 _UNAVAILABLE_TITLE = "Async job"
 _AWAITING = "no snapshot yet — awaiting orchestrator update"
@@ -167,12 +191,18 @@ def _build_card(state: dict) -> dict:
     if note:
         lines.append(note)
 
-    updated_at = _clean_str(state.get("updated_at"), 40)
-    footer = (
-        f"snapshot as of {updated_at}; awaiting next check"
-        if updated_at
-        else "awaiting next orchestrator update"
-    )
+    if status in _TERMINAL_STATUSES:
+        # The job has finished: ask the orchestrator to stop the watcher now so the
+        # completed card does not stay resident. A non-terminal status keeps the
+        # awaiting-next-check footer.
+        footer = _TERMINAL_FOOTER
+    else:
+        updated_at = _clean_str(state.get("updated_at"), 40)
+        footer = (
+            f"snapshot as of {updated_at}; awaiting next check"
+            if updated_at
+            else "awaiting next orchestrator update"
+        )
 
     title = _clean_str(state.get("title")) or _UNAVAILABLE_TITLE
     return {"title": title, "lines": lines[:_MAX_LINES], "footer": footer}

--- a/src/lingtai/mcp_servers/telegram/task_card/assets/render_daemon.py
+++ b/src/lingtai/mcp_servers/telegram/task_card/assets/render_daemon.py
@@ -57,6 +57,21 @@ each time — build the full JSON in memory and write it in one call (an atomic
 temp-file-plus-`os.replace` in the same directory avoids a reader seeing a
 half-written file) — so the renderer never parses a partial object.
 
+Terminal cleanup — you MUST stop the watcher yourself
+-----------------------------------------------------
+This renderer is PASSIVE: it only prints title/lines/footer and has no
+`watch_id` and no tool access, so it CANNOT stop the watch or clear the card by
+itself. When the daemon reaches a terminal state (`done`, `failed`, `cancelled`,
+or `timeout`) — which you learn from the terminal `daemon` notification or a
+terminal `daemon(check)` result — record that terminal snapshot, then
+IMMEDIATELY call `task_card(action="stop", watch_id="<watch_id>")` (the
+`watch_id` that `task_card(action="start", ...)` returned) to quiesce the watcher
+and clear the programmable slot so the finished card does not stay resident. If
+it returns a retryable `stop_failed`, call the SAME `task_card(action="stop", ...)`
+again — do not restart or duplicate the watch. A terminal snapshot's footer says
+`terminal snapshot — stop/clear this watch now` as your reminder. Non-terminal
+states (`running`) stay resident and keep updating.
+
 Safety: stdlib-only; reads at most a few KiB of the snapshot; accepts only the
 allow-listed primitive fields; strips control characters; clips every string;
 caps the line count; and prints a valid bounded card on any missing/partial/
@@ -88,6 +103,15 @@ _STATE_GLYPH = {
     "cancelled": "⊘",
     "timeout": "⏳",
 }
+
+# Terminal states: the daemon has finished (successfully or not). When the
+# snapshot records one of these, the work is over and the watcher should be
+# quiesced. The renderer is PASSIVE — it cannot stop itself — so it asks the
+# orchestrator, in the footer, to call
+# ``task_card(action="stop", watch_id="<watch_id>")``. Only ``running`` is
+# non-terminal.
+_TERMINAL_STATES = {"done", "failed", "cancelled", "timeout"}
+_TERMINAL_FOOTER = "terminal snapshot — stop/clear this watch now"
 
 # The only accepted health verdicts YOU record after comparing checks.
 _HEALTH_GLYPH = {
@@ -204,12 +228,18 @@ def _build_card(state: dict) -> dict:
     if note:
         lines.append(note)
 
-    updated_at = _clean_str(state.get("updated_at"), 40)
-    footer = (
-        f"snapshot as of {updated_at}; awaiting next check"
-        if updated_at
-        else "awaiting next orchestrator update"
-    )
+    if run_state in _TERMINAL_STATES:
+        # The daemon has finished: ask the orchestrator to stop the watcher now so
+        # the completed card does not stay resident. A non-terminal state keeps the
+        # awaiting-next-check footer.
+        footer = _TERMINAL_FOOTER
+    else:
+        updated_at = _clean_str(state.get("updated_at"), 40)
+        footer = (
+            f"snapshot as of {updated_at}; awaiting next check"
+            if updated_at
+            else "awaiting next orchestrator update"
+        )
 
     title = _clean_str(state.get("title")) or _UNAVAILABLE_TITLE
     return {"title": title, "lines": lines[:_MAX_LINES], "footer": footer}

--- a/tests/test_telegram_task_card_templates.py
+++ b/tests/test_telegram_task_card_templates.py
@@ -98,6 +98,25 @@ _ALLOWED_STATES = {
     "render_daemon.py": ["running", "done", "failed", "cancelled", "timeout"],
 }
 
+# Terminal states: the work has finished, so the terminal snapshot's footer must
+# request that the orchestrator stop/clear the watcher (the passive renderer
+# cannot stop itself). Non-terminal states are the remaining allow-listed states —
+# derived, not hand-maintained, so the two lists cannot drift apart.
+_TERMINAL_STATES = {
+    "render_bash_async.py": ["done", "failed", "cancelled"],
+    "render_daemon.py": ["done", "failed", "cancelled", "timeout"],
+}
+_NON_TERMINAL_STATES = {
+    asset: [s for s in _ALLOWED_STATES[asset] if s not in _TERMINAL_STATES[asset]]
+    for asset in _ALLOWED_STATES
+}
+
+# The exact model-facing stop call the templates/manual must teach (action-based,
+# like bash(action="poll") / daemon(action="check")) and the terminal footer text.
+_STOP_CALL = 'task_card(action="stop", watch_id="<watch_id>")'
+_TERMINAL_FOOTER_TEXT = "terminal snapshot — stop/clear this watch now"
+_TERMINAL_FOOTER_MARKER = "stop/clear this watch"
+
 
 # =========================================================================
 # 1. Two-entry-point human contract (bound concepts, not loose substrings)
@@ -216,6 +235,35 @@ def test_nested_manual_binds_watcher_default_in_when_to_reach_section():
     assert "live progress" not in section
 
 
+def test_nested_manual_binds_terminal_cleanup_in_its_own_section():
+    """The nested manual must lock the terminal-cleanup workflow in its own
+    section: a finished watch is stopped by the orchestrator (the renderer is
+    passive) via the exact action-based stop call, every terminal state is named,
+    a retryable stop_failed is retried with the same call (not restarted), and
+    non-terminal states stay resident. This is the core behavioral promise of this
+    change, so a regression that drops it must fail here."""
+    section = _section(
+        _NESTED_SKILL.read_text(encoding="utf-8"),
+        "### Terminal cleanup: stop a finished watch",
+    ).lower()
+    # The renderer cannot end itself; the orchestrator must stop it with the exact
+    # action-based tool call (no method-style pseudo-invocation).
+    assert "passive" in section
+    assert _STOP_CALL.lower() in section
+    assert "stop(watch_id)" not in section  # no bare/method-style pseudo-call
+    # Every terminal state is named (bash + daemon), plus the terminal footer cue.
+    for terminal in ("done", "failed", "cancelled", "timeout"):
+        assert terminal in section, terminal
+    assert _TERMINAL_FOOTER_TEXT.lower() in section
+    # Retryable stop_failed is retried with the SAME stop call, never restarted.
+    assert "stop_failed" in section
+    assert "same" in section
+    assert "restart" in section or "duplicate" in section
+    # Non-terminal states stay resident.
+    assert "starting" in section and "running" in section
+    assert "resident" in section
+
+
 # =========================================================================
 # 4. Asset shape / packaging
 # =========================================================================
@@ -242,6 +290,21 @@ def test_template_asset_exists_and_is_stdlib_only(asset, state_file, _id, _state
     assert state_file in source
     assert "STATE_FILE" in source
     assert "_MAX_BYTES" in source
+
+    # Documents the terminal-cleanup workflow with the EXACT action-based stop
+    # call (no method-style pseudo-invocation): the passive renderer cannot stop
+    # itself, so the orchestrator calls task_card(action="stop", ...) on a terminal
+    # state and retries the same call (never restart) on a retryable stop_failed.
+    # Whitespace is normalized so the concepts bind regardless of line wrapping.
+    normalized = " ".join(source.split())
+    lowered = normalized.lower()
+    assert _STOP_CALL in normalized
+    assert "task_card.stop(" not in normalized  # no method-style pseudo-call
+    assert "cannot stop" in lowered
+    assert "stop_failed" in normalized
+    # The retry guidance points at the SAME stop call, not a restart.
+    assert "call the same" in lowered
+    assert '`task_card(action="stop", ...)` again' in normalized
 
 
 # =========================================================================
@@ -339,6 +402,55 @@ def test_every_allowlisted_state_renders_when_identity_present(asset, state_file
     for st in _ALLOWED_STATES[asset]:
         frame = _render(asset, workdir, state_file, {id_key: "the-id", state_key: st})
         _assert_live(frame, "the-id", st)
+
+
+# -- terminal cleanup: finished work must request stopping the watcher ------
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_terminal_state_footer_requests_stop_and_clear(asset, state_file, id_key, state_key, workdir):
+    """A terminal snapshot (finished work) must render a live card whose FOOTER
+    asks the orchestrator to stop/clear the watcher — the passive renderer cannot
+    stop itself, so this footer is the human/orchestrator cue that the completed
+    card should not stay resident. The updated_at path is used to prove the
+    terminal footer wins over the ordinary 'snapshot as of …' footer."""
+    for st in _TERMINAL_STATES[asset]:
+        frame = _render(
+            asset,
+            workdir,
+            state_file,
+            {id_key: "the-id", state_key: st, "updated_at": "2026-07-13T10:30:00Z"},
+        )
+        _assert_live(frame, "the-id", st)  # still a truthful live/terminal card
+        footer = frame.get("footer", "")
+        assert _TERMINAL_FOOTER_MARKER in footer, (st, footer)
+        # The terminal footer replaces the awaiting-next semantics entirely.
+        assert "awaiting next" not in footer, (st, footer)
+        assert "snapshot as of" not in footer, (st, footer)
+
+
+@pytest.mark.parametrize("asset,state_file,id_key,state_key", _TEMPLATES, ids=_IDS)
+def test_non_terminal_state_footer_stays_resident_awaiting(asset, state_file, id_key, state_key, workdir):
+    """A non-terminal snapshot (still running) must keep the awaiting-next footer
+    and MUST NOT request a stop — the watch stays resident and keeps updating."""
+    for st in _NON_TERMINAL_STATES[asset]:
+        # With updated_at: the 'snapshot as of …; awaiting next check' footer.
+        frame = _render(
+            asset,
+            workdir,
+            state_file,
+            {id_key: "the-id", state_key: st, "updated_at": "2026-07-13T10:30:00Z"},
+        )
+        _assert_live(frame, "the-id", st)
+        footer = frame.get("footer", "")
+        assert "awaiting next" in footer, (st, footer)
+        assert _TERMINAL_FOOTER_MARKER not in footer, (st, footer)
+
+        # Without updated_at: the bare 'awaiting next orchestrator update' footer.
+        frame = _render(asset, workdir, state_file, {id_key: "the-id", state_key: st})
+        footer = frame.get("footer", "")
+        assert "awaiting next orchestrator update" in footer, (st, footer)
+        assert _TERMINAL_FOOTER_MARKER not in footer, (st, footer)
 
 
 # -- truthfulness: no fabricated progress ----------------------------------


### PR DESCRIPTION
## Stack

- **Depends on #907** and intentionally targets base branch `docs/task-card-long-work-watchers`.
- Exact base/head at creation: `df74269598092355bd111049756a7cf5c8a8eaaf` → `9c8d5f2ec0957bc5c2d8d83b6fd95931a1a95664`.
- This is a single-commit stacked delta; it does not duplicate #907 against live `main` and does not authorize merging either PR.

## Summary

- teach both shipped watcher templates that their renderers are passive and cannot stop their own controller;
- after a terminal daemon notification/check or terminal bash poll, require the orchestrator to record the terminal snapshot and immediately call `task_card(action="stop", watch_id="<watch_id>")` so the completed programmable frame is cleared;
- on retryable `stop_failed`, retry the same stop action only—never restart or duplicate the watch;
- render a terminal-only footer (`terminal snapshot — stop/clear this watch now`) while preserving the existing awaiting-next-update footer for non-terminal `starting` / `running` states;
- lock terminal/non-terminal behavior plus the exact action-based stop syntax in targeted tests.

## Ownership and taste check

Task Card remains Telegram MCP-owned. This deliberately changes only the nested Task Card manual, the two #907 renderer assets, and their targeted tests. It does **not** invent an in-band renderer control field or change `controller.py`, manager/interface behavior, Contract, or Anatomy. The shape was checked against the `lingtai-taste` skill: smallest honest owning-layer workflow, no new public runtime surface, and no redundant main-based PR.

## Validation

- both renderer assets byte-compile successfully;
- `149 passed` across:
  - `tests/test_telegram_task_card_templates.py`
  - `tests/test_mcp_skill_manuals.py`
  - `tests/test_skills.py`
  - `tests/test_architecture_documents.py`
- `git diff --check` clean;
- exact Claude implementation model mechanically verified as `claude-opus-4-8`, followed by parent diff review and independent test rerun.

## Scope

Four modified files, no deletions/renames:

- `src/lingtai/mcp_servers/telegram/task_card/SKILL.md`
- `src/lingtai/mcp_servers/telegram/task_card/assets/render_bash_async.py`
- `src/lingtai/mcp_servers/telegram/task_card/assets/render_daemon.py`
- `tests/test_telegram_task_card_templates.py`
