### PR TITLE
fix(telegram): restore Task Card session telemetry

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -487,6 +487,11 @@ class TelegramManager:
         self._task_card_event_size = 0
         self._task_card_event_inode: int | None = None
         self._task_card_event_rows: list[dict] = []
+        # The current telemetry snapshot is carried only by the latest final
+        # ``tool_result`` event. ``None`` means no such carrier has been seen;
+        # an empty dict is a seen-but-malformed carrier and deliberately clears
+        # any older snapshot.
+        self._task_card_event_metadata: dict | None = None
         self._task_card_event_lock = threading.Lock()
         self._task_card_tail_thread: threading.Thread | None = None
         self._task_card_tail_stop = threading.Event()
@@ -1780,17 +1785,18 @@ class TelegramManager:
     #
     # The automatic slot is a mechanical, bounded projection of the agent's own
     # authoritative ``logs/events.jsonl`` — a broadcast of the agent's behavior,
-    # not a per-chat/per-route view. It whitelists exactly one event type,
-    # ``tool_call``; every other event type is skipped immediately. Only a
-    # fixed, bounded, safe field allowlist is ever read from a matching row
+    # not a per-chat/per-route view. Tool rows whitelist exactly one event type,
+    # ``tool_call``; every other event type is skipped for row projection. A
+    # final-carrier ``tool_result`` is read separately for the latest whole
+    # ``_meta.agent_meta`` snapshot, from which only the supported session
+    # telemetry fields are projected. Row fields remain the bounded allowlist
     # (``tool_name``, ``tool_args.action``, ``tool_args._reasoning``, and the
     # event's own canonical ``ts`` converted to a row stamp) — raw
     # ``tool_args`` is never forwarded. A missing/malformed ``ts`` safely omits
     # the row's stamp rather than crashing or fabricating one. The projection
     # keeps only the most recent ``_TASK_CARD_EVENT_WINDOW`` matching rows and
-    # never inspects ``tool_result``/dispatch events or reconstructs
-    # completion, elapsed time, or a second lifecycle model; row order alone
-    # conveys recency.
+    # never reconstructs completion, elapsed time, or a second lifecycle model;
+    # row order alone conveys recency.
     #
     # There is no durable cursor/checkpoint file: ``events.jsonl`` is the only
     # durable behavior source. On start (and after any truncation/replacement)
@@ -1814,6 +1820,11 @@ class TelegramManager:
     def _task_card_event_window(self) -> list[dict]:
         with self._task_card_event_lock:
             return list(self._task_card_event_rows)
+
+    def _task_card_event_metadata_snapshot(self) -> dict | None:
+        with self._task_card_event_lock:
+            metadata = self._task_card_event_metadata
+            return dict(metadata) if isinstance(metadata, dict) else None
 
     @staticmethod
     def _project_tool_call_row(event: dict) -> dict | None:
@@ -1849,6 +1860,47 @@ class TelegramManager:
         if started_at:
             row["started_at"] = started_at
         return row
+
+    @staticmethod
+    def _project_tool_result_metadata(event: dict) -> dict | None:
+        """Project current session telemetry from one final-carrier result.
+
+        ``agent_meta`` is a whole current snapshot: only the newest
+        ``tool_result`` carrier is consulted, and only its
+        ``agent_state.token_usage.session`` fields cross into the Task Card.
+        An empty dict is a recognized-but-malformed carrier, so it clears an
+        older snapshot instead of leaving stale telemetry visible. ``None``
+        means this event is not a final carrier and must not change state.
+        """
+        if event.get("type") != "tool_result":
+            return None
+        envelope = event.get("_meta")
+        if envelope is None:
+            return None
+        if not isinstance(envelope, dict):
+            return {}
+        agent_meta = envelope.get("agent_meta")
+        if not isinstance(agent_meta, dict):
+            return {}
+        state = agent_meta.get("agent_state")
+        if not isinstance(state, dict):
+            return {}
+        token_usage = state.get("token_usage")
+        if not isinstance(token_usage, dict):
+            return {}
+        session = token_usage.get("session")
+        if not isinstance(session, dict):
+            return {}
+        supported = (
+            "session_cache_rate",
+            "cache_miss_tokens",
+            "cache_miss_budget",
+            "api_calls",
+            "context_tokens",
+            "context_window",
+            "context_usage",
+        )
+        return {key: session[key] for key in supported if key in session}
 
     @staticmethod
     def _format_task_card_row_timestamp(ts: object) -> str:
@@ -1888,6 +1940,7 @@ class TelegramManager:
                 self._task_card_event_size = 0
                 self._task_card_event_inode = None
                 self._task_card_event_rows = []
+                self._task_card_event_metadata = None
             return
 
         result = self._reverse_tail_latest_rows(path, stat.st_size)
@@ -1902,18 +1955,20 @@ class TelegramManager:
                 self._task_card_event_size = 0
                 self._task_card_event_inode = None
                 self._task_card_event_rows = []
+                self._task_card_event_metadata = None
             return
-        rows, offset = result
+        rows, offset, metadata = result
         with self._task_card_event_lock:
             self._task_card_event_path = path
             self._task_card_event_offset = offset
             self._task_card_event_size = stat.st_size
             self._task_card_event_inode = getattr(stat, "st_ino", None)
             self._task_card_event_rows = rows
+            self._task_card_event_metadata = metadata
 
     def _reverse_tail_latest_rows(
         self, path: Path, size: int,
-    ) -> tuple[list[dict], int] | None:
+    ) -> tuple[list[dict], int, dict | None] | None:
         """Reverse-scan bounded chunks from EOF to collect the latest-N matches.
 
         Reads growing chunks backward from the end of the file until either
@@ -1922,8 +1977,10 @@ class TelegramManager:
         The tail chunk may start mid-line; the leading partial fragment is
         discarded (its predecessor chunk will complete it on the next round).
 
-        Returns ``(rows, offset)`` where ``offset`` is the forward byte offset
-        the poller should resume from — ``size`` unless the file's final line
+        Returns ``(rows, offset, metadata)`` where ``offset`` is the forward
+        byte offset the poller should resume from and ``metadata`` is the latest
+        final-carrier session projection (or ``None`` when no carrier exists)
+        — ``size`` unless the file's final line
         has no trailing newline yet (writer mid-append), in which case it is
         the start of that incomplete tail so the poller re-reads it whole once
         it is completed, instead of treating it as an already-consumed row.
@@ -1932,6 +1989,7 @@ class TelegramManager:
         """
         window = self._TASK_CARD_EVENT_WINDOW
         matches: list[dict] = []
+        latest_metadata: dict | None = None
         tail_offset = size
         try:
             with open(path, "rb") as f:
@@ -1939,6 +1997,10 @@ class TelegramManager:
                 chunk_size = self._TASK_CARD_EVENT_TAIL_CHUNK
                 carry = b""
                 first_chunk = True
+                # Reverse order means the first recognized carrier in the
+                # bounded tail is the latest one available to this rehydrate.
+                # Keep the existing latest-row bound; a log without a nearby
+                # carrier must not turn startup into an unbounded full scan.
                 while end > 0 and len(matches) < window:
                     start = max(0, end - chunk_size)
                     f.seek(start)
@@ -1965,18 +2027,29 @@ class TelegramManager:
                     carry = lines[0] if start > 0 else b""
                     complete = lines[1:] if start > 0 else lines
                     round_matches: list[dict] = []
+                    round_metadata: dict | None = None
                     for raw in complete:
-                        row = self._decode_and_project_line(raw)
+                        event = self._decode_event_line(raw)
+                        if event is None:
+                            continue
+                        row = self._project_tool_call_row(event)
                         if row is not None:
                             round_matches.append(row)
+                        candidate = self._project_tool_result_metadata(event)
+                        if candidate is not None:
+                            # ``complete`` is oldest-to-newest within this
+                            # chunk; the last candidate is the newest here.
+                            round_metadata = candidate
+                    if latest_metadata is None and round_metadata is not None:
+                        latest_metadata = round_metadata
                     matches = round_matches + matches
                     chunk_size *= 2
         except OSError:
             return None
-        return matches[-window:], tail_offset
+        return matches[-window:], tail_offset, latest_metadata
 
     @staticmethod
-    def _decode_and_project_line(raw: bytes) -> dict | None:
+    def _decode_event_line(raw: bytes) -> dict | None:
         line = raw.strip()
         if not line:
             return None
@@ -1984,9 +2057,12 @@ class TelegramManager:
             event = json.loads(line.decode("utf-8"))
         except (json.JSONDecodeError, UnicodeDecodeError):
             return None
-        if not isinstance(event, dict):
-            return None
-        return TelegramManager._project_tool_call_row(event)
+        return event if isinstance(event, dict) else None
+
+    @staticmethod
+    def _decode_and_project_line(raw: bytes) -> dict | None:
+        event = TelegramManager._decode_event_line(raw)
+        return TelegramManager._project_tool_call_row(event) if event is not None else None
 
     def _poll_event_tail(self) -> None:
         """Read any newly appended complete lines and broadcast on change.
@@ -2002,7 +2078,8 @@ class TelegramManager:
             with self._task_card_event_lock:
                 path = self._task_card_event_path
                 rehydrated_rows = bool(self._task_card_event_rows)
-            if rehydrated_rows:
+                rehydrated_metadata = self._task_card_event_metadata is not None
+            if rehydrated_rows or rehydrated_metadata:
                 self._broadcast_task_card_event_window()
             return
 
@@ -2062,23 +2139,33 @@ class TelegramManager:
         new_offset = offset + len(complete)
 
         new_rows: list[dict] = []
+        latest_metadata: dict | None = None
         for raw in complete.split(b"\n"):
-            row = self._decode_and_project_line(raw)
+            event = self._decode_event_line(raw)
+            if event is None:
+                continue
+            row = self._project_tool_call_row(event)
             if row is not None:
                 new_rows.append(row)
-
-        if not new_rows:
-            with self._task_card_event_lock:
-                self._task_card_event_offset = new_offset
-                self._task_card_event_size = size
-            return False
+            candidate = self._project_tool_result_metadata(event)
+            if candidate is not None:
+                # Forward append order is oldest-to-newest, so the last
+                # candidate is the only current snapshot.
+                latest_metadata = candidate
 
         with self._task_card_event_lock:
-            rows = self._task_card_event_rows + new_rows
-            self._task_card_event_rows = rows[-self._TASK_CARD_EVENT_WINDOW:]
+            metadata_changed = (
+                latest_metadata is not None
+                and latest_metadata != self._task_card_event_metadata
+            )
+            if latest_metadata is not None:
+                self._task_card_event_metadata = latest_metadata
             self._task_card_event_offset = new_offset
             self._task_card_event_size = size
-        return True
+            if new_rows:
+                rows = self._task_card_event_rows + new_rows
+                self._task_card_event_rows = rows[-self._TASK_CARD_EVENT_WINDOW:]
+        return bool(new_rows) or metadata_changed
 
     def _resident_task_card_targets(self) -> list[tuple[str, int]]:
         """Enumerate every ``(account, chat_id)`` with a resident Task Card.
@@ -2114,7 +2201,10 @@ class TelegramManager:
         normal_rows = self._taskcard_normal_rows()
         rows = self._task_card_event_window()[-normal_rows:]
         automatic = self._format_task_card_text(
-            "", "", "", rows=rows, normal_rows=normal_rows)
+            "", "", "", rows=rows,
+            metadata=self._task_card_event_metadata_snapshot(),
+            normal_rows=normal_rows,
+        )
         for account, chat_id in self._resident_task_card_targets():
             try:
                 self._deliver_channel_frame(

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -488,7 +488,7 @@ class TelegramManager:
         self._task_card_event_inode: int | None = None
         self._task_card_event_rows: list[dict] = []
         # The current telemetry snapshot is carried only by the latest final
-        # ``tool_result`` event. ``None`` means no such carrier has been seen;
+        # ``notification_block_injected`` event. ``None`` means no such carrier has been seen;
         # an empty dict is a seen-but-malformed carrier and deliberately clears
         # any older snapshot.
         self._task_card_event_metadata: dict | None = None
@@ -1787,7 +1787,7 @@ class TelegramManager:
     # authoritative ``logs/events.jsonl`` — a broadcast of the agent's behavior,
     # not a per-chat/per-route view. Tool rows whitelist exactly one event type,
     # ``tool_call``; every other event type is skipped for row projection. A
-    # final-carrier ``tool_result`` is read separately for the latest whole
+    # final-carrier ``notification_block_injected`` event is read separately for the latest whole
     # ``_meta.agent_meta`` snapshot, from which only the supported session
     # telemetry fields are projected. Row fields remain the bounded allowlist
     # (``tool_name``, ``tool_args.action``, ``tool_args._reasoning``, and the
@@ -1862,21 +1862,19 @@ class TelegramManager:
         return row
 
     @staticmethod
-    def _project_tool_result_metadata(event: dict) -> dict | None:
-        """Project current session telemetry from one final-carrier result.
+    def _project_final_carrier_metadata(event: dict) -> dict | None:
+        """Project current session telemetry from one final-carrier event.
 
         ``agent_meta`` is a whole current snapshot: only the newest
-        ``tool_result`` carrier is consulted, and only its
+        ``notification_block_injected`` carrier is consulted, and only its
         ``agent_state.token_usage.session`` fields cross into the Task Card.
         An empty dict is a recognized-but-malformed carrier, so it clears an
         older snapshot instead of leaving stale telemetry visible. ``None``
         means this event is not a final carrier and must not change state.
         """
-        if event.get("type") != "tool_result":
+        if event.get("type") != "notification_block_injected":
             return None
         envelope = event.get("_meta")
-        if envelope is None:
-            return None
         if not isinstance(envelope, dict):
             return {}
         agent_meta = envelope.get("agent_meta")
@@ -2035,7 +2033,7 @@ class TelegramManager:
                         row = self._project_tool_call_row(event)
                         if row is not None:
                             round_matches.append(row)
-                        candidate = self._project_tool_result_metadata(event)
+                        candidate = self._project_final_carrier_metadata(event)
                         if candidate is not None:
                             # ``complete`` is oldest-to-newest within this
                             # chunk; the last candidate is the newest here.
@@ -2147,7 +2145,7 @@ class TelegramManager:
             row = self._project_tool_call_row(event)
             if row is not None:
                 new_rows.append(row)
-            candidate = self._project_tool_result_metadata(event)
+            candidate = self._project_final_carrier_metadata(event)
             if candidate is not None:
                 # Forward append order is oldest-to-newest, so the last
                 # candidate is the only current snapshot.

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -107,8 +107,8 @@ Normative promises live in the paired [`CONTRACT.md`](CONTRACT.md).
   render time are never timestamp sources. Navigation:
   `manager.py:_project_tool_call_row`, `_format_task_card_row_timestamp`, and
   `_format_rows_task_card_text` (currently around lines 1819, 1854, and 2720).
-- **Current telemetry:** `_project_tool_result_metadata` accepts only a
-  final-carrier `type == "tool_result"` event's latest whole
+- **Current telemetry:** `_project_final_carrier_metadata` accepts only a
+  final-carrier `type == "notification_block_injected"` event's latest whole
   `_meta.agent_meta`, then projects
   `_meta.agent_meta.agent_state.token_usage.session` fields
   `session_cache_rate`, `cache_miss_tokens`, `cache_miss_budget`, `api_calls`,
@@ -117,7 +117,7 @@ Normative promises live in the paired [`CONTRACT.md`](CONTRACT.md).
   `_format_task_card_metadata` two-line/150-character formatter through
   `_broadcast_task_card_event_window`; malformed or missing values omit safely.
   It never reads retired `tool_meta.token_usage`, row args, notifications, or
-  render time. Navigation: `manager.py:_project_tool_result_metadata`,
+  render time. Navigation: `manager.py:_project_final_carrier_metadata`,
   `_reverse_tail_latest_rows`, `_append_new_lines`, and
   `_broadcast_task_card_event_window` (currently around lines 1849, 1980, 2140,
   and 2190).

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -96,9 +96,38 @@ Normative promises live in the paired [`CONTRACT.md`](CONTRACT.md).
   else returns `indeterminate_send` so cold-send/old-first replacement fail closed.
 - Fail-loud: after-handle failures call `agent._enqueue_system_notification`.
 
-## Automatic row timestamp path
+## Automatic event-tail projection paths
 
-The automatic slot keeps time provenance in the same bounded event projection: only after an event is validated as `type == "tool_call"`, `TelegramManager` reads that event's own top-level Unix-epoch `ts`, formats a valid value as the latest `HH:MM:SS UTC±HH`, and projects it as optional row `started_at`. Missing, boolean, non-numeric, non-finite, or out-of-range values omit the suffix; `_meta` and the current render instant are never substitutes. The path is `tool_call.ts` → `_format_task_card_row_timestamp` → `_project_tool_call_row` → `_format_rows_task_card_text` (`src/lingtai/mcp_servers/telegram/manager.py:1854`, `src/lingtai/mcp_servers/telegram/manager.py:1819`, `src/lingtai/mcp_servers/telegram/manager.py:2656`). Owning event-to-render and malformed-input regressions live at `tests/test_telegram_task_card_event_tail.py:403` and `tests/test_telegram_task_card_event_tail.py:443`.
+- **Rows/timestamps:** after validating `type == "tool_call"`,
+  `_project_tool_call_row` reads only `tool_name`, `tool_args.action`,
+  `tool_args._reasoning`, and that same event's top-level Unix-epoch `ts`.
+  `_format_task_card_row_timestamp` projects a valid value as optional
+  `started_at` in `HH:MM:SS UTC±HH`; missing, boolean, non-numeric, non-finite,
+  or out-of-range values omit it. `_meta`, row arguments, notifications, and
+  render time are never timestamp sources. Navigation:
+  `manager.py:_project_tool_call_row`, `_format_task_card_row_timestamp`, and
+  `_format_rows_task_card_text` (currently around lines 1819, 1854, and 2720).
+- **Current telemetry:** `_project_tool_result_metadata` accepts only a
+  final-carrier `type == "tool_result"` event's latest whole
+  `_meta.agent_meta`, then projects
+  `_meta.agent_meta.agent_state.token_usage.session` fields
+  `session_cache_rate`, `cache_miss_tokens`, `cache_miss_budget`, `api_calls`,
+  `context_tokens`, `context_window`, and `context_usage`. The tail stores no
+  historical holders and passes this bounded projection to the existing
+  `_format_task_card_metadata` two-line/150-character formatter through
+  `_broadcast_task_card_event_window`; malformed or missing values omit safely.
+  It never reads retired `tool_meta.token_usage`, row args, notifications, or
+  render time. Navigation: `manager.py:_project_tool_result_metadata`,
+  `_reverse_tail_latest_rows`, `_append_new_lines`, and
+  `_broadcast_task_card_event_window` (currently around lines 1849, 1980, 2140,
+  and 2190).
+- **Regression/drift triggers:** the event-to-final-render coverage is
+  `tests/test_telegram_task_card_event_tail.py:test_event_log_final_carrier_projects_session_telemetry_into_final_render`
+  plus `test_malformed_current_telemetry_carrier_clears_previous_snapshot` and the adjacent timestamp/malformed-input cases. Update this anatomy and
+  the paired contract/tests together if event types, the final-carrier metadata
+  path, supported session fields, the two-line formatter budget, or timestamp
+  provenance changes; do not broaden the automatic source without revisiting
+  the authoritative-event rule.
 
 ## Composition
 

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -330,7 +330,7 @@ one source of truth for each projection axis:
    out-of-range `ts` omits `started_at` without failing the tail. `_meta`, row
    arguments, notification payloads, and the current render instant are never
    timestamp sources.
-2. **Current telemetry.** Only the latest final-carrier `type == "tool_result"`
+2. **Current telemetry.** Only the latest final-carrier `type == "notification_block_injected"`
    event's whole `_meta.agent_meta` is current. The manager projects only
    `_meta.agent_meta.agent_state.token_usage.session` and only these supported
    fields: `session_cache_rate`, `cache_miss_tokens`, `cache_miss_budget`,
@@ -348,7 +348,7 @@ one source of truth for each projection axis:
    changes.
 4. **Implementation and tests.** The event path is
    `manager.py:_decode_event_line` → `_project_tool_call_row` /
-   `_project_tool_result_metadata` → `_reverse_tail_latest_rows` or
+   `_project_final_carrier_metadata` → `_reverse_tail_latest_rows` or
    `_append_new_lines` → `_broadcast_task_card_event_window` →
    `_format_task_card_text`. The formatter anchors are
    `manager.py:_format_task_card_metadata` and

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -316,11 +316,51 @@ Verification commands (repo venv):
   tests/test_mcp_skill_manuals.py
 ```
 
-## Automatic row timestamp interface
+## Automatic Task Card telemetry and timestamp interface
 
-1. An automatic row MAY expose `started_at` only from the same already-validated `tool_call` event's top-level Unix-epoch `ts`; `_meta`, tool arguments, notification payloads, and the current render instant are not time sources.
-2. A valid event time MUST use the current row presentation `HH:MM:SS UTC±HH`. Missing, boolean, non-numeric, non-finite, or out-of-range `ts` MUST omit `started_at` without failing the event tail.
-3. The event-to-final-render suffix and fail-closed malformed cases are contract-tested at `tests/test_telegram_task_card_event_tail.py:403` and `tests/test_telegram_task_card_event_tail.py:443`. The implementation anchors are `src/lingtai/mcp_servers/telegram/manager.py:1854` and `src/lingtai/mcp_servers/telegram/manager.py:1819`.
+The automatic slot is a bounded projection of the agent's authoritative
+`logs/events.jsonl` event order, broadcast to each resident Task Card. It has
+one source of truth for each projection axis:
+
+1. **Tool rows and timestamps.** A row is projected only from a validated
+   `type == "tool_call"` event. Its allowlisted fields are `tool_name`,
+   `tool_args.action`, and redacted/capped `tool_args._reasoning`. Its optional
+   `started_at` is derived only from that same event's top-level Unix-epoch `ts`
+   and uses `HH:MM:SS UTC±HH`. Missing, boolean, non-numeric, non-finite, or
+   out-of-range `ts` omits `started_at` without failing the tail. `_meta`, row
+   arguments, notification payloads, and the current render instant are never
+   timestamp sources.
+2. **Current telemetry.** Only the latest final-carrier `type == "tool_result"`
+   event's whole `_meta.agent_meta` is current. The manager projects only
+   `_meta.agent_meta.agent_state.token_usage.session` and only these supported
+   fields: `session_cache_rate`, `cache_miss_tokens`, `cache_miss_budget`,
+   `api_calls`, `context_tokens`, `context_window`, and `context_usage`.
+   Historical `agent_meta` holders are not merged; retired
+   `tool_meta.token_usage`, row args, notifications, and render time are not
+   telemetry sources. A missing/malformed carrier or field omits safely and
+   must not leave an older snapshot visible after a malformed current carrier.
+3. **Formatting and composition.** The supported fields are passed to the
+   existing `_format_task_card_metadata` projection, which preserves the
+   bounded two-line metadata footer and its 150-character joined budget. The
+   rows continue through `_format_rows_task_card_text`; telemetry never changes
+   row ordering, row timestamps, or the programmable slot. A broadcast occurs
+   when either the bounded tool-row window or the current telemetry projection
+   changes.
+4. **Implementation and tests.** The event path is
+   `manager.py:_decode_event_line` → `_project_tool_call_row` /
+   `_project_tool_result_metadata` → `_reverse_tail_latest_rows` or
+   `_append_new_lines` → `_broadcast_task_card_event_window` →
+   `_format_task_card_text`. The formatter anchors are
+   `manager.py:_format_task_card_metadata` and
+   `manager.py:_format_rows_task_card_text`. The event-log-to-final-render
+   regression is
+   `tests/test_telegram_task_card_event_tail.py:test_event_log_final_carrier_projects_session_telemetry_into_final_render`;
+   malformed-carrier coverage is
+   `test_malformed_current_telemetry_carrier_clears_previous_snapshot`, while
+   timestamp and malformed-input coverage is in the adjacent
+   `test_row_started_at_is_...` cases. Update this contract and its paired
+   anatomy/tests together if the event schema, final-carrier path, supported
+   fields, formatter budget, or timestamp provenance changes.
 
 ## Maintenance
 

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -3,7 +3,7 @@
 Jason's final contract (Telegram 8266-8295): the automatic slot mechanically
 consumes the agent's authoritative ``logs/events.jsonl`` in file order, keeps
 the most recent N ``tool_call`` events using only safe bounded fields, projects
-current session telemetry only from the latest final-carrier ``tool_result``,
+current session telemetry only from the latest final-carrier ``notification_block_injected``,
 and broadcasts the same projection to every resident Task Card for the agent
 (no per-route correlation — this is an agent-behavior broadcast, not per-chat
 visibility).
@@ -425,7 +425,7 @@ def test_row_started_at_is_derived_from_event_ts_and_rendered(tmp_path):
 def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tmp_path):
     """Rows and the footer telemetry come from their authoritative events.
 
-    The final-carrier ``tool_result`` owns the current whole ``agent_meta``
+    The final-carrier ``notification_block_injected`` owns the current whole ``agent_meta``
     snapshot; a retired ``tool_meta`` snapshot and row arguments are present as
     decoys and must not affect the automatic card.
     """
@@ -448,8 +448,19 @@ def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tm
     row_event["tool_args"]["metadata"] = {"api_calls": 999}
     _write_lines(events_path, [
         json.dumps(row_event),
+        # A plain tool_result is the live decoy immediately before the real
+        # notification carrier; even if it fabricates agent_meta, it must not
+        # own the current snapshot.
         json.dumps({
             "type": "tool_result",
+            "tool_name": "bash",
+            "tool_call_id": "c1",
+            "_meta": {"agent_meta": {"agent_state": {"token_usage": {
+                "session": {"api_calls": 888},
+            }}}},
+        }),
+        json.dumps({
+            "type": "notification_block_injected",
             "tool_name": "bash",
             "tool_call_id": "c1",
             "ts": event_ts + 1,
@@ -480,6 +491,7 @@ def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tm
     assert f" · {expected_stamp}" in rendered
     assert "session · cache 87.8% · miss 170.6k/1.0M · calls 13" in rendered
     assert "ctx · 171.2k/272.0k · 63%" in rendered
+    assert "calls 888" not in rendered
     assert "calls 999" not in rendered
     assert "calls 777" not in rendered
 
@@ -493,7 +505,7 @@ def test_malformed_current_telemetry_carrier_clears_previous_snapshot(tmp_path):
     _write_lines(events_path, [
         _tool_call_line(),
         json.dumps({
-            "type": "tool_result",
+            "type": "notification_block_injected",
             "_meta": {"agent_meta": {"agent_state": {"token_usage": {
                 "session": {"api_calls": 7},
             }}}},
@@ -504,7 +516,7 @@ def test_malformed_current_telemetry_carrier_clears_previous_snapshot(tmp_path):
     assert "calls 7" in edits[-1][3]
 
     _write_lines(events_path, [json.dumps({
-        "type": "tool_result",
+        "type": "notification_block_injected",
         "_meta": {"agent_meta": {"agent_state": {"token_usage": {
             "session": {"api_calls": "malformed"},
         }}}},

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -1,11 +1,12 @@
 """Automatic Task Card as a broadcast projection of the agent's ``events.jsonl``.
 
 Jason's final contract (Telegram 8266-8295): the automatic slot mechanically
-consumes the agent's authoritative ``logs/events.jsonl`` in file order, skips
-every non-whitelisted event type, keeps the most recent N matching
-``tool_call`` events using only safe bounded fields, and broadcasts the same
-projection to every resident Task Card for the agent (no per-route
-correlation — this is an agent-behavior broadcast, not per-chat visibility).
+consumes the agent's authoritative ``logs/events.jsonl`` in file order, keeps
+the most recent N ``tool_call`` events using only safe bounded fields, projects
+current session telemetry only from the latest final-carrier ``tool_result``,
+and broadcasts the same projection to every resident Task Card for the agent
+(no per-route correlation — this is an agent-behavior broadcast, not per-chat
+visibility).
 
 These tests exercise ``TelegramManager``'s tailer directly: no durable
 cursor/checkpoint file, no BaseAgent pre-dispatch/result callback dependency,
@@ -419,6 +420,100 @@ def test_row_started_at_is_derived_from_event_ts_and_rendered(tmp_path):
     edits = [call for call in acct.calls if call[0] == "edit_message"]
     assert edits
     assert f" · {expected}" in edits[-1][3]
+
+
+def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tmp_path):
+    """Rows and the footer telemetry come from their authoritative events.
+
+    The final-carrier ``tool_result`` owns the current whole ``agent_meta``
+    snapshot; a retired ``tool_meta`` snapshot and row arguments are present as
+    decoys and must not affect the automatic card.
+    """
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    event_ts = 1752600000.0
+    session = {
+        "session_cache_rate": 0.87803,
+        "cache_miss_tokens": 170631,
+        "cache_miss_budget": 1_000_000,
+        "api_calls": 13,
+        "context_tokens": 171246,
+        "context_window": 272000,
+        "context_usage": 0.62958,
+    }
+    events_path = _events_path(tmp_path)
+    row_event = json.loads(_tool_call_line(ts=event_ts, reasoning="event-log row"))
+    row_event["tool_args"]["metadata"] = {"api_calls": 999}
+    _write_lines(events_path, [
+        json.dumps(row_event),
+        json.dumps({
+            "type": "tool_result",
+            "tool_name": "bash",
+            "tool_call_id": "c1",
+            "ts": event_ts + 1,
+            "_meta": {
+                "tool_meta": {"token_usage": {"session": {
+                    "session_cache_rate": 0.01,
+                    "api_calls": 1,
+                }}},
+                "agent_meta": {
+                    "agent_state": {"token_usage": {
+                        "current_call": {"api_calls": 999},
+                        "session": session,
+                    }},
+                    "notifications": {"persistent": {"api_calls": 777}},
+                },
+            },
+        }),
+    ])
+
+    manager._poll_event_tail()
+
+    local = datetime.fromtimestamp(event_ts).astimezone()
+    expected_stamp = f"{local:%H:%M:%S} UTC{local:%z}"[:-2]
+    edits = [call for call in acct.calls if call[0] == "edit_message"]
+    assert edits
+    rendered = edits[-1][3]
+    assert "bash.run" in rendered
+    assert f" · {expected_stamp}" in rendered
+    assert "session · cache 87.8% · miss 170.6k/1.0M · calls 13" in rendered
+    assert "ctx · 171.2k/272.0k · 63%" in rendered
+    assert "calls 999" not in rendered
+    assert "calls 777" not in rendered
+
+
+def test_malformed_current_telemetry_carrier_clears_previous_snapshot(tmp_path):
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    events_path = _events_path(tmp_path)
+    _write_lines(events_path, [
+        _tool_call_line(),
+        json.dumps({
+            "type": "tool_result",
+            "_meta": {"agent_meta": {"agent_state": {"token_usage": {
+                "session": {"api_calls": 7},
+            }}}},
+        }),
+    ])
+    manager._poll_event_tail()
+    edits = [call for call in acct.calls if call[0] == "edit_message"]
+    assert "calls 7" in edits[-1][3]
+
+    _write_lines(events_path, [json.dumps({
+        "type": "tool_result",
+        "_meta": {"agent_meta": {"agent_state": {"token_usage": {
+            "session": {"api_calls": "malformed"},
+        }}}},
+    })])
+    manager._poll_event_tail()
+
+    edits = [call for call in acct.calls if call[0] == "edit_message"]
+    assert "calls 7" not in edits[-1][3]
+    assert "session ·" not in edits[-1][3]
 
 
 def test_row_started_at_omitted_when_ts_missing(tmp_path):


