### PR TITLE
docs: clarify daemon preset batch refusal

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -560,8 +560,8 @@ the gate above.
   different loadable default; if an existing active preset is malformed,
   materialization fails rather than silently substituting another preset.
 - An unauthorized explicit `tasks[].preset` (not in `manifest.preset.allowed`)
-  is rejected before load, connectivity/capability preflight, run-dir
-  creation, scheduling, or dispatch of that task.
+  refuses the whole batch before load, connectivity/capability preflight,
+  run-dir creation, scheduling, or dispatch.
 - Once past the allowlist gate, daemon explicit-path preflight failure
   (unloadable path, failed connectivity, failed capability instantiation)
-  still prevents dispatch of that task.
+  still refuses the whole batch before any emanation is scheduled.

--- a/tests/test_preset_runtime_model_docs.py
+++ b/tests/test_preset_runtime_model_docs.py
@@ -99,6 +99,12 @@ def test_substrate_reference_daemon_explicit_preset_must_be_allowed():
     assert "_preset_ref_in" in text
 
 
+def test_substrate_reference_daemon_preset_failures_refuse_whole_batch():
+    text = _read(SUBSTRATE_REFERENCE)
+    assert text.count("refuses the whole batch") >= 2
+    assert "before any emanation is scheduled" in text
+
+
 def test_substrate_reference_omitted_daemon_preset_is_parent_derived():
     text = _read(SUBSTRATE_REFERENCE)
     assert "parent-derived" in text


### PR DESCRIPTION
## Summary

- clarify that an unauthorized explicit daemon preset refuses the **whole batch**, not only the task carrying that preset
- clarify that later explicit-preset preflight failures also refuse the whole batch before any emanation is scheduled
- add a focused documentation regression check for both whole-batch statements

## Why

The runtime and daemon Anatomy already enforce and document batch-atomic refusal, but two failure-boundary bullets in the canonical substrate manual said only “that task.” This small follow-up aligns the explanatory wording with the existing behavior without changing runtime code or adding product surface.

## Validation

- `git diff --check`
- `python -m pytest tests/test_preset_runtime_model_docs.py tests/test_daemon.py::test_emanate_lingtai_valid_but_unallowed_preset_rejected_before_preflight tests/test_daemon.py::test_emanate_with_preset_validates_preset_exists -q` — 24 passed
- independent frozen-snapshot review on mechanically verified `gpt-5.6-terra` — **APPROVE**, no findings
  - report: local review artifact, intentionally not committed
  - frozen patch SHA-256: `68805108a455882e3045f258ab2c5849c30fd163cbe3ee95f79aca0576e53d2c`

## Scope / provenance

- documentation and its focused anchor test only; no runtime, config, auth, refresh, deployment, or cleanup change
- separate post-merge follow-up to the non-blocking whole-batch wording note after #917; does not rewrite #917 history
- branch/push/PR creation is covered by Jason H’s standing 2026-07-14 authorization for dev agents’ own reviewed work; merge remains separately gated
