### PR TITLE
fix: prevent trace redaction from corrupting write/edit tool content

### DIFF
--- a/src/lingtai/kernel/trace_redaction.py
+++ b/src/lingtai/kernel/trace_redaction.py
@@ -109,4 +109,29 @@ def redact_for_trajectory(value: Any) -> Any:
             return value
 
 
-__all__ = ["redact_for_trajectory", "redact_text"]
+# Fields that carry file content for write/edit tools — these should NOT be
+# redacted because the agent is intentionally creating config/secrets files.
+_CONTENT_FIELDS: frozenset[str] = frozenset({"content", "new_string", "old_string"})
+_TOOLS_WITH_CONTENT: frozenset[str] = frozenset({"write", "edit"})
+
+
+def redact_tool_args(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Redact tool arguments, preserving content fields for write/edit.
+
+    File-content fields (``content``, ``new_string``, ``old_string``) on
+    ``write`` and ``edit`` tools are passed through unredacted so that
+    intentionally-created config and secrets files are not corrupted.
+    All other arguments and tool names are redacted normally.
+    """
+    result: dict[str, Any] = {}
+    for key, value in args.items():
+        if key in _CONTENT_FIELDS and tool_name in _TOOLS_WITH_CONTENT:
+            result[key] = value
+        elif isinstance(value, str):
+            result[key] = redact_text(value)
+        else:
+            result[key] = value
+    return result
+
+
+__all__ = ["redact_for_trajectory", "redact_text", "redact_tool_args"]


### PR DESCRIPTION
## Problem

The kernel's `trace_redaction.redact_text()` is applied to tool call arguments at the LLM transport level, including `content` fields passed to the `write` and `edit` tools. The `_UNQUOTED_ASSIGNMENT_RE` regex matches patterns like `email_password: zzvplzhuxakicxuv` in JSON content bound for config/secrets files, silently replacing the value with `<REDACTED:secret>` before the tool handler receives it.

This results in:
- Corrupted `.secrets/` config files
- Cryptic "Invalid credentials" errors from MCP addons
- Wasted debugging time (direct Python tests show credentials work, but MCP fails)

## Fix

Add `redact_tool_args(tool_name, args)` function that preserves content fields (`content`, `new_string`, `old_string`) on `write` and `edit` tools while still redacting all other argument text normally.

The function is intentionally narrow — only file-content fields on write/edit tools are exempted. All other text (conversation, reasoning, other tool args) continues to be redacted as before.

## Files Changed

- `src/lingtai/kernel/trace_redaction.py`: Add `redact_tool_args()`, `_CONTENT_FIELDS`, `_TOOLS_WITH_CONTENT`

## Next Steps

- Wire `redact_tool_args` into the LLM adapter where tool call arguments are processed (the point where tool args enter the agent from the provider)
- Add `force` parameter to write/edit tools for explicit secret-file writes
- Add redaction notice to tool results when content was modified