### PR TITLE
fix(telegram): restore Task Card entry timestamps

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -13,6 +13,7 @@ Mirrors IMAPMailManager patterns with Telegram-specific adaptations.
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import tempfile
@@ -1782,11 +1783,14 @@ class TelegramManager:
     # not a per-chat/per-route view. It whitelists exactly one event type,
     # ``tool_call``; every other event type is skipped immediately. Only a
     # fixed, bounded, safe field allowlist is ever read from a matching row
-    # (``tool_name``, ``tool_args.action``, ``tool_args._reasoning``) — raw
-    # ``tool_args`` is never forwarded. The projection keeps only the most
-    # recent ``_TASK_CARD_EVENT_WINDOW`` matching rows and never inspects
-    # ``tool_result``/dispatch events or reconstructs completion, elapsed time,
-    # or a second lifecycle model; row order alone conveys recency.
+    # (``tool_name``, ``tool_args.action``, ``tool_args._reasoning``, and the
+    # event's own canonical ``ts`` converted to a row stamp) — raw
+    # ``tool_args`` is never forwarded. A missing/malformed ``ts`` safely omits
+    # the row's stamp rather than crashing or fabricating one. The projection
+    # keeps only the most recent ``_TASK_CARD_EVENT_WINDOW`` matching rows and
+    # never inspects ``tool_result``/dispatch events or reconstructs
+    # completion, elapsed time, or a second lifecycle model; row order alone
+    # conveys recency.
     #
     # There is no durable cursor/checkpoint file: ``events.jsonl`` is the only
     # durable behavior source. On start (and after any truncation/replacement)
@@ -1840,7 +1844,31 @@ class TelegramManager:
         if len(reasoning) > cap:
             # The ellipsis itself must stay inside the cap, not extend past it.
             reasoning = reasoning[:cap - 1] + "…"
