### PR TITLE
docs(procedures): prefer daemon backends for coding harnesses

### DIFF
--- a/src/lingtai/prompts/procedures/procedures.md
+++ b/src/lingtai/prompts/procedures/procedures.md
@@ -129,6 +129,11 @@ so they are often the token-efficient body for temporary work. Choose the daemon
 or model by exercising judgment about the task; when the human gives an explicit
 instruction, follow that instruction.
 
+When the same coding harness is available as a daemon backend option, prefer the
+daemon backend over launching that harness through Bash async, using the
+first-class daemon context-isolation and supervision path. Read `daemon-manual`
+for backend details.
+
 Treat daemon use as a practice to learn from, not a rigid policy: daemon need not
 always come first. Observe how humans route work to daemons and subagents — what
 they correct, what they approve, what they reject — and after a meaningful daemon


### PR DESCRIPTION
## Summary

- prefer the first-class daemon backend when the same coding harness is already available as a daemon backend option, instead of launching it through Bash async
- point the concise resident `procedures` guidance to `daemon-manual` for backend details
- retain the surrounding judgment and non-rigid daemon-routing guidance

## Validation

- `python -m pytest -q tests/test_preset_runtime_model_docs.py tests/test_prompt_catalog.py` (44 passed, repo `.venv` with `PYTHONPATH=src`)
- `python scripts/check_docs_governance.py --check` (248 documents validated)
- `git diff --check`
