### PR TITLE
feat(imap): support personal Outlook OAuth2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     # without separate PyPI wheels. Keep their third-party runtime dependencies
     # here.
     "imapclient>=3.0.0",
+    "msal>=1.37.0",
     "lark-oapi>=1.4.0",
     "cryptography>=42.0.0",
     "qrcode>=7.4.0",
@@ -42,6 +43,7 @@ dependencies = [
 [project.scripts]
 lingtai-agent = "lingtai.cli:main"
 lingtai-imap = "lingtai.mcp_servers.imap.__main__:main"
+lingtai-imap-bootstrap = "lingtai.mcp_servers.imap.oauth:main"
 lingtai-telegram = "lingtai.mcp_servers.telegram.__main__:main"
 lingtai-feishu = "lingtai.mcp_servers.feishu.__main__:main"
 lingtai-wechat = "lingtai.mcp_servers.wechat.__main__:main"

--- a/src/lingtai/mcp_servers/imap/SKILL.md
+++ b/src/lingtai/mcp_servers/imap/SKILL.md
@@ -4,14 +4,16 @@ description: |
   Progressive-disclosure usage manual for the IMAP/SMTP email MCP tool. Read this
   when you need detail beyond the one-line action descriptions: send vs reply,
   check/read/search over folders, the compound email_id (account:folder:uid),
-  attachments, move/flag/delete/folders, contacts/accounts basics, and the
-  important external-email side-effect caveats (real outbound mail — confirm
-  before sending). Pulled on demand via action='manual'; you do not need to call
-  it before every send.
-version: 1.0.0
-last_changed_at: 2026-07-19T00:00:00Z
+  attachments, move/flag/delete/folders, contacts/accounts basics, Microsoft
+  personal-account OAuth bootstrap, and the important external-email side-effect
+  caveats. Pulled on demand via action='manual'; you do not need to call it before
+  every send.
+version: 1.1.0
+last_changed_at: 2026-07-20T00:00:00Z
 related_files:
+- src/lingtai/mcp_servers/imap/account.py
 - src/lingtai/mcp_servers/imap/manager.py
+- src/lingtai/mcp_servers/imap/oauth.py
 - src/lingtai/mcp_servers/imap/server.py
 - src/lingtai/mcp_servers/imap/service.py
 maintenance: |
@@ -44,6 +46,35 @@ schema's one-line action descriptions.
 
 `address`/`cc`/`bcc` accept a single string or a list; `email_id` takes one id or
 a list of ids.
+
+## OUTLOOK.COM PERSONAL OAUTH2
+
+Password accounts are unchanged. For a personal Microsoft account, omit
+`email_password` and opt in explicitly:
+
+```json
+{
+  "email_address": "agent@example.com",
+  "imap_host": "outlook.office365.com",
+  "smtp_host": "smtp-mail.outlook.com",
+  "auth": {
+    "type": "microsoft_oauth2",
+    "client_id": "PUBLIC_CLIENT_ID",
+    "token_cache": "imap/oauth2/outlook.cache",
+    "smtp_enabled": false
+  }
+}
+```
+
+Register the app for personal Microsoft accounts and enable public-client flows.
+With the MCP stopped, run from the agent directory (or set `LINGTAI_AGENT_DIR`):
+`lingtai-imap-bootstrap --config PATH --account ADDRESS`. It shows Microsoft's
+device instructions and writes an owner-only MSAL cache; it never prints token
+results. Runtime acquisition is silent, MSAL adds its reserved `offline_access`
+scope automatically, and missing/revoked consent reports
+`oauth_reauthorization_required` without password fallback. Set `smtp_enabled`
+to `true` only when send/reply is needed; status exposes only `auth_type`,
+`auth_state`, and `smtp_enabled`.
 
 ## IDS, FOLDERS, ACCOUNTS
 

--- a/src/lingtai/mcp_servers/imap/account.py
+++ b/src/lingtai/mcp_servers/imap/account.py
@@ -32,6 +32,7 @@ from imapclient import IMAPClient
 from imapclient.exceptions import IMAPClientError
 
 from ._watermark import WatermarkStore
+from .oauth import AuthProvider, OAuthError, PasswordAuthProvider
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +118,7 @@ class IMAPAccount:
     def __init__(
         self,
         email_address: str,
-        email_password: str,
+        email_password: str = "",
         *,
         imap_host: str = "imap.gmail.com",
         imap_port: int = 993,
@@ -126,9 +127,12 @@ class IMAPAccount:
         working_dir: Path | str | None = None,
         allowed_senders: list[str] | None = None,
         poll_interval: int = 30,
+        auth_provider: AuthProvider | None = None,
+        smtp_enabled: bool = True,
     ) -> None:
         self._email_address = email_address
-        self._email_password = email_password
+        self._auth_provider = auth_provider or PasswordAuthProvider(email_password)
+        self._smtp_enabled = smtp_enabled
         self._imap_host = imap_host
         self._imap_port = imap_port
         self._smtp_host = smtp_host
@@ -200,6 +204,13 @@ class IMAPAccount:
         return dict(self._folders)
 
     @property
+    def auth_status(self) -> dict:
+        status = dict(self._auth_provider.status())
+        status.setdefault("auth_type", self._auth_provider.mode)
+        status["smtp_enabled"] = self._smtp_enabled
+        return status
+
+    @property
     def connected(self) -> bool:
         """True iff the tool-call connection is alive (NOOP succeeds)."""
         if self._tool_imap is None:
@@ -228,7 +239,7 @@ class IMAPAccount:
         if self._tool_imap is not None:
             return
         client = IMAPClient(self._imap_host, port=self._imap_port, ssl=True)
-        client.login(self._email_address, self._email_password)
+        self._auth_provider.authenticate_imap(client, account=self._email_address)
         self._tool_imap = client
         self._fetch_capabilities()
         self._discover_folders()
@@ -671,6 +682,8 @@ class IMAPAccount:
         in_reply_to: str | None = None,
         references: str | None = None,
     ) -> str | None:
