### PR TITLE
feat(workbench): support durable NoKV restore

### DIFF
--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -6,10 +6,10 @@ description: >
   asked to persist task inputs, scripts, outputs, logs, provenance, or run
   manifests through the `workbench_*` MCP tools instead of ordinary local
   file writes. Covers MCP registration, directory layout, append and edit
-  discipline, conditional reads, cross-workbench queries, commit discipline,
-  leased checkpoint snapshots with naming, renewal, discovery, point-in-time
-  history reads, and durable restore-to-fork recovery.
-version: 0.4.0
+  discipline, conditional reads, cross-workbench queries, content-identified
+  commits, leased checkpoint snapshots with annotations, renewal, retirement,
+  discovery, point-in-time history reads, and durable restore-to-fork recovery.
+version: 0.5.0
 tags: [nokv, mcp, workbench, artifacts, provenance, snapshots, checkpoints, leases, restore]
 related_files:
 - src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
@@ -97,10 +97,12 @@ local LingTai workdir.
 ```
 
 2. Write inputs, scripts, outputs, and evidence with
-   `workbench_put_file`. Pass `replace=true` only when intentionally
-   replacing a prior artifact. When `section` is set, `path` is relative to
-   that section: use `section="outputs", path="spectrum.csv"`, not
-   `path="outputs/spectrum.csv"`.
+   `workbench_put_file`. It is not upsert: `replace=false` (the default) is
+   create-only and fails when the target exists; `replace=true` is
+   replace-only and fails when the target is missing. Pass `replace=true` only
+   when intentionally replacing an existing whole artifact. When `section` is
+   set, `path` is relative to that section: use `section="outputs",
+   path="spectrum.csv"`, not `path="outputs/spectrum.csv"`.
 
 3. Grow logs and journals with `workbench_append` — one file per stream,
    appended record by record:
@@ -126,6 +128,7 @@ local LingTai workdir.
 ```json
 {
   "id": "spedas-task-001",
+  "content_digest_uri": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   "manifest": {
     "task": "spedas-task-001",
     "inputs": ["input/event.json", "input/dataset-ref.json"],
@@ -137,8 +140,14 @@ local LingTai workdir.
 }
 ```
 
-`workbench_commit` publishes `metadata/run_manifest.json`. In v0 this file
-is the completion marker. A workbench without it is not complete.
+`workbench_commit` publishes `metadata/run_manifest.json` with schema
+`nokv.workbench.run_manifest.v1`. The caller must compute the stable
+`content_digest_uri` before the call; it is not a phase label and must have the
+exact form `sha256:<64 lowercase hex>`. NoKV separately hashes the canonical
+manifest and derives `commit_identity`. Replaying the same identity is
+idempotent, while a different content identity conflicts even when the two
+manifests have the same phase. Use `replace=true` only for an intentional
+replacement. A workbench without the v1 commit file is not complete.
 
 6. Snapshot the committed workbench with `workbench_snapshot`, choosing a
    `ttl_days` that outlasts how long the handoff must stay restorable — see
@@ -157,14 +166,19 @@ unreachable a couple of days later because nobody extended it.
 along with a `name`:
 
 ```json
-{"id":"spedas-task-001","name":"final-v1","ttl_days":30}
+{"id":"spedas-task-001","name":"final-v1","ttl_days":30,"reason":"handoff","metadata":{"job_hash":"sha256:...","owner":"scout"}}
 ```
 
 The response adds `name`, `lease_expires_at` (the reap deadline), and an
-`expiry_warning` when the lease is short, alongside the usual `snapshot_id` and
-`read_version`. **A snapshot minted with the bare NoKV CLI outside this tool
-gets only the 1-hour default lease** — never hand a raw-CLI snapshot to a
-handoff.
+`expiry_warning` when the default TTL was used, alongside the usual
+`snapshot_id`, `read_version`, and optional `annotation`. `reason` and
+`metadata` are bounded registry annotations; they are not encoded into the
+64-character checkpoint
+name. If the snapshot pin is created but its registry annotation cannot be
+appended, the tool returns `SnapshotRegistryWritePartial` with the authoritative
+snapshot id and explicit compensation instead of reporting success. **A
+snapshot minted with the bare NoKV CLI outside this tool gets only the 1-hour
+default lease** — never hand a raw-CLI snapshot to a handoff.
 
 **Name your checkpoints.** `name` is a workbench-scoped alias you can renew,
 list, read, and initially select for restore. The alias is useful only while
@@ -189,8 +203,26 @@ the checkpoint by `name` or `snapshot_id`.
 Do not rely on a `snapshot_id` you remembered in a note — that note is exactly
 what goes stale. `workbench_snapshot_list {"id":"spedas-task-001"}` enumerates
 every checkpoint of the workbench with its `name`, `snapshot_id`,
-`lease_expires_at`, and lifecycle `state` (`alive`, `expired`, or `reaped`).
+`lease_expires_at`, and lifecycle `state` (`alive`, `expired`, `retired`, or
+`reaped`).
 Use it to see what is still restorable before you try to read history.
+
+### Retire a checkpoint explicitly
+
+Use `workbench_snapshot_retire` when the point-in-time view is no longer
+needed. Pass the workbench `id` and exactly one of `snapshot_id` or `name`; an
+optional bounded `reason` is recorded on the lifecycle event:
+
+```json
+{"id":"spedas-task-001","snapshot_id":417,"reason":"handoff accepted"}
+```
+
+The operation releases the retention pin. The first successful retirement
+returns `retired=true`; an exact retry after the pin is absent returns
+`retired=false` and does not fabricate deletion attribution. A checkpoint list
+reports `state="retired"` only after an acknowledged `retired=true` event;
+otherwise an absent pin remains `state="reaped"`. Root mismatches and active
+fork retention remain typed errors.
 
 ### Read history with at_snapshot
 
@@ -321,8 +353,10 @@ For the MVP, use a parent-created workbench and child-filled files:
   serialized by the server with automatic retry. Everything else stays
   disjoint: assign prefixes such as `outputs/agent-a/` and never let two
   agents `put_file` or `edit` the same path. Same-path `put_file` with
-  `replace=false` intentionally fails with an exists conflict; treat that as
-  a coordination bug, not a reason to bypass with `replace=true`.
+  `replace=false` intentionally fails with an exists conflict; `replace=true`
+  on a missing target intentionally fails with not-found. Neither mode is
+  upsert. Treat either race as a coordination bug, not a reason to flip the
+  flag and retry blindly.
 
 ## Read and search
 
@@ -338,10 +372,14 @@ Reading inside one workbench:
 - Files larger than the structured limit: use `format="bytes"` with
   `offset`/`limit` ranges (bytes come back base64-encoded), or
   `workbench_grep` to locate lines first.
-- Record shape depends on content type: `.json` files parse into JSON
-  records; `.jsonl`, `.log`, and other text files come back as `text_lines`
-  records whose `value.text` holds the raw line — parse it yourself when the
-  line is JSON.
+- Record shape depends on content type. `.json` files parse into JSON records;
+  YAML and UTF-8 `text/*` files use their corresponding structured modes.
+  NoKV does not natively parse `application/x-ndjson` and does not promise
+  NDJSON record pagination. A `.jsonl` suffix alone selects no parser: write it
+  with a `text/*` content type to receive raw `text_lines` whose `value.text`
+  you parse yourself, or use `format="bytes"` for
+  `application/x-ndjson`/other unsupported types. At-snapshot non-bytes reads
+  are a raw UTF-8 text-lines mode, not an NDJSON record parser.
 - `workbench_grep` searches file bodies for case-insensitive **literal**
   substrings (not regex). Pass several alternatives at once with
   `patterns: ["营养", "食谱", "recipe"]` (OR semantics); a single `pattern`
@@ -391,3 +429,5 @@ Before calling `workbench_commit`, verify:
 - `metadata/provenance.json` exists when provenance is required.
 - `logs/` contains the evidence streams (appended files are fine).
 - The manifest lists relative paths inside the workbench sections.
+- A stable caller-owned `content_digest_uri` has been computed from the
+  committed content before the call; a phase name alone is not an identity.

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -7,10 +7,10 @@ description: >
   manifests through the `workbench_*` MCP tools instead of ordinary local
   file writes. Covers MCP registration, directory layout, append and edit
   discipline, conditional reads, cross-workbench queries, commit discipline,
-  and leased checkpoint snapshots with naming, renewal, discovery, and
-  point-in-time history reads.
-version: 0.3.0
-tags: [nokv, mcp, workbench, artifacts, provenance, snapshots, checkpoints, leases]
+  leased checkpoint snapshots with naming, renewal, discovery, point-in-time
+  history reads, and durable restore-to-fork recovery.
+version: 0.4.0
+tags: [nokv, mcp, workbench, artifacts, provenance, snapshots, checkpoints, leases, restore]
 related_files:
 - src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
 - src/lingtai/intrinsic_skills/nokv-workbench/assets/init-snippet.json
@@ -166,9 +166,10 @@ The response adds `name`, `lease_expires_at` (the reap deadline), and an
 gets only the 1-hour default lease** — never hand a raw-CLI snapshot to a
 handoff.
 
-**Name your checkpoints.** `name` is a stable alias you can renew, list, and
-read by, instead of memorizing an opaque `snapshot_id`. The name is the durable
-handle; the id is for pinning an exact version.
+**Name your checkpoints.** `name` is a workbench-scoped alias you can renew,
+list, read, and initially select for restore. The alias is useful only while
+the checkpoint lease is live; it is not an archive or an independent durability
+guarantee. Exact restore requests use the resolved numeric `snapshot_id`.
 
 In final reports or handoff notes, cite the checkpoint `name`, its
 `snapshot_id`, and the returned `lease_expires_at` so a later reader knows both
@@ -188,7 +189,7 @@ the checkpoint by `name` or `snapshot_id`.
 Do not rely on a `snapshot_id` you remembered in a note — that note is exactly
 what goes stale. `workbench_snapshot_list {"id":"spedas-task-001"}` enumerates
 every checkpoint of the workbench with its `name`, `snapshot_id`,
-`lease_expires_at`, and lifecycle `status` (`alive`, `expired`, or `reaped`).
+`lease_expires_at`, and lifecycle `state` (`alive`, `expired`, or `reaped`).
 Use it to see what is still restorable before you try to read history.
 
 ### Read history with at_snapshot
@@ -202,13 +203,106 @@ that checkpoint** instead of its current state:
 ```
 
 Historical `workbench_read` serves the checkpoint's bytes/text-lines. Reading a
-checkpoint whose lease has expired now fails **loudly** — an explicit error that
-tells you to `workbench_snapshot_renew` (if a grace window remains) or re-mint —
-rather than silently returning current state or empty data.
+checkpoint whose lease has expired fails **loudly**. Expiry is terminal:
+expired checkpoints cannot be renewed, even if the background collector has not
+yet removed the pin. Re-mint from the current committed state when that is still
+useful; NoKV never revives a checkpoint whose historical records may already
+have been reclaimed.
+
+## Restore to a new workbench
+
+Use `workbench_restore` to continue from a live checkpoint. The workbench
+contract is restore-to-fork only: it creates a new independently writable
+workbench and never rolls back or overwrites the source.
+
+Before restoring by checkpoint name, call `workbench_snapshot_list`, select an
+entry whose `state` is `alive`, and resolve the name to its numeric
+`snapshot_id`. Build one fixed request using that number:
+
+```json
+{
+  "id": "spedas-task-001",
+  "at_snapshot": 417,
+  "destination_id": "spedas-task-001-restored"
+}
+```
+
+Keep these exact three values for the duration of the workflow. If the MCP
+transport, NoKV server, or Agent connection restarts, resend the same request
+with the same numeric `snapshot_id` and `destination_id`. Do not re-resolve a
+checkpoint name during a retry: an alias can be rebound, while the numeric id
+pins the original request. A retry can return `RestoreInProgress`; use bounded
+backoff and resend the exact request. No separate LingTai restore state or
+multi-step copy protocol is needed.
+
+Success means `state="complete"` and `cleanup_pending=false`. The response
+contains the deterministic `operation_id`, source and destination workbench
+ids, numeric `snapshot_id`, read version, roots, and
+`metadata/restore_manifest.json`. Exact retries return the same completed
+operation even after the source checkpoint registry or source workbench has
+been removed. A request that reuses the destination for a different source or
+snapshot is a conflict.
+
+The destination is first exposed only after its restore manifest is readable
+and the source-owned `metadata/checkpoints.jsonl` has been removed. It does not
+inherit checkpoint aliases. The source remains unchanged throughout the
+restore.
+
+### Validate the completed restore
+
+After a successful response, read the destination's
+`metadata/restore_manifest.json` with `workbench_read`. Parse the JSON and
+require all of the following before using or handing off the destination:
+
+- `schema` is `nokv.workbench.restore_manifest.v1`;
+- `operation_id`, `source_workbench_id`, `destination_workbench_id`, and
+  `snapshot_id` exactly match the restore response and fixed request;
+- `restored_from.workbench_id` is the source id,
+  `restored_from.snapshot_id` is the same numeric snapshot id, and
+  `restored_from.path` identifies that source workbench;
+- `destination_path` identifies the requested destination.
+
+Treat a missing field or mismatch as an integrity failure. Stop and report it;
+do not repair the manifest or silently continue. Do not request in-place
+rollback from an agent workflow—operator recovery APIs are outside this skill.
+
+### Handle structured checkpoint and restore errors
+
+MCP failures preserve top-level `status`, `code`, `message`, `retryable`, and
+`details`. Branch on `code`; never parse the human message:
+
+| Code | Agent action |
+|---|---|
+| `SnapshotNotFound` | Stop. The numeric snapshot was reaped or never existed; never re-resolve an alias as an exact retry. |
+| `SnapshotLeaseExpired` | Do not retry or attempt revival. Mint a new checkpoint from current state when appropriate. |
+| `SnapshotRootMismatch` | Stop. The checkpoint belongs to another workbench root. |
+| `SnapshotBindingChanged` | Refresh workbench resolution and retry once only when `retryable=true`. |
+| `SnapshotRenewContended` | Retry renewal with bounded backoff. |
+| `NotOwner` | Reconnect to the advertised owner endpoint, then resend the exact request when `retryable=true`. |
+| `StaleOwnerEpoch` | Refresh owner routing and resend the exact request with bounded backoff when `retryable=true`. |
+| `InvalidOwnerEpoch` | Stop deployment. The owner epoch configuration is invalid and the unchanged request is not retryable. |
+| `LeaseExpired` | Reconnect or reacquire the transport lease, then resend the exact request with bounded backoff when `retryable=true`. |
+| `RestoreTransportUnavailable` | Restore metadata transport or owner availability, then resend the unchanged numeric restore request with bounded backoff when `retryable=true`; never switch destinations or re-resolve an alias. |
+| `RestoreInProgress` | Retry the exact numeric restore request with bounded backoff. |
+| `RestoreRootChanged` | Stop and escalate to the operator. Detached restore membership no longer matches the durable operation. |
+| `RestoreBindingChanged` | Stop and escalate to the operator. The temporary history-retention binding failed its identity check. |
+| `RestoreProtocolMismatch` | Stop. Do not use or retry the mismatched outcome; preserve the response and escalate to the operator. |
+| `RestoreDestinationConflict` | Stop. Choose a new absent destination only for a new operation, never during an exact retry. |
+| `RestoreResourceLimit` | Do not retry unchanged; reduce the reported subtree or initialization payload before taking a new checkpoint. |
+| `RestoreHardlinkUnsupported` | Stop and remove unsupported non-directory hardlinks before taking a new checkpoint. |
+| `RestoreCrossShardUnsupported` | Stop and choose source and destination under the same metadata shard. |
+| `StalePreparedArtifactObjectGcEpoch` | Discard the stale prepared upload state and resend the exact restore request with bounded backoff when `retryable=true`; do not reuse the stale artifact preparation. |
+| `SyncLogArchiveFailed` | Preserve `details.committed`. Resend the exact request when `retryable=true`; never invent a new destination to work around an ambiguous committed result. |
+| `CapabilityMismatch` | Stop deployment. The connected owner does not support `restore_to_fork_v1`; do not downgrade to a client-side copy. |
+
+Honor `retryable=false` even when a table entry otherwise permits a bounded
+retry. Preserve the original request on every retry; changing any of its three
+fields starts a different operation.
 
 ### Expired is not the same as data lost
 
-An expired checkpoint loses only the **point-in-time view**, not your work. The
+An expired checkpoint loses only the **point-in-time view**, not your current
+work. The
 workbench's committed files stay put: after `workbench_commit`, the current
 artifacts remain reachable with `workbench_read`, `workbench_list`, and
 `workbench_stat` (no `at_snapshot`). Only the frozen historical view needs a

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
@@ -2,7 +2,7 @@
 related_files:
 - src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
 maintenance: |
-  Developer-facing TUI deployment preflight pointed to by nokv-workbench/SKILL.md; update it whenever the workbench MCP tool surface (9-tool vs 16-tool, checkpoint-lifecycle fields) or the runtime-version compatibility check changes.
+  Developer-facing TUI deployment preflight referenced by nokv-workbench/SKILL.md; update it whenever the 17-tool workbench MCP surface, checkpoint/restore contract, capability gate, or runtime-version compatibility check changes.
 ---
 
 # TUI runtime preflight (developer-facing)
@@ -34,17 +34,98 @@ print((root / "nokv-workbench" / "SKILL.md").exists())
 PY
 ```
 
-Tool-surface note: parts of the SKILL.md surface depend on the NoKV build. An
-older server still works with this skill — the newer tools and parameters are
-simply absent from tools/list, and the SKILL sections about them do not apply.
+## NoKV contract gate
 
-- **16-tool workbench MCP** (workbench_append / workbench_edit /
-  workbench_search / workbench_aggregate / workbench_catalog and conditional
-  reads) requires a build shipping the specialized workbench MCP; older 9-tool
-  NoKV servers lack it.
-- **Checkpoint lifecycle** (workbench_snapshot_renew, workbench_snapshot_list,
-  the workbench_snapshot `name`/`ttl_days` parameters and its
-  `lease_expires_at`/`expiry_warning` output, and the `at_snapshot` parameter
-  on workbench_read / workbench_list / workbench_stat) requires a build
-  shipping Phase 1 snapshot leasing. Without it, snapshots fall back to the
-  legacy 1-hour lease with no renewal path.
+The v0.4 skill requires the complete 17-tool workbench surface, strict terminal
+checkpoint expiry, root-bound snapshot operations, and the metadata capability
+`restore_to_fork_v1`. Do not silently downgrade to an older NoKV build or
+replace restore with a client-side read/copy loop.
+
+Run this gate against the exact NoKV command, metadata owner, object store, and
+resolved per-agent workbench root that the deployment will use. `NOKV_MCP_ARGS`
+is a JSON array containing the same arguments from the registry record. Keep
+global NoKV flags before `mcp`.
+
+```bash
+export NOKV_BIN=/path/to/nokv
+export NOKV_MCP_ARGS='["--server-bind","127.0.0.1:7777","--object-backend","rustfs","--s3-bucket","nokv-lingtai-workbench","mcp","--profile","workbench","--workbench-root","/agents/preflight/wb"]'
+
+~/.lingtai-tui/runtime/venv/bin/python - <<'PY'
+import json
+import os
+
+from lingtai.services.mcp import MCPClient
+
+expected_tools = {
+    "workbench_create", "workbench_put_file", "workbench_append",
+    "workbench_edit", "workbench_stat", "workbench_list", "workbench_read",
+    "workbench_grep", "workbench_search", "workbench_aggregate",
+    "workbench_catalog", "workbench_find", "workbench_commit",
+    "workbench_snapshot", "workbench_snapshot_renew",
+    "workbench_snapshot_list", "workbench_restore",
+}
+expected_restore_schema = {
+    "type": "object",
+    "required": ["id", "at_snapshot", "destination_id"],
+    "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "at_snapshot": {
+            "anyOf": [
+                {"type": "integer", "minimum": 0},
+                {"type": "string", "minLength": 1},
+            ],
+        },
+        "destination_id": {"type": "string", "minLength": 1},
+    },
+    "additionalProperties": False,
+}
+
+client = MCPClient(os.environ["NOKV_BIN"], json.loads(os.environ["NOKV_MCP_ARGS"]))
+try:
+    tools = {tool["name"]: tool for tool in client.list_tools()}
+    missing = sorted(expected_tools - tools.keys())
+    if missing:
+        raise SystemExit(f"NoKV workbench tools missing: {missing}")
+    actual = tools["workbench_restore"].get("schema")
+    if actual != expected_restore_schema:
+        raise SystemExit(
+            "workbench_restore raw schema mismatch:\n"
+            + json.dumps(actual, indent=2, sort_keys=True)
+        )
+finally:
+    client.close()
+
+print("NoKV workbench v0.4 raw contract: OK")
+PY
+```
+
+Run the check before Agent registration. LingTai adapts MCP schemas for model
+tool registration, including removing top-level `additionalProperties`; that
+adapted schema is not evidence that the server enforces strict input. The raw
+gate above must observe all three required fields, non-empty string ids,
+non-negative integer or non-empty string `at_snapshot`, and
+`additionalProperties=false`. The server must still reject unknown fields,
+`null`, and equal source/destination ids at runtime.
+
+Advertising `workbench_restore` is the deployment proof that the connected
+metadata owner supports `restore_to_fork_v1`. If capability probing fails, the
+tool must be absent or calls must return `CapabilityMismatch` with
+`retryable=false` and `details.capability="restore_to_fork_v1"`. Either result
+fails deployment; do not add a hard-coded NoKV gate to LingTai Agent startup.
+
+## Live acceptance gate
+
+Run the checked-in NoKV/LingTai live acceptance harness with
+`--profile full --require-all` before deploying a new pair of builds. It must
+exercise the real RustFS service, NoKV metadata server, workbench MCP
+subprocess, LingTai Agent MCP registration/reconnect path, and two real MCP
+clients created from the resolved per-agent launch configuration. Unit-only
+schema checks are not a deployment substitute.
+
+The acceptance run must cover exact numeric-`snapshot_id` redrive after
+transport/server/Agent restart and response-ack ambiguity, first-visible
+manifest validity, source checkpoint retirement/deletion, independent
+destination writes, and final shared-object reclamation. A successful restore
+must report `state="complete"` and `cleanup_pending=false`; validate
+`metadata/restore_manifest.json` as documented in SKILL.md before accepting the
+destination.

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
@@ -2,7 +2,7 @@
 related_files:
 - src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
 maintenance: |
-  Developer-facing TUI deployment preflight referenced by nokv-workbench/SKILL.md; update it whenever the 17-tool workbench MCP surface, checkpoint/restore contract, capability gate, or runtime-version compatibility check changes.
+  Developer-facing TUI deployment preflight referenced by nokv-workbench/SKILL.md; update it whenever the 18-tool restore-capable workbench MCP surface, checkpoint/restore contract, capability gate, or runtime-version compatibility check changes.
 ---
 
 # TUI runtime preflight (developer-facing)
@@ -36,10 +36,13 @@ PY
 
 ## NoKV contract gate
 
-The v0.4 skill requires the complete 17-tool workbench surface, strict terminal
-checkpoint expiry, root-bound snapshot operations, and the metadata capability
-`restore_to_fork_v1`. Do not silently downgrade to an older NoKV build or
-replace restore with a client-side read/copy loop.
+The v0.5 skill requires the complete 18-tool restore-capable workbench surface,
+strict terminal checkpoint expiry, root-bound snapshot operations, stable v1
+commit identity, bounded snapshot annotations, explicit snapshot retirement,
+and the metadata capability `restore_to_fork_v1`. The base surface has 17 tools;
+`workbench_restore` is the capability-gated eighteenth tool. Do not silently
+downgrade to an older NoKV build or replace restore with a client-side read/copy
+loop.
 
 Run this gate against the exact NoKV command, metadata owner, object store, and
 resolved per-agent workbench root that the deployment will use. `NOKV_MCP_ARGS`
@@ -62,7 +65,83 @@ expected_tools = {
     "workbench_grep", "workbench_search", "workbench_aggregate",
     "workbench_catalog", "workbench_find", "workbench_commit",
     "workbench_snapshot", "workbench_snapshot_renew",
-    "workbench_snapshot_list", "workbench_restore",
+    "workbench_snapshot_retire", "workbench_snapshot_list",
+    "workbench_restore",
+}
+expected_commit_schema = {
+    "type": "object",
+    "required": ["id", "manifest", "content_digest_uri"],
+    "properties": {
+        "id": {"type": "string"},
+        "manifest": {"type": "object"},
+        "content_digest_uri": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "description": "Stable caller-computed digest of the committed content. It must be known before this call and exactly match sha256:<64 lowercase hex>.",
+        },
+        "replace": {
+            "type": "boolean",
+            "description": "Explicitly replace a different or legacy commit. Concurrent identity changes still fail closed. Defaults false.",
+        },
+    },
+    "additionalProperties": False,
+}
+expected_snapshot_schema = {
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+        "id": {"type": "string"},
+        "name": {
+            "type": ["string", "null"],
+            "description": "Checkpoint alias matching [A-Za-z0-9_-]{1,64}. Resolves to this snapshot in workbench_snapshot_renew, workbench_snapshot_list, and at_snapshot reads.",
+        },
+        "ttl_days": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 90,
+            "description": "Lease length in days. Defaults to 7; values above 90 are rejected.",
+        },
+        "reason": {
+            "type": ["string", "null"],
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "Optional human-readable checkpoint reason. At most 256 Unicode characters and 1024 UTF-8 bytes.",
+        },
+        "metadata": {
+            "type": ["object", "null"],
+            "maxProperties": 64,
+            "description": "Optional JSON annotation object. Canonical encoded size is at most 4096 bytes, with at most 8 container levels and 64 object keys across the complete value.",
+        },
+    },
+    "additionalProperties": False,
+}
+expected_retire_schema = {
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "snapshot_id": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Snapshot id to retire. Provide exactly one of snapshot_id or name.",
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Checkpoint name to retire. Provide exactly one of snapshot_id or name.",
+        },
+        "reason": {
+            "type": ["string", "null"],
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "Optional human-readable retirement reason. At most 256 Unicode characters and 1024 UTF-8 bytes.",
+        },
+    },
+    "oneOf": [
+        {"required": ["snapshot_id"]},
+        {"required": ["name"]},
+    ],
+    "additionalProperties": False,
 }
 expected_restore_schema = {
     "type": "object",
@@ -86,16 +165,23 @@ try:
     missing = sorted(expected_tools - tools.keys())
     if missing:
         raise SystemExit(f"NoKV workbench tools missing: {missing}")
-    actual = tools["workbench_restore"].get("schema")
-    if actual != expected_restore_schema:
-        raise SystemExit(
-            "workbench_restore raw schema mismatch:\n"
-            + json.dumps(actual, indent=2, sort_keys=True)
-        )
+    expected_schemas = {
+        "workbench_commit": expected_commit_schema,
+        "workbench_snapshot": expected_snapshot_schema,
+        "workbench_snapshot_retire": expected_retire_schema,
+        "workbench_restore": expected_restore_schema,
+    }
+    for name, expected in expected_schemas.items():
+        actual = tools[name].get("schema")
+        if actual != expected:
+            raise SystemExit(
+                f"{name} raw schema mismatch:\n"
+                + json.dumps(actual, indent=2, sort_keys=True)
+            )
 finally:
     client.close()
 
-print("NoKV workbench v0.4 raw contract: OK")
+print("NoKV workbench v0.5 raw contract: OK")
 PY
 ```
 

--- a/src/lingtai/services/ANATOMY.md
+++ b/src/lingtai/services/ANATOMY.md
@@ -19,6 +19,7 @@ related_files:
   - src/lingtai/kernel/services/ANATOMY.md
   - tests/test_mcp_closed_resource_restart.py
   - src/lingtai/intrinsic_skills/system-manual/reference/environment-variables/SKILL.md
+  - tests/test_mcp_structured_result.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. Include neighboring
   ANATOMY.md files so the anatomy graph stays connected rather than isolated;
@@ -40,7 +41,7 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 | `file_io.py` | 530 | `FileIOService` facade contract + `FileIOBackend`/`LocalFileIOBackend` — backs read/edit/write/glob/grep. `grep` accepts an optional basename `glob_filter` that prunes the candidate set before stat/read |
 | `file_io_sidecar.py` | 698 | Rust-backed grep/glob: `RustFileIOBackend`, `SidecarAdapter`, `SidecarError`, plus the `resolve_sidecar_binary` resolver and the `default_file_io_service` factory used by `Agent.__init__`. `grep`'s `glob_filter` is applied as a Python-side basename post-filter (the sidecar wire protocol carries no glob field yet) |
 | `mail.py` | 19 | High-level compatibility surface: re-exports the Core `MailTransportPort` as `MailService` and the POSIX adapter as both `PosixFilesystemMailAdapter` and the legacy public name `FilesystemMailService` |
-| `mcp.py` | 510 | `MCPClient` (stdio) + `HTTPMCPClient` (streamable HTTP) — async-to-sync MCP bridges |
+| `mcp.py` | 565 | `MCPClient` (stdio) + `HTTPMCPClient` (streamable HTTP) — async-to-sync MCP bridges with shared structured-result decoding |
 | `mcp_registry.py` | — | MCP registry infrastructure (the non-tool half of the `lingtai/tools/mcp` capability): record schema (`validate_record`), JSONL registry I/O (`read_registry`, `_append_record`), catalog loader (`_load_catalog`, path constant recomputed for this location), secret-safe identity projection (`read_identities`, `IDENTITY_SAFE_ACCOUNT_KEYS`), boot-time addon decompression (`decompress_addons`), and the system-prompt XML renderer (`_build_registry_xml`). Consumed by the `lingtai/tools/mcp` tool slice (lazy import) and `agent.py` |
 | `mcp_inbox.py` | — | LICC v1 filesystem inbox poller plus Core projection; in-process publication receives the agent and uses its injected Notification Store while the external inbox path/envelope stays unchanged (`src/lingtai/services/mcp_inbox.py:373-395`). |
 | `mcp_licc.py` | — | LICC v1 client producer (`push_inbox_event`); imports contract constants from `mcp_inbox.py` |
@@ -54,18 +55,18 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 - **→ `lingtai.kernel.logging.get_logger`** (mcp.py:16) — structured logging.
 - **→ `lingtai.kernel.mail_transport`** (`mail.py:9`) — re-exports the Core-owned Port as `MailService`.
 - **→ `lingtai.adapters.posix.mail`** (`mail.py:10-13`) — re-exports the production adapter under its canonical name and the legacy public `FilesystemMailService` alias.
-- **→ `mcp.client.stdio`**, **`mcp.client.streamable_http`**, **`mcp.client.session`** (mcp.py:224, 406-407) — third-party MCP SDK. Imported lazily inside async connect methods.
+- **→ `mcp.client.stdio`**, **`mcp.client.streamable_http`**, **`mcp.client.session`** (mcp.py:368-369, 540-541) — third-party MCP SDK. Imported lazily inside async connect methods.
 - **← `lingtai.tools.vision`** — uses `services.vision.VisionService`.
 - **← `lingtai.tools.web_search`** — uses `services.websearch.SearchService`.
 - **← `tools.{read,write,edit,glob,grep}`** — the file tools use `FileIOService` (injected as `agent._file_io`).
 
 ## Composition
 
-`file_io.py` is a pure stdlib abstraction layer. `LocalFileIOService` is the tool-facing facade while `LocalFileIOBackend` owns the default Python local filesystem implementation. `file_io_sidecar.py` provides `RustFileIOBackend`, an opt-in alternative backend that delegates `read`/`write`/`edit` to a private `LocalFileIOBackend` but routes `grep`/`glob` to the Rust binary under `crates/lingtai-search-sidecar/` via short-lived JSON subprocess calls. `mail.py` is a high-level compatibility re-export across the Core Port and POSIX Adapter; it owns no implementation. `mcp.py` is the heavy module — two parallel client classes sharing the same pattern.
+`file_io.py` is a pure stdlib abstraction layer. `LocalFileIOService` is the tool-facing facade while `LocalFileIOBackend` owns the default Python local filesystem implementation. `file_io_sidecar.py` provides `RustFileIOBackend`, an opt-in alternative backend that delegates `read`/`write`/`edit` to a private `LocalFileIOBackend` but routes `grep`/`glob` to the Rust binary under `crates/lingtai-search-sidecar/` via short-lived JSON subprocess calls. `mail.py` is a high-level compatibility re-export across the Core Port and POSIX Adapter; it owns no implementation. `mcp.py` keeps two transport-specific client classes and composes both with one protocol-generic result decoder.
 
 ## State
 
-- **`MCPClient` / `HTTPMCPClient`**: each instance manages a background daemon thread (L68, 292), an asyncio event loop (`_loop`), a `ClientSession` (`_session`), and a 50-entry activity log (`_activity_log`, L54, 286). Thread-safe via `threading.Lock` and `threading.Event`.
+- **`MCPClient` / `HTTPMCPClient`**: each instance manages a background daemon thread, an asyncio event loop (`_loop`), a `ClientSession` (`_session`), and a 50-entry activity log (`mcp.py:103-118,420-431`). Thread-safe via `threading.Lock` and `threading.Event`.
 - **`LocalFileIOService`**: facade over a `_backend`; exposes `last_traversal` from the backend for tool metadata.
 - **`LocalFileIOBackend`**: default Python local filesystem backend; state is optional `_root` plus `last_traversal`.
 - **`RustFileIOBackend`**: holds an embedded `LocalFileIOBackend` (for read/write/edit), a `SidecarAdapter` (subprocess client), and a `last_traversal` rebuilt from each sidecar envelope.
@@ -76,7 +77,8 @@ Root services package — pluggable backends for intrinsic tools and MCP clients
 
 - `MCPClient` uses `stdio_client` transport (subprocess); `HTTPMCPClient` uses `streamablehttp_client` (remote HTTP/SSE). Both expose identical `call_tool()` / `list_tools()` / `close()` API.
 - Lazy start: both clients auto-connect on first `call_tool()`.
+- **Structured MCP results:** `_decode_tool_result` (`mcp.py:44-80`) is shared by stdio and HTTP. It prefers dictionary `structuredContent`, then JSON-object text, and preserves structured error fields at top level while forcing protocol-authoritative `status="error"`; plain-text errors retain the legacy `status`/`message` envelope. Tests: `tests/test_mcp_structured_result.py`.
 - **Stale-resource recovery (issue #104):** `MCPClient` detects a dead stdio transport in `call_tool` and recovers. `_format_exception` renders `ClassName: message` (class-only when `str(e)` is empty) so an empty `ClosedResourceError` never surfaces as a blank `{"status":"error","message":""}`. `_is_stale_resource_error` flags closed/broken transports by class name + message substrings. On a stale error `call_tool` calls `restart()` (which `close()`s, clears `_ready`/`_error`, resets `_closed`/`_session`/`_loop`/`_thread`/`*_cm` so `start()` cannot lie) and retries **once**; a failed retry returns a helpful error naming the class and the retry failure. Non-stale errors surface the class name without churning the subprocess. `HTTPMCPClient` reuses `MCPClient._format_exception` for its connect error only — it has no stale-resource restart (stdio is the reported transport). Tests: `tests/test_mcp_closed_resource_restart.py`.
-- `mcp.py` has significant code duplication between the two classes — same `call_tool()`, `list_tools()`, `_run_loop()`, `_async_cleanup()` pattern.
+- The transport lifecycle, `list_tools()`, `_run_loop()`, and `_async_cleanup()` patterns remain duplicated between the two clients; result normalization is deliberately shared.
 - `mail.py` is a compatibility-only alias surface. The normative boundary is `lingtai.kernel.mail_transport.MailTransportPort`; the production implementation is `lingtai.adapters.posix.mail.PosixFilesystemMailAdapter`. The legacy public names remain aliases, not a second implementation or a Core shim.
 - `file_io_sidecar.py` is the **default native backend** for `Agent`-created file-I/O services. `default_file_io_service` is the factory that `Agent.__init__` calls; it consults `LINGTAI_FILE_IO_BACKEND` (`auto` / `rust` / `python`, default `auto`) and `resolve_sidecar_binary` to pick between Rust and the pure-Python `LocalFileIOBackend`. Resolver priority: explicit `binary_path=` > `LINGTAI_FILE_IO_SIDECAR` env > `LINGTAI_SEARCH_SIDECAR` (legacy) env > packaged `lingtai/bin/` binary (shipped in platform-specific wheels by `setup.py`) > dev-tree `crates/lingtai-search-sidecar/target/{release,debug}/`. The strict `SidecarAdapter()` constructor still ignores packaged / dev-tree sources — opt-in callers see `not_configured` rather than picking up a stale binary. Defaults (`DEFAULT_*` constants) are imported from `file_io.py` so both backends stay in lock-step. Cargo is **not** required for install or the normal test suite — tests use a Python-script "sidecar"; only `test_rust_sidecar_integration_grep_and_glob` is cargo-gated.

--- a/src/lingtai/services/mcp.py
+++ b/src/lingtai/services/mcp.py
@@ -18,6 +18,69 @@ from lingtai.kernel.logging import get_logger
 
 logger = get_logger()
 
+_JSON_PARSE_FAILED = object()
+
+
+def _first_text_content(result: Any) -> str | None:
+    """Return the first text block carried by an MCP tool result."""
+    for block in getattr(result, "content", None) or []:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            return text
+    return None
+
+
+def _error_payload(payload: dict[str, Any], fallback_message: str) -> dict[str, Any]:
+    """Keep a structured MCP error while retaining the legacy envelope."""
+    error = dict(payload)
+    # The protocol's isError bit is authoritative. Do not let a malformed or
+    # hostile payload disguise a failed tool call as success.
+    error["status"] = "error"
+    message = error.get("message")
+    if not isinstance(message, str) or not message:
+        error["message"] = fallback_message
+    return error
+
+
+def _decode_tool_result(result: Any) -> Any:
+    """Decode an MCP result without flattening structured tool errors.
+
+    MCP transports may return the same object in ``structuredContent`` and in
+    a JSON text block. Prefer the structured form, then a JSON object in text.
+    Plain-text errors retain the historical ``status``/``message`` envelope.
+    This decoder is intentionally protocol-generic and is shared by stdio and
+    HTTP clients.
+    """
+    text = _first_text_content(result)
+    structured = getattr(result, "structuredContent", None)
+
+    if isinstance(structured, dict):
+        if getattr(result, "isError", False):
+            return _error_payload(
+                structured,
+                text if text else "Unknown MCP error",
+            )
+        return dict(structured)
+
+    if text is not None:
+        try:
+            decoded = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            decoded = _JSON_PARSE_FAILED
+        if isinstance(decoded, dict):
+            if getattr(result, "isError", False):
+                return _error_payload(decoded, text)
+            return decoded
+        if not getattr(result, "isError", False) and decoded is not _JSON_PARSE_FAILED:
+            # Preserve the pre-existing behavior for successful JSON values,
+            # even though MCP tool handlers conventionally return objects.
+            return decoded
+
+    if getattr(result, "isError", False):
+        return {"status": "error", "message": text or "Unknown MCP error"}
+    return {"status": "success", "text": text or ""}
+
+
 # A stale stdio response has an unknowable remote commit point. Replay is
 # therefore opt-in and limited to callers that can justify that it is safe.
 _STALE_RETRY_POLICIES = frozenset({"never", "safe"})
@@ -180,7 +243,7 @@ class MCPClient:
         timeout: float = 120,
         *,
         retry_policy: str = "never",
-    ) -> dict:
+    ) -> Any:
         """Call an MCP tool synchronously.
 
         Starts the connection lazily if not yet connected.
@@ -196,12 +259,14 @@ class MCPClient:
                 This client does not infer safety from tool names or arguments.
 
         Returns:
-            Parsed dict from the tool's JSON response. A default-policy stale
-            failure returns an error with ``outcome="ambiguous"`` and
-            ``retryable=False`` after attempting transport recovery without
-            replaying the call. A timeout after the call has been submitted is
-            also returned as ambiguous and non-retryable; the remote may have
-            committed even though no response reached this caller.
+            Decoded MCP result. JSON scalars, arrays, and ``null`` retain
+            their protocol value; structured objects remain dictionaries.
+            A default-policy stale failure returns an error with
+            ``outcome="ambiguous"`` and ``retryable=False`` after attempting
+            transport recovery without replaying the call. A timeout after the
+            call has been submitted is also returned as ambiguous and
+            non-retryable; the remote may have committed even though no
+            response reached this caller.
 
         Raises:
             RuntimeError: If the client is closed or connection fails.
@@ -221,30 +286,14 @@ class MCPClient:
         if self._session is None or self._loop is None:
             raise RuntimeError("MCP client not connected")
 
-        def _attempt() -> dict:
+        def _attempt() -> Any:
             async def _call():
                 result = await self._session.call_tool(
                     name=name,
                     arguments=args,
                     read_timeout_seconds=timedelta(seconds=timeout),
                 )
-                if result.isError:
-                    error_text = (
-                        result.content[0].text
-                        if result.content
-                        else "Unknown MCP error"
-                    )
-                    return {"status": "error", "message": error_text}
-
-                if result.content:
-                    for block in result.content:
-                        if hasattr(block, "text"):
-                            try:
-                                return json.loads(block.text)
-                            except (json.JSONDecodeError, TypeError):
-                                return {"status": "success", "text": block.text}
-
-                return {"status": "success", "text": ""}
+                return _decode_tool_result(result)
 
             future = asyncio.run_coroutine_threadsafe(_call(), self._loop)
             try:
@@ -497,7 +546,7 @@ class HTTPMCPClient:
             and not self._closed
         )
 
-    def call_tool(self, name: str, args: dict, timeout: float = 120) -> dict:
+    def call_tool(self, name: str, args: dict, timeout: float = 120) -> Any:
         """Call an MCP tool synchronously. Same interface as MCPClient."""
         import asyncio
 
@@ -514,19 +563,7 @@ class HTTPMCPClient:
                 arguments=args,
                 read_timeout_seconds=timedelta(seconds=timeout),
             )
-            if result.isError:
-                error_text = (
-                    result.content[0].text if result.content else "Unknown MCP error"
-                )
-                return {"status": "error", "message": error_text}
-            if result.content:
-                for block in result.content:
-                    if hasattr(block, "text"):
-                        try:
-                            return json.loads(block.text)
-                        except (json.JSONDecodeError, TypeError):
-                            return {"status": "success", "text": block.text}
-            return {"status": "success", "text": ""}
+            return _decode_tool_result(result)
 
         future = asyncio.run_coroutine_threadsafe(_call(), self._loop)
         result = future.result(timeout=timeout)

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -7,11 +7,11 @@ registry membership.
 """
 from __future__ import annotations
 
+import copy
 import json
 import re
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -170,6 +170,151 @@ def test_nokv_workbench_registry_example_is_valid():
     assert spec["type"] == "stdio"
     assert spec["command"] == record["command"]
     assert spec["args"] == record["args"]
+
+
+def test_nokv_workbench_skill_documents_durable_restore_contract():
+    skill_root = Path("src/lingtai/intrinsic_skills/nokv-workbench")
+    skill = (skill_root / "SKILL.md").read_text(encoding="utf-8")
+    preflight = (skill_root / "assets" / "PREFLIGHT.md").read_text(encoding="utf-8")
+
+    assert "version: 0.4.0" in skill
+    assert "workbench_restore" in skill
+    assert '"at_snapshot": 417' in skill
+    assert "same numeric `snapshot_id`" in skill
+    assert "resend the exact request" in skill
+    assert "No separate LingTai restore state" in skill
+    assert "metadata/restore_manifest.json" in skill
+    assert "nokv.workbench.restore_manifest.v1" in skill
+    assert "restored_from.snapshot_id" in skill
+    assert 'Success means `state="complete"`' in skill
+    assert "expired checkpoints cannot be renewed" in skill
+    assert "lifecycle `state` (`alive`, `expired`, or `reaped`)" in skill
+    assert "lifecycle `status`" not in skill
+    assert "grace window" not in skill
+
+    for code in (
+        "SnapshotNotFound",
+        "SnapshotLeaseExpired",
+        "SnapshotRootMismatch",
+        "SnapshotBindingChanged",
+        "SnapshotRenewContended",
+        "NotOwner",
+        "StaleOwnerEpoch",
+        "InvalidOwnerEpoch",
+        "LeaseExpired",
+        "RestoreTransportUnavailable",
+        "RestoreInProgress",
+        "RestoreRootChanged",
+        "RestoreBindingChanged",
+        "RestoreProtocolMismatch",
+        "RestoreDestinationConflict",
+        "RestoreResourceLimit",
+        "RestoreHardlinkUnsupported",
+        "RestoreCrossShardUnsupported",
+        "StalePreparedArtifactObjectGcEpoch",
+        "SyncLogArchiveFailed",
+        "CapabilityMismatch",
+    ):
+        assert code in skill
+
+    assert "complete 17-tool workbench surface" in preflight
+    assert '"required": ["id", "at_snapshot", "destination_id"]' in preflight
+    assert '"additionalProperties": False' in preflight
+    assert '"type": "integer", "minimum": 0' in preflight
+    assert '"type": "string", "minLength": 1' in preflight
+    assert "restore_to_fork_v1" in preflight
+    assert "raw schema mismatch" in preflight
+    assert "before Agent registration" in preflight
+    assert "--profile full --require-all" in preflight
+    assert "two real MCP" in preflight
+    assert "hard-coded NoKV gate" in preflight
+
+
+def _run_nokv_preflight_contract(monkeypatch, tools):
+    preflight_path = Path(
+        "src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md"
+    )
+    preflight = preflight_path.read_text(encoding="utf-8")
+    blocks = re.findall(r"<<'PY'\n(.*?)\nPY", preflight, flags=re.DOTALL)
+    code = next(block for block in blocks if "expected_restore_schema" in block)
+
+    class FakeMCPClient:
+        def __init__(self, command, args):
+            self.command = command
+            self.args = args
+
+        def list_tools(self):
+            return copy.deepcopy(tools)
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("lingtai.services.mcp.MCPClient", FakeMCPClient)
+    monkeypatch.setenv("NOKV_BIN", "/tmp/nokv")
+    monkeypatch.setenv("NOKV_MCP_ARGS", "[]")
+    exec(compile(code, str(preflight_path), "exec"), {})
+
+
+def _strict_nokv_preflight_tools():
+    names = {
+        "workbench_create", "workbench_put_file", "workbench_append",
+        "workbench_edit", "workbench_stat", "workbench_list", "workbench_read",
+        "workbench_grep", "workbench_search", "workbench_aggregate",
+        "workbench_catalog", "workbench_find", "workbench_commit",
+        "workbench_snapshot", "workbench_snapshot_renew",
+        "workbench_snapshot_list", "workbench_restore",
+    }
+    restore_schema = {
+        "type": "object",
+        "required": ["id", "at_snapshot", "destination_id"],
+        "properties": {
+            "id": {"type": "string", "minLength": 1},
+            "at_snapshot": {
+                "anyOf": [
+                    {"type": "integer", "minimum": 0},
+                    {"type": "string", "minLength": 1},
+                ]
+            },
+            "destination_id": {"type": "string", "minLength": 1},
+        },
+        "additionalProperties": False,
+    }
+    return [
+        {"name": name, "schema": restore_schema if name == "workbench_restore" else {}}
+        for name in sorted(names)
+    ]
+
+
+def test_nokv_preflight_executes_strict_raw_schema_gate(monkeypatch):
+    _run_nokv_preflight_contract(monkeypatch, _strict_nokv_preflight_tools())
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("missing-surface-tool", "NoKV workbench tools missing"),
+        ("capability-tool-absent", "NoKV workbench tools missing"),
+        ("nullable-snapshot", "workbench_restore raw schema mismatch"),
+        ("additional-properties", "workbench_restore raw schema mismatch"),
+    ],
+)
+def test_nokv_preflight_rejects_contract_drift(monkeypatch, mutation, message):
+    tools = _strict_nokv_preflight_tools()
+    if mutation == "missing-surface-tool":
+        tools = [tool for tool in tools if tool["name"] != "workbench_read"]
+    elif mutation == "capability-tool-absent":
+        tools = [tool for tool in tools if tool["name"] != "workbench_restore"]
+    else:
+        restore = next(tool for tool in tools if tool["name"] == "workbench_restore")
+        if mutation == "nullable-snapshot":
+            restore["schema"]["properties"]["at_snapshot"]["anyOf"].append(
+                {"type": "null"}
+            )
+        else:
+            restore["schema"]["additionalProperties"] = True
+
+    with pytest.raises(SystemExit, match=message):
+        _run_nokv_preflight_contract(monkeypatch, tools)
 
 
 def test_expand_agent_placeholders_scopes_workbench_root(tmp_path):

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -177,7 +177,7 @@ def test_nokv_workbench_skill_documents_durable_restore_contract():
     skill = (skill_root / "SKILL.md").read_text(encoding="utf-8")
     preflight = (skill_root / "assets" / "PREFLIGHT.md").read_text(encoding="utf-8")
 
-    assert "version: 0.4.0" in skill
+    assert "version: 0.5.0" in skill
     assert "workbench_restore" in skill
     assert '"at_snapshot": 417' in skill
     assert "same numeric `snapshot_id`" in skill
@@ -188,7 +188,7 @@ def test_nokv_workbench_skill_documents_durable_restore_contract():
     assert "restored_from.snapshot_id" in skill
     assert 'Success means `state="complete"`' in skill
     assert "expired checkpoints cannot be renewed" in skill
-    assert "lifecycle `state` (`alive`, `expired`, or `reaped`)" in skill
+    assert "lifecycle `state` (`alive`, `expired`, `retired`, or" in skill
     assert "lifecycle `status`" not in skill
     assert "grace window" not in skill
 
@@ -217,7 +217,11 @@ def test_nokv_workbench_skill_documents_durable_restore_contract():
     ):
         assert code in skill
 
-    assert "complete 17-tool workbench surface" in preflight
+    assert "complete 18-tool restore-capable workbench surface" in preflight
+    assert "The base surface has 17 tools" in preflight
+    assert '"workbench_snapshot_retire"' in preflight
+    assert '"required": ["id", "manifest", "content_digest_uri"]' in preflight
+    assert '"metadata": {' in preflight
     assert '"required": ["id", "at_snapshot", "destination_id"]' in preflight
     assert '"additionalProperties": False' in preflight
     assert '"type": "integer", "minimum": 0' in preflight
@@ -228,6 +232,48 @@ def test_nokv_workbench_skill_documents_durable_restore_contract():
     assert "--profile full --require-all" in preflight
     assert "two real MCP" in preflight
     assert "hard-coded NoKV gate" in preflight
+
+
+def test_nokv_workbench_docs_pin_write_read_and_lifecycle_contracts():
+    skill_root = Path("src/lingtai/intrinsic_skills/nokv-workbench")
+    skill = " ".join(
+        (skill_root / "SKILL.md").read_text(encoding="utf-8").split()
+    )
+    preflight = " ".join(
+        (skill_root / "assets" / "PREFLIGHT.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    assert (
+        "`replace=false` (the default) is create-only and fails when the "
+        "target exists; `replace=true` is replace-only and fails when the "
+        "target is missing"
+    ) in skill
+    assert "It is not upsert" in skill
+    assert "NoKV does not natively parse `application/x-ndjson`" in skill
+    assert "does not promise NDJSON record pagination" in skill
+    assert "A `.jsonl` suffix alone selects no parser" in skill
+    assert (
+        "write it with a `text/*` content type to receive raw `text_lines` "
+        "whose `value.text` you parse yourself"
+    ) in skill
+    assert "use `format=\"bytes\"` for `application/x-ndjson`" in skill
+
+    assert "`nokv.workbench.run_manifest.v1`" in skill
+    assert "`content_digest_uri` before the call" in skill
+    assert "different content identity conflicts even when" in skill
+    assert "`reason` and `metadata` are bounded registry annotations" in skill
+    assert "`SnapshotRegistryWritePartial`" in skill
+    assert "Use `workbench_snapshot_retire`" in skill
+    assert "returns `retired=false` and does not fabricate deletion attribution" in skill
+
+    assert "complete 18-tool restore-capable workbench surface" in preflight
+    assert "The base surface has 17 tools" in preflight
+    assert '"workbench_snapshot_retire"' in preflight
+    assert '"required": ["id", "manifest", "content_digest_uri"]' in preflight
+    assert '"reason": {' in preflight
+    assert '"metadata": {' in preflight
 
 
 def _run_nokv_preflight_contract(monkeypatch, tools):
@@ -262,7 +308,113 @@ def _strict_nokv_preflight_tools():
         "workbench_grep", "workbench_search", "workbench_aggregate",
         "workbench_catalog", "workbench_find", "workbench_commit",
         "workbench_snapshot", "workbench_snapshot_renew",
-        "workbench_snapshot_list", "workbench_restore",
+        "workbench_snapshot_retire", "workbench_snapshot_list",
+        "workbench_restore",
+    }
+    commit_schema = {
+        "type": "object",
+        "required": ["id", "manifest", "content_digest_uri"],
+        "properties": {
+            "id": {"type": "string"},
+            "manifest": {"type": "object"},
+            "content_digest_uri": {
+                "type": "string",
+                "pattern": "^sha256:[0-9a-f]{64}$",
+                "description": (
+                    "Stable caller-computed digest of the committed content. "
+                    "It must be known before this call and exactly match "
+                    "sha256:<64 lowercase hex>."
+                ),
+            },
+            "replace": {
+                "type": "boolean",
+                "description": (
+                    "Explicitly replace a different or legacy commit. "
+                    "Concurrent identity changes still fail closed. Defaults false."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    }
+    snapshot_schema = {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+            "id": {"type": "string"},
+            "name": {
+                "type": ["string", "null"],
+                "description": (
+                    "Checkpoint alias matching [A-Za-z0-9_-]{1,64}. Resolves "
+                    "to this snapshot in workbench_snapshot_renew, "
+                    "workbench_snapshot_list, and at_snapshot reads."
+                ),
+            },
+            "ttl_days": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 90,
+                "description": (
+                    "Lease length in days. Defaults to 7; values above 90 are "
+                    "rejected."
+                ),
+            },
+            "reason": {
+                "type": ["string", "null"],
+                "minLength": 1,
+                "maxLength": 256,
+                "description": (
+                    "Optional human-readable checkpoint reason. At most 256 "
+                    "Unicode characters and 1024 UTF-8 bytes."
+                ),
+            },
+            "metadata": {
+                "type": ["object", "null"],
+                "maxProperties": 64,
+                "description": (
+                    "Optional JSON annotation object. Canonical encoded size "
+                    "is at most 4096 bytes, with at most 8 container levels "
+                    "and 64 object keys across the complete value."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    }
+    retire_schema = {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+            "id": {"type": "string", "minLength": 1},
+            "snapshot_id": {
+                "type": "integer",
+                "minimum": 0,
+                "description": (
+                    "Snapshot id to retire. Provide exactly one of snapshot_id "
+                    "or name."
+                ),
+            },
+            "name": {
+                "type": "string",
+                "minLength": 1,
+                "description": (
+                    "Checkpoint name to retire. Provide exactly one of "
+                    "snapshot_id or name."
+                ),
+            },
+            "reason": {
+                "type": ["string", "null"],
+                "minLength": 1,
+                "maxLength": 256,
+                "description": (
+                    "Optional human-readable retirement reason. At most 256 "
+                    "Unicode characters and 1024 UTF-8 bytes."
+                ),
+            },
+        },
+        "oneOf": [
+            {"required": ["snapshot_id"]},
+            {"required": ["name"]},
+        ],
+        "additionalProperties": False,
     }
     restore_schema = {
         "type": "object",
@@ -279,8 +431,14 @@ def _strict_nokv_preflight_tools():
         },
         "additionalProperties": False,
     }
+    schemas = {
+        "workbench_commit": commit_schema,
+        "workbench_snapshot": snapshot_schema,
+        "workbench_snapshot_retire": retire_schema,
+        "workbench_restore": restore_schema,
+    }
     return [
-        {"name": name, "schema": restore_schema if name == "workbench_restore" else {}}
+        {"name": name, "schema": schemas.get(name, {})}
         for name in sorted(names)
     ]
 
@@ -294,6 +452,9 @@ def test_nokv_preflight_executes_strict_raw_schema_gate(monkeypatch):
     [
         ("missing-surface-tool", "NoKV workbench tools missing"),
         ("capability-tool-absent", "NoKV workbench tools missing"),
+        ("commit-content-identity", "workbench_commit raw schema mismatch"),
+        ("snapshot-annotation", "workbench_snapshot raw schema mismatch"),
+        ("retire-target", "workbench_snapshot_retire raw schema mismatch"),
         ("nullable-snapshot", "workbench_restore raw schema mismatch"),
         ("additional-properties", "workbench_restore raw schema mismatch"),
     ],
@@ -304,6 +465,19 @@ def test_nokv_preflight_rejects_contract_drift(monkeypatch, mutation, message):
         tools = [tool for tool in tools if tool["name"] != "workbench_read"]
     elif mutation == "capability-tool-absent":
         tools = [tool for tool in tools if tool["name"] != "workbench_restore"]
+    elif mutation == "commit-content-identity":
+        commit = next(tool for tool in tools if tool["name"] == "workbench_commit")
+        commit["schema"]["required"].remove("content_digest_uri")
+    elif mutation == "snapshot-annotation":
+        snapshot = next(
+            tool for tool in tools if tool["name"] == "workbench_snapshot"
+        )
+        del snapshot["schema"]["properties"]["metadata"]
+    elif mutation == "retire-target":
+        retire = next(
+            tool for tool in tools if tool["name"] == "workbench_snapshot_retire"
+        )
+        del retire["schema"]["oneOf"]
     else:
         restore = next(tool for tool in tools if tool["name"] == "workbench_restore")
         if mutation == "nullable-snapshot":

--- a/tests/test_mcp_structured_result.py
+++ b/tests/test_mcp_structured_result.py
@@ -1,0 +1,226 @@
+"""MCP structured-result decoding shared by stdio and HTTP transports."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from mcp.types import CallToolResult, ImageContent, TextContent
+
+from lingtai.services.mcp import HTTPMCPClient, MCPClient
+
+
+class _ImmediateFuture:
+    def __init__(self, value):
+        self._value = value
+
+    def result(self, timeout=None):
+        return self._value
+
+
+class _RunningLoop:
+    def is_running(self):
+        return True
+
+
+class _Session:
+    def __init__(self, result):
+        self._result = result
+
+    async def call_tool(self, **kwargs):
+        return self._result
+
+
+def _result(*, is_error, structured=None, text=None):
+    content = [] if text is None else [TextContent(type="text", text=text)]
+    return CallToolResult(
+        isError=is_error,
+        structuredContent=structured,
+        content=content,
+    )
+
+
+@pytest.fixture(params=["stdio", "http"])
+def client(request, monkeypatch):
+    if request.param == "stdio":
+        instance = MCPClient(command="/bin/true")
+    else:
+        instance = HTTPMCPClient(url="https://example.invalid/mcp")
+
+    instance._loop = _RunningLoop()
+    instance._closed = False
+
+    real_asyncio_run = asyncio.run
+
+    def run_now(coro, loop):
+        return _ImmediateFuture(real_asyncio_run(coro))
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", run_now)
+    return instance
+
+
+def _call(client, result):
+    client._session = _Session(result)
+    return client.call_tool("example", {"value": 1})
+
+
+def test_structured_error_has_priority_and_keeps_fields(client):
+    structured = {
+        "status": "success",
+        "code": "RestoreInProgress",
+        "message": "restore is still preparing",
+        "retryable": True,
+        "details": {"operation_id": "restore-123"},
+    }
+    result = _call(
+        client,
+        _result(
+            is_error=True,
+            structured=structured,
+            text='{"code":"WrongTextFallback","message":"wrong"}',
+        ),
+    )
+
+    assert result == {**structured, "status": "error"}
+
+
+@pytest.mark.parametrize(
+    ("structured", "text", "expected_message"),
+    [
+        (
+            {"code": "RestoreProtocolMismatch", "retryable": True},
+            "metadata owner returned an inconsistent outcome",
+            "metadata owner returned an inconsistent outcome",
+        ),
+        (
+            {
+                "code": "RestoreProtocolMismatch",
+                "message": "",
+                "retryable": True,
+            },
+            None,
+            "Unknown MCP error",
+        ),
+    ],
+    ids=["missing-message-uses-text", "empty-message-uses-default"],
+)
+def test_structured_error_fills_missing_or_empty_message(
+    client,
+    structured,
+    text,
+    expected_message,
+):
+    result = _call(
+        client,
+        _result(is_error=True, structured=structured, text=text),
+    )
+
+    assert result == {
+        **structured,
+        "status": "error",
+        "message": expected_message,
+    }
+
+
+def test_json_object_error_is_promoted_to_top_level(client):
+    result = _call(
+        client,
+        _result(
+            is_error=True,
+            text=(
+                '{"code":"SnapshotLeaseExpired",'
+                '"message":"checkpoint expired","retryable":false,'
+                '"details":{"snapshot_id":42},'
+                '"error":{"kind":"checkpoint"}}'
+            ),
+        ),
+    )
+
+    assert result == {
+        "status": "error",
+        "code": "SnapshotLeaseExpired",
+        "message": "checkpoint expired",
+        "retryable": False,
+        "details": {"snapshot_id": 42},
+        "error": {"kind": "checkpoint"},
+    }
+
+
+def test_plain_text_error_keeps_legacy_envelope(client):
+    result = _call(
+        client,
+        _result(is_error=True, text="tool rejected the request"),
+    )
+
+    assert result == {
+        "status": "error",
+        "message": "tool rejected the request",
+    }
+
+
+def test_empty_error_keeps_nonempty_fallback(client):
+    result = _call(client, _result(is_error=True))
+
+    assert result == {"status": "error", "message": "Unknown MCP error"}
+
+
+def test_structured_success_is_preferred_over_text(client):
+    result = _call(
+        client,
+        _result(
+            is_error=False,
+            structured={"status": "success", "value": 7},
+            text='{"status":"success","value":8}',
+        ),
+    )
+
+    assert result == {"status": "success", "value": 7}
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("true", True),
+        ("42", 42),
+        ('[1,"two",null]', [1, "two", None]),
+        ("null", None),
+    ],
+    ids=["bool", "number", "list", "null"],
+)
+def test_json_non_object_success_preserves_legacy_result(client, text, expected):
+    result = _call(client, _result(is_error=False, text=text))
+
+    assert result == expected
+
+
+def test_empty_success_text_keeps_legacy_envelope(client):
+    result = _call(client, _result(is_error=False, text=""))
+
+    assert result == {"status": "success", "text": ""}
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["ordinary success text", "{malformed-json"],
+    ids=["plain-text", "malformed-json"],
+)
+def test_non_json_success_keeps_legacy_envelope(client, text):
+    result = _call(client, _result(is_error=False, text=text))
+
+    assert result == {"status": "success", "text": text}
+
+
+def test_first_text_block_wins_after_non_text_content(client):
+    result = _call(
+        client,
+        CallToolResult(
+            isError=False,
+            content=[
+                ImageContent(type="image", data="AA==", mimeType="image/png"),
+                TextContent(type="text", text='{"value":"first"}'),
+                TextContent(type="text", text='{"value":"second"}'),
+            ],
+        ),
+    )
+
+    assert result == {"value": "first"}

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -251,7 +251,7 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert "name: nokv-workbench" in nokv_body
         assert "workbench_find" in nokv_body
         assert "workbench_commit" in nokv_body
-        assert "version: 0.4.0" in nokv_body
+        assert "version: 0.5.0" in nokv_body
         assert "workbench_restore" in nokv_body
         assert "restore-to-fork" in nokv_body
         assert "same numeric `snapshot_id`" in nokv_body
@@ -261,6 +261,10 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert "RestoreDestinationConflict" in nokv_body
         assert "CapabilityMismatch" in nokv_body
         assert "metadata/run_manifest.json" in nokv_body
+        assert "nokv.workbench.run_manifest.v1" in nokv_body
+        assert "content_digest_uri" in nokv_body
+        assert "workbench_snapshot_retire" in nokv_body
+        assert "application/x-ndjson" in nokv_body
         assert (
             nokv_md.parent / "assets" / "mcp_registry.example.jsonl"
         ).is_file()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -7,8 +7,6 @@ import json
 import sqlite3
 import time
 from pathlib import Path
-from unittest.mock import MagicMock
-
 from lingtai.agent import Agent
 from tests._service_helpers import make_gemini_mock_service as make_mock_service
 
@@ -253,6 +251,15 @@ def test_skills_setup_hard_copies_intrinsics(tmp_path):
         assert "name: nokv-workbench" in nokv_body
         assert "workbench_find" in nokv_body
         assert "workbench_commit" in nokv_body
+        assert "version: 0.4.0" in nokv_body
+        assert "workbench_restore" in nokv_body
+        assert "restore-to-fork" in nokv_body
+        assert "same numeric `snapshot_id`" in nokv_body
+        assert "metadata/restore_manifest.json" in nokv_body
+        assert "nokv.workbench.restore_manifest.v1" in nokv_body
+        assert "RestoreInProgress" in nokv_body
+        assert "RestoreDestinationConflict" in nokv_body
+        assert "CapabilityMismatch" in nokv_body
         assert "metadata/run_manifest.json" in nokv_body
         assert (
             nokv_md.parent / "assets" / "mcp_registry.example.jsonl"


### PR DESCRIPTION
## Summary

- preserve MCP `structuredContent` across stdio and HTTP transports
- promote structured JSON tool errors to stable top-level `code`, `message`, `retryable`, and `details` fields while preserving legacy plain-text behavior
- update the NoKV workbench skill to v0.4 with durable restore retry, terminal-state, and manifest validation rules
- strengthen deployment preflight to validate the raw restore schema and capability-gated tool advertisement

## Design boundary

LingTai does not keep a second restore state machine or orchestrate a multi-step copy. After MCP reconnect it reuses the saved numeric snapshot ID and resends the same strict request. No Agent startup path is hard-coded to NoKV, and the change does not auto-revive a destination workbench or couple restore to CPR internals.

The transport decoder is protocol-generic; NoKV-specific policy remains in the intrinsic workbench skill and deployment preflight.

## Validation

- 179 focused MCP, capability, skill, reconnect, config, discovery, LICC, and skill-manual tests passed
- Ruff checks passed for all changed Python files
- companion NoKV full `--require-all` live E2E passed with real RustFS, NoKV serve, Agent registration/reconnect, and two independent MCP clients

Companion NoKV PR: NoKV-Lab/NoKV#407
Prerequisite Holt PR: NoKV-Lab/holt#29
