### PR TITLE
fix(mail): soften transient liveness bounces

### DIFF
--- a/src/lingtai/adapters/posix/mail.py
+++ b/src/lingtai/adapters/posix/mail.py
@@ -34,12 +34,41 @@ from lingtai.kernel.services.mail import _new_mailbox_id
 
 logger = logging.getLogger(__name__)
 
+# A single strict 2s heartbeat read is too brittle for cross-network email on
+# external volumes or during agent wake/refresh.  Delivery still requires the
+# same Core presence predicate, but the mailman thread gives transient heartbeat
+# lag a short grace window before refusing and emitting a bounce.
+MAIL_DELIVERY_LIVENESS_GRACE_SECONDS: float = 1.5
+MAIL_DELIVERY_LIVENESS_RETRY_INTERVAL_SECONDS: float = 0.2
+
 
 def _presence_store_for(recipient_dir: Path):
     """Build a target-bound POSIX presence adapter for a recipient directory."""
     from lingtai.adapters.posix.agent_presence import PosixAgentPresenceStoreAdapter
 
     return PosixAgentPresenceStoreAdapter(recipient_dir)
+
+
+
+def _recipient_alive_with_grace(presence_store) -> bool:
+    """Return True once the recipient is observed alive within the mail grace.
+
+    CPR and other lifecycle actions still use the Core strict heartbeat
+    predicate directly.  Email delivery is different because the mailman thread
+    can afford a brief wait before producing a user-visible bounce; this avoids
+    false "not running" failures from heartbeat write/read races while
+    preserving the same liveness source of truth.
+    """
+
+    deadline = time.monotonic() + max(0.0, MAIL_DELIVERY_LIVENESS_GRACE_SECONDS)
+    interval = max(0.0, MAIL_DELIVERY_LIVENESS_RETRY_INTERVAL_SECONDS)
+    while True:
+        if _presence_observe_alive(presence_store, wall_now=time.time()):
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(interval, remaining))
 
 
 class PosixFilesystemMailAdapter(MailTransportPort):
@@ -126,11 +155,12 @@ class PosixFilesystemMailAdapter(MailTransportPort):
         if not _presence_is_agent(recipient_presence.observe_manifest()):
             return f"No agent at {address}"
 
-        if not _presence_observe_alive(
-            recipient_presence,
-            wall_now=time.time(),
-        ):
-            return f"Agent at {address} is not running"
+        if not _recipient_alive_with_grace(recipient_presence):
+            return (
+                f"Agent at {address} is not currently deliverable "
+                "(liveness uncertain: heartbeat was not fresh during the "
+                f"{MAIL_DELIVERY_LIVENESS_GRACE_SECONDS:g}s mail-delivery grace window)"
+            )
 
         # --- create inbox entry ---------------------------------------
         msg_id = _new_mailbox_id()

--- a/tests/test_filesystem_mail.py
+++ b/tests/test_filesystem_mail.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
 
 import pytest
@@ -90,8 +91,11 @@ class TestSend:
         assert result is not None  # error string
         assert "no agent" in result.lower()
 
-    def test_send_fails_stale_heartbeat(self, tmp_path):
+    def test_send_fails_stale_heartbeat(self, tmp_path, monkeypatch):
+        import lingtai.adapters.posix.mail as mail_mod
         from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+        monkeypatch.setattr(mail_mod, "MAIL_DELIVERY_LIVENESS_GRACE_SECONDS", 0.0)
 
         sender_dir = _make_agent_dir(tmp_path, "sender01")
         recip_dir = _make_agent_dir(tmp_path, "recip01")
@@ -102,7 +106,41 @@ class TestSend:
         svc = PosixFilesystemMailAdapter(sender_dir, mailbox_rel="mailbox")
         result = svc.send(str(recip_dir), {"message": "hello"})
         assert result is not None
