### PR TITLE
fix(vision): route standalone vision through native providers

### DIFF
--- a/src/lingtai/services/vision/ANATOMY.md
+++ b/src/lingtai/services/vision/ANATOMY.md
@@ -30,7 +30,7 @@ Provider-specific image understanding — standalone services that own their own
 |------|-----|------|
 | `__init__.py` | 112 | `VisionService` ABC, `_MIME_BY_EXT` map, `_read_image()` helper, `create_vision_service()` factory |
 | `anthropic.py` | 61 | `AnthropicVisionService` — base64 inline image via Anthropic Messages API |
-| `codex.py` | 78 | `CodexVisionService` — ChatGPT Codex Responses API vision via OAuth token |
+| `codex.py` | 87 | `CodexVisionService` — ChatGPT Codex Responses API vision via OAuth token |
 | `gemini.py` | 53 | `GeminiVisionService` — `genai.Client` + `types.Part.from_bytes` |
 | `local.py` | 72 | `LocalVisionService` — mlx-vlm on Apple Silicon, lazy model load |
 | `mimo.py` | 75 | `MiMoVisionService` — OpenAI SDK to `api.xiaomimimo.com/v1` |
@@ -61,11 +61,11 @@ Provider-specific image understanding — standalone services that own their own
 
 ## Notes
 
-- **Image encoding** — Anthropic (`anthropic.py:34`) and OpenAI/MiMo/Codex (`openai.py:38`, `mimo.py:57`, `codex.py:45`) use base64 data URLs. Gemini (`gemini.py:37`) uses `types.Part.from_bytes`. Local passes file path directly to mlx-vlm. MCP providers send base64 in tool args (minimax) or file path (zhipu).
+- **Image encoding** — Anthropic (`anthropic.py:34`) and OpenAI/MiMo/Codex (`openai.py:38`, `mimo.py:57`, `codex.py:45-49`) use base64 data URLs. Gemini (`gemini.py:37`) uses `types.Part.from_bytes`. Local passes file path directly to mlx-vlm. MCP providers send base64 in tool args (minimax) or file path (zhipu).
 - **Default models** — Anthropic: `claude-sonnet-4-20250514`; Gemini: `gemini-2.5-flash`; OpenAI: `gpt-4o`; MiMo: `mimo-v2.5`; Codex: `gpt-5.5`; Local: `mlx-community/paligemma2-3b-ft-docci-448-8bit`.
 - **MCP tool names** — MiniMax: `understand_image` (`minimax.py:77`); Zhipu: `analyze_image` (`zhipu.py:70`).
 - **MCP launchers** — MiniMax uses `uvx minimax-coding-plan-mcp -y` (`minimax.py:64`); Zhipu uses `npx -y @z_ai/mcp-server` (`zhipu.py:58`).
 - **Zhipu path vs base64** — Zhipu MCP reads the file directly by path (`zhipu.py:70`), unlike other providers that base64-encode.
-- **Codex Responses API** — `codex.py` constructs `OpenAI(base_url="https://chatgpt.com/backend-api/codex")`, passes `instructions`, `stream=True`, `store=False`, `input_text` + `input_image` content blocks, and concatenates `response.output_text.delta` events. It omits `max_output_tokens` by default because the live ChatGPT Codex backend rejected that parameter (`codex.py:25-28`, `codex.py:70-71`).
+- **Codex Responses API** — `codex.py` refreshes access token and account id on every call, sends `ChatGPT-Account-ID` when available, constructs `OpenAI` with the selected base URL, passes `instructions`, `stream=True`, `store=False`, `input_text` + `input_image` content blocks, and concatenates `response.output_text.delta` events. It omits `max_output_tokens` by default because the live ChatGPT Codex backend rejected that parameter (`codex.py:25-28`, `codex.py:51-82`).
 - **Gemini thought filtering** — `gemini.py:51` skips `part.text` when `part.thought` is True to exclude reasoning output.
 - **Git history** — 7 commits. Key: MiMo provider addition (`a728864`), zhipu path-based input fix (`2e6d53c`), region-aware ZAI/ZHIPU mode (`bed1c1e`).

--- a/src/lingtai/services/vision/ANATOMY.md
+++ b/src/lingtai/services/vision/ANATOMY.md
@@ -28,7 +28,7 @@ Provider-specific image understanding — standalone services that own their own
 
 | File | LOC | Role |
 |------|-----|------|
-| `__init__.py` | 112 | `VisionService` ABC, `_MIME_BY_EXT` map, `_read_image()` helper, `create_vision_service()` factory |
+| `__init__.py` | 131 | `VisionService` ABC, `_MIME_BY_EXT` map, `_read_image()` helper, `create_vision_service()` factory |
 | `anthropic.py` | 61 | `AnthropicVisionService` — base64 inline image via Anthropic Messages API |
 | `codex.py` | 87 | `CodexVisionService` — ChatGPT Codex Responses API vision via OAuth token |
 | `gemini.py` | 53 | `GeminiVisionService` — `genai.Client` + `types.Part.from_bytes` |
@@ -40,8 +40,8 @@ Provider-specific image understanding — standalone services that own their own
 
 ## Connections
 
-- **ABC contract** — all providers inherit `VisionService` (`__init__.py:17`); single abstract method `analyze_image(image_path, prompt) -> str`.
-- **Factory** — `create_vision_service(provider, api_key=...)` at `__init__.py:63` dispatches by name with lazy imports. Supported: `anthropic`, `openai`, `gemini`, `minimax`, `zhipu`, `mimo`, `codex`, `local`.
+- **ABC contract** — all providers inherit `VisionService` (`__init__.py:18`); single abstract method `analyze_image(image_path, prompt) -> str`.
+- **Factory** — `create_vision_service(provider, api_key=...)` at `__init__.py:82` dispatches by name with lazy imports. Supported: `anthropic`, `openai`, `gemini`, `minimax`, `zhipu`, `mimo`, `codex`, `local`.
 - **MCP dependency** — `minimax.py` and `zhipu.py` import `lingtai.services.mcp.MCPClient` for subprocess-based tool calls.
 - **External SDKs** — `anthropic` (Anthropic SDK), `openai` (OpenAI SDK; OpenAI/MiMo/Codex), `google.genai` (Gemini), `mlx_vlm` (local).
 - **Logging** — MCP providers use `lingtai.kernel.logging.get_logger`.
@@ -49,7 +49,7 @@ Provider-specific image understanding — standalone services that own their own
 ## Composition
 
 - **Standalone ownership** — each service creates and owns its own SDK client + credentials. API providers use API keys; Codex uses `CodexTokenManager`/ChatGPT OAuth; all remain independent of LLM adapters or agents.
