### PR TITLE
fix(imap): set socket timeout on IMAPClient to prevent stale-connection hangs

### DIFF
--- a/src/lingtai/mcp_servers/imap/account.py
+++ b/src/lingtai/mcp_servers/imap/account.py
@@ -140,6 +140,13 @@ class IMAPAccount:
         self._allowed_senders = allowed_senders
         self._poll_interval = poll_interval
 
+        # Socket timeout (seconds) applied to every IMAPClient created by this
+        # account.  When the OS suspends (e.g. WSL sleep) TCP connections go
+        # stale but the kernel does not know it until the next send/recv.  A
+        # short timeout turns an otherwise 120 s OS-level hang into a quick
+        # socket.timeout → reconnect via _ensure_connected / _with_reconnect.
+        self._socket_timeout = 30
+
         # Tool-call connection
         self._tool_imap: IMAPClient | None = None
         self._lock = threading.Lock()
@@ -260,7 +267,10 @@ class IMAPAccount:
         """Open the tool-call connection, parse capabilities, discover folders."""
         if self._tool_imap is not None:
             return
-        client = IMAPClient(self._imap_host, port=self._imap_port, ssl=True)
+        client = IMAPClient(
+            self._imap_host, port=self._imap_port, ssl=True,
+            timeout=self._socket_timeout,
+        )
         self._login(client)
         self._tool_imap = client
         self._fetch_capabilities()
@@ -941,7 +951,10 @@ class IMAPAccount:
                 self._listen_imap.logout()
             except Exception:
                 pass
-        client = IMAPClient(self._imap_host, port=self._imap_port, ssl=True)
+        client = IMAPClient(
+            self._imap_host, port=self._imap_port, ssl=True,
+            timeout=self._socket_timeout,
+        )
         self._login(client)
         client.select_folder(folder)
         self._listen_imap = client


### PR DESCRIPTION
## Problem

After ~6hr sleep on WSL (Ubuntu 22.04.3 LTS under WSL2), the IMAP MCP addon's TCP connection to Gmail is dead. Any `imap(check)` call gets a `TimeoutError` after 120 seconds. The agent silently misses all emails received during the sleep window.

## Root Cause

The IMAP addon's `_ensure_connected()` method already probes cached connections with NOOP before reuse — the logic is correct. But **no socket timeout is set** on the underlying `IMAPClient` connection. When the OS suspends and the remote (Gmail) closes the connection, the NOOP read on the dead socket blocks for the full OS-level TCP retransmission timeout (~120 seconds).

## Fix

Set `timeout=30` on every `IMAPClient` created by `IMAPAccount` (3 locations in `account.py`):

1. `connect()` — the tool-call connection
2. `_connect_listener()` — the IDLE listener connection
3. `__init__`-timeout parameter forwarded to `IMAPClient`

With a 30s socket timeout:
- The NOOP probe in `_ensure_connected` fails fast (`socket.timeout`)
- `socket.timeout` is caught by `_TRANSIENT_IMAP_ERRORS` (via `socket.error`)
- `_with_reconnect` drops the dead client and opens a fresh connection
- User-visible hang drops from 120s to ≤30s

## Changes

- **+15/-2 lines** in `src/lingtai/mcp_servers/imap/account.py`
- No changes to the kernel MCP manager itself — the addon is the correct layer for connection-specific timeout behavior

## Related

This is documented in the IMAP stale-connection diagnosis at https://github.com/Lingtai-AI/lingtai-kernel/discussions (see `discussions/imap-stale-keepalive.md` from the parent investigation).