### PR TITLE
docs(system-manual): explain kernel updates and nudges

### DIFF
--- a/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
@@ -8,7 +8,7 @@ description: >
   producing, or debugging notification payloads; skip for dismissal policy.
 version: 0.1.0
 tags: [lingtai, notifications, channels, protocol, sync, nudge]
-last_changed_at: "2026-07-12T20:20:43-07:00"
+last_changed_at: "2026-07-15T12:00:00-07:00"
 related_files:
 - src/lingtai/intrinsic_skills/notification-manual/SKILL.md
 - src/lingtai/tools/notification/schema.py
@@ -36,11 +36,12 @@ ignored by collection, and kernel publish/dismiss helpers reject names outside
 the allowlist. This prevents arbitrary workdir files from entering the
 model-visible notification lane.
 
-`nudge` is the formal channel for mechanical, throttled checks. For example,
-runtime update checks publish `data.nudges[]` entries with
-`kind: kernel_version`; route those through
-`../../../system-manual/reference/runtime-update-checks/SKILL.md` before asking a human to update or
-refresh.
+`nudge` is the formal channel for mechanical, throttled checks. Runtime update
+checks publish `data.nudges[]` entries with `kind: kernel_version`, and source
+freshness checks may publish `kind: source_drift`; route both through the
+system-manual's nested `runtime-update-checks` reference before asking a human
+to update or refresh. That reference is the detailed source of truth; this
+manual owns only the generic channel protocol.
 
 ## Envelope and producer instructions
 

--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -13,21 +13,24 @@ description: >
   summarize-vs-molt distinctions; and `reference/sqlite-log-query/SKILL.md` for
   SQLite/log.sqlite runtime trace inspection and trajectory/anomaly mining from
   event traces; and `reference/runtime-update-checks/SKILL.md` for
-  runtime/kernel self-checks, nudge-driven update reminders, editable/dev-mode
-  identification, and safe refresh/update handoffs. Also
+  runtime/kernel self-checks, the complete nudge lifecycle, editable/dev/source
+  identification, safe refresh/update handoffs, and read-only diagnostics. Also
   route here for lifecycle operations, notification/nudge
   handling (including direct `notification(action='manual')` retrieval),
   runtime/kernel update checks, molt/memory questions, MCP/addon
   ownership, preset tiers, collaboration/network topology, resident prompt
   design, and the `system` tool actions.
-version: 1.6.0
+version: 1.7.0
 tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize, nudge, updates, runtime-checks, preset]
-last_changed_at: "2026-07-13T00:00:00-07:00"
+last_changed_at: "2026-07-15T12:00:00-07:00"
 related_files:
 - src/lingtai/prompts/substrate/substrate.md
 - src/lingtai/prompts/procedures/procedures.md
 - src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
 - src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+- src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
+- src/lingtai/kernel/nudge/ANATOMY.md
 maintenance: |
   Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
@@ -91,11 +94,11 @@ selects that topic.
 - name: runtime-update-checks
   location: reference/runtime-update-checks/SKILL.md
   description: |
-    Runtime/kernel self-check and update-nudge manual: handling `.notification/nudge.json`
-    entries with `kind: kernel_version`, distinguishing running/installed/latest
-    LingTai kernel versions, recognizing editable/dev/source installs, honoring
-    the once-per-day packaged-runtime update check, asking the human before
-    downloading/updating, and refreshing only when safe.
+    Complete kernel update/nudge lifecycle: runtime and source discovery,
+    `kernel_version` and `source_drift` checks, heartbeat dispatch, durable
+    throttle state, `.notification/nudge.json` envelopes, sync/wake/dismiss
+    behavior, packaged versus editable/source paths, human confirmation, TUI
+    update ownership, refresh boundaries, verification, and read-only diagnosis.
 - name: goal-manual
   location: reference/goal-manual/SKILL.md
   description: |
@@ -114,7 +117,7 @@ selects that topic.
 | Tool-result summarization; large-result ranking via agent_meta; progressive disclosure of raw outputs; original-result recovery; summarize vs molt | `reference/summarize-manual/SKILL.md` |
 | SQLite; `log.sqlite`; LingTai runtime logs; JSONL traces; `lingtai-agent log doctor`; `lingtai-agent log query`; `lingtai-agent log rebuild`; events/chat_entries schema; daemon/chat-history trace indexing; WAL/live-read caveats; SQL recipes; trajectory/anomaly mining; improvement digests; cheap-model strategy | `reference/sqlite-log-query/SKILL.md` |
 | Notifications; direct `notification(action='manual')`; check/dismiss_channel/dismiss_event/dismiss_ref/manual; `.notification/<channel>.json`; channel allowlist; top-level `instructions`; protected channels; generic vs producer dismiss; stale-version/force; legacy `large_tool_result` dismiss | `notification-manual` |
