### PR TITLE
ci: support exact-tag release recovery

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,7 +57,34 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
+          persist-credentials: false
+
+      - name: Validate manual recovery tag
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          PUBLISH_REQUESTED: ${{ inputs.publish }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$PUBLISH_REQUESTED" == "true" && -z "$RELEASE_TAG" ]]; then
+            echo "::error::Manual publishing requires an explicit existing vX.Y.Z release_tag."
+            exit 1
+          fi
+          if [[ -z "$RELEASE_TAG" ]]; then
+            exit 0
+          fi
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release_tag must be a simple semantic-version tag such as v0.17.1."
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$tag_commit" != "$head_commit" ]]; then
+            echo "::error::Checked-out HEAD does not match refs/tags/${RELEASE_TAG}."
+            exit 1
+          fi
 
       - name: Set up QEMU for Linux aarch64 wheels
         if: runner.os == 'Linux'
@@ -161,7 +188,34 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
+          persist-credentials: false
+
+      - name: Validate manual recovery tag
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          PUBLISH_REQUESTED: ${{ inputs.publish }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$PUBLISH_REQUESTED" == "true" && -z "$RELEASE_TAG" ]]; then
+            echo "::error::Manual publishing requires an explicit existing vX.Y.Z release_tag."
+            exit 1
+          fi
+          if [[ -z "$RELEASE_TAG" ]]; then
+            exit 0
+          fi
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release_tag must be a simple semantic-version tag such as v0.17.1."
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$tag_commit" != "$head_commit" ]]; then
+            echo "::error::Checked-out HEAD does not match refs/tags/${RELEASE_TAG}."
+            exit 1
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -197,11 +251,38 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_tag || github.ref }}
+          ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
+          persist-credentials: false
           # sync_gitee_mirror.py needs the full history reachable from
           # the checked-out commit to `git cat-file -e`/push it; a shallow
           # checkout (the actions/checkout@v4 default) would make that fail.
           fetch-depth: 0
+
+      - name: Validate manual recovery tag
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          PUBLISH_REQUESTED: ${{ inputs.publish }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$PUBLISH_REQUESTED" == "true" && -z "$RELEASE_TAG" ]]; then
+            echo "::error::Manual publishing requires an explicit existing vX.Y.Z release_tag."
+            exit 1
+          fi
+          if [[ -z "$RELEASE_TAG" ]]; then
+            exit 0
+          fi
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release_tag must be a simple semantic-version tag such as v0.17.1."
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$tag_commit" != "$head_commit" ]]; then
+            echo "::error::Checked-out HEAD does not match refs/tags/${RELEASE_TAG}."
+            exit 1
+          fi
 
       - name: Set up Python for the manifest/publish scripts
         uses: actions/setup-python@v5
@@ -258,6 +339,10 @@ jobs:
           if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "execute=1" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.publish }}" == "true" ]]; then
+            if [[ -z "${{ inputs.release_tag }}" ]]; then
+              echo "::error::Manual publishing requires release_tag."
+              exit 1
+            fi
             echo "execute=1" >> "$GITHUB_OUTPUT"
           else
             echo "execute=0" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,6 +11,12 @@ on:
           release.published trigger always publishes.
         type: boolean
         default: false
+      release_tag:
+        description: >-
+          Optional existing v* tag to check out for an exact-tag manual
+          recovery. Empty keeps the selected workflow ref.
+        type: string
+        default: ""
   release:
     types: [published]
 
@@ -50,6 +56,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
 
       - name: Set up QEMU for Linux aarch64 wheels
         if: runner.os == 'Linux'
@@ -152,6 +160,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -187,8 +197,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           # sync_gitee_mirror.py needs the full history reachable from
-          # ${{ github.sha }} to `git cat-file -e`/push it; a shallow
+          # the checked-out commit to `git cat-file -e`/push it; a shallow
           # checkout (the actions/checkout@v4 default) would make that fail.
           fetch-depth: 0
 
@@ -216,10 +227,10 @@ jobs:
       - name: Generate release manifest + SHA256SUMS
         env:
           # release.published fires with a real tag; workflow_dispatch has no
-          # tag, so fall back to the pyproject version prefixed with "v" and
-          # the checked-out commit — this keeps manual-dispatch runs usable
-          # for manifest-shape testing without pretending a release exists.
-          KERNEL_TAG: ${{ github.event.release.tag_name || '' }}
+          # tag unless release_tag explicitly selects an existing tag for
+          # exact-source recovery. Otherwise fall back to the pyproject version
+          # and checked-out workflow ref for dry-run manifest-shape testing.
+          KERNEL_TAG: ${{ github.event.release.tag_name || inputs.release_tag || '' }}
         run: |
           set -euo pipefail
           version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
@@ -229,7 +240,7 @@ jobs:
             --assets-dir release-assets \
             --kernel-version "$version" \
             --kernel-tag "$tag" \
-            --commit "${{ github.sha }}" \
+            --commit "$(git rev-parse HEAD)" \
             --generated-at "$generated_at" \
             --out-manifest release-assets/lingtai-kernel-release-manifest.json \
             --out-sha256sums release-assets/SHA256SUMS
@@ -259,25 +270,26 @@ jobs:
         run: |
           set -euo pipefail
           version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
-          tag="${{ github.event.release.tag_name || '' }}"
+          tag="${{ github.event.release.tag_name || inputs.release_tag || '' }}"
           tag="${tag:-v${version}}"
           # Skips cleanly (exit 0, prints why) when GITEE_ACCESS_TOKEN is
           # unset — see sync_gitee_mirror.py. Every push is non-force; a
           # divergence/existing-tag conflict fails this step loud rather than
           # silently overwriting the mirror.
           python scripts/sync_gitee_mirror.py \
-            --commit "${{ github.sha }}" \
+            --commit "$(git rev-parse HEAD)" \
             --tag "$tag" \
             --branch main \
             --execute
 
       - name: Publish manifest/wheels/sdist
         env:
+          GH_TOKEN: ${{ github.token }}
           GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
         run: |
           set -euo pipefail
           version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
-          tag="${{ github.event.release.tag_name || '' }}"
+          tag="${{ github.event.release.tag_name || inputs.release_tag || '' }}"
           tag="${tag:-v${version}}"
           execute_flag=""
           if [[ "${{ steps.publish_mode.outputs.execute }}" == "1" ]]; then

--- a/tests/test_wheels_workflow_publish_gating.py
+++ b/tests/test_wheels_workflow_publish_gating.py
@@ -1,7 +1,8 @@
 """Static assertions over .github/workflows/wheels.yml's release-manifest job:
 proves the publish step is actually reachable with --execute on the real
-release trigger (Blocker 3 repair), that manual dispatch defaults to dry-run, that exact-tag recovery checks out
-the selected tag, that GitHub publication is authenticated, and that the
+release trigger (Blocker 3 repair), that manual dispatch defaults to dry-run,
+that exact-tag recovery checks out and validates the selected tag, that GitHub
+publication is authenticated without persisted checkout credentials, and that the
 Gitee sync step never force-pushes. This is a workflow-shape
 test, not a live GitHub Actions run — it parses the committed YAML/shell
 text.
@@ -145,10 +146,11 @@ def test_workflow_dispatch_exact_tag_recovery_input_defaults_empty():
 
 def test_all_release_jobs_checkout_the_optional_exact_recovery_tag():
     data = _load_workflow()
-    expected = "${{ inputs.release_tag || github.ref }}"
+    expected = "${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}"
     for job_name in ("build-wheels", "build-sdist", "release-manifest"):
         step = _step(data["jobs"][job_name], "Check out repository")
         assert step.get("with", {}).get("ref") == expected, job_name
+        assert step.get("with", {}).get("persist-credentials") is False, job_name
 
 
 def test_manifest_and_gitee_sync_use_the_checked_out_commit_and_recovery_tag():
@@ -169,3 +171,23 @@ def test_publish_step_receives_github_cli_token_without_printing_it():
     step = _step(job, "Publish manifest")
     assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
     assert "$GH_TOKEN" not in step["run"]
+
+
+def test_manual_publish_requires_and_validates_an_exact_semver_tag():
+    data = _load_workflow()
+    for job_name in ("build-wheels", "build-sdist", "release-manifest"):
+        step = _step(data["jobs"][job_name], "Validate manual recovery tag")
+        assert step.get("if") == "github.event_name == 'workflow_dispatch'"
+        assert step.get("shell") == "bash"
+        assert "inputs.publish" in step["env"]["PUBLISH_REQUESTED"]
+        assert "inputs.release_tag" in step["env"]["RELEASE_TAG"]
+        script = step["run"]
+        assert '"$PUBLISH_REQUESTED" == "true" && -z "$RELEASE_TAG"' in script
+        assert "^v[0-9]+\\.[0-9]+\\.[0-9]+$" in script
+        assert 'refs/tags/${RELEASE_TAG}^{commit}' in script
+        assert "git rev-parse HEAD" in script
+        assert '"$tag_commit" != "$head_commit"' in script
+
+    publish_mode = _step(_release_manifest_job(data), "Determine publish mode")["run"]
+    assert "inputs.release_tag" in publish_mode
+    assert "Manual publishing requires release_tag" in publish_mode

--- a/tests/test_wheels_workflow_publish_gating.py
+++ b/tests/test_wheels_workflow_publish_gating.py
@@ -1,7 +1,8 @@
 """Static assertions over .github/workflows/wheels.yml's release-manifest job:
 proves the publish step is actually reachable with --execute on the real
-release trigger (Blocker 3 repair), that manual dispatch defaults to dry-run,
-and that the Gitee sync step never force-pushes. This is a workflow-shape
+release trigger (Blocker 3 repair), that manual dispatch defaults to dry-run, that exact-tag recovery checks out
+the selected tag, that GitHub publication is authenticated, and that the
+Gitee sync step never force-pushes. This is a workflow-shape
 test, not a live GitHub Actions run — it parses the committed YAML/shell
 text.
 """
@@ -131,3 +132,40 @@ def test_release_manifest_job_installs_declared_packaging_dependency():
     script = step["run"]
     assert "python -m pip install" in script
     assert "packaging>=24.0" in script
+
+
+
+def test_workflow_dispatch_exact_tag_recovery_input_defaults_empty():
+    data = _load_workflow()
+    on = data.get("on") or data.get(True)
+    recovery = on["workflow_dispatch"]["inputs"]["release_tag"]
+    assert recovery["type"] == "string"
+    assert recovery["default"] == ""
+
+
+def test_all_release_jobs_checkout_the_optional_exact_recovery_tag():
+    data = _load_workflow()
+    expected = "${{ inputs.release_tag || github.ref }}"
+    for job_name in ("build-wheels", "build-sdist", "release-manifest"):
+        step = _step(data["jobs"][job_name], "Check out repository")
+        assert step.get("with", {}).get("ref") == expected, job_name
+
+
+def test_manifest_and_gitee_sync_use_the_checked_out_commit_and_recovery_tag():
+    job = _release_manifest_job(_load_workflow())
+    manifest = _step(job, "Generate release manifest")
+    sync = _step(job, "synchronize the exact commit/tag to Gitee")
+    publish = _step(job, "Publish manifest")
+    assert "inputs.release_tag" in manifest["env"]["KERNEL_TAG"]
+    for step in (manifest, sync):
+        assert "git rev-parse HEAD" in step["run"]
+        assert "github.sha" not in step["run"]
+    assert "inputs.release_tag" in sync["run"]
+    assert "inputs.release_tag" in publish["run"]
+
+
+def test_publish_step_receives_github_cli_token_without_printing_it():
+    job = _release_manifest_job(_load_workflow())
+    step = _step(job, "Publish manifest")
+    assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert "$GH_TOKEN" not in step["run"]


### PR DESCRIPTION
## Summary

- add an optional `release_tag` workflow-dispatch input and force any non-empty value into the `refs/tags/` namespace for every build/publish checkout
- reject manual publishing without an explicit simple `vX.Y.Z` tag, then verify the fetched tag commit equals checked-out `HEAD` before any source build or release script runs
- derive manifest and Gitee provenance from the checked-out commit, not the workflow-definition commit
- disable persisted checkout credentials and pass GitHub Actions' scoped token only to the final `gh` publisher without printing it
- preserve ordinary `release.published` behavior and manual-dispatch dry-run defaults

## Why

The v0.17.1 release run built all 15 wheels and one sdist and generated a valid 16-artifact manifest, but its publisher failed because the `gh` subprocess had no `GH_TOKEN`. A normal rerun from a newer workflow-definition commit would corrupt exact-tag provenance; this adds a bounded exact-tag recovery path.

## Validation

- YAML parse + exactly three validation steps: PASS
- complete relevant workflow/manifest/Gitee/publisher suite: 90 passed
- extracted validation-script smoke: exact tag PASS; dry empty PASS; blank publish, branch input, and mismatched HEAD rejected
- `git diff --check`: PASS
- Terra review findings repaired: exact tag/provenance gate + non-persisted checkout credentials
- frozen full candidate diff SHA-256: `3be2d25b27f130676c7ca6da26a3450569b9a21d2bfa43a802cce02576fc4f4d`
- frozen Terra-repair delta SHA-256: `9c8555c31e5280090d8f9e23e4eb2db20cfb67d481f60ec9be57d697a71c7681`