-        return {"tool": tool_name, "tool_action": action, "reasoning": reasoning}
+        row = {"tool": tool_name, "tool_action": action, "reasoning": reasoning}
+        started_at = TelegramManager._format_task_card_row_timestamp(event.get("ts"))
+        if started_at:
+            row["started_at"] = started_at
+        return row
+
+    @staticmethod
+    def _format_task_card_row_timestamp(ts: object) -> str:
+        """Convert an event's canonical epoch ``ts`` to the row stamp shape.
+
+        Mirrors ``_format_task_card_current_time``'s ``HH:MM:SS UTC±HH``
+        format so a row's own stamp and the render-time line read
+        consistently. Missing, non-numeric (incl. ``bool``), non-finite, or
+        out-of-range ``ts`` values safely resolve to ``""`` (row renders with
+        no inline stamp) rather than crashing or fabricating a timestamp.
+        """
+        if type(ts) not in (int, float):
+            return ""
+        if isinstance(ts, float) and not math.isfinite(ts):
+            return ""
+        try:
+            local = datetime.fromtimestamp(ts).astimezone()
+        except (OverflowError, OSError, ValueError):
+            return ""
+        return _format_task_card_current_time(local)
 
     def _init_event_tail(self) -> None:
         """Rehydrate the latest-N window and forward offset from the file tail.

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -96,6 +96,10 @@ Normative promises live in the paired [`CONTRACT.md`](CONTRACT.md).
   else returns `indeterminate_send` so cold-send/old-first replacement fail closed.
 - Fail-loud: after-handle failures call `agent._enqueue_system_notification`.
 
+## Automatic row timestamp path
+
+The automatic slot keeps time provenance in the same bounded event projection: only after an event is validated as `type == "tool_call"`, `TelegramManager` reads that event's own top-level Unix-epoch `ts`, formats a valid value as the latest `HH:MM:SS UTC±HH`, and projects it as optional row `started_at`. Missing, boolean, non-numeric, non-finite, or out-of-range values omit the suffix; `_meta` and the current render instant are never substitutes. The path is `tool_call.ts` → `_format_task_card_row_timestamp` → `_project_tool_call_row` → `_format_rows_task_card_text` (`src/lingtai/mcp_servers/telegram/manager.py:1854`, `src/lingtai/mcp_servers/telegram/manager.py:1819`, `src/lingtai/mcp_servers/telegram/manager.py:2656`). Owning event-to-render and malformed-input regressions live at `tests/test_telegram_task_card_event_tail.py:403` and `tests/test_telegram_task_card_event_tail.py:443`.
+
 ## Composition
 
 - **Parent:** [`src/lingtai/mcp_servers/ANATOMY.md`](../../ANATOMY.md).

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -316,6 +316,12 @@ Verification commands (repo venv):
   tests/test_mcp_skill_manuals.py
 ```
 
+## Automatic row timestamp interface
+
+1. An automatic row MAY expose `started_at` only from the same already-validated `tool_call` event's top-level Unix-epoch `ts`; `_meta`, tool arguments, notification payloads, and the current render instant are not time sources.
+2. A valid event time MUST use the current row presentation `HH:MM:SS UTC±HH`. Missing, boolean, non-numeric, non-finite, or out-of-range `ts` MUST omit `started_at` without failing the event tail.
+3. The event-to-final-render suffix and fail-closed malformed cases are contract-tested at `tests/test_telegram_task_card_event_tail.py:403` and `tests/test_telegram_task_card_event_tail.py:443`. The implementation anchors are `src/lingtai/mcp_servers/telegram/manager.py:1854` and `src/lingtai/mcp_servers/telegram/manager.py:1819`.
+
 ## Maintenance
 
 Follow the canonical maintenance block in frontmatter. Behavioral changes require

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import threading
+from datetime import datetime
 from pathlib import Path
 
 from lingtai.mcp_servers.telegram.manager import TelegramManager
@@ -380,7 +381,7 @@ def test_only_safe_bounded_fields_are_projected(tmp_path):
     window = manager._task_card_event_window()
     assert len(window) == 1
     row = window[0]
-    assert set(row.keys()) <= {"tool", "tool_action", "reasoning", "ts"}
+    assert set(row.keys()) <= {"tool", "tool_action", "reasoning", "started_at"}
     assert row["tool"] == "bash"
     assert row["tool_action"] == "run"
     assert row["reasoning"] == "safe text"
@@ -391,6 +392,79 @@ def test_only_safe_bounded_fields_are_projected(tmp_path):
     assert "sk-should-never-appear" not in rendered
     assert "/very/secret/path" not in rendered
     assert "--token=abc123" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Row timestamp: derived from the event's own canonical ``ts``, never raw
+# tool args, never the current render instant, safely omitted when malformed
+# ---------------------------------------------------------------------------
+
+
+def test_row_started_at_is_derived_from_event_ts_and_rendered(tmp_path):
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    event_ts = 1752600000.0
+    events_path = _events_path(tmp_path)
+    _write_lines(events_path, [_tool_call_line(ts=event_ts)])
+
+    manager._poll_event_tail()
+
+    local = datetime.fromtimestamp(event_ts).astimezone()
+    expected = f"{local:%H:%M:%S} UTC{local:%z}"[:-2]
+    window = manager._task_card_event_window()
+    assert len(window) == 1
+    assert window[0]["started_at"] == expected
+    edits = [call for call in acct.calls if call[0] == "edit_message"]
+    assert edits
+    assert f" · {expected}" in edits[-1][3]
+
+
+def test_row_started_at_omitted_when_ts_missing(tmp_path):
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    events_path = _events_path(tmp_path)
+    line = json.dumps({
+        "type": "tool_call", "tool_name": "bash",
+        "tool_args": {"action": "run", "_reasoning": "no ts here"},
+    })
+    _write_lines(events_path, [line])
+
+    manager._poll_event_tail()
+
+    window = manager._task_card_event_window()
+    assert len(window) == 1
+    assert "started_at" not in window[0]
+
+
+def test_row_started_at_omitted_when_ts_malformed(tmp_path):
+    """Bool, non-numeric, non-finite, and out-of-range ``ts`` all safely omit
+    the row's stamp rather than crashing or fabricating one."""
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    events_path = _events_path(tmp_path)
+    bad_values = [True, "not-a-number", float("nan"), float("inf"), 1e20, 10**400]
+    lines = [
+        json.dumps({
+            "type": "tool_call", "tool_name": f"tool{i}",
+            "tool_args": {"action": "run", "_reasoning": "x"},
+            "ts": v,
+        })
+        for i, v in enumerate(bad_values)
+    ]
+    _write_lines(events_path, lines)
+
+    manager._poll_event_tail()
+
+    window = manager._task_card_event_window()
+    assert len(window) == len(bad_values)
+    for row in window:
+        assert "started_at" not in row
 
 
 def test_events_missing_expected_fields_are_skipped_fail_closed(tmp_path):

