### PR TITLE
fix: scrub OpenAI-compat tool schemas for Moonshot/Kimi compat

### DIFF
--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -974,11 +974,50 @@ def _build_http_timeout(request_timeout: float | None):
 # ---------------------------------------------------------------------------
 
 
+def _scrub_openai_schema(node: Any) -> Any:
+    """Recursively normalize a JSON schema for OpenAI-compat Chat Completions.
+
+    Moonshot/Kimi's "flavored JSON Schema" enforces three constraints:
+
+      1. ``oneOf`` is not accepted — rewrite to ``anyOf``.
+      2. ``not`` is not accepted — drop it entirely.
+      3. When a node contains both ``anyOf`` and ``type``, the ``type`` must
+         live inside each ``anyOf`` child, not on the parent. Push ``type``
+         down into children that lack one, and remove it from the parent.
+
+    Pure function — returns a new object, never mutates the input.
+    """
+    if isinstance(node, dict):
+        out: dict = {}
+        for key, value in node.items():
+            if key == "oneOf":
+                out["anyOf"] = [_scrub_openai_schema(v) for v in value]
+            elif key == "not":
+                continue  # no accepted equivalent — drop
+            else:
+                out[key] = _scrub_openai_schema(value)
+        # Core fix: anyOf + type coexistence — push type into children
+        if "anyOf" in out and "type" in out:
+            parent_type = out.pop("type")
+            out["anyOf"] = [
+                {**child, "type": parent_type}
+                if isinstance(child, dict) and "type" not in child
+                else child
+                for child in out["anyOf"]
+            ]
+        return out
+    if isinstance(node, list):
+        return [_scrub_openai_schema(v) for v in node]
+    return node
+
+
 def _build_tools(schemas: list[FunctionSchema] | None) -> list[dict] | None:
     """Convert FunctionSchema list to OpenAI tool format.
 
     The wire description is the constant ``WIRE_TOOL_DESCRIPTION``; the full
-    prose stays in the system prompt's ``## tools`` section.
+    prose stays in the system prompt's ``## tools`` section. Schemas are
+    scrubbed for OpenAI-compat provider requirements (e.g. Moonshot/Kimi
+    rejects oneOf and requires type inside anyOf items).
     """
     if not schemas:
         return None
@@ -988,7 +1027,7 @@ def _build_tools(schemas: list[FunctionSchema] | None) -> list[dict] | None:
             "function": {
                 "name": s.name,
                 "description": WIRE_TOOL_DESCRIPTION,
-                "parameters": s.parameters,
+                "parameters": _scrub_openai_schema(s.parameters),
             },
         }
         for s in schemas