-| Runtime/kernel state; `nudge` notification channel; `.notification/nudge.json`; `kind: kernel_version`; running vs installed vs latest LingTai kernel; editable/dev/source installs; daily update checks; safe `system(action='refresh')`; ask the human before downloading/updating | `reference/runtime-update-checks/SKILL.md` |
+| Kernel update lifecycle; runtime/source discovery; `kernel_version` and `source_drift`; heartbeat nudge dispatch; `.notification/nudge.json`; durable state; sync/wake/dismiss mechanics; packaged vs editable/source installs; refresh vs TUI-managed update; verification/troubleshooting | `reference/runtime-update-checks/SKILL.md` |
 | Goal notifications; `.notification/goal.json`; active goal source of truth; goal `instructions`; idle goal reminder; cancel/complete goal | `reference/goal-manual/SKILL.md` |
 | Molt mechanics, pad tending, session journals, post-wipe recovery | `psyche-manual` |
 | Soul tool; soul flow opt-in (`LINGTAI_SOUL_FLOW_ENABLED`); disabled-flow behavior; `delay_seconds` as cadence-not-off-switch; inquiry/config/voice/dismiss; privacy/cost rationale | `soul-manual` |

--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -66,9 +66,11 @@ The end-to-end path is:
    running process is stale relative to code already on disk. Editable,
    source-checkout, and dev-version runtimes skip this check deliberately.
 4. **Dispatch — `nudge/__init__.py` and `lifecycle.py`.** The heartbeat loop
-   runs the nudge dispatcher once per one-second tick. Each producer has its own
-   roughly 60-second in-memory probe gate; one failing producer is logged and
-   does not block the others.
+   runs the nudge dispatcher once per one-second tick. `kernel_version` and
+   `source_drift` each have their own roughly 60-second in-memory probe gate;
+   `goal` runs on each dispatch while IDLE and applies its configured
+   idle-reminder delay. One failing producer is logged and does not block the
+   others.
 5. **Persist and publish — `nudge/__init__.py` and the Notification Store.**
    Kernel-version daily state lives in
    `.notification/.nudge_state.json`. The user-facing mirror is
@@ -98,11 +100,14 @@ The end-to-end path is:
    bare `pip install --upgrade lingtai` the normal user instruction. Pip/venv
    commands below are diagnostic or developer verification only.
 10. **Refresh and verify — kernel lifecycle plus the operator.**
-    `system(action="refresh")` performs the kernel's full relaunch/rebuild
-    boundary using the installed/on-disk runtime. It does not pull commits,
-    contact PyPI, install a package, or switch an editable checkout. After a
-    confirmed update or refresh, verify the new process's interpreter,
-    `lingtai.__file__`, `lingtai.kernel.__file__`, version, and import path.
+    `system(action="refresh")` requests a deferred relaunch only when the
+    runtime can build a valid launch command and has a configured refresh
+    watcher. Without a launch command it returns without relaunching; without
+    a refresh watcher it raises. Diagnose either outcome before treating the
+    refresh as successful. Refresh never pulls commits, contacts PyPI, installs
+    a package, or switches an editable checkout. After a confirmed update or
+    refresh, verify the new process's interpreter, `lingtai.__file__`,
+    `lingtai.kernel.__file__`, version, and import path.
 
 ## Packaged, editable, and source/dev runtimes
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -1,121 +1,168 @@
 ---
 name: runtime-update-checks
 description: >
