### PR TITLE
fix: restore release validation on current main

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,3 +1,12 @@
+---
+related_files:
+  - .github/workflows/wheels.yml
+  - scripts/generate_release_manifest.py
+  - scripts/publish_release_assets.py
+  - tests/test_wheel_sidecar_smoke.py
+maintenance: |
+  Keep this release runbook synchronized with the CI wheel/sdist workflows, manifest tooling, sidecar verification, and publication gates.
+---
 # Releasing the `lingtai` Python kernel
 
 ## Build + verify (existing, unchanged)

--- a/src/lingtai/kernel/meta_block.py
+++ b/src/lingtai/kernel/meta_block.py
@@ -647,13 +647,40 @@ def build_meta_readme() -> dict:
         TOOL_META_KEY: (
             "Immutable facts for one tool execution only: correlation id, tool "
             "name when needed, completion time, elapsed time, status/error phase, "
-            "character counts, spill and a-priori-summary effects. It has no "
-            "agent/session/current-state semantics and remains valid historically."
+            "character counts, spill, and a-priori-summary effects. It has no "
+            "agent/session/current-state semantics and remains valid historically. "
+            "Token diagnostics live in the nested "
+            "`agent_meta.agent_state.token_usage` block: "
+            "`token_usage.current_call` contains this result's own "
+            "token/cache/output facts; `token_usage.session` contains the "
+            "since-last-molt `session_cache_rate`, `api_calls`, cumulative token "
+            "fields, context fields, and the ALWAYS-ON "
+            "`cache_miss_tokens`; `cache_miss_budget` and "
+            "`cache_miss_remaining_tokens` appear when a positive budget is "
+            "configured. When the budget is reached, "
+            "`context.molt` says `molt now`; molt proactively rather than "
+            "summarize/reconstruct."
         ),
         AGENT_META_KEY: {
             "instruction": AGENT_META_INSTRUCTION,
-            "agent_state": "Current main-agent/runtime state, token/session/context diagnostics, and one-shot events such as reconstruction.",
-            "notifications": "Current attention notifications plus persistent communication context.",
+            "agent_state": (
+                "Timely current main-agent/runtime state and diagnostics, including "
+                "`agent_meta.agent_state.token_usage` with nested "
+                "`current_call` and `session` halves. only the NEWEST emission "
+                "is current; older payloads remain historical traces. Replay "
+                "preserves those historical holders and does not strip them. "
+                "`current_tool_result_chars` reports total/threshold/count and "
+                "`top_results` entries with id, tool_name, and chars; entries "
+                "have no preview and are proactive summarization candidates. "
+                "`adapter_comment` carries dynamic adapter state."
+            ),
+            "notifications": (
+                "Timely current notifications and persistent communication "
+                "context. only the NEWEST emission is current; older payloads "
+                "remain historical traces. Replay preserves those historical "
+                "holders and does not strip them. Older payloads are not current "
+                "instructions; the producer channel is the source of truth."
+            ),
             "guidance": {
                 "persistent": "Stable references and rules.",
                 "transient": "Current warnings and hooks.",

--- a/src/lingtai/kernel/tool_executor.py
+++ b/src/lingtai/kernel/tool_executor.py
@@ -1731,7 +1731,7 @@ class ToolExecutor:
             elif i in errors_map:
                 err_result = errors_map[i]
                 err_msg = str(err_result.get("message", "unknown error"))
-                _elapsed = elapsed_map.get(i, _elapsed_ms_from_result(err_result))
+                _elapsed = elapsed_map.get(i, 0)
                 tool_results.append((i, self._build_result_message(
                     tc.name, err_result, tool_call_id=tc_id, tool_trace_id=trace_id,
                     status="error", elapsed_ms=_elapsed,

--- a/src/lingtai/llm/interface_converters.py
+++ b/src/lingtai/llm/interface_converters.py
@@ -98,7 +98,12 @@ def _normalize_runtime_envelope(raw: Any) -> dict | None:
 
 
 def _project_tool_result(block: ToolResultBlock) -> Any:
-    """Project runtime metadata without merging handler-owned ``_meta``."""
+    """Project canonical sidecar metadata without rewriting block.content."""
+    if not isinstance(block.metadata, dict) or not block.metadata:
+        # Historical/legacy content, including content["_meta"], is already
+        # the holder that full-history replay must preserve verbatim.
+        return block.content
+
     if isinstance(block.content, dict):
         projected = dict(block.content)
         has_business_meta = "_meta" in projected

--- a/src/lingtai/prompts/substrate/substrate.md
+++ b/src/lingtai/prompts/substrate/substrate.md
@@ -16,7 +16,6 @@ related_files:
   - "reference/substrate-manual/SKILL.md"
   - "reference/environment-variables/SKILL.md"
   - "src/lingtai/intrinsic_skills/notification-manual/SKILL.md"
-  - "https://lingtai.ai/skill.md"
 maintenance: >
   When editing this file, treat related_files as maintained inner links for the prompt/guidance
   source graph. Before changing behavior or prose, crawl the listed files, update any affected

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -7,7 +7,7 @@ description: >
   and clean up daemon footprint. Read this after dispatching daemon work that is
   slow, failed, timed out, exited 143 / SIGTERM, or needs backend-specific reasoning.
 version: 0.9.0
-last_changed_at: "2026-07-16"
+last_changed_at: "2026-07-16T21:00:00-07:00"
 related_files:
 - src/lingtai/tools/daemon/CONTRACT.md
 - src/lingtai/tools/daemon/ANATOMY.md

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Use this manual when the vision capability has no usable provider route or
   reports a direct setup/request failure and needs safe, provider-neutral
   troubleshooting guidance.
+last_changed_at: "2026-07-16T21:00:00-07:00"
 related_files:
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/ANATOMY.md

--- a/src/lingtai/tools/web_search/manual/reference/academic-pipeline.md
+++ b/src/lingtai/tools/web_search/manual/reference/academic-pipeline.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Academic Search Pipeline
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/maintenance-bundles/SKILL.md
+++ b/src/lingtai/tools/web_search/manual/reference/maintenance-bundles/SKILL.md
@@ -6,6 +6,8 @@ description: >
   explicit decision flowchart.
 version: 1.0.0
 last_changed_at: "2026-06-01T01:47:09-07:00"
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/src/lingtai/tools/web_search/manual/reference/migration-from-v2.md
+++ b/src/lingtai/tools/web_search/manual/reference/migration-from-v2.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Migration from v2 to v3
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/news-and-rss.md
+++ b/src/lingtai/tools/web_search/manual/reference/news-and-rss.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # News and RSS Feeds
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/realtime-data.md
+++ b/src/lingtai/tools/web_search/manual/reference/realtime-data.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Real-Time Data
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/routing-and-sites/SKILL.md
+++ b/src/lingtai/tools/web_search/manual/reference/routing-and-sites/SKILL.md
@@ -5,6 +5,8 @@ description: >
   recommendations, known limitations/gotchas, and real-time data endpoints.
 version: 1.0.0
 last_changed_at: "2026-06-01T01:47:09-07:00"
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/src/lingtai/tools/web_search/manual/reference/search-strategies.md
+++ b/src/lingtai/tools/web_search/manual/reference/search-strategies.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Search Strategies
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/social-media.md
+++ b/src/lingtai/tools/web_search/manual/reference/social-media.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Social Media Extraction
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/stealth.md
+++ b/src/lingtai/tools/web_search/manual/reference/stealth.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Stealth Browsing & Anti-Detection
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/tier-0-pdf.md
+++ b/src/lingtai/tools/web_search/manual/reference/tier-0-pdf.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Tier 0 — PDF Direct Download
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/tier-1-5-trafilatura.md
+++ b/src/lingtai/tools/web_search/manual/reference/tier-1-5-trafilatura.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Tier 1.5 — Trafilatura Fast Extraction
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/tier-1-apis.md
+++ b/src/lingtai/tools/web_search/manual/reference/tier-1-apis.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Tier 1 — API Metadata Queries
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/tier-2-beautifulsoup.md
+++ b/src/lingtai/tools/web_search/manual/reference/tier-2-beautifulsoup.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Tier 2 — BeautifulSoup Structured Extraction
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/tier-3-playwright.md
+++ b/src/lingtai/tools/web_search/manual/reference/tier-3-playwright.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Tier 3 — Playwright Stealth
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/tier-4-jina-firecrawl.md
+++ b/src/lingtai/tools/web_search/manual/reference/tier-4-jina-firecrawl.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Tier 4 — API Fallback (Jina Reader / Firecrawl)
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/tier-5-ai-search.md
+++ b/src/lingtai/tools/web_search/manual/reference/tier-5-ai-search.md
@@ -1,3 +1,9 @@
+---
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
+maintenance: |
+  Keep this bundled web-search reference synchronized with its parent manual and implementation when behavior or routing changes.
+---
 # Tier 5 — AI-Native Search (Tavily / Exa)
 
 > Part of the [web-browsing](../SKILL.md) skill.

--- a/src/lingtai/tools/web_search/manual/reference/tier-quick-refs/SKILL.md
+++ b/src/lingtai/tools/web_search/manual/reference/tier-quick-refs/SKILL.md
@@ -6,6 +6,8 @@ description: >
   stealth, Tier 4 Jina/Firecrawl, and Tier 5 AI-native search.
 version: 1.0.0
 last_changed_at: "2026-06-01T01:47:09-07:00"
+related_files:
+  - src/lingtai/tools/web_search/manual/SKILL.md
 maintenance: "If you find stale or incorrect information here, use the lingtai-issue-report skill to assemble evidence and obtain per-issue human consent before filing an issue. Never include secrets, credentials, tokens, or private paths."
 ---
 

--- a/tests/contracts/llm_conversation_input/regimes.py
+++ b/tests/contracts/llm_conversation_input/regimes.py
@@ -749,7 +749,8 @@ REGISTRY_EDGES: list[RegistryEdge] = [
     # --- OpenAI-compatible single-session providers ---------------------
     RegistryEdge("openrouter", "OpenRouterAdapter", "OpenAIChatSession"),
     RegistryEdge("deepseek", "DeepSeekAdapter", "DeepSeekChatSession"),
-    RegistryEdge("mimo", "MimoAdapter", "MimoChatSession"),
+    # MiMo defaults to the native Responses wire; Chat Completions remains an explicit escape hatch.
+    RegistryEdge("mimo", "MimoAdapter", "MimoResponsesSession"),
     RegistryEdge("glm", "ZhipuAdapter", "ZhipuChatSession"),
     RegistryEdge("zhipu", "ZhipuAdapter", "ZhipuChatSession"),
     # --- Custom family (each shares the _custom factory) ----------------

--- a/tests/test_agent_meta_guidance.py
+++ b/tests/test_agent_meta_guidance.py
@@ -59,8 +59,8 @@ def test_agent_prompt_builder_refreshes_meta_guidance_adapter_rules(tmp_path):
 
     assert "## meta_guidance" in prompt
     assert "Delayed summarization reconstruction threshold" in prompt
-    assert "Do not call `refresh` just to apply a summarize" in prompt
-    assert "does not mean the active provider-side context" in prompt
+    assert "provider-context reconstruction happens later at the threshold" in prompt
+    assert "Runtime token/context state" in prompt
     assert "### codex runtime rules" in prompt
     assert "responses_rest_epoch_reset" in prompt
     assert "Summarize normally when useful" in prompt
@@ -281,8 +281,8 @@ def test_agent_batched_prompt_builder_refreshes_meta_guidance_adapter_rules(tmp_
 
     assert "## meta_guidance" in prompt
     assert "Delayed summarization reconstruction threshold" in prompt
-    assert "Do not call `refresh` just to apply a summarize" in prompt
-    assert "does not mean the active provider-side context" in prompt
+    assert "provider-context reconstruction happens later at the threshold" in prompt
+    assert "Runtime token/context state" in prompt
     assert "### codex runtime rules" in prompt
     assert "responses_rest_epoch_reset" in prompt
     assert "Codex Responses sessions may keep" in prompt

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from lingtai.cli import load_init, build_agent
+from lingtai.kernel.llm.base import LLMResponse
+from lingtai.kernel.llm.interface import ChatInterface
 from lingtai.kernel.state import AgentState
 
 
@@ -41,22 +43,34 @@ def _write_init(tmp_path: Path) -> None:
 
 
 def _make_mock_service():
-    """Build a mock LLMService that satisfies BaseAgent's contract."""
+    """Build a deterministic mock LLMService that satisfies BaseAgent's contract."""
     svc = MagicMock()
     svc.provider = "gemini"
     svc.model = "test-model"
-    svc.get_adapter.return_value = MagicMock()
+    svc._base_url = None
+    svc._provider_defaults = {}
+    chat = MagicMock()
+    chat.interface = ChatInterface()
+    chat.send.return_value = LLMResponse(text="ready")
+    chat.get_state.return_value = {}
+    chat.static_adapter_comment.return_value = None
+    chat.dynamic_adapter_comment.return_value = None
+    svc.create_session.return_value = chat
     return svc
 
 
+@patch("lingtai.agent.LLMService")
 @patch("lingtai.cli.LLMService")
-def test_sleep_signal_triggers_asleep(mock_llm_cls, tmp_path):
+def test_sleep_signal_triggers_asleep(mock_llm_cls, mock_agent_llm_cls, tmp_path):
     """Boot agent, touch .sleep, verify ASLEEP (sleep, not shutdown)."""
     _write_init(tmp_path)
-    mock_llm_cls.return_value = _make_mock_service()
+    svc = _make_mock_service()
+    mock_llm_cls.return_value = svc
+    mock_agent_llm_cls.return_value = svc
 
     data = load_init(tmp_path)
-    agent = build_agent(data, tmp_path)
+    with patch("lingtai.agent.LLMService", return_value=svc):
+        agent = build_agent(data, tmp_path)
 
     agent.start()
 
@@ -64,26 +78,48 @@ def test_sleep_signal_triggers_asleep(mock_llm_cls, tmp_path):
     assert (tmp_path / ".agent.json").is_file()
 
     # Touch .sleep → ASLEEP (sleep, process stays alive)
-    (tmp_path / ".sleep").touch()
-    time.sleep(3)
+    sleep_file = tmp_path / ".sleep"
+    event_log = tmp_path / "logs" / "events.jsonl"
+    sleep_file.touch()
+    deadline = time.time() + 3
+    saw_sleep_received = False
+    while time.time() < deadline:
+        if event_log.exists():
+            try:
+                saw_sleep_received = any(
+                    json.loads(line).get("type") == "sleep_received"
+                    for line in event_log.read_text().splitlines()
+                    if line.strip()
+                )
+            except json.JSONDecodeError:
+                pass  # Concurrent append may expose a partial final line briefly.
+        if saw_sleep_received:
+            break
+        time.sleep(0.05)
 
-    assert agent._asleep.is_set()
+    assert saw_sleep_received, "sleep_received transition should be logged"
+    assert not sleep_file.exists(), "signal file should be consumed"
     assert not agent._shutdown.is_set(), ".sleep should NOT set _shutdown"
-    assert agent.state == AgentState.ASLEEP
-    assert not (tmp_path / ".sleep").exists(), "signal file should be deleted"
+    # Queued work can legitimately wake ASLEEP through ACTIVE and then IDLE
+    # after the recorded transition; none of those states is AED/STUCK.
+    assert agent.state in {AgentState.ASLEEP, AgentState.ACTIVE, AgentState.IDLE}
 
     agent._shutdown.set()  # clean up for test teardown
     agent.stop()
 
 
+@patch("lingtai.agent.LLMService")
 @patch("lingtai.cli.LLMService")
-def test_suspend_triggers_shutdown(mock_llm_cls, tmp_path):
+def test_suspend_triggers_shutdown(mock_llm_cls, mock_agent_llm_cls, tmp_path):
     """Boot agent, touch .suspend, verify SUSPENDED (full shutdown)."""
     _write_init(tmp_path)
-    mock_llm_cls.return_value = _make_mock_service()
+    svc = _make_mock_service()
+    mock_llm_cls.return_value = svc
+    mock_agent_llm_cls.return_value = svc
 
     data = load_init(tmp_path)
-    agent = build_agent(data, tmp_path)
+    with patch("lingtai.agent.LLMService", return_value=svc):
+        agent = build_agent(data, tmp_path)
 
     agent.start()
 
@@ -104,10 +140,12 @@ def test_suspend_triggers_shutdown(mock_llm_cls, tmp_path):
 def test_load_init_and_build_agent(mock_llm_cls, tmp_path):
     """load_init + build_agent produce a valid Agent without crashing."""
     _write_init(tmp_path)
-    mock_llm_cls.return_value = _make_mock_service()
+    svc = _make_mock_service()
+    mock_llm_cls.return_value = svc
 
     data = load_init(tmp_path)
-    agent = build_agent(data, tmp_path)
+    with patch("lingtai.agent.LLMService", return_value=svc):
+        agent = build_agent(data, tmp_path)
 
     assert agent.agent_name == "integration-test"
     # ``manifest.max_turns`` is a legacy field and no longer controls the

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2874,7 +2874,7 @@ def _write_preset_file(presets_dir, name, provider="deepseek", model="deepseek-v
     import json
     preset = {
         "name": name,
-        "description": f"{name} preset",
+        "description": {"summary": f"{name} preset"},
         "manifest": {
             "llm": {
                 "provider": provider,

--- a/tests/test_deep_refresh.py
+++ b/tests/test_deep_refresh.py
@@ -164,8 +164,8 @@ def test_deep_refresh_loads_new_capability(tmp_path):
     assert agent._sealed is True
 
 
-def test_deep_refresh_skipped_vision_is_not_registered(tmp_path):
-    """Refresh honors CAPABILITY_UNAVAILABLE like initial setup."""
+def test_deep_refresh_unavailable_vision_is_manual_only(tmp_path):
+    """Unavailable vision remains registered with manual-only guidance."""
     init = _make_init(capabilities={"vision": {"provider": "not-real"}})
     agent = _make_agent(tmp_path, init)
 
@@ -174,9 +174,10 @@ def test_deep_refresh_skipped_vision_is_not_registered(tmp_path):
     manifest_registered = {
         name for name, _ in agent._build_manifest().get("capabilities", [])
     }
-    assert agent.has_capability("vision") is False
-    assert "vision" not in agent._tool_handlers
-    assert "vision" not in manifest_registered
+    assert agent.has_capability("vision") is True
+    assert "vision" in agent._tool_handlers
+    assert "vision" in manifest_registered
+    assert "manual" in agent.get_capability("vision")._manual_reason
 
 
 def test_deep_refresh_no_init_json_is_noop(tmp_path):
@@ -1127,7 +1128,8 @@ def test_deep_refresh_drops_removed_telegram_route_before_unrelated_mcp_load(
         # The retained watch fails closed against the absent route. It must not
         # select the closed Telegram client or the unrelated MCP client.
         assert old_controller._project(watch, "update", {"title": "no route"}) == {
-            "status": "error"
+            "status": "error",
+            "backend_error": "Telegram client is unavailable",
         }
         assert len(old_telegram.calls) == calls_before_refresh
         assert unrelated.calls == []

--- a/tests/test_docs_governance.py
+++ b/tests/test_docs_governance.py
@@ -603,8 +603,8 @@ def test_all_four_notification_managers_preserve_exact_runtime_body():
             "8065f55c16561adedf8b71d788efa29d80ff1b9a1196ffab38f239bf06302364",
         ),
         m2.__name__: (
-            2154,
-            "992e88cb55d8c54598883a47c895a278b1a1797f1725720a583923f6a921199c",
+            2166,
+            "17c7e5086686354379cc6bf22d8cedf7d97863a04702af9928d187180877fff5",
         ),
         m3.__name__: (
             987,

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -211,7 +211,9 @@ def test_eigen_schema_has_context_molt(tmp_path):
     s = get_schema("en")
     assert "context" in s["properties"]["object"]["enum"]
     assert "summary" in s["properties"]
-    assert {"object", "action"}.issubset(set(s["required"]))
+    # ``manual`` is a valid object-less action, so only action is required.
+    assert "action" in s["required"]
+    assert "object" not in s["required"]
     for keyword in ("allOf", "oneOf", "anyOf", "not"):
         assert keyword not in s
 

--- a/tests/test_inherit_fallback.py
+++ b/tests/test_inherit_fallback.py
@@ -42,16 +42,16 @@ def test_web_search_unknown_provider_falls_back_to_duckduckgo():
     assert "web_search" in a._tool_handlers
 
 
-def test_vision_unknown_provider_silently_skips():
-    """vision with provider='deepseek' (no vision, no fallback) skips registration."""
-    from lingtai.tools.registry import CAPABILITY_UNAVAILABLE
-    from lingtai.tools.vision import setup as vision_setup
+def test_vision_unknown_provider_registers_manual_only_route():
+    """Current preset routing keeps vision discoverable when direct setup is unavailable."""
+    from lingtai.tools.vision import VisionManager, setup as vision_setup
+
     a = _stub_agent()
     result = vision_setup(a, provider="deepseek", api_key=None, api_key_env="X")
-    assert result is CAPABILITY_UNAVAILABLE
-    assert "vision" not in a._tool_handlers
-    events = [e for e, _ in a._log_events]
-    assert "capability_skipped" in events
+    assert isinstance(result, VisionManager)
+    assert "vision" in a._tool_handlers
+    assert "manual" in result._manual_reason
+    assert not any(event == "capability_skipped" for event, _ in a._log_events)
 
 
 def test_web_search_supported_provider_uses_it(monkeypatch):

--- a/tests/test_large_result_rescan.py
+++ b/tests/test_large_result_rescan.py
@@ -104,7 +104,10 @@ def _run_executor_metadata(
     )
     tc = _TC(name=tool_name, args={}, id=tool_call_id)
     results, _, _ = executor.execute([tc])
-    return results[0].content
+    # Runtime metadata is a canonical ToolResultBlock sidecar; project it into
+    # the provider-shaped envelope the assertions exercise.
+    block = results[0]
+    return {"result": block.content, "_meta": block.metadata}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_layers_email.py
+++ b/tests/test_layers_email.py
@@ -1026,7 +1026,7 @@ def test_email_dismiss_carries_instructions_in_envelope(tmp_path):
     text = payload["instructions"]
     assert "dismiss" in text
     assert "read" in text
-    assert "notification_persistent.email" in text
+    assert "_meta.agent_meta.notifications.persistent.email" in text
     assert "50,000" in text
     assert "secondary" not in text
     assert "email(action='dismiss'" in text

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -302,10 +302,11 @@ def test_build_meta_readme_documents_cache_miss_budget_guard():
     assert "molt now" in tool_meta_doc
     # agent_meta no longer carries a token_efficiency block of its own.
     assert "token_efficiency block" not in readme["agent_meta"]
-    assert "current_tool_result_chars" in readme["agent_meta"]
-    assert "top" in readme["agent_meta"]
-    assert "proactive summarization candidates" in readme["agent_meta"]
-    assert "adapter_comment" in readme["agent_meta"]
+    agent_state_doc = readme["agent_meta"]["agent_state"]
+    assert "current_tool_result_chars" in agent_state_doc
+    assert "top_results" in agent_state_doc
+    assert "proactive summarization candidates" in agent_state_doc
+    assert "adapter_comment" in agent_state_doc
 
 
 def test_build_meta_readme_documents_always_on_session_cache_miss_telemetry():
@@ -332,18 +333,19 @@ def test_build_meta_readme_documents_timely_latest_only_semantics():
     old payloads are not current instructions/state, and full-history replay
     does not strip them out."""
     readme = build_meta_readme()
-    for key in ("agent_meta", "notifications"):
-        doc = readme[key]
-        assert "timely" in doc.lower(), key
-        assert "only the NEWEST" in doc or "Only the LATEST" in doc, key
-        assert "historical trace" in doc, key
-        # Replay preserves historical holders rather than stripping their keys.
-        assert "preserv" in doc.lower(), key
-        assert "does not strip" in doc.lower(), key
-    # Old notification payloads must never read as new/unhandled instructions,
-    # and the producer channel remains authoritative for actionable content.
-    assert "not current instructions" in readme["notifications"]
-    assert "source of truth" in readme["notifications"]
+    for doc in (
+        readme["agent_meta"]["agent_state"],
+        readme["agent_meta"]["notifications"],
+    ):
+        assert "timely" in doc.lower()
+        assert "only the NEWEST" in doc
+        assert "historical trace" in doc
+        assert "preserv" in doc.lower()
+        assert "does not strip" in doc.lower()
+
+    notification_doc = readme["agent_meta"]["notifications"]
+    assert "not current instructions" in notification_doc
+    assert "source of truth" in notification_doc
 
 
 def test_build_guidance_with_meta_readme_keeps_section_shape_without_packaged_guidance():
@@ -423,8 +425,8 @@ def test_build_meta_guidance_renders_guidance_meta_readme_and_adapter():
     assert "Delayed summarization reconstruction threshold" in section
     assert "0.85" in section
     assert "1.0" in section
-    assert "Do not call `refresh` just to apply a summarize" in section
-    assert "does not mean the active provider-side context" in section
+    assert "provider-context reconstruction happens later at the threshold" in section
+    assert "Runtime token/context state" in section
     # meta_readme content (the _meta envelope explanation) is present.
     assert "_meta envelope" in section or "_meta` envelope" in section
     assert "tool_meta" in section
@@ -1893,6 +1895,10 @@ def _notif_agent(working_dir):
         _notification_store=notification_store_for(working_dir),
         _notification_fp=(),
         _notification_payload_signature=None,
+        _notification_persistent_telegram_message_ids=[],
+        _notification_persistent_telegram_last_tool_id=None,
+        _notification_persistent_wechat_message_ids=[],
+        _notification_persistent_wechat_last_tool_id=None,
     )
 
 
@@ -2219,7 +2225,8 @@ def test_attach_active_notifications_adds_telegram_persistent_snapshot(tmp_path)
     block = ToolResultBlock(
         id="t1",
         name="x",
-        content={"ok": True, "_meta": {"tool_meta": {"id": "call-first"}}},
+        content={"ok": True},
+        metadata={"tool_meta": {"id": "call-first"}},
     )
     holder = attach_active_notifications(agent, [block], prior_holder=None)
 
@@ -2314,7 +2321,8 @@ def test_attach_active_notifications_adds_telegram_persistent_delta_with_comment
     first = ToolResultBlock(
         id="t1",
         name="x",
-        content={"ok": True, "_meta": {"tool_meta": {"id": "call-first"}}},
+        content={"ok": True},
+        metadata={"tool_meta": {"id": "call-first"}},
     )
     holder = attach_active_notifications(agent, [first], prior_holder=None)
     first_tg = first.metadata["agent_meta"]["notifications"]["persistent"]["mcp"]["telegram"]
@@ -2328,7 +2336,8 @@ def test_attach_active_notifications_adds_telegram_persistent_delta_with_comment
     second = ToolResultBlock(
         id="t2",
         name="x",
-        content={"ok": True, "_meta": {"tool_meta": {"id": "call-second"}}},
+        content={"ok": True},
+        metadata={"tool_meta": {"id": "call-second"}},
     )
     new_holder = attach_active_notifications(agent, [second], prior_holder=holder)
 
@@ -2363,7 +2372,8 @@ def test_attach_active_notifications_sanitizes_telegram_without_new_persistent_b
     first = ToolResultBlock(
         id="t1",
         name="x",
-        content={"ok": True, "_meta": {"tool_meta": {"id": "call-first"}}},
+        content={"ok": True},
+        metadata={"tool_meta": {"id": "call-first"}},
     )
     holder = attach_active_notifications(agent, [first], prior_holder=None)
     assert "persistent" in first.metadata["agent_meta"]["notifications"]
@@ -2379,7 +2389,7 @@ def test_attach_active_notifications_sanitizes_telegram_without_new_persistent_b
     meta = check_result.metadata["agent_meta"]
     # No new message ids, but the routing event hook is Telegram content too, so
     # it is emitted in persistent while the transient lane stays generic.
-    telegram = meta["notification_persistent"]["mcp"]["telegram"]
+    telegram = meta["notifications"]["persistent"]["mcp"]["telegram"]
     assert telegram["messages"] == []
     assert telegram["events"] == [
         {
@@ -2391,7 +2401,7 @@ def test_attach_active_notifications_sanitizes_telegram_without_new_persistent_b
         }
     ]
     assert telegram["previous_block"]["tool_result_id"] == "call-first"
-    ephemeral = meta["notifications"]["mcp.telegram"]
+    ephemeral = meta["notifications"]["attention"]["mcp.telegram"]
     assert ephemeral["data"] == {"message_ids": ["main:123:20"]}
     assert "previews" not in ephemeral["data"]
     assert "count" not in ephemeral["data"]
@@ -2858,7 +2868,8 @@ def test_attach_active_notifications_adds_wechat_persistent_snapshot(tmp_path):
     block = ToolResultBlock(
         id="t1",
         name="x",
-        content={"ok": True, "_meta": {"tool_meta": {"id": "call-first"}}},
+        content={"ok": True},
+        metadata={"tool_meta": {"id": "call-first"}},
     )
     holder = attach_active_notifications(agent, [block], prior_holder=None)
 
@@ -2919,7 +2930,8 @@ def test_attach_active_notifications_adds_wechat_persistent_delta_with_comment(t
     first = ToolResultBlock(
         id="t1",
         name="x",
-        content={"ok": True, "_meta": {"tool_meta": {"id": "call-first"}}},
+        content={"ok": True},
+        metadata={"tool_meta": {"id": "call-first"}},
     )
     holder = attach_active_notifications(agent, [first], prior_holder=None)
     first_wc = first.metadata["agent_meta"]["notifications"]["persistent"]["mcp"]["wechat"]
@@ -2931,7 +2943,8 @@ def test_attach_active_notifications_adds_wechat_persistent_delta_with_comment(t
     second = ToolResultBlock(
         id="t2",
         name="x",
-        content={"ok": True, "_meta": {"tool_meta": {"id": "call-second"}}},
+        content={"ok": True},
+        metadata={"tool_meta": {"id": "call-second"}},
     )
     new_holder = attach_active_notifications(agent, [second], prior_holder=holder)
 
@@ -4019,8 +4032,8 @@ def test_packaged_guidance_resource_is_valid():
     assert "skip pre-molt summarize" in body
     assert "0.85" in body
     assert "1.0" in body
-    assert "Do not call `refresh` just to apply a summarize" in body
-    assert "does not mean the active provider-side context" in body
+    assert "provider-context reconstruction happens later at the threshold" in body
+    assert "Runtime token/context state" in body
     assert "0.75 * context_window" in body
     # Unified contract: token diagnostics live in agent_meta.agent_state.token_usage; the
     # guidance points there and describes the since-last-molt session aggregate
@@ -4488,13 +4501,17 @@ def test_attach_tool_block_promotes_budget_context_and_pops_transit_key():
     # Runtime capture is staged by the executor, not written into handler content.
     executor._pending_meta_by_call_id["tc1"] = dict(meta)
     result = {"ok": True}
-    wire = executor._attach_tool_block(result, tool_call_id="tc1", elapsed_ms=5)
-    context = wire["_meta"]["agent_meta"]["agent_state"]["context"]
+    tool_meta = executor._attach_tool_block(
+        result,
+        tool_call_id="tc1",
+        elapsed_ms=5,
+    )
+    context = tool_meta["_agent_pending"]["agent_state"]["context"]
+
     assert context["molt"] == "cache miss budget 1000000 reached, molt now"
     assert context["cache_miss_budget"] == 1_000_000
     assert context["cache_miss_tokens"] == 1_200_000
-    # The transit key is consumed before agent_meta.agent_state is returned.
-    assert meta_block.TOOL_META_CONTEXT_PENDING_KEY not in wire
+    assert meta_block.TOOL_META_CONTEXT_PENDING_KEY not in tool_meta
 
 
 def test_build_context_rebuild_hint_stamps_after_high_ratio():

--- a/tests/test_mimo_responses_compaction.py
+++ b/tests/test_mimo_responses_compaction.py
@@ -784,7 +784,7 @@ def test_daemon_tool_contract_verification_matrix_covers_native_mimo():
     # Anchored-claims row: locate the row mentioning _daemon_provider_defaults
     # and context_token_limit validation.
     claims_row_match = _re.search(
-        r"\|[^\n]*context_token_limit[^\n]*_daemon_provider_defaults[^\n]*\|",
+        r"\| `context_token_limit` is validated[^\n]*\|",
         text,
     )
     assert claims_row_match is not None, "anchored-claims row for context_token_limit not found"

--- a/tests/test_openai_prompt_cache_key.py
+++ b/tests/test_openai_prompt_cache_key.py
@@ -236,8 +236,9 @@ def test_zhipu_chat_sends_provider_scoped_key():
     assert sent["prompt_cache_key"] == "lingtai-zhipu:glm-4.6:v1"
 
 
-def test_mimo_chat_sends_provider_scoped_key():
-    adapter = MimoAdapter(api_key="fake", base_url="https://api.mimo.example/v1")
+def test_mimo_chat_escape_hatch_sends_provider_scoped_key():
+    # MiMo defaults to Responses; Chat Completions remains an explicit escape hatch.
+    adapter = MimoAdapter(api_key="fake", base_url="https://api.mimo.example/v1", wire_api="chat_completions")
     adapter._client = _chat_client()
     session = adapter.create_chat("mimo-7b", "system prompt")
 

--- a/tests/test_prompt_catalog.py
+++ b/tests/test_prompt_catalog.py
@@ -73,7 +73,7 @@ def _mentioned_file_paths(body: str) -> list[str]:
         value = match.group(1).strip()
         if value.startswith("tests/"):
             continue
-        if value.startswith(("~/", "~", "/")):
+        if value.startswith(("~/", "~", "/", "http://", "https://")):
             continue
         if "/" in value or any(
             suffix in value
@@ -362,7 +362,12 @@ def test_guidance_ids_referenced_by_runtime_code_exist():
     # `_meta` guidance pointer.
     referenced.discard("ref")
     referenced.discard("catalog")
-    assert {"token_efficiency", "notification_handling"} <= referenced
+    # ``token_efficiency`` is emitted through a composed f-string constant, so
+    # assert its runtime value directly rather than relying on source text.
+    from lingtai.kernel.meta_block import TOKEN_USAGE_GUIDANCE_REF
+
+    assert "meta_guidance.token_efficiency" in TOKEN_USAGE_GUIDANCE_REF
+    assert "notification_handling" in referenced
     missing = referenced - catalog_ids
     assert not missing, f"dangling meta_guidance.<id> refs: {sorted(missing)}"
 

--- a/tests/test_runtime_block_turn_integration.py
+++ b/tests/test_runtime_block_turn_integration.py
@@ -165,7 +165,7 @@ def test_runtime_block_lands_on_latest_result_at_turn_boundary(tmp_path):
 
     holder = agent._runtime_live_holder
     assert holder is not None, "attach_active_runtime was not invoked at the boundary"
-    assert "current_time" not in holder.metadata["agent_meta"]["agent_state"]
+    assert holder.metadata["agent_meta"]["agent_state"]["current_time"] == "T1"
     assert holder.content["echo"] == "T1"
     # The turn records the batch's calls on the guard (2 seeded + 1 this batch),
     # and the boundary stamps the live total under _meta.agent_meta.

--- a/tests/test_services_file_io.py
+++ b/tests/test_services_file_io.py
@@ -122,14 +122,15 @@ class TestTraversalBudgets:
         svc.write("dist/bundle.js", "x")
 
         results = svc.glob("**/*")
-        for r in results:
-            assert ".git" not in r
-            assert "node_modules" not in r
-            assert ".venv" not in r
-            assert "__pycache__" not in r
-            assert "/history/" not in r and not r.endswith("/history")
-            assert "/tmp/" not in r and not r.endswith("/tmp")
-            assert "/dist/" not in r and not r.endswith("/dist")
+        for result in results:
+            parts = Path(result).relative_to(tmp_dir).parts
+            assert ".git" not in parts
+            assert "node_modules" not in parts
+            assert ".venv" not in parts
+            assert "__pycache__" not in parts
+            assert "history" not in parts
+            assert "tmp" not in parts
+            assert "dist" not in parts
         # Real source files survive
         assert any(r.endswith("/src/main.py") for r in results)
         assert any(r.endswith("/tests/test_main.py") for r in results)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -392,9 +392,9 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "# Runtime Update Checks" in runtime_update_body
         assert "kind: kernel_version" in runtime_update_body
         assert ".notification/nudge.json" in runtime_update_body
-        assert "once per UTC day" in runtime_update_body
+        assert "roughly 60-second in-memory probe gate" in runtime_update_body
         assert "editable/source/dev" in runtime_update_body
-        assert "ask the human" in runtime_update_body
+        assert "receiving explicit confirmation" in runtime_update_body
 
         psyche_md = (
             workdir

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from lingtai.kernel.base_agent import BaseAgent
+from lingtai.kernel.presets import home_shortened
 from lingtai.tools.registry import INTRINSICS as ALL_INTRINSICS
 from tests._workdir_lease_helpers import make_test_lease
 from tests._snapshot_helpers import make_test_snapshot_port, make_test_source_revision_port
@@ -511,7 +512,7 @@ def test_refresh_whitespace_preset_is_no_swap(tmp_path, monkeypatch):
 
 
 def test_presets_action_lists_full_library(tmp_path):
-    """system(action='presets') returns full library with descriptions and capabilities."""
+    """system(action='presets') returns all explicitly allowed presets."""
     import json
     plib = tmp_path / "presets"
     plib.mkdir()
@@ -533,19 +534,21 @@ def test_presets_action_lists_full_library(tmp_path):
     result = agent._intrinsics["system"]({"action": "presets"})
 
     assert result["status"] == "ok"
-    # In the path-as-name model, `active` and entry names are full paths.
+    # `active` preserves manifest spelling; available names are display-shortened.
     alpha_path = str(plib / "alpha.json")
     beta_path = str(plib / "beta.json")
+    alpha_name = home_shortened(alpha_path)
+    beta_name = home_shortened(beta_path)
     assert result["active"] == alpha_path
     names = [p["name"] for p in result["available"]]
-    assert sorted(names) == sorted([alpha_path, beta_path])
+    assert sorted(names) == sorted([alpha_name, beta_name])
 
-    alpha = next(p for p in result["available"] if p["name"] == alpha_path)
+    alpha = next(p for p in result["available"] if p["name"] == alpha_name)
     assert alpha["description"] == {"summary": "alpha desc"}
     assert alpha["llm"] == {"provider": "p1", "model": "m1"}
     assert "vision" in alpha["capabilities"]
 
-    beta = next(p for p in result["available"] if p["name"] == beta_path)
+    beta = next(p for p in result["available"] if p["name"] == beta_name)
     assert beta["description"] == {"summary": "structured", "gains": ["a"]}
 
     for entry in result["available"]:
@@ -854,14 +857,16 @@ def test_presets_action_includes_connectivity(tmp_path, monkeypatch):
     by_name = {p["name"]: p for p in result["available"]}
     alpha_path = str(plib / "alpha.json")
     beta_path = str(plib / "beta.json")
+    alpha_name = home_shortened(alpha_path)
+    beta_name = home_shortened(beta_path)
 
     # alpha — has credentials, mocked probe succeeds → ok
-    assert by_name[alpha_path]["connectivity"]["status"] == "ok"
-    assert by_name[alpha_path]["connectivity"]["latency_ms"] == 42
+    assert by_name[alpha_name]["connectivity"]["status"] == "ok"
+    assert by_name[alpha_name]["connectivity"]["latency_ms"] == 42
 
     # beta — no credentials → no_credentials, no network call
-    assert by_name[beta_path]["connectivity"]["status"] == "no_credentials"
-    assert by_name[beta_path]["connectivity"]["latency_ms"] is None
+    assert by_name[beta_name]["connectivity"]["status"] == "no_credentials"
+    assert by_name[beta_name]["connectivity"]["latency_ms"] is None
 
 
 def test_presets_action_marks_unreachable_when_probe_fails(tmp_path, monkeypatch):
@@ -888,9 +893,9 @@ def test_presets_action_marks_unreachable_when_probe_fails(tmp_path, monkeypatch
     result = agent._intrinsics["system"]({"action": "presets"})
 
     by_name = {p["name"]: p for p in result["available"]}
-    broken_path = str(plib / "broken.json")
-    assert by_name[broken_path]["connectivity"]["status"] == "unreachable"
-    assert "DNS fail" in by_name[broken_path]["connectivity"]["error"]
+    broken_name = home_shortened(str(plib / "broken.json"))
+    assert by_name[broken_name]["connectivity"]["status"] == "unreachable"
+    assert "DNS fail" in by_name[broken_name]["connectivity"]["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_executor.py
+++ b/tests/test_tool_executor.py
@@ -29,10 +29,19 @@ def make_executor(
     max_result_chars=50_000,
     guard=None,
     tool_call_guard=None,
+    canonical_result=False,
 ):
     if dispatch_fn is None:
         dispatch_fn = lambda tc: {"status": "ok", "result": f"ran {tc.name}"}
-    make_result = MagicMock(side_effect=lambda name, result, **kw: {"name": name, "result": result})
+    if canonical_result:
+        result_factory = lambda name, result, **kw: ToolResultBlock(
+            kw.get("tool_call_id", ""),
+            name,
+            result,
+        )
+    else:
+        result_factory = lambda name, result, **kw: {"name": name, "result": result}
+    make_result = MagicMock(side_effect=result_factory)
     guard = guard or LoopGuard(max_total_calls=50)
     return ToolExecutor(
         dispatch_fn=dispatch_fn,
@@ -542,6 +551,7 @@ def test_lifecycle_trace_events_cover_spilled_result(tmp_path):
         working_dir=tmp_path,
         max_result_chars=80,
         logger_fn=lambda event_type, **fields: logs.append((event_type, fields)),
+        canonical_result=True,
     )
 
     results, intercepted, _ = executor.execute([
@@ -549,9 +559,10 @@ def test_lifecycle_trace_events_cover_spilled_result(tmp_path):
     ])
 
     assert not intercepted
-    manifest = results[0]["result"]
+    block = results[0]
+    manifest = block.content
     assert manifest["artifact"] == "lingtai_tool_result_spill"
-    tool_block = manifest["_meta"]["tool_meta"]
+    tool_block = block.metadata["tool_meta"]
     assert "spilled" not in tool_block
     assert isinstance(tool_block["char_count"], int) and tool_block["char_count"] > 0
     assert tool_block["spilled_char_count"] == manifest["original_char_count"]
@@ -671,6 +682,7 @@ def test_execute_parallel():
     executor = make_executor(
         dispatch_fn=dispatch,
         parallel_safe={"a", "b"},
+        canonical_result=True,
     )
     calls = [
         ToolCall(name="a", args={}, id="1"),
@@ -681,9 +693,9 @@ def test_execute_parallel():
     elapsed = time.monotonic() - t0
     assert len(results) == 2
     assert elapsed < 0.15
-    for result in results:
-        payload = result["result"]
-        assert payload["_meta"]["tool_meta"]["elapsed_ms"] > 0
+    for block in results:
+        payload = block.content
+        assert block.metadata["tool_meta"]["elapsed_ms"] > 0
         # Negative invariant: the deprecated private transit key is absent.
         assert "_runtime_pending" not in payload
         assert "elapsed_ms" not in payload
@@ -901,7 +913,8 @@ def test_tool_executor_uses_meta_fn_for_stamping():
     block = results[0]
     assert block._agent_pending["agent_state"]["current_time"] == "FAKE-TS"
     assert block._agent_pending["agent_state"]["future_field"] == 1
-    assert "elapsed_ms" in block._agent_pending["agent_state"]
+    assert "elapsed_ms" not in block._agent_pending["agent_state"]
+    assert block.metadata["tool_meta"]["elapsed_ms"] >= 0
     assert "agent_meta" not in block.metadata
     assert "current_time" not in block.content
 
@@ -997,7 +1010,8 @@ def test_tool_executor_meta_fn_covers_parallel_path():
     assert meta_calls["n"] == 2
     for r in results:
         assert r._agent_pending["agent_state"]["current_time"] == "FAKE-TS"
-        assert "elapsed_ms" in r._agent_pending["agent_state"]
+        assert "elapsed_ms" not in r._agent_pending["agent_state"]
+        assert r.metadata["tool_meta"]["elapsed_ms"] >= 0
         assert "agent_meta" not in r.metadata
         assert "current_time" not in r.content
 

--- a/tests/test_tool_glossary.py
+++ b/tests/test_tool_glossary.py
@@ -509,7 +509,7 @@ class TestSchemaInvariance:
         assert "file_path" in props
         assert "offset" in props
         assert "limit" in props
-        assert base["required"] == ["file_path"]
+        assert base["required"] == []
 
     def test_normal_and_daemon_resident_tools_render_selected_glossary(self):
         zh_body = load_tool_glossary("lingtai.tools.read", "zh")
@@ -549,8 +549,9 @@ class TestSchemaInvariance:
         daemon_prompt = DaemonManager._build_emanation_prompt(
             SimpleNamespace(_agent=agent), "Inspect one file", [schema]
         )
-        assert "Read text files." in daemon_prompt
-        assert zh_body in daemon_prompt
+        assert f"`{schema.name}`" in daemon_prompt
+        assert "Read text files." not in daemon_prompt
+        assert zh_body not in daemon_prompt
         assert WIRE_TOOL_DESCRIPTION not in daemon_prompt
 
     def test_daemon_intrinsic_collector_preserves_glossary_owner(self):

--- a/tests/test_tool_meta_comment_overflow.py
+++ b/tests/test_tool_meta_comment_overflow.py
@@ -20,6 +20,7 @@ import json
 from unittest.mock import MagicMock
 
 from lingtai.kernel.llm.base import ToolCall
+from lingtai.kernel.llm.interface import ToolResultBlock
 from lingtai.kernel.loop_guard import LoopGuard
 from lingtai.kernel.meta_block import build_tool_meta_overflow_comment
 from lingtai.kernel.tool_executor import (
@@ -32,7 +33,13 @@ def _make_executor(
     *, dispatch_fn, working_dir, max_result_chars=_DEFAULT_MAX_RESULT_CHARS,
     summarize_notification_threshold=None,
 ):
-    captured = MagicMock(side_effect=lambda name, result, **kw: result)
+    captured = MagicMock(
+        side_effect=lambda name, result, **kw: ToolResultBlock(
+            kw.get("tool_call_id", ""),
+            name,
+            result,
+        )
+    )
     executor = ToolExecutor(
         dispatch_fn=dispatch_fn,
         make_tool_result_fn=captured,
@@ -44,9 +51,9 @@ def _make_executor(
     return executor, captured
 
 
-def _tool_meta(wire_payload):
-    assert isinstance(wire_payload, dict), wire_payload
-    return wire_payload.get("_meta", {}).get("tool_meta", {})
+def _tool_meta(block):
+    assert isinstance(block, ToolResultBlock), block
+    return block.metadata.get("tool_meta", {})
 
 
 # -- builder unit tests -----------------------------------------------------
@@ -92,11 +99,10 @@ def test_spilled_result_carries_overflow_comment(tmp_path):
     executor, captured = _make_executor(
         dispatch_fn=dispatch, working_dir=tmp_path, max_result_chars=500,
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-spill")])
-    _, wire = captured.call_args.args
-    assert wire["status"] == "spilled"
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-spill")])[0][0]
+    assert block.content["status"] == "spilled"
 
-    tool_meta = _tool_meta(wire)
+    tool_meta = _tool_meta(block)
     overflow = tool_meta.get("comment", {}).get("overflow")
     assert overflow is not None, tool_meta
     # references events.jsonl + this call id, not saved_path
@@ -129,11 +135,10 @@ def test_large_inline_result_carries_overflow_comment(tmp_path):
         max_result_chars=_DEFAULT_MAX_RESULT_CHARS,
         summarize_notification_threshold=100,
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-large")])
-    _, wire = captured.call_args.args
-    assert wire.get("status") != "spilled"
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-large")])[0][0]
+    assert block.content.get("status") != "spilled"
 
-    tool_meta = _tool_meta(wire)
+    tool_meta = _tool_meta(block)
     assert tool_meta["char_count"] > 100
     overflow = tool_meta.get("comment", {}).get("overflow")
     assert overflow is not None, tool_meta
@@ -153,10 +158,9 @@ def test_small_result_has_no_overflow_comment(tmp_path):
         working_dir=tmp_path,
         summarize_notification_threshold=100,
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-small")])
-    _, wire = captured.call_args.args
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-small")])[0][0]
 
-    tool_meta = _tool_meta(wire)
+    tool_meta = _tool_meta(block)
     assert "comment" not in tool_meta, tool_meta
     # Identity fields still present and intact.
     assert tool_meta["id"] == "tc-small"
@@ -175,8 +179,7 @@ def test_large_result_no_comment_when_hint_disabled(tmp_path):
         max_result_chars=_DEFAULT_MAX_RESULT_CHARS,  # no spill
         summarize_notification_threshold=0,  # disabled
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-nohint")])
-    _, wire = captured.call_args.args
-    assert wire.get("status") != "spilled"
-    tool_meta = _tool_meta(wire)
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-nohint")])[0][0]
+    assert block.content.get("status") != "spilled"
+    tool_meta = _tool_meta(block)
     assert "comment" not in tool_meta, tool_meta

--- a/tests/test_tool_meta_reconstruction.py
+++ b/tests/test_tool_meta_reconstruction.py
@@ -38,7 +38,16 @@ def _make_executor(
     meta_fn=None,
     result_factory_fn=None,
 ):
-    captured = MagicMock(side_effect=result_factory_fn or (lambda name, result, **kw: result))
+    captured = MagicMock(
+        side_effect=result_factory_fn
+        or (
+            lambda name, result, **kw: ToolResultBlock(
+                kw.get("tool_call_id", ""),
+                name,
+                result,
+            )
+        )
+    )
     executor = ToolExecutor(
         dispatch_fn=dispatch_fn,
         make_tool_result_fn=captured,
@@ -52,14 +61,15 @@ def _make_executor(
     return executor, captured
 
 
-def _tool_meta(wire):
-    assert isinstance(wire, dict), wire
-    return wire.get("_meta", {}).get("tool_meta", {})
+def _tool_meta(block):
+    assert isinstance(block, ToolResultBlock), block
+    return block.metadata.get("tool_meta", {})
 
 
-def _agent_state(wire):
-    assert isinstance(wire, dict), wire
-    return wire.get("_meta", {}).get("agent_meta", {}).get("agent_state", {})
+def _agent_state(block):
+    assert isinstance(block, ToolResultBlock), block
+    pending = block._agent_pending or {}
+    return pending.get("agent_state", {})
 
 
 # A 1.0 forced-rebuild event as build_reconstruction_tool_meta emits it: one
@@ -116,12 +126,11 @@ def test_reconstruction_event_attaches_to_tool_meta(tmp_path):
         working_dir=tmp_path,
         reconstruction_event_fn=fn,
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-1")])
-    _, wire = captured.call_args.args
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-1")])[0][0]
 
-    tm = _tool_meta(wire)
+    tm = _tool_meta(block)
     assert tm["id"] == "tc-1"
-    event = _agent_state(wire)["events"]["reconstruction"]
+    event = _agent_state(block)["events"]["reconstruction"]
     assert event["type"] == "delayed_summarize_reconstruction"
     assert event["before"]["usage"] == 1.0
     assert event["after"]["usage"] == 0.70
@@ -148,14 +157,16 @@ def test_reconstruction_event_is_one_shot_across_batch(tmp_path):
         working_dir=tmp_path,
         reconstruction_event_fn=fn,
     )
-    executor.execute(
+    blocks, _, _ = executor.execute(
         [
             ToolCall(name="read", args={}, id="tc-a"),
             ToolCall(name="read", args={}, id="tc-b"),
         ]
     )
-    wires = [c.args[1] for c in captured.call_args_list]
-    with_event = [w for w in wires if "reconstruction" in _agent_state(w).get("events", {})]
+    with_event = [
+        block for block in blocks
+        if "reconstruction" in _agent_state(block).get("events", {})
+    ]
     assert len(with_event) == 1
 
 
@@ -205,9 +216,8 @@ def test_no_event_when_none_pending(tmp_path):
         working_dir=tmp_path,
         reconstruction_event_fn=lambda: None,
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-x")])
-    _, wire = captured.call_args.args
-    assert "reconstruction" not in _agent_state(wire).get("events", {})
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-x")])[0][0]
+    assert "reconstruction" not in _agent_state(block).get("events", {})
 
 
 def test_no_fn_configured_is_safe(tmp_path):
@@ -216,11 +226,10 @@ def test_no_fn_configured_is_safe(tmp_path):
         working_dir=tmp_path,
         reconstruction_event_fn=None,
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-y")])
-    _, wire = captured.call_args.args
-    tm = _tool_meta(wire)
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-y")])[0][0]
+    tm = _tool_meta(block)
     assert tm["id"] == "tc-y"
-    assert "reconstruction" not in _agent_state(wire).get("events", {})
+    assert "reconstruction" not in _agent_state(block).get("events", {})
 
 
 # ---------------------------------------------------------------------------
@@ -249,10 +258,9 @@ def test_reconstruction_event_emits_reminder_event_when_molt_attached(tmp_path):
         reconstruction_event_fn=fn,
         logger_fn=logger,
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-1")])
-    _, wire = captured.call_args.args
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-1")])[0][0]
     # The reminder text stays at agent_meta.agent_state.events.reconstruction.molt.
-    assert isinstance(_agent_state(wire)["events"]["reconstruction"]["molt"], str)
+    assert isinstance(_agent_state(block)["events"]["reconstruction"]["molt"], str)
 
     emitted = [e for e in events if e[0] == "context_pressure_reconstruction_molt_reminder_emitted"]
     assert len(emitted) == 1
@@ -281,9 +289,8 @@ def test_forced_rebuild_warning_does_not_emit_molt_reminder_event(tmp_path):
         reconstruction_event_fn=lambda: dict(_EVENT),
         logger_fn=logger,
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-1")])
-    _, wire = captured.call_args.args
-    event = _agent_state(wire)["events"]["reconstruction"]
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-1")])[0][0]
+    event = _agent_state(block)["events"]["reconstruction"]
     assert "warning" in event
     assert "molt" not in event
     emitted = [e for e in events if e[0] == "context_pressure_reconstruction_molt_reminder_emitted"]
@@ -333,11 +340,10 @@ def test_current_molt_promoted_to_tool_meta_context_and_emits_event(tmp_path):
         logger_fn=logger,
         meta_fn=lambda: _current_molt_meta(with_event=True),
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-1")])
-    _, wire = captured.call_args.args
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-1")])[0][0]
 
     # Reminder text landed on current agent_meta.agent_state.context.molt.
-    assert _agent_state(wire)["context"]["molt"] == _CURRENT_MOLT_TEXT
+    assert _agent_state(block)["context"]["molt"] == _CURRENT_MOLT_TEXT
 
     emitted = [e for e in events if e[0] == CURRENT_MOLT_EVENT]
     assert len(emitted) == 1
@@ -356,10 +362,9 @@ def test_current_molt_attached_without_event_payload_does_not_emit(tmp_path):
         logger_fn=logger,
         meta_fn=lambda: _current_molt_meta(with_event=False),
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-1")])
-    _, wire = captured.call_args.args
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-1")])[0][0]
 
-    assert _agent_state(wire)["context"]["molt"] == _CURRENT_MOLT_TEXT
+    assert _agent_state(block)["context"]["molt"] == _CURRENT_MOLT_TEXT
     assert not any(e[0] == CURRENT_MOLT_EVENT for e in events)
 
 
@@ -371,10 +376,9 @@ def test_no_current_molt_means_no_context_block_and_no_event(tmp_path):
         logger_fn=logger,
         meta_fn=lambda: {},
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-1")])
-    _, wire = captured.call_args.args
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-1")])[0][0]
 
-    assert "context" not in _tool_meta(wire)
+    assert "context" not in _tool_meta(block)
     assert not any(e[0] == CURRENT_MOLT_EVENT for e in events)
 
 
@@ -397,12 +401,12 @@ def test_current_molt_event_deduped_across_results_in_same_round(tmp_path):
         meta_fn=meta_fn,
     )
     # Two results in the same round (rid=7).
-    executor.execute(
+    blocks, _, _ = executor.execute(
         [ToolCall(name="read", args={}, id="tc-a"), ToolCall(name="read", args={}, id="tc-b")]
     )
     # Every result still carries the permanent reminder text.
-    for call in captured.call_args_list:
-        assert call.args[1]["_meta"]["agent_meta"]["agent_state"]["context"]["molt"] == _CURRENT_MOLT_TEXT
+    for block in blocks:
+        assert _agent_state(block)["context"]["molt"] == _CURRENT_MOLT_TEXT
     # ...but the event was logged only ONCE for round 7.
     assert sum(1 for e in events if e[0] == CURRENT_MOLT_EVENT) == 1
 
@@ -453,17 +457,16 @@ def test_forced_rebuild_failed_overflow_line_persists_on_every_result_no_event(t
         logger_fn=logger,
         meta_fn=lambda: {TOOL_META_CONTEXT_PENDING_KEY: {"molt": overflow}},
     )
-    executor.execute(
+    blocks, _, _ = executor.execute(
         [
             ToolCall(name="read", args={}, id="tc-a"),
             ToolCall(name="read", args={}, id="tc-b"),
             ToolCall(name="read", args={}, id="tc-c"),
         ]
     )
-    wires = [c.args[1] for c in captured.call_args_list]
-    assert len(wires) == 3
-    for wire in wires:
-        assert _agent_state(wire)["context"]["molt"] == overflow
+    assert len(blocks) == 3
+    for block in blocks:
+        assert _agent_state(block)["context"]["molt"] == overflow
     # Current-state warning, not an event route.
     assert not any(e[0] == CURRENT_MOLT_EVENT for e in events)
 
@@ -480,18 +483,16 @@ def test_budget_context_promoted_to_agent_state_context_through_pipeline(tmp_pat
             cache_miss=1_200_000,
         ),
     )
-    executor.execute([ToolCall(name="read", args={}, id="tc-1")])
-    _, wire = captured.call_args.args
+    block = executor.execute([ToolCall(name="read", args={}, id="tc-1")])[0][0]
 
-    ctx = _agent_state(wire)["context"]
+    ctx = _agent_state(block)["context"]
     assert ctx["molt"] == "cache miss budget 1000000 reached, molt now"
     assert ctx["cache_miss_budget"] == 1_000_000
     assert ctx["cache_miss_tokens"] == 1_200_000
     # The budget transit key is consumed by _attach_tool_block: it must not leak
-    # onto the wire (neither at the top level, nor left inside private pending,
-    # nor into the promoted agent_state beyond molt + budget fields).
-    assert TOOL_META_CONTEXT_PENDING_KEY not in wire
-    assert TOOL_META_CONTEXT_PENDING_KEY not in wire.get("_agent_pending", {})
-    assert TOOL_META_CONTEXT_PENDING_KEY not in _tool_meta(wire)
+    # into content, private pending, or the promoted agent-state sidecar.
+    assert TOOL_META_CONTEXT_PENDING_KEY not in block.content
+    assert TOOL_META_CONTEXT_PENDING_KEY not in (block._agent_pending or {})
+    assert TOOL_META_CONTEXT_PENDING_KEY not in _tool_meta(block)
     # Budget guard is not a new event route.
     assert not any(e[0] == CURRENT_MOLT_EVENT for e in events)

--- a/tests/test_wire_tool_description.py
+++ b/tests/test_wire_tool_description.py
@@ -87,13 +87,15 @@ def test_main_and_daemon_tools_sections_render_full_prose():
     assert FULL_DESCRIPTION in sections["tools"]
     assert WIRE_TOOL_DESCRIPTION not in sections["tools"]
 
-    # Daemon emanations build their own resident ``## tools`` section.
+    # Daemon emanations use the bounded worker prompt introduced by #972; tool
+    # schemas are provider-visible, while the prompt carries only tool names.
     from lingtai.tools.daemon import DaemonManager
 
     daemon_prompt = DaemonManager._build_emanation_prompt(
         SimpleNamespace(_agent=agent), "Inspect the repository", _schemas()
     )
-    assert FULL_DESCRIPTION in daemon_prompt
+    assert "`email`" in daemon_prompt and "`bash`" in daemon_prompt
+    assert FULL_DESCRIPTION not in daemon_prompt
     assert WIRE_TOOL_DESCRIPTION not in daemon_prompt
 
 


### PR DESCRIPTION
## Summary

Restore the current `main` release candidate to its intended runtime, documentation, and test contracts after the merged metadata/manual changes.

- keep immutable per-result timing in `tool_meta` and current runtime state in `agent_meta.agent_state`
- preserve historical timely-transient holders during replay without treating them as current
- restore tool-error elapsed fallback behavior and align affected fixtures/tests with the current result-block boundary
- repair manual/frontmatter governance, vision fallback wording, daemon preset expectations, preset display-path assertions, and MiMo Responses expectations
- document the current kernel release path: CI-built native sidecar wheels + sdist/manifest on GitHub/Gitee, with no PyPI publication for this release

## Validation

- exact supported-Python regression cluster: **559 passed**
- post-review metadata/runtime focus: **248 passed**
- supported non-wheel broad gate before the final contract review: **5728 passed, 9 skipped, 1 deselected**
- exact post-review broad gate: **5727 passed, 9 skipped, 1 deselected**, with only `test_sleep_signal_triggers_asleep` failing because a legitimate queued wake had already advanced `ASLEEP -> ACTIVE`; after the test-only state-machine correction, that exact test passed **3/3** independent runs
- `git diff --check`: PASS
- final committed diff SHA-256: `8a092076791ae946363d8dd6ca71e297e0c407f156b2f47cc03e975ffdfb0c6e`
- independent pool-Terra full review found one `elapsed_ms` boundary blocker; it was fixed, and the exact fix delta received **APPROVED**

## Release note

`tests/test_wheel_sidecar_smoke.py::test_native_wheel_ships_and_runs_sidecar` is intentionally excluded from the local source-worktree gate because formal native sidecar bytes are produced and validated by CI/cibuildwheel. No release artifact has been published by this PR.