-        assert "not running" in result.lower()
+        assert "not currently deliverable" in result.lower()
+        assert "heartbeat" in result.lower()
+
+    def test_send_retries_transient_stale_heartbeat(self, tmp_path, monkeypatch):
+        """A heartbeat that becomes fresh during the grace window should deliver."""
+        import lingtai.adapters.posix.mail as mail_mod
+        from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+        monkeypatch.setattr(mail_mod, "MAIL_DELIVERY_LIVENESS_GRACE_SECONDS", 0.5)
+        monkeypatch.setattr(mail_mod, "MAIL_DELIVERY_LIVENESS_RETRY_INTERVAL_SECONDS", 0.01)
+
+        sender_dir = _make_agent_dir(tmp_path, "sender01")
+        recip_dir = _make_agent_dir(tmp_path, "recip01")
+        (recip_dir / "mailbox" / "inbox").mkdir(parents=True)
+        heartbeat = recip_dir / ".agent.heartbeat"
+        heartbeat.write_text(str(time.time() - 10))
+
+        def _refresh_heartbeat():
+            time.sleep(0.05)
+            heartbeat.write_text(str(time.time()))
+
+        thread = threading.Thread(target=_refresh_heartbeat)
+        thread.start()
+        try:
+            svc = PosixFilesystemMailAdapter(sender_dir, mailbox_rel="mailbox")
+            result = svc.send(str(recip_dir), {"message": "hello after lag"})
+        finally:
+            thread.join(timeout=1.0)
+
+        assert result is None
+        inbox = recip_dir / "mailbox" / "inbox"
+        msgs = list(inbox.iterdir())
+        assert len(msgs) == 1
+        data = json.loads((msgs[0] / "message.json").read_text())
+        assert data["message"] == "hello after lag"
 
     def test_send_self(self, tmp_path):
         """Send to own address should work (self-send)."""
@@ -160,8 +198,11 @@ class TestSend:
         msg = json.loads((entries[0] / "message.json").read_text())
         assert msg["message"] == "hello human"
 
-    def test_send_fails_no_heartbeat_file(self, tmp_path):
+    def test_send_fails_no_heartbeat_file(self, tmp_path, monkeypatch):
+        import lingtai.adapters.posix.mail as mail_mod
         from lingtai.adapters.posix.mail import PosixFilesystemMailAdapter
+
+        monkeypatch.setattr(mail_mod, "MAIL_DELIVERY_LIVENESS_GRACE_SECONDS", 0.0)
 
         sender_dir = _make_agent_dir(tmp_path, "sender01")
         recip_dir = tmp_path / "recip01"
@@ -175,7 +216,8 @@ class TestSend:
         svc = PosixFilesystemMailAdapter(sender_dir, mailbox_rel="mailbox")
         result = svc.send(str(recip_dir), {"message": "hello"})
         assert result is not None
-        assert "not running" in result.lower()
+        assert "not currently deliverable" in result.lower()
+        assert "heartbeat" in result.lower()
 
     def test_send_atomic_write(self, tmp_path):
         """Verify no .tmp file is left behind after successful send."""


### PR DESCRIPTION
## Summary
- Retry the existing heartbeat/presence liveness predicate briefly before refusing filesystem email delivery, so transient heartbeat lag does not immediately produce a false bounce.
- Change the refusal text from an over-assertive "not running" to "not currently deliverable / liveness uncertain" with the heartbeat source named.
- Add tests for stale heartbeat, missing heartbeat, and transient stale heartbeat that becomes fresh during the mail-delivery grace window.

## Root cause
The observed email bounce versus later CPR result is best explained by a transient heartbeat observation, not two wholly different predicates.

Both paths use the same Core presence predicate for non-human agents: the target must have an agent manifest and a fresh heartbeat under the default two-second threshold.

The previous email path sampled that predicate once in PosixFilesystemMailAdapter.send(). If the one sample failed, the mailman reported "Agent at ... is not running" and emitted an email.bounce. CPR sampled the same predicate later; when heartbeat was fresh by then, system.cpr correctly returned "already running".

## Fix
- Keep the same Core presence predicate as the source of truth.
- In the mailman delivery path only, wait up to 1.5s with a 0.2s retry interval before refusing delivery.
- When refusal remains, report deliverability uncertainty and heartbeat freshness rather than declaring the process not running.

## Evidence included in investigation
- Manager timeline: first email(abs) bounce, CPR shortly after said already running, retry email succeeded.
- Xiaohui analyst/chief evidence: bounce/CPR heartbeat timeout/later already-running patterns.
- Worker-still-running logs show a separate health layer: an agent can be heartbeat-alive while the LLM interface is unsafe/unresponsive. This PR does not claim to solve that layer.

## Validation
- python3 -m py_compile src/lingtai/adapters/posix/mail.py
- git diff --check HEAD^..HEAD
- uv run --with pytest python -m pytest tests/test_filesystem_mail.py tests/test_mail_transport.py tests/test_agent_presence.py tests/test_karma.py -q

Result: 91 passed in 14.78s.

## Out of scope
- Does not solve worker_still_running or "alive but unresponsive" states.
- Does not add a unified runtime health helper. That should be a follow-up design if needed, separating heartbeat liveness, mail deliverability, worker safety, and last-turn responsiveness.
- No hotpatch, release, deploy, installed runtime/venv edit, or Xiaohui/Wenda runtime/mailbox/SCU/P0 mutation was performed.
