### PR TITLE
refactor(refresh): reuse canonical process matcher

### DIFF
--- a/src/lingtai/kernel/refresh_watcher/ANATOMY.md
+++ b/src/lingtai/kernel/refresh_watcher/ANATOMY.md
@@ -47,12 +47,12 @@ what/how/why walkthrough.
 - `_decode_identity_fields(identity_fields_json)` — decodes+validates the
   JSON snapshot back to a `dict`, raising `ValueError` on invalid JSON or a
   non-object top-level value
-  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:61-84`).
+  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:69-92`).
 - `render_watcher_script(request)` — pure Core-owned function rendering the
   complete watcher program source from a `RefreshWatcherRequest` (decoding
   `identity_fields_json` via `_decode_identity_fields` for the rendered
   literal shape); performs no OS calls
-  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:87-476`). The
+  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:95-471`). The
   rendered program's stale same-agent duplicate-process guard
   (`_is_same_agent_run`) imports the canonical Core process-command matcher
   `lingtai.kernel.process_match.match_agent_run`
@@ -127,8 +127,10 @@ detached process, not a redesign of that policy. The one deliberate structural
 change since that extraction: the rendered program's stale-duplicate guard now
 imports `lingtai.kernel.process_match.match_agent_run`
 (`src/lingtai/kernel/process_match.py`) instead of embedding its own copy of
-that matching policy, so the launch-form matching rules have exactly one
-implementation shared with the CLI's duplicate-process check — this is not a
+that matching policy, so the watcher and CLI runtime consumers share one
+importable Core implementation, while the standalone `lingtai-doctor` bundle
+intentionally retains its stdlib-only copy under
+`tests/test_process_match.py` parity coverage — this is not a
 claim that the watcher's own retry/heartbeat/duplicate-cleanup policy became
 independently unit-testable, only that one helper it calls is now imported
 rather than duplicated. `base_agent/ANATOMY.md`

--- a/src/lingtai/kernel/refresh_watcher/ANATOMY.md
+++ b/src/lingtai/kernel/refresh_watcher/ANATOMY.md
@@ -4,6 +4,7 @@ related_files:
   - src/lingtai/kernel/refresh_watcher/__init__.py
   - src/lingtai/kernel/refresh_watcher/watcher_program.py
   - src/lingtai/kernel/refresh_watcher/MANUAL.md
+  - src/lingtai/kernel/process_match.py
   - src/lingtai/kernel/ANATOMY.md
   - src/lingtai/adapters/posix/ANATOMY.md
   - src/lingtai/adapters/posix/refresh_watcher_entrypoint.py
@@ -51,7 +52,13 @@ what/how/why walkthrough.
   complete watcher program source from a `RefreshWatcherRequest` (decoding
   `identity_fields_json` via `_decode_identity_fields` for the rendered
   literal shape); performs no OS calls
