### PR TITLE
refactor: split prerelease bundle from publishing

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,17 +2,6 @@ name: Build Python wheels
 
 on:
   workflow_dispatch:
-    inputs:
-      publish:
-        description: >-
-          Actually publish the manifest/wheels/sdist to the GitHub release and
-          (when GITEE_ACCESS_TOKEN is configured) Gitee. Default false keeps
-          manual dispatch a safe dry-run/shape-check; the automatic
-          release.published trigger always publishes.
-        type: boolean
-        default: false
-  release:
-    types: [published]
 
 permissions:
   contents: read
@@ -178,19 +167,11 @@ jobs:
     # rather than silently shipping an incomplete manifest.
     timeout-minutes: 15
     permissions:
-      # write is required only for the actual publish path (gh release
-      # upload / create); the dry-run path never mutates anything regardless
-      # of this permission grant.
-      contents: write
+      contents: read
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          # sync_gitee_mirror.py needs the full history reachable from
-          # ${{ github.sha }} to `git cat-file -e`/push it; a shallow
-          # checkout (the actions/checkout@v4 default) would make that fail.
-          fetch-depth: 0
 
       - name: Set up Python for the manifest/publish scripts
         uses: actions/setup-python@v5
@@ -211,92 +192,22 @@ jobs:
           path: release-assets
 
       - name: Generate release manifest + SHA256SUMS
-        env:
-          # release.published fires with a real tag; workflow_dispatch has no
-          # tag, so fall back to the pyproject version prefixed with "v" and
-          # the checked-out commit — this keeps manual-dispatch runs usable
-          # for manifest-shape testing without pretending a release exists.
-          KERNEL_TAG: ${{ github.event.release.tag_name || '' }}
         run: |
           set -euo pipefail
           version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
-          tag="${KERNEL_TAG:-v${version}}"
           generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           python scripts/generate_release_manifest.py \
             --assets-dir release-assets \
             --kernel-version "$version" \
-            --kernel-tag "$tag" \
+            --kernel-tag "v${version}" \
             --commit "${{ github.sha }}" \
             --generated-at "$generated_at" \
             --out-manifest release-assets/lingtai-kernel-release-manifest.json \
             --out-sha256sums release-assets/SHA256SUMS
 
-      - name: Determine publish mode
-        id: publish_mode
-        run: |
-          set -euo pipefail
-          # Publish for real only on the automatic release.published trigger,
-          # or on an explicit workflow_dispatch with publish=true. Every other
-          # run (default workflow_dispatch, or any run without the input)
-          # stays dry-run — this is the fix for the prior version of this job,
-          # which unconditionally omitted --execute and so could never
-          # publish anything even on a real release.
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "execute=1" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.publish }}" == "true" ]]; then
-            echo "execute=1" >> "$GITHUB_OUTPUT"
-          else
-            echo "execute=0" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Non-force synchronize the exact commit/tag to Gitee
-        if: steps.publish_mode.outputs.execute == '1'
-        env:
-          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
-          tag="${{ github.event.release.tag_name || '' }}"
-          tag="${tag:-v${version}}"
-          # Skips cleanly (exit 0, prints why) when GITEE_ACCESS_TOKEN is
-          # unset — see sync_gitee_mirror.py. Every push is non-force; a
-          # divergence/existing-tag conflict fails this step loud rather than
-          # silently overwriting the mirror.
-          python scripts/sync_gitee_mirror.py \
-            --commit "${{ github.sha }}" \
-            --tag "$tag" \
-            --branch main \
-            --execute
-
-      - name: Publish manifest/wheels/sdist
-        env:
-          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
-          tag="${{ github.event.release.tag_name || '' }}"
-          tag="${tag:-v${version}}"
-          execute_flag=""
-          if [[ "${{ steps.publish_mode.outputs.execute }}" == "1" ]]; then
-            execute_flag="--execute"
-            echo "Publishing $tag for real (event=${{ github.event_name }})."
-          else
-            echo "Manifest ready for $tag. Dry run only (event=${{ github.event_name }}, publish input=${{ inputs.publish }})."
-          fi
-          # publish_release_assets.py is idempotent (skips already-attached
-          # same-name assets) and never force-syncs/deletes — safe to run
-          # repeatedly. Gitee leg is skipped internally when
-          # GITEE_ACCESS_TOKEN is unset, regardless of execute_flag.
-          python scripts/publish_release_assets.py \
-            --manifest release-assets/lingtai-kernel-release-manifest.json \
-            --assets-dir release-assets \
-            $execute_flag
-
-      - name: Upload release manifest artifact
+      - name: Upload immutable release bundle
         uses: actions/upload-artifact@v4
         with:
