### PR TITLE
fix(release): add Gitee-only asset recovery

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,6 +11,13 @@ on:
           release.published trigger always publishes.
         type: boolean
         default: false
+      gitee_only_recovery:
+        description: >-
+          Gitee-only recovery: download the exact existing GitHub release bytes
+          for an explicit release_tag and resume only Gitee publication; requires
+          publish=true and a simple vX.Y.Z tag. No builds or GitHub replacement.
+        type: boolean
+        default: false
       release_tag:
         description: >-
           Optional existing v* tag to check out for an exact-tag manual
@@ -25,6 +32,7 @@ permissions:
 
 jobs:
   build-wheels:
+    if: inputs.gitee_only_recovery != true
     name: Wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     # Fail loud instead of hanging: cibuildwheel across three CPythons plus a
@@ -177,6 +185,7 @@ jobs:
           if-no-files-found: error
 
   build-sdist:
+    if: inputs.gitee_only_recovery != true
     name: Source distribution
     runs-on: ubuntu-latest
     # Independent of build-wheels so a wheel/auditwheel failure on any platform
@@ -231,6 +240,7 @@ jobs:
           if-no-files-found: error
 
   release-manifest:
+    if: inputs.gitee_only_recovery != true
     name: Generate release manifest
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
@@ -400,3 +410,102 @@ jobs:
             release-assets/lingtai-kernel-release-manifest.json
             release-assets/SHA256SUMS
           if-no-files-found: error
+
+  gitee-only-recovery:
+    name: Recover Gitee assets from the existing GitHub release
+    if: github.event_name == 'workflow_dispatch' && inputs.gitee_only_recovery == true
+    runs-on: ubuntu-latest
+    # Asset discovery plus a bounded retry loop must outlive the original
+    # publisher's 15-minute manifest-job ceiling, but never run indefinitely.
+    timeout-minutes: 120
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out exact release tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ inputs.release_tag }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Validate Gitee-only recovery inputs and checkout
+        shell: bash
+        env:
+          RECOVERY_REQUESTED: ${{ inputs.gitee_only_recovery }}
+          PUBLISH_REQUESTED: ${{ inputs.publish }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$RECOVERY_REQUESTED" != "true" || "$PUBLISH_REQUESTED" != "true" ]]; then
+            echo "::error::Gitee-only recovery requires gitee_only_recovery=true and publish=true."
+            exit 1
+          fi
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Gitee-only recovery requires an explicit simple vX.Y.Z release_tag."
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$tag_commit" != "$head_commit" ]]; then
+            echo "::error::Checked-out HEAD does not match refs/tags/${RELEASE_TAG}."
+            exit 1
+          fi
+
+      - name: Set up Python for the Gitee publisher
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install publisher runtime dependency
+        run: python -m pip install "packaging>=24.0"
+
+      - name: Download exact GitHub release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ -e release-assets ]]; then
+            echo "::error::release-assets must be fresh on the recovery runner."
+            exit 1
+          fi
+          mkdir release-assets
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir release-assets
+
+      - name: Resume Gitee publication (idempotent bounded retry)
+        shell: bash
+        env:
+          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GITEE_ACCESS_TOKEN:-}" ]]; then
+            echo "::error::GITEE_ACCESS_TOKEN must be configured for Gitee-only recovery."
+            exit 1
+          fi
+          max_attempts=10
+          for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+            echo "Gitee-only publisher attempt ${attempt}/${max_attempts} (10-minute timeout)."
+            set +e
+            PYTHONUNBUFFERED=1 timeout --foreground --signal=TERM --kill-after=30s 10m \
+              python scripts/publish_release_assets.py \
+                --manifest release-assets/lingtai-kernel-release-manifest.json \
+                --assets-dir release-assets \
+                --skip-github \
+                --execute
+            status=$?
+            set -e
+            if (( status == 0 )); then
+              exit 0
+            fi
+            if (( status == 124 || status == 137 )); then
+              echo "::warning::Gitee-only publisher timed out (exit ${status}); retrying so remote completion can be rediscovered."
+              continue
+            fi
+            echo "::error::Gitee-only publisher failed with non-timeout exit ${status}."
+            exit "$status"
+          done
+          echo "::error::Gitee-only publisher timed out after ${max_attempts} bounded attempts."
+          exit 124

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -475,6 +475,35 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --dir release-assets
 
+      - name: Verify downloaded manifest matches requested release
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          export EXPECTED_COMMIT="$(git rev-parse HEAD)"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path("release-assets/lingtai-kernel-release-manifest.json")
+          data = json.loads(path.read_text(encoding="utf-8"))
+          expected_tag = os.environ["RELEASE_TAG"]
+          expected_commit = os.environ["EXPECTED_COMMIT"].lower()
+          actual_tag = data.get("kernel_tag")
+          actual_commit = data.get("commit")
+          if actual_tag != expected_tag:
+              raise SystemExit(
+                  f"downloaded manifest kernel_tag {actual_tag!r} does not match requested release tag {expected_tag!r}"
+              )
+          if not isinstance(actual_commit, str) or actual_commit.lower() != expected_commit:
+              raise SystemExit(
+                  f"downloaded manifest commit {actual_commit!r} does not match checked-out commit {expected_commit!r}"
+              )
+          print(f"Downloaded manifest target verified: {expected_tag} at {expected_commit[:12]}.")
+          PY
+
       - name: Resume Gitee publication (idempotent bounded retry)
         shell: bash
         env:

--- a/tests/test_wheels_workflow_publish_gating.py
+++ b/tests/test_wheels_workflow_publish_gating.py
@@ -191,3 +191,128 @@ def test_manual_publish_requires_and_validates_an_exact_semver_tag():
     publish_mode = _step(_release_manifest_job(data), "Determine publish mode")["run"]
     assert "inputs.release_tag" in publish_mode
     assert "Manual publishing requires release_tag" in publish_mode
+
+
+def _recovery_job(data: dict) -> dict:
+    return data["jobs"]["gitee-only-recovery"]
+
+
+def test_gitee_only_recovery_input_has_boolean_default_and_safety_description():
+    data = _load_workflow()
+    on = data.get("on") or data.get(True)
+    recovery = on["workflow_dispatch"]["inputs"]["gitee_only_recovery"]
+    assert recovery["type"] == "boolean"
+    assert recovery["default"] is False
+    assert "Gitee-only recovery" in recovery["description"]
+    assert "publish=true" in recovery["description"]
+    assert "No builds" in recovery["description"]
+
+
+def test_gitee_only_gate_is_on_exactly_the_three_existing_jobs():
+    data = _load_workflow()
+    existing = ("build-wheels", "build-sdist", "release-manifest")
+    assert all(name in data["jobs"] for name in existing)
+    assert all(data["jobs"][name].get("if") == "inputs.gitee_only_recovery != true" for name in existing)
+    assert [name for name, job in data["jobs"].items() if job.get("if") == "inputs.gitee_only_recovery != true"] == list(existing)
+
+
+def test_gitee_only_recovery_job_is_ubuntu_bounded_and_read_only():
+    job = _recovery_job(_load_workflow())
+    assert job["if"] == "github.event_name == 'workflow_dispatch' && inputs.gitee_only_recovery == true"
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == 120
+    assert job["permissions"] == {"contents": "read"}
+
+
+def test_gitee_only_recovery_checks_out_exact_tag_with_no_persisted_credentials():
+    job = _recovery_job(_load_workflow())
+    checkout = _step(job, "Check out exact release tag")
+    assert checkout["uses"] == "actions/checkout@v4"
+    assert checkout["with"] == {
+        "ref": "refs/tags/${{ inputs.release_tag }}",
+        "persist-credentials": False,
+        "fetch-depth": 0,
+    }
+    validation = _step(job, "Validate Gitee-only recovery inputs and checkout")
+    assert validation["shell"] == "bash"
+    assert validation["env"] == {
+        "RECOVERY_REQUESTED": "${{ inputs.gitee_only_recovery }}",
+        "PUBLISH_REQUESTED": "${{ inputs.publish }}",
+        "RELEASE_TAG": "${{ inputs.release_tag }}",
+    }
+    script = validation["run"]
+    assert '"$RECOVERY_REQUESTED" != "true"' in script
+    assert '"$PUBLISH_REQUESTED" != "true"' in script
+    assert "^v[0-9]+\\.[0-9]+\\.[0-9]+$" in script
+    assert 'refs/tags/${RELEASE_TAG}^{commit}' in script
+    assert "git rev-parse HEAD" in script
+    assert '"$tag_commit" != "$head_commit"' in script
+
+
+def test_gitee_only_download_scopes_gh_token_and_uses_exact_release_tag():
+    job = _recovery_job(_load_workflow())
+    download = _step(job, "Download exact GitHub release assets")
+    assert download["env"] == {
+        "GH_TOKEN": "${{ github.token }}",
+        "RELEASE_TAG": "${{ inputs.release_tag }}",
+    }
+    script = download["run"]
+    assert 'if [[ -e release-assets ]]' in script
+    assert "mkdir release-assets" in script
+    assert 'gh release download "$RELEASE_TAG"' in script
+    assert '--repo "$GITHUB_REPOSITORY"' in script
+    assert "--dir release-assets" in script
+    token_steps = [step for step in job["steps"] if "GH_TOKEN" in step.get("env", {})]
+    assert token_steps == [download]
+
+
+def test_gitee_only_publisher_requires_token_without_echoing_it():
+    job = _recovery_job(_load_workflow())
+    publisher = _step(job, "Resume Gitee publication")
+    assert publisher["env"] == {"GITEE_ACCESS_TOKEN": "${{ secrets.GITEE_ACCESS_TOKEN }}"}
+    script = publisher["run"]
+    assert '[[ -z "${GITEE_ACCESS_TOKEN:-}" ]]' in script
+    assert "must be configured" in script
+    token_steps = [step for step in job["steps"] if "GITEE_ACCESS_TOKEN" in step.get("env", {})]
+    assert token_steps == [publisher]
+    for line in script.splitlines():
+        stripped = line.strip()
+        if "$GITEE_ACCESS_TOKEN" in stripped or "${GITEE_ACCESS_TOKEN" in stripped:
+            assert not stripped.startswith(("echo", "print", "cat")), line
+
+
+def test_gitee_only_publisher_is_unbuffered_execute_and_github_skipping():
+    script = _step(_recovery_job(_load_workflow()), "Resume Gitee publication")["run"]
+    assert "PYTHONUNBUFFERED=1" in script
+    assert "scripts/publish_release_assets.py" in script
+    assert "--skip-github" in script
+    assert "--execute" in script
+
+
+def test_gitee_only_retry_budget_and_timeout_codes_are_bounded():
+    script = _step(_recovery_job(_load_workflow()), "Resume Gitee publication")["run"]
+    assert "max_attempts=10" in script
+    assert "10m" in script
+    assert "--kill-after=30s" in script
+    assert "status == 124 || status == 137" in script
+    assert 'exit "$status"' in script
+    assert "failed with non-timeout exit" in script
+    assert 'exit 124' in script
+
+
+def test_gitee_only_recovery_does_not_build_sync_or_publish_to_github():
+    job = _recovery_job(_load_workflow())
+    recovery_text = "\\n".join(
+        [step.get("uses", "") + "\\n" + step.get("run", "") for step in job["steps"]]
+    )
+    for forbidden in (
+        "cibuildwheel",
+        "uv build",
+        "actions/upload-artifact",
+        "actions/download-artifact",
+        "sync_gitee_mirror.py",
+        "gh release upload",
+        "gh release create",
+    ):
+        assert forbidden not in recovery_text
+    assert "gh release download" in recovery_text

--- a/tests/test_wheels_workflow_publish_gating.py
+++ b/tests/test_wheels_workflow_publish_gating.py
@@ -9,7 +9,11 @@ text.
 """
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import yaml
 
@@ -316,3 +320,58 @@ def test_gitee_only_recovery_does_not_build_sync_or_publish_to_github():
     ):
         assert forbidden not in recovery_text
     assert "gh release download" in recovery_text
+
+
+def test_gitee_only_downloaded_manifest_is_bound_to_requested_tag_and_checkout(tmp_path):
+    job = _recovery_job(_load_workflow())
+    steps = job["steps"]
+    names = [step.get("name", "") for step in steps]
+    download_index = names.index("Download exact GitHub release assets")
+    verify_index = names.index("Verify downloaded manifest matches requested release")
+    publish_index = names.index("Resume Gitee publication (idempotent bounded retry)")
+    assert download_index < verify_index < publish_index
+
+    verifier = steps[verify_index]
+    assert verifier["shell"] == "bash"
+    assert verifier["env"] == {"RELEASE_TAG": "${{ inputs.release_tag }}"}
+    shell_script = verifier["run"]
+    assert 'export EXPECTED_COMMIT="$(git rev-parse HEAD)"' in shell_script
+    assert "data.get(\"kernel_tag\")" in shell_script
+    assert "data.get(\"commit\")" in shell_script
+    marker = "python - <<'PY'\n"
+    assert marker in shell_script and "\nPY" in shell_script
+    verifier_code = shell_script.split(marker, 1)[1].rsplit("\nPY", 1)[0]
+
+    assets = tmp_path / "release-assets"
+    assets.mkdir()
+    manifest_path = assets / "lingtai-kernel-release-manifest.json"
+    expected_tag = "v0.17.1"
+    expected_commit = "a" * 40
+    env = {
+        **os.environ,
+        "RELEASE_TAG": expected_tag,
+        "EXPECTED_COMMIT": expected_commit,
+    }
+
+    def run_verifier(manifest: dict) -> subprocess.CompletedProcess[str]:
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, "-c", verifier_code],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    matching = run_verifier({"kernel_tag": expected_tag, "commit": expected_commit.upper()})
+    assert matching.returncode == 0, matching.stderr
+    assert "target verified" in matching.stdout
+
+    wrong_tag = run_verifier({"kernel_tag": "v0.17.0", "commit": expected_commit})
+    assert wrong_tag.returncode != 0
+    assert "kernel_tag" in wrong_tag.stderr and "requested release tag" in wrong_tag.stderr
+
+    wrong_commit = run_verifier({"kernel_tag": expected_tag, "commit": "b" * 40})
+    assert wrong_commit.returncode != 0
+    assert "manifest commit" in wrong_commit.stderr and "checked-out commit" in wrong_commit.stderr


### PR DESCRIPTION
## Summary

- add an explicit `gitee_only_recovery` manual mode that skips all wheel/sdist/manifest rebuild jobs
- download the already-public exact GitHub release bytes for the requested tag, then fail closed unless the downloaded manifest's `kernel_tag` and `commit` match that requested tag and checked-out commit
- resume only the idempotent Gitee attachment publisher; fail loud on missing Gitee credentials and bound recovery to ten 10-minute attempts under one 120-minute job ceiling
- keep GitHub credentials scoped to download, Gitee credentials scoped to publishing, and retry only GNU timeout exits 124/137

This is the non-destructive recovery for run [29578902019](https://github.com/Lingtai-AI/lingtai-kernel/actions/runs/29578902019): GitHub v0.17.1 is already complete and byte-validated, while Gitee release id 750660 has only the first three attachments. This PR does not rebuild artifacts, replace GitHub bytes, retag, delete, or force-sync anything.

## Validation

`python -m pytest -q tests/test_wheels_workflow_publish_gating.py`  
**25 passed**

`python -m pytest -q tests/test_wheels_workflow_publish_gating.py tests/test_publish_release_assets.py tests/test_release_manifest.py tests/test_sync_gitee_mirror.py`  
**100 passed**

- PyYAML parse + exact job/manifest-binding step-order assertion: **PASS**
- `git diff --check`: **PASS**
- executable fixtures: matching manifest passes; wrong tag and wrong commit each fail before publisher: **PASS**

Exact full candidate diff SHA-256: `443d9d5153513b8014507ccd514cc948db08b6d1015758db8690479deb69bd46`.  
Terra repair delta SHA-256: `5019cb5945766e550365e315892b2d65422fb580d0bd28f7a52c6ea326afac49`.

Implementation support used canonical pool Luna (`gpt-5.6-luna`, `codex-pool`); canonical pool Terra (`gpt-5.6-terra`) found the manifest-target binding blocker, now repaired. A fresh Terra re-review and exact Opus 4.8 final review follow on this immutable head before merge.