-  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:87-476`).
+  (`src/lingtai/kernel/refresh_watcher/watcher_program.py:87-476`). The
+  rendered program's stale same-agent duplicate-process guard
+  (`_is_same_agent_run`) imports the canonical Core process-command matcher
+  `lingtai.kernel.process_match.match_agent_run`
+  (`src/lingtai/kernel/process_match.py`) at runtime rather than embedding a
+  second local definition — the same matcher `lingtai.cli._check_duplicate_process`
+  uses.
 - `encode_request(request)` / `decode_request(payload)` — pure Core-owned,
   technology-neutral functions defining a compact deterministic JSON wire
   shape for a `RefreshWatcherRequest` (fixed field order; `cmd` round-trips
@@ -116,7 +123,15 @@ For Core-produced requests, `watcher_program.render_watcher_script` preserves
 the previously inline `lifecycle.py` script's runtime behavior (handshake
 deadlines, relaunch retry, stale-duplicate cleanup, redaction) without claiming
 textual byte identity — this Port and its renderer govern only the hand-off to a
-detached process, not a redesign of that policy. `base_agent/ANATOMY.md`
+detached process, not a redesign of that policy. The one deliberate structural
+change since that extraction: the rendered program's stale-duplicate guard now
+imports `lingtai.kernel.process_match.match_agent_run`
+(`src/lingtai/kernel/process_match.py`) instead of embedding its own copy of
+that matching policy, so the launch-form matching rules have exactly one
+implementation shared with the CLI's duplicate-process check — this is not a
+claim that the watcher's own retry/heartbeat/duplicate-cleanup policy became
+independently unit-testable, only that one helper it calls is now imported
+rather than duplicated. `base_agent/ANATOMY.md`
 still narrates that behavior in its `lifecycle.py` entry for readers
 descending from `base_agent/`. The transport that carries a
 `RefreshWatcherRequest` across the process boundary (`encode_request`/

--- a/src/lingtai/kernel/refresh_watcher/CONTRACT.md
+++ b/src/lingtai/kernel/refresh_watcher/CONTRACT.md
@@ -7,6 +7,7 @@ related_files:
   - src/lingtai/kernel/refresh_watcher/__init__.py
   - src/lingtai/kernel/refresh_watcher/watcher_program.py
   - src/lingtai/kernel/refresh_watcher/MANUAL.md
+  - src/lingtai/kernel/process_match.py
   - src/lingtai/adapters/posix/refresh_watcher.py
   - src/lingtai/adapters/posix/refresh_watcher_entrypoint.py
   - src/lingtai/kernel/base_agent/__init__.py
@@ -15,6 +16,7 @@ related_files:
   - src/lingtai/cli.py
   - tests/_refresh_watcher_helpers.py
   - tests/test_perform_refresh_handshake.py
+  - tests/test_process_match.py
   - tests/test_deep_refresh.py
   - tests/test_base_agent.py
 maintenance: |
@@ -228,14 +230,26 @@ Windows production adapter is explicitly out of scope for this slice.
    compact deterministic JSON wire shape and validate it on the way back, but
    know nothing about how a transport delivers the encoded string (argv, a
    file, stdin, ...) — that remains the adapter/entrypoint's concern.
-6. The generated watcher program's terminal-failure metadata bounds and
+6. The generated watcher program's stale same-agent duplicate-process guard
+   (`_is_same_agent_run`) MUST import and call the canonical Core process
+   policy `lingtai.kernel.process_match.match_agent_run`
+   (`src/lingtai/kernel/process_match.py`) — the same function
+   `lingtai.cli._check_duplicate_process` uses — at runtime via
+   `from lingtai.kernel.process_match import match_agent_run` in the
+   rendered program text. The generated program MUST NOT embed or maintain
+   a second local `match_agent_run` definition; `match_agent_run`'s launch-form
+   matching policy (module/console/legacy command forms, program-anchoring,
+   working-directory match) has exactly one implementation, shared by the CLI
+   duplicate-process check and the watcher's stale-duplicate cleanup, not two
+   copies kept in parity by a test.
+7. The generated watcher program's terminal-failure metadata bounds and
    redacts `last_stderr_tail`, `last_cleanup_error`, and `last_relaunch_error`
    identically (via the shared `_redact_bounded` helper in the rendered
    program) before writing `refresh_failed_permanent.json`, the
    `.notification/system.json` alert, or the final `refresh_failed_permanent`
    event. No raw or unbounded exception text may reach any of those three
    sinks.
-7. `build_watcher_env(request)` MUST make `request.env_overwrite` fully
+8. `build_watcher_env(request)` MUST make `request.env_overwrite` fully
    authoritative in both directions: when `True` it sets `ENV_OVERWRITE_VAR`
    in the copied environment; when `False` it explicitly removes
    `ENV_OVERWRITE_VAR` from the copy, even if the parent process's own
@@ -243,7 +257,7 @@ Windows production adapter is explicitly out of scope for this slice.
    inherit a stale `True` value from the parent environment. The parent
    process's `os.environ` itself is never mutated — `build_watcher_env`
    returns a fresh `dict` copy.
-8. `RefreshWatcherRequest.cmd` is a tuple (`tuple[str, ...]`), not a `list`.
+9. `RefreshWatcherRequest.cmd` is a tuple (`tuple[str, ...]`), not a `list`.
    `frozen=True` alone only blocks attribute reassignment; a mutable
    container field would let a caller mutate the request's owned data after
    construction despite the dataclass being "frozen". `RefreshWatcherRequest.
