### PR TITLE
feat(avatar): unify model-facing tool surface

### DIFF
--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -40,8 +40,8 @@ composes them.
 **Tool sub-packages:** `email/`, `system/`, `psyche/`, `soul/`, `notification/`
 (the five mandatory intrinsics); canonical `shell` (retained `bash/` implementation), `knowledge/`, `skills/`, `avatar/`,
 `daemon/`, `mcp/`, `read/`, `write/`, `edit/`, `glob/`, `grep/` (always-on
-floor); `vision/`, `web_search/` (opt-in). `avatar/` registers two tools
-(`avatar_spawn`, `avatar_rules`).
+floor); `vision/`, `web_search/` (opt-in). `avatar/` registers one tool,
+`avatar`, dispatched by `action` (`spawn`\|`rules`\|`manual`).
 
 ## Connections
 

--- a/src/lingtai/tools/avatar/ANATOMY.md
+++ b/src/lingtai/tools/avatar/ANATOMY.md
@@ -42,26 +42,37 @@ independent life — its existence does not depend on yours.
 
 ## Public API
 
-The capability exposes two public tools:
+The capability exposes one public tool, `avatar`, dispatched by an `action`
+enum:
 
-| Tool | Description |
+| Action | Description |
 |------|-------------|
-| `avatar_spawn` | Spawn a new avatar agent (shallow or deep) with a given name, optional type, and optional comment. Accepts `dry_run` (preview-only) and `confirm` (acknowledge mission-quality gate). |
-| `avatar_rules` | Set rules content and distribute via `.rules` signal files to self + all descendants. |
+| `spawn` | Spawn a new avatar agent (shallow or deep) with a given name, optional type, and optional comment. Accepts `dry_run` (preview-only) and `confirm` (acknowledge mission-quality gate). |
+| `rules` | Set rules content and distribute via `.rules` signal files to self + all descendants. |
+| `manual` | Read-only: returns the exact `manual/SKILL.md` body. No mutation. |
 