-  Nested system-manual reference for LingTai runtime/kernel self-checks and
-  update nudges: handle `.notification/nudge.json` entries with
-  `kind: kernel_version`, identify editable/dev/source installs, compare the
-  running, installed, and latest kernel versions, respect the once-per-day
-  packaged-runtime check, ask the human before downloading/updating, and refresh
-  only when safe.
-version: 0.1.0
-tags: [lingtai, runtime, kernel, nudge, updates, refresh, editable, dev-mode]
-last_changed_at: "2026-06-23T23:50:45-07:00"
+  Nested system-manual reference for tracing LingTai kernel update nudges:
+  runtime/version/source identity, packaged versus editable/source behavior,
+  heartbeat dispatch, nudge persistence and notification delivery, refresh
+  versus installation, human confirmation, and post-refresh verification.
+version: 0.2.0
+tags: [lingtai, runtime, kernel, nudge, updates, refresh, editable, source, diagnostics]
+last_changed_at: "2026-07-15T12:00:00-07:00"
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
-- src/lingtai/kernel/nudge/kernel_version.py
+- src/lingtai/intrinsic_skills/notification-manual/SKILL.md
+- src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
+- src/lingtai/kernel/nudge/ANATOMY.md
 - src/lingtai/kernel/nudge/__init__.py
+- src/lingtai/kernel/nudge/kernel_version.py
+- src/lingtai/kernel/nudge/source_drift.py
+- src/lingtai/kernel/base_agent/lifecycle.py
+- src/lingtai/kernel/base_agent/__init__.py
+- src/lingtai/kernel/notification_store/__init__.py
+- src/lingtai/kernel/runtime_identity.py
+- src/lingtai/kernel/snapshot/__init__.py
+- src/lingtai/kernel/snapshot/ANATOMY.md
+- src/lingtai/cli.py
+- src/lingtai/venv_resolve.py
+- tests/test_kernel_version_nudge.py
+- tests/test_source_drift.py
+- tests/test_runtime_identity.py
 maintenance: |
-  Tracks the runtime-update-checks topic it documents; update when that integration changes.
+  Keep this as the single detailed source for kernel update and nudge
+  interpretation. Update it when the nudge producers, heartbeat dispatch,
+  notification sync, runtime identity, refresh boundary, or supported update
+  ownership changes; keep system-manual and notification-manual as routers.
 ---
 
 # Runtime Update Checks
 
-Nested system-manual reference for mechanical runtime/kernel checks and update
-nudges. Read this when:
+Kernel updates and nudges — the complete lifecycle
 
-- a `nudge` notification contains an entry with `kind: kernel_version`;
-- you suspect the running LingTai kernel is not the code currently installed on
-  disk;
-- a refresh did not seem to pick up a kernel change;
-- you need to tell whether this agent is in editable/source/dev mode; or
-- about once per day, a packaged runtime reports that a newer LingTai kernel is
-  available.
+Read this reference when a `nudge` notification mentions `kernel_version` or
+`source_drift`, when versions or import paths disagree, or when deciding
+whether a refresh or an update is appropriate. This is operational guidance,
+not permission to download, install, change configuration, or relaunch a
+runtime.
 
-This reference is about **checking and reporting**. It does not authorize
-installing, downloading, publishing, or refreshing across important work without
-human confirmation.
+## The lifecycle and its owners
 
-## Nudge payload contract
+The end-to-end path is:
 
