### PR TITLE
fix(daemon): normalize provider defaults in detached capsule

### DIFF
--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -2289,10 +2289,15 @@ class DaemonManager:
         )
         if isinstance(resolved_key, str):
             runtime_llm["api_key"] = resolved_key
-        for key in ("provider_defaults", "_provider_defaults"):
-            value = effective_llm.get(key)
-            if isinstance(value, dict):
-                runtime_llm[key] = value
+        # The durable manifest always exposes the normalized public key
+        # ``provider_defaults``.  Effective in-process presets may instead carry
+        # their raw provider bucket under the private alias
+        # ``_provider_defaults``; copying that alias into the capsule would leave
+        # the public redacted map untouched in the execution child.  Overlay the
+        # exact normalized/per-run map that was used to build the manifest.
+        normalized_defaults = resolved_llm.get("provider_defaults")
+        if isinstance(normalized_defaults, dict):
+            runtime_llm["provider_defaults"] = normalized_defaults
         if runtime_llm:
             capsule.setdefault("llm", {}).update(runtime_llm)
         PosixDaemonSupervisorAdapter().spawn_detached(request, capsule=capsule)

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -624,7 +624,15 @@ def test_real_manager_handle_emanate_capsule_and_fresh_active_control(tmp_path, 
     agent.service.model = "fake-model"
     agent.service.api_key = "INLINE_API_KEY_SENTINEL"
     agent.service._base_url = None
-    agent.service._provider_defaults = {}
+    # The private in-process alias must be normalized to the public manifest
+    # key in the one-shot capsule.  ``api_compat`` is intentionally
+    # redaction-shaped: the durable manifest hides it, while the execution
+    # child must still receive the real value and pass its redaction gate.
+    agent.service._provider_defaults = {
+        "lingtai-supervisor-test-fake": {
+            "api_compat": "PROVIDER_DEFAULT_RUNTIME_SENTINEL",
+        },
+    }
     monkeypatch.setenv(FAKE_LLM_ENV, "1")
     monkeypatch.setenv(
         "PYTHONPATH",
@@ -668,6 +676,11 @@ def test_real_manager_handle_emanate_capsule_and_fresh_active_control(tmp_path, 
     raw = "INLINE_API_KEY_SENTINEL"
     manifest = (run_dir.path / "supervisor_manifest.json").read_text(encoding="utf-8")
     assert raw not in manifest
+    assert "PROVIDER_DEFAULT_RUNTIME_SENTINEL" not in manifest
+    manifest_data = json.loads(manifest)
+    assert manifest_data["llm"]["provider_defaults"] == {
+        "lingtai-supervisor-test-fake": {"api_compat": "<redacted>"}
+    }
     for path in run_dir.path.rglob("*"):
         if path.is_file():
             assert raw not in path.read_text(encoding="utf-8", errors="replace")


### PR DESCRIPTION
## Problem

The first live daemon launches after #942 exposed a provider-default capsule alias mismatch. Native LingTai daemons from two different explicit presets both failed in the detached execution child before the first tool call with:

```text
runtime field 'llm' still contains a redaction marker; the detached secret capsule was not supplied
```

The durable manifest correctly normalizes the in-process private `_provider_defaults` bucket to public `provider_defaults` and redacts credential-shaped key names. But the one-shot capsule copied `_provider_defaults` under the private alias again. The execution child therefore added a second key instead of replacing the public redacted map, and the runtime redaction gate rejected the run.

## Fix

Carry the already-computed normalized/per-run `resolved_llm["provider_defaults"]` map through the ephemeral capsule under the exact public key that the execution child overlays. This also preserves the daemon-specific Codex session anchor and Codex/MiMo compaction limit without writing their values to durable state.

## Regression

The existing real-process detached-manager acceptance now supplies a provider default named `api_compat`, which is intentionally redaction-shaped. It proves both sides of the boundary:

- the real detached run completes through supervisor + execution child;
- the durable manifest contains `<redacted>` and never the runtime sentinel.

## Validation

- focused literal real-process regression: `1 passed in 4.22s`
- full detached-supervisor suite: `20 passed in 21.13s`
- provider-default-related daemon tests: `5 passed, 100 deselected in 0.35s`
- `git diff --check`
- changed production/test files compile

No runtime refresh, merge, deploy, release, configuration, auth, deletion, or cleanup is performed by this PR.
