### PR TITLE
fix(release): allow dry-run before GitHub release exists

### DIFF
--- a/scripts/publish_release_assets.py
+++ b/scripts/publish_release_assets.py
@@ -455,9 +455,13 @@ def main(argv: list[str] | None = None) -> int:
                      "--title", manifest.kernel_tag, "--notes", f"Kernel release {manifest.kernel_tag}"],
                     check=True,
                 )
+                github_files = plan_github_uploads(manifest, args.assets_dir, args.manifest, args.github_repo, manifest.kernel_tag)
             else:
                 print(f"  [github] DRY RUN: would create release {manifest.kernel_tag}")
-        github_files = plan_github_uploads(manifest, args.assets_dir, args.manifest, args.github_repo, manifest.kernel_tag)
+                print("  [github] DRY RUN: cannot plan attachment uploads without a release object (would create first)")
+                github_files = []
+        else:
+            github_files = plan_github_uploads(manifest, args.assets_dir, args.manifest, args.github_repo, manifest.kernel_tag)
         if args.execute:
             execute_github_upload(manifest.kernel_tag, args.github_repo, github_files)
         else:

--- a/scripts/publish_release_assets.py
+++ b/scripts/publish_release_assets.py
@@ -477,10 +477,15 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     print(f"\n[gitee] target: {args.gitee_owner}/{args.gitee_repo} tag {manifest.kernel_tag}")
-    gitee_verify_tag_synchronized(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, manifest.commit, gitee_token)
-    print(f"  [gitee] tag {manifest.kernel_tag} is synchronized to {manifest.commit[:12]}")
-
-    release = gitee_find_release_by_tag(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, gitee_token)
+    if args.execute:
+        gitee_verify_tag_synchronized(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, manifest.commit, gitee_token)
+        print(f"  [gitee] tag {manifest.kernel_tag} is synchronized to {manifest.commit[:12]}")
+        release = gitee_find_release_by_tag(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, gitee_token)
+    else:
+        release = gitee_find_release_by_tag(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, gitee_token)
+        if release is not None:
+            gitee_verify_tag_synchronized(args.gitee_owner, args.gitee_repo, manifest.kernel_tag, manifest.commit, gitee_token)
+            print(f"  [gitee] tag {manifest.kernel_tag} is synchronized to {manifest.commit[:12]}")
     if release is None:
         print(f"  [gitee] release {manifest.kernel_tag} does not exist yet")
         if args.execute:

--- a/tests/test_publish_release_assets.py
+++ b/tests/test_publish_release_assets.py
@@ -477,6 +477,7 @@ def test_main_dry_run_default_never_executes_github_upload(tmp_path, monkeypatch
 def test_main_dry_run_missing_github_release_does_not_plan_assets(tmp_path, monkeypatch, capsys):
     manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
     calls = []
+    monkeypatch.setenv("GITEE_ACCESS_TOKEN", "fake-token")
 
     def fake_run(cmd, capture_output=True, text=True, check=False):
         calls.append(cmd)
@@ -485,11 +486,18 @@ def test_main_dry_run_missing_github_release_does_not_plan_assets(tmp_path, monk
         raise AssertionError(f"unexpected command before dry-run release exists: {cmd}")
 
     monkeypatch.setattr(pub.subprocess, "run", fake_run)
+    monkeypatch.setattr(pub, "gitee_find_release_by_tag", lambda *a, **k: None)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("Gitee verification, planning, or mutation must not run")
+
+    monkeypatch.setattr(pub, "gitee_verify_tag_synchronized", fail_if_called)
+    monkeypatch.setattr(pub, "plan_gitee_uploads", fail_if_called)
+    monkeypatch.setattr(pub, "execute_gitee_upload", fail_if_called)
     rc = pub.main([
         "--manifest", str(manifest_path),
         "--assets-dir", str(assets_dir),
         "--github-repo", "Lingtai-AI/lingtai-kernel",
-        "--skip-gitee",
     ])
 
     assert rc == 0
@@ -497,9 +505,35 @@ def test_main_dry_run_missing_github_release_does_not_plan_assets(tmp_path, monk
     assert "does not exist yet" in out
     assert "DRY RUN: would create release" in out
     assert "cannot plan attachment uploads without a release" in out
+    assert "[gitee] release v0.16.4 does not exist yet" in out
+    assert "[gitee] DRY RUN: would create release v0.16.4" in out
+    assert "[gitee] DRY RUN: cannot plan attachment uploads without a release id" in out
     assert not any(cmd[:3] == ["gh", "release", "create"] for cmd in calls)
     assert not any(cmd[:3] == ["gh", "release", "upload"] for cmd in calls)
     assert not any("--json" in cmd for cmd in calls)
+
+
+def test_main_dry_run_existing_gitee_release_verifies_then_plans(tmp_path, monkeypatch, capsys):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    monkeypatch.setenv("GITEE_ACCESS_TOKEN", "fake-token")
+    calls = []
+
+    monkeypatch.setattr(pub, "gitee_find_release_by_tag", lambda *args: calls.append(("find", args)) or {"id": 42})
+    monkeypatch.setattr(pub, "gitee_verify_tag_synchronized", lambda *args: calls.append(("verify", args)))
+    monkeypatch.setattr(pub, "plan_gitee_uploads", lambda *args: calls.append(("plan", args)) or [])
+
+    rc = pub.main([
+        "--manifest", str(manifest_path),
+        "--assets-dir", str(assets_dir),
+        "--skip-github",
+    ])
+
+    assert rc == 0
+    assert [name for name, _ in calls] == ["find", "verify", "plan"]
+    assert calls[0][1] == ("huangzesen1997", "lingtai-kernel", "v0.16.4", "fake-token")
+    assert calls[1][1] == ("huangzesen1997", "lingtai-kernel", "v0.16.4", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "fake-token")
+    assert calls[2][1] == (manifest, assets_dir, manifest_path, "huangzesen1997", "lingtai-kernel", 42, "fake-token")
+    assert "tag v0.16.4 is synchronized" in capsys.readouterr().out
 
 
 def test_main_skips_gitee_when_token_env_unset(tmp_path, monkeypatch, capsys):

--- a/tests/test_publish_release_assets.py
+++ b/tests/test_publish_release_assets.py
@@ -474,6 +474,34 @@ def test_main_dry_run_default_never_executes_github_upload(tmp_path, monkeypatch
     assert "DRY RUN" in out
 
 
+def test_main_dry_run_missing_github_release_does_not_plan_assets(tmp_path, monkeypatch, capsys):
+    manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
+    calls = []
+
+    def fake_run(cmd, capture_output=True, text=True, check=False):
+        calls.append(cmd)
+        if cmd[:3] == ["gh", "release", "view"] and "--json" not in cmd:
+            return _FakeCompletedProcess(returncode=1)
+        raise AssertionError(f"unexpected command before dry-run release exists: {cmd}")
+
+    monkeypatch.setattr(pub.subprocess, "run", fake_run)
+    rc = pub.main([
+        "--manifest", str(manifest_path),
+        "--assets-dir", str(assets_dir),
+        "--github-repo", "Lingtai-AI/lingtai-kernel",
+        "--skip-gitee",
+    ])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "does not exist yet" in out
+    assert "DRY RUN: would create release" in out
+    assert "cannot plan attachment uploads without a release" in out
+    assert not any(cmd[:3] == ["gh", "release", "create"] for cmd in calls)
+    assert not any(cmd[:3] == ["gh", "release", "upload"] for cmd in calls)
+    assert not any("--json" in cmd for cmd in calls)
+
+
 def test_main_skips_gitee_when_token_env_unset(tmp_path, monkeypatch, capsys):
     manifest, assets_dir, manifest_path = _sample_manifest_and_assets(tmp_path)
     monkeypatch.delenv("GITEE_ACCESS_TOKEN", raising=False)


### PR DESCRIPTION
## Summary

- stop GitHub asset-metadata planning when a dry run observes that the target release does not exist yet
- make the real token-present Gitee dry-run check release existence before tag verification: an absent release prints would-create/cannot-plan and exits 0, while an existing release still verifies the synchronized tag and plans/hashes attachments fail-closed
- preserve execute mode’s safety order: verify the exact Gitee tag first, then find/create, plan/hash, and upload
- add workflow-equivalent regressions for both providers absent and for an existing Gitee release retaining verification/planning

This restores the existing `RELEASING.md` contract that default `workflow_dispatch` runs are side-effect-free plan checks which exit successfully and still allow the workflow to upload its generated manifest artifact. It fixes the sole blocker exposed by exact-main PRECHECK run `29857085688`; that run had already built and sidecar-verified the sdist plus all four wheel matrix jobs and generated the 16-artifact manifest.

## Review history

The first candidate correctly fixed the absent GitHub release but its test used `--skip-gitee`. Exact Terra-fast independent review blocked it because the real workflow always supplies `GITEE_ACCESS_TOKEN`; dry-run could still reach Gitee tag verification before the tag/release existed. The corrected candidate models that actual workflow, proves the absent Gitee release skips verification/planning, and separately proves an existing Gitee release still verifies and plans.

## Validation

- failing-first GitHub regression reproduced the forbidden `gh release view ... --json assets` call before the first source edit
- failing-first token-present workflow harness reproduced `RuntimeError: should not verify absent Gitee release during dry run` before the correction
- corrected harness returned 0 with both GitHub and Gitee would-create/cannot-plan output
- `TMPDIR=<authorized-precheck-runtime-temp> PYTHONDONTWRITEBYTECODE=1 /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_publish_release_assets.py tests/test_wheels_workflow_publish_gating.py` — **61 passed**
- `git diff --check` — PASS
- exact base-to-candidate PR diff: 2 files, +76/-5, zero deleted paths

Implementation/correction candidates were produced by explicitly selected `gpt-5.6-luna` Codex CLI with `service_tier="fast"`; the first candidate received exact `gpt-5.6-terra` fast read-only review, and the correction was independently inspected and revalidated by the parent agent. No tag, release, upload, publish, deploy, config/auth change, deletion, or cleanup was performed.