-          name: release-manifest
-          path: |
-            release-assets/lingtai-kernel-release-manifest.json
-            release-assets/SHA256SUMS
+          name: release-bundle
+          path: release-assets
           if-no-files-found: error

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -171,10 +171,10 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
 - [`scripts/`](scripts/) — root utility/checker scripts, including the
   docs-governance validator described below and the release-manifest
   generator/publisher/Gitee-mirror-sync scripts described in
-  [`RELEASING.md`](RELEASING.md). `wheels.yml`'s `release-manifest` job
-  actually invokes these with `--execute` on a real `release.published`
-  event (or an explicit `workflow_dispatch` with `publish: true`) — every
-  other trigger shape stays dry-run.
+  [`RELEASING.md`](RELEASING.md). A manual `wheels.yml` prerelease run invokes
+  only the generator and freezes one complete `release-bundle`; the mirror
+  sync and publisher are separate, explicitly authorized mechanical-release
+  commands and never run inside that workflow.
 - [`.github/`](.github/) — GitHub Actions, issue templates, and pull request
   templates.
 - [`crates/lingtai-search-sidecar/`](crates/lingtai-search-sidecar/) — Rust file

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,10 @@
 # Releasing the `lingtai` Python kernel
 
-## Build + verify (existing, unchanged)
+## Phase A — prerelease build + verify
 
-`.github/workflows/wheels.yml` runs on `workflow_dispatch` or when a GitHub
-Release is published. Two independent jobs build the artifacts:
+`.github/workflows/wheels.yml` runs only on `workflow_dispatch`. It has
+`contents: read` permission and cannot create a release, push a mirror, or
+publish assets. Two independent jobs build the artifacts:
 
 - **`build-wheels`** — cibuildwheel matrix across cp311/cp312/cp313 for Linux
   (x86_64 + aarch64), macOS (Intel + Apple Silicon), and Windows. Every wheel
@@ -18,10 +19,10 @@ Release is published. Two independent jobs build the artifacts:
   Rust required.
 
 Both jobs upload their outputs as GitHub Actions artifacts (`wheels-<os>`,
-`sdist`) — Actions artifacts are CI-internal and are not directly visible to
-end users or the installer.
+`sdist`) for the aggregation job. These intermediate artifacts are CI-internal
+and are not the mechanical release handoff.
 
-## Manifest (new)
+## Immutable release bundle
 
 A third job, **`release-manifest`**, runs after both build jobs
 (`needs: [build-wheels, build-sdist]`) so it only ever aggregates already-built