-`avatar_spawn` and `avatar_rules` are separate tools so both schemas can stay
-as simple top-level `type: object` declarations with ordinary `required`
-fields. Some OpenAI-compatible strict tool validators reject top-level JSON
-Schema combinators such as `allOf`.
+`action` has no default — it is required both by the schema
+(`"required": ["action"]`) and at runtime, matching the established action-tool
+convention already used by `knowledge`, `mcp`, `skills`, `notification`,
+`system`, `soul`, and `daemon`. Omitting `action` fails deterministically via
+the same `dispatch_action` unknown-action envelope as an unrecognized value;
+it never falls through to `spawn`.
+
+`avatar` uses a single plain top-level `type: object` schema with an explicit
+`action` enum, not a top-level `allOf`/`oneOf` combinator — some
+OpenAI-compatible strict tool validators reject top-level JSON Schema
+combinators. Action-specific required inputs beyond `action` itself (`name`
+for spawn, `rules_content` for rules) are validated in the handler, not the
+schema.
 
 ## Internal Module Layout
 
 ```
 avatar/__init__.py
   ├── AvatarManager.__init__        — stores parent agent ref
-  ├── handle()                      — legacy action dispatcher used internally
-  ├── handle_spawn()                — spawn handler for the avatar_spawn tool
-  ├── handle_rules()                — rules handler for the avatar_rules tool
+  ├── handle()                      — public dispatcher for the avatar tool
+  │                                    (action: spawn | rules | manual)
+  ├── _manual()                     — reads the packaged manual/SKILL.md body
   │
   │  Spawn pipeline:
   ├── _spawn()                      — validates name, checks liveness, prepares working dir, launches process
@@ -105,7 +116,7 @@ avatar/__init__.py
 
 - **Parent:** `src/lingtai/tools/` (tool package).
 - **Siblings:** `daemon/`, `mcp/`, `knowledge/` (private durable memory), `skills/` (skill catalog), `bash/`.
-- **Kernel hooks:** `setup()` is called during capability initialization; `AvatarManager.handle_spawn()` is registered as the `avatar_spawn` tool handler and `AvatarManager.handle_rules()` as `avatar_rules`. The daemon capability blacklists both tools to prevent avatar-in-daemon recursion and rules mutation from emanations.
+- **Kernel hooks:** `setup()` is called during capability initialization; `AvatarManager.handle()` is registered as the single `avatar` tool handler, internally dispatching `spawn`/`rules`/`manual` via `lingtai.kernel.tool_dispatch.dispatch_action`. The daemon capability blacklists `avatar` to prevent avatar-in-daemon recursion and rules mutation from emanations.
 
 Platform process mechanics are in `adapters/avatar_launcher.py` and the
 POSIX reference adapter. Unsupported Windows selection fails loudly; a future

--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -1,11 +1,12 @@
 ---
 name: avatar-contract
-tool: avatar_spawn, avatar_rules
-contract_version: 1
+tool: avatar
+contract_version: 3
 related_files:
   - src/lingtai/tools/avatar/__init__.py
   - src/lingtai/tools/avatar/_launcher.py
   - src/lingtai/tools/avatar/ANATOMY.md
+  - src/lingtai/tools/avatar/manual/SKILL.md
   - src/lingtai/adapters/avatar_launcher.py
   - src/lingtai/adapters/posix/avatar_launcher.py
 maintenance: |
@@ -17,9 +18,25 @@ maintenance: |
 # Avatar capability contract
 
 `avatar` spawns independent peer agents (分身) as fully detached processes, and
-distributes shared rules across the avatar subtree. It registers **two** tools:
-`avatar_spawn` and `avatar_rules`. The implementation lives in
-`src/lingtai/tools/avatar/`; the code is the source of truth.
+distributes shared rules across the avatar subtree. It registers **one** public
+tool, `avatar`, dispatched by an `action` enum (`spawn` | `rules` | `manual`).
+The implementation lives in `src/lingtai/tools/avatar/`; the code is the source
+of truth.
+
+**contract_version 2** (breaking): the former two-tool surface (`avatar_spawn`,
+`avatar_rules`) was merged into the single `avatar` tool below. `avatar_spawn`
+and `avatar_rules` are no longer registered as model-facing tools; there is no
+compatibility alias.
+
+**contract_version 3** (breaking): `action` is now schema-required
+(`"required": ["action"]`) and runtime-required — omitting `action` no longer
+defaults to `spawn`. This aligns `avatar` with the established action-tool
+contract already followed by `knowledge`, `mcp`, `skills`, `notification`,
+`system`, `soul`, and `daemon`: every action tool in this repository requires
+an explicit `action`, with no implicit default action. A missing `action`
+returns the same deterministic `dispatch_action` unknown-action error envelope
+as any other unrecognized action value, and performs no spawn, rules, or
+manual side effect.
 
 ## Routing Card
 
@@ -41,15 +58,24 @@ storage; detached-process launch -> §Cross-platform invariants.
 
 ## Scope
 
-- Canonical tool names: `avatar_spawn` and `avatar_rules`. They are registered
-  as two separate tools with plain top-level object schemas (deliberately no
-  `allOf` combinator, which some strict OpenAI-compatible validators reject).
-- `avatar_spawn` creates a sibling agent directory named after the avatar and
-  launches it via the global venv. Shallow copies only `init.json` (no
-  identity/pad/history); deep also copies `system/`, `knowledge/`, `exports/`,
-  and `combo.json`.
-- `avatar_rules` writes a `.rules` signal to the caller and every descendant so
-  each agent refreshes its own `system/rules.md`-derived prompt.
+- Canonical tool name: `avatar`. It is registered as a single tool with a plain
+  top-level object schema (deliberately no `allOf`/`oneOf` combinator, which
+  some strict OpenAI-compatible validators reject) and an explicit `action`
+  enum (`spawn` | `rules` | `manual`). `action` is schema-required
+  (`"required": ["action"]`) — the same convention as `knowledge`, `mcp`,
+  `skills`, `notification`, `system`, `soul`, and `daemon`. Action-specific
+  required inputs beyond `action` itself (`name` for spawn, `rules_content`
+  for rules) are validated in the handler, not the schema.
+- `action="spawn"` (must be passed explicitly — there is no default action)
+  creates a sibling agent directory named after the avatar and launches it via
+  the global venv. Shallow copies only `init.json` (no identity/pad/history);
+  deep also copies `system/`, `knowledge/`, `exports/`, and `combo.json`.
+- `action="rules"` writes a `.rules` signal to the caller and every descendant
+  so each agent refreshes its own `system/rules.md`-derived prompt. It carries
+  its own admin gate, independent of `spawn` — spawning never requires admin.
+- `action="manual"` is read-only: it returns the exact packaged
+  `src/lingtai/tools/avatar/manual/SKILL.md` body and performs no filesystem
+  mutation (no spawn, no ledger write, no `.rules` write).
 
 **Non-goals:** the parent holds no in-process handle to the avatar — liveness is
 checked purely via the filesystem handshake. The tool does not manage the
@@ -57,10 +83,10 @@ avatar's ongoing lifecycle after boot (mail/system intrinsics do that).
 
 ## Tool surface
 
-### `avatar_spawn`
+### `avatar` — `action="spawn"`
 
-Schema requires `name`. The mission/task brief arrives via the injected
-`_reasoning` field (becomes the avatar's first prompt), not a schema property.
+Requires `name`. The mission/task brief arrives via the injected `_reasoning`
+field (becomes the avatar's first prompt), not a schema property.
 
 | Inputs | Optional inputs | Success output | Error / gate shapes |
 |---|---|---|---|
@@ -71,13 +97,32 @@ missions unless `confirm=true`; `dry_run` is exempt. Avatar names must match
 `^[\w-]+$` (Unicode letters, digits, `_`, `-`), be ≤64 chars, and carry no dot,
 slash, or leading `.` — the name doubles as the working-dir basename.
 
-### `avatar_rules`
+### `avatar` — `action="rules"`
 
 | Inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|
 | `rules_content` (required) | — | `{status: "ok", message, distributed_to: [...]}` | `{error: ...}` — empty `rules_content`, no admin privilege, or failure writing the self `.rules` signal |
 
-`avatar_rules` requires at least one truthy admin privilege on the caller.
+`action="rules"` requires at least one truthy admin privilege on the caller.
+This gate applies only to `rules`; `spawn` never checks admin.
+
+### `avatar` — `action="manual"`
+
+No inputs consumed beyond `action`.
+
+| Inputs | Optional inputs | Success output | Error shapes |
+|---|---|---|---|
+| — | — | `{status: "ok", action: "manual", manual: <exact SKILL.md body>}` | `{status: "degraded", action: "manual", manual: "", error: ...}` if the packaged manual file is missing |
+
+### Invalid or missing `action`
+
+An `action` value outside `spawn`/`rules`/`manual` — including an entirely
+omitted `action` key — returns
+`{error: "unknown action: <repr>, only 'spawn', 'rules', or 'manual' is supported"}`
+(for the omitted case, `<repr>` is `''`) without touching the filesystem, the
+ledger, `.rules`, or launching any process. There is no default action: a
+`name`- or `rules_content`-shaped payload with `action` omitted still fails
+this way rather than being inferred as `spawn` or `rules`.
 
 ## State & storage
 
@@ -139,27 +184,33 @@ live descendant.
 |---|---|---|
 | The POSIX launcher preserves exact detached launch, PID/exit truth, one-process termination, and non-killing release contracts; unsupported platforms fail loudly | `src/lingtai/adapters/posix/avatar_launcher.py`, `src/lingtai/adapters/avatar_launcher.py` | `tests/test_avatar_launcher.py::test_posix_launch_contract_and_release`, `::test_selector_selects_posix_and_fails_loud_for_unsupported` |
 | Boot policy keeps heartbeat-first precedence, exact early-exit truth, and a live-process slow path without termination | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_launcher.py::test_manager_boot_policy_uses_opaque_port_and_preserves_precedence`, `::test_manager_slow_observation_does_not_terminate_child` |
-| `setup` registers both `avatar_spawn` and `avatar_rules` | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_setup_avatar`, `::test_add_capability_avatar` |
+| `setup` registers exactly one public tool, `avatar`, and no old public names | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_setup_avatar`, `::test_add_capability_avatar`, `::TestUnifiedAvatarTool::test_setup_registers_exactly_one_public_tool` |
 | Each spawn appends a ledger record | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_ledger_records_spawn` |
 | `dry_run` previews without spawning and does not require `confirm` | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_dry_run_returns_preview_without_spawning`, `::test_dry_run_does_not_require_confirm` |
 | The mission-quality gate rejects empty/short/placeholder missions | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_helper_rejects_empty`, `::test_helper_rejects_short`, `::test_helper_rejects_test_word`, `::test_helper_rejects_test_prefix` |
 | Unsafe / duplicate avatar names are rejected | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_spawn_rejects_unsafe_name`, `::test_spawn_duplicate_name_error` |
 | Shallow spawn does not copy identity files | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_spawn_does_not_copy_identity_files` |
-| `avatar_rules` requires admin and non-empty content | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_rules_requires_admin`, `::test_rules_requires_content` |
+| `action="rules"` requires admin and non-empty content; `spawn` does not inherit that gate | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_rules_requires_admin`, `::test_rules_requires_content`; `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_spawn_does_not_inherit_rules_permission_gate` |
 | Rules are distributed recursively to descendants (cycle-safe) | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_rules_distributes_recursively`, `::test_rules_root_not_duplicated_via_cycle` |
 | Spawning distributes existing rules to the newborn | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_spawn_distributes_existing_rules`, `::test_spawn_deep_clone_also_gets_rules_signal` |
 | `_prepare_deep` refuses a non-sibling destination | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_prepare_deep_refuses_non_sibling_dst` |