-Kernel-owned periodic checks publish mechanical nudges through
-`.notification/nudge.json`. The shared channel stores a list under
-`data.nudges`; each entry has a unique `kind`. Kernel version/update entries use
-`kind: kernel_version`.
+1. **Discover runtime facts — `kernel_version.py` and runtime identity.** The
+   kernel reads the already-loaded `lingtai` wrapper from `sys.modules` for the
+   running version, and `importlib.metadata` for the installed distribution
+   version. `runtime_identity.py` separately stamps durable event identity with
+   package/dev mode, source kind, and available git state. No package-index
+   request is needed for the local comparison.
+2. **Check `kernel_version` — `kernel_version.py`.** If running and installed
+   versions differ, it emits a local refresh nudge and does not query PyPI. For
+   packaged, non-editable, non-dev runtimes whose versions match, it checks
+   `https://pypi.org/pypi/lingtai/json` at most once per UTC day. A newer
+   `info.version` produces a package-availability nudge; network or response
+   errors are recorded in durable throttle state and do not become an update.
+3. **Check `source_drift` — `source_drift.py`.** For non-dev runtimes it
+   compares the startup runtime fingerprint (git revision and curated source
+   digest when available) with a fresh on-disk fingerprint. Drift means the
+   running process is stale relative to code already on disk. Editable,
+   source-checkout, and dev-version runtimes skip this check deliberately.
+4. **Dispatch — `nudge/__init__.py` and `lifecycle.py`.** The heartbeat loop
+   runs the nudge dispatcher once per one-second tick. Each producer has its own
+   roughly 60-second in-memory probe gate; one failing producer is logged and
+   does not block the others.
+5. **Persist and publish — `nudge/__init__.py` and the Notification Store.**
+   Kernel-version daily state lives in
+   `.notification/.nudge_state.json`. The user-facing mirror is
+   `.notification/nudge.json`; it is not the throttle state or a canonical
+   package state. Each entry has a unique `kind`; `upsert` replaces that kind,
+   `remove` deletes it, and clearing the last entry clears the channel file.
+   Updates use the store's atomic compare/update operation.
+6. **Sync and wake — `BaseAgent._sync_notifications`.** The heartbeat polls
+   allowlisted `.notification` files by fingerprint. A changed nudge file is
+   injected as a synthesized `notification(action="check")` pair when IDLE;
+   ACTIVE work defers delivery until an IDLE boundary; ASLEEP is moved to IDLE,
+   then the pair and `MSG_TC_WAKE` are queued. STUCK/SUSPENDED cannot inject.
+   A failed injection leaves the fingerprint uncommitted for retry (with the
+   documented degraded recovery path after healing pending tool calls).
+7. **Interpret — the agent, using this reference.** Treat the payload as
+   kernel-synchronized facts, not a human command. Compare `running`,
+   `installed`, `latest`, and `source`; inspect the runtime when ambiguous.
+8. **Confirm — the human.** A PyPI availability nudge requires telling the
+   human what was found and receiving an explicit imperative confirmation before
+   any download, installation, or refresh. A local refresh is still gated by
+   work safety and the human's intent when it could interrupt active work.
+   In short: ask the human before downloading or updating.
+9. **Install/update — the separate TUI-owned `lingtai-update` skill.** Normal
+   user-facing installation and updates, including `lingtai-tui` and
+   `lingtai-portal` maintenance, belong to that TUI skill and its command.
+   This kernel manual does not reproduce its cross-repository path or make
+   bare `pip install --upgrade lingtai` the normal user instruction. Pip/venv
+   commands below are diagnostic or developer verification only.
+10. **Refresh and verify — kernel lifecycle plus the operator.**
+    `system(action="refresh")` performs the kernel's full relaunch/rebuild
+    boundary using the installed/on-disk runtime. It does not pull commits,
+    contact PyPI, install a package, or switch an editable checkout. After a
+    confirmed update or refresh, verify the new process's interpreter,
+    `lingtai.__file__`, `lingtai.kernel.__file__`, version, and import path.
 
-Common fields:
+## Packaged, editable, and source/dev runtimes
 
-| Field | Meaning |
-| --- | --- |
-| `running` | Version frozen in the currently running process (`lingtai.__version__`). |
-| `installed` | Version visible from the installed `lingtai` distribution on disk. |
-| `latest` | Latest package version found by the daily packaged-runtime check, or `null` for local refresh nudges. |
-| `source` | `installed-distribution` for local refresh nudges, `pypi-json` for package-update nudges. |
-| `cadence` | `at-most-once-per-utc-day` for both local refresh and package-update nudges (re-emitted at most once per UTC day per version pair). |
-| `suggested_action` | The safe next-step hint; still verify context before acting. |
+For a packaged/non-editable install, the distribution metadata and package
+index are meaningful. A local `running != installed` mismatch means a package
+landed on disk after this process started: it is a refresh opportunity, not a
+package upgrade. A `latest > installed` mismatch means PyPI advertises a
+possible package upgrade; it does not mean that package has been downloaded.
 
