### PR TITLE
fix(daemon): preserve finish MCP in external CLI configs

### DIFF
--- a/src/lingtai/tools/daemon/execution_host.py
+++ b/src/lingtai/tools/daemon/execution_host.py
@@ -374,9 +374,11 @@ class DetachedDaemonExecutionHost:
         """Write unavoidable run-private native files only inside the owner."""
         if not self._capsule.get("mcp"):
             return
+        # External CLIs do not receive LingTai's local completion surface, so
+        # their native config must retain the reserved daemon_common server.
         regs = [
             r for r in self._capsule.get("mcp", [])
-            if isinstance(r, dict) and r.get("name") != _DAEMON_COMMON_NAME
+            if isinstance(r, dict)
         ]
         argv = self._manifest.get("backend_argv") or []
         if not isinstance(argv, list):

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -489,6 +489,132 @@ def test_cli_session_policy_preserves_legacy_and_inherits_for_detached():
     assert host._cli_start_new_session() is False
 
 
+@pytest.mark.parametrize("backend", ["claude-p", "claude-code", "qwen-code"])
+def test_detached_native_mcp_rehydration_preserves_common_and_owner_values(
+    tmp_path, backend,
+):
+    """The last native-config writer keeps finish plus real owner-only values."""
+    from lingtai.tools.daemon.execution_host import DetachedDaemonExecutionHost
+    from threading import Event
+
+    run_dir = _make_run_dir(tmp_path, task=f"{backend} native MCP rehydration")
+    config_path = run_dir.path / f"{backend}-mcp.json"
+    marker = (
+        "--mcp-config"
+        if backend in {"claude-p", "claude-code"}
+        else "__lingtai_qwen_system_settings_path"
+    )
+    backend_argv = [marker, str(config_path)]
+    real_mcp = [
+        {
+            "name": "daemon_common",
+            "transport": "stdio",
+            "command": sys.executable,
+            "args": ["-m", "lingtai.mcp_servers.daemon_common"],
+            "env": {
+                "LINGTAI_DAEMON_COMPLETION_FILE": str(
+                    run_dir.path / "daemon_completion.json"
+                )
+            },
+        },
+        {
+            "name": "parent-docs",
+            "transport": "stdio",
+            "command": "/bin/echo",
+            "args": ["docs"],
+            "env": {"DOC_TOKEN": "owner-only-token"},
+        },
+    ]
+    manifest = build_manifest(
+        run_id=run_dir.run_id,
+        backend=backend,
+        parent_working_dir=str(run_dir.path.parent.parent),
+        run_dir=str(run_dir.path),
+        task="native MCP rehydration",
+        tools=[],
+        max_turns=1,
+        timeout_s=30,
+        group_id=None,
+        backend_argv=backend_argv,
+        mcp=real_mcp,
+    )
+    assert manifest["mcp"][1]["env"]["DOC_TOKEN"] == "<redacted>"
+
+    host = DetachedDaemonExecutionHost(
+        run_dir,
+        manifest,
+        Event(),
+        Event(),
+        capsule={"mcp": real_mcp, "backend_argv": backend_argv},
+    )
+    host._rehydrate_native_mcp_files()
+
+    servers = json.loads(config_path.read_text(encoding="utf-8"))["mcpServers"]
+    assert list(servers) == ["daemon_common", "parent-docs"]
+    assert servers["daemon_common"]["args"] == [
+        "-m", "lingtai.mcp_servers.daemon_common"
+    ]
+    assert servers["daemon_common"]["env"][
+        "LINGTAI_DAEMON_COMPLETION_FILE"
+    ].endswith("daemon_completion.json")
+    assert servers["parent-docs"]["env"] == {
+        "DOC_TOKEN": "owner-only-token"
+    }
+
+
+def test_detached_lingtai_surface_keeps_one_local_finish_without_external_common(
+    tmp_path, monkeypatch,
+):
+    """LingTai filters the reserved server because it owns one local finish."""
+    from lingtai.tools.daemon.execution_host import DetachedDaemonExecutionHost
+    from threading import Event
+
+    run_dir = _make_run_dir(tmp_path, task="local completion surface")
+    real_mcp = [
+        {
+            "name": "daemon_common",
+            "transport": "stdio",
+            "command": sys.executable,
+            "args": ["-m", "lingtai.mcp_servers.daemon_common"],
+        },
+        {
+            "name": "parent-docs",
+            "transport": "stdio",
+            "command": "/bin/echo",
+            "args": ["docs"],
+        },
+    ]
+    manifest = build_manifest(
+        run_id=run_dir.run_id,
+        backend="lingtai",
+        parent_working_dir=str(run_dir.path.parent.parent),
+        run_dir=str(run_dir.path),
+        task="local completion surface",
+        tools=[],
+        max_turns=1,
+        timeout_s=30,
+        group_id=None,
+        mcp=real_mcp,
+    )
+    host = DetachedDaemonExecutionHost(
+        run_dir, manifest, Event(), Event(), capsule={"mcp": real_mcp}
+    )
+    connected = []
+
+    def fake_connect(_host, registrations):
+        connected.extend(registrations)
+        return {}, {}, []
+
+    monkeypatch.setattr(
+        host._manager_type, "_connect_task_mcp_registrations", fake_connect
+    )
+    schemas, dispatch = host._build_lingtai_surface()
+
+    assert [schema.name for schema in schemas].count("finish") == 1
+    assert list(dispatch).count("finish") == 1
+    assert [registration["name"] for registration in connected] == ["parent-docs"]
+
+
 def test_codex_detached_reclaim_kills_exact_own_process_group_only(tmp_path):
     """Explicit reclaim of a detached codex run kills only its own pgid."""
     from lingtai.kernel.daemon_supervisor import DaemonSupervisorRequest


### PR DESCRIPTION
## Summary

- preserve the reserved `daemon_common` MCP registration when detached execution rehydrates external CLI native config files
- add post-capsule regression coverage for `claude-p`, `claude-code`, and `qwen-code`, including real owner-only env values after durable manifest redaction
- keep the LingTai-native path unchanged: exactly one local `finish` tool, with no external `daemon_common` server mounted

## Root cause

The daemon manager initially wrote `daemon_common` correctly, but detached `ExecutionHost` is the final native-config writer after owner-only capsule overlay. Its external rehydration path filtered `daemon_common` before rewriting Claude/Qwen config files, removing those CLIs' only `finish` tool while the prompt and allowlist still advertised it. The hard terminal completion gate then correctly failed closed.

The same filter remains correct in the LingTai-native surface because that path owns a local `finish` FunctionSchema/handler and must avoid a duplicate stdio server.

## Other backend audit

- affected and covered: `claude-p`, `claude-code`, `qwen-code` (native config files are rewritten by the offending path)
- not affected by this filter: Codex and OpenCode carry MCP config in the owner-only capsule argv; Kimicode uses its separately written run-private `mcp.json`

## Validation

- focused new regressions: `4 passed, 32 deselected`
- detached owner + backend config + Claude completion/usage/interactive suites: `144 passed in 30.53s`
- `git diff --check`
- exact-candidate live `claude-p` smoke: terminal state `done`; strict config contained `daemon_common`; `finish(status="done")` was recorded
- canonical pool `gpt-5.6-terra` independent review: `VERDICT: PASS`
- explicit, no-tools Claude Opus 4.8 final review (`modelUsage: claude-opus-4-8`): `VERDICT: PASS`

Residual non-blocking risk: Qwen is covered at the post-capsule native-file writer but did not receive a separate live CLI smoke. The Qwen file format is unchanged; this patch only stops removing the reserved server.

## Non-goals

- no terminal success-from-text fallback
- no weakening of the fail-closed completion gate
- no daemon architecture refactor or unrelated telemetry change