+        if not self._smtp_enabled:
+            return "smtp_disabled"
         if not subject and not body and not attachments:
             return "Cannot send empty email (no subject, no body, and no attachments)"
         if attachments:
@@ -717,11 +730,14 @@ class IMAPAccount:
 
             with smtplib.SMTP(self._smtp_host, self._smtp_port) as server:
                 server.starttls()
-                server.login(self._email_address, self._email_password)
+                self._auth_provider.authenticate_smtp(server, account=self._email_address)
                 server.sendmail(
                     self._email_address, all_recipients, mime_msg.as_string(),
                 )
             return None
+        except OAuthError as e:
+            logger.error("SMTP send failed: %s", e.code)
+            return e.code
         except Exception as e:
             error = f"SMTP send failed: {e}"
             logger.error(error)
@@ -884,6 +900,12 @@ class IMAPAccount:
                 # cycle. A connection that succeeds but immediately fails
                 # in IDLE should still advance the reconnect backoff.
                 self._backoff_index = 0
+            except OAuthError as e:
+                logger.warning("listener auth error on %s: %s", self._email_address, e.code)
+                self._disconnect_listener()
+                if self._stop_event.wait(self._backoff_steps[min(self._backoff_index, len(self._backoff_steps) - 1)]):
+                    return
+                self._backoff_index += 1
             except (socket.error, OSError, IMAPClientError) as e:
                 logger.warning(
                     "listener error on %s: %s", self._email_address, e,
@@ -909,7 +931,7 @@ class IMAPAccount:
             except Exception:
                 pass
         client = IMAPClient(self._imap_host, port=self._imap_port, ssl=True)
-        client.login(self._email_address, self._email_password)
+        self._auth_provider.authenticate_imap(client, account=self._email_address)
         client.select_folder(folder)
         self._listen_imap = client
 

--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -774,11 +774,15 @@ class IMAPMailManager:
                 and acct._bg_thread.is_alive()
                 and getattr(acct, "_listen_imap", None) is not None
             )
+            status = getattr(acct, "auth_status", {})
             out.append({
                 "address": acct.address,
                 "tool_connected": acct.connected,
                 "listener_connected": listener_connected,
                 "listening": getattr(acct, "listening", False),
+                "auth_type": status.get("auth_type", "password"),
+                "auth_state": status.get("auth_state", "configured"),
+                "smtp_enabled": status.get("smtp_enabled", True),
             })
         return {"accounts": out}
 

