### PR TITLE
fix(telegram): preserve Task Card backend errors

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -64,6 +64,7 @@ _CONVERSATION_PREVIEW_MESSAGES = 20
 # Keep 20 structured Telegram messages below the MCP inbox structured metadata cap.
 _STRUCTURED_MESSAGE_TEXT_CAP = 500
 _DOCUMENT_DOWNLOAD_REASON_CAP = 200
+_TASK_CARD_BACKEND_REASON_CAP = 200
 _TELEGRAM_API_ERROR_PREFIX = "Telegram API error: "
 
 # Task Card edit outcomes are deliberately narrower than generic transport
@@ -152,6 +153,14 @@ def _safe_document_download_reason(exc: Exception) -> str:
     if isinstance(status, int) and not isinstance(status, bool):
         return f"{exc_class} (HTTP {status})"
     return exc_class
+
+
+def _safe_task_card_backend_reason(exc: Exception) -> str:
+    """Return one redacted, bounded Telegram transport reason for controller use."""
+    from lingtai.kernel.trace_redaction import redact_text
+
+    reason = " ".join(redact_text(_safe_document_download_reason(exc)).split())
+    return reason[:_TASK_CARD_BACKEND_REASON_CAP] or type(exc).__name__
 
 
 def _document_download_failure_notice(reason: str) -> str:
@@ -1579,13 +1588,13 @@ class TelegramManager:
         self,
         compound_id: str,
         text: str,
-    ) -> str:
-        """Edit once and preserve whether replacement is actually permissible."""
+    ) -> tuple[str, str | None]:
+        """Edit once; return its semantic outcome and a safe failure reason."""
         try:
             account, chat_id, tg_msg_id = self._parse_compound_id(compound_id)
             acct = self._service.get_account(account)
             acct.edit_message(chat_id, tg_msg_id, text)
-            return _TASK_CARD_EDIT_OK
+            return _TASK_CARD_EDIT_OK, None
         except Exception as exc:
             outcome = self._task_card_edit_error_outcome(exc)
             if outcome == _TASK_CARD_EDIT_OK:
@@ -1597,7 +1606,12 @@ class TelegramManager:
                     "Task card edit failed; resident retained (error_type=%s)",
                     type(exc).__name__,
                 )
-            return outcome
+            reason = (
+                _safe_task_card_backend_reason(exc)
+                if outcome == _TASK_CARD_EDIT_FAILED
+                else None
+            )
+            return outcome, reason
 
     def update_progress_message(
         self,
@@ -1605,7 +1619,8 @@ class TelegramManager:
         text: str,
     ) -> bool:
         """Compatibility bool: true for an applied edit or identical-content no-op."""
-        return self._try_update_progress_message(compound_id, text) == _TASK_CARD_EDIT_OK
+        outcome, _reason = self._try_update_progress_message(compound_id, text)
+        return outcome == _TASK_CARD_EDIT_OK
 
     # ------------------------------------------------------------------
     # Private Task Card helpers (internally driven — by the kernel automatic
@@ -1734,14 +1749,17 @@ class TelegramManager:
                 if rotated.get("status") == "ok":
                     self._set_channel_frame(account, chat_id, channel, frame)
                 return rotated
-            edit_outcome = self._try_update_progress_message(resident_id, text)
+            edit_outcome, edit_error = self._try_update_progress_message(
+                resident_id, text
+            )
             if edit_outcome == _TASK_CARD_EDIT_OK:
                 self._set_channel_frame(account, chat_id, channel, frame)
                 return {"status": "ok", "message_id": resident_id}
             if edit_outcome == _TASK_CARD_EDIT_FAILED:
                 # Unknown, transient, network, and provider failures do not prove
-                # that replacement is safe. Preserve both resident and slot state.
-                return {"status": "error", "error": error}
+                # that replacement is safe. Preserve both resident and slot state,
+                # and surface only the redacted bounded provider reason.
+                return {"status": "error", "error": edit_error or error}
             # The provider confirmed this exact message is missing/uneditable.
             # Confirm exact delete-or-missing before any replacement send.
             recovered = self._recover_task_card_by_replacement(
@@ -2568,11 +2586,11 @@ class TelegramManager:
         """
         committed_text = self._compose_channels(account, chat_id)
         if committed_text:
-            probe_outcome = self._try_update_progress_message(
+            probe_outcome, probe_error = self._try_update_progress_message(
                 stale_id, committed_text
             )
             if probe_outcome == _TASK_CARD_EDIT_FAILED:
-                return {"status": "error", "error": error}
+                return {"status": "error", "error": probe_error or error}
         return self._replace_task_card_after_probe(
             account, chat_id, stale_id, text, error=error
         )

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -106,7 +106,10 @@ the procedure lives in [`SKILL.md`](SKILL.md), not here:
    types are handled failures, never crashes.
 4. After a handle exists, failures preserve the last valid frame and emit a
    **deduped, per-episode** fail-loud `task_card.error` wake plus one `recovered`
-   wake; raw renderer output and secrets never enter the wake.
+   wake. A Telegram backend rejection keeps the stable controller error code and
+   carries its redacted, whitespace-normalized, bounded provider reason as optional
+   `backend_error` through `retry`/`inspect`/`stop` results and the failure wake;
+   raw renderer output and secrets never enter the wake.
 5. Projection uses `channel="programmable"` only; the controller forwards a
    validated card object, **never** code. Updating the programmable slot never
    disturbs the automatic slot.

--- a/src/lingtai/mcp_servers/telegram/task_card/controller.py
+++ b/src/lingtai/mcp_servers/telegram/task_card/controller.py
@@ -49,6 +49,7 @@ _DEFAULT_TIMEOUT_S = 10.0
 _DEFAULT_INTERVAL_S = 5.0
 _MIN_INTERVAL_S = 1.0
 _REVERSE_CALL_TIMEOUT_S = 5.0
+_BACKEND_ERROR_CAP = 300
 # Watcher-thread join budget on stop/shutdown. A tick blocked in the reverse
 # call can take up to ``_REVERSE_CALL_TIMEOUT_S``; join must exceed that (plus a
 # small margin) to be a truthful join rather than a premature timeout.
@@ -361,15 +362,16 @@ class TaskCardController:
         # preserves the old programmable frame on a transient/unknown edit failure,
         # so reporting ``stopped`` and dropping the handle would strand a visible
         # frame with no way to retry.
-        if self._project(watch, "finalize", None).get("status") == "error":
-            error = {
-                "code": "stop_finalize_failed",
-                "retryable": True,
-                "message": (
+        project_result = self._project(watch, "finalize", None)
+        if project_result.get("status") == "error":
+            error = self._backend_failure(
+                "stop_finalize_failed",
+                (
                     "task card backend rejected the stop/finalize; the watch is "
                     "retained so stop can be retried"
                 ),
-            }
+                project_result,
+            )
             with watch.lock:
                 if not watch.finalized:
                     watch.error = error
@@ -460,11 +462,11 @@ class TaskCardController:
         if result.get("status") == "error":
             self._mark_error(
                 watch,
-                {
-                    "code": "backend_edit_failed",
-                    "retryable": True,
-                    "message": "task card backend rejected the frame",
-                },
+                self._backend_failure(
+                    "backend_edit_failed",
+                    "task card backend rejected the frame",
+                    result,
+                ),
             )
             return
         self._mark_recovered(watch, frame)
@@ -485,7 +487,8 @@ class TaskCardController:
         (accepted) or re-attempt the clear (failed). No duplicate/concurrent
         finalize is possible: public stop/retry refuse to finalize while this
         thread is alive."""
-        accepted = self._project(watch, "finalize", None).get("status") != "error"
+        project_result = self._project(watch, "finalize", None)
+        accepted = project_result.get("status") != "error"
         with watch.lock:
             if accepted:
                 watch.finalized = True
@@ -501,14 +504,14 @@ class TaskCardController:
                     ),
                 }
             elif not watch.finalized:
-                watch.error = {
-                    "code": "stop_finalize_failed",
-                    "retryable": True,
-                    "message": (
+                watch.error = self._backend_failure(
+                    "stop_finalize_failed",
+                    (
                         "stop requested; clearing the in-flight update failed — "
                         "retry stop to re-attempt the clear"
                     ),
-                }
+                    project_result,
+                )
 
     # -- fail-loud / recovery transitions ----------------------------------
 
@@ -575,6 +578,11 @@ class TaskCardController:
                 "code": code,
                 "retryable": (error or {}).get("retryable", "unknown"),
             }
+            backend_error = self._safe_backend_error(
+                (error or {}).get("backend_error")
+            )
+            if backend_error:
+                extra["backend_error"] = backend_error
             if last_valid_at:
                 extra["last_valid_frame_at"] = last_valid_at
             key = f"task_card.error:{watch.watch_id}:{epoch}:{code}"
@@ -665,13 +673,43 @@ class TaskCardController:
             code = "renderer_failed"
         return {"code": code, "message": msg, "retryable": True}
 
+    @staticmethod
+    def _safe_backend_error(value: object) -> str | None:
+        """Redact, normalize, and bound one downstream transport reason."""
+        if not isinstance(value, str):
+            return None
+        from lingtai.kernel.trace_redaction import redact_text
+
+        text = " ".join(redact_text(value).split())
+        return text[:_BACKEND_ERROR_CAP] or None
+
+    @classmethod
+    def _backend_failure(
+        cls, code: str, message: str, project_result: dict
+    ) -> dict:
+        """Build one stable controller error while retaining a safe backend reason."""
+        error = {"code": code, "retryable": True, "message": message}
+        reason = cls._safe_backend_error(project_result.get("backend_error"))
+        if reason:
+            error["backend_error"] = reason
+            error["message"] = f"{message}: {reason}"
+        return error
+
     # -- reverse call to the private Telegram programmable channel ----------
 
     def _project(self, watch: _Watch, sub_action: str, frame: dict | None) -> dict:
         """Forward validated data to the programmable channel; never raises."""
+
+        def rejected(value: object = None) -> dict:
+            outcome = {"status": "error"}
+            reason = self._safe_backend_error(value)
+            if reason:
+                outcome["backend_error"] = reason
+            return outcome
+
         client = getattr(self._agent, "_mcp_clients_by_tool", {}).get("telegram")
         if client is None:
-            return {"status": "error"}
+            return rejected("Telegram client is unavailable")
         payload: dict[str, Any] = {
             "sub_action": sub_action,
             "channel": "programmable",
@@ -684,15 +722,15 @@ class TaskCardController:
             result = client.call_tool(
                 _TASK_CARD_TOOL, payload, timeout=_REVERSE_CALL_TIMEOUT_S
             )
-        except Exception:
-            return {"status": "error"}
+        except Exception as exc:
+            return rejected(type(exc).__name__)
         if not isinstance(result, dict) or result.get("status") != "ok":
-            return {"status": "error"}
+            return rejected(result.get("error") if isinstance(result, dict) else None)
         # ``stale_delete_failed`` is the manager's pre-send error condition,
         # never a successful partial delivery. Reject contradictory payloads
         # rather than claiming a new resident was adopted.
         if result.get("stale_delete_failed") is True:
-            return {"status": "error"}
+            return rejected(result.get("error"))
         message_id = result.get("message_id")
         if result.get("resident_persist_failed") is True:
             # The ONE allowed successful partial. It REQUIRES a validated,

--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -581,6 +581,31 @@ def test_retry_action_reruns_now(agent, controller):
     controller.handle({"action": "stop", "watch_id": wid})
 
 
+def test_backend_reason_reaches_retry_inspect_and_notification(agent, controller):
+    renderer = agent._working_dir / "backend.py"
+    renderer.write_text(_OK_BODY)
+    wid = controller.handle(
+        {"action": "start", "renderer_path": str(renderer), "interval_s": 3600}
+    )["watch_id"]
+
+    reason = "Forbidden: bot was blocked by the user"
+    agent._client.result = {"status": "error", "error": reason}
+    retry = controller.handle({"action": "retry", "watch_id": wid})
+    assert retry["state"] == "error"
+    assert retry["error"]["code"] == "backend_edit_failed"
+    assert retry["error"]["backend_error"] == reason
+    assert reason in retry["error"]["message"]
+
+    inspect = controller.handle({"action": "inspect", "watch_id": wid})
+    assert inspect["error"]["backend_error"] == reason
+    wake = [w for w in agent.wakes if w["extra"]["state"] == "error"][-1]
+    assert wake["extra"]["backend_error"] == reason
+    assert reason in wake["body"]
+
+    agent._client.result = None
+    controller.handle({"action": "stop", "watch_id": wid})
+
+
 # -- stop finalizes only the programmable slot ----------------------------
 
 
@@ -622,6 +647,8 @@ def test_failed_stop_is_truthful_retryable_and_retains_watch(agent, controller):
     assert result["state"] == "stop_failed"
     assert result["error"]["code"] == "stop_finalize_failed"
     assert result["error"]["retryable"] is True
+    assert result["error"]["backend_error"] == "backend down"
+    assert "backend down" in result["error"]["message"]
     # The watch is retained so stop can be retried...
     assert wid in controller._watches
     # ...but the renderer thread is already stopped (not "watching" with a live thread).
@@ -629,6 +656,7 @@ def test_failed_stop_is_truthful_retryable_and_retains_watch(agent, controller):
     inspect = controller.handle({"action": "inspect", "watch_id": wid})
     assert inspect["state"] == "stop_failed"
     assert inspect["error"]["code"] == "stop_finalize_failed"
+    assert inspect["error"]["backend_error"] == "backend down"
 
     # Retry only re-attempts finalization; on an accepted clear the watch is
     # removed and ``stopped`` is returned.

--- a/tests/test_telegram_task_card_programmable.py
+++ b/tests/test_telegram_task_card_programmable.py
@@ -113,6 +113,23 @@ def test_programmable_first_frame_sends_and_persists_resident(tmp_path):
     assert acct.calls[-1][0] == "edit"
 
 
+def test_programmable_edit_failure_surfaces_safe_provider_reason(tmp_path):
+    manager, acct = _manager(tmp_path)
+    _prog(manager, "create", {"title": "Watch", "lines": ["x"]})
+
+    def rejected_edit(*_args, **_kwargs):
+        raise RuntimeError(
+            "Telegram API error: Forbidden: bot was blocked by the user"
+        )
+
+    acct.edit_message = rejected_edit
+    result = _prog(manager, "update", {"lines": ["y"]})
+    assert result == {
+        "status": "error",
+        "error": "Forbidden: bot was blocked by the user",
+    }
+
+
 # -- two-slot composition + update isolation -------------------------------
 
 


### PR DESCRIPTION
## Summary

- preserve one redacted, whitespace-normalized, bounded Telegram Bot API reason when a programmable Task Card edit/probe fails
- carry that reason as optional `backend_error` through `retry` / `inspect` / `stop` results and fail-loud notification metadata/body while keeping the existing stable controller error codes
- document the additive contract and cover both the Telegram manager boundary and controller propagation

## Validation

- `276 passed` — `tests/test_task_card_controller.py` plus all `tests/test_telegram_task_card*.py`
- `12 passed` — architecture-document and anatomy-drift tests
- `ruff check --ignore E402` on the four changed Python/test files: PASS (`manager.py:39` has a pre-existing repository-wide E402 when not ignored)
- `git diff --check`: PASS

## Scope

No release, deployment, configuration, authentication, cleanup, or unrelated Task Card behavior changes.
