### PR TITLE
fix(release): install manifest dependency for v0.17.1

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -197,6 +197,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install manifest runtime dependencies
+        run: python -m pip install "packaging>=24.0"
+
       - name: Download all wheel + sdist artifacts
         uses: actions/download-artifact@v4
         with:

--- a/migration/migration.md
+++ b/migration/migration.md
@@ -1,13 +1,15 @@
 ---
 product: kernel
-release_version: "0.17.0"
-release_tag: "v0.17.0"
+release_version: "0.17.1"
+release_tag: "v0.17.1"
 migration: no-op
 refresh_required: true
 related_files:
   - RELEASING.md
   - pyproject.toml
   - src/lingtai/kernel/nudge/kernel_version.py
+  - src/lingtai/kernel/release_manifest.py
+  - .github/workflows/wheels.yml
   - src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
 maintenance: |
   Replace this document for every kernel release. Keep the stable repository
@@ -15,20 +17,21 @@ maintenance: |
   per-release versions. Never append a second release history here or invent a
   version that disagrees with package metadata.
 ---
-# LingTai kernel 0.17.0 migration
+# LingTai kernel 0.17.1 migration
 
 ## Applies when
 
-The target kernel release is `0.17.0` / tag `v0.17.0` and that tag lies in the
+The target kernel release is `0.17.1` / tag `v0.17.1` and that tag lies in the
 open update interval `(current, target]`.
 
 ## Migration
 
-**No configuration rewrite.** This release replaces package-index latest-version
-discovery with official GitHub/Gitee release-manifest comparison and routes
-normal install/update work through `https://lingtai.ai/install.sh`. It does not
-change an agent workdir, preset, `init.json`, or another kernel-owned on-disk
-configuration shape.
+**No configuration rewrite.** This patch declares the `packaging` dependency
+required by the strict release-manifest parser, reports its absence as a stable
+`ManifestError`, and installs it in the isolated release-manifest CI job. The
+official GitHub/Gitee manifest and `https://lingtai.ai/install.sh` update contract
+is otherwise unchanged. It does not change an agent workdir, preset, `init.json`,
+or another kernel-owned on-disk configuration shape.
 
 Before mutation, confirm that the installer selected the intended
 `LINGTAI_RUNTIME_PYTHON`. If more than one LingTai runtime is present, rerun with
@@ -40,7 +43,7 @@ user machine, and do not use PyPI metadata to choose the release version.
 ## Validate
 
 - Do not rewrite agent configuration for this kernel migration.
-- Confirm this file was read from the kernel repository at exact tag `v0.17.0`.
+- Confirm this file was read from the kernel repository at exact tag `v0.17.1`.
 - Verify `lingtai.__version__`, `lingtai.__file__`, and
   `lingtai.kernel.__file__` from the selected runtime interpreter after install.
 - If the product, version, tag, stable path, mirror content, or artifact hash does
@@ -52,4 +55,4 @@ user machine, and do not use PyPI metadata to choose the release version.
 The verified wheel changes bytes on disk but a running agent still has the old
 code loaded. After active work is checkpointed and refresh is authorized, call
 `system(action='refresh')` and verify the new process uses the selected
-interpreter and reports `0.17.0`.
+interpreter and reports `0.17.1`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.17.0"
+version = "0.17.1"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -27,6 +27,7 @@ dependencies = [
     "trafilatura>=2.0",
     "filelock>=3.0",
     "pyyaml>=6.0",
+    "packaging>=24.0",
     # Curated MCP server implementations live in this distribution under
     # `lingtai.mcp_servers.*` so the catalog can launch them with `python -m`
     # without separate PyPI wheels. Keep their third-party runtime dependencies

--- a/src/lingtai/kernel/release_manifest.py
+++ b/src/lingtai/kernel/release_manifest.py
@@ -155,12 +155,12 @@ def _pep440_version(value: object, *, field: str) -> str:
         raise ManifestError(f"manifest field {field!r} must be a non-empty PEP 440 version")
     try:
         from packaging.version import InvalidVersion, Version
-
+    except ImportError as exc:
+        raise ManifestError("packaging is required to validate release versions") from exc
+    try:
         Version(value)
     except (InvalidVersion, TypeError) as exc:
         raise ManifestError(f"manifest field {field!r} is not a valid PEP 440 version: {value!r}") from exc
-    except ImportError as exc:  # pragma: no cover - release environments provide packaging
-        raise ManifestError("packaging is required to validate release versions") from exc
     return value
 
 

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -4,6 +4,8 @@ CLI). No network, no subprocess against a real wheel build — fixtures only.
 """
 from __future__ import annotations
 
+import builtins
+
 import hashlib
 import json
 import subprocess
@@ -147,6 +149,19 @@ def test_validate_manifest_dict_rejects_invalid_pep440_version():
     data["kernel_version"] = "999-not-a-release"
     with pytest.raises(ManifestError, match="PEP 440"):
         validate_manifest_dict(data)
+
+
+def test_validate_manifest_dict_reports_missing_packaging_without_scope_error(monkeypatch):
+    original_import = builtins.__import__
+
+    def import_without_packaging(name, *args, **kwargs):
+        if name == "packaging.version":
+            raise ModuleNotFoundError("No module named 'packaging'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_packaging)
+    with pytest.raises(ManifestError, match="packaging is required"):
+        validate_manifest_dict(_valid_manifest_dict())
 
 
 def test_validate_manifest_dict_requires_version_tag_relation():

--- a/tests/test_wheels_workflow_publish_gating.py
+++ b/tests/test_wheels_workflow_publish_gating.py
@@ -123,3 +123,11 @@ def test_checkout_step_has_full_history_for_gitee_push():
         "sync_gitee_mirror.py needs the release commit's full history reachable "
         "to push it; a shallow checkout would break the non-force push"
     )
+
+
+def test_release_manifest_job_installs_declared_packaging_dependency():
+    job = _release_manifest_job(_load_workflow())
+    step = _step(job, "Install manifest runtime dependencies")
+    script = step["run"]
+    assert "python -m pip install" in script
+    assert "packaging>=24.0" in script


### PR DESCRIPTION
## Problem

Kernel v0.17.0 release run [29574545011](https://github.com/Lingtai-AI/lingtai-kernel/actions/runs/29574545011) built every native wheel and the sdist successfully, then failed in the serial manifest job before publishing any assets:

- `ModuleNotFoundError: No module named 'packaging'`
- the missing import then exposed `UnboundLocalError: InvalidVersion` because the exception tuple referenced a name that the failed import never bound.

`packaging` was used by the strict runtime manifest parser but was neither a declared runtime dependency nor installed in the isolated release-manifest job.

## Fix

- bump the non-destructive patch release to `0.17.1` (the already-public v0.17.0 tag/release is not moved or deleted);
- declare `packaging>=24.0` as a runtime dependency;
- install that dependency in the isolated manifest/publish GitHub Actions job;
- scope `ImportError` around the import before catching `InvalidVersion` from parsing;
- add focused missing-dependency and workflow-shape regressions;
- replace the authoritative migration document with exact v0.17.1 no-config-rewrite guidance.

## Validation

- `52 passed` — release manifest, wheels workflow publish gating, and kernel update/migration contract
- `py_compile` — manifest parser + generator
- `git diff --check`

## Release recovery

After merge, publish v0.17.1 from the exact merge commit and repin the pending TUI v0.11.0 bundle from v0.17.0 to v0.17.1. Do not rewrite or delete the public v0.17.0 tag/release.