--- a/src/lingtai/mcp_servers/imap/oauth.py
+++ b/src/lingtai/mcp_servers/imap/oauth.py
@@ -1,0 +1,349 @@
+"""Small, Outlook.com consumer-account authentication boundary.
+
+The runtime never performs interactive authorization.  ``bootstrap`` is the
+separate human-operated device-flow entry point; the account provider only uses
+the serialized MSAL cache and silent acquisition.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import stat
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+AUTH_TYPE = "microsoft_oauth2"
+AUTHORITY = "https://login.microsoftonline.com/consumers"
+IMAP_SCOPE = "https://outlook.office.com/IMAP.AccessAsUser.All"
+SMTP_SCOPE = "https://outlook.office.com/SMTP.Send"
+
+
+class OAuthError(RuntimeError):
+    """An intentionally secret-free authentication/configuration failure."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class AuthProvider(Protocol):
+    mode: str
+
+    def authenticate_imap(self, client: Any, *, account: str) -> None: ...
+    def authenticate_smtp(self, server: Any, *, account: str) -> None: ...
+    def status(self) -> dict[str, Any]: ...
+
+
+class PasswordAuthProvider:
+    mode = "password"
+
+    def __init__(self, password: str) -> None:
+        self._password = password
+
+    def authenticate_imap(self, client: Any, *, account: str) -> None:
+        client.login(account, self._password)
+
+    def authenticate_smtp(self, server: Any, *, account: str) -> None:
+        server.login(account, self._password)
+
+    def status(self) -> dict[str, Any]:
+        return {"auth_type": self.mode, "auth_state": "configured"}
+
+
+class TokenCacheStore:
+    """Owner-only, same-directory atomic storage for serialized MSAL state."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path).expanduser()
+        self._lock = threading.RLock()
+
+    def _parent(self) -> Path:
+        parent = self.path.parent
+        if parent.is_symlink():
+            raise OAuthError("oauth_cache_permissions")
+        parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        mode = stat.S_IMODE(parent.stat().st_mode)
+        if mode & 0o077 or not parent.is_dir():
+            raise OAuthError("oauth_cache_permissions")
+        return parent
+
+    def _safe_file(self) -> None:
+        if self.path.is_symlink():
+            raise OAuthError("oauth_cache_permissions")
+        if self.path.exists():
+            mode = stat.S_IMODE(self.path.stat().st_mode)
+            if not self.path.is_file() or mode & 0o077:
+                raise OAuthError("oauth_cache_permissions")
+
+    def load(self) -> str | None:
+        with self._lock:
+            self._parent()
+            self._safe_file()
+            if not self.path.exists():
+                return None
+            try:
+                return self.path.read_bytes().decode("utf-8")
+            except (OSError, UnicodeError) as exc:
+                raise OAuthError("oauth_cache_unreadable") from exc
+
+    def save(self, state: str) -> None:
+        if not isinstance(state, str):
+            raise OAuthError("oauth_cache_unreadable")
+        with self._lock:
+            parent = self._parent()
+            self._safe_file()
+            temp_name: str | None = None
+            try:
+                with tempfile.NamedTemporaryFile(
+                    mode="wb", dir=parent,
+                    prefix=f".{self.path.name}.", delete=False,
+                ) as tmp:
+                    temp_name = tmp.name
+                    os.chmod(tmp.name, 0o600)
+                    tmp.write(state.encode("utf-8"))
+                    tmp.flush()
+                    os.fsync(tmp.fileno())
+                os.replace(temp_name, self.path)
+                temp_name = None
+                try:
+                    dir_fd = os.open(parent, os.O_RDONLY)
+                    try:
+                        os.fsync(dir_fd)
+                    finally:
+                        os.close(dir_fd)
+                except OSError:
+                    pass
+            except OSError as exc:
+                raise OAuthError("oauth_cache_write_failed") from exc
+            finally:
+                if temp_name:
+                    try:
+                        os.unlink(temp_name)
+                    except OSError:
+                        pass
+
+    def exists(self) -> bool:
+        with self._lock:
+            self._parent()
+            self._safe_file()
+            return self.path.exists()
+
+
+def _msal(module: Any | None) -> Any:
+    try:
+        return module or importlib.import_module("msal")
+    except ImportError as exc:
+        raise OAuthError("oauth_dependency_missing") from exc
+
+
+class OAuth2AuthProvider:
+    mode = AUTH_TYPE
+
+    def __init__(
+        self,
+        email: str,
+        client_id: str,
+        token_cache: str | Path,
+        *,
+        smtp_enabled: bool = False,
+        msal_module: Any | None = None,
+        client_factory: Callable[..., Any] | None = None,
+    ) -> None:
+        self.email = email
+        self.client_id = client_id
+        self.smtp_enabled = smtp_enabled
+        self.store = token_cache if isinstance(token_cache, TokenCacheStore) else TokenCacheStore(token_cache)
+        self._msal_module = msal_module
+        self._client_factory = client_factory
+        self._client: Any | None = None
+        self._cache: Any | None = None
+        self._auth_state = "configured"
+        self._lock = threading.RLock()
+
+    def _client_for_cache(self) -> Any:
+        if self._client is not None:
+            return self._client
+        module = _msal(self._msal_module)
+        cache = module.SerializableTokenCache()
+        state = self.store.load()
+        if state:
+            try:
+                cache.deserialize(state)
+            except Exception as exc:
+                raise OAuthError("oauth_cache_unreadable") from exc
+        factory = self._client_factory or module.PublicClientApplication
+        self._cache = cache
+        self._client = factory(
+            client_id=self.client_id, authority=AUTHORITY, token_cache=cache,
+        )
+        return self._client
+
+    def _acquire(self, *, smtp: bool) -> str:
+        scopes = [IMAP_SCOPE]
+        if smtp:
+            if not self.smtp_enabled:
+                raise OAuthError("smtp_disabled")
+            scopes.append(SMTP_SCOPE)
+        with self._lock:
+            client = self._client_for_cache()
+            accounts = client.get_accounts(username=self.email)
+            account = accounts[0] if accounts else None
+            result = client.acquire_token_silent(scopes, account=account) if account else None
+            if self._cache is not None and self._cache.has_state_changed:
+                self.store.save(self._cache.serialize())
+            token = result.get("access_token") if isinstance(result, dict) else None
+            if not token:
+                self._auth_state = "reauth_required"
+                raise OAuthError("oauth_reauthorization_required")
+            self._auth_state = "ready"
+            return token
+
+    def authenticate_imap(self, client: Any, *, account: str) -> None:
+        token = self._acquire(smtp=False)
+        try:
+            client.oauth2_login(account, token, mech="XOAUTH2")
+        except Exception as exc:
+            self._auth_state = "failed"
+            raise OAuthError("oauth_imap_auth_failed") from exc
+
+    def authenticate_smtp(self, server: Any, *, account: str) -> None:
+        token = self._acquire(smtp=True)
+        payload = f"user={account}\x01auth=Bearer {token}\x01\x01"
+        try:
+            # STARTTLS resets SMTP capabilities; EHLO again before AUTH.
+            server.ehlo_or_helo_if_needed()
+            server.auth("XOAUTH2", lambda challenge=None: payload, initial_response_ok=True)
+        except Exception as exc:
+            self._auth_state = "failed"
+            raise OAuthError("oauth_smtp_auth_failed") from exc
+
+    def status(self) -> dict[str, Any]:
+        try:
+            present = self.store.exists()
+        except OAuthError:
+            present = False
+        state = self._auth_state if self._auth_state != "configured" else ("configured" if present else "bootstrap_required")
+        return {
+            "auth_type": AUTH_TYPE,
+            "smtp_enabled": self.smtp_enabled,
+            "auth_state": state,
+        }
+
+
+def normalize_account(account: dict[str, Any], index: int = 0) -> dict[str, Any]:
+    if not isinstance(account, dict) or not isinstance(account.get("email_address"), str) or not account["email_address"].strip():
+        raise ValueError(f"config_invalid: accounts[{index}].email_address")
+    account = dict(account)
+    has_auth = "auth" in account
+    auth = account.get("auth")
+    if not has_auth:
+        if "email_password" not in account:
+            raise ValueError(f"config_invalid: accounts[{index}].email_password")
+        if "client_secret" in account:
+            raise ValueError(f"config_invalid: accounts[{index}].client_secret")
+        return account
+    if not isinstance(auth, dict) or auth.get("type") != AUTH_TYPE:
+        raise ValueError(f"config_invalid: accounts[{index}].auth.type")
+    if "email_password" in account or "client_secret" in account:
+        raise ValueError(f"config_invalid: accounts[{index}].auth")
+    unknown = set(auth) - {"type", "client_id", "token_cache", "smtp_enabled"}
+    if unknown or not isinstance(auth.get("client_id"), str) or not auth["client_id"].strip() or not isinstance(auth.get("token_cache"), str) or not auth["token_cache"].strip():
+        raise ValueError(f"config_invalid: accounts[{index}].auth")
+    if "smtp_enabled" in auth and not isinstance(auth["smtp_enabled"], bool):
+        raise ValueError(f"config_invalid: accounts[{index}].auth.smtp_enabled")
+    if "smtp_enabled" in account and not isinstance(account["smtp_enabled"], bool):
+        raise ValueError(f"config_invalid: accounts[{index}].smtp_enabled")
+    if "smtp_enabled" in auth and "smtp_enabled" in account:
+        raise ValueError(f"config_invalid: accounts[{index}].smtp_enabled")
+    return account
+
+
+def normalize_accounts(cfg: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(cfg, dict):
+        raise ValueError("config_invalid: root")
+    if "accounts" in cfg and "email_address" in cfg:
+        raise ValueError("config_invalid: accounts")
+    if "accounts" in cfg:
+        accounts = cfg["accounts"]
+        if not isinstance(accounts, list) or not accounts:
+            raise ValueError("config_invalid: accounts")
+    elif "email_address" in cfg:
+        legacy = {k: cfg[k] for k in cfg if k != "accounts"}
+        legacy.setdefault("email_password", "")
+        accounts = [legacy]
+    else:
+        raise ValueError("config_invalid: accounts")
+    return [normalize_account(item, i) for i, item in enumerate(accounts)]
+
+
+def provider_from_config(account: dict[str, Any], working_dir: Path | None = None) -> tuple[AuthProvider, bool]:
+    auth = account.get("auth")
+    if auth is None:
+        return PasswordAuthProvider(account["email_password"]), account.get("smtp_enabled", True)
+    cache_path = Path(auth["token_cache"]).expanduser()
+    if not cache_path.is_absolute() and working_dir:
+        cache_path = working_dir / cache_path
+    enabled = auth.get("smtp_enabled", account.get("smtp_enabled", False))
+    return OAuth2AuthProvider(account["email_address"], auth["client_id"], cache_path, smtp_enabled=enabled), enabled
+
+
+def bootstrap_device_flow(email: str, client_id: str, token_cache: str | Path, *, smtp_enabled: bool = False, msal_module: Any | None = None, client_factory: Callable[..., Any] | None = None, output: Callable[[str], None] = print) -> None:
+    module = _msal(msal_module)
+    store = TokenCacheStore(token_cache)
+    cache = module.SerializableTokenCache()
+    state = store.load()
+    if state:
+        try:
+            cache.deserialize(state)
+        except Exception as exc:
+            raise OAuthError("oauth_cache_unreadable") from exc
+    factory = client_factory or module.PublicClientApplication
+    client = factory(client_id=client_id, authority=AUTHORITY, token_cache=cache)
+    # MSAL automatically adds its reserved offline_access/openid/profile scopes.
+    scopes = [IMAP_SCOPE] + ([SMTP_SCOPE] if smtp_enabled else [])
+    flow = client.initiate_device_flow(scopes=scopes)
+    if not isinstance(flow, dict) or not flow.get("user_code") or not flow.get("message"):
+        raise OAuthError("oauth_bootstrap_failed")
+    output(flow["message"])
+    result = client.acquire_token_by_device_flow(flow)
+    if not isinstance(result, dict) or not result.get("access_token"):
+        raise OAuthError("oauth_reauthorization_required")
+    if cache.has_state_changed:
+        store.save(cache.serialize())
+
+
+def bootstrap_from_config(cfg: dict[str, Any], account: str | None = None, *, working_dir: Path | None = None, **kwargs: Any) -> None:
+    accounts = normalize_accounts(cfg)
+    if account is None and len(accounts) != 1:
+        raise ValueError("config_invalid: selected OAuth account")
+    selected = next((a for a in accounts if not account or a["email_address"] == account), None)
+    if not selected or "auth" not in selected:
+        raise ValueError("config_invalid: selected OAuth account")
+    auth = selected["auth"]
+    cache_path = Path(auth["token_cache"]).expanduser()
+    if working_dir and not cache_path.is_absolute():
+        cache_path = working_dir / cache_path
+    bootstrap_device_flow(selected["email_address"], auth["client_id"], cache_path, smtp_enabled=auth.get("smtp_enabled", selected.get("smtp_enabled", False)), **kwargs)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Bootstrap a Microsoft personal-account IMAP cache")
+    parser.add_argument("--config", default=os.environ.get("LINGTAI_IMAP_CONFIG"))
+    parser.add_argument("--account")
+    args = parser.parse_args(argv)
+    if not args.config:
+        raise SystemExit("LINGTAI_IMAP_CONFIG or --config is required")
+    try:
+        with open(args.config, encoding="utf-8") as fh:
+            work_dir = Path(os.environ.get("LINGTAI_AGENT_DIR") or Path.cwd())
+            bootstrap_from_config(json.load(fh), args.account, working_dir=work_dir)
+    except (OSError, ValueError, OAuthError) as exc:
+        raise SystemExit(str(exc)) from None
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lingtai/mcp_servers/imap/server.py
+++ b/src/lingtai/mcp_servers/imap/server.py
@@ -14,16 +14,24 @@ Config schema (plaintext, no env-indirection):
       "accounts": [
         {
           "email_address": "agent@example.com",
-          "email_password": "16-char-app-password",
-          "imap_host": "imap.gmail.com",      // optional, default Gmail
-          "imap_port": 993,                    // optional
-          "smtp_host": "smtp.gmail.com",       // optional
+          "auth": {
+            "type": "microsoft_oauth2",
+            "client_id": "PUBLIC_CLIENT_ID",
+            "token_cache": "imap/oauth2/outlook.cache",
+            "smtp_enabled": false
+          },
+          "imap_host": "outlook.office365.com",
+          "imap_port": 993,
+          "smtp_host": "smtp-mail.outlook.com",
           "smtp_port": 587,                    // optional
           "allowed_senders": ["a@x.com"],      // optional allow-list
           "poll_interval": 30                  // optional, seconds
         }
       ]
     }
+
+For password mode, use `email_password` in place of `auth`. OAuth and password
+fields must never be combined.
 
 Env vars injected by the LingTai kernel for LICC:
     LINGTAI_AGENT_DIR — host agent's working directory.
@@ -50,6 +58,7 @@ from .bridge import FilesystemMailBridge
 from .licc import push_inbox_event
 from .manager import IMAPMailManager, SCHEMA, DESCRIPTION
 from .service import IMAPMailService
+from .oauth import normalize_accounts
 
 log = logging.getLogger("lingtai.mcp_servers.imap")
 
@@ -60,8 +69,8 @@ _SERVER_INSTRUCTIONS = (
     "Inbound mail flows into the host agent's inbox via LICC. "
     "This server publishes LingTai profile resources; read lingtai://manifest "
     "to discover MCP-owned docs, routing hints, and status. "
-    "Setup, config schema, and troubleshooting: "
-    "https://github.com/Lingtai-AI/lingtai-imap"
+    "Read lingtai://docs/configuration and lingtai://docs/troubleshooting "
+    "for setup and diagnostics."
 )
 
 LINGTAI_PROFILE_MIME = "application/vnd.lingtai.mcp-profile+json"
@@ -284,11 +293,40 @@ The value points to a JSON file; relative paths are resolved under
 A legacy single-account flat object with `email_address` is still accepted, but
 new configs should use the `accounts` list.
 
+## Microsoft personal-account OAuth2
+
+Password accounts remain unchanged. Explicitly opt in with nested `auth` and no
+`email_password`:
+
+```json
+{
+  "email_address": "agent@example.com",
+  "auth": {
+    "type": "microsoft_oauth2",
+    "client_id": "PUBLIC_CLIENT_ID",
+    "token_cache": "imap/oauth2/outlook.cache",
+    "smtp_enabled": false
+  },
+  "imap_host": "outlook.office365.com",
+  "smtp_host": "smtp-mail.outlook.com"
+}
+```
+
+This path uses the fixed Microsoft `consumers` authority and Outlook delegated
+IMAP permission, plus SMTP permission only when `smtp_enabled` is true. Register
+the app for personal Microsoft accounts and enable public-client flows. Bootstrap
+separately, while the server is stopped, from the agent directory (or with
+`LINGTAI_AGENT_DIR` set): `lingtai-imap-bootstrap --config PATH --account ADDRESS`;
+it displays only
+Microsoft's device instructions and stores an owner-only MSAL cache. Runtime
+acquisition is silent and never falls back to a password. Missing or revoked
+consent is reported as `oauth_reauthorization_required`. Status exposes only
+`auth_type`, `auth_state`, and `smtp_enabled`.
+
 ## Field notes
 
-- `email_address` and `email_password` are required for each account. Prefer an
-  app password or provider token; do not store a primary account password unless
-  the provider requires it.
+- Password configurations require `email_password`; OAuth configurations reject
+  passwords, client secrets, and unknown auth fields.
 - `imap_host`, `imap_port`, `smtp_host`, and `smtp_port` default to Gmail values
   when omitted. Set them explicitly for Outlook, custom domains, or other
   providers.
@@ -316,8 +354,9 @@ Most often the server could not initialize the manager. Check:
    `LINGTAI_AGENT_DIR`.
 3. The JSON is valid and contains either `accounts: [...]` or the legacy
    single-account `email_address` shape.
-4. Credentials are valid for both IMAP and SMTP. Many providers require app
-   passwords or OAuth/app-specific tokens.
+4. Password credentials are valid for both IMAP and SMTP, or the account's
+   Microsoft OAuth cache was bootstrapped separately. OAuth failures are explicit
+   and never fall back to a password.
 
 Read `lingtai://status`; if `manager_initialized` is `false`, fix config and
 restart or refresh the host agent.
@@ -394,14 +433,16 @@ the agent's secret/config file according to the local LingTai deployment convent
 
 ## Verification checklist
 
-1. Refresh/restart the host agent after config changes.
-2. Read `lingtai://status`; confirm `manager_initialized: true` and the account is
+1. For Microsoft OAuth, run `lingtai-imap-bootstrap --config PATH --account ADDRESS`
+   once while the server is stopped; do not put tokens in config or chat.
+2. Refresh/restart the host agent after config changes.
+3. Read `lingtai://status`; confirm `manager_initialized: true` and the account is
    listed. Status is secret-redacted by design.
-3. Run `imap(action="accounts")`; confirm the account and listener fields look sane.
-4. Send a test email from an allowed sender to the configured mailbox.
-5. Run `imap(action="check", n=5)` or wait for the MCP notification.
-6. Send a test outbound message with `imap(action="send", ...)` to confirm SMTP.
-7. If inbound works but wake notifications do not, check `allowed_senders` and LICC
+4. Run `imap(action="accounts")`; confirm the account and listener fields look sane.
+5. Send a test email from an allowed sender to the configured mailbox.
+6. Run `imap(action="check", n=5)` or wait for the MCP notification.
+7. Send a test outbound message with `imap(action="send", ...)` to confirm SMTP.
+8. If inbound works but wake notifications do not, check `allowed_senders` and LICC
    delivery logs.
 
 ## Agent guidance
@@ -480,28 +521,8 @@ def load_config() -> dict:
 
 
 def _accounts_from_config(cfg: dict) -> list[dict]:
-    """Normalize config into the accounts list IMAPMailService expects.
-
-    Accepts either the canonical ``{accounts: [...]}`` shape or a flat
-    single-account dict for back-compat with very old configs.
-    """
-    if "accounts" in cfg:
-        return list(cfg["accounts"])
-    if "email_address" in cfg:
-        return [{
-            "email_address": cfg["email_address"],
-            "email_password": cfg.get("email_password", ""),
-            "imap_host": cfg.get("imap_host", "imap.gmail.com"),
-            "imap_port": cfg.get("imap_port", 993),
-            "smtp_host": cfg.get("smtp_host", "smtp.gmail.com"),
-            "smtp_port": cfg.get("smtp_port", 587),
-            "allowed_senders": cfg.get("allowed_senders"),
-            "poll_interval": cfg.get("poll_interval", 30),
-        }]
-    raise ValueError(
-        "config must contain either 'accounts' (list) or 'email_address' "
-        "(single-account back-compat shape)"
-    )
+    """Validate and normalize canonical or legacy account configuration."""
+    return normalize_accounts(cfg)
 
 
 # ---------------------------------------------------------------------------

--- a/src/lingtai/mcp_servers/imap/service.py
+++ b/src/lingtai/mcp_servers/imap/service.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Callable
 
 from .account import IMAPAccount
+from .oauth import normalize_account, provider_from_config
 
 logger = logging.getLogger(__name__)
 
@@ -26,10 +27,12 @@ class IMAPMailService:
     ) -> None:
         self._working_dir = Path(working_dir) if working_dir else None
         self._accounts: list[IMAPAccount] = []
-        for cfg in accounts:
+        for index, raw_cfg in enumerate(accounts):
+            cfg = normalize_account(raw_cfg, index)
+            provider, smtp_enabled = provider_from_config(cfg, self._working_dir)
             acct = IMAPAccount(
                 email_address=cfg["email_address"],
-                email_password=cfg["email_password"],
+                email_password=cfg.get("email_password", ""),
                 imap_host=cfg.get("imap_host", "imap.gmail.com"),
                 imap_port=cfg.get("imap_port", 993),
                 smtp_host=cfg.get("smtp_host", "smtp.gmail.com"),
@@ -37,6 +40,8 @@ class IMAPMailService:
                 working_dir=self._working_dir,
                 allowed_senders=cfg.get("allowed_senders"),
                 poll_interval=cfg.get("poll_interval", 30),
+                auth_provider=provider,
+                smtp_enabled=smtp_enabled,
             )
             self._accounts.append(acct)
         self._account_map: dict[str, IMAPAccount] = {

--- a/tests/test_imap_outlook_oauth.py
+++ b/tests/test_imap_outlook_oauth.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from lingtai.mcp_servers.imap import account as account_module
+from lingtai.mcp_servers.imap.oauth import (
+    AUTHORITY,
+    IMAP_SCOPE,
+    SMTP_SCOPE,
+    OAuth2AuthProvider,
+    OAuthError,
+    PasswordAuthProvider,
+    TokenCacheStore,
+    bootstrap_device_flow,
+    normalize_accounts,
+    provider_from_config,
+)
+
+
+class FakeCache:
+    def __init__(self):
+        self.state = ""
+        self.has_state_changed = False
+
+    def deserialize(self, state):
+        self.state = state
+
+    def serialize(self):
+        self.has_state_changed = False
+        return self.state or "synthetic-cache"
+
+
+class FakeClient:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.silent_scopes = []
+        self.result = {"access_token": "synthetic-access-value"}
+        self.flow = {"user_code": "SYNTHETIC-CODE", "message": "Microsoft message SYNTHETIC-CODE"}
+        self.device_scopes = None
+
+    def get_accounts(self, **kwargs):
+        return [{"username": kwargs["username"]}]
+
+    def acquire_token_silent(self, scopes, account):
+        self.silent_scopes.append((scopes, account))
+        return self.result
+
+    def initiate_device_flow(self, scopes):
+        self.device_scopes = scopes
+        return self.flow
+
+    def acquire_token_by_device_flow(self, flow):
+        self.kwargs["token_cache"].state = "synthetic-cache"
+        self.kwargs["token_cache"].has_state_changed = True
+        return {"access_token": "synthetic-access-value", "refresh_token": "synthetic-refresh-value"}
+
+
+@pytest.fixture
+def fake_msal():
+    clients = []
+
+    def factory(**kwargs):
+        client = FakeClient(**kwargs)
+        clients.append(client)
+        return client
+
+    return SimpleNamespace(SerializableTokenCache=FakeCache), factory, clients
+
+
+def test_legacy_password_provider_keeps_login_calls():
+    class Client:
+        def __init__(self): self.calls = []
+        def login(self, *args): self.calls.append(args)
+    client = Client()
+    provider = PasswordAuthProvider("synthetic-password")
+    provider.authenticate_imap(client, account="person@example.com")
+    assert client.calls == [("person@example.com", "synthetic-password")]
+    assert provider.status() == {"auth_type": "password", "auth_state": "configured"}
+
+
+def test_oauth_config_is_explicit_and_rejects_password_or_secret():
+    password = {"accounts": [{"email_address": "person@example.com", "email_password": "synthetic-password"}]}
+    assert normalize_accounts(password) == password["accounts"]
+    oauth = {"accounts": [{"email_address": "person@example.com", "auth": {
+        "type": "microsoft_oauth2", "client_id": "synthetic-client",
+        "token_cache": "oauth.cache",
+    }}]}
+    assert normalize_accounts(oauth) == oauth["accounts"]
+    provider, smtp_enabled = provider_from_config(oauth["accounts"][0])
+    assert isinstance(provider, OAuth2AuthProvider)
+    assert smtp_enabled is False
+    with pytest.raises(ValueError, match="config_invalid"):
+        normalize_accounts({"accounts": [{**oauth["accounts"][0], "email_password": "synthetic-password"}]})
+    with pytest.raises(ValueError, match="config_invalid"):
+        normalize_accounts({"accounts": [{"email_address": "person@example.com", "auth": {
+            "type": "microsoft_oauth2", "client_id": "synthetic-client",
+            "token_cache": "oauth.cache", "client_secret": "synthetic-secret",
+        }}]})
+
+
+def test_oauth_imap_uses_silent_cache_and_native_login(tmp_path, fake_msal):
+    module, factory, clients = fake_msal
+    provider = OAuth2AuthProvider(
+        "person@example.com", "synthetic-client", tmp_path / "cache",
+        msal_module=module, client_factory=factory,
+    )
+    class Imap:
+        def __init__(self): self.calls = []
+        def oauth2_login(self, *args, **kwargs): self.calls.append((args, kwargs))
+    client = Imap()
+    provider.authenticate_imap(client, account="person@example.com")
+    assert client.calls == [(
+        ("person@example.com", "synthetic-access-value"), {"mech": "XOAUTH2"}
+    )]
+    assert clients[0].kwargs["authority"] == AUTHORITY
+    assert clients[0].silent_scopes == [([IMAP_SCOPE], {"username": "person@example.com"})]
+    assert provider.status()["auth_state"] == "ready"
+
+
+def test_listener_reconnect_authenticates_each_new_connection(monkeypatch, tmp_path, fake_msal):
+    module, factory, clients = fake_msal
+    provider = OAuth2AuthProvider("person@example.com", "synthetic-client", tmp_path / "cache", msal_module=module, client_factory=factory)
+    made = []
+    class Imap:
+        def __init__(self, *args, **kwargs): made.append(self)
+        def logout(self): pass
+        def oauth2_login(self, *args, **kwargs): self.oauth = args
+        def select_folder(self, folder): self.folder = folder
+    monkeypatch.setattr(account_module, "IMAPClient", Imap)
+    acct = account_module.IMAPAccount("person@example.com", "unused", auth_provider=provider)
+    acct._connect_listener("INBOX")
+    acct._connect_listener("INBOX")
+    assert len(made) == 2
+    assert len(clients[0].silent_scopes) == 2
+    assert all(c.oauth[1] == "synthetic-access-value" for c in made)
+
+
+def test_smtp_xoauth2_callable_has_exact_payload(tmp_path, fake_msal):
+    module, factory, _ = fake_msal
+    provider = OAuth2AuthProvider(
+        "person@example.com", "synthetic-client", tmp_path / "cache",
+        smtp_enabled=True, msal_module=module, client_factory=factory,
+    )
+    class SMTP:
+        def __init__(self): self.calls = []
+        def ehlo_or_helo_if_needed(self): self.calls.append(("ehlo", {}))
+        def auth(self, *args, **kwargs): self.calls.append((args, kwargs))
+    server = SMTP()
+    provider.authenticate_smtp(server, account="person@example.com")
+    assert server.calls[0] == ("ehlo", {})
+    args, kwargs = server.calls[1]
+    assert args[0] == "XOAUTH2"
+    assert args[1](b"challenge") == "user=person@example.com\x01auth=Bearer synthetic-access-value\x01\x01"
+    assert kwargs == {"initial_response_ok": True}
+    client = provider._client
+    assert client.silent_scopes[-1][0] == [IMAP_SCOPE, SMTP_SCOPE]
+
+
+def test_smtp_disabled_does_not_open_socket(monkeypatch, tmp_path, fake_msal):
+    module, factory, _ = fake_msal
+    provider = OAuth2AuthProvider("person@example.com", "synthetic-client", tmp_path / "cache", smtp_enabled=False, msal_module=module, client_factory=factory)
+    acct = account_module.IMAPAccount("person@example.com", "unused", auth_provider=provider, smtp_enabled=False)
+    monkeypatch.setattr(account_module.smtplib, "SMTP", lambda *a, **k: pytest.fail("SMTP opened"))
+    assert acct.send_email(["recipient@example.com"], "subject", "body") == "smtp_disabled"
+
+
+def test_reauth_error_is_redacted(tmp_path, fake_msal):
+    module, factory, clients = fake_msal
+    provider = OAuth2AuthProvider("person@example.com", "synthetic-client", tmp_path / "cache", msal_module=module, client_factory=factory)
+    provider._client_for_cache()
+    clients[0].result = {"error": "consent_required", "error_description": "synthetic-access-value"}
+    with pytest.raises(OAuthError) as exc:
+        provider._acquire(smtp=False)
+    assert str(exc.value) == "oauth_reauthorization_required"
+    assert "synthetic-access-value" not in str(exc.value)
+    assert provider.status()["auth_state"] == "reauth_required"
+
+
+def test_cache_is_owner_only_and_atomic(tmp_path):
+    path = tmp_path / "private" / "cache"
+    store = TokenCacheStore(path)
+    store.save("synthetic-cache-state")
+    assert store.load() == "synthetic-cache-state"
+    assert stat.S_IMODE(path.stat().st_mode) & 0o077 == 0
+    assert stat.S_IMODE(path.parent.stat().st_mode) & 0o077 == 0
+    assert not list(path.parent.glob(".*.tmp"))
+
+
+def test_bootstrap_fake_msal_prints_only_microsoft_message(tmp_path, fake_msal, capsys):
+    module, factory, _ = fake_msal
+    bootstrap_device_flow(
+        "person@example.com", "synthetic-client", tmp_path / "cache",
+        msal_module=module, client_factory=factory,
+    )
+    output = capsys.readouterr().out
+    assert output == "Microsoft message SYNTHETIC-CODE\n"
+    assert "synthetic-access-value" not in output
+    assert "synthetic-refresh-value" not in output
+    assert (tmp_path / "cache").read_text() == "synthetic-cache"
+
+
+def test_bootstrap_smtp_scope_is_opt_in(tmp_path, fake_msal):
+    module, factory, clients = fake_msal
+    bootstrap_device_flow(
+        "person@example.com", "synthetic-client", tmp_path / "cache",
+        smtp_enabled=False, msal_module=module, client_factory=factory, output=lambda _: None,
+    )
+    # offline_access is reserved and added by MSAL; passing it explicitly fails.
+    assert clients[0].device_scopes == [IMAP_SCOPE]
+
+
+def test_status_contains_only_safe_auth_fields(tmp_path, fake_msal):
+    module, factory, _ = fake_msal
+    provider = OAuth2AuthProvider("person@example.com", "synthetic-client", tmp_path / "cache", smtp_enabled=False, msal_module=module, client_factory=factory)
+    status = provider.status()
+    assert status == {"auth_type": "microsoft_oauth2", "smtp_enabled": False, "auth_state": "bootstrap_required"}
+    assert "token_cache" not in status and "access_token" not in status
+
+
+def test_dependency_and_docs_contract():
+    root = Path(__file__).parents[1]
+    pyproject = (root / "pyproject.toml").read_text()
+    manual = (root / "src/lingtai/mcp_servers/imap/SKILL.md").read_text()
+    assert '"msal>=1.37.0"' in pyproject
+    assert "lingtai-imap-bootstrap" in pyproject
+    assert "microsoft_oauth2" in manual
+    assert "oauth_reauthorization_required" in manual
+
+
+def test_account_tool_connection_uses_oauth2_login(monkeypatch, tmp_path, fake_msal):
+    module, factory, _ = fake_msal
+    provider = OAuth2AuthProvider("person@example.com", "synthetic-client", tmp_path / "cache", msal_module=module, client_factory=factory)
+    made = []
+    class Imap:
+        def __init__(self, *args, **kwargs): made.append(self)
+        def oauth2_login(self, *args, **kwargs): self.oauth = (args, kwargs)
+        def capabilities(self): return [b"IDLE", b"UIDPLUS"]
+        def list_folders(self): return [([], "/", "INBOX")]
+    monkeypatch.setattr(account_module, "IMAPClient", Imap)
+    acct = account_module.IMAPAccount("person@example.com", auth_provider=provider)
+    acct.connect()
+    assert made[0].oauth == (("person@example.com", "synthetic-access-value"), {"mech": "XOAUTH2"})
+    assert acct.auth_status["auth_type"] == "microsoft_oauth2"


### PR DESCRIPTION
## Summary

- add explicit per-account `microsoft_oauth2` authentication for personal Outlook.com accounts while preserving canonical and legacy password configs with no fallback
- use MSAL's consumer device bootstrap + serialized silent token cache, `IMAPClient.oauth2_login` for tool/listener connections, and `SMTP.auth("XOAUTH2")` only when SMTP is explicitly enabled
- add owner-only atomic cache persistence, safe account status, required `msal` dependency, focused synthetic tests, and setup docs

## Validation

- `46 passed` — OAuth + all existing IMAP-focused tests
- affected IMAP modules `py_compile`: PASS
- `git diff --check`: PASS
- production/docs secret-shape and private-path scans: PASS
- full suite: `5873 passed, 28 skipped, 4 failed`; the four failures are unrelated current-main baselines in daemon Claude-P manual length, Cursor manual wording, environment catalogue coverage, and wheel sidecar smoke. No IMAP/OAuth/MSAL failure.

## Size

- total: +734/-53 across 8 files
- production/config: +450/-47
- tests: +247/-0
- docs: +37/-6
- `oauth.py` is 349 lines because it is the one cohesive Outlook OAuth surface: strict config, MSAL silent provider, minimal owner-only atomic cache, and human device-bootstrap CLI. No generic multi-provider framework or unrelated refactor was added.

No real device flow, token, mailbox, live-runtime install, refresh, release, or deploy was performed.
