### PR TITLE
MCP connections can go stale on sleep — add application-layer keepalive or socket timeout

### DIFF
--- a/discussions/imap-stale-keepalive.md
+++ b/discussions/imap-stale-keepalive.md
@@ -1,0 +1,12 @@
+# IMAP Stale Connection Bug & Proposed Keepalive Fix
+
+See the PR description for the full analysis.
+
+## TL;DR
+
+MCP IMAP connections to Gmail go stale during WSL sleep because:
+1. Gmail drops idle connections after ~30 minutes
+2. TCP keepalive defaults (7200s on both Linux and macOS) are far too long to detect this
+3. No socket timeout is set on the IMAP connection
+
+Fix: application-layer keepalive in the kernel's MCP manager.


### PR DESCRIPTION
# MCP connections can go stale on sleep — add application-layer keepalive or socket timeout

## Summary

MCP IMAP connections go stale on WSL during sleep — the TCP connection to Gmail is dead by the time the agent wakes, and no keepalive mechanism catches it. The addon's own NOOP-probe and reconnect logic is correct but never gets a chance to run because the OS hasn't detected the dead connection yet. This PR adds an application-layer keepalive in the kernel's MCP manager to detect and heal broken connections regardless of OS TCP defaults.

---

## Problem

After a ~6-hour sleep on WSL (Ubuntu 22.04.3 LTS under WSL2), the IMAP MCP addon's TCP connection to Gmail is dead. Any `imap(check)` call gets a `TimeoutError` (120s). The agent silently misses all emails received during the sleep window. The only current workaround is a manual system refresh, which tears down and re-establishes the connection.

## Root Cause Analysis

The root cause is a **stale cached TCP connection combined with no socket timeout**, not a platform-specific TCP keepalive difference.

Key factors:

1. **Gmail IMAP server drops idle connections after ~30 minutes.** After the agent goes to sleep, Gmail sees no packets and eventually closes the connection from its side.

2. **OS-level TCP keepalive is irrelevant here.** Both macOS and Linux default to `tcp_keepidle = 7200` seconds — far longer than Gmail's ~30-minute idle timeout. Additionally, **the IMAP addon does not set `SO_KEEPALIVE` or `TCP_KEEPIDLE`/`TCP_KEEPALIVE` on its sockets**, so OS-level TCP keepalive defaults may not even apply to these connections in the first place.

3. **The known-failure seam is the cached tool-call connection, not the listener.** When the agent wakes and a tool call arrives, the addon's `_ensure_connected()` sends a NOOP on the cached connection to verify liveness. Since the remote has already closed the connection and the OS hasn't detected it, this NOOP read blocks for up to 120 seconds before timing out and triggering reconnect. The listener is not the problem — it's the cached connection reuse path.

4. **No socket timeout is set on the IMAP connection.** Without an explicit socket timeout, a read on a dead connection can hang for the full OS-level TCP retransmission timeout (up to ~120 seconds in practice), well beyond any acceptable user-facing delay.

## Why macOS Appeared to Self-Heal (But It's Not TCP Keepalive)

| | macOS | WSL (Linux) |
|---|---|---|
| `tcp_keepidle` | 7200 seconds (7200000 ms) | 7200 seconds |
| `tcp_keepintvl` | 75 seconds | 75 seconds |
| Gmail IMAP idle timeout | ~30 minutes | ~30 minutes |
| Keepalive beats timeout? | ❌ No (7200s ≫ 30min) | ❌ No (7200s ≫ 30min) |

Both macOS and Linux default to the same `tcp_keepidle` of 7200 seconds — neither OS's TCP keepalive can detect Gmail's ~30-minute idle disconnect. The previously reported "~75 seconds" macOS keepalive is actually `tcp_keepintvl` (the interval *between* probes once keepalive has begun), not `tcp_keepidle` (the idle time *before* the first probe). Neither fires in time.

The fact that the same addon code appeared to self-heal on macOS is likely coincidental — possibly different socket-buffer or RST-handling behavior on wake — not evidence of a platform keepalive difference.

## The Addon Logic Is Correct

The IMAP addon's self-healing pipeline (periodic NOOP probe → detect failure → reconnect → retry the pending operation) works correctly on macOS. The implementation uses standard Python/imapclient and is entirely platform-agnostic. The failure is at the OS TCP layer, not in the addon. Verified by:

- Post-refresh `imap(check)` succeeds immediately with no changes to addon code.
- The same addon code on macOS correctly self-heals after sleep (Jason confirmed this during investigation).
- The NOOP-probe/reconnect path works as designed when it actually gets a chance to run.

## Proposed Fix

Add an **application-layer MCP keepalive in the kernel** that:

1. Sends a lightweight ping/heartbeat every 30 seconds on MCP connections while the agent is idle or sleeping.
2. Detects broken connections (timeout, ECONNRESET, EPIPE) and triggers automatic reconnection before the agent resumes work.
3. Works regardless of OS TCP defaults — no reliance on `tcp_keepalive_time`, `SO_KEEPALIVE`, or any kernel tunable.

### Implementation options

- **Kernel MCP manager periodic task**: A background coroutine in the MCP manager that iterates over active connections and pings each on a configurable interval.
- **MCP registration contract extension**: A `keepalive` option in the MCP registration schema that the kernel honors for any MCP that opts in.
- **Agent-level heartbeat**: A single heartbeat loop for all active MCPs during sleep/idle, triggered by the agent lifecycle.

### Why this level?

Putting the keepalive in the kernel (not each addon individually) means every MCP transport benefits — not just IMAP. Any long-lived MCP connection (database pools, WebSocket bridges, SSH tunnels) is vulnerable to the same OS TCP default mismatch. A single kernel-level keepalive is the right abstraction.

## Evidence

- WSL TCP keepalive: `cat /proc/sys/net/ipv4/tcp_keepalive_time` → `7200`
- macOS TCP keepidle: `sysctl net.inet.tcp.keepidle` → `7200000` (ms) = 7200 seconds (same as Linux)
- Symptom: `imap(check)` → `TimeoutError` after 6hr sleep; fixed immediately by system refresh.
- Addon health: Post-refresh `imap(check)` succeeds with correct mailbox state.
- macOS reference: Same addon code self-heals correctly after macOS sleep (not due to TCP keepalive — keepidle is identical; likely incidental socket/RST behavior on wake).
- Jason (human/host) confirmed the NOOP-probe/reconnect path works on macOS and authorized this investigation.

## Related

- This is not specific to IMAP or Gmail. Any MCP transport over TCP is affected on platforms with long TCP keepalive defaults (most Linux distributions, WSL, Docker Desktop).
- Setting `tcp_keepalive_time` lower on the host is a possible workaround but requires root and is not portable. The application-layer fix is the correct long-term solution.