--- a/tests/test_openai_adapter_schema.py
+++ b/tests/test_openai_adapter_schema.py
@@ -1,0 +1,171 @@
+"""Tests for OpenAI adapter schema scrubbing (Moonshot/Kimi compat)."""
+
+import copy
+
+import pytest
+from lingtai.llm.openai.adapter import _scrub_openai_schema, _build_tools
+from lingtai.kernel.llm.base import FunctionSchema
+
+
+class TestScrubOpenaiSchema:
+    """Pure-function tests for _scrub_openai_schema."""
+
+    def test_passes_through_simple_schema(self):
+        """Simple schema passes through unchanged."""
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        assert _scrub_openai_schema(schema) == schema
+
+    def test_converts_oneOf_to_anyOf(self):
+        """oneOf is rewritten to anyOf."""
+        schema = {"oneOf": [{"type": "string"}, {"type": "number"}]}
+        result = _scrub_openai_schema(schema)
+        assert "oneOf" not in result
+        assert result == {"anyOf": [{"type": "string"}, {"type": "number"}]}
+
+    def test_drops_not(self):
+        """not combinator is dropped."""
+        schema = {"type": "string", "not": {"type": "number"}}
+        result = _scrub_openai_schema(schema)
+        assert "not" not in result
+        assert result == {"type": "string"}
+
+    def test_pushes_type_into_anyof_items(self):
+        """Core fix: anyOf + type coexistence — type pushed into children."""
+        schema = {
+            "type": "object",
+            "anyOf": [
+                {"properties": {"kind": {"const": "file"}}},
+                {"properties": {"kind": {"const": "dir"}}},
+            ],
+        }
+        result = _scrub_openai_schema(schema)
+        assert "type" not in result
+        assert result["anyOf"][0] == {
+            "type": "object",
+            "properties": {"kind": {"const": "file"}},
+        }
+        assert result["anyOf"][1] == {
+            "type": "object",
+            "properties": {"kind": {"const": "dir"}},
+        }
+
+    def test_does_not_overwrite_child_type(self):
+        """Children that already have type are not overwritten."""
+        schema = {
+            "type": "object",
+            "anyOf": [
+                {"type": "string"},
+                {"properties": {"x": {"type": "number"}}},
+            ],
+        }
+        result = _scrub_openai_schema(schema)
+        assert "type" not in result
+        assert result["anyOf"][0] == {"type": "string"}  # original preserved
+        assert result["anyOf"][1] == {
+            "type": "object",
+            "properties": {"x": {"type": "number"}},
+        }
+
+    def test_handles_nested_anyof(self):
+        """Nested anyOf + type is handled correctly."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "anyOf": [
+                        {"format": "email"},
+                        {"format": "uri"},
+                    ],
+                }
+            },
+        }
+        result = _scrub_openai_schema(schema)
+        # Top-level type preserved (no anyOf coexistence)
+        assert result.get("type") == "object"
+        # Nested anyOf + type handled
+        value_schema = result["properties"]["value"]
+        assert "type" not in value_schema
+        assert value_schema["anyOf"][0] == {"type": "string", "format": "email"}
+
+    def test_does_not_mutate_input(self):
+        """Original schema is not mutated."""
+        schema = {
+            "type": "object",
+            "anyOf": [{"properties": {"x": {"type": "string"}}}],
+        }
+        original = copy.deepcopy(schema)
+        _scrub_openai_schema(schema)
+        assert schema == original
+
+    def test_handles_empty_schema(self):
+        """Empty dict passes through."""
+        assert _scrub_openai_schema({}) == {}
+
+    def test_handles_primitive_values(self):
+        """Primitive values pass through unchanged."""
+        assert _scrub_openai_schema("string") == "string"
+        assert _scrub_openai_schema(42) == 42
+        assert _scrub_openai_schema(None) is None
+        assert _scrub_openai_schema(True) is True
+
+    def test_handles_list_of_schemas(self):
+        """List of schemas is processed element-wise."""
+        schemas = [
+            {"type": "object", "anyOf": [{"properties": {"x": {"type": "string"}}}]},
+            {"type": "string"},
+        ]
+        result = _scrub_openai_schema(schemas)
+        assert "type" not in result[0]
+        assert result[0]["anyOf"][0] == {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+        }
+        assert result[1] == {"type": "string"}
+
+
+class TestBuildTools:
+    """Tests for _build_tools with schema scrubbing."""
+
+    def test_scrubs_tool_parameters(self):
+        """_build_tools scrubs parameters for Moonshot compat."""
+        schemas = [
+            FunctionSchema(
+                name="test_tool",
+                description="A test tool",
+                parameters={
+                    "type": "object",
+                    "anyOf": [
+                        {"properties": {"kind": {"const": "file"}}},
+                    ],
+                },
+            )
+        ]
+        result = _build_tools(schemas)
+        assert result is not None
+        assert len(result) == 1
+        params = result[0]["function"]["parameters"]
+        # type should be pushed into anyOf children
+        assert "type" not in params
+        assert params["anyOf"][0] == {
+            "type": "object",
+            "properties": {"kind": {"const": "file"}},
+        }
+
+    def test_returns_none_for_empty(self):
+        """None input returns None."""
+        assert _build_tools(None) is None
+        assert _build_tools([]) is None
+
+    def test_preserves_original_parameters(self):
+        """Original FunctionSchema.parameters is not mutated."""
+        params = {
+            "type": "object",
+            "anyOf": [{"properties": {"x": {"type": "string"}}}],
+        }
+        schemas = [
+            FunctionSchema(name="t", description="d", parameters=params)
+        ]
+        original = copy.deepcopy(params)
+        _build_tools(schemas)
+        assert params == original


### PR DESCRIPTION
Fixes Lingtai-AI/lingtai#694

## Problem
Moonshot/Kimi's "flavored JSON Schema" rejects tool schemas where `anyOf` and `type` coexist at the same node. The Chat Completions path (`_build_tools`) passed `FunctionSchema.parameters` directly without scrubbing, causing daemon emanation to fail with:

```
tools.function.parameters is not a valid moonshot flavored json schema
```

## Solution
Add `_scrub_openai_schema()` to recursively normalize schemas for OpenAI-compat Chat Completions endpoints:

- `oneOf` → `anyOf` (Moonshot does not accept `oneOf`)
- Drop `not` (no accepted equivalent)
- Push parent `type` into `anyOf` children that lack one

Apply the scrubbing in `_build_tools()` for all OpenAI-compat endpoints. The stricter JSON Schema format is backward-compatible with other providers (DeepSeek, Together, Groq, etc.).

## Testing
- Added `tests/test_openai_adapter_schema.py` with 13 unit tests covering simple schemas, `oneOf`, `not`, `anyOf`+`type` coercion, nested schemas, and immutability.
- All 13 tests pass locally.

## Files changed
- `src/lingtai/llm/openai/adapter.py`
- `tests/test_openai_adapter_schema.py`