### PR DESCRIPTION
## Summary

- read automatic Task Card rows directly from authoritative `logs/events.jsonl` `tool_call` events
- read current cache/context telemetry directly from the latest `notification_block_injected` event in the same log
- project only the seven supported fields from `_meta.agent_meta.agent_state.token_usage.session`
- broadcast metadata-only changes, rehydrate rows plus current telemetry after restart, and clear stale telemetry when the latest eligible notification carrier is malformed
- define the producer-to-renderer boundary in the owning `CONTRACT.md` and `ANATOMY.md`

## Root cause and live correction

The event-tail refactor kept `tool_call` events authoritative for rows but stopped rendering the session footer.

The first PR head (`39bd007c`) incorrectly assumed that the plain `tool_result` line was the telemetry carrier, and its focused fixture fabricated a telemetry-bearing `tool_result`. A real checkout + refresh therefore loaded the intended source but still showed no footer.

Direct inspection of the live event sequence established the actual contract:

1. `tool_call` — Task Card row
2. plain `tool_result` — no `_meta`
3. `notification_block_injected` — complete current `_meta.agent_meta`

Follow-up head `be9b74e9` makes only `notification_block_injected` eligible for the footer. The regression now includes a preceding plain `tool_result` decoy with fake `agent_meta` and proves it cannot own or leak into the current snapshot.

## Interface boundaries

The projector accepts only:

- `session_cache_rate`
- `cache_miss_tokens`
- `cache_miss_budget`
- `api_calls`
- `context_tokens`
- `context_window`
- `context_usage`

It does not read plain `tool_result`, retired `tool_meta.token_usage`, `current_call`, row arguments, notifications, historical holders, or render time as telemetry authority.

## Validation

- `git diff --check`
- actual LingTai runtime: `/Users/huangzesen/.lingtai-tui/runtime/venv/bin/python`
- in-memory `compile(...)` of changed Python source and focused regression
- direct replay of this agent's latest real `notification_block_injected` event from `logs/events.jsonl`
- exact seven-field projection from the live carrier
- explicit rejection of a plain `tool_result` containing the same fake `agent_meta`
- malformed current notification carrier clears older telemetry
- direct formatter output produced both `session · ...` and `ctx · ...` lines
- candidate module path mechanically verified as this PR worktree

Local pytest was intentionally not invoked because the active no-deletion boundary forbids fixture/temp lifecycle cleanup; CI remains the full test gate.

A separate read-only producer audit had already found the latest 16 live `notification_block_injected` carriers complete and internally consistent. The failed live test proved the remaining defect was the Task Card consumer's wrong event-type assumption, not producer data loss.

## Live acceptance gate

The corrected head still requires a second real checkout + refresh and visible Task Card confirmation. Source/import proof alone is not treated as product success, and merge remains blocked until that visible test and normal PR gates are clean.

## Scope

This PR changes only the Telegram Task Card consumer/projection, its owning contract/anatomy, and focused regression coverage. It does not change the `agent_meta` producer, notification semantics, runtime guidance, or prompt construction.