-After handling, clear the channel with:
+The editable/source/dev modes are detected through `direct_url.json` with
+`dir_info.editable: true`; source checkouts are recognized from the module path
+and the checkout's `.git` plus `pyproject.toml`; dev-version markers also
+suppress the package-index check. Missing distribution metadata is treated as
+source/dev rather than as permission to install. In these modes, the checkout,
+branch, commit, dirty state, and import path are the useful truth. A source-drift
+refresh nudge is also intentionally suppressed: refreshing arbitrary in-flight
+checkout changes could amplify a broken development edit.
+
+## Nudge mechanics and dismissal
+
+`kernel_version` and `source_drift` are producers of the shared low-priority
+`.notification/nudge.json` envelope. The envelope carries `data.nudges`, a
+`published_at` timestamp, and channel-level instructions to clear all nudges.
+`kind: kernel_version` has `running`, `installed`, `latest` (or `null` for a
+local refresh), `source`, `cadence`, `checked_at_date`, and a suggested action.
+`source_drift` carries startup and disk fingerprints instead.
+
+The kernel-version producer records mismatch and remote-check dedupe in
+`.notification/.nudge_state.json`, surviving refreshes and process restarts.
+The one-day rule is per UTC date and version pair/latest observation; the
+60-second gate is only a cheap heartbeat probe throttle. Dismissing the nudge
+channel clears the mirror. It does not install anything, alter producer state,
+or guarantee the producer will never publish again: the durable daily dedupe
+prevents a same-day nudge storm, and a new UTC day or new mismatch can surface
+one again. A producer can also remove an entry when versions match, a remote
+version is no longer newer, or dev/source mode is detected.
+
+After interpreting a nudge, use the narrowest safe action:
 
 ```text
 notification(action="dismiss_channel", channel="nudge")
 ```
 
-## How to respond
+Do not call `notification(action="check")` merely to confirm dismissal. The
+generic notification protocol and guarded dismissal rules live in
+`notification-manual`; this reference owns the meaning of these two kinds.
 
-### Local refresh nudge (`source: installed-distribution`)
+## Read-only diagnosis
 
-If `running != installed`, the package on disk differs from the process already
-in memory. This usually means code was updated while the agent kept running.
+Inspect the current mirror and durable state without changing them:
 
-1. Check whether the agent is in the middle of sensitive work, active daemons, or
-   a task where refresh would lose useful in-flight state.
-2. If safe, call `system(action="refresh", reason="Load installed LingTai kernel update")`.
-3. After refresh, verify the import path/version and report any blocker to the
-   human or peer who requested the update.
+```bash
+ls -l .notification/nudge.json .notification/.nudge_state.json 2>/dev/null
+sed -n '1,240p' .notification/nudge.json 2>/dev/null
+sed -n '1,240p' .notification/.nudge_state.json 2>/dev/null
+```
 
-### Package-update nudge (`source: pypi-json`)
-
-If `latest > installed`, a newer LingTai kernel package exists for packaged
-runtimes. This check is throttled to at most once per UTC day per agent and is
-skipped for editable/source/dev installs.
-
-1. Tell the human the current `running`, `installed`, and `latest` versions.
-2. Explain that this is an update availability nudge, not an automatic upgrade.
-3. Ask whether they want you to update through their normal LingTai runtime/TUI
-   upgrade path.
-4. Do **not** download, install, edit config, or refresh until the human gives an
-   explicit imperative confirmation for that side effect.
-
-For user-facing instructions, follow the project standing rule: do not present a
-bare `pip install --upgrade lingtai` as the normal user upgrade path unless the
-human explicitly asks for development/diagnostic PyPI validation.
-
-## Editable/source/dev installs
-
-Package-update nudges are skipped when the kernel can identify the runtime as an
-editable install, a source checkout, or a dev/local version. In those modes the
-source of truth is usually the local checkout and git state, not the package
-index. Diagnose with:
-
-- the Python executable used by the agent runtime — prefer the platform-neutral
-  `LINGTAI_RUNTIME_PYTHON` environment variable when available, and otherwise
-  trust the live process over a convenient shell `python` or conda env;
-- `lingtai.__version__`, `lingtai.__file__`, and `lingtai.kernel.__file__`;
-- installed distribution metadata, especially `direct_url.json` with
-  `dir_info.editable: true`;
-- the nearest git checkout, branch, HEAD, dirty state, and relation to remote;
-- whether `system.refresh` has reloaded the code already present on disk.
-
-A refresh reloads configuration and imports in a fresh process. It does not pull
-new commits, install packages, or publish anything.
-
-## Quick manual check
-
-Use a short local Python probe when the nudge payload is ambiguous. Prefer the
-same interpreter used by the running agent. `LINGTAI_RUNTIME_PYTHON` is the
-platform-neutral path exposed by the runtime when available; if it is absent,
-choose the platform-specific TUI venv Python (`$HOME/.lingtai-tui/runtime/venv/bin/python`
-on macOS/Linux, `%USERPROFILE%\.lingtai-tui\runtime\venv\Scripts\python.exe`
-on Windows):
+Use the interpreter that launched the agent. The CLI exports
+`LINGTAI_RUNTIME_PYTHON`; if it is absent, use the platform-specific TUI
+runtime Python, not a convenient shell environment:
 
 ```bash
 PYTHON=${LINGTAI_RUNTIME_PYTHON:-$HOME/.lingtai-tui/runtime/venv/bin/python}
@@ -123,23 +170,71 @@ PYTHON=${LINGTAI_RUNTIME_PYTHON:-$HOME/.lingtai-tui/runtime/venv/bin/python}
 import importlib.metadata as md
 import sys
 import lingtai, lingtai.kernel
-print('python=', sys.executable)
-print('lingtai_version=', getattr(lingtai, '__version__', 'unknown'))
-print('lingtai_dist=', md.version('lingtai'))
-print('lingtai_file=', getattr(lingtai, '__file__', 'unknown'))
-print('lingtai.kernel_file=', getattr(lingtai.kernel, '__file__', 'unknown'))
+print("python=", sys.executable)
+print("lingtai_version=", getattr(lingtai, "__version__", "unknown"))
+print("lingtai_dist=", md.version("lingtai"))
+print("lingtai_file=", getattr(lingtai, "__file__", "unknown"))
+print("lingtai.kernel_file=", getattr(lingtai.kernel, "__file__", "unknown"))
 try:
-    dist = md.distribution('lingtai')
-    print('direct_url=', dist.read_text('direct_url.json'))
+    print("direct_url=", md.distribution("lingtai").read_text("direct_url.json"))
 except Exception as exc:
-    print('direct_url_error=', type(exc).__name__, str(exc)[:120])
+    print("direct_url_error=", type(exc).__name__, str(exc)[:120])
 PY
 ```
 
