### PR TITLE
docs: enforce repository-wide YAML governance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!--
+related_files:
+- CONTRIBUTING.md
+maintenance: |
+  Tracks the PR validation checklist required by CONTRIBUTING.md; update the Summary/Validation/Notes sections whenever the mandatory pre-review checks (git diff --check, targeted tests, secret-scrubbing reminder) change. Metadata lives in a hidden HTML-comment block (docs.yaml metadata_modes: html_comment) so the visible template body GitHub injects into a new PR description stays byte-for-byte unchanged.
+-->
 ## Summary
 
 - TODO

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -155,6 +155,8 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
 - [`dev-guide-skill/`](dev-guide-skill/) — the repository-local agent dev kit:
   its skill routes agents into the Anatomy and Contract systems and may grow
   focused scripts, references, templates, or assets as real workflows recur.
+- [`scripts/`](scripts/) — root utility/checker scripts, including the
+  docs-governance validator described below.
 - [`.github/`](.github/) — GitHub Actions, issue templates, and pull request
   templates.
 - [`crates/lingtai-search-sidecar/`](crates/lingtai-search-sidecar/) — Rust file
@@ -172,6 +174,10 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
 - [`ANATOMY.md`](ANATOMY.md) — this repository map and anatomy-of-anatomy.
 - [`CONTRACT.md`](CONTRACT.md) — the distributed code interface definition root
   and contract-of-contract.
+- [`docs.yaml`](docs.yaml) — the canonical, machine-readable all-doc
+  metadata contract and authoring template; validated by
+  [`scripts/check_docs_governance.py`](scripts/check_docs_governance.py)
+  and [`tests/test_docs_governance.py`](tests/test_docs_governance.py).
 - [`README.md`](README.md) — public English network entry point; translated
   readmes live under `docs/readmes/`.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — public contributor entry point.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,12 @@
+---
+related_files:
+- docs/references/claude-code-guide.md
+- dev-guide-skill/SKILL.md
+- CONTRIBUTING.md
+maintenance: |
+  Tracks the Claude Code entry-point routing (worktree rule, dev-guide-skill lookup, full-guide pointer); update it whenever the mandatory pre-task routing sequence or its linked targets change.
+---
+
 # CLAUDE.md
 
 This root file is intentionally short. It is the entry point Claude Code reads

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,10 @@
+---
+related_files:
+- CONTRIBUTING.md
+maintenance: |
+  Tracks community conduct expectations and the maintainer reporting path; keep it synced with how the project actually moderates issues, PRs, and reviews.
+---
+
 # Code of Conduct
 
 LingTai is a research and developer community. We expect contributors and users

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,17 @@
+---
+related_files:
+- ANATOMY.md
+- CONTRACT.md
+- docs/references/claude-code-guide.md
+- src/lingtai/kernel/ANATOMY.md
+- crates/lingtai-search-sidecar/README.md
+- CODE_OF_CONDUCT.md
+- SECURITY.md
+- SUPPORT.md
+maintenance: |
+  Tracks the contributor workflow and repository navigation map (Anatomy/Contract entry points, worktree usage, community links); update it whenever those referenced entry points move or the workflow steps change.
+---
+
 # Contributing to lingtai-kernel
 
 Thank you for helping improve the LingTai Python runtime. GitHub discovers this root file as the repository contributing guide.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+---
+related_files:
+- docs/readmes/README.zh.md
+- docs/readmes/README.wen.md
+- CONTRIBUTING.md
+- SECURITY.md
+- SUPPORT.md
+- docs/references/acknowledgements.md
+- dev-guide-skill/SKILL.md
+- ANATOMY.md
+- CONTRACT.md
+- src/lingtai/kernel/ANATOMY.md
+- src/lingtai/ANATOMY.md
+- src/lingtai/tools/ANATOMY.md
+- src/lingtai/mcp_servers/ANATOMY.md
+- docs/references/claude-code-guide.md
+maintenance: |
+  Tracks the public repo overview and architecture entry-point table; must stay synced with docs/readmes/ translations and with the linked entry-point files whenever the repository's structure or onboarding steps change.
+---
+
 <div align="center">
 
 # lingtai-kernel

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- CONTRIBUTING.md
+- README.md
+maintenance: |
+  Tracks the vulnerability-reporting process; update it if the private disclosure channel, GitHub Security Advisory availability, or required report contents change.
+---
+
 # Security Policy
 
 ## Reporting a vulnerability

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- README.md
+- CONTRIBUTING.md
+maintenance: |
+  Tracks the support channels and what to include when asking for help; update it if the support intake path (GitHub Issues) or expected report contents change.
+---
+
 # Support
 
 For questions and help with `lingtai-kernel`:

--- a/crates/lingtai-search-sidecar/README.md
+++ b/crates/lingtai-search-sidecar/README.md
@@ -1,3 +1,14 @@
+---
+related_files:
+- crates/lingtai-search-sidecar/Cargo.toml
+- crates/lingtai-search-sidecar/src/main.rs
+- MANIFEST.in
+- pyproject.toml
+- src/lingtai/services/file_io.py
+maintenance: |
+  Tracks the Rust sidecar's build/runtime-selection contract (env vars, resolver priority, wire protocol); update it whenever the cargo build hook, resolver order, or JSON request/response shape in src/main.rs changes.
+---
+
 # lingtai-search-sidecar
 
 Rust sidecar that backs LingTai's `glob` and `grep` ops behind the

--- a/dev-guide-skill/SKILL.md
+++ b/dev-guide-skill/SKILL.md
@@ -6,6 +6,15 @@ description: >
   packaging, capabilities, adapters, or developer documentation in
   lingtai-kernel. Routes each task through the exact baseline, the distributed
   ANATOMY/CONTRACT systems, focused validation, and pull-request safety gates.
+related_files:
+- ANATOMY.md
+- CONTRACT.md
+- CONTRIBUTING.md
+- docs.yaml
+- src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
+- tests/test_architecture_documents.py
+maintenance: |
+  Mandatory repository-local development router; update it, tests/test_architecture_documents.py's public-entry-points test, and README/Anatomy/Contract entry routes together whenever the workflow, the docs.yaml governance pointer, or the pull-request/side-effect gate changes.
 ---
 
 # LingTai Kernel Development
@@ -162,6 +171,18 @@ or opening the PR:
 Commit, push, open/close/merge PRs, publish, install, refresh, release, or change
 configuration only within the maintainer's explicit authorization for that
 specific side effect. Opening a PR does not imply permission to merge it.
+
+## Keep documentation frontmatter current
+
+Every Markdown file in the repository — including this file's own
+frontmatter above — must carry `related_files` and `maintenance` YAML
+metadata, checked by [`docs.yaml`](../docs.yaml) and validated by
+`scripts/check_docs_governance.py` / `tests/test_docs_governance.py`. This
+is a separate, generic baseline from the Anatomy/Contract frontmatter
+schemas above — do not conflate them. When you add or edit a doc, fill in
+real `related_files`/`maintenance`; when you create a new governed
+component ANATOMY.md/CONTRACT.md, its stricter specialized schema already
+satisfies this baseline.
 
 ## Grow this as the repository agent dev kit
 

--- a/discussions/headless-runtime-contract.md
+++ b/discussions/headless-runtime-contract.md
@@ -1,3 +1,10 @@
+---
+related_files:
+- CONTRACT.md
+maintenance: |
+  Tracks the external, non-model-generated liveness/mailbox-probe contract for headless controllers; update it whenever the runtime lock/heartbeat files, `.status.json` fields, or the probe/ack message shape change.
+---
+
 # Headless Runtime Contract
 
 This contract is for external controllers that need to prove a LingTai agent is