+| `action="manual"` returns the exact packaged manual body and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` |
+| Invalid `action` fails deterministically without touching other actions | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_invalid_action_fails_deterministically`, `::test_spawn_missing_name_fails_without_affecting_other_actions` |
+| `action` is schema-required (`required: ["action"]`) and runtime-required — a missing `action` never defaults to `spawn`, `rules`, or `manual`, regardless of which action's fields are present, and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_omitted_action_fails_deterministically_and_does_not_default_to_spawn`, `::test_missing_action_fails_deterministically_regardless_of_payload_shape`; `tests/test_avatar_rules.py::TestAvatarRulesAction::test_explicit_spawn_action_required` |
+| The daemon blacklists the canonical `avatar` name (not the retired two-tool names) | `src/lingtai/tools/daemon/__init__.py` | `tests/test_daemon.py::test_build_tool_surface_blacklist`, `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_daemon_excludes_avatar_from_child_surface` |
 
 ## Verification matrix
 
 | Invariant | Automated test | Manual check | Risk if broken |
 |---|---|---|---|
-| Both tools register on setup | `tests/test_layers_avatar.py::test_setup_avatar` | Boot with `capabilities={"avatar": {}}` and inspect tools | Rules distribution or spawning silently unavailable |
+| Exactly one tool registers on setup | `tests/test_layers_avatar.py::test_setup_avatar` | Boot with `capabilities={"avatar": {}}` and inspect tools | Rules distribution or spawning silently unavailable |
 | Spawn is ledgered with boot status | `tests/test_layers_avatar.py::test_ledger_records_spawn` | Spawn an avatar, inspect `delegates/ledger.jsonl` | No audit trail; duplicate/liveness checks break |
-| Mission gate stops accidental spawns | `tests/test_layers_avatar.py::test_helper_rejects_short` | `avatar_spawn(name="x")` with a 5-char mission, confirm gate | Stray detached processes from batched calls |
+| Mission gate stops accidental spawns | `tests/test_layers_avatar.py::test_helper_rejects_short` | `avatar(action="spawn", name="x")` with a 5-char mission, confirm gate | Stray detached processes from batched calls |
 | Name validation / path-scope guard holds | `tests/test_layers_avatar.py::test_spawn_rejects_unsafe_name` | Spawn with `name="../x"`, confirm refusal | Avatar dir escapes the network root |
 | Boot verification catches early child exit | `tests/test_avatar_launcher.py::test_manager_boot_policy_uses_opaque_port_and_preserves_precedence` | Corrupt an avatar `init.json`, spawn, confirm `failed` + stderr | Parent thinks a crashed avatar is alive |
+| Omitted `action` never defaults to spawn | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_omitted_action_fails_deterministically_and_does_not_default_to_spawn` | Call `avatar(name="x", confirm=true)` with no `action`, confirm error + no spawned process | A model omitting `action` could accidentally spawn an untracked process |
 | Rules propagate to the whole subtree | `tests/test_avatar_rules.py::test_rules_distributes_recursively` | Set rules on a root, confirm `.rules` on each descendant | Descendants run stale/ungoverned rules |
+| `manual` action is read-only | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` | Call `avatar(action="manual")`, confirm no new files | A "manual" call could accidentally spawn or mutate rules |
 
 Run before merging avatar changes:
 

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -17,9 +17,10 @@ every spawn event.
 
 Usage:
     Agent(capabilities=["avatar"])
-    # avatar_spawn(name="researcher")              — shallow (初生)
-    # avatar_spawn(name="clone", type="deep")      — deep (二重身)
-    # avatar_rules(rules_content="...")            — distribute rules
+    # avatar(action="spawn", name="researcher")              — shallow (初生)
+    # avatar(action="spawn", name="clone", type="deep")      — deep (二重身)
+    # avatar(action="rules", rules_content="...")            — distribute rules
+    # avatar(action="manual")                                — read the avatar manual
 """
 from __future__ import annotations
 
@@ -29,11 +30,13 @@ import re
 import shutil
 import sys
 import time
+from importlib import resources
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lingtai.kernel.agent_presence import observe_alive as _presence_observe_alive
 from lingtai.kernel.i18n import t
+from lingtai.kernel.tool_dispatch import dispatch_action
 from ._launcher import AvatarLaunchReceipt, AvatarLaunchRequest, AvatarLauncherPort
 
 
@@ -93,23 +96,42 @@ if TYPE_CHECKING:
 PROVIDERS = {"providers": [], "default": "builtin"}
 
 def get_description(lang: str = "en") -> str:
-    return 'Spawn an independent agent (他我). Inherits init.json; boots on default preset. See avatar-manual skill for full guidance.'
+    return (
+        "Spawn an independent agent (他我), set network rules for descendants, "
+        "or read the avatar manual. Requires an explicit action — no default. "
+        "action='spawn': inherits init.json, boots on default preset — requires "
+        "'name'. action='rules': distribute rules_content to self + all "
+        "descendants (requires karma). action='manual': return the "
+        "avatar-manual skill body. See avatar-manual skill for full guidance."
+    )
 
 
 def get_schema(lang: str = "en") -> dict:
-    """Schema for the public ``avatar_spawn`` tool.
+    """Schema for the single public ``avatar`` tool.
 
-    Rules distribution is exposed as a separate ``avatar_rules`` tool so both
-    tools can use simple top-level object schemas with ordinary ``required``
-    fields. Some OpenAI-compatible strict validators reject top-level JSON
-    Schema combinators such as ``allOf``.
+    A plain top-level ``type: object`` with an explicit ``action`` enum —
+    deliberately no top-level ``allOf``/``oneOf`` combinator, which some
+    OpenAI-compatible strict tool validators reject. Action-specific required
+    inputs (``name`` for spawn, ``rules_content`` for rules) are validated in
+    the handler, not the schema, so all three actions share one flat property
+    bag.
     """
     return {
         "type": "object",
         "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["spawn", "rules", "manual"],
+                "description": (
+                    "spawn: create a new avatar — requires 'name'. "
+                    "rules: distribute network rules to self + descendants — "
+                    "requires 'rules_content'. manual: return the avatar-manual "
+                    "skill body; no other inputs used. Required — no default."
+                ),
+            },
             "name": {
                 "type": "string",
-                "description": 'True name for the avatar (required). Also the working-directory basename under .lingtai/. Single segment: letters/digits/underscore/hyphen, max 64 chars.',
+                "description": 'True name for the avatar (required for action=spawn). Also the working-directory basename under .lingtai/. Single segment: letters/digits/underscore/hyphen, max 64 chars.',
             },
             "type": {
                 "type": "string",
@@ -128,25 +150,12 @@ def get_schema(lang: str = "en") -> dict:
                 "type": "boolean",
                 "description": 'Confirm you have reviewed the mission and intend to spawn. Required when the mission looks empty/short/test-like.',
             },