-Do not print credentials, tokens, or environment dumps while doing update checks.
+For source/dev disagreement, read-only git evidence is appropriate:
 
-## Relationship to notification-manual
+```bash
+git -C /path/to/checkout status --short --branch
+git -C /path/to/checkout log -1 --format='%H %cI %s'
+git -C /path/to/checkout remote -v
+```
 
-`notification-manual` owns the generic channel protocol and dismissal mechanics.
-This reference owns the `kernel_version` nudge interpretation and the safe human
-handoff for runtime updates.
+Replace the checkout path with the path containing the imported module; do not
+assume the current directory is that checkout. Do not print credentials or
+environment dumps.
+
+## Troubleshooting
+
+**Running and installed versions disagree.** Confirm the live interpreter and
+both module files first. If the installed distribution is newer, the safe
+meaning is “code already on disk can be loaded by a refresh.” If the running
+process is newer, inspect whether metadata or the import path is stale; do not
+blindly downgrade or install.
+
+**Runtime and checkout disagree.** `sys.executable`, `lingtai.__file__`,
+`lingtai.kernel.__file__`, `direct_url.json`, and read-only git status identify
+which checkout/environment is actually active. A checkout's version alone does
+not prove what the running process imported.
+
+**PyPI/network failure.** A failed remote request records `last_error` and the
+date in `.nudge_state.json`; it is not evidence that an update exists. Check
+connectivity or package-index policy with the human, then allow the next daily
+check. Do not turn a transient failure into a manual install recommendation.
+
+**Nudge is missing or stale.** Check both files above. Missing `nudge.json` can
+mean no producer currently has an entry, a matching version cleared it, a dev
+runtime skipped it, or it was dismissed. A stale entry can be a mirror waiting
+for the next heartbeat sync; compare its kind and version pair with durable
+state. Unknown JSON files are not collected as notification channels.
+
+**Refresh did not activate new code.** A refresh only rebuilds/relaunches the
+runtime from code already visible on disk. Re-run the read-only interpreter and
+import-path probe in the new process, inspect the refresh/runtime logs, and
+check for a still-held old process or a different environment. It cannot pull a
+commit or repair an incomplete source checkout.
+
+**Interpreter/import path is unknown.** Stop before any update action. Ask the
+human or launcher owner which process is authoritative, then compare
+`LINGTAI_RUNTIME_PYTHON`, `sys.executable`, the two module `__file__` values,
+distribution metadata, and `direct_url.json`. Do not use an unrelated shell
+Python as a substitute.
+
+## Boundaries
+
+The notification-manual owns channel allowlisting, generic sync concepts, and
+dismissal safety. The system router owns navigation. The TUI-owned
+`lingtai-update` skill owns normal update/install commands and debugging of
+`lingtai-tui`/`lingtai-portal`. This reference is the one source of truth for
+kernel update lifecycle, `kernel_version`/`source_drift` interpretation, and
+read-only diagnosis.

