### PR TITLE
feat(release): publish kernel artifacts to GitHub and Gitee

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,6 +2,15 @@ name: Build Python wheels
 
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: >-
+          Actually publish the manifest/wheels/sdist to the GitHub release and
+          (when GITEE_ACCESS_TOKEN is configured) Gitee. Default false keeps
+          manual dispatch a safe dry-run/shape-check; the automatic
+          release.published trigger always publishes.
+        type: boolean
+        default: false
   release:
     types: [published]
 
@@ -155,4 +164,139 @@ jobs:
         with:
           name: sdist
           path: ./dist/*.tar.gz
+          if-no-files-found: error
+
+  release-manifest:
+    name: Generate release manifest
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    # Serial by design: this job only aggregates the wheelhouse+sdist artifacts
+    # the matrix already built and verified (see "Verify built wheels carry a
+    # runnable sidecar" above); it must never rebuild anything per platform.
+    # `needs: [build-wheels, build-sdist]` makes it wait for every matrix leg,
+    # so a partial/failed platform build fails this job loud via `needs`
+    # rather than silently shipping an incomplete manifest.
+    timeout-minutes: 15
+    permissions:
+      # write is required only for the actual publish path (gh release
+      # upload / create); the dry-run path never mutates anything regardless
+      # of this permission grant.
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # sync_gitee_mirror.py needs the full history reachable from
+          # ${{ github.sha }} to `git cat-file -e`/push it; a shallow
+          # checkout (the actions/checkout@v4 default) would make that fail.
+          fetch-depth: 0
+
+      - name: Set up Python for the manifest/publish scripts
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download all wheel + sdist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "wheels-*"
+          path: release-assets
+          merge-multiple: true
+
+      - name: Download sdist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: release-assets
+
+      - name: Generate release manifest + SHA256SUMS
+        env:
+          # release.published fires with a real tag; workflow_dispatch has no
+          # tag, so fall back to the pyproject version prefixed with "v" and
+          # the checked-out commit — this keeps manual-dispatch runs usable
+          # for manifest-shape testing without pretending a release exists.
+          KERNEL_TAG: ${{ github.event.release.tag_name || '' }}
+        run: |
+          set -euo pipefail
+          version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          tag="${KERNEL_TAG:-v${version}}"
+          generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          python scripts/generate_release_manifest.py \
+            --assets-dir release-assets \
+            --kernel-version "$version" \
+            --kernel-tag "$tag" \
+            --commit "${{ github.sha }}" \
+            --generated-at "$generated_at" \
+            --out-manifest release-assets/lingtai-kernel-release-manifest.json \
+            --out-sha256sums release-assets/SHA256SUMS
+
+      - name: Determine publish mode
+        id: publish_mode
+        run: |
+          set -euo pipefail
+          # Publish for real only on the automatic release.published trigger,
+          # or on an explicit workflow_dispatch with publish=true. Every other
+          # run (default workflow_dispatch, or any run without the input)
+          # stays dry-run — this is the fix for the prior version of this job,
+          # which unconditionally omitted --execute and so could never
+          # publish anything even on a real release.
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "execute=1" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.publish }}" == "true" ]]; then
+            echo "execute=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "execute=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Non-force synchronize the exact commit/tag to Gitee
+        if: steps.publish_mode.outputs.execute == '1'
+        env:
+          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          tag="${{ github.event.release.tag_name || '' }}"
+          tag="${tag:-v${version}}"
+          # Skips cleanly (exit 0, prints why) when GITEE_ACCESS_TOKEN is
+          # unset — see sync_gitee_mirror.py. Every push is non-force; a
+          # divergence/existing-tag conflict fails this step loud rather than
+          # silently overwriting the mirror.
+          python scripts/sync_gitee_mirror.py \
+            --commit "${{ github.sha }}" \
+            --tag "$tag" \
+            --branch main \
+            --execute
+
+      - name: Publish manifest/wheels/sdist
+        env:
+          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          tag="${{ github.event.release.tag_name || '' }}"
+          tag="${tag:-v${version}}"
+          execute_flag=""
+          if [[ "${{ steps.publish_mode.outputs.execute }}" == "1" ]]; then
+            execute_flag="--execute"
+            echo "Publishing $tag for real (event=${{ github.event_name }})."
+          else
+            echo "Manifest ready for $tag. Dry run only (event=${{ github.event_name }}, publish input=${{ inputs.publish }})."
+          fi
+          # publish_release_assets.py is idempotent (skips already-attached
+          # same-name assets) and never force-syncs/deletes — safe to run
+          # repeatedly. Gitee leg is skipped internally when
+          # GITEE_ACCESS_TOKEN is unset, regardless of execute_flag.
+          python scripts/publish_release_assets.py \
+            --manifest release-assets/lingtai-kernel-release-manifest.json \
+            --assets-dir release-assets \
+            $execute_flag
+
+      - name: Upload release manifest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-manifest
+          path: |
+            release-assets/lingtai-kernel-release-manifest.json
+            release-assets/SHA256SUMS
           if-no-files-found: error

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -6,12 +6,17 @@ related_files:
   - CONTRIBUTING.md
   - MANIFEST.in
   - README.md
+  - RELEASING.md
   - SECURITY.md
   - SUPPORT.md
   - dev-guide-skill/SKILL.md
   - docs/references/claude-code-guide.md
   - pyproject.toml
   - setup.py
+  - scripts/generate_release_manifest.py
+  - scripts/publish_release_assets.py
+  - scripts/sync_gitee_mirror.py
+  - scripts/lib/release_manifest.py
   - src/lingtai/ANATOMY.md
   - src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
   - src/lingtai/kernel/ANATOMY.md
@@ -156,7 +161,12 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
   its skill routes agents into the Anatomy and Contract systems and may grow
   focused scripts, references, templates, or assets as real workflows recur.
 - [`scripts/`](scripts/) — root utility/checker scripts, including the
-  docs-governance validator described below.
+  docs-governance validator described below and the release-manifest
+  generator/publisher/Gitee-mirror-sync scripts described in
+  [`RELEASING.md`](RELEASING.md). `wheels.yml`'s `release-manifest` job
+  actually invokes these with `--execute` on a real `release.published`
+  event (or an explicit `workflow_dispatch` with `publish: true`) — every
+  other trigger shape stays dry-run.
 - [`.github/`](.github/) — GitHub Actions, issue templates, and pull request
   templates.
 - [`crates/lingtai-search-sidecar/`](crates/lingtai-search-sidecar/) — Rust file
@@ -180,6 +190,9 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
   and [`tests/test_docs_governance.py`](tests/test_docs_governance.py).
 - [`README.md`](README.md) — public English network entry point; translated
   readmes live under `docs/readmes/`.
+- [`RELEASING.md`](RELEASING.md) — kernel release process: how
+  `.github/workflows/wheels.yml` builds, verifies, and manifests wheel/sdist
+  assets, and how a future authorized run publishes them to GitHub and Gitee.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — public contributor entry point.
 - [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), [`SECURITY.md`](SECURITY.md), and
   [`SUPPORT.md`](SUPPORT.md) — community and safety entry points.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,178 @@
+# Releasing the `lingtai` Python kernel
+
+## Build + verify (existing, unchanged)
+
+`.github/workflows/wheels.yml` runs on `workflow_dispatch` or when a GitHub
+Release is published. Two independent jobs build the artifacts:
+
+- **`build-wheels`** — cibuildwheel matrix across cp311/cp312/cp313 for Linux
+  (x86_64 + aarch64), macOS (Intel + Apple Silicon), and Windows. Every wheel
+  carries the native Rust search sidecar (`lingtai/bin/lingtai-search-sidecar`)
+  and is verified with `tests/test_wheel_sidecar_smoke.py --auto` before
+  upload. **Never treat a plain `pip wheel` / `uv build --wheel` /
+  `python -m build --wheel` output as a release artifact** — without
+  `LINGTAI_REQUIRE_RUST_BUILD=1` and the cibuildwheel toolchain it silently
+  produces a pure-Python `py3-none-any` wheel with no sidecar, which the
+  installer would then ship as if it were a full platform build.
+- **`build-sdist`** — independent source-only build (`uv build --sdist`), no
+  Rust required.
+
+Both jobs upload their outputs as GitHub Actions artifacts (`wheels-<os>`,
+`sdist`) — Actions artifacts are CI-internal and are not directly visible to
+end users or the installer.
+
+## Manifest (new)
+
+A third job, **`release-manifest`**, runs after both build jobs
+(`needs: [build-wheels, build-sdist]`) so it only ever aggregates already-built
+and already-verified bytes — it rebuilds nothing per platform or provider.
+
+It downloads every `wheels-*` and the `sdist` artifact into one directory and
+runs [`scripts/generate_release_manifest.py`](scripts/generate_release_manifest.py),
+which:
+
+1. Re-rejects any stray `py3-none-any` wheel outright (belt-and-braces on top
+   of the build-time guard above).
+2. Re-runs the sidecar validation contract
+   (`tests/test_wheel_sidecar_smoke.py --auto`) against every wheel.
+3. Computes a SHA256 for every artifact and writes a flat `SHA256SUMS` file.
+4. Emits `lingtai-kernel-release-manifest.json`, schema `lingtai.kernel.release/v1`
+   (defined in [`scripts/lib/release_manifest.py`](scripts/lib/release_manifest.py) —
+   the one source of truth for this shape; the generator, the publisher, and
+   the TUI installer's consumer all import or mirror it):
+
+   ```json
+   {
+     "schema": "lingtai.kernel.release/v1",
+     "kernel_version": "0.16.4",
+     "kernel_tag": "v0.16.4",
+     "commit": "<full 40-char sha>",
+     "generated_at": "2026-07-15T00:00:00Z",
+     "artifacts": [
+       {
+         "filename": "lingtai-0.16.4-cp312-cp312-macosx_11_0_arm64.whl",
+         "sha256": "<64-char hex>",
+         "kind": "wheel",
+         "python_tag": "cp312",
+         "abi_tag": "cp312",
+         "platform_tag": "macosx_11_0_arm64"
+       },
+       {
+         "filename": "lingtai-0.16.4.tar.gz",
+         "sha256": "<64-char hex>",
+         "kind": "sdist",
+         "python_tag": null,
+         "abi_tag": null,
+         "platform_tag": null
+       }
+     ],
+     "sdist_fallback": "lingtai-0.16.4.tar.gz"
+   }
+   ```
+
+The manifest and `SHA256SUMS` are uploaded as their own `release-manifest`
+Actions artifact so any run (including a manual `workflow_dispatch` shape
+check) produces inspectable output without publishing anything.
+
+## Publish
+
+`wheels.yml`'s `release-manifest` job actually publishes on the real trigger:
+
+- **`release: {types: [published]}`** — a real kernel GitHub Release always
+  publishes (syncs Gitee, then uploads to GitHub + Gitee).
+- **`workflow_dispatch`** — dry-run by default (the `publish` boolean input
+  defaults `false`); pass `publish: true` to deliberately publish from a
+  manual run too (for example to republish after a partial failure).
+- Every other shape (default manual dispatch) stays dry-run, so re-running
+  this workflow to sanity-check the manifest/wheel matrix has no side
+  effects.
+
+### Step 1 — non-force Gitee mirror sync (only when publishing)
+
+[`scripts/sync_gitee_mirror.py`](scripts/sync_gitee_mirror.py) pushes the
+exact release commit to `main` and creates the exact release tag on
+`huangzesen1997/lingtai-kernel`, using a **non-force** `git push` for both:
+the branch push only succeeds as a fast-forward, and the tag push only
+succeeds if that tag name doesn't already point somewhere else. Either
+condition failing is a **fail-loud stop** for the whole publish (the workflow
+does not proceed to upload against an unsynchronized mirror). The token
+travels via a short-lived, owner-only-permission `GIT_ASKPASS` helper file
+(deleted after use) — never in argv, a URL, or a log line. Skips cleanly
+(prints why, exits 0) when `GITEE_ACCESS_TOKEN` is unset.
+
+### Step 2 — publish manifest/wheels/sdist
+
+[`scripts/publish_release_assets.py`](scripts/publish_release_assets.py)
+uploads the exact manifest + asset bytes to:
+
+- **GitHub Releases**, via the `gh` CLI (`gh release create` / `gh release
+  upload`), attaching the manifest and `SHA256SUMS` alongside the wheels/sdist.
+- **Gitee Releases** (`huangzesen1997/lingtai-kernel`), via the Gitee v5 REST
+  API, gated entirely on the `GITEE_ACCESS_TOKEN` secret. When that secret is
+  unset the Gitee leg is skipped with a printed reason — it is never a hard
+  failure, since Gitee credentials/configuration are a separate authorization
+  step from having the workflow code in place.
+
+Every mutating action requires the explicit `--execute` flag; the workflow
+passes it only when the trigger is a real release (or an explicit
+`publish: true` dispatch) — see "Determine publish mode" in the job. Without
+it the script only prints its plan and exits 0.
+
+Before publishing to Gitee, the script re-verifies (independent of Step 1's
+push) that the Gitee tag ref already points at the exact release commit
+(`gitee_verify_tag_synchronized`) — belt-and-braces after Step 1's sync.
+**Neither script ever force-pushes or otherwise mutates history** on the
+Gitee git repository.
+
+Idempotency: an asset already attached under the same filename is skipped
+(GitHub: by name; Gitee: by name, since Gitee's attachment listing exposes no
+checksum). A same-name Gitee attachment already present with different bytes
+always triggers `AssetConflict` for a human to investigate — see
+`plan_gitee_uploads`. **There is no delete-and-replace path.** If a bad asset
+was ever uploaded, remove it by hand through the Gitee UI/API and re-run.
+
+### Manual dry run (safe, no token required)
+
+```bash
+# after a wheels.yml run, download its `wheels-*` + `sdist` artifacts into
+# ./release-assets, then:
+python scripts/generate_release_manifest.py \
+  --assets-dir release-assets \
+  --kernel-version 0.16.4 --kernel-tag v0.16.4 \
+  --commit "$(git rev-parse HEAD)" \
+  --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --out-manifest release-assets/lingtai-kernel-release-manifest.json \
+  --out-sha256sums release-assets/SHA256SUMS
+
+python scripts/publish_release_assets.py \
+  --manifest release-assets/lingtai-kernel-release-manifest.json \
+  --assets-dir release-assets
+# (no --execute: prints the GitHub/Gitee plan only)
+```
+
+### Manual authorized publish (maintainer-run, outside this task's authorization)
+
+```bash
+export GITEE_ACCESS_TOKEN=...  # never echo or log this
+python scripts/sync_gitee_mirror.py \
+  --commit "$(git rev-parse HEAD)" --tag v0.16.4 --branch main --execute
+python scripts/publish_release_assets.py \
+  --manifest release-assets/lingtai-kernel-release-manifest.json \
+  --assets-dir release-assets \
+  --execute
+```
+
+As of this writing the Gitee kernel mirror's `main` lags GitHub's `main` and
+has no releases — the first real publish run is also the first time the sync
+step has anything to fast-forward from empty, which is the expected/supported
+case (see `test_sync_fast_forwards_empty_remote`).
+
+## Non-goals (v1)
+
+- No PyPI publication. LingTai's own kernel package is fetched by the TUI
+  installer from GitHub/Gitee release assets, by explicit local file path —
+  never `pip install lingtai` against any package index. Third-party
+  dependency resolution is unaffected and continues to use PyPI or a
+  configured mirror.
+- No offline wheelhouse / vendored third-party dependency bundle.
+- No automatic Gitee mirror synchronization from this repository or workflow.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,7 +72,8 @@ which:
 
 The manifest and `SHA256SUMS` are uploaded as their own `release-manifest`
 Actions artifact so any run (including a manual `workflow_dispatch` shape
-check) produces inspectable output without publishing anything.
+check) produces inspectable output without publishing anything. The publisher
+also attaches both files alongside the wheels/sdist.
 
 ## Publish
 
@@ -124,12 +125,11 @@ push) that the Gitee tag ref already points at the exact release commit
 **Neither script ever force-pushes or otherwise mutates history** on the
 Gitee git repository.
 
-Idempotency: an asset already attached under the same filename is skipped
-(GitHub: by name; Gitee: by name, since Gitee's attachment listing exposes no
-checksum). A same-name Gitee attachment already present with different bytes
-always triggers `AssetConflict` for a human to investigate — see
-`plan_gitee_uploads`. **There is no delete-and-replace path.** If a bad asset
-was ever uploaded, remove it by hand through the Gitee UI/API and re-run.
+Idempotency: an asset already attached under the same filename is skipped only
+after the actual GitHub or Gitee download bytes match the local SHA256. A
+same-name asset with different bytes, missing/ambiguous metadata, or a failed
+download always triggers a fail-loud error before upload planning completes.
+**There is no delete-and-replace path.**
 
 ### Manual dry run (safe, no token required)
 

--- a/scripts/generate_release_manifest.py
+++ b/scripts/generate_release_manifest.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Aggregate built wheel/sdist artifacts into a release manifest + SHA256SUMS.
+
+Usage (CI, after downloading all `wheels-*` and `sdist` Actions artifacts into
+one flat directory):
+
+    python scripts/generate_release_manifest.py \\
+        --assets-dir ./release-assets \\
+        --kernel-version 0.16.4 \\
+        --kernel-tag v0.16.4 \\
+        --commit "$GITHUB_SHA" \\
+        --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \\
+        --out-manifest ./release-assets/lingtai-kernel-release-manifest.json \\
+        --out-sha256sums ./release-assets/SHA256SUMS
+
+By default every ``*.whl`` in --assets-dir is verified with the existing
+sidecar contract (tests/test_wheel_sidecar_smoke.py's --auto mode: install+run
+when the wheel matches this interpreter, archive-only check otherwise) before
+it is trusted into the manifest. This is what stops a plain local
+`py3-none-any` fallback wheel (no Rust sidecar) from ever being published as a
+platform artifact — it fails the archive check because it carries no
+`lingtai/bin/lingtai-search-sidecar`. Pass --skip-sidecar-check only for
+manifest-shape testing, never for a real release.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+from release_manifest import (  # noqa: E402
+    ReleaseManifest,
+    classify_artifact,
+    sha256_file,
+)
+
+SIDECAR_SMOKE_SCRIPT = REPO_ROOT / "tests" / "test_wheel_sidecar_smoke.py"
+
+
+def verify_wheel_sidecar(wheel: Path) -> None:
+    """Run the established sidecar validation contract against one wheel.
+
+    Shells out to tests/test_wheel_sidecar_smoke.py --auto rather than
+    importing it, so this script has the same dependency-free guarantee the
+    smoke test itself documents (no lingtai runtime deps required).
+    """
+    result = subprocess.run(
+        [sys.executable, str(SIDECAR_SMOKE_SCRIPT), "--auto", str(wheel)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"error: {wheel.name} failed the sidecar validation contract:\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+    print(f"  sidecar OK: {wheel.name} -> {result.stdout.strip()}")
+
+
+def discover_artifacts(assets_dir: Path) -> list[Path]:
+    wheels = sorted(assets_dir.glob("*.whl"))
+    sdists = sorted(assets_dir.glob("*.tar.gz"))
+    if not wheels:
+        raise SystemExit(f"error: no *.whl files found in {assets_dir}")
+    if not sdists:
+        raise SystemExit(f"error: no *.tar.gz sdist found in {assets_dir}")
+    if len(sdists) > 1:
+        raise SystemExit(
+            f"error: expected exactly one sdist in {assets_dir}, found {len(sdists)}: "
+            f"{[p.name for p in sdists]}"
+        )
+    return wheels + sdists
+
+
+def reject_plain_fallback_wheel(wheel: Path) -> None:
+    """Guard against publishing the local `uv build --wheel` pure wheel.
+
+    A pure-Python fallback wheel built without the Rust sidecar carries the
+    'py3-none-any' platform/ABI/python tag combination and, more decisively,
+    contains no lingtai/bin/lingtai-search-sidecar. The sidecar smoke check
+    already fails such a wheel on the archive check, but this explicit early
+    guard produces a clearer diagnostic for the exact known-bad case named in
+    the task evidence, before spending time on a subprocess invocation.
+    """
+    if wheel.name.endswith("-py3-none-any.whl"):
+        raise SystemExit(
+            f"error: {wheel.name} looks like a plain pure-Python fallback wheel "
+            "(py3-none-any) — this is not a cibuildwheel platform artifact and "
+            "must never be published as one. Use the wheels-* Actions artifacts "
+            "from the matrix build, not a local `uv build --wheel` / "
+            "`python -m build --wheel` output."
+        )
+
+
+def build_manifest(
+    assets_dir: Path,
+    kernel_version: str,
+    kernel_tag: str,
+    commit: str,
+    generated_at: str,
+    skip_sidecar_check: bool,
+) -> ReleaseManifest:
+    files = discover_artifacts(assets_dir)
+    artifacts = []
+    sdist_filename = None
+
+    for path in files:
+        if path.suffix == ".whl":
+            reject_plain_fallback_wheel(path)
+            if not skip_sidecar_check:
+                verify_wheel_sidecar(path)
+        digest = sha256_file(path)
+        artifact = classify_artifact(path.name, digest)
+        if artifact.kind == "sdist":
+            sdist_filename = artifact.filename
+        artifacts.append(artifact)
+        print(f"  {artifact.kind:5s} {artifact.filename}  sha256={digest}")
+
+    assert sdist_filename is not None  # discover_artifacts guarantees exactly one sdist
+
+    return ReleaseManifest(
+        kernel_version=kernel_version,
+        kernel_tag=kernel_tag,
+        commit=commit,
+        generated_at=generated_at,
+        artifacts=tuple(artifacts),
+        sdist_fallback=sdist_filename,
+    )
+
+
+def write_sha256sums(manifest: ReleaseManifest, out_path: Path) -> None:
+    lines = [f"{a.sha256}  {a.filename}" for a in manifest.artifacts]
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--assets-dir", type=Path, required=True, help="directory containing built .whl/.tar.gz files")
+    parser.add_argument("--kernel-version", required=True, help="PEP 440 version, e.g. 0.16.4")
+    parser.add_argument("--kernel-tag", required=True, help="release tag, e.g. v0.16.4")
+    parser.add_argument("--commit", required=True, help="full git commit SHA the release was built from")
+    parser.add_argument("--generated-at", required=True, help="UTC ISO8601 timestamp, injected by the caller")
+    parser.add_argument("--out-manifest", type=Path, required=True)
+    parser.add_argument("--out-sha256sums", type=Path, required=True)
+    parser.add_argument(
+        "--skip-sidecar-check",
+        action="store_true",
+        help="skip the sidecar validation contract (manifest-shape testing only, never for a real release)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.assets_dir.is_dir():
+        raise SystemExit(f"error: --assets-dir is not a directory: {args.assets_dir}")
+
+    print(f"Aggregating release assets from {args.assets_dir} ...")
+    manifest = build_manifest(
+        args.assets_dir,
+        args.kernel_version,
+        args.kernel_tag,
+        args.commit,
+        args.generated_at,
+        args.skip_sidecar_check,
+    )
+
+    args.out_manifest.parent.mkdir(parents=True, exist_ok=True)
+    args.out_manifest.write_text(json.dumps(manifest.to_dict(), indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    print(f"Wrote manifest: {args.out_manifest}")
+
+    args.out_sha256sums.parent.mkdir(parents=True, exist_ok=True)
+    write_sha256sums(manifest, args.out_sha256sums)
+    print(f"Wrote checksums: {args.out_sha256sums}")
+
+    print(f"\n{len(manifest.artifacts)} artifact(s) for {manifest.kernel_tag} ({manifest.commit[:12]})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/release_manifest.py
+++ b/scripts/lib/release_manifest.py
@@ -1,0 +1,233 @@
+"""Schema and validator for the kernel release manifest (``lingtai.kernel.release/v1``).
+
+One source of truth for the manifest shape: ``generate_release_manifest.py``
+builds it, ``publish_release_assets.py`` and the TUI installer's Gitee/GitHub
+consumer both read it. Keep this module free of network/subprocess calls so it
+stays trivially unit-testable and importable from a throwaway venv.
+
+Filename convention this schema assumes (wheel filenames per PEP 427):
+``lingtai-{version}-{python_tag}-{abi_tag}-{platform_tag}.whl``. The sdist has
+no python/abi/platform tag and is recorded with ``kind: "sdist"``.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SCHEMA = "lingtai.kernel.release/v1"
+
+# lingtai-0.16.4-cp312-cp312-macosx_11_0_arm64.whl
+_WHEEL_RE = re.compile(
+    r"^(?P<name>[^-]+)-(?P<version>[^-]+)-(?P<python_tag>[^-]+)-(?P<abi_tag>[^-]+)-(?P<platform_tag>[^-]+)\.whl$"
+)
+# lingtai-0.16.4.tar.gz
+_SDIST_RE = re.compile(r"^(?P<name>[^-]+)-(?P<version>.+)\.tar\.gz$")
+
+REQUIRED_TOP_LEVEL_KEYS = {
+    "schema",
+    "kernel_version",
+    "kernel_tag",
+    "commit",
+    "generated_at",
+    "artifacts",
+    "sdist_fallback",
+}
+REQUIRED_ARTIFACT_KEYS = {
+    "filename",
+    "sha256",
+    "kind",
+    "python_tag",
+    "abi_tag",
+    "platform_tag",
+}
+VALID_KINDS = {"wheel", "sdist"}
+
+
+class ManifestError(ValueError):
+    """Raised when a manifest dict violates the schema."""
+
+
+@dataclass(frozen=True)
+class Artifact:
+    filename: str
+    sha256: str
+    kind: str  # "wheel" | "sdist"
+    python_tag: str | None
+    abi_tag: str | None
+    platform_tag: str | None
+
+    def to_dict(self) -> dict:
+        return {
+            "filename": self.filename,
+            "sha256": self.sha256,
+            "kind": self.kind,
+            "python_tag": self.python_tag,
+            "abi_tag": self.abi_tag,
+            "platform_tag": self.platform_tag,
+        }
+
+
+@dataclass(frozen=True)
+class ReleaseManifest:
+    kernel_version: str
+    kernel_tag: str
+    commit: str
+    generated_at: str
+    artifacts: tuple[Artifact, ...] = field(default_factory=tuple)
+    sdist_fallback: str = ""
+    schema: str = SCHEMA
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": self.schema,
+            "kernel_version": self.kernel_version,
+            "kernel_tag": self.kernel_tag,
+            "commit": self.commit,
+            "generated_at": self.generated_at,
+            "artifacts": [a.to_dict() for a in self.artifacts],
+            "sdist_fallback": self.sdist_fallback,
+        }
+
+
+def sha256_file(path: Path) -> str:
+    """Stream-hash a file; used by both the generator and its tests."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def parse_wheel_filename(filename: str) -> dict | None:
+    m = _WHEEL_RE.match(filename)
+    if not m:
+        return None
+    return m.groupdict()
+
+
+def parse_sdist_filename(filename: str) -> dict | None:
+    m = _SDIST_RE.match(filename)
+    if not m:
+        return None
+    return m.groupdict()
+
+
+def classify_artifact(filename: str, sha256: str) -> Artifact:
+    """Build an Artifact from a filename, inferring kind/tags. Raises ManifestError
+    for a filename that is neither a recognized wheel nor a recognized sdist —
+    this is the guard against publishing an unexpected/mislabeled file."""
+    if filename.endswith(".whl"):
+        parsed = parse_wheel_filename(filename)
+        if parsed is None:
+            raise ManifestError(f"filename does not match wheel naming convention: {filename}")
+        if parsed["name"] != "lingtai":
+            raise ManifestError(f"wheel is not a lingtai wheel: {filename}")
+        return Artifact(
+            filename=filename,
+            sha256=sha256,
+            kind="wheel",
+            python_tag=parsed["python_tag"],
+            abi_tag=parsed["abi_tag"],
+            platform_tag=parsed["platform_tag"],
+        )
+    if filename.endswith(".tar.gz"):
+        parsed = parse_sdist_filename(filename)
+        if parsed is None:
+            raise ManifestError(f"filename does not match sdist naming convention: {filename}")
+        if parsed["name"] != "lingtai":
+            raise ManifestError(f"sdist is not a lingtai sdist: {filename}")
+        return Artifact(
+            filename=filename,
+            sha256=sha256,
+            kind="sdist",
+            python_tag=None,
+            abi_tag=None,
+            platform_tag=None,
+        )
+    raise ManifestError(f"unrecognized artifact extension (expected .whl or .tar.gz): {filename}")
+
+
+def validate_manifest_dict(data: dict) -> None:
+    """Raise ManifestError with a specific message on any schema violation.
+
+    Deliberately strict: an unknown/missing key or an out-of-band kind fails
+    loud rather than silently accepting a malformed manifest that a consumer
+    (the TUI installer) would otherwise trust.
+    """
+    if not isinstance(data, dict):
+        raise ManifestError(f"manifest must be an object, got {type(data).__name__}")
+
+    missing = REQUIRED_TOP_LEVEL_KEYS - data.keys()
+    if missing:
+        raise ManifestError(f"manifest missing required keys: {sorted(missing)}")
+
+    if data["schema"] != SCHEMA:
+        raise ManifestError(f"unexpected schema {data['schema']!r}, expected {SCHEMA!r}")
+
+    for key in ("kernel_version", "kernel_tag", "commit", "generated_at", "sdist_fallback"):
+        if not isinstance(data[key], str) or not data[key]:
+            raise ManifestError(f"manifest field {key!r} must be a non-empty string")
+
+    artifacts = data["artifacts"]
+    if not isinstance(artifacts, list) or not artifacts:
+        raise ManifestError("manifest 'artifacts' must be a non-empty list")
+
+    seen_filenames: set[str] = set()
+    has_sdist = False
+    for i, art in enumerate(artifacts):
+        if not isinstance(art, dict):
+            raise ManifestError(f"artifacts[{i}] must be an object")
+        art_missing = REQUIRED_ARTIFACT_KEYS - art.keys()
+        if art_missing:
+            raise ManifestError(f"artifacts[{i}] missing keys: {sorted(art_missing)}")
+        if not isinstance(art["filename"], str) or not art["filename"]:
+            raise ManifestError(f"artifacts[{i}].filename must be a non-empty string")
+        if art["filename"] in seen_filenames:
+            raise ManifestError(f"duplicate artifact filename: {art['filename']}")
+        seen_filenames.add(art["filename"])
+        if not isinstance(art["sha256"], str) or not re.match(r"^[0-9a-f]{64}$", art["sha256"]):
+            raise ManifestError(f"artifacts[{i}].sha256 must be a 64-char lowercase hex string")
+        if art["kind"] not in VALID_KINDS:
+            raise ManifestError(f"artifacts[{i}].kind must be one of {sorted(VALID_KINDS)}")
+        if art["kind"] == "sdist":
+            has_sdist = True
+            if art["python_tag"] is not None or art["abi_tag"] is not None or art["platform_tag"] is not None:
+                raise ManifestError(f"artifacts[{i}] is a sdist but has non-null python/abi/platform tag")
+        else:  # wheel
+            for tag_key in ("python_tag", "abi_tag", "platform_tag"):
+                if not isinstance(art[tag_key], str) or not art[tag_key]:
+                    raise ManifestError(f"artifacts[{i}].{tag_key} must be a non-empty string for a wheel")
+
+    if data["sdist_fallback"] not in seen_filenames:
+        raise ManifestError(
+            f"sdist_fallback {data['sdist_fallback']!r} is not among the listed artifact filenames"
+        )
+    if not has_sdist:
+        raise ManifestError("manifest has no artifact with kind='sdist'; sdist_fallback is unsatisfiable")
+
+
+def manifest_from_dict(data: dict) -> ReleaseManifest:
+    """Validate then construct a typed ReleaseManifest. Raises ManifestError."""
+    validate_manifest_dict(data)
+    artifacts = tuple(
+        Artifact(
+            filename=a["filename"],
+            sha256=a["sha256"],
+            kind=a["kind"],
+            python_tag=a["python_tag"],
+            abi_tag=a["abi_tag"],
+            platform_tag=a["platform_tag"],
+        )
+        for a in data["artifacts"]
+    )
+    return ReleaseManifest(
+        kernel_version=data["kernel_version"],
+        kernel_tag=data["kernel_tag"],
+        commit=data["commit"],
+        generated_at=data["generated_at"],
+        artifacts=artifacts,
+        sdist_fallback=data["sdist_fallback"],
+        schema=data["schema"],
+    )

--- a/scripts/publish_release_assets.py
+++ b/scripts/publish_release_assets.py
@@ -4,8 +4,8 @@ configured, Gitee. Uploads the SAME bytes already produced by the build
 matrix — this script never rebuilds anything per platform/provider.
 
 Safety: every mutating action requires --execute. Without it (the default)
-the script only prints the plan (a "dry run") and exits 0. This session must
-never pass --execute; it exists for a future authorized release run.
+the script only prints the plan (a "dry run") and exits 0. Callers must pass
+--execute only for an explicitly authorized release publication.
 
 GitHub upload uses the `gh` CLI (`gh release upload`/`gh release create`),
 consistent with the TUI repo's existing release.yml. Gitee upload speaks the
@@ -41,6 +41,8 @@ sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
 from release_manifest import ManifestError, manifest_from_dict, sha256_file  # noqa: E402
 
 GITEE_API_BASE = "https://gitee.com/api/v5"
+GITEE_API_TIMEOUT_SECONDS = 15
+GITEE_TRANSFER_TIMEOUT_SECONDS = 300
 
 
 class PublishError(RuntimeError):
@@ -209,7 +211,14 @@ def execute_github_upload(tag: str, repo_slug: str, files: list[Path]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _gitee_request(method: str, path: str, token: str, data: bytes | None = None, content_type: str | None = None) -> dict:
+def _gitee_request(
+    method: str,
+    path: str,
+    token: str,
+    data: bytes | None = None,
+    content_type: str | None = None,
+    timeout: int = GITEE_API_TIMEOUT_SECONDS,
+) -> dict | list:
     url = f"{GITEE_API_BASE}{path}"
     headers = {"Content-Type": content_type} if content_type else {}
     req = urllib.request.Request(url, data=data, method=method, headers=headers)
@@ -218,7 +227,7 @@ def _gitee_request(method: str, path: str, token: str, data: bytes | None = None
     sep = "&" if "?" in url else "?"
     req.full_url = url + f"{sep}access_token={token}"
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             body = resp.read()
     except urllib.error.HTTPError as exc:
         body = exc.read()
@@ -237,8 +246,14 @@ def gitee_find_release_by_tag(owner: str, repo: str, tag: str, token: str) -> di
         raise
 
 
-def gitee_create_release(owner: str, repo: str, tag: str, name: str, token: str) -> dict:
-    payload = json.dumps({"tag_name": tag, "name": name, "body": f"Release {name}", "prerelease": False}).encode()
+def gitee_create_release(owner: str, repo: str, tag: str, name: str, target_commitish: str, token: str) -> dict:
+    payload = json.dumps({
+        "tag_name": tag,
+        "name": name,
+        "body": f"Release {name}",
+        "target_commitish": target_commitish,
+        "prerelease": False,
+    }).encode()
     return _gitee_request("POST", f"/repos/{owner}/{repo}/releases", token, data=payload, content_type="application/json;charset=UTF-8")
 
 
@@ -247,15 +262,37 @@ def gitee_verify_tag_synchronized(owner: str, repo: str, tag: str, expected_comm
     was built from. Never force-pushes or otherwise mutates the Gitee git
     repository — synchronization is a precondition this script checks, not an
     action it performs."""
+    ref = None
+    page = 1
     try:
-        ref = _gitee_request("GET", f"/repos/{owner}/{repo}/tags/{tag}", token)
+        while True:
+            refs = _gitee_request(
+                "GET", f"/repos/{owner}/{repo}/tags?per_page=100&page={page}", token
+            )
+            if not isinstance(refs, list):
+                raise PublishError("Gitee tag-list response is not a JSON array")
+            matches = [item for item in refs if isinstance(item, dict) and item.get("name") == tag]
+            if len(matches) > 1:
+                raise PublishError(f"Gitee tag-list response contains duplicate entries for {tag!r}")
+            if matches:
+                ref = matches[0]
+                break
+            if len(refs) < 100:
+                break
+            page += 1
     except PublishError as exc:
         raise PublishError(
-            f"Gitee tag {tag!r} not found on {owner}/{repo} (or lookup failed): {exc}\n"
+            f"Gitee tag {tag!r} lookup failed on {owner}/{repo}: {exc}\n"
             f"The kernel Gitee mirror must be synchronized to commit {expected_commit} "
             f"and tag {tag} before publishing there. This script will not push or "
             f"force-sync the mirror — synchronize it out of band, then retry."
         ) from exc
+    if ref is None:
+        raise PublishError(
+            f"Gitee tag {tag!r} not found on {owner}/{repo}. The kernel Gitee mirror "
+            f"must be synchronized to commit {expected_commit} and tag {tag} before "
+            f"publishing there. This script will not push or force-sync the mirror."
+        )
     commit_sha = (ref.get("commit") or {}).get("sha", "")
     if commit_sha != expected_commit:
         raise PublishError(
@@ -296,7 +333,7 @@ def _gitee_download_sha256(attachment: dict, filename: str, token: str) -> str:
     separator = "&" if "?" in url else "?"
     request = urllib.request.Request(url + f"{separator}access_token={token}")
     try:
-        with urllib.request.urlopen(request, timeout=15) as response:
+        with urllib.request.urlopen(request, timeout=GITEE_TRANSFER_TIMEOUT_SECONDS) as response:
             with destination.open("xb") as output:
                 while chunk := response.read(1024 * 1024):
                     output.write(chunk)
@@ -347,6 +384,7 @@ def execute_gitee_upload(owner: str, repo: str, release_id: int, files: list[Pat
             token,
             data=body,
             content_type=f"multipart/form-data; boundary={boundary}",
+            timeout=GITEE_TRANSFER_TIMEOUT_SECONDS,
         )
         print(f"  [gitee] uploaded {path.name}")
 
@@ -408,7 +446,14 @@ def main(argv: list[str] | None = None) -> int:
     if release is None:
         print(f"  [gitee] release {manifest.kernel_tag} does not exist yet")
         if args.execute:
-            release = gitee_create_release(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, manifest.kernel_tag, gitee_token)
+            release = gitee_create_release(
+                args.gitee_owner,
+                args.gitee_repo,
+                manifest.kernel_tag,
+                manifest.kernel_tag,
+                manifest.commit,
+                gitee_token,
+            )
         else:
             print(f"  [gitee] DRY RUN: would create release {manifest.kernel_tag}")
             print("  [gitee] DRY RUN: cannot plan attachment uploads without a release id (would create first)")

--- a/scripts/publish_release_assets.py
+++ b/scripts/publish_release_assets.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Publish a kernel release manifest + its assets to GitHub and, when
+configured, Gitee. Uploads the SAME bytes already produced by the build
+matrix — this script never rebuilds anything per platform/provider.
+
+Safety: every mutating action requires --execute. Without it (the default)
+the script only prints the plan (a "dry run") and exits 0. This session must
+never pass --execute; it exists for a future authorized release run.
+
+GitHub upload uses the `gh` CLI (`gh release upload`/`gh release create`),
+consistent with the TUI repo's existing release.yml. Gitee upload speaks the
+verified v5 REST contract directly:
+  - create release:   POST /v5/repos/{owner}/{repo}/releases
+  - upload attachment: POST /v5/repos/{owner}/{repo}/releases/{release_id}/attach_files
+  - list attachments:  GET  /v5/repos/{owner}/{repo}/releases/{release_id}
+using the GITEE_ACCESS_TOKEN environment variable. The token is never echoed,
+logged, or included in any printed command.
+
+Idempotency: for each asset, if the target release already has an attachment
+of the same filename AND the same sha256 (GitHub: compare against the local
+SHA256SUMS/manifest before upload by checking `gh release view --json assets`;
+Gitee: compare against the attachment list), the upload is skipped. If an
+existing same-name attachment has a DIFFERENT sha256, this is a fail-loud
+condition — the script refuses to overwrite it. There is no delete-and-replace
+cleanup path by design (see the task's non-negotiable safety constraints).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+from release_manifest import ManifestError, manifest_from_dict, sha256_file  # noqa: E402
+
+GITEE_API_BASE = "https://gitee.com/api/v5"
+
+
+class PublishError(RuntimeError):
+    pass
+
+
+class AssetConflict(PublishError):
+    """An existing remote attachment has the same name but a different sha256."""
+
+
+# ---------------------------------------------------------------------------
+# Manifest + local asset loading
+# ---------------------------------------------------------------------------
+
+
+def load_manifest(manifest_path: Path):
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    try:
+        return manifest_from_dict(data)
+    except ManifestError as exc:
+        raise PublishError(f"invalid manifest at {manifest_path}: {exc}") from exc
+
+
+def verify_local_assets(manifest, assets_dir: Path) -> None:
+    """Re-hash every asset on disk and confirm it matches the manifest before
+    any upload is attempted. Publishing must use the exact bytes the manifest
+    describes, never a re-derived or re-built file that happens to share a
+    name."""
+    for artifact in manifest.artifacts:
+        path = assets_dir / artifact.filename
+        if not path.is_file():
+            raise PublishError(f"asset listed in manifest is missing on disk: {path}")
+        digest = sha256_file(path)
+        if digest != artifact.sha256:
+            raise PublishError(
+                f"asset {artifact.filename} sha256 mismatch: manifest={artifact.sha256} "
+                f"on-disk={digest} (refusing to publish bytes that disagree with the manifest)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# GitHub (gh CLI)
+# ---------------------------------------------------------------------------
+
+
+def gh_release_exists(tag: str, repo_slug: str) -> bool:
+    result = subprocess.run(
+        ["gh", "release", "view", tag, "--repo", repo_slug],
+        capture_output=True, text=True,
+    )
+    return result.returncode == 0
+
+
+def gh_release_asset_shas(tag: str, repo_slug: str) -> dict[str, None]:
+    """Return the set of asset filenames already attached to the release.
+
+    `gh release view --json assets` does not expose a checksum, so filename
+    presence is the signal; the caller re-verifies bytes by re-downloading
+    only when a name collision is found (kept out of v1 scope — see
+    plan_github_uploads' fail-loud-on-name-collision behavior instead of a
+    silent re-download-and-compare, which would add real network cost to
+    every dry run).
+    """
+    result = subprocess.run(
+        ["gh", "release", "view", tag, "--repo", repo_slug, "--json", "assets"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return {}
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {}
+    return {a["name"]: None for a in data.get("assets", [])}
+
+
+def plan_github_uploads(manifest, assets_dir: Path, manifest_path: Path, repo_slug: str, tag: str) -> list[Path]:
+    """Return the list of local file paths that still need uploading to GitHub.
+
+    Fails loud (PublishError) rather than silently skipping when an existing
+    asset can't be trusted byte-identical (name present but no way to verify
+    without a download this script deliberately does not perform in v1 —
+    the operator is told to inspect manually instead of the script guessing).
+    """
+    existing = gh_release_asset_shas(tag, repo_slug)
+    to_upload = []
+    all_files = [assets_dir / a.filename for a in manifest.artifacts] + [manifest_path]
+    for path in all_files:
+        if path.name in existing:
+            print(f"  [github] {path.name}: already attached to {tag}; skipping (idempotent)")
+            continue
+        to_upload.append(path)
+    return to_upload
+
+
+def execute_github_upload(tag: str, repo_slug: str, files: list[Path]) -> None:
+    if not files:
+        print("  [github] nothing new to upload")
+        return
+    subprocess.run(
+        ["gh", "release", "upload", tag, *[str(f) for f in files], "--repo", repo_slug],
+        check=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gitee (v5 REST)
+# ---------------------------------------------------------------------------
+
+
+def _gitee_request(method: str, path: str, token: str, data: bytes | None = None, content_type: str | None = None) -> dict:
+    url = f"{GITEE_API_BASE}{path}"
+    headers = {"Content-Type": content_type} if content_type else {}
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    # access_token travels as a query/body param per Gitee v5 convention, not a
+    # header — appended here rather than logged anywhere.
+    sep = "&" if "?" in url else "?"
+    req.full_url = url + f"{sep}access_token={token}"
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as exc:
+        body = exc.read()
+        raise PublishError(f"Gitee API {method} {path} failed: HTTP {exc.code}: {body[:500]!r}") from exc
+    if not body:
+        return {}
+    return json.loads(body)
+
+
+def gitee_find_release_by_tag(owner: str, repo: str, tag: str, token: str) -> dict | None:
+    try:
+        return _gitee_request("GET", f"/repos/{owner}/{repo}/releases/tags/{tag}", token)
+    except PublishError as exc:
+        if "404" in str(exc):
+            return None
+        raise
+
+
+def gitee_create_release(owner: str, repo: str, tag: str, name: str, token: str) -> dict:
+    payload = json.dumps({"tag_name": tag, "name": name, "body": f"Release {name}", "prerelease": False}).encode()
+    return _gitee_request("POST", f"/repos/{owner}/{repo}/releases", token, data=payload, content_type="application/json;charset=UTF-8")
+
+
+def gitee_verify_tag_synchronized(owner: str, repo: str, tag: str, expected_commit: str, token: str) -> None:
+    """Fail loud unless Gitee's tag ref points at the exact commit the manifest
+    was built from. Never force-pushes or otherwise mutates the Gitee git
+    repository — synchronization is a precondition this script checks, not an
+    action it performs."""
+    try:
+        ref = _gitee_request("GET", f"/repos/{owner}/{repo}/tags/{tag}", token)
+    except PublishError as exc:
+        raise PublishError(
+            f"Gitee tag {tag!r} not found on {owner}/{repo} (or lookup failed): {exc}\n"
+            f"The kernel Gitee mirror must be synchronized to commit {expected_commit} "
+            f"and tag {tag} before publishing there. This script will not push or "
+            f"force-sync the mirror — synchronize it out of band, then retry."
+        ) from exc
+    commit_sha = (ref.get("commit") or {}).get("sha", "")
+    if commit_sha != expected_commit:
+        raise PublishError(
+            f"Gitee tag {tag!r} points at commit {commit_sha or '<unknown>'}, expected "
+            f"{expected_commit}. Refusing to publish assets against a mismatched tag — "
+            f"synchronize the Gitee mirror to the exact release commit first."
+        )
+
+
+def gitee_existing_attachments(owner: str, repo: str, release_id: int, token: str) -> dict[str, dict]:
+    release = _gitee_request("GET", f"/repos/{owner}/{repo}/releases/{release_id}", token)
+    return {a["name"]: a for a in release.get("attach_files", [])}
+
+
+def plan_gitee_uploads(manifest, assets_dir: Path, manifest_path: Path, owner: str, repo: str, release_id: int, token: str) -> list[Path]:
+    existing = gitee_existing_attachments(owner, repo, release_id, token)
+    to_upload = []
+    all_files = [assets_dir / a.filename for a in manifest.artifacts] + [manifest_path]
+    for path in all_files:
+        att = existing.get(path.name)
+        if att is None:
+            to_upload.append(path)
+            continue
+        # Gitee's attachment listing does not expose a checksum; the browser
+        # download URL is the only public evidence available without fetching
+        # the bytes. v1 treats "attachment with this name already exists" as
+        # an idempotent skip ONLY when re-verified against browserDownloadUrl
+        # is out of scope for this script (no network fetch-and-hash here);
+        # instead it fails loud so a human confirms before any manual retry,
+        # matching the "no delete-and-replace" and "fail loud on mismatch"
+        # requirements rather than silently trusting a name match.
+        raise AssetConflict(
+            f"Gitee release already has an attachment named {path.name!r} "
+            f"(id={att.get('id')}, url={att.get('browser_download_url', '?')}). "
+            "This script does not delete-and-replace attachments. If the bytes "
+            "are known identical, skip re-publishing this asset manually; "
+            "otherwise investigate before retrying."
+        )
+    return to_upload
+
+
+def execute_gitee_upload(owner: str, repo: str, release_id: int, files: list[Path], token: str) -> None:
+    import mimetypes
+    import uuid
+
+    for path in files:
+        boundary = uuid.uuid4().hex
+        mime = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        body_parts = [
+            f"--{boundary}\r\n".encode(),
+            f'Content-Disposition: form-data; name="file"; filename="{path.name}"\r\n'.encode(),
+            f"Content-Type: {mime}\r\n\r\n".encode(),
+            path.read_bytes(),
+            f"\r\n--{boundary}--\r\n".encode(),
+        ]
+        body = b"".join(body_parts)
+        _gitee_request(
+            "POST",
+            f"/repos/{owner}/{repo}/releases/{release_id}/attach_files",
+            token,
+            data=body,
+            content_type=f"multipart/form-data; boundary={boundary}",
+        )
+        print(f"  [gitee] uploaded {path.name}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--assets-dir", type=Path, required=True)
+    parser.add_argument("--github-repo", default="Lingtai-AI/lingtai-kernel", help="owner/repo slug for gh CLI")
+    parser.add_argument("--gitee-owner", default="huangzesen1997")
+    parser.add_argument("--gitee-repo", default="lingtai-kernel")
+    parser.add_argument("--gitee-token-env", default="GITEE_ACCESS_TOKEN", help="env var name holding the Gitee token; never printed")
+    parser.add_argument("--skip-github", action="store_true")
+    parser.add_argument("--skip-gitee", action="store_true", help="also implied when the Gitee token env var is unset")
+    parser.add_argument("--execute", action="store_true", help="actually upload; default is dry-run/plan-only")
+    args = parser.parse_args(argv)
+
+    manifest = load_manifest(args.manifest)
+    verify_local_assets(manifest, args.assets_dir)
+    print(f"Manifest OK: {manifest.kernel_tag} ({manifest.commit[:12]}), {len(manifest.artifacts)} artifact(s)")
+
+    if not args.skip_github:
+        print(f"\n[github] target: {args.github_repo} tag {manifest.kernel_tag}")
+        if not gh_release_exists(manifest.kernel_tag, args.github_repo):
+            print(f"  [github] release {manifest.kernel_tag} does not exist yet")
+            if args.execute:
+                subprocess.run(
+                    ["gh", "release", "create", manifest.kernel_tag, "--repo", args.github_repo,
+                     "--title", manifest.kernel_tag, "--notes", f"Kernel release {manifest.kernel_tag}"],
+                    check=True,
+                )
+            else:
+                print(f"  [github] DRY RUN: would create release {manifest.kernel_tag}")
+        github_files = plan_github_uploads(manifest, args.assets_dir, args.manifest, args.github_repo, manifest.kernel_tag)
+        if args.execute:
+            execute_github_upload(manifest.kernel_tag, args.github_repo, github_files)
+        else:
+            for f in github_files:
+                print(f"  [github] DRY RUN: would upload {f.name}")
+
+    import os
+
+    gitee_token = os.environ.get(args.gitee_token_env, "")
+    if args.skip_gitee or not gitee_token:
+        reason = "--skip-gitee" if args.skip_gitee else f"{args.gitee_token_env} is not set"
+        print(f"\n[gitee] skipped ({reason})")
+        return 0
+
+    print(f"\n[gitee] target: {args.gitee_owner}/{args.gitee_repo} tag {manifest.kernel_tag}")
+    gitee_verify_tag_synchronized(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, manifest.commit, gitee_token)
+    print(f"  [gitee] tag {manifest.kernel_tag} is synchronized to {manifest.commit[:12]}")
+
+    release = gitee_find_release_by_tag(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, gitee_token)
+    if release is None:
+        print(f"  [gitee] release {manifest.kernel_tag} does not exist yet")
+        if args.execute:
+            release = gitee_create_release(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, manifest.kernel_tag, gitee_token)
+        else:
+            print(f"  [gitee] DRY RUN: would create release {manifest.kernel_tag}")
+            print("  [gitee] DRY RUN: cannot plan attachment uploads without a release id (would create first)")
+            return 0
+
+    release_id = release["id"]
+    gitee_files = plan_gitee_uploads(manifest, args.assets_dir, args.manifest, args.gitee_owner, args.gitee_repo, release_id, gitee_token)
+    if args.execute:
+        execute_gitee_upload(args.gitee_owner, args.gitee_repo, release_id, gitee_files, gitee_token)
+    else:
+        for f in gitee_files:
+            print(f"  [gitee] DRY RUN: would upload {f.name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PublishError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/publish_release_assets.py
+++ b/scripts/publish_release_assets.py
@@ -16,20 +16,21 @@ verified v5 REST contract directly:
 using the GITEE_ACCESS_TOKEN environment variable. The token is never echoed,
 logged, or included in any printed command.
 
-Idempotency: for each asset, if the target release already has an attachment
-of the same filename AND the same sha256 (GitHub: compare against the local
-SHA256SUMS/manifest before upload by checking `gh release view --json assets`;
-Gitee: compare against the attachment list), the upload is skipped. If an
-existing same-name attachment has a DIFFERENT sha256, this is a fail-loud
-condition — the script refuses to overwrite it. There is no delete-and-replace
-cleanup path by design (see the task's non-negotiable safety constraints).
+Idempotency: for each asset, an existing same-name attachment is downloaded
+and hashed before it is accepted as an idempotent skip. A different digest,
+missing/ambiguous metadata, or download failure is fail-loud. Comparison files
+are retained under unique runner temp paths. There is no delete-and-replace
+cleanup path by design.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
+import tempfile
+import uuid
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -80,6 +81,23 @@ def verify_local_assets(manifest, assets_dir: Path) -> None:
             )
 
 
+def release_files(manifest, assets_dir: Path, manifest_path: Path) -> list[Path]:
+    checksum_path = assets_dir / "SHA256SUMS"
+    if not checksum_path.is_file():
+        raise PublishError(f"release checksum file is missing on disk: {checksum_path}")
+    return [assets_dir / a.filename for a in manifest.artifacts] + [manifest_path, checksum_path]
+
+
+def _comparison_path(provider: str, filename: str) -> Path:
+    root = Path(os.environ.get("RELEASE_ASSET_COMPARISON_DIR", tempfile.gettempdir()))
+    directory = root / "lingtai-release-comparisons" / provider
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{uuid.uuid4().hex}-{filename}"
+    if path.exists():
+        raise PublishError(f"refusing comparison-path collision: {path}")
+    return path
+
+
 # ---------------------------------------------------------------------------
 # GitHub (gh CLI)
 # ---------------------------------------------------------------------------
@@ -93,43 +111,84 @@ def gh_release_exists(tag: str, repo_slug: str) -> bool:
     return result.returncode == 0
 
 
-def gh_release_asset_shas(tag: str, repo_slug: str) -> dict[str, None]:
-    """Return the set of asset filenames already attached to the release.
-
-    `gh release view --json assets` does not expose a checksum, so filename
-    presence is the signal; the caller re-verifies bytes by re-downloading
-    only when a name collision is found (kept out of v1 scope — see
-    plan_github_uploads' fail-loud-on-name-collision behavior instead of a
-    silent re-download-and-compare, which would add real network cost to
-    every dry run).
-    """
+def gh_release_asset_shas(tag: str, repo_slug: str) -> dict[str, dict]:
+    """Return GitHub release asset metadata, including download URLs."""
     result = subprocess.run(
         ["gh", "release", "view", tag, "--repo", repo_slug, "--json", "assets"],
         capture_output=True, text=True,
     )
     if result.returncode != 0:
-        return {}
+        raise PublishError("GitHub release asset metadata lookup failed; refusing to plan uploads")
     try:
         data = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return {}
-    return {a["name"]: None for a in data.get("assets", [])}
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise PublishError("GitHub release asset metadata was not valid JSON; refusing to plan uploads") from exc
+    if not isinstance(data, dict):
+        raise PublishError("GitHub release asset metadata has an invalid top-level shape")
+    if "assets" not in data:
+        raise PublishError("GitHub release asset metadata is missing assets")
+    assets = data["assets"]
+    if not isinstance(assets, list):
+        raise PublishError("GitHub release asset metadata is ambiguous: assets is not a list")
+    result = {}
+    for asset in assets:
+        if not isinstance(asset, dict):
+            raise PublishError("GitHub release asset metadata is ambiguous: asset is not an object")
+        name = asset.get("name")
+        if not isinstance(name, str) or not name:
+            raise PublishError("GitHub release asset metadata is ambiguous: asset has no name")
+        if name in result:
+            raise PublishError(f"GitHub release has ambiguous duplicate asset name {name!r}")
+        url = _github_asset_url(asset)
+        if not isinstance(url, str) or not url:
+            raise PublishError(f"GitHub asset {name!r} has no usable download URL")
+        result[name] = asset
+    return result
+
+
+def _github_asset_url(asset: dict) -> str | None:
+    return (
+        asset.get("apiUrl")
+        or asset.get("api_url")
+        or asset.get("url")
+        or asset.get("browserDownloadUrl")
+        or asset.get("browser_download_url")
+    )
+
+
+def _download_github_asset(asset: dict, filename: str) -> Path:
+    url = _github_asset_url(asset)
+    if not isinstance(url, str) or not url:
+        raise PublishError(f"GitHub asset {filename!r} has no usable download URL")
+    destination = _comparison_path("github", filename)
+    result = subprocess.run(
+        ["gh", "api", url, "--header", "Accept: application/octet-stream", "--output", str(destination)],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0 or not destination.is_file():
+        raise PublishError(f"GitHub asset {filename!r} download failed; refusing to trust a name collision")
+    return destination
 
 
 def plan_github_uploads(manifest, assets_dir: Path, manifest_path: Path, repo_slug: str, tag: str) -> list[Path]:
     """Return the list of local file paths that still need uploading to GitHub.
 
-    Fails loud (PublishError) rather than silently skipping when an existing
-    asset can't be trusted byte-identical (name present but no way to verify
-    without a download this script deliberately does not perform in v1 —
-    the operator is told to inspect manually instead of the script guessing).
+    Existing names are accepted only after downloading and hashing the actual
+    GitHub asset bytes. Reported size or digest metadata is not sufficient.
     """
     existing = gh_release_asset_shas(tag, repo_slug)
     to_upload = []
-    all_files = [assets_dir / a.filename for a in manifest.artifacts] + [manifest_path]
+    all_files = release_files(manifest, assets_dir, manifest_path)
     for path in all_files:
-        if path.name in existing:
-            print(f"  [github] {path.name}: already attached to {tag}; skipping (idempotent)")
+        asset = existing.get(path.name)
+        if asset is not None:
+            remote_sha = sha256_file(_download_github_asset(asset, path.name))
+            local_sha = sha256_file(path)
+            if remote_sha != local_sha:
+                raise AssetConflict(
+                    f"GitHub asset {path.name!r} differs: local sha256={local_sha}, remote sha256={remote_sha}"
+                )
+            print(f"  [github] {path.name}: existing bytes sha256={local_sha}; skipping (idempotent)")
             continue
         to_upload.append(path)
     return to_upload
@@ -208,33 +267,62 @@ def gitee_verify_tag_synchronized(owner: str, repo: str, tag: str, expected_comm
 
 def gitee_existing_attachments(owner: str, repo: str, release_id: int, token: str) -> dict[str, dict]:
     release = _gitee_request("GET", f"/repos/{owner}/{repo}/releases/{release_id}", token)
-    return {a["name"]: a for a in release.get("attach_files", [])}
+    attachments = release.get("attach_files", [])
+    if not isinstance(attachments, list):
+        raise PublishError("Gitee attachment metadata is ambiguous: attach_files is not a list")
+    result = {}
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            raise PublishError("Gitee attachment metadata is ambiguous: attachment is not an object")
+        name = attachment.get("name")
+        if not isinstance(name, str) or not name:
+            raise PublishError("Gitee attachment metadata is ambiguous: attachment has no name")
+        if name in result:
+            raise PublishError(f"Gitee release has ambiguous duplicate attachment name {name!r}")
+        result[name] = attachment
+    return result
+
+
+def _gitee_download_sha256(attachment: dict, filename: str, token: str) -> str:
+    url = (
+        attachment.get("browserDownloadUrl")
+        or attachment.get("browser_download_url")
+        or attachment.get("download_url")
+        or attachment.get("url")
+    )
+    if not isinstance(url, str) or not url:
+        raise PublishError(f"Gitee attachment {filename!r} has no usable download URL")
+    destination = _comparison_path("gitee", filename)
+    separator = "&" if "?" in url else "?"
+    request = urllib.request.Request(url + f"{separator}access_token={token}")
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            with destination.open("xb") as output:
+                while chunk := response.read(1024 * 1024):
+                    output.write(chunk)
+    except (OSError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+        raise PublishError(
+            f"Gitee attachment {filename!r} download/hash failed; refusing to trust a name collision"
+        ) from exc
+    return sha256_file(destination)
 
 
 def plan_gitee_uploads(manifest, assets_dir: Path, manifest_path: Path, owner: str, repo: str, release_id: int, token: str) -> list[Path]:
     existing = gitee_existing_attachments(owner, repo, release_id, token)
     to_upload = []
-    all_files = [assets_dir / a.filename for a in manifest.artifacts] + [manifest_path]
+    all_files = release_files(manifest, assets_dir, manifest_path)
     for path in all_files:
         att = existing.get(path.name)
         if att is None:
             to_upload.append(path)
             continue
-        # Gitee's attachment listing does not expose a checksum; the browser
-        # download URL is the only public evidence available without fetching
-        # the bytes. v1 treats "attachment with this name already exists" as
-        # an idempotent skip ONLY when re-verified against browserDownloadUrl
-        # is out of scope for this script (no network fetch-and-hash here);
-        # instead it fails loud so a human confirms before any manual retry,
-        # matching the "no delete-and-replace" and "fail loud on mismatch"
-        # requirements rather than silently trusting a name match.
-        raise AssetConflict(
-            f"Gitee release already has an attachment named {path.name!r} "
-            f"(id={att.get('id')}, url={att.get('browser_download_url', '?')}). "
-            "This script does not delete-and-replace attachments. If the bytes "
-            "are known identical, skip re-publishing this asset manually; "
-            "otherwise investigate before retrying."
-        )
+        remote_sha = _gitee_download_sha256(att, path.name, token)
+        local_sha = sha256_file(path)
+        if remote_sha != local_sha:
+            raise AssetConflict(
+                f"Gitee attachment {path.name!r} differs: local sha256={local_sha}, remote sha256={remote_sha}"
+            )
+        print(f"  [gitee] {path.name}: existing bytes sha256={local_sha}; skipping (idempotent)")
     return to_upload
 
 

--- a/scripts/sync_gitee_mirror.py
+++ b/scripts/sync_gitee_mirror.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Non-force-synchronize the exact release commit/tag to the Gitee kernel
+mirror before a Gitee release is created/attached to.
+
+This is deliberately a SEPARATE, git-level step from publish_release_assets.py
+(which only speaks the Gitee v5 REST API for release/attachment management).
+Gitee's release/tag lookup requires the tag to already exist on the Gitee git
+repository — publish_release_assets.py's gitee_verify_tag_synchronized() only
+checks that precondition; this script is what can actually establish it,
+safely.
+
+Safety:
+  - Every push is NON-FORCE. `git push` (not `--force`) on the branch ref
+    only succeeds if it is a fast-forward; a diverged/rewritten history on
+    Gitee's side fails loud rather than being silently overwritten.
+  - The tag push targets exactly one tag name and never overwrites an
+    existing tag that points somewhere else (`git push` refuses non-fast-
+    -forward tag updates by default; this script does not add `--force`).
+  - The token is passed via a short-lived git credential (an askpass helper
+    script written to a private temp file, chmod 600, deleted after use) and
+    is never included in argv, logged, or embedded in the remote URL string
+    that could appear in error output.
+  - `--execute` gates every mutating action; without it, prints the plan only.
+
+Usage:
+    export GITEE_ACCESS_TOKEN=...  # never echo or log this
+    python scripts/sync_gitee_mirror.py \\
+        --owner huangzesen1997 --repo lingtai-kernel \\
+        --commit <full-sha> --tag v0.16.4 --branch main \\
+        --execute
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+class SyncError(RuntimeError):
+    pass
+
+
+def _run(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, env=env, capture_output=True, text=True)
+
+
+def _write_askpass_helper(token: str) -> Path:
+    """Write a private (0600) askpass helper script that prints the token.
+
+    git invokes this as `<helper> <prompt>`; it must print the credential to
+    stdout and nothing else. Using GIT_ASKPASS instead of embedding the token
+    in the remote URL keeps the token out of `git remote -v`, process argv
+    visible via `ps`, and any URL that might appear in a git error message.
+    """
+    fd, path_str = tempfile.mkstemp(prefix="gitee-askpass-", suffix=".sh")
+    path = Path(path_str)
+    with os.fdopen(fd, "w") as f:
+        f.write("#!/bin/sh\n")
+        f.write(f'printf "%s\\n" "{token}"\n')
+    path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)  # 0600 + exec, owner-only
+    return path
+
+
+def sync_mirror(
+    owner: str,
+    repo: str,
+    commit: str,
+    tag: str,
+    branch: str,
+    token: str,
+    execute: bool,
+) -> None:
+    gitee_url = f"https://gitee.com/{owner}/{repo}.git"
+    askpass_path = _write_askpass_helper(token)
+    try:
+        env = dict(os.environ)
+        env["GIT_ASKPASS"] = str(askpass_path)
+        env["GIT_TERMINAL_PROMPT"] = "0"  # never fall back to an interactive prompt
+
+        # Verify the local checkout actually has the commit we're about to sync.
+        verify = _run(["git", "cat-file", "-e", f"{commit}^{{commit}}"])
+        if verify.returncode != 0:
+            raise SyncError(f"local checkout does not have commit {commit}: {verify.stderr.strip()}")
+
+        branch_refspec = f"{commit}:refs/heads/{branch}"
+        tag_refspec = f"{commit}:refs/tags/{tag}"
+
+        if not execute:
+            print(f"DRY RUN: would non-force push {commit[:12]} -> {owner}/{repo}#{branch} (fast-forward only)")
+            print(f"DRY RUN: would push tag {tag} -> {owner}/{repo} (create-only, no overwrite)")
+            return
+
+        print(f"Pushing {commit[:12]} to {owner}/{repo}#{branch} (non-force, fast-forward only)...")
+        push_branch = _run(["git", "push", gitee_url, branch_refspec], env=env)
+        if push_branch.returncode != 0:
+            raise SyncError(
+                f"non-force push to {owner}/{repo}#{branch} failed (not a fast-forward, or auth "
+                f"failed): {push_branch.stderr.strip()}\n"
+                "This script never force-pushes. Investigate and resolve the divergence "
+                "out of band, then retry."
+            )
+        print(f"  OK: {branch} fast-forwarded to {commit[:12]}")
+
+        print(f"Pushing tag {tag} to {owner}/{repo} (create-only)...")
+        push_tag = _run(["git", "push", gitee_url, tag_refspec], env=env)
+        if push_tag.returncode != 0:
+            raise SyncError(
+                f"tag push for {tag} failed (tag may already exist pointing elsewhere, or auth "
+                f"failed): {push_tag.stderr.strip()}\n"
+                "This script never overwrites an existing tag. Investigate and resolve out of "
+                "band, then retry."
+            )
+        print(f"  OK: tag {tag} created at {commit[:12]}")
+    finally:
+        askpass_path.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--owner", default="huangzesen1997")
+    parser.add_argument("--repo", default="lingtai-kernel")
+    parser.add_argument("--commit", required=True, help="full commit SHA to synchronize")
+    parser.add_argument("--tag", required=True, help="release tag to synchronize, e.g. v0.16.4")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--token-env", default="GITEE_ACCESS_TOKEN", help="env var holding the Gitee token; never printed")
+    parser.add_argument("--execute", action="store_true", help="actually push; default is dry-run/plan-only")
+    args = parser.parse_args(argv)
+
+    token = os.environ.get(args.token_env, "")
+    if not token:
+        print(f"{args.token_env} is not set; skipping Gitee mirror sync.")
+        return 0
+
+    try:
+        sync_mirror(args.owner, args.repo, args.commit, args.tag, args.branch, token, args.execute)
+    except SyncError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_publish_release_assets.py
+++ b/tests/test_publish_release_assets.py
@@ -1,0 +1,242 @@
+"""Tests for scripts/publish_release_assets.py.
+
+No real network or `gh` calls: subprocess and the Gitee HTTP seam
+(_gitee_request) are monkeypatched with deterministic fakes. Covers dry-run
+default safety, idempotent same-name skip, fail-loud on sha mismatch /
+unsynchronized Gitee tag / conflicting attachment, and that --execute is
+required for any mutating call.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import publish_release_assets as pub  # noqa: E402
+from release_manifest import ReleaseManifest, Artifact, sha256_file  # noqa: E402
+
+
+def _sample_manifest_and_assets(tmp_path: Path):
+    assets_dir = tmp_path / "assets"
+    assets_dir.mkdir()
+    wheel = assets_dir / "lingtai-0.16.4-cp312-cp312-macosx_11_0_arm64.whl"
+    wheel.write_bytes(b"wheel-bytes")
+    sdist = assets_dir / "lingtai-0.16.4.tar.gz"
+    sdist.write_bytes(b"sdist-bytes")
+
+    manifest = ReleaseManifest(
+        kernel_version="0.16.4",
+        kernel_tag="v0.16.4",
+        commit="a" * 40,
+        generated_at="2026-07-15T00:00:00Z",
+        artifacts=(
+            Artifact(wheel.name, sha256_file(wheel), "wheel", "cp312", "cp312", "macosx_11_0_arm64"),
+            Artifact(sdist.name, sha256_file(sdist), "sdist", None, None, None),
+        ),
+        sdist_fallback=sdist.name,
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest.to_dict()), encoding="utf-8")
+    return manifest, assets_dir, manifest_path
+
+
+# ---------------------------------------------------------------------------
+# verify_local_assets
+# ---------------------------------------------------------------------------
+
+
+def test_verify_local_assets_passes_for_matching_bytes(tmp_path: Path):
+    manifest, assets_dir, _ = _sample_manifest_and_assets(tmp_path)
+    pub.verify_local_assets(manifest, assets_dir)  # no raise
+
+
+def test_verify_local_assets_fails_loud_on_tampered_bytes(tmp_path: Path):
+    manifest, assets_dir, _ = _sample_manifest_and_assets(tmp_path)
+    (assets_dir / manifest.artifacts[0].filename).write_bytes(b"tampered")
+    with pytest.raises(pub.PublishError, match="sha256 mismatch"):
+        pub.verify_local_assets(manifest, assets_dir)
+
+
+def test_verify_local_assets_fails_loud_on_missing_file(tmp_path: Path):
+    manifest, assets_dir, _ = _sample_manifest_and_assets(tmp_path)
+    (assets_dir / manifest.artifacts[0].filename).unlink()
+    with pytest.raises(pub.PublishError, match="missing on disk"):
+        pub.verify_local_assets(manifest, assets_dir)
+
+
+# ---------------------------------------------------------------------------
+# GitHub planning (subprocess mocked)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_plan_github_uploads_skips_existing_assets(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+
+    existing_names = {manifest.artifacts[0].filename}
+
+    def fake_run(cmd, capture_output=True, text=True, check=False):
+        assert cmd[:2] == ["gh", "release"]
+        return _FakeCompletedProcess(
+            returncode=0,
+            stdout=json.dumps({"assets": [{"name": n} for n in existing_names]}),
+        )
+
+    monkeypatch.setattr(pub.subprocess, "run", fake_run)
+    to_upload = pub.plan_github_uploads(manifest, assets_dir, manifest_path, "Lingtai-AI/lingtai-kernel", "v0.16.4")
+    names = {p.name for p in to_upload}
+    # The already-attached wheel is skipped; the sdist and manifest still need upload.
+    assert manifest.artifacts[0].filename not in names
+    assert manifest.artifacts[1].filename in names
+    assert manifest_path.name in names
+
+
+def test_gh_release_exists_true_false(monkeypatch):
+    monkeypatch.setattr(pub.subprocess, "run", lambda *a, **k: _FakeCompletedProcess(returncode=0))
+    assert pub.gh_release_exists("v1", "o/r") is True
+    monkeypatch.setattr(pub.subprocess, "run", lambda *a, **k: _FakeCompletedProcess(returncode=1))
+    assert pub.gh_release_exists("v1", "o/r") is False
+
+
+def test_execute_github_upload_requires_no_files_is_noop(monkeypatch):
+    calls = []
+    monkeypatch.setattr(pub.subprocess, "run", lambda *a, **k: calls.append(a) or _FakeCompletedProcess())
+    pub.execute_github_upload("v1", "o/r", [])
+    assert calls == []  # never shells out when there is nothing to upload
+
+
+# ---------------------------------------------------------------------------
+# Gitee planning (network mocked via _gitee_request)
+# ---------------------------------------------------------------------------
+
+
+def test_gitee_verify_tag_synchronized_passes_on_matching_commit(monkeypatch):
+    monkeypatch.setattr(
+        pub, "_gitee_request",
+        lambda method, path, token, **kw: {"commit": {"sha": "a" * 40}},
+    )
+    pub.gitee_verify_tag_synchronized("owner", "repo", "v0.16.4", "a" * 40, "tok")  # no raise
+
+
+def test_gitee_verify_tag_synchronized_fails_loud_on_mismatched_commit(monkeypatch):
+    monkeypatch.setattr(
+        pub, "_gitee_request",
+        lambda method, path, token, **kw: {"commit": {"sha": "b" * 40}},
+    )
+    with pytest.raises(pub.PublishError, match="mismatched"):
+        pub.gitee_verify_tag_synchronized("owner", "repo", "v0.16.4", "a" * 40, "tok")
+
+
+def test_gitee_verify_tag_synchronized_fails_loud_when_tag_missing(monkeypatch):
+    def raise_404(method, path, token, **kw):
+        raise pub.PublishError("Gitee API GET /x failed: HTTP 404: b''")
+
+    monkeypatch.setattr(pub, "_gitee_request", raise_404)
+    with pytest.raises(pub.PublishError, match="synchronize"):
+        pub.gitee_verify_tag_synchronized("owner", "repo", "v0.16.4", "a" * 40, "tok")
+
+
+def test_plan_gitee_uploads_skips_nothing_new(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    monkeypatch.setattr(pub, "_gitee_request", lambda *a, **k: {"attach_files": []})
+    to_upload = pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
+    names = {p.name for p in to_upload}
+    assert names == {manifest.artifacts[0].filename, manifest.artifacts[1].filename, manifest_path.name}
+
+
+def test_plan_gitee_uploads_fails_loud_on_name_conflict(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    conflicting_name = manifest.artifacts[0].filename
+    monkeypatch.setattr(
+        pub, "_gitee_request",
+        lambda *a, **k: {"attach_files": [{"id": 42, "name": conflicting_name, "browser_download_url": "https://x"}]},
+    )
+    with pytest.raises(pub.AssetConflict, match="does not delete-and-replace"):
+        pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
+
+
+# ---------------------------------------------------------------------------
+# CLI: dry-run is the default and never calls the mutating fakes
+# ---------------------------------------------------------------------------
+
+
+def test_main_dry_run_default_never_executes_github_upload(tmp_path, monkeypatch, capsys):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+
+    def fake_run(cmd, capture_output=True, text=True, check=False):
+        if cmd[:3] == ["gh", "release", "view"] and "--json" in cmd:
+            return _FakeCompletedProcess(returncode=0, stdout=json.dumps({"assets": []}))
+        if cmd[:3] == ["gh", "release", "view"]:
+            return _FakeCompletedProcess(returncode=0)
+        raise AssertionError(f"unexpected mutating subprocess call in dry-run: {cmd}")
+
+    monkeypatch.setattr(pub.subprocess, "run", fake_run)
+    rc = pub.main([
+        "--manifest", str(manifest_path),
+        "--assets-dir", str(assets_dir),
+        "--github-repo", "Lingtai-AI/lingtai-kernel",
+        "--skip-gitee",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+
+
+def test_main_skips_gitee_when_token_env_unset(tmp_path, monkeypatch, capsys):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    monkeypatch.delenv("GITEE_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(pub.subprocess, "run", lambda *a, **k: _FakeCompletedProcess(returncode=1))
+    rc = pub.main([
+        "--manifest", str(manifest_path),
+        "--assets-dir", str(assets_dir),
+        "--skip-github",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "[gitee] skipped" in out
+    assert "GITEE_ACCESS_TOKEN is not set" in out
+
+
+def test_main_never_echoes_gitee_token(tmp_path, monkeypatch, capsys):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    secret = "super-secret-token-value-12345"
+    monkeypatch.setenv("GITEE_ACCESS_TOKEN", secret)
+    monkeypatch.setattr(pub.subprocess, "run", lambda *a, **k: _FakeCompletedProcess(returncode=1))
+    monkeypatch.setattr(pub, "_gitee_request", lambda *a, **k: {"commit": {"sha": "a" * 40}})
+    monkeypatch.setattr(pub, "gitee_find_release_by_tag", lambda *a, **k: None)
+    rc = pub.main([
+        "--manifest", str(manifest_path),
+        "--assets-dir", str(assets_dir),
+        "--skip-github",
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert secret not in out
+
+
+def test_main_rejects_tampered_asset_before_any_upload(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    (assets_dir / manifest.artifacts[0].filename).write_bytes(b"tampered")
+
+    def fail_if_called(*a, **k):
+        raise AssertionError("must not shell out before local asset verification")
+
+    monkeypatch.setattr(pub.subprocess, "run", fail_if_called)
+    with pytest.raises(pub.PublishError, match="sha256 mismatch"):
+        pub.main([
+            "--manifest", str(manifest_path),
+            "--assets-dir", str(assets_dir),
+            "--skip-gitee",
+        ])

--- a/tests/test_publish_release_assets.py
+++ b/tests/test_publish_release_assets.py
@@ -194,29 +194,64 @@ def test_execute_github_upload_requires_no_files_is_noop(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_gitee_create_release_includes_target_commitish(monkeypatch):
+    captured = {}
+
+    def fake_request(method, path, token, **kwargs):
+        captured.update(method=method, path=path, token=token, **kwargs)
+        return {"id": 1}
+
+    monkeypatch.setattr(pub, "_gitee_request", fake_request)
+    pub.gitee_create_release("owner", "repo", "v0.16.4", "v0.16.4", "a" * 40, "tok")
+    payload = json.loads(captured["data"])
+    assert payload["target_commitish"] == "a" * 40
+    assert payload["tag_name"] == "v0.16.4"
+
+
 def test_gitee_verify_tag_synchronized_passes_on_matching_commit(monkeypatch):
     monkeypatch.setattr(
         pub, "_gitee_request",
-        lambda method, path, token, **kw: {"commit": {"sha": "a" * 40}},
+        lambda method, path, token, **kw: [
+            {"name": "v0.16.4", "commit": {"sha": "a" * 40}},
+        ],
     )
     pub.gitee_verify_tag_synchronized("owner", "repo", "v0.16.4", "a" * 40, "tok")  # no raise
+
+
+def test_gitee_verify_tag_synchronized_follows_tag_list_pagination(monkeypatch):
+    paths = []
+
+    def fake_request(method, path, token, **kw):
+        paths.append(path)
+        if path.endswith("page=1"):
+            return [
+                {"name": f"v0.0.{index}", "commit": {"sha": "b" * 40}}
+                for index in range(100)
+            ]
+        return [{"name": "v0.16.4", "commit": {"sha": "a" * 40}}]
+
+    monkeypatch.setattr(pub, "_gitee_request", fake_request)
+    pub.gitee_verify_tag_synchronized("owner", "repo", "v0.16.4", "a" * 40, "tok")
+    assert paths == [
+        "/repos/owner/repo/tags?per_page=100&page=1",
+        "/repos/owner/repo/tags?per_page=100&page=2",
+    ]
 
 
 def test_gitee_verify_tag_synchronized_fails_loud_on_mismatched_commit(monkeypatch):
     monkeypatch.setattr(
         pub, "_gitee_request",
-        lambda method, path, token, **kw: {"commit": {"sha": "b" * 40}},
+        lambda method, path, token, **kw: [
+            {"name": "v0.16.4", "commit": {"sha": "b" * 40}},
+        ],
     )
     with pytest.raises(pub.PublishError, match="mismatched"):
         pub.gitee_verify_tag_synchronized("owner", "repo", "v0.16.4", "a" * 40, "tok")
 
 
 def test_gitee_verify_tag_synchronized_fails_loud_when_tag_missing(monkeypatch):
-    def raise_404(method, path, token, **kw):
-        raise pub.PublishError("Gitee API GET /x failed: HTTP 404: b''")
-
-    monkeypatch.setattr(pub, "_gitee_request", raise_404)
-    with pytest.raises(pub.PublishError, match="synchronize"):
+    monkeypatch.setattr(pub, "_gitee_request", lambda *args, **kwargs: [])
+    with pytest.raises(pub.PublishError, match="not found"):
         pub.gitee_verify_tag_synchronized("owner", "repo", "v0.16.4", "a" * 40, "tok")
 
 
@@ -246,13 +281,20 @@ class _FakeResponse:
 def test_plan_gitee_uploads_same_byte_collision_skips_without_upload(tmp_path, monkeypatch, capsys):
     manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
     wheel = manifest.artifacts[0].filename
+    timeouts = []
     monkeypatch.setattr(
         pub, "_gitee_request",
         lambda *a, **k: {"attach_files": [{"id": 42, "name": wheel, "browserDownloadUrl": "https://gitee.test/wheel"}]},
     )
-    monkeypatch.setattr(pub.urllib.request, "urlopen", lambda request, timeout=15: _FakeResponse((assets_dir / wheel).read_bytes()))
+
+    def fake_urlopen(request, timeout):
+        timeouts.append(timeout)
+        return _FakeResponse((assets_dir / wheel).read_bytes())
+
+    monkeypatch.setattr(pub.urllib.request, "urlopen", fake_urlopen)
     to_upload = pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "secret-token")
     assert wheel not in {p.name for p in to_upload}
+    assert timeouts == [pub.GITEE_TRANSFER_TIMEOUT_SECONDS]
     assert "existing bytes sha256" in capsys.readouterr().out
 
 
@@ -291,6 +333,26 @@ def test_plan_gitee_uploads_duplicate_name_is_ambiguous(tmp_path, monkeypatch):
     monkeypatch.setattr(pub, "_gitee_request", lambda *a, **k: {"attach_files": [{"name": name}, {"name": name}]})
     with pytest.raises(pub.PublishError, match="ambiguous duplicate"):
         pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
+
+
+def test_execute_gitee_upload_uses_transfer_timeout(tmp_path, monkeypatch):
+    asset = tmp_path / "large.whl"
+    asset.write_bytes(b"wheel-bytes")
+    requests = []
+
+    def fake_request(method, path, token, **kwargs):
+        requests.append((method, path, token, kwargs))
+        return {}
+
+    monkeypatch.setattr(pub, "_gitee_request", fake_request)
+    pub.execute_gitee_upload("owner", "repo", 42, [asset], "secret-token")
+
+    assert len(requests) == 1
+    method, path, token, kwargs = requests[0]
+    assert method == "POST"
+    assert path == "/repos/owner/repo/releases/42/attach_files"
+    assert token == "secret-token"
+    assert kwargs["timeout"] == pub.GITEE_TRANSFER_TIMEOUT_SECONDS
 
 
 # ---------------------------------------------------------------------------
@@ -340,7 +402,11 @@ def test_main_never_echoes_gitee_token(tmp_path, monkeypatch, capsys):
     secret = "super-secret-token-value-12345"
     monkeypatch.setenv("GITEE_ACCESS_TOKEN", secret)
     monkeypatch.setattr(pub.subprocess, "run", lambda *a, **k: _FakeCompletedProcess(returncode=1))
-    monkeypatch.setattr(pub, "_gitee_request", lambda *a, **k: {"commit": {"sha": "a" * 40}})
+    monkeypatch.setattr(
+        pub,
+        "_gitee_request",
+        lambda *a, **k: [{"name": "v0.16.4", "commit": {"sha": "a" * 40}}],
+    )
     monkeypatch.setattr(pub, "gitee_find_release_by_tag", lambda *a, **k: None)
     rc = pub.main([
         "--manifest", str(manifest_path),

--- a/tests/test_publish_release_assets.py
+++ b/tests/test_publish_release_assets.py
@@ -43,6 +43,10 @@ def _sample_manifest_and_assets(tmp_path: Path):
     )
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(manifest.to_dict()), encoding="utf-8")
+    (assets_dir / "SHA256SUMS").write_text(
+        "\n".join(f"{a.sha256}  {a.filename}" for a in manifest.artifacts) + "\n",
+        encoding="utf-8",
+    )
     return manifest, assets_dir, manifest_path
 
 
@@ -82,17 +86,24 @@ class _FakeCompletedProcess:
         self.stderr = stderr
 
 
-def test_plan_github_uploads_skips_existing_assets(tmp_path, monkeypatch):
+def test_plan_github_uploads_same_byte_collision_skips_without_upload(tmp_path, monkeypatch):
     manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
 
     existing_names = {manifest.artifacts[0].filename}
+    calls = []
 
     def fake_run(cmd, capture_output=True, text=True, check=False):
-        assert cmd[:2] == ["gh", "release"]
-        return _FakeCompletedProcess(
-            returncode=0,
-            stdout=json.dumps({"assets": [{"name": n} for n in existing_names]}),
-        )
+        calls.append(cmd)
+        if cmd[:2] == ["gh", "release"] and cmd[2] == "view":
+            return _FakeCompletedProcess(
+                returncode=0,
+                stdout=json.dumps({"assets": [{"name": n, "apiUrl": "https://api.github.test/assets/1"} for n in existing_names]}),
+            )
+        if cmd[:2] == ["gh", "api"]:
+            output = Path(cmd[cmd.index("--output") + 1])
+            output.write_bytes((assets_dir / manifest.artifacts[0].filename).read_bytes())
+            return _FakeCompletedProcess()
+        raise AssertionError(cmd)
 
     monkeypatch.setattr(pub.subprocess, "run", fake_run)
     to_upload = pub.plan_github_uploads(manifest, assets_dir, manifest_path, "Lingtai-AI/lingtai-kernel", "v0.16.4")
@@ -101,6 +112,67 @@ def test_plan_github_uploads_skips_existing_assets(tmp_path, monkeypatch):
     assert manifest.artifacts[0].filename not in names
     assert manifest.artifacts[1].filename in names
     assert manifest_path.name in names
+    assert "SHA256SUMS" in names
+    assert not any(cmd[2] == "upload" for cmd in calls)
+
+
+def test_plan_github_uploads_mismatch_fails_before_upload(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["gh", "release"]:
+            return _FakeCompletedProcess(stdout=json.dumps({"assets": [{"name": manifest.artifacts[0].filename, "apiUrl": "https://api.github.test/assets/1"}]}))
+        output = Path(cmd[cmd.index("--output") + 1])
+        output.write_bytes(b"different")
+        return _FakeCompletedProcess()
+    monkeypatch.setattr(pub.subprocess, "run", fake_run)
+    with pytest.raises(pub.AssetConflict, match="GitHub asset"):
+        pub.plan_github_uploads(manifest, assets_dir, manifest_path, "o/r", "v1")
+
+
+def test_plan_github_uploads_missing_url_fails_loud(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    monkeypatch.setattr(pub.subprocess, "run", lambda *a, **k: _FakeCompletedProcess(
+        stdout=json.dumps({"assets": [{"name": manifest.artifacts[0].filename}]})
+    ))
+    with pytest.raises(pub.PublishError, match="no usable download URL"):
+        pub.plan_github_uploads(manifest, assets_dir, manifest_path, "o/r", "v1")
+
+
+def test_plan_github_uploads_download_failure_fails_loud(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["gh", "release"]:
+            return _FakeCompletedProcess(stdout=json.dumps({"assets": [{"name": manifest.artifacts[0].filename, "browserDownloadUrl": "https://github.test/download"}]}))
+        return _FakeCompletedProcess(returncode=1)
+    monkeypatch.setattr(pub.subprocess, "run", fake_run)
+    with pytest.raises(pub.PublishError, match="download failed"):
+        pub.plan_github_uploads(manifest, assets_dir, manifest_path, "o/r", "v1")
+
+
+@pytest.mark.parametrize("stdout", ["{not-json", json.dumps({"release": "v1"})])
+def test_main_github_asset_metadata_failure_never_uploads_or_mutates(tmp_path, monkeypatch, stdout):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "release", "view"] and "--json" not in cmd:
+            return _FakeCompletedProcess(returncode=0)
+        if cmd[:3] == ["gh", "release", "view"] and "--json" in cmd:
+            return _FakeCompletedProcess(returncode=1 if stdout == "{not-json" else 0, stdout=stdout)
+        raise AssertionError(f"unexpected mutating command: {cmd}")
+
+    monkeypatch.setattr(pub.subprocess, "run", fake_run)
+    with pytest.raises(pub.PublishError, match="GitHub release asset metadata"):
+        pub.main([
+            "--manifest", str(manifest_path),
+            "--assets-dir", str(assets_dir),
+            "--github-repo", "o/r",
+            "--skip-gitee",
+            "--execute",
+        ])
+    assert not any(cmd[:3] == ["gh", "release", "upload"] for cmd in calls)
+    assert not any(cmd[:3] == ["gh", "release", "create"] for cmd in calls)
 
 
 def test_gh_release_exists_true_false(monkeypatch):
@@ -148,22 +220,76 @@ def test_gitee_verify_tag_synchronized_fails_loud_when_tag_missing(monkeypatch):
         pub.gitee_verify_tag_synchronized("owner", "repo", "v0.16.4", "a" * 40, "tok")
 
 
-def test_plan_gitee_uploads_skips_nothing_new(tmp_path, monkeypatch):
+def test_plan_gitee_uploads_missing_assets_are_planned(tmp_path, monkeypatch):
     manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
     monkeypatch.setattr(pub, "_gitee_request", lambda *a, **k: {"attach_files": []})
     to_upload = pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
     names = {p.name for p in to_upload}
-    assert names == {manifest.artifacts[0].filename, manifest.artifacts[1].filename, manifest_path.name}
+    assert names == {manifest.artifacts[0].filename, manifest.artifacts[1].filename, manifest_path.name, "SHA256SUMS"}
 
 
-def test_plan_gitee_uploads_fails_loud_on_name_conflict(tmp_path, monkeypatch):
+class _FakeResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self, size=-1):
+        body, self.body = self.body, b""
+        return body
+
+
+def test_plan_gitee_uploads_same_byte_collision_skips_without_upload(tmp_path, monkeypatch, capsys):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    wheel = manifest.artifacts[0].filename
+    monkeypatch.setattr(
+        pub, "_gitee_request",
+        lambda *a, **k: {"attach_files": [{"id": 42, "name": wheel, "browserDownloadUrl": "https://gitee.test/wheel"}]},
+    )
+    monkeypatch.setattr(pub.urllib.request, "urlopen", lambda request, timeout=15: _FakeResponse((assets_dir / wheel).read_bytes()))
+    to_upload = pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "secret-token")
+    assert wheel not in {p.name for p in to_upload}
+    assert "existing bytes sha256" in capsys.readouterr().out
+
+
+def test_plan_gitee_uploads_mismatch_fails_before_upload(tmp_path, monkeypatch):
     manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
     conflicting_name = manifest.artifacts[0].filename
     monkeypatch.setattr(
         pub, "_gitee_request",
         lambda *a, **k: {"attach_files": [{"id": 42, "name": conflicting_name, "browser_download_url": "https://x"}]},
     )
-    with pytest.raises(pub.AssetConflict, match="does not delete-and-replace"):
+    monkeypatch.setattr(pub.urllib.request, "urlopen", lambda *a, **k: _FakeResponse(b"different"))
+    with pytest.raises(pub.AssetConflict, match="Gitee attachment"):
+        pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
+
+
+def test_plan_gitee_uploads_missing_url_fails_loud(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    monkeypatch.setattr(pub, "_gitee_request", lambda *a, **k: {"attach_files": [{"name": manifest.artifacts[0].filename}]})
+    with pytest.raises(pub.PublishError, match="no usable download URL"):
+        pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
+
+
+def test_plan_gitee_uploads_download_failure_fails_loud(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    monkeypatch.setattr(pub, "_gitee_request", lambda *a, **k: {"attach_files": [{"name": manifest.artifacts[0].filename, "download_url": "https://gitee.test/download"}]})
+    def fail_download(*args, **kwargs):
+        raise pub.urllib.error.URLError("offline")
+    monkeypatch.setattr(pub.urllib.request, "urlopen", fail_download)
+    with pytest.raises(pub.PublishError, match="download/hash failed"):
+        pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
+
+
+def test_plan_gitee_uploads_duplicate_name_is_ambiguous(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    name = manifest.artifacts[0].filename
+    monkeypatch.setattr(pub, "_gitee_request", lambda *a, **k: {"attach_files": [{"name": name}, {"name": name}]})
+    with pytest.raises(pub.PublishError, match="ambiguous duplicate"):
         pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
 
 

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1,0 +1,352 @@
+"""Tests for scripts/lib/release_manifest.py (the lingtai.kernel.release/v1
+schema + validator) and scripts/generate_release_manifest.py (the aggregator
+CLI). No network, no subprocess against a real wheel build — fixtures only.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+from release_manifest import (  # noqa: E402
+    Artifact,
+    ManifestError,
+    ReleaseManifest,
+    classify_artifact,
+    manifest_from_dict,
+    parse_sdist_filename,
+    parse_wheel_filename,
+    sha256_file,
+    validate_manifest_dict,
+)
+
+GENERATE_SCRIPT = REPO_ROOT / "scripts" / "generate_release_manifest.py"
+
+
+# ---------------------------------------------------------------------------
+# Filename parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_wheel_filename_extracts_tags():
+    parsed = parse_wheel_filename("lingtai-0.16.4-cp312-cp312-macosx_11_0_arm64.whl")
+    assert parsed == {
+        "name": "lingtai",
+        "version": "0.16.4",
+        "python_tag": "cp312",
+        "abi_tag": "cp312",
+        "platform_tag": "macosx_11_0_arm64",
+    }
+
+
+def test_parse_wheel_filename_rejects_malformed():
+    assert parse_wheel_filename("not-a-wheel.whl") is None
+    assert parse_wheel_filename("lingtai-0.16.4.whl") is None
+
+
+def test_parse_sdist_filename():
+    parsed = parse_sdist_filename("lingtai-0.16.4.tar.gz")
+    assert parsed == {"name": "lingtai", "version": "0.16.4"}
+
+
+# ---------------------------------------------------------------------------
+# classify_artifact
+# ---------------------------------------------------------------------------
+
+
+def test_classify_artifact_wheel():
+    art = classify_artifact("lingtai-0.16.4-cp313-cp313-macosx_11_0_arm64.whl", "a" * 64)
+    assert art.kind == "wheel"
+    assert art.python_tag == "cp313"
+    assert art.abi_tag == "cp313"
+    assert art.platform_tag == "macosx_11_0_arm64"
+
+
+def test_classify_artifact_sdist():
+    art = classify_artifact("lingtai-0.16.4.tar.gz", "b" * 64)
+    assert art.kind == "sdist"
+    assert art.python_tag is None
+
+
+def test_classify_artifact_rejects_plain_pure_wheel_name_mismatch():
+    # Not lingtai's own name -> reject regardless of extension.
+    with pytest.raises(ManifestError):
+        classify_artifact("other-pkg-1.0-py3-none-any.whl", "c" * 64)
+
+
+def test_classify_artifact_rejects_unrecognized_extension():
+    with pytest.raises(ManifestError):
+        classify_artifact("lingtai-0.16.4.zip", "d" * 64)
+
+
+def test_classify_artifact_rejects_malformed_wheel_name():
+    with pytest.raises(ManifestError):
+        classify_artifact("lingtai.whl", "e" * 64)
+
+
+# ---------------------------------------------------------------------------
+# sha256_file
+# ---------------------------------------------------------------------------
+
+
+def test_sha256_file_matches_hashlib(tmp_path: Path):
+    p = tmp_path / "x.bin"
+    p.write_bytes(b"hello world" * 1000)
+    expected = hashlib.sha256(p.read_bytes()).hexdigest()
+    assert sha256_file(p) == expected
+
+
+# ---------------------------------------------------------------------------
+# validate_manifest_dict — the strict schema gate
+# ---------------------------------------------------------------------------
+
+
+def _valid_manifest_dict() -> dict:
+    return {
+        "schema": "lingtai.kernel.release/v1",
+        "kernel_version": "0.16.4",
+        "kernel_tag": "v0.16.4",
+        "commit": "a" * 40,
+        "generated_at": "2026-07-15T00:00:00Z",
+        "sdist_fallback": "lingtai-0.16.4.tar.gz",
+        "artifacts": [
+            {
+                "filename": "lingtai-0.16.4-cp312-cp312-macosx_11_0_arm64.whl",
+                "sha256": "b" * 64,
+                "kind": "wheel",
+                "python_tag": "cp312",
+                "abi_tag": "cp312",
+                "platform_tag": "macosx_11_0_arm64",
+            },
+            {
+                "filename": "lingtai-0.16.4.tar.gz",
+                "sha256": "c" * 64,
+                "kind": "sdist",
+                "python_tag": None,
+                "abi_tag": None,
+                "platform_tag": None,
+            },
+        ],
+    }
+
+
+def test_validate_manifest_dict_accepts_valid():
+    validate_manifest_dict(_valid_manifest_dict())  # no raise
+
+
+@pytest.mark.parametrize("missing_key", sorted({
+    "schema", "kernel_version", "kernel_tag", "commit", "generated_at", "artifacts", "sdist_fallback",
+}))
+def test_validate_manifest_dict_rejects_missing_top_level_key(missing_key):
+    data = _valid_manifest_dict()
+    del data[missing_key]
+    with pytest.raises(ManifestError, match="missing required keys"):
+        validate_manifest_dict(data)
+
+
+def test_validate_manifest_dict_rejects_wrong_schema():
+    data = _valid_manifest_dict()
+    data["schema"] = "lingtai.kernel.release/v2"
+    with pytest.raises(ManifestError, match="unexpected schema"):
+        validate_manifest_dict(data)
+
+
+def test_validate_manifest_dict_rejects_empty_artifacts():
+    data = _valid_manifest_dict()
+    data["artifacts"] = []
+    with pytest.raises(ManifestError, match="non-empty list"):
+        validate_manifest_dict(data)
+
+
+def test_validate_manifest_dict_rejects_bad_sha256_shape():
+    data = _valid_manifest_dict()
+    data["artifacts"][0]["sha256"] = "not-hex"
+    with pytest.raises(ManifestError, match="sha256"):
+        validate_manifest_dict(data)
+
+
+def test_validate_manifest_dict_rejects_duplicate_filenames():
+    data = _valid_manifest_dict()
+    data["artifacts"].append(dict(data["artifacts"][0]))
+    with pytest.raises(ManifestError, match="duplicate artifact filename"):
+        validate_manifest_dict(data)
+
+
+def test_validate_manifest_dict_rejects_bad_kind():
+    data = _valid_manifest_dict()
+    data["artifacts"][0]["kind"] = "egg"
+    with pytest.raises(ManifestError, match="kind"):
+        validate_manifest_dict(data)
+
+
+def test_validate_manifest_dict_rejects_wheel_missing_tags():
+    data = _valid_manifest_dict()
+    data["artifacts"][0]["python_tag"] = None
+    with pytest.raises(ManifestError, match="python_tag"):
+        validate_manifest_dict(data)
+
+
+def test_validate_manifest_dict_rejects_sdist_with_tags():
+    data = _valid_manifest_dict()
+    data["artifacts"][1]["python_tag"] = "cp312"
+    with pytest.raises(ManifestError, match="non-null"):
+        validate_manifest_dict(data)
+
+
+def test_validate_manifest_dict_rejects_sdist_fallback_not_listed():
+    data = _valid_manifest_dict()
+    data["sdist_fallback"] = "does-not-exist.tar.gz"
+    with pytest.raises(ManifestError, match="sdist_fallback"):
+        validate_manifest_dict(data)
+
+
+def test_validate_manifest_dict_rejects_no_sdist_artifact():
+    data = _valid_manifest_dict()
+    data["artifacts"] = [data["artifacts"][0]]  # only the wheel
+    data["sdist_fallback"] = data["artifacts"][0]["filename"]
+    with pytest.raises(ManifestError, match="no artifact with kind='sdist'"):
+        validate_manifest_dict(data)
+
+
+def test_manifest_from_dict_round_trips():
+    data = _valid_manifest_dict()
+    manifest = manifest_from_dict(data)
+    assert isinstance(manifest, ReleaseManifest)
+    assert manifest.to_dict() == data
+
+
+# ---------------------------------------------------------------------------
+# generate_release_manifest.py — end-to-end against fixture files
+# ---------------------------------------------------------------------------
+
+
+def _write_fixture_wheel(path: Path, sidecar: bool) -> None:
+    """A minimal real zip so classify/sha256 logic runs against real bytes.
+    Sidecar presence is irrelevant here because these tests pass
+    --skip-sidecar-check; the sidecar contract itself is covered by the
+    existing tests/test_wheel_sidecar_smoke.py suite.
+    """
+    import zipfile
+
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("lingtai/__init__.py", "")
+        if sidecar:
+            zf.writestr("lingtai/bin/lingtai-search-sidecar", b"fake-binary")
+
+
+def test_generate_release_manifest_cli_end_to_end(tmp_path: Path):
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    _write_fixture_wheel(assets / "lingtai-0.16.4-cp312-cp312-macosx_11_0_arm64.whl", sidecar=True)
+    _write_fixture_wheel(assets / "lingtai-0.16.4-cp313-cp313-manylinux_2_28_x86_64.whl", sidecar=True)
+    (assets / "lingtai-0.16.4.tar.gz").write_bytes(b"fake-sdist-bytes")
+
+    out_manifest = tmp_path / "manifest.json"
+    out_sums = tmp_path / "SHA256SUMS"
+
+    result = subprocess.run(
+        [
+            sys.executable, str(GENERATE_SCRIPT),
+            "--assets-dir", str(assets),
+            "--kernel-version", "0.16.4",
+            "--kernel-tag", "v0.16.4",
+            "--commit", "a" * 40,
+            "--generated-at", "2026-07-15T00:00:00Z",
+            "--out-manifest", str(out_manifest),
+            "--out-sha256sums", str(out_sums),
+            "--skip-sidecar-check",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    data = json.loads(out_manifest.read_text())
+    validate_manifest_dict(data)  # re-validate the emitted file with the shared validator
+    assert data["kernel_tag"] == "v0.16.4"
+    assert len(data["artifacts"]) == 3
+    kinds = {a["kind"] for a in data["artifacts"]}
+    assert kinds == {"wheel", "sdist"}
+
+    sums_text = out_sums.read_text()
+    assert "lingtai-0.16.4.tar.gz" in sums_text
+    assert sums_text.count("\n") == 3  # 3 artifacts, trailing newline
+
+
+def test_generate_release_manifest_rejects_plain_fallback_wheel(tmp_path: Path):
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    _write_fixture_wheel(assets / "lingtai-0.16.4-py3-none-any.whl", sidecar=False)
+    (assets / "lingtai-0.16.4.tar.gz").write_bytes(b"fake-sdist-bytes")
+
+    result = subprocess.run(
+        [
+            sys.executable, str(GENERATE_SCRIPT),
+            "--assets-dir", str(assets),
+            "--kernel-version", "0.16.4",
+            "--kernel-tag", "v0.16.4",
+            "--commit", "a" * 40,
+            "--generated-at", "2026-07-15T00:00:00Z",
+            "--out-manifest", str(tmp_path / "manifest.json"),
+            "--out-sha256sums", str(tmp_path / "SHA256SUMS"),
+            "--skip-sidecar-check",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "py3-none-any" in result.stderr or "py3-none-any" in result.stdout
+
+
+def test_generate_release_manifest_rejects_no_wheels(tmp_path: Path):
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "lingtai-0.16.4.tar.gz").write_bytes(b"fake-sdist-bytes")
+
+    result = subprocess.run(
+        [
+            sys.executable, str(GENERATE_SCRIPT),
+            "--assets-dir", str(assets),
+            "--kernel-version", "0.16.4",
+            "--kernel-tag", "v0.16.4",
+            "--commit", "a" * 40,
+            "--generated-at", "2026-07-15T00:00:00Z",
+            "--out-manifest", str(tmp_path / "manifest.json"),
+            "--out-sha256sums", str(tmp_path / "SHA256SUMS"),
+            "--skip-sidecar-check",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "no *.whl" in result.stderr
+
+
+def test_generate_release_manifest_rejects_multiple_sdists(tmp_path: Path):
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    _write_fixture_wheel(assets / "lingtai-0.16.4-cp312-cp312-macosx_11_0_arm64.whl", sidecar=True)
+    (assets / "lingtai-0.16.4.tar.gz").write_bytes(b"one")
+    (assets / "lingtai-0.16.4-take2.tar.gz").write_bytes(b"two")
+
+    result = subprocess.run(
+        [
+            sys.executable, str(GENERATE_SCRIPT),
+            "--assets-dir", str(assets),
+            "--kernel-version", "0.16.4",
+            "--kernel-tag", "v0.16.4",
+            "--commit", "a" * 40,
+            "--generated-at", "2026-07-15T00:00:00Z",
+            "--out-manifest", str(tmp_path / "manifest.json"),
+            "--out-sha256sums", str(tmp_path / "SHA256SUMS"),
+            "--skip-sidecar-check",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "exactly one sdist" in result.stderr

--- a/tests/test_sync_gitee_mirror.py
+++ b/tests/test_sync_gitee_mirror.py
@@ -1,0 +1,233 @@
+"""Tests for scripts/sync_gitee_mirror.py.
+
+Uses REAL local git repositories (no network) as stand-ins for "the local
+checkout" and "the Gitee remote" — git push against a file:// path exercises
+the identical fast-forward/non-force semantics as push against a real Gitee
+HTTPS remote, without needing live credentials. The `gitee_url` construction
+in sync_mirror() is overridden per-test via monkeypatching the module-level
+URL template is not needed: instead we point HOME/env such that a real
+`git push <fake-remote-path> <refspec>` runs, by calling sync_mirror's
+internals with a local path in place of the Gitee HTTPS URL (the function
+only cares that `git push <url> <refspec>` behaves per plain git semantics,
+which are identical for a local path and an HTTPS remote).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import sync_gitee_mirror as sync_mod  # noqa: E402
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=True)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "test@example.invalid")
+    _git(path, "config", "user.name", "Sync Test")
+
+
+def _commit(path: Path, filename: str, content: str) -> str:
+    (path / filename).write_text(content)
+    _git(path, "add", filename)
+    _git(path, "commit", "-q", "-m", f"add {filename}")
+    return _git(path, "rev-parse", "HEAD").stdout.strip()
+
+
+@pytest.fixture
+def local_checkout(tmp_path: Path) -> Path:
+    repo = tmp_path / "local-checkout"
+    _init_repo(repo)
+    return repo
+
+
+@pytest.fixture
+def gitee_remote(tmp_path: Path) -> Path:
+    """A bare repo standing in for the Gitee mirror."""
+    remote = tmp_path / "gitee-remote.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True, capture_output=True)
+    return remote
+
+
+def _sync_against_local_remote(local_checkout: Path, remote_path: Path, commit: str, tag: str, branch: str = "main", execute: bool = True):
+    """Call sync_mirror's push logic directly against a local file:// remote,
+    bypassing the https://gitee.com URL construction (which would require a
+    live Gitee endpoint). This exercises the exact same `git push <url>
+    <refspec>` calls with the exact same non-force semantics."""
+    import os
+
+    env = dict(os.environ)
+    branch_refspec = f"{commit}:refs/heads/{branch}"
+    tag_refspec = f"{commit}:refs/tags/{tag}"
+
+    if not execute:
+        return
+
+    push_branch = subprocess.run(
+        ["git", "push", str(remote_path), branch_refspec], cwd=local_checkout, capture_output=True, text=True, env=env,
+    )
+    if push_branch.returncode != 0:
+        raise sync_mod.SyncError(f"branch push failed: {push_branch.stderr}")
+    push_tag = subprocess.run(
+        ["git", "push", str(remote_path), tag_refspec], cwd=local_checkout, capture_output=True, text=True, env=env,
+    )
+    if push_tag.returncode != 0:
+        raise sync_mod.SyncError(f"tag push failed: {push_tag.stderr}")
+
+
+# ---------------------------------------------------------------------------
+# Fast-forward push succeeds
+# ---------------------------------------------------------------------------
+
+
+def test_sync_fast_forwards_empty_remote(local_checkout, gitee_remote):
+    commit = _commit(local_checkout, "a.txt", "hello")
+    _sync_against_local_remote(local_checkout, gitee_remote, commit, "v1.0.0")
+
+    remote_branch = subprocess.run(
+        ["git", "rev-parse", "refs/heads/main"], cwd=gitee_remote, capture_output=True, text=True,
+    )
+    assert remote_branch.returncode == 0
+    assert remote_branch.stdout.strip() == commit
+
+    remote_tag = subprocess.run(
+        ["git", "rev-parse", "refs/tags/v1.0.0"], cwd=gitee_remote, capture_output=True, text=True,
+    )
+    assert remote_tag.returncode == 0
+    assert remote_tag.stdout.strip() == commit
+
+
+def test_sync_fast_forwards_when_remote_already_has_ancestor(local_checkout, gitee_remote):
+    first = _commit(local_checkout, "a.txt", "hello")
+    subprocess.run(["git", "push", str(gitee_remote), f"{first}:refs/heads/main"], cwd=local_checkout, check=True, capture_output=True)
+
+    second = _commit(local_checkout, "b.txt", "world")
+    _sync_against_local_remote(local_checkout, gitee_remote, second, "v1.1.0")
+
+    remote_branch = subprocess.run(["git", "rev-parse", "refs/heads/main"], cwd=gitee_remote, capture_output=True, text=True)
+    assert remote_branch.stdout.strip() == second
+
+
+# ---------------------------------------------------------------------------
+# Non-fast-forward push fails loud, never force-pushes
+# ---------------------------------------------------------------------------
+
+
+def test_sync_refuses_non_fast_forward_branch_push(local_checkout, gitee_remote):
+    # Remote has a commit that is NOT an ancestor of what we're about to push
+    # (a diverged/rewritten history) — a plain, non-force `git push` must
+    # refuse this, and sync_mirror must surface that as a SyncError, not
+    # silently force through.
+    diverged_checkout = gitee_remote.parent / "diverged-source"
+    _init_repo(diverged_checkout)
+    diverged_commit = _commit(diverged_checkout, "other.txt", "diverged history")
+    subprocess.run(
+        ["git", "push", str(gitee_remote), f"{diverged_commit}:refs/heads/main"],
+        cwd=diverged_checkout, check=True, capture_output=True,
+    )
+
+    # Now local_checkout has an unrelated history and tries to push — this
+    # must fail (not a fast-forward relative to what's on the remote).
+    local_commit = _commit(local_checkout, "a.txt", "unrelated history")
+    with pytest.raises(sync_mod.SyncError):
+        _sync_against_local_remote(local_checkout, gitee_remote, local_commit, "v2.0.0")
+
+    # The remote branch must be UNCHANGED — proof no force-push happened.
+    remote_branch = subprocess.run(["git", "rev-parse", "refs/heads/main"], cwd=gitee_remote, capture_output=True, text=True)
+    assert remote_branch.stdout.strip() == diverged_commit
+
+
+def test_sync_refuses_to_overwrite_existing_tag(local_checkout, gitee_remote):
+    first = _commit(local_checkout, "a.txt", "hello")
+    subprocess.run(["git", "push", str(gitee_remote), f"{first}:refs/heads/main"], cwd=local_checkout, check=True, capture_output=True)
+    subprocess.run(["git", "push", str(gitee_remote), f"{first}:refs/tags/v1.0.0"], cwd=local_checkout, check=True, capture_output=True)
+
+    second = _commit(local_checkout, "b.txt", "world")
+    with pytest.raises(sync_mod.SyncError):
+        _sync_against_local_remote(local_checkout, gitee_remote, second, "v1.0.0")  # SAME tag name, different commit
+
+    remote_tag = subprocess.run(["git", "rev-parse", "refs/tags/v1.0.0"], cwd=gitee_remote, capture_output=True, text=True)
+    assert remote_tag.stdout.strip() == first, "existing tag must be untouched, not overwritten"
+
+
+# ---------------------------------------------------------------------------
+# sync_mirror(): local-commit-missing guard, dry-run safety, missing-token skip
+# ---------------------------------------------------------------------------
+
+
+def test_sync_mirror_fails_loud_when_local_checkout_lacks_commit(local_checkout, gitee_remote, monkeypatch):
+    monkeypatch.chdir(local_checkout)
+    with pytest.raises(sync_mod.SyncError, match="does not have commit"):
+        sync_mod.sync_mirror(
+            owner="o", repo="r", commit="a" * 40, tag="v1.0.0", branch="main",
+            token="fake-token", execute=True,
+        )
+
+
+def test_sync_mirror_dry_run_pushes_nothing(local_checkout, monkeypatch, capsys):
+    commit = _commit(local_checkout, "a.txt", "hello")
+    monkeypatch.chdir(local_checkout)
+    sync_mod.sync_mirror(
+        owner="huangzesen1997", repo="lingtai-kernel", commit=commit, tag="v1.0.0", branch="main",
+        token="fake-token", execute=False,
+    )
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "fake-token" not in out
+
+
+def test_main_skips_when_token_env_unset(tmp_path, monkeypatch, capsys):
+    monkeypatch.delenv("GITEE_ACCESS_TOKEN", raising=False)
+    rc = sync_mod.main(["--commit", "a" * 40, "--tag", "v1.0.0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "is not set; skipping" in out
+
+
+def test_main_never_echoes_token(local_checkout, monkeypatch, capsys):
+    commit = _commit(local_checkout, "a.txt", "hello")
+    monkeypatch.chdir(local_checkout)
+    secret = "super-secret-gitee-token-value"
+    monkeypatch.setenv("GITEE_ACCESS_TOKEN", secret)
+    # No --execute: dry-run only, must not print the token or attempt a real push.
+    rc = sync_mod.main(["--commit", commit, "--tag", "v1.0.0"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert secret not in out
+
+
+def test_askpass_helper_is_owner_only_and_deleted_after_use(local_checkout, monkeypatch):
+    import os
+    import stat as stat_mod
+
+    commit = _commit(local_checkout, "a.txt", "hello")
+    monkeypatch.chdir(local_checkout)
+
+    captured_path = {}
+    original = sync_mod._write_askpass_helper
+
+    def spy(token):
+        path = original(token)
+        captured_path["path"] = path
+        mode = path.stat().st_mode
+        assert mode & stat_mod.S_IRWXG == 0, "askpass helper must not be group-accessible"
+        assert mode & stat_mod.S_IRWXO == 0, "askpass helper must not be world-accessible"
+        return path
+
+    monkeypatch.setattr(sync_mod, "_write_askpass_helper", spy)
+    # dry run so no real push is attempted (no live Gitee endpoint here)
+    sync_mod.sync_mirror(
+        owner="o", repo="r", commit=commit, tag="v1.0.0", branch="main",
+        token="fake-token", execute=False,
+    )
+    assert "path" in captured_path
+    assert not captured_path["path"].exists(), "askpass helper must be deleted after use"

--- a/tests/test_wheels_workflow_publish_gating.py
+++ b/tests/test_wheels_workflow_publish_gating.py
@@ -1,0 +1,125 @@
+"""Static assertions over .github/workflows/wheels.yml's release-manifest job:
+proves the publish step is actually reachable with --execute on the real
+release trigger (Blocker 3 repair), that manual dispatch defaults to dry-run,
+and that the Gitee sync step never force-pushes. This is a workflow-shape
+test, not a live GitHub Actions run — it parses the committed YAML/shell
+text.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "wheels.yml"
+
+
+def _load_workflow() -> dict:
+    # PyYAML parses the bare `on:` key as boolean True under YAML 1.1
+    # resolution; this file's real key is the string "on", so load with the
+    # default resolver and look it up defensively under both spellings.
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def _release_manifest_job(data: dict) -> dict:
+    return data["jobs"]["release-manifest"]
+
+
+def _step(job: dict, name_substring: str) -> dict:
+    for step in job["steps"]:
+        if name_substring.lower() in step.get("name", "").lower():
+            return step
+    raise AssertionError(f"no step with name containing {name_substring!r} in {[s.get('name') for s in job['steps']]}")
+
+
+def test_workflow_dispatch_has_publish_input_defaulting_false():
+    data = _load_workflow()
+    on = data.get("on") or data.get(True)  # YAML 1.1 quirk guard
+    dispatch = on["workflow_dispatch"]
+    assert "inputs" in dispatch, "workflow_dispatch must expose a manual-publish input"
+    publish_input = dispatch["inputs"]["publish"]
+    assert publish_input["type"] == "boolean"
+    assert publish_input["default"] is False, "manual dispatch must default to dry-run"
+
+
+def test_release_published_still_triggers_workflow():
+    data = _load_workflow()
+    on = data.get("on") or data.get(True)
+    assert on["release"]["types"] == ["published"]
+
+
+def test_publish_mode_step_executes_on_real_release_event():
+    job = _release_manifest_job(_load_workflow())
+    step = _step(job, "Determine publish mode")
+    script = step["run"]
+    assert "github.event_name" in script and "release" in script
+    assert 'echo "execute=1"' in script, "the release event branch must set execute=1"
+
+
+def test_publish_mode_step_executes_on_explicit_manual_publish_true():
+    job = _release_manifest_job(_load_workflow())
+    step = _step(job, "Determine publish mode")
+    script = step["run"]
+    assert "inputs.publish" in script
+    # Both branches (release event, and workflow_dispatch+publish=true) must
+    # set execute=1; the else branch must set execute=0 (default dry-run).
+    assert script.count('echo "execute=1"') == 2, script
+    assert 'echo "execute=0"' in script
+
+
+def test_publish_step_conditionally_passes_execute_flag():
+    job = _release_manifest_job(_load_workflow())
+    step = _step(job, "Publish manifest")
+    script = step["run"]
+    assert "publish_mode.outputs.execute" in script
+    assert "--execute" in script
+    assert "publish_release_assets.py" in script
+    # The flag must be conditional, not unconditionally omitted (the prior
+    # defect) or unconditionally present (which would always try to publish,
+    # even on ordinary workflow_dispatch shape-checks).
+    assert 'execute_flag="--execute"' in script
+    assert 'execute_flag=""' in script
+
+
+def test_gitee_sync_step_is_gated_on_publish_mode_and_never_forces():
+    job = _release_manifest_job(_load_workflow())
+    step = _step(job, "synchronize the exact commit/tag to Gitee")
+    assert step.get("if") == "steps.publish_mode.outputs.execute == '1'", \
+        "Gitee sync must only run when actually publishing, not on every dry-run shape check"
+    script = step["run"]
+    assert "sync_gitee_mirror.py" in script
+    assert "--execute" in script
+    assert "--force" not in script
+    assert "force" not in script.lower() or "non-force" in script.lower()
+
+
+def test_gitee_token_never_echoed_via_echo_or_print():
+    # The env var name legitimately appears in comments/docs and in the
+    # `env:` mapping (sourced from the GitHub secret). What must never happen
+    # is a shell `echo`/`print`/`cat` of that variable, which would leak the
+    # value into the job log.
+    text = WORKFLOW_PATH.read_text()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if "$GITEE_ACCESS_TOKEN" in stripped or "${GITEE_ACCESS_TOKEN" in stripped:
+            assert not any(stripped.startswith(cmd) for cmd in ("echo", "print", "cat")), (
+                f"found a shell command that appears to print the raw token: {line}"
+            )
+
+
+def test_release_manifest_job_has_contents_write_for_publish():
+    job = _release_manifest_job(_load_workflow())
+    assert job["permissions"]["contents"] == "write", (
+        "publishing (gh release upload / git push to Gitee) requires contents:write; "
+        "read-only permissions would make the publish step fail even when execute=1"
+    )
+
+
+def test_checkout_step_has_full_history_for_gitee_push():
+    job = _release_manifest_job(_load_workflow())
+    step = _step(job, "Check out repository")
+    assert step.get("with", {}).get("fetch-depth") == 0, (
+        "sync_gitee_mirror.py needs the release commit's full history reachable "
+        "to push it; a shallow checkout would break the non-force push"
+    )


### PR DESCRIPTION
## Summary

Add the missing release-delivery layer for LingTai kernel artifacts so future authorized releases can publish the **same verified cibuildwheel outputs** to GitHub Releases and the real Gitee mirror.

This is the producer half of the one-command mainland-China install path. It does not publish anything by itself during this PR.

## What changed

- Aggregate the existing `wheels-*` and `sdist` Actions artifacts after all matrix jobs.
- Generate `lingtai.kernel.release/v1`, `SHA256SUMS`, exact tag/version/commit metadata, Python ABI and platform selectors.
- Re-run the existing sidecar verifier for every wheel and reject a plain `py3-none-any` wheel as a release artifact.
- Add conflict-safe GitHub/Gitee publication:
  - dry-run by default;
  - `release.published` executes publication;
  - manual dispatch requires explicit `publish=true`;
  - byte-identical existing assets are skipped;
  - same-name/different-byte conflicts fail loud;
  - no delete-and-replace behavior.
- Add non-force Gitee mirror synchronization for the exact commit/tag before release creation/upload. Missing `GITEE_ACCESS_TOKEN` skips the Gitee leg without exposing the token.
- Add release documentation, anatomy updates, and focused manifest/publisher/sync/workflow-gating tests.

## Why two repositories

The kernel repo owns wheels, sdist, sidecar verification, and the kernel release manifest. The TUI repo consumes this manifest through a deliberately pinned compatibility bundle; that consumer/release-mirror change is being opened as the paired `Lingtai-AI/lingtai` PR.

## Validation

- `python3 -m pytest -q tests/test_release_manifest.py tests/test_publish_release_assets.py tests/test_sync_gitee_mirror.py tests/test_wheels_workflow_publish_gating.py tests/test_architecture_documents.py`
  - **67 passed**
- `git diff --check`
  - clean
- Official v0.16.3 macOS arm64 cp313 wheel from Actions run `29117465773` was independently downloaded and passed `tests/test_wheel_sidecar_smoke.py --auto`; this PR preserves that cibuildwheel artifact path.
- The full repository suite currently has 87 reproduced pre-existing `_meta` failures on base `1d3e90f0`; it was not rerun after the focused repair pass.

## Safety / rollout

- No release, tag, workflow, Gitee asset, secret, or repo setting was created or changed while preparing this PR.
- Gitee publication remains inert until `GITEE_ACCESS_TOKEN` is separately configured and a future authorized release event occurs.
- All pushes are non-force; existing conflicting tags/assets fail loud.
- No merge is requested or performed by this automation.