-        },
-        "required": ["name"],
-    }
-
-
-def get_rules_description(lang: str = "en") -> str:
-    return 'Set network rules for all descendants (requires karma). See avatar-manual skill for full guidance.'
-
-
-def get_rules_schema(lang: str = "en") -> dict:
-    return {
-        "type": "object",
-        "properties": {
             "rules_content": {
                 "type": "string",
-                "description": 'Rules content for avatar_rules. Plain text, one rule per line. Non-negotiable constraints distributed to all descendants.',
+                "description": 'Rules content for action=rules. Plain text, one rule per line. Non-negotiable constraints distributed to all descendants.',
             },
         },
-        "required": ["rules_content"],
+        "required": ["action"],
     }
 
 
@@ -171,16 +180,25 @@ class AvatarManager:
     # ------------------------------------------------------------------
 
     def handle(self, args: dict) -> dict:
-        action = args.get("action", "spawn")
-        if action == "rules":
-            return self._rules(args)
-        return self._spawn(args)
+        return dispatch_action(
+            args,
+            {
+                "spawn": self._spawn,
+                "rules": self._rules,
+                "manual": lambda _args: self._manual(),
+            },
+            unknown=lambda action: {
+                "error": f"unknown action: {action!r}, only 'spawn', 'rules', or 'manual' is supported",
+            },
+        )
 
-    def handle_spawn(self, args: dict) -> dict:
-        return self._spawn(args)
-
-    def handle_rules(self, args: dict) -> dict:
-        return self._rules(args)
+    def _manual(self) -> dict:
+        """Return the exact packaged avatar-manual body; performs no mutation."""
+        try:
+            body = resources.files(__package__).joinpath("manual/SKILL.md").read_text(encoding="utf-8")
+        except (FileNotFoundError, ModuleNotFoundError, AttributeError):
+            return {"status": "degraded", "action": "manual", "manual": "", "error": "avatar manual missing"}
+        return {"status": "ok", "action": "manual", "manual": body}
 
     # ------------------------------------------------------------------
     # Ledger (append-only JSONL log of avatar spawn events)
@@ -251,7 +269,7 @@ class AvatarManager:
                     "warning": (
                         f"Mission appears short/test-like ({reason}). "
                         f"Pass confirm=true to proceed, or dry_run=true to preview. "
-                        f"Each avatar_spawn call creates an independent process — "
+                        f"Each avatar(action='spawn') call creates an independent process — "
                         f"double-check your reasoning field before retrying."
                     ),
                     "reason": reason,
@@ -810,17 +828,10 @@ def setup(agent: "Agent", **kwargs) -> AvatarManager:
     """Set up the avatar capability on an agent."""
     mgr = AvatarManager(agent)
     agent.add_tool(
-        "avatar_spawn",
+        "avatar",
         schema=get_schema(),
-        handler=mgr.handle_spawn,
+        handler=mgr.handle,
         description=get_description(),
-        glossary_package=__package__,
-    )
-    agent.add_tool(
-        "avatar_rules",
-        schema=get_rules_schema(),
-        handler=mgr.handle_rules,
-        description=get_rules_description(),
         glossary_package=__package__,
     )
     return mgr

--- a/src/lingtai/tools/avatar/glossary-wen.md
+++ b/src/lingtai/tools/avatar/glossary-wen.md
@@ -15,11 +15,11 @@ maintenance: |
 ---
 **名相对照**
 
-- `avatar_spawn`：化出独立他我。承 init.json，以默认预设启。详见 avatar-manual 技。
-- `avatar_rules`：设网法以布一切后嗣（需 karma）。详见 avatar-manual 技。
-- `name`：他我真名（必填）。亦为 .lingtai/ 下目录之名。单段：字母/数/下划线/连字，至长六十四。
+- `avatar`：唯一公开之器，以 `action` 分遣。详见 avatar-manual 技。
+- `action`：必填，无默认。`spawn`（化出独立他我，承 init.json，以默认预设启）｜`rules`（设网法以布一切后嗣，需 karma）｜`manual`（只读，还 avatar 手册全文）。
+- `name`：他我真名（action=spawn 时必填）。亦为 .lingtai/ 下目录之名。单段：字母/数/下划线/连字，至长六十四。
 - `type`：'shallow'（默认，初生）：白纸，仅 init.json。'deep'（二重身）：全拷灵台、简、典。
 - `comment`：他我提示之恒注（跨蜕/刷/眠不去）。不承自父。无事勿填。
 - `dry_run`：预览而不化。用于提交前省察。
 - `confirm`：确认已审任务且决意化。任务空/短/似试时必填。
-- `rules_content`：avatar_rules 所需法则之文。纯文每行一则。不可议之约束，布一切后嗣。
+- `rules_content`：action=rules 所需法则之文。纯文每行一则。不可议之约束，布一切后嗣。

--- a/src/lingtai/tools/avatar/glossary-zh.md
+++ b/src/lingtai/tools/avatar/glossary-zh.md
@@ -15,11 +15,11 @@ maintenance: |
 ---
 **术语对照**
 
-- `avatar_spawn`：化出独立他我。继承 init.json，用默认预设启动。详见 avatar-manual 技能。
-- `avatar_rules`：设置网络法则并分发给所有后代（需 karma）。详见 avatar-manual 技能。
-- `name`：他我之真名（必填）。兼作 .lingtai/ 下目录名。单段：字母/数字/下划线/连字符，最长64字。
+- `avatar`：唯一公开工具，以 `action` 分派。详见 avatar-manual 技能。
+- `action`：必填，无默认值。`spawn`（化出独立他我，继承 init.json，用默认预设启动）｜`rules`（设置网络法则并分发给所有后代，需 karma）｜`manual`（只读，返回 avatar 手册全文）。
+- `name`：他我之真名（action=spawn 时必填）。兼作 .lingtai/ 下目录名。单段：字母/数字/下划线/连字符，最长64字。
 - `type`：'shallow'（默认，初生）：白纸，仅 init.json。'deep'（二重身）：完整复制灵台、简、典。
 - `comment`：写入他我系统提示之持久注解（跨凝蜕/刷新/休眠不变）。不承自父。非必要勿填。
 - `dry_run`：预览化出而不生进程。用于提交前审查。
 - `confirm`：确认已审阅任务并决意化出。任务空白/过短/似试时必填。