@@ -256,7 +270,7 @@ Windows production adapter is explicitly out of scope for this slice.
    failing loudly (`ValueError`) on invalid JSON or a non-object top-level
    value, before any generated source is produced — an invalid snapshot MUST
    NOT silently render broken or empty watcher-program text.
-9. `decode_request(encode_request(request))` MUST equal `request` for every
+10. `decode_request(encode_request(request))` MUST equal `request` for every
    valid `RefreshWatcherRequest`, including restoring `cmd` to a `tuple`
    (JSON has no tuple type, so the decoded value would otherwise be a `list`).
    `encode_request` MUST be deterministic — the same request always encodes
@@ -268,6 +282,19 @@ Windows production adapter is explicitly out of scope for this slice.
    malformed request from untrusted transport input.
 
 ## Contract tests
+
+`test_refresh_watcher_script_cleans_stale_duplicate_process`
+(`tests/test_perform_refresh_handshake.py`) and
+`test_refresh_watcher_imports_canonical_match_agent_run`
+(`tests/test_process_match.py`) pin contract rule 6: the rendered watcher
+program text must contain
+`from lingtai.kernel.process_match import match_agent_run` and must NOT
+contain a `def match_agent_run` definition of its own.
+`tests/test_process_match.py` owns the shared `MATCH_CASES` policy matrix and
+exercises it directly against the canonical
+`lingtai.kernel.process_match.match_agent_run` and the `lingtai-doctor`
+script's own copy; it does not re-derive the watcher's copy from generated
+program text, since the watcher no longer has one.
 
 `tests/test_perform_refresh_handshake.py` and `tests/test_deep_refresh.py`
 inject `FakeRefreshWatcher` (`tests/_refresh_watcher_helpers.py`) in place of

--- a/src/lingtai/kernel/refresh_watcher/CONTRACT.md
+++ b/src/lingtai/kernel/refresh_watcher/CONTRACT.md
@@ -237,11 +237,13 @@ Windows production adapter is explicitly out of scope for this slice.
    `lingtai.cli._check_duplicate_process` uses — at runtime via
    `from lingtai.kernel.process_match import match_agent_run` in the
    rendered program text. The generated program MUST NOT embed or maintain
