### PR TITLE
docs(skills): slim kernel and curated MCP guidance

### DIFF
--- a/dev-guide-skill/SKILL.md
+++ b/dev-guide-skill/SKILL.md
@@ -20,16 +20,16 @@ maintenance: |
 # LingTai Kernel Development
 
 Read this skill before every development task in this repository. It owns the
-**workflow**, not the architecture facts or interface promises. Follow its links
-instead of copying the root documents into this file.
+**workflow**; Anatomy owns structure and Contract owns interface promises.
+Follow its links instead of copying the root documents into this file.
 
-Above all, the root [`CONTRACT.md`](../CONTRACT.md) `## Design principles`
-section is mandatory reading, and you MUST apply those principles to every
-change: gate any new or expanded i18n on explicit human confirmation, prefer
-progressive disclosure, ensure every capability you touch is taught by a manual
-(what/how/why), and keep that manual discoverable from **both** the corresponding
-`CONTRACT.md` and its paired `ANATOMY.md` (`related_files` on both twins) — one
-edge alone is a defect.
+Above all, root [`CONTRACT.md`](../CONTRACT.md) `## Design principles` is
+mandatory reading, and you MUST apply every one of those principles to each
+change — including the i18n gate, progressive disclosure, the
+manual-per-capability rule, and manual discoverability from **both** the
+capability `CONTRACT.md` and its paired `ANATOMY.md` (`related_files` on both
+twins; one edge alone is a defect). Route each change to the manual that teaches
+the capability it touches.
 
 ## First establish the task and baseline
 
@@ -49,28 +49,22 @@ workflow and its route to the full coding-agent and test reference.
 
 Use progressive disclosure in this order:
 
-1. Read root [`ANATOMY.md`](../ANATOMY.md), then descend through
-   the nearest child
-   anatomy until cited code answers where the relevant files, connections,
-   composition, and state live.
-2. Read root [`CONTRACT.md`](../CONTRACT.md), **beginning with its
-   `## Design principles` section, and apply those principles to every change**
-   (i18n gate, progressive disclosure, every-capability-has-a-manual, and manual
-   discoverability from both the corresponding Contract and Anatomy). If the
-   component is
-   governed, read its
-   paired local contract before changing its interface or expected behavior.
+1. Read root [`ANATOMY.md`](../ANATOMY.md), then descend through the nearest
+   child anatomy until cited code answers where the relevant files,
+   connections, composition, and state live.
+2. Read root [`CONTRACT.md`](../CONTRACT.md), beginning with `## Design
+   principles`. If the component is governed, read its paired local contract
+   before changing its interface or expected behavior.
 3. Read the cited code and narrow tests. Anatomy is navigation, not evidence in
    place of code; Contract is the normative promise, not a description to weaken
    when implementation drifts.
 4. Load a narrower manual only when the task needs its commands, examples, or
    troubleshooting. Do not preload unrelated references.
 
-The three local systems have different jobs:
-
-- **ANATOMY** tells you where code is and how it is connected.
-- **CONTRACT** tells you what interfaces and expected agent behavior promise.
-- **This skill** tells you how to develop and validate a change.
+The
+[`lingtai-kernel-anatomy`](../src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md)
+skill owns how to enter and descend those two graphs; this skill owns how to
+develop and validate a change.
 
 ## Make the smallest complete change
 
@@ -89,24 +83,23 @@ For every code or architecture-document change, assess both distributed systems:
 - Neither changed: record that both were checked; do not create documentation
   churn to simulate compliance.
 
-Follow the repair direction defined by the roots. Verified code is normally the
-structural truth for Anatomy. Contract is normative for interface and Behavior:
-implementation drift is a defect unless a maintainer explicitly authorizes a
-promise change. Do not create a second graph registry; maintain YAML
-`related_files` around the nodes you touch.
+Follow the repair direction defined by root `CONTRACT.md` `## Maintenance
+contract`: verified code is normally the structural truth for Anatomy, while
+Contract is normative for interface and Behavior, so implementation drift is a
+defect unless a maintainer explicitly authorizes a promise change. Do not create
+a second graph registry; maintain YAML `related_files` around the nodes you
+touch.
 
 ### Classify the Anatomy/Contract relationship first
 
-Follow the full pairing and ownership rule in root
-[`CONTRACT.md`](../CONTRACT.md). A governed architectural component owns
-reciprocal Anatomy/Contract twins; an implementation, Adapter, or
-navigation-only Anatomy may instead point to exactly one owning governed
-Contract and explain why it has no independent local Contract. Read Anatomy
-for structure and Contract for promises, following their reciprocal links
-rather than copying either body. Never manufacture an empty or duplicate
-Contract for filename symmetry. If the relationship does not satisfy the root
-rule, stop and report the root-defined mismatch fields and suggested action;
-do not normalize or auto-fix it without authorization.
+Root [`CONTRACT.md`](../CONTRACT.md) owns the full pairing and ownership rule: a
+governed architectural component owns reciprocal Anatomy/Contract twins, while an
+implementation, Adapter, or navigation-only Anatomy instead points to exactly one
+owning governed Contract and explains why it has no independent local Contract.
+Never manufacture an empty or duplicate Contract for filename symmetry. If the
+relationship does not satisfy the root rule, stop and report the root-defined
+mismatch fields and suggested action; do not normalize or auto-fix it without
+authorization.
 
 ### Keep Maintenance guidance aligned
 
@@ -116,17 +109,6 @@ retain complete, safe `related_files`, reciprocal Anatomy/Contract and ownership
 links, and the rule to update the pair when structure or normative behavior
 changes. The note is documentation, not a byte-identical snapshot; do not add a
 second registry or a generated/hash-based maintenance mechanism.
-
-Run the focused architecture check when the graph changes:
-
-```bash
-python -m pytest -q tests/test_architecture_documents.py
-```
-
-It validates frontmatter path safety, root and child pairing, reciprocal graph
-links, and unique ownership for linked implementation Anatomies. If it reports
-a mismatch, stop and report the offending path and links rather than silently
-normalizing or auto-fixing documents.
 
 ## Validate in layers
 
@@ -139,6 +121,11 @@ python -m pytest -q tests/test_architecture_documents.py  # when either graph ch
 # Run the canonical Anatomy drift checker in --check mode (see the Anatomy skill).
 git diff --check
 ```
+
+`tests/test_architecture_documents.py` validates frontmatter path safety, root
+and child pairing, reciprocal graph links, and unique ownership for linked
+implementation Anatomies. If it reports a mismatch, stop and report the offending
+path and links rather than silently normalizing or auto-fixing documents.
 
 Also run package, import, build, adapter, or source-drift tests when the diff
 crosses those boundaries. Use the repository virtual environment, inspect every
@@ -176,21 +163,13 @@ satisfies this baseline.
 
 This directory owns the kernel repository's complete reusable development kit,
 not only this entry document. Add supporting material when real repeated work
-justifies it:
+justifies it: `scripts/` for deterministic checks, maintenance, or generation;
+`references/` for deep procedures loaded only when needed; `assets/` for
+templates, examples, or fixed resources. Do not create empty directories or copy
+repository rules into support files.
 
-- `scripts/` for deterministic checks, maintenance, or generation;
-- `references/` for deep procedures loaded only when needed;
-- `assets/` for templates, examples, or fixed resources.
-
-Do not create empty directories or copy repository rules into support files.
-Keep one `SKILL.md` entry, let it route progressively, and validate every script
-or asset against the workflow that needs it.
-
-## Keep the network maintainable
-
-When this workflow changes, update this repository-local skill and the
-README/Anatomy/Contract entry routes together. Change
-the normative root documents only when their own meaning, schema, or promises
-change. Keep this file a concise router: detailed
-architecture belongs in Anatomy/Contract, and tool-specific recipes belong in
-the narrower manuals they own.
+Keep one `SKILL.md` entry and let it route progressively: detailed architecture
+belongs in Anatomy/Contract, and tool-specific recipes belong in the narrower
+manuals they own. When this workflow changes, update this skill and the
+README/Anatomy/Contract entry routes together; change the normative root
+documents only when their own meaning, schema, or promises change.

--- a/src/lingtai/intrinsic_skills/file-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/file-manual/SKILL.md
@@ -3,7 +3,7 @@ name: file-manual
 description: "Operational guide for LingTai's built-in file tools: read, write, edit, glob, and grep. Use when working with local text files, deciding whether to use file tools versus bash, handling large files, avoiding binary/image misuse, or reading non-UTF-8 text via explicit bash/Python/iconv instead of complicating the core read tool. Covers UTF-8 policy, safe write/edit discipline, search workflows, and examples for GBK/Shift-JIS/Latin-1 conversion."
 version: 0.1.0
 tags: [files, read, write, edit, grep, glob, encoding, utf-8]
-last_changed_at: "2026-05-26T03:24:43-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/tools/read/__init__.py
 - src/lingtai/tools/write/__init__.py
@@ -15,182 +15,126 @@ maintenance: |
 
 # File Manual
 
-This skill is the working guide for LingTai's built-in file tools:
+Working guide for LingTai's built-in file tools. Use them for ordinary project
+text: source code, Markdown, JSON/YAML/TOML, logs, prompts, skills, and notes.
 
-- `read` — read a text file with line numbers.
-- `write` — create or fully overwrite a text file.
-- `edit` — perform exact string replacement inside an existing text file.
-- `glob` — find files by path pattern.
-- `grep` — search file contents by regex.
-
-Use these tools for ordinary project text: source code, Markdown, JSON/YAML/TOML, logs, prompts, skills, and notes.
-
-Do **not** use these tools for binary/image/audio/video content. For images, use the `vision` skill/tool. For arbitrary binary inspection or transcoding, use `bash` with explicit commands.
-
-## Encoding policy
-
-LingTai's own text assets should be UTF-8:
-
-- source code;
-- prompts and system notes;
-- skills and knowledge entries;
-- JSON/YAML/TOML/Markdown config and documentation.
-
-Do not rely on the host locale. In particular, Windows Chinese/Japanese/Korean locales may default Python text I/O to GBK/CP936/Shift-JIS-like encodings. Internal LingTai assets should not be decoded by guessing the locale; they should be read and written as UTF-8.
-
-For external or user-provided non-UTF-8 files, keep the core `read` tool simple. Use `bash` with an explicit encoding instead.
-
-### Read a GBK file with Python
-
-```bash
-python - <<'PY'
-from pathlib import Path
-print(Path('file.txt').read_text(encoding='gbk'))
-PY
-```
-
-If the goal is to inspect imperfect text without crashing on bad bytes:
-
-```bash
-python - <<'PY'
-from pathlib import Path
-print(Path('file.txt').read_text(encoding='gbk', errors='replace'))
-PY
-```
-
-For Shift-JIS or Latin-1, change the encoding:
-
-```bash
-python - <<'PY'
-from pathlib import Path
-print(Path('file.txt').read_text(encoding='shift_jis', errors='replace'))
-print(Path('latin1.txt').read_text(encoding='latin-1'))
-PY
-```
-
-### Convert a file to UTF-8
-
-With Python:
-
-```bash
-python - <<'PY'
-from pathlib import Path
-src = Path('legacy-gbk.txt')
-dst = Path('legacy-gbk.utf8.txt')
-dst.write_text(src.read_text(encoding='gbk'), encoding='utf-8')
-print(dst)
-PY
-```
-
-With `iconv` when available:
-
-```bash
-iconv -f gbk -t utf-8 legacy-gbk.txt > legacy-gbk.utf8.txt
-iconv -f shift_jis -t utf-8 legacy-sjis.txt > legacy-sjis.utf8.txt
-```
-
-Recommended rule: if a file will become part of the project, convert it to UTF-8 before committing or storing it as a durable LingTai asset.
+Do **not** use them for binary/image/audio/video content. For images, use the
+`vision` skill/tool. For arbitrary binary inspection or transcoding, use `bash`
+with explicit commands.
 
 ## Choosing the right tool
 
 | Need | Tool |
 |---|---|
-| Read a known text file | `read` |
-| Read a large file section | `read` with `offset` / `limit` |
+| Read a known text file (returns numbered lines) | `read` |
+| Read a large file, paginate, or handle truncation | `read` with `offset`/`limit` — deeper semantics in `read-manual` |
 | Create a new text file or replace a whole file | `write` |
 | Make a small exact change | `edit` |
 | Find files by name/path | `glob` |
-| Search text across files | `grep` |
+| Search file contents by regex | `grep` |
 | Decode non-UTF-8 text | `bash` + Python or `iconv` |
 | Inspect binary format, archive, media | `bash` or a domain skill/tool |
 | Analyze image content | `vision` |
 
-## Reading files safely
+## Encoding policy
 
-Prefer `read` for known text files. It returns line numbers, which makes later edits and citations easier.
+LingTai's own text assets are UTF-8 — source code, prompts and system notes,
+skills and knowledge entries, and JSON/YAML/TOML/Markdown config and docs. The
+`read`/`write`/`edit` tools pin UTF-8 for exactly this reason.
 
-For large files, avoid loading everything at once:
+Do not rely on the host locale. Windows Chinese/Japanese/Korean locales may
+default Python text I/O to GBK/CP936/Shift-JIS-like encodings; internal LingTai
+assets must never be decoded by guessing the locale.
 
-```python
-read({"file_path": "/abs/path/to/file.log", "offset": 1, "limit": 120})
-read({"file_path": "/abs/path/to/file.log", "offset": 500, "limit": 120})
+For external or user-provided non-UTF-8 files, keep the core `read` tool simple
+and use `bash` with an explicit encoding instead:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+# encoding: 'gbk', 'shift_jis', 'latin-1', ... ; errors='replace' survives bad bytes
+print(Path('file.txt').read_text(encoding='gbk', errors='replace'))
+PY
 ```
 
-If a file may be generated, minified, huge, or noisy, search before reading:
+Convert to UTF-8 with Python or `iconv`:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+Path('legacy.utf8.txt').write_text(Path('legacy-gbk.txt').read_text(encoding='gbk'), encoding='utf-8')
+PY
+
+iconv -f gbk -t utf-8 legacy-gbk.txt > legacy-gbk.utf8.txt
+iconv -f shift_jis -t utf-8 legacy-sjis.txt > legacy-sjis.utf8.txt
+```
+
+Rule: if a file will become part of the project, convert it to UTF-8 before
+committing or storing it as a durable LingTai asset.
+
+## Reading safely
+
+Prefer `read` for known text files; its line numbers make later edits and
+citations easier. If a file may be generated, minified, huge, or noisy, search
+first and read only the relevant region:
 
 ```python
 grep({"pattern": "class Agent|def handle", "path": "/abs/path/src", "glob": "*.py", "max_matches": 50})
+read({"file_path": "/abs/path/src/module.py", "offset": 40, "limit": 80})
 ```
 
-Then read only the relevant region.
+For the cap model, continuation via `next_offset`, and `line_truncated`
+handling, read `read-manual` rather than improvising.
 
-## Writing files safely
+## Writing and editing safely
 
-`write` is a full-file operation. Use it when:
+`write` is a full-file operation: use it to create a new file, replace a
+generated artifact, or deliberately rewrite a small file you already understand.
+Before overwriting an important existing file, read it first unless the human
+explicitly asked for a blind overwrite. Do not use `write` for tiny
+modifications to large files — use `edit`.
 
-- creating a new file;
-- replacing a generated artifact;
-- deliberately rewriting a small file you already understand.
-
-Before overwriting an important existing file, read it first unless the human explicitly asked for a blind overwrite.
-
-Avoid using `write` for tiny modifications to large files. Use `edit` instead.
-
-## Editing files safely
-
-`edit` replaces an exact string. It fails when the old string is absent or ambiguous, which is a feature: it prevents accidental broad changes.
-
-Good pattern:
+`edit` replaces an exact string and fails when the old string is absent or
+ambiguous. That failure is a feature: it prevents accidental broad changes.
 
 1. `read` the relevant lines.
 2. Copy an exact old-string region with enough surrounding context to be unique.
 3. Call `edit` once.
 4. Re-read the changed region or run tests.
 
-Use `replace_all=true` only when every occurrence is supposed to change and you have checked the match set with `grep` first.
+Use `replace_all=true` only when every occurrence is supposed to change and you
+have checked the match set with `grep` first.
 
 ## Search workflow
 
-Start broad with `glob`, then narrow with `grep`, then inspect with `read`.
-
-Examples:
+Start broad with `glob` (file names), narrow with `grep` (file contents), then
+inspect with `read`.
 
 ```python
 glob({"pattern": "**/*.py", "path": "/abs/path/project"})
 grep({"pattern": "read_text\\(", "path": "/abs/path/project/src", "glob": "*.py", "max_matches": 100})
-read({"file_path": "/abs/path/project/src/module.py", "offset": 40, "limit": 80})
 ```
-
-Use `grep` for text content. Use `glob` for file names.
 
 ## File paths and privacy
 
-Use absolute paths with file tools. Paths inside your working directory may be private to this agent. Do not send local private paths to other agents or humans unless they are useful and safe for that recipient.
-
-When sharing file content, quote the relevant content or attach/export a file through the appropriate communication channel. Do not assume another agent can dereference your local path.
-
-## Quick checklist
-
-Before using file tools:
-
-- Is this text, not binary/media?
-- Is it expected to be UTF-8? If not, use bash with explicit encoding.
-- Is the file large? If yes, search or read a slice.
-- Am I about to overwrite? If yes, read first or confirm intent.
-- Am I about to replace many occurrences? If yes, grep first.
-
+Use absolute paths with file tools. Paths inside your working directory may be
+private to this agent. Do not send local private paths to other agents or
+humans unless they are useful and safe for that recipient; another agent cannot
+dereference your local path. When sharing file content, quote the relevant
+content or attach/export a file through the appropriate communication channel.
 
 ## Manual versus ordinary calls
 
 Normal file work is primary. Each file tool has two explicit modes:
 
-- **Ordinary work:** for backward compatibility, omit `action` or set it to
-  the tool name: `action="read"`, `"write"`, `"edit"`, `"glob"`, or `"grep"`.
+- **Ordinary work:** for backward compatibility, omit `action` or set it to the
+  tool name: `action="read"`, `"write"`, `"edit"`, `"glob"`, or `"grep"`.
   Supply the ordinary arguments shown in that tool's schema.
-- **Manual lookup:** use `action="manual"` as a one-time entry when you need
-  the installed workflow guide. This returns documentation and does not
-  perform the file operation.
+- **Manual lookup:** use `action="manual"` as a one-time entry when you need the
+  installed workflow guide. It returns documentation and performs no file
+  operation. `write`, `edit`, `glob`, and `grep` return this manual; `read`
+  returns `read-manual`.
 
-After a manual result, continue the original task with an ordinary call.
-Do not request the same manual again. Repeating an identical manual call is
-an error loop, not progress.
+After a manual result, continue the original task with an ordinary call. Do not
+request the same manual again. Repeating an identical manual call is an error loop,
+not progress.

--- a/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
@@ -9,7 +9,7 @@ description: >
   local checks without exposing secrets.
 version: 0.1.0
 tags: [doctor, diagnostics, mcp, addons, heartbeat, migration, recovery]
-last_changed_at: "2026-06-12T14:27:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
 maintenance: |
@@ -23,85 +23,65 @@ the evidence is mixed: Telegram/Feishu/WeChat cannot reach it, the TUI says it
 is offline, a heartbeat is fresh, MCP configuration points at an old runtime, or
 logs/notifications/status files disagree.
 
-The goal is **diagnosis before repair**. The bundled script is read-only. It
-summarizes local evidence, redacts secrets, and suggests safe next steps; it does
-not edit `init.json`, touch mailboxes, refresh agents, or kill processes.
+**Diagnosis before repair.** The bundled script is read-only: it summarizes local
+evidence, redacts secrets, and suggests next steps. It never edits `init.json`,
+touches mailboxes, refreshes agents, or kills processes. Repairs belong to the
+owning manuals routed below.
 
-## Quick use
-
-From any shell with access to an agent workdir:
+## Run it
 
 ```bash
+# From a source checkout, against any agent workdir:
 python3 src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py \
   --agent-dir /path/to/project/.lingtai/mimo-1
-```
 
-From inside an agent process where `LINGTAI_AGENT_DIR` is set:
-
-```bash
+# From inside an agent (installed bundle); --agent-dir defaults to $LINGTAI_AGENT_DIR:
 python3 .library/intrinsic/capabilities/lingtai-doctor/scripts/doctor.py
-```
 
-For machine-readable output:
-
-```bash
-python3 .../doctor.py --agent-dir /path/to/agent --json
-```
-
-For a packaging/sanity check:
-
-```bash
-python3 .../doctor.py --self-test
+# Add --json for machine-readable output, or --self-test for a packaging check.
 ```
 
 ## What it checks
 
-The script layers evidence so you do not confuse one broken surface with a dead
-agent:
+Layered so one broken surface is not mistaken for a dead agent:
 
 1. **Identity / lifecycle files** — `.agent.json`, `.status.json`, and
    `.agent.heartbeat` freshness.
 2. **Process evidence** — best-effort `ps` scan for `lingtai-agent run <agent-dir>` / `python -m lingtai run <agent-dir>`.
-3. **Notifications and logs** — channel files, mtimes, sizes, and common log
-   files such as `logs/events.jsonl`, `logs/agent.log`, and token ledgers.
+3. **Notifications and logs** — channel files plus common logs such as
+   `logs/events.jsonl`, `logs/agent.log`, and token ledgers, by mtime/size only.
 4. **Internal mail footprint** — inbox/outbox counts without message bodies.
 5. **MCP/addon configuration** — `init.json` top-level `mcp` entries and
-   `mcp_registry.jsonl` stdio commands. Commands are checked for existence and
-   executability (or `PATH` resolution). Environment values are redacted; only
-   path-like existence facts are reported.
+   `mcp_registry.jsonl` stdio commands, checked for existence and executability
+   (or `PATH` resolution). Environment values are redacted; only path-like
+   existence facts are reported.
 6. **Migration drift hints** — stale Linux `/home/...` paths on macOS-style
    hosts, stale macOS `/Users/...` paths on Linux-style hosts, and likely
    `~/.lingtai-tui/runtime/venv/bin/python` replacements.
 7. **First-party MCP server imports** — if a configured stdio command points at a
-   usable Python executable, the script can try importing configured LingTai
-   curated MCP modules (`lingtai.mcp_servers.telegram`, `lingtai.mcp_servers.feishu`,
-   `lingtai.mcp_servers.wechat`, `lingtai.mcp_servers.whatsapp`,
-   `lingtai.mcp_servers.imap`) without reading credentials.
+   usable Python executable, tries importing the configured LingTai curated MCP
+   modules (`lingtai.mcp_servers.` `telegram`/`feishu`/`wechat`/`whatsapp`/`imap`)
+   without reading credentials.
 
 ## Reading the result
 
-The top-level severity is:
+Top-level severity is **OK** (no obvious local mismatch), **WARN** (at least one
+surface looks stale, missing, or inconsistent), or **FAIL** (a critical local
+file/config/path is missing or broken).
 
-- **OK** — no obvious local mismatch was found.
-- **WARN** — at least one surface looks stale, missing, or inconsistent.
-- **FAIL** — a critical local file/config/path is missing or broken.
+The report ends with the same next steps summarized here. Triage in this order,
+then follow the owning manual rather than improvising a repair:
 
-Suggested recovery order:
+| Doctor evidence | Do | Owner |
+|---|---|---|
+| `.agent.heartbeat` is fresh | The agent is probably alive; internal email should wake it even if an external addon is broken. | [`email-manual`](../../tools/email/manual/SKILL.md) |
+| Heartbeat and process are both dead | CPR may be appropriate. If the process is alive but status/logs are stale, investigate before CPR. | [`substrate-manual`](../system-manual/reference/substrate-manual/SKILL.md) |
+| An MCP stdio command points at a missing runtime | **Back up `init.json` and `mcp_registry.jsonl` first**, then replace the stale command path and refresh the agent. | [`mcp-manual` troubleshooting](../../tools/mcp/manual/reference/troubleshooting.md) |
+| Notifications are stale while the agent is healthy | Clear the producer channel after reading/handling it; generic dismiss only clears a mirror, so do not use it for producer state unless you know it is stale. | [`notification-manual` dismissal safety](../notification-manual/reference/dismissal-safety/SKILL.md) |
 
-1. If `.agent.heartbeat` is fresh, the agent is probably alive. Internal email
-   should wake it even if an external addon is broken.
-2. If heartbeat/process are dead, CPR may be appropriate; if the process is
-   alive but status/logs are stale, investigate before CPR.
-3. If MCP stdio commands point at missing runtimes, back up `init.json` and
-   `mcp_registry.jsonl`, replace stale command paths, then refresh the agent.
-4. If notifications are stale while the agent is healthy, clear the producer
-   channel after reading/handling it; do not use generic dismiss for producer
-   state unless you know it is only a stale mirror.
+## Scope
 
-## Scope and follow-ups
-
-This intrinsic skill is the shared diagnostic foundation. TUI `/doctor` should
-become a thin caller of these scripts instead of maintaining a separate copy of
-logic. Kernel-level `mcp(action="info")` executable validation is also a natural
-follow-up, but the doctor script remains useful because it checks the whole
-agent footprint, not only MCP registry syntax.
+Doctor is the shared diagnostic foundation and covers the whole agent footprint,
+not only MCP registry syntax — `mcp(action="info")` validates the registry, not
+lifecycle, process, log, or mail evidence. TUI `/doctor` should call these
+scripts instead of maintaining a separate copy of the logic.

--- a/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
@@ -8,7 +8,7 @@ description: >
   distributed CONTRACT.md interface-definition graph, and what to do when code
   and navigation disagree.
 version: 0.3.0
-last_changed_at: "2026-07-11T18:35:00-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - ANATOMY.md
 - src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py
@@ -22,77 +22,83 @@ maintenance: |
 ## Canonical source
 
 The repository-root [`ANATOMY.md`](../../../../ANATOMY.md) is the normative
-**anatomy of anatomy**. It defines the distributed navigation system, YAML and
-body template, pairing/link rules, component-grain gate, and maintenance
-contract. Do not maintain a second competing convention in this skill.
+**anatomy of anatomy**: the template, frontmatter and body conventions,
+component-grain gate, link/pairing semantics, and maintenance contract. Root
+[`CONTRACT.md`](../../../../CONTRACT.md) owns the governed-component pairing,
+ownership, mutual-progressive-disclosure, and fail-loud mismatch rule. Read
+them there; do not maintain a competing convention in this skill.
+
+- **ANATOMY** describes where code lives and how it composes. Code is the
+  structural source of truth.
+- **CONTRACT** defines each layer's Core, Ports, Adapters, promises, and
+  expected agent behavior. Contract is normative when implementation behavior
+  disagrees.
 
 When this skill is read from an installed package without a source checkout,
-locate the checkout you intend to modify and read its root `ANATOMY.md` before
-editing. A packaged copy is routing help, not evidence that an arbitrary local
-checkout follows the same revision.
-
-## Two paired distributed systems
-
-- **ANATOMY is the distributed code navigation system.** It describes where
-  files and symbols live, how layers connect and compose, and where state lives.
-  Code is the structural source of truth.
-- **CONTRACT is the distributed code interface definition system.** It defines
-  each layer's Core, inbound/outbound Ports, Adapters, code-interface promises,
-  expected agent behavior, and conformance tests. Contract is normative when
-  implementation behavior accidentally disagrees; manuals and skills explain
-  how agents fulfill its obligations.
-
-A root-governed architectural component keeps reciprocal `ANATOMY.md` and
-`CONTRACT.md` twins beside its code. An implementation, Adapter, or
-navigation-only Anatomy that owns no independent promise instead points to
-its unique owning governed Contract. Root `CONTRACT.md` owns the full pairing,
-ownership, mutual-progressive-disclosure, and fail-loud reporting rule; do not
-duplicate or auto-fix that rule here.
+locate the checkout you intend to modify and read *its* root `ANATOMY.md`
+before editing. A packaged copy is routing help, not evidence that an arbitrary
+local checkout follows the same revision.
 
 ## Navigation workflow
 
-For a structural question:
-
 1. Open the repository-root `ANATOMY.md`.
 2. Read its `Components` and `Composition` sections.
-3. Choose the relevant child anatomy and descend.
-4. Repeat until the local anatomy points at the exact code citation.
-5. Open the cited code. Anatomy is navigation; code is evidence.
+3. Choose the relevant child anatomy and descend; repeat until the local
+   anatomy points at an exact code citation.
+4. Open the cited code. Anatomy is navigation; code is evidence.
 
 For enumeration questions — every callsite, matching file, or import — use
 search after anatomy identifies the correct territory.
 
 The current source root is `src/lingtai/`; the kernel implementation descends
-through `src/lingtai/kernel/ANATOMY.md`.
-
-## When a layer earns a pair
-
-Create or govern a component layer when a competent agent can reason about it as
-an independent architectural unit and it owns a meaningful responsibility or
-interface boundary. Do not create ceremonial anatomies for trivial helper
-folders, single value objects, or one-function leaves.
-
-During staged migration, existing anatomy files remain useful navigation. A
-component joins the paired governed system when its co-located contract is
-linked from the root contract; from then on, the reciprocal pair and
-parent/child graph rules in root `ANATOMY.md` apply.
+through [`src/lingtai/kernel/ANATOMY.md`](../../kernel/ANATOMY.md).
 
 ## Maintenance direction
+
+Who repairs drift depends on which agent you are:
+
+- **Coding agents** update the affected anatomy in the same commit as the code
+  change that moved files, symbols, ownership, connections, composition, or
+  state.
+- **LingTai agents** report drift as issues, mail, or PR proposals. Do not
+  silently fix.
 
 The repair direction differs by document:
 
 - **Code vs Anatomy:** code is normally the current structural fact. Repair
-  stale paths, citations, connections, composition, or state descriptions in
-  the same PR. If the code move itself is defective, fix/report the code rather
-  than encoding a false map.
-- **Code vs Contract:** do not rewrite the promise to match accidental behavior.
-  Treat implementation as defective unless an authorized contract change
-  updates the Port, affected Adapters, contract version, and shared tests.
+  stale paths, citations, connections, composition, or state descriptions. If
+  the code move itself is defective, fix or report the code rather than
+  encoding a false map.
+- **Code vs Contract:** do not rewrite the promise to match accidental
+  behavior. Treat implementation as defective unless an authorized contract
+  change updates the Port, affected Adapters, contract version, and shared
+  tests.
 
-Every code change that moves or renames mapped symbols, changes ownership or
-connections, or changes persistent/ephemeral state updates the relevant anatomy
-in the same commit. Verify touched citations and run the repository's
-architecture-document validator plus the anatomy drift checker.
+Verify every touched citation, then run the repository's architecture-document
+validator and the drift checker below.
+
+## Drift checker
+
+This skill owns the canonical advisory citation-rot checker. Run it from the
+repository root (cwd is taken as the repo root):
+
+```bash
+# Report only; exits 0 even when drift is found.
+python src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py
+# CI / pre-commit gate: exits 1 if any drift is found.
+python src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --check
+# Narrow the scan (default: src).
+python src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py --root src/lingtai/kernel
+```
+
+It catches only mechanical citation rot — a `file.py:line` target that is
+missing or past end-of-file. An in-range citation can still point at the wrong
+code, so an agent must open the cited line to confirm the claim.
+
+`scripts/bench_agent_session_rebuild.py` is the companion benchmark cited by
+`src/lingtai/kernel/ANATOMY.md` for the tiered `rebuild_agent_session_from_events()`
+path; it takes `--events`/`--molt-every` against a synthetic temp agent dir, or
+`--agent-dir <path>` to time an existing one.
 
 ## Fallback essentials
 

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -1,5 +1,5 @@
 ---
-last_changed_at: 2026-07-08T14:30:00-07:00
+last_changed_at: 2026-07-19T00:00:00Z
 name: nokv-workbench
 description: >
   Thin routing manual for NoKV-controlled workbenches. Use when an agent is
@@ -28,25 +28,18 @@ manual.
 
 ## MCP registration
 
-Register the MCP with a per-agent `mcp_registry.jsonl` line like:
+Add one line to the per-agent `mcp_registry.jsonl` (copy
+`assets/mcp_registry.example.jsonl`):
 
 ```json
 {"name":"nokv-workbench","summary":"NoKV-controlled workbench artifact namespace.","transport":"stdio","command":"/path/to/nokv","args":["--server-bind","127.0.0.1:7777","--object-backend","rustfs","--s3-bucket","nokv-lingtai-workbench","mcp","--profile","workbench","--workbench-root","/agents/{agent_id}/wb"],"source":"local-nokv"}
 ```
 
-Activate it from `init.json`:
-
-```json
-{
-  "mcp": {
-    "nokv-workbench": {
-      "type": "stdio",
-      "command": "/path/to/nokv",
-      "args": ["--server-bind", "127.0.0.1:7777", "--object-backend", "rustfs", "--s3-bucket", "nokv-lingtai-workbench", "mcp", "--profile", "workbench", "--workbench-root", "/agents/{agent_id}/wb"]
-    }
-  }
-}
-```
+Activate the same `command` and `args` from `init.json` under
+`mcp.nokv-workbench` with `"type": "stdio"` — copy `assets/init-snippet.json`.
+Where the registry file lives, how to edit it, and how `system(action="refresh")`
+applies the change belong to `mcp-manual`; only the NoKV-specific arguments
+are documented here.
 
 Keep the global NoKV flags before `mcp`, and set them to the same metadata
 server and object-store bucket used by the running NoKV service. If your
@@ -83,16 +76,6 @@ LingTai's local `read`, `write`, `edit`, `grep`, or `glob` tools.
 Each workbench id maps to `<workbench-root>/<id>/` (with the per-agent root
 above, `/agents/<agent_id>/wb/<id>/`) with these sections:
 
-```text
-input/
-scripts/
-outputs/
-logs/
-metadata/
-```
-
-Use the sections consistently:
-
 | Section | Contents |
 |---|---|
 | `input` | task event payloads, dataset references, parameters |
@@ -107,13 +90,11 @@ local LingTai workdir.
 
 ## Workflow
 
-1. Create the workbench:
+1. Create the workbench with `workbench_create`:
 
 ```json
 {"id":"spedas-task-001"}
 ```
-
-with `workbench_create`.
 
 2. Write inputs, scripts, outputs, and evidence with
    `workbench_put_file`. Pass `replace=true` only when intentionally
@@ -159,13 +140,9 @@ with `workbench_create`.
 `workbench_commit` publishes `metadata/run_manifest.json`. In v0 this file
 is the completion marker. A workbench without it is not complete.
 
-6. Snapshot the committed workbench with `workbench_snapshot`, giving it a
-   `name` (a stable checkpoint alias) and a `ttl_days` that outlasts how long
-   the handoff must stay restorable (default lease is 7 days). In final reports
-   or handoff notes, cite the checkpoint `name`, its `snapshot_id`, and the
-   returned `lease_expires_at` so a later reader knows both what to restore and
-   when it reaps. If the note must outlive the lease, call
-   `workbench_snapshot_renew` first — see "Checkpoints and leases".
+6. Snapshot the committed workbench with `workbench_snapshot`, choosing a
+   `ttl_days` that outlasts how long the handoff must stay restorable — see
+   "Checkpoints and leases" for naming, lease, renewal, and citation rules.
 
 ## Checkpoints and leases
 
@@ -176,7 +153,8 @@ failure mode that strands handoffs — a `snapshot_id` cited in a note, then
 unreachable a couple of days later because nobody extended it.
 
 **The default lease is 7 days, but only when you mint through this tool.** Pass
-`ttl_days` to `workbench_snapshot` to choose the lease (default 7, maximum 90):
+`ttl_days` to `workbench_snapshot` to choose the lease (default 7, maximum 90),
+along with a `name`:
 
 ```json
 {"id":"spedas-task-001","name":"final-v1","ttl_days":30}
@@ -192,18 +170,18 @@ handoff.
 read by, instead of memorizing an opaque `snapshot_id`. The name is the durable
 handle; the id is for pinning an exact version.
 
+In final reports or handoff notes, cite the checkpoint `name`, its
+`snapshot_id`, and the returned `lease_expires_at` so a later reader knows both
+what to restore and when it reaps.
+
 ### Renew before a handoff outlives the lease
 
 If a checkpoint must survive longer than its lease — a cross-session handoff, a
-note someone opens next week — renew it **before** you commit or hand off:
-
-```json
-{"id":"spedas-task-001","name":"final-v1","ttl_days":30}
-```
-
-with `workbench_snapshot_renew`. Renew is **extend-only**: it pushes
-`lease_expires_at` further out and never pulls it in, so a `ttl_days` that would
-shorten the lease is ignored. Address the checkpoint by `name` or `snapshot_id`.
+note someone opens next week — call `workbench_snapshot_renew` **before** you
+commit or hand off, with the same argument shape as `workbench_snapshot` above.
+Renew is **extend-only**: it pushes `lease_expires_at` further out and never
+pulls it in, so a `ttl_days` that would shorten the lease is ignored. Address
+the checkpoint by `name` or `snapshot_id`.
 
 ### Discover checkpoints with workbench_snapshot_list
 
@@ -266,10 +244,6 @@ Reading inside one workbench:
 - Files larger than the structured limit: use `format="bytes"` with
   `offset`/`limit` ranges (bytes come back base64-encoded), or
   `workbench_grep` to locate lines first.
-- To read a past checkpoint instead of the current state, pass `at_snapshot`
-  (a checkpoint `name` or `snapshot_id`) to `workbench_read`, `workbench_list`,
-  or `workbench_stat`. Reaped checkpoints error loudly — see "Checkpoints and
-  leases".
 - Record shape depends on content type: `.json` files parse into JSON
   records; `.jsonl`, `.log`, and other text files come back as `text_lines`
   records whose `value.text` holds the raw line — parse it yourself when the
@@ -282,6 +256,8 @@ Reading inside one workbench:
   `glob` (basename match, `*` and `?`, CJK-safe, e.g. `"*.md"`). `limit`
   accepts up to 300 matches. Narrow with `section`/`glob` first; huge result
   sets get compacted out of your context later.
+- To read a past state instead of the current one, pass `at_snapshot` — see
+  "Checkpoints and leases".
 
 Searching across workbenches:
 
@@ -296,13 +272,12 @@ Searching across workbenches:
   (no index registration needed): `path`, `name`, `kind`, `size_bytes`,
   `body.content_type`, `body.producer`, `body.manifest_id`. A single
   `workbench_search` with `facets: ["body.content_type"]` replaces a
-  list-then-stat sweep.
+  list-then-stat sweep. **It matches paths and metadata, not file contents —
+  content search stays with `workbench_grep`.**
 - `workbench_aggregate` computes count/sum/avg/min/max with `group_by` over
   the same fields. `workbench_catalog` lists the queryable fields; until
   custom indexes exist it always returns the built-in set above, so calling
   it is rarely necessary.
-- **Content search stays with `workbench_grep`** — `workbench_search`
-  matches paths and metadata, not file contents.
 
 `workbench_search`, `workbench_grep`, `workbench_list`, `workbench_stat`,
 and `workbench_read` return flat `section`, `relative_path`, and `path`

--- a/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/assets/PREFLIGHT.md
@@ -2,7 +2,7 @@
 related_files:
 - src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
 maintenance: |
-  Developer-facing TUI deployment preflight pointed to by nokv-workbench/SKILL.md:49; update it whenever the workbench MCP tool surface (9-tool vs 16-tool, checkpoint-lifecycle fields) or the runtime-version compatibility check changes.
+  Developer-facing TUI deployment preflight pointed to by nokv-workbench/SKILL.md; update it whenever the workbench MCP tool surface (9-tool vs 16-tool, checkpoint-lifecycle fields) or the runtime-version compatibility check changes.
 ---
 
 # TUI runtime preflight (developer-facing)
@@ -34,18 +34,17 @@ print((root / "nokv-workbench" / "SKILL.md").exists())
 PY
 ```
 
-Tool-surface note: the 16-tool surface documented in SKILL.md (including
-workbench_append / workbench_edit / workbench_search / workbench_aggregate /
-workbench_catalog and conditional reads) requires a NoKV build that ships the
-specialized workbench MCP. Older 9-tool NoKV servers still work with this
-skill; the extra tools are simply absent from tools/list and the SKILL
-sections about them do not apply.
+Tool-surface note: parts of the SKILL.md surface depend on the NoKV build. An
+older server still works with this skill — the newer tools and parameters are
+simply absent from tools/list, and the SKILL sections about them do not apply.
 
-The checkpoint-lifecycle surface — workbench_snapshot_renew and
-workbench_snapshot_list, the workbench_snapshot `name`/`ttl_days` parameters
-and its `lease_expires_at`/`expiry_warning` output, and the `at_snapshot`
-parameter on workbench_read / workbench_list / workbench_stat — needs a NoKV
-build that ships Phase 1 snapshot leasing. Against an older build these tools
-and parameters are absent, and the "Checkpoints and leases" SKILL section does
-not apply; snapshots there fall back to the legacy 1-hour lease with no
-renewal path.
+- **16-tool workbench MCP** (workbench_append / workbench_edit /
+  workbench_search / workbench_aggregate / workbench_catalog and conditional
+  reads) requires a build shipping the specialized workbench MCP; older 9-tool
+  NoKV servers lack it.
+- **Checkpoint lifecycle** (workbench_snapshot_renew, workbench_snapshot_list,
+  the workbench_snapshot `name`/`ttl_days` parameters and its
+  `lease_expires_at`/`expiry_warning` output, and the `at_snapshot` parameter
+  on workbench_read / workbench_list / workbench_stat) requires a build
+  shipping Phase 1 snapshot leasing. Without it, snapshots fall back to the
+  legacy 1-hour lease with no renewal path.

--- a/src/lingtai/intrinsic_skills/notification-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/SKILL.md
@@ -9,7 +9,7 @@ description: >
   large-result compaction remains owned by summarize-manual.
 version: 0.4.0
 tags: [lingtai, notifications, channels, dismiss, manual, force, stale, nudge]
-last_changed_at: "2026-07-12T20:20:43-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/tools/notification/__init__.py
 - src/lingtai/tools/notification/schema.py
@@ -50,11 +50,11 @@ do not voluntarily call `check` again merely to confirm the clear.
 <agent>/.library/intrinsic/capabilities/notification-manual/SKILL.md
 ```
 
-Success returns exactly `status`, `notification_manual`, and `manual_path`.
-A missing installed file returns `status: degraded`, an empty
+Success returns exactly `status`, `notification_manual`, and `manual_path`. A
+missing installed file returns `status: degraded`, an empty
 `notification_manual`, the same fixed `manual_path`, and an actionable `error`
-that points to an initializer or capability-install problem. It never falls back
-to a source checkout and never touches `.notification/`, the Notification Store,
+naming an initializer or capability-install problem. It never falls back to a
+source checkout and never touches `.notification/`, the Notification Store,
 producer state, delivery fingerprints, or acknowledgement state.
 
 ## Nested reference catalog
@@ -88,22 +88,20 @@ producer state, delivery fingerprints, or acknowledgement state.
 
 ## Safety boundaries to keep resident
 
-- `manual` is documentation retrieval only; it is not a notification-state read.
-- `check` is the notification-state read and does not itself write state.
+- `check` is the notification-state read; `manual` is documentation retrieval
+  only. Neither writes notification state.
 - Generic dismiss clears a notification mirror, never producer-owned canonical
   state. Prefer the producer's own verb when one exists.
 - `force=true` is for knowingly clearing a stale or guarded mirror. It does not
   override protected source-of-truth channels and never mutates producer state.
 - Large tool results are ranked under
   `_meta.agent_meta.agent_state.current_tool_result_chars`, not emitted as new
-  notifications. Follow `../system-manual/reference/summarize-manual/SKILL.md`; do not invent a second
-  summarization procedure here.
+  notifications. Follow `../system-manual/reference/summarize-manual/SKILL.md`;
+  do not invent a second summarization procedure here.
 
 ## Why the boundary is split this way
 
 The filesystem protocol lets in-process and external producers publish one
-current surface without sharing a queue. Atomic action names make the clearing
-target explicit. Producer guards prevent a mirror clear from being mistaken for
-handling source-of-truth state. The read-only `manual` action completes
-progressive disclosure without coupling documentation access to notification
-persistence, delivery, or dismissal policy.
+current surface without sharing a queue; atomic action names make the clearing
+target explicit; producer guards keep a mirror clear from being mistaken for
+handling source-of-truth state.

--- a/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
@@ -8,7 +8,7 @@ description: >
   producing, or debugging notification payloads; skip for dismissal policy.
 version: 0.1.0
 tags: [lingtai, notifications, channels, protocol, sync, nudge]
-last_changed_at: "2026-07-15T12:00:00-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/notification-manual/SKILL.md
 - src/lingtai/tools/notification/schema.py
@@ -110,7 +110,7 @@ clearing guarded, stale, protected, or event-granular state.
 ## Footprint
 
 The protocol footprint is `.notification/<channel>.json` plus kernel-owned
-notification metadata such as legacy acknowledgement state. Inspect it
-read-only before diagnosing a producer. Do not delete the directory or bulk
-remove files: use the producer's action or an authorized atomic notification
-action so guards and stale checks remain effective.
+notification metadata such as legacy acknowledgement state. Inspect it read-only
+before diagnosing a producer. Never delete the directory or bulk-remove files —
+that bypasses the guards and stale checks that only the producer verb or an
+atomic notification action honor.

--- a/src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
@@ -9,7 +9,7 @@ description: >
   summarize-manual instead.
 version: 0.1.0
 tags: [lingtai, notifications, dismiss, force, stale, safety]
-last_changed_at: "2026-07-12T20:20:43-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/notification-manual/SKILL.md
 - src/lingtai/tools/notification/__init__.py
@@ -77,10 +77,6 @@ notification(
 )
 ```
 
-A dismissal clears only the notification surface. It never removes producer
-history, mailbox state, goal semantics, or the underlying result that caused a
-legacy reminder.
-
 ## Large results and legacy reminder escape hatch
 
 New large tool results are not notification events. The kernel ranks formal
@@ -104,16 +100,17 @@ system events, so prefer event/ref targeting. Dismissal acknowledges and removes
 the reminder surface only; the original tool result remains unchanged in chat
 history and `events.jsonl`.
 
-## Refusal checklist
+## On a refusal
 
-1. Confirm the channel and whether its `instructions` name a producer action.
-2. If the reason is stale, read the current delivered payload before deciding on
-   `force=true`.
-3. If the channel is protected, follow its owning manual rather than retrying.
-4. If `post-molt` lacks a reason, record the real continue/defer/obsolete
+1. Check whether the channel's `instructions` name a producer action; if so, use
+   it instead of retrying the generic dismiss.
+2. Stale — read the current delivered payload before deciding on `force=true`.
+3. Protected — follow the channel's owning manual; do not retry.
+4. `post-molt` without a reason — record the real continue/defer/obsolete
    decision.
-5. If the target is one system event, use `dismiss_event` or `dismiss_ref`, not a
+5. Targeting one system event — use `dismiss_event`/`dismiss_ref`, not a
    whole-channel clear.
 
-These rules prevent a notification mirror operation from silently becoming a
-producer-state decision or from erasing concurrent unseen events.
+These rules keep a mirror operation from silently becoming a producer-state
+decision or erasing concurrent unseen events. No dismissal ever removes producer
+history, mailbox state, or goal semantics.

--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -3,7 +3,7 @@ name: psyche-manual
 description: |
   Router and operational guide for the psyche tool — molt, pad management, session journaling, and post-wipe recovery. Read this when: you are about to molt; you need to tend the four durable stores; you want guidance on writing a good summary or session journal; you wake up after a system-performed wipe with a system-authored summary; or you need to understand keep_tool_calls, keep_last, and pad.append. Routes consequential molt handoffs to assets/molt-template.md while keeping routine guidance compact.
 version: 1.1.0
-last_changed_at: "2026-07-06T14:50:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/psyche/__init__.py
 - src/lingtai/tools/psyche/_molt.py
@@ -72,7 +72,7 @@ reachable only through the parent index. That is why the parent must list every
 child explicitly. See the knowledge manual's "Nesting and sub-knowledge" section
 (`.library/intrinsic/capabilities/knowledge/SKILL.md`) for the structural rule.
 
-The directory name is `<YYYY-MM-DD>-molt-<molt-count>-<slug>`. Read the molt count from your resident system prompt's identity section — "You have undergone N molts since birth." Use that N: the entry records the pre-molt segment, written *before* you call `psyche(context, molt)`. (The molt tool result afterward reports the next count, N+1; that belongs to the next segment, not this one.) Embedding the count keeps chronology stable when you molt more than once on the same date: the date alone cannot order two same-day entries, but the molt count always can.
+The directory name is `<YYYY-MM-DD>-molt-<molt-count>-<slug>`. Read `<molt-count>` from your resident system prompt's identity section — "You have undergone N molts since birth." Use that N: the entry records the pre-molt segment. Embedding the count keeps chronology stable when you molt more than once on the same date, which the date alone cannot order.
 
 **The parent `knowledge/session-journal/KNOWLEDGE.md` is routing-only** — short,
 scannable, progressive-disclosure. It is a table of contents, not a journal. One
@@ -81,20 +81,9 @@ line per sub-entry: date, slug, one-sentence hook, and the child's *relative* pa
 Never let narrative leak into the parent — if a line grows past its hook, the
 detail belongs in the child.
 
-**The sub-entry `<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md` is the substance** — write it as the molt-history record of the segment, *before* you molt. Use `assets/session-journal-entry-template.md` from this skill directory for the frontmatter (including the `molt_count` field **and the required `type: session-journal` marker**) and section layout. This sub-entry's path is what you pass to `psyche(context, molt, session_journal_path=...)`, and the kernel validates the marker before letting the molt proceed (see §6). It is a journal, not a transcript — capture, in roughly this shape:
+**The sub-entry `<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md` is the substance** — write it as the molt-history record of the segment, *before* you molt, via `write`/`edit` directly. Read `assets/session-journal-entry-template.md` from this skill directory for the frontmatter (including `molt_count`, the required `type: session-journal` marker, and the YAML block-scalar `description` that keeps a `: ` in the text from breaking the gate) and the section layout. It is a journal, not a transcript. Several thousand tokens is fine when the segment was rich; keep it concise when it was small.
 
-**YAML frontmatter safety:** `name` and `description` are real YAML, not free-form text. Prefer the template's `description: >-` block scalar. If you write a one-line value containing a colon followed by a space (for example `description: Session record for runtime relay: cache handoff`), YAML treats the second colon as a mapping separator and the molt gate rejects the file. Quote the value or use the block scalar, then retry the same `psyche(context, molt, session_journal_path=...)` call.
-
-- **Top-of-entry timestamp + TL;DR** *(soft convention)* — open the body with a visible timestamp and a one- or two-line gist before the sections, so the next you can date and grasp the entry at a glance; the molt gate validates only frontmatter, never this
-- **What the segment was about** — the original ask, the framing
-- **Accomplishments** — what you completed/moved forward, the outputs, who was told and where
-- **Decisions and their reasoning** — the *why*, especially where an alternative was rejected
-- **Artifacts and paths** — files, reports, branches, PRs, commits, message IDs that anchor the work; reference paths/IDs, never inline secrets or large blobs
-- **Open tasks** — things noticed or started but deferred, each with a next step
-- **Collaborators** — who is involved, their channels, who is waiting on what
-- **Gotchas and lessons** — actionable warnings and failed approaches
-
-Several thousand tokens is fine when the segment was rich; keep it concise when it was small. The `<YYYY-MM-DD>-molt-<molt-count>-<slug>` prefix keeps chronology visible and stable in `ls` even across multiple molts on one day. Each child is sub-knowledge under the routing parent — the scanner does not catalog it separately, so it is reachable only via the parent index; that is why you append the index line below. Write files via `write`/`edit` directly.
+This sub-entry's path is what you pass to `psyche(context, molt, session_journal_path=...)`, and the kernel validates it before letting the molt proceed (see §6).
 
 Updating the parent index at each session is part of the practice — append one line referencing the new sub-entry. Then write the successor summary (§6), which points back at this entry's path.
 
@@ -172,25 +161,19 @@ For a routine molt, include:
 - **The session journal sub-entry path** — so the next you can read the full narrative
 - **Anything else worth carrying forward** — insights, gotchas
 
-For a consequential molt — long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, or any handoff the next you could not reconstruct quickly — read `assets/molt-template.md` from this skill directory and use the full scaffold there. Fill every section; write `None` rather than omitting a section.
-
 Quick routing:
 
 | Need | Use |
 |---|---|
 | Routine molt | The short bullet list above. |
-| Consequential molt / successor handoff | Read `assets/molt-template.md` from this skill directory; use its full scaffold and checklist. |
+| Consequential molt / successor handoff — long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, or any handoff the next you could not reconstruct quickly | Read `assets/molt-template.md` from this skill directory; use its full scaffold and checklist. Fill every section; write `None` rather than omitting one. |
 | Unsure whether the handoff is complex | Use the asset; extra structure is cheaper than a bad handoff. |
 
 Before you call `psyche(object="context", action="molt", ...)`, always verify at minimum:
 
-- The just-finished session segment is recorded as a session-journal sub-entry
-  (your molt history) under `knowledge/session-journal/`, using
-  `assets/session-journal-entry-template.md` — see §4. Write this *before* the
-  summary; it is the narrative the summary points back to. **Its path is the
-  required `session_journal_path` argument and the kernel validates it before
-  shedding context** — the journal must carry the `type: session-journal`
-  marker or the molt is refused.
+- The session-journal sub-entry for the just-finished segment exists and is
+  written *before* the summary (§4) — it is the narrative the summary points
+  back to, and its path is the validated `session_journal_path`.
 - Durable stores and session journal were updated where needed before writing the summary.
 - Every outstanding task has an explicit next action.
 - Collaborators, channels, approvals, and key paths are named where relevant.
@@ -205,7 +188,7 @@ Before you call `psyche(object="context", action="molt", ...)`, always verify at
 
 Context pressure is agent state, not a dismissible notification. Tool results surface a natural-language reminder under `_meta.agent_meta.agent_state.context.molt` only after context has stayed high for several consecutive fresh provider rounds (the sustained-pressure threshold is 85%). It rides on the current `agent_meta` snapshot (carried on the designated final result of each batch; restamped there while active) so the reminder persists. The field name is historical: the reminder is a context-pressure action, not an early staged molt order or a machine-readable tag block.
 
-When this reminder appears, batch already-digested noisy history before summarizing. Repeated summarize calls while context stays above 85% substantially hurt token efficiency, so avoid summarizing one small piece at a time. If a batched summarize/reconstruction pass still leaves context above 85%, stop repeating summarize, tend durable stores, and molt deliberately. If context falls below the high-pressure threshold but remains above the recovery target, continue only when the current task still needs the carried context; otherwise molt at a natural task boundary. The reminder points back to this manual/procedure without inlining the full workflow.
+When this reminder appears, batch already-digested noisy history into one summarize pass rather than summarizing a small piece at a time — the summarize cadence, rebuild semantics, and recovery target are owned by `system-manual` → `reference/summarize-manual/SKILL.md`. The molt decision is yours: if a batched summarize/reconstruction pass still leaves context above 85%, stop repeating summarize, tend durable stores, and molt deliberately. If context falls below 85% but stays above the recovery target, continue only when the current task still needs the carried context; otherwise molt at a natural task boundary.
 
 ### Cache-miss budget
 

--- a/src/lingtai/intrinsic_skills/psyche-manual/assets/molt-template.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/assets/molt-template.md
@@ -51,17 +51,13 @@ Fill every section. Write `None` rather than omitting a section. This template i
 
 Before you call `psyche(object="context", action="molt", summary=..., session_journal_path=...)`, verify:
 
-- The just-finished session segment is recorded as a session-journal child
-  (your molt history) — sub-knowledge under the routing parent
-  `knowledge/session-journal/KNOWLEDGE.md`, at
+- The just-finished session segment is recorded as a session-journal child at
   `knowledge/session-journal/<YYYY-MM-DD>-molt-<molt-count>-<slug>/KNOWLEDGE.md`,
-  written from `assets/session-journal-entry-template.md`, before the summary. It
-  is NOT a top-level knowledge entry. **Its frontmatter carries the
-  `type: session-journal` marker and its path is the required
-  `session_journal_path` argument — the kernel validates it and refuses the molt
-  (before shedding any context) if it is missing, mislocated, or unmarked.** The
-  parent index has a new one-line, relative-path hook for it, and the summary
-  points at the child's path.
+  written before the summary — **its path is the required
+  `session_journal_path` argument and the kernel refuses the molt, before
+  shedding any context, if it is missing, mislocated, or unmarked** (see
+  psyche-manual §4 and §6). The parent index has a new one-line, relative-path
+  hook for it, and the summary points at the child's path.
 - Pad, lingtai/character, knowledge, skills, and session journal were updated where needed before writing the summary.
 - Every outstanding task has an action checklist entry.
 - Every action names who/where and what exact content or command is needed.

--- a/src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/assets/session-journal-entry-template.md
@@ -26,14 +26,9 @@ where the substance lives, and stop. Reference paths/PRs/message IDs — never
 inline secrets or full file contents. After writing it, append one line to the
 parent index at `knowledge/session-journal/KNOWLEDGE.md`.
 
-It also helps to open the body with an **immediately visible timestamp and a
-one- or two-line TL;DR** before the sections — so the next you can date the
-entry and grasp its gist at a glance without reading the whole record. This is a
-soft convention, not a gate: the molt validator checks only the frontmatter
-marker and structure, never the body. Skip or reshape it when it does not fit.
-
 The frontmatter below is the on-disk format; fill every section, writing `None`
-rather than omitting one.
+rather than omitting one. The molt validator checks only the frontmatter marker
+and structure, never the body.
 
 > **Required marker (the molt gate):** the frontmatter **must** include
 > `type: session-journal` (or, equivalently, `session_journal: true`). The

--- a/src/lingtai/intrinsic_skills/read-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/read-manual/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: read-manual
-description: "Complete guide for the read tool: continuation workflow, next_offset pagination, line_truncated handling, runtime tool-result spill vs read-level pagination, 50k read default / 200k runtime hard cap, and when to use bash/grep/sed for truncated lines. Use when implementing complete file-read workflows, handling large files, or understanding cap and truncation semantics."
+description: "Complete guide for the read tool: continuation workflow, next_offset pagination, line_truncated handling, runtime tool-result spill vs read-level pagination, 100k read default / 200k runtime hard cap, and when to use bash/grep/sed for truncated lines. Use when implementing complete file-read workflows, handling large files, or understanding cap and truncation semantics."
 version: 0.1.0
 tags: [read, files, continuation, truncation, cap, pagination]
-last_changed_at: "2026-06-27T02:45:37-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/tools/read/__init__.py
 - src/lingtai/intrinsic_skills/file-manual/SKILL.md
@@ -13,87 +13,78 @@ maintenance: |
 
 # Read Manual
 
-This skill documents the complete workflow for reading files with the `read` tool.
-For basic tool choice (read vs write vs edit vs grep vs glob), see the `file-manual` skill.
+Complete workflow for reading files with the `read` tool. Load it for large
+files, complete-content workflows, truncation, or `line_truncated` results.
 
-## Cap model: 100k read default, 200k runtime hard ceiling
+For basic tool choice (read vs write vs edit vs grep vs glob), UTF-8 policy, and
+the shared `action="manual"` versus ordinary-call rule, see the `file-manual`
+skill — including that repeating an identical manual call is an error loop, not
+progress. After this manual returns, continue the original task with an ordinary
+read.
 
-Before using `read`, load this manual when you are dealing with large files,
-complete-content workflows, truncation, or `line_truncated` results.
+## Two caps
 
-There are two limits:
+| Cap | Value | Configurable |
+|---|---|---|
+| `read` per-call page budget | **100 000 chars** (default) | yes, via per-call `max_chars` |
+| Runtime tool-result hard ceiling | **200 000 chars** | no — not by agents or prompts |
 
-- `read` default page budget: **100 000 characters per call**.
-- Runtime tool-result hard ceiling: **200 000 characters**. This ceiling is not
-  configurable by agents or prompts; it prevents provider-visible tool results
-  from exploding.
-
-`read` accepts an optional per-call `max_chars` parameter. Use it to request a
-smaller or larger chunk for that call. Values above the runtime hard ceiling are
-clamped to 200 000; the actual effective value appears as `cap_chars` when the
-result is truncated. Do not assume the old 10 000-character or 8 000-character
+`max_chars` requests a smaller or larger chunk for one call. Values above the
+hard ceiling are clamped to 200 000; the effective value appears as `cap_chars`
+when the result is truncated. Do not assume the old 10 000- or 8 000-character
 limits from earlier versions.
 
-## Recommended metadata/stats preflight
+These two caps act at different layers:
 
-For unknown or large files, inspect cheap metadata before reading big chunks. This
-replaces a dedicated `read(dry_run=true)` mode: use local tools to learn the shape
-of the file, then choose `offset`, `limit`, and `max_chars`.
+1. **Read-level pagination** — exceeding the effective per-call budget returns
+   `truncated=true` plus continuation metadata. You page on with `next_offset`.
+2. **Runtime preventive ceiling** — `ToolExecutor` applies the non-configurable
+   200k cap to every tool result just before it reaches the LLM wire. A result
+   still over the ceiling is written to `<workdir>/tmp/tool-results/<…>` and
+   replaced on the wire by a compact manifest containing `status="spilled"`,
+   `spill_path`, `artifact`, `preview`, and `original_char_count`.
+
+A well-formed `read` result normally stays under the outer ceiling because
+`max_chars` is clamped to 200k. If you still see a spill manifest from `read`,
+inspect the `spill_path` artifact, then re-call `read` with a smaller
+`limit`/`max_chars` or process the artifact via `bash`/`grep`/Python.
+
+## Metadata/stats preflight
+
+For unknown or large files, inspect cheap metadata before reading big chunks.
+This replaces a dedicated `read(dry_run=true)` mode.
 
 ```bash
-# File size in bytes
 python - <<'PY'
 from pathlib import Path
 p = Path('/path/to/file')
-print(p.stat().st_size)
-PY
-
-# Total lines and longest physical line
-python - <<'PY'
-from pathlib import Path
-p = Path('/path/to/file')
-max_len = 0
-max_line = 0
-count = 0
+count = max_len = max_line = 0
 with p.open('r', encoding='utf-8', errors='replace') as f:
     for i, line in enumerate(f, 1):
         count = i
-        n = len(line)
-        if n > max_len:
-            max_len = n
-            max_line = i
-print({'lines': count, 'longest_line': max_line, 'longest_chars': max_len})
-PY
-
-# Preview line lengths around a target region
-python - <<'PY'
-from pathlib import Path
-p = Path('/path/to/file')
-for i, line in enumerate(p.open('r', encoding='utf-8', errors='replace'), 1):
-    if 100 <= i <= 120:
-        print(i, len(line))
+        if len(line) > max_len:
+            max_len, max_line = len(line), i
+print({'bytes': p.stat().st_size, 'lines': count,
+       'longest_line': max_line, 'longest_chars': max_len})
 PY
 ```
 
-Use the result to decide:
+Use the result to choose the window:
 
-- `limit` = how many lines to request.
-- `max_chars` = per-call character budget (default 100k, max 200k).
-- `offset` = where to begin or resume.
+- `offset` — where to begin or resume (1-based).
+- `limit` — how many lines to request; a tight `limit` (e.g. `50`) narrows the
+  window, and a large `offset` with a small `limit` reads an arbitrary slice.
+- `max_chars` — per-call character budget (default 100k, max 200k).
 
 ## Complete-content workflow
 
-For any file that may be larger than the cap, follow this loop:
+For any file that may exceed the cap:
 
 1. Call `read` with the desired `offset` (default 1) and `limit`.
-2. Check the result for `truncated=true`.
-   - If absent or `false`: the entire requested range was returned. Done.
-   - If `true`: proceed to step 3.
-3. Note `next_offset` from the result metadata.
-4. Call `read` again with `offset=next_offset` (keep the same `limit`).
-5. Repeat until `truncated` is absent or `false`.
-
-Minimal Python pseudocode:
+2. If `truncated` is absent or `false`, the whole requested range was returned —
+   done. If `true`, continue.
+3. Re-call with `offset=next_offset`, keeping the same `limit`, until
+   `truncated` is absent or `false`.
 
 ```python
 offset = 1
@@ -121,65 +112,29 @@ When `truncated=true` the result includes:
 | `remaining_lines_estimate` | approximate lines still unread |
 | `line_truncated` | `true` only when a single physical line exceeded the cap |
 
-## When to reduce offset or limit
-
-If you need a smaller window (to avoid transport spill or to target a region):
-
-- Pass a smaller `limit` (e.g., `limit=50`) to get fewer lines per call.
-- Pass a specific `offset` to jump directly to a region (e.g., `offset=500`).
-- Combining a large `offset` with a small `limit` reads an arbitrary slice.
-
-## Runtime tool-result spill vs read-level pagination
-
-Two separate caps apply:
-
-1. **Read-level pagination cap**: the effective per-call budget chosen by
-   `max_chars` or the 100k default. When content exceeds this cap, the result is
-   returned with `truncated=true` and continuation metadata. The agent reads the
-   next chunk by calling `read` again with `next_offset`.
-
-2. **Runtime preventive hard ceiling**: the non-configurable 200k cap applied by
-   `ToolExecutor` to every tool result just before it reaches the LLM wire. If
-   any result still exceeds this ceiling, the full content is written to
-   `<workdir>/tmp/tool-results/<…>` and a compact manifest replaces the wire
-   payload. The manifest contains `status="spilled"`, `spill_path`, `artifact`,
-   `preview`, and `original_char_count`.
-
-A well-formed `read` result should normally stay under the outer hard ceiling
-because `max_chars` is clamped to 200k. If you still see a spill manifest from
-`read`, inspect the `spill_path` artifact for the full payload; then re-call
-`read` with a smaller `limit`/`max_chars` or process the artifact via
-`bash`/`grep`/Python.
-
 ## Handling line_truncated=true
 
-`line_truncated=true` appears when a single physical line in the file is longer than the
-cap. In that case:
+`line_truncated=true` appears when a single physical line is longer than the cap.
+Then:
 
 - The result contains only a **prefix** of that line (bounded by the cap).
 - `next_offset` points to the **next line**, not to a mid-line continuation.
-- The hidden tail of the long line is **not recoverable** through further `read` calls.
+- The hidden tail of the long line is **not recoverable** through further `read`
+  calls.
 
 To inspect a long line fully, use targeted local processing instead of `read`:
 
 ```bash
-# Print one specific line (e.g., line 42):
-sed -n '42p' /path/to/file
+sed -n '42p' /path/to/file                        # print one specific line
+awk '{print NR, length($0)}' /path/to/file | head -20   # characters per line
+grep -n "pattern" /path/to/file                   # search within a long line
 
-# Count characters on each line:
-awk '{print NR, length($0)}' /path/to/file | head -20
-
-# Search within a long line:
-grep -n "pattern" /path/to/file
-
-# Extract a byte range from a long line with Python:
+# Extract a byte range from a long line
 python - <<'PY'
 with open('/path/to/file') as f:
     for i, line in enumerate(f, 1):
         if i == 42:
-            print(line[0:2000])   # first 2000 chars
-            print("...")
-            print(line[-500:])    # last 500 chars
+            print(line[0:2000], "...", line[-500:], sep="\n")
             break
 PY
 ```
@@ -188,22 +143,15 @@ PY
 
 Before calling `read`:
 
-- Is the file large? Start with `limit=100` or `limit=200` to probe.
-- Do you need the whole file? Use the continuation loop above.
-- Does the result show `line_truncated=true`? Switch to `bash`/`grep`/`sed`/Python.
-- Does the result show `status=spilled`? Read the `spill_path` artifact or reduce `limit`.
-- Do you need a specific region? Pass `offset` and a tight `limit`.
-
+- Large file? Probe with `limit=100`–`200`, or run the preflight above.
+- Need the whole file? Use the continuation loop.
+- `line_truncated=true`? Switch to `bash`/`grep`/`sed`/Python.
+- `status=spilled`? Read the `spill_path` artifact or reduce `limit`.
+- Need a specific region? Pass `offset` and a tight `limit`.
 
 ## Manual versus ordinary reads
 
-Normal reading is primary:
-
-- For backward compatibility, an ordinary read may omit `action` or set
-  `action="read"`, then provide `file_path` and any window controls.
-- Use `action="manual"` as a one-time entry when you need this guide. It
-  returns the installed manual and does not read a target file.
-
-After the manual returns, continue the original task with an ordinary read.
-Do not request the same manual again. Repeating an identical manual call is
-an error loop, not progress.
+For backward compatibility, an ordinary read may omit `action` or set
+`action="read"`. Use `action="manual"` only as a one-time entry to this guide.
+After the manual returns, continue the original task with an ordinary read; do
+not repeat the same manual call. Repeating it is an error loop, not progress.

--- a/src/lingtai/intrinsic_skills/soul-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/soul-manual/SKILL.md
@@ -3,7 +3,7 @@ name: soul-manual
 description: |
   Operational guide for the `soul` tool — your inner voice. Read this when: you call `soul(action='flow')` and get a `status: disabled` result; you want to understand why soul flow is off by default and how the operator enables it; you are tuning `delay_seconds`/`consultation_past_count` with `config` and want to know whether fires will actually happen; or you need the difference between the always-available actions (inquiry/config/voice/dismiss) and the opt-in `flow`. Covers the `LINGTAI_SOUL_FLOW_ENABLED` env gate, disabled-flow behavior, delay-vs-off-switch semantics, enabling/disabling, troubleshooting, and the privacy/cost rationale.
 version: 1.0.0
-last_changed_at: "2026-07-01T09:00:00-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/tools/soul/__init__.py
 - src/lingtai/tools/soul/flow.py
@@ -15,53 +15,30 @@ maintenance: |
 
 # Soul Manual
 
-`soul` is your inner voice. It has five actions. Four of them —
-`inquiry`, `config`, `voice`, `dismiss` — are **always available**. The
-fifth, `flow`, is **opt-in and disabled by default**.
+`soul` is your inner voice. `inquiry`, `config`, `voice`, and `dismiss` are
+**always available**. `flow` is **opt-in and disabled by default**.
 
-## 1. Soul flow is opt-in and disabled by default
+## 1. The soul-flow gate
 
-**Soul flow does not run unless an operator turns it on.** It is gated by a
-single environment variable:
+**Soul flow does not run unless an operator turns it on.** It is gated by one
+environment variable, `LINGTAI_SOUL_FLOW_ENABLED`:
 
-```
-LINGTAI_SOUL_FLOW_ENABLED
-```
+- **Enabled** when the value is `1`, `true`, `yes`, or `on` (case-insensitive,
+  surrounding whitespace ignored).
+- **Disabled** when unset, empty, or anything else (`0`, `false`, `no`,
+  `off`, ...).
 
-- **Enabled** when the value is one of `1`, `true`, `yes`, `on`
-  (case-insensitive, surrounding whitespace ignored).
-- **Disabled** when the variable is unset, empty, or anything else
-  (`0`, `false`, `no`, `off`, ...).
-
-The env gate governs **both** firing paths:
+The gate governs **both** firing paths:
 
 1. **The wall-clock timer** — the periodic cadence that would otherwise fire
-   every `delay_seconds` while you are IDLE. When disabled, no timer is ever
-   armed.
+   every `delay_seconds` while you are IDLE. When disabled, no timer is armed.
 2. **Voluntary `soul(action='flow')`** — a call you make yourself. When
-   disabled, it returns immediately with a `disabled` status and never spawns
-   a fire.
+   disabled, it returns immediately and never spawns a fire.
 
-There is also a defensive last-line check inside the fire itself, so even a
-stray residual caller cannot fire while the gate is off.
+A defensive last-line check inside the fire itself means even a stray residual
+caller cannot fire while the gate is off.
 
-### Why a gate instead of a giant delay
-
-Historically, soul flow was "muted" by setting `delay_seconds` to a huge
-sentinel (e.g. `999999999`, ~31.7 years). That was a **trust-based
-non-trigger**, and it was unsafe:
-
-- The giant delay only muted the **timer**. The **voluntary** path stayed
-  live and could still fire — and could loop against the sleep gate, producing
-  retry storms (observed in trajectory audits: repeated
-  `voluntary_waiting_idle → voluntary_triggered` and simultaneous
-  `soul_fire_gate_check state=asleep` bursts).
-- The sentinel had to be re-applied by hand and was easy to get wrong.
-
-The env gate replaces that fragile convention with an explicit, structural
-opt-in that covers **both** paths.
-
-## 2. What happens when you call `flow` while disabled
+## 2. Calling `flow` while disabled
 
 `soul(action='flow')` returns, **before** taking any lock or spawning any
 thread:
@@ -77,39 +54,42 @@ thread:
 
 **This is expected configuration state, not an error.** Do **not** retry it in
 a loop — the result will not change until an operator sets the env var. If you
-want soul flow, ask the operator to enable it (see §5); otherwise use
-`inquiry` for on-demand self-reflection.
+want soul flow, ask the operator to enable it (§4); otherwise use `inquiry` for
+on-demand self-reflection.
 
 ## 3. `delay_seconds` is cadence, not an off switch
 
-Once soul flow is enabled by the env var, `delay_seconds` (set via
+After the env opt-in, `delay_seconds` (set via
 `soul(action='config', delay_seconds=...)`) controls **how often** the timer
 fires — e.g. `300` = every 5 minutes, `7200` = every 2 hours; minimum `30`.
+That is *all* it does:
 
-`delay_seconds` is **only** the cadence after opt-in. It is **not** an off
-switch:
+- A **large** `delay_seconds` does not suppress flow — the env gate decides
+  whether flow runs at all.
+- A **small** `delay_seconds` does not enable flow — with the env var unset, no
+  fires occur regardless of the delay.
+- `config` itself never enables flow. It tunes and persists the knobs
+  (`delay_seconds`, `consultation_past_count`) to `init.json`; while flow is
+  disabled the result carries `soul_flow_enabled: false` and a `note` saying the
+  knobs are saved but no fires will occur. Enabling is an **operator** action.
 
-- A **large** `delay_seconds` no longer even half-suppresses flow — the env
-  gate decides whether flow runs at all.
-- A **small** `delay_seconds` does **not** enable flow — if the env var is
-  unset, no fires occur regardless of the delay.
+Historically flow was "muted" by setting `delay_seconds` to a huge sentinel
+(e.g. `999999999`, ~31.7 years). That was a trust-based non-trigger and it was
+unsafe: the giant delay only muted the **timer**, while the **voluntary** path
+stayed live and could loop against the sleep gate, producing retry storms
+(observed in trajectory audits: repeated
+`voluntary_waiting_idle → voluntary_triggered` and simultaneous
+`soul_fire_gate_check state=asleep` bursts). The sentinel also had to be
+re-applied by hand and was easy to get wrong. The env gate replaces that
+fragile convention with an explicit opt-in covering both paths.
 
-## 4. `config` does not enable flow
-
-`soul(action='config', ...)` tunes and persists the flow knobs
-(`delay_seconds`, `consultation_past_count`) to `init.json`. It **does not**
-enable soul flow. When you run `config` while flow is disabled, the result
-carries `soul_flow_enabled: false` and a `note` reminding you the knobs are
-saved but no fires will occur until the operator sets the env var. Enabling
-flow is an **operator** action (the env var), never a `config` call.
-
-## 5. How to enable / disable
+## 4. How to enable / disable
 
 Enabling is an operator/deployment action, not something the agent does to
 itself:
 
-1. Set the environment variable in the agent's runtime environment, e.g.
-   `LINGTAI_SOUL_FLOW_ENABLED=1` (or `true`/`yes`/`on`).
+1. Set `LINGTAI_SOUL_FLOW_ENABLED=1` (or `true`/`yes`/`on`) in the agent's
+   runtime environment.
 2. Refresh/restart the agent so the new environment is loaded.
 3. (Optional) tune cadence with `soul(action='config', delay_seconds=...)` and
    voice count with `consultation_past_count`.
@@ -118,35 +98,32 @@ To **disable** again: unset the variable (or set it to `0`/`false`) and
 refresh/restart. No `delay_seconds` sentinel is needed — the gate is the off
 switch.
 
-## 6. Troubleshooting / checking the current state
+## 5. Checking the current state
 
-- **Is flow enabled right now?** Run `soul(action='flow')`. A `status: ok`
-  acknowledgement means enabled; a `status: disabled` result means the env var
-  is not set. You can also run `soul(action='config', ...)` and read
-  `soul_flow_enabled` in the result.
+- **Is flow enabled right now?** Run `soul(action='flow')` — `status: ok`
+  means enabled, `status: disabled` means the env var is not set. You can also
+  run `soul(action='config', ...)` and read `soul_flow_enabled` in the result.
 - **Check the env from a shell:**
   `shell({"command": "printenv LINGTAI_SOUL_FLOW_ENABLED"})` — empty output
   means unset (disabled).
 - **Enabled but no fires?** Fires only happen while you are IDLE and only after
   `delay_seconds` elapses. Confirm `delay_seconds` is a small, sane value and
   that you actually reach IDLE between turns.
-- **Repeated `disabled` results:** stop retrying — the env var must be set by
-  the operator first.
 
-## 7. Actions that always work (flow disabled or not)
+## 6. Actions that always work (flow disabled or not)
+
+None of these depend on the env gate.
 
 - **`inquiry`** — ask a deep copy of yourself a question; the answer returns in
   the tool result. Use this for deliberate, on-demand self-reflection instead
   of waiting on flow. Requires the `inquiry` field.
 - **`config`** — tune `delay_seconds` / `consultation_past_count`; persists to
-  `init.json`. (Does not enable flow — see §4.)
+  `init.json`. (Does not enable flow — see §3.)
 - **`voice`** — read or set how your own soul-flow voice sounds
   (`inner`/`observer`/`custom`). Yours to choose; persists to `init.json`.
 - **`dismiss`** — clear the current soul-flow notification from the panel.
 
-None of these depend on the env gate.
-
-## 8. Privacy and cost rationale
+## 7. Privacy and cost rationale
 
 Soul flow is **off by default** deliberately:
 

--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -2,27 +2,18 @@
 name: system-manual
 description: >
   Second-layer router for LingTai's progressive-disclosure operating manuals.
-  Read this when resident substrate/procedures are too compact and you need to
-  route to the right lower reference. References include
-  `reference/substrate-manual/SKILL.md` for the expanded substrate/body/lifecycle/
-  communication/memory/idle/system-operations model;
-  `reference/procedures-manual/SKILL.md` for the expanded procedures/action discipline,
-  skill routing, responsiveness, deliverables, artifact sharing, and issue
-  reporting guidance; `reference/summarize-manual/SKILL.md` for tool-result
-  summarization, progressive disclosure, original-result recovery, and
-  summarize-vs-molt distinctions; and `reference/sqlite-log-query/SKILL.md` for
-  SQLite/log.sqlite runtime trace inspection and trajectory/anomaly mining from
-  event traces; and `reference/runtime-update-checks/SKILL.md` for
-  runtime/kernel self-checks, the complete nudge lifecycle, editable/dev/source
-  identification, safe refresh/update handoffs, and read-only diagnostics. Also
-  route here for lifecycle operations, notification/nudge
-  handling (including direct `notification(action='manual')` retrieval),
-  runtime/kernel update checks, molt/memory questions, MCP/addon
-  ownership, preset tiers, collaboration/network topology, resident prompt
-  design, and the `system` tool actions.
-version: 1.7.0
+  Read this when resident substrate/procedures are too compact and you need the
+  right lower reference. Route here for the expanded substrate/runtime model,
+  lifecycle and `system` tool actions, the init.json composition and preset
+  runtime model route, action/procedure discipline and skill routing, tool-result
+  summarization, SQLite/`log.sqlite` trace inspection and trajectory mining,
+  runtime/kernel update checks and nudges, environment variables, goal
+  notifications, molt/memory questions, MCP/addon ownership, collaboration
+  topology, and resident prompt design. The nested catalog below names each
+  reference and its exact trigger.
+version: 1.8.0
 tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize, nudge, updates, runtime-checks, preset]
-last_changed_at: "2026-07-15T12:00:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/prompts/substrate/substrate.md
 - src/lingtai/prompts/procedures/procedures.md
@@ -59,59 +50,59 @@ selects that topic.
 - name: substrate-manual
   location: reference/substrate-manual/SKILL.md
   description: |
-    Expanded LingTai substrate/runtime model: body/extensions, bash vs daemon vs
-    avatar vs MCP, lifecycle states, system tool actions, notification/read/
-    dismiss discipline, communication channels, memory layers, molt model,
-    runtime log routing, collaboration topology, MCP/addon ownership, idle/soul,
-    preset tiers, the detailed preset runtime model and init.json composition
-    route (raw vs resolved manifest, preset identity, TUI/library vs main-agent
-    allowed-only catalogs, swap/revert/refresh, daemon task explicit/omitted/
-    CLI-skip paths), and resident substrate maintenance.
+    Nested system-manual reference for the expanded substrate/runtime model:
+    body/extensions, lifecycle states, `system` tool actions, communication and
+    notification discipline, memory layers and the molt model, collaboration
+    topology, MCP/addon ownership, idle/soul, preset tiers, and (§11) the
+    canonical `init.json` composition and preset runtime model.
 - name: procedures-manual
   location: reference/procedures-manual/SKILL.md
   description: |
-    Expanded LingTai procedure/action guidance: progressive disclosure,
-    responsiveness, external side-effect authorization, choosing bash vs daemon
-    vs avatar vs MCP, depositing work into pad/knowledge/skills/character,
-    idle/lifecycle procedure, molt checklist, skill routing, web/file/media/
-    artifact handling, standalone HTML deliverables, sharing artifacts, issue
-    reporting, and resident procedures maintenance.
-
+    Nested system-manual reference for expanded action discipline: progressive
+    disclosure, responsiveness, external side-effect authorization, the daemon
+    workflow methodology, depositing work into pad/knowledge/skills/character,
+    idle/lifecycle procedure, skill routing, HTML deliverables, artifact
+    sharing, and issue reporting.
 - name: summarize-manual
   location: reference/summarize-manual/SKILL.md
   description: |
-    Detailed operational guide for `system(action="summarize")`: what tool-result summarization is, why it implements progressive disclosure, when to summarize urgently versus during idle cleanup, how to write good summaries, how to recover the original result by `tool_call_id`, and how summarize differs from molt.
-
+    Nested system-manual reference and canonical owner of tool-result
+    summarization: the three compression modes (a-priori `summary=true`,
+    a-posteriori `system(action="summarize")`, molt), summarize cadences,
+    delayed provider reconstruction and the 0.85/1.0 rebuild boundaries,
+    original-result recovery by `tool_call_id`, and summarize versus molt.
 - name: sqlite-log-query
   location: reference/sqlite-log-query/SKILL.md
   description: |
-    SQLite/log.sqlite runtime trace inspection and trajectory/anomaly mining:
-    `lingtai-agent log doctor`, `lingtai-agent log query`,
-    `lingtai-agent log rebuild`, JSONL source-of-truth rules, read-only SQL
-    safety, offline rebuild/WAL caveats, events and chat_entries schema,
-    daemon/chat-history indexing, query recipes, runtime problem investigation,
-    SQL-based event metrics, cheap-model daemon strategy, finding schema,
-    improvement digest output, redaction/privacy rules, and event_summary.py script.
+    Nested system-manual reference for SQLite/`log.sqlite` runtime trace
+    inspection and trajectory/anomaly mining: `lingtai-agent log doctor`,
+    `lingtai-agent log query`, `lingtai-agent log rebuild`, JSONL
+    source-of-truth rules, read-only SQL safety, offline rebuild/WAL caveats,
+    the events/chat_entries/token_entries schema, query recipes, cheap-model
+    daemon strategy, finding schema, digests, redaction rules, and
+    event_summary.py.
 - name: runtime-update-checks
   location: reference/runtime-update-checks/SKILL.md
   description: |
-    Complete kernel update/nudge lifecycle: runtime and source discovery,
-    `kernel_version` and `source_drift` checks, heartbeat dispatch, durable
-    throttle state, `.notification/nudge.json` envelopes, sync/wake/dismiss
-    behavior, packaged versus editable/source paths, human confirmation, TUI
-    update ownership, refresh boundaries, verification, and read-only diagnosis.
+    Nested system-manual reference for the kernel update/nudge lifecycle:
+    runtime and source discovery, `kernel_version` and `source_drift`,
+    heartbeat dispatch, `.notification/nudge.json` envelopes, sync/wake/dismiss,
+    packaged versus editable/source runtimes, installer ownership and human
+    confirmation, refresh boundaries, and read-only diagnosis.
 - name: environment-variables
   location: reference/environment-variables/SKILL.md
   description: |
-    Complete catalogue of LingTai environment variables: purpose, defaults,
-    accepted values, scope, read point, reload/restart behavior, invalid-value
-    handling, implementation anchors, examples, and security cautions.
+    Nested system-manual reference cataloguing every LingTai environment
+    variable: purpose, default, accepted values, scope, read point,
+    reload/restart behavior, invalid-value handling, implementation anchor,
+    and security caution.
 - name: goal-manual
   location: reference/goal-manual/SKILL.md
   description: |
-    Goal notification manual: protected `.notification/goal.json` as the active
-    goal source of truth, recommended fields and instructions, idle goal
-    reminders as short system events, and cancellation/completion semantics.
+    Nested system-manual reference for goal notifications: protected
+    `.notification/goal.json` as the active-goal source of truth, `/goal`
+    guided setup, recommended fields, idle goal reminders, and
+    cancellation/completion semantics.
 ```
 
 ## Router table
@@ -147,25 +138,10 @@ selects that topic.
 
 ## Substrate and procedures are separate on purpose
 
-`substrate` describes what an agent *is* and how the runtime behaves: bodies,
-lifecycle states, communication surfaces, memory layers, idle/soul, and system
-operations. `procedures` describes how an agent *acts*: progressive disclosure,
-tool/body selection, responsiveness, durable-store tending, skill routing,
-deliverables, artifact sharing, and issue reporting.
-
-Do not collapse their long explanations back into one resident prompt or one
-monolithic manual body. Keep the resident prompt compact, keep this file as a
-router, and put detailed explanations in `reference/substrate-manual/SKILL.md`,
-`reference/procedures-manual/SKILL.md`, and topic-specific references.
-
-## Runtime log / SQLite note
-
-SQLite log guidance, including trajectory/anomaly mining from event traces,
-lives only in this manual's nested reference:
-`reference/sqlite-log-query/SKILL.md`. Route here for keywords such as SQLite,
-`log.sqlite`, runtime logs, trace index, `lingtai-agent log query`, `doctor`,
-`rebuild`, JSONL source of truth, daemon events, chat history, WAL, SQL recipes,
-improvement digests, cheap-model strategy, or finding schema.
+`substrate` describes what an agent *is* and how the runtime behaves;
+`procedures` describes how an agent *acts*. Keep the resident prompt compact,
+keep this file a router, and put detailed explanations in the nested references
+above rather than collapsing them back into one monolithic body.
 
 ## Maintaining this router
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/goal-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/goal-manual/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Goal notification manual: `.notification/goal.json` source-of-truth, fields,
   instructions, idle reminders, protected dismiss behavior, and cancellation or
   completion semantics.
-version: 0.2.0
+version: 0.2.1
 tags: [lingtai, goal, notifications, reminders]
-last_changed_at: "2026-07-12T20:20:43-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/kernel/nudge/goal.py
@@ -52,11 +52,8 @@ When you receive a `source="goal.request"` event:
    - reminder cadence: optional `data.reminder_delay_seconds`;
    - constraints: deadlines, channels to report on, what not to do, or approval
      gates.
-4. **Explain cancellation and completion before writing.** Canceling the goal
-   means deleting `.notification/goal.json` or marking `data.status`
-   `inactive`/`cancelled`/`canceled`. Completing or superseding it means marking
-   status `done`/`complete`/`completed`/`superseded`, or deleting/replacing the
-   file. Dismissing a `goal.reminder` does **not** cancel the goal.
+4. **Explain cancellation and completion before writing** — see "Protected
+   dismiss behavior" below for the exact semantics.
 5. **Write `.notification/goal.json` only after confirmation.** If the human gave
    a complete inline draft with `/goal <text>`, restate the structured goal and
    ask for confirmation unless the instruction explicitly and unambiguously says
@@ -115,8 +112,10 @@ details.
 notification(action="dismiss_channel", channel="goal")  # refused
 ```
 
-To cancel the goal, delete `.notification/goal.json`. To complete the goal, either
-mark `data.status` as `done`/`superseded` or delete/replace the file. Agents are
+To cancel the goal, delete `.notification/goal.json` or mark `data.status`
+`inactive`/`cancelled`/`canceled`. To complete or supersede it, mark
+`data.status` `done`/`complete`/`completed`/`superseded`, or delete/replace the
+file. Dismissing a `goal.reminder` does **not** cancel the goal. Agents are
 trusted to decide when the source-of-truth file should change; the protection only
 prevents misleading API semantics where dismissing a notification looks like
 canceling a goal.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -11,9 +11,9 @@ description: >
   maintenance. This is a nested skill-reference under `system-manual`, not a
   standalone catalog skill; its folder may carry scripts/assets as procedure
   guidance grows.
-version: 1.2.0
+version: 1.3.0
 tags: [lingtai, system-manual, procedures, progressive-disclosure, responsiveness, deliverables, issue-reporting]
-last_changed_at: "2026-07-03T00:00:00Z"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/prompts/procedures/procedures.md
@@ -76,47 +76,19 @@ methodology.
 
 ### Delayed summarization reconstruction threshold
 
-Summarize records compact replacements in runtime history and may clear large-result
-reminders immediately, but provider-side reconstruction is deliberate: recording a
-summary does not by itself rebuild the active provider context. Runtimes usually
-append onto a stable cache/continuation prefix instead of rebuilding that prefix
-every turn. Below the full-context boundary, keep working: do not treat pending
-summarized history as failure, and do not call `refresh` just to force a rebuild.
-Once context is at/above 0.85, the runtime stamps `_meta.agent_meta.agent_state.context.rebuild`;
-if a fresh provider context is worth the cost, make one proactive tactical
-`system(action="summarize", rebuild=true)` call — with new items (record then
-apply the pending set) or with no items (pure rebuild of the already-pending
-summaries); applied summaries flip to `status: done`. Do not loop
-rebuild/summarize. At context usage 1.0 (the full-context hard boundary) the
-runtime forces a rebuild on the next request regardless of whether pending
-summaries exist, but only ONCE per continuous full-context episode (it does not
-re-force while context stays at/above 1.0, and re-arms only after context later
-drops below 1.0): pending markers are applied and marked done. `summarize` is
-the only historical tool-result body replacement a rebuild applies; the fresh
-replay otherwise preserves each historical timely-transient holder and does
-not strip its `agent_meta`/`guidance` or
-`notifications`/`notification_guidance` keys, on every provider, without
-rewriting recorded history — only the LATEST holder
-per family represents current state, older holders are historical traces and
-must not be acted on. Every 1.0 forced rebuild
-ALWAYS carries a one-shot `reconstruction.warning` (before→after context,
-proactive-0.85-rebuild advice, and "if still above the 0.75 recovery target, molt").
-If that one forced rebuild does NOT clear the overflow (post-rebuild context stays
-strictly above 1.0), every result then also carries a permanent
-`_meta.agent_meta.agent_state.context.molt` line `100% context Forced Rebuild Failed to Bring Usage Below 100%. Context
-overflowed!! (xxx %) Molt IMMEDIATELY!!` — molt immediately.
-Waiting for the 1.0 boundary is not ideal — prefer the proactive 0.85 rebuild; if
-the pending total is 0, the forced rebuild has nothing to apply, so summarize more
-or molt instead. At task completion, default to proactive task-boundary molt only when
-session (since-last-molt) API calls exceed 100. Below that threshold, go idle
-unless context pressure, explicit human request, or conversation confusion makes
-the fresh briefing worth the molt cost. Summarize is a mini molt for a consumed
-tool result. If you have already decided to molt, do not summarize first merely
-to prepare: molt is the stronger whole-conversation summarize boundary.
+Summarize records compact replacements in runtime history immediately, but
+provider-side reconstruction is deliberately delayed. Below the full-context
+boundary, keep working: pending summarized history is not a failure, and
+`refresh` is reserved for emergencies (broken/stale context), never a way to
+force a rebuild.
 
-Reserve `refresh` for emergencies (broken/stale context). If summarize or a
-rebuild still cannot bring context below `0.75 * context_window`, tend durable
-stores and molt deliberately.
+`reference/summarize-manual/SKILL.md` §3a owns this mechanism in full — the 0.85
+`context.rebuild` stamp and the one proactive
+`system(action="summarize", rebuild=true)` call it permits, the 1.0
+once-per-episode forced rebuild, the `reconstruction.warning`, the persistent
+overflow `Molt IMMEDIATELY` line, and the task-boundary molt threshold. Do not
+loop rebuild/summarize. If summarize or a rebuild still cannot bring context
+below `0.75 * context_window`, tend durable stores and molt deliberately.
 
 ## 2. Action and responsiveness
 
@@ -128,9 +100,9 @@ For human-facing work:
 
 - Acknowledge human instructions promptly on the same channel.
 - If the next action may take more than a few seconds, send a short progress
-  message first with the communication tool directly. If the notification
-  preview is truncated, ambiguous, or needs exact anchoring, fetch the full
-  message first with the producer channel's normal read action.
+  message first with the communication tool directly. When a notification
+  preview is not enough, read the producer channel first — the conditions are
+  listed in `reference/substrate-manual/SKILL.md` §4.
 - During long work, report meaningful progress, blockers, or completion evidence.
 - Never reply to humans via diary text.
 - Do not infer approval for external side effects when standing rules require
@@ -150,15 +122,9 @@ standing exceptions.
 
 ## 3. Use the right body
 
-Choose the smallest durable body:
-
-- Use shell for deterministic local work.
-- Use daemon for noisy, isolated, disposable exploration, batch analysis, and
-  long-context branches that would otherwise burden the parent.
-- Use avatar for persistent specialization or recurring collaboration.
-- Use MCP for durable external integrations.
-- Use knowledge for private durable facts.
-- Use skills for reusable procedures.
+`reference/substrate-manual/SKILL.md` §1 owns the extension table and the
+smallest-durable-form decision tree (shell, daemon, avatar, MCP, knowledge,
+skill). This section owns the *procedure* built on it.
 
 If a task exceeds current capability, acquire capability rather than stalling:
 search documentation, install tools when appropriate, use daemon for isolated
@@ -273,26 +239,9 @@ mechanics here. For the checklist, templates, and summary rules, go to
 
 ## 7. Skill routing
 
-| Situation | Load |
-|---|---|
-| Runtime model, lifecycle, communication, memory layers, substrate expansion | `system-manual` → `reference/substrate-manual/SKILL.md` |
-| Procedures expansion, routing logic, deliverable/reporting discipline | `system-manual` → `reference/procedures-manual/SKILL.md` |
-| SQLite, log.sqlite, runtime trace inspection, `lingtai-agent log doctor/query/rebuild` | `system-manual` → `reference/sqlite-log-query/SKILL.md` |
-| Tool-result summarization, large-result ranking via agent_meta, original-result recovery, summarize vs molt | `system-manual` → `reference/summarize-manual/SKILL.md` |
-| Molt, pad tending, session journaling, post-wipe recovery | `psyche-manual` |
-| Spawning/managing avatars | `avatar-manual` |
-| Internal email protocol | `email-manual` |
-| Real email/chat/MCP configuration | `mcp-manual` plus the addon's README/resources |
-| Daemon inspection/debugging | `daemon-manual` |
-| Skill authoring/publishing | `skills-manual` |
-| Knowledge entries | `knowledge-manual` |
-| Shell commands, cron, host scheduling | `shell-manual` |
-| Querying LingTai runtime logs / SQLite log sidecar | `system-manual` → `reference/sqlite-log-query/SKILL.md` |
-| Kernel architecture / breaking changes | `lingtai-kernel-anatomy` |
-| TUI / portal code navigation | `lingtai-tui-anatomy` |
-| Web fetching/search/scraping | `web-browsing` |
-| Image understanding | `vision` |
-| Bug/stale-doc/missing-capability reports | `lingtai-issue-report` |
+The situation→manual table is resident in `procedures`, and the `system-manual`
+router table owns routing into this manual's sibling references. Do not maintain
+a third copy here.
 
 Read the named manual before using tools whose developer instructions require it
 (e.g. bash, daemon, skills, knowledge, MCP, web browsing).

--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -5,9 +5,9 @@ description: >
   runtime/version/source identity, packaged versus editable/source behavior,
   heartbeat dispatch, nudge persistence and notification delivery, refresh
   versus installation, human confirmation, and post-refresh verification.
-version: 0.2.0
+version: 0.2.1
 tags: [lingtai, runtime, kernel, nudge, updates, refresh, editable, source, diagnostics]
-last_changed_at: "2026-07-15T12:00:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/intrinsic_skills/system-manual/reference/environment-variables/SKILL.md
@@ -47,10 +47,10 @@ Kernel-local read-only diagnosis and refresh mechanics
 For a `kernel_version` nudge, use the release-manifest facts for diagnosis.
 When a newer release exists, let Shell execute the official installer at
 `https://lingtai.ai/install.sh` with `--help` and then `update --help`; do not
-read or paste the large script source into agent context. Use this bundled
-reference for the local read-only diagnosis and refresh mechanics. A `source_drift` nudge stays local to those mechanics and never
-enters release-migration routing. This is operational guidance, not permission
-to download, install, change configuration, or relaunch a runtime.
+read or paste the large script source into agent context. A `source_drift` nudge
+stays local to these mechanics and never enters release-migration routing. This
+is operational guidance, not permission to download, install, change
+configuration, or relaunch a runtime.
 
 ## The lifecycle and its owners
 
@@ -111,17 +111,16 @@ The end-to-end path is:
    authorization for every migration/config write and for refresh. Apply only
    authorized writes, validate
    the resulting configuration, and refresh last. A release-manifest availability
-   nudge also requires telling the human what was found and receiving explicit
-   confirmation before any download or package update. A nudge or this manual
+   nudge also requires telling the human what was found and receiving explicit confirmation
+   before any download or package update. A nudge or this manual
    never grants authority; a local refresh remains gated by work safety and the
    human's intent when it could interrupt active work.
 9. **Install/update — the single official installer.** Normal user-facing
    installation and updates, including `lingtai-tui`, `lingtai-portal`, the
    managed kernel runtime, exact-tag migration guidance, mirror comparison, and
-   artifact verification, belong to `https://lingtai.ai/install.sh`. This kernel
-   manual does not reproduce that cross-repository procedure or make bare
-   `pip install --upgrade lingtai` the normal user instruction. Pip/venv commands
-   below are diagnostic or developer verification only.
+   artifact verification, belong to `https://lingtai.ai/install.sh`. Bare
+   `pip install --upgrade lingtai` is not the normal user instruction; pip/venv
+   commands below are diagnostic or developer verification only.
 10. **Refresh and verify — kernel lifecycle plus the operator.**
     After authorized writes are validated, `system(action="refresh")` requests a
     deferred relaunch only when the runtime can build a valid launch command and
@@ -161,14 +160,13 @@ policy block. `kind: kernel_version` has `running`, `installed`, `latest` (or
 carries startup and disk fingerprints instead.
 
 The shared Nudge policy records finding identity and dismissal mute expiry in
-`.notification/.nudge_state.json`. `LINGTAI_NUDGE_ENABLED` defaults to `on` and
-suppresses all kinds when `off`; `LINGTAI_NUDGE_REPEAT_INTERVAL` defaults to
-`24h` and controls when the same unresolved finding may reappear after
- dismissal. Values are reread at each Nudge operation; invalid values fail safe
-and are diagnosed. Producer probe gates are only bounded observation costs, not
-product cadence. A producer removes an entry when its real fact resolves or the
-runtime is intentionally skipped. Read the complete env catalogue for exact
-accepted values and reload behavior.
+`.notification/.nudge_state.json`. The two global controls
+(`LINGTAI_NUDGE_ENABLED`, `LINGTAI_NUDGE_REPEAT_INTERVAL`) suppress publication
+and set the post-dismiss repeat window for an unresolved finding; their defaults,
+accepted values, reload behavior, and invalid-value fallback are owned by
+`reference/environment-variables/SKILL.md`. Producer probe gates are only bounded
+observation costs, not product cadence. A producer removes an entry when its real
+fact resolves or the runtime is intentionally skipped.
 
 After interpreting a nudge, use the narrowest safe action:
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
@@ -12,9 +12,9 @@ description: >
   digest output, or log redaction pitfalls. This is a nested skill-reference
   under `system-manual`, not a standalone catalog skill; its folder may carry
   companion scripts and assets as SQLite trace tooling grows.
-version: 1.2.0
+version: 1.2.1
 tags: [lingtai, system-manual, sqlite, log.sqlite, runtime-logs, trace, jsonl, daemon, trajectory, mining, event-log, improvement, pitfalls, observability, cheap-model]
-last_changed_at: "2026-06-24T23:45:17-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/scripts/event_summary.py
@@ -399,17 +399,8 @@ to shared storage.
 
 ### Mechanical first-pass metrics (SQL queries)
 
-Run cheap aggregations before any LLM call. These are free signal.
-
-**Event-type counts:**
-
-```sql
-SELECT type, COUNT(*) AS n
-FROM events
-GROUP BY type
-ORDER BY n DESC
-LIMIT 30;
-```
+Run cheap aggregations before any LLM call. These are free signal. Start with the
+event-type and source-kind counts from **Query recipes** above, then add:
 
 **Tool call / result summary:**
 
@@ -881,41 +872,25 @@ Write the digest to: reports/trajectory-digest-YYYYMMDD.md
 
 ### On-demand procedure (step-by-step)
 
-1. **Clarify window and scope**
-   - Default: recent event logs for the current agent/project plus daemon
-     events from the active workstream.
-   - "最近轨迹" → last 24h or current active workstream.
-   - Named subsystem → filter events to that subsystem.
+Run the sections above in this order:
 
-2. **Discover sources** (source discovery above)
-   - Run SQL source discovery. Build manifest.
-
-3. **Schema discovery**
-   - Sample keys via `json_each()` before writing any extraction code.
-
-4. **Mechanical first-pass** (SQL metric queries above)
-   - Run aggregation queries. Capture output. Do not pass raw logs to any LLM.
-
-5. **Chunk and redact** (slicing queries + redaction rules below)
-   - Apply chunking strategy. Redact secrets and paths.
-
-6. **Dispatch cheap daemon batch**
-   - Send manifests + aggregates + bounded redacted excerpts to cheap models.
-     One daemon per source family / time window.
-
-7. **Primary-agent triage**
-   - Merge daemon findings. Validate each against the confidence rubric.
-
-8. **Produce digest**
-   - Render digest template. Include evidence appendix.
-
-9. **Route outputs**
-   - Propose routing for each finding. Wait for human approval before any
-     side effect.
-
-10. **Stop**
-    A good digest gives the human enough to choose: update skill, file issue,
-    make patch, ignore, or schedule.
+1. **Clarify window and scope.** Default: recent event logs for the current
+   agent/project plus daemon events from the active workstream. "最近轨迹" →
+   last 24h or current active workstream. Named subsystem → filter to it.
+2. **Discover sources** and build the manifest.
+3. **Schema discovery** — sample keys via `json_each()` before writing any
+   extraction code.
+4. **Mechanical first-pass** — run the aggregation queries; do not pass raw logs
+   to any LLM.
+5. **Chunk and redact** — apply a slicing strategy, then the redaction rules.
+6. **Dispatch cheap daemon batch** — one daemon per source family / time window.
+7. **Primary-agent triage** — merge findings, validate against the confidence
+   rubric.
+8. **Produce digest** — render the template, include the evidence appendix.
+9. **Route outputs** — propose routing; wait for human approval before any side
+   effect.
+10. **Stop.** A good digest gives the human enough to choose: update skill, file
+    issue, make patch, ignore, or schedule.
 
 ---
 
@@ -939,6 +914,8 @@ Apply these in order, before any LLM call:
    jobs, or agent refreshes.
 
 ## Pitfalls
+
+Beyond the safety contract above:
 
 - Do not treat `log.sqlite` as a coordination database. It is an observability
   index, not agent state.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -13,9 +13,9 @@ description: >
   and resident substrate maintenance. This is
   a nested skill-reference under `system-manual`, not a standalone catalog skill;
   its folder may carry scripts/assets as the substrate reference grows.
-version: 1.2.0
+version: 1.3.0
 tags: [lingtai, system-manual, substrate, runtime, lifecycle, communication, memory, notifications, mcp, preset]
-last_changed_at: "2026-07-14T00:00:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/prompts/substrate/substrate.md
@@ -140,11 +140,8 @@ single `system` event. Prefer producer-specific verbs first for guarded
 producers (`email.read`, `email.dismiss`, Telegram `read`, other MCP read
 actions); a generic channel dismiss is for channels that do not own their own
 read state, or for stale mirrors when the producer-owned state is already
-handled.
-
-Never treat a notification preview as the full source of truth when it is
-truncated, ambiguous, lacks an exact anchor, includes media/attachments, or
-contains human instructions. Read the producer channel.
+handled. Never treat a notification preview as the full source of truth — §4
+lists when to read the producer channel instead.
 
 For channel allowlist, envelope shape, protected channels, stale-version/force
 semantics, and how large results are ranked via agent_meta and summarized (plus
@@ -157,29 +154,17 @@ LingTai has three deliberate ways to keep context lean, from local to
 whole-conversation. All three preserve the raw original in durable logs; none is
 canonical.
 
-1. **A priori — reasoning-guided** (`summary=true` on `bash`/`read`/`grep`/`daemon`/`glob`): the
-   tool runs normally and the raw is preserved, but the result is replaced by a
-   generated summary *before* it ever enters your context. Prefer this over a
-   posteriori summarization when you can predict bulk and already know the facts,
-   counts, anchors, or conclusion to retain; it is the cheapest path because raw
-   bulk never spends context. The summary is driven by your `reasoning` field. Hard cap:
-   500,000 raw chars, above which no summary is generated and you get a refusal
-   pointing at the preserved raw. A priori is **lossy** and assumption-driven —
-   it compresses *before* you inspect, so prefer it only when you already know the
-   narrow facts to keep. It does **not** replace a posteriori for
-   high-information-density daemon outputs, reviews, long reports, or results
-   whose important facts you cannot name in advance; for those, leave
-   `summary=false`, consume, then summarize a posteriori. See
-   `reference/summarize-manual/SKILL.md`.
-2. **A posteriori — agent-guided** (`system(action="summarize")`, below): replace
-   a result you have *already seen* and digested with your own summary.
+1. **A priori — reasoning-guided** (`summary=true` on
+   `bash`/`read`/`grep`/`daemon`/`glob`): the raw is replaced by a
+   `reasoning`-driven generated summary *before* it enters your context.
+2. **A posteriori — agent-guided** (`system(action="summarize")`): replace a
+   result you have *already seen* and digested with your own summary.
 3. **Molt — context-pressure-triggered** (§5): the whole-conversation
-   continuation / reset, the stronger boundary when per-result summarization
-   cannot keep context healthy.
+   continuation / reset.
 
-Pick a priori first when you can predict bulk, do not need the raw, and already
-know what the call must retain; use a posteriori when you've already consumed a
-result or the important facts could not be named before inspection; molt when the
+Pick a priori when you can predict bulk, do not need the raw, and already know
+what the call must retain; a posteriori when you have already consumed a result
+or could not name the important facts before inspection; molt when the
 conversation as a whole is the problem.
 
 ### `summarize`
@@ -187,62 +172,28 @@ conversation as a whole is the problem.
 `summarize` is the a-posteriori system action for tool-result context hygiene:
 after you have consumed a completed prior tool result and no longer need the raw
 text visible, record a compact summary replacement for its raw payload regardless
-of length. The
-summary preserves the conclusion, evidence, anchors, validation, risks, and next
-steps while lowering active context. Runtime high-attention guidance for this
-behavior is carried in `_meta.agent_meta.guidance`, including the resident 0.85 manual
-rebuild hint and the 1.0 hard forced-rebuild boundary rule.
-Treat guidance as a system-prompt-like appendix placed at the end of context: it
-is an ordered `sections[]` structure, not a loose metadata bag.  The kernel's
-`meta_readme` explanation of the `_meta` envelope is therefore one guidance
-section inside `sections[]`, alongside the packaged sections assembled from the
-skill-style Markdown guidance catalog under `src/lingtai/prompts/meta_guidance/catalog/`
-(`INDEX.md` + one `<id>.md` per section); follow that latest guidance first when
-it appears.
+of length. The summary preserves the conclusion, evidence, anchors, validation,
+risks, and next steps while lowering active context.
 
-Summarize records a compact replacement in runtime history and may clear large-result
-reminders, but active provider-side reconstruction is delayed.
-At the provider layer, runtimes serve requests by *appending* onto a stable
-cache/continuation prefix rather than *reconstructing* it each turn; rebuilding
-that prefix on every summarize would discard the cache benefit. So below the
-full-context boundary the summarize stays pending and the session keeps appending —
-this delay is normal. Once context is at/above 0.85, the runtime stamps
-`_meta.agent_meta.agent_state.context.rebuild`; if an earlier fresh provider context is worth
-the cost, make one proactive tactical `system(action="summarize", rebuild=true)`
-call — with new items (record then apply the pending set) or with no items (pure
-rebuild of the already-pending summaries); applied summaries flip to
-`status: done`. Do not loop rebuild/summarize. At context usage 1.0 (the
-full-context hard boundary) the runtime forces a rebuild on the next request
-regardless of whether pending summaries exist, but only ONCE per continuous
-full-context episode (it does not re-force while context stays at/above 1.0, and
-re-arms only after context later drops below 1.0): pending markers are applied and
-marked done, and with no pending summaries it still runs to release transient
-context. Every 1.0 forced rebuild ALWAYS carries a one-shot
-`reconstruction.warning` (before→after context, proactive-0.85-rebuild advice, and
-"if still above the 0.75 recovery target, molt"). If that one forced rebuild does
-NOT clear the overflow (post-rebuild context stays strictly above 1.0), every
-result then also carries a permanent `_meta.agent_meta.agent_state.context.molt` line `100%
-context Forced Rebuilt Failed. Context overflowed!! (xxx %) Molt IMMEDIATELY!!` —
-molt immediately. Waiting until full context is not
-ideal — prefer the proactive 0.85 rebuild; if the pending total is 0, the forced
-rebuild has nothing to apply, so summarize more or molt instead.
-`refresh` is reserved for emergency reconstruction (see above). Summarize
-is a mini molt for a consumed tool result; molt is the stronger
-whole-conversation summarize boundary when summarize/reconstruction cannot get
-context below `0.75 * context_window`. A completed task can also be an
-efficiency boundary, but molt is not free cleanup: after necessary reporting and
-durable-store updates, if no concrete next action remains, default to proactive
-task-boundary molt only once session (since-last-molt) API calls exceed 100. Below that
-threshold, go idle unless context pressure, explicit human request, or
-conversation confusion makes the fresh briefing worth the molt cost. If you have
-already decided to molt, do not spend a separate summarize call merely to
-prepare.
+Runtime high-attention guidance for this behavior is carried in
+`_meta.agent_meta.guidance`. Treat guidance as a system-prompt-like appendix
+placed at the end of context: it is an ordered `sections[]` structure, not a
+loose metadata bag. The kernel's `meta_readme` explanation of the `_meta`
+envelope is therefore one guidance section inside `sections[]`, alongside the
+packaged sections assembled from the skill-style Markdown guidance catalog under
+`src/lingtai/prompts/meta_guidance/catalog/` (`INDEX.md` + one `<id>.md` per
+section); follow that latest guidance first when it appears.
 
-For the full operating procedure — urgent large-result summarization, idle
-cleanup sweeps, original-result recovery by `tool_call_id`, summary quality,
-large-result notification behavior, append-vs-reconstruction timing, and the
-distinction between summarize and molt — read
-`reference/summarize-manual/SKILL.md`.
+Two boundaries matter here and are **owned in full by
+`reference/summarize-manual/SKILL.md`**: summarize records history now but
+provider-side reconstruction is delayed, so a pending summary is normal and
+`refresh` is not the way to apply one; and `refresh` stays reserved for emergency
+context reconstruction (see above), never as a summarize substitute. Read that
+reference for the 0.85 proactive-rebuild stamp, the 1.0 forced-rebuild boundary
+and its overflow warning, urgent versus idle-cleanup cadence, summary quality,
+original-result recovery by `tool_call_id`, and the summarize-versus-molt
+distinction — including when a completed task is worth a proactive
+task-boundary molt.
 
 ### Sleep, lull, interrupt, suspend, CPR, clear, nirvana
 
@@ -276,12 +227,9 @@ Notification previews are hints. Read the producer channel when:
 - exact wording matters for authorization;
 - the channel has producer-owned read/dismiss state.
 
-For human instructions, acknowledge promptly. If work will take longer than a few
-seconds, send a progress message with the communication tool directly before the
-long tool call. If the notification preview is incomplete, ambiguous, or exact
-anchoring matters, fetch the full message first with the producer channel's
-normal read action, then continue. During long work, report meaningful progress
-or blockers.
+The responsiveness discipline built on this surface — acknowledging promptly,
+sending a progress message before long work, and reporting blockers — belongs to
+`reference/procedures-manual/SKILL.md` §2.
 
 ## 5. Memory layers and molt model
 
@@ -351,14 +299,12 @@ When there is no concrete task, go idle/asleep rather than spinning, polling, or
 using timed sleeps. Idle keeps listeners available.
 
 Soul flow is advice, not command — and it is **opt-in, disabled by default**
-(gated by the `LINGTAI_SOUL_FLOW_ENABLED` env var). When it is off,
-`soul(action='flow')` returns a `disabled` status; `inquiry`/`config`/`voice`/
-`dismiss` still work. Verify external-event claims through the relevant channel
-before acting on any voice. Use self-inquiry when you need a deliberate pause for
-judgment; use durable stores for conclusions that should survive molt. For the
-full soul-flow mechanics — the env gate, disabled behavior, `delay_seconds` as
-cadence-not-off-switch, enabling/disabling, and the privacy/cost rationale — read
-the `soul-manual` skill.
+(gated by the `LINGTAI_SOUL_FLOW_ENABLED` env var). Verify external-event claims
+through the relevant channel before acting on any voice. Use self-inquiry when
+you need a deliberate pause for judgment; use durable stores for conclusions that
+should survive molt. `soul-manual` owns the full soul-flow mechanics: the env
+gate, disabled-flow behavior, `delay_seconds` as cadence-not-off-switch,
+enabling/disabling, and the privacy/cost rationale.
 
 ## 10. Resident substrate maintenance
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   is, why it implements progressive disclosure, when to summarize urgently versus
   during idle cleanup, how to write good summaries, how to recover the original
   tool result by tool_call_id, and how summarize differs from molt.
-last_changed_at: "2026-07-03T00:00:00Z"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/tools/system/summarize.py
@@ -45,13 +45,9 @@ is canonical.
 | **A posteriori** — agent-guided | `system(action="summarize")` | *after* you have already seen and digested it | you |
 | **Molt** — context-pressure-triggered | `psyche(context, molt, ...)` | the whole conversation is continued/reset | you (briefing) |
 
-A priori is preferred when you can predict bulk, do not need the raw text, and
-already know what the call must retain, because the raw never enters context. A
-posteriori reclaims context after the fact for results you have consumed or whose
-important facts could not be named before inspection. Molt
-is the strongest boundary when per-result summarization is not enough. Sections
-1–6 below are mostly about the a-posteriori `summarize` action; §1a covers the
-a-priori `summary=true` option; §6 contrasts both with molt.
+Sections 1–6 below are mostly about the a-posteriori `summarize` action; §1a
+covers the a-priori `summary=true` option and when to prefer it; §6 contrasts
+both with molt.
 
 ## 1a · A priori summary: `summary=true` on bash / read / grep / daemon / glob
 
@@ -279,17 +275,12 @@ summarize would discard cache benefit.
   overflow warning (the warning is for strictly `> 1.0`).
 
 Waiting for the 1.0 forced boundary is the emergency path — prefer the proactive
-0.85 rebuild. If no summary is pending, the forced rebuild has nothing to apply;
-the fresh replay still preserves each historical timely-transient holder and
-does not strip its agent_meta/guidance or notifications/notification_guidance
-keys on any provider, without rewriting recorded history — only the LATEST
-holder per
-family represents current state, older holders are historical traces and must
-not be acted on. `refresh`
-remains the emergency path for broken/stale context or explicit human direction,
-not the normal way to apply summarize. If summarize or a rebuild still cannot
-bring context below `0.75 * context_window` (the recovery target), tend durable
-stores and molt deliberately.
+0.85 rebuild. If no summary is pending, the forced rebuild has nothing to apply
+(the replay-preservation rule above still holds), so summarize more or molt
+instead. `refresh` remains the emergency path for broken/stale context or
+explicit human direction, not the normal way to apply summarize. If summarize or
+a rebuild still cannot bring context below `0.75 * context_window` (the recovery
+target), tend durable stores and molt deliberately.
 
 ## 4 · Recovering the original result
 

--- a/src/lingtai/mcp_servers/cloud_mail/SKILL.md
+++ b/src/lingtai/mcp_servers/cloud_mail/SKILL.md
@@ -8,7 +8,7 @@ description: |
   external-email side-effect caveats. Pulled on demand via action='manual'; you
   do not need to call it before every send.
 version: 1.0.0
-last_changed_at: "2026-06-26T14:33:19-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/mcp_servers/cloud_mail/manager.py
 - src/lingtai/mcp_servers/cloud_mail/server.py
@@ -19,28 +19,26 @@ maintenance: |
 
 # Cloud Mail MCP — usage manual (progressive disclosure)
 
-This manual is pulled on demand via `action='manual'` so the per-action tool
-schema can stay concise. Read it when you need detail beyond the one-line action
-descriptions; you do not need to call it before every send.
+Inbound mail also arrives automatically in your inbox via per-account polling,
+so you don't have to poll `check` yourself.
 
-Cloud Mail is a REST email client for a self-hosted Cloud Mail deployment
-(Cloudflare Workers). Inbound mail also arrives automatically in your inbox via
-per-account polling, so you don't have to poll `check` yourself.
+Setup, config file/schema, credential and auth model, and watermark state are
+owned by the `mcp-manual` skill (`reference/curated-addons.md`, §Cloud Mail
+setup). Read it before editing config; do not guess field names.
 
 ## EMAIL IDS
 
-- `read` takes a compound id `id='<account>:<emailId>'`, or `account` plus a
-  numeric `email_id`. Use the ids returned by `check`/`search`; do not construct
-  them by hand.
+- `read` fetches the full content of one email by compound id
+  `id='<account>:<emailId>'`, or by `account` plus a numeric `email_id`. Use the
+  ids returned by `check`/`search`; do not construct them by hand.
 
-## READING: check / search / read
+## READING: check / search
 
 - `check`: list recent inbound emails (optional `limit`/`n`, plus the same
   filters as search).
 - `search`: filter the public email list by `to_email`, `send_email`,
   `send_name`, `subject`, `content`, `time_sort` (`asc`/`desc`), and paginate
   with `num`/`size`. Filters are LIKE matches.
-- `read`: fetch the full content of one email by compound `id`.
 
 ## SEND
 

--- a/src/lingtai/mcp_servers/feishu/SKILL.md
+++ b/src/lingtai/mcp_servers/feishu/SKILL.md
@@ -8,8 +8,8 @@ description: |
   transient-hook vs persistent-context split, and side-effect caveats.
   Pulled on demand via action='manual'; you do not need to call it before every
   send.
-version: 1.1.0
-last_changed_at: "2026-07-06T00:00:00-07:00"
+version: 1.2.0
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/mcp_servers/feishu/manager.py
 - src/lingtai/mcp_servers/feishu/server.py
@@ -19,10 +19,6 @@ maintenance: |
 ---
 
 # Feishu (Lark) MCP — usage manual (progressive disclosure)
-
-This manual is pulled on demand via `action='manual'` so the per-action tool
-schema can stay concise. Read it when you need detail beyond the one-line action
-descriptions; you do not need to call it before every send.
 
 ## RECIPIENTS: receive_id / receive_id_type
 
@@ -70,22 +66,25 @@ descriptions; you do not need to call it before every send.
 
 ## NOTIFICATIONS: TRANSIENT HOOK vs PERSISTENT CONTEXT
 
-- Inbound Feishu messages surface to the agent in two `_meta` lanes:
-  - `_meta.agent_meta.notifications.attention.mcp.feishu` is a compact high-attention hook only —
-    `data.message_ids` (compound `{alias}:{chat_id}:{feishu_message_id}` ids)
-    and dismiss guidance, never message text or routing context.
-  - `_meta.agent_meta.notifications.persistent.mcp.feishu` carries durable context:
-    recent conversation messages (bounded text, both directions), sender/chat
-    routing hooks, reply refs when present, and per-message comments for the
-    agent's own outgoing messages or truncated text.
-- The feishu tool remains the source of truth. Neither lane marks anything
-  read; use `read`/`check` for exact producer state, especially when a
-  persistent message is truncated.
-- Reply in Feishu when the message arrived through Feishu (`reply` with the
-  compound message id, or `send` to the chat/open_id).
-- After handling, dismiss the transient hook via
-  `notification.dismiss_channel("mcp.feishu")`; the persistent block is
-  context history, not unread state.
+Inbound Feishu messages surface to the agent in two `_meta` lanes:
+
+- `_meta.agent_meta.notifications.attention.mcp.feishu` — a compact
+  high-attention hook only: `data.message_ids` and dismiss guidance, never
+  message text or routing context.
+- `_meta.agent_meta.notifications.persistent.mcp.feishu` — durable context:
+  recent conversation messages (bounded text, both directions), sender/chat
+  routing hooks, reply refs when present, and per-message comments for the
+  agent's own outgoing messages or truncated text.
+
+The feishu tool remains the source of truth: neither lane marks anything read,
+so use `read`/`check` for exact producer state — especially when a persistent
+message is truncated. Reply in Feishu when the message arrived through Feishu
+(`reply` with the compound message id, or `send` to the chat/open_id). After
+handling, dismiss the transient hook with
+`notification.dismiss_channel("mcp.feishu")`; the persistent block is context
+history, not unread state. Generic mirror-vs-canonical-state and dismiss-safety
+rules live in
+[`notification-manual`](../../intrinsic_skills/notification-manual/SKILL.md).
 
 ## SIDE EFFECTS & ERROR SURFACING
 

--- a/src/lingtai/mcp_servers/imap/SKILL.md
+++ b/src/lingtai/mcp_servers/imap/SKILL.md
@@ -9,7 +9,7 @@ description: |
   before sending). Pulled on demand via action='manual'; you do not need to call
   it before every send.
 version: 1.0.0
-last_changed_at: "2026-06-27T17:30:57-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/mcp_servers/imap/manager.py
 - src/lingtai/mcp_servers/imap/server.py
@@ -20,64 +20,57 @@ maintenance: |
 
 # IMAP/SMTP email MCP — usage manual (progressive disclosure)
 
-This manual is pulled on demand via `action='manual'` so the per-action tool
-schema can stay concise. Read it when you need detail beyond the one-line action
-descriptions; you do not need to call it before every send.
+Pulled on demand via `action='manual'`; read it for detail beyond the tool
+schema's one-line action descriptions.
 
-## EMAIL IDS
+## ACTIONS
+
+| Action | Purpose | Arguments |
+|---|---|---|
+| `send` | compose a new email | `address`, `message`; optional `subject`, `cc`, `bcc`, `attachments` |
+| `reply` | reply to an existing email; preserves threading/subject from the original | `email_id`, `message`; optional `cc`, `attachments` |
+| `check` | list recent envelopes from a folder | optional `folder`, `n` |
+| `read` | fetch full email(s) | `email_id` |
+| `search` | server-side IMAP search | `query`; optional `folder` |
+| `folders` | list available IMAP folders | — |
+| `move` | move email(s) to another folder | `email_id`, `folder` (destination) |
+| `flag` | set/clear flags | `email_id`, `flags` |
+| `delete` | delete email(s) | `email_id` |
+| `contacts` | list all contacts | — |
+| `add_contact` | add/update a contact | `address`, `name`; optional `note` |
+| `edit_contact` | update contact fields | `address`; optional `name`, `note` |
+| `remove_contact` | remove a contact | `address` |
+| `accounts` | list configured IMAP accounts and connection status | — |
+
+`address`/`cc`/`bcc` accept a single string or a list; `email_id` takes one id or
+a list of ids.
+
+## IDS, FOLDERS, ACCOUNTS
 
 - `email_id` is a compound key: `account:folder:uid` (e.g.
-  `me@example.com:INBOX:1234`). `read`, `reply`, `delete`, `move`, and `flag`
-  take one id or a list of ids. Use the ids returned by `check`/`search`; do not
+  `me@example.com:INBOX:1234`). Use the ids returned by `check`/`search`; do not
   construct them by hand.
-
-## READING: check / read / search
-
-- `check`: list recent envelopes from a folder (optional `folder`, `n`). An
-  empty or whitespace-only `folder` is treated as omitted and defaults to
-  `INBOX`.
-- `read`: fetch full email(s) by `email_id` (a single id or a list). You are
-  encouraged to read multiple relevant — or even all unread — emails and think
-  before acting.
-- `search`: server-side IMAP search (`query`; optional `folder`, empty/whitespace-only defaults to `INBOX`). Queries use a server-side search DSL, e.g.
+- An empty or whitespace-only `folder` (check/search) or `account` (any action)
+  is treated as omitted: `folder` defaults to `INBOX`, and `account` uses the
+  default/sole account rather than failing with `Unknown account`. Most actions
+  accept an optional `account` (email address), defaulting to the primary
+  account. `move` is the exception — its destination `folder` is required, must
+  be non-empty, and is never defaulted to `INBOX`.
+- `flags` is required for `flag` and maps flag name to bool, e.g.
+  `flags={"seen": true, "flagged": false}`; `flags={"seen": true}` marks read. A
+  missing or empty `flags` returns an error rather than silently doing nothing.
+- `search` queries use a server-side search DSL, e.g.
   `from:addr subject:text unseen since:YYYY-MM-DD`; supported fields depend on
   the IMAP addon, so prefer examples returned by this tool over raw RFC IMAP
   search syntax.
-- `folders`: list available IMAP folders.
 
-## SEND vs REPLY
+## READING & ATTACHMENTS
 
-- `send`: compose a new email (`address`, `message`; optional `subject`, `cc`,
-  `bcc`, `attachments`). `address`/`cc`/`bcc` accept a single string or a list.
-- `reply`: reply to an existing email (`email_id`, `message`; optional `cc`,
-  `attachments`). Reply preserves threading/subject from the original.
-
-## ATTACHMENTS
-
+- You are encouraged to `read` multiple relevant — or even all unread — emails
+  and think before acting.
 - `attachments` is a list of file paths (absolute or relative to the working
   dir) for `send`/`reply`. Attach generated artifacts (charts, reports, CSVs,
   PDFs) as files rather than pasting a path into the body.
-
-## ORGANIZING: move / flag / delete
-
-- `move`: move email(s) to another folder (`email_id`, `folder`=destination).
-  The destination `folder` is required and must be non-empty — unlike
-  check/search it is never defaulted to `INBOX`.
-- `flag`: set/clear flags (`email_id`, `flags={"seen": true, "flagged": false}`).
-  `flags` is required; e.g. `flags={"seen": true}` marks read. A missing or
-  empty `flags` returns an error rather than silently doing nothing.
-- `delete`: delete email(s) by `email_id`.
-
-## CONTACTS / ACCOUNTS
-
-- `contacts`: list all contacts.
-- `add_contact`: add/update a contact (`address`, `name`; optional `note`).
-- `edit_contact`: update contact fields (`address`; optional `name`, `note`).
-- `remove_contact`: remove a contact (`address`).
-- `accounts`: list configured IMAP accounts and connection status. Most actions
-  accept an optional `account` (email address); it defaults to the primary
-  account. An empty or whitespace-only `account` is treated as omitted and
-  uses the default/sole account rather than failing with `Unknown account`.
 
 ## SIDE EFFECTS & SAFETY
 

--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -9,7 +9,7 @@ description: |
   design for meaningful long-running work — and error surfacing. Pulled on demand
   via action='manual'; you do not need to call it before every send.
 version: 1.5.2
-last_changed_at: "2026-07-16T14:57:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/mcp_servers/ANATOMY.md
 - src/lingtai/mcp_servers/telegram/manager.py
@@ -25,6 +25,30 @@ maintenance: |
 This manual is pulled on demand via `action='manual'` so the per-action tool
 schema can stay concise. Read it when you need detail beyond the one-line action
 descriptions; you do not need to call it before every send.
+
+Registration, `init.json` activation, config-file placement/permissions, and the
+setup readiness checklist are **not** here — they belong to `mcp-manual`
+(`reference/curated-addons.md`).
+
+## Nested reference catalog
+
+```yaml
+- name: telegram-task-card-manual
+  location: task_card/SKILL.md
+  description: |
+    Nested telegram-mcp-manual reference for the programmable Task Card
+    (`task_card` tool): when a watcher is warranted, the watcher information
+    contract, how to inspect a task's producer evidence, a safe runnable
+    custom-renderer example, the renderer contract, the
+    start|inspect|retry|stop walkthrough, and terminal/fail-loud cleanup.
+    Read this before authoring a renderer.
+```
+
+| Need | Read |
+|---|---|
+| Send/reply/edit, media, reading, rich text, slash commands, `/taskcard`, errors | this file |
+| Authoring or operating a programmable Task Card watcher | [`task_card/SKILL.md`](task_card/SKILL.md) |
+| Normative resident/slot promises and code structure | [`task_card/CONTRACT.md`](task_card/CONTRACT.md), [`task_card/ANATOMY.md`](task_card/ANATOMY.md) |
 
 ## MEDIA: document vs photo
 
@@ -49,35 +73,13 @@ descriptions; you do not need to call it before every send.
 - The final answer must be a **separate durable message** using `action='send'`
   or `action='reply'`. Do **not** edit the placeholder into the final answer;
   the placeholder shows progress only (it may optionally be deleted).
-- When the current agent has `taskcard: True`, the manager-owned automatic Task
-  Card updates separately from your own send/reply messages. It is a mechanical
-  view of recent `tool_call` events in `logs/events.jsonl`, not a turn-local
-  heartbeat or completion lifecycle. While the resident Task Card is still the
-  chat's last message, automatic event-tail and programmable frames edit that one
-  stable resident message ID in place; an identical Telegram edit is a successful
-  no-op. See **AUTOMATIC TASK CARD: `events.jsonl` → resident broadcast** and
-  **TASKCARD STATE** below.
-- The Task Card's tracked resident target is kept as the last message. When a
-  newer message has arrived below it — your own durable send/reply, or an incoming
-  user message — the addon same-content-probes the exact old resident with its last committed
-  render when available. After a cold in-memory start, the exact delete result is
-  itself the existence/removal probe. Unknown/transient probe failures fail closed
-  and send nothing.
-- Before injecting a replacement, the exact old resident must be confirmed deleted
-  or Telegram must explicitly report it already missing. A delete failure blocks
-  the new send. Only then is the fresh card sent and persisted, so tracked rotation
-  never deliberately displays two cards. A later send failure may leave zero and
-  is reported explicitly; a new-id persistence failure retains the in-process id
-  and surfaces a partial durability failure. Malformed/cross-bound resident ids
-  never reach transport, ordinary messages are never deletion candidates, and
-  unknown historical orphan cards are not scanned or deleted. The durable map is
-  one tracked target per account+chat, not proof of global chat-history cardinality.
-- Automatic and programmable delivery shares one per-account+chat transaction.
-  While the tracked resident remains latest it is edited in place; an identical
-  Telegram edit is a successful no-op. An unknown latest-message high-water stays
-  conservative and does not authorize rotation or deletion.
 - For very fast responses (under ~5s), native Telegram typing/👀 presence is
   enough — skip the placeholder.
+- The Task Card is a separate surface from your placeholder. When the current
+  agent has `taskcard: True`, the manager-owned automatic Task Card updates on
+  its own; it is a mechanical view of recent `tool_call` events in
+  `logs/events.jsonl`, not a turn-local heartbeat or completion lifecycle. See
+  **AUTOMATIC TASK CARD** and **TASKCARD STATE** below.
 
 ## REPLY vs SEND
 
@@ -126,9 +128,7 @@ Telegram has two separate slash-command layers:
 To dynamically add a command such as `/tokenstats` to a bot's Telegram menu:
 
 1. Edit the Telegram config file used by that agent (normally
-   `<agent>/.secrets/telegram.json`; the active path is exposed as
-   `LINGTAI_TELEGRAM_CONFIG` in the MCP process, and `lingtai://status` reports
-   only a redacted, non-secret view).
+   `<agent>/.secrets/telegram.json`, the path in `LINGTAI_TELEGRAM_CONFIG`).
 2. Add or update the account's `commands` list. Command names are stored
    **without** the leading slash and should follow Telegram's Bot API
    constraints (lowercase letters, digits, underscores; 1-32 characters; short
@@ -169,7 +169,7 @@ Important behavior notes:
 - If `commands` is omitted or `null`, the addon falls back to its built-in
   default command menu.
 - Do not edit or print `bot_token` values while documenting or debugging slash
-  commands.
+  commands. `lingtai://status` reports only a redacted, non-secret view.
 
 ## AUTOMATIC TASK CARD: `events.jsonl` → resident broadcast
 
@@ -180,23 +180,27 @@ programmable slot:
 1. `TelegramManager` owns one tail worker for its lifetime. It reads
    `<workdir>/logs/events.jsonl` and accepts only canonical public `diary` text
    plus validated `tool_call` name and redacted/bounded `_reasoning`. Hidden
-   thinking, aliases, raw action/arguments/results, auth material, and private
-   runtime diagnostics are never projected.
+   thinking, aliases, raw action/arguments/results, external response bodies,
+   URLs, tokens, prompts, paths, tracebacks, auth material, and private runtime
+   diagnostics are never projected. `tool_result`, completion, elapsed,
+   heartbeat, API-error, and provider-error rows are not rendered either.
 2. A provider/API call is identified by its `api_call_id`. All public text and
    safe tool events with the same id remain in one atomic group. The card emits
    exactly one TUI-style divider (`──────────`) before each selected group;
    multiple text/tool events do not create extra dividers.
 3. `/taskcard N` selects the latest N API-call groups (1–10), not N tool uses.
    The existing persisted `normal_rows` value is reused as this numeric group
-   window, so no schema migration or latest-chat route is needed. If a selected
-   group is larger than the card budget, content is truncated inside that group
-   after the group count has been chosen.
-4. The manager renders the bounded groups once and broadcasts the same
+   window. If a selected group is larger than the card budget, content is
+   truncated inside that group after the group count has been chosen.
+4. Each rendered card carries the safe public text and tool rows, the fixed
+   no-reply footer naming both `/taskcard` command forms, and the render-time
+   timestamp.
+5. The manager renders the bounded groups once and broadcasts the same
    agent-behavior view to every tracked resident Task Card across configured
    Telegram accounts and chats. Groups carry no account/chat route and are not
    correlated to the chat that created a resident card; one target's failure
    does not block the others.
-5. There is no durable cursor or second behavior store. The byte offset, groups,
+6. There is no durable cursor or second behavior store. The byte offset, groups,
    and channel frames are in-memory optimizations. Startup, refresh, molt, and
    detected log truncation/replacement rehydrate from the existing
    `events.jsonl` and `TelegramAccount.task_cards` state. An unterminated final
@@ -208,6 +212,22 @@ Architecture and lifecycle details live in the owning
 [`task_card/resident.py`](task_card/resident.py); the programmable renderer/tool
 structure lives in the separate
 [`telegram/task_card` Anatomy](task_card/ANATOMY.md).
+
+### Resident-card behavior you can rely on
+
+Both slots share one per-account+chat delivery transaction over a single tracked
+resident target. While that resident is still the chat's last message it is edited
+in place (an identical Telegram edit is a successful no-op). Once a newer message
+sits below it — your own durable send/reply, or an incoming user message — the
+manager replaces it old-first and fails closed: the exact old card must be
+confirmed deleted, or Telegram must explicitly report it already missing, before a
+replacement is sent, so rotation never deliberately shows two cards. A replacement
+that then fails may leave **zero** cards and says so explicitly; a durable-id write
+failure surfaces as a partial, not as success. Ordinary messages are never deletion
+candidates and unknown historical orphan cards are never scanned or deleted; the
+durable map is one tracked target per account+chat, not proof of global
+chat-history cardinality. Normative source:
+[`task_card/CONTRACT.md`](task_card/CONTRACT.md) §Behavior 7–8.
 
 ## TASKCARD STATE
 
@@ -229,54 +249,43 @@ structure lives in the separate
   many of the newest bounded API-call groups the automatic card renders; it is
   not a tool-row count.
 - `taskcard: True` means automatic and programmable Task Cards may be sent to
-  Telegram. `taskcard: False` hides delivery of **both** slots at the presentation
-  boundary. The event tail still follows the journal and programmable renderers,
-  watchers, retries, and bookkeeping continue, but no automatic broadcast is
-  delivered while disabled. Turning delivery back on needs no restart.
-- Automatic event-tail cards render safe public text and tool rows, one divider
-  per selected API-call group, the fixed no-reply footer
-  that names both command forms, and the render-time timestamp. They do not render
-  `tool_result`, completion, elapsed, heartbeat, API-error, or provider-error rows,
-  and they do not forward raw arguments, external response bodies, URLs, tokens,
-  prompts, paths, or tracebacks.
+  Telegram. **`taskcard: False` / `/taskcard off` hides delivery of *both* slots**
+  at the presentation boundary while every mechanic continues — the event tail
+  still follows the journal, and programmable renderers, watches, retries, and
+  bookkeeping keep running. Nothing is broadcast while disabled. Turning delivery
+  back on needs no restart.
 - When answering whether Task Cards are on or how many normal rows they keep, use
   the explicit current `/taskcard` status rather than inferring from a visible card.
 
 ## PROGRAMMABLE TASK CARD (`task_card` tool)
 
-- **Task-specific watcher guidance during Telegram-originated turns:** when you
-  launch meaningful long-running work and then wait for its producer, inspect the
-  actual task and producer evidence and design a human-visible watcher when it will
+- **When to reach for it:** during a Telegram-originated turn, when you launch
+  meaningful long-running work and then wait for its producer, inspect the actual
+  task and producer evidence and design a human-visible watcher if it will
   prevent a silent gap. Record a truthful snapshot after launch, after meaningful
   polls/checks, and at the terminal result. Skip it for quick or invisible work;
   do not treat a watcher as a fixed layout or an autonomous live feed.
-- The resident Task Card has two independent slots: the **automatic** event-journal
-  slot (manager-owned, described under **AUTOMATIC TASK CARD: `events.jsonl` →
-  resident broadcast**) and a **programmable** slot you drive with the separate
-  public `task_card` tool. With both present, the
+- The resident Task Card has two independent slots: the **automatic**
+  event-journal slot described above (manager-owned) and a **programmable** slot
+  you drive with the separate public `task_card` tool. With both present, the
   programmable block appears under a `— WATCH —` header; updating one slot never
   disturbs the other.
-- You surface your latest reported snapshot on the programmable slot by supplying
-  a small **Python renderer** file inside your working directory whose stdout is
-  exactly one Task Card JSON object (`title` string, `lines` array of ≤20 strings,
-  `footer` string; at least one present). Telegram never runs your code — the
-  controller runs the renderer as a subprocess and forwards only the validated
-  data.
-- Actions: `start` (validate + run once, then watch on an interval; returns a
-  `watch_id`), `inspect` (state + last valid frame), `retry` (re-run now), `stop`
-  (end the watch, clear only the programmable frame; renderer files are never
-  deleted). A bad first run is an immediate error and starts no watch; later
-  failures keep the last valid frame and raise a deduped fail-loud system wake.
-- `/taskcard off` hides delivery of **both** slots (see **TASKCARD STATE**) while
-  the renderer, watches, and last-valid bookkeeping keep running.
-- **Full task-specific manual (evidence selection, required watcher facts, safe
-  custom-renderer example, renderer contract, and the full
-  start|inspect|retry|stop walkthrough):** follow the relative path
-  `task_card/SKILL.md` from this manual's directory (the co-located Programmable
-  Task Card manual). Starting a watch drives the programmable slot of the
-  `TelegramManager`-owned single resident card, reusing the tracked resident or
-  creating its one resident if none exists yet; it does not start another manager
-  or a second card.
+- You drive the programmable slot by supplying a small **Python renderer** file
+  inside your working directory whose stdout is exactly one Task Card JSON
+  object. Telegram never runs your code — the controller runs the renderer as a
+  subprocess and forwards only the validated data.
+- Actions are `start | inspect | retry | stop`. `start` validates and runs the
+  renderer once synchronously, so a bad first run is an immediate error that
+  starts no watch; later failures keep the last valid frame and raise a deduped
+  fail-loud system wake. `stop` clears only the programmable frame; renderer
+  files are never deleted.
+- Starting a watch drives the programmable slot of the `TelegramManager`-owned
+  single resident card, reusing the tracked resident or creating its one resident
+  if none exists yet; it does not start another manager or a second card.
+- **Read [`task_card/SKILL.md`](task_card/SKILL.md) before authoring a
+  renderer.** It owns evidence selection, the required watcher facts, a safe
+  runnable custom-renderer example, the renderer contract, the full
+  `start|inspect|retry|stop` walkthrough, and terminal/fail-loud cleanup.
 
 ## ERROR SURFACING
 

--- a/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: telegram-task-card-manual
 description: |
-  Manual for the programmable Telegram Task Card (`task_card` tool). Read this
-  when a task needs a truthful, task-specific watcher: inspect the actual task
-  and producer evidence, design a small renderer, and use the start | inspect |
-  retry | stop lifecycle without prescribing a fixed layout or data source.
-last_changed_at: "2026-07-16T14:57:00-07:00"
+  Nested telegram-mcp-manual reference for the programmable Telegram Task Card
+  (`task_card` tool). Read this when a task needs a truthful, task-specific
+  watcher: inspect the actual task and producer evidence, design a small
+  renderer, and use the start | inspect | retry | stop lifecycle without
+  prescribing a fixed layout or data source.
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/mcp_servers/telegram/SKILL.md
 - src/lingtai/mcp_servers/telegram/task_card/controller.py
@@ -60,10 +61,8 @@ reliably available:
    the next evidence-based transition or review gate, and any blocker. Do not call
    work `running`, `done`, or `healthy` without evidence; say `unknown` or
    `unavailable` when that is the truth.
-6. **Feedback and improvement** — after the watcher has had meaningful real use,
-   proactively ask whether it helped and what should improve. Use the answer to
-   improve this current watcher first; only then extract a reusable method into a
-   skill.
+6. **Feedback and improvement** — after meaningful real use, ask whether the
+   watcher helped (see **Feedback and reuse loop**).
 
 These are information requirements, not a visual template. The frame may use any
 layout that keeps the facts legible and bounded. Do not add decorative fields just
@@ -88,6 +87,23 @@ proof of progress. If the task has no reliable activity or token signal, report
 that limitation plainly and choose another truthful signal rather than inventing
 one. Write snapshots atomically when the orchestrator owns them, so a renderer
 never mistakes a half-written update for a real state.
+
+## Renderer contract
+
+A renderer is an ordinary Python file inside the agent working directory. Each run
+must exit `0` and print exactly one JSON object to stdout:
+
+- `title` is a string (optional);
+- `lines` is an array of at most 20 strings (optional);
+- `footer` is a string (optional);
+- at least one of those values must be non-empty.
+
+Nonzero exit, timeout, empty or multi-object output, a non-object, or wrong field
+types are handled failures. The controller uses `sys.executable`, the working
+directory as `cwd`, a per-run timeout, and symlink-resolved containment for
+`renderer_path`. Telegram receives only the validated card data, never renderer
+code. Keep secrets, credentials, raw logs, and unbounded output out of the frame;
+the manager also redacts at its boundary but cannot make an unsafe source safe.
 
 ## Safe custom renderer example
 
@@ -163,23 +179,6 @@ not report. Start it with the controller only after adapting and testing it:
 {"action": "start", "renderer_path": "watcher.py", "interval_s": 5, "timeout_s": 10}
 ```
 
-## Renderer contract
-
-A renderer is an ordinary Python file inside the agent working directory. Each run
-must exit `0` and print exactly one JSON object to stdout:
-
-- `title` is a string (optional);
-- `lines` is an array of at most 20 strings (optional);
-- `footer` is a string (optional);
-- at least one of those values must be non-empty.
-
-Nonzero exit, timeout, empty or multi-object output, a non-object, or wrong field
-types are handled failures. The controller uses `sys.executable`, the working
-directory as `cwd`, a per-run timeout, and symlink-resolved containment for
-`renderer_path`. Telegram receives only the validated card data, never renderer
-code. Keep secrets, credentials, raw logs, and unbounded output out of the frame;
-the manager also redacts at its boundary but cannot make an unsafe source safe.
-
 ## Lifecycle: `start` | `inspect` | `retry` | `stop`
 
 - **`start`** validates the path and runs the renderer once synchronously. A bad
@@ -204,18 +203,18 @@ the manager also redacts at its boundary but cannot make an unsafe source safe.
 
 The Telegram manager remains the single owner of the tracked resident, composition,
 transport, persistence, and the independent automatic slot. `/taskcard off` hides
-both slots at presentation time while rendering, watches, retries, and bookkeeping
-continue; re-enabling needs no restart.
+both slots at presentation time while everything here keeps running — see
+**TASKCARD STATE** in the parent [`telegram` manual](../SKILL.md).
 
 ## Terminal cleanup and fail-loud behavior
 
 A passive renderer cannot stop itself. When the producer reaches a terminal state,
 record that terminal evidence and immediately call
-`task_card(action="stop", watch_id="<watch_id>")`. Retry the same call if it
-returns `stop_failed`; do not restart or duplicate the watch. Terminal evidence
-must still distinguish success, failure, cancellation, timeout, or an unavailable
-outcome according to the producer's contract. Do not leave a completed watcher
-resident merely because its card can still refresh.
+`task_card(action="stop", watch_id="<watch_id>")`. Terminal evidence must still
+distinguish success, failure, cancellation, timeout, or an unavailable outcome
+according to the producer's contract. Do not restart or duplicate the watch, and
+do not leave a completed watcher resident merely because its card can still
+refresh.
 
 After a handle exists, a renderer or backend failure preserves the last valid frame
 and emits one deduplicated, fail-loud `task_card.error` wake per failure episode,
@@ -240,11 +239,8 @@ It is harmful when a static renderer, guessed token count, or redraw timestamp
 creates the appearance of movement. The controller therefore owns validation,
 confinement, lifecycle, and fail-loud recovery, while the Agent owns judgment about
 the task, evidence source, facts to show, and how to improve the current watcher.
-The paired `CONTRACT.md` defines the stable interface and behavior promises; this
-manual defines how an Agent should design and operate a watcher without weakening
-those promises.
 
-This manual is co-located at
-`src/lingtai/mcp_servers/telegram/task_card/SKILL.md`. The top-level Telegram
-manual routes here for the programmable Task Card procedure. The paired
-`ANATOMY.md` maps the controller, resident, transport, and producer connections.
+The paired [`CONTRACT.md`](CONTRACT.md) defines the stable interface and behavior
+promises; this manual defines how an Agent should design and operate a watcher
+without weakening those promises. The paired [`ANATOMY.md`](ANATOMY.md) maps the
+controller, resident, transport, and producer connections.

--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -6,8 +6,8 @@ description: |
   reply, check/read/search, media_path attachments (image/video/voice/file),
   contacts/accounts basics, and external-delivery side-effect caveats. Pulled on
   demand via action='manual'; you do not need to call it before every send.
-version: 1.0.0
-last_changed_at: "2026-06-26T14:33:19-07:00"
+version: 1.0.1
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/mcp_servers/wechat/manager.py
 - src/lingtai/mcp_servers/wechat/server.py
@@ -18,14 +18,12 @@ maintenance: |
 
 # WeChat MCP — usage manual (progressive disclosure)
 
-This manual is pulled on demand via `action='manual'` so the per-action tool
-schema can stay concise. Read it when you need detail beyond the one-line action
-descriptions; you do not need to call it before every send.
-
 ## RECIPIENTS: user_id
 
-- Messages target a WeChat user by `user_id` (e.g. `wxid_abc123@im.wechat`). Use
-  the `user_id` returned by `check`/`read`/`contacts`; do not invent one.
+- Messages target a WeChat user by `user_id` (e.g. `wxid_abc123@im.wechat`).
+  `user_id` is the routing truth; aliases are convenience labels only. Use the
+  `user_id` returned by `check`/`read`/`contacts` and do not invent one — when
+  in doubt, especially for replies, take it from `read`/`check`.
 
 ## SEND vs REPLY
 
@@ -69,8 +67,6 @@ descriptions; you do not need to call it before every send.
 
 ## WAKE / REPLAY / DUPLICATE-REPLY DISCIPLINE
 
-- `user_id` is the routing truth; aliases are convenience labels only. When in
-  doubt, use the `user_id` returned by `read`/`check`, especially for replies.
 - Reply once per inbound `message_id`. Before sending after a refresh, molt, or
   worker-hang recovery, use `read` to reconcile the merged inbox+sent view and
   avoid duplicate replies.

--- a/src/lingtai/mcp_servers/whatsapp/SKILL.md
+++ b/src/lingtai/mcp_servers/whatsapp/SKILL.md
@@ -8,8 +8,8 @@ description: |
   notification transient-hook vs persistent-context split, and
   external-delivery side-effect caveats. Pulled on demand via action='manual'; you
   do not need to call it before every send.
-version: 1.1.0
-last_changed_at: "2026-07-06T00:00:00-07:00"
+version: 1.2.0
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/mcp_servers/whatsapp/manager.py
 - src/lingtai/mcp_servers/whatsapp/server.py
@@ -19,10 +19,6 @@ maintenance: |
 ---
 
 # WhatsApp MCP — usage manual (progressive disclosure)
-
-This manual is pulled on demand via `action='manual'` so the per-action tool
-schema can stay concise. Read it when you need detail beyond the one-line action
-descriptions; you do not need to call it before every send.
 
 This client uses the official Meta WhatsApp Cloud API only (no WhatsApp Web
 bridge).
@@ -53,8 +49,9 @@ bridge).
 ## READING: check / read / search
 
 - `check`: list recent conversations.
-- `read`: read messages from one conversation (`wa_id`; optional `limit`,
-  `mark_read`).
+- `read`: read messages from one conversation (`wa_id`, or a `message_id` to
+  resolve it; optional `limit`). `mark_read` defaults to true — `read` marks the
+  conversation read on WhatsApp unless you pass `mark_read=false`.
 - `search`: regex search over message text (`query`).
 
 ## CONTACTS / ACCOUNTS / STATUS

--- a/src/lingtai/tools/avatar/manual/SKILL.md
+++ b/src/lingtai/tools/avatar/manual/SKILL.md
@@ -3,7 +3,7 @@ name: avatar-manual
 description: |
   Complete operational guide for the avatar tool — spawning, managing, and communicating with 他我 (alter-ego agents). Read this when: you are about to spawn an avatar; an avatar you spawned goes quiet; you need to decide between avatar, daemon, or bash; or you are an avatar and need to know how to escalate to your parent. Covers spawn types, naming rules, discipline, escalation protocol, and the parent_prompt contract.
 version: 1.0.0
-last_changed_at: "2026-06-14T00:11:48-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/avatar/__init__.py
 - src/lingtai/tools/avatar/ANATOMY.md
@@ -27,11 +27,11 @@ Once spawned, it is **detached** — a new life. It has its own working director
 
 ### Avatar vs Daemon vs Bash
 
-| Tool | Use when | Persistence |
-|------|----------|-------------|
-| **Avatar** | Work that needs *persistence and learning* — a specialist that accumulates knowledge across sessions | Independent process, survives until sleep/suspend |
-| **Daemon** | Work you only need the *conclusion* of — large file scans, batch transforms, exploratory search | Ephemeral, fire-and-forget |
-| **Bash** | *One-off commands* — scripts, git, curl, package management | No persistence |
+Pick avatar only for work that needs *persistence and learning* — a specialist
+that accumulates knowledge across sessions and survives until sleep/suspend.
+Use `daemon` when you only need the *conclusion* (ephemeral, fire-and-forget)
+and `bash` for one-off commands. The full body-selection model lives in
+`system-manual` → `reference/substrate-manual/SKILL.md` §1.
 
 ## 2. Spawn Types
 
@@ -68,7 +68,7 @@ This is the most important part of the spawn. A vague briefing produces a confus
 Every `avatar(action="spawn")` call creates an independent process that consumes resources until `system(sleep)` or `system(suspend)`. Treat spawns as expensive:
 
 1. **Never include `avatar(action="spawn")` in a parallel batch** with unrelated tool calls.
-2. **Re-read your `reasoning` field before invoking** — that text becomes the avatar's first prompt.
+2. **Re-read your `reasoning` field before invoking** (§4).
 3. **For inspection or one-off commands, use `bash` or `system`** — not `avatar`.
 4. **Use `dry_run=true` to preview** a spawn without creating a process. Sanity-check the name, type, working directory, and mission before committing.
 5. **Use `confirm=true`** to acknowledge you have double-checked the mission and intend to spawn. Required when the mission looks empty/very short/test-like.
@@ -77,13 +77,10 @@ Every `avatar(action="spawn")` call creates an independent process that consumes
 
 ### Record in pad
 
-After spawning, record in your pad:
-
-- The avatar's address (working directory name)
-- The mission you gave it
-- Why you delegated
-
-Pad is the living roster of delegations you are accountable for. Update when the avatar reports back or completes.
+After spawning, record the avatar's address (working-directory name), the
+mission you gave it, and why you delegated. Pad is the roster of delegations you
+are accountable for — update it when the avatar reports back or completes.
+(Pad practice itself: `psyche-manual` §5.)
 
 ### When an avatar goes quiet
 

--- a/src/lingtai/tools/bash/manual/SKILL.md
+++ b/src/lingtai/tools/bash/manual/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: shell-manual
 description: >
-  **Read this before running long-lived agent/coding CLIs (`claude -p`,
-  `codex exec`, `opencode run`, Cursor Agent, Gemini CLI, Aider, Goose,
-  OpenHands, Crush, or similar harnesses), or before setting up cron,
-  launchd, systemd timers, crontab jobs, or scheduled reminders.** Router for
-  Shell-related operational depth beyond the shell tool schema: async + poll
-  discipline for long-running child agents, host-scheduler setup, LingTai
-  wake-by-mailbox-drop, built-in async last-resort reminders, script hygiene, one-shot `.notification/cron.json`
-  reminders, debugging silent jobs, and safe cleanup. Start here for any
-  long-running agent CLI, time-driven recurring work ("every hour", "weekdays at
-  9", "remind me later"), or when a scheduled job misbehaves.
-version: 1.7.1
-last_changed_at: "2026-07-13T04:44:00-07:00"
+  **Read before running a long-lived agent/coding CLI (`claude -p`, `codex exec`,
+  `opencode run`, Cursor Agent, Gemini CLI, Aider, Goose, OpenHands, Crush, or a
+  similar harness), or before setting up cron, launchd, systemd timers, crontab
+  jobs, or scheduled reminders.** Router for Shell depth beyond the tool schema:
+  async + poll discipline for long-running children, host-scheduler setup,
+  LingTai wake-by-mailbox-drop, async last-resort reminders, script hygiene,
+  one-shot `.notification/cron.json` reminders, debugging silent jobs, and safe
+  cleanup. Start here for time-driven recurring work ("every hour", "weekdays at
+  9", "remind me later") or a misbehaving scheduled job.
+version: 1.8.0
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/__init__.py
 - src/lingtai/tools/bash/CONTRACT.md
@@ -61,78 +60,75 @@ files, not standalone top-level skills.
 - name: bash-claude-code
   location: reference/bash-claude-code/SKILL.md
   description: |
-    Claude Code CLI as a long-running bash subprocess: explicit model selection,
-    async/poll discipline, allowed tools, JSON output, and stuck-run recovery.
+    Claude Code CLI (`claude -p`) subprocess usage: the auth-env (`env -u …`)
+    hygiene rule and weekly-limit/credit-balance diagnosis, key flags, print-mode
+    background-job rule, recommended patterns, and stuck-run recovery.
 - name: bash-openai-codex
   location: reference/bash-openai-codex/SKILL.md
   description: |
-    OpenAI Codex CLI (`codex exec`) subprocess usage: sandbox/approval flags,
-    model selection, async handling, and automation caveats.
+    OpenAI Codex CLI (`codex exec`) subprocess usage: install/config, model and
+    auth setup, feature surface, Codex-vs-Claude-Code style choice, and
+    troubleshooting.
 - name: bash-opencode
   location: reference/bash-opencode/SKILL.md
   description: |
-    OpenCode CLI (`opencode run` / `opencode serve`) subprocess usage, provider
-    configuration, JSON output, session caveats, and daemon-harness notes.
+    OpenCode CLI (`opencode run` / `opencode serve`) subprocess usage: provider
+    auth, command/flag surface, warm-server and custom-agent patterns, and the
+    "daemon backend may not exist" caveat.
 - name: bash-cursor-agent
   location: reference/bash-cursor-agent/SKILL.md
-  description: |
-    Cursor Agent CLI subprocess usage and daemon-harness checks.
+  description: Cursor Agent CLI (`cursor-agent --print`) command shape and status.
 - name: bash-mimocode
   location: reference/bash-mimocode/SKILL.md
   description: |
-    MiMo Code CLI subprocess usage; provider discovery stays with swiss-knife,
-    while shell execution hygiene lives here.
+    MiMo Code CLI (`mimocode` / `mimo`) command shape and status; provider
+    discovery stays with swiss-knife, shell execution hygiene lives here.
 - name: bash-qwen-code
   location: reference/bash-qwen-code/SKILL.md
-  description: |
-    Qwen Code CLI subprocess usage and daemon-harness checks.
+  description: Qwen Code CLI (`qwen-code` / `qwen`) command shape and status.
 - name: bash-oh-my-pi
   location: reference/bash-oh-my-pi/SKILL.md
   description: |
-    Oh-My-Pi / Pi Coding Agent (`omp`) subprocess usage, JSON mode, approval
-    mode, and session-resume caveats.
+    Oh-My-Pi / Pi Coding Agent (`omp`) command shape: JSON mode, approval mode,
+    and `--session` resume.
 - name: bash-kimicode
   location: reference/bash-kimicode/SKILL.md
   description: |
     Kimi Code (`kimi`) subprocess usage: one-shot `--prompt`/`--output-format`
-    mode, the `--prompt` + `--yolo` conflict, and why ask/resume is unsupported.
+    mode, the `--prompt` + `--yolo` conflict, per-run environment, the
+    run-private `mcp.json` loader, and why ask/resume is unsupported.
 - name: bash-gemini-cli
   location: reference/bash-gemini-cli/SKILL.md
-  description: |
-    Gemini CLI as a candidate coding harness: non-interactive prompt mode,
-    approval flags, resume questions, and promotion checklist.
+  description: Gemini CLI (`gemini -p`) candidate-harness command shape and status.
 - name: bash-aider
   location: reference/bash-aider/SKILL.md
-  description: |
-    Aider as a scriptable coding harness: `--message` mode, git behavior,
-    one-shot automation, and daemon suitability caveats.
+  description: Aider (`aider --message`) candidate-harness command shape and status.
 - name: bash-goose
   location: reference/bash-goose/SKILL.md
-  description: |
-    Goose CLI as a candidate coding harness: session/no-session modes and
-    daemon promotion checklist.
+  description: Goose CLI candidate-harness command shape and status.
 - name: bash-openhands
   location: reference/bash-openhands/SKILL.md
   description: |
-    OpenHands CLI headless mode as a candidate harness: `--task`/`--file`, JSONL,
-    dependency footprint, and daemon promotion checklist.
+    OpenHands CLI headless mode (`--task`/`--file`, JSONL) candidate-harness
+    command shape, status, and dependency-footprint caveat.
 - name: bash-crush
   location: reference/bash-crush/SKILL.md
-  description: |
-    Charm Crush CLI as a candidate harness: `crush run`, permission/session
-    questions, and daemon promotion checklist.
+  description: Charm Crush (`crush run`) candidate-harness command shape and status.
 - name: bash-zed-acp
   location: reference/bash-zed-acp/SKILL.md
   description: |
-    Zed/ACP external-agent bridge notes: ecosystem integration, not a direct
-    daemon backend unless a headless ACP client command is available.
+    Zed/ACP external-agent bridge: ACP is a protocol, not a binary — identify a
+    concrete headless client command before treating it as a harness.
 ```
+
+Every `bash-*` page above assumes the shared **Coding-CLI harness baseline**
+below; the page itself carries only what is specific to that CLI.
 
 ## Router table
 
 | Need / keywords | Read |
 |---|---|
-| Running a long-running agent/coding CLI as a sub-process: `claude -p`, `codex exec`, `opencode run`, Cursor Agent, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, Gemini CLI, Aider, Goose, OpenHands, Crush; "run an agent in the background"; avoid blocking the turn | `reference/bash-claude-code/SKILL.md`, `reference/bash-openai-codex/SKILL.md`, `reference/bash-opencode/SKILL.md`, or the matching `reference/bash-*/SKILL.md`; keep the core async/poll rules below resident |
+| Running a long-running agent/coding CLI as a sub-process: `claude -p`, `codex exec`, `opencode run`, Cursor Agent, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, Gemini CLI, Aider, Goose, OpenHands, Crush; "run an agent in the background"; avoid blocking the turn | `reference/bash-claude-code/SKILL.md`, `reference/bash-openai-codex/SKILL.md`, `reference/bash-opencode/SKILL.md`, or the matching `reference/bash-*/SKILL.md`; keep `## Core rules to keep resident` and `## Coding-CLI harness baseline` below resident |
 | Human asks for time-driven recurring work: "every hour", "daily", "weekdays at 9", "write/check/send on a schedule"; choose cron vs event watcher; create launchd/systemd/crontab wiring; understand wake-by-mailbox-drop; write scheduler prompt/script hygiene | `reference/scheduled-work/SKILL.md` |
 | Need a one-shot reminder or wakeup nudge while work is pending; `.notification/cron.json`; atomic reminder writer; rest checklist | `reference/notification-reminders/SKILL.md` |
 | Scheduled job is silent, fires twice, exits immediately, gets killed by launchd, fails to deliver mail, or must be retired/cleaned up | `reference/debugging-cleanup/SKILL.md` |
@@ -313,6 +309,65 @@ reading the whole file when you only need recent events.
   record remains for evidence, but any later poll/cancel returns `Job already
   finished` instead of exposing a second result. New job IDs carry full UUID4 hex;
   legacy eight-hex IDs are accepted only to read retained old records.
+
+## Coding-CLI harness baseline
+
+This section is the single owner of the rules every `reference/bash-*/SKILL.md`
+page shares. Read it once; each page then adds only its own command shape,
+status, flags, and caveats.
+
+**Before relying on any coding CLI in automation:** run the installed CLI's own
+`--help`. Flag surfaces rev between releases, so a documented flag is
+illustrative, never authoritative.
+
+**CLI vs daemon — pick by the shape of the work.** A CLI subprocess is one
+synchronous run whose transcript you read yourself; a LingTai daemon is a
+dispatched worker with its own worktree, branch, and context window.
+
+| Signal | Pick |
+|---|---|
+| "I want the answer in this conversation, now" | **CLI** |
+| "The output is a small string/snippet I'll paste somewhere" | **CLI** |
+| "I need this exact CLI model/agent/flag, or a warm attached server" | **CLI** |
+| "I want to do three of these at once" | **Daemon** (one per task) |
+| "I'll review a diff afterward, not the transcript" | **Daemon** |
+| "This will take 15+ minutes and produce a branch" | **Daemon** |
+| "This might block my main turn while a human waits" | **Daemon** or supervised background wrapper |
+| "I'm the orchestrator; the daemon is the worker" | **Daemon** |
+
+When in doubt for non-trivial work: daemon. A CLI has **no LingTai job protocol
+of its own** — "async" always means a LingTai or OS wrapper around it
+(`shell(async=true)`, a supervised background job, or a daemon backend), and
+that wrapper owns logs, timeout, cancellation, and recovery notes. Keep
+synchronous inline calls short and explicitly timed (for example a 300 s bash
+timeout); do not solve a long task by raising the synchronous timeout to 15+
+minutes while the main agent waits. Checkpoint the worktree, branch, goal, and
+recovery instructions to pad or a journal before dispatching anything that might
+outlive the turn, and prefer several smaller bounded calls over one monolithic
+prompt. Backend names, `backend_options`, `ask`/resume, and per-backend parser
+caveats belong to `daemon-manual` → `reference/cli-backends/SKILL.md`, not here.
+
+**Candidate-harness promotion criteria.** Several pages document a CLI that is
+*not* a daemon backend yet. A backend needs all of:
+
+- a deterministic non-interactive start command;
+- a stable session id plus a tested resume command, for `ask`/resume;
+- JSON/JSONL output, or a transcript parser whose output contract is pinned by
+  tests.
+
+If any is missing, keep the CLI as a documented bash harness rather than adding
+a speculative daemon backend.
+
+**Generic validation checklist** for any page above:
+
+1. `command -v <binary>` succeeds, or the documented installation path exists.
+2. `--help` confirms the non-interactive command and approval flags.
+3. A dry-run in a disposable worktree exits non-interactively.
+4. If promoted to a daemon backend, tests mock subprocess launch, output
+   parsing, session capture, resume/ask, and reserved `backend_options`
+   handling.
+
+## Scheduling rules to keep resident
 
 - LingTai has no built-in recurring scheduler. Host schedulers wake agents by
   producing channel input, usually a mailbox-drop or notification file.

--- a/src/lingtai/tools/bash/manual/reference/bash-aider/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-aider/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `aider` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-06-13T04:32:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/_async_supervisor.py
@@ -15,9 +15,10 @@ maintenance: |
 
 # Aider CLI
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`aider`: command shape, async/poll discipline, approval flags, session/resume
-caveats, and whether the CLI is ready for a LingTai daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -28,24 +29,3 @@ Candidate harness. Official scripting docs support `--message`; it is strong for
 ```bash
 aider --message "<prompt>"
 ```
-
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
-
-## LingTai daemon notes
-
-- A daemon backend needs a deterministic non-interactive start command.
-- `ask`/resume needs a stable session id and a tested resume command.
-- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
-  tests pin the output contract.
-- If any of those are missing, keep the CLI as a documented bash harness rather
-  than adding a speculative daemon backend.
-
-## Validation checklist
-
-1. `command -v aider` or documented installation path exists.
-2. `--help` confirms the non-interactive command and approval flags.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
-   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/tools/bash/manual/reference/bash-claude-code/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-claude-code/SKILL.md
@@ -7,9 +7,9 @@ description: >
   quality/effort/budget controls. Use this when you need to write code, generate
   patches, refactor files, create documentation, or do any multi-file code work
   that would be faster delegated than done manually.
-version: 1.0.3
+version: 1.1.0
 tags: [cli, code, delegation, claude, implementation]
-last_changed_at: "2026-06-30T00:00:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
@@ -46,7 +46,9 @@ env \
 
 This runs Claude Code in non-interactive mode (`-p` = print and exit), skipping permission checks for automation.
 
-> **Agent responsiveness rule:** long synchronous `claude -p` jobs in an agent's main turn are **strongly discouraged**. The Claude CLI itself is synchronous: `claude -p` starts a subprocess, waits until the work is done, prints stdout, and exits. If you run that subprocess through a normal blocking bash tool call, the whole agent is blocked until it returns: the agent cannot answer new human messages, cannot checkpoint progress, and appears "stuck" even though the process is alive. Use inline `claude -p` only for short, bounded jobs where waiting inline is acceptable. For PR-sized, multi-file, exploratory, or 15+ minute work, prefer the LingTai daemon Claude-Code backend; if you must use the CLI, wrap it in an explicitly supervised background/async job with logs, timeout, and recovery instructions.
+`claude -p` is itself synchronous: it starts a subprocess, waits, prints stdout,
+and exits. Long synchronous runs in an agent's main turn are strongly
+discouraged — see `shell-manual` `## Coding-CLI harness baseline`.
 
 ### Weekly-limit smoke test
 
@@ -84,72 +86,30 @@ env -u CLAUDE_CODE_OAUTH_TOKEN /bin/zsh -lc \
 
 If the variable is hard-coded in a shell startup file, comment out only that export line and keep a backup. A plain `claude` process can then use Claude Code's own refreshed local OAuth credentials instead of a stale environment override. Already-running LingTai agents may still have inherited the old environment until they are refreshed or restarted; for those current processes, keep using the `env -u ...` child-process wrapper.
 
-## CLI vs Daemon — Which to Use
+## CLI vs Daemon — Claude-specific notes
 
-LingTai exposes Claude Code in two forms. They are **not interchangeable** — pick the one whose shape matches the work.
+The general CLI-vs-daemon choice, the "a CLI has no LingTai job protocol of its
+own" rule, and the short-and-explicitly-timed discipline live in `shell-manual`
+`## Coding-CLI harness baseline`. Read that first. What is specific to Claude
+Code:
 
-### CLI (`claude -p ...` via shell)
-
-A single synchronous subprocess. You wait for it to finish, you get one transcript, the conversation ends when the bash call returns.
-
-**Use the CLI when:**
-- The task is **one-off** and you want the result inline — a typo fix, a single-file refactor, generating a snippet
-- You want the output **threaded back into your current reasoning** (you'll read the diff and decide next steps yourself)
-- The task is **quick** (under a few minutes), budget-bounded, and has an explicit bash timeout
-- You only need **one** of these running at a time
-
-**Synchronous CLI is strongly discouraged when:**
-- The work is PR-sized, branch-producing, exploratory, or likely to run 15+ minutes
-- The human is waiting for responsiveness or may send follow-up instructions
-- A stalled subprocess would make the parent agent look dead
-- You need progress checkpoints, retries, or the ability to inspect/interrupt work independently
-
-`claude -p` does not provide its own async/job protocol. "Async" means a LingTai or OS wrapper around the CLI (for example bash `async=true`, a supervised background job, or an independent daemon/backend), and that wrapper must own logs, timeout, cancellation, and recovery notes.
+- The daemon form is the LingTai `daemon` capability with `backend="claude-code"`
+  (alias of `claude-p`). It runs in its own worktree, context window, and branch.
+- **Claude Code daemons** suit exploratory code reading, multi-file edits,
+  skill/doc work, and PR composition; Codex daemons suit tightly-scoped
+  deterministic diffs. See `../bash-openai-codex/SKILL.md`.
+- Claude Code has **no built-in timeout** — the bash tool's timeout is the only
+  bound on an inline `claude -p`.
+- `--max-budget-usd` bounds spend on ambiguous tasks; there is no daemon-side
+  equivalent, so use it whenever the scope is unknown.
+- Claude Code reads the repo context itself: give it the goal, constraints, and
+  acceptance criteria rather than dumping the codebase into the prompt.
 
 > **Inside `claude -p` (print mode), the inner Claude's own background jobs never notify it back.** `run_in_background`, `&`, and wait-loops are interactive-session affordances; in `--print` there is no second prompt and no `<task-notification>` re-entry, so the model is never woken when the job finishes. If you are the Claude running inside a `claude -p` daemon, **do not background a job and then end your turn waiting for its completion** — run validation synchronously with an adequate explicit timeout and read the result in the same turn, or report a blocker. (The LingTai `claude-p` daemon backend enforces this: a run that ends while awaiting a background-job notification is marked failed, not done.)
 
-**Examples:**
-```bash
-# Fix a typo
-claude -p "fix the typo in line 42 of README.md" --dangerously-skip-permissions
-
-# Generate a small patch you'll review immediately
-claude -p "add a --verbose flag to the build script" --dangerously-skip-permissions
-
-# Quick documentation pass on one file
-claude -p "add docstrings to utils/parser.py" --dangerously-skip-permissions
-```
-
-### Daemon (LingTai `daemon` capability with `backend="claude-code"`)
-
-A persistent agent spawned by the LingTai kernel. Runs in its **own worktree**, with its **own context window**, on its **own branch**. You dispatch it, it works asynchronously, you come back and review the diff.
-
-**Use the daemon when:**
-- You need to run **multiple tasks in parallel** — three disjoint refactors at once, batch validation across N files
-- The task is **complex or multi-step** — designing then implementing, exploring then refactoring — and you want a fresh context window dedicated to it (not competing with your conversation history)
-- You need **context isolation** — the daemon shouldn't see (and shouldn't pollute) your current session's context
-- The work runs **long enough** that a synchronous bash call would be awkward — large refactors, multi-file feature implementations, PR composition
-- You're acting as an **orchestrator** — planning and reviewing, not hand-coding (see the LingTai contributing guide's orchestrator-and-daemons discipline)
-
-**Examples of daemon-shaped work:**
-- "Implement the caching layer in `feat/cache` branch, with tests, and open a PR" — long, multi-step, deserves its own worktree
-- Three parallel skill rewrites that don't share files — dispatch three daemons, review three diffs
-- An exploratory refactor where you don't want intermediate steps cluttering your conversation
-- A "fire-and-check-back-later" task
-
-### Quick decision rule
-
-| Signal | Pick |
-|--------|------|
-| "I want the answer in this conversation, now" | **CLI** |
-| "I want to do three of these at once" | **Daemon** (one per task) |
-| "I'll review a diff afterward, not the transcript" | **Daemon** |
-| "The output is a small string/snippet I'll paste somewhere" | **CLI** |
-| "This might block my main turn while a human waits" | **Daemon** or supervised background wrapper |
-| "This will take 15+ minutes and produce a branch" | **Daemon** |
-| "I'm the orchestrator; the daemon is the worker" | **Daemon** |
-
-When in doubt for non-trivial work: daemon. The orchestrator/daemon split is the project's default discipline — see `utilities/lingtai-dev-guide/reference/contributing/SKILL.md` for the full convention.
+The orchestrator/daemon split is the project's default discipline — see
+`utilities/lingtai-dev-guide/reference/contributing/SKILL.md` for the full
+convention.
 
 ## Key Flags
 
@@ -168,71 +128,43 @@ When in doubt for non-trivial work: daemon. The orchestrator/daemon split is the
 
 ## Recommended Patterns
 
-### Simple task (default quality)
 ```bash
+# Simple task, default quality
 claude -p "fix the typo in README.md" --dangerously-skip-permissions
-```
 
-### Bounded implementation (max quality, still short)
-
-Use this shape only when you expect the task to finish quickly enough that blocking the current turn is acceptable. If it is PR-sized or exploratory, prefer a daemon; if you must use CLI anyway, run it through a supervised background wrapper rather than a blocking main-turn bash call.
-
-```bash
-# Run inside a bash tool call with an explicit timeout, e.g. timeout=300.
+# Bounded implementation at max quality — run inside a bash tool call with an
+# explicit timeout, e.g. timeout=300, and only when blocking the turn is
+# acceptable. PR-sized or exploratory work belongs in a daemon.
 claude -p "implement the small caching helper described in DESIGN.md" \
-  --dangerously-skip-permissions \
-  --effort max \
-  --model opus
-```
+  --dangerously-skip-permissions --effort max --model opus
 
-### With budget control
-```bash
+# Budget-capped for an ambiguous scope
 claude -p "refactor the auth module" \
-  --dangerously-skip-permissions \
-  --effort max \
-  --model opus \
-  --max-budget-usd 5.0
-```
+  --dangerously-skip-permissions --effort max --model opus --max-budget-usd 5.0
 
-### Working in a specific repo
-```bash
+# Target a specific repo
 claude -p "add unit tests for the parser module" \
-  --dangerously-skip-permissions \
-  -d /path/to/repo
-```
+  --dangerously-skip-permissions -d /path/to/repo
 
-### Restricted tools (safer)
-```bash
+# Restrict the tool surface (safer)
 claude -p "generate a patch for issue #42" \
-  --dangerously-skip-permissions \
-  --allowedTools "Bash Edit Read Write"
+  --dangerously-skip-permissions --allowedTools "Bash Edit Read Write"
 ```
 
 ## Best Practices
 
-1. **Keep synchronous calls short and explicitly timed**: Claude Code has no built-in timeout; the bash tool's timeout controls it. For inline `claude -p`, set a short explicit timeout (for example 300 seconds). Solving a long task by raising the synchronous timeout to 15+ minutes while the main agent waits is strongly discouraged.
+The generic ones — keep synchronous calls short and explicitly timed, prefer a
+daemon or supervised wrapper for long/PR-sized work, checkpoint before
+delegating, split large tasks — are in the baseline. Claude-specific:
 
-2. **Prefer daemon or supervised background execution for long or PR-sized work**: If the task is complex, multi-file, branch-producing, or exploratory, dispatch it to the LingTai daemon Claude-Code backend or another independently inspectable supervised wrapper. The parent agent should stay responsive and able to report progress. Remember: the wrapper is asynchronous; `claude -p` itself is not.
-
-3. **Checkpoint before delegation**: For any task that might outlive the current turn, write the worktree, branch, goal, and recovery instructions to pad or a journal before dispatching.
-
-4. **Use `--effort max` for complex work**: This tells Claude to think harder. Worth it for architecture, refactoring, and multi-file changes — but complexity is also a signal to avoid synchronous `claude -p` in the main turn.
-
-5. **Use `--model opus` for quality**: Opus produces better code for complex logic. Use Sonnet (default) for simple tasks.
-
-6. **Split large tasks**: Multiple smaller, bounded `claude -p` calls are safer than one monolithic prompt. If the steps still take long or need a branch, prefer a daemon or supervised background wrapper.
-
-7. **Write clear prompts**: Claude Code reads the repo context itself. Give it the goal, constraints, and acceptance criteria — don't dump the entire codebase into the prompt.
-
-8. **Set budget for unknown tasks**: Use `--max-budget-usd` to prevent runaway spending on ambiguous tasks.
+1. **Use `--effort max` for complex work**: This tells Claude to think harder. Worth it for architecture, refactoring, and multi-file changes — but complexity is also a signal to avoid synchronous `claude -p` in the main turn.
+2. **Use `--model opus` for quality**: Opus produces better code for complex logic. Use Sonnet (default) for simple tasks.
 
 ## Workflow for Patch/PR Creation
 
-1. **Design**: Write a clear spec (what to change, why, constraints)
-2. **Choose execution shape**: quick, bounded patch → `claude -p` with an explicit short bash timeout; PR-sized or long-running work → LingTai daemon Claude-Code backend or a supervised background wrapper, not a blocking main-turn subprocess
-3. **Delegate**: run the chosen workflow with clear constraints and a recovery checkpoint
-4. **Review**: Check the output, run tests
-5. **Push**: Create branch, commit, push as PR
+Design a clear spec → choose the execution shape per the baseline → delegate
+with explicit constraints and a recovery checkpoint → review the output and run
+tests → create the branch, commit, and push as a PR.
 
 ## What to Delegate
 

--- a/src/lingtai/tools/bash/manual/reference/bash-crush/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-crush/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `crush` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-06-13T04:32:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/_async_supervisor.py
@@ -15,9 +15,10 @@ maintenance: |
 
 # Charm Crush CLI
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`crush`: command shape, async/poll discipline, approval flags, session/resume
-caveats, and whether the CLI is ready for a LingTai daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -28,24 +29,3 @@ Candidate harness. Docs describe non-interactive `crush run`; verify permission/
 ```bash
 crush run "<prompt>"
 ```
-
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
-
-## LingTai daemon notes
-
-- A daemon backend needs a deterministic non-interactive start command.
-- `ask`/resume needs a stable session id and a tested resume command.
-- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
-  tests pin the output contract.
-- If any of those are missing, keep the CLI as a documented bash harness rather
-  than adding a speculative daemon backend.
-
-## Validation checklist
-
-1. `command -v crush` or documented installation path exists.
-2. `--help` confirms the non-interactive command and approval flags.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
-   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/tools/bash/manual/reference/bash-cursor-agent/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-cursor-agent/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `cursor-agent` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-06-13T04:32:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
@@ -15,9 +15,10 @@ maintenance: |
 
 # Cursor Agent CLI
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`cursor-agent`: command shape, async/poll discipline, approval flags, session/resume
-caveats, and whether the CLI is ready for a LingTai daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -28,24 +29,3 @@ Use for Cursor Agent CLI subprocesses and daemon backend checks. Prefer async ba
 ```bash
 cursor-agent --print <prompt>
 ```
-
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
-
-## LingTai daemon notes
-
-- A daemon backend needs a deterministic non-interactive start command.
-- `ask`/resume needs a stable session id and a tested resume command.
-- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
-  tests pin the output contract.
-- If any of those are missing, keep the CLI as a documented bash harness rather
-  than adding a speculative daemon backend.
-
-## Validation checklist
-
-1. `command -v cursor-agent` or documented installation path exists.
-2. `--help` confirms the non-interactive command and approval flags.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
-   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/tools/bash/manual/reference/bash-gemini-cli/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-gemini-cli/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `gemini` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-06-13T04:32:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/_async_supervisor.py
@@ -15,9 +15,10 @@ maintenance: |
 
 # Gemini CLI
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`gemini`: command shape, async/poll discipline, approval flags, session/resume
-caveats, and whether the CLI is ready for a LingTai daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -28,24 +29,3 @@ Candidate harness. Public docs indicate non-interactive prompt mode, YOLO approv
 ```bash
 gemini -p "<prompt>" / gemini --prompt "<prompt>"
 ```
-
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
-
-## LingTai daemon notes
-
-- A daemon backend needs a deterministic non-interactive start command.
-- `ask`/resume needs a stable session id and a tested resume command.
-- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
-  tests pin the output contract.
-- If any of those are missing, keep the CLI as a documented bash harness rather
-  than adding a speculative daemon backend.
-
-## Validation checklist
-
-1. `command -v gemini` or documented installation path exists.
-2. `--help` confirms the non-interactive command and approval flags.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
-   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/tools/bash/manual/reference/bash-goose/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-goose/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `goose` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-06-13T04:32:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/_async_supervisor.py
@@ -15,9 +15,10 @@ maintenance: |
 
 # Goose CLI
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`goose`: command shape, async/poll discipline, approval flags, session/resume
-caveats, and whether the CLI is ready for a LingTai daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -28,24 +29,3 @@ Candidate harness. Docs mention start/resume sessions and `--no-session`; exact 
 ```bash
 goose run/session commands (verify current `goose --help`)
 ```
-
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
-
-## LingTai daemon notes
-
-- A daemon backend needs a deterministic non-interactive start command.
-- `ask`/resume needs a stable session id and a tested resume command.
-- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
-  tests pin the output contract.
-- If any of those are missing, keep the CLI as a documented bash harness rather
-  than adding a speculative daemon backend.
-
-## Validation checklist
-
-1. `command -v goose` or documented installation path exists.
-2. `--help` confirms the non-interactive command and approval flags.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
-   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/tools/bash/manual/reference/bash-kimicode/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-kimicode/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `kimicode / kimi` as a long-running shell subprocess or
   LingTai daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-07-01T00:00:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
@@ -15,9 +15,10 @@ maintenance: |
 
 # Kimi Code CLI
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`kimicode / kimi`: command shape, async/poll discipline, one-shot mode, and the
-session/resume caveats that keep `ask` unsupported in the daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -38,10 +39,6 @@ kimi --prompt '<prompt>' --output-format text
 - **Do not combine `--prompt` with `--yolo`** — the CLI refuses that pairing.
 - The daemon backend owns `--prompt` / `--output-format` and forbids `--yolo`;
   free-form `backend_options` are inserted before those owned flags.
-
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
 
 ## Environment
 
@@ -78,11 +75,10 @@ native MCP config.
   `daemon.json` contexts still redact `env`/`headers` values; the unredacted
   values live only in the native per-run config.
 
-## Validation checklist
+## Validation — Kimi-specific steps
 
-1. `command -v kimi` or documented installation path exists.
-2. `--help` confirms `--prompt` / `--output-format` and that `--yolo` conflicts
-   with `--prompt`.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. Before enabling `ask`, source-cite a stable session-id output + tested resume
-   command from local help/code (do not guess).
+Run the baseline checklist, with these substitutions:
+
+- Step 2 must additionally confirm that `--yolo` conflicts with `--prompt`.
+- Before enabling `ask`, source-cite a stable session-id output plus a tested
+  resume command from local help/code — do not guess.

--- a/src/lingtai/tools/bash/manual/reference/bash-mimocode/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-mimocode/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `mimocode / mimo` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-06-13T04:32:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
@@ -15,9 +15,10 @@ maintenance: |
 
 # MiMo Code CLI
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`mimocode / mimo`: command shape, async/poll discipline, approval flags, session/resume
-caveats, and whether the CLI is ready for a LingTai daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -28,24 +29,3 @@ Use for Xiaomi MiMo Code subprocesses. Keep provider/model credential discovery 
 ```bash
 mimocode <prompt> (daemon backend uses the tested command shape in daemon docs)
 ```
-
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
-
-## LingTai daemon notes
-
-- A daemon backend needs a deterministic non-interactive start command.
-- `ask`/resume needs a stable session id and a tested resume command.
-- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
-  tests pin the output contract.
-- If any of those are missing, keep the CLI as a documented bash harness rather
-  than adding a speculative daemon backend.
-
-## Validation checklist
-
-1. `command -v mimocode` or documented installation path exists.
-2. `--help` confirms the non-interactive command and approval flags.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
-   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/tools/bash/manual/reference/bash-oh-my-pi/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-oh-my-pi/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `omp` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-06-13T04:32:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/oh-my-pi/SKILL.md
@@ -15,9 +15,10 @@ maintenance: |
 
 # Oh-My-Pi CLI
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`omp`: command shape, async/poll discipline, approval flags, session/resume
-caveats, and whether the CLI is ready for a LingTai daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -28,24 +29,3 @@ Use for Pi Coding Agent / Oh-My-Pi subprocesses. Daemon ask/resume uses `--sessi
 ```bash
 omp --mode json --approval-mode yolo <prompt>
 ```
-
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
-
-## LingTai daemon notes
-
-- A daemon backend needs a deterministic non-interactive start command.
-- `ask`/resume needs a stable session id and a tested resume command.
-- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
-  tests pin the output contract.
-- If any of those are missing, keep the CLI as a documented bash harness rather
-  than adding a speculative daemon backend.
-
-## Validation checklist
-
-1. `command -v omp` or documented installation path exists.
-2. `--help` confirms the non-interactive command and approval flags.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
-   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/tools/bash/manual/reference/bash-openai-codex/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-openai-codex/SKILL.md
@@ -7,9 +7,9 @@ description: >
   browser integration. Read this when the human asks to use OpenAI Codex CLI,
   wants to compare it with Claude Code, or needs help with installation and
   configuration.
-version: 1.0.1
+version: 1.1.0
 tags: [cli, code, delegation, openai, codex]
-last_changed_at: "2026-06-13T04:41:27-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/codex/SKILL.md
@@ -26,31 +26,28 @@ maintenance: |
 > **OpenAI's coding agent — run locally from your terminal.**
 > Built in Rust for speed. Open source. ~4 million weekly active users (as of April 2026).
 
-## CLI vs Daemon — Which to Use
+## CLI vs Daemon — Codex-specific notes
 
-LingTai exposes Codex in two forms. They are **not interchangeable** — pick the one whose shape matches the work.
+The general CLI-vs-daemon choice, the "a CLI has no LingTai job protocol of its
+own" rule, and the responsiveness practices (short explicitly-timed synchronous
+calls, checkpoint before delegating, split large tasks) live in `shell-manual`
+`## Coding-CLI harness baseline`. Read that first.
 
-### CLI (`codex exec ...` via shell)
+**Codex vs Claude Code — a different axis.** CLI-vs-daemon is about the *shape*
+of the work; Codex-vs-Claude-Code is about its *style*:
 
-A single synchronous subprocess. You wait for it to finish, you get one transcript back, the conversation ends when the bash call returns.
+- **Codex** — tightly-scoped diffs, deterministic refactors, mechanical
+  validation sweeps. More conservative; the right choice when the change is
+  well-specified and the scope is clear.
+- **Claude Code** — exploratory code reading, multi-file edits, skill/doc work,
+  PR composition.
 
-> **Agent responsiveness rule:** long synchronous `codex exec` jobs in an agent's main turn are **strongly discouraged**. The Codex CLI command is a blocking subprocess from the parent agent's point of view: if you run it through a normal blocking bash tool call, the whole agent is blocked until it returns. The agent cannot answer new human messages, cannot checkpoint progress, and appears "stuck" even though the process is alive. Use inline `codex exec` only for short, bounded jobs where waiting inline is acceptable. For PR-sized, multi-file, exploratory, or 15+ minute work, prefer the LingTai daemon Codex backend; if you must use the CLI, wrap it in an explicitly supervised background/async job with logs, timeout, and recovery instructions.
+The daemon form is the LingTai `daemon` capability with `backend="codex"`. See
+`utilities/lingtai-dev-guide/reference/contributing/SKILL.md` for the full
+orchestrator/daemon convention.
 
-**Use the CLI when:**
-- The task is **one-off** and you want the result inline — a tightly-scoped edit, a single deterministic refactor, a quick mechanical pass
-- You want the output **threaded back into your current reasoning** (you'll read it and decide next steps yourself)
-- The task is **quick**, well-bounded, and has an explicit bash timeout
-- You only need **one** of these running at a time
+**Inline CLI examples:**
 
-**Synchronous CLI is strongly discouraged when:**
-- The work is PR-sized, branch-producing, exploratory, or likely to run 15+ minutes
-- The human is waiting for responsiveness or may send follow-up instructions
-- A stalled subprocess would make the parent agent look dead
-- You need progress checkpoints, retries, or the ability to inspect/interrupt work independently
-
-`codex exec` does not provide a LingTai job protocol by itself. "Async" means a LingTai or OS wrapper around the CLI (for example bash `async=true`, a supervised background job, or an independent daemon/backend), and that wrapper must own logs, timeout, cancellation, and recovery notes.
-
-**Examples:**
 ```bash
 # Rename a symbol across a small file
 codex exec "rename the function foo() to fooBar() in utils/helpers.py"
@@ -61,57 +58,6 @@ codex exec --model gpt-5.5 "remove unused imports from src/main.py"
 # Quick scoped fix
 codex exec --dir /path/to/project "fix the off-by-one in parse_range()"
 ```
-
-### Daemon (LingTai `daemon` capability with `backend="codex"`)
-
-A persistent agent spawned by the LingTai kernel. Runs in its **own worktree**, with its **own context window**, on its **own branch**. You dispatch it, it works asynchronously, you come back and review the diff.
-
-**Use the daemon when:**
-- You need to run **multiple tasks in parallel** — several disjoint deterministic refactors at once, a batch validation sweep
-- The task is **complex or multi-step** enough to deserve a fresh context window dedicated to it (not competing with your conversation history)
-- You need **context isolation** — the daemon shouldn't see (and shouldn't pollute) your current session's context
-- The work runs **long enough** that a synchronous bash call would be awkward — wide mechanical refactors, multi-file deterministic diffs, validation passes that touch the whole tree
-- You're acting as an **orchestrator** — planning and reviewing, not hand-coding (see the LingTai contributing guide's orchestrator-and-daemons discipline)
-
-Per the LingTai dev guide, Codex daemons are particularly good for **tightly-scoped diffs, deterministic refactors, and mechanical validation passes** — they're more conservative than Claude Code daemons and are the right choice when the change is well-specified and the scope is clear.
-
-**Examples of daemon-shaped work:**
-- "Apply this codemod across `src/**/*.ts` and open a PR" — wide, mechanical, deserves its own worktree
-- Three parallel deterministic refactors that don't share files — dispatch three daemons, review three diffs
-- A validation sweep over the repo that produces a report and (optionally) fixes
-- A "fire-and-check-back-later" task
-
-### Quick decision rule
-
-| Signal | Pick |
-|--------|------|
-| "I want the answer in this conversation, now" | **CLI** |
-| "I want to do three of these at once" | **Daemon** (one per task) |
-| "I'll review a diff afterward, not the transcript" | **Daemon** |
-| "The output is a small string/snippet I'll paste somewhere" | **CLI** |
-| "This might block my main turn while a human waits" | **Daemon** or supervised background wrapper |
-| "This will take 15+ minutes and produce a branch" | **Daemon** |
-| "I'm the orchestrator; the daemon is the worker" | **Daemon** |
-
-### Codex vs Claude Code (same axis)
-
-Both backends are available as CLI and daemon. The CLI-vs-daemon choice is about **shape of work** (one-shot vs parallel/long/isolated). The Codex-vs-Claude-Code choice is about **style of work**:
-
-- **Codex daemons** — tightly-scoped diffs, deterministic refactors, mechanical validation
-- **Claude Code daemons** — exploratory code reading, multi-file edits, skill/doc work, PR composition
-
-When in doubt for non-trivial work: daemon. See `utilities/lingtai-dev-guide/reference/contributing/SKILL.md` for the full orchestrator/daemon convention.
-
-## Agent Responsiveness Practices
-
-1. **Keep synchronous calls short and explicitly timed**: For inline `codex exec`, set a short explicit bash timeout appropriate to the scoped task. Solving a long task by raising the synchronous timeout to 15+ minutes while the main agent waits is strongly discouraged.
-
-2. **Prefer daemon or supervised background execution for long or PR-sized work**: If the task is complex, multi-file, branch-producing, exploratory, or a wide validation sweep, dispatch it to the LingTai daemon Codex backend or another independently inspectable supervised wrapper. The parent agent should stay responsive and able to report progress. Remember: the wrapper is asynchronous; the CLI subprocess itself is not a LingTai job.
-
-3. **Checkpoint before delegation**: For any task that might outlive the current turn, write the worktree, branch, goal, and recovery instructions to pad or a journal before dispatching.
-
-4. **Split large tasks**: Multiple smaller, bounded `codex exec` calls are safer than one monolithic prompt. If the steps still take long or need a branch, prefer a daemon or supervised background wrapper.
-
 
 ## Installation
 
@@ -165,6 +111,7 @@ codex exec "your prompt"
 New in 0.130.0 — headless, remotely controllable app-server:
 ```bash
 codex remote-control
+codex connect localhost:8080
 ```
 - Start a headless app-server
 - Control Codex remotely
@@ -183,7 +130,7 @@ codex exec "your prompt"
 Workspace sharing and marketplace:
 ```bash
 codex plugins list      # List installed plugins
-codex plugins install   # Install from marketplace
+codex plugins install @openai/plugin-name  # Install from marketplace
 codex plugins share     # Share with workspace
 ```
 
@@ -199,6 +146,7 @@ Browseable and toggleable hooks:
 ```bash
 codex hooks list        # List available hooks
 codex hooks toggle      # Toggle hook on/off
+codex exec --hooks my-hook "<prompt>"
 ```
 
 Capabilities:
@@ -208,95 +156,18 @@ Capabilities:
 - MCP elicitations through TUI/Guardian flows
 
 ### 5. Chrome Extension
-Browser integration without takeover:
-- Works in parallel across tabs
-- Background operation
-- User controls which websites Codex can use
-- Install from Chrome Web Store
+Browser integration without takeover: works in parallel across tabs, operates in
+the background, and the user controls which websites Codex may use. Install from
+the Chrome Web Store.
 
 ### 6. App-Server
-Thread management and pagination:
-```bash
-codex exec "your prompt"
-# In TUI:
-# - Resume/fork picker
-# - Raw scrollback mode
-# - /ide context injection
-# - /diff workspace-aware diffing
-```
+Thread management and pagination inside the TUI: resume/fork picker, raw
+scrollback mode, `/ide` context injection, and `/diff` workspace-aware diffing.
 
-## Usage Examples
+## Codex vs Claude Code — capability differences
 
-### Basic Usage
-```bash
-# Start interactive session
-codex exec "Create a Python script that reads CSV files"
-
-# With specific model
-codex exec --model gpt-5.5 "Refactor this function"
-
-# In specific directory
-codex exec --dir /path/to/project "Fix the bug in main.py"
-```
-
-### Remote Control
-```bash
-# Start headless server
-codex remote-control
-
-# Connect from another terminal
-codex connect localhost:8080
-```
-
-### Plugin Management
-```bash
-# List plugins
-codex plugins list
-
-# Install plugin
-codex plugins install @openai/plugin-name
-
-# Share with workspace
-codex plugins share ./my-plugin
-```
-
-### Hooks
-```bash
-# List hooks
-codex hooks list
-
-# Toggle hook
-codex hooks toggle my-hook
-
-# Run with hooks
-codex exec --hooks my-hook "your prompt"
-```
-
-## Integration with LingTai
-
-### Workflow Integration
-Codex CLI can be used alongside Claude Code for different tasks:
-
-| Task | Claude Code | OpenAI Codex |
-|------|-------------|--------------|
-| Complex reasoning | ✅ Excellent | ✅ Good |
-| Local file operations | ✅ Good | ✅ Excellent |
-| Browser integration | ❌ No | ✅ Chrome extension |
-| Remote control | ❌ No | ✅ Yes |
-| Plugin ecosystem | ❌ Limited | ✅ Rich marketplace |
-
-### When to Use Codex CLI
-- **Browser automation**: Use Chrome extension for web tasks
-- **Remote development**: Use remote-control for headless operation
-- **Plugin ecosystem**: Leverage marketplace for specialized tools
-- **Vim users**: Native Vim editing support
-
-### When to Use Claude Code
-- **Complex reasoning**: Deep analysis and multi-step problem solving
-- **LingTai integration**: Native integration with LingTai kernel
-- **Cost efficiency**: Uses Claude Max subscription
-
-## Comparison with Claude Code
+Both ship a LingTai daemon backend and a bash subskill. The *style* axis is
+above under "CLI vs Daemon"; these are the capability facts behind it:
 
 | Feature | OpenAI Codex CLI | Claude Code |
 |---------|------------------|-------------|
@@ -304,10 +175,16 @@ Codex CLI can be used alongside Claude Code for different tasks:
 | Open Source | ✅ Yes | ❌ No |
 | Vim Support | ✅ Native | ❌ No |
 | Browser Extension | ✅ Chrome | ❌ No |
-| Remote Control | ✅ Yes | ❌ No |
+| Remote Control | ✅ Yes (headless app-server) | ❌ No |
 | Plugin Marketplace | ✅ Rich | ❌ Limited |
-| LingTai Integration | ✅ Daemon backend + bash subskill | ✅ Daemon backend + bash subskill |
+| Local file operations | ✅ Excellent | ✅ Good |
+| Complex reasoning | ✅ Good | ✅ Excellent |
 | Cost | API usage | Claude Max subscription |
+
+So reach for Codex CLI specifically for browser automation (Chrome extension),
+remote/headless development (`codex remote-control`), the plugin marketplace, or
+native Vim editing; reach for Claude Code for deep multi-step analysis and
+subscription-based cost.
 
 ## Troubleshooting
 

--- a/src/lingtai/tools/bash/manual/reference/bash-opencode/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-opencode/SKILL.md
@@ -7,9 +7,9 @@ description: >
   Read this when the human asks to use OpenCode as a CLI tool, compare it with
   Claude Code or Codex, configure providers/agents/MCPs, or run non-interactive
   coding tasks from bash.
-version: 1.0.0
+version: 1.1.0
 tags: [cli, code, delegation, opencode, automation]
-last_changed_at: "2026-06-13T04:32:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
@@ -52,19 +52,29 @@ OpenCode stores provider credentials in `~/.local/share/opencode/auth.json`. It 
 
 ## CLI vs Long-Running Work
 
-This sub-skill is about using OpenCode directly from the shell. For longer work, first check whether your active LingTai daemon schema explicitly supports an OpenCode backend; otherwise supervise OpenCode through bash/worktrees.
+The general CLI-vs-daemon choice lives in `shell-manual` `## Coding-CLI harness
+baseline`. One OpenCode-specific caveat overrides its "pick the daemon" advice:
 
-### CLI (`opencode run ...` via shell)
+> **Do not assume an OpenCode daemon backend exists.** Some LingTai
+> installations expose external coding CLIs through `daemon` backends, but only
+> use one if the active `daemon` tool schema explicitly lists
+> `backend="opencode"`.
 
-A single synchronous subprocess. You wait for it to finish, review its transcript/diff, and decide the next step in your own context.
+If `backend="opencode"` is present, treat the baseline table as written. If it
+is **not**, every "Daemon" row degrades to supervised CLI work from bash:
 
-**Use the CLI when:**
-- The task is **one-off** and bounded: a small edit, quick code review, narrow documentation pass, or a question about a repo.
-- You want the result **threaded back into your current reasoning** instead of launching a background worker.
-- You need a specific OpenCode flag, provider/model, agent, attached file, or headless-server attachment.
-- You only need **one** OpenCode run at a time.
+- create a disposable git worktree;
+- run `opencode run --dir /path/to/worktree ...` with a generous bash timeout or
+  async bash job;
+- periodically inspect `git diff`, captured stdout/stderr, and test output
+  yourself;
+- commit only after review.
 
-**Examples:**
+Two rows also stay **CLI** regardless of backend availability: when you need a
+specific OpenCode model/agent/flag, and when you want to attach to a warm
+`opencode serve` backend.
+
+**Inline CLI examples:**
 
 ```bash
 # Quick answer without opening the TUI
@@ -79,27 +89,6 @@ opencode run --model openai/gpt-5.5 "Review the auth module for race conditions"
 # Ask for raw JSON events, useful for scripts
 opencode run --format json "Summarize the public API changes"
 ```
-
-### Long-running work from the CLI
-
-This sub-skill documents OpenCode as a direct CLI. Some LingTai installations may also expose external coding CLIs through `daemon` backends, but do not assume an OpenCode daemon is available unless the active `daemon` tool schema explicitly lists `backend="opencode"`.
-
-If `backend="opencode"` is available, use the daemon for parallel or long-running worker tasks that should be tracked outside your current context. If it is not available, keep OpenCode CLI work supervised from bash:
-
-- create a disposable git worktree;
-- run `opencode run --dir /path/to/worktree ...` with a generous bash timeout or async bash job;
-- periodically inspect `git diff`, captured stdout/stderr, and test output yourself;
-- commit only after review.
-
-**Quick decision rule:**
-
-| Signal | Pick |
-|--------|------|
-| “I need the answer inline now” | **CLI** |
-| “Use this exact OpenCode model/agent/flag” | **CLI** |
-| “I want to attach to a warm OpenCode server” | **CLI** |
-| “Run three disjoint coding tasks at once” | **Daemon only if `backend="opencode"` is present; otherwise separate supervised worktrees/async bash jobs** |
-| “This may take 15+ minutes and produce a branch/diff” | **Daemon if supported; otherwise supervised CLI in a worktree** |
 
 ## Key Commands
 

--- a/src/lingtai/tools/bash/manual/reference/bash-openhands/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-openhands/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `openhands` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-06-13T04:32:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/_async_supervisor.py
@@ -15,9 +15,10 @@ maintenance: |
 
 # OpenHands CLI
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`openhands`: command shape, async/poll discipline, approval flags, session/resume
-caveats, and whether the CLI is ready for a LingTai daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -28,24 +29,3 @@ Candidate harness. Docs mention headless mode with `--task`/`--file` and JSONL; 
 ```bash
 openhands --task "<prompt>" --json
 ```
-
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
-
-## LingTai daemon notes
-
-- A daemon backend needs a deterministic non-interactive start command.
-- `ask`/resume needs a stable session id and a tested resume command.
-- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
-  tests pin the output contract.
-- If any of those are missing, keep the CLI as a documented bash harness rather
-  than adding a speculative daemon backend.
-
-## Validation checklist
-
-1. `command -v openhands` or documented installation path exists.
-2. `--help` confirms the non-interactive command and approval flags.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
-   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/tools/bash/manual/reference/bash-qwen-code/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-qwen-code/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `qwen-code / qwen` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-06-13T04:32:46-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
@@ -15,9 +15,10 @@ maintenance: |
 
 # Qwen Code CLI
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`qwen-code / qwen`: command shape, async/poll discipline, approval flags, session/resume
-caveats, and whether the CLI is ready for a LingTai daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -28,24 +29,3 @@ Use for Qwen Code subprocesses. Verify installed CLI help before passing backend
 ```bash
 qwen-code <prompt> (daemon backend uses the tested command shape in daemon docs)
 ```
-
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
-
-## LingTai daemon notes
-
-- A daemon backend needs a deterministic non-interactive start command.
-- `ask`/resume needs a stable session id and a tested resume command.
-- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
-  tests pin the output contract.
-- If any of those are missing, keep the CLI as a documented bash harness rather
-  than adding a speculative daemon backend.
-
-## Validation checklist
-
-1. `command -v qwen-code` or documented installation path exists.
-2. `--help` confirms the non-interactive command and approval flags.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
-   session capture, resume/ask, and reserved `backend_options` handling.

--- a/src/lingtai/tools/bash/manual/reference/bash-zed-acp/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/bash-zed-acp/SKILL.md
@@ -5,7 +5,7 @@ description: >
   validate, or document `ACP servers` as a long-running shell subprocess or LingTai
   daemon harness candidate.
 version: 0.1.0
-last_changed_at: "2026-06-13T04:41:27-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/_async_supervisor.py
@@ -15,9 +15,10 @@ maintenance: |
 
 # Zed / ACP agent bridge
 
-Nested shell-manual reference. This page owns **shell execution hygiene** for
-`ACP servers`: command shape, async/poll discipline, approval flags, session/resume
-caveats, and whether the CLI is ready for a LingTai daemon backend.
+Nested shell-manual reference. Read `shell-manual` `## Coding-CLI harness
+baseline` first — it owns the shared run-`--help`-before-you-rely rule, the
+CLI-vs-daemon choice, the candidate-harness promotion criteria, and the generic
+validation checklist. This page adds only what is specific to this CLI.
 
 ## Status
 
@@ -29,23 +30,9 @@ Ecosystem bridge rather than a daemon backend by itself. Document only unless th
 agent-specific ACP command
 ```
 
-Before relying on the command in production, run the current CLI's `--help` and
-prefer `shell(async=true)` for work that can think, edit files, or run tools for
-minutes. Do not run long coding CLIs synchronously from the parent turn.
+## Validation — ACP-specific step before the baseline checklist
 
-## LingTai daemon notes
-
-- A daemon backend needs a deterministic non-interactive start command.
-- `ask`/resume needs a stable session id and a tested resume command.
-- JSON/JSONL output is preferred, but a transcript parser may be acceptable when
-  tests pin the output contract.
-- If any of those are missing, keep the CLI as a documented bash harness rather
-  than adding a speculative daemon backend.
-
-## Validation checklist
-
-1. Identify the specific ACP-compatible client or server command you intend to wrap; ACP is a protocol, not a standalone `ACP` binary.
-2. Run that command's `--help` (or documented equivalent) to confirm non-interactive mode and approval flags.
-3. A dry-run in a disposable worktree exits non-interactively.
-4. If promoted to daemon backend, tests mock subprocess launch, output parsing,
-   session capture, resume/ask, and reserved `backend_options` handling.
+ACP is a protocol, not a standalone `ACP` binary, so there is no single command
+to probe. First identify the specific ACP-compatible client or server command
+you intend to wrap, then run the baseline checklist against *that* command
+(using its documented equivalent when it has no `--help`).

--- a/src/lingtai/tools/bash/manual/reference/debugging-cleanup/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/debugging-cleanup/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Nested shell-manual reference for debugging silent scheduled jobs and retiring
   cron jobs safely: scheduler fired, script ran, work landed, agent saw mail,
   worked launchd diagnosis, cleanup, and bash work footprint hygiene.
-version: 1.0.0
-last_changed_at: "2026-06-01T01:47:09-07:00"
+version: 1.0.1
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
@@ -95,12 +95,6 @@ Reverse of setup, in this order:
 5. Remove any `~/Library/LaunchAgents/<label>.plist` entry that wasn't caught above.
 
 Don't delete the script first — if the unit is still loaded and tries to fire a missing executable, you get noisy error logs.
-
----
-
-## Future debugging topics
-
-This section is empty. As more operational knowledge accumulates (debugging pipelines, working with binary data, locale handling), it gets added here.
 
 ## Cleanup / Footprint for bash work
 

--- a/src/lingtai/tools/bash/manual/reference/notification-reminders/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/notification-reminders/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Nested shell-manual reference for one-shot wakeup reminders using
   `.notification/cron.json`: payload shape, atomic writer, shell example, and the
   rest checklist for agents leaving work pending.
-version: 1.0.0
-last_changed_at: "2026-06-20T13:05:49-07:00"
+version: 1.0.1
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/notification/__init__.py
@@ -148,7 +148,7 @@ tmp.replace(target)
 PY' >/tmp/lingtai-cron-reminder.log 2>&1 &
 ```
 
-This is not a replacement for OS scheduling: a detached sleeper can be lost if the shell/process tree is killed or the machine sleeps through the interval. For long delays or repeated checks, put the same writer into launchd/systemd/crontab using the sections above.
+This is not a replacement for OS scheduling: a detached sleeper can be lost if the shell/process tree is killed or the machine sleeps through the interval. For long delays or repeated checks, put the same writer into launchd/systemd/crontab following `../scheduled-work/SKILL.md`.
 
 ### Rest checklist
 

--- a/src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
+++ b/src/lingtai/tools/bash/manual/reference/scheduled-work/SKILL.md
@@ -5,8 +5,8 @@ description: >
   schedulers, the LingTai wake-by-mailbox-drop contract, prompt boundaries,
   script hygiene, macOS launchd, Linux systemd timers, crontab fallback, and the
   launchd process-tree reaping gotcha.
-version: 1.0.0
-last_changed_at: "2026-06-01T01:47:09-07:00"
+version: 1.0.1
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/bash/manual/SKILL.md
 - src/lingtai/tools/bash/_async_supervisor.py
@@ -18,8 +18,6 @@ maintenance: |
 
 Nested shell-manual reference. Open this when the top-level `shell-manual` router
 selects host-scheduler setup for recurring or time-driven work.
-
-## Scheduled / cron-driven work
 
 ## When to use scheduled work
 

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -7,7 +7,7 @@ description: >
   and clean up daemon footprint. Read this after dispatching daemon work that is
   slow, failed, timed out, exited 143 / SIGTERM, or needs backend-specific reasoning.
 version: 0.9.0
-last_changed_at: "2026-07-16T21:00:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/CONTRACT.md
 - src/lingtai/tools/daemon/ANATOMY.md
@@ -157,10 +157,8 @@ files, not standalone top-level skills.
     returns. Omitting `preset` inherits the parent's regular (non-MCP)
     effective surface instead of a fresh independent default, and does not
     perform this allowlist check at all. External CLI backends skip LingTai
-    preset resolution entirely and use their own model/tools/permissions. For
-    the full preset runtime model (raw vs resolved `init.json`, preset
-    identity, main-agent catalog vs this worker path, and how to authorize a
-    new preset for this path), read `system-manual` →
+    preset resolution entirely and use their own model/tools/permissions. The
+    full preset runtime model is owned by `system-manual` →
     `reference/substrate-manual/SKILL.md` §11.
   - `backend_options`: raw CLI flags for CLI backends only.
 - `context_token_limit`: optional context-token compaction threshold (rendered/provider-context tokens, not cumulative spend). Effective only for `backend="lingtai"` tasks whose resolved provider is Codex (`codex`/`codex-pool`) or the native `mimo` LLM provider (`manifest.llm.provider="mimo"` — NOT the `backend` enum's `mimo`/`mimocode` alias, which drives the external `mimo` CLI as a subprocess and never consults this field at all); every other provider and every external CLI backend ignores it. When the session's provider-visible input-token count reaches the limit, the runtime compacts provider context via that provider's standalone compaction (`POST /responses/compact`) and continues the same tool loop — the daemon keeps running; nothing restarts or drops history. Native `mimo` defaults to the stateless OpenAI Responses wire (full-history/raw-output-item replay; never `store`/`previous_response_id`/`conversation`/generic `context_management` — MiMo's Responses API marks those incompatible); an explicit `wire_api="chat_completions"` on the preset still selects the Chat Completions escape hatch instead. **Failure policy differs by provider:** a standalone-compaction failure is non-fatal for Codex (that turn's compaction is skipped; the loop continues on full history) but a HARD failure for native `mimo` (it propagates to the caller — never silently continuing on full history and never falling back to a different wire), because MiMo has no generic `context_management` fallback and no server-side state to lean on. Omit to inherit the parent service's resolved context window as the threshold. Must be a positive integer; a boolean is rejected.
@@ -198,15 +196,12 @@ files, not standalone top-level skills.
   and selected skills/MCP context, not only for communication. If a daemon receives `shell`,
   say whether it may run mutating commands; if it receives file access, say what
   it may read/write; if it receives web/MCP tools, say what external calls are
-  allowed; if it can communicate, say who it may contact and what context it may
-  share; if `skills` or `mcp` are selected, say when to read/apply/call them.
-- `email` is daemon-eligible but opt-in. Grant it only with `tools: ["email"]`
-  when a daemon truly needs to communicate in the local agent network: reporting
-  to peers, asking a sibling for context, or handing off a result. Availability
-  is not authorization to broadcast. The parent should specify communication
-  rules in `task`: allowed recipients, purpose, tone, thread/reply
-  discipline, information boundaries, whether the daemon may ask questions or
-  only report, how to report back to the parent, and when not to send mail.
+  allowed; if `skills` or `mcp` are selected, say when to read/apply/call them.
+  For `email` specifically — daemon-eligible but opt-in, granted only with
+  `tools: ["email"]` — availability is not authorization to broadcast: state the
+  allowed recipients, purpose, thread/reply discipline, information boundaries,
+  whether the daemon may ask questions or only report, and how to report back to
+  the parent.
 - LingTai-backend daemon tool calls go through the kernel `ToolExecutor` /
   `ToolCallGuard` path before dispatch, so guarded side effects are not allowed
   to bypass normal proposal/execution policy just because they run in a daemon.
@@ -230,13 +225,10 @@ files, not standalone top-level skills.
   easy to point at over copying or reviving a daemon session.
 - Each emanation is disposable memory but durable evidence: its folder persists
   after completion or reclaim until cleanup.
-- `daemon(action="list")` is the first layer of progressive disclosure: it
-  reads active in-memory runs plus historical `daemons/*/daemon.json` run
-  records, returning compact metadata, prompt/result previews, paths, and
-  optional `contains`/`status`/`last` filtering. If a historical
-  `daemon.json` is missing, invalid, or has an old `data_version`, list
-  does a best-effort lazy rebuild from the run folder before indexing it.
-  It is not a full transcript; use the returned paths for details.
+- `daemon(action="list")` is the first layer of progressive disclosure over
+  active and historical runs — compact metadata, previews, and paths, not a full
+  transcript. Use the returned paths for detail; see
+  `reference/cli-backends/SKILL.md` for its filters and lazy-rebuild behavior.
 - **Every terminal outcome is push-notified exactly once** — done, failed,
   cancelled, or timed out. After you dispatch, you can safely go IDLE and wait
   for the notification; do not poll only to ask "is it done yet". The
@@ -245,12 +237,10 @@ files, not standalone top-level skills.
   `daemon(action="check", id=...)` (and read `result.txt` for the full output).
 - **Use a Task Card for progress when one is available for this turn.**
   The dispatch success `handoff` is conditional: if Telegram is connected and a
-  Task Card is available for the current turn, use it to report progress; call
-  `telegram(action='manual')` and follow its `Programmable Task Card` section
-  for details. The daemon tool does not create a Task Card automatically or
-  require a watcher; the calling agent follows the Task Card manual. This keeps
-  daemon lifecycle and terminal-notification behavior unchanged while giving
-  Telegram-originated turns a better progress surface.
+  Task Card is available for the current turn, use it to report progress — call
+  `telegram(action='manual')` and follow its `Programmable Task Card` section.
+  The daemon tool does not create a Task Card automatically or require a
+  watcher; daemon lifecycle and terminal-notification behavior are unchanged.
 - **`check` still resolves a daemon after refresh/molt.** A refresh/molt gives
   you a fresh daemon registry with no in-memory entries, but the run folders
   and their notifications survive on disk. New daemon ids are compact run ids
@@ -265,12 +255,10 @@ files, not standalone top-level skills.
   that never reaches a terminal state at all.** The terminal notification covers
   every state a run can *finish* in, but a run that hangs without the watchdog
   firing, or a degraded notification-wake path, could leave you waiting forever.
-  When daemon work is pending and unverified-healthy, you may arm one self-wake
-  (a `.notification/cron.json` reminder) sized to the task's expected duration as
-  a backstop. On wake, health-check — `state`/`last_output_at` advancing,
-  `current_tool`/`tool_call_count` changing, events alive — and if there is no
-  progress, reclaim/downgrade/switch path and report rather than waiting
-  indefinitely. Do not turn this backstop into frequent polling. See
+  When daemon work is pending and unverified-healthy, arm one self-wake sized to
+  the task's expected duration as a backstop, then health-check on wake and
+  reclaim/downgrade/switch path rather than waiting indefinitely. Do not turn
+  this backstop into frequent polling. Procedure:
   `reference/inspection/SKILL.md`.
 - If repeated-call `_advisory` appears on `daemon(list/check)`, the call still
   ran; treat it as a signal to stop the loop, centralize status checking in the
@@ -300,9 +288,9 @@ Use `prompt` only when LingTai needs a custom first ordinary user message:
 }
 ```
 
-The same pattern applies to non-email tools: `tools` grants a capability surface;
-`skills` grants a selected workflow catalog; `mcp` grants one-run MCP registrations (serialized for all backends and mounted only where the backend has a native MCP path); `task` tells the daemon how to
-exercise all of them in this one run.
+`tools` grants a capability surface, `skills` a selected workflow catalog, `mcp`
+one-run registrations; `task` tells the daemon how to exercise all of them in
+this one run.
 
 ## Maintenance
 

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
@@ -7,7 +7,7 @@ description: >
   per-backend references (Codex, OpenCode, claude-p, MiMo Code, Qwen Code,
   Kimi Code, Cursor, and Oh-My-Pi flag discovery, built-in LingTai knowledge entrypoint).
 version: 1.13.0
-last_changed_at: "2026-07-09T19:24:35-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/SKILL.md
 - src/lingtai/tools/daemon/CONTRACT.md
@@ -36,80 +36,65 @@ catalog. Only backends with proven demand get a page.
 - name: daemon-backend-codex
   location: reference/backends/codex/SKILL.md
   description: |
-    Nested daemon-cli-backends reference for the Codex daemon backend's flag
-    surface. Read this only when a daemon task needs Codex-specific CLI flags
-    (model selection, reasoning effort, config overrides): it routes to the
-    installed CLI's live help via shell and shows how to translate that help
-    into generic `backend_options` (e.g. repeated `--config` overrides).
+    Nested daemon-cli-backends reference for the Codex backend's flag surface.
+    Read this only when a daemon task needs Codex-specific CLI flags: model
+    selection, reasoning effort, repeated `--config` overrides.
 - name: daemon-backend-opencode
   location: reference/backends/opencode/SKILL.md
   description: |
-    Nested daemon-cli-backends reference for the OpenCode daemon backend's
-    flag surface. Read this only when a daemon task needs OpenCode-specific
-    CLI flags (model selection, reasoning variants, agent choice): it routes
-    to the installed CLI's live help via shell and shows how to translate that
-    help into generic `backend_options` (e.g. `--model provider/model`).
+    Nested daemon-cli-backends reference for the OpenCode backend's flag
+    surface. Read this only when a daemon task needs OpenCode-specific CLI
+    flags: `--model provider/model`, `--variant`, agent choice, the reserved
+    `--format` boundary.
 - name: daemon-backend-claude-p
   location: reference/backends/claude-p/SKILL.md
   description: |
     Nested daemon-cli-backends reference for the claude-p (alias claude-code)
-    daemon backend's flag surface. Read this only when a daemon task needs
-    Claude Code-specific CLI flags (model selection, fallback model, tool
-    restrictions): it routes to the installed CLI's live help via shell and
-    shows how to translate that help into generic `backend_options` (e.g.
-    underscore keys becoming dashed long flags like `--fallback-model`).
+    backend's flag surface. Read this only when a daemon task needs Claude
+    Code-specific CLI flags (model, `--fallback-model`, tool restrictions), the
+    reserved-flag boundary, resume, or auth-env hygiene.
 - name: daemon-backend-mimocode
   location: reference/backends/mimocode/SKILL.md
   description: |
     Nested daemon-cli-backends reference for the MiMo Code (`mimocode` /
-    `mimo`) daemon backend's flag surface. Read this only when a daemon task
-    needs MiMo-specific CLI flags (model selection, provider switches): it
-    routes to the installed CLI's live help via shell (`mimo run --help`) and
-    shows how to translate that help into generic `backend_options`.
+    `mimo`) backend's flag surface. Read this only when a daemon task needs
+    MiMo-specific CLI flags, the reserved session flags, or the verified JSONL
+    answer/error and usage contract.
 - name: daemon-backend-qwen-code
   location: reference/backends/qwen-code/SKILL.md
   description: |
     Nested daemon-cli-backends reference for the Qwen Code (`qwen-code` /
-    `qwen`) daemon backend's flag surface. Read this only when a daemon task
-    needs Qwen-specific CLI flags (model selection, provider tunables): it
-    routes to the installed CLI's live help via shell and shows how to
-    translate that help into generic `backend_options`, plus the backend's
-    reserved-flag and no-resume boundaries.
+    `qwen`) backend's flag surface. Read this only when a daemon task needs
+    Qwen-specific CLI flags, the reserved `--prompt`/`--yolo`/`--approval-mode`
+    boundary, or the no-`ask` planning constraint.
 - name: daemon-backend-kimicode
   location: reference/backends/kimicode/SKILL.md
   description: |
-    Nested daemon-cli-backends reference for the Kimi Code daemon backend's
-    flag surface. Read this only when a daemon task needs Kimi-specific CLI
-    flags (model selection, skills/workspace directories): it routes to the
-    installed CLI's live help via shell and shows how to translate that help
-    into generic `backend_options`, plus the exact reserved harness flags,
-    the run-private `mcp.json` loader, and the current ask/resume limitation.
+    Nested daemon-cli-backends reference for the Kimi Code backend's flag
+    surface. Read this only when a daemon task needs Kimi-specific CLI flags,
+    the exact reserved harness flags, the run-private `mcp.json` loader, or the
+    ask/resume limitation.
 - name: daemon-backend-cursor
   location: reference/backends/cursor/SKILL.md
   description: |
-    Nested daemon-cli-backends reference for the Cursor daemon backend's flag
-    surface. Read this only when a daemon task needs Cursor-specific CLI
-    flags (model selection, output/tooling switches): it routes to the
-    installed `agent` CLI's live help via shell and shows how to translate
-    that help into generic `backend_options`.
+    Nested daemon-cli-backends reference for the Cursor backend's flag surface.
+    Read this only when a daemon task needs Cursor-specific `agent` CLI flags,
+    the harness-owned surfaces, or the source-pinned stream-json usage contract.
 - name: daemon-backend-oh-my-pi
   location: reference/backends/oh-my-pi/SKILL.md
   description: |
-    Nested daemon-cli-backends reference for the Oh-My-Pi (`omp`) daemon
-    backend's flag surface. Read this only when a daemon task needs
-    Oh-My-Pi-specific CLI flags (model selection, tool or provider
-    switches): it routes to the installed CLI's live help via shell, lists
-    the exact harness-reserved flags, and shows how to translate that help
-    into generic `backend_options`.
+    Nested daemon-cli-backends reference for the Oh-My-Pi (`omp`) backend's
+    flag surface. Read this only when a daemon task needs Oh-My-Pi-specific CLI
+    flags, the exact harness-reserved mode/approval/session flags, or its
+    session/ask/MCP status.
 - name: daemon-backend-lingtai
   location: reference/backends/lingtai/SKILL.md
   description: |
-    Nested daemon-cli-backends reference for the built-in `lingtai` daemon
-    backend (the in-process ChatSession default). Read this when routing a
-    daemon task to the built-in backend: it has no external CLI and no
-    `backend_options` flag surface; the page routes to the live authorities
-    for preset selection/inspection, lingtai/tools/skills/MCP inheritance, and the
-    daemon completion contract.
+    Nested daemon-cli-backends reference for the built-in `lingtai` backend
+    (the in-process ChatSession default). Read this when routing a task to the
+    built-in backend: it has no CLI and no `backend_options` surface, and the
+    page routes to the live authorities for preset selection/inspection,
+    tools/skills/MCP inheritance, and the completion contract.
 ```
 
 ## Routing table
@@ -176,15 +161,15 @@ The `backend` parameter selects the execution engine for emanations. Default is
 `lingtai` (the built-in ChatSession loop). External CLI backends are also
 available:
 
-For Claude Code daemon work, use the print-mode backend `claude-p` (alias
-`claude-code`). The legacy interactive PTY/TUI backend (`claude` /
-`claude-interactive`) is **no longer a user-selectable backend** — it is hidden
-from the daemon schema enum and description. Do not select it for new work; it
-proved unreliable under the daemon watchdog (mid-exploration SIGTERM / exit code
-143). The print-mode backend covers the same Claude Code use cases without
-driving a TUI. The interactive code path remains in the tree only so older
-callers and stored daemon entries that recorded `backend="claude"` keep
-resolving.
+**Claude backend naming.** For Claude Code daemon work select `claude-p`, the
+print-mode backend that wraps Claude Code's official `--print`/stream-json mode;
+`claude-code` is a compatibility alias with the same runner and reserved-flag
+set. The legacy interactive PTY/TUI names (`claude` / `claude-interactive`) are
+**no longer user-selectable** — hidden from the daemon schema enum and
+description. Do not select them for new work; that path proved unreliable under
+the daemon watchdog (mid-exploration SIGTERM / exit code 143). The code path
+remains in the tree only so older callers and stored entries that recorded
+`backend="claude"` keep resolving.
 
 > **MCP completion contract.** MCP-capable daemon backends load LingTai's
 > built-in `daemon_common` MCP for every run. The model must call the MCP
@@ -208,75 +193,47 @@ resolving.
 | `kimicode` / `kimi` | `KIMI_CODE_HOME=<run>/kimi-code-home kimi --prompt <prompt> --output-format text` (same per-run env: telemetry/auto-update off, `KIMI_MODEL_API_KEY` mapped from `KIMICODE_API_KEY`/`KIMI_API_KEY`/`MOONSHOT_API_KEY` when unset, provider/base-url/model/context defaults only when absent) | Not supported yet; `ask` returns an explicit unsupported-backend error | MoonshotAI Kimi Code CLI backend (official `MoonshotAI/kimi-code`, binary `kimi`, source-verified v0.22.3 for MCP config). `kimi` canonicalizes to `kimicode`. LingTai owns `--prompt`/`--output-format` and forbids `--yolo` (the CLI refuses `--prompt` + `--yolo`); session/`--continue` flags are reserved because resume is not wired. Stable session-id output was not verified, so `ask`/resume is intentionally unsupported. The daemon writes `<run>/kimi-code-home/mcp.json` with `daemon_common` plus parent stdio and HTTP MCP registrations; secret env/header values stay out of prompts/logs and live only in the native per-run config. |
 | `cursor` | `agent -p <prompt>` | `agent -p --resume <cursor_session_id> ...` via `ask` (async) | Cursor Agent CLI backend. Per-run MCP injection is not wired yet; local `agent --help` could not be inspected in this environment because the CLI attempted macOS keychain access and failed before printing help. |
 
-**Per-task mapping.** `task` is the complete parent-controlled system
-instruction for LingTai and the exact CLI prompt for external backends. LingTai
-alone accepts optional `prompt` as its first ordinary user message (blank or
-omitted defaults to `Begin the assigned daemon task.`). External CLI tasks that
-contain `prompt` are rejected before run-dir creation. The removed
-`system_prompt` field has no alias: migrate its complete behavior contract into
-`task`. When the daemon needs a workflow, pass `skills: [...]` as skill
-directories or direct `SKILL.md` paths; the runtime renders a compact YAML
-catalog in the one-run context. Omit `prompt` for the exact default.
-For the built-in `lingtai` backend the complete `task` is compiled into the
-daemon system prompt beside selected skills/MCP/tool guidance; it cannot
+**Per-task mapping.** The task-shape contract (`task` / `prompt` / `tools` /
+`skills` / `mcp`) is owned by the `daemon-manual` router. The backend-dependent
+part: for the built-in `lingtai` backend the complete `task` is compiled into the
+daemon system prompt beside selected skills/MCP/tool guidance, and it cannot
 override lifecycle limits, tool schemas, or the ToolExecutor/ToolCallGuard
-execution gate. For CLI backends, `task` remains the exact CLI prompt and is
-persisted in the daemon `.prompt` file for forensics.
+execution gate. For external CLI backends `task` is the exact CLI prompt,
+persisted in the daemon `.prompt` file for forensics, and a task containing
+`prompt` is rejected before run-dir creation (`prompt` is LingTai-only).
 
 **LingTai backend tool surface.** The built-in `lingtai` backend uses preset
 resolution plus daemon tool curation. Parent MCP tools are not auto-inherited:
 provide full one-run MCP registrations per task with `mcp: [{name, transport,
 ...}]`. The runtime serializes those registrations into the oneshot prompt as
-YAML for every backend. For the built-in LingTai backend, it also starts the
+YAML for every backend; for the built-in LingTai backend it also starts the
 registered MCP clients for this run and exposes their tools in the daemon tool
-surface; clients are closed when the run finishes. The `daemon_common` MCP is
-added automatically and its `finish` tool is the hard terminal-success contract.
-Claude print backends receive a per-run `--mcp-config` file; Codex receives
-`-c mcp_servers.daemon_common.*` overrides; OpenCode receives
-`OPENCODE_CONFIG_CONTENT`; and Qwen receives a per-run settings file path.
-MiMo, Oh-My-Pi, and Cursor are not declared unsupported: they have documented
-(or plausible) MCP entrypoints that still need daemon-native config wiring and
-tests. Kimi Code is wired through its source-verified run-private `mcp.json`
-loader for stdio and HTTP registrations. Secret
-`env`/`headers` values are redacted in prompts. The daemon-eligible `email`
-intrinsic is available only
-when explicitly requested in the task `tools` list, so result-only/no-tool
-emanations cannot communicate in the local agent network unless the parent opted
-in. Other intrinsics remain unavailable to keep daemon lightweight and
-non-recursive. As with file/shell/web/MCP tools, technical availability is not a
-policy by itself: the parent should use `task` to say when and how the
-daemon may use any available tool, including who it may contact and what context
-it may share if email is involved.
+surface, closing them when the run finishes. Secret `env`/`headers` values are
+redacted in prompts. Beyond the daemon-eligible, opt-in `email` intrinsic, other
+intrinsics remain unavailable to keep daemon lightweight and non-recursive.
+
+Where each backend receives its native `daemon_common` MCP config:
+
+| Backend | Injection path |
+|---|---|
+| `claude-p` / `claude-code` | per-run `--mcp-config` file |
+| `codex` | `-c mcp_servers.daemon_common.*` overrides |
+| `opencode` | `OPENCODE_CONFIG_CONTENT` environment variable |
+| `qwen-code` | per-run settings file path |
+| `kimicode` | run-private `mcp.json` loader (stdio **and** HTTP registrations) |
+| `mimocode`, `oh-my-pi`, `cursor` | **not wired yet** — documented or plausible MCP entrypoints still needing daemon-native config and tests; not declared unsupported |
 
 **When to use CLI backends:** Use them when the task benefits from a different
 agent runtime's tool surface (for example Claude Code's built-in file editing or
 Codex's sandboxed execution) rather than the LingTai emanation's curated tool
 set. `mimocode`/`mimo`, `qwen-code`/`qwen`, `oh-my-pi`/`omp`, and `kimicode`/`kimi` are accepted as canonical backend names plus short aliases; persisted daemon entries use the canonical name.
 
-**Claude backend naming:** Select `claude-p` for Claude Code daemon work; it is
-the print-mode backend that wraps Claude Code's official `--print`/stream-json
-mode. `claude-code` remains a compatibility alias for `claude-p` so older calls
-and persisted daemon entries keep working. The interactive PTY/TUI names
-(`claude` / `claude-interactive`) are hidden from the daemon schema and are not
-user-selectable; only existing stored entries still resolve through them.
-
-**Claude Code auth environment hygiene.** The print-mode Claude backend
-(`claude-p` / compatibility `claude-code`) — and the hidden legacy interactive
-path it shares code with — start `claude` with auth override variables stripped
-from the subprocess environment.
-This includes `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` (which force API
-billing; GH #107) and `CLAUDE_CODE_OAUTH_TOKEN` (a stale inherited token can
-override a refreshed `~/.claude/.credentials.json` and appear as a false
-"weekly limit"; see Lingtai-AI/lingtai#189). If a manual shell invocation of
-`claude` reports a quota/weekly-limit error, run a tiny smoke test with the stale
-env token unset before concluding the account is actually exhausted:
-
-```bash
-env -u CLAUDE_CODE_OAUTH_TOKEN claude -p 'Reply exactly OK' --allowedTools Read -c
-```
-
-Do not print token values while diagnosing; `claude auth status` plus redacted
-environment variable names are enough.
+**Claude Code auth environment hygiene.** The print-mode Claude backend strips
+auth override variables from the subprocess environment, so daemon runs are
+already protected; a *manual* `claude` shell invocation is not. For the exact
+variables, the weekly-limit smoke test, and how to find a stale token's source,
+read `reference/backends/claude-p/SKILL.md` and `shell-manual` →
+`reference/bash-claude-code/SKILL.md`. Never print token values while diagnosing.
 
 **CLI backends skip preset resolution** — the external CLI manages its own model,
 tools, and permissions. The `tools` field in the task spec is ignored for CLI
@@ -290,32 +247,15 @@ prompt. This lets you reach the underlying CLI's flag surface (model selection,
 search/web access, effort levels, sandbox/policy switches, etc.) without the
 daemon needing to hard-code every flag. This is the default generic path for
 backend flags: one object may carry any number of keys, each converted
-independently in insertion order. For Codex-specific discovery and translation
-examples (e.g. reasoning effort via repeated `--config` overrides), read
-`reference/backends/codex/SKILL.md`. For OpenCode-specific examples (e.g.
-`--model provider/model`, `--variant`), read
-`reference/backends/opencode/SKILL.md`. For Claude Code-specific discovery and
-the `claude-p` harness boundary (reserved flags, MCP config, resume, auth-env
-hygiene), read `reference/backends/claude-p/SKILL.md`. For MiMo Code
-(`mimocode` / `mimo`) discovery and translation, read
-`reference/backends/mimocode/SKILL.md`. For Qwen Code–specific discovery and
-translation (e.g. model selection, reserved headless flags), read
-`reference/backends/qwen-code/SKILL.md`. For Kimi Code-specific discovery and
-translation (model selection, exact reserved flags, the run-private `mcp.json`
-loader), read `reference/backends/kimicode/SKILL.md`. For Cursor (binary `agent`), read
-`reference/backends/cursor/SKILL.md`.
+independently in insertion order. Per-backend discovery and translation examples
+live on each backend's page — see the routing table above.
 
-This is intentionally a passthrough, not a fixed table. Claude Code, Codex,
-OpenCode, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, and Cursor rev their flag
-lists between releases. Before adding new options, run the installed CLI's
-`--help` in `shell` to discover what it supports today (`claude --help`,
-`codex exec --help`, `opencode run --help`, `mimo run --help`, `qwen --help`,
-`omp --help`, `kimi --help`, or `agent --help`). Anything here is illustrative,
-not authoritative. Note that each backend reserves its own harness-owned flags
-(e.g. Oh-My-Pi reserves `--mode`, `--approval-mode yolo`, and the
-session/`--resume` flags; Kimi Code reserves `--prompt`, `--output-format`,
-`--yolo`, and session/`--continue`) — passing a reserved flag in
-`backend_options` refuses the whole batch with a clear error.
+This is intentionally a passthrough, not a fixed table. Every wrapped CLI revs
+its flag list between releases, so before adding new options run the installed
+CLI's `--help` in `shell` (`claude --help`, `codex exec --help`,
+`opencode run --help`, `mimo run --help`, `qwen --help`, `omp --help`,
+`kimi --help`, or `agent --help`). Anything here is illustrative, not
+authoritative.
 
 ```jsonc
 // Print-mode Claude backend (the recommended Claude backend)
@@ -364,23 +304,18 @@ becomes `--approval-policy never`. Unsafe keys are rejected before any subproces
 call.
 
 **Do not set a CLI backend's `max_turns` too low.** A turn budget that fits a
-quick scripted task will kill a Claude Code / Codex backend mid-exploration — the
-agent is still reading files and orienting when the watchdog terminates it,
+quick scripted task will kill a Claude Code / Codex backend mid-exploration,
 surfacing as **exit code 143** (SIGTERM) with little or no useful output. The
 exploration-then-act shape of these agents means early turns are spent on reads
-and greps, not the deliverable; budget for that. If you must cap turns, size the
-cap to the *full* task (explore + act + verify), not to a single edit, and prefer
-leaving `max_turns` unset over guessing low. Treat a 143 exit with a short
-transcript as "I starved it," not "the model failed."
+and greps, not the deliverable; budget for that. Size any cap to the *full* task
+(explore + act + verify), not to a single edit, and prefer leaving `max_turns`
+unset over guessing low. For how to read and report a 143, see
+`../forensics/SKILL.md`.
 
-**Claude reserved flags:** The `claude-p` daemon backend owns its execution mode.
-`backend_options` cannot override harness-owned flags such as `--print` or
-`--output-format`, or completion-MCP flags such as `--mcp-config` and
-`--strict-mcp-config`; attempts are rejected before spawn. `claude-p` must keep
-stream-json output and the per-run MCP config so daemon progress/result
-extraction and completion enforcement remain reliable. (The hidden legacy
-interactive `claude` path also reserves `--settings` and the managed
-system-prompt flags, but that backend is no longer user-selectable.)
+**Reserved flags are per backend.** Each backend refuses its own harness-owned
+flags in `backend_options` before spawn — one bad key refuses the whole batch.
+The exact list lives on that backend's page under "Harness boundary"; consult it
+before adding options.
 
 **When it applies:** `backend_options` is honored only at `emanate` time (when
 the CLI session is first spawned). `daemon(action="ask", ...)` reuses the
@@ -429,12 +364,10 @@ is drained by the in-process run loop.
 
 ## Backend-specific observability
 
-**Legacy interactive Claude (`claude` — hidden, not user-selectable).** This
-backend is no longer offered in the daemon schema. Older stored runs may still
+**Legacy interactive Claude (`claude` — hidden).** Older stored runs may still
 carry `claude_interactive_*` fields in `daemon.json` (managed-workspace path,
 transcript path, raw PTY log, trust-answer flag, etc.); they are kept only for
-forensics on historical runs. Do not start new emanations on this backend — use
-`claude-p`.
+forensics on historical runs.
 
 **Print-mode Claude (`claude-p` / `claude-code`).** `claude_session_id` is set on
 the first stream-json event that carries a session id (typically the system

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
@@ -8,7 +8,7 @@ description: >
   shows how to translate that help into the generic `backend_options`
   mechanism. It is not a flag catalog.
 version: 0.1.0
-last_changed_at: "2026-07-14T19:04:52-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-claude-code/SKILL.md
@@ -18,10 +18,11 @@ maintenance: |
 
 # claude-p Daemon Backend — Flag Discovery Entrypoint
 
-This page is deliberately tiny: the Claude Code CLI revs its flags between
-releases, so the installed CLI's own help output is the authority — not this
-page. `claude-p` is the canonical print-mode backend id; `claude-code` is a
-compatibility alias with the same runner and reserved-flag set.
+The installed CLI's own help is the authority for Claude Code flags; this page is
+only the entrypoint. Conversion rules, key safety, and persistence live in the
+parent [`reference/cli-backends/SKILL.md`](../../../SKILL.md). `claude-p` is the
+canonical print-mode backend id; `claude-code` is a compatibility alias with the
+same runner and reserved-flag set.
 
 ## Discover flags from the installed CLI
 
@@ -31,10 +32,8 @@ compatibility alias with the same runner and reserved-flag set.
    wraps `claude --print`, so the print-mode flags in `claude --help` are the
    relevant surface. These are local read-only commands; no session is
    started.
-3. Translate the long flags you found into `backend_options` using the
-   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
-   (key→flag mapping, value handling, key safety, persistence). Nothing
-   Claude-specific is added to that contract here.
+3. Translate what you found into `backend_options` with the parent's generic
+   conversion rules. Nothing Claude-specific is added to that contract here.
 
 ## Example: automatic fallback model for a long print run
 
@@ -54,9 +53,8 @@ Through `backend_options`, an underscore key becomes a dashed long flag:
 // argv: --fallback-model claude-sonnet-5
 ```
 
-The model-name vocabulary belongs to the installed CLI and the provider
-account — LingTai does not validate, enumerate, or simulate model names. A
-value passes through and the CLI decides its semantics (or rejects it).
+The model-name vocabulary belongs to the installed CLI and the provider account —
+LingTai does not validate, enumerate, or simulate model names.
 
 ## Harness boundary
 
@@ -82,9 +80,13 @@ Related run-scoped behavior you should not fight through flags:
   --print ...` against the session id persisted to
   `daemon.json.claude_session_id`; `backend_options` are not re-passed on
   ask — emanate-time flags persist for the session's life.
-- Auth-env hygiene: the spawn environment strips `ANTHROPIC_API_KEY`,
-  `ANTHROPIC_AUTH_TOKEN`, and `CLAUDE_CODE_OAUTH_TOKEN` so the CLI's own
-  OAuth credentials win; do not re-inject auth overrides via flags.
-
-To debug what was actually sent, `daemon.json` records the raw
-`backend_options` alongside the resolved `backend_argv` / `backend_harness_argv`.
+- Auth-env hygiene: the spawn environment strips `ANTHROPIC_API_KEY` and
+  `ANTHROPIC_AUTH_TOKEN` (they force API billing; GH #107) plus
+  `CLAUDE_CODE_OAUTH_TOKEN` (a stale inherited token can override a refreshed
+  `~/.claude/.credentials.json` and surface as a false "weekly limit"; see
+  Lingtai-AI/lingtai#189), so the CLI's own OAuth credentials win. Do not
+  re-inject auth overrides via flags. A *manual* `claude` shell invocation has no
+  such protection — for the weekly-limit smoke test and how to find the stale
+  token's source, read `shell-manual` →
+  `reference/bash-claude-code/SKILL.md`. Never print token values while
+  diagnosing.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/codex/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/codex/SKILL.md
@@ -7,7 +7,7 @@ description: >
   installed CLI's live help via shell and shows how to translate that help into
   the generic `backend_options` mechanism. It is not a flag catalog.
 version: 0.1.0
-last_changed_at: "2026-07-09T18:55:23-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-openai-codex/SKILL.md
@@ -17,10 +17,9 @@ maintenance: |
 
 # Codex Daemon Backend — Flag Discovery Entrypoint
 
-This page is deliberately tiny: it only tells you where the knowledge lives.
-The Codex CLI revs its flags and accepted values between releases, so the
-installed CLI's own help output is the authority — not this page, and not any
-flag list LingTai could ship.
+The installed CLI's own help is the authority for Codex flags; this page is only
+the entrypoint. Conversion rules, key safety, and persistence live in the parent
+[`reference/cli-backends/SKILL.md`](../../../SKILL.md).
 
 ## Discover flags from the installed CLI
 
@@ -30,10 +29,8 @@ flag list LingTai could ship.
    The daemon backend wraps `codex exec`, so `codex exec --help` is the
    relevant flag surface. These are local read-only commands; no session is
    started.
-3. Translate the long flags you found into `backend_options` using the
-   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
-   (key→flag mapping, value handling, key safety, persistence). Nothing
-   Codex-specific is added to that contract here.
+3. Translate what you found into `backend_options` with the parent's generic
+   conversion rules. Nothing Codex-specific is added to that contract here.
 
 ## Example: reasoning effort via the generic `config` route
 
@@ -57,8 +54,7 @@ overrides (see `codex exec --help` for the key=value syntax). Through
 
 The effort vocabulary belongs to the installed CLI and the selected model —
 LingTai does not validate, enumerate, or simulate effort levels. A value like
-`ultra` passes through and the CLI/model decides its semantics (or rejects
-it).
+`ultra` passes through and the CLI/model decides its semantics (or rejects it).
 
 ## Harness boundary
 
@@ -67,7 +63,3 @@ nothing is refused for this backend beyond the generic key/value safety rules.
 Still, do not re-set harness-owned surfaces (`--json`, sandbox/approval
 bypass, or `mcp_servers.daemon_common.*` config keys): breaking them silently
 breaks progress/result extraction and completion enforcement.
-
-To debug what was actually sent, `daemon.json` records the raw
-`backend_options` object alongside the resolved `backend_argv` /
-`backend_harness_argv` token lists.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
@@ -7,7 +7,7 @@ description: >
   CLI's live help via shell and shows how to translate that help into the
   generic `backend_options` mechanism. It is not a flag catalog.
 version: 0.1.0
-last_changed_at: "2026-07-09T19:23:56-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-cursor-agent/SKILL.md
@@ -17,9 +17,9 @@ maintenance: |
 
 # Cursor Daemon Backend — Flag Discovery Entrypoint
 
-This page is deliberately tiny: it only tells you where the knowledge lives.
-The Cursor Agent CLI revs its flags and accepted values, so installed CLI help
-is the authority — not this page, and not any flag list LingTai could ship.
+The installed CLI's own help is the authority for Cursor Agent flags; this page
+is only the entrypoint. Conversion rules, key safety, and persistence live in the
+parent [`reference/cli-backends/SKILL.md`](../../../SKILL.md).
 
 ## Discover flags from the installed CLI
 
@@ -29,10 +29,8 @@ is the authority — not this page, and not any flag list LingTai could ship.
    `agent` directly — `agent -p --force --output-format stream-json <prompt>` —
    so root help is authoritative (open a subcommand only if root routes there).
    These are read-only checks; keychain errors happen before help on some builds.
-3. Translate the long flags you found into `backend_options` using the
-   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
-   (key→flag mapping, value handling, key safety, persistence). Nothing
-   Cursor-specific is added to that contract here.
+3. Translate what you found into `backend_options` with the parent's generic
+   conversion rules. Nothing Cursor-specific is added to that contract here.
 
 ## Example: model selection via the generic route
 
@@ -53,10 +51,10 @@ flags and before the task prompt:
 // argv: --model opus
 ```
 
-The flag and model vocabulary belong to the installed CLI — LingTai does
-not validate, enumerate, or simulate them. Confirm `--model` and its
-accepted values in your installed `agent --help` before relying on this;
-an unknown flag or value is the CLI's error, not the daemon's.
+The flag and model vocabulary belong to the installed CLI — LingTai does not
+validate, enumerate, or simulate them. Confirm `--model` and its accepted values
+in your installed `agent --help` before relying on this; an unknown flag or value
+is the CLI's error, not the daemon's.
 
 ## Source-pinned stream-json usage
 For installed `agent-cli@2026.05.28-a70ca7c`, accept usage only from `type=result`, `subtype=success`, `is_error=false` with all four non-negative integer fields: `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheWriteTokens`.
@@ -84,7 +82,5 @@ this backend yet, so there are no MCP loader flags to collide with and no
 `finish` contract: success comes from the stream's final result event and
 the process exit code.
 
-`backend_options` is honored only at `emanate` time; `ask` follow-ups reuse
-the session without re-passing it. To debug what was actually sent,
-`daemon.json` records the raw `backend_options` object alongside the
-resolved `backend_argv` token list.
+`backend_options` is honored only at `emanate` time; `ask` follow-ups reuse the
+session without re-passing it.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
@@ -7,7 +7,7 @@ description: >
   installed CLI's live help via shell and shows how to translate that help into
   the generic `backend_options` mechanism. It is not a flag catalog.
 version: 0.1.0
-last_changed_at: "2026-07-09T19:22:52-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-kimicode/SKILL.md
@@ -17,11 +17,11 @@ maintenance: |
 
 # Kimi Code Daemon Backend — Flag Discovery Entrypoint
 
-This page is deliberately tiny: it only tells you where the knowledge lives.
-The Kimi Code CLI revs its flags and accepted values between releases, so the
-installed CLI's own help output is the authority — not this page, and not any
-flag list LingTai could ship. `kimi` is the accepted short alias; persisted
-daemon entries use the canonical backend name `kimicode`.
+The installed CLI's own help is the authority for Kimi Code flags; this page is
+only the entrypoint. Conversion rules, key safety, and persistence live in the
+parent [`reference/cli-backends/SKILL.md`](../../../SKILL.md). `kimi` is the
+accepted short alias; persisted daemon entries use the canonical backend name
+`kimicode`.
 
 ## Discover flags from the installed CLI
 
@@ -34,10 +34,8 @@ daemon entries use the canonical backend name `kimicode`.
    `exec`-style wrapper subcommand. Run `kimi <subcommand> --help` only when a
    task actually needs one of the listed subcommands. These are local
    read-only commands; no session is started.
-3. Translate the long flags you found into `backend_options` using the
-   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
-   (key→flag mapping, value handling, key safety, persistence). Nothing
-   Kimi-specific is added to that contract here.
+3. Translate what you found into `backend_options` with the parent's generic
+   conversion rules. Nothing Kimi-specific is added to that contract here.
 
 ## Example: model selection
 
@@ -59,9 +57,7 @@ Through `backend_options`, a string value becomes `--flag <value>`:
 ```
 
 The model vocabulary belongs to the installed CLI and its provider
-configuration — LingTai does not validate, enumerate, or simulate model
-names. A value passes through and the CLI decides its semantics (or rejects
-it).
+configuration — LingTai does not validate, enumerate, or simulate model names.
 
 ## Harness boundary
 
@@ -84,6 +80,4 @@ stdout becomes the result. The run-private MCP loader is not argv-based —
 the daemon writes `daemon_common` plus parent stdio and HTTP registrations
 to `<run>/kimi-code-home/mcp.json` (path recorded in `daemon.json` under
 `backend_harness_files.kimicode_mcp_config`); secret env/header values stay
-out of prompts and logs. To debug what was actually sent, `daemon.json`
-records the raw `backend_options` object alongside the resolved
-`backend_argv` token list.
+out of prompts and logs.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/lingtai/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/lingtai/SKILL.md
@@ -8,7 +8,7 @@ description: >
   authorities for preset selection/inspection, lingtai/tools/skills/MCP inheritance,
   and the daemon completion contract. It is not a rules catalog.
 version: 0.1.0
-last_changed_at: "2026-07-09T19:22:26-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/daemon/manual/SKILL.md
@@ -19,7 +19,6 @@ maintenance: |
 
 # LingTai Daemon Backend — Knowledge Entrypoint
 
-This page is deliberately tiny: it only tells you where the knowledge lives.
 `backend="lingtai"` is the built-in default — an in-process ChatSession run
 loop, not a wrapped external CLI. There is no installed binary whose help
 output could be consulted, and `backend_options` is ignored (there is no CLI
@@ -30,9 +29,10 @@ and source — route to the current authority instead of memorizing snapshots.
 ## Where the knowledge lives
 
 1. **Task shape and behavior contract** — the `daemon-manual` router
-   (`manual/SKILL.md`): `task` vs `system_prompt` vs `tools` vs `skills` vs
-   `mcp` semantics, and the shared parent `reference/cli-backends/SKILL.md`
-   ("LingTai backend tool surface") for how this backend curates tools.
+   ([`manual/SKILL.md`](../../../../../SKILL.md)): `task` vs `prompt` vs
+   `tools` vs `skills` vs `mcp` semantics, and the shared parent
+   [`reference/cli-backends/SKILL.md`](../../../SKILL.md) ("LingTai backend
+   tool surface") for how this backend curates tools.
 2. **Preset selection and inspection** — run `system(action="presets")` for
    the live tier/connectivity/capability listing (guidance:
    `system-manual` → `reference/substrate-manual/SKILL.md`). A per-task
@@ -78,7 +78,7 @@ in prompts).
 
 There is nothing to tune at the process-spawn layer: no reserved flags, no
 argv, no `backend_argv`/`backend_harness_argv` in `daemon.json`. Model and
-tool shape are chosen through `preset`; behavior is guided through
-`system_prompt`; capability comes from `tools`/`skills`/`mcp`. LingTai-backend
-tool calls still pass the kernel ToolExecutor/ToolCallGuard gate — a daemon
-run does not bypass normal execution policy.
+tool shape are chosen through `preset`; behavior is guided through `task`;
+capability comes from `tools`/`skills`/`mcp`. LingTai-backend tool calls still
+pass the kernel ToolExecutor/ToolCallGuard gate — a daemon run does not bypass
+normal execution policy.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
@@ -7,7 +7,7 @@ description: >
   to the installed CLI's live help via shell and shows how to translate that
   help into the generic `backend_options` mechanism. It is not a flag catalog.
 version: 0.2.0
-last_changed_at: "2026-07-11T00:00:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-mimocode/SKILL.md
@@ -17,10 +17,10 @@ maintenance: |
 
 # MiMo Code Daemon Backend — Flag Discovery Entrypoint
 
-This page is deliberately tiny: it only tells you where the knowledge lives.
-The MiMo Code CLI (npm package `@mimo-ai/cli`, binary `mimo`) revs its flags
-and accepted values between releases, so the installed CLI's own help output
-is the authority — not this page, and not any flag list LingTai could ship.
+The installed CLI's own help is the authority for MiMo Code (npm package
+`@mimo-ai/cli`, binary `mimo`) flags; this page is only the entrypoint.
+Conversion rules, key safety, and persistence live in the parent
+[`reference/cli-backends/SKILL.md`](../../../SKILL.md).
 
 ## Backend identity and spawn shape
 
@@ -36,10 +36,8 @@ between the harness flags and the trailing prompt positional.
 2. Run, in bash: `mimo --version`, `mimo --help`, and `mimo run --help`.
    The daemon backend wraps `mimo run`, so `mimo run --help` is the relevant
    flag surface. These are local read-only commands; no session is started.
-3. Translate the long flags you found into `backend_options` using the
-   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
-   (key→flag mapping, value handling, key safety, persistence). Nothing
-   MiMo-specific is added to that contract here.
+3. Translate what you found into `backend_options` with the parent's generic
+   conversion rules. Nothing MiMo-specific is added to that contract here.
 
 ## Example: model selection via the generic route
 
@@ -58,8 +56,7 @@ between the harness flags and the trailing prompt positional.
 ```
 
 The flag/value vocabulary belongs to the installed CLI — LingTai does not
-validate, enumerate, or simulate it. A value passes through and the CLI
-decides its semantics (or rejects it).
+validate, enumerate, or simulate it.
 
 ## Harness boundary
 
@@ -99,7 +96,3 @@ writes either token ledger and does not infer provider or model.
 Per-run `daemon_common` MCP injection is not wired for `mimocode` yet, so the
 MCP completion contract is not enforced on this backend; parent MCP
 registrations reach the run as prompt catalog only.
-
-To debug what was actually sent, `daemon.json` records the raw
-`backend_options` object alongside the resolved `backend_argv` /
-`backend_harness_argv` token lists.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/oh-my-pi/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/oh-my-pi/SKILL.md
@@ -8,7 +8,7 @@ description: >
   translate that help into the generic `backend_options` mechanism. It is
   not a flag catalog.
 version: 0.1.0
-last_changed_at: "2026-07-09T19:24:35-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-oh-my-pi/SKILL.md
@@ -18,12 +18,12 @@ maintenance: |
 
 # Oh-My-Pi Daemon Backend — Flag Discovery Entrypoint
 
-This page is deliberately tiny: it only tells you where the knowledge lives.
-The Oh-My-Pi CLI (npm package `@oh-my-pi/pi-coding-agent`, binary `omp`) revs
-its flags and accepted values between releases, so the installed CLI's own
-help output is the authority — not this page, and not any flag list LingTai
-could ship. `omp` is an accepted backend alias that canonicalizes to
-`oh-my-pi`; persisted daemon entries use the canonical name.
+The installed CLI's own help is the authority for Oh-My-Pi (npm package
+`@oh-my-pi/pi-coding-agent`, binary `omp`) flags; this page is only the
+entrypoint. Conversion rules, key safety, and persistence live in the parent
+[`reference/cli-backends/SKILL.md`](../../../SKILL.md). `omp` is an accepted
+backend alias that canonicalizes to `oh-my-pi`; persisted daemon entries use the
+canonical name.
 
 ## Discover flags from the installed CLI
 
@@ -35,10 +35,8 @@ could ship. `omp` is an accepted backend alias that canonicalizes to
    started. Run `omp <command> --help` only on demand for a subcommand the
    installed root help itself lists — subcommands are outside the daemon
    wrapper.
-3. Translate the long flags you found into `backend_options` using the
-   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
-   (key→flag mapping, value handling, key safety, persistence). Nothing
-   Oh-My-Pi-specific is added to that contract here.
+3. Translate what you found into `backend_options` with the parent's generic
+   conversion rules. Nothing Oh-My-Pi-specific is added to that contract here.
 
 ## Example: model selection
 
@@ -56,10 +54,9 @@ could ship. `omp` is an accepted backend alias that canonicalizes to
 // argv: --model <model id from the installed CLI>
 ```
 
-The model vocabulary belongs to the installed CLI and its configured
-providers — LingTai does not validate, enumerate, or simulate model ids. Use
-the CLI's own discovery surface (root `--help`) and
-pass the id through; the CLI decides its semantics (or rejects it).
+The model vocabulary belongs to the installed CLI and its configured providers —
+LingTai does not validate, enumerate, or simulate model ids. Use the CLI's own
+discovery surface (root `--help`) and pass the id through.
 
 ## Harness boundary: reserved flags
 
@@ -89,6 +86,3 @@ prompting, or hijack session ownership.
   (pending source evidence of an accepted config/env path), so the MCP
   `finish` completion contract does not apply here — and `backend_options`
   is not the place to hand-wire MCP.
-- To debug what was actually sent, `daemon.json` records the raw
-  `backend_options` object alongside the resolved `backend_argv` /
-  `backend_harness_argv` token lists.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
@@ -8,7 +8,7 @@ description: >
   translate that help into the generic `backend_options` mechanism. It is not
   a flag catalog.
 version: 0.1.0
-last_changed_at: "2026-07-09T19:22:21-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-opencode/SKILL.md
@@ -18,10 +18,9 @@ maintenance: |
 
 # OpenCode Daemon Backend — Flag Discovery Entrypoint
 
-This page is deliberately tiny: it only tells you where the knowledge lives.
-The OpenCode CLI revs its flags and accepted values between releases, so the
-installed CLI's own help output is the authority — not this page, and not any
-flag list LingTai could ship.
+The installed CLI's own help is the authority for OpenCode flags; this page is
+only the entrypoint. Conversion rules, key safety, and persistence live in the
+parent [`reference/cli-backends/SKILL.md`](../../../SKILL.md).
 
 ## Discover flags from the installed CLI
 
@@ -31,10 +30,8 @@ flag list LingTai could ship.
    `opencode run --help`. The daemon backend wraps `opencode run`, so
    `opencode run --help` is the relevant flag surface. These are local
    read-only commands; no session is started.
-3. Translate the long flags you found into `backend_options` using the
-   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
-   (key→flag mapping, value handling, key safety, persistence). Nothing
-   OpenCode-specific is added to that contract here.
+3. Translate what you found into `backend_options` with the parent's generic
+   conversion rules. Nothing OpenCode-specific is added to that contract here.
 
 ## Example: model and reasoning variant
 
@@ -57,10 +54,8 @@ for both). Through `backend_options`, plain scalars become `--flag <value>`:
 // argv: --model anthropic/claude-sonnet-4-5 --variant high
 ```
 
-The model and variant vocabularies belong to the installed CLI and the
-selected provider — LingTai does not validate, enumerate, or simulate them. A
-value passes through and the CLI/provider decides its semantics (or rejects
-it).
+The model and variant vocabularies belong to the installed CLI and the selected
+provider — LingTai does not validate, enumerate, or simulate them.
 
 ## Harness boundary
 
@@ -74,8 +69,6 @@ completion MCP is injected through the `OPENCODE_CONFIG_CONTENT` environment
 variable — not argv — so breaking either silently breaks progress/result
 extraction and completion enforcement.
 
-To debug what was actually sent, `daemon.json` records the raw
-`backend_options` object alongside the resolved `backend_argv` /
-`backend_harness_argv` token lists. For OpenCode, `backend_harness_argv`
-holds a sentinel token pair that the runner converts into the
-`OPENCODE_CONFIG_CONTENT` environment variable rather than real argv flags.
+In `daemon.json`, OpenCode's `backend_harness_argv` holds a sentinel token pair
+that the runner converts into the `OPENCODE_CONFIG_CONTENT` environment variable
+rather than real argv flags.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
@@ -8,7 +8,7 @@ description: >
   translate that help into the generic `backend_options` mechanism. It is
   not a flag catalog.
 version: 0.1.0
-last_changed_at: "2026-07-09T19:22:18-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-qwen-code/SKILL.md
@@ -18,11 +18,11 @@ maintenance: |
 
 # Qwen Code Daemon Backend — Flag Discovery Entrypoint
 
-This page is deliberately tiny: it only tells you where the knowledge lives.
-The Qwen Code CLI (npm package `@qwen-code/qwen-code`, binary `qwen`) revs its
-flags and accepted values between releases, so the installed CLI's own help
-output is the authority — not this page, and not any flag list LingTai could
-ship. The alias `qwen` canonicalizes to the `qwen-code` backend id.
+The installed CLI's own help is the authority for Qwen Code (npm package
+`@qwen-code/qwen-code`, binary `qwen`) flags; this page is only the entrypoint.
+Conversion rules, key safety, and persistence live in the parent
+[`reference/cli-backends/SKILL.md`](../../../SKILL.md). The alias `qwen`
+canonicalizes to the `qwen-code` backend id.
 
 ## Discover flags from the installed CLI
 
@@ -33,10 +33,8 @@ ship. The alias `qwen` canonicalizes to the `qwen-code` backend id.
    `qwen --yolo <backend_argv...> -p <prompt>`, no subcommand — so
    `qwen --help` is the whole relevant flag surface. These are local
    read-only commands; no session is started.
-3. Translate the long flags you found into `backend_options` using the
-   generic conversion rules in the parent `reference/cli-backends/SKILL.md`
-   (key→flag mapping, value handling, key safety, persistence). Nothing
-   Qwen-specific is added to that contract here.
+3. Translate what you found into `backend_options` with the parent's generic
+   conversion rules. Nothing Qwen-specific is added to that contract here.
 
 ## Example: model selection via the generic route
 
@@ -58,10 +56,8 @@ Your options land between the harness-owned `--yolo` and the final
 // argv: qwen --yolo --model qwen3-coder-plus -p <prompt>
 ```
 
-The model vocabulary belongs to the installed CLI and the configured
-provider — LingTai does not validate, enumerate, or simulate model names. A
-value passes through and the CLI/provider decides its semantics (or rejects
-it).
+The model vocabulary belongs to the installed CLI and the configured provider —
+LingTai does not validate, enumerate, or simulate model names.
 
 ## Harness boundary
 
@@ -81,7 +77,3 @@ text — Qwen Code headless mode has no machine-readable event stream here, so
 stdout/stderr are recorded as-is and the result is the final stdout text;
 the `daemon_common` `finish(status="done")` call is still required for
 success.
-
-To debug what was actually sent, `daemon.json` records the raw
-`backend_options` object alongside the resolved `backend_argv` /
-`backend_harness_argv` token lists.

--- a/src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
@@ -6,7 +6,7 @@ description: >
   chat_history.jsonl, token_ledger.jsonl, events.jsonl, exit code 143 / SIGTERM,
   and how to inspect progress without guessing.
 version: 1.2.1
-last_changed_at: "2026-07-03T10:53:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/SKILL.md
 - src/lingtai/tools/daemon/run_dir.py
@@ -70,14 +70,10 @@ the manifest, computes an equivalent listing on the fly (`source: "fallback"`).
 Read the `artifacts` block first to learn which files exist and how big they are,
 then open `result_path` / `error_path` for the full content.
 
-Progressive disclosure starts with `daemon(action="list")`: it reads these
-per-run JSON/files and returns a compact searchable index (metadata, visible call
-parameters, prompt/result previews, paths). `daemon.json` carries a
-`data_version`; if the file is missing, corrupt, or stale, list-time lazy
-migration rebuilds a best-effort replacement from the folder name, `.prompt`,
-`result.txt`, mtimes, and recent `events.jsonl`, recording a `migration`
-reason. If the index is not enough, read the returned `.prompt` or
-`result.txt` directly. Only then drop to full forensic grep over
+Read these artifacts in disclosure order: start with `daemon(action="list")` (the
+compact searchable index over these per-run files — see
+`../cli-backends/SKILL.md` for its filters and lazy-rebuild behavior), then the
+returned `.prompt` / `result.txt`, and only then drop to full forensic grep over
 `logs/events.jsonl`, `history/chat_history.jsonl`, or `logs/token_ledger.jsonl`.
 
 ## Inspection patterns

--- a/src/lingtai/tools/daemon/manual/reference/inspection/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/inspection/SKILL.md
@@ -5,7 +5,7 @@ description: >
   patterns, backend-specific polling notes, and setting reminders before resting
   while daemon work remains pending.
 version: 1.1.0
-last_changed_at: "2026-06-24T16:24:16-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
@@ -44,7 +44,7 @@ Use `elapsed_s` (from `daemon.json` or `list`) to pick an interval. These are st
 ### Which call to use, in order
 
 1. **`daemon(action="list")` first** when multiple emanations are in flight and you want a status sweep. Cheap; one line per emanation with `elapsed_s` and `state`. Use it to decide *which* (if any) to investigate.
-2. **`daemon(action="check", id="em-N", last=20, truncate=500)`** when one emanation looks suspicious. `last=20` covers ~10 tool dispatches; bump to `last=50` for wider history. Keep `truncate=500` unless you specifically need full tool I/O. The response also carries an `artifacts` block (the run's artifact manifest: relative path/size/mtime/role per important file, plus `result_path`/`error_path`) — read it to learn which files exist and how big they are before opening any of them, instead of `ls`-ing the run folder by hand.
+2. **`daemon(action="check", id="em-N", last=20, truncate=500)`** when one emanation looks suspicious. `last=20` covers ~10 tool dispatches; bump to `last=50` for wider history. Keep `truncate=500` unless you specifically need full tool I/O. Read the response's `artifacts` block to learn which files exist and how big they are before opening any of them, instead of `ls`-ing the run folder by hand (see `../forensics/SKILL.md`).
 3. **Direct `Read` of `daemon.json`** — only when you need a field `check` doesn't surface (rare). Prefer `check`.
 4. **`tail` of `history/chat_history.jsonl`** — when `check` events don't tell you what the LLM is *thinking*. The last assistant text shows the current line of reasoning. (lingtai backend only — CLI backends don't write the LLM transcript here.)
 
@@ -96,20 +96,7 @@ When the reminder fires, **health-check before trusting it kept working**:
 
 If there is **no** progress, do not re-arm and wait again — apply the stall heuristic and `reclaim`, downgrade the backend/scope, switch path, and **report to the human**. Indefinite waiting on a dead daemon is the failure this rule exists to prevent.
 
-Use this when:
-
-- a Claude Code / Codex backend task is still running but has enough context to finish alone;
-- you opened a PR and want to check CI/mergeability later;
-- a render/download/build/test run is expected to complete after you sleep;
-- the human asked for a later follow-up and the reminder is for you, not for them.
-
-The reminder should say what is pending and what to check, for example:
-
-```text
-⏺ Codex active. Plot regenerated (362KB, 23:38) — waiting for caption + commit. Polling at 23:42.
-```
-
-When the `cron` notification wakes you, read pad first, inspect the relevant daemon/job/PR, act, then dismiss the channel with `notification(action="dismiss_channel", channel="cron")`.
+The reminder payload shape, the atomic writer, the rest checklist, and dismissing the `cron` channel afterward are owned by that `shell-manual` section — follow it rather than improvising a second procedure here.
 
 This complements the polling rule above: completion is push-notified, stalls are inspected sparingly, and deliberate rest gets one future reminder rather than a busy loop.
 

--- a/src/lingtai/tools/email/manual/SKILL.md
+++ b/src/lingtai/tools/email/manual/SKILL.md
@@ -1,20 +1,16 @@
 ---
 name: email-manual
 description: >
-  Operational guide for the `email` tool — LingTai email protocol within
-  your `.lingtai/` network. Covers send/check/read/dismiss/reply/reply_all/
-  search/delete/archive/contacts, reply discipline (always reply on the
-  channel the message arrived on), addressing (bare paths like `human`,
-  `mimo-1`), self-send for persistent notes that survive molt, time
-  capsules (delayed self-send via `delay`; for recurring alarms use the
-  host scheduler — see `shell-manual` and `system-manual`), the full-body
-  persistent notification contract, the 50,000-character send cap, and addon
-  ownership. This is for INTERNAL email
-  only — for real internet email via IMAP/SMTP, see the `mcp-manual`
-  skill (the lingtai-imap addon owns that surface).
+  Operational guide for the `email` tool — LingTai email protocol within your
+  `.lingtai/` network. Covers send/check/read/dismiss/reply/reply_all/search/
+  archive/delete/contacts, reply discipline, bare-path addressing (`human`,
+  `mimo-1`) and `peer`/`abs` modes, self-send notes that survive molt, delayed
+  self-send time capsules, the full-body persistent notification contract, and
+  the 50,000-char send cap. INTERNAL only — real internet email is `mcp-manual`;
+  recurring schedules are `shell-manual`.
 version: 1.0.1
 tags: [capabilities, email, communication]
-last_changed_at: "2026-07-09T22:24:00-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/tools/email/manager.py
 - src/lingtai/tools/email/primitives.py
@@ -33,26 +29,22 @@ maintenance: |
 The `email` tool moves messages as files between agents that share a `.lingtai/` directory tree:
 
 - `email(action="send")` records sender-side outbox/sent state, then starts one `_mailman` daemon thread per recipient. Even when `delay=0`, the tool may return `status: "sent"` before that background delivery attempt finishes.
-- Peer/absolute delivery to a normal agent accepts only a target with `.agent.json` and a fresh `.agent.heartbeat` (normally younger than two seconds); human recipients (`admin: null`) skip the heartbeat check. If the target is refreshing/relaunching and its heartbeat is not fresh yet, delivery is refused as `not running`; no recipient inbox entry is queued for later. The eventual failure is surfaced to the sender as an `email.bounce` system notification.
+- Delivery to a normal agent accepts only a target with `.agent.json` and a fresh `.agent.heartbeat` (normally younger than two seconds); human recipients (`admin: null`) skip the heartbeat check. If the target is refreshing/relaunching and its heartbeat is not fresh yet, delivery is refused as `not running`; no recipient inbox entry is queued for later. The eventual failure is surfaced to the sender as an `email.bounce` event in `.notification/system.json`.
 - Read state lives in the recipient's `mailbox/read.json` (a set of message IDs).
 - The kernel mirrors current unread mail into `.notification/email.json`, which surfaces as a notification block read via `notification(action="check")` — that's how you find out new mail arrived.
 
 > **Refresh/relaunch window.** A target `lingtai run` process can already be visible in `ps` before it publishes a fresh heartbeat. In that interval, internal email may bounce for liveness while a CPR attempt's child launch exits because the CLI duplicate-process guard finds the existing same-workdir PID. Those results are compatible: do not stack CPR attempts. Wait for the target heartbeat to become fresh, then retry the email once. Use CPR only if the existing startup exits or fails to become live.
 
-There is no concept of an SMTP server, an MX record, or an external address. **If a request involves `@gmail.com`, `@outlook.com`, IMAP folders, or anything that needs to leave the machine, the right tool is the `lingtai-imap` MCP addon — see the `mcp-manual` skill, not this one.**
+**If a request involves `@gmail.com`, `@outlook.com`, IMAP folders, or anything that needs to leave the machine, the right tool is the `imap` MCP addon — see the `mcp-manual` skill, not this one.**
 
-## Internal Email vs IMAP
-
-| Feature         | Internal Email (this skill)                                  | IMAP (see `mcp-manual`)                                         |
-|-----------------|--------------------------------------------------------------|-----------------------------------------------------------------|
-| What            | LingTai email protocol within `.lingtai/` network            | Real email via IMAP/SMTP (Gmail, Outlook, etc.)                 |
-| Address format  | Bare path (e.g. `human`, `mimo-1`)                           | `@` address (e.g. `alice@gmail.com`)                            |
-| Tool            | `email` (intrinsic)                                          | `imap` (MCP server, `lingtai-imap` addon)                       |
-| Reply policy    | Always reply on the same channel                             | Requires confirmation for unknown senders                       |
-| Persistence     | Survives molt, lives in working directory                    | External mailbox, managed by IMAP server                        |
-| Use case        | Agent-to-agent communication, self-send, time capsules       | Real-world email integration                                    |
-
-This skill covers INTERNAL email only. For IMAP/SMTP email, see the `mcp-manual` skill.
+| Feature         | Internal Email (this skill)                            | IMAP (see `mcp-manual`)                          |
+|-----------------|--------------------------------------------------------|--------------------------------------------------|
+| What            | LingTai email protocol within `.lingtai/` network      | Real email via IMAP/SMTP (Gmail, Outlook, etc.)  |
+| Address format  | Bare path (e.g. `human`, `mimo-1`)                     | `@` address (e.g. `alice@gmail.com`)             |
+| Tool            | `email` (intrinsic)                                    | `imap` (MCP server, `imap` addon)                |
+| Reply policy    | Always reply on the same channel                       | Requires confirmation for unknown senders        |
+| Persistence     | Survives molt, lives in working directory              | External mailbox, managed by IMAP server         |
+| Use case        | Agent-to-agent communication, self-send, time capsules | Real-world email integration                     |
 
 ## 2. Addressing
 
@@ -71,9 +63,16 @@ email(action="send", address=["mimo-1", "scribe"], cc=["human"],
       subject="status", message="ready")
 ```
 
-To discover who exists: glob `.lingtai/*/.agent.json` from a shell. Use the `agent_name` field of each as the address. Do not invent addresses—a refused dispatch produces an `email.bounce` event in `.notification/system.json`; no recipient inbox entry is queued for later.
+To discover who exists: glob `.lingtai/*/.agent.json` from a shell. Use the `agent_name` field of each as the address. Do not invent addresses — a refused dispatch produces an `email.bounce` event and queues no recipient inbox entry.
 
-When displaying a sender to the human or another agent, prefer **`sender_nickname` if set, else `sender_name`** (both are in the inbound message's `identity` block). Bare addresses are routable but ugly.
+### `mode` — peer vs abs address resolution
+
+`mode` is the **address mode for `send`**, not an output-verbosity knob. Almost always leave it unset:
+
+- `peer` (default) — `address` is a bare agent name resolved against your own network folder. Correct for the human, fellow agents, and your own avatars.
+- `abs` — `address` is a literal absolute path to another agent's working directory, e.g. `/Users/alice/projectB/.lingtai/外援`. Use it only to reach an agent in a *different* `.lingtai/` network on the same machine. It embeds a `_return_route` so replies resolve unambiguously, and it does **not** bypass the handshake: the recipient still needs a valid `.agent.json` and a fresh heartbeat.
+
+Any other value is rejected with `invalid mode`.
 
 ## 3. Reply discipline — the one rule you cannot break
 
@@ -105,8 +104,6 @@ When you mention the sender in a reply body or in a summary you give the human, 
 
 ## 5. Actions — full surface
 
-The `email` tool dispatches by `action`. All actions take optional `mode` for output verbosity (see §11).
-
 | Action            | Purpose                                                            | Required args                                      |
 |-------------------|--------------------------------------------------------------------|----------------------------------------------------|
 | `send`            | Start a new thread; body hard-capped at 50,000 characters          | `address`, `subject`, `message`                    |
@@ -117,7 +114,7 @@ The `email` tool dispatches by `action`. All actions take optional `mode` for ou
 | `reply_all`       | Reply to sender + all original recipients minus self               | `email_id`, `message`                              |
 | `search`          | Search across inbox/sent/archive by `query` + `filter`             | `query` (and/or `filter`)                          |
 | `archive`         | Move from inbox to archive folder (keeps thread, removes from view)| `email_id`                                         |
-| `delete`          | Permanently delete                                                 | `email_id`                                         |
+| `delete`          | Permanently delete (inbox/archive only; `sent` is read-only)       | `email_id`                                         |
 | `contacts`        | List your address book                                             | —                                                  |
 | `add_contact`     | Add or upsert by `address`                                         | `address`, `name`, optional `note`                 |
 | `remove_contact`  | Remove by `address`                                                | `address`                                          |
@@ -125,13 +122,15 @@ The `email` tool dispatches by `action`. All actions take optional `mode` for ou
 
 ### `read` vs `dismiss` — when to use which
 
-Unread email bodies are injected in full into `_meta.agent_meta.notifications.persistent.email` (up to the 50,000-character send-layer cap described below). You do **not** need `email.read` merely to see ordinary message text. After you have handled the visible content, prefer `dismiss`: same read-state effect, no body returned, and the unread notification clears once count reaches zero.
+Unread email bodies are injected in full into `_meta.agent_meta.notifications.persistent.email` (up to the 50,000-character send-layer cap below). You do **not** need `read` merely to see ordinary message text. After you have handled the visible content, prefer `dismiss`: same read-state effect, no body returned, and the unread notification clears once count reaches zero.
 
 Use `read` when you need to refresh the source-of-truth mailbox record, inspect attachment/metadata details, or deliberately fetch the producer state before a reply/audit. Use `reply`/`reply_all` when answering. Failing to `dismiss`, `read`, `archive`, or `delete` a handled mail keeps the notification reminding you on every heartbeat.
 
+These are the producer-owned verbs for the `email` notification channel; a generic `notification(action='dismiss_channel', channel='email')` would clear only the mirror. See `notification-manual` → `reference/dismissal-safety/SKILL.md`.
+
 ### 50,000-character send cap
 
-Internal email bodies are intentionally capped at 50,000 characters at **send time**. The reason is architectural: unread bodies are injected in full into the persistent notification stream, so the reading/notification layer should not guess, summarize, or truncate ordinary mail. If a message is too large for that guarantee, `send` refuses it with `limit_chars` and `actual_chars`; shorten the body, attach a file, or put bulky material somewhere else and mail a pointer.
+Internal email bodies are capped at 50,000 characters at **send time**. The reason is architectural: unread bodies are injected in full into the persistent notification stream, so the reading/notification layer should not guess, summarize, or truncate ordinary mail. If a message is too large for that guarantee, `send` refuses it with `limit_chars` and `actual_chars`; shorten the body, attach a file, or put bulky material somewhere else and mail a pointer.
 
 ### `check` filter
 
@@ -160,60 +159,37 @@ Mail sent to **your own address** lands in your own inbox. It is marked self-sen
 - It surfaces in the persistent unread notification lane until you `dismiss`, `read`, `archive`, or `delete` it.
 - It can be `search`ed by the future you.
 
-Use this for: TODOs you want to remember after a memory rotation, breadcrumbs about decisions, "hand-off to self" notes during a long task.
-
-```python
-email(action="send", address="<your-own-name>",
-      subject="resume here", message="Picked the Helmholtz approach; see paper/drafts/2026-05-18.md")
-```
+Use this for: TODOs you want to remember after a memory rotation, breadcrumbs about decisions, "hand-off to self" notes during a long task. See the recipes in §10.
 
 ## 7. Time capsule — delayed self-send
 
-Add `delay=<seconds>` to defer delivery. The outbox entry is written immediately; the `_mailman` daemon thread sleeps until the deadline, then dispatches.
+Add `delay=<seconds>` to defer delivery. The outbox entry is written immediately; the `_mailman` daemon thread sleeps until the deadline, then dispatches. Combined with self-send this gives you cheap one-shot alarms without standing up a cron; the notification is delivered exactly once.
 
-```python
-# Remind self in 1 hour
-email(action="send", address="<your-own-name>", delay=3600,
-      subject="check on long task", message="Did `daemon(check, id=...)` finish?")
-```
+Use delayed self-send as a **future nudge**, not delayed tool execution. The message should tell the future you what to inspect and why, then let that future turn decide with current context whether to run `shell(action="poll")`, `daemon(check)`, a channel read, or nothing at all. It is one of the escape hatches when a repeated-call `_advisory` says you may be polling the same thing: write one concrete reminder, then yield/idle.
 
-Combined with self-send, this gives you cheap one-shot alarms without standing up a cron. The notification is delivered exactly once. For **recurring** reminders, use a host scheduler (cron, launchd, systemd, or an event watcher) via `shell-manual`; do not use the email tool for recurring execution.
+**Recurring work is not an email feature.** The internal `email` tool has no recurring scheduling API. For repeating reminders or agent-side scheduled work, use a host scheduler (cron, launchd, systemd, or an event watcher) via `shell-manual` → `reference/scheduled-work/SKILL.md`; for a single lightweight wakeup that does not need mailbox state, `shell-manual` → `reference/notification-reminders/SKILL.md` owns the `.notification/cron.json` pattern.
 
-Use delayed self-send as a **future nudge**, not delayed tool execution. The message should tell the future you what to inspect and why, then let that future turn decide with current context whether to run `shell(action="poll")`, `daemon(check)`, a channel read, or nothing at all. This is the preferred escape hatch when a repeated-call `_advisory` tells you that you may be polling the same thing: write one concrete reminder, then yield/idle instead of immediately calling the same tool again.
+## 8. Privacy — internal IDs
 
-## 8. Recurring reminders live outside email
-
-The internal `email` tool no longer has a recurring scheduling API. Use delayed
-self-send (`delay=`) for one-shot time capsules only. For repeating reminders or
-agent-side scheduled work, use a host scheduler (cron, launchd, systemd, or an
-event watcher) following `shell-manual`; consult `system-manual` for lifecycle and
-notification behavior.
-
-## 9. Privacy — internal IDs
-
-The mailbox UUID (`email_id`) is **local to your working directory**. Never paste a raw mailbox ID into a message to another agent or to the human — it has no meaning outside your tree and reveals nothing useful. Refer to messages by `subject` + `from` + approximate time. If you must show the human exactly which mail you're acting on, use the **subject line and sender**.
+The mailbox UUID (`email_id`) is **local to your working directory**. Never paste a raw mailbox ID into a message to another agent or to the human — it has no meaning outside your tree and reveals nothing useful. Refer to messages by `subject` + `from` + approximate time.
 
 The exception: when you call `email(action="read"/"dismiss"/"reply", email_id=[...])`, you pass IDs you read out of *your own* persistent notification or mailbox listing. That's internal plumbing, fine.
 
-## 10. Addon ownership — what this skill does NOT cover
+## 9. Addon ownership — what this skill does NOT cover
 
 This skill is the manual for the **kernel-intrinsic `email` tool** only. Adjacent surfaces live elsewhere:
 
 | Want to …                                          | Use                                          |
 |----------------------------------------------------|----------------------------------------------|
-| Send/receive real internet email (Gmail, etc.)     | `mcp-manual` → `lingtai-imap` MCP addon      |
-| Send Telegram / Feishu / WeChat messages           | `mcp-manual` → respective MCP addon          |
+| Send/receive real internet email (Gmail, etc.)     | `mcp-manual` → `imap` or `cloud_mail` addon  |
+| Send Telegram / Feishu / WeChat / WhatsApp messages | `mcp-manual` → respective MCP addon          |
 | Send a notification-style ping to another agent    | This skill — it IS the notification channel  |
 | Schedule a one-off wake-up of your own loop        | This skill, `delay` + self-send (§7)         |
-| Run recurring agent-side work                       | Host scheduler / event watcher via `shell-manual` (§8) |
+| Run recurring agent-side work                       | Host scheduler / event watcher via `shell-manual` |
 
-The IMAP, Telegram, Feishu, and WeChat MCP addons each ship their own SKILL.md and `mcp-manual` entry. They are separate processes, separate auth surfaces, and separate failure modes. Do not try to use the `email` tool for an external address: an unknown target is refused without creating a recipient inbox entry and is reported through `email.bounce`.
+Those MCP addons are separate processes with separate auth surfaces and failure modes; each ships its own manual. Do not try to use the `email` tool for an external address: an unknown target is refused without creating a recipient inbox entry and is reported through `email.bounce`.
 
-## 11. Mode (output verbosity)
-
-Every `email` action accepts an optional `mode` (set by `mode_field`) controlling how much detail is rendered in the tool result. Defaults are usually fine. Bump it when you are debugging delivery or read-state issues; lower it when you are iterating in a tight loop and only need confirmation.
-
-## 12. Quick reference — common recipes
+## 10. Quick reference — common recipes
 
 ```python
 # Handle content already injected into notification_persistent.email
@@ -229,14 +205,16 @@ email(action="check", filter={"unread_only": True}, n=20)
 email(action="reply", email_id=["<id>"], message="ack, looking now")
 
 # Self-note that survives molt
-email(action="send", address="<self>", subject="resume", message="next: ...")
+email(action="send", address="<self>", subject="resume",
+      message="Picked the Helmholtz approach; see paper/drafts/2026-05-18.md")
 
 # 5-minute timer
 email(action="send", address="<self>", delay=300,
       subject="ding", message="check the deploy")
 
-# Recurring nudges/work are not an email feature; use a host scheduler
-# or event watcher via shell-manual/system-manual instead.
+# Reach an agent in another .lingtai/ network on this machine
+email(action="send", mode="abs", address="/Users/alice/projectB/.lingtai/外援",
+      subject="cross-network", message="ping")
 
 # Find related mail
 email(action="search", query="helmholtz",
@@ -255,8 +233,8 @@ email(action="add_contact", address="mimo-1", name="MiMo (vision)",
 Internal email persists under the agent mailbox: inbox/archive/sent message
 files, attachments, contacts, and read/archive state. Mail is also memory: do not
 blindly delete it. Prefer `email(archive)` or `email(delete)` verbs over `rm`,
-and never delete mail that is the only copy of a decision,
-handoff, or attachment the human may expect you to retain.
+and never delete mail that is the only copy of a decision, handoff, or
+attachment the human may expect you to retain.
 
 Footprint check (read-only, records the audit):
 

--- a/src/lingtai/tools/knowledge/manual/SKILL.md
+++ b/src/lingtai/tools/knowledge/manual/SKILL.md
@@ -8,7 +8,7 @@ description: >
   need to create, organize, or load private knowledge, lay out a routing parent
   over related entries, or explain how knowledge differs from portable skills.
 version: 1.0.0
-last_changed_at: "2026-06-09T13:24:44-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/tools/knowledge/__init__.py
 - src/lingtai/tools/knowledge/ANATOMY.md
@@ -21,29 +21,32 @@ maintenance: |
 
 Knowledge is an agent's private long-term memory. It is for facts, decisions, observations, local paths, mail context, and operational lessons that are useful to this agent but are not necessarily portable to every other agent.
 
-Skills are different: a skill is a reusable procedure meant to travel across agents. Knowledge may point to skills; skills should not depend on private knowledge.
+The private-memory capability is named `knowledge`, and it registers exactly one
+tool, also named `knowledge`.
 
+## Knowledge vs skills
 
-## Names you will see
-
-The private-memory capability is named `knowledge`, and the only tool it registers is:
-
-```text
-knowledge({"action": "info"})
-```
-
-Do not confuse `knowledge` with the `.library/` directory: `.library/` is the on-disk home for **skills** (`SKILL.md` files), not for private `knowledge` entries.
-
-Quick map:
+Knowledge and skills are **isomorphic in layout and progressive disclosure**:
+each entry is a folder with a marker file (`KNOWLEDGE.md` here, `SKILL.md`
+there), the prompt carries only the catalog, and a top-level entry may act as a
+routing/index parent over nested children. They are physically separate stores
+with different audiences:
 
 | Term / path | Meaning |
 |---|---|
 | `knowledge` tool / capability | Private per-agent durable memory catalog. |
 | `<agent>/knowledge/<name>/KNOWLEDGE.md` | One private knowledge entry. |
-| `.library/intrinsic`, `.library/custom`, `.library_shared` | Skill shelves containing `SKILL.md` files. |
 | `skills` tool / capability | Catalog of reusable portable procedures. |
+| `.library/intrinsic`, `.library/custom`, `.library_shared` | Skill shelves holding `SKILL.md` files — never private `knowledge` entries. |
 
-Prefer `knowledge` for private memory and `skills` for reusable procedures.
+Knowledge is **private, local, and non-portable** by default: it may reference
+agent-local paths, mail IDs, and logs. Skills are **reusable, shareable, and
+portable**.
+
+**Direction matters:** private knowledge may point outward to skills; shared
+skills must not point inward to private knowledge paths, mail IDs, or local
+logs. If content is a reusable how-to another agent could apply without your
+private context, write a skill instead.
 
 ## Layout
 
@@ -77,31 +80,17 @@ Required fields are `name` and `description`. Supporting files are optional and 
 
 ## Progressive disclosure
 
-The system prompt only receives a compact catalog: each entry's `name`, `description`, and `location`. The body of `KNOWLEDGE.md` and supporting files stay on disk until you explicitly read them.
+The system prompt only receives a compact catalog: each entry's `name`, `description`, and `location`. The body of `KNOWLEDGE.md` and supporting files stay on disk until you explicitly read them. This keeps the prompt small while still making the memory discoverable.
 
-Use:
-
-```text
-knowledge({"action": "info"})
-```
-
-to rescan the catalog and refresh the prompt section, then use `read` on the listed `location` when an entry becomes relevant.
-
-This keeps the prompt small while still making the memory discoverable.
+Call `knowledge({"action": "info"})` to rescan the catalog and refresh the prompt section, then use `read` on the listed `location` when an entry becomes relevant.
 
 ## Nesting and sub-knowledge
 
-Knowledge and skills are **isomorphic in layout and progressive disclosure**:
-each top-level entry is a folder with a marker file (`KNOWLEDGE.md` here,
-`SKILL.md` there), the prompt carries only the catalog, and a top-level entry may
-act as a **routing/index parent** with nested children that hold the substance —
-exactly the nested-reference pattern documented in the skills manual.
+A top-level entry may act as a **routing/index parent** with nested children that
+hold the substance — exactly the nested-reference pattern documented in the
+skills manual.
 
-The only real difference is *audience*: knowledge is **private, local, and
-non-portable** by default (it may reference agent-local paths, mail IDs, and
-logs); skills are **reusable, shareable, and portable**.
-
-So for the routing/index parent pattern — when to use it, how the parent stays a
+For the routing/index parent pattern — when to use it, how the parent stays a
 short scannable index, how children carry the detail, relative child paths,
 keeping the catalog in sync — **read the skills manual's nested reference
 section** (`.library/intrinsic/capabilities/skills/SKILL.md`, "Nested
@@ -138,8 +127,6 @@ Knowledge may also reference skills when a reusable procedure exists:
 For the repeatable workflow, read `.library/intrinsic/capabilities/skills/SKILL.md`.
 ```
 
-Direction matters: private knowledge can point outward to skills, but shared skills should not point inward to private knowledge paths, mail IDs, or local logs.
-
 ## When to create knowledge
 
 Create or update a knowledge entry when the information is useful beyond the current turn but is not a portable procedure:
@@ -149,8 +136,6 @@ Create or update a knowledge entry when the information is useful beyond the cur
 - local repo paths, branch relationships, and known gotchas;
 - incident notes and debugging evidence;
 - conclusions from research that are specific to this agent's work.
-
-If the content is a reusable how-to that another agent should be able to apply without your private context, write a skill instead.
 
 ## Cleanup / Footprint
 

--- a/src/lingtai/tools/mcp/manual/SKILL.md
+++ b/src/lingtai/tools/mcp/manual/SKILL.md
@@ -1,47 +1,40 @@
 ---
 name: mcp-manual
 description: >
-  Operational guide for the `mcp` capability — register, activate, update,
-  deregister, and troubleshoot MCP (Model Context Protocol) servers in your
-  agent. Single source of truth for both generic MCP setup AND the six
-  kernel-curated LingTai addon MCPs (`imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, `cloud_mail`).
+  Router for the `mcp` capability — register, activate, update, deregister,
+  and troubleshoot MCP (Model Context Protocol) servers. Covers both generic
+  third-party MCPs and the six kernel-curated LingTai addons (`imap`,
+  `telegram`, `feishu`, `wechat`, `whatsapp`, `cloud_mail`).
 
   Reach for this manual when:
     - The human asks to install, set up, configure, or remove an MCP server.
-      Decision tree: is it kernel-curated (imap/telegram/feishu/wechat/whatsapp/cloud_mail) → the
-      `addons:` + `init.json mcp.<name>` workflow using modules shipped inside
-      the `lingtai` wheel is here. Is it third-party → the registry route OR the legacy
-      `mcp/servers.json` route, both documented here.
-    - The human asks to set up the `imap` / `telegram` / `feishu` / `wechat`
-      addon, or any LingTai email/chat integration. **Step 1 is always**:
-      read the curated-addon setup section and, when exact config fields are
-      needed, inspect the shipped module docs/resources or the catalog homepage.
-      Field names like `email_password`, `bot_token`, `app_id`/`app_secret`,
-      and gewechat hosts are documented by the addon docs — do NOT guess.
-    - You want to know what MCPs you currently have. `mcp(action="info")`
-      returns the registry plus health; this manual explains the output.
-    - An MCP isn't behaving — registry validation, `problems` list,
-      refresh-after-edit verification, common boot errors are here.
-    - You're exploring an unfamiliar third-party MCP. The doc-discovery flow
-      (local `scripts/find_readme.py` first, homepage URL fallback) is here.
+      Kernel-curated → the `addons:` + `init.json mcp.<name>` workflow;
+      third-party → the registry route or the legacy `mcp/servers.json` route.
+    - The human asks to set up an `imap` / `telegram` / `feishu` / `wechat` /
+      `whatsapp` / `cloud_mail` addon, or any LingTai email/chat integration.
+      **Step 1 is always** `reference/curated-addons.md`; exact config field
+      names come from the addon docs — do NOT guess them.
+    - You want to know what MCPs you currently have (`mcp(action="info")`).
+    - An MCP isn't behaving: registry validation, the `problems` list,
+      refresh-after-edit verification, common boot errors.
+    - You're exploring an unfamiliar third-party MCP and need its docs.
 
   Covers (progressively, via reference/): the three states (catalog →
-  registry → active), the curated-vs-third-party install paths, the legacy
-  `mcp/servers.json` direct mount route (still functional, ungated), HTTP
-  and stdio server configurations, where the registry file
-  (`mcp_registry.jsonl`) lives and how to mutate it (`write` / `edit` /
-  `bash` — the `mcp` capability is read-only), the `<homepage>` field as
-  fallback documentation, and the relationship between `init.json`'s
-  `addons:` list, `mcp:` activation entries, and the registry. Replaces the
-  deprecated `lingtai-mcp` skill.
+  registry → active); curated vs third-party install paths; the legacy
+  `mcp/servers.json` direct mount route (still functional, ungated); stdio
+  and HTTP server config; where `mcp_registry.jsonl` lives and how to mutate
+  it (`write`/`edit`/`bash` — the `mcp` capability itself is read-only); the
+  `<homepage>` fallback doc field; and how `init.json`'s `addons:` list and
+  `mcp:` activation entries relate to the registry. Replaces the deprecated
+  `lingtai-mcp` skill.
 
-  Does NOT cover the protocol spec itself: schema validation rules, env
-  injection mechanics (the `LINGTAI_AGENT_DIR` / `LINGTAI_MCP_NAME`
-  variables), the LICC v1 inbox callback contract, and the validator's
-  internal logic all live in `lingtai-kernel-anatomy reference/mcp-protocol.md`.
-  Read this for *what to do*; read anatomy for *how it works*.
-version: 3.2.0
-last_changed_at: "2026-06-24T16:26:32-07:00"
+  Does NOT cover the protocol spec: schema validation, env injection
+  (`LINGTAI_AGENT_DIR` / `LINGTAI_MCP_NAME`), the LICC v1 inbox callback
+  contract, and validator internals live in `lingtai-kernel-anatomy
+  reference/mcp-protocol.md`. Read this for *what to do*, anatomy for *how
+  it works*.
+version: 3.3.0
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
 - src/lingtai/tools/mcp/__init__.py
 - src/lingtai/tools/mcp/ANATOMY.md
@@ -52,7 +45,7 @@ maintenance: |
 
 # MCP Capability — How To Use It
 
-The `mcp` capability is your interface to Model Context Protocol (MCP) servers — both generic third-party servers and the six kernel-curated LingTai addons (`imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, `cloud_mail`). Like the `library` capability, it is **pure presentation**: registered MCPs are listed in your system prompt under `<registered_mcp>`, and the registry itself is a JSONL file you edit directly with `write` / `edit` / `bash`.
+The `mcp` capability is your interface to Model Context Protocol (MCP) servers — both generic third-party servers and the six kernel-curated LingTai addons (`imap`, `telegram`, `feishu`, `wechat`, `whatsapp`, `cloud_mail`). Like the `skills` capability, it is **pure presentation**: registered MCPs are listed in your system prompt under `<registered_mcp>`, and the registry itself is a JSONL file you edit directly with `write` / `edit` / `bash`.
 
 This is the router. Detail lives in `reference/`. Load only what you need.
 
@@ -77,16 +70,9 @@ Promotion path: catalog → registry → active. You move things along by editin
 | Update or deregister an MCP | `reference/troubleshooting.md` |
 | Spec-level questions (schema, env injection, LICC) | `lingtai-kernel-anatomy reference/mcp-protocol.md` |
 
-**Before curated addon setup**, start with `reference/curated-addons.md`; those first-party servers now ship inside the `lingtai` wheel under `lingtai.mcp_servers.*`; historical `lingtai_*` packages remain as thin compatibility wrappers.
+**Before curated addon setup**, start with `reference/curated-addons.md`; it owns the setup contract and the registry-name → module-name table. Those first-party servers now ship inside the `lingtai` wheel under `lingtai.mcp_servers.*`; historical `lingtai_*` packages remain as thin compatibility wrappers.
 
-**Before third-party setup or troubleshooting**, fetch the relevant server README with:
-
-```bash
-~/.lingtai-tui/runtime/venv/bin/python3 \
-  .library/intrinsic/capabilities/mcp/scripts/find_readme.py <pkg-name>
-```
-
-For third-party Python MCPs, `<pkg-name>` is the installed distribution name. Full details: see §Reading an MCP's README below.
+**Before third-party setup or troubleshooting**, read the server's own docs — see below.
 
 ## Reading an MCP's README
 
@@ -94,27 +80,16 @@ Every MCP server's README is the canonical install + config + troubleshooting do
 
 ### 1. Local README (preferred for third-party Python MCPs)
 
-If the MCP is installed as its own Python package, run the script with the **runtime venv's Python** — the same interpreter where the server package is actually installed:
+If the MCP is installed as its own Python package, run the bundled script with the **runtime venv's Python** — the same interpreter where the server package is actually installed:
 
 ```bash
 ~/.lingtai-tui/runtime/venv/bin/python3 \
   .library/intrinsic/capabilities/mcp/scripts/find_readme.py <pkg-name>
 ```
 
-(`python3` from your `$PATH` may resolve to a system or conda interpreter that doesn't see the venv's installed packages — always use the venv's Python explicitly.)
+`<pkg-name>` is the installed distribution name. (`python3` from your `$PATH` may resolve to a system or conda interpreter that doesn't see the venv's installed packages — always use the venv's Python explicitly.)
 
-The script tries the editable repo on disk first, then falls back to the README embedded in the wheel's `METADATA` file (PEP 566). Works for editable installs and normal PyPI wheels alike. Pass `--module <modname>` if you only know the importable module name instead of the distribution name. For embedded curated modules, `--module lingtai.mcp_servers.imap` resolves to the owning `lingtai` distribution, so use `reference/curated-addons.md` for the concise setup contract and the homepage for deep provider docs.
-
-Curated addon modules shipped by the `lingtai` wheel:
-
-| Registry name | Historical distribution | Module name        |
-|---------------|-------------------------|--------------------|
-| `imap`        | formerly `lingtai-imap`     | `lingtai.mcp_servers.imap`     |
-| `telegram`    | formerly `lingtai-telegram` | `lingtai.mcp_servers.telegram` |
-| `feishu`      | formerly `lingtai-feishu`   | `lingtai.mcp_servers.feishu`   |
-| `wechat`      | formerly `lingtai-wechat`   | `lingtai.mcp_servers.wechat`   |
-| `whatsapp`    | formerly `lingtai-whatsapp` | `lingtai.mcp_servers.whatsapp` |
-| `cloud_mail`  | (no standalone distribution) | `lingtai.mcp_servers.cloud_mail` |
+The script tries the editable repo on disk first, then falls back to the README embedded in the wheel's `METADATA` file (PEP 566). Works for editable installs and normal PyPI wheels alike. Pass `--module <modname>` if you only know the importable module name instead of the distribution name.
 
 ### 2. Homepage URL (fallback)
 

--- a/src/lingtai/tools/mcp/manual/reference/curated-addons.md
+++ b/src/lingtai/tools/mcp/manual/reference/curated-addons.md
@@ -77,7 +77,7 @@ Use this checklist as the Telegram setup acceptance test. It is intentionally se
 `cloud_mail` is a REST client for a self-hosted [Cloud Mail](https://github.com/maillab/cloud-mail) deployment (Cloudflare Workers). It is **not** IMAP/SMTP — it talks to Cloud Mail's HTTP API. Inbound mail is discovered by polling Cloud Mail's `POST /public/emailList` and delivered to your inbox via LICC.
 
 - **Env var:** `LINGTAI_CLOUD_MAIL_CONFIG` — path to the config JSON (resolved relative to the agent dir when not absolute).
-- **Omnibus tool:** `cloud_mail` with actions `check` (recent inbound mail), `search` (filter by sender/recipient/subject/content), `read` (full content by compound id `<account>:<emailId>`), `send` (requires user credentials), `accounts` (redacted status), and `add_user` (admin convenience).
+- **Omnibus tool:** `cloud_mail`. Its action surface is owned by the addon's own manual — `cloud_mail(action="manual")`.
 - **Auth model:** the addon mints a *public token* from `admin_email`/`admin_password` via `/public/genToken` for read/poll/search, and logs in with `user_email`/`user_password` via `/login` for `send`. If user creds are absent, read/check/search/poll still work; only `send` is disabled with a clear error.
 - **Watermark:** the first poll seeds the per-account high-water mark silently (no flood of old mail) unless `notify_existing: true`. State lives under `<agent_dir>/cloud_mail/<alias>/watermark.json`.
 
@@ -106,7 +106,7 @@ Config schema (plaintext; copy verbatim, never commit real passwords):
 
 ## After it's running
 
-Inbound events (new emails, chat messages) flow into your `.mcp_inbox/<name>/` via the LICC v1 inbox callback contract — the kernel auto-injects them into your next turn as `[system]` messages. You don't poll; the kernel does. Outbound calls go through the omnibus tool: `imap(action="send", ...)`, `telegram(action="send", ...)`, etc. — see each addon's README for the action list.
+Inbound events (new emails, chat messages) flow into your `.mcp_inbox/<name>/` via the LICC v1 inbox callback contract — the kernel auto-injects them into your next turn as `[system]` messages. You don't poll; the kernel does. Outbound calls go through the omnibus tool: `imap(action="send", ...)`, `telegram(action="send", ...)`, etc. Each addon owns its own action surface and side-effect rules — pull it with `<addon>(action="manual")`; this file stops at setup.
 
 ## WeChat setup checklist
 

--- a/src/lingtai/tools/mcp/manual/reference/third-party-and-legacy.md
+++ b/src/lingtai/tools/mcp/manual/reference/third-party-and-legacy.md
@@ -13,12 +13,10 @@ Two routes for non-curated MCPs: the **registry route** (recommended, gated by `
 
 For any non-curated MCP — typically `npx`/`uvx`-launched servers from the broader MCP ecosystem.
 
-1. **Fetch the MCP's setup doc.** If it's pip-installed, use the bundled script:
-   ```bash
-   ~/.lingtai-tui/runtime/venv/bin/python3 \
-     .library/intrinsic/capabilities/mcp/scripts/find_readme.py <pkg-name>
-   ```
-   Otherwise (npx/uvx servers), `web_read` the homepage URL. Either way, get the install command, env vars, and config schema before writing any config.
+1. **Fetch the MCP's setup doc.** If it's pip-installed, use the bundled
+   `find_readme.py` script; otherwise (npx/uvx servers) `web_read` the homepage
+   URL. Both routes are in `SKILL.md` §Reading an MCP's README. Either way, get
+   the install command, env vars, and config schema before writing any config.
 2. Append a single JSON record to `mcp_registry.jsonl` (one line, atomic write). For the schema, see `lingtai-kernel-anatomy reference/file-formats.md` §6.5.
 3. Add an `init.json` `mcp.<name>` activation entry.
 4. Run `system(action="refresh")`.

--- a/src/lingtai/tools/mcp/manual/reference/troubleshooting.md
+++ b/src/lingtai/tools/mcp/manual/reference/troubleshooting.md
@@ -20,17 +20,12 @@ Call `mcp(action="info")` to see:
 - The `problems` list (invalid registry lines, missing config, etc.)
 - A runtime health snapshot (registry path, count, status per server)
 
-Invalid registry lines are skipped silently with a warning at refresh time, so always verify with `show` after editing.
+Invalid registry lines are skipped silently with a warning at refresh time, so always verify with `mcp(action="info")` after editing.
 
 ## Common boot failures
 
 **Boot failure with cryptic `KeyError`**
-The MCP subprocess hit a missing config field. The error message *is* the missing field name. For kernel-curated addons, first re-read `reference/curated-addons.md`, then use the catalog homepage for deep provider docs if needed. For third-party Python MCPs, fetch the server README via:
-
-```bash
-~/.lingtai-tui/runtime/venv/bin/python3 \
-  .library/intrinsic/capabilities/mcp/scripts/find_readme.py <pkg-name>
-```
+The MCP subprocess hit a missing config field. The error message *is* the missing field name. For kernel-curated addons, first re-read `curated-addons.md`, then use the catalog homepage for deep provider docs if needed. For third-party Python MCPs, fetch the server README (see §When in doubt, step 1).
 
 Check the exact field name spelling — `email_password` not `password`, `bot_token` not `token`, etc. This is the single most common failure mode and the docs always have the correct field name.
 
@@ -48,7 +43,9 @@ Eager-start failed silently. Check the agent's stderr / `logs/agent.log` for the
 
 ## When in doubt
 
-1. Read the relevant docs — `reference/curated-addons.md` for kernel-curated addons, or a third-party README via:
+1. Read the relevant docs — `curated-addons.md` for kernel-curated addons, or a
+   third-party README via the bundled script (`<pkg-name>` is the installed
+   distribution name; use the runtime venv's Python):
    ```bash
    ~/.lingtai-tui/runtime/venv/bin/python3 \
      .library/intrinsic/capabilities/mcp/scripts/find_readme.py <pkg-name>

--- a/src/lingtai/tools/skills/manual/SKILL.md
+++ b/src/lingtai/tools/skills/manual/SKILL.md
@@ -1,41 +1,15 @@
 ---
 name: skills-manual
 description: >
-  Operational guide for the `skills` capability — your skill catalog's
-  on-disk layout, how the YAML skill catalog in your system prompt
-  is built, and the full authoring/publishing workflow for new skills.
-
-  Reach for this manual when:
-    - You're authoring a new skill in `.library/custom/<name>/` and need
-      the frontmatter schema, the bundled template, the validator, or the
-      "do create a skill / do NOT create a skill" decision rules.
-    - You received an external skill repository and need the intake flow:
-      install it into this agent's `.library/custom/<skill-name>/`, validate it,
-      then refresh so it enters the skills catalog.
-    - A skill you expect to see isn't showing up in the catalog — the
-      health-check workflow (`skills({"action": "info"})`) and the
-      `intrinsic` vs `custom` directory split tell you what's wrong.
-    - You want to pin a skill's body into your pad (so it survives the
-      next molt and stays in the cached prefix) — the `psyche` pinning
-      recipe lives here.
-    - You're adding a new skills path source (e.g. a project-specific
-      utilities directory) by editing `init.json`'s
-      `manifest.capabilities.skills.paths`.
-    - You're turning a large manual into a progressive-disclosure router
-      and need the nested skill/reference pattern.
-
-  Covers: directory layout (`.library/{intrinsic,custom}/`), required vs
-  optional frontmatter fields, name-collision discipline, when to author
-  a skill and when not to, what makes a skill description trigger-friendly,
-  nested skill/reference catalogs, the validator's failure modes, and the
-  relationship between the kernel's intrinsic skill bundles and your
-  editable `custom/` territory.
-
-  Does NOT cover: the bundled skills themselves — their READMEs and
-  SKILL.md files document them. This is meta — how the skills *system*
-  works, not what's *inside* it.
+  Meta-manual for the `skills` capability: how your catalog is built from
+  `.library/{intrinsic,custom}/` plus `init.json` paths, and how to author,
+  validate, install, share, publish, and pin skills. Read when writing a skill in
+  `.library/custom/<name>/`, installing an external skill repo, debugging a skill
+  missing from the catalog, adding a skills path, or turning a manual into a
+  progressive-disclosure router. Does NOT document the bundled skills themselves
+  — their own SKILL.md files do.
 version: 1.1.0
-last_changed_at: "2026-07-06T14:50:00-07:00"
+last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
 - src/lingtai/tools/skills/__init__.py
 - src/lingtai/tools/skills/ANATOMY.md
@@ -46,7 +20,15 @@ maintenance: |
 
 # The Skills Capability
 
-This is the skills capability's own manual. It documents how the skill catalog works from your side: the on-disk layout, the YAML catalog, and the authoring/publishing workflow. The skills capability scans `.library/` plus any extra paths declared in `init.json`, builds the YAML skill catalog, and injects it into your system prompt. An external skill is not loaded merely because someone shared a URL; it must be installed into a scanned skill root and then loaded by refresh.
+This is the skills capability's own manual — how the skills *system* works, not
+what is inside it. The capability scans `.library/` plus any extra paths declared
+in `init.json`, builds a YAML catalog, and injects it into your system prompt.
+
+**The one rule behind everything below:** a skill exists for you only after it is
+(1) installed into a scanned skill root and (2) picked up by
+`system({"action": "refresh"})`. A shared URL, a temporary clone, or a file you
+just wrote is not yet in the catalog. Every write/install step in this manual
+ends with a refresh.
 
 ## On-disk layout
 
@@ -62,62 +44,88 @@ Your skill catalog lives at `<agent>/.library/`:
 └── custom/
 ```
 
-- `intrinsic/` — **CLI-managed.** Wiped and rewritten from kernel-shipped manual bundles on every `system({"action": "refresh"})`. Do not edit — your edits will be erased. Read-only territory.
-- `intrinsic/capabilities/<cap>/` — manual for each loaded capability (e.g. `skills/`, `email/`, `psyche/`).
-- `intrinsic/addons/<addon>/` — manual for each loaded addon (e.g. `imap/`, `telegram/`, `feishu/`).
-- `custom/` — **your territory.** Authored skills live here. The CLI never touches this directory.
+- `intrinsic/` — **CLI-managed.** Wiped and rewritten from kernel-shipped manual
+  bundles on every refresh. Do not edit; your edits will be erased.
+  `capabilities/<cap>/` holds each loaded capability's manual (`skills/`,
+  `email/`, `psyche/`); `addons/<addon>/` holds each loaded addon's
+  (`imap/`, `telegram/`, `feishu/`).
+- `custom/` — **your territory.** Authored skills live here; the CLI never
+  touches this directory.
 
-Additional paths come from `init.json` at `manifest.capabilities.skills.paths` — typically `~/.lingtai-tui/utilities/` (operational utilities shipped by the TUI), plus any project-specific roots. `../.library_shared/` is an opt-in local-network sharing path, not a default path to add to every agent. For ordinary sharing, install the skill into each receiving agent's `custom/` directory instead.
+Additional roots come from `init.json` at `manifest.capabilities.skills.paths` —
+typically `~/.lingtai-tui/utilities/`, plus any project-specific roots. To add
+one: `edit` that list (absolute, or relative to your working dir; `~/` expansion
+honored), then refresh. `init.json` is the ground truth — there is no runtime
+state, so whatever is in `paths` at setup time is the exact set scanned.
 
-If the skills capability is NOT loaded, the files still exist on disk — you just don't get a catalog in your prompt. You can still reach the manuals via `read`, `grep`, `ls`.
+`../.library_shared/` is an **opt-in** local-network sharing root, not a default.
+For ordinary sharing, install into each receiving agent's `custom/` instead.
 
-## External skill intake (default flow)
+If the skills capability is not loaded, the files still exist on disk — you just
+get no catalog in your prompt. Reach the manuals with `read`, `grep`, `ls`.
 
-When a human, peer, or repository URL shares an external skill, do **not** treat the
-URL or a temporary clone as "loaded." The default intake flow is local-first:
+## The catalog, and checking its health
 
-1. **Clone or copy into this agent's custom root:**
-   `<agent>/.library/custom/<skill-name>/`. Keep the repository metadata when the
-   skill has an upstream so future syncs can use `git pull --ff-only`.
-2. **Validate structure before trusting it:** run the bundled validator against
-   the installed folder and inspect `SKILL.md` frontmatter (`name`,
-   `description`) plus any referenced `scripts/`, `assets/`, or `references/`.
-3. **Refresh this agent:** call `system({"action": "refresh"})` so the skills
-   catalog is rebuilt and the skill appears in the system prompt. Until refresh
-   succeeds, the skill is only a file on disk.
-4. **Load it by catalog entry:** after refresh, use the cataloged `location:` to
-   read the skill body (and follow any nested references). Record the commit or
-   source URL in your task notes when it matters.
-5. **Share by telling recipients to install into their own `custom/`:** if other
-   agents need the skill, send the URL plus this intake recipe. Each receiving
-   agent installs, validates, and refreshes itself. Do not make a network shared
-   folder the default distribution path.
+The `skills` section of your system prompt is a YAML list. Each skill is one
+`- name: <name>` block with a `location:` (absolute path to that skill's
+`SKILL.md`) and a `description:` block scalar. To read a skill's body, `read` the
+file at its `location`.
 
-Use a temporary/quarantine clone only for pre-inspection when the source is
-untrusted; move or clone a reviewed copy into `.library/custom/<skill-name>/`
-before relying on the skill. Installing a skill does not authorize external side
-effects described by that skill; normal human authorization boundaries still
-apply.
+`skills({"action": "info"})` refreshes/reconciles the catalog and returns a
+runtime snapshot — `skills_dir`/`library_dir`, `catalog_size`, resolved paths
+with exist/skill-count info, and any `problems` (invalid frontmatter, unreadable
+folders) — without the manual body. Use it first when a skill you expect is
+missing. `skills({"action": "manual"})` returns this SKILL.md body instead. A
+`status` of `"degraded"` carries an error message naming the fix — typically a
+missing manual under `intrinsic/capabilities/skills/`, meaning the initializer
+did not install manuals correctly.
 
-## How the catalog works
-
-The `skills` section of your system prompt is a YAML list. Each skill is one `- name: <name>` block with a `location:` (absolute path to the skill's `SKILL.md`) and a `description:` block scalar. To read a skill's body, use `read` on the file at that `location`. That gives you the full Markdown for that one turn.
-
-## Loading a skill into active working memory
-
-If you plan to use a skill across many turns or need it to survive a molt, pin its `SKILL.md` into your pad:
+To pin a skill's body into your pad so it survives a molt and rides in the cached
+system-prompt prefix:
 
 ```
 psyche({"object": "pad", "action": "append", "files": ["<location>"]})
 ```
 
-The body is appended to your pad's read-only reference section, which is part of the cached system-prompt prefix. To unpin, call the same action with a new `files` list that omits the path (or `files: []` to clear everything).
+Pinning is cheap per-token over a session; repeated `read`s of the same file are
+not. Pad semantics (read-only reference section, clearing with `files: []`, the
+token ceiling) belong to `psyche-manual` §5 — read it there.
 
-Pinning is cheap per-token over a session because the pad sits in the cached prefix — repeated `read`s of the same file do NOT benefit from that cache.
+## External skill intake (default flow)
+
+When a human, peer, or repository URL shares a skill, do not treat the URL or a
+temporary clone as loaded. The default flow is local-first:
+
+1. **Clone or copy into this agent's `<agent>/.library/custom/<skill-name>/`.**
+   Keep repository metadata when the skill has an upstream, so future syncs can
+   use `git pull --ff-only`.
+2. **Validate before trusting it** — run the bundled validator (below) against
+   the installed folder and inspect `SKILL.md` frontmatter plus any referenced
+   `scripts/`, `assets/`, or `references/`.
+3. **Refresh** — call `system({"action": "refresh"})`. Until refresh succeeds
+   the skill is only a file on disk.
+4. **Load it by catalog entry** — `read` the cataloged `location:` and follow any
+   nested references. Record the commit or source URL in your task notes when it
+   matters.
+
+Use a temporary/quarantine clone only to pre-inspect an untrusted source; move or
+re-clone a reviewed copy into `.library/custom/<skill-name>/` before relying on
+it. **Installing a skill does not authorize the external side effects it
+describes** — normal human authorization boundaries still apply.
+
+**Sharing works the same way in reverse.** Send peers the source URL (or artifact
+path) plus this recipe. Each receiving agent clones/copies it into its own
+`.library/custom/<name>/`, validates it, then refreshes itself. That keeps
+ownership, updates, and rollback local to the agent actually using the skill.
+A network may instead maintain `.library_shared/<name>/`; add `../.library_shared` to each participating
+agent's `manifest.capabilities.skills.paths`. Do not assume `.library_shared` is loaded by default:
+it is an explicit opt-in with a shared stewardship burden, never the default
+distribution path.
 
 ## Authoring a new skill
 
-Create a folder under `<agent>/.library/custom/<skill-name>/` with a `SKILL.md` starting with YAML frontmatter:
+Create `<agent>/.library/custom/<skill-name>/SKILL.md` starting with YAML
+frontmatter, then refresh:
 
 ```
 ---
@@ -131,101 +139,92 @@ last_changed_at: "2026-06-29T08:00:00Z"
 Full instructions in Markdown below...
 ```
 
-Required frontmatter for ordinary custom/external skills: `name`,
-`description`. Optional for those skills: `version`, `author`, `tags`,
+Required: `name`, `description`. Optional: `version`, `author`, `tags`,
 `last_changed_at`.
 
-**LingTai-maintained skill metadata:** every skill bundle maintained inside a
-LingTai repository must also include `last_changed_at` in its YAML frontmatter.
-This applies to intrinsic capability manuals, standalone intrinsic skills, MCP
-manual bundles, TUI preset utility skills, and their nested reference
-`SKILL.md` files. Use an ISO 8601 timestamp with timezone, for example:
+**LingTai-maintained skill metadata.** Every skill bundle maintained inside a
+LingTai repository — intrinsic capability manuals, standalone intrinsic skills,
+MCP manual bundles, TUI preset utility skills, and their nested reference
+`SKILL.md` files — must carry `last_changed_at` as an ISO 8601 timestamp with
+timezone (`"2026-06-29T08:00:00Z"`). Update it in the same commit as any
+substantive edit to the skill body. For a historical backfill or metadata-only
+edit, derive the value from git history
+(`git log -1 --format=%cI -- path/to/SKILL.md`) so it points at the latest
+meaningful content change rather than the bookkeeping commit.
 
-```yaml
-last_changed_at: "2026-06-29T08:00:00Z"
+`tags` is a list of lowercase, hyphenated strings aiding discoverability and
+(eventually) tier filtering, along three axes — language/runtime (`python`,
+`fortran`, `bash`, `node`), domain (`physics`, `mhd`, `plasma`, `ml`, `web`), and
+type (`solver`, `workflow`, `reference`, `cheatsheet`). Example:
+`tags: [python, physics, mhd, solver]`. Tags are best-effort metadata, not
+load-bearing — the catalog still finds skills without them.
+
+**Check for name collisions first.** Two skills sharing a `name` collide in the
+catalog:
+
+```
+shell({"command": "grep -rh '^name:' .library/ ~/.lingtai-tui/utilities/ 2>/dev/null"})
 ```
 
-For a historical backfill or metadata-only edit, derive the value from git
-history, e.g. `git log -1 --format=%cI -- path/to/SKILL.md`, so the field points
-to the latest meaningful skill-content change rather than the bookkeeping commit.
-For any substantive future edit to the skill body, update `last_changed_at` in
-the same commit.
-
-`tags` is a list of lowercase, hyphenated strings that aid discoverability and (eventually) tier filtering. Three useful axes:
-
-- **Language / runtime**: `python`, `fortran`, `bash`, `node`
-- **Domain**: `physics`, `mhd`, `plasma`, `ml`, `web`
-- **Type**: `solver`, `workflow`, `reference`, `cheatsheet`
-
-Example: `tags: [python, physics, mhd, solver]`. Tags are best-effort metadata, not load-bearing — the catalog still finds skills without them.
-
-After writing, call `system({"action": "refresh"})` so the skills capability rescans and re-injects the catalog.
-
-
-### Cleanup / Footprint contract for tool manuals
-
-Every tool/capability manual that owns persistent state must include a `Cleanup / Footprint` section. This is a contract, not a janitor: the section teaches agents what the tool leaves behind and how to audit it safely.
-
-Minimum requirements:
-
-- list concrete files/directories/caches/logs the tool creates;
-- say what must never be deleted blindly;
-- provide a read-only footprint check script or command;
-- recommend an audit/cleanup cadence;
-- require a dry-run report plus explicit user consent before destructive cleanup;
-- append a cleanup/audit record to `logs/cleanup.jsonl` after the script runs;
-- guide agents who read the manual for setup/troubleshooting/long-running work to self-audit the footprint.
-
-The full template and consent rule live in `reference/cleanup-footprint-contract.md`.
+On a hit: rename, or adapt the existing skill instead of forking a second one.
 
 ### Starting from the template
-
-If you'd rather not start from a blank file, copy the bundled template:
 
 ```
 cp .library/intrinsic/capabilities/skills/assets/skill-template.md \
    .library/custom/<skill-name>/SKILL.md
 ```
 
-The template has placeholder slots (`[SKILL_NAME]`, `[ONE_LINE_DESCRIPTION]`, etc.) and a soft skeleton of headings (`When this applies` / `Procedure` / `What to expect` / `Constraints` / `Scripts` / `Assets`). It works for code/executable skills out of the box; for reference-style skills (manuals, cheatsheets, chronicles) delete the `Procedure` section and write prose instead — there is a note at the top of the template reminding you of this.
+The template carries placeholder slots (`[SKILL_NAME]`,
+`[ONE_LINE_DESCRIPTION]`, …) and a soft heading skeleton (`When this applies` /
+`Procedure` / `What to expect` / `Constraints` / `Scripts` / `Assets`). It works
+for code/executable skills as-is; for reference-style skills (manuals,
+cheatsheets, chronicles) delete the `Procedure` section and write prose — a note
+at the top of the template says so.
 
 ### Validating before installing or publishing
 
-A bundled validator script catches the common failures before you ship:
-
 ```
 python3 .library/intrinsic/capabilities/skills/scripts/validate.py \
-   .library/custom/<skill-name>/
+   [--require-last-changed-at] .library/custom/<skill-name>/
 ```
 
-It checks: required frontmatter (`name`, `description`), unfilled `[PLACEHOLDER]` slots from the template, broken internal references (paths under `scripts/`, `assets/`, `references/` mentioned in `SKILL.md` that don't exist on disk), and `chmod +x` on Python scripts under `scripts/`. Exits 1 on any FAIL, 0 on PASS (warnings allowed). Run it after authoring, after installing an external skill into `.library/custom/`, and before any broader distribution.
-
-For LingTai-maintained skill bundles, require the timestamp field too:
-
-```
-python3 .library/intrinsic/capabilities/skills/scripts/validate.py \
-   --require-last-changed-at .library/custom/<skill-name>/
-```
+It checks required frontmatter (`name`, `description`), unfilled `[PLACEHOLDER]`
+slots left over from the template, broken internal references (paths under
+`scripts/`, `assets/`, `references/` mentioned in `SKILL.md` that do not exist on
+disk), and `chmod +x` on Python scripts under `scripts/`. Exits 1 on any FAIL, 0
+on PASS (warnings allowed). Add `--require-last-changed-at` for
+LingTai-maintained bundles. Run it after authoring, after installing an external
+skill, and before any broader distribution.
 
 ### Self-test before publishing
 
-The validator catches structural issues but not content errors. After writing, walk through your skill as a fresh agent:
+The validator catches structure, not content. After writing, walk your skill as a
+fresh agent:
 
-1. **Decision-tree test** — start at SKILL.md's first decision. Follow each branch. Does every reference file actually exist? Is the content reachable from the routing hub?
-2. **Assertion test** — `grep` the actual codebase / file system for every claim in your skill: file paths, API signatures, parameter names, default values. Do NOT trust your memory of the code.
-3. **Regression test** — fix any issues found, then repeat step 2.
+1. **Decision-tree test** — start at SKILL.md's first decision and follow each
+   branch. Does every reference file exist? Is the content reachable from the
+   routing hub?
+2. **Assertion test** — `grep` the actual codebase/filesystem for every claim:
+   file paths, API signatures, parameter names, default values. Do NOT trust your
+   memory of the code.
+3. **Regression test** — fix what you found, then repeat step 2.
 
-Common errors this catches that the validator misses:
+This catches what the validator cannot see: fictional file paths (e.g.
+referencing a `helmholtz*.f90` that does not exist), API signatures from an older
+code version, and default parameter values that have since changed. Treat it as
+mandatory for skills documenting an external codebase — fabricated paths and
+stale signatures are the most damaging failure mode.
 
-- Fictional file paths (e.g. referencing `helmholtz*.f90` that doesn't exist)
-- API signatures from a previous code version
-- Default parameter values that have since changed
+## Structuring a skill
 
-Treat the self-test as mandatory for skills that document an external codebase — fabricated paths and stale signatures are the most damaging failure mode and the validator cannot see them.
+| Content | Shape |
+|---|---|
+| Under ~300 lines, or one path through it | Flat `SKILL.md` |
+| Multi-topic reference, decision tree, ≥300 lines | Two-level: `SKILL.md` router + `reference/<topic>.md` files |
+| Umbrella router whose children need their own frontmatter, scripts, or assets | Nested skill/reference pattern (below) |
 
-### Recommended structure for complex knowledge skills
-
-For skills that bundle non-trivial domain knowledge (multi-topic references, decision trees, ≥300 lines of total content), use a two-level progressive-disclosure structure:
+### Two-level progressive disclosure
 
 ```
 <skill-name>/
@@ -233,23 +232,25 @@ For skills that bundle non-trivial domain knowledge (multi-topic references, dec
 ├── README.md             # GitHub-facing description (humans, not agents)
 └── reference/
     ├── topic-a.md        # Self-contained deep-dive, loaded on demand
-    ├── topic-b.md
-    └── ...
+    └── topic-b.md
 ```
 
-`SKILL.md` is a **decision tree** (~150–180 lines): the agent picks a path, then does a single `read` on the right reference file. Each reference doc covers ONE topic (100–300 lines). The agent loads SKILL.md (~150 lines) plus one reference (~150 lines) instead of one 1000-line monolith.
+`SKILL.md` is a **decision tree** (~150–180 lines): the agent picks a path, then
+does a single `read` on the right reference file. Each reference covers ONE topic
+(100–300 lines). The agent loads ~150 lines plus one reference instead of a
+1000-line monolith. Do not use this for simple skills — single-API wrappers,
+linear checklists, prose-only references.
 
-When NOT to use this pattern: simple skills (single-API wrappers, linear checklists, prose-only references). A flat SKILL.md is correct when total content is under ~300 lines or there is only one path through it.
-
-Reference implementations: `huangzesen/laps-skill`, `huangzesen/helmholtz-skill`.
+Reference implementations: `huangzesen/laps-skill`,
+`huangzesen/helmholtz-skill`.
 
 ### Nested skill/reference pattern for umbrella manuals
 
-Use this pattern when a parent skill is itself a **router** and some child
-references need to behave like mini-skills: their own frontmatter, trigger
-summary, future `scripts/` or `assets/`, and a stable addressable folder. This is
-for second-layer progressive disclosure inside one top-level catalog entry, not a
-way to hide unrelated reusable skills.
+Use this when a parent skill is itself a **router** and some children need to
+behave like mini-skills: their own frontmatter, trigger summary, future
+`scripts/` or `assets/`, and a stable addressable folder. This is second-layer
+progressive disclosure inside one top-level catalog entry, not a way to hide
+unrelated reusable skills.
 
 ```
 <parent-skill>/
@@ -257,26 +258,22 @@ way to hide unrelated reusable skills.
 └── reference/
     ├── topic-a/
     │   └── SKILL.md                 # Nested reference, loaded only via parent
-    ├── topic-b/
-    │   └── SKILL.md
-    └── ...
+    └── topic-b/
+        └── SKILL.md
 ```
 
-Key rule: a nested `reference/<topic>/SKILL.md` is **not automatically promoted**
-to the global skills catalog. The catalog scanner treats a directory that already
-has `SKILL.md` as a skill boundary and does not descend into that folder for
-additional catalog entries. Therefore the parent `SKILL.md` must inject the
-children's routing metadata explicitly and keep the heavy procedural content in
-the children.
+**Key rule: a nested `reference/<topic>/SKILL.md` is not automatically promoted
+to the global catalog.** The catalog scanner treats a directory that already has
+a `SKILL.md` as a skill boundary and does not descend into it for additional
+entries. The parent must therefore inject the children's routing metadata explicitly
+and keep the heavy procedural content in the children.
 
-Every parent-owned nested-reference router should contain **both**:
+Every such parent must contain **both**:
 
-1. a `## Nested reference catalog` section with a fenced YAML list containing one
-   item per child (`name`, `location`, `description`); and
-2. a human-readable `## Routing table` (or equivalent decision table) that maps
-   user/agent needs to the same child `location`s.
-
-Preferred catalog shape:
+1. a `## Nested reference catalog` section with a fenced YAML list, one item per
+   child (`name`, `location`, `description`); and
+2. a human-readable `## Routing table` (or equivalent decision table) mapping
+   needs to the same child `location`s.
 
 ```yaml
 - name: parent-topic-a
@@ -290,157 +287,131 @@ Preferred catalog shape:
     Nested <parent-skill> reference for ...
 ```
 
-The YAML catalog is not just decoration: it is the machine-readable routing table
-for the second layer. Keep it in sync with child frontmatter and with the human
+The YAML catalog is not decoration — it is the machine-readable routing table for
+the second layer. Keep it in sync with child frontmatter and with the human
 routing table. Do not leave the parent as only a prose list of links.
 
-Use nested references when all of these are true:
-
-- callers should enter through one umbrella skill first;
-- the child topic is substantial enough to deserve frontmatter and possibly its
-  own `scripts/` or `assets/` later;
-- exposing the child as a standalone top-level skill would clutter the catalog or
-  bypass important routing context;
-- the parent can clearly say when to read each child.
-
-Do **not** use nested references for independent workflows that agents should
-find directly from the top-level catalog. Those should be normal skills under
-`.library/custom/<name>/`, an opt-in shared root such as `.library_shared/<name>/`, or an intrinsic skill root.
+Use nested references when all of these hold: callers should enter through one
+umbrella skill first; the child is substantial enough to deserve frontmatter and
+possibly its own `scripts/` or `assets/` later; exposing it standalone would clutter
+the catalog or bypass important routing context; and the parent can clearly say
+when to read each child. Do **not** use them for independent workflows agents
+should find directly from the top-level catalog — those belong in
+`.library/custom/<name>/`, an opt-in shared root such as `.library_shared/<name>/`,
+or an intrinsic skill root.
 
 Nested child conventions:
 
-- Each child `reference/<topic>/SKILL.md` must have normal skill frontmatter:
-  `name` and `description` required; `version`/`tags` optional. If the parent
-  skill is maintained inside a LingTai repository, the child must also carry
-  `last_changed_at`. `name` should be unique within the parent and descriptive
-  (`system-manual-sqlite-log-query`, `daily-reflection-data-collection`), even
+- Each child `reference/<topic>/SKILL.md` carries normal skill frontmatter:
+  `name` and `description` required, `version`/`tags` optional, plus
+  `last_changed_at` when the parent is maintained inside a LingTai repository.
+  `name` should be unique within the parent and descriptive
+  (`system-manual-sqlite-log-query`, `daily-reflection-data-collection`) even
   though it is not globally cataloged.
-- The child `description` and the parent catalog `description` should start with
-  the fact that it is nested, name the parent, and give the trigger condition:
+- The child `description` and the parent catalog `description` should open by
+  saying it is nested, name the parent, and give the trigger condition:
   `Nested system-manual reference for ...`.
-- `location` in the parent YAML catalog should be relative to the parent folder so
-  it survives copy/install moves; agents reading the parent can resolve it next to
-  the parent `SKILL.md`.
-- The parent should remain the routing hub. Resident prompts and sibling skills
-  should route to the parent first, then to the nested reference; do not bypass
-  the parent unless the caller already has the parent context loaded.
+- `location` in the parent YAML catalog is relative to the parent folder, so it
+  survives copy/install moves and resolves next to the parent `SKILL.md`.
+- The parent stays the routing hub. Resident prompts and sibling skills route to
+  the parent first, then the nested reference; do not bypass the parent unless
+  the caller already has parent context loaded.
 - Tests should verify both levels: the parent body contains the YAML catalog,
-  every child `name` and `location`, and the human routing table; the
-  installed/copied skill tree contains each child `SKILL.md` with valid
-  frontmatter and key content.
-- The bundled validator checks one skill folder at a time. For nested children,
-  validate the parent and then validate each nested child folder directly, e.g.
+  every child `name`/`location`, and the human routing table; the
+  installed/copied tree contains each child `SKILL.md` with valid frontmatter and
+  key content.
+- The validator handles one skill folder at a time — validate the parent, then
+  each nested child folder directly, e.g.
   `python3 .../validate.py reference/topic-a/` from the parent skill folder.
 
 Reference implementations: `system-manual` is a top-level router with nested
 `reference/substrate-manual/SKILL.md`, `reference/procedures-manual/SKILL.md`,
-and `reference/sqlite-log-query/SKILL.md`, advertised through a `Nested reference
-catalog` in the parent. Utility routers such as `swiss-knife`, `web-browsing`,
-and `daily-reflection` use the same two-part shape: YAML child metadata first,
-human routing table second.
+and `reference/sqlite-log-query/SKILL.md`. Utility routers such as
+`swiss-knife`, `web-browsing`, and `daily-reflection` use the same two-part
+shape: YAML child metadata first, human routing table second.
 
-### SKILL.md vs README.md
+### Cleanup / Footprint contract for tool manuals
 
-Skills published as standalone repos need both files — they serve different audiences.
-
-| File         | Audience                      | Loaded by                            |
-|--------------|-------------------------------|--------------------------------------|
-| `SKILL.md`   | LingTai agents                | `skills` capability (system prompt) |
-| `README.md`  | Humans browsing GitHub        | Not loaded by agents                 |
-
-`SKILL.md` is the agent-facing routing hub (frontmatter + decision tree). `README.md` is the human-facing repo description (purpose, install, examples). They are NOT redundant — `README.md` carries information agents do not need (project status, license, contributor notes, screenshots), and `SKILL.md` carries fields humans do not parse (frontmatter `tags`, `version`, machine-readable description).
-
-If you only ship through an opt-in local shared root such as `.library_shared/` and never publish to GitHub, you can omit `README.md`.
-
-## Sharing skills with other agents
-
-If a custom skill is worth sharing with other agents, the recommended path is
-simple skill sharing: send them the source URL (or an artifact path) plus the
-external-skill intake recipe above. Each receiving agent clones/copies it into
-its own `.library/custom/<name>/`, validates it, then refreshes itself. This
-keeps ownership, updates, and rollback local to the agent that will actually use
-the skill.
-
-A local network can still choose a shared-root model, but it must be explicit:
-maintain `.library_shared/<name>/`, add `../.library_shared` to each participating
-agent's `init.json` under `manifest.capabilities.skills.paths`, and refresh those
-agents. Do not assume `.library_shared` is loaded by default; it is an opt-in
-coordination mechanism for agents that deliberately choose to share one on-disk
-copy and accept the stewardship/update burden.
-
-## Adding a new skills path
-
-To expand your skill catalog with another source directory:
-
-1. `edit` `init.json` under `manifest.capabilities.skills.paths`. Append your new path (absolute or relative to your working dir; `~/` expansion honored).
-2. Call `system({"action": "refresh"})`.
-
-`init.json` is the ground truth. There is no runtime state — whatever is in `paths` at setup time is the exact set scanned.
-
-## Name collision discipline
-
-Two skills with the same `name` in the catalog would collide. Before authoring or installing a skill in `custom/`, grep the existing catalog:
-
-```
-shell({"command": "grep -rh '^name:' .library/ ~/.lingtai-tui/utilities/ 2>/dev/null"})
-```
-
-If you hit a collision: rename, or adapt the existing skill instead of forking a second one.
-
-## Health check
-
-Call `skills({"action": "info"})` to verify your skill catalog is wired correctly. It refreshes/reconciles the catalog and returns a runtime snapshot: `library_dir`, `catalog_size`, resolved paths with exist/skill-count info, and any `problems` (invalid frontmatter, unreadable folders), without returning the manual body. Use `skills({"action": "manual"})` when you need this SKILL.md body. If `status` is `"degraded"`, the error message tells you what needs fixing — typically a missing manual under `intrinsic/capabilities/skills/`, which means the initializer didn't install manuals correctly.
+Every tool/capability manual that owns persistent state must include a
+`Cleanup / Footprint` section. It is a contract, not a janitor: it teaches agents
+what the tool leaves behind and how to audit it safely. The required fields, the
+consent rule, the self-audit rule, and the standard `logs/cleanup.jsonl` record
+snippet live in [`reference/cleanup-footprint-contract.md`](reference/cleanup-footprint-contract.md)
+— read it before writing or reviewing such a section.
 
 ## When to create a skill
 
-**Do create a skill when:**
+**Do** when the task is repeatable with consistent steps; the procedure needs
+domain knowledge not reliably available without notes; the workflow involves
+multi-step orchestration or error handling worth codifying; or you want to share
+expertise with other agents in the network.
 
-- The task is repeatable with consistent steps.
-- The procedure requires domain knowledge not reliably available without notes.
-- A workflow involves multi-step orchestration or error handling worth codifying.
-- You want to share expertise with other agents in the network.
-
-**Do NOT create a skill when:**
-
-- It's a one-off task with no reuse value.
-- The task is just "call this one API endpoint" — pick it up at the call site.
-- The instructions are personality or style preferences — those live in the covenant or your lingtai character, not here.
+**Do NOT** when it is a one-off with no reuse value; the task is just "call this
+one API endpoint" (pick it up at the call site); or the instructions are
+personality or style preferences — those live in the covenant or your lingtai
+character, not here.
 
 ## Writing a good skill
 
-1. **Trigger-optimized description.** The `description` is the only thing visible in the catalog without loading the file, so it has to answer: *what does this skill do, what domain is it for, and when should the agent reach for it vs skip?* Aim for 2–4 sentences.
+1. **Trigger-optimized description.** The `description` is the only thing visible
+   in the catalog without loading the file, so it must answer: what does this
+   skill do, what domain is it for, and when should the agent reach for it vs
+   skip? Aim for 2–4 sentences, and spell out what it does NOT cover — that is
+   what stops an agent loading the file on a superficial match.
 
    - Bad: `description: "Helmholtz solver"` — what about it? when would I use it?
    - Good: `description: "Python implementation of the Helmholtz algorithm — an iterative alternating-projection method for constructing divergence-free, constant-magnitude 3D vector fields. Used to generate SPAW initial conditions for MHD simulations."`
+2. **Numbered steps in imperative form.** "Extract the text...", not "You should
+   extract...".
+3. **Concrete templates in `assets/`** rather than prose describing the desired
+   output format.
+4. **Deterministic scripts in `scripts/`** for fragile or repetitive operations —
+   a script that always produces the same result beats prose the LLM must
+   re-derive every time.
+5. **Keep `SKILL.md` focused.** Target under 500 lines; offload dense content to
+   references and heavy logic to scripts.
+6. **Structure subdirectories conventionally.** `scripts/` for executables,
+   `references/` for supplementary context (schemas, cheatsheets, worked
+   examples), `assets/` for templates and static files.
 
-   Spell out what the skill does NOT cover too — that is what stops an agent from loading the file when the task only superficially matches.
-2. **Numbered steps in imperative form.** "Extract the text...", not "You should extract...".
-3. **Concrete templates in `assets/`** rather than prose descriptions of desired output format.
-4. **Deterministic scripts in `scripts/`** for fragile or repetitive operations — a Python script that always produces the same result is better than prose the LLM has to re-derive every time.
-5. **Keep `SKILL.md` focused.** Target under 500 lines. Offload dense content to `references/` and heavy logic to `scripts/`. The body is the procedure; supporting material is a `read` call away.
-6. **Structure subdirectories conventionally.** `scripts/` for executables, `references/` for supplementary context (schemas, cheatsheets, worked examples), `assets/` for templates and static files.
+## SKILL.md vs README.md
+
+Skills published as standalone repos need both — they serve different audiences.
+
+| File | Audience | Loaded by |
+|---|---|---|
+| `SKILL.md` | LingTai agents | `skills` capability (system prompt) |
+| `README.md` | Humans browsing GitHub | Not loaded by agents |
+
+They are not redundant: `README.md` carries project status, license, contributor
+notes, and screenshots that agents do not need, while `SKILL.md` carries
+frontmatter fields (`tags`, `version`, machine-readable description) humans do
+not parse. If you only ship through an opt-in shared root such as
+`.library_shared/` and never publish to GitHub, you can omit `README.md`.
 
 ## Publishing to GitHub
 
-If a custom skill is worth sharing outside the network — with humans, external collaborators, or as a standalone resource — publish it as its own GitHub repo:
+To share a skill outside the network — with humans, external collaborators, or as
+a standalone resource:
 
-1. Author the skill in `<agent>/.library/custom/<name>/` as usual.
-2. Copy to a temp directory: `cp -r .library/custom/<name> /tmp/<name>`.
-3. Initialize: `cd /tmp/<name> && git init && git add . && git commit -m "Initial release"`.
-4. Add `README.md` (human-facing — see "SKILL.md vs README.md" above).
-5. Create the repo: `gh repo create <owner>/<name>-skill --public --source=. --push`.
+1. Author it in `<agent>/.library/custom/<name>/` as usual.
+2. Copy out: `cp -r .library/custom/<name> /tmp/<name>`.
+3. `cd /tmp/<name> && git init && git add . && git commit -m "Initial release"`.
+4. Add `README.md` (human-facing — see above).
+5. `gh repo create <owner>/<name>-skill --public --source=. --push`.
 
-Do NOT `git init` inside `.library/custom/` directly — it is a subtree of your agent working directory and you would entangle two repos. Always copy out first.
-
-Once published, agents elsewhere can install it with `git clone` into their `.library/custom/` and call `system({"action": "refresh"})`.
+Do NOT `git init` inside `.library/custom/` directly — it is a subtree of your
+agent working directory and you would entangle two repos. Always copy out first.
+Once published, other agents install it with `git clone` into their
+`.library/custom/` and refresh.
 
 ## Cleanup / Footprint
 
-Skills live under `.library/intrinsic/`, `.library/custom/`, opt-in shared
-skill paths when configured, and any extra paths configured in `init.json`.
-Intrinsic skills are runtime-owned; do not delete them. Custom skills are
-portable procedure memory: cleanup should usually mean validation, renaming,
-consolidation, or git removal through a reviewed PR, not ad-hoc `rm`.
+Skills live under `.library/intrinsic/`, `.library/custom/`, opt-in shared skill
+paths when configured, and any extra paths configured in `init.json`. Intrinsic
+skills are runtime-owned; do not delete them. Custom skills are portable
+procedure memory: cleanup should usually mean validation, renaming,
+consolidation, or git removal through a reviewed PR — not ad-hoc `rm`.
 
 Footprint check (read-only, records the audit):
 
@@ -460,6 +431,6 @@ log.open("a", encoding="utf-8").write(json.dumps({"ts": time.strftime("%Y-%m-%dT
 PY
 ```
 
-Recommended cadence: after authoring/publishing skills, before recipe export,
-and monthly for shared libraries. Destructive cleanup requires a dry-run report,
+Recommended cadence: after authoring/publishing skills, before recipe export, and
+monthly for shared libraries. Destructive cleanup requires a dry-run report,
 explicit user consent, and a git commit/PR when the skill root is tracked.

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use this manual when the vision capability has no usable provider route or
   reports a direct setup/request failure and needs safe, provider-neutral
   troubleshooting guidance.
-last_changed_at: "2026-07-16T21:00:00-07:00"
+last_changed_at: 2026-07-19T00:00:00Z
 related_files:
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/ANATOMY.md
@@ -18,21 +18,21 @@ maintenance: |
 This is the provider-neutral fallback for `vision`. It contains guidance only;
 it does not discover, install, start, or invoke a backend.
 
-## OpenRouter and custom try first
+## Route behavior and failures
 
 For OpenRouter and custom OpenAI-compatible presets, `vision(action="analyze")`
 first tries the current endpoint, model, and credential. It does not reject the
-route merely because downstream image support cannot be known in advance. If
-the real request fails, the sanitized vision tool result reports the failure
-type and points here for explicit alternatives; it does not expose exception
-contents or silently switch provider, model, credential, or MCP.
+route merely because downstream image support cannot be known in advance. Any
+direct setup or request failure returns a sanitized vision tool result that
+reports the failure type and points here for explicit alternatives; it never
+exposes exception contents.
 
-## Direct route
+## Stay on the active preset
 
-When `vision` reports a direct setup or request failure, inspect the identity
-already shown in the prompt: the current provider, model, and sanitized
-endpoint. Do not substitute another provider, model, credential, endpoint, or
-wire protocol. Retry only after the operator has corrected the active preset.
+Inspect the identity already shown in the prompt: the current provider, model,
+and sanitized endpoint. Do not substitute another provider, model, credential,
+endpoint, or wire protocol, and never silently switch or auto-invoke an MCP.
+Retry only after the operator has corrected the active preset.
 
 ## Find the current preset's method
 


### PR DESCRIPTION
## Summary

- trim duplicated guidance across LingTai kernel manuals and curated MCP skill manuals
- route shared mechanics to real canonical owners while retaining unique safety, authorization, lifecycle, API, credential, notification, scheduler, model, and failure semantics
- keep the change documentation-only and limited to existing Markdown files across the reviewed kernel/MCP skill surface

## Scope

- 68 existing Markdown files
- 1,706 insertions / 2,696 deletions
- no add, delete, rename, code, schema, runtime mechanism, config, auth, release, deploy, or cleanup change
- frozen patch SHA-256: `d98618d809d4005ca0720d14cd555965b1f60a61f193bfb0db6cd07d0d8a6974`

The three blockers found by the first whole-candidate review were repaired narrowly: the email self-send section pointer, the recurring-work route, and three unique Codex CLI facts.

## Validation

```text
git diff --check
PASS

python3 -m pytest -q \
  tests/test_validate_skill.py \
  tests/test_skills.py \
  tests/test_catalog_helpers.py \
  tests/test_mcp_skill_manuals.py \
  tests/test_intrinsic_manual_actions.py \
  tests/test_tools_package_data.py \
  tests/test_wheel_sidecar_smoke.py \
  tests/test_docs_governance.py \
  tests/test_preset_runtime_model_docs.py \
  tests/test_environment_variable_catalogue.py \
  tests/test_kernel_update_contract.py \
  tests/test_goal_notification.py \
  tests/test_prompt.py \
  tests/test_nudge_policy.py \
  tests/test_mcp_capability.py \
  tests/test_architecture_documents.py \
  tests/test_read_continuation.py \
  tests/test_vision_capability.py \
  tests/test_knowledge.py \
  tests/test_lingtai_doctor.py \
  tests/test_process_match.py \
  tests/test_notification_tool.py
438 passed in 16.98s

64-directory skill-validator parity
base failing: 7
candidate failing: 7
new failures: 0
```

Review gates:

- fresh explicit primary-Opus whole-candidate re-review: PASS, P0=0, P1=0
- independent `gpt-5.6-terra` final whole-candidate review: PASS, P0=0, P1=0
- frozen reviewer snapshot: 68 tracked modifications, zero untracked/ignored input, 68/68 file hashes, exact patch reconstruction

Residual P2 style/discoverability notes remain intentionally out of scope for this one-concern PR.