-- `rules_content`：avatar_rules 的法则内容。纯文，每行一则。不可协商之约束，分发一切后代。
+- `rules_content`：action=rules 所需之法则内容。纯文，每行一则。不可协商之约束，分发一切后代。

--- a/src/lingtai/tools/avatar/manual/SKILL.md
+++ b/src/lingtai/tools/avatar/manual/SKILL.md
@@ -52,7 +52,7 @@ The avatar's display name (nickname) can be set separately via `psyche(name, nic
 
 ## 4. The `reasoning` Field — Mission Briefing
 
-The `reasoning` parameter you write on the `avatar_spawn` call **automatically becomes the avatar's first prompt**. Write it as a thorough mission briefing, not just a one-liner rationale. Include:
+The `reasoning` parameter you write on the `avatar(action="spawn")` call **automatically becomes the avatar's first prompt**. Write it as a thorough mission briefing, not just a one-liner rationale. Include:
 
 - What the task is
 - Why it matters
@@ -65,9 +65,9 @@ This is the most important part of the spawn. A vague briefing produces a confus
 
 ## 5. Spawn Discipline
 
-Every `avatar_spawn` call creates an independent process that consumes resources until `system(sleep)` or `system(suspend)`. Treat spawns as expensive:
+Every `avatar(action="spawn")` call creates an independent process that consumes resources until `system(sleep)` or `system(suspend)`. Treat spawns as expensive:
 
-1. **Never include `avatar_spawn` in a parallel batch** with unrelated tool calls.
+1. **Never include `avatar(action="spawn")` in a parallel batch** with unrelated tool calls.
 2. **Re-read your `reasoning` field before invoking** — that text becomes the avatar's first prompt.
 3. **For inspection or one-off commands, use `bash` or `system`** — not `avatar`.
 4. **Use `dry_run=true` to preview** a spawn without creating a process. Sanity-check the name, type, working directory, and mission before committing.
@@ -122,9 +122,9 @@ The `comment` parameter is a persistent system-level note injected into the avat
 
 Leave empty unless you have something the avatar should never forget.
 
-## 9. Network Rules (`avatar_rules`)
+## 9. Network Rules (`avatar(action="rules")`)
 