-- **Shared helper** — `_read_image(image_path) -> (bytes, mime_type)` at `__init__.py:47` used by all API-based providers.
+- **Shared helper** — `_read_image(image_path) -> (bytes, mime_type)` at `__init__.py:48` used by all API-based providers.
 - **MCP lazy init** — `minimax.py:34` (`_ensure_client`) and `zhipu.py:29` (`_ensure_client`) start MCP subprocesses on first call, with stale-connection recovery. Both expose `close()` for subprocess teardown.
 - **Local lazy load** — `local.py:39` (`_ensure_loaded`) defers `mlx_vlm.load()` to first `analyze_image` call.
 
@@ -62,7 +62,7 @@ Provider-specific image understanding — standalone services that own their own
 ## Notes
 
 - **Image encoding** — Anthropic (`anthropic.py:34`) and OpenAI/MiMo/Codex (`openai.py:38`, `mimo.py:57`, `codex.py:45-49`) use base64 data URLs. Gemini (`gemini.py:37`) uses `types.Part.from_bytes`. Local passes file path directly to mlx-vlm. MCP providers send base64 in tool args (minimax) or file path (zhipu).
-- **Default models** — Anthropic: `claude-sonnet-4-20250514`; Gemini: `gemini-2.5-flash`; OpenAI: `gpt-4o`; MiMo: `mimo-v2.5`; Codex: `gpt-5.5`; Local: `mlx-community/paligemma2-3b-ft-docci-448-8bit`.
+- **Default models** — Anthropic: `claude-sonnet-4-20250514`; Gemini: `gemini-3-flash-preview`; OpenAI: `gpt-4o`; MiMo: `mimo-v2.5`; Codex: `gpt-5.5`; Local: `mlx-community/paligemma2-3b-ft-docci-448-8bit`.
 - **MCP tool names** — MiniMax: `understand_image` (`minimax.py:77`); Zhipu: `analyze_image` (`zhipu.py:70`).
 - **MCP launchers** — MiniMax uses `uvx minimax-coding-plan-mcp -y` (`minimax.py:64`); Zhipu uses `npx -y @z_ai/mcp-server` (`zhipu.py:58`).
 - **Zhipu path vs base64** — Zhipu MCP reads the file directly by path (`zhipu.py:70`), unlike other providers that base64-encode.

--- a/src/lingtai/services/vision/codex.py
+++ b/src/lingtai/services/vision/codex.py
@@ -48,11 +48,19 @@ class CodexVisionService(VisionService):
         b64 = base64.b64encode(image_bytes).decode("utf-8")
         data_url = f"data:{mime_type};base64,{b64}"
 
-        client = self._openai.OpenAI(
-            api_key=self._token_manager.get_access_token(),
-            base_url=self._base_url,
-            timeout=self._timeout,
-        )
+        # Refresh both bearer and account metadata for every standalone image
+        # request. Account ids are non-secret and only identify the ChatGPT
+        # account; omit the header when the selected auth data has none.
+        access_token = self._token_manager.get_access_token()
+        account_id = self._token_manager.get_account_id()
+        client_kwargs: dict[str, Any] = {
+            "api_key": access_token,
+            "base_url": self._base_url,
+            "timeout": self._timeout,
+        }
+        if isinstance(account_id, str) and account_id:
+            client_kwargs["default_headers"] = {"ChatGPT-Account-ID": account_id}
+        client = self._openai.OpenAI(**client_kwargs)
         kwargs: dict[str, Any] = {
             "model": self._model,
             "instructions": self._instructions,

--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -23,19 +23,20 @@ Vision capability — image understanding via pluggable VisionService backends.
 
 | File | LOC | Role |
 |---|---|---|
-| `__init__.py` | 153 | `VisionManager`, `setup()`, provider registry, tool schema |
+| `__init__.py` | 232 | `VisionManager`, `setup()`, provider registry, tool schema |
 
 **Key symbols:**
-- `PROVIDERS` (L27-31) — supported providers: `minimax`, `zhipu`, `mimo`, `gemini`, `anthropic`, `openai`, `codex`. No static default; OpenAI-compat inherit fallback lives in `setup()`, not the registry.
-- `VisionManager` (L53) — handles tool calls; resolves relative image paths via `agent._working_dir` (L73).
-- `setup()` (L90) — entry point called by `capabilities.setup_capability()`. Creates `VisionManager`, registers `"vision"` tool on agent (L134).
+- `PROVIDERS` (L28-35) — supported providers include `codex`, `codex-pool`, and `codex_pool`; no static default.
+- `VisionManager` (L57-91) — handles tool calls; resolves relative image paths via `agent._working_dir` (L75-80).
+- `setup()` (L94-232) — entry point called by `capabilities.setup_capability()`. Creates `VisionManager`, registers `"vision"` tool on agent (L230-231).
 
 ## Connections
 
-- **→ `lingtai.i18n.t`** (L21) — i18n for tool description and schema strings.
-- **→ `lingtai.services.vision.VisionService`** (L22) — abstract service interface + `create_vision_service()` factory.
-- **→ `capabilities._media_host.resolve_media_host`** (L120) — injected for `minimax` provider.
-- **→ `capabilities._zhipu_mode.resolve_z_ai_mode`** (L123) — injected for `zhipu` provider.
+- **→ `lingtai.services.vision.VisionService`** (L24-26) — abstract service interface, imported only for type checking.
+- **→ `lingtai.services.vision.create_vision_service`** (L206-223) — lazy factory import for dedicated provider services.
+- **→ `lingtai.auth.codex_pool.select_codex_pool_auth`** (L195-199) — lazy pool auth selection for Codex-family vision aliases.
+- **→ `capabilities._media_host.resolve_media_host`** (L212-213) — injected for `minimax` provider.
+- **→ `capabilities._zhipu_mode.resolve_z_ai_mode`** (L215-216) — injected for `zhipu` provider.
 - **→ `lingtai.kernel.base_agent.BaseAgent`** — type-only (L25).
 - **← `capabilities.__init__`** — registered as `".vision"` in `_BUILTIN`.
 
@@ -45,13 +46,13 @@ Single file. No internal state — `VisionManager` instances hold agent + servic
 
 ## State
 
-- `VisionManager._agent` / `_vision_service` (L61-62) — per-agent instance state. Stateless tool handler otherwise.
+- `VisionManager._agent` / `_vision_service` (L65-66) — per-agent instance state. Stateless tool handler otherwise.
 - `PROVIDERS` dict is module-level constant.
 
 ## Notes
 
 - OpenAI-compat fallback: if the agent's provider isn't in `PROVIDERS` but the main LLM's `_provider_defaults["api_compat"] == "openai"`, vision routes through `OpenAIVisionService` using the LLM's own `base_url`/`model`/`api_key`. Lets `custom`/`openrouter`/`deepseek`/`kimi` users opt into vision via `vision: {"provider": "inherit"}` in their preset. Succeeds only if the relay+model actually support OpenAI-style `image_url` content blocks; otherwise the runtime call surfaces the relay's error.
 - Graceful skip: if the agent's provider isn't in `PROVIDERS` AND the LLM is not OpenAI-compatible, setup returns `None` silently. Agent logs `capability_skipped`.
-- Codex is exposed through `PROVIDERS` and flows to `create_vision_service("codex", api_key=None)`; the service uses ChatGPT OAuth rather than an API key.
+- Codex-family aliases flow to `create_vision_service("codex", api_key=None)` (L173-207); pool aliases select a non-secret auth path first, while direct Codex honors its provider bucket's `codex_auth_path`. Active Codex-family model/endpoint values are forwarded only for a Codex-family main service.
 - Provider-specific kwarg injection is opt-in per provider — prevents `TypeError` from passing unsupported kwargs to heterogeneous service constructors.
-- Local mlx-vlm provider exists in `services/vision/local.py` but is intentionally hidden from `PROVIDERS` (see docstring L11-14).
+- Local mlx-vlm provider exists in `services/vision/local.py` but is intentionally hidden from `PROVIDERS` (see docstring L10-14).

--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -51,7 +51,7 @@ Single file. No internal state — `VisionManager` instances hold agent + servic
 
 ## Notes
 
-- OpenAI-compat fallback: if the agent's provider isn't in `PROVIDERS` but the main LLM's `_provider_defaults["api_compat"] == "openai"`, vision routes through `OpenAIVisionService` using the LLM's own `base_url`/`model`/`api_key`. Lets `custom`/`openrouter`/`deepseek`/`kimi` users opt into vision via `vision: {"provider": "inherit"}` in their preset. Succeeds only if the relay+model actually support OpenAI-style `image_url` content blocks; otherwise the runtime call surfaces the relay's error.
+- OpenAI-compat fallback: if the agent's provider isn't in `PROVIDERS` but the main LLM's provider-keyed `_provider_defaults[provider.lower()]["api_compat"] == "openai"`, vision routes through `OpenAIVisionService` using the LLM's own `base_url`/`model`/`api_key`. Lets `custom`/`openrouter`/`deepseek`/`kimi` users opt into vision via `vision: {"provider": "inherit"}` in their preset. Succeeds only if the relay+model actually support OpenAI-style `image_url` content blocks; otherwise the runtime call surfaces the relay's error.
 - Graceful skip: if the agent's provider isn't in `PROVIDERS` AND the LLM is not OpenAI-compatible, setup returns `None` silently. Agent logs `capability_skipped`.
 - Codex-family aliases flow to `create_vision_service("codex", api_key=None)` (L173-207); pool aliases select a non-secret auth path first, while direct Codex honors its provider bucket's `codex_auth_path`. Active Codex-family model/endpoint values are forwarded only for a Codex-family main service.
 - Provider-specific kwarg injection is opt-in per provider — prevents `TypeError` from passing unsupported kwargs to heterogeneous service constructors.

--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -23,20 +23,20 @@ Vision capability — image understanding via pluggable VisionService backends.
 
 | File | LOC | Role |
 |---|---|---|
-| `__init__.py` | 232 | `VisionManager`, `setup()`, provider registry, tool schema |
+| `__init__.py` | 250 | `VisionManager`, `setup()`, provider registry, tool schema |
 
 **Key symbols:**
-- `PROVIDERS` (L28-35) — supported providers include `codex`, `codex-pool`, and `codex_pool`; no static default.
+- `PROVIDERS` (L28-35) — supported providers include `zhipu`/`glm`, `codex`, `codex-pool`, and `codex_pool`; no static default.
 - `VisionManager` (L57-91) — handles tool calls; resolves relative image paths via `agent._working_dir` (L75-80).
-- `setup()` (L94-232) — entry point called by `capabilities.setup_capability()`. Creates `VisionManager`, registers `"vision"` tool on agent (L230-231).
+- `setup()` (L94-250) — entry point called by `capabilities.setup_capability()`. Creates `VisionManager`, registers `"vision"` tool on agent (L248-249).
 
 ## Connections
 
 - **→ `lingtai.services.vision.VisionService`** (L24-26) — abstract service interface, imported only for type checking.
-- **→ `lingtai.services.vision.create_vision_service`** (L206-223) — lazy factory import for dedicated provider services.
+- **→ `lingtai.services.vision.create_vision_service`** (L206-241) — lazy factory import for dedicated provider services.
 - **→ `lingtai.auth.codex_pool.select_codex_pool_auth`** (L195-199) — lazy pool auth selection for Codex-family vision aliases.
-- **→ `capabilities._media_host.resolve_media_host`** (L212-213) — injected for `minimax` provider.
-- **→ `capabilities._zhipu_mode.resolve_z_ai_mode`** (L215-216) — injected for `zhipu` provider.
+- **→ `capabilities._media_host.resolve_media_host`** (L228-230) — injected for `minimax` provider.
+- **→ `capabilities._zhipu_mode.resolve_z_ai_mode`** (L231-233) — injected for `zhipu`/`glm` provider routing.
 - **→ `lingtai.kernel.base_agent.BaseAgent`** — type-only (L25).
 - **← `capabilities.__init__`** — registered as `".vision"` in `_BUILTIN`.
 
@@ -53,6 +53,8 @@ Single file. No internal state — `VisionManager` instances hold agent + servic
 
 - OpenAI-compat fallback: if the agent's provider isn't in `PROVIDERS` but the main LLM's provider-keyed `_provider_defaults[provider.lower()]["api_compat"] == "openai"`, vision routes through `OpenAIVisionService` using the LLM's own `base_url`/`model`/`api_key`. Lets `custom`/`openrouter`/`deepseek`/`kimi` users opt into vision via `vision: {"provider": "inherit"}` in their preset. Succeeds only if the relay+model actually support OpenAI-style `image_url` content blocks; otherwise the runtime call surfaces the relay's error.
 - Graceful skip: if the agent's provider isn't in `PROVIDERS` AND the LLM is not OpenAI-compatible, setup returns `None` silently. Agent logs `capability_skipped`.
-- Codex-family aliases flow to `create_vision_service("codex", api_key=None)` (L173-207); pool aliases select a non-secret auth path first, while direct Codex honors its provider bucket's `codex_auth_path`. Active Codex-family model/endpoint values are forwarded only for a Codex-family main service.
+- Codex-family aliases flow to `create_vision_service("codex", api_key=None)` (L174-207); pool aliases select a non-secret auth path first, while direct Codex honors its provider bucket's `codex_auth_path`. Active Codex-family model/endpoint values are forwarded only for a Codex-family main service.
+- Direct-native `openai`, `anthropic`, and `gemini` preserve same-provider active model values in standalone vision unless capability `model` is explicit; `openai`/`anthropic` also preserve same-provider `base_url` (L217-225). MiMo preserves explicit model/default vision model behavior and may preserve same-provider `base_url` (L226-227).
+- `glm` is normalized to the existing `zhipu` MCP vision service rather than treated as a new direct provider (L209, L231-233, L241).
 - Provider-specific kwarg injection is opt-in per provider — prevents `TypeError` from passing unsupported kwargs to heterogeneous service constructors.
 - Local mlx-vlm provider exists in `services/vision/local.py` but is intentionally hidden from `PROVIDERS` (see docstring L10-14).

--- a/src/lingtai/tools/vision/CONTRACT.md
+++ b/src/lingtai/tools/vision/CONTRACT.md
@@ -40,10 +40,19 @@ lazy-import DAG rule -> §Cross-platform invariants.
 - Canonical tool name: `vision`.
 - One tool, one call — no actions, no persistent state.
 - Advertised providers (`PROVIDERS["providers"]`): `minimax`, `zhipu`, `mimo`,
-  `gemini`, `anthropic`, `openai`, `codex`. Default provider is `None` and there
+  `gemini`, `anthropic`, `openai`, `codex`, `codex-pool`, `codex_pool`. Default provider is `None` and there
   is no agnostic inherit fallback (`fallback_on_inherit: None`).
 - A local `mlx-vlm` provider (`provider="local"`) exists but is intentionally
   **not** advertised in `PROVIDERS`; users opt in explicitly.
+
+- `codex`, `codex-pool`, and `codex_pool` all construct the native standalone
+  Codex Responses vision service. Pool aliases select their initial auth path
+  with `select_codex_pool_auth(defaults, model=<exact configured model>)` and
+  never route through another provider's vision service.
+- When the active main provider is Codex-family, its configured model and
+  endpoint are forwarded to standalone vision. A non-Codex main provider does
+  not supply those values to an explicitly configured Codex vision provider.
+  Direct Codex uses the selected provider bucket's `codex_auth_path`.
 
 **Non-goals:** the capability does not pre-validate that the resolved
 model/relay can actually do vision — an incapable relay fails at runtime, not at
@@ -77,8 +86,13 @@ DOCUMENT ONLY — do not change these assumptions and do not propose Windows wor
   module import.
 - Provider-specific kwargs are injected per branch (e.g. MiniMax `api_host`,
   Zhipu `z_ai_mode`) because vision services have heterogeneous constructor
-  signatures; `api_compat` / `base_url` are popped before forwarding to
-  dedicated services.
+  signatures. Non-Codex dedicated services receive neither `api_compat` nor the
+  inherited LLM `base_url`. Codex-family vision strips `api_compat` but may
+  forward `base_url` intentionally when it came from an explicit capability
+  override or the active main provider is Codex-family.
+- `CodexVisionService` refreshes the selected OAuth token and account id for
+  each image call. It sends `ChatGPT-Account-ID` only when a non-secret account
+  id is available, and uses Responses `input_text` plus `input_image` blocks.
 - Unknown providers route through the OpenAI- or Anthropic-compatible service
   based on `api_compat`; if neither matches, the capability logs
   `capability_skipped` and returns `CAPABILITY_UNAVAILABLE`.

--- a/src/lingtai/tools/vision/CONTRACT.md
+++ b/src/lingtai/tools/vision/CONTRACT.md
@@ -39,9 +39,10 @@ lazy-import DAG rule -> §Cross-platform invariants.
 
 - Canonical tool name: `vision`.
 - One tool, one call — no actions, no persistent state.
-- Advertised providers (`PROVIDERS["providers"]`): `minimax`, `zhipu`, `mimo`,
-  `gemini`, `anthropic`, `openai`, `codex`, `codex-pool`, `codex_pool`. Default provider is `None` and there
-  is no agnostic inherit fallback (`fallback_on_inherit: None`).
+- Advertised providers (`PROVIDERS["providers"]`): `minimax`, `zhipu`, `glm`,
+  `mimo`, `gemini`, `anthropic`, `openai`, `codex`, `codex-pool`,
+  `codex_pool`. Default provider is `None` and there is no agnostic inherit
+  fallback (`fallback_on_inherit: None`).
 - A local `mlx-vlm` provider (`provider="local"`) exists but is intentionally
   **not** advertised in `PROVIDERS`; users opt in explicitly.
 
@@ -53,6 +54,18 @@ lazy-import DAG rule -> §Cross-platform invariants.
   endpoint are forwarded to standalone vision. A non-Codex main provider does
   not supply those values to an explicitly configured Codex vision provider.
   Direct Codex uses the selected provider bucket's `codex_auth_path`.
+- When the active main provider is the same direct-native provider, `openai`,
+  `anthropic`, and `gemini` standalone vision use the active model unless the
+  capability explicitly set `model`. `openai` and `anthropic` also use the
+  active base URL unless the capability explicitly set `base_url`; Gemini has
+  no base-url constructor and does not receive one here.
+- MiMo is a deliberate exception: explicit capability `model` wins, but without
+  one setup leaves the vision service on its known vision-capable default
+  (`mimo-v2.5`) instead of forwarding text-only active MiMo chat models. When
+  the active main provider is MiMo, setup may still forward the active base URL
+  unless the capability explicitly set `base_url`.
+- `glm` is a first-class vision alias for the existing Zhipu MCP vision service.
+  It is not a new direct-native provider.
 
 **Non-goals:** the capability does not pre-validate that the resolved
 model/relay can actually do vision — an incapable relay fails at runtime, not at
@@ -86,10 +99,13 @@ DOCUMENT ONLY — do not change these assumptions and do not propose Windows wor
   module import.
 - Provider-specific kwargs are injected per branch (e.g. MiniMax `api_host`,
   Zhipu `z_ai_mode`) because vision services have heterogeneous constructor
-  signatures. Non-Codex dedicated services receive neither `api_compat` nor the
-  inherited LLM `base_url`. Codex-family vision strips `api_compat` but may
-  forward `base_url` intentionally when it came from an explicit capability
-  override or the active main provider is Codex-family.
+  signatures. Dedicated services never receive `api_compat`. Direct-native
+  `openai`, `anthropic`, `gemini`, and Codex-family services may receive the
+  active model only from the same active provider family unless capability
+  `model` was explicit. `openai`, `anthropic`, MiMo, and Codex-family services
+  may receive `base_url` when it came from an explicit capability override or
+  from the same active provider family; Gemini, MiniMax, and Zhipu/`glm` do not
+  receive inherited `base_url` through the service constructor.
 - `CodexVisionService` refreshes the selected OAuth token and account id for
   each image call. It sends `ChatGPT-Account-ID` only when a non-secret account
   id is available, and uses Responses `input_text` plus `input_image` blocks.
@@ -110,6 +126,10 @@ There are no subprocess/shell/PTY/binary-spawn assumptions in this tool.
 | Unsupported provider with an api_compat routes to the compat service | `src/lingtai/tools/vision/__init__.py` | `tests/test_vision_capability.py::test_vision_fallback_anthropic_compat_routes_to_anthropic_service`, `::test_vision_fallback_reads_api_compat_from_provider_bucket` |
 | Unknown api_compat skips the capability with a diagnostic | `src/lingtai/tools/vision/__init__.py` | `tests/test_vision_capability.py::test_vision_fallback_unknown_api_compat_skips_with_diagnostic`, `::test_vision_setup_unsupported_provider_skips` |
 | `api_key_env` overrides the raw key at setup | `src/lingtai/tools/vision/__init__.py` | `tests/test_vision_capability.py::test_vision_setup_resolves_api_key_env` |
+| Direct-native vision preserves same-provider model/endpoint identity without cross-provider fallback | `src/lingtai/tools/vision/__init__.py` | `tests/test_vision_capability.py::test_direct_native_vision_inherits_same_provider_model_and_endpoint`, `::test_direct_native_vision_honors_explicit_model_and_endpoint_over_active_provider`, `::test_direct_native_vision_does_not_inherit_from_mismatched_provider` |
+| MiMo preserves explicit/default vision-capable model behavior while preserving same-provider endpoint | `src/lingtai/tools/vision/__init__.py` | `tests/test_vision_capability.py::test_mimo_vision_keeps_default_model_but_preserves_same_provider_endpoint`, `::test_mimo_vision_honors_explicit_model_and_endpoint` |
+| MiniMax/Zhipu MCP vision do not forward active chat models; `glm` aliases Zhipu MCP | `src/lingtai/tools/vision/__init__.py` | `tests/test_vision_capability.py::test_minimax_vision_does_not_forward_active_chat_model`, `::test_zhipu_vision_does_not_forward_active_chat_model_or_base_url`, `::test_glm_vision_alias_uses_zhipu_mcp_service` |
+| Text-only/provider-relay aliases remain unavailable by default | `src/lingtai/tools/vision/__init__.py` | `tests/test_vision_capability.py::test_unsupported_text_providers_remain_unavailable_by_default` |
 | Dedicated provider services parse valid/invalid responses correctly | `src/lingtai/services/vision/` | `tests/test_vision_services.py::test_mimo_vision_returns_content_on_valid_response`, `::test_openai_vision_returns_content_on_valid_response`, `::test_create_vision_service_unknown_provider` |
 
 ## Verification matrix

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 PROVIDERS = {
     "providers": [
-        "minimax", "zhipu", "mimo", "gemini", "anthropic", "openai",
+        "minimax", "zhipu", "glm", "mimo", "gemini", "anthropic", "openai",
         "codex", "codex-pool", "codex_pool",
     ],
     "default": None,
@@ -108,7 +108,8 @@ def setup(
         if api_key_env:
             from lingtai.kernel.config_resolve import resolve_env
             api_key = resolve_env(api_key, api_key_env)
-        if provider not in PROVIDERS["providers"]:
+        provider_key = provider.lower()
+        if provider_key not in PROVIDERS["providers"]:
             # No dedicated VisionService for this provider (custom relay,
             # OpenRouter, an anthropic-compat local proxy, ...). Route vision
             # through the OpenAI- or Anthropic-compatible service, picking the
@@ -170,7 +171,6 @@ def setup(
                 )
                 return CAPABILITY_UNAVAILABLE
         else:
-            provider_key = provider.lower()
             if provider_key in {"codex", "codex-pool", "codex_pool"}:
                 # Codex vision is a standalone Responses request. It may share
                 # the active Codex family's model and endpoint, but never
@@ -206,21 +206,39 @@ def setup(
                 from lingtai.services.vision import create_vision_service
                 vision_service = create_vision_service("codex", api_key=None, **kwargs)
             else:
+                service_provider = "zhipu" if provider_key == "glm" else provider_key
+                main_provider = getattr(getattr(agent, "service", None), "provider", "")
+                active_provider_key = main_provider.lower() if isinstance(main_provider, str) else ""
+                active_model = getattr(agent.service, "_model", None)
+                active_base_url = getattr(agent.service, "_base_url", None)
+
                 # Provider-specific kwarg injection. Each branch is opt-in because
                 # vision services have heterogeneous constructor signatures.
-                if provider == "minimax" and "api_host" not in kwargs:
+                if service_provider in {"openai", "anthropic", "gemini"}:
+                    if active_provider_key == provider_key and active_model:
+                        kwargs.setdefault("model", active_model)
+                    if (
+                        service_provider in {"openai", "anthropic"}
+                        and active_provider_key == provider_key
+                        and active_base_url
+                    ):
+                        kwargs.setdefault("base_url", active_base_url)
+                if service_provider == "mimo" and active_provider_key == provider_key and active_base_url:
+                    kwargs.setdefault("base_url", active_base_url)
+                if service_provider == "minimax" and "api_host" not in kwargs:
                     from .._media_host import resolve_media_host
                     kwargs["api_host"] = resolve_media_host(agent)
-                if provider == "zhipu" and "z_ai_mode" not in kwargs:
+                if service_provider == "zhipu" and "z_ai_mode" not in kwargs:
                     from .._zhipu_mode import resolve_z_ai_mode
                     kwargs["z_ai_mode"] = resolve_z_ai_mode(agent)
                 # Dedicated vision services do not consume the LLM adapter's
                 # transport selector.
                 kwargs.pop("api_compat", None)
-                kwargs.pop("base_url", None)
+                if service_provider not in {"openai", "anthropic", "mimo"}:
+                    kwargs.pop("base_url", None)
                 # Lazy import: the provider service lives in ``lingtai.services``.
                 from lingtai.services.vision import create_vision_service
-                vision_service = create_vision_service(provider, api_key=api_key, **kwargs)
+                vision_service = create_vision_service(service_provider, api_key=api_key, **kwargs)
     elif vision_service is None:
         raise ValueError(
             "vision capability requires 'vision_service' or 'provider' + 'api_key'. "

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -26,7 +26,10 @@ if TYPE_CHECKING:
     from lingtai.services.vision import VisionService
 
 PROVIDERS = {
-    "providers": ["minimax", "zhipu", "mimo", "gemini", "anthropic", "openai", "codex"],
+    "providers": [
+        "minimax", "zhipu", "mimo", "gemini", "anthropic", "openai",
+        "codex", "codex-pool", "codex_pool",
+    ],
     "default": None,
     "fallback_on_inherit": None,  # no agnostic fallback for vision
 }
@@ -167,27 +170,57 @@ def setup(
                 )
                 return CAPABILITY_UNAVAILABLE
         else:
-            # Provider-specific kwarg injection. Each branch is opt-in because
-            # vision services have heterogeneous constructor signatures —
-            # passing api_host to a service that doesn't accept it raises
-            # TypeError at construction (silently swallowed by the agent's
-            # capability-setup try/except, leaving the agent without vision).
-            if provider == "minimax" and "api_host" not in kwargs:
-                from .._media_host import resolve_media_host
-                kwargs["api_host"] = resolve_media_host(agent)
-            if provider == "zhipu" and "z_ai_mode" not in kwargs:
-                from .._zhipu_mode import resolve_z_ai_mode
-                kwargs["z_ai_mode"] = resolve_z_ai_mode(agent)
-            # Dedicated vision services do not consume the LLM adapter's
-            # transport selector. ``expand_inherit`` copies it for capability
-            # routing, but forwarding it into service constructors breaks
-            # providers such as MiniMax that only accept provider-native args.
-            kwargs.pop("api_compat", None)
-            kwargs.pop("base_url", None)
-            # Lazy import: the provider service lives in ``lingtai.services`` and
-            # the ``lingtai.tools → lingtai`` edge is allowed only inside setup/handlers.
-            from lingtai.services.vision import create_vision_service
-            vision_service = create_vision_service(provider, api_key=api_key, **kwargs)
+            provider_key = provider.lower()
+            if provider_key in {"codex", "codex-pool", "codex_pool"}:
+                # Codex vision is a standalone Responses request. It may share
+                # the active Codex family's model and endpoint, but never
+                # inherits those from an unrelated main provider.
+                main_provider = getattr(getattr(agent, "service", None), "provider", "")
+                if main_provider.lower() in {"codex", "codex-pool", "codex_pool"}:
+                    kwargs.setdefault("model", getattr(agent.service, "_model", None))
+                    kwargs.setdefault("base_url", getattr(agent.service, "_base_url", None))
+                codex_base_url = kwargs.get("base_url")
+
+                defaults = getattr(getattr(agent, "service", None), "_provider_defaults", None)
+                bucket = defaults.get(provider_key) if isinstance(defaults, dict) else None
+                if not isinstance(bucket, dict):
+                    bucket = {}
+                if provider_key == "codex":
+                    token_path = kwargs.pop("token_path", None) or bucket.get("codex_auth_path")
+                    if token_path:
+                        kwargs["token_path"] = token_path
+                else:
+                    # The pool selector is the single owner of deterministic
+                    # account choice. It reads only the non-secret pool file.
+                    from lingtai.auth.codex_pool import select_codex_pool_auth
+                    selection = select_codex_pool_auth(
+                        bucket,
+                        model=kwargs.get("model"),
+                    )
+                    if selection:
+                        kwargs["token_path"] = selection["auth_path"]
+                kwargs.pop("api_compat", None)
+                kwargs.pop("base_url", None)
+                if codex_base_url:
+                    kwargs["base_url"] = codex_base_url
+                from lingtai.services.vision import create_vision_service
+                vision_service = create_vision_service("codex", api_key=None, **kwargs)
+            else:
+                # Provider-specific kwarg injection. Each branch is opt-in because
+                # vision services have heterogeneous constructor signatures.
+                if provider == "minimax" and "api_host" not in kwargs:
+                    from .._media_host import resolve_media_host
+                    kwargs["api_host"] = resolve_media_host(agent)
+                if provider == "zhipu" and "z_ai_mode" not in kwargs:
+                    from .._zhipu_mode import resolve_z_ai_mode
+                    kwargs["z_ai_mode"] = resolve_z_ai_mode(agent)
+                # Dedicated vision services do not consume the LLM adapter's
+                # transport selector.
+                kwargs.pop("api_compat", None)
+                kwargs.pop("base_url", None)
+                # Lazy import: the provider service lives in ``lingtai.services``.
+                from lingtai.services.vision import create_vision_service
+                vision_service = create_vision_service(provider, api_key=api_key, **kwargs)
     elif vision_service is None:
         raise ValueError(
             "vision capability requires 'vision_service' or 'provider' + 'api_key'. "

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -29,6 +29,23 @@ def make_mock_agent(tmp_path, svc=None):
     return agent
 
 
+def make_provider_agent(
+    tmp_path,
+    *,
+    provider: str,
+    model: str | None,
+    base_url: str | None,
+    defaults: dict | None = None,
+):
+    svc = MagicMock()
+    svc.provider = provider
+    svc._model = model
+    svc._base_url = base_url
+    svc._provider_defaults = defaults if defaults is not None else {provider: {}}
+    svc._key_resolver = MagicMock(return_value="fake-key")
+    return make_mock_agent(tmp_path, svc=svc)
+
+
 def test_vision_added_by_setup(tmp_path):
     """setup() should register the vision tool on the agent."""
     mock_svc = MagicMock(spec=VisionService)
@@ -221,6 +238,191 @@ def test_codex_pool_vision_selects_exact_model_and_passes_result(tmp_path):
         assert mock_factory.call_args.kwargs["model"] == "gpt-5.6-terra"
         assert mock_factory.call_args.kwargs["base_url"] == "https://codex-pool.example/backend-api/codex"
         assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-b.json"
+
+
+@pytest.mark.parametrize(
+    ("provider", "model", "base_url", "expects_base_url"),
+    [
+        ("openai", "gpt-4.1", "https://openai.example/v1", True),
+        ("anthropic", "claude-sonnet-4-20250514", "https://anthropic.example", True),
+        ("gemini", "gemini-3-flash-preview", "https://gemini.example", False),
+    ],
+)
+def test_direct_native_vision_inherits_same_provider_model_and_endpoint(
+    tmp_path, provider, model, base_url, expects_base_url
+):
+    """Direct-native vision keeps the active provider identity when providers match."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_provider_agent(
+            tmp_path,
+            provider=provider,
+            model=model,
+            base_url=base_url,
+        )
+        setup(agent, provider=provider, api_key="sk-test")
+
+        mock_factory.assert_called_once()
+        assert mock_factory.call_args.args == (provider,)
+        kwargs = mock_factory.call_args.kwargs
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["model"] == model
+        if expects_base_url:
+            assert kwargs["base_url"] == base_url
+        else:
+            assert "base_url" not in kwargs
+
+
+def test_direct_native_vision_honors_explicit_model_and_endpoint_over_active_provider(tmp_path):
+    """Capability kwargs remain authoritative for direct-native services."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_provider_agent(
+            tmp_path,
+            provider="openai",
+            model="gpt-4.1",
+            base_url="https://active-openai.example/v1",
+        )
+        setup(
+            agent,
+            provider="openai",
+            api_key="sk-test",
+            model="gpt-4o",
+            base_url="https://vision-openai.example/v1",
+        )
+
+        kwargs = mock_factory.call_args.kwargs
+        assert kwargs["model"] == "gpt-4o"
+        assert kwargs["base_url"] == "https://vision-openai.example/v1"
+
+
+def test_direct_native_vision_does_not_inherit_from_mismatched_provider(tmp_path):
+    """An explicit OpenAI vision provider must not inherit Anthropic model/endpoint."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_provider_agent(
+            tmp_path,
+            provider="anthropic",
+            model="claude-opus-4.1",
+            base_url="https://anthropic.example",
+        )
+        setup(agent, provider="openai", api_key="sk-test")
+
+        kwargs = mock_factory.call_args.kwargs
+        assert kwargs["api_key"] == "sk-test"
+        assert "model" not in kwargs
+        assert "base_url" not in kwargs
+
+
+def test_mimo_vision_keeps_default_model_but_preserves_same_provider_endpoint(tmp_path):
+    """MiMo does not forward text-only active models into standalone vision."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_provider_agent(
+            tmp_path,
+            provider="mimo",
+            model="mimo-v2.5-pro",
+            base_url="https://mimo-proxy.example/v1",
+        )
+        setup(agent, provider="mimo", api_key="sk-test")
+
+        kwargs = mock_factory.call_args.kwargs
+        assert kwargs["api_key"] == "sk-test"
+        assert "model" not in kwargs
+        assert kwargs["base_url"] == "https://mimo-proxy.example/v1"
+
+
+def test_mimo_vision_honors_explicit_model_and_endpoint(tmp_path):
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_provider_agent(
+            tmp_path,
+            provider="mimo",
+            model="mimo-v2.5-pro",
+            base_url="https://active-mimo.example/v1",
+        )
+        setup(
+            agent,
+            provider="mimo",
+            api_key="sk-test",
+            model="mimo-v2-omni",
+            base_url="https://vision-mimo.example/v1",
+        )
+
+        kwargs = mock_factory.call_args.kwargs
+        assert kwargs["model"] == "mimo-v2-omni"
+        assert kwargs["base_url"] == "https://vision-mimo.example/v1"
+
+
+def test_minimax_vision_does_not_forward_active_chat_model(tmp_path):
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_provider_agent(
+            tmp_path,
+            provider="minimax",
+            model="MiniMax-M3",
+            base_url="https://api.minimax.io/anthropic",
+        )
+        setup(agent, provider="minimax", api_key="sk-test")
+
+        mock_factory.assert_called_once_with(
+            "minimax",
+            api_key="sk-test",
+            api_host="https://api.minimax.io",
+        )
+
+
+def test_zhipu_vision_does_not_forward_active_chat_model_or_base_url(tmp_path):
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_provider_agent(
+            tmp_path,
+            provider="zhipu",
+            model="GLM-5.2",
+            base_url="https://open.bigmodel.cn/api/coding/paas/v4",
+        )
+        setup(agent, provider="zhipu", api_key="sk-test")
+
+        mock_factory.assert_called_once_with(
+            "zhipu",
+            api_key="sk-test",
+            z_ai_mode="ZHIPU",
+        )
+
+
+def test_glm_vision_alias_uses_zhipu_mcp_service(tmp_path):
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_provider_agent(
+            tmp_path,
+            provider="glm",
+            model="GLM-5.2",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+        setup(agent, provider="glm", api_key="sk-test")
+
+        mock_factory.assert_called_once_with(
+            "zhipu",
+            api_key="sk-test",
+            z_ai_mode="ZAI",
+        )
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["openrouter", "deepseek", "kimi", "grok", "qwen", "claude-code", "claude_code", "custom"],
+)
+def test_unsupported_text_providers_remain_unavailable_by_default(tmp_path, provider):
+    agent = make_provider_agent(
+        tmp_path,
+        provider=provider,
+        model="text-only",
+        base_url="https://relay.example/v1",
+        defaults={provider: {}},
+    )
+    result = setup(agent, provider=provider, api_key="sk-test")
+    assert result is CAPABILITY_UNAVAILABLE
+    agent.add_tool.assert_not_called()
 
 
 def test_vision_setup_unsupported_provider_skips(tmp_path):

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -147,6 +147,82 @@ def test_vision_setup_with_codex_provider_without_api_key(tmp_path):
         assert isinstance(mgr, VisionManager)
 
 
+@pytest.mark.parametrize("provider", ["codex", "codex-pool", "codex_pool"])
+def test_codex_family_vision_aliases_use_codex_service(tmp_path, provider):
+    """All Codex vision aliases construct the native Codex service path."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_pool.select_codex_pool_auth", return_value=None
+    ) as mock_select:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        setup(agent, provider=provider)
+        assert mock_factory.call_args.args == ("codex",)
+        assert mock_factory.call_args.kwargs["api_key"] is None
+        if provider == "codex":
+            mock_select.assert_not_called()
+        else:
+            mock_select.assert_called_once_with({}, model=None)
+
+
+def test_codex_vision_inherits_active_model_and_endpoint(tmp_path):
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "codex"
+        agent.service._model = "gpt-5.6-sol"
+        agent.service._base_url = "https://codex.example/backend-api/codex"
+        agent.service._provider_defaults = {"codex": {}}
+        setup(agent, provider="codex")
+        kwargs = mock_factory.call_args.kwargs
+        assert kwargs["model"] == "gpt-5.6-sol"
+        assert kwargs["base_url"] == "https://codex.example/backend-api/codex"
+
+
+def test_codex_vision_does_not_inherit_non_codex_model(tmp_path):
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "gemini"
+        agent.service._model = "gemini-2.5-pro"
+        agent.service._base_url = "https://generativelanguage.example"
+        setup(agent, provider="codex")
+        kwargs = mock_factory.call_args.kwargs
+        assert "model" not in kwargs
+        assert "base_url" not in kwargs
+
+
+def test_direct_codex_vision_uses_configured_auth_path(tmp_path):
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "codex"
+        agent.service._model = None
+        agent.service._base_url = None
+        agent.service._provider_defaults = {"codex": {"codex_auth_path": "/tmp/codex-a.json"}}
+        setup(agent, provider="codex")
+        assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-a.json"
+
+
+def test_codex_pool_vision_selects_exact_model_and_passes_result(tmp_path):
+    selected = {"auth_path": "/tmp/codex-b.json", "selection": {"source_index": 1}}
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_pool.select_codex_pool_auth", return_value=selected
+    ) as mock_select:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "codex-pool"
+        agent.service._model = "gpt-5.6-terra"
+        agent.service._base_url = "https://codex-pool.example/backend-api/codex"
+        agent.service._provider_defaults = {"codex-pool": {"codex_auth_pool_path": "pool.json"}}
+        setup(agent, provider="codex-pool")
+        mock_select.assert_called_once_with(
+            {"codex_auth_pool_path": "pool.json"}, model="gpt-5.6-terra"
+        )
+        assert mock_factory.call_args.kwargs["model"] == "gpt-5.6-terra"
+        assert mock_factory.call_args.kwargs["base_url"] == "https://codex-pool.example/backend-api/codex"
+        assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-b.json"
+
+
 def test_vision_setup_unsupported_provider_skips(tmp_path):
     """Unsupported providers gracefully skip and log capability_skipped.
 
@@ -224,6 +300,7 @@ def test_codex_vision_service_streams_responses_api(monkeypatch, tmp_path):
 
     with patch("lingtai.services.vision.codex.CodexTokenManager") as mock_mgr_cls:
         mock_mgr_cls.return_value.get_access_token.return_value = "oauth-token"
+        mock_mgr_cls.return_value.get_account_id.return_value = None
         from lingtai.services.vision.codex import CodexVisionService
 
         svc = CodexVisionService(timeout=9.5)
@@ -246,6 +323,33 @@ def test_codex_vision_service_streams_responses_api(monkeypatch, tmp_path):
     assert content[0] == {"type": "input_text", "text": "What is shown?"}
     assert content[1]["type"] == "input_image"
     assert content[1]["image_url"].startswith("data:image/png;base64,")
+
+
+def test_codex_vision_sends_account_header_and_refreshes_auth_each_call(monkeypatch, tmp_path):
+    img_path = tmp_path / "chart.png"
+    img_path.write_bytes(b"fake png bytes")
+    responses = MagicMock()
+    responses.create.return_value = [SimpleNamespace(type="response.output_text.delta", delta="ok")]
+    client = SimpleNamespace(responses=responses)
+    openai_cls = MagicMock(return_value=client)
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=openai_cls))
+
+    with patch("lingtai.services.vision.codex.CodexTokenManager") as mock_mgr_cls:
+        manager = mock_mgr_cls.return_value
+        manager.get_access_token.side_effect = ["token-1", "token-2"]
+        manager.get_account_id.side_effect = ["acct-1", None]
+        from lingtai.services.vision.codex import CodexVisionService
+
+        svc = CodexVisionService()
+        assert svc.analyze_image(str(img_path)) == "ok"
+        assert svc.analyze_image(str(img_path)) == "ok"
+
+    assert manager.get_access_token.call_count == 2
+    assert manager.get_account_id.call_count == 2
+    assert openai_cls.call_args_list[0].kwargs["default_headers"] == {
+        "ChatGPT-Account-ID": "acct-1"
+    }
+    assert "default_headers" not in openai_cls.call_args_list[1].kwargs
 
 def test_create_vision_service_unknown_provider():
     """create_vision_service should raise ValueError for unknown providers."""


### PR DESCRIPTION
## Summary

- register `codex-pool` and `codex_pool` as native Codex vision aliases and route the Codex family through the existing Responses `input_image` service
- preserve same-provider identity for direct-native OpenAI, Anthropic, and Gemini vision: explicit capability overrides win; otherwise the active model is reused, and OpenAI/Anthropic also reuse the active endpoint
- keep MiMo on an explicit or known vision-capable model (`mimo-v2.5` by default) while preserving its same-provider endpoint; do not forward text-only MiMo chat models
- map `glm` to the existing Zhipu MCP vision service; keep MiniMax/Zhipu MCP routing unchanged
- keep OpenRouter, DeepSeek, Kimi, custom relays, Claude Code aliases, and local vision unavailable by default unless the user explicitly configures the existing compatibility/skill+MCP path
- add focused routing/isolation/request regressions and update the vision Contract/Anatomy documents

## Scope

This PR keeps the existing explicit `vision(image_path, question)` tool. It does **not** add canonical main-session image blocks, auto-enable omitted optional capabilities, infer whether a relay/upstream model accepts images, install/download a local model, or introduce any silent cross-provider fallback.

MiniMax and Zhipu remain explicitly configured MCP-backed services. Built-in preset declarations/editor choices are owned by the TUI repository; this kernel PR makes declared vision capabilities route correctly but does not silently turn on vision for a TUI preset that omits it (notably the current Gemini preset source).

## Validation

Parent-run validation on exact head `d8abcdc772e88228ce5efcf07f6c3526f8f1fd11`:

- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_vision_capability.py tests/test_vision_services.py -q` — **56 passed**
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_codex_pool*.py -q` — **109 passed**
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest tests/test_architecture_documents.py tests/test_anatomy_drift_checker.py -q` — **12 passed**
- `/Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m lingtai.tools.glossary_validator --check` — **54 resources validated**
- `py_compile`, lazy-import smoke (`lingtai.tools.vision` does not import `lingtai.services`), and `git diff --check` — passed

## Live evidence and safety

After the initial Codex production commit `0a9fdfc66f004068477cc6394812ac8c4e09e598`, one explicitly authorized controlled PNG smoke through the active `codex-pool` / `gpt-5.6-sol` route returned the exact red/yellow/white/blue geometry. The broader provider expansion was validated only with mocked/local tests: there were no live OpenAI, Anthropic, Gemini, MiMo, MiniMax, or Zhipu calls.

The current live runtime remains on `0a9fdfc6`; this expanded PR head was not installed or refreshed. No auth/config mutation, credential-file inspection, fallback-provider call, dependency change, or local model download was performed.