-   a second local `match_agent_run` definition; `match_agent_run`'s launch-form
-   matching policy (module/console/legacy command forms, program-anchoring,
-   working-directory match) has exactly one implementation, shared by the CLI
-   duplicate-process check and the watcher's stale-duplicate cleanup, not two
-   copies kept in parity by a test.
+   a second local `match_agent_run` definition; the CLI duplicate-process check
+   and the watcher's stale-duplicate cleanup MUST share the one importable Core
+   implementation of the launch-form policy (module/console/legacy command
+   forms, program-anchoring, working-directory match). The standalone
+   `lingtai-doctor` bundle intentionally retains a stdlib-only copy because it
+   cannot import kernel modules; `tests/test_process_match.py` MUST continue to
+   keep that bundle copy in parity with the canonical Core implementation.
 7. The generated watcher program's terminal-failure metadata bounds and
    redacts `last_stderr_tail`, `last_cleanup_error`, and `last_relaunch_error`
    identically (via the shared `_redact_bounded` helper in the rendered
@@ -321,7 +323,7 @@ hand-off or how the request crosses the process boundary.
 `test_encode_decode_request_roundtrip`, `test_encode_request_is_deterministic`,
 `test_decode_request_invalid_payload_fails_loudly`, and
 `test_decode_request_rejects_extra_and_wrong_type_fields`
-(`tests/test_perform_refresh_handshake.py`) pin contract rule 9's
+(`tests/test_perform_refresh_handshake.py`) pin contract rule 10's
 serialization/validation guarantees directly against
 `refresh_watcher.encode_request`/`decode_request`, independent of any
 transport or subprocess.

--- a/src/lingtai/kernel/refresh_watcher/MANUAL.md
+++ b/src/lingtai/kernel/refresh_watcher/MANUAL.md
@@ -49,17 +49,17 @@ data afterward.
    (`src/lingtai/kernel/refresh_watcher/watcher_program.py`) first decodes
    `request.identity_fields_json` back to a `dict` via `_decode_identity_fields`
    — raising `ValueError` before generating any source if the snapshot is
-   invalid JSON or not a JSON object — then renders a complete,
-   self-contained Python program source: the ACK/lock handshake poll, the
+   invalid JSON or not a JSON object — then renders complete Python program
+   source independent of the parent process's live objects: the ACK/lock handshake poll, the
    12-attempt relaunch loop with a 10s health-check wait, stale same-agent
    duplicate-process cleanup (SIGTERM → 5s grace → SIGKILL), redacted event
    logging, and the terminal failure artifact/notification. This module
-   performs no OS calls itself. The rendered program's duplicate-process
-   guard imports the canonical Core process-command matcher
-   (`from lingtai.kernel.process_match import match_agent_run`,
-   `src/lingtai/kernel/process_match.py`) at runtime instead of embedding a
-   second copy of that policy — the same function the CLI's own
-   `_check_duplicate_process` uses.
+   performs no OS calls itself. Executing the rendered source requires an
+   importable LingTai package for the kernel's redaction helper and canonical
+   Core process-command matcher. The duplicate-process guard imports
+   `from lingtai.kernel.process_match import match_agent_run` at runtime
+   instead of embedding a second watcher copy of that policy — the same function
+   the CLI's own `_check_duplicate_process` uses.
 3. **The POSIX adapter encodes the request and launches the entrypoint.**
    `PosixRefreshWatcherAdapter.spawn_detached(request)`
    (`src/lingtai/adapters/posix/refresh_watcher.py`) calls
@@ -84,9 +84,11 @@ data afterward.
    watcher policy of its own — it is a thin decode→render→exec pipeline, so
    the watcher's actual runtime behavior remains entirely owned by
    `render_watcher_script`.
-5. **The watcher program runs standalone.** Once running it re-derives
-   everything it needs from literals embedded by `render_watcher_script`; it
-   holds no reference to the parent process's live objects and outlives it.
+5. **The watcher program runs independently of the parent's live objects.**
+   Once running it gets every request-derived value from literals embedded by
+   `render_watcher_script` and outlives the parent process. Its runtime imports
+   still require the LingTai package that supplied the entrypoint, redaction
+   helper, and canonical process-command matcher.
 
 ## Why
 
@@ -141,11 +143,14 @@ for a later slice.
 A later slice replaced the rendered program's embedded, duplicated
 `match_agent_run` definition with an import of the canonical Core policy
 (`lingtai.kernel.process_match.match_agent_run`) that the CLI's own
-duplicate-process check already used. Before this, the launch-form matching
-rule set existed as two hand-synchronized copies — the CLI's and one baked
+duplicate-process check already used. Before this, the CLI and watcher runtime
+consumers carried two hand-synchronized copies of the launch-form matching
+rule set — the CLI's and one baked
 into every rendered watcher program — kept in parity only by a test that
 string-sliced the generated source back into an executable function. Import
-replaces duplication: the matching policy now has exactly one implementation,
-still shared by both consumers, with no change to the policy itself, the
-watcher's own retry/heartbeat/duplicate-cleanup behavior, or anything else
-this Port renders.
+removes only the watcher duplicate: the CLI and watcher now share one
+importable Core implementation. The standalone `lingtai-doctor` bundle
+intentionally retains its stdlib-only copy, kept in parity by
+`tests/test_process_match.py`. This changes neither the matching policy nor the
+watcher's own retry/heartbeat/duplicate-cleanup behavior or anything else this
+Port renders.

--- a/src/lingtai/kernel/refresh_watcher/MANUAL.md
+++ b/src/lingtai/kernel/refresh_watcher/MANUAL.md
@@ -4,6 +4,7 @@ related_files:
   - src/lingtai/kernel/refresh_watcher/ANATOMY.md
   - src/lingtai/kernel/refresh_watcher/__init__.py
   - src/lingtai/kernel/refresh_watcher/watcher_program.py
+  - src/lingtai/kernel/process_match.py
   - src/lingtai/adapters/posix/refresh_watcher.py
   - src/lingtai/adapters/posix/refresh_watcher_entrypoint.py
 maintenance: |
@@ -53,7 +54,12 @@ data afterward.
    12-attempt relaunch loop with a 10s health-check wait, stale same-agent
    duplicate-process cleanup (SIGTERM → 5s grace → SIGKILL), redacted event
    logging, and the terminal failure artifact/notification. This module
-   performs no OS calls itself.
+   performs no OS calls itself. The rendered program's duplicate-process
+   guard imports the canonical Core process-command matcher
+   (`from lingtai.kernel.process_match import match_agent_run`,
+   `src/lingtai/kernel/process_match.py`) at runtime instead of embedding a
+   second copy of that policy — the same function the CLI's own
+   `_check_duplicate_process` uses.
 3. **The POSIX adapter encodes the request and launches the entrypoint.**
    `PosixRefreshWatcherAdapter.spawn_detached(request)`
    (`src/lingtai/adapters/posix/refresh_watcher.py`) calls
@@ -131,3 +137,15 @@ transport-shape improvement — replacing "raw generated source on argv" with
 Clock/Filesystem/Publication Port abstraction, a Windows adapter, or a
 broader process-supervision redesign, all of which remain explicit non-goals
 for a later slice.
+
+A later slice replaced the rendered program's embedded, duplicated
+`match_agent_run` definition with an import of the canonical Core policy
+(`lingtai.kernel.process_match.match_agent_run`) that the CLI's own
+duplicate-process check already used. Before this, the launch-form matching
+rule set existed as two hand-synchronized copies — the CLI's and one baked
+into every rendered watcher program — kept in parity only by a test that
+string-sliced the generated source back into an executable function. Import
+replaces duplication: the matching policy now has exactly one implementation,
+still shared by both consumers, with no change to the policy itself, the
+watcher's own retry/heartbeat/duplicate-cleanup behavior, or anything else
+this Port renders.

--- a/src/lingtai/kernel/refresh_watcher/watcher_program.py
+++ b/src/lingtai/kernel/refresh_watcher/watcher_program.py
@@ -15,6 +15,13 @@ preserves the previously shipped runtime behavior; this slice does not claim
 textual byte identity, redesign retry/heartbeat/duplicate policy, or
 introduce a process-supervision Port; that remains a later slice.
 
+The rendered program's stale same-agent duplicate-process guard
+(``_is_same_agent_run``) imports the canonical Core process-command matcher,
+``lingtai.kernel.process_match.match_agent_run``, at runtime via
+``from lingtai.kernel.process_match import match_agent_run`` in the generated
+source, rather than embedding a second local ``match_agent_run`` definition —
+the same matcher ``lingtai.cli._check_duplicate_process`` already uses.
+
 Identity fields cross the request boundary as
 ``RefreshWatcherRequest.identity_fields_json`` — a JSON object snapshot, not
 a live dict or a shallow tuple-of-pairs — because the producer
@@ -337,21 +344,7 @@ def render_watcher_script(request: RefreshWatcherRequest) -> str:
         "        if len(parts) >= 2 and parts[1].rstrip(':').isdigit():\n"
         "            return int(parts[1].rstrip(':'))\n"
         "    return None\n"
-        "def match_agent_run(cmdline, working_dir):\n"
-        "    target = os.path.normpath(working_dir)\n"
-        "    for token, label, program_anchored in (\n"
-        "        (' -m lingtai run ', 'module', False),\n"
-        "        ('lingtai-agent run ', 'console', True),\n"
-        "        ('lingtai run ', 'legacy', True),\n"
-        "    ):\n"
-        "        idx = cmdline.find(token)\n"
-        "        while idx != -1:\n"
-        "            if (not program_anchored) or idx == 0 or cmdline[idx - 1] == '/':\n"
-        "                tail = cmdline[idx + len(token):].strip()\n"
-        "                if tail and os.path.normpath(tail) == target:\n"
-        "                    return label\n"
-        "            idx = cmdline.find(token, idx + 1)\n"
-        "    return None\n"
+        "from lingtai.kernel.process_match import match_agent_run\n"
         "def _is_same_agent_run(pid):\n"
         "    if not pid or pid == os.getpid():\n"
         "        return False\n"

--- a/src/lingtai/kernel/refresh_watcher/watcher_program.py
+++ b/src/lingtai/kernel/refresh_watcher/watcher_program.py
@@ -8,10 +8,11 @@ redaction, and terminal-failure artifact/notification publication. Moving the
 text-assembly logic here makes *rendering* it importable, directly callable
 production code instead of a string literal buried in lifecycle control
 flow — it does not turn the watcher's own policy into independently
-executable/importable code: the returned value is still generated ``python
--c`` program *source text*, run later as a detached subprocess, not a
-function this process calls. For Core-produced requests, the generated program
-preserves the previously shipped runtime behavior; this slice does not claim
+executable/importable code: the returned value is still generated Python
+program *source text*, executed later by the detached
+``refresh_watcher_entrypoint`` process, not a function this process calls. For
+Core-produced requests, the generated program preserves the previously shipped
+runtime behavior; this slice does not claim
 textual byte identity, redesign retry/heartbeat/duplicate policy, or
 introduce a process-supervision Port; that remains a later slice.
 
@@ -50,9 +51,9 @@ concrete environment-variable name the transport uses — is entirely adapter
 mechanism: see ``lingtai.adapters.posix.refresh_watcher.build_watcher_env``
 and its ``ENV_OVERWRITE_VAR``. This module does not define or reference that
 variable name; Core knows only the boolean ``request.env_overwrite`` policy
-bit, never the concrete env-var transport. The POSIX adapter
-(`lingtai.adapters.posix.refresh_watcher`) is the only caller that launches
-the rendered text as a real detached process.
+bit, never the concrete env-var transport. The POSIX entrypoint executes the
+rendered text inside the detached process launched by
+``lingtai.adapters.posix.refresh_watcher``.
 """
 from __future__ import annotations
 
@@ -92,13 +93,13 @@ def _decode_identity_fields(identity_fields_json: str) -> dict:
 
 
 def render_watcher_script(request: RefreshWatcherRequest) -> str:
-    """Render the complete, self-contained watcher program source.
+    """Render the complete watcher program source.
 
-    The returned text is a standalone Python program: it re-derives every
-    value it needs (handshake paths, relaunch command, identity fields) from
-    literals embedded by this function, and it imports only stdlib plus the
-    kernel's redaction helper at runtime. It carries no reference to this
-    process's live objects.
+    The returned text embeds every request-derived value it needs (handshake
+    paths, relaunch command, identity fields), and carries no reference to this
+    process's live objects. Execution requires an importable LingTai package for
+    the kernel's redaction helper and canonical process-command matcher in
+    addition to the Python standard library.
     """
     taken_path = request.taken_path
     lock_path = request.lock_path

--- a/tests/test_perform_refresh_handshake.py
+++ b/tests/test_perform_refresh_handshake.py
@@ -756,7 +756,10 @@ def test_refresh_watcher_script_cleans_stale_duplicate_process(tmp_path):
     """Production incident 2026-06-04: refresh watcher relaunches can be
     blocked by a stale LingTai run process. The watcher script
     must detect the duplicate-process guard stderr and terminate only a stale
-    same-agent process (no fresh heartbeat) before retrying.
+    same-agent process (no fresh heartbeat) before retrying. The matcher
+    itself is the canonical Core policy
+    (`lingtai.kernel.process_match.match_agent_run`), imported at runtime
+    rather than duplicated/embedded in the generated script.
     """
     agent = _make_agent_with_launch_cmd(tmp_path)
 
@@ -766,7 +769,8 @@ def test_refresh_watcher_script_cleans_stale_duplicate_process(tmp_path):
     script = agent._refresh_watcher.last_script
     assert "another lingtai agent is already running" in script
     assert "def _cleanup_stale_duplicate" in script
-    assert "def match_agent_run" in script
+    assert "from lingtai.kernel.process_match import match_agent_run" in script
+    assert "def match_agent_run" not in script
     assert "match_agent_run(cmdline, wd) is not None" in script
     assert "heartbeat_age" in script
     assert "signal.SIGTERM" in script
@@ -1028,6 +1032,10 @@ def test_refresh_watcher_permanent_failure_writes_operator_alert(tmp_path):
         capture_output=True,
         text=True,
         timeout=10,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+        },
     )
 
     assert result.returncode == 0, result.stderr