-The `avatar_rules` tool writes a `.rules` file to your directory and distributes it to **all descendants** in the avatar tree. Properties:
+The `rules` action writes a `.rules` file to your directory and distributes it to **all descendants** in the avatar tree. Properties:
 
 - Requires **karma** privilege (admin)
 - Rules are injected into the system prompt (after covenant, before tools)

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -127,8 +127,6 @@ _SOURCE_ROOT = Path(__file__).resolve().parents[3]
 EMANATION_BLACKLIST = {
     "daemon",
     "avatar",
-    "avatar_spawn",
-    "avatar_rules",
     "psyche",
     "skills",
     "knowledge",

--- a/tests/test_avatar_rules.py
+++ b/tests/test_avatar_rules.py
@@ -310,11 +310,19 @@ class TestAvatarRulesAction:
         result = mgr.handle({"action": "rules"})
         assert "error" in result
 
-    def test_spawn_default_action(self, tmp_path):
-        """Omitting action should default to spawn (backward compatible).
+    def test_explicit_spawn_action_required(self, tmp_path):
+        """action='spawn' must be explicit; omitting action must NOT spawn.
 
         NOTE: Real spawning launches a subprocess. We patch _launch to avoid
         that, and pre-create init.json so _spawn reaches the launch path.
+
+        Historical intent: this test formerly proved that an omitted
+        'action' defaulted to spawn (a back-compat shorthand from the
+        avatar_spawn/avatar_rules two-tool era). That shorthand was removed
+        so the unified 'avatar' tool matches the schema-and-runtime-required
+        'action' contract every other canonical action tool (knowledge, mcp,
+        skills, notification, system, soul, daemon) already follows — see
+        avatar CONTRACT.md contract_version 3.
         """
         from lingtai.agent import Agent
 
@@ -332,8 +340,16 @@ class TestAvatarRulesAction:
         )
 
         mgr = agent.get_capability("avatar")
-        with _patch_avatar_launch():
-            result = mgr.handle({"name": "child", "confirm": True})
+        with _patch_avatar_launch() as launch:
+            # Omitted action must fail deterministically and spawn nothing.
+            omitted = mgr.handle({"name": "child", "confirm": True})
+            assert "error" in omitted
+            assert omitted["error"] == "unknown action: '', only 'spawn', 'rules', or 'manual' is supported"
+            launch.assert_not_called()
+            assert not (parent_dir.parent / "child").exists()
+
+            # Explicit action='spawn' behaves exactly as before.
+            result = mgr.handle({"action": "spawn", "name": "child", "confirm": True})
         assert result["status"] == "ok"
         assert result["agent_name"] == "child"
         assert result["address"] == "child"  # relative name (current convention)
@@ -419,7 +435,7 @@ class TestAutoDistributeAfterSpawn:
 
         mgr = parent.get_capability("avatar")
         with _patch_avatar_launch():
-            result = mgr.handle({"name": "child", "confirm": True})
+            result = mgr.handle({"action": "spawn", "name": "child", "confirm": True})
         assert result["status"] == "ok"
 
         # Child dir is a sibling of parent_dir (avatar_working_dir = parent.parent / name)
@@ -433,7 +449,7 @@ class TestAutoDistributeAfterSpawn:
 
         mgr = parent.get_capability("avatar")
         with _patch_avatar_launch():
-            result = mgr.handle({"name": "child", "confirm": True})
+            result = mgr.handle({"action": "spawn", "name": "child", "confirm": True})
         assert result["status"] == "ok"
 
         child_dir = parent_dir.parent / "child"
@@ -447,7 +463,7 @@ class TestAutoDistributeAfterSpawn:
 
         mgr = parent.get_capability("avatar")
         with _patch_avatar_launch():
-            result = mgr.handle({"name": "clone", "type": "deep", "confirm": True})
+            result = mgr.handle({"action": "spawn", "name": "clone", "type": "deep", "confirm": True})
         assert result["status"] == "ok"
 
         clone_dir = parent_dir.parent / "clone"
@@ -499,7 +515,7 @@ class TestSpawnNameValidation:
         mgr = parent.get_capability("avatar")
 
         with _patch_avatar_launch() as launch:
-            result = mgr.handle({"name": bad_name})
+            result = mgr.handle({"action": "spawn", "name": bad_name})
 
         assert "error" in result, f"name={bad_name!r} should have been rejected but got {result}"
         # No subprocess launched
@@ -524,7 +540,7 @@ class TestSpawnNameValidation:
         mgr = parent.get_capability("avatar")
 
         with _patch_avatar_launch():
-            result = mgr.handle({"name": good_name, "confirm": True})
+            result = mgr.handle({"action": "spawn", "name": good_name, "confirm": True})
 
         assert result.get("status") == "ok", f"name={good_name!r} should have been accepted but got {result}"
         assert (parent_dir.parent / good_name).is_dir()
@@ -538,7 +554,7 @@ class TestSpawnNameValidation:
 
         with _patch_avatar_launch():
             # Pass both a safe name and a malicious legacy dir; name wins.
-            result = mgr.handle({"name": "safe", "dir": "avatars/evil", "confirm": True})
+            result = mgr.handle({"action": "spawn", "name": "safe", "dir": "avatars/evil", "confirm": True})
 
         assert result.get("status") == "ok"
         assert (parent_dir.parent / "safe").is_dir()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -274,17 +274,12 @@ def test_build_tool_surface_blacklist(tmp_path):
     schemas, dispatch = mgr._build_tool_surface([
         "file",
         "avatar",
-        "avatar_spawn",
-        "avatar_rules",
         "daemon",
     ])
     names = {s.name for s in schemas}
     assert "daemon" not in names
     assert "avatar" not in names
-    assert "avatar_spawn" not in names
-    assert "avatar_rules" not in names
-    assert "avatar_spawn" not in dispatch
-    assert "avatar_rules" not in dispatch
+    assert "avatar" not in dispatch
     assert "read" in names
 
 

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -74,7 +74,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
         assert result["status"] == "ok"
         assert "address" in result
         assert result["address"]  # filesystem path (non-empty string)
@@ -86,7 +86,7 @@ class TestAvatarManager:
         from lingtai.agent import Agent
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities={"bash": {"yolo": True}, "avatar": {}})
-        result = parent._tool_handlers["avatar_spawn"]({"name": "child", "confirm": True})
+        result = parent._tool_handlers["avatar"]({"action": "spawn", "name": "child", "confirm": True})
         assert result["status"] == "ok"
         # New architecture: avatars run as their own processes; introspection
         # is via the avatar's on-disk init.json, not an in-process _peers map.
@@ -104,7 +104,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"], covenant="Be helpful and concise.")
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
         assert result["status"] == "ok"
 
     def test_spawn_no_admin(self, tmp_path):
@@ -113,7 +113,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"], admin={"karma": True})
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
         assert result["status"] == "ok"
         child_init = json.loads((parent._working_dir.parent / "helper" / "init.json").read_text())
         child_admin = child_init.get("manifest", {}).get("admin", {})
@@ -133,9 +133,9 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        r1 = mgr.handle({"name": "helper", "confirm": True})
+        r1 = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
         assert r1["status"] == "ok"
-        r2 = mgr.handle({"name": "helper", "confirm": True})
+        r2 = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
         assert "error" in r2 or r2.get("status") == "already_active"
 
     def test_spawn_does_not_copy_identity_files(self, tmp_path):
@@ -154,7 +154,7 @@ class TestAvatarManager:
         (knowledge_dir / "knowledge.json").write_text('{"entries": []}')
 
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"name": "blank", "confirm": True})
+        result = mgr.handle({"action": "spawn", "name": "blank", "confirm": True})
         assert result["status"] == "ok"
         child_dir = parent._working_dir.parent / "blank"
         # Character and knowledge should NOT be copied
@@ -167,7 +167,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"name": "clone", "confirm": True})
+        result = mgr.handle({"action": "spawn", "name": "clone", "confirm": True})
         assert result["status"] == "ok"
 
     def test_ledger_records_spawn(self, tmp_path):
@@ -176,7 +176,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        mgr.handle({"name": "clone", "confirm": True})
+        mgr.handle({"action": "spawn", "name": "clone", "confirm": True})
         ledger = (parent._working_dir / "delegates" / "ledger.jsonl").read_text().strip()
         record = json.loads(ledger)
         assert record["name"] == "clone"
@@ -230,7 +230,7 @@ class TestMissionQualityGate:
         """Spawn with no _reasoning and no confirm should be refused with a preview."""
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"name": "helper"})
+        result = mgr.handle({"action": "spawn", "name": "helper"})
         assert result["status"] == "confirmation_needed"
         assert "warning" in result
         assert "preview" in result
@@ -243,7 +243,7 @@ class TestMissionQualityGate:
     def test_spawn_with_short_mission_returns_confirmation_needed(self, tmp_path):
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"name": "helper", "_reasoning": "test"})
+        result = mgr.handle({"action": "spawn", "name": "helper", "_reasoning": "test"})
         assert result["status"] == "confirmation_needed"
         assert result["preview"]["mission"] == "test"
         assert result["preview"]["mission_chars"] == 4
@@ -252,7 +252,7 @@ class TestMissionQualityGate:
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
         # No mission, but confirm=True acknowledges the risk.
-        result = mgr.handle({"name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
         assert result["status"] == "ok"
         assert (parent._working_dir.parent / "helper").is_dir()
 
@@ -260,6 +260,7 @@ class TestMissionQualityGate:
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
+            "action": "spawn",
             "name": "helper",
             "_reasoning": "Investigate the heartbeat regression and report back via mail",
         })
@@ -268,7 +269,7 @@ class TestMissionQualityGate:
     def test_dry_run_returns_preview_without_spawning(self, tmp_path):
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"name": "helper", "dry_run": True})
+        result = mgr.handle({"action": "spawn", "name": "helper", "dry_run": True})
         assert result["status"] == "dry_run"
         assert result["preview"]["name"] == "helper"
         assert result["preview"]["type"] == "shallow"
@@ -284,13 +285,14 @@ class TestMissionQualityGate:
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
         # Empty mission + no confirm + dry_run=True → returns dry_run, not confirmation_needed.
-        result = mgr.handle({"name": "helper", "dry_run": True})
+        result = mgr.handle({"action": "spawn", "name": "helper", "dry_run": True})
         assert result["status"] == "dry_run"
 
     def test_dry_run_preview_reports_real_mission_safe(self, tmp_path):
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
+            "action": "spawn",
             "name": "helper",
             "dry_run": True,
             "_reasoning": "Investigate the heartbeat regression and report back via mail",
@@ -300,20 +302,16 @@ class TestMissionQualityGate:
         assert result["preview"]["mission_reason"] == ""
 
     def test_schema_exposes_dry_run_and_confirm(self):
-        from lingtai.tools.avatar import get_rules_schema, get_schema
+        from lingtai.tools.avatar import get_schema
         sch = get_schema("en")
         assert "dry_run" in sch["properties"]
         assert sch["properties"]["dry_run"]["type"] == "boolean"
         assert "confirm" in sch["properties"]
         assert sch["properties"]["confirm"]["type"] == "boolean"
-        assert "rules_content" not in sch["properties"]
-        assert sch["required"] == ["name"]
-        assert not {"oneOf", "anyOf", "allOf", "enum", "not"} & set(sch)
-
-        rules_sch = get_rules_schema("en")
-        assert rules_sch["required"] == ["rules_content"]
-        assert "rules_content" in rules_sch["properties"]
-        assert not {"oneOf", "anyOf", "allOf", "enum", "not"} & set(rules_sch)
+        assert "rules_content" in sch["properties"]
+        assert sch["required"] == ["action"]
+        assert not {"oneOf", "anyOf", "allOf", "not"} & set(sch)
+        assert sch["properties"]["action"]["enum"] == ["spawn", "rules", "manual"]
 
     def test_description_points_to_avatar_manual_after_prompt_compaction(self):
         """The terse tool description should route safety guidance to the manual.
@@ -330,7 +328,7 @@ class TestMissionQualityGate:
         assert "WARNING" not in desc
         assert "confirm" in schema["properties"]
         assert "dry_run" in schema["properties"]
-        assert "action" not in schema["properties"]
+        assert "action" in schema["properties"]
 
 
 class TestSetupAvatar:
@@ -338,9 +336,9 @@ class TestSetupAvatar:
         agent = MagicMock()
         mgr = setup_avatar(agent)
         assert isinstance(mgr, AvatarManager)
-        assert agent.add_tool.call_count == 2
+        assert agent.add_tool.call_count == 1
         tool_names = {call.args[0] for call in agent.add_tool.call_args_list}
-        assert tool_names == {"avatar_spawn", "avatar_rules"}
+        assert tool_names == {"avatar"}
 
 
 class TestAddCapability:
@@ -350,12 +348,12 @@ class TestAddCapability:
                            capabilities=["avatar"])
         mgr = agent.get_capability("avatar")
         assert isinstance(mgr, AvatarManager)