@@ -70,89 +71,71 @@ which:
    }
    ```
 
-The manifest and `SHA256SUMS` are uploaded as their own `release-manifest`
-Actions artifact so any run (including a manual `workflow_dispatch` shape
-check) produces inspectable output without publishing anything. The publisher
-also attaches both files alongside the wheels/sdist.
+The checked wheels, sdist, manifest, and `SHA256SUMS` are uploaded together as
+one `release-bundle` Actions artifact. That exact bundle is the only handoff to
+Phase B. Do not download the intermediate `wheels-*` / `sdist` artifacts or run
+the generator again during mechanical release.
 
-## Publish
+## Phase B — mechanical publish (separate)
 
-`wheels.yml`'s `release-manifest` job actually publishes on the real trigger:
+`wheels.yml` never enters this phase: it has no release trigger, `publish`
+input, repository write permission, mirror-sync step, or publisher step.
+Mechanical publish starts only after a maintainer selects one successful
+prerelease run and receives explicit release authorization.
 
-- **`release: {types: [published]}`** — a real kernel GitHub Release always
-  publishes (syncs Gitee, then uploads to GitHub + Gitee).
-- **`workflow_dispatch`** — dry-run by default (the `publish` boolean input
-  defaults `false`); pass `publish: true` to deliberately publish from a
-  manual run too (for example to republish after a partial failure).
-- Every other shape (default manual dispatch) stays dry-run, so re-running
-  this workflow to sanity-check the manifest/wheel matrix has no side
-  effects.
-
-### Step 1 — non-force Gitee mirror sync (only when publishing)
-
-[`scripts/sync_gitee_mirror.py`](scripts/sync_gitee_mirror.py) pushes the
-exact release commit to `main` and creates the exact release tag on
-`huangzesen1997/lingtai-kernel`, using a **non-force** `git push` for both:
-the branch push only succeeds as a fast-forward, and the tag push only
-succeeds if that tag name doesn't already point somewhere else. Either
-condition failing is a **fail-loud stop** for the whole publish (the workflow
-does not proceed to upload against an unsynchronized mirror). The token
-travels via a short-lived, owner-only-permission `GIT_ASKPASS` helper file
-(deleted after use) — never in argv, a URL, or a log line. Skips cleanly
-(prints why, exits 0) when `GITEE_ACCESS_TOKEN` is unset.
-
-### Step 2 — publish manifest/wheels/sdist
+1. Download that run's exact `release-bundle` into one `release-assets`
+   directory. Do not rebuild or regenerate it.
+2. Run the publisher without `--execute` when a read-only plan is needed. It
+   validates the manifest and every local artifact hash.
+3. If Gitee is selected, run the separate non-force mirror sync for the exact
+   commit and tag. A divergence or conflicting tag stops the release.
+4. Run the publisher with `--execute`. It completes every selected GitHub and
+   Gitee release/attachment plan before its first release create/upload call,
+   then executes only those recorded mutations.
 
 [`scripts/publish_release_assets.py`](scripts/publish_release_assets.py)
-uploads the exact manifest + asset bytes to:
+attaches the exact bundle's manifest, `SHA256SUMS`, wheels, and sdist to GitHub
+Releases and, when `GITEE_ACCESS_TOKEN` is configured, Gitee Releases. Every
+release create/upload requires the explicit `--execute` flag. Without it the
+script prints the plan and exits without release mutation.
 
-- **GitHub Releases**, via the `gh` CLI (`gh release create` / `gh release
-  upload`), attaching the manifest and `SHA256SUMS` alongside the wheels/sdist.
-- **Gitee Releases** (`huangzesen1997/lingtai-kernel`), via the Gitee v5 REST
-  API, gated entirely on the `GITEE_ACCESS_TOKEN` secret. When that secret is
-  unset the Gitee leg is skipped with a printed reason — it is never a hard
-  failure, since Gitee credentials/configuration are a separate authorization
-  step from having the workflow code in place.
-
-Every mutating action requires the explicit `--execute` flag; the workflow
-passes it only when the trigger is a real release (or an explicit
-`publish: true` dispatch) — see "Determine publish mode" in the job. Without
-it the script only prints its plan and exits 0.
-
-Before publishing to Gitee, the script re-verifies (independent of Step 1's
-push) that the Gitee tag ref already points at the exact release commit
-(`gitee_verify_tag_synchronized`) — belt-and-braces after Step 1's sync.
-**Neither script ever force-pushes or otherwise mutates history** on the
-Gitee git repository.
+[`scripts/sync_gitee_mirror.py`](scripts/sync_gitee_mirror.py) remains a
+separate git-level prerequisite for Gitee. Its branch and tag pushes are
+non-force; the publisher independently verifies that the Gitee tag points at
+the exact release commit before it plans Gitee attachments. Neither path has
+a delete-and-replace or force-push mode.
 
 Idempotency: an asset already attached under the same filename is skipped only
 after the actual GitHub or Gitee download bytes match the local SHA256. A
 same-name asset with different bytes, missing/ambiguous metadata, or a failed
-download always triggers a fail-loud error before upload planning completes.
-**There is no delete-and-replace path.**
+download is a fail-loud stop before upload planning completes.
 
-### Manual dry run (safe, no token required)
+### Read-only plan from a frozen bundle
 
 ```bash
-# after a wheels.yml run, download its `wheels-*` + `sdist` artifacts into
-# ./release-assets, then:
-python scripts/generate_release_manifest.py \
-  --assets-dir release-assets \
-  --kernel-version 0.16.4 --kernel-tag v0.16.4 \
-  --commit "$(git rev-parse HEAD)" \
-  --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --out-manifest release-assets/lingtai-kernel-release-manifest.json \
-  --out-sha256sums release-assets/SHA256SUMS
+# RUN_ID is the selected successful workflow_dispatch run.
+gh run download "$RUN_ID" --name release-bundle --dir release-assets
 
 python scripts/publish_release_assets.py \
   --manifest release-assets/lingtai-kernel-release-manifest.json \
-  --assets-dir release-assets
-# (no --execute: prints the GitHub/Gitee plan only)
+  --assets-dir release-assets \
+  --skip-gitee
+# No --execute: validates exact local bytes and prints the GitHub plan.
+
+# Optional Gitee mirror plan; also no --execute.
+python scripts/sync_gitee_mirror.py \
+  --commit "$(git rev-parse HEAD)" --tag v0.16.4 --branch main
 ```
 
-### Manual authorized publish (maintainer-run, outside this task's authorization)
+A fresh Gitee release cannot plan attachments until its tag exists on Gitee.
+That tag is established only in the authorized mechanical phase below; after
+sync, the publisher plans both selected providers before creating either
+release or uploading any attachment.
+
+### Authorized mechanical publish
 
 ```bash
+# External release authority is required before either --execute call.
 export GITEE_ACCESS_TOKEN=...  # never echo or log this
 python scripts/sync_gitee_mirror.py \
   --commit "$(git rev-parse HEAD)" --tag v0.16.4 --branch main --execute
