### PR TITLE
fix(telegram): recover non-deletable task card

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -84,9 +84,14 @@ _TASK_CARD_EDIT_IMPOSSIBLE_DESCRIPTIONS = frozenset({
 })
 _TASK_CARD_DELETE_OK = "ok"
 _TASK_CARD_DELETE_MISSING = "missing"
+_TASK_CARD_DELETE_NONDELETABLE = "nondeletable"
 _TASK_CARD_DELETE_FAILED = "failed"
 _TASK_CARD_DELETE_MISSING_DESCRIPTIONS = frozenset({
     "bad request: message to delete not found",
+})
+_TASK_CARD_DELETE_NONDELETABLE_DESCRIPTIONS = frozenset({
+    "bad request: message can't be deleted for everyone",
+    "bad request: message can not be deleted for everyone",
 })
 
 # Fixed human warning shown on every Task Card render (running and frozen
@@ -1573,7 +1578,7 @@ class TelegramManager:
 
     @staticmethod
     def _task_card_delete_error_outcome(exc: Exception) -> str:
-        """Classify only explicit not-found as an already-absent old card."""
+        """Classify only explicit terminal delete semantics; unknowns fail closed."""
         detail = str(exc)
         if not detail.startswith(_TELEGRAM_API_ERROR_PREFIX):
             return _TASK_CARD_DELETE_FAILED
@@ -1582,6 +1587,8 @@ class TelegramManager:
         ).casefold()
         if description in _TASK_CARD_DELETE_MISSING_DESCRIPTIONS:
             return _TASK_CARD_DELETE_MISSING
+        if description in _TASK_CARD_DELETE_NONDELETABLE_DESCRIPTIONS:
+            return _TASK_CARD_DELETE_NONDELETABLE
         return _TASK_CARD_DELETE_FAILED
 
     def _try_update_progress_message(
@@ -2494,7 +2501,7 @@ class TelegramManager:
     def _replace_task_card_after_probe(
         self, account: str, chat_id: int, stale_id: str, text: str, *, error: str,
     ) -> dict:
-        """Delete/missing-confirm the exact old resident, then send and persist."""
+        """Resolve the exact old resident, then send and persist one replacement."""
         delete_outcome = self._delete_task_card_message_outcome(stale_id)
         if delete_outcome == _TASK_CARD_DELETE_FAILED:
             return {
@@ -2617,9 +2624,9 @@ class TelegramManager:
     def _delete_task_card_message_outcome(self, compound_id: str) -> str:
         """Delete the exact tracked old card, distinguishing explicit absence.
 
-        ``missing`` is returned only for Telegram's exact not-found response; all
-        malformed ids, unknown provider responses, network errors, and permission
-        failures are ``failed`` so callers cannot inject a second card on a guess.
+        ``missing`` and ``nondeletable`` are returned only for Telegram's exact
+        terminal responses; malformed ids and every other failure remain ``failed``
+        so callers cannot inject a second card on a guess.
         """
         try:
             account, chat_id, tg_msg_id = self._parse_compound_id(compound_id)
@@ -2630,6 +2637,8 @@ class TelegramManager:
             outcome = self._task_card_delete_error_outcome(exc)
             if outcome == _TASK_CARD_DELETE_MISSING:
                 log.debug("Prior task card was already missing")
+            elif outcome == _TASK_CARD_DELETE_NONDELETABLE:
+                log.debug("Prior task card cannot be deleted for everyone")
             else:
                 log.debug(
                     "Failed to delete prior task card message (error_type=%s)",

--- a/tests/test_telegram_task_card_in_place.py
+++ b/tests/test_telegram_task_card_in_place.py
@@ -17,6 +17,7 @@ class FakeAccount:
         self.resident: dict[int, str] = {}
         self.next_id = 100
         self.edit_error: Exception | None = None
+        self.delete_error: Exception | None = None
 
     def send_message(self, chat_id, text, reply_to_message_id=None, **kwargs):
         message_id = self.next_id
@@ -34,6 +35,8 @@ class FakeAccount:
 
     def delete_message(self, chat_id, message_id):
         self.calls.append(("delete", chat_id, message_id))
+        if self.delete_error is not None:
+            raise self.delete_error
         self.messages.pop(message_id, None)
         return {"ok": True}
 
@@ -175,3 +178,40 @@ def test_edit_impossible_replaces_only_after_failed_edit_attempt(tmp_path):
     assert recovered["message_id"] != stale_id
     assert [call[0] for call in account.calls[-3:]] == ["edit", "delete", "send"]
     assert account.get_task_card(55) == recovered["message_id"]
+
+
+def test_exact_nondeletable_resident_self_heals_once_per_chat(tmp_path):
+    descriptions = (
+        "Bad Request: message can't be deleted for everyone",
+        "  Bad   Request: message can not be deleted for everyone  ",
+    )
+    for index, description in enumerate(descriptions):
+        manager, account = _manager(tmp_path / str(index))
+        stale_id = _automatic(manager, "create", reasoning="first")["message_id"]
+        account.set_task_card(77, "mybot:77:88")
+        account.edit_error = RuntimeError(
+            "Telegram API error: Bad Request: message can't be edited"
+        )
+        account.delete_error = RuntimeError(
+            f"Telegram API error: {description}"
+        )
+
+        recovered = _automatic(
+            manager, "update", card_message_id=stale_id, reasoning="replacement"
+        )
+
+        replacement_id = recovered["message_id"]
+        assert recovered["status"] == "ok"
+        assert replacement_id != stale_id
+        assert set(account.messages) == {100, 101}
+        assert account.get_task_card(55) == replacement_id
+        assert account.get_task_card(77) == "mybot:77:88"
+
+        account.edit_error = None
+        assert _programmable(manager, {"lines": ["watch"]})["message_id"] == replacement_id
+        assert _automatic(
+            manager, "update", card_message_id=stale_id, reasoning="later"
+        )["message_id"] == replacement_id
+        assert len(_calls(account, "send")) == 2
+        assert len(_calls(account, "delete")) == 1
+        assert [call[2] for call in _calls(account, "edit")[-2:]] == [101, 101]


### PR DESCRIPTION
## Summary
- recognize only Telegram's exact `message can't be deleted for everyone` terminal response (including the `can not` wording)
- leave the undeletable historical message alone, send one replacement through the existing per-chat route lock, and advance only that chat's resident mapping
- keep every other delete failure fail-closed and verify later automatic/programmable updates edit the replacement without churn

## Tests
- `python3 -m pytest tests/test_telegram_task_card_*.py -q` (194 passed)
- `python3 -m py_compile src/lingtai/mcp_servers/telegram/manager.py src/lingtai/mcp_servers/telegram/task_card/resident.py`
- `git diff --check`

## Scope
2 files, +54/-5. No account/controller state machine, persistence protocol, manual, deployment, or runtime change.