### PR TITLE
fix: clarify file actions and enable daemon summaries

### DIFF
--- a/src/lingtai/intrinsic_skills/file-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/file-manual/SKILL.md
@@ -178,3 +178,19 @@ Before using file tools:
 - Is the file large? If yes, search or read a slice.
 - Am I about to overwrite? If yes, read first or confirm intent.
 - Am I about to replace many occurrences? If yes, grep first.
+
+
+## Manual versus ordinary calls
+
+Normal file work is primary. Each file tool has two explicit modes:
+
+- **Ordinary work:** for backward compatibility, omit `action` or set it to
+  the tool name: `action="read"`, `"write"`, `"edit"`, `"glob"`, or `"grep"`.
+  Supply the ordinary arguments shown in that tool's schema.
+- **Manual lookup:** use `action="manual"` as a one-time entry when you need
+  the installed workflow guide. This returns documentation and does not
+  perform the file operation.
+
+After a manual result, continue the original task with an ordinary call.
+Do not request the same manual again. Repeating an identical manual call is
+an error loop, not progress.

--- a/src/lingtai/intrinsic_skills/read-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/read-manual/SKILL.md
@@ -193,3 +193,17 @@ Before calling `read`:
 - Does the result show `line_truncated=true`? Switch to `bash`/`grep`/`sed`/Python.
 - Does the result show `status=spilled`? Read the `spill_path` artifact or reduce `limit`.
 - Do you need a specific region? Pass `offset` and a tight `limit`.
+
+
+## Manual versus ordinary reads
+
+Normal reading is primary:
+
+- For backward compatibility, an ordinary read may omit `action` or set
+  `action="read"`, then provide `file_path` and any window controls.
+- Use `action="manual"` as a one-time entry when you need this guide. It
+  returns the installed manual and does not read a target file.
+
+After the manual returns, continue the original task with an ordinary read.
+Do not request the same manual again. Repeating an identical manual call is
+an error loop, not progress.

--- a/src/lingtai/tools/daemon/ANATOMY.md
+++ b/src/lingtai/tools/daemon/ANATOMY.md
@@ -6,6 +6,9 @@ related_files:
   - src/lingtai/tools/daemon/system_prompt.py
   - src/lingtai/prompts/ANATOMY.md
   - src/lingtai/kernel/meta_block.py
+  - src/lingtai/kernel/tool_executor.py
+  - src/lingtai/kernel/tool_result_summary.py
+  - src/lingtai/llm/service.py
   - src/lingtai/llm/interface_converters.py
   - src/lingtai/tools/daemon/process_port.py
   - src/lingtai/tools/daemon/interactive_terminal/__init__.py
@@ -18,6 +21,7 @@ related_files:
   - src/lingtai/tools/daemon/run_dir.py
   - src/lingtai/mcp_servers/daemon_common/server.py
   - tests/test_daemon.py
+  - tests/test_apriori_summary_executor.py
   - tests/test_daemon_run_dir.py
   - tests/test_daemon_codex_usage.py
   - tests/test_codex_standalone_compaction.py
@@ -276,6 +280,12 @@ intentional omission of the parent notification axis.
 
 - **Parent:** `src/lingtai/tools/` (tool package).
 - **Siblings:** `avatar/`, `mcp/`, `knowledge/` (private durable memory), `skills/` (skill catalog), canonical `shell` (retained `bash/` implementation).
+- **Summary composition edge:** `_build_daemon_apriori_summarizer_fn` in
+  `daemon/__init__.py` closes over the effective daemon `LLMService` and
+  `DaemonRunDir`; `_run_emanation` injects it into the kernel `ToolExecutor`.
+  The executor retains raw-log, cap, and fail-closed replacement ownership;
+  the daemon logger preserves the raw result in the parent `logs/events.jsonl`
+  before the generated summary reaches the worker.
 - **Manual:** `daemon/manual/SKILL.md` — skill documentation for the LLM.
 - **Contract:** `daemon/CONTRACT.md` — unified daemon contract for tool-surface behavior, selected skills, one-run MCP registrations, completion, artifacts, backend support status, review triggers, and acceptance gates.
 - **Kernel hooks:** `setup()` is called during capability initialization; `DaemonManager.handle()` is registered as the `daemon` tool handler.

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -14,6 +14,9 @@ related_files:
   - src/lingtai/tools/daemon/__init__.py
   - src/lingtai/tools/daemon/system_prompt.py
   - src/lingtai/kernel/meta_block.py
+  - src/lingtai/kernel/tool_executor.py
+  - src/lingtai/kernel/tool_result_summary.py
+  - src/lingtai/llm/service.py
   - src/lingtai/llm/interface_converters.py
   - src/lingtai/tools/daemon/process_port.py
   - src/lingtai/tools/daemon/interactive_terminal/__init__.py
@@ -29,6 +32,7 @@ related_files:
   - src/lingtai/llm/mimo/ANATOMY.md
   - tests/test_daemon_contract_doc.py
   - tests/test_daemon.py
+  - tests/test_apriori_summary_executor.py
   - tests/test_daemon_backend_options.py
   - tests/test_daemon_claude_p_background_guard.py
   - tests/test_daemon_opencode_backend.py
@@ -347,6 +351,23 @@ general skills/MCP/completion/backend-support invariants above:
 - Trigger/boundary/invalidation mechanics are shared Responses adapter/session
   internals (`_StandaloneCompactionMixin`), not daemon-owned. This contract
   states only the daemon-task-object capability boundary.
+
+## A-priori summary composition
+
+The LingTai backend builds one daemon-local summary closure and passes it to the
+kernel `ToolExecutor`. The closure:
+
+- uses the effective daemon `LLMService`, provider, and model;
+- creates a `tracked=False` session with no tools;
+- forwards the existing kernel summary prompt contract; and
+- accounts usage through `DaemonRunDir.append_tokens`, keeping daemon and parent
+  ledgers consistent.
+
+`ToolExecutor` remains responsible for the explicit `summary=true` gate, raw
+logging before replacement, fail-closed error/refusal behavior, and the 500,000
+character cap. The daemon logger preserves the raw result in the parent
+`logs/events.jsonl`, which remains the recovery locator exposed to the worker.
+The closure is inert unless a tool explicitly requests `summary=true`.
 
 ## Backend Support Matrix
 

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -123,6 +123,42 @@ DAEMON_CONTEXT_WARNING = "context warning, consider compact! see compact.manual 
 _DAEMON_SKILL_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?\n)---\s*\n", re.DOTALL)
 
 
+def _build_daemon_apriori_summarizer_fn(service, run_dir, *, provider, model, endpoint=None):
+    """Build the daemon-local a-priori summary gateway.
+
+    The closure deliberately owns the effective daemon service and run directory for this run:
+    it creates an untracked, no-tools session on that same provider/model and
+    accounts usage through the daemon dual-ledger path. It is inert unless the
+    ToolExecutor receives summary=true.
+    """
+    if service is None or not callable(getattr(service, "create_session", None)):
+        return None
+
+    def _summarize(system_prompt, user_prompt, tool_name, tool_call_id=None):
+        session = service.create_session(
+            system_prompt=system_prompt,
+            tools=None,
+            model=model,
+            tracked=False,
+            provider=provider,
+        )
+        response = session.send(user_prompt)
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            run_dir.append_tokens(
+                input=usage.input_tokens,
+                output=usage.output_tokens,
+                thinking=usage.thinking_tokens,
+                cached=usage.cached_tokens,
+                model=model,
+                endpoint=endpoint,
+                usage_extra=getattr(usage, "extra", None),
+            )
+        return getattr(response, "text", "") or ""
+
+    return _summarize
+
+
 class _DaemonMetaState:
     """Daemon-local projector inputs for the canonical ``agent_meta`` envelope.
 
@@ -2687,6 +2723,9 @@ class DaemonManager:
         compact_reset_accepted = False
 
         endpoint = getattr(service, "_base_url", None)
+        daemon_summarizer_fn = _build_daemon_apriori_summarizer_fn(
+            service, run_dir, provider=provider, model=effective_model, endpoint=endpoint,
+        )
 
         if "compact" in {schema.name for schema in schemas}:
             dispatch = dict(dispatch)
@@ -2763,6 +2802,7 @@ class DaemonManager:
             meta_fn=lambda: {"agent_state": daemon_meta_state.snapshot(session)},
             working_dir=self._agent._working_dir,
             tool_call_guard=getattr(self._agent, "_tool_call_guard", None),
+            summarizer_fn=daemon_summarizer_fn,
         )
 
         def _accum(resp):

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -102,6 +102,11 @@ files, not standalone top-level skills.
   finish truthfully. The complete rendered system prompt is capped at 20,000
   characters and fails instead of truncating task/skill/MCP context. Keep the
   run-specific objective, authority, safety boundary, and deliverable in `task`.
+- On the LingTai backend, explicit `summary=true` uses a daemon-local,
+  no-tools session on the same effective service, provider, and model.
+  `ToolExecutor` logs the raw result first through the daemon logger into the
+  parent `logs/events.jsonl`, then returns only the generated summary or
+  fail-closed refusal/error to the worker.
 - Think of each task item as **task objective + behavior guidance + tool
   surface**:
   - `task` is the complete parent-controlled daemon system instruction:

--- a/src/lingtai/tools/edit/CONTRACT.md
+++ b/src/lingtai/tools/edit/CONTRACT.md
@@ -1,11 +1,12 @@
 ---
 name: edit-contract
 tool: edit
-contract_version: 1
+contract_version: 2
 related_files:
   - src/lingtai/tools/edit/__init__.py
   - src/lingtai/tools/_file_paths.py
   - src/lingtai/services/file_io_sidecar.py
+  - src/lingtai/intrinsic_skills/file-manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -44,8 +45,17 @@ lives in `src/lingtai/tools/edit/__init__.py`; the code is the source of truth.
 
 ## Tool surface
 
-Single action; the handler is `handle_edit`. The schema requires `file_path`,
-`old_string`, and `new_string`.
+`handle_edit` has two modes:
+
+- **Ordinary:** omit `action` (backward compatible) or set
+  `action="edit"`; both forms run the same edit operation.
+- **Manual:** `action="manual"` returns the installed `file-manual` without
+  attempting to edit a file.
+
+The schema lists `edit` before `manual`. Any other explicit action
+returns a plain error before file I/O. After a manual response, the caller
+continues the original task with an ordinary call rather than repeating the
+manual.
 
 | Call | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|

--- a/src/lingtai/tools/edit/__init__.py
+++ b/src/lingtai/tools/edit/__init__.py
@@ -14,14 +14,14 @@ if TYPE_CHECKING:
 
 
 def get_description(lang: str = "en") -> str:
-    return "Replace an exact string in a file. Fails if old_string is not found or is ambiguous. Call edit(action='manual') to return the installed file-manual skill."
+    return "Replace an exact string in a file. Normal edits are the primary operation: omit action for the legacy ordinary call or use action='edit' explicitly. Fails if old_string is not found or is ambiguous. Use action='manual' once to return the installed file-manual skill; after the manual result, continue the original ordinary edit instead of repeating manual, because repeated identical manual calls are an error loop."
 
 
 def get_schema(lang: str = "en") -> dict:
     return {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "enum": ["manual"], "description": "Use action='manual' to return the installed file-manual skill without editing a file."},
+            "action": {"type": "string", "enum": ["edit", "manual"], "description": "Omit action for the legacy ordinary edit, use action='edit' for an explicit ordinary edit, or use action='manual' once for the installed file-manual skill."},
             "file_path": {"type": "string", "description": "Absolute path to the file to edit. Required for ordinary edits; omit for action='manual'."},
             "old_string": {"type": "string", "description": "The exact text to find and replace. Required for ordinary edits; omit for action='manual'."},
             "new_string": {"type": "string", "description": "The replacement text. Required for ordinary edits; omit for action='manual'."},
@@ -36,8 +36,11 @@ def setup(agent: "BaseAgent") -> None:
     """Set up the edit capability on an agent."""
 
     def handle_edit(args: dict) -> dict:
-        if args.get("action") == "manual":
+        action = args.get("action")
+        if action == "manual":
             return load_installed_manual(agent, "file-manual")
+        if action is not None and action != "edit":
+            return {"status": "error", "message": f"Unsupported action for edit: {action!r}"}
         path = args.get("file_path", "")
         if not path:
             return {"status": "error", "message": "file_path is required"}

--- a/src/lingtai/tools/glob/CONTRACT.md
+++ b/src/lingtai/tools/glob/CONTRACT.md
@@ -1,11 +1,12 @@
 ---
 name: glob-contract
 tool: glob
-contract_version: 1
+contract_version: 2
 related_files:
   - src/lingtai/tools/glob/__init__.py
   - src/lingtai/tools/_file_paths.py
   - src/lingtai/services/file_io_sidecar.py
+  - src/lingtai/intrinsic_skills/file-manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -43,7 +44,17 @@ fields -> §Tool surface; path handling -> §Cross-platform invariants.
 
 ## Tool surface
 
-Single action; the handler is `handle_glob`. The schema requires `pattern`.
+`handle_glob` has two modes:
+
+- **Ordinary:** omit `action` (backward compatible) or set
+  `action="glob"`; both forms run the same glob operation.
+- **Manual:** `action="manual"` returns the installed `file-manual` without
+  attempting to search for paths.
+
+The schema lists `glob` before `manual`. Any other explicit action
+returns a plain error before file I/O. After a manual response, the caller
+continues the original task with an ordinary call rather than repeating the
+manual.
 
 | Call | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|

--- a/src/lingtai/tools/glob/__init__.py
+++ b/src/lingtai/tools/glob/__init__.py
@@ -14,14 +14,14 @@ if TYPE_CHECKING:
 
 
 def get_description(lang: str = "en") -> str:
-    return "Find files matching a glob pattern. Use '**/' for recursive search (e.g. '**/*.py' finds all Python files). Returns sorted list of matching file paths. Call glob(action='manual') to return the installed file-manual skill."
+    return "Find files matching a glob pattern. Normal searches are the primary operation: omit action for the legacy ordinary call or use action='glob' explicitly. Use '**/' for recursive search (e.g. '**/*.py' finds all Python files). Returns sorted list of matching file paths. Use action='manual' once to return the installed file-manual skill; after the manual result, continue the original ordinary glob instead of repeating manual, because repeated identical manual calls are an error loop."
 
 
 def get_schema(lang: str = "en") -> dict:
     return {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "enum": ["manual"], "description": "Use action='manual' to return the installed file-manual skill without searching."},
+            "action": {"type": "string", "enum": ["glob", "manual"], "description": "Omit action for the legacy ordinary glob, use action='glob' for an explicit ordinary search, or use action='manual' once for the installed file-manual skill."},
             "pattern": {"type": "string", "description": "Glob pattern (e.g., '**/*.py'). Required for ordinary searches; omit for action='manual'."},
             "path": {"type": "string", "description": 'Directory to search in'},
             "summary": {"type": "boolean", "description": 'Optional. Default false. When true, this tool runs normally and the raw result is preserved in the durable log (retrievable by tool_call_id), but before the result enters your context it is replaced by an LLM-generated summary driven by your `reasoning` field — so make `reasoning` specific about what to retain. Set true only when the output is expected to be large (>10k chars) and you do NOT need the exact raw text. Leave false when you need exact line/file/diff/stderr text. The summary is non-canonical; if the raw exceeds 500,000 chars no summary is generated and you get a refusal pointing at the preserved raw.', "default": False},
@@ -35,8 +35,11 @@ def setup(agent: "BaseAgent") -> None:
     """Set up the glob capability on an agent."""
 
     def handle_glob(args: dict) -> dict:
-        if args.get("action") == "manual":
+        action = args.get("action")
+        if action == "manual":
             return load_installed_manual(agent, "file-manual")
+        if action is not None and action != "glob":
+            return {"status": "error", "message": f"Unsupported action for glob: {action!r}"}
         pattern = args.get("pattern", "")
         if not pattern:
             return {"status": "error", "message": "pattern is required"}

--- a/src/lingtai/tools/grep/CONTRACT.md
+++ b/src/lingtai/tools/grep/CONTRACT.md
@@ -1,11 +1,12 @@
 ---
 name: grep-contract
 tool: grep
-contract_version: 1
+contract_version: 2
 related_files:
   - src/lingtai/tools/grep/__init__.py
   - src/lingtai/tools/_file_paths.py
   - src/lingtai/services/file_io_sidecar.py
+  - src/lingtai/intrinsic_skills/file-manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -44,10 +45,21 @@ the code is the source of truth.
 
 ## Tool surface
 
-Single action; the handler is `handle_grep`. The schema requires `pattern`. Note
-the tool-facing names differ from the service kwargs: the schema exposes `glob`
-and `max_matches`, which the handler maps to the service's `glob_filter` and
-`max_results`.
+`handle_grep` has two modes:
+
+- **Ordinary:** omit `action` (backward compatible) or set
+  `action="grep"`; both forms run the same grep operation.
+- **Manual:** `action="manual"` returns the installed `file-manual` without
+  attempting to search file content.
+
+The schema lists `grep` before `manual`. Any other explicit action
+returns a plain error before file I/O. After a manual response, the caller
+continues the original task with an ordinary call rather than repeating the
+manual.
+
+The tool-facing names differ from the service kwargs: the schema exposes
+`glob` and `max_matches`, which the handler maps to the service's
+`glob_filter` and `max_results`.
 
 | Call | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|

--- a/src/lingtai/tools/grep/__init__.py
+++ b/src/lingtai/tools/grep/__init__.py
@@ -14,14 +14,14 @@ if TYPE_CHECKING:
 
 
 def get_description(lang: str = "en") -> str:
-    return "Search file contents for lines matching a regex pattern. Returns matching lines with file path and line number. Searches recursively when given a directory. Use the glob filter to narrow to specific file types. Call grep(action='manual') to return the installed file-manual skill."
+    return "Search file contents for lines matching a regex pattern. Normal searches are the primary operation: omit action for the legacy ordinary call or use action='grep' explicitly. Returns matching lines with file path and line number. Searches recursively when given a directory. Use the glob filter to narrow to specific file types. Use action='manual' once to return the installed file-manual skill; after the manual result, continue the original ordinary grep instead of repeating manual, because repeated identical manual calls are an error loop."
 
 
 def get_schema(lang: str = "en") -> dict:
     return {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "enum": ["manual"], "description": "Use action='manual' to return the installed file-manual skill without searching."},
+            "action": {"type": "string", "enum": ["grep", "manual"], "description": "Omit action for the legacy ordinary grep, use action='grep' for an explicit ordinary search, or use action='manual' once for the installed file-manual skill."},
             "pattern": {"type": "string", "description": "Regex pattern to search for. Required for ordinary searches; omit for action='manual'."},
             "path": {"type": "string", "description": 'File or directory to search in'},
             "glob": {"type": "string", "description": "File glob filter (e.g., '*.py')", "default": "*"},
@@ -37,8 +37,11 @@ def setup(agent: "BaseAgent") -> None:
     """Set up the grep capability on an agent."""
 
     def handle_grep(args: dict) -> dict:
-        if args.get("action") == "manual":
+        action = args.get("action")
+        if action == "manual":
             return load_installed_manual(agent, "file-manual")
+        if action is not None and action != "grep":
+            return {"status": "error", "message": f"Unsupported action for grep: {action!r}"}
         pattern = args.get("pattern", "")
         if not pattern:
             return {"status": "error", "message": "pattern is required"}

--- a/src/lingtai/tools/read/CONTRACT.md
+++ b/src/lingtai/tools/read/CONTRACT.md
@@ -1,11 +1,13 @@
 ---
 name: read-contract
 tool: read
-contract_version: 1
+contract_version: 2
 related_files:
   - src/lingtai/tools/read/__init__.py
   - src/lingtai/tools/_file_paths.py
   - src/lingtai/services/file_io_sidecar.py
+  - src/lingtai/intrinsic_skills/file-manual/SKILL.md
+  - src/lingtai/intrinsic_skills/read-manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -58,7 +60,17 @@ invariants.
 
 ## Tool surface
 
-Single action; the handler is `handle_read`. The schema requires `file_path`.
+`handle_read` has two modes:
+
+- **Ordinary:** omit `action` (backward compatible) or set
+  `action="read"`; both forms run the same read operation.
+- **Manual:** `action="manual"` returns the installed `read-manual` without
+  attempting to read a target file.
+
+The schema lists `read` before `manual`. Any other explicit action
+returns a plain error before file I/O. After a manual response, the caller
+continues the original task with an ordinary call rather than repeating the
+manual.
 
 | Call | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|

--- a/src/lingtai/tools/read/__init__.py
+++ b/src/lingtai/tools/read/__init__.py
@@ -52,14 +52,14 @@ def _resolve_call_cap(agent: "BaseAgent", requested_max_chars: object) -> int:
 
 
 def get_description(lang: str = "en") -> str:
-    return "Read the contents of a text file. Returns numbered lines. Text files only — cannot read binary, images, or audio. Call read(action='manual') to return the installed read-manual skill. Before ordinary reads, especially for large files, complete-content workflows, truncation, or line_truncated handling, read that manual. If the file is non-UTF-8 or needs careful search/edit workflow, read file-manual first. Use offset/limit for line windows and optional max_chars to choose the per-call character budget. Default read budget is 100 000 characters; max_chars can raise/lower that per call but is clamped by the non-configurable runtime hard cap of 200 000 characters. A successful read can still be truncated: check truncated=true, cap_chars, returned_chars, next_offset, remaining_lines_estimate, and line_truncated. Continue with next_offset until done. If line_truncated=true, the shown physical line is only a prefix; next_offset skips to the next line and does not recover the hidden tail. Use the read-manual's bash/Python metadata/stats workflow (file size, line count, longest line) and targeted grep/sed/Python processing for such content."
+    return "Read the contents of a text file. Normal reads are the primary operation: omit action for the legacy ordinary call or use action='read' explicitly. Returns numbered lines. Text files only — cannot read binary, images, or audio. Use action='manual' once to return the installed read-manual skill; after the manual result, continue the original ordinary read instead of repeating manual, because repeated identical manual calls are an error loop. Before using read for ordinary reads, especially for large files, complete-content workflows, truncation, or line_truncated handling, read that manual. If the file is non-UTF-8 or needs careful search/edit workflow, read file-manual first. Use offset/limit for line windows and optional max_chars to choose the per-call character budget. Default read budget is 100 000 characters; max_chars can raise/lower that per call but is clamped by the non-configurable runtime hard cap of 200 000 characters. A successful read can still be truncated: check truncated=true, cap_chars, returned_chars, next_offset, remaining_lines_estimate, and line_truncated. Continue with next_offset until done. If line_truncated=true, the shown physical line is only a prefix; next_offset skips to the next line and does not recover the hidden tail. Use the read-manual's bash/Python metadata/stats workflow (file size, line count, longest line) and targeted grep/sed/Python processing for such content."
 
 
 def get_schema(lang: str = "en") -> dict:
     return {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "enum": ["manual"], "description": "Use action='manual' to return the installed read-manual skill without reading a target file."},
+            "action": {"type": "string", "enum": ["read", "manual"], "description": "Omit action for the legacy ordinary read, use action='read' for an explicit ordinary read, or use action='manual' once for the installed read-manual skill."},
             "file_path": {"type": "string", "description": "Absolute path to the file to read. Required for ordinary reads; omit for action='manual'."},
             "offset": {"type": "integer", "description": 'Line number to start from (1-based)', "default": 1},
             "limit": {"type": "integer", "description": 'Max lines to read', "default": 2000},
@@ -131,8 +131,11 @@ def setup(agent: "BaseAgent") -> None:
     """Set up the read capability on an agent."""
 
     def handle_read(args: dict) -> dict:
-        if args.get("action") == "manual":
+        action = args.get("action")
+        if action == "manual":
             return load_installed_manual(agent, "read-manual")
+        if action is not None and action != "read":
+            return {"status": "error", "message": f"Unsupported action for read: {action!r}"}
         path = args.get("file_path", "")
         if not path:
             return {"status": "error", "message": "file_path is required"}

--- a/src/lingtai/tools/write/CONTRACT.md
+++ b/src/lingtai/tools/write/CONTRACT.md
@@ -1,11 +1,12 @@
 ---
 name: write-contract
 tool: write
-contract_version: 1
+contract_version: 2
 related_files:
   - src/lingtai/tools/write/__init__.py
   - src/lingtai/tools/_file_paths.py
   - src/lingtai/services/file_io_sidecar.py
+  - src/lingtai/intrinsic_skills/file-manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -44,8 +45,17 @@ truth.
 
 ## Tool surface
 
-Single action; the handler is `handle_write`. The schema requires `file_path`
-and `content`.
+`handle_write` has two modes:
+
+- **Ordinary:** omit `action` (backward compatible) or set
+  `action="write"`; both forms run the same write operation.
+- **Manual:** `action="manual"` returns the installed `file-manual` without
+  attempting to write a file.
+
+The schema lists `write` before `manual`. Any other explicit action
+returns a plain error before file I/O. After a manual response, the caller
+continues the original task with an ordinary call rather than repeating the
+manual.
 
 | Call | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|

--- a/src/lingtai/tools/write/__init__.py
+++ b/src/lingtai/tools/write/__init__.py
@@ -14,14 +14,14 @@ if TYPE_CHECKING:
 
 
 def get_description(lang: str = "en") -> str:
-    return "Create or overwrite a file with the given content. Parent directories are created automatically. Use this for creating new files or complete rewrites. For small changes to existing files, prefer edit. Call write(action='manual') to return the installed file-manual skill."
+    return "Create or overwrite a file with the given content. Normal writes are the primary operation: omit action for the legacy ordinary call or use action='write' explicitly. Parent directories are created automatically. Use this for creating new files or complete rewrites. For small changes to existing files, prefer edit. Use action='manual' once to return the installed file-manual skill; after the manual result, continue the original ordinary write instead of repeating manual, because repeated identical manual calls are an error loop."
 
 
 def get_schema(lang: str = "en") -> dict:
     return {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "enum": ["manual"], "description": "Use action='manual' to return the installed file-manual skill without writing a file."},
+            "action": {"type": "string", "enum": ["write", "manual"], "description": "Omit action for the legacy ordinary write, use action='write' for an explicit ordinary write, or use action='manual' once for the installed file-manual skill."},
             "file_path": {"type": "string", "description": "Absolute path to the file to write. Required for ordinary writes; omit for action='manual'."},
             "content": {"type": "string", "description": "Content to write. Required for ordinary writes; omit for action='manual'."},
         },
@@ -34,8 +34,11 @@ def setup(agent: "BaseAgent") -> None:
     """Set up the write capability on an agent."""
 
     def handle_write(args: dict) -> dict:
-        if args.get("action") == "manual":
+        action = args.get("action")
+        if action == "manual":
             return load_installed_manual(agent, "file-manual")
+        if action is not None and action != "write":
+            return {"status": "error", "message": f"Unsupported action for write: {action!r}"}
         path = args.get("file_path", "")
         if not path:
             return {"status": "error", "message": "file_path is required"}

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -13,6 +13,7 @@ from lingtai.kernel.config import AgentConfig
 from lingtai.kernel.llm.base import ChatSession, FunctionSchema, LLMResponse, ToolCall, UsageMetadata
 from lingtai.kernel.llm.interface import ChatInterface, TextBlock, ToolCallBlock, ToolResultBlock
 from lingtai.kernel.tool_call_guard import GuardDecision, ToolCallGuard
+from lingtai.tools import daemon as daemon_tool
 
 from tests._daemon_helpers import make_daemon_agent as _make_agent
 from tests._daemon_helpers import make_daemon_run_dir as _make_run_dir
@@ -4177,3 +4178,105 @@ def test_implicit_parent_preset_llm_does_not_resolve_primary_key(tmp_path):
     assert preset["context_window"] == 200000
     assert preset["key_resolver"] is exploding_resolver
     assert preset["_provider_defaults"] == {"max_rpm": 5}
+
+
+class _SummaryRunDir:
+    def __init__(self):
+        self.calls = []
+
+    def append_tokens(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class _SummarySession:
+    def __init__(self, response):
+        self.response = response
+        self.messages = []
+
+    def send(self, message):
+        self.messages.append(message)
+        return self.response
+
+
+class _SummaryService:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+        self.session = _SummarySession(response)
+
+    def create_session(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.session
+
+
+def test_daemon_summary_closure_uses_effective_session_and_accounts_usage(tmp_path):
+    usage = UsageMetadata(input_tokens=17, output_tokens=5, thinking_tokens=2, cached_tokens=3)
+    response = LLMResponse(text="LOCAL SUMMARY", tool_calls=[], usage=usage)
+    service = _SummaryService(response)
+    run_dir = _SummaryRunDir()
+    fn = daemon_tool._build_daemon_apriori_summarizer_fn(
+        service, run_dir, provider="mock", model="daemon-model", endpoint="endpoint",
+    )
+
+    assert fn("SUMMARY SYSTEM", "SUMMARY USER", "read", "tc-summary") == "LOCAL SUMMARY"
+    assert service.calls == [{
+        "system_prompt": "SUMMARY SYSTEM",
+        "tools": None,
+        "model": "daemon-model",
+        "tracked": False,
+        "provider": "mock",
+    }]
+    assert service.session.messages == ["SUMMARY USER"]
+    assert run_dir.calls == [{
+        "input": 17, "output": 5, "thinking": 2, "cached": 3,
+        "model": "daemon-model", "endpoint": "endpoint",
+        "usage_extra": {},
+    }]
+
+
+def test_daemon_tool_executor_wires_summary_gateway_and_preserves_raw_log(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path, ["file", "daemon"])
+    mgr = agent.get_capability("daemon")
+    raw = {"content": "DAEMON-RAW-MARKER"}
+    agent._tool_handlers["read"] = MagicMock(return_value=raw)
+    first = LLMResponse(
+        text="",
+        tool_calls=[ToolCall(name="read", args={"file_path": "/tmp/x", "summary": True, "reasoning": "retain marker"}, id="tc-daemon-summary")],
+        usage=None,
+    )
+    final = LLMResponse(text="daemon finished", tool_calls=[], usage=None)
+    summary = LLMResponse(
+        text="DAEMON-SUMMARY-MARKER", tool_calls=[],
+        usage=UsageMetadata(input_tokens=11, output_tokens=7, thinking_tokens=1, cached_tokens=2),
+    )
+    service = _CanonicalFakeService([[first, final], [summary]])
+    import lingtai.llm.service as service_mod
+    monkeypatch.setattr(service_mod, "LLMService", lambda **_kwargs: service)
+    run_dir = _make_run_dir(agent, em_id="em-summary")
+    mgr._emanations["em-summary"] = {
+        "followup_buffer": "", "followup_lock": threading.Lock(), "run_dir": run_dir,
+    }
+
+    result = mgr._run_emanation(
+        "em-summary", run_dir, *mgr._build_tool_surface(["file"]),
+        "summarize the read result", threading.Event(),
+    )
+
+    assert result == "daemon finished"
+    assert len(service.sessions) == 2
+    summary_call = service.sessions[1]
+    assert summary_call.sent_messages
+    assert "DAEMON-RAW-MARKER" in summary_call.sent_messages[0]
+    worker_tool_batch = service.sessions[0].request_snapshots[1]
+    worker_visible = str(worker_tool_batch[-1])
+    assert "DAEMON-SUMMARY-MARKER" in worker_visible
+    assert "DAEMON-RAW-MARKER" not in worker_visible
+    assert "logs/events.jsonl" in worker_visible
+    assert run_dir.events_path.relative_to(agent._working_dir).as_posix() not in worker_visible
+    parent_events = [json.loads(line) for line in (agent._working_dir / "logs" / "events.jsonl").read_text().splitlines()]
+    raw_events = [event for event in parent_events if event.get("type") == "daemon_tool_result"]
+    assert any("DAEMON-RAW-MARKER" in str(event.get("result")) for event in raw_events)
+    daemon_rows = [json.loads(line) for line in run_dir.token_ledger_path.read_text().splitlines()]
+    assert any(row["input"] == 11 and row["output"] == 7 and row["source"] == "daemon" for row in daemon_rows)
+    parent_rows = [json.loads(line) for line in (agent._working_dir / "logs" / "token_ledger.jsonl").read_text().splitlines()]
+    assert any(row["input"] == 11 and row["output"] == 7 and row["source"] == "daemon" for row in parent_rows)

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -156,3 +156,76 @@ def test_missing_installed_manual_degrades_without_side_effects(tmp_path: Path) 
         ),
     }
     assert not (tmp_path / ".library").exists()
+
+
+class _ActionFileIO:
+    def __init__(self, root: Path):
+        self.root = root
+        self.last_traversal = None
+
+    def read(self, path):
+        return Path(path).read_text(encoding="utf-8")
+
+    def write(self, path, content):
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    def glob(self, pattern, *, root):
+        return sorted(str(path) for path in Path(root).glob(pattern))
+
+    def grep(self, pattern, *, path, max_results, glob_filter):
+        import re
+        result = []
+        target = Path(path)
+        paths = [target] if target.is_file() else sorted(target.rglob(glob_filter or "*"))
+        for current in paths:
+            if not current.is_file():
+                continue
+            for number, line in enumerate(current.read_text(encoding="utf-8").splitlines(), 1):
+                if re.search(pattern, line):
+                    result.append(type("Match", (), {"path": str(current), "line_number": number, "line": line})())
+                    if len(result) >= max_results:
+                        return result
+        return result
+
+
+def test_file_action_modes_keep_omission_and_fail_loudly(tmp_path: Path) -> None:
+    agent = _StubAgent(tmp_path)
+    agent._file_io = _ActionFileIO(tmp_path)
+    modules = (read_tool, write_tool, edit_tool, glob_tool, grep_tool)
+    for module in modules:
+        schema = module.get_schema()
+        tool_name = module.__name__.rsplit(".", 1)[-1]
+        assert schema["properties"]["action"]["enum"] == [tool_name, "manual"]
+        description = module.get_description()
+        assert "omit action" in description
+        assert f"action='{tool_name}'" in description
+        assert "after the manual result" in description
+        assert "error loop" in description
+        module.setup(agent)
+
+    source = tmp_path / "source.txt"
+    source.write_text("alpha\n", encoding="utf-8")
+    assert agent.handlers["read"]({"file_path": str(source)})["total_lines"] == 1
+    assert agent.handlers["read"]({"action": "read", "file_path": str(source)})["total_lines"] == 1
+    assert agent.handlers["write"]({"action": "write", "file_path": str(tmp_path / "written.txt"), "content": "beta"})["status"] == "ok"
+    assert agent.handlers["edit"]({"action": "edit", "file_path": str(source), "old_string": "alpha", "new_string": "gamma"})["status"] == "ok"
+    assert agent.handlers["glob"]({"action": "glob", "pattern": "*.txt", "path": str(tmp_path)})["count"] >= 2
+    assert agent.handlers["grep"]({"action": "grep", "pattern": "gamma", "path": str(source)})["count"] == 1
+
+    for name in ("read", "write", "edit", "glob", "grep"):
+        result = agent.handlers[name]({"action": "unsupported"})
+        assert result["status"] == "error"
+        assert "Unsupported action" in result["message"]
+
+
+def test_file_manual_bodies_explain_one_time_dual_mode_guidance() -> None:
+    file_body = Path("src/lingtai/intrinsic_skills/file-manual/SKILL.md").read_text(encoding="utf-8")
+    read_body = Path("src/lingtai/intrinsic_skills/read-manual/SKILL.md").read_text(encoding="utf-8")
+    for body in (file_body, read_body):
+        assert "backward compatibility" in body
+        assert "ordinary" in body
+        assert "one-time" in body
+        assert "After" in body
+        assert "error loop" in body


### PR DESCRIPTION
## Summary

- make the ordinary `read` / `write` / `edit` / `glob` / `grep` action visible in each schema while preserving omitted-action compatibility
- make unsupported explicit file actions fail before file I/O, and teach the installed manuals to stop repeated `action="manual"` loops
- give LingTai daemons a daemon-owned `summary=true` gateway using their effective service/provider/model and existing dual-ledger token accounting

## Why

The live daemon smoke after #972 exposed two gaps:

1. file schemas presented only `manual`, so a worker could keep asking for the manual instead of returning to ordinary file work;
2. LingTai daemon `ToolExecutor` instances had no summarizer gateway, so explicit `summary=true` failed closed instead of producing a generated summary.

The daemon path reuses the existing `ToolExecutor` summary contract unchanged. Raw tool output is logged first through the daemon logger in the parent `logs/events.jsonl`; only the generated summary or fail-closed payload reaches the worker.

## Validation

- `tests/test_tool_result_summary.py tests/test_apriori_summary_executor.py`: **36 passed**
- `tests/test_intrinsic_manual_actions.py tests/test_layers_file.py tests/test_read_continuation.py tests/test_utf8_read_text.py`: **41 passed**
- `tests/test_daemon.py -k 'summary_closure or summary_gateway'`: **2 passed, 119 deselected** (one unrelated Google deprecation warning)
- `tests/test_architecture_documents.py tests/test_daemon_contract_doc.py`: **7 passed**
- `py_compile`: **8 changed Python files passed**
- `git diff --check`: **passed**

## Boundaries

- no merge, release, deployment, config/auth change, cleanup, or deletion
- live checkout/refresh smoke will be reported separately before merge consideration