@@ -162,10 +145,9 @@ python scripts/publish_release_assets.py \
   --execute
 ```
 
-As of this writing the Gitee kernel mirror's `main` lags GitHub's `main` and
-has no releases — the first real publish run is also the first time the sync
-step has anything to fast-forward from empty, which is the expected/supported
-case (see `test_sync_fast_forwards_empty_remote`).
+A failed guard or plan stops Phase B. Repair belongs back in Phase A; do not
+add tests, rebuild artifacts, regenerate the manifest, or widen release scope
+while publishing.
 
 ## Non-goals (v1)
 

--- a/scripts/generate_release_manifest.py
+++ b/scripts/generate_release_manifest.py
@@ -135,7 +135,8 @@ def build_manifest(
 
 def write_sha256sums(manifest: ReleaseManifest, out_path: Path) -> None:
     lines = [f"{a.sha256}  {a.filename}" for a in manifest.artifacts]
-    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    with out_path.open("x", encoding="utf-8") as output:
+        output.write("\n".join(lines) + "\n")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -153,6 +154,12 @@ def main(argv: list[str] | None = None) -> int:
         help="skip the sidecar validation contract (manifest-shape testing only, never for a real release)",
     )
     args = parser.parse_args(argv)
+
+    for output_path in (args.out_manifest, args.out_sha256sums):
+        if output_path.exists():
+            raise SystemExit(
+                f"error: refusing to replace existing release output: {output_path}"
+            )
 
     if not args.assets_dir.is_dir():
         raise SystemExit(f"error: --assets-dir is not a directory: {args.assets_dir}")

--- a/scripts/lib/release_manifest.py
+++ b/scripts/lib/release_manifest.py
@@ -162,6 +162,9 @@ def validate_manifest_dict(data: dict) -> None:
     missing = REQUIRED_TOP_LEVEL_KEYS - data.keys()
     if missing:
         raise ManifestError(f"manifest missing required keys: {sorted(missing)}")
+    unknown = data.keys() - REQUIRED_TOP_LEVEL_KEYS
+    if unknown:
+        raise ManifestError(f"manifest has unknown top-level keys: {sorted(unknown)}")
 
     if data["schema"] != SCHEMA:
         raise ManifestError(f"unexpected schema {data['schema']!r}, expected {SCHEMA!r}")
@@ -182,6 +185,9 @@ def validate_manifest_dict(data: dict) -> None:
         art_missing = REQUIRED_ARTIFACT_KEYS - art.keys()
         if art_missing:
             raise ManifestError(f"artifacts[{i}] missing keys: {sorted(art_missing)}")
+        art_unknown = art.keys() - REQUIRED_ARTIFACT_KEYS
+        if art_unknown:
+            raise ManifestError(f"artifacts[{i}] has unknown keys: {sorted(art_unknown)}")
         if not isinstance(art["filename"], str) or not art["filename"]:
             raise ManifestError(f"artifacts[{i}].filename must be a non-empty string")
         if art["filename"] in seen_filenames:
@@ -206,6 +212,11 @@ def validate_manifest_dict(data: dict) -> None:
         )
     if not has_sdist:
         raise ManifestError("manifest has no artifact with kind='sdist'; sdist_fallback is unsatisfiable")
+    fallback = next(art for art in artifacts if art["filename"] == data["sdist_fallback"])
+    if fallback["kind"] != "sdist":
+        raise ManifestError(
+            f"sdist_fallback {data['sdist_fallback']!r} must name an artifact with kind='sdist'"
+        )
 
 
 def manifest_from_dict(data: dict) -> ReleaseManifest:

--- a/scripts/publish_release_assets.py
+++ b/scripts/publish_release_assets.py
@@ -28,6 +28,7 @@ import argparse
 import json
 import os
 import subprocess
+from dataclasses import dataclass
 import sys
 import tempfile
 import uuid
@@ -51,6 +52,19 @@ class PublishError(RuntimeError):
 
 class AssetConflict(PublishError):
     """An existing remote attachment has the same name but a different sha256."""
+
+
+@dataclass(frozen=True)
+class GithubPlan:
+    create_release: bool
+    files: tuple[Path, ...]
+
+
+@dataclass(frozen=True)
+class GiteePlan:
+    create_release: bool
+    release_id: int | None
+    files: tuple[Path, ...]
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +208,16 @@ def plan_github_uploads(manifest, assets_dir: Path, manifest_path: Path, repo_sl
             continue
         to_upload.append(path)
     return to_upload
+
+
+def plan_github_release(manifest, assets_dir: Path, manifest_path: Path, repo_slug: str, tag: str) -> GithubPlan:
+    """Plan all GitHub reads and the later create/upload mutations."""
+    exists = gh_release_exists(tag, repo_slug)
+    if exists:
+        files = plan_github_uploads(manifest, assets_dir, manifest_path, repo_slug, tag)
+    else:
+        files = release_files(manifest, assets_dir, manifest_path)
+    return GithubPlan(create_release=not exists, files=tuple(files))
 
 
 def execute_github_upload(tag: str, repo_slug: str, files: list[Path]) -> None:
@@ -363,6 +387,33 @@ def plan_gitee_uploads(manifest, assets_dir: Path, manifest_path: Path, owner: s
     return to_upload
 
 
+def plan_gitee_release(
+    manifest,
+    assets_dir: Path,
+    manifest_path: Path,
+    owner: str,
+    repo: str,
+    token: str,
+) -> GiteePlan:
+    """Plan all Gitee reads and the later create/upload mutations."""
+    gitee_verify_tag_synchronized(owner, repo, manifest.kernel_tag, manifest.commit, token)
+    release = gitee_find_release_by_tag(owner, repo, manifest.kernel_tag, token)
+    if release is None:
+        return GiteePlan(
+            create_release=True,
+            release_id=None,
+            files=tuple(release_files(manifest, assets_dir, manifest_path)),
+        )
+
+    release_id = release.get("id")
+    if not isinstance(release_id, int) or isinstance(release_id, bool):
+        raise PublishError("Gitee release metadata is missing a valid numeric id")
+    files = plan_gitee_uploads(
+        manifest, assets_dir, manifest_path, owner, repo, release_id, token
+    )
+    return GiteePlan(create_release=False, release_id=release_id, files=tuple(files))
+
+
 def execute_gitee_upload(owner: str, repo: str, release_id: int, files: list[Path], token: str) -> None:
     import mimetypes
     import uuid
@@ -411,41 +462,73 @@ def main(argv: list[str] | None = None) -> int:
     verify_local_assets(manifest, args.assets_dir)
     print(f"Manifest OK: {manifest.kernel_tag} ({manifest.commit[:12]}), {len(manifest.artifacts)} artifact(s)")
 
+    # Phase one: finish every selected provider's read-only plan before any
+    # create/upload call. The plan records both idempotent skips and mutations.
+    github_plan = None
     if not args.skip_github:
         print(f"\n[github] target: {args.github_repo} tag {manifest.kernel_tag}")
-        if not gh_release_exists(manifest.kernel_tag, args.github_repo):
+        github_plan = plan_github_release(
+            manifest, args.assets_dir, args.manifest, args.github_repo, manifest.kernel_tag
+        )
+        if github_plan.create_release:
             print(f"  [github] release {manifest.kernel_tag} does not exist yet")
-            if args.execute:
-                subprocess.run(
-                    ["gh", "release", "create", manifest.kernel_tag, "--repo", args.github_repo,
-                     "--title", manifest.kernel_tag, "--notes", f"Kernel release {manifest.kernel_tag}"],
-                    check=True,
-                )
-            else:
+        if not args.execute:
+            if github_plan.create_release:
                 print(f"  [github] DRY RUN: would create release {manifest.kernel_tag}")
-        github_files = plan_github_uploads(manifest, args.assets_dir, args.manifest, args.github_repo, manifest.kernel_tag)
-        if args.execute:
-            execute_github_upload(manifest.kernel_tag, args.github_repo, github_files)
-        else:
-            for f in github_files:
-                print(f"  [github] DRY RUN: would upload {f.name}")
+            for path in github_plan.files:
+                print(f"  [github] DRY RUN: would upload {path.name}")
 
-    import os
-
+    gitee_plan = None
     gitee_token = os.environ.get(args.gitee_token_env, "")
     if args.skip_gitee or not gitee_token:
         reason = "--skip-gitee" if args.skip_gitee else f"{args.gitee_token_env} is not set"
         print(f"\n[gitee] skipped ({reason})")
+    else:
+        print(f"\n[gitee] target: {args.gitee_owner}/{args.gitee_repo} tag {manifest.kernel_tag}")
+        gitee_plan = plan_gitee_release(
+            manifest,
+            args.assets_dir,
+            args.manifest,
+            args.gitee_owner,
+            args.gitee_repo,
+            gitee_token,
+        )
+        print(f"  [gitee] tag {manifest.kernel_tag} is synchronized to {manifest.commit[:12]}")
+        if gitee_plan.create_release:
+            print(f"  [gitee] release {manifest.kernel_tag} does not exist yet")
+        if not args.execute:
+            if gitee_plan.create_release:
+                print(f"  [gitee] DRY RUN: would create release {manifest.kernel_tag}")
+            for path in gitee_plan.files:
+                print(f"  [gitee] DRY RUN: would upload {path.name}")
+
+    if not args.execute:
         return 0
 
-    print(f"\n[gitee] target: {args.gitee_owner}/{args.gitee_repo} tag {manifest.kernel_tag}")
-    gitee_verify_tag_synchronized(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, manifest.commit, gitee_token)
-    print(f"  [gitee] tag {manifest.kernel_tag} is synchronized to {manifest.commit[:12]}")
+    # Phase two: execute only the already-recorded mutations. No provider
+    # discovery/preflight occurs after this point.
+    if github_plan is not None:
+        if github_plan.create_release:
+            subprocess.run(
+                [
+                    "gh",
+                    "release",
+                    "create",
+                    manifest.kernel_tag,
+                    "--repo",
+                    args.github_repo,
+                    "--title",
+                    manifest.kernel_tag,
+                    "--notes",
+                    f"Kernel release {manifest.kernel_tag}",
+                ],
+                check=True,
+            )
+        execute_github_upload(manifest.kernel_tag, args.github_repo, list(github_plan.files))
 
-    release = gitee_find_release_by_tag(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, gitee_token)
-    if release is None:
-        print(f"  [gitee] release {manifest.kernel_tag} does not exist yet")
-        if args.execute:
+    if gitee_plan is not None:
+        release_id = gitee_plan.release_id
+        if gitee_plan.create_release:
             release = gitee_create_release(
                 args.gitee_owner,
                 args.gitee_repo,
@@ -454,18 +537,17 @@ def main(argv: list[str] | None = None) -> int:
                 manifest.commit,
                 gitee_token,
             )
-        else:
-            print(f"  [gitee] DRY RUN: would create release {manifest.kernel_tag}")
-            print("  [gitee] DRY RUN: cannot plan attachment uploads without a release id (would create first)")
-            return 0
-
-    release_id = release["id"]
-    gitee_files = plan_gitee_uploads(manifest, args.assets_dir, args.manifest, args.gitee_owner, args.gitee_repo, release_id, gitee_token)
-    if args.execute:
-        execute_gitee_upload(args.gitee_owner, args.gitee_repo, release_id, gitee_files, gitee_token)
-    else:
-        for f in gitee_files:
-            print(f"  [gitee] DRY RUN: would upload {f.name}")
+            release_id = release.get("id")
+            if not isinstance(release_id, int) or isinstance(release_id, bool):
+                raise PublishError("Gitee create-release response is missing a valid numeric id")
+        assert release_id is not None
+        execute_gitee_upload(
+            args.gitee_owner,
+            args.gitee_repo,
+            release_id,
+            list(gitee_plan.files),
+            gitee_token,
+        )
 
     return 0
 

--- a/tests/test_publish_release_assets.py
+++ b/tests/test_publish_release_assets.py
@@ -432,3 +432,34 @@ def test_main_rejects_tampered_asset_before_any_upload(tmp_path, monkeypatch):
             "--assets-dir", str(assets_dir),
             "--skip-gitee",
         ])
+
+
+def test_main_late_gitee_plan_failure_prevents_github_execute(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    monkeypatch.setenv("GITEE_ACCESS_TOKEN", "token")
+    github_executes = []
+
+    monkeypatch.setattr(
+        pub,
+        "plan_github_release",
+        lambda *args: pub.GithubPlan(create_release=False, files=()),
+    )
+    monkeypatch.setattr(
+        pub,
+        "execute_github_upload",
+        lambda *args: github_executes.append(args),
+    )
+    monkeypatch.setattr(
+        pub,
+        "plan_gitee_release",
+        lambda *args: (_ for _ in ()).throw(pub.PublishError("late Gitee planning failure")),
+    )
+
+    with pytest.raises(pub.PublishError, match="late Gitee planning failure"):
+        pub.main([
+            "--manifest", str(manifest_path),
+            "--assets-dir", str(assets_dir),
+            "--github-repo", "o/r",
+            "--execute",
+        ])
+    assert github_executes == []

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -142,6 +142,25 @@ def test_validate_manifest_dict_accepts_valid():
     validate_manifest_dict(_valid_manifest_dict())  # no raise
 
 
+def test_validate_manifest_dict_rejects_unknown_keys():
+    top_level = _valid_manifest_dict()
+    top_level["unexpected"] = True
+    with pytest.raises(ManifestError, match="unknown top-level keys"):
+        validate_manifest_dict(top_level)
+
+    artifact = _valid_manifest_dict()
+    artifact["artifacts"][0]["unexpected"] = True
+    with pytest.raises(ManifestError, match="unknown keys"):
+        validate_manifest_dict(artifact)
+
+
+def test_validate_manifest_dict_requires_sdist_fallback_kind():
+    data = _valid_manifest_dict()
+    data["sdist_fallback"] = data["artifacts"][0]["filename"]
+    with pytest.raises(ManifestError, match="kind='sdist'"):
+        validate_manifest_dict(data)
+
+
 @pytest.mark.parametrize("missing_key", sorted({
     "schema", "kernel_version", "kernel_tag", "commit", "generated_at", "artifacts", "sdist_fallback",
 }))
@@ -350,3 +369,33 @@ def test_generate_release_manifest_rejects_multiple_sdists(tmp_path: Path):
     )
     assert result.returncode != 0
     assert "exactly one sdist" in result.stderr
+
+
+@pytest.mark.parametrize("existing_output", ["manifest.json", "SHA256SUMS"])
+def test_generate_release_manifest_refuses_existing_outputs(tmp_path: Path, existing_output: str):
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    _write_fixture_wheel(assets / "lingtai-0.16.4-cp312-cp312-macosx_11_0_arm64.whl", sidecar=True)
+    (assets / "lingtai-0.16.4.tar.gz").write_bytes(b"fake-sdist-bytes")
+    existing = tmp_path / existing_output
+    existing.write_text("immutable receipt", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable, str(GENERATE_SCRIPT),
+            "--assets-dir", str(assets),
+            "--kernel-version", "0.16.4",
+            "--kernel-tag", "v0.16.4",
+            "--commit", "a" * 40,
+            "--generated-at", "2026-07-15T00:00:00Z",
+            "--out-manifest", str(tmp_path / "manifest.json"),
+            "--out-sha256sums", str(tmp_path / "SHA256SUMS"),
+            "--skip-sidecar-check",
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "refusing to replace existing release output" in result.stderr
+    assert existing.read_text(encoding="utf-8") == "immutable receipt"
+    other = tmp_path / ("SHA256SUMS" if existing_output == "manifest.json" else "manifest.json")
+    assert not other.exists()

--- a/tests/test_wheels_workflow_publish_gating.py
+++ b/tests/test_wheels_workflow_publish_gating.py
@@ -1,10 +1,4 @@
-"""Static assertions over .github/workflows/wheels.yml's release-manifest job:
-proves the publish step is actually reachable with --execute on the real
-release trigger (Blocker 3 repair), that manual dispatch defaults to dry-run,
-and that the Gitee sync step never force-pushes. This is a workflow-shape
-test, not a live GitHub Actions run — it parses the committed YAML/shell
-text.
-"""
+"""Static contract tests for the prerelease-only wheel workflow."""
 from __future__ import annotations
 
 from pathlib import Path
@@ -16,110 +10,42 @@ WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "wheels.yml"
 
 
 def _load_workflow() -> dict:
-    # PyYAML parses the bare `on:` key as boolean True under YAML 1.1
-    # resolution; this file's real key is the string "on", so load with the
-    # default resolver and look it up defensively under both spellings.
-    return yaml.safe_load(WORKFLOW_PATH.read_text())
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(data: dict) -> dict:
+    # PyYAML resolves bare `on:` as boolean True under YAML 1.1.
+    return data.get("on") or data.get(True)
 
 
 def _release_manifest_job(data: dict) -> dict:
     return data["jobs"]["release-manifest"]
 
 
-def _step(job: dict, name_substring: str) -> dict:
-    for step in job["steps"]:
-        if name_substring.lower() in step.get("name", "").lower():
-            return step
-    raise AssertionError(f"no step with name containing {name_substring!r} in {[s.get('name') for s in job['steps']]}")
-
-
-def test_workflow_dispatch_has_publish_input_defaulting_false():
+def test_workflow_is_manual_prerelease_only():
     data = _load_workflow()
-    on = data.get("on") or data.get(True)  # YAML 1.1 quirk guard
-    dispatch = on["workflow_dispatch"]
-    assert "inputs" in dispatch, "workflow_dispatch must expose a manual-publish input"
-    publish_input = dispatch["inputs"]["publish"]
-    assert publish_input["type"] == "boolean"
-    assert publish_input["default"] is False, "manual dispatch must default to dry-run"
+    assert set(_triggers(data)) == {"workflow_dispatch"}
+    assert data["permissions"] == {"contents": "read"}
 
 
-def test_release_published_still_triggers_workflow():
-    data = _load_workflow()
-    on = data.get("on") or data.get(True)
-    assert on["release"]["types"] == ["published"]
-
-
-def test_publish_mode_step_executes_on_real_release_event():
+def test_release_manifest_job_cannot_publish():
     job = _release_manifest_job(_load_workflow())
-    step = _step(job, "Determine publish mode")
-    script = step["run"]
-    assert "github.event_name" in script and "release" in script
-    assert 'echo "execute=1"' in script, "the release event branch must set execute=1"
+    assert set(job["needs"]) == {"build-wheels", "build-sdist"}
+    assert job["permissions"] == {"contents": "read"}
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "publish_release_assets.py" not in text
+    assert "sync_gitee_mirror.py" not in text
+    assert "--execute" not in text
 
 
-def test_publish_mode_step_executes_on_explicit_manual_publish_true():
+def test_release_manifest_job_uploads_one_complete_bundle():
     job = _release_manifest_job(_load_workflow())
-    step = _step(job, "Determine publish mode")
-    script = step["run"]
-    assert "inputs.publish" in script
-    # Both branches (release event, and workflow_dispatch+publish=true) must
-    # set execute=1; the else branch must set execute=0 (default dry-run).
-    assert script.count('echo "execute=1"') == 2, script
-    assert 'echo "execute=0"' in script
-
-
-def test_publish_step_conditionally_passes_execute_flag():
-    job = _release_manifest_job(_load_workflow())
-    step = _step(job, "Publish manifest")
-    script = step["run"]
-    assert "publish_mode.outputs.execute" in script
-    assert "--execute" in script
-    assert "publish_release_assets.py" in script
-    # The flag must be conditional, not unconditionally omitted (the prior
-    # defect) or unconditionally present (which would always try to publish,
-    # even on ordinary workflow_dispatch shape-checks).
-    assert 'execute_flag="--execute"' in script
-    assert 'execute_flag=""' in script
-
-
-def test_gitee_sync_step_is_gated_on_publish_mode_and_never_forces():
-    job = _release_manifest_job(_load_workflow())
-    step = _step(job, "synchronize the exact commit/tag to Gitee")
-    assert step.get("if") == "steps.publish_mode.outputs.execute == '1'", \
-        "Gitee sync must only run when actually publishing, not on every dry-run shape check"
-    script = step["run"]
-    assert "sync_gitee_mirror.py" in script
-    assert "--execute" in script
-    assert "--force" not in script
-    assert "force" not in script.lower() or "non-force" in script.lower()
-
-
-def test_gitee_token_never_echoed_via_echo_or_print():
-    # The env var name legitimately appears in comments/docs and in the
-    # `env:` mapping (sourced from the GitHub secret). What must never happen
-    # is a shell `echo`/`print`/`cat` of that variable, which would leak the
-    # value into the job log.
-    text = WORKFLOW_PATH.read_text()
-    for line in text.splitlines():
-        stripped = line.strip()
-        if "$GITEE_ACCESS_TOKEN" in stripped or "${GITEE_ACCESS_TOKEN" in stripped:
-            assert not any(stripped.startswith(cmd) for cmd in ("echo", "print", "cat")), (
-                f"found a shell command that appears to print the raw token: {line}"
-            )
-
-
-def test_release_manifest_job_has_contents_write_for_publish():
-    job = _release_manifest_job(_load_workflow())
-    assert job["permissions"]["contents"] == "write", (
-        "publishing (gh release upload / git push to Gitee) requires contents:write; "
-        "read-only permissions would make the publish step fail even when execute=1"
+    upload = next(
+        step for step in job["steps"]
+        if step.get("uses") == "actions/upload-artifact@v4"
     )
-
-
-def test_checkout_step_has_full_history_for_gitee_push():
-    job = _release_manifest_job(_load_workflow())
-    step = _step(job, "Check out repository")
-    assert step.get("with", {}).get("fetch-depth") == 0, (
-        "sync_gitee_mirror.py needs the release commit's full history reachable "
-        "to push it; a shallow checkout would break the non-force push"
-    )
+    assert upload["with"] == {
+        "name": "release-bundle",
+        "path": "release-assets",
+        "if-no-files-found": "error",
+    }


### PR DESCRIPTION
## Goal

Split release preparation from publication so the wheel workflow finishes one bounded prerelease check and freezes one immutable bundle; publication remains a separate, explicit mechanical action.

## Changes

- make `.github/workflows/wheels.yml` `workflow_dispatch`-only and read-only
- remove release/publish/Gitee mutation paths from that workflow
- upload all checked wheels, sdist, manifest, and `SHA256SUMS` as one `release-bundle`
- reject unknown manifest fields, invalid sdist fallback kinds, and existing output paths
- plan every selected GitHub/Gitee release operation before the publisher's first create/upload call
- replace obsolete publish-gating workflow tests with three prerelease-boundary assertions
- update `RELEASING.md` and root `ANATOMY.md` so the immutable `release-bundle` is the sole handoff into the separate mechanical publisher

## Validation

- `66 passed`:
  - `tests/test_release_manifest.py`
  - `tests/test_publish_release_assets.py`
  - `tests/test_wheels_workflow_publish_gating.py`
- changed Python files compile
- workflow YAML contract parse passes
- `git diff --check` passes

## Scope

This PR refactors the workflow boundary only. It does not run prerelease, tag, upload, publish, merge a release, change TUI/Homebrew, or add website/blog work.