@@ -1115,6 +1123,10 @@ def test_refresh_watcher_cleanup_then_success_does_not_write_failure_alert(tmp_p
             capture_output=True,
             text=True,
             timeout=10,
+            env={
+                **os.environ,
+                "PYTHONPATH": str(Path(__file__).resolve().parents[1] / "src"),
+            },
         )
     finally:
         try:

--- a/tests/test_process_match.py
+++ b/tests/test_process_match.py
@@ -1,21 +1,15 @@
 """Tests for LingTai agent process-command matching."""
 from __future__ import annotations
-from lingtai.tools.registry import INTRINSICS as _TEST_INTRINSICS
 
 import importlib.util
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from lingtai.kernel.process_match import match_agent_run
-from tests._workdir_lease_helpers import make_test_lease
-from tests._snapshot_helpers import make_test_snapshot_port, make_test_source_revision_port
-from tests._lifecycle_clock_helpers import make_test_lifecycle_clock
-from tests._notification_store_helpers import notification_store_for
-from tests._agent_presence_helpers import make_test_presence_store
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -52,33 +46,6 @@ def _load_doctor_module():
     return module
 
 
-def _watcher_match_agent_run(tmp_path):
-    from lingtai.kernel.base_agent import BaseAgent
-
-    service = MagicMock()
-    service.get_adapter.return_value = MagicMock()
-    service.provider = "p"
-    service.model = "m"
-
-    working_dir = tmp_path / "agent"
-    working_dir.mkdir()
-    agent = BaseAgent(intrinsics=_TEST_INTRINSICS, service=service, agent_name="alice", working_dir=working_dir, workdir_lease=make_test_lease(), snapshot_port=make_test_snapshot_port(), agent_presence=make_test_presence_store(), lifecycle_clock=make_test_lifecycle_clock(), source_revision_port=make_test_source_revision_port(), notification_store=notification_store_for(working_dir))
-    agent._build_launch_cmd = lambda: ["python", "-c", "print('relaunch sentinel')"]
-
-    with patch("subprocess.Popen") as mock_popen:
-        agent._perform_refresh()
-    assert mock_popen.called
-    args, _kwargs = mock_popen.call_args
-    script = args[0][2]
-    function_source = script.split("def match_agent_run", 1)[1]
-    function_source = "def match_agent_run" + function_source.split(
-        "def _is_same_agent_run", 1
-    )[0]
-    ns: dict[str, object] = {}
-    exec(compile("import os\n" + function_source, "<relaunch_matcher>", "exec"), ns)
-    return ns["match_agent_run"]
-
-
 @pytest.mark.parametrize(("cmdline", "working_dir", "expected"), MATCH_CASES)
 def test_canonical_match_agent_run_matrix(cmdline, working_dir, expected):
     assert match_agent_run(cmdline, working_dir) == expected