--- a/src/lingtai/kernel/nudge/ANATOMY.md
+++ b/src/lingtai/kernel/nudge/ANATOMY.md
@@ -7,6 +7,7 @@ related_files:
   - src/lingtai/kernel/nudge/kernel_version.py
   - src/lingtai/kernel/nudge/source_drift.py
   - src/lingtai/kernel/snapshot/ANATOMY.md
+  - src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;
@@ -114,6 +115,14 @@ Three similar lines is better than a premature abstraction
 than maintaining a `Check` protocol and a registry. If the duplication starts
 to hurt, lift a `_throttled_probe` helper into `__init__.py` — but the right
 abstraction shape will be obvious by then.
+
+## Manual route
+
+The detailed agent-facing update lifecycle, nudge interpretation, TUI ownership,
+and troubleshooting route is
+`src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md`.
+This anatomy remains the structural map; the nested manual is the one source of
+truth for operational guidance.
 
 ## Wire surface
 

--- a/src/lingtai/prompts/substrate/substrate.md
+++ b/src/lingtai/prompts/substrate/substrate.md
@@ -56,7 +56,10 @@ example `~/.lingtai-tui/runtime/venv` on macOS/Linux) and should confirm the
 module files it imports (`lingtai.__file__`, `lingtai.kernel.__file__`). Do not
 infer freshness from a convenient shell `python`, conda env, or checkout;
 `refresh` reloads the current on-disk/runtime surface but does not fetch or
-switch code by itself.
+switch code by itself. For a `kernel_version` or `source_drift` nudge, route to
+the system-manual nested `runtime-update-checks` reference for the lifecycle,
+human-confirmation gate, and read-only diagnosis; normal installation/update
+commands remain TUI-managed.
 
 ## II · Life states
 


### PR DESCRIPTION
## Summary

- evolve the existing `system-manual/reference/runtime-update-checks` reference into the single detailed kernel update+nudge manual instead of adding a duplicate sibling
- explain the actual discovery → `kernel_version` / `source_drift` → heartbeat dispatch → durable nudge state → notification sync/wake → human confirmation → TUI-managed install → refresh/verify lifecycle
- distinguish packaged, editable/source/dev, local source-drift, and remote PyPI availability cases
- add read-only diagnosis for runtime/interpreter/import-path disagreement, stale or missing nudges, network failures, and refreshes that did not activate new code
- keep `system-manual`, notification-manual, resident substrate, and nudge anatomy as concise routes into the one source of truth
- narratively cross-link the paired TUI-owned `lingtai-update` skill without creating a fake cross-repo relative path

No runtime Python behavior changes in this PR.

## Validation

Using the repository venv with this worktree's `src` on `PYTHONPATH`:

- `pytest tests/test_skills.py tests/test_kernel_version_nudge.py tests/test_source_drift.py tests/test_runtime_identity.py -q`: **69 passed**
- `pytest tests/test_prompt_catalog.py -q -k 'not test_guidance_ids_referenced_by_runtime_code_exist'`: **21 passed, 1 deselected**
- `pytest tests/test_docs_governance.py -q -k 'not test_all_four_notification_managers_preserve_exact_runtime_body'`: **69 passed, 1 deselected**
- skill validator with `--require-last-changed-at` for `system-manual`: pass
- skill validator with `--require-last-changed-at` for `runtime-update-checks`: pass
- `python scripts/check_docs_governance.py --check`: **250 documents (+ docs.yaml) validated**
- `git diff --check`: pass

Both deselected assertions were run separately against the exact `origin/main` checkout and reproduced the same failures: the prompt-catalog test expects a `meta_guidance.token_efficiency` runtime literal absent from base, and the notification-manager exact-body test expects length 2154 while base currently renders 2166. This candidate changes no `src/lingtai/kernel/**/*.py` file.

## Ownership / non-goals

The kernel detects and publishes update/source-drift facts; it does not own the TUI/portal binary update procedure. Normal installation/update commands and TUI-specific debugging live in the paired `Lingtai-AI/lingtai` update-skill PR: https://github.com/Lingtai-AI/lingtai/pull/656 This PR does not install, refresh, release, or change update machinery.