### PR TITLE
chore(release): prepare kernel 0.18.0

### DIFF
--- a/migration/migration.md
+++ b/migration/migration.md
@@ -1,7 +1,7 @@
 ---
 product: kernel
-release_version: "0.17.1"
-release_tag: "v0.17.1"
+release_version: "0.18.0"
+release_tag: "v0.18.0"
 migration: no-op
 refresh_required: true
 related_files:
@@ -17,20 +17,17 @@ maintenance: |
   per-release versions. Never append a second release history here or invent a
   version that disagrees with package metadata.
 ---
-# LingTai kernel 0.17.1 migration
+# LingTai kernel 0.18.0 migration
 
 ## Applies when
 
-The target kernel release is `0.17.1` / tag `v0.17.1` and that tag lies in the
+The target kernel release is `0.18.0` / tag `v0.18.0` and that tag lies in the
 open update interval `(current, target]`.
 
 ## Migration
 
-**No configuration rewrite.** This patch declares the `packaging` dependency
-required by the strict release-manifest parser, reports its absence as a stable
-`ManifestError`, and installs it in the isolated release-manifest CI job. The
-official GitHub/Gitee manifest and `https://lingtai.ai/install.sh` update contract
-is otherwise unchanged. It does not change an agent workdir, preset, `init.json`,
+**No configuration rewrite.** This release contains kernel/backend feature and
+maintenance changes, but does not change an agent workdir, preset, `init.json`,
 or another kernel-owned on-disk configuration shape.
 
 Before mutation, confirm that the installer selected the intended
@@ -43,7 +40,7 @@ user machine, and do not use PyPI metadata to choose the release version.
 ## Validate
 
 - Do not rewrite agent configuration for this kernel migration.
-- Confirm this file was read from the kernel repository at exact tag `v0.17.1`.
+- Confirm this file was read from the kernel repository at exact tag `v0.18.0`.
 - Verify `lingtai.__version__`, `lingtai.__file__`, and
   `lingtai.kernel.__file__` from the selected runtime interpreter after install.
 - If the product, version, tag, stable path, mirror content, or artifact hash does
@@ -55,4 +52,4 @@ user machine, and do not use PyPI metadata to choose the release version.
 The verified wheel changes bytes on disk but a running agent still has the old
 code loaded. After active work is checkpointed and refresh is authorized, call
 `system(action='refresh')` and verify the new process uses the selected
-interpreter and reports `0.17.1`.
+interpreter and reports `0.18.0`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.17.1"
+version = "0.18.0"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the authoritative `lingtai` package version from `0.17.1` to `0.18.0`
- replace the current migration contract with the matching `v0.18.0` no-op migration guidance
- keep historical release workflow/test fixtures unchanged

## Validation

- `git diff --check` — passed
- stdlib TOML/version + migration tag/version assertions — passed
- changed-path/deletion gate — exactly 2 modified files, 0 deleted paths
- `python -m pytest -q tests/test_kernel_update_contract.py` — environment blocker: `/Users/huangzesen/anaconda3/bin/python` 3.12.7 exited 139 during collection without product test output; GitHub CI remains the executable test gate

This PR only prepares the backend release version. It does not tag, publish, upload artifacts, or change the release workflow/wheel matrix.
