### PR TITLE
fix(release): authenticate Gitee and bump to 0.16.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.16.4"
+version = "0.16.5"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/sync_gitee_mirror.py
+++ b/scripts/sync_gitee_mirror.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import stat
 import subprocess
 import sys
@@ -48,20 +49,25 @@ def _run(cmd: list[str], cwd: Path | None = None, env: dict | None = None) -> su
     return subprocess.run(cmd, cwd=cwd, env=env, capture_output=True, text=True)
 
 
-def _write_askpass_helper(token: str) -> Path:
-    """Write a private (0600) askpass helper script that prints the token.
+def _write_askpass_helper(username: str, token: str) -> Path:
+    """Write a private askpass helper that keeps username/password distinct.
 
-    git invokes this as `<helper> <prompt>`; it must print the credential to
-    stdout and nothing else. Using GIT_ASKPASS instead of embedding the token
-    in the remote URL keeps the token out of `git remote -v`, process argv
-    visible via `ps`, and any URL that might appear in a git error message.
+    Git invokes the helper once for the HTTPS username and again for the
+    password.  Gitee expects the account username for the first prompt and the
+    personal access token for the second; returning the token for both prompts
+    is rejected as ``The token username invalid``.  Shell-quote both values so
+    neither credential is interpreted as helper source.
     """
     fd, path_str = tempfile.mkstemp(prefix="gitee-askpass-", suffix=".sh")
     path = Path(path_str)
     with os.fdopen(fd, "w") as f:
         f.write("#!/bin/sh\n")
-        f.write(f'printf "%s\\n" "{token}"\n')
-    path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)  # 0600 + exec, owner-only
+        f.write('case "$1" in\n')
+        f.write(f'  *Username*) printf "%s\\n" {shlex.quote(username)} ;;\n')
+        f.write(f'  *Password*) printf "%s\\n" {shlex.quote(token)} ;;\n')
+        f.write('  *) exit 1 ;;\n')
+        f.write('esac\n')
+    path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)  # 0700, owner-only
     return path
 
 
@@ -73,9 +79,10 @@ def sync_mirror(
     branch: str,
     token: str,
     execute: bool,
+    username: str | None = None,
 ) -> None:
     gitee_url = f"https://gitee.com/{owner}/{repo}.git"
-    askpass_path = _write_askpass_helper(token)
+    askpass_path = _write_askpass_helper(username or owner, token)
     try:
         env = dict(os.environ)
         env["GIT_ASKPASS"] = str(askpass_path)
@@ -126,6 +133,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--commit", required=True, help="full commit SHA to synchronize")
     parser.add_argument("--tag", required=True, help="release tag to synchronize, e.g. v0.16.4")
     parser.add_argument("--branch", default="main")
+    parser.add_argument("--username", help="Gitee HTTPS username; defaults to --owner")
     parser.add_argument("--token-env", default="GITEE_ACCESS_TOKEN", help="env var holding the Gitee token; never printed")
     parser.add_argument("--execute", action="store_true", help="actually push; default is dry-run/plan-only")
     args = parser.parse_args(argv)
@@ -136,7 +144,16 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     try:
-        sync_mirror(args.owner, args.repo, args.commit, args.tag, args.branch, token, args.execute)
+        sync_mirror(
+            args.owner,
+            args.repo,
+            args.commit,
+            args.tag,
+            args.branch,
+            token,
+            args.execute,
+            username=args.username,
+        )
     except SyncError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/tests/test_sync_gitee_mirror.py
+++ b/tests/test_sync_gitee_mirror.py
@@ -205,6 +205,29 @@ def test_main_never_echoes_token(local_checkout, monkeypatch, capsys):
     assert secret not in out
 
 
+def test_askpass_helper_returns_username_and_token_for_their_own_prompts():
+    username = "huangzesen1997"
+    token = "token-with-$-and-single-quote-'"
+    helper = sync_mod._write_askpass_helper(username, token)
+    try:
+        username_result = subprocess.run(
+            [str(helper), "Username for 'https://gitee.com':"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        password_result = subprocess.run(
+            [str(helper), "Password for 'https://gitee.com':"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert username_result.stdout.rstrip("\n") == username
+        assert password_result.stdout.rstrip("\n") == token
+    finally:
+        helper.unlink(missing_ok=True)
+
+
 def test_askpass_helper_is_owner_only_and_deleted_after_use(local_checkout, monkeypatch):
     import os
     import stat as stat_mod
@@ -215,9 +238,11 @@ def test_askpass_helper_is_owner_only_and_deleted_after_use(local_checkout, monk
     captured_path = {}
     original = sync_mod._write_askpass_helper
 
-    def spy(token):
-        path = original(token)
+    def spy(username, token):
+        path = original(username, token)
         captured_path["path"] = path
+        captured_path["username"] = username
+        captured_path["token"] = token
         mode = path.stat().st_mode
         assert mode & stat_mod.S_IRWXG == 0, "askpass helper must not be group-accessible"
         assert mode & stat_mod.S_IRWXO == 0, "askpass helper must not be world-accessible"
@@ -230,4 +255,6 @@ def test_askpass_helper_is_owner_only_and_deleted_after_use(local_checkout, monk
         token="fake-token", execute=False,
     )
     assert "path" in captured_path
+    assert captured_path["username"] == "o", "Gitee owner must be the default HTTPS username"
+    assert captured_path["token"] == "fake-token"
     assert not captured_path["path"].exists(), "askpass helper must be deleted after use"


### PR DESCRIPTION
## Why

The published Kernel `v0.16.4` workflow run [`29565585310`](https://github.com/Lingtai-AI/lingtai-kernel/actions/runs/29565585310) built the sdist and all four native wheel matrices successfully and generated the release manifest, then failed before any asset upload in **Non-force synchronize the exact commit/tag to Gitee**:

```text
remote: [session-…] The token username invalid
fatal: unable to access 'https://gitee.com/huangzesen1997/lingtai-kernel.git/': 403
```

`GIT_ASKPASS` is called once for the HTTPS username and again for the password. The helper returned the access token for both prompts, so Gitee rejected the token in the username slot.

## What changed

- return the Gitee account username for Git's `Username` prompt and the access token only for `Password`
- default the HTTPS username to `--owner`, with an explicit `--username` override for future organization/user splits
- shell-quote both credential values inside the private temporary helper
- add regression coverage for prompt routing, special-character preservation, owner-as-default, owner-only helper permissions, and helper removal
- bump the kernel version to `0.16.5` for a clean fix-forward without moving or rewriting the already-public `v0.16.4` tag

## Validation

- `python -m py_compile scripts/sync_gitee_mirror.py tests/test_sync_gitee_mirror.py`
- `git diff --check`
- `46 passed`:
  - `tests/test_sync_gitee_mirror.py`
  - `tests/test_wheels_workflow_publish_gating.py`
  - `tests/test_publish_release_assets.py`
- exact candidate diff SHA-256: `60051849ec4135f1cd4cd1036bd9f29e0341cc35463f2f6798ace80a59d2a8f0`

## Release safety

This PR does not move tags, upload assets, retry workflows, change secrets, or publish anything. After merge, the Release Captain will freeze the new exact main, update the downstream TUI pin to `v0.16.5`, and run the normal non-force release path under the existing external-side-effect gates.