@@ -90,10 +57,30 @@ def test_doctor_copy_matches_canonical_matrix():
         assert doctor.match_agent_run(cmdline, working_dir) == expected
 
 
-def test_refresh_watcher_copy_matches_canonical_matrix(tmp_path):
-    watcher_match = _watcher_match_agent_run(tmp_path)
-    for cmdline, working_dir, expected in MATCH_CASES:
-        assert watcher_match(cmdline, working_dir) == expected
+def test_refresh_watcher_imports_canonical_match_agent_run(tmp_path):
+    """The generated watcher program must import and use the canonical
+    Core matcher (`lingtai.kernel.process_match.match_agent_run`) at
+    runtime rather than embedding/maintaining a second local definition —
+    the policy source of truth is `MATCH_CASES` above, exercised directly
+    against the canonical function in `test_canonical_match_agent_run_matrix`.
+    """
+    from lingtai.kernel.refresh_watcher import RefreshWatcherRequest
+    from lingtai.kernel.refresh_watcher.watcher_program import render_watcher_script
+
+    request = RefreshWatcherRequest(
+        taken_path="/wd/.refresh.taken",
+        lock_path="/wd/.agent.lock",
+        events_path="/wd/logs/events.jsonl",
+        stderr_log="/wd/logs/refresh_relaunch.log",
+        working_dir="/wd",
+        cmd=("lingtai-agent", "run", "/wd"),
+        agent_name="alice",
+        address="wd",
+    )
+    script = render_watcher_script(request)
+
+    assert "from lingtai.kernel.process_match import match_agent_run" in script
+    assert "def match_agent_run" not in script
 
 
 def test_cli_duplicate_process_detects_console_script(tmp_path):