--- a/docs.yaml
+++ b/docs.yaml
@@ -1,0 +1,99 @@
+name: docs-governance-contract
+version: 6
+extensions:
+  - .md
+discovery:
+  tracked: true
+  untracked_not_ignored: true
+required_fields:
+  - related_files
+  - maintenance
+field_constraints:
+  related_files:
+    type: list
+    min_items: 1
+    unique: true
+    no_self_reference: true
+    target_policy: owner_validated_relative_link
+  maintenance:
+    type: string
+    min_length: 20
+    forbidden_exact_values:
+      - todo
+      - tbd
+      - fixme
+      - xxx
+      - n/a
+      - none
+      - x
+metadata_modes:
+  frontmatter:
+    description: "Default. Leading '---'-fenced YAML block."
+    applies_to: "*"
+  html_comment:
+    description: >
+      YAML wrapped in a leading HTML comment ('<!--' / '-->') instead of a
+      '---' fence, for a file whose external raw-byte consumer cannot be
+      patched (GitHub injecting .github/PULL_REQUEST_TEMPLATE.md verbatim
+      into a new PR's description). Alternate SYNTAX for the same two
+      required fields, not a content exemption.
+metadata_mode_overrides:
+  .github/PULL_REQUEST_TEMPLATE.md: html_comment
+placeholder_patterns:
+  - "\\[[A-Z][A-Z_]*\\]"
+related_files:
+  - scripts/check_docs_governance.py
+  - tests/test_docs_governance.py
+  - dev-guide-skill/SKILL.md
+  - tests/test_architecture_documents.py
+  - ANATOMY.md
+maintenance: |
+  This file is the canonical, machine-readable authoring template and
+  validation contract for every Markdown document in the repository — all
+  244 candidates, with zero path-level content exemptions. A change to
+  required_fields, field_constraints, metadata_modes,
+  metadata_mode_overrides, or placeholder_patterns requires updating
+  scripts/check_docs_governance.py and tests/test_docs_governance.py in the
+  same change, and requires bumping version. The checker keeps only the
+  versioned interpreter/schema guards needed to reject unsupported contract
+  shapes, then executes the parsed contract values; it must not maintain a
+  separate path exemption list or silently ignore a declared rule.
+
+  maintenance.min_length and maintenance.forbidden_exact_values form a
+  deliberately small, language-agnostic anti-placeholder floor: at least 20
+  non-whitespace characters and no exact case-insensitive placeholder value.
+  They do not pretend to prove semantic quality; document owners and review
+  remain responsible for making each rule specific to the document.
+
+  related_files.target_policy is owner_validated_relative_link: this
+  generic contract validates that every related_files entry is a
+  non-empty, unique, repo-relative-POSIX-syntax string without a Windows
+  drive designator, placeholder, or self-reference. It does NOT universally
+  require every entry to resolve to a real file at the repository root,
+  because many
+  existing owners (Anatomy/Contract twins, the prompt-source
+  progressive-disclosure crawl graph in src/lingtai/prompts/*.yaml, the
+  molt-gate session-journal path convention) already encode owner-specific
+  logical or crawl-relative link semantics predating this contract, and a
+  generic all-doc governance layer must not redefine or invalidate those
+  established, specialized semantics. Presence and syntax are validated
+  generically here; deeper resolution/crawl correctness remains owned by
+  each document's existing specialized validator
+  (tests/test_architecture_documents.py for governed Anatomy/Contract
+  pairs, the prompt catalog loader for prompt-source YAML, the psyche molt
+  gate for session-journal paths, and so on). The one-time migration that
+  introduced this contract held its OWN new related_files values to a
+  stricter existence-or-planned-in-manifest preflight before writing them;
+  that stricter check was migration-specific, not part of this generic,
+  ongoing contract.
+
+  This contract does not redefine or weaken the root ANATOMY.md/CONTRACT.md
+  architecture-document frontmatter schemas (tests/test_architecture_documents.py
+  remains separately, more strictly authoritative for those) or the
+  tool-glossary schema in src/lingtai/kernel/tool_glossary.py, which this
+  same change extends to require related_files/maintenance alongside its
+  four identity fields rather than being exempted from them.
+  metadata_mode_overrides is a syntax accommodation for one unpatchable
+  external consumer; it is not a mechanism for excluding a document from
+  the required_fields check, and its value is itself closed (exactly one
+  entry) so a future addition must be an explicit, reviewed contract change.

--- a/docs.yaml
+++ b/docs.yaml
@@ -1,5 +1,5 @@
 name: docs-governance-contract
-version: 6
+version: 7
 extensions:
   - .md
 discovery:
@@ -41,6 +41,16 @@ metadata_mode_overrides:
   .github/PULL_REQUEST_TEMPLATE.md: html_comment
 placeholder_patterns:
   - "\\[[A-Z][A-Z_]*\\]"
+lifecycle_contract:
+  field: lifecycle
+  supported_values:
+    - temporary
+  exit_condition_field: temporary_until
+  exit_condition_min_length: 20
+  exit_condition_forbidden_patterns:
+    - '(?i)\b(?:tbd|todo|fixme|xxx|n/a)\b'
+    - '(?i)^\s*when(?:\s+\w+){0,4}\s+(?:is\s+)?done\s*[.!]?\s*$'
+    - '(?i)^\s*after\s+(?:the\s+)?migration(?:\s+is\s+(?:done|complete|completed))?\s*[.!]?\s*$'
 related_files:
   - scripts/check_docs_governance.py
   - tests/test_docs_governance.py
@@ -52,12 +62,34 @@ maintenance: |
   validation contract for every Markdown document in the repository — all
   244 candidates, with zero path-level content exemptions. A change to
   required_fields, field_constraints, metadata_modes,
-  metadata_mode_overrides, or placeholder_patterns requires updating
-  scripts/check_docs_governance.py and tests/test_docs_governance.py in the
-  same change, and requires bumping version. The checker keeps only the
+  metadata_mode_overrides, placeholder_patterns, or lifecycle_contract requires
+  updating scripts/check_docs_governance.py and tests/test_docs_governance.py
+  in the same change, and requires bumping version. The checker keeps only the
   versioned interpreter/schema guards needed to reject unsupported contract
   shapes, then executes the parsed contract values; it must not maintain a
   separate path exemption list or silently ignore a declared rule.
+
+  lifecycle_contract defines a small, OPTIONAL per-document `lifecycle`
+  marker for genuinely temporary documents (e.g. a dated migration-backlog
+  plan). The field is not part of required_fields: most documents omit it
+  entirely and are unaffected. A document may declare `lifecycle: temporary`
+  (the only supported value) alongside a `temporary_until` string of at least
+  lifecycle_contract.exit_condition_min_length non-whitespace characters
+  describing a concrete, checkable exit condition — not a placeholder.
+  Declaring `temporary_until` without `lifecycle: temporary`, declaring an
+  unsupported/empty/non-string lifecycle value, or omitting/providing an
+  invalid `temporary_until` when `lifecycle: temporary` is declared is a
+  contract violation. exit_condition_forbidden_patterns supplies a small
+  mechanical anti-placeholder floor: placeholder tokens and generic bare
+  "when done" / "after migration" statements are rejected, while owners and
+  review remain responsible for semantic concreteness. This marker grants no
+  content or path-level exemption: it adds lifecycle-specific requirements to
+  a document that explicitly opts in, while every
+  required_fields/field_constraints check above still applies
+  unchanged. Reports, frozen investigations, active contracts, and templates
+  are durable by default and must not declare lifecycle: temporary merely for
+  convenience — the field exists for documents whose owner has an actual,
+  evidence-grounded plan to archive them.
 
   maintenance.min_length and maintenance.forbidden_exact_values form a
   deliberately small, language-agnostic anti-placeholder floor: at least 20

--- a/docs/plans/2026-06-25-fsutil-migration.md
+++ b/docs/plans/2026-06-25-fsutil-migration.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- src/lingtai/kernel/_fsutil.py
+- tests/test_fsutil.py
+maintenance: |
+  Dated migration plan (issue #510); update the staged caller backlog checklist as each call site is migrated in its own PR — do not let it silently drift out of sync with actual `_fsutil` adoption.
+---
+
 # `_fsutil` staged migration plan (issue #510)
 
 `src/lingtai/kernel/_fsutil.py` is the shared, stdlib-only foundation for

--- a/docs/plans/2026-06-25-fsutil-migration.md
+++ b/docs/plans/2026-06-25-fsutil-migration.md
@@ -4,6 +4,12 @@ related_files:
 - tests/test_fsutil.py
 maintenance: |
   Dated migration plan (issue #510); update the staged caller backlog checklist as each call site is migrated in its own PR — do not let it silently drift out of sync with actual `_fsutil` adoption.
+lifecycle: temporary
+temporary_until: |
+  Archive once every remaining Stage 1-3 checkbox above is resolved by a
+  follow-up PR with format-parity coverage, or explicitly closed as a
+  non-commitment, and the checklist matches actual `_fsutil` adoption;
+  preserve any final migration record separately before removing this file.
 ---
 
 # `_fsutil` staged migration plan (issue #510)

--- a/docs/readmes/README.wen.md
+++ b/docs/readmes/README.wen.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- README.md
+- docs/readmes/README.zh.md
+maintenance: |
+  Must stay synced with the source-locale README.md; update together when English content changes.
+---
+
 <div align="center">
 
 # lingtai-kernel 灵台内核

--- a/docs/readmes/README.zh.md
+++ b/docs/readmes/README.zh.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- README.md
+- docs/readmes/README.wen.md
+maintenance: |
+  Must stay synced with the source-locale README.md; update together when English content changes.
+---
+
 <div align="center">
 
 # lingtai-kernel 灵台内核

--- a/docs/references/acknowledgements.md
+++ b/docs/references/acknowledgements.md
@@ -1,3 +1,10 @@
+---
+related_files:
+- README.md
+maintenance: |
+  Tiny credits note linked from README.md; update only when acknowledgement facts change (new named contributor/collaborator).
+---
+
 # Acknowledgements
 
 Z. Huang thanks valuable discussion with Runyuan Wang.

--- a/docs/references/claude-code-guide.md
+++ b/docs/references/claude-code-guide.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- CLAUDE.md
+- dev-guide-skill/SKILL.md
+maintenance: |
+  The full coding-agent reference CLAUDE.md routes to; keep its worktree rule, package-architecture description, and anatomy-navigation guidance synced with actual repository conventions as they evolve.
+---
+
 # Claude Code Guide
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.

--- a/docs/references/codex-http-anatomy-investigation.md
+++ b/docs/references/codex-http-anatomy-investigation.md
@@ -1,3 +1,12 @@
+---
+related_files:
+- src/lingtai/llm/openai/adapter.py
+- src/lingtai/llm/openai/codex_ws.py
+- src/lingtai/llm/openai/ANATOMY.md
+maintenance: |
+  Historical wire-shape investigation report (dated 2026-06-22, PR #454 era); content is frozen as a point-in-time capture — do not rewrite retroactively, but correct factual errors and note in-repo if the adapter's header/body shape it describes later diverges.
+---
+
 # Codex HTTP anatomy investigation: LingTai vs. Codex CLI
 
 Date: 2026-06-22  

--- a/docs/references/lifecycle-clock.md
+++ b/docs/references/lifecycle-clock.md
@@ -1,3 +1,12 @@
+---
+related_files:
+- src/lingtai/kernel/lifecycle_clock/CONTRACT.md
+- src/lingtai/kernel/lifecycle_clock/ANATOMY.md
+- src/lingtai/kernel/lifecycle_clock/__init__.py
+maintenance: |
+  Capability manual for the lifecycle clock Port; reciprocally linked from lifecycle_clock/CONTRACT.md and ANATOMY.md related_files (enforced by tests/test_architecture_documents.py) — keep the wall/monotonic domain guidance synced with the Port's actual contract and implementation.
+---
+
 # Lifecycle Clock — capability manual
 
 The **lifecycle clock** is the kernel's Core-owned boundary for reading time in

--- a/docs/references/runtime-vs-agent-session-objects.md
+++ b/docs/references/runtime-vs-agent-session-objects.md
@@ -1,3 +1,14 @@
+---
+related_files:
+- src/lingtai/kernel/session.py
+- src/lingtai/kernel/base_agent/__init__.py
+- src/lingtai/kernel/base_agent/identity.py
+- src/lingtai/tools/psyche/_molt.py
+- src/lingtai/llm/openai/adapter.py
+maintenance: |
+  Spec-first design doc (status: spec-first, dated 2026-07-02, branch spec/runtime-agent-session-objects-20260702) that cites code by file:line; update its citations and "Implementation status" section as the runtime/agent session objects move from spec to shipped code, so the file:line grounding does not rot.
+---
+
 # Runtime session vs. agent session — explicit kernel objects
 
 Status: **spec-first** (this branch ships the spec + a benchmark/prototype of the

--- a/reports/kernel-release-v0.13.0-20260620/commits.md
+++ b/reports/kernel-release-v0.13.0-20260620/commits.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- reports/kernel-release-v0.13.0-20260620/prs.md
+- reports/kernel-release-v0.13.0-20260620/release-body.md
+maintenance: |
+  Historical record of the v0.13.0 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 - `17d12d4` docs: add GitHub community entry points (#402)
 - `8061f04` feat(read): add max_chars continuation control and manual
 - `b77d91f` docs(procedures): emphasize daemon context isolation

--- a/reports/kernel-release-v0.13.0-20260620/prs.md
+++ b/reports/kernel-release-v0.13.0-20260620/prs.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- reports/kernel-release-v0.13.0-20260620/commits.md
+- reports/kernel-release-v0.13.0-20260620/release-body.md
+maintenance: |
+  Historical record of the v0.13.0 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 - [#402](https://github.com/Lingtai-AI/lingtai-kernel/pull/402) docs: add GitHub community entry points — @huangzesen (13 files, +185/-7)
 - [#405](https://github.com/Lingtai-AI/lingtai-kernel/pull/405) feat(system): add summarize action for tool results — @huangzesen (12 files, +1531/-16)
 - [#406](https://github.com/Lingtai-AI/lingtai-kernel/pull/406) feat(codex): rotate affinity id on refresh and stalled cache — @huangzesen (4 files, +896/-81)

--- a/reports/kernel-release-v0.13.0-20260620/release-body.md
+++ b/reports/kernel-release-v0.13.0-20260620/release-body.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- reports/kernel-release-v0.13.0-20260620/commits.md
+- reports/kernel-release-v0.13.0-20260620/prs.md
+maintenance: |
+  Historical record of the v0.13.0 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 ## LingTai kernel v0.13.0
 
 This release ships the post-v0.12.4 runtime/tooling update set from `v0.12.4..cfebe167`.

--- a/reports/kernel-release-v0.13.1-20260621/commits.md
+++ b/reports/kernel-release-v0.13.1-20260621/commits.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- reports/kernel-release-v0.13.1-20260621/prs.md
+- reports/kernel-release-v0.13.1-20260621/release-body.md
+maintenance: |
+  Historical record of the v0.13.1 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 # Commits
 
 ```

--- a/reports/kernel-release-v0.13.1-20260621/prs.md
+++ b/reports/kernel-release-v0.13.1-20260621/prs.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- reports/kernel-release-v0.13.1-20260621/commits.md
+- reports/kernel-release-v0.13.1-20260621/release-body.md
+maintenance: |
+  Historical record of the v0.13.1 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 # Merge commits / PRs
 
 ```

--- a/reports/kernel-release-v0.13.1-20260621/release-body.md
+++ b/reports/kernel-release-v0.13.1-20260621/release-body.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- reports/kernel-release-v0.13.1-20260621/commits.md
+- reports/kernel-release-v0.13.1-20260621/prs.md
+maintenance: |
+  Historical record of the v0.13.1 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 # LingTai kernel v0.13.1
 
 Patch release for the Python runtime/kernel package after the tool-result metadata and summarize-guidance work.

--- a/reports/kernel-release-v0.14.1-20260623/commits.md
+++ b/reports/kernel-release-v0.14.1-20260623/commits.md
@@ -1,3 +1,10 @@
+---
+related_files:
+- reports/kernel-release-v0.14.1-20260623/release-body.md
+maintenance: |
+  Historical record of the v0.14.1 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 # Commits since v0.14.0
 
 60bc74f fix(daemon): preserve terminal-state notifications

--- a/reports/kernel-release-v0.14.1-20260623/release-body.md
+++ b/reports/kernel-release-v0.14.1-20260623/release-body.md
@@ -1,3 +1,10 @@
+---
+related_files:
+- reports/kernel-release-v0.14.1-20260623/commits.md
+maintenance: |
+  Historical record of the v0.14.1 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 # LingTai kernel v0.14.1
 
 Patch release v0.14.1 is a Codex/runtime stability release on top of v0.14.0. It keeps the kernel package version moving after the Responses/WebSocket cache work landed on main and before the release blogs/docs follow-up.

--- a/reports/kernel-release-v0.15.2-20260627/commits.md
+++ b/reports/kernel-release-v0.15.2-20260627/commits.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- reports/kernel-release-v0.15.2-20260627/release-body.md
+- reports/kernel-release-v0.15.2-20260627/release-report.md
+maintenance: |
+  Historical record of the v0.15.2 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 73cd6fb Delay Codex summarize epoch resets (#534)
 6b12a0d Fix Codex summarize threshold guidance (#535)
 b5b9d58 Expose current-session token efficiency metadata (#537)

--- a/reports/kernel-release-v0.15.2-20260627/release-body.md
+++ b/reports/kernel-release-v0.15.2-20260627/release-body.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- reports/kernel-release-v0.15.2-20260627/commits.md
+- reports/kernel-release-v0.15.2-20260627/release-report.md
+maintenance: |
+  Historical record of the v0.15.2 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 ## Highlights
 - Codex summarize/cache behavior now waits for the provider-side reconstruction trigger before resetting the websocket epoch, preserving incremental continuation when summarize only changed local visible history (#534).
 - Summarize/molt guidance now distinguishes local compaction from delayed provider reconstruction, treats task-boundary molt as the stronger completed-work boundary, and avoids summarize-first when a molt is already planned (#535).

--- a/reports/kernel-release-v0.15.2-20260627/release-report.md
+++ b/reports/kernel-release-v0.15.2-20260627/release-report.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- reports/kernel-release-v0.15.2-20260627/commits.md
+- reports/kernel-release-v0.15.2-20260627/release-body.md
+maintenance: |
+  Historical record of the v0.15.2 release; content is frozen except for factual corrections — do not rewrite retroactively to reflect later changes.
+---
+
 # LingTai kernel v0.15.2 release report
 
 ## Scope

--- a/scripts/check_docs_governance.py
+++ b/scripts/check_docs_governance.py
@@ -36,10 +36,10 @@ EXPECTED_TOP_LEVEL_KEYS = frozenset(
     {
         "name", "version", "extensions", "discovery", "required_fields",
         "field_constraints", "metadata_modes", "metadata_mode_overrides",
-        "placeholder_patterns", "related_files", "maintenance",
+        "placeholder_patterns", "lifecycle_contract", "related_files", "maintenance",
     }
 )
-EXPECTED_CONTRACT_VERSION = 6
+EXPECTED_CONTRACT_VERSION = 7
 EXPECTED_CONTRACT_NAME = "docs-governance-contract"
 EXPECTED_EXTENSIONS = [".md"]
 EXPECTED_DISCOVERY = {"tracked": True, "untracked_not_ignored": True}
@@ -54,6 +54,18 @@ EXPECTED_MAINTENANCE_CONSTRAINT_KEYS = frozenset(
 )
 EXPECTED_METADATA_MODE_NAMES = frozenset({"frontmatter", "html_comment"})
 EXPECTED_METADATA_MODE_OVERRIDES = {".github/PULL_REQUEST_TEMPLATE.md": "html_comment"}
+EXPECTED_LIFECYCLE_KEYS = frozenset(
+    {
+        "field",
+        "supported_values",
+        "exit_condition_field",
+        "exit_condition_min_length",
+        "exit_condition_forbidden_patterns",
+    }
+)
+EXPECTED_LIFECYCLE_FIELD = "lifecycle"
+EXPECTED_LIFECYCLE_SUPPORTED_VALUES = ["temporary"]
+EXPECTED_LIFECYCLE_EXIT_CONDITION_FIELD = "temporary_until"
 
 
 class ContractError(RuntimeError):
@@ -181,6 +193,56 @@ def validate_docs_contract_shape(contract: object) -> dict:
         except re.error as exc:
             raise ContractError(f"docs.yaml: bad placeholder pattern {pattern!r}: {exc}") from exc
 
+    lifecycle_contract = contract.get("lifecycle_contract")
+    if (
+        not isinstance(lifecycle_contract, dict)
+        or set(lifecycle_contract) != EXPECTED_LIFECYCLE_KEYS
+    ):
+        raise ContractError("docs.yaml: lifecycle_contract has the wrong key set")
+    if lifecycle_contract.get("field") != EXPECTED_LIFECYCLE_FIELD:
+        raise ContractError(
+            f"docs.yaml: lifecycle_contract.field must be {EXPECTED_LIFECYCLE_FIELD!r}"
+        )
+    if lifecycle_contract.get("supported_values") != EXPECTED_LIFECYCLE_SUPPORTED_VALUES:
+        raise ContractError(
+            "docs.yaml: lifecycle_contract.supported_values must be exactly "
+            f"{EXPECTED_LIFECYCLE_SUPPORTED_VALUES!r}"
+        )
+    if (
+        lifecycle_contract.get("exit_condition_field")
+        != EXPECTED_LIFECYCLE_EXIT_CONDITION_FIELD
+    ):
+        raise ContractError(
+            "docs.yaml: lifecycle_contract.exit_condition_field must be "
+            f"{EXPECTED_LIFECYCLE_EXIT_CONDITION_FIELD!r}"
+        )
+    exit_min_length = lifecycle_contract.get("exit_condition_min_length")
+    if (
+        not isinstance(exit_min_length, int)
+        or isinstance(exit_min_length, bool)
+        or exit_min_length < 1
+    ):
+        raise ContractError(
+            "docs.yaml: lifecycle_contract.exit_condition_min_length must be a positive integer"
+        )
+    exit_forbidden_patterns = lifecycle_contract.get("exit_condition_forbidden_patterns")
+    if (
+        not isinstance(exit_forbidden_patterns, list)
+        or not exit_forbidden_patterns
+        or not all(isinstance(pattern, str) for pattern in exit_forbidden_patterns)
+    ):
+        raise ContractError(
+            "docs.yaml: lifecycle_contract.exit_condition_forbidden_patterns "
+            "must be a non-empty list of strings"
+        )
+    for pattern in exit_forbidden_patterns:
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            raise ContractError(
+                f"docs.yaml: bad lifecycle exit condition pattern {pattern!r}: {exc}"
+            ) from exc
+
     return contract
 
 
@@ -195,6 +257,13 @@ def load_docs_contract() -> dict:
 
 def compiled_placeholder_patterns(contract: dict) -> list:
     return [re.compile(p) for p in contract["placeholder_patterns"]]
+
+
+def compiled_lifecycle_exit_condition_forbidden_patterns(contract: dict) -> list:
+    return [
+        re.compile(pattern)
+        for pattern in contract["lifecycle_contract"]["exit_condition_forbidden_patterns"]
+    ]
 
 
 def _is_clean_repo_relative_posix_path(rp) -> str | None:
@@ -275,6 +344,62 @@ def validate_metadata_mapping(rel: str, meta, contract: dict) -> list[str]:
             for pat in patterns:
                 if pat.search(value):
                     failures.append(f"{rel}: placeholder left unfilled in maintenance: {value!r}")
+    failures.extend(validate_lifecycle_mapping(rel, meta, contract))
+    return failures
+
+
+def validate_lifecycle_mapping(rel: str, meta: dict, contract: dict) -> list[str]:
+    """OPTIONAL per-document lifecycle check: both fields absent is valid.
+    See docs.yaml's lifecycle_contract prose for the full rationale."""
+    lc = contract["lifecycle_contract"]
+    lifecycle_field = lc["field"]
+    exit_field = lc["exit_condition_field"]
+    has_lifecycle = lifecycle_field in meta
+    has_exit_condition = exit_field in meta
+    if not has_lifecycle and not has_exit_condition:
+        return []
+
+    failures: list[str] = []
+    patterns = compiled_placeholder_patterns(contract)
+    exit_forbidden_patterns = compiled_lifecycle_exit_condition_forbidden_patterns(contract)
+
+    if not has_lifecycle:
+        failures.append(
+            f"{rel}: {exit_field} present without {lifecycle_field!r} set to a supported value"
+        )
+        return failures
+
+    lifecycle_value = meta[lifecycle_field]
+    if not isinstance(lifecycle_value, str) or not lifecycle_value or lifecycle_value not in lc["supported_values"]:
+        failures.append(
+            f"{rel}: {lifecycle_field} must be one of {lc['supported_values']!r}, got {lifecycle_value!r}"
+        )
+        return failures
+
+    if not has_exit_condition:
+        failures.append(f"{rel}: {lifecycle_field}: {lifecycle_value!r} requires {exit_field!r}")
+        return failures
+
+    exit_value = meta[exit_field]
+    if not isinstance(exit_value, str):
+        failures.append(f"{rel}: {exit_field} must be a string, got {type(exit_value).__name__}")
+        return failures
+    if sum(not char.isspace() for char in exit_value) < lc["exit_condition_min_length"]:
+        failures.append(
+            f"{rel}: {exit_field} must contain at least "
+            f"{lc['exit_condition_min_length']} non-whitespace characters"
+        )
+        return failures
+    for pat in patterns:
+        if pat.search(exit_value):
+            failures.append(f"{rel}: placeholder left unfilled in {exit_field}: {exit_value!r}")
+    for pat in exit_forbidden_patterns:
+        if pat.search(exit_value):
+            failures.append(
+                f"{rel}: {exit_field} is non-concrete or contains a placeholder: "
+                f"{exit_value!r}"
+            )
+            break
     return failures
 
 

--- a/scripts/check_docs_governance.py
+++ b/scripts/check_docs_governance.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Standalone docs-governance validator (not a hosted CI workflow — this
+repository has no PR-triggered pytest workflow today; only wheels.yml
+exists, release-triggered, no test step). Runnable locally/anywhere and
+imported by tests/test_docs_governance.py so pytest exercises identical
+logic.
+
+docs.yaml is mechanically authoritative. related_files.target_policy is
+owner_validated_relative_link: this checker validates syntax (non-empty,
+unique, clean repo-relative POSIX-ish string, no self-reference, no
+placeholder) for EVERY document's related_files, but does NOT require
+universal existence — many existing owners (Anatomy/Contract twins, the
+prompt-source progressive-disclosure crawl graph, the molt-gate
+session-journal convention) already encode owner-specific logical/crawl
+link semantics that predate this contract and remain validated by their
+own specialized systems, not by this generic layer.
+
+Usage:
+    python scripts/check_docs_governance.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_YAML = ROOT / "docs.yaml"
+
+EXPECTED_TOP_LEVEL_KEYS = frozenset(
+    {
+        "name", "version", "extensions", "discovery", "required_fields",
+        "field_constraints", "metadata_modes", "metadata_mode_overrides",
+        "placeholder_patterns", "related_files", "maintenance",
+    }
+)
+EXPECTED_CONTRACT_VERSION = 6
+EXPECTED_CONTRACT_NAME = "docs-governance-contract"
+EXPECTED_EXTENSIONS = [".md"]
+EXPECTED_DISCOVERY = {"tracked": True, "untracked_not_ignored": True}
+EXPECTED_REQUIRED_FIELDS = ["related_files", "maintenance"]
+EXPECTED_FIELD_CONSTRAINT_KEYS = frozenset({"related_files", "maintenance"})
+EXPECTED_RELATED_FILES_CONSTRAINT_KEYS = frozenset(
+    {"type", "min_items", "unique", "no_self_reference", "target_policy"}
+)
+EXPECTED_TARGET_POLICIES = frozenset({"owner_validated_relative_link"})
+EXPECTED_MAINTENANCE_CONSTRAINT_KEYS = frozenset(
+    {"type", "min_length", "forbidden_exact_values"}
+)
+EXPECTED_METADATA_MODE_NAMES = frozenset({"frontmatter", "html_comment"})
+EXPECTED_METADATA_MODE_OVERRIDES = {".github/PULL_REQUEST_TEMPLATE.md": "html_comment"}
+
+
+class ContractError(RuntimeError):
+    pass
+
+
+class _UniqueKeyLoader(yaml.SafeLoader):
+    pass
+
+
+def _construct_no_duplicates(loader, node, deep=False):
+    if not isinstance(node, yaml.MappingNode):
+        raise yaml.constructor.ConstructorError(None, None, "expected a mapping node", node.start_mark)
+    mapping = {}
+    for key_node, value_node in node.value:
+        try:
+            key = loader.construct_object(key_node, deep=deep)
+        except TypeError as exc:
+            raise yaml.constructor.ConstructorError(
+                None, None, f"key is not constructible: {exc}", key_node.start_mark
+            ) from exc
+        try:
+            hash(key)
+        except TypeError as exc:
+            raise yaml.constructor.ConstructorError(
+                None, None, f"key is unhashable: {key!r}", key_node.start_mark
+            ) from exc
+        value = loader.construct_object(value_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(None, None, f"duplicate key: {key!r}", key_node.start_mark)
+        mapping[key] = value
+    return mapping
+
+
+_UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_no_duplicates
+)
+
+
+def safe_load_unique(text: str):
+    return yaml.load(text, Loader=_UniqueKeyLoader)  # noqa: S506
+
+
+def validate_docs_contract_shape(contract: object) -> dict:
+    if not isinstance(contract, dict):
+        raise ContractError("docs.yaml: top level is not a mapping")
+    actual_keys = set(contract.keys())
+    if actual_keys != EXPECTED_TOP_LEVEL_KEYS:
+        extra = actual_keys - EXPECTED_TOP_LEVEL_KEYS
+        missing = EXPECTED_TOP_LEVEL_KEYS - actual_keys
+        parts = []
+        if extra:
+            parts.append(f"unrecognized top-level keys: {sorted(map(str, extra))}")
+        if missing:
+            parts.append(f"missing top-level keys: {sorted(missing)}")
+        raise ContractError(f"docs.yaml: {'; '.join(parts)}")
+    if contract.get("name") != EXPECTED_CONTRACT_NAME:
+        raise ContractError(f"docs.yaml: name must be {EXPECTED_CONTRACT_NAME!r}")
+    if contract.get("version") != EXPECTED_CONTRACT_VERSION:
+        raise ContractError(f"docs.yaml: unsupported version {contract.get('version')!r}")
+    if contract.get("extensions") != EXPECTED_EXTENSIONS:
+        raise ContractError("docs.yaml: extensions must be exactly ['.md']")
+    if contract.get("discovery") != EXPECTED_DISCOVERY:
+        raise ContractError(f"docs.yaml: discovery must be exactly {EXPECTED_DISCOVERY!r}")
+    if contract.get("required_fields") != EXPECTED_REQUIRED_FIELDS:
+        raise ContractError(f"docs.yaml: required_fields must be exactly {EXPECTED_REQUIRED_FIELDS!r}")
+
+    fc = contract.get("field_constraints")
+    if not isinstance(fc, dict) or set(fc) != EXPECTED_FIELD_CONSTRAINT_KEYS:
+        raise ContractError("docs.yaml: field_constraints has the wrong key set")
+    rf = fc["related_files"]
+    if not isinstance(rf, dict) or set(rf) != EXPECTED_RELATED_FILES_CONSTRAINT_KEYS:
+        raise ContractError("docs.yaml: field_constraints.related_files has the wrong key set")
+    if rf.get("type") != "list" or not isinstance(rf.get("min_items"), int) or isinstance(rf.get("min_items"), bool) or rf["min_items"] < 1:
+        raise ContractError("docs.yaml: field_constraints.related_files has an invalid type/min_items")
+    if rf.get("unique") is not True:
+        raise ContractError("docs.yaml: field_constraints.related_files.unique must be true")
+    if rf.get("no_self_reference") is not True:
+        raise ContractError("docs.yaml: field_constraints.related_files.no_self_reference must be true")
+    if rf.get("target_policy") not in EXPECTED_TARGET_POLICIES:
+        raise ContractError(
+            f"docs.yaml: field_constraints.related_files.target_policy must be one of "
+            f"{sorted(EXPECTED_TARGET_POLICIES)}"
+        )
+    maint = fc["maintenance"]
+    if not isinstance(maint, dict) or set(maint) != EXPECTED_MAINTENANCE_CONSTRAINT_KEYS:
+        raise ContractError("docs.yaml: field_constraints.maintenance has the wrong key set")
+    if maint.get("type") != "string" or not isinstance(maint.get("min_length"), int) or isinstance(maint.get("min_length"), bool) or maint["min_length"] < 1:
+        raise ContractError("docs.yaml: field_constraints.maintenance has an invalid type/min_length")
+    forbidden = maint.get("forbidden_exact_values")
+    if not isinstance(forbidden, list) or not forbidden or not all(
+        isinstance(item, str) and item for item in forbidden
+    ):
+        raise ContractError(
+            "docs.yaml: field_constraints.maintenance.forbidden_exact_values "
+            "must be a non-empty list of strings"
+        )
+    normalized_forbidden = [item.strip().casefold() for item in forbidden]
+    if forbidden != normalized_forbidden or len(forbidden) != len(set(forbidden)):
+        raise ContractError(
+            "docs.yaml: field_constraints.maintenance.forbidden_exact_values "
+            "must contain unique, stripped, casefolded values"
+        )
+
+    modes = contract.get("metadata_modes")
+    if not isinstance(modes, dict) or set(modes) != EXPECTED_METADATA_MODE_NAMES:
+        raise ContractError("docs.yaml: metadata_modes has the wrong key set")
+    defaults = [n for n, m in modes.items() if isinstance(m, dict) and m.get("applies_to") == "*"]
+    if len(defaults) != 1:
+        raise ContractError(f"docs.yaml: expected exactly one default metadata mode, found {len(defaults)}")
+
+    overrides = contract.get("metadata_mode_overrides")
+    if overrides != EXPECTED_METADATA_MODE_OVERRIDES:
+        raise ContractError(f"docs.yaml: metadata_mode_overrides must be exactly {EXPECTED_METADATA_MODE_OVERRIDES!r}")
+    for path, mode_name in overrides.items():
+        if mode_name not in modes:
+            raise ContractError(f"docs.yaml: metadata_mode_overrides[{path!r}] references unsupported mode {mode_name!r}")
+
+    patterns = contract.get("placeholder_patterns")
+    if not isinstance(patterns, list) or not patterns or not all(isinstance(p, str) for p in patterns):
+        raise ContractError("docs.yaml: placeholder_patterns must be a non-empty list of strings")
+    for pattern in patterns:
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            raise ContractError(f"docs.yaml: bad placeholder pattern {pattern!r}: {exc}") from exc
+
+    return contract
+
+
+def load_docs_contract() -> dict:
+    text = DOCS_YAML.read_text(encoding="utf-8")
+    try:
+        contract = safe_load_unique(text)
+    except yaml.YAMLError as exc:
+        raise ContractError(f"docs.yaml: YAML parse error: {exc}") from exc
+    return validate_docs_contract_shape(contract)
+
+
+def compiled_placeholder_patterns(contract: dict) -> list:
+    return [re.compile(p) for p in contract["placeholder_patterns"]]
+
+
+def _is_clean_repo_relative_posix_path(rp) -> str | None:
+    if not isinstance(rp, str):
+        return f"not a string: {rp!r}"
+    if not rp:
+        return "empty path"
+    if rp != rp.strip():
+        return f"has leading/trailing whitespace: {rp!r}"
+    if re.match(r"^[A-Za-z]:", rp):
+        return f"contains a Windows drive designator: {rp!r}"
+    if "\\" in rp:
+        return f"contains a backslash: {rp!r}"
+    if rp.startswith("/") or rp.endswith("/"):
+        return f"absolute or trailing-slash path: {rp!r}"
+    # Validate raw segments instead of normalizing with PurePosixPath: path
+    # normalization would silently erase './' and repeated-slash segments.
+    for segment in rp.split("/"):
+        if segment in ("", ".", ".."):
+            return f"contains an empty/'.'/'..' segment: {rp!r}"
+    return None
+
+
+def validate_metadata_mapping(rel: str, meta, contract: dict) -> list[str]:
+    """SYNTAX-ONLY generic validation for related_files under
+    target_policy: owner_validated_relative_link — no repo_root, no
+    existence check. This is intentional: see module docstring."""
+    if not isinstance(meta, dict):
+        return [f"{rel}: metadata did not parse to a mapping"]
+    failures: list[str] = []
+    patterns = compiled_placeholder_patterns(contract)
+    constraints = contract["field_constraints"]
+    for field in contract["required_fields"]:
+        if field not in meta:
+            failures.append(f"{rel}: missing required field {field!r}")
+            continue
+        value = meta[field]
+        if field == "related_files":
+            c = constraints["related_files"]
+            if not isinstance(value, list):
+                failures.append(f"{rel}: related_files must be a list, got {type(value).__name__}")
+                continue
+            if len(value) < c["min_items"]:
+                failures.append(f"{rel}: related_files must have at least {c['min_items']} item(s)")
+                continue
+            hashable_items = []
+            for item in value:
+                path_error = _is_clean_repo_relative_posix_path(item)
+                if path_error is not None:
+                    failures.append(f"{rel}: related_files invalid entry: {path_error}")
+                    continue
+                hashable_items.append(item)
+            if c["unique"] and len(hashable_items) != len(set(hashable_items)):
+                failures.append(f"{rel}: related_files contains duplicate paths")
+            if c["no_self_reference"] and rel in hashable_items:
+                failures.append(f"{rel}: related_files self-reference")
+            for rp in hashable_items:
+                for pat in patterns:
+                    if pat.search(rp):
+                        failures.append(f"{rel}: placeholder left unfilled in related_files: {rp!r}")
+        elif field == "maintenance":
+            c = constraints["maintenance"]
+            if not isinstance(value, str):
+                failures.append(f"{rel}: maintenance must be a string, got {type(value).__name__}")
+                continue
+            normalized_value = value.strip().casefold()
+            if normalized_value in c["forbidden_exact_values"]:
+                failures.append(
+                    f"{rel}: maintenance is a forbidden exact placeholder value: {value!r}"
+                )
+                continue
+            if len(value.strip()) < c["min_length"]:
+                failures.append(
+                    f"{rel}: maintenance must contain at least "
+                    f"{c['min_length']} non-whitespace characters"
+                )
+                continue
+            for pat in patterns:
+                if pat.search(value):
+                    failures.append(f"{rel}: placeholder left unfilled in maintenance: {value!r}")
+    return failures
+
+
+def _mode_for(rel: str, contract: dict) -> str | None:
+    override = contract["metadata_mode_overrides"].get(rel)
+    if override is not None:
+        return override if override in contract["metadata_modes"] else None
+    for name, mode in contract["metadata_modes"].items():
+        if isinstance(mode, dict) and mode.get("applies_to") == "*":
+            return name
+    return None
+
+
+def parse_doc_metadata_text(rel: str, text: str, contract: dict):
+    mode = _mode_for(rel, contract)
+    if mode is None:
+        return None, f"{rel}: no supported metadata mode resolved (contract drift)"
+    if mode == "html_comment":
+        if not text.lstrip().startswith("<!--"):
+            return None, f"{rel}: missing HTML-comment metadata block"
+        start = text.index("<!--") + 4
+        if "-->" not in text[start:]:
+            return None, f"{rel}: malformed HTML-comment metadata block (no closing -->)"
+        end = text.index("-->", start)
+        raw = text[start:end]
+    elif mode == "frontmatter":
+        if not text.startswith("---\n"):
+            return None, f"{rel}: missing or unparseable frontmatter (no --- fence)"
+        lines = text.splitlines(keepends=True)
+        end_idx = None
+        for i in range(1, len(lines)):
+            if lines[i].rstrip("\n") == "---":
+                end_idx = i
+                break
+        if end_idx is None:
+            return None, f"{rel}: frontmatter opening fence with no closing fence"
+        raw = "".join(lines[1:end_idx])
+    else:
+        return None, f"{rel}: unsupported metadata mode {mode!r} (contract drift)"
+    try:
+        meta = safe_load_unique(raw)
+    except yaml.YAMLError as exc:
+        return None, f"{rel}: YAML parse error: {exc}"
+    if not isinstance(meta, dict):
+        return None, f"{rel}: metadata did not parse to a mapping"
+    return meta, None
+
+
+def _git_files(*args: str) -> list[str]:
+    proc = subprocess.run(
+        ["git", "ls-files", *args], cwd=ROOT, capture_output=True, text=True, check=True
+    )
+    return [line for line in proc.stdout.splitlines() if line]
+
+
+def discover_doc_paths(contract: dict) -> list[Path]:
+    exts = tuple(contract["extensions"])
+    tracked = _git_files() if contract["discovery"].get("tracked") else []
+    untracked = (
+        _git_files("--others", "--exclude-standard")
+        if contract["discovery"].get("untracked_not_ignored") else []
+    )
+    all_paths = sorted(set(tracked) | set(untracked))
+    return [ROOT / p for p in all_paths if p.endswith(exts)]
+
+
+def check_one_document_path(path: Path, contract: dict, *, repo_root: Path) -> list[str]:
+    rel = path.relative_to(repo_root).as_posix()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return [f"{rel}: could not read file: {exc}"]
+    meta, error = parse_doc_metadata_text(rel, text, contract)
+    if error is not None:
+        return [error]
+    return validate_metadata_mapping(rel, meta, contract)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.check:
+        parser.print_help()
+        return 1
+
+    try:
+        contract = load_docs_contract()
+    except ContractError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    all_failures: list[str] = []
+    paths = discover_doc_paths(contract)
+    for path in paths:
+        all_failures.extend(check_one_document_path(path, contract, repo_root=ROOT))
+    # docs.yaml validates its OWN related_files/maintenance via the same
+    # shared function — never fed through Markdown/comment parsing.
+    all_failures.extend(validate_metadata_mapping("docs.yaml", contract, contract))
+
+    if all_failures:
+        print("FAIL: docs governance validation found violations:", file=sys.stderr)
+        for failure in all_failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {len(paths)} documents (+ docs.yaml itself) validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lingtai/intrinsic_skills/file-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/file-manual/SKILL.md
@@ -4,6 +4,13 @@ description: "Operational guide for LingTai's built-in file tools: read, write, 
 version: 0.1.0
 tags: [files, read, write, edit, grep, glob, encoding, utf-8]
 last_changed_at: "2026-05-26T03:24:43-07:00"
+related_files:
+- src/lingtai/tools/read/__init__.py
+- src/lingtai/tools/write/__init__.py
+- src/lingtai/tools/edit/__init__.py
+- src/lingtai/intrinsic_skills/read-manual/SKILL.md
+maintenance: |
+  Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
 ---
 
 # File Manual

--- a/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
@@ -10,6 +10,10 @@ description: >
 version: 0.1.0
 tags: [doctor, diagnostics, mcp, addons, heartbeat, migration, recovery]
 last_changed_at: "2026-06-12T14:27:46-07:00"
+related_files:
+- src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
+maintenance: |
+  Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
 ---
 
 # LingTai Doctor

--- a/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
@@ -9,6 +9,12 @@ description: >
   and navigation disagree.
 version: 0.3.0
 last_changed_at: "2026-07-11T18:35:00-07:00"
+related_files:
+- ANATOMY.md
+- src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py
+- src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/bench_agent_session_rebuild.py
+maintenance: |
+  Tracks the ANATOMY.md/CONTRACT.md convention it routes into; update when the root anatomy-of-anatomy or the pairing/link rules it summarizes change.
 ---
 
 # LingTai Kernel Anatomy — Navigation Router

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -11,6 +11,12 @@ description: >
   point-in-time history reads.
 version: 0.3.0
 tags: [nokv, mcp, workbench, artifacts, provenance, snapshots, checkpoints, leases]
+related_files:
+- src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
+- src/lingtai/intrinsic_skills/nokv-workbench/assets/init-snippet.json
+- src/lingtai/intrinsic_skills/nokv-workbench/assets/mcp_registry.example.jsonl
+maintenance: |
+  Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
 ---
 
 # NoKV Workbench

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
@@ -1,3 +1,10 @@
+---
+related_files:
+- src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+maintenance: |
+  Developer-facing TUI deployment preflight pointed to by nokv-workbench/SKILL.md:49; update it whenever the workbench MCP tool surface (9-tool vs 16-tool, checkpoint-lifecycle fields) or the runtime-version compatibility check changes.
+---
+
 # TUI runtime preflight (developer-facing)
 
 This is deployment guidance for developers installing a workbench-enabled

--- a/src/lingtai/intrinsic_skills/notification-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/SKILL.md
@@ -10,6 +10,13 @@ description: >
 version: 0.4.0
 tags: [lingtai, notifications, channels, dismiss, manual, force, stale, nudge]
 last_changed_at: "2026-07-12T20:20:43-07:00"
+related_files:
+- src/lingtai/tools/notification/__init__.py
+- src/lingtai/tools/notification/schema.py
+- src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
+- src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
+maintenance: |
+  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # Notification Manual — Router

--- a/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
@@ -9,6 +9,12 @@ description: >
 version: 0.1.0
 tags: [lingtai, notifications, channels, protocol, sync, nudge]
 last_changed_at: "2026-07-12T20:20:43-07:00"
+related_files:
+- src/lingtai/intrinsic_skills/notification-manual/SKILL.md
+- src/lingtai/tools/notification/schema.py
+- src/lingtai/kernel/notification_store/__init__.py
+maintenance: |
+  Tracks the notification channel-model/protocol topic it documents; update when that integration changes.
 ---
 
 # Notification Channel Model

--- a/src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
@@ -10,6 +10,12 @@ description: >
 version: 0.1.0
 tags: [lingtai, notifications, dismiss, force, stale, safety]
 last_changed_at: "2026-07-12T20:20:43-07:00"
+related_files:
+- src/lingtai/intrinsic_skills/notification-manual/SKILL.md
+- src/lingtai/tools/notification/__init__.py
+- src/lingtai/tools/notification/schema.py
+maintenance: |
+  Tracks the notification dismissal-safety topic it documents; update when that integration changes.
 ---
 
 # Notification Dismissal Safety

--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -4,6 +4,13 @@ description: |
   Router and operational guide for the psyche tool — molt, pad management, session journaling, and post-wipe recovery. Read this when: you are about to molt; you need to tend the four durable stores; you want guidance on writing a good summary or session journal; you wake up after a system-performed wipe with a system-authored summary; or you need to understand keep_tool_calls, keep_last, and pad.append. Routes consequential molt handoffs to assets/molt-template.md while keeping routine guidance compact.
 version: 1.1.0
 last_changed_at: "2026-07-06T14:50:00-07:00"
+related_files:
+- src/lingtai/tools/psyche/__init__.py
+- src/lingtai/tools/psyche/_molt.py
+- src/lingtai/tools/psyche/_pad.py
+- src/lingtai/tools/psyche/_session_journal.py
+maintenance: |
+  Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
 ---
 
 # Psyche Manual

--- a/src/lingtai/intrinsic_skills/psyche-manual/assets/molt-template.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/assets/molt-template.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+- tests/test_skills.py
+maintenance: |
+  Consequential-molt summary scaffold referenced by psyche-manual/SKILL.md and asserted on by tests/test_skills.py; keep its 9-section structure and heading text synced with both, since the test pins exact section headings verbatim.
+---
+
 # Consequential Molt Summary Template
 
 Use this asset when a molt is more than routine: long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, active background jobs, or any handoff the next you could not reconstruct quickly.

--- a/src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
@@ -1,3 +1,12 @@
+---
+related_files:
+- src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+- src/lingtai/tools/psyche/_session_journal.py
+- src/lingtai/tools/psyche/ANATOMY.md
+maintenance: |
+  Session-journal / molt-history entry scaffold whose required frontmatter marker (`type: session-journal`) and path convention are enforced by the molt gate in src/lingtai/tools/psyche/_session_journal.py; update it in lockstep whenever that validator's required fields or path rule change.
+---
+
 # Session-Journal / Molt-History Entry Template
 
 Use this when writing the molt-history record for a session segment, *before* a

--- a/src/lingtai/intrinsic_skills/read-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/read-manual/SKILL.md
@@ -4,6 +4,11 @@ description: "Complete guide for the read tool: continuation workflow, next_offs
 version: 0.1.0
 tags: [read, files, continuation, truncation, cap, pagination]
 last_changed_at: "2026-06-27T02:45:37-07:00"
+related_files:
+- src/lingtai/tools/read/__init__.py
+- src/lingtai/intrinsic_skills/file-manual/SKILL.md
+maintenance: |
+  Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
 ---
 
 # Read Manual

--- a/src/lingtai/intrinsic_skills/soul-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/soul-manual/SKILL.md
@@ -4,6 +4,13 @@ description: |
   Operational guide for the `soul` tool — your inner voice. Read this when: you call `soul(action='flow')` and get a `status: disabled` result; you want to understand why soul flow is off by default and how the operator enables it; you are tuning `delay_seconds`/`consultation_past_count` with `config` and want to know whether fires will actually happen; or you need the difference between the always-available actions (inquiry/config/voice/dismiss) and the opt-in `flow`. Covers the `LINGTAI_SOUL_FLOW_ENABLED` env gate, disabled-flow behavior, delay-vs-off-switch semantics, enabling/disabling, troubleshooting, and the privacy/cost rationale.
 version: 1.0.0
 last_changed_at: "2026-07-01T09:00:00-07:00"
+related_files:
+- src/lingtai/tools/soul/__init__.py
+- src/lingtai/tools/soul/flow.py
+- src/lingtai/tools/soul/config.py
+- src/lingtai/tools/soul/consultation.py
+maintenance: |
+  Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
 ---
 
 # Soul Manual

--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -23,6 +23,13 @@ description: >
 version: 1.6.0
 tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize, nudge, updates, runtime-checks, preset]
 last_changed_at: "2026-07-13T00:00:00-07:00"
+related_files:
+- src/lingtai/prompts/substrate/substrate.md
+- src/lingtai/prompts/procedures/procedures.md
+- src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+maintenance: |
+  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # System Manual — Progressive Disclosure Router

--- a/src/lingtai/intrinsic_skills/system-manual/reference/goal-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/goal-manual/SKILL.md
@@ -7,6 +7,11 @@ description: >
 version: 0.2.0
 tags: [lingtai, goal, notifications, reminders]
 last_changed_at: "2026-07-12T20:20:43-07:00"
+related_files:
+- src/lingtai/intrinsic_skills/system-manual/SKILL.md
+- src/lingtai/kernel/nudge/goal.py
+maintenance: |
+  Tracks the goal-notification topic it documents; update when that integration changes.
 ---
 
 # Goal Manual

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -14,6 +14,12 @@ description: >
 version: 1.2.0
 tags: [lingtai, system-manual, procedures, progressive-disclosure, responsiveness, deliverables, issue-reporting]
 last_changed_at: "2026-07-03T00:00:00Z"
+related_files:
+- src/lingtai/intrinsic_skills/system-manual/SKILL.md
+- src/lingtai/prompts/procedures/procedures.md
+- src/lingtai/prompts/procedures/procedures.yaml
+maintenance: |
+  Tracks the procedures-manual topic it documents; update when that integration changes.
 ---
 
 # Procedures Manual

--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -10,6 +10,12 @@ description: >
 version: 0.1.0
 tags: [lingtai, runtime, kernel, nudge, updates, refresh, editable, dev-mode]
 last_changed_at: "2026-06-23T23:50:45-07:00"
+related_files:
+- src/lingtai/intrinsic_skills/system-manual/SKILL.md
+- src/lingtai/kernel/nudge/kernel_version.py
+- src/lingtai/kernel/nudge/__init__.py
+maintenance: |
+  Tracks the runtime-update-checks topic it documents; update when that integration changes.
 ---
 
 # Runtime Update Checks

--- a/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
@@ -15,6 +15,11 @@ description: >
 version: 1.2.0
 tags: [lingtai, system-manual, sqlite, log.sqlite, runtime-logs, trace, jsonl, daemon, trajectory, mining, event-log, improvement, pitfalls, observability, cheap-model]
 last_changed_at: "2026-06-24T23:45:17-07:00"
+related_files:
+- src/lingtai/intrinsic_skills/system-manual/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/scripts/event_summary.py
+maintenance: |
+  Tracks the sqlite-log-query topic it documents; update when that integration changes.
 ---
 
 # SQLite Log Query

--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -16,6 +16,12 @@ description: >
 version: 1.2.0
 tags: [lingtai, system-manual, substrate, runtime, lifecycle, communication, memory, notifications, mcp, preset]
 last_changed_at: "2026-07-14T00:00:00-07:00"
+related_files:
+- src/lingtai/intrinsic_skills/system-manual/SKILL.md
+- src/lingtai/prompts/substrate/substrate.md
+- src/lingtai/prompts/substrate/substrate.yaml
+maintenance: |
+  Tracks the substrate-manual topic it documents; update when that integration changes.
 ---
 
 # Substrate Manual

--- a/src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual/SKILL.md
@@ -9,6 +9,13 @@ description: >-
   during idle cleanup, how to write good summaries, how to recover the original
   tool result by tool_call_id, and how summarize differs from molt.
 last_changed_at: "2026-07-03T00:00:00Z"
+related_files:
+- src/lingtai/intrinsic_skills/system-manual/SKILL.md
+- src/lingtai/tools/system/summarize.py
+- src/lingtai/prompts/meta_guidance/catalog/summarize_best_practice.md
+- src/lingtai/prompts/meta_guidance/catalog/summarize_reconstruction_threshold.md
+maintenance: |
+  Tracks the summarize-manual topic it documents; update when that integration changes.
 ---
 
 # Summarize Manual

--- a/src/lingtai/kernel/tool_glossary.py
+++ b/src/lingtai/kernel/tool_glossary.py
@@ -94,7 +94,14 @@ def normalize_tool_glossary_language(language: object) -> str:
 _FILENAME_BY_LANG: dict[str, str] = {lang: f"glossary-{lang}.md" for lang in _KNOWN}
 
 _EXPECTED_FRONTMATTER_KEYS = frozenset(
-    {"kind", "schema_version", "tool_package", "language"}
+    {
+        "kind",
+        "schema_version",
+        "tool_package",
+        "language",
+        "related_files",
+        "maintenance",
+    }
 )
 
 
@@ -169,6 +176,8 @@ def parse_glossary(
         schema_version: 1
         tool_package: <tool_package>
         language: <language>
+        related_files: [<repo-relative path>, ...]
+        maintenance: <non-empty string>
         ---
 
     The body (everything after the closing fence) is returned verbatim.
@@ -229,6 +238,21 @@ def parse_glossary(
     lang = doc["language"]
     if not isinstance(lang, str) or lang != language:
         raise GlossaryValidationError(f"language must be {language!r}, got {lang!r}")
+
+    related = doc["related_files"]
+    if not isinstance(related, list) or not related or not all(
+        isinstance(item, str) and item for item in related
+    ):
+        raise GlossaryValidationError(
+            "related_files must be a non-empty list of non-empty strings, "
+            f"got {related!r}"
+        )
+
+    maint = doc["maintenance"]
+    if not isinstance(maint, str) or not maint.strip():
+        raise GlossaryValidationError(
+            f"maintenance must be a non-empty string, got {maint!r}"
+        )
 
     return body
 

--- a/src/lingtai/mcp_servers/cloud_mail/SKILL.md
+++ b/src/lingtai/mcp_servers/cloud_mail/SKILL.md
@@ -9,6 +9,12 @@ description: |
   do not need to call it before every send.
 version: 1.0.0
 last_changed_at: "2026-06-26T14:33:19-07:00"
+related_files:
+- src/lingtai/mcp_servers/cloud_mail/manager.py
+- src/lingtai/mcp_servers/cloud_mail/server.py
+- src/lingtai/mcp_servers/cloud_mail/client.py
+maintenance: |
+  Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
 ---
 
 # Cloud Mail MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/feishu/SKILL.md
+++ b/src/lingtai/mcp_servers/feishu/SKILL.md
@@ -10,6 +10,12 @@ description: |
   send.
 version: 1.1.0
 last_changed_at: "2026-07-06T00:00:00-07:00"
+related_files:
+- src/lingtai/mcp_servers/feishu/manager.py
+- src/lingtai/mcp_servers/feishu/server.py
+- src/lingtai/mcp_servers/feishu/service.py
+maintenance: |
+  Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
 ---
 
 # Feishu (Lark) MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/feishu/manager.py
+++ b/src/lingtai/mcp_servers/feishu/manager.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, TYPE_CHECKING
 from uuid import uuid4
 
 from .. import _skill
+from lingtai.kernel._frontmatter import strip_frontmatter
 
 if TYPE_CHECKING:
     from .service import FeishuService
@@ -33,9 +34,10 @@ log = logging.getLogger(__name__)
 
 
 def _load_notification_header_template() -> str:
-    return resources.files(__package__).joinpath("notification_header.md").read_text(
+    text = resources.files(__package__).joinpath("notification_header.md").read_text(
         encoding="utf-8"
     )
+    return strip_frontmatter(text)
 
 
 _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()

--- a/src/lingtai/mcp_servers/feishu/notification_header.md
+++ b/src/lingtai/mcp_servers/feishu/notification_header.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- src/lingtai/mcp_servers/feishu/manager.py
+- src/lingtai/mcp_servers/telegram/notification_header.md
+maintenance: |
+  Outbound chat-message header template loaded raw by _load_notification_header_template() in manager.py and sent verbatim to Feishu users after .format(channel=...); the loader strips YAML frontmatter via lingtai.kernel._frontmatter.strip_frontmatter before use, so this file's body — not its frontmatter — is user-facing. Update the body in lockstep with the other three notification_header.md siblings when the shared preview/responsiveness guidance changes.
+---
+
 **How to read this {channel} conversation preview (high attention)**
 This preview is context for one notification; it is not itself a list of new instructions.
 The newest unresponded incoming message(s) are the message(s) to handle for this notification.

--- a/src/lingtai/mcp_servers/imap/SKILL.md
+++ b/src/lingtai/mcp_servers/imap/SKILL.md
@@ -10,6 +10,12 @@ description: |
   it before every send.
 version: 1.0.0
 last_changed_at: "2026-06-27T17:30:57-07:00"
+related_files:
+- src/lingtai/mcp_servers/imap/manager.py
+- src/lingtai/mcp_servers/imap/server.py
+- src/lingtai/mcp_servers/imap/service.py
+maintenance: |
+  Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
 ---
 
 # IMAP/SMTP email MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -11,6 +11,12 @@ description: |
   before every send.
 version: 1.5.1
 last_changed_at: "2026-07-13T12:15:00-07:00"
+related_files:
+- src/lingtai/mcp_servers/telegram/manager.py
+- src/lingtai/mcp_servers/telegram/server.py
+- src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+maintenance: |
+  Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
 ---
 
 # Telegram MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -34,10 +34,14 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+from lingtai.kernel._frontmatter import strip_frontmatter
+
+
 def _load_notification_header_template() -> str:
-    return resources.files(__package__).joinpath("notification_header.md").read_text(
+    text = resources.files(__package__).joinpath("notification_header.md").read_text(
         encoding="utf-8"
     )
+    return strip_frontmatter(text)
 
 
 # ---------------------------------------------------------------------------

--- a/src/lingtai/mcp_servers/telegram/notification_header.md
+++ b/src/lingtai/mcp_servers/telegram/notification_header.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- src/lingtai/mcp_servers/telegram/manager.py
+- src/lingtai/mcp_servers/feishu/notification_header.md
+maintenance: |
+  Outbound chat-message header template loaded raw by _load_notification_header_template() in manager.py and sent verbatim to Telegram users after .format(channel=...); the loader strips YAML frontmatter via lingtai.kernel._frontmatter.strip_frontmatter before use, so this file's body — not its frontmatter — is user-facing. Update the body in lockstep with the other three notification_header.md siblings when the shared preview/responsiveness guidance changes.
+---
+
 **How to read this {channel} conversation preview (high attention)**
 This preview is context for one notification; it is not itself a list of new instructions.
 The newest unresponded incoming message(s) are the message(s) to handle for this notification.

--- a/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
@@ -10,6 +10,13 @@ description: |
   start | inspect | retry | stop lifecycle, path/timeout/validation rules,
   fail-loud error wakes, and how the /taskcard toggle interacts.
 last_changed_at: "2026-07-13T15:00:00-07:00"
+related_files:
+- src/lingtai/mcp_servers/telegram/SKILL.md
+- src/lingtai/mcp_servers/telegram/task_card/controller.py
+- src/lingtai/mcp_servers/telegram/task_card/interface.py
+- src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+maintenance: |
+  Tracks the Telegram Task Card renderer/controller behavior it documents; update when that integration changes.
 ---
 
 # Programmable Telegram Task Card — manual (what / how / why)

--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -8,6 +8,12 @@ description: |
   demand via action='manual'; you do not need to call it before every send.
 version: 1.0.0
 last_changed_at: "2026-06-26T14:33:19-07:00"
+related_files:
+- src/lingtai/mcp_servers/wechat/manager.py
+- src/lingtai/mcp_servers/wechat/server.py
+- src/lingtai/mcp_servers/wechat/api.py
+maintenance: |
+  Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
 ---
 
 # WeChat MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -33,10 +33,14 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+from lingtai.kernel._frontmatter import strip_frontmatter
+
+
 def _load_notification_header_template() -> str:
-    return resources.files(__package__).joinpath("notification_header.md").read_text(
+    text = resources.files(__package__).joinpath("notification_header.md").read_text(
         encoding="utf-8"
     )
+    return strip_frontmatter(text)
 
 
 _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()

--- a/src/lingtai/mcp_servers/wechat/notification_header.md
+++ b/src/lingtai/mcp_servers/wechat/notification_header.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- src/lingtai/mcp_servers/wechat/manager.py
+- src/lingtai/mcp_servers/feishu/notification_header.md
+maintenance: |
+  Outbound chat-message header template loaded raw by _load_notification_header_template() in manager.py and sent verbatim to WeChat users after .format(channel=...); the loader strips YAML frontmatter via lingtai.kernel._frontmatter.strip_frontmatter before use, so this file's body — not its frontmatter — is user-facing. Update the body in lockstep with the other three notification_header.md siblings when the shared preview/responsiveness guidance changes.
+---
+
 **How to read this {channel} conversation preview (high attention)**
 This preview is context for one notification; it is not itself a list of new instructions.
 The newest unresponded incoming message(s) are the message(s) to handle for this notification.

--- a/src/lingtai/mcp_servers/whatsapp/SKILL.md
+++ b/src/lingtai/mcp_servers/whatsapp/SKILL.md
@@ -10,6 +10,12 @@ description: |
   do not need to call it before every send.
 version: 1.1.0
 last_changed_at: "2026-07-06T00:00:00-07:00"
+related_files:
+- src/lingtai/mcp_servers/whatsapp/manager.py
+- src/lingtai/mcp_servers/whatsapp/server.py
+- src/lingtai/mcp_servers/whatsapp/client.py
+maintenance: |
+  Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
 ---
 
 # WhatsApp MCP — usage manual (progressive disclosure)

--- a/src/lingtai/mcp_servers/whatsapp/manager.py
+++ b/src/lingtai/mcp_servers/whatsapp/manager.py
@@ -19,8 +19,12 @@ from .. import _identity, _skill
 log = logging.getLogger(__name__)
 
 
+from lingtai.kernel._frontmatter import strip_frontmatter
+
+
 def _load_notification_header_template() -> str:
-    return resources.files(__package__).joinpath("notification_header.md").read_text(encoding="utf-8")
+    text = resources.files(__package__).joinpath("notification_header.md").read_text(encoding="utf-8")
+    return strip_frontmatter(text)
 
 
 _NOTIFICATION_HEADER_TEMPLATE = _load_notification_header_template()

--- a/src/lingtai/mcp_servers/whatsapp/notification_header.md
+++ b/src/lingtai/mcp_servers/whatsapp/notification_header.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- src/lingtai/mcp_servers/whatsapp/manager.py
+- src/lingtai/mcp_servers/feishu/notification_header.md
+maintenance: |
+  Outbound chat-message header template loaded raw by _load_notification_header_template() in manager.py and sent verbatim to WhatsApp users after .format(channel=...); the loader strips YAML frontmatter via lingtai.kernel._frontmatter.strip_frontmatter before use, so this file's body — not its frontmatter — is user-facing. Update the body in lockstep with the other three notification_header.md siblings when the shared preview/responsiveness guidance changes.
+---
+
 **How to read this {channel} conversation preview (high attention)**
 This preview is context for one notification; it is not itself a list of new instructions.
 The newest unresponded incoming message(s) are the message(s) to handle for this notification.

--- a/src/lingtai/tools/avatar/glossary-en.md
+++ b/src/lingtai/tools/avatar/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.avatar
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/avatar/glossary-zh.md
+- src/lingtai/tools/avatar/glossary-wen.md
+maintenance: |
+  English glossary for the `avatar` tool package (lingtai.tools.avatar); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when avatar's public tool schema (function names, JSON property names, action/enum values) changes.
 ---

--- a/src/lingtai/tools/avatar/glossary-wen.md
+++ b/src/lingtai/tools/avatar/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.avatar
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/avatar/glossary-en.md
+- src/lingtai/tools/avatar/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `avatar` tool package (lingtai.tools.avatar); body must stay non-empty and distinct from glossary-zh.md (tool_glossary.py enforces both). Update in lockstep with glossary-en.md/glossary-zh.md whenever avatar's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/avatar/glossary-zh.md
+++ b/src/lingtai/tools/avatar/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.avatar
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/avatar/glossary-en.md
+- src/lingtai/tools/avatar/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `avatar` tool package (lingtai.tools.avatar); body must stay non-empty (tool_glossary.py enforces this). Update in lockstep with glossary-en.md/glossary-wen.md whenever avatar's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/avatar/manual/SKILL.md
+++ b/src/lingtai/tools/avatar/manual/SKILL.md
@@ -4,6 +4,12 @@ description: |
   Complete operational guide for the avatar tool — spawning, managing, and communicating with 他我 (alter-ego agents). Read this when: you are about to spawn an avatar; an avatar you spawned goes quiet; you need to decide between avatar, daemon, or bash; or you are an avatar and need to know how to escalate to your parent. Covers spawn types, naming rules, discipline, escalation protocol, and the parent_prompt contract.
 version: 1.0.0
 last_changed_at: "2026-06-14T00:11:48-07:00"
+related_files:
+- src/lingtai/tools/avatar/__init__.py
+- src/lingtai/tools/avatar/ANATOMY.md
+- src/lingtai/tools/avatar/CONTRACT.md
+maintenance: |
+  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # Avatar Manual

--- a/src/lingtai/tools/bash/glossary-en.md
+++ b/src/lingtai/tools/bash/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.bash
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/bash/glossary-zh.md
+- src/lingtai/tools/bash/glossary-wen.md
+maintenance: |
+  English glossary for the `bash` tool package (lingtai.tools.bash); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when bash's public tool schema changes.
 ---

--- a/src/lingtai/tools/bash/glossary-wen.md
+++ b/src/lingtai/tools/bash/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.bash
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/bash/glossary-en.md
+- src/lingtai/tools/bash/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `bash` tool package (lingtai.tools.bash); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever bash's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/bash/glossary-zh.md
+++ b/src/lingtai/tools/bash/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.bash
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/bash/glossary-en.md
+- src/lingtai/tools/bash/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `bash` tool package (lingtai.tools.bash); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever bash's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/bash/manual/SKILL.md
+++ b/src/lingtai/tools/bash/manual/SKILL.md
@@ -13,6 +13,13 @@ description: >
   9", "remind me later"), or when a scheduled job misbehaves.
 version: 1.7.1
 last_changed_at: "2026-07-13T04:44:00-07:00"
+related_files:
+- src/lingtai/tools/bash/__init__.py
+- src/lingtai/tools/bash/CONTRACT.md
+- src/lingtai/tools/bash/ANATOMY.md
+- src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
+maintenance: |
+  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # Bash Manual — Router

--- a/src/lingtai/tools/bash/manual/reference/bash-aider/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-aider/SKILL.md
@@ -6,6 +6,11 @@ description: >
   daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-06-13T04:32:46-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/bash/_async_supervisor.py
+maintenance: |
+  Tracks the Aider CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # Aider CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-claude-code/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-claude-code/SKILL.md
@@ -10,6 +10,11 @@ description: >
 version: 1.0.3
 tags: [cli, code, delegation, claude, implementation]
 last_changed_at: "2026-06-30T00:00:00-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
+maintenance: |
+  Tracks the Claude Code CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # Claude Code CLI — Code Delegation

--- a/src/lingtai/tools/bash/manual/reference/bash-crush/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-crush/SKILL.md
@@ -6,6 +6,11 @@ description: >
   daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-06-13T04:32:46-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/bash/_async_supervisor.py
+maintenance: |
+  Tracks the Charm Crush CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # Charm Crush CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-cursor-agent/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-cursor-agent/SKILL.md
@@ -6,6 +6,11 @@ description: >
   daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-06-13T04:32:46-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
+maintenance: |
+  Tracks the Cursor Agent CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # Cursor Agent CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-gemini-cli/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-gemini-cli/SKILL.md
@@ -6,6 +6,11 @@ description: >
   daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-06-13T04:32:46-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/bash/_async_supervisor.py
+maintenance: |
+  Tracks the Gemini CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # Gemini CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-goose/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-goose/SKILL.md
@@ -6,6 +6,11 @@ description: >
   daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-06-13T04:32:46-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/bash/_async_supervisor.py
+maintenance: |
+  Tracks the Goose CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # Goose CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-kimicode/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-kimicode/SKILL.md
@@ -6,6 +6,11 @@ description: >
   LingTai daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-07-01T00:00:00-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
+maintenance: |
+  Tracks the Kimi Code CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # Kimi Code CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-mimocode/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-mimocode/SKILL.md
@@ -6,6 +6,11 @@ description: >
   daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-06-13T04:32:46-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
+maintenance: |
+  Tracks the MiMo Code CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # MiMo Code CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-oh-my-pi/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-oh-my-pi/SKILL.md
@@ -6,6 +6,11 @@ description: >
   daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-06-13T04:32:46-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/oh-my-pi/SKILL.md
+maintenance: |
+  Tracks the Oh-My-Pi CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # Oh-My-Pi CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-openai-codex/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-openai-codex/SKILL.md
@@ -10,6 +10,11 @@ description: >
 version: 1.0.1
 tags: [cli, code, delegation, openai, codex]
 last_changed_at: "2026-06-13T04:41:27-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/codex/SKILL.md
+maintenance: |
+  Tracks the OpenAI Codex CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # OpenAI Codex CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-opencode/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-opencode/SKILL.md
@@ -10,6 +10,11 @@ description: >
 version: 1.0.0
 tags: [cli, code, delegation, opencode, automation]
 last_changed_at: "2026-06-13T04:32:46-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
+maintenance: |
+  Tracks the OpenCode CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # OpenCode CLI — Local Coding Agent

--- a/src/lingtai/tools/bash/manual/reference/bash-openhands/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-openhands/SKILL.md
@@ -6,6 +6,11 @@ description: >
   daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-06-13T04:32:46-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/bash/_async_supervisor.py
+maintenance: |
+  Tracks the OpenHands CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # OpenHands CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-qwen-code/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-qwen-code/SKILL.md
@@ -6,6 +6,11 @@ description: >
   daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-06-13T04:32:46-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
+maintenance: |
+  Tracks the Qwen Code CLI backend/topic behavior it documents; update when that integration changes.
 ---
 
 # Qwen Code CLI

--- a/src/lingtai/tools/bash/manual/reference/bash-zed-acp/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-zed-acp/SKILL.md
@@ -6,6 +6,11 @@ description: >
   daemon harness candidate.
 version: 0.1.0
 last_changed_at: "2026-06-13T04:41:27-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/bash/_async_supervisor.py
+maintenance: |
+  Tracks the Zed / ACP agent bridge backend/topic behavior it documents; update when that integration changes.
 ---
 
 # Zed / ACP agent bridge

--- a/src/lingtai/tools/bash/manual/reference/debugging-cleanup/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/debugging-cleanup/SKILL.md
@@ -6,6 +6,11 @@ description: >
   worked launchd diagnosis, cleanup, and bash work footprint hygiene.
 version: 1.0.0
 last_changed_at: "2026-06-01T01:47:09-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
+maintenance: |
+  Tracks the scheduled-job debugging/cleanup topic it documents; update when that integration changes.
 ---
 
 # Debugging and Cleanup Reference

--- a/src/lingtai/tools/bash/manual/reference/notification-reminders/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/notification-reminders/SKILL.md
@@ -6,6 +6,12 @@ description: >
   rest checklist for agents leaving work pending.
 version: 1.0.0
 last_changed_at: "2026-06-20T13:05:49-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/notification/__init__.py
+- src/lingtai/tools/notification/schema.py
+maintenance: |
+  Tracks the one-shot notification-reminder topic it documents; update when that integration changes.
 ---
 
 # Notification Reminder Reference

--- a/src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
@@ -7,6 +7,11 @@ description: >
   launchd process-tree reaping gotcha.
 version: 1.0.0
 last_changed_at: "2026-06-01T01:47:09-07:00"
+related_files:
+- src/lingtai/tools/bash/manual/SKILL.md
+- src/lingtai/tools/bash/_async_supervisor.py
+maintenance: |
+  Tracks the cron-driven scheduled-work topic it documents; update when that integration changes.
 ---
 
 # Scheduled Work Reference

--- a/src/lingtai/tools/daemon/glossary-en.md
+++ b/src/lingtai/tools/daemon/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.daemon
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/daemon/glossary-zh.md
+- src/lingtai/tools/daemon/glossary-wen.md
+maintenance: |
+  English glossary for the `daemon` tool package (lingtai.tools.daemon); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when daemon's public tool schema changes.
 ---

--- a/src/lingtai/tools/daemon/glossary-wen.md
+++ b/src/lingtai/tools/daemon/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.daemon
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/daemon/glossary-en.md
+- src/lingtai/tools/daemon/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `daemon` tool package (lingtai.tools.daemon); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever daemon's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/daemon/glossary-zh.md
+++ b/src/lingtai/tools/daemon/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.daemon
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/daemon/glossary-en.md
+- src/lingtai/tools/daemon/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `daemon` tool package (lingtai.tools.daemon); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever daemon's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -8,6 +8,13 @@ description: >
   slow, failed, timed out, exited 143 / SIGTERM, or needs backend-specific reasoning.
 version: 0.7.0
 last_changed_at: "2026-07-14T00:00:00-07:00"
+related_files:
+- src/lingtai/tools/daemon/DAEMON_CONTRACT.md
+- src/lingtai/tools/daemon/CONTRACT.md
+- src/lingtai/tools/daemon/ANATOMY.md
+- src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
+maintenance: |
+  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # Daemon Manual — Router

--- a/src/lingtai/tools/daemon/manual/reference/cleanup/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cleanup/SKILL.md
@@ -6,6 +6,11 @@ description: >
   of old daemon artifacts.
 version: 1.0.0
 last_changed_at: "2026-06-01T01:56:31-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
+maintenance: |
+  Tracks the daemon footprint cleanup topic it documents; update when that integration changes.
 ---
 
 # Daemon Cleanup Reference

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
@@ -8,6 +8,12 @@ description: >
   Kimi Code, Cursor, and Oh-My-Pi flag discovery, built-in LingTai knowledge entrypoint).
 version: 1.13.0
 last_changed_at: "2026-07-09T19:24:35-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/SKILL.md
+- src/lingtai/tools/daemon/DAEMON_CONTRACT.md
+- src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/lingtai/SKILL.md
+maintenance: |
+  Tracks the daemon CLI backends topic it documents; update when that integration changes.
 ---
 
 # Daemon CLI Backend Reference

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
@@ -9,6 +9,11 @@ description: >
   mechanism. It is not a flag catalog.
 version: 0.1.0
 last_changed_at: "2026-07-09T19:22:27-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+- src/lingtai/tools/bash/manual/reference/bash-claude-code/SKILL.md
+maintenance: |
+  Tracks the claude-p daemon backend flag-discovery topic it documents; update when that integration changes.
 ---
 
 # claude-p Daemon Backend — Flag Discovery Entrypoint

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/codex/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/codex/SKILL.md
@@ -8,6 +8,11 @@ description: >
   the generic `backend_options` mechanism. It is not a flag catalog.
 version: 0.1.0
 last_changed_at: "2026-07-09T18:55:23-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+- src/lingtai/tools/bash/manual/reference/bash-openai-codex/SKILL.md
+maintenance: |
+  Tracks the Codex daemon backend flag-discovery topic it documents; update when that integration changes.
 ---
 
 # Codex Daemon Backend — Flag Discovery Entrypoint

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
@@ -8,6 +8,11 @@ description: >
   generic `backend_options` mechanism. It is not a flag catalog.
 version: 0.1.0
 last_changed_at: "2026-07-09T19:23:56-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+- src/lingtai/tools/bash/manual/reference/bash-cursor-agent/SKILL.md
+maintenance: |
+  Tracks the Cursor daemon backend flag-discovery topic it documents; update when that integration changes.
 ---
 
 # Cursor Daemon Backend — Flag Discovery Entrypoint

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
@@ -8,6 +8,11 @@ description: >
   the generic `backend_options` mechanism. It is not a flag catalog.
 version: 0.1.0
 last_changed_at: "2026-07-09T19:22:52-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+- src/lingtai/tools/bash/manual/reference/bash-kimicode/SKILL.md
+maintenance: |
+  Tracks the Kimi Code daemon backend flag-discovery topic it documents; update when that integration changes.
 ---
 
 # Kimi Code Daemon Backend — Flag Discovery Entrypoint

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/lingtai/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/lingtai/SKILL.md
@@ -9,6 +9,12 @@ description: >
   and the daemon completion contract. It is not a rules catalog.
 version: 0.1.0
 last_changed_at: "2026-07-09T19:22:26-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+- src/lingtai/tools/daemon/manual/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+maintenance: |
+  Tracks the built-in lingtai daemon backend topic it documents; update when that integration changes.
 ---
 
 # LingTai Daemon Backend — Knowledge Entrypoint

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
@@ -8,6 +8,11 @@ description: >
   help into the generic `backend_options` mechanism. It is not a flag catalog.
 version: 0.2.0
 last_changed_at: "2026-07-11T00:00:00-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+- src/lingtai/tools/bash/manual/reference/bash-mimocode/SKILL.md
+maintenance: |
+  Tracks the MiMo Code daemon backend flag-discovery topic it documents; update when that integration changes.
 ---
 
 # MiMo Code Daemon Backend — Flag Discovery Entrypoint

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/oh-my-pi/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/oh-my-pi/SKILL.md
@@ -9,6 +9,11 @@ description: >
   not a flag catalog.
 version: 0.1.0
 last_changed_at: "2026-07-09T19:24:35-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+- src/lingtai/tools/bash/manual/reference/bash-oh-my-pi/SKILL.md
+maintenance: |
+  Tracks the Oh-My-Pi daemon backend flag-discovery topic it documents; update when that integration changes.
 ---
 
 # Oh-My-Pi Daemon Backend — Flag Discovery Entrypoint

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
@@ -9,6 +9,11 @@ description: >
   a flag catalog.
 version: 0.1.0
 last_changed_at: "2026-07-09T19:22:21-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+- src/lingtai/tools/bash/manual/reference/bash-opencode/SKILL.md
+maintenance: |
+  Tracks the OpenCode daemon backend flag-discovery topic it documents; update when that integration changes.
 ---
 
 # OpenCode Daemon Backend — Flag Discovery Entrypoint

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
@@ -9,6 +9,11 @@ description: >
   not a flag catalog.
 version: 0.1.0
 last_changed_at: "2026-07-09T19:22:18-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+- src/lingtai/tools/bash/manual/reference/bash-qwen-code/SKILL.md
+maintenance: |
+  Tracks the Qwen Code daemon backend flag-discovery topic it documents; update when that integration changes.
 ---
 
 # Qwen Code Daemon Backend — Flag Discovery Entrypoint

--- a/src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
@@ -7,6 +7,12 @@ description: >
   and how to inspect progress without guessing.
 version: 1.2.1
 last_changed_at: "2026-07-03T10:53:00-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/SKILL.md
+- src/lingtai/tools/daemon/run_dir.py
+- src/lingtai/tools/daemon/runtime.py
+maintenance: |
+  Tracks the daemon artifact-forensics topic it documents; update when that integration changes.
 ---
 
 # Daemon Forensics Reference

--- a/src/lingtai/tools/daemon/manual/reference/inspection/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/inspection/SKILL.md
@@ -6,6 +6,11 @@ description: >
   while daemon work remains pending.
 version: 1.1.0
 last_changed_at: "2026-06-24T16:24:16-07:00"
+related_files:
+- src/lingtai/tools/daemon/manual/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
+maintenance: |
+  Tracks the daemon polling/inspection topic it documents; update when that integration changes.
 ---
 
 # Daemon Inspection Reference

--- a/src/lingtai/tools/edit/glossary-en.md
+++ b/src/lingtai/tools/edit/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.edit
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/edit/glossary-zh.md
+- src/lingtai/tools/edit/glossary-wen.md
+maintenance: |
+  English glossary for the `edit` tool package (lingtai.tools.edit); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when edit's public tool schema changes.
 ---

--- a/src/lingtai/tools/edit/glossary-wen.md
+++ b/src/lingtai/tools/edit/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.edit
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/edit/glossary-en.md
+- src/lingtai/tools/edit/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `edit` tool package (lingtai.tools.edit); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever edit's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/edit/glossary-zh.md
+++ b/src/lingtai/tools/edit/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.edit
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/edit/glossary-en.md
+- src/lingtai/tools/edit/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `edit` tool package (lingtai.tools.edit); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever edit's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/email/glossary-en.md
+++ b/src/lingtai/tools/email/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.email
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/email/glossary-zh.md
+- src/lingtai/tools/email/glossary-wen.md
+maintenance: |
+  English glossary for the `email` tool package (lingtai.tools.email); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when email's public tool schema changes.
 ---

--- a/src/lingtai/tools/email/glossary-wen.md
+++ b/src/lingtai/tools/email/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.email
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/email/glossary-en.md
+- src/lingtai/tools/email/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `email` tool package (lingtai.tools.email); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever email's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/email/glossary-zh.md
+++ b/src/lingtai/tools/email/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.email
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/email/glossary-en.md
+- src/lingtai/tools/email/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `email` tool package (lingtai.tools.email); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever email's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/email/manual/SKILL.md
+++ b/src/lingtai/tools/email/manual/SKILL.md
@@ -15,6 +15,13 @@ description: >
 version: 1.0.1
 tags: [capabilities, email, communication]
 last_changed_at: "2026-07-09T22:24:00-07:00"
+related_files:
+- src/lingtai/tools/email/manager.py
+- src/lingtai/tools/email/primitives.py
+- src/lingtai/tools/email/ANATOMY.md
+- src/lingtai/tools/email/CONTRACT.md
+maintenance: |
+  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # Email Manual — the internal `email` tool

--- a/src/lingtai/tools/glob/glossary-en.md
+++ b/src/lingtai/tools/glob/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.glob
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/glob/glossary-zh.md
+- src/lingtai/tools/glob/glossary-wen.md
+maintenance: |
+  English glossary for the `glob` tool package (lingtai.tools.glob); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when glob's public tool schema changes.
 ---

--- a/src/lingtai/tools/glob/glossary-wen.md
+++ b/src/lingtai/tools/glob/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.glob
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/glob/glossary-en.md
+- src/lingtai/tools/glob/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `glob` tool package (lingtai.tools.glob); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever glob's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/glob/glossary-zh.md
+++ b/src/lingtai/tools/glob/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.glob
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/glob/glossary-en.md
+- src/lingtai/tools/glob/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `glob` tool package (lingtai.tools.glob); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever glob's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/grep/glossary-en.md
+++ b/src/lingtai/tools/grep/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.grep
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/grep/glossary-zh.md
+- src/lingtai/tools/grep/glossary-wen.md
+maintenance: |
+  English glossary for the `grep` tool package (lingtai.tools.grep); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when grep's public tool schema changes.
 ---

--- a/src/lingtai/tools/grep/glossary-wen.md
+++ b/src/lingtai/tools/grep/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.grep
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/grep/glossary-en.md
+- src/lingtai/tools/grep/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `grep` tool package (lingtai.tools.grep); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever grep's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/grep/glossary-zh.md
+++ b/src/lingtai/tools/grep/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.grep
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/grep/glossary-en.md
+- src/lingtai/tools/grep/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `grep` tool package (lingtai.tools.grep); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever grep's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/knowledge/glossary-en.md
+++ b/src/lingtai/tools/knowledge/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.knowledge
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/knowledge/glossary-zh.md
+- src/lingtai/tools/knowledge/glossary-wen.md
+maintenance: |
+  English glossary for the `knowledge` tool package (lingtai.tools.knowledge); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when knowledge's public tool schema changes.
 ---

--- a/src/lingtai/tools/knowledge/glossary-wen.md
+++ b/src/lingtai/tools/knowledge/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.knowledge
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/knowledge/glossary-en.md
+- src/lingtai/tools/knowledge/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `knowledge` tool package (lingtai.tools.knowledge); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever knowledge's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/knowledge/glossary-zh.md
+++ b/src/lingtai/tools/knowledge/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.knowledge
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/knowledge/glossary-en.md
+- src/lingtai/tools/knowledge/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `knowledge` tool package (lingtai.tools.knowledge); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever knowledge's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/knowledge/manual/SKILL.md
+++ b/src/lingtai/tools/knowledge/manual/SKILL.md
@@ -9,6 +9,12 @@ description: >
   over related entries, or explain how knowledge differs from portable skills.
 version: 1.0.0
 last_changed_at: "2026-06-09T13:24:44-07:00"
+related_files:
+- src/lingtai/tools/knowledge/__init__.py
+- src/lingtai/tools/knowledge/ANATOMY.md
+- src/lingtai/tools/knowledge/CONTRACT.md
+maintenance: |
+  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # The Knowledge Capability

--- a/src/lingtai/tools/mcp/glossary-en.md
+++ b/src/lingtai/tools/mcp/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.mcp
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/mcp/glossary-zh.md
+- src/lingtai/tools/mcp/glossary-wen.md
+maintenance: |
+  English glossary for the `mcp` tool package (lingtai.tools.mcp); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when mcp's public tool schema changes.
 ---

--- a/src/lingtai/tools/mcp/glossary-wen.md
+++ b/src/lingtai/tools/mcp/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.mcp
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/mcp/glossary-en.md
+- src/lingtai/tools/mcp/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `mcp` tool package (lingtai.tools.mcp); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever mcp's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/mcp/glossary-zh.md
+++ b/src/lingtai/tools/mcp/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.mcp
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/mcp/glossary-en.md
+- src/lingtai/tools/mcp/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `mcp` tool package (lingtai.tools.mcp); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever mcp's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/mcp/manual/SKILL.md
+++ b/src/lingtai/tools/mcp/manual/SKILL.md
@@ -42,6 +42,12 @@ description: >
   Read this for *what to do*; read anatomy for *how it works*.
 version: 3.2.0
 last_changed_at: "2026-06-24T16:26:32-07:00"
+related_files:
+- src/lingtai/tools/mcp/__init__.py
+- src/lingtai/tools/mcp/ANATOMY.md
+- src/lingtai/tools/mcp/CONTRACT.md
+maintenance: |
+  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # MCP Capability — How To Use It

--- a/src/lingtai/tools/mcp/manual/reference/curated-addons.md
+++ b/src/lingtai/tools/mcp/manual/reference/curated-addons.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- src/lingtai/tools/mcp/manual/SKILL.md
+- src/lingtai/tools/mcp/manual/reference/troubleshooting.md
+maintenance: |
+  Kernel-curated MCP addon setup contract routed to from mcp/manual/SKILL.md and cross-linked from troubleshooting.md; update it whenever a curated addon (imap/telegram/feishu/wechat/whatsapp/cloud_mail) changes its config fields or install story.
+---
+
 # Curated addons — imap / telegram / feishu / wechat / whatsapp / cloud_mail
 
 LingTai's first-party email and chat integrations. They now ship inside the `lingtai` distribution under `lingtai.mcp_servers.{imap,telegram,feishu,wechat,whatsapp,cloud_mail}` so a single kernel release carries the curated MCP surface atomically. Historical `lingtai_*` import packages remain as thin compatibility wrappers. Historical standalone package names remain useful as provenance/homepage names, but the normal runtime path no longer depends on separate addon wheels.

--- a/src/lingtai/tools/mcp/manual/reference/third-party-and-legacy.md
+++ b/src/lingtai/tools/mcp/manual/reference/third-party-and-legacy.md
@@ -1,3 +1,10 @@
+---
+related_files:
+- src/lingtai/tools/mcp/manual/SKILL.md
+maintenance: |
+  Third-party/legacy MCP wiring reference routed to from mcp/manual/SKILL.md; update it whenever the npx/uvx/HTTP server wiring path or the legacy mcp/servers.json mechanism changes.
+---
+
 # Third-party and legacy MCP routes
 
 Two routes for non-curated MCPs: the **registry route** (recommended, gated by `mcp_registry.jsonl`) and the **legacy `mcp/servers.json` route** (ungated, kept for quick experiments).

--- a/src/lingtai/tools/mcp/manual/reference/troubleshooting.md
+++ b/src/lingtai/tools/mcp/manual/reference/troubleshooting.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- src/lingtai/tools/mcp/manual/SKILL.md
+- src/lingtai/tools/mcp/manual/reference/curated-addons.md
+maintenance: |
+  MCP troubleshooting reference routed to from mcp/manual/SKILL.md and cross-linking curated-addons.md; update it as new boot-error patterns or update/deregister flows are discovered.
+---
+
 # MCP troubleshooting
 
 ## Updating, deregistering

--- a/src/lingtai/tools/notification/glossary-en.md
+++ b/src/lingtai/tools/notification/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.notification
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/notification/glossary-zh.md
+- src/lingtai/tools/notification/glossary-wen.md
+maintenance: |
+  English glossary for the `notification` tool package (lingtai.tools.notification); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when notification's public tool schema changes.
 ---

--- a/src/lingtai/tools/notification/glossary-wen.md
+++ b/src/lingtai/tools/notification/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.notification
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/notification/glossary-en.md
+- src/lingtai/tools/notification/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `notification` tool package (lingtai.tools.notification); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever notification's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/notification/glossary-zh.md
+++ b/src/lingtai/tools/notification/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.notification
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/notification/glossary-en.md
+- src/lingtai/tools/notification/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `notification` tool package (lingtai.tools.notification); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever notification's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/psyche/glossary-en.md
+++ b/src/lingtai/tools/psyche/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.psyche
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/psyche/glossary-zh.md
+- src/lingtai/tools/psyche/glossary-wen.md
+maintenance: |
+  English glossary for the `psyche` tool package (lingtai.tools.psyche); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when psyche's public tool schema changes.
 ---

--- a/src/lingtai/tools/psyche/glossary-wen.md
+++ b/src/lingtai/tools/psyche/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.psyche
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/psyche/glossary-en.md
+- src/lingtai/tools/psyche/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `psyche` tool package (lingtai.tools.psyche); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever psyche's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/psyche/glossary-zh.md
+++ b/src/lingtai/tools/psyche/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.psyche
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/psyche/glossary-en.md
+- src/lingtai/tools/psyche/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `psyche` tool package (lingtai.tools.psyche); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever psyche's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/read/glossary-en.md
+++ b/src/lingtai/tools/read/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.read
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/read/glossary-zh.md
+- src/lingtai/tools/read/glossary-wen.md
+maintenance: |
+  English glossary for the `read` tool package (lingtai.tools.read); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when read's public tool schema changes.
 ---

--- a/src/lingtai/tools/read/glossary-wen.md
+++ b/src/lingtai/tools/read/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.read
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/read/glossary-en.md
+- src/lingtai/tools/read/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `read` tool package (lingtai.tools.read); body must stay non-empty and distinct from glossary-zh.md — tests/test_tool_glossary.py::test_wen_uses_classical_chinese_not_zh exercises exactly this file. Update in lockstep with glossary-en.md/glossary-zh.md whenever read's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/read/glossary-zh.md
+++ b/src/lingtai/tools/read/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.read
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/read/glossary-en.md
+- src/lingtai/tools/read/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `read` tool package (lingtai.tools.read); body must stay non-empty — tests/test_tool_glossary.py::test_chinese_body_is_non_empty exercises exactly this file. Update in lockstep with glossary-en.md/glossary-wen.md whenever read's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/skills/glossary-en.md
+++ b/src/lingtai/tools/skills/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.skills
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/skills/glossary-zh.md
+- src/lingtai/tools/skills/glossary-wen.md
+maintenance: |
+  English glossary for the `skills` tool package (lingtai.tools.skills); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when skills's public tool schema changes.
 ---

--- a/src/lingtai/tools/skills/glossary-wen.md
+++ b/src/lingtai/tools/skills/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.skills
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/skills/glossary-en.md
+- src/lingtai/tools/skills/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `skills` tool package (lingtai.tools.skills); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever skills's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/skills/glossary-zh.md
+++ b/src/lingtai/tools/skills/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.skills
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/skills/glossary-en.md
+- src/lingtai/tools/skills/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `skills` tool package (lingtai.tools.skills); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever skills's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/skills/manual/SKILL.md
+++ b/src/lingtai/tools/skills/manual/SKILL.md
@@ -36,6 +36,12 @@ description: >
   works, not what's *inside* it.
 version: 1.1.0
 last_changed_at: "2026-07-06T14:50:00-07:00"
+related_files:
+- src/lingtai/tools/skills/__init__.py
+- src/lingtai/tools/skills/ANATOMY.md
+- src/lingtai/tools/skills/CONTRACT.md
+maintenance: |
+  Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # The Skills Capability

--- a/src/lingtai/tools/skills/manual/assets/skill-template.md
+++ b/src/lingtai/tools/skills/manual/assets/skill-template.md
@@ -4,6 +4,11 @@ description: [ONE_LINE_DESCRIPTION]  # REQUIRED: What this skill does + when NOT
 version: 1.0.0              # Semantic versioning
 tags: [[optional, tags]]      # Optional: search/categorization tags
 # last_changed_at: "YYYY-MM-DDTHH:MM:SSZ"  # Required only for LingTai-maintained skills
+related_files:
+- src/lingtai/tools/skills/manual/SKILL.md
+- src/lingtai/tools/skills/manual/scripts/validate.py
+maintenance: |
+  Copy-paste SKILL.md authoring template referenced by skills/manual/SKILL.md's scaffolding steps; keep its structure valid against scripts/validate.py so skills built from it pass validation without modification. This file's pre-existing `name`/`description` frontmatter values carry the intentional skill-name and one-line-description authoring placeholders for authors to fill in on copies of this file, owned by scripts/validate.py's own PLACEHOLDER_RE — docs-governance placeholder checking applies only to the `maintenance`/`related_files` fields below, which are real, non-placeholder text, so no field-level carve-out is needed.
 ---
 
 # [SKILL NAME]

--- a/src/lingtai/tools/skills/manual/reference/cleanup-footprint-contract.md
+++ b/src/lingtai/tools/skills/manual/reference/cleanup-footprint-contract.md
@@ -1,3 +1,10 @@
+---
+related_files:
+- src/lingtai/tools/skills/manual/SKILL.md
+maintenance: |
+  Cleanup-footprint contract referenced from skills/manual/SKILL.md's cleanup section; update it whenever the footprint/consent rules for skill installation cleanup change.
+---
+
 # Cleanup / Footprint Contract for Tool Manuals
 
 Every tool/capability manual that owns persistent files MUST include a section named

--- a/src/lingtai/tools/soul/glossary-en.md
+++ b/src/lingtai/tools/soul/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.soul
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/soul/glossary-zh.md
+- src/lingtai/tools/soul/glossary-wen.md
+maintenance: |
+  English glossary for the `soul` tool package (lingtai.tools.soul); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when soul's public tool schema changes.
 ---

--- a/src/lingtai/tools/soul/glossary-wen.md
+++ b/src/lingtai/tools/soul/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.soul
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/soul/glossary-en.md
+- src/lingtai/tools/soul/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `soul` tool package (lingtai.tools.soul); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever soul's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/soul/glossary-zh.md
+++ b/src/lingtai/tools/soul/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.soul
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/soul/glossary-en.md
+- src/lingtai/tools/soul/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `soul` tool package (lingtai.tools.soul); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever soul's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/system/glossary-en.md
+++ b/src/lingtai/tools/system/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.system
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/system/glossary-zh.md
+- src/lingtai/tools/system/glossary-wen.md
+maintenance: |
+  English glossary for the `system` tool package (lingtai.tools.system); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when system's public tool schema changes.
 ---

--- a/src/lingtai/tools/system/glossary-wen.md
+++ b/src/lingtai/tools/system/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.system
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/system/glossary-en.md
+- src/lingtai/tools/system/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `system` tool package (lingtai.tools.system); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever system's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/system/glossary-zh.md
+++ b/src/lingtai/tools/system/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.system
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/system/glossary-en.md
+- src/lingtai/tools/system/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `system` tool package (lingtai.tools.system); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever system's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/vision/glossary-en.md
+++ b/src/lingtai/tools/vision/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.vision
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/vision/glossary-zh.md
+- src/lingtai/tools/vision/glossary-wen.md
+maintenance: |
+  English glossary for the `vision` tool package (lingtai.tools.vision); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when vision's public tool schema changes.
 ---

--- a/src/lingtai/tools/vision/glossary-wen.md
+++ b/src/lingtai/tools/vision/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.vision
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/vision/glossary-en.md
+- src/lingtai/tools/vision/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `vision` tool package (lingtai.tools.vision); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever vision's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/vision/glossary-zh.md
+++ b/src/lingtai/tools/vision/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.vision
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/vision/glossary-en.md
+- src/lingtai/tools/vision/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `vision` tool package (lingtai.tools.vision); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever vision's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/web_search/glossary-en.md
+++ b/src/lingtai/tools/web_search/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.web_search
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/web_search/glossary-zh.md
+- src/lingtai/tools/web_search/glossary-wen.md
+maintenance: |
+  English glossary for the `web_search` tool package (lingtai.tools.web_search); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when web_search's public tool schema changes.
 ---

--- a/src/lingtai/tools/web_search/glossary-wen.md
+++ b/src/lingtai/tools/web_search/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.web_search
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/web_search/glossary-en.md
+- src/lingtai/tools/web_search/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `web_search` tool package (lingtai.tools.web_search); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever web_search's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/web_search/glossary-zh.md
+++ b/src/lingtai/tools/web_search/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.web_search
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/web_search/glossary-en.md
+- src/lingtai/tools/web_search/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `web_search` tool package (lingtai.tools.web_search); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever web_search's public tool schema changes.
 ---
 **术语对照**
 

--- a/src/lingtai/tools/write/glossary-en.md
+++ b/src/lingtai/tools/write/glossary-en.md
@@ -3,4 +3,12 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.write
 language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/write/glossary-zh.md
+- src/lingtai/tools/write/glossary-wen.md
+maintenance: |
+  English glossary for the `write` tool package (lingtai.tools.write); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when write's public tool schema changes.
 ---

--- a/src/lingtai/tools/write/glossary-wen.md
+++ b/src/lingtai/tools/write/glossary-wen.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.write
 language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/write/glossary-en.md
+- src/lingtai/tools/write/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `write` tool package (lingtai.tools.write); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever write's public tool schema changes.
 ---
 **名相对照**
 

--- a/src/lingtai/tools/write/glossary-zh.md
+++ b/src/lingtai/tools/write/glossary-zh.md
@@ -3,6 +3,14 @@ kind: tool-glossary
 schema_version: 1
 tool_package: lingtai.tools.write
 language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/write/glossary-en.md
+- src/lingtai/tools/write/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `write` tool package (lingtai.tools.write); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever write's public tool schema changes.
 ---
 **术语对照**
 

--- a/tests/CONTRACT.md
+++ b/tests/CONTRACT.md
@@ -1,3 +1,11 @@
+---
+related_files:
+- CONTRACT.md
+- tests/test_architecture_documents.py
+maintenance: |
+  Self-declared methodology/workflow charter, explicitly NOT a governed component Contract under the root CONTRACT.md system (no related_files entry there, no paired tests/ANATOMY.md); update it only when the testing methodology itself changes, and do not promote it into the governed Contract graph without giving tests/ a real implemented Port. This generic docs.yaml two-field baseline applies independently of that opt-out.
+---
+
 # Test Methodology Charter
 
 > **This is a methodology/workflow charter, not a governed component Contract.**

--- a/tests/test_anatomy_drift_checker.py
+++ b/tests/test_anatomy_drift_checker.py
@@ -80,9 +80,11 @@ def test_check_mode_exit_code(tmp_path, monkeypatch):
 def test_checker_lives_in_skill_bundle():
     """The checker's only operational ownership is the anatomy skill bundle."""
     assert _CHECKER_PATH.is_file(), f"checker missing from skill bundle: {_CHECKER_PATH}"
-    # No repo-root scripts/ or tools/ directory should exist (PR #827
-    # ownership contract — skill sidecars live in the skill bundle).
-    assert not (ROOT / "scripts").is_dir(), "stale repo-root scripts/ directory"
+    # PR #827 forbids a duplicate repo-root copy of this anatomy sidecar;
+    # root scripts/ now legitimately owns the separate docs-governance checker.
+    assert not (ROOT / "scripts" / "check_anatomy_drift.py").exists(), (
+        "stale repo-root anatomy checker"
+    )
     assert not (ROOT / "tools").is_dir(), "stale repo-root tools/ directory"
 
 

--- a/tests/test_architecture_documents.py
+++ b/tests/test_architecture_documents.py
@@ -676,7 +676,7 @@ def test_public_and_agent_entry_points_route_to_the_local_network() -> None:
     dev_meta, dev_skill = _read_document(ROOT_DEV_SKILL)
     anatomy_skill = ANATOMY_SKILL.read_text(encoding="utf-8")
 
-    assert list(dev_meta) == ["name", "description"]
+    assert list(dev_meta) == ["name", "description", "related_files", "maintenance"]
     assert dev_meta["name"] == "lingtai-kernel-dev"
     assert "Use this before changing code" in dev_meta["description"]
     assert "repository’s local dev guide skill" in readme

--- a/tests/test_daemon_mimocode_submanual.py
+++ b/tests/test_daemon_mimocode_submanual.py
@@ -100,7 +100,7 @@ def test_mimocode_child_states_verified_backend_contract():
 
 
 def test_mimocode_child_stays_tiny_not_a_flag_catalog():
-    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    line_count = len(_body(CHILD).splitlines())
     assert line_count <= 90, (
         "the MiMo Code backend submanual is a tiny entrypoint to live CLI "
         f"help; {line_count} lines suggests it is growing into a flag catalog"

--- a/tests/test_daemon_oh_my_pi_submanual.py
+++ b/tests/test_daemon_oh_my_pi_submanual.py
@@ -119,7 +119,7 @@ def test_oh_my_pi_child_mcp_status_matches_source():
 
 
 def test_oh_my_pi_child_stays_tiny_not_a_flag_catalog():
-    line_count = len(CHILD.read_text(encoding="utf-8").splitlines())
+    line_count = len(_body(CHILD).splitlines())
     assert line_count <= 90, (
         "the Oh-My-Pi backend submanual is a tiny entrypoint to live CLI help; "
         f"{line_count} lines suggests it is growing into a flag catalog"

--- a/tests/test_docs_governance.py
+++ b/tests/test_docs_governance.py
@@ -1,0 +1,438 @@
+"""Docs YAML governance validator tests (V6).
+
+related_files.target_policy is owner_validated_relative_link: generic
+validation is syntax-only, never existence. Tests here prove both that
+syntax violations are still caught AND that an owner-relative logical
+link (e.g. a prompt-catalog crawl-graph entry style path) passes generic
+validation without requiring it to resolve to a real file.
+
+Every test passes an explicit repo root or none at all where none is
+needed (syntax-only checks need no filesystem). Imports
+scripts/check_docs_governance.py so pytest exercises the exact same logic
+as `python scripts/check_docs_governance.py --check`. The canonical rationale
+and owner-specific resolution boundary live in docs.yaml.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import check_docs_governance as checker  # noqa: E402
+
+
+def test_docs_yaml_validates_against_its_own_contract():
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping("docs.yaml", contract, contract)
+    assert not failures, failures
+
+
+def test_contract_has_no_path_or_content_exemptions():
+    contract = checker.load_docs_contract()
+    assert "exempt" not in contract
+    assert "exempt_paths" not in contract
+    assert "placeholder_exempt_fields" not in contract
+    assert contract["field_constraints"]["related_files"]["target_policy"] == "owner_validated_relative_link"
+    assert "must_resolve_to_repo_file" not in contract["field_constraints"]["related_files"]
+
+
+def test_discovery_unions_tracked_and_untracked_via_git_files(monkeypatch):
+    contract = checker.load_docs_contract()
+    calls = []
+
+    def fake_git_files(*args):
+        calls.append(args)
+        return ["a.md", "shared.md"] if args == () else ["b.md", "shared.md"]
+
+    monkeypatch.setattr(checker, "_git_files", fake_git_files)
+    result = checker.discover_doc_paths(contract)
+    rels = sorted(str(p.relative_to(ROOT)) for p in result)
+    assert rels == ["a.md", "b.md", "shared.md"]
+    assert () in calls
+    assert ("--others", "--exclude-standard") in calls
+
+
+def test_every_in_scope_doc_has_required_fields():
+    contract = checker.load_docs_contract()
+    failures: list[str] = []
+    for path in checker.discover_doc_paths(contract):
+        failures.extend(checker.check_one_document_path(path, contract, repo_root=ROOT))
+    assert not failures, "\n".join(failures)
+
+
+def test_root_anatomy_and_contract_pass_generic_check_without_weakening_architecture_tests():
+    contract = checker.load_docs_contract()
+    for name in ("ANATOMY.md", "CONTRACT.md"):
+        failures = checker.check_one_document_path(ROOT / name, contract, repo_root=ROOT)
+        assert not failures, (name, failures)
+    sys.path.insert(0, str(ROOT / "tests"))
+    import test_architecture_documents as arch_tests  # noqa: E402
+    arch_tests.test_root_architecture_documents_are_reciprocal_and_well_formed()
+
+
+def test_owner_relative_logical_link_passes_generic_syntax_validation():
+    """POSITIVE test (V5): an owner-specific logical/crawl-graph-style
+    relative link — modeled on the real
+    reference/substrate-manual/SKILL.md-style entries already present in
+    src/lingtai/prompts/*.yaml related_files — must pass the generic
+    syntax-only check even though it does not resolve as a repo-root
+    physical path. This directly proves target_policy:
+    owner_validated_relative_link does not re-impose the old universal
+    existence rule."""
+    contract = checker.load_docs_contract()
+    meta = {
+        "related_files": ["reference/substrate-manual/SKILL.md"],
+        "maintenance": "Owner-specific crawl-graph link; resolved by the prompt catalog loader, not this generic contract.",
+    }
+    failures = checker.validate_metadata_mapping("some/owner/doc.md", meta, contract)
+    assert not failures, failures
+
+
+def test_preexisting_dangling_i18n_reference_does_not_fail_generic_check():
+    """Models the real, pre-existing src/lingtai/kernel/i18n/ANATOMY.md
+    related_files entries (src/lingtai/i18n/ANATOMY.md,
+    src/lingtai/i18n/__init__.py) which do not resolve to real files at
+    the current repository layout. The generic contract must not fail
+    this — it is a pre-existing drift issue for Anatomy-specific tooling
+    to report, not something docs.yaml's generic syntax layer re-flags."""
+    contract = checker.load_docs_contract()
+    meta = {
+        "related_files": ["src/lingtai/i18n/ANATOMY.md", "src/lingtai/i18n/__init__.py"],
+        "maintenance": "Pre-existing owner-specific anatomy links; syntax-valid, generically unresolved by design.",
+    }
+    failures = checker.validate_metadata_mapping("src/lingtai/kernel/i18n/ANATOMY.md", meta, contract)
+    assert not failures, failures
+
+
+def test_missing_required_field_rejected(tmp_path):
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text("---\nmaintenance: Update when this test fixture changes.\n---\nbody\n", encoding="utf-8")
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("related_files" in f for f in failures)
+
+
+def test_duplicate_yaml_key_rejected(tmp_path):
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text(
+        "---\nmaintenance: a\nmaintenance: b\nrelated_files:\n  - x.md\n---\nbody\n",
+        encoding="utf-8",
+    )
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("duplicate" in f.lower() or "parse error" in f.lower() for f in failures)
+
+
+def test_empty_maintenance_rejected(tmp_path):
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text('---\nmaintenance: ""\nrelated_files:\n  - y.md\n---\n', encoding="utf-8")
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("at least 20" in f for f in failures)
+
+
+@pytest.mark.parametrize("value", ["x", "TODO", "tbd", "FIXME", "xxx", "N/A", "none"])
+def test_exact_placeholder_maintenance_rejected(value):
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {"maintenance": value, "related_files": ["y.md"]},
+        contract,
+    )
+    assert any("forbidden exact placeholder" in f for f in failures)
+
+
+def test_maintenance_minimum_boundary_is_exact():
+    contract = checker.load_docs_contract()
+    minimum = contract["field_constraints"]["maintenance"]["min_length"]
+    assert minimum == 20
+
+    too_short = checker.validate_metadata_mapping(
+        "x.md",
+        {"maintenance": "a" * (minimum - 1), "related_files": ["y.md"]},
+        contract,
+    )
+    assert any(f"at least {minimum}" in f for f in too_short)
+
+    exact = checker.validate_metadata_mapping(
+        "x.md",
+        {"maintenance": "a" * minimum, "related_files": ["y.md"]},
+        contract,
+    )
+    assert not exact, exact
+
+
+def test_concise_real_maintenance_rule_is_valid():
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {"maintenance": "Update when the API changes.", "related_files": ["y.md"]},
+        contract,
+    )
+    assert not failures, failures
+
+
+def test_duplicate_related_path_rejected(tmp_path):
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text(
+        "---\nmaintenance: Update when this test fixture changes.\nrelated_files:\n  - y.md\n  - y.md\n---\n",
+        encoding="utf-8",
+    )
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("duplicate" in f for f in failures)
+
+
+def test_self_reference_rejected(tmp_path):
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text("---\nmaintenance: Update when this test fixture changes.\nrelated_files:\n  - x.md\n---\n", encoding="utf-8")
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("self-reference" in f for f in failures)
+
+
+def test_absolute_related_path_rejected(tmp_path):
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text(
+        "---\nmaintenance: Update when this test fixture changes.\nrelated_files:\n  - /etc/passwd\n---\n", encoding="utf-8"
+    )
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("absolute" in f or "invalid entry" in f for f in failures)
+
+
+def test_dot_dot_segment_rejected(tmp_path):
+    """V5 no longer has a generic 'outside repo' EXISTENCE check (that
+    would require resolving the path); '..' segments are still rejected
+    on SYNTAX grounds alone, via _is_clean_repo_relative_posix_path."""
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text(
+        "---\nmaintenance: Update when this test fixture changes.\nrelated_files:\n  - ../outside.md\n---\n", encoding="utf-8"
+    )
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("invalid entry" in f for f in failures)
+
+
+@pytest.mark.parametrize("bad_path", ["./child.md", "dir/./child.md", "dir//child.md"])
+def test_dot_or_empty_path_segment_rejected(tmp_path, bad_path):
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text(
+        f"---\nmaintenance: Update when this test fixture changes.\nrelated_files:\n  - {bad_path}\n---\n",
+        encoding="utf-8",
+    )
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("invalid entry" in f for f in failures)
+
+
+@pytest.mark.parametrize("bad_path", ["C:/outside.md", "C:relative.md", r"C:\outside.md"])
+def test_windows_drive_designator_path_rejected(bad_path):
+    error = checker._is_clean_repo_relative_posix_path(bad_path)
+    assert error is not None
+    assert "drive designator" in error
+
+
+def test_non_string_unhashable_related_files_item_does_not_crash(tmp_path):
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text(
+        "---\nmaintenance: Update when this test fixture changes.\nrelated_files:\n  - [nested, list]\n---\n",
+        encoding="utf-8",
+    )
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("not a string" in f or "invalid entry" in f for f in failures)
+
+
+def test_placeholder_in_maintenance_rejected(tmp_path):
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text(
+        "---\nmaintenance: Update this document when [FILL_IN] changes.\nrelated_files:\n  - y.md\n---\n", encoding="utf-8"
+    )
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("placeholder" in f for f in failures)
+
+
+def test_malformed_frontmatter_rejected(tmp_path):
+    contract = checker.load_docs_contract()
+    doc = tmp_path / "x.md"
+    doc.write_text("---\nmaintenance: a\n", encoding="utf-8")
+    failures = checker.check_one_document_path(doc, contract, repo_root=tmp_path)
+    assert any("closing fence" in f for f in failures)
+
+
+def test_malformed_html_comment_rejected():
+    contract = dict(checker.load_docs_contract())
+    contract["metadata_mode_overrides"] = {"x.md": "html_comment"}
+    text = "<!--\nmaintenance: a\n"  # no closing -->
+    meta, error = checker.parse_doc_metadata_text("x.md", text, contract)
+    assert meta is None
+    assert "closing -->" in error
+
+
+def test_unsupported_mode_override_rejected():
+    contract = dict(checker.load_docs_contract())
+    contract["metadata_mode_overrides"] = {"x.md": "not_a_real_mode"}
+    meta, error = checker.parse_doc_metadata_text("x.md", "anything", contract)
+    assert meta is None
+    assert "no supported metadata mode" in error
+
+
+def test_wrong_required_fields_order_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["required_fields"] = ["maintenance", "related_files"]
+    with pytest.raises(checker.ContractError, match="required_fields"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_missing_field_constraint_key_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["field_constraints"] = {"related_files": bad["field_constraints"]["related_files"]}
+    with pytest.raises(checker.ContractError, match="field_constraints"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_noncanonical_maintenance_forbidden_values_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["field_constraints"] = dict(bad["field_constraints"])
+    bad["field_constraints"]["maintenance"] = dict(
+        bad["field_constraints"]["maintenance"]
+    )
+    bad["field_constraints"]["maintenance"]["forbidden_exact_values"] = ["TODO"]
+    with pytest.raises(checker.ContractError, match="forbidden_exact_values"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_wrong_target_policy_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["field_constraints"] = dict(bad["field_constraints"])
+    bad["field_constraints"]["related_files"] = dict(bad["field_constraints"]["related_files"])
+    bad["field_constraints"]["related_files"]["target_policy"] = "must_resolve_to_repo_file"
+    with pytest.raises(checker.ContractError, match="target_policy"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_wrong_discovery_type_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["discovery"] = {"tracked": "yes", "untracked_not_ignored": True}
+    with pytest.raises(checker.ContractError, match="discovery"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_unknown_mode_override_target_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["metadata_mode_overrides"] = {"some/other.md": "html_comment"}
+    with pytest.raises(checker.ContractError, match="metadata_mode_overrides"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_invalid_placeholder_pattern_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["placeholder_patterns"] = ["[unclosed"]
+    with pytest.raises(checker.ContractError, match="placeholder pattern"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_unsupported_version_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["version"] = 999
+    with pytest.raises(checker.ContractError, match="version"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_unrecognized_top_level_key_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["bogus_extra_key"] = 1
+    with pytest.raises(checker.ContractError, match="unrecognized"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_pr_template_visible_body_byte_identical_and_metadata_hidden():
+    contract = checker.load_docs_contract()
+    path = ROOT / ".github/PULL_REQUEST_TEMPLATE.md"
+    text = path.read_text(encoding="utf-8")
+    visible = text.split("-->\n", 1)[1]
+    expected_visible = (
+        "## Summary\n"
+        "\n"
+        "- TODO\n"
+        "\n"
+        "## Validation\n"
+        "\n"
+        "- [ ] `git diff --check`\n"
+        "- [ ] Relevant tests or documentation checks:\n"
+        "\n"
+        "## Notes\n"
+        "\n"
+        "- Link related issues or context here.\n"
+        "- Confirm that logs, screenshots, and examples do not contain secrets.\n"
+    )
+    assert visible == expected_visible
+    failures = checker.check_one_document_path(path, contract, repo_root=ROOT)
+    assert not failures, failures
+
+
+def test_all_four_notification_managers_preserve_exact_runtime_body():
+    sys.path.insert(0, str(ROOT / "src"))
+    from lingtai.mcp_servers.feishu import manager as m1
+    from lingtai.mcp_servers.telegram import manager as m2
+    from lingtai.mcp_servers.wechat import manager as m3
+    from lingtai.mcp_servers.whatsapp import manager as m4
+
+    expected = {
+        m1.__name__: (
+            987,
+            "8065f55c16561adedf8b71d788efa29d80ff1b9a1196ffab38f239bf06302364",
+        ),
+        m2.__name__: (
+            2154,
+            "992e88cb55d8c54598883a47c895a278b1a1797f1725720a583923f6a921199c",
+        ),
+        m3.__name__: (
+            987,
+            "8065f55c16561adedf8b71d788efa29d80ff1b9a1196ffab38f239bf06302364",
+        ),
+        m4.__name__: (
+            1245,
+            "e671f269c783a6a68b9d2294f0de1eb8e397ce22e13cd73b6cd9426453b8cb9e",
+        ),
+    }
+    for mod in (m1, m2, m3, m4):
+        template = mod._NOTIFICATION_HEADER_TEMPLATE
+        expected_length, expected_sha256 = expected[mod.__name__]
+        assert len(template) == expected_length
+        assert hashlib.sha256(template.encode("utf-8")).hexdigest() == expected_sha256
+        assert template.startswith("**How to read this {channel} conversation preview")
+        assert not template.startswith("\n")
+        assert template.endswith("\n")
+        assert not template.endswith("\n\n")
+        assert template.count("{channel}") == 1
+        assert not template.startswith("---")
+        assert "related_files:" not in template
+
+
+def test_glossary_owner_preserves_rendered_body_without_metadata():
+    sys.path.insert(0, str(ROOT / "src"))
+    from lingtai.kernel import tool_glossary
+
+    before = tool_glossary.load_tool_glossary("lingtai.tools.read", "zh")
+    assert before.strip()
+    assert "kind:" not in before
+    assert "related_files:" not in before
+
+
+def test_dev_guide_skill_exact_schema():
+    contract_text = (ROOT / "dev-guide-skill/SKILL.md").read_text(encoding="utf-8")
+    assert contract_text.startswith("---\n")
+    end = contract_text.index("\n---\n", 4)
+    fm = yaml.safe_load(contract_text[4:end])
+    assert list(fm) == ["name", "description", "related_files", "maintenance"]

--- a/tests/test_docs_governance.py
+++ b/tests/test_docs_governance.py
@@ -1,4 +1,4 @@
-"""Docs YAML governance validator tests (V6).
+"""Docs YAML governance validator tests (V7).
 
 related_files.target_policy is owner_validated_relative_link: generic
 validation is syntax-only, never existence. Tests here prove both that
@@ -66,6 +66,20 @@ def test_every_in_scope_doc_has_required_fields():
     for path in checker.discover_doc_paths(contract):
         failures.extend(checker.check_one_document_path(path, contract, repo_root=ROOT))
     assert not failures, "\n".join(failures)
+
+
+def test_fsutil_migration_plan_is_marked_temporary_with_valid_exit_condition():
+    contract = checker.load_docs_contract()
+    path = ROOT / "docs/plans/2026-06-25-fsutil-migration.md"
+    text = path.read_text(encoding="utf-8")
+    meta, error = checker.parse_doc_metadata_text(
+        "docs/plans/2026-06-25-fsutil-migration.md", text, contract
+    )
+    assert error is None, error
+    assert meta["lifecycle"] == "temporary"
+    assert len(meta["temporary_until"].strip()) >= contract["lifecycle_contract"]["exit_condition_min_length"]
+    failures = checker.check_one_document_path(path, contract, repo_root=ROOT)
+    assert not failures, failures
 
 
 def test_root_anatomy_and_contract_pass_generic_check_without_weakening_architecture_tests():
@@ -178,6 +192,154 @@ def test_concise_real_maintenance_rule_is_valid():
         contract,
     )
     assert not failures, failures
+
+
+def test_durable_doc_omits_lifecycle_fields_and_is_valid():
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {"maintenance": "Update when the API changes.", "related_files": ["y.md"]},
+        contract,
+    )
+    assert not failures, failures
+
+
+def test_valid_temporary_lifecycle_metadata_passes():
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {
+            "maintenance": "Update when the API changes.",
+            "related_files": ["y.md"],
+            "lifecycle": "temporary",
+            "temporary_until": "Archive once the migration checklist is fully resolved.",
+        },
+        contract,
+    )
+    assert not failures, failures
+
+
+def test_temporary_lifecycle_missing_exit_condition_rejected():
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {"maintenance": "Update when the API changes.", "related_files": ["y.md"], "lifecycle": "temporary"},
+        contract,
+    )
+    assert any("requires" in f and "temporary_until" in f for f in failures)
+
+
+def test_temporary_until_without_lifecycle_rejected():
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {
+            "maintenance": "Update when the API changes.",
+            "related_files": ["y.md"],
+            "temporary_until": "Archive once the migration checklist is fully resolved.",
+        },
+        contract,
+    )
+    assert any("temporary_until present without" in f for f in failures)
+
+
+@pytest.mark.parametrize("bad_value", ["archived", "", "TEMPORARY", 1, None, True])
+def test_unsupported_or_non_string_lifecycle_value_rejected(bad_value):
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {
+            "maintenance": "Update when the API changes.",
+            "related_files": ["y.md"],
+            "lifecycle": bad_value,
+            "temporary_until": "Archive once the migration checklist is fully resolved.",
+        },
+        contract,
+    )
+    assert any("must be one of" in f for f in failures)
+
+
+def test_non_string_exit_condition_rejected():
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {
+            "maintenance": "Update when the API changes.",
+            "related_files": ["y.md"],
+            "lifecycle": "temporary",
+            "temporary_until": 12345,
+        },
+        contract,
+    )
+    assert any("must be a string" in f for f in failures)
+
+
+def test_too_short_exit_condition_rejected():
+    contract = checker.load_docs_contract()
+    minimum = contract["lifecycle_contract"]["exit_condition_min_length"]
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {
+            "maintenance": "Update when the API changes.",
+            "related_files": ["y.md"],
+            "lifecycle": "temporary",
+            "temporary_until": ("a " * (minimum - 1)).rstrip(),
+        },
+        contract,
+    )
+    assert any(f"at least {minimum}" in f for f in failures)
+
+
+def test_placeholder_exit_condition_rejected():
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {
+            "maintenance": "Update when the API changes.",
+            "related_files": ["y.md"],
+            "lifecycle": "temporary",
+            "temporary_until": "Archive once [FILL_IN] is resolved.",
+        },
+        contract,
+    )
+    assert any("placeholder" in f for f in failures)
+
+
+@pytest.mark.parametrize(
+    "exit_condition",
+    [
+        "When done, TBD TBD TBD TBD",
+        "When everything is finally completely done.",
+        "After the migration is complete.",
+    ],
+)
+def test_non_concrete_exit_condition_rejected(exit_condition):
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {
+            "maintenance": "Update when the API changes.",
+            "related_files": ["y.md"],
+            "lifecycle": "temporary",
+            "temporary_until": exit_condition,
+        },
+        contract,
+    )
+    assert any("non-concrete or contains a placeholder" in failure for failure in failures)
+
+
+def test_temporary_lifecycle_does_not_exempt_required_fields():
+    contract = checker.load_docs_contract()
+    failures = checker.validate_metadata_mapping(
+        "x.md",
+        {
+            "lifecycle": "temporary",
+            "temporary_until": "Archive once the migration checklist is fully resolved.",
+        },
+        contract,
+    )
+    assert "x.md: missing required field 'related_files'" in failures
+    assert "x.md: missing required field 'maintenance'" in failures
 
 
 def test_duplicate_related_path_rejected(tmp_path):
@@ -346,6 +508,53 @@ def test_unsupported_version_rejected():
     bad = dict(checker.load_docs_contract())
     bad["version"] = 999
     with pytest.raises(checker.ContractError, match="version"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_canonical_contract_is_v7_with_lifecycle_contract_block():
+    contract = checker.load_docs_contract()
+    assert contract["version"] == 7
+    assert contract["lifecycle_contract"] == {
+        "field": "lifecycle",
+        "supported_values": ["temporary"],
+        "exit_condition_field": "temporary_until",
+        "exit_condition_min_length": 20,
+        "exit_condition_forbidden_patterns": [
+            r"(?i)\b(?:tbd|todo|fixme|xxx|n/a)\b",
+            r"(?i)^\s*when(?:\s+\w+){0,4}\s+(?:is\s+)?done\s*[.!]?\s*$",
+            r"(?i)^\s*after\s+(?:the\s+)?migration(?:\s+is\s+(?:done|complete|completed))?\s*[.!]?\s*$",
+        ],
+    }
+
+
+def test_missing_lifecycle_contract_block_rejected():
+    bad = dict(checker.load_docs_contract())
+    del bad["lifecycle_contract"]
+    with pytest.raises(checker.ContractError, match="lifecycle"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_wrong_lifecycle_supported_values_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["lifecycle_contract"] = dict(bad["lifecycle_contract"])
+    bad["lifecycle_contract"]["supported_values"] = ["temporary", "deprecated"]
+    with pytest.raises(checker.ContractError, match="supported_values"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_lifecycle_exit_condition_min_length_must_be_positive_int():
+    bad = dict(checker.load_docs_contract())
+    bad["lifecycle_contract"] = dict(bad["lifecycle_contract"])
+    bad["lifecycle_contract"]["exit_condition_min_length"] = 0
+    with pytest.raises(checker.ContractError, match="exit_condition_min_length"):
+        checker.validate_docs_contract_shape(bad)
+
+
+def test_bad_lifecycle_exit_condition_pattern_rejected():
+    bad = dict(checker.load_docs_contract())
+    bad["lifecycle_contract"] = dict(bad["lifecycle_contract"])
+    bad["lifecycle_contract"]["exit_condition_forbidden_patterns"] = ["[unclosed"]
+    with pytest.raises(checker.ContractError, match="exit condition pattern"):
         checker.validate_docs_contract_shape(bad)
 
 

--- a/tests/test_tool_glossary.py
+++ b/tests/test_tool_glossary.py
@@ -104,6 +104,9 @@ _GOOD_FM = textwrap.dedent("""\
     schema_version: 1
     tool_package: lingtai.tools.test
     language: zh
+    related_files:
+      - docs.yaml
+    maintenance: Test fixture glossary for parse_glossary unit tests.
     ---
     body text""")
 
@@ -647,6 +650,9 @@ class TestSourceValidation:
                 schema_version: 1
                 tool_package: lingtai.tools.fake
                 language: {lang}
+                related_files:
+                  - docs.yaml
+                maintenance: Fake fixture glossary for validator mutation tests.
                 ---
                 {body}"""
             )
@@ -697,3 +703,54 @@ class TestSourceValidation:
         monkeypatch.setattr(validator.importlib_resources, "files", lambda _pkg: root)
         errors = validator.validate_package("fake")
         assert any(expected in error for error in errors), errors
+
+
+# ---------------------------------------------------------------------------
+# related_files / maintenance — docs-governance fields (V5)
+# ---------------------------------------------------------------------------
+
+
+class TestDocsGovernanceFields:
+    def test_missing_related_files_rejected(self):
+        text = _GOOD_FM.replace("related_files:\n  - docs.yaml\n", "")
+        with pytest.raises(GlossaryValidationError, match="missing"):
+            parse_glossary(text, tool_package="lingtai.tools.test", language="zh")
+
+    def test_empty_related_files_rejected(self):
+        text = _GOOD_FM.replace(
+            "related_files:\n  - docs.yaml\n", "related_files: []\n"
+        )
+        with pytest.raises(GlossaryValidationError, match="related_files"):
+            parse_glossary(text, tool_package="lingtai.tools.test", language="zh")
+
+    def test_missing_maintenance_rejected(self):
+        text = _GOOD_FM.replace(
+            "maintenance: Test fixture glossary for parse_glossary unit tests.\n", ""
+        )
+        with pytest.raises(GlossaryValidationError, match="missing"):
+            parse_glossary(text, tool_package="lingtai.tools.test", language="zh")
+
+    def test_empty_maintenance_rejected(self):
+        text = _GOOD_FM.replace(
+            "maintenance: Test fixture glossary for parse_glossary unit tests.\n",
+            "maintenance: \"\"\n",
+        )
+        with pytest.raises(GlossaryValidationError, match="maintenance"):
+            parse_glossary(text, tool_package="lingtai.tools.test", language="zh")
+
+    def test_extra_field_beyond_six_still_rejected(self):
+        text = _GOOD_FM.replace(
+            "maintenance: Test fixture glossary for parse_glossary unit tests.\n",
+            "maintenance: Test fixture glossary for parse_glossary unit tests.\n"
+            "extra: field\n",
+        )
+        with pytest.raises(GlossaryValidationError, match="unknown"):
+            parse_glossary(text, tool_package="lingtai.tools.test", language="zh")
+
+    def test_non_string_related_files_item_rejected_not_crashed(self):
+        text = _GOOD_FM.replace(
+            "related_files:\n  - docs.yaml\n",
+            "related_files:\n  - docs.yaml\n  - [nested, list]\n",
+        )
+        with pytest.raises(GlossaryValidationError, match="related_files"):
+            parse_glossary(text, tool_package="lingtai.tools.test", language="zh")


### PR DESCRIPTION
## Summary

- add root `docs.yaml` as the single machine-readable contract for repository Markdown metadata
- migrate all 244 current Markdown documents to nonempty repo-relative `related_files` plus a document-specific `maintenance` rule, with no path-level content exemptions
- add `scripts/check_docs_governance.py` and regression coverage for strict frontmatter/YAML, maintenance placeholders and the exact 19/20 boundary, unsafe paths including Windows drive designators, specialized-owner boundaries, package/runtime consumers, and byte-exact notification bodies
- preserve existing Anatomy/Contract, prompt-crawl, glossary, session-journal, PR-template, and raw-consumer ownership semantics
- reconcile the reviewed V6R governance candidate onto live main `a2b7d729`: 167 files remain byte-identical to the reviewed candidate, while four overlapping manuals preserve the intervening #917/#918 content and add only the exact reviewed governance blocks
- add an optional `lifecycle: temporary` marker with a required, concrete `temporary_until` exit condition; the marker adds obligations and never exempts `maintenance` or `related_files`
- mark exactly one evidence-backed transitional document, `docs/plans/2026-06-25-fsutil-migration.md`, while leaving durable/history documents unclassified by default

## Validation

Current head `f4163f2e9d2780d3d7a694b331b6f3b03e9aa670`:

```text
python scripts/check_docs_governance.py --check
OK: 244 documents (+ docs.yaml itself) validated.

python -m pytest -q -p no:cacheprovider --basetemp <scratch> \
  tests/test_docs_governance.py \
  tests/test_tool_glossary.py \
  tests/test_architecture_documents.py \
  tests/test_mcp_capability.py
288 passed in 1.83s
```

Earlier reconciled V6R full-suite baseline, before the lifecycle-only follow-up:

```text
python -m pytest -q -p no:cacheprovider --basetemp <scratch>
4 failed, 5374 passed, 3 skipped in 240.78s (0:04:00)
# exact failed-node set matches the prior four classified baseline cases; candidate-specific failures: 0
```

Additional exact-candidate checks:

- scratch simulated post-commit: 881 tracked files, 244 Markdown documents, 0 untracked files; `git diff --cached --check` passed; real worktree index remained byte-identical
- initial reconciled candidate tree: `bac66b18c2a7c8d55881c017e7f1516c19e617e2`
- independently applied scratch-index tree: `bac66b18c2a7c8d55881c017e7f1516c19e617e2`
- initial exact live packet patch SHA-256: `0e3003629670b56d0d0197bf9a1fd69213d05d487ff9cbe6fba2ca1e51f524ce`
- lifecycle follow-up exact diff SHA-256: `96167b10d8109a28d58cb9f375e1dc99281a04beb8255176886a2cd65a4b448e`
- canonical pool Terra initial governance review: PASS, 0 blocker / 0 important / 0 NIT after its two bounded quality repairs
- capability-enforced and mechanically verified `claude-opus-4-8` initial governance review: PASS, 0 blocker / 0 important / 1 cosmetic non-blocking NIT (three stale “V5” labels in test comments/docstrings only)
- lifecycle follow-up Terra exact review: PASS, 0 blocker / 0 important / 0 NIT after closing its anti-placeholder finding and non-whitespace-count NIT
- lifecycle follow-up no-tools, mechanically verified `claude-opus-4-8` final review: PASS, 0 blocker / 0 important; two observational non-blocking NITs, with no candidate change required

## Scope notes

- `related_files` remains a safe repo-relative logical/crawl-link field; deeper existence and graph semantics stay with their existing specialized owners.
- `lifecycle_contract` supplies only a small mechanical floor. It rejects placeholder tokens and bare generic “when done” / “after migration” conditions, but owners and review remain responsible for semantic concreteness.
- The read-only expiry audit found zero deletion-ready stale documents. This PR does not delete, archive, or move any document.
- Two stale `related_files` entries discovered in `src/lingtai/kernel/i18n/ANATOMY.md` are reported separately and deliberately not mixed into this PR.
- The HTML explainer is local-only and is not included in this PR.
- This PR does not add or claim a new hosted CI workflow.