--- a/tests/test_telegram_task_card_timestamp.py
+++ b/tests/test_telegram_task_card_timestamp.py
@@ -13,11 +13,13 @@ stamping ``started_at`` once per row, immutability across heartbeats/finalize).
 That capture mechanism no longer exists — rows the automatic Task Card renders
 now come from ``TelegramManager``'s own bounded projection of
 ``logs/events.jsonl`` (see ``tests/test_telegram_task_card_event_tail.py``),
-which does not track a per-row start instant at all (only ``tool``,
-``tool_action``, ``reasoning``). The manager's ``_format_task_card_text``
-rendering behavior tested below is unaffected — it still accepts an optional
-``started_at`` per row (rendered inline when present, omitted safely when not)
-and always renders the render-instant ``Current Time`` line.
+which derives each row's ``started_at`` from that same ``tool_call`` event's
+own canonical ``ts`` field (converted to the ``HH:MM:SS UTC±HH`` shape),
+omitting it only when ``ts`` is missing or malformed. The manager's
+``_format_task_card_text`` rendering behavior tested below is unaffected — it
+still accepts an optional ``started_at`` per row (rendered inline when
+present, omitted safely when not) and always renders the render-instant
+``Current Time`` line.
 """
 
 from __future__ import annotations
@@ -126,10 +128,10 @@ def test_api_error_row_never_carries_a_stamp_alongside_a_stamped_tool_row():
 
 
 def test_render_tool_row_without_started_at_is_safe():
-    """Backward-compatible: a row missing started_at renders without any inline
-    stamp (no crash) — the event-tail projection never sets this field, so this
-    is now the common case, not an edge case; the render-time line still
-    renders unconditionally."""
+    """A row missing started_at (the event-tail projection omits it when the
+    source event's ``ts`` was missing or malformed) renders without any
+    inline stamp — no crash, no fabricated timestamp; the render-time line
+    still renders unconditionally."""
     text = TelegramManager._format_task_card_text("", "", "", rows=[
         {"tool": "bash", "tool_action": "", "reasoning": "x",
          "elapsed_s": 1, "done": False},


### PR DESCRIPTION
## Summary

- restore automatic Telegram Task Card per-entry timestamps from each validated `tool_call` event's own top-level `ts`
- preserve the current `HH:MM:SS UTC±HH` presentation and omit malformed event times without fabrication
- pin the source, format, and fail-closed interface in the owning `ANATOMY.md` and `CONTRACT.md`

## Root cause

The event-log migration kept the existing row renderer but projected only tool/action/reasoning, so the renderer no longer received `started_at`.

## Validation

- in-memory compile of the changed Python sources
- direct valid event `ts` → projected `started_at` → final rendered row suffix assertion
- direct missing/bool/non-numeric/non-finite/out-of-range omission checks, including a huge integer
- non-`tool_call` type-first fail-closed check
- `git diff --check`

`pytest` was not run locally because this strict no-deletion task does not permit pytest temp/cache lifecycle; the focused regressions are included for CI.
