### PR TITLE
fix(release): make Gitee recovery retries idempotent

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -422,10 +422,18 @@ jobs:
       contents: read
 
     steps:
-      - name: Check out exact release tag
+      - name: Check out reviewed publisher/tools at workflow SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check out exact release tag as target source
         uses: actions/checkout@v4
         with:
           ref: refs/tags/${{ inputs.release_tag }}
+          path: release-source
           persist-credentials: false
           fetch-depth: 0
 
@@ -435,6 +443,7 @@ jobs:
           RECOVERY_REQUESTED: ${{ inputs.gitee_only_recovery }}
           PUBLISH_REQUESTED: ${{ inputs.publish }}
           RELEASE_TAG: ${{ inputs.release_tag }}
+          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [[ "$RECOVERY_REQUESTED" != "true" || "$PUBLISH_REQUESTED" != "true" ]]; then
@@ -445,10 +454,15 @@ jobs:
             echo "::error::Gitee-only recovery requires an explicit simple vX.Y.Z release_tag."
             exit 1
           fi
-          tag_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
-          head_commit="$(git rev-parse HEAD)"
-          if [[ "$tag_commit" != "$head_commit" ]]; then
-            echo "::error::Checked-out HEAD does not match refs/tags/${RELEASE_TAG}."
+          main_head="$(git rev-parse HEAD)"
+          if [[ "$main_head" != "$WORKFLOW_SHA" ]]; then
+            echo "::error::Reviewed publisher checkout HEAD does not equal github.sha."
+            exit 1
+          fi
+          tag_commit="$(git -C release-source rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          target_head="$(git -C release-source rev-parse HEAD)"
+          if [[ "$tag_commit" != "$target_head" ]]; then
+            echo "::error::release-source HEAD does not match refs/tags/${RELEASE_TAG}."
             exit 1
           fi
 
@@ -475,13 +489,13 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --dir release-assets
 
-      - name: Verify downloaded manifest matches requested release
+      - name: Verify downloaded manifest and SHA256SUMS
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
-          export EXPECTED_COMMIT="$(git rev-parse HEAD)"
+          export EXPECTED_COMMIT="$(git -C release-source rev-parse HEAD)"
           python - <<'PY'
           import json
           import os
@@ -490,19 +504,23 @@ jobs:
           path = Path("release-assets/lingtai-kernel-release-manifest.json")
           data = json.loads(path.read_text(encoding="utf-8"))
           expected_tag = os.environ["RELEASE_TAG"]
-          expected_commit = os.environ["EXPECTED_COMMIT"].lower()
+          expected_commit = os.environ["EXPECTED_COMMIT"]
           actual_tag = data.get("kernel_tag")
           actual_commit = data.get("commit")
           if actual_tag != expected_tag:
               raise SystemExit(
                   f"downloaded manifest kernel_tag {actual_tag!r} does not match requested release tag {expected_tag!r}"
               )
-          if not isinstance(actual_commit, str) or actual_commit.lower() != expected_commit:
+          if actual_commit != expected_commit:
               raise SystemExit(
-                  f"downloaded manifest commit {actual_commit!r} does not match checked-out commit {expected_commit!r}"
+                  f"downloaded manifest commit {actual_commit!r} does not match release-source commit {expected_commit!r}"
               )
           print(f"Downloaded manifest target verified: {expected_tag} at {expected_commit[:12]}.")
           PY
+          (
+            cd release-assets
+            sha256sum --check --strict SHA256SUMS
+          )
 
       - name: Resume Gitee publication (idempotent bounded retry)
         shell: bash

--- a/scripts/publish_release_assets.py
+++ b/scripts/publish_release_assets.py
@@ -17,10 +17,12 @@ using the GITEE_ACCESS_TOKEN environment variable. The token is never echoed,
 logged, or included in any printed command.
 
 Idempotency: for each asset, an existing same-name attachment is downloaded
-and hashed before it is accepted as an idempotent skip. A different digest,
-missing/ambiguous metadata, or download failure is fail-loud. Comparison files
-are retained under unique runner temp paths. There is no delete-and-replace
-cleanup path by design.
+and hashed before it is accepted as an idempotent skip. Gitee release metadata
+accepts the exact `assets` list or legacy `attach_files` list; duplicate names
+are grouped only when every resolved download URL agrees, with a warning. A
+different digest, missing/ambiguous metadata, or download failure is fail-loud.
+Comparison files are retained under unique runner temp paths. There is no
+delete-and-replace cleanup path by design.
 """
 from __future__ import annotations
 
@@ -32,6 +34,7 @@ import sys
 import tempfile
 import uuid
 import urllib.error
+import warnings
 import urllib.request
 from pathlib import Path
 
@@ -302,11 +305,38 @@ def gitee_verify_tag_synchronized(owner: str, repo: str, tag: str, expected_comm
         )
 
 
+_GITEE_ATTACHMENT_URL_KEYS = (
+    "browserDownloadUrl",
+    "browser_download_url",
+    "download_url",
+    "url",
+)
+
+
+def _gitee_download_url(attachment: dict, filename: str) -> str:
+    present_urls = [attachment[key] for key in _GITEE_ATTACHMENT_URL_KEYS if key in attachment]
+    if not present_urls or any(
+        not isinstance(url, str) or not url.startswith("https://") for url in present_urls
+    ):
+        raise PublishError(f"Gitee attachment {filename!r} has no usable download URL")
+    if len(set(present_urls)) != 1:
+        raise PublishError(f"Gitee attachment {filename!r} has ambiguous download URLs")
+    return present_urls[0]
+
+
 def gitee_existing_attachments(owner: str, repo: str, release_id: int, token: str) -> dict[str, dict]:
     release = _gitee_request("GET", f"/repos/{owner}/{repo}/releases/{release_id}", token)
-    attachments = release.get("attach_files", [])
+    if not isinstance(release, dict):
+        raise PublishError("Gitee attachment metadata is ambiguous: release is not an object")
+    list_keys = [key for key in ("assets", "attach_files") if key in release]
+    if not list_keys:
+        raise PublishError("Gitee attachment metadata is missing assets/attach_files")
+    if len(list_keys) > 1:
+        raise PublishError("Gitee attachment metadata is ambiguous: both assets and attach_files are present")
+    list_key = list_keys[0]
+    attachments = release[list_key]
     if not isinstance(attachments, list):
-        raise PublishError("Gitee attachment metadata is ambiguous: attach_files is not a list")
+        raise PublishError(f"Gitee attachment metadata is ambiguous: {list_key} is not a list")
     result = {}
     for attachment in attachments:
         if not isinstance(attachment, dict):
@@ -315,20 +345,24 @@ def gitee_existing_attachments(owner: str, repo: str, release_id: int, token: st
         if not isinstance(name, str) or not name:
             raise PublishError("Gitee attachment metadata is ambiguous: attachment has no name")
         if name in result:
-            raise PublishError(f"Gitee release has ambiguous duplicate attachment name {name!r}")
+            canonical_url = _gitee_download_url(result[name], name)
+            duplicate_url = _gitee_download_url(attachment, name)
+            if duplicate_url != canonical_url:
+                raise PublishError(
+                    f"Gitee release has duplicate attachment {name!r} with divergent download URLs"
+                )
+            warnings.warn(
+                f"Gitee release has duplicate attachment {name!r}; using one canonical remote URL",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            continue
         result[name] = attachment
     return result
 
 
 def _gitee_download_sha256(attachment: dict, filename: str, token: str) -> str:
-    url = (
-        attachment.get("browserDownloadUrl")
-        or attachment.get("browser_download_url")
-        or attachment.get("download_url")
-        or attachment.get("url")
-    )
-    if not isinstance(url, str) or not url:
-        raise PublishError(f"Gitee attachment {filename!r} has no usable download URL")
+    url = _gitee_download_url(attachment, filename)
     destination = _comparison_path("gitee", filename)
     separator = "&" if "?" in url else "?"
     request = urllib.request.Request(url + f"{separator}access_token={token}")

--- a/tests/test_publish_release_assets.py
+++ b/tests/test_publish_release_assets.py
@@ -298,6 +298,94 @@ def test_plan_gitee_uploads_same_byte_collision_skips_without_upload(tmp_path, m
     assert "existing bytes sha256" in capsys.readouterr().out
 
 
+def test_plan_gitee_uploads_reads_actual_assets_schema(tmp_path, monkeypatch):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    wheel = manifest.artifacts[0].filename
+    monkeypatch.setattr(
+        pub,
+        "_gitee_request",
+        lambda *a, **k: {"assets": [{"name": wheel, "browser_download_url": "https://gitee.test/wheel"}]},
+    )
+    monkeypatch.setattr(pub.urllib.request, "urlopen", lambda *a, **k: _FakeResponse((assets_dir / wheel).read_bytes()))
+    to_upload = pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
+    assert wheel not in {path.name for path in to_upload}
+
+
+def test_plan_gitee_uploads_groups_same_url_duplicates_warns_and_hash_skips_canonical_url(
+    tmp_path, monkeypatch, recwarn
+):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    wheel = manifest.artifacts[0].filename
+    canonical_url = "https://gitee.test/attachments/42"
+    monkeypatch.setattr(
+        pub,
+        "_gitee_request",
+        lambda *a, **k: {
+            "assets": [
+                {"id": 42, "name": wheel, "browserDownloadUrl": canonical_url},
+                {"id": 43, "name": wheel, "browser_download_url": canonical_url},
+            ]
+        },
+    )
+    downloaded = []
+
+    def fake_urlopen(request, timeout):
+        downloaded.append(request.full_url.split("?", 1)[0])
+        return _FakeResponse((assets_dir / wheel).read_bytes())
+
+    monkeypatch.setattr(pub.urllib.request, "urlopen", fake_urlopen)
+    to_upload = pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
+    assert wheel not in {path.name for path in to_upload}
+    assert downloaded == [canonical_url]
+    assert len(recwarn) == 1
+    assert "duplicate attachment" in str(recwarn[0].message)
+
+
+@pytest.mark.parametrize(
+    ("rows", "message"),
+    [
+        (
+            [
+                {"name": "TARGET", "browser_download_url": "https://gitee.test/1"},
+                {"name": "TARGET", "browser_download_url": "https://gitee.test/2"},
+            ],
+            "divergent download URLs",
+        ),
+        (
+            [
+                {"name": "TARGET", "browser_download_url": "https://gitee.test/1"},
+                {"name": "TARGET"},
+            ],
+            "no usable download URL",
+        ),
+        (
+            [
+                {"name": "TARGET", "browser_download_url": "https://gitee.test/1"},
+                {"name": "TARGET", "browser_download_url": "http://gitee.test/1"},
+            ],
+            "no usable download URL",
+        ),
+        (
+            [
+                {
+                    "name": "TARGET",
+                    "browserDownloadUrl": "https://gitee.test/1",
+                    "browser_download_url": "https://gitee.test/2",
+                },
+                {"name": "TARGET", "browser_download_url": "https://gitee.test/1"},
+            ],
+            "ambiguous download URLs",
+        ),
+    ],
+)
+def test_plan_gitee_uploads_duplicate_metadata_fails_closed(tmp_path, monkeypatch, rows, message):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    rows = [{**row, "name": manifest.artifacts[0].filename} for row in rows]
+    monkeypatch.setattr(pub, "_gitee_request", lambda *a, **k: {"assets": rows})
+    with pytest.raises(pub.PublishError, match=message):
+        pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
+
+
 def test_plan_gitee_uploads_mismatch_fails_before_upload(tmp_path, monkeypatch):
     manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
     conflicting_name = manifest.artifacts[0].filename
@@ -327,11 +415,15 @@ def test_plan_gitee_uploads_download_failure_fails_loud(tmp_path, monkeypatch):
         pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
 
 
-def test_plan_gitee_uploads_duplicate_name_is_ambiguous(tmp_path, monkeypatch):
+def test_plan_gitee_uploads_duplicate_name_missing_url_fails_loud(tmp_path, monkeypatch):
     manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
     name = manifest.artifacts[0].filename
-    monkeypatch.setattr(pub, "_gitee_request", lambda *a, **k: {"attach_files": [{"name": name}, {"name": name}]})
-    with pytest.raises(pub.PublishError, match="ambiguous duplicate"):
+    monkeypatch.setattr(
+        pub,
+        "_gitee_request",
+        lambda *a, **k: {"attach_files": [{"name": name}, {"name": name, "url": "https://gitee.test/wheel"}]},
+    )
+    with pytest.raises(pub.PublishError, match="no usable download URL"):
         pub.plan_gitee_uploads(manifest, assets_dir, manifest_path, "owner", "repo", 1, "tok")
 
 
@@ -432,3 +524,11 @@ def test_main_rejects_tampered_asset_before_any_upload(tmp_path, monkeypatch):
             "--assets-dir", str(assets_dir),
             "--skip-gitee",
         ])
+
+
+def test_publisher_has_no_delete_replace_or_github_mutation_path():
+    text = Path(pub.__file__).read_text(encoding="utf-8")
+    assert "gh release delete" not in text
+    assert "gh release replace" not in text
+    assert "gitee_delete" not in text
+    assert "gitee_replace" not in text

--- a/tests/test_wheels_workflow_publish_gating.py
+++ b/tests/test_wheels_workflow_publish_gating.py
@@ -230,10 +230,18 @@ def test_gitee_only_recovery_job_is_ubuntu_bounded_and_read_only():
 
 def test_gitee_only_recovery_checks_out_exact_tag_with_no_persisted_credentials():
     job = _recovery_job(_load_workflow())
-    checkout = _step(job, "Check out exact release tag")
+    main_checkout = _step(job, "Check out reviewed publisher/tools")
+    assert main_checkout["uses"] == "actions/checkout@v4"
+    assert main_checkout["with"] == {
+        "ref": "${{ github.sha }}",
+        "persist-credentials": False,
+        "fetch-depth": 0,
+    }
+    checkout = _step(job, "Check out exact release tag as target source")
     assert checkout["uses"] == "actions/checkout@v4"
     assert checkout["with"] == {
         "ref": "refs/tags/${{ inputs.release_tag }}",
+        "path": "release-source",
         "persist-credentials": False,
         "fetch-depth": 0,
     }
@@ -243,6 +251,7 @@ def test_gitee_only_recovery_checks_out_exact_tag_with_no_persisted_credentials(
         "RECOVERY_REQUESTED": "${{ inputs.gitee_only_recovery }}",
         "PUBLISH_REQUESTED": "${{ inputs.publish }}",
         "RELEASE_TAG": "${{ inputs.release_tag }}",
+        "WORKFLOW_SHA": "${{ github.sha }}",
     }
     script = validation["run"]
     assert '"$RECOVERY_REQUESTED" != "true"' in script
@@ -250,7 +259,9 @@ def test_gitee_only_recovery_checks_out_exact_tag_with_no_persisted_credentials(
     assert "^v[0-9]+\\.[0-9]+\\.[0-9]+$" in script
     assert 'refs/tags/${RELEASE_TAG}^{commit}' in script
     assert "git rev-parse HEAD" in script
-    assert '"$tag_commit" != "$head_commit"' in script
+    assert "git -C release-source rev-parse HEAD" in script
+    assert '"$main_head" != "$WORKFLOW_SHA"' in script
+    assert '"$tag_commit" != "$target_head"' in script
 
 
 def test_gitee_only_download_scopes_gh_token_and_uses_exact_release_tag():
@@ -327,7 +338,7 @@ def test_gitee_only_downloaded_manifest_is_bound_to_requested_tag_and_checkout(t
     steps = job["steps"]
     names = [step.get("name", "") for step in steps]
     download_index = names.index("Download exact GitHub release assets")
-    verify_index = names.index("Verify downloaded manifest matches requested release")
+    verify_index = names.index("Verify downloaded manifest and SHA256SUMS")
     publish_index = names.index("Resume Gitee publication (idempotent bounded retry)")
     assert download_index < verify_index < publish_index
 
@@ -335,9 +346,10 @@ def test_gitee_only_downloaded_manifest_is_bound_to_requested_tag_and_checkout(t
     assert verifier["shell"] == "bash"
     assert verifier["env"] == {"RELEASE_TAG": "${{ inputs.release_tag }}"}
     shell_script = verifier["run"]
-    assert 'export EXPECTED_COMMIT="$(git rev-parse HEAD)"' in shell_script
+    assert 'export EXPECTED_COMMIT="$(git -C release-source rev-parse HEAD)"' in shell_script
     assert "data.get(\"kernel_tag\")" in shell_script
     assert "data.get(\"commit\")" in shell_script
+    assert "sha256sum --check --strict SHA256SUMS" in shell_script
     marker = "python - <<'PY'\n"
     assert marker in shell_script and "\nPY" in shell_script
     verifier_code = shell_script.split(marker, 1)[1].rsplit("\nPY", 1)[0]
@@ -364,9 +376,13 @@ def test_gitee_only_downloaded_manifest_is_bound_to_requested_tag_and_checkout(t
             check=False,
         )
 
-    matching = run_verifier({"kernel_tag": expected_tag, "commit": expected_commit.upper()})
+    matching = run_verifier({"kernel_tag": expected_tag, "commit": expected_commit})
     assert matching.returncode == 0, matching.stderr
     assert "target verified" in matching.stdout
+
+    wrong_case_commit = run_verifier({"kernel_tag": expected_tag, "commit": expected_commit.upper()})
+    assert wrong_case_commit.returncode != 0
+    assert "manifest commit" in wrong_case_commit.stderr and "release-source commit" in wrong_case_commit.stderr
 
     wrong_tag = run_verifier({"kernel_tag": "v0.17.0", "commit": expected_commit})
     assert wrong_tag.returncode != 0
@@ -374,4 +390,4 @@ def test_gitee_only_downloaded_manifest_is_bound_to_requested_tag_and_checkout(t
 
     wrong_commit = run_verifier({"kernel_tag": expected_tag, "commit": "b" * 40})
     assert wrong_commit.returncode != 0
-    assert "manifest commit" in wrong_commit.stderr and "checked-out commit" in wrong_commit.stderr
+    assert "manifest commit" in wrong_commit.stderr and "release-source commit" in wrong_commit.stderr


### PR DESCRIPTION
## Summary

- read the actual Gitee release `assets` schema while retaining the legacy `attach_files` contract
- coalesce same-name duplicate rows only when every usable download URL is identical, then download/hash the canonical remote bytes before an idempotent skip
- fail closed for divergent, missing, unusable, or ambiguous attachment metadata; do not delete or replace existing rows
- run recovery tooling from the reviewed workflow SHA while checking the exact release tag out separately under `release-source/`
- bind the downloaded manifest and `SHA256SUMS` to the requested tag and target commit before `--skip-github` publication

This repairs the live v0.17.1 recovery incident where nine bounded attempts repeatedly uploaded the same prefix because the publisher looked only at `attach_files`; the public response uses `assets`. The cancelled run left 25 duplicate rows, which this PR deliberately preserves.

## Validation

- `python -m pytest -q --basetemp=<task scratch>/pytest-basetemp tests/test_publish_release_assets.py tests/test_wheels_workflow_publish_gating.py` — `59 passed`
- Python AST parse for the publisher and both focused test files — PASS
- `git diff --check` — PASS
- candidate code executed directly against the preserved 30-row live Gitee JSON snapshot — `30 rows / 5 unique / 25 duplicate warnings`, PASS
- exact source scope — 4 files, `202 insertions / 34 deletions`

## Non-goals

- no deletion, replacement, or cleanup of existing Gitee attachments
- no GitHub release mutation in recovery mode
- no release-byte rebuild, mirror force-sync, public flag, or retry-policy redesign
