### PR TITLE
docs(mcp): retire stale addon setup guidance

### DIFF
--- a/src/lingtai/tools/mcp/manual/SKILL.md
+++ b/src/lingtai/tools/mcp/manual/SKILL.md
@@ -49,6 +49,12 @@ The `mcp` capability is your interface to Model Context Protocol (MCP) servers â
 
 This is the router. Detail lives in `reference/`. Load only what you need.
 
+## TUI command boundary
+
+`/addon` is retired; never recommend it. `/mcp` is the only current TUI command for this surface, and it is read-only config/status inspection. It is **not** a guided setup or configuration screen; never describe it as one or redirect a human there for addon setup.
+
+For curated addon setup, load `reference/curated-addons.md` (the curated-addon setup contract) and the relevant provider docs before editing. Make exact configuration changes only within explicit human authorization, using that contract's four-step mechanism; do not redirect the human to a nonexistent or setup-like TUI screen.
+
 ## Three states of an MCP
 
 For any MCP server, relative to this agent:

--- a/src/lingtai/tools/mcp/manual/reference/curated-addons.md
+++ b/src/lingtai/tools/mcp/manual/reference/curated-addons.md
@@ -12,7 +12,7 @@ LingTai's first-party email and chat integrations. They now ship inside the `lin
 
 ## The four-step setup
 
-1. **Read the curated setup docs before editing config.** The table below gives the registry/module/env/config-file names. If exact provider-specific fields are needed, inspect the shipped module resources or the catalog `homepage` for that addon. Field names like `email_password` (imap), `bot_token` (telegram), `app_id`/`app_secret` (feishu), and gewechat host (wechat) are addon-specific; do not guess them from memory.
+1. **Read the curated setup docs before editing config.** The table below gives the registry/module/env/config-file names. If exact provider-specific fields are needed, inspect the shipped module resources or the catalog `homepage` for that addon. Field names like `email_password` (imap), `bot_token` (telegram), `app_id`/`app_secret` (feishu), and gewechat host (wechat) are addon-specific; do not guess them from memory. Make exact configuration changes only within explicit human authorization; this contract is the setup procedure, not a TUI setup screen.
 
 2. **Add the addon to `init.json`.** Append the registry name to the top-level `addons:` list, then add an `mcp.<name>` activation entry with the subprocess spec from this table or the addon docs:
 

--- a/tests/test_mcp_capability.py
+++ b/tests/test_mcp_capability.py
@@ -8,6 +8,7 @@ registry membership.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -293,6 +294,40 @@ def test_mcp_show_action_returns_health_snapshot(tmp_path):
     manual = handler({"action": "manual"})
     assert manual["status"] == "ok"
     assert "mcp_manual" in manual and manual["mcp_manual"]  # umbrella SKILL.md body
+
+
+def test_mcp_manual_preserves_tui_command_boundary():
+    """The shipped MCP router must not route setup to a retired TUI surface."""
+    manual_root = Path(__file__).resolve().parents[1] / "src/lingtai/tools/mcp/manual"
+    router = (manual_root / "SKILL.md").read_text(encoding="utf-8")
+    curated = (manual_root / "reference/curated-addons.md").read_text(encoding="utf-8")
+
+    assert re.search(r'/addon.{0,120}(?:retired|never recommended)', router, re.I | re.S)
+    assert not re.search(r'(?:use|open|run|launch|recommend)[ \t]+`?/addon', router, re.I)
+    assert re.search(r'/mcp.{0,140}only current TUI command', router, re.I | re.S)
+    assert re.search(r'/mcp.{0,180}read[- ]only', router, re.I | re.S)
+    assert re.search(
+        r"/mcp.{0,240}(?:not|isn't).{0,90}(?:guided[ \t]+)?(?:setup|configuration)",
+        router,
+        re.I | re.S,
+    )
+    assert re.search(
+        r'curated addon setup.{0,220}(?:curated-addons.*contract|provider docs)',
+        router,
+        re.I | re.S,
+    )
+    assert re.search(r'explicit human authorization', router, re.I)
+
+    # Keep the existing four-step mechanism in the owning reference while the
+    # router adds only the TUI boundary and authorization rule.
+    assert re.search(r'## The four-step setup', curated)
+    for step in (
+        r'1[.].*read.*setup docs',
+        r'2[.].*init[.]json',
+        r'3[.].*config file',
+        r"4[.].*system[(]action=.*refresh.*[)]",
+    ):
+        assert re.search(step, curated, re.I | re.S)
 
 
 def test_mcp_show_unknown_action_returns_error(tmp_path):


### PR DESCRIPTION
## Root cause

The active MCP manual described curated-addon setup but did not state the current TUI command boundary. That gap let an agent recommend the retired `/addon` command and misdescribe `/mcp` as a guided setup screen during a WhatsApp setup request.

Current TUI behavior is deterministic: `/addon` was retired; `/mcp` is the only command for this surface, and it is read-only configuration/status inspection.

## Fix

- state the retired `/addon` / read-only `/mcp` boundary in the MCP manual router
- keep curated setup on the existing provider-doc + exact-authorization path instead of redirecting users to a nonexistent setup UI
- add a semantic regression against the real shipped router/reference so stale command guidance cannot return silently

No TUI command, alias, wizard, runtime guard, provider schema, or WhatsApp credential behavior is added here.

## Validation

Failing-first: the new regression failed against the unchanged base because the shipped manual had no current-command/read-only contract.

Final parent gates:

- `python -m pytest -q tests/test_mcp_capability.py` — 28 passed
- related MCP/manual/identity/docs tests — 117 passed
- `python -m pytest -q tests/test_architecture_documents.py` — 3 passed
- `python scripts/check_docs_governance.py --check` — 277 documents validated
- `python -m py_compile tests/test_mcp_capability.py`
- `git diff --check`

Requested from Jason's screenshot showing the stale `/addon` recommendation. Personal-account WhatsApp transport is a separate product feature; this PR corrects the current shipped setup contract without pretending that such transport already exists.