### PR DESCRIPTION
## Summary

- remove the generated refresh watcher's second hand-maintained `match_agent_run` implementation
- import the canonical Core matcher from `lingtai.kernel.process_match` in the rendered watcher program
- replace stale generated-source copy-parity coverage with direct canonical-import/no-local-definition contract evidence
- synchronize the Refresh Watcher Contract, Manual, and Anatomy

## Why

The CLI already calls the canonical Core process-command matcher, while every rendered watcher program carried a second copy of the same launch-form policy. Importing the canonical implementation removes that dual truth without changing watcher handshake, retry, heartbeat, stale-duplicate cleanup, redaction, notification, or transport behavior.

The two direct source-layout `python -c` tests now expose this exact checkout's `src` tree to the child interpreter, matching the existing real `python -m` transport smoke convention. No production import fallback was added.

## Validation

- `python -m py_compile src/lingtai/kernel/process_match.py src/lingtai/kernel/refresh_watcher/watcher_program.py`
- `python -m pytest -q tests/test_process_match.py tests/test_perform_refresh_handshake.py tests/test_deep_refresh.py` — **98 passed**
- `git diff --check`

All validation artifacts are preserved under the task scratch root. No branch, worktree, scratch, report, transcript, failed run, or daemon artifact was deleted.

## Non-goals

- no redesign of watcher retry/heartbeat/cleanup policy
- no new process-supervision Port
- no Clock/Filesystem/Publication abstraction expansion
- no Windows adapter work
