### PR TITLE
fix(meta): restore runtime guidance startup globals

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: component-contract-convention
-contract_version: 3
+contract_version: 4
 related_files:
   - ANATOMY.md
   - src/lingtai/kernel/event_journal/CONTRACT.md
@@ -18,6 +18,8 @@ related_files:
   - README.md
   - dev-guide-skill/SKILL.md
   - src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
+  - src/lingtai/kernel/meta_block.py
+  - tests/test_runtime_guidance_globals.py
   - tests/test_architecture_documents.py
 maintenance: |
   This file is the normative root of the distributed code interface definition
@@ -69,6 +71,13 @@ in the manuals and references they point to (progressive disclosure), not inline
    strongly emphasize reading and applying this section before every development
    task and route each change to the manual that teaches the capability it
    touches.
+6. **Runtime prompt and metadata changes require executable startup proof.** Any
+   change to runtime-guidance loading, `_meta` ownership/projection, or system-
+   prompt assembly MUST be accepted only after focused regression tests plus a
+   hermetic real `Agent` construction and complete system-prompt build on the
+   exact candidate tree. Compilation alone is insufficient: missing globals and
+   incomplete wiring can compile successfully while making every refreshed or
+   relaunched agent fail before heartbeat.
 
 ## Purpose
 

--- a/src/lingtai/kernel/meta_block.py
+++ b/src/lingtai/kernel/meta_block.py
@@ -667,6 +667,10 @@ def now_iso_plain() -> str:
         return ""
 
 
+_GUIDANCE_CACHE: dict | None = None
+_GUIDANCE_REQUIRED_TOP_KEYS = ("schema_version", "guidance_version", "priority", "render_mode", "sections")
+
+
 class GuidanceSchemaError(ValueError):
     """Raised when the runtime guidance payload does not match the expected shape.
 

--- a/tests/test_runtime_guidance_globals.py
+++ b/tests/test_runtime_guidance_globals.py
@@ -1,0 +1,21 @@
+"""Focused regression coverage for packaged runtime-guidance globals."""
+
+from lingtai.kernel import meta_block
+
+
+def test_runtime_guidance_globals_cache_valid_catalog(monkeypatch):
+    """The loader's cache and validation-key declarations must ship together."""
+    assert meta_block._GUIDANCE_REQUIRED_TOP_KEYS == (
+        "schema_version",
+        "guidance_version",
+        "priority",
+        "render_mode",
+        "sections",
+    )
+
+    monkeypatch.setattr(meta_block, "_GUIDANCE_CACHE", None)
+    guidance = meta_block.build_runtime_guidance()
+
+    assert guidance is meta_block._GUIDANCE_CACHE
+    assert meta_block.build_runtime_guidance() is guidance
+    assert all(key in guidance for key in meta_block._GUIDANCE_REQUIRED_TOP_KEYS)


### PR DESCRIPTION
## Summary

- restore `_GUIDANCE_CACHE` and `_GUIDANCE_REQUIRED_TOP_KEYS`, which #939 removed while retaining live runtime reads
- add a focused regression that requires both declarations and proves cache/schema behavior together
- add Jason's Contract rule: runtime guidance, `_meta`, and system-prompt changes require focused tests plus a hermetic real Agent startup and complete prompt build; compile-only validation is insufficient

## Impact

This restores the startup path that currently kills refreshed/relaunched agents before heartbeat. It does not change #939's two-axis metadata design or PR #942's held daemon-supervisor candidate.

## Validation

- `33 passed` focused regression + two-axis + Agent-session wiring + architecture Contract checks
- real hermetic `Agent(...)` construction and complete system-prompt build: passed, 35,249 chars
- `git diff --check`: passed
- broader #939-changed test surface after this startup fix: `377 passed, 65 failed`; importantly there is no longer a suite-wide startup/global failure. Those residual #939 wiring/test-contract failures are disclosed follow-up debt, not introduced by this three-file recovery diff.

## Authorization

Jason explicitly instructed: merge this recovery fix first, then revive affected agents. No live refresh/CPR is part of this PR itself.