-        assert "avatar_spawn" in agent._tool_handlers
-        assert "avatar_spawn" in {s.name for s in agent._tool_schemas}
-        assert "avatar_rules" in agent._tool_handlers
-        assert "avatar_rules" in {s.name for s in agent._tool_schemas}
-        assert "avatar" not in agent._tool_handlers
-        assert "avatar" not in {s.name for s in agent._tool_schemas}
+        assert "avatar" in agent._tool_handlers
+        assert "avatar" in {s.name for s in agent._tool_schemas}
+        assert "avatar_spawn" not in agent._tool_handlers
+        assert "avatar_spawn" not in {s.name for s in agent._tool_schemas}
+        assert "avatar_rules" not in agent._tool_handlers
+        assert "avatar_rules" not in {s.name for s in agent._tool_schemas}
 
     def test_add_capability_unknown(self, tmp_path):
         """Unknown capability is logged + skipped (not raised) so a bad name
@@ -392,3 +390,175 @@ class TestAddCapability:
         assert caps_by_name.get("shell") == {"yolo": True}
         assert "bash" not in caps_by_name
         assert caps_by_name.get("avatar") == {}
+
+
+class TestUnifiedAvatarTool:
+    """Regression coverage for the avatar_spawn + avatar_rules → avatar merge."""
+
+    def test_setup_registers_exactly_one_public_tool(self):
+        """setup() must register exactly one tool named 'avatar' and no old names."""
+        agent = MagicMock()
+        setup_avatar(agent)
+        assert agent.add_tool.call_count == 1
+        (name,), kwargs = agent.add_tool.call_args
+        assert name == "avatar"
+        assert kwargs["schema"]["properties"]["action"]["enum"] == ["spawn", "rules", "manual"]
+
+    def test_schema_is_plain_object_with_no_top_level_combinators(self):
+        from lingtai.tools.avatar import get_schema
+        sch = get_schema("en")
+        assert sch["type"] == "object"
+        assert not ({"allOf", "oneOf", "anyOf"} & set(sch))
+        assert sch["properties"]["action"]["type"] == "string"
+        assert sch["properties"]["action"]["enum"] == ["spawn", "rules", "manual"]
+
+    def test_spawn_dispatch_preserves_behavior_and_reasoning(self, tmp_path, fake_avatar_launch):
+        """action='spawn' preserves outputs and _reasoning → first-prompt propagation."""
+        from lingtai.agent import Agent
+        parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
+                            capabilities=["avatar"])
+        mgr = parent.get_capability("avatar")
+        result = mgr.handle({
+            "action": "spawn",
+            "name": "helper",
+            "_reasoning": "Investigate the heartbeat regression and report back via mail",
+        })
+        assert result["status"] == "ok"
+        assert result["agent_name"] == "helper"
+        prompt_path = parent._working_dir.parent / "helper" / ".prompt"
+        assert "Investigate the heartbeat regression" in prompt_path.read_text(encoding="utf-8")
+
+    def test_omitted_action_fails_deterministically_and_does_not_default_to_spawn(
+        self, tmp_path, fake_avatar_launch,
+    ):
+        """Missing 'action' must NOT default to spawn — action is schema- and
+        runtime-required, matching the knowledge/mcp/skills/notification/system/
+        soul/daemon canonical action-tool contract."""
+        from lingtai.agent import Agent
+        parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
+                            capabilities=["avatar"])
+        mgr = parent.get_capability("avatar")
+
+        # Even with a fully valid spawn payload (name + confirm), omitting
+        # 'action' must fail deterministically rather than silently spawning.
+        result = mgr.handle({"name": "helper2", "confirm": True})
+        assert "error" in result
+        assert result["error"] == "unknown action: '', only 'spawn', 'rules', or 'manual' is supported"
+        assert result.get("status") != "ok"
+
+        # No process/filesystem/ledger mutation happened.
+        assert not (parent._working_dir.parent / "helper2").exists()
+        assert not (parent._working_dir / "delegates" / "ledger.jsonl").exists()
+        fake_avatar_launch.poll.assert_not_called()
+
+    def test_rules_dispatch_preserves_admin_gate_and_content_validation(self, tmp_path):
+        """action='rules' keeps admin gate + non-empty content validation."""
+        from lingtai.agent import Agent
+        no_admin = Agent(service=make_mock_service(), agent_name="worker",
+                          working_dir=tmp_path / "worker", capabilities=["avatar"], admin={})
+        mgr = no_admin.get_capability("avatar")
+        result = mgr.handle({"action": "rules", "rules_content": "No deleting."})
+        assert "error" in result
+
+        admin = Agent(service=make_mock_service(), agent_name="admin",
+                       working_dir=tmp_path / "admin", capabilities=["avatar"],
+                       admin={"karma": True})
+        mgr2 = admin.get_capability("avatar")
+        empty_result = mgr2.handle({"action": "rules", "rules_content": ""})
+        assert "error" in empty_result
+
+        ok_result = mgr2.handle({"action": "rules", "rules_content": "Be concise."})
+        assert ok_result["status"] == "ok"
+        assert (admin._working_dir / ".rules").read_text() == "Be concise."
+
+    def test_spawn_does_not_inherit_rules_permission_gate(self, tmp_path, fake_avatar_launch):
+        """A non-admin agent can still spawn — the rules admin gate must not leak into spawn."""
+        from lingtai.agent import Agent
+        no_admin = Agent(service=make_mock_service(), agent_name="worker",
+                          working_dir=tmp_path / "worker", capabilities=["avatar"], admin={})
+        mgr = no_admin.get_capability("avatar")
+        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        assert result["status"] == "ok"
+
+    def test_manual_returns_exact_body_and_performs_no_mutation(self, tmp_path):
+        """action='manual' is read-only: returns the exact SKILL.md body, no fs mutation."""
+        from lingtai.agent import Agent
+        parent = Agent(service=make_mock_service(), agent_name="parent",
+                        working_dir=tmp_path / "test", capabilities=["avatar"])
+        mgr = parent.get_capability("avatar")
+
+        manual_source = (
+            Path(__file__).resolve().parents[1]
+            / "src" / "lingtai" / "tools" / "avatar" / "manual" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+
+        result = mgr.handle({"action": "manual"})
+        assert result["status"] == "ok"
+        assert result["manual"] == manual_source
+
+        # No spawn side effects: no sibling directory, no ledger.
+        assert not (parent._working_dir.parent / "helper").exists()
+        assert not (parent._working_dir / "delegates" / "ledger.jsonl").exists()
+        # No rules side effects: no .rules signal written.
+        assert not (parent._working_dir / ".rules").exists()
+
+    def test_daemon_excludes_avatar_from_child_surface(self, tmp_path):
+        """The daemon's emanation blacklist covers the new canonical 'avatar' name only."""
+        from lingtai.tools.daemon import EMANATION_BLACKLIST
+        assert "avatar" in EMANATION_BLACKLIST
+        assert "avatar_spawn" not in EMANATION_BLACKLIST
+        assert "avatar_rules" not in EMANATION_BLACKLIST
+
+    def test_invalid_action_fails_deterministically(self, tmp_path):
+        from lingtai.agent import Agent
+        parent = Agent(service=make_mock_service(), agent_name="parent",
+                        working_dir=tmp_path / "test", capabilities=["avatar"])
+        mgr = parent.get_capability("avatar")
+        result = mgr.handle({"action": "bogus"})
+        assert "error" in result
+        assert "bogus" in result["error"]
+
+    def test_missing_action_fails_deterministically_regardless_of_payload_shape(self, tmp_path):
+        """Missing 'action' must fail the same way no matter which action's
+        fields happen to be present — it must never be inferred from payload
+        shape, and must mutate nothing (no spawn, no ledger, no .rules)."""
+        from lingtai.agent import Agent
+        parent = Agent(service=make_mock_service(), agent_name="parent",
+                        working_dir=tmp_path / "test", capabilities=["avatar"],
+                        admin={"karma": True})
+        mgr = parent.get_capability("avatar")
+
+        # Payload shaped like a valid rules call, but action omitted.
+        rules_shaped = mgr.handle({"rules_content": "Be concise."})
+        assert "error" in rules_shaped
+        assert "unknown action: ''" in rules_shaped["error"]
+        assert not (parent._working_dir / ".rules").exists()
+
+        # Payload shaped like a valid spawn call, but action omitted.
+        spawn_shaped = mgr.handle({"name": "helper3", "confirm": True})
+        assert "error" in spawn_shaped
+        assert "unknown action: ''" in spawn_shaped["error"]
+        assert not (parent._working_dir.parent / "helper3").exists()
+        assert not (parent._working_dir / "delegates" / "ledger.jsonl").exists()
+
+        # Entirely empty payload.
+        empty = mgr.handle({})
+        assert "error" in empty
+        assert "unknown action: ''" in empty["error"]
+
+    def test_spawn_missing_name_fails_without_affecting_other_actions(self, tmp_path):
+        from lingtai.agent import Agent
+        parent = Agent(service=make_mock_service(), agent_name="parent",
+                        working_dir=tmp_path / "test", capabilities=["avatar"],
+                        admin={"karma": True})
+        mgr = parent.get_capability("avatar")
+
+        spawn_result = mgr.handle({"action": "spawn"})
+        assert "error" in spawn_result
+        assert "name is required" in spawn_result["error"]
+
+        rules_result = mgr.handle({"action": "rules", "rules_content": "Be concise."})
+        assert rules_result["status"] == "ok"
+
+        manual_result = mgr.handle({"action": "manual"})
+        assert manual_result["status"] == "ok"


### PR DESCRIPTION
## Summary

- replace the separate model-facing `avatar_spawn` and `avatar_rules` tools with one canonical `avatar` tool
- preserve existing spawn and rules behavior through `action=spawn` / `action=rules`
- add `action=manual` to return the existing avatar manual skill body
- update the tool schema, dispatch surface, contract, anatomy, glossaries, manual, and focused tests

## Stack order

This PR is intentionally stacked on #967 (`feat/task-card-feedback-guidance-20260716-livebase`) per the locked dev-2 → dev-1 → dev-3 integration order. Do not merge this PR before #967.

## Validation

- `188 passed, 3 deselected` across `tests/test_environment_variable_catalogue.py`, `tests/test_avatar_rules.py`, `tests/test_daemon.py`, and `tests/test_layers_avatar.py`
- the three deselected preset-connectivity nodes fail identically on the exact upstream because their temporary preset fixtures omit the newly-required `description.summary`; they are not introduced by this avatar delta
- `git diff --check` passed
- exact avatar delta against #967 head: 11 files, +398/-146