### PR TITLE
fix(vision): follow active Codex route for generic provider

### DIFF
--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -20,11 +20,11 @@ provider-neutral manual route when direct setup is unavailable.
 
 ## Components
 
-- `__init__.py:34-66` — Codex-family route resolution and same-provider alias check; GLM/Zhipu and Codex-pool spelling pairs share current identity, a generic `codex` request adopts the active Codex direct/pool route, and explicit pool spellings share the active identity only with an active pool (not an active direct/unrelated service).
-- `__init__.py:85-93` — exact advertised provider registry; the local pseudo-provider remains explicit opt-in and intentionally excluded.
-- `__init__.py:104-129` — compatible tool schema; neither action requires an image path at schema level.
-- `__init__.py:131-179` — `VisionManager`; `manual` reads bundled guidance without a backend, while `analyze` validates and reads the image.
-- `__init__.py:182-456` — `setup`; resolves only the same current model/endpoint/credential/headers/wire, routes generic Codex through the active direct/pool credential reference (the pool-selected candidate's token path), creates supported services, fails closed to manual guidance when identity is incomplete, and always registers the tool.
+- `__init__.py:34-88` — Codex-family gate and bucket-driven route resolution plus the same-provider alias check; GLM/Zhipu and Codex spelling pairs share current identity, provider spelling is only a Codex-family compatibility gate, `_normalize_codex_auth_path` trims the bucket `codex_auth_path` once, and `_codex_bucket_route` picks direct (nonblank trimmed `codex_auth_path` in the active bucket) vs pool exactly as the canonical Codex factory does.
+- `__init__.py:108-125` — exact advertised provider registry; the local pseudo-provider remains explicit opt-in and intentionally excluded.
+- `__init__.py:127-152` — compatible tool schema; neither action requires an image path at schema level.
+- `__init__.py:154-203` — `VisionManager`; `manual` reads bundled guidance without a backend, while `analyze` validates and reads the image.
+- `__init__.py:205-494` — `setup`; resolves only the same current model/endpoint/credential/headers/wire, routes active Codex-family services by the bucket-driven direct (trimmed `codex_auth_path`) vs pool (pool-selected candidate token path) rule, creates supported services, fails closed to manual guidance when identity is incomplete, and always registers the tool.
 
 ## Connections
 

--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -20,11 +20,11 @@ provider-neutral manual route when direct setup is unavailable.
 
 ## Components
 
-- `__init__.py:34-41` — exact same-provider alias check; only GLM/Zhipu and codex-pool spelling pairs share current identity.
-- `__init__.py:44-52` — exact advertised provider registry; the local pseudo-provider remains explicit opt-in and intentionally excluded.
-- `__init__.py:58-76` — compatible tool schema; neither action requires an image path at schema level.
-- `__init__.py:80-128` — `VisionManager`; `manual` reads bundled guidance without a backend, while `analyze` validates and reads the image.
-- `__init__.py:131-379` — `setup`; resolves only the same current model/endpoint/credential/headers/wire, creates supported services, fails closed to manual guidance when identity is incomplete, and always registers the tool.
+- `__init__.py:34-66` — Codex-family route resolution and same-provider alias check; GLM/Zhipu and Codex-pool spelling pairs share current identity, a generic `codex` request adopts the active Codex direct/pool route, and explicit pool spellings share the active identity only with an active pool (not an active direct/unrelated service).
+- `__init__.py:85-93` — exact advertised provider registry; the local pseudo-provider remains explicit opt-in and intentionally excluded.
+- `__init__.py:104-129` — compatible tool schema; neither action requires an image path at schema level.
+- `__init__.py:131-179` — `VisionManager`; `manual` reads bundled guidance without a backend, while `analyze` validates and reads the image.
+- `__init__.py:182-456` — `setup`; resolves only the same current model/endpoint/credential/headers/wire, routes generic Codex through the active direct/pool credential reference (the pool-selected candidate's token path), creates supported services, fails closed to manual guidance when identity is incomplete, and always registers the tool.
 
 ## Connections
 

--- a/src/lingtai/tools/vision/CONTRACT.md
+++ b/src/lingtai/tools/vision/CONTRACT.md
@@ -42,6 +42,18 @@ Direct routes inherit identity only from the same current provider (including th
 explicit GLM/Zhipu and codex-pool spelling pairs); a different provider must supply
 its own model and credential. Missing identity fails closed to `manual` instead of
 using a service default model, a default OAuth path, or an SDK environment key.
+A generic `codex` request follows the active Codex service's route: over an active
+`codex-pool`/`codex_pool` service it takes the pool route, preserving the active
+pool model/endpoint and passing the exact pool-selected credential reference (the
+selected candidate's token path) to the native Codex vision service; over an active
+direct `codex` service it keeps the explicit `codex_auth_path` route and never
+borrows pool accounts. Explicit `codex-pool`/`codex_pool` spellings share the
+active identity only with an active pool; over an active direct or unrelated
+service they do not inherit its model or direct auth and fail closed to `manual`
+unless a complete explicit capability identity is supplied independently per the
+preceding rule. Any Codex request over an unrelated provider, or a missing
+pool-selected credential reference, likewise fails closed without manufacturing an
+identity.
 OpenAI preserves current default headers, endpoint, model, and `wire_api`.
 A missing, blank/whitespace-only, or `auto` selector means automatic selection:
 the current route uses Responses only when it explicitly prefers Responses and

--- a/src/lingtai/tools/vision/CONTRACT.md
+++ b/src/lingtai/tools/vision/CONTRACT.md
@@ -42,18 +42,25 @@ Direct routes inherit identity only from the same current provider (including th
 explicit GLM/Zhipu and codex-pool spelling pairs); a different provider must supply
 its own model and credential. Missing identity fails closed to `manual` instead of
 using a service default model, a default OAuth path, or an SDK environment key.
-A generic `codex` request follows the active Codex service's route: over an active
-`codex-pool`/`codex_pool` service it takes the pool route, preserving the active
-pool model/endpoint and passing the exact pool-selected credential reference (the
-selected candidate's token path) to the native Codex vision service; over an active
-direct `codex` service it keeps the explicit `codex_auth_path` route and never
-borrows pool accounts. Explicit `codex-pool`/`codex_pool` spellings share the
-active identity only with an active pool; over an active direct or unrelated
-service they do not inherit its model or direct auth and fail closed to `manual`
-unless a complete explicit capability identity is supplied independently per the
-preceding rule. Any Codex request over an unrelated provider, or a missing
-pool-selected credential reference, likewise fails closed without manufacturing an
-identity.
+Codex provider spelling (`codex`, `codex-pool`, `codex_pool`) is only a
+Codex-family compatibility gate: all three resolve to the one native Codex service,
+and the spelling never selects the fixed/direct vs weighted/pool route. Within an
+active Codex-family service, the route follows the active provider-default bucket
+exactly as the canonical Codex factory does — it is the fixed/direct route iff the
+active bucket carries a nonblank `codex_auth_path` (whose trimmed value is used as
+the `token_path`), otherwise the weighted/pool route, which passes the exact pool-selected
+credential reference (the selected candidate's token path) to the native Codex
+vision service and never borrows the direct auth path. This holds regardless of the
+requested spelling: an active `codex-pool`/`codex_pool` service that configures a
+`codex_auth_path` is a direct route even when a pool path is also present, and an
+active direct `codex` service stays direct even for an explicit `codex-pool`
+request. Codex vision may inherit only the same active Codex-family service's model
+and endpoint; a Codex request over an unrelated provider fails closed on the missing
+current model without borrowing that provider's model, endpoint, or credential. When
+no `base_url` is resolved, the native Codex service uses its existing official
+default Codex endpoint (`https://chatgpt.com/backend-api/codex`) rather than failing
+closed on base. A pool route that yields no selected candidate fails closed to
+`manual` without manufacturing a direct or legacy-default identity.
 OpenAI preserves current default headers, endpoint, model, and `wire_api`.
 A missing, blank/whitespace-only, or `auto` selector means automatic selection:
 the current route uses Responses only when it explicitly prefers Responses and

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -35,22 +35,47 @@ _CODEX_POOL_ALIASES = {"codex-pool", "codex_pool"}
 _CODEX_FAMILY = {"codex"} | _CODEX_POOL_ALIASES
 
 
-def _codex_active_route(requested: str, active: str) -> str | None:
-    """Resolve the current Codex sub-route a request shares with the active service.
+def _same_codex_family(requested: str, active: str) -> bool:
+    """Return whether both names are Codex-family spellings.
 
-    Returns ``"pool"`` or ``"direct"`` when the request identifies the same
-    current Codex route, else ``None`` (fail closed to manual). A *generic*
-    ``codex`` request adopts whatever the active Codex service is (a pool when
-    the active service is a pool, direct otherwise); the explicit
-    ``codex-pool``/``codex_pool`` spellings match only an active pool, so an
-    explicit pool request over an active *direct* Codex service does not match.
+    Provider spelling is only a Codex-family *compatibility gate*: ``codex``,
+    ``codex-pool``, and ``codex_pool`` all resolve to the one native Codex
+    factory (see ``lingtai/llm/_register.py``). Spelling never selects the
+    fixed/direct vs weighted/pool route; that choice is made solely from the
+    active provider-default bucket (``_codex_bucket_route``).
     """
-    if requested not in _CODEX_FAMILY or active not in _CODEX_FAMILY:
-        return None
-    if requested == "codex":
-        return "pool" if active in _CODEX_POOL_ALIASES else "direct"
-    # Explicit pool spellings require an active pool.
-    return "pool" if active in _CODEX_POOL_ALIASES else None
+    return requested in _CODEX_FAMILY and active in _CODEX_FAMILY
+
+
+def _normalize_codex_auth_path(raw: object) -> str | None:
+    """Return a trimmed nonblank Codex auth path, or ``None``.
+
+    Mirrors the canonical Codex factory (``lingtai/llm/_register.py`` ``_codex``),
+    which strips ``codex_auth_path`` before constructing ``FixedAccountSource``.
+    The single trimmed value is used both to decide the direct route and as the
+    propagated ``token_path``, so a space-padded path never routes direct while
+    forwarding an invalid, un-normalized value.
+    """
+    if isinstance(raw, str):
+        trimmed = raw.strip()
+        if trimmed:
+            return trimmed
+    return None
+
+
+def _codex_bucket_route(bucket: dict | None) -> str:
+    """Resolve the active Codex route from the provider-default bucket.
+
+    Mirrors the canonical Codex factory: the route is ``"direct"`` iff the
+    active bucket carries a nonblank ``codex_auth_path`` (trimmed; Fixed
+    account); otherwise it is ``"pool"`` (Weighted account selection). The
+    request spelling is irrelevant — an active ``codex-pool`` service that
+    configures a ``codex_auth_path`` is a direct/Fixed route, exactly as the
+    factory treats it.
+    """
+    if isinstance(bucket, dict) and _normalize_codex_auth_path(bucket.get("codex_auth_path")):
+        return "direct"
+    return "pool"
 
 
 def _same_provider_identity(requested: str, active: str) -> bool:
@@ -59,9 +84,7 @@ def _same_provider_identity(requested: str, active: str) -> bool:
         return True
     if {requested, active} <= {"glm", "zhipu"}:
         return True
-    if requested in _CODEX_FAMILY or active in _CODEX_FAMILY:
-        return _codex_active_route(requested, active) is not None
-    return False
+    return _same_codex_family(requested, active)
 
 
 def _effective_openai_wire(
@@ -313,12 +336,12 @@ def setup(
             if provider_key in _CODEX_FAMILY:
                 # Codex vision is a standalone Responses request. It may share
                 # the active Codex family's model and endpoint, but never
-                # inherits those from an unrelated main provider. The direct vs
-                # pool credential route follows the *active* Codex service: a
-                # generic ``codex`` request over an active pool takes the pool
-                # route, while explicit pool spellings still require an active
-                # pool (``None`` means no shared identity → manual-only).
-                codex_route = _codex_active_route(provider_key, active_provider_key)
+                # inherits those from an unrelated main provider. The fixed/
+                # direct vs weighted/pool credential route is *not* chosen from
+                # provider spelling: it follows the active provider-default
+                # bucket exactly as the canonical Codex factory does — direct
+                # iff the bucket carries a nonblank trimmed ``codex_auth_path``,
+                # otherwise pool (see ``lingtai/llm/_register.py``).
                 if same_provider:
                     if active_model:
                         kwargs.setdefault("model", active_model)
@@ -330,21 +353,42 @@ def setup(
                 bucket = defaults.get(active_provider_key) if isinstance(defaults, dict) else None
                 if not isinstance(bucket, dict):
                     bucket = {}
+                # Bucket-driven route: the active Codex service is direct iff its
+                # bucket configures a nonblank ``codex_auth_path``, else pool. An
+                # unrelated active provider carries an empty bucket → ``"pool"``,
+                # and its pool branch stays gated by ``same_provider`` below, so it
+                # never reads a default pool and still fails closed.
+                codex_route = _codex_bucket_route(bucket)
+                # Normalize an explicit capability identity on every route. This
+                # preserves a valid independent token path while ensuring a
+                # whitespace-only value cannot bypass either fail-closed branch.
+                explicit_token_path = _normalize_codex_auth_path(kwargs.pop("token_path", None))
+                if explicit_token_path:
+                    kwargs["token_path"] = explicit_token_path
                 if not kwargs.get("model"):
                     manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual')."
                 elif codex_route == "direct":
-                    token_path = kwargs.pop("token_path", None) or bucket.get("codex_auth_path")
+                    # A whitespace-only explicit ``token_path`` is not an identity;
+                    # normalize both it and the inherited bucket path once so the
+                    # trimmed value drives ``token_path`` exactly like the factory.
+                    token_path = (
+                        explicit_token_path
+                        or _normalize_codex_auth_path(bucket.get("codex_auth_path"))
+                    )
                     if token_path:
                         kwargs["token_path"] = token_path
                     else:
                         manual_reason = "Codex vision has no explicit current OAuth identity; use vision(action='manual')."
                 else:
+                    # Pool route (bucket has no nonblank ``codex_auth_path``).
                     # WeightedAccountSource selects an account from the pool file
                     # (thin-wrapper spec v3).  Reads only the non-secret pool;
                     # Codex core owns token refresh, quota, retry, and transport.
-                    # Runs only for a resolved active pool route (generic codex
-                    # over an active pool, or explicit pool over an active pool).
-                    if codex_route == "pool":
+                    # Only an active Codex-family service (``same_provider``) may
+                    # supply a pool identity; an unrelated active provider never
+                    # runs the selector and falls through to fail-closed below,
+                    # so no unrelated/default pool file is read on its behalf.
+                    if same_provider:
                         from lingtai.auth.codex_pool import (
                             resolve_codex_pool_path,
                             resolve_codex_tui_dir,

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -31,14 +31,37 @@ def _setup_failure(provider: str, exc: BaseException) -> str:
     )
 
 
+_CODEX_POOL_ALIASES = {"codex-pool", "codex_pool"}
+_CODEX_FAMILY = {"codex"} | _CODEX_POOL_ALIASES
+
+
+def _codex_active_route(requested: str, active: str) -> str | None:
+    """Resolve the current Codex sub-route a request shares with the active service.
+
+    Returns ``"pool"`` or ``"direct"`` when the request identifies the same
+    current Codex route, else ``None`` (fail closed to manual). A *generic*
+    ``codex`` request adopts whatever the active Codex service is (a pool when
+    the active service is a pool, direct otherwise); the explicit
+    ``codex-pool``/``codex_pool`` spellings match only an active pool, so an
+    explicit pool request over an active *direct* Codex service does not match.
+    """
+    if requested not in _CODEX_FAMILY or active not in _CODEX_FAMILY:
+        return None
+    if requested == "codex":
+        return "pool" if active in _CODEX_POOL_ALIASES else "direct"
+    # Explicit pool spellings require an active pool.
+    return "pool" if active in _CODEX_POOL_ALIASES else None
+
+
 def _same_provider_identity(requested: str, active: str) -> bool:
     """Return whether two provider names identify the same current route."""
     if requested == active:
         return True
-    return {requested, active} <= {"glm", "zhipu"} or {
-        requested,
-        active,
-    } <= {"codex-pool", "codex_pool"}
+    if {requested, active} <= {"glm", "zhipu"}:
+        return True
+    if requested in _CODEX_FAMILY or active in _CODEX_FAMILY:
+        return _codex_active_route(requested, active) is not None
+    return False
 
 
 def _effective_openai_wire(
@@ -287,10 +310,15 @@ def setup(
             else:
                 manual_reason = f"No direct vision route is supported for provider {provider!r}; use vision(action='manual')."
         else:
-            if provider_key in {"codex", "codex-pool", "codex_pool"}:
+            if provider_key in _CODEX_FAMILY:
                 # Codex vision is a standalone Responses request. It may share
                 # the active Codex family's model and endpoint, but never
-                # inherits those from an unrelated main provider.
+                # inherits those from an unrelated main provider. The direct vs
+                # pool credential route follows the *active* Codex service: a
+                # generic ``codex`` request over an active pool takes the pool
+                # route, while explicit pool spellings still require an active
+                # pool (``None`` means no shared identity → manual-only).
+                codex_route = _codex_active_route(provider_key, active_provider_key)
                 if same_provider:
                     if active_model:
                         kwargs.setdefault("model", active_model)
@@ -304,7 +332,7 @@ def setup(
                     bucket = {}
                 if not kwargs.get("model"):
                     manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual')."
-                elif provider_key == "codex":
+                elif codex_route == "direct":
                     token_path = kwargs.pop("token_path", None) or bucket.get("codex_auth_path")
                     if token_path:
                         kwargs["token_path"] = token_path
@@ -314,7 +342,9 @@ def setup(
                     # WeightedAccountSource selects an account from the pool file
                     # (thin-wrapper spec v3).  Reads only the non-secret pool;
                     # Codex core owns token refresh, quota, retry, and transport.
-                    if same_provider:
+                    # Runs only for a resolved active pool route (generic codex
+                    # over an active pool, or explicit pool over an active pool).
+                    if codex_route == "pool":
                         from lingtai.auth.codex_pool import (
                             resolve_codex_pool_path,
                             resolve_codex_tui_dir,

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -381,8 +381,17 @@ def test_vision_setup_resolves_api_key_env(tmp_path, monkeypatch):
 
 
 def test_codex_vision_without_explicit_current_oauth_identity_is_manual_only(tmp_path):
-    """Codex must not silently open the legacy default OAuth account."""
-    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+    """Codex must not silently open the legacy default OAuth account.
+
+    An active ``codex`` service whose bucket configures neither ``codex_auth_path``
+    nor a populated pool resolves to the bucket-driven pool route (no nonblank
+    ``codex_auth_path``); with an empty pool it must fail closed to manual rather
+    than fall back to the legacy single-token default. The pool loader is mocked
+    empty so no real pool file on the host is consulted."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_pool.load_codex_auth_pool",
+        return_value=[],
+    ):
         agent = make_provider_agent(
             tmp_path,
             provider="codex",
@@ -393,7 +402,9 @@ def test_codex_vision_without_explicit_current_oauth_identity_is_manual_only(tmp
 
     mock_factory.assert_not_called()
     assert mgr._vision_service is None
-    assert "no explicit current OAuth identity" in mgr._manual_reason
+    assert "no selected current OAuth identity" in mgr._manual_reason
+    # The legacy single-token default must never be silently opened.
+    assert "codex-auth.json" not in mgr._manual_reason
 
 
 @pytest.mark.parametrize("provider", ["codex", "codex-pool", "codex_pool"])
@@ -544,29 +555,253 @@ def test_generic_codex_over_active_pool_follows_active_pool_route(tmp_path, acti
     mock_select.assert_called()
 
 
-def test_explicit_pool_request_over_active_direct_codex_fails_closed(tmp_path):
-    """Inverse route: an explicit ``codex-pool`` request over an active *direct*
-    Codex service must not borrow the direct ``codex_auth_path`` credential as a
-    pool identity. An explicit capability ``model`` is supplied so the request
-    gets past the missing-model guard, proving the failure is the pool
-    identity/candidate failure rather than merely a missing model."""
+def test_explicit_pool_request_over_active_direct_codex_follows_bucket_direct(tmp_path):
+    """Spelling is only a Codex-family gate, not a route selector. An explicit
+    ``codex-pool`` request over an active *direct* Codex service (bucket carries a
+    nonblank ``codex_auth_path``) resolves to the bucket-driven direct route,
+    exactly as the canonical Codex factory does — the pool selector is never
+    consulted and the configured direct ``codex_auth_path`` is used."""
     with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
         "lingtai.auth.codex_account_source.WeightedAccountSource.select",
         return_value=None,
-    ):
+    ) as mock_select:
+        mock_factory.return_value = MagicMock(spec=VisionService)
         agent = make_mock_agent(tmp_path)
         agent.service.provider = "codex"
         agent.service._model = "gpt-5.6-sol"
         agent.service._base_url = None
         agent.service._provider_defaults = {"codex": {"codex_auth_path": "/tmp/codex-direct.json"}}
-        mgr = setup(agent, provider="codex-pool", model="gpt-5.6-sol")
+        setup(agent, provider="codex-pool")
+
+    mock_select.assert_not_called()
+    assert mock_factory.call_args.args == ("codex",)
+    assert mock_factory.call_args.kwargs["model"] == "gpt-5.6-sol"
+    assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-direct.json"
+
+
+# ---------------------------------------------------------------------------
+# PR #1012 — bucket-driven Codex vision route matrix
+#
+# The fixed/direct vs weighted/pool choice is determined SOLELY by whether the
+# active provider-default bucket carries a nonblank trimmed ``codex_auth_path``,
+# mirroring the canonical Codex factory in ``lingtai/llm/_register.py`` — never
+# by the ``codex`` / ``codex-pool`` / ``codex_pool`` provider spelling.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("active_provider", ["codex-pool", "codex_pool"])
+def test_active_pool_spelling_with_auth_path_takes_direct_route(tmp_path, active_provider):
+    """Matrix (a) — the core regression. An active ``codex-pool``/``codex_pool``
+    service that ALSO configures a nonblank ``codex_auth_path`` is a direct/Fixed
+    route: the pool selector must not be called even though a pool path is present,
+    and the direct ``codex_auth_path`` is propagated. This is the case the old
+    spelling-driven code got wrong (it saw ``codex-pool`` and forced the pool).
+
+    The bucket path is space-padded to prove canonical parity: like the factory's
+    ``FixedAccountSource``, the route uses the *trimmed* value, and that same
+    trimmed value — not the raw padded string — reaches ``create_vision_service``."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_account_source.WeightedAccountSource.select",
+        return_value=None,
+    ) as mock_select:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = active_provider
+        agent.service._model = "gpt-5.6-sol"
+        agent.service._base_url = "https://codex-pool.example/backend-api/codex"
+        agent.service._provider_defaults = {
+            active_provider: {
+                "codex_auth_path": "  /tmp/codex-direct.json  ",
+                "codex_auth_pool_path": "pool.json",
+            }
+        }
+        setup(agent, provider=active_provider)
+
+    mock_select.assert_not_called()
+    assert mock_factory.call_args.args == ("codex",)
+    assert mock_factory.call_args.kwargs["api_key"] is None
+    assert mock_factory.call_args.kwargs["model"] == "gpt-5.6-sol"
+    assert mock_factory.call_args.kwargs["base_url"] == "https://codex-pool.example/backend-api/codex"
+    # The trimmed value is used as token_path, never the raw space-padded string.
+    assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-direct.json"
+
+
+def test_whitespace_only_bucket_auth_path_does_not_route_direct(tmp_path):
+    """Canonical parity — a whitespace-only bucket ``codex_auth_path`` is not a
+    fixed identity (the factory would trim it to empty and fall to Weighted), so
+    vision must not route direct. With an empty pool it fails closed to manual
+    rather than forwarding the blank path as a direct ``token_path``."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_pool.load_codex_auth_pool",
+        return_value=[],
+    ):
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "codex"
+        agent.service._model = "gpt-5.6-sol"
+        agent.service._base_url = None
+        agent.service._provider_defaults = {"codex": {"codex_auth_path": "   "}}
+        mgr = setup(agent, provider="codex")
 
     mock_factory.assert_not_called()
     assert mgr._vision_service is None
-    # Fail-closed on the pool identity, never borrowing the active direct auth path.
+    # Fails on the pool identity (blank fixed path never counts as a direct one).
     assert "no selected current OAuth identity" in mgr._manual_reason
-    assert "no resolved current model" not in mgr._manual_reason
-    assert "/tmp/codex-direct.json" not in mgr._manual_reason
+
+
+def test_whitespace_only_explicit_token_path_falls_back_to_bucket_identity(tmp_path):
+    """A whitespace-only explicit capability ``token_path`` is not an identity: it
+    must not be forwarded as a direct credential. Over an active direct bucket the
+    blank explicit value is dropped and the trimmed bucket path is used instead."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "codex"
+        agent.service._model = "gpt-5.6-sol"
+        agent.service._base_url = None
+        agent.service._provider_defaults = {"codex": {"codex_auth_path": "/tmp/codex-bucket.json"}}
+        setup(agent, provider="codex", token_path="   ")
+
+    # The blank explicit token_path is normalized away; the trimmed bucket path wins.
+    assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-bucket.json"
+
+
+def test_active_codex_pool_path_only_selects_pool_candidate(tmp_path):
+    """Matrix (b) — active ``codex`` with only a pool path (no ``codex_auth_path``)
+    takes the pool route: the pool selector is called and its selected candidate's
+    ``auth_ref`` token path is propagated to the native Codex vision service."""
+    from lingtai.auth.codex_account_source import AccountCandidate
+    selected = AccountCandidate(
+        auth_ref="/tmp/codex-pool-b.json",
+        source_ref="pool.json",
+        source_index=0,
+        weight=1,
+    )
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_account_source.WeightedAccountSource.select",
+        return_value=selected,
+    ) as mock_select, patch(
+        "lingtai.auth.codex_pool.load_codex_auth_pool",
+        return_value=[{"path": "pool.json", "weight": 1}],
+    ):
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "codex"
+        agent.service._model = "gpt-5.6-sol"
+        agent.service._base_url = "https://codex.example/backend-api/codex"
+        agent.service._provider_defaults = {"codex": {"codex_auth_pool_path": "pool.json"}}
+        setup(agent, provider="codex")
+
+    mock_select.assert_called()
+    assert mock_factory.call_args.args == ("codex",)
+    assert mock_factory.call_args.kwargs["model"] == "gpt-5.6-sol"
+    assert mock_factory.call_args.kwargs["base_url"] == "https://codex.example/backend-api/codex"
+    assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-pool-b.json"
+
+
+def test_active_codex_fixed_path_takes_direct_route(tmp_path):
+    """Matrix (c) — active ``codex`` with a nonblank ``codex_auth_path`` is the
+    direct/Fixed route: no pool selection, the configured auth path is used."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_account_source.WeightedAccountSource.select",
+        return_value=None,
+    ) as mock_select:
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "codex"
+        agent.service._model = "gpt-5.6-sol"
+        agent.service._base_url = None
+        agent.service._provider_defaults = {"codex": {"codex_auth_path": "/tmp/codex-c.json"}}
+        setup(agent, provider="codex")
+
+    mock_select.assert_not_called()
+    assert mock_factory.call_args.kwargs["model"] == "gpt-5.6-sol"
+    assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-c.json"
+
+
+@pytest.mark.parametrize("active_provider", ["codex-pool", "codex_pool"])
+def test_active_pool_path_only_takes_pool_route(tmp_path, active_provider):
+    """Matrix (d) — active ``codex-pool``/``codex_pool`` with only a pool path
+    (no ``codex_auth_path``) takes the pool route and uses the selected candidate."""
+    from lingtai.auth.codex_account_source import AccountCandidate
+    selected = AccountCandidate(
+        auth_ref="/tmp/codex-pool-d.json",
+        source_ref="pool.json",
+        source_index=0,
+        weight=1,
+    )
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_account_source.WeightedAccountSource.select",
+        return_value=selected,
+    ) as mock_select, patch(
+        "lingtai.auth.codex_pool.load_codex_auth_pool",
+        return_value=[{"path": "pool.json", "weight": 1}],
+    ):
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = active_provider
+        agent.service._model = "gpt-5.6-terra"
+        agent.service._base_url = "https://codex-pool.example/backend-api/codex"
+        agent.service._provider_defaults = {active_provider: {"codex_auth_pool_path": "pool.json"}}
+        setup(agent, provider=active_provider)
+
+    mock_select.assert_called()
+    assert mock_factory.call_args.kwargs["model"] == "gpt-5.6-terra"
+    assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-pool-d.json"
+
+
+@pytest.mark.parametrize("provider", ["codex", "codex-pool", "codex_pool"])
+def test_codex_request_over_unrelated_active_provider_fails_closed(tmp_path, provider):
+    """Matrix (e) — any Codex-family request over an unrelated active provider
+    must fail closed to manual, never borrowing the unrelated provider's model,
+    base URL, or credential and never calling the pool selector."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_account_source.WeightedAccountSource.select",
+        return_value=None,
+    ) as mock_select:
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "gemini"
+        agent.service._model = "gemini-2.5-pro"
+        agent.service._base_url = "https://generativelanguage.example"
+        agent.service._provider_defaults = {"gemini": {"codex_auth_path": "/tmp/should-not-be-used.json"}}
+        mgr = setup(agent, provider=provider)
+
+    mock_factory.assert_not_called()
+    mock_select.assert_not_called()
+    assert mgr._vision_service is None
+    assert "no resolved current model" in mgr._manual_reason
+    assert "gemini-2.5-pro" not in mgr._manual_reason
+    assert "/tmp/should-not-be-used.json" not in mgr._manual_reason
+
+
+@pytest.mark.parametrize("provider", ["codex", "codex-pool", "codex_pool"])
+def test_codex_request_over_unrelated_provider_with_explicit_model_never_reads_pool(
+    tmp_path, provider
+):
+    """Matrix (e), explicit-model variant — even when the request supplies its own
+    ``model`` (clearing the missing-model guard) and a whitespace-only explicit
+    ``token_path``, an unrelated active provider must NOT treat that blank value as
+    an identity, run the pool selector, or read any default pool file; the request
+    fails closed on the missing pool identity instead. Proves both normalization
+    and the ``same_provider`` gate, not merely the model guard."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_account_source.WeightedAccountSource.select",
+        return_value=None,
+    ) as mock_select, patch(
+        "lingtai.auth.codex_pool.load_codex_auth_pool",
+        return_value=[{"path": "pool.json", "weight": 1}],
+    ) as mock_pool_load:
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "gemini"
+        agent.service._model = "gemini-2.5-pro"
+        agent.service._base_url = "https://generativelanguage.example"
+        agent.service._provider_defaults = {"gemini": {}}
+        mgr = setup(agent, provider=provider, model="gpt-5.6-sol", token_path="   ")
+
+    mock_factory.assert_not_called()
+    mock_select.assert_not_called()
+    mock_pool_load.assert_not_called()
+    assert mgr._vision_service is None
+    assert "no selected current OAuth identity" in mgr._manual_reason
 
 
 def test_generic_codex_over_active_pool_without_candidate_fails_closed(tmp_path):

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -505,6 +505,94 @@ def test_codex_pool_vision_selects_exact_model_and_passes_result(tmp_path):
         assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-b.json"
 
 
+@pytest.mark.parametrize("active_provider", ["codex-pool", "codex_pool"])
+def test_generic_codex_over_active_pool_follows_active_pool_route(tmp_path, active_provider):
+    """Live mixed-name repro: generic ``codex`` over an active ``codex-pool``/
+    ``codex_pool`` service must take the active pool route — preserving the active
+    pool model/base and passing the exact pool-selected credential reference
+    (the selected candidate's ``auth_ref`` token path) to the native Codex vision
+    service, never a direct ``codex_auth_path``."""
+    from lingtai.auth.codex_account_source import AccountCandidate
+    selected = AccountCandidate(
+        auth_ref="/tmp/codex-pool-selected.json",
+        source_ref="pool.json",
+        source_index=0,
+        weight=1,
+    )
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_account_source.WeightedAccountSource.select",
+        return_value=selected,
+    ) as mock_select, patch(
+        "lingtai.auth.codex_pool.load_codex_auth_pool",
+        return_value=[{"path": "pool.json", "weight": 1}],
+    ):
+        mock_factory.return_value = MagicMock(spec=VisionService)
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = active_provider
+        agent.service._model = "gpt-5.6-sol"
+        agent.service._base_url = "https://codex-pool.example/backend-api/codex"
+        agent.service._provider_defaults = {
+            active_provider: {"codex_auth_pool_path": "pool.json"}
+        }
+        setup(agent, provider="codex")
+
+    assert mock_factory.call_args.args == ("codex",)
+    assert mock_factory.call_args.kwargs["api_key"] is None
+    assert mock_factory.call_args.kwargs["model"] == "gpt-5.6-sol"
+    assert mock_factory.call_args.kwargs["base_url"] == "https://codex-pool.example/backend-api/codex"
+    assert mock_factory.call_args.kwargs["token_path"] == "/tmp/codex-pool-selected.json"
+    mock_select.assert_called()
+
+
+def test_explicit_pool_request_over_active_direct_codex_fails_closed(tmp_path):
+    """Inverse route: an explicit ``codex-pool`` request over an active *direct*
+    Codex service must not borrow the direct ``codex_auth_path`` credential as a
+    pool identity. An explicit capability ``model`` is supplied so the request
+    gets past the missing-model guard, proving the failure is the pool
+    identity/candidate failure rather than merely a missing model."""
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_account_source.WeightedAccountSource.select",
+        return_value=None,
+    ):
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "codex"
+        agent.service._model = "gpt-5.6-sol"
+        agent.service._base_url = None
+        agent.service._provider_defaults = {"codex": {"codex_auth_path": "/tmp/codex-direct.json"}}
+        mgr = setup(agent, provider="codex-pool", model="gpt-5.6-sol")
+
+    mock_factory.assert_not_called()
+    assert mgr._vision_service is None
+    # Fail-closed on the pool identity, never borrowing the active direct auth path.
+    assert "no selected current OAuth identity" in mgr._manual_reason
+    assert "no resolved current model" not in mgr._manual_reason
+    assert "/tmp/codex-direct.json" not in mgr._manual_reason
+
+
+def test_generic_codex_over_active_pool_without_candidate_fails_closed(tmp_path):
+    """Generic ``codex`` over an active pool whose source yields no candidate must
+    stay manual-only rather than manufacture a direct/default identity."""
+    from lingtai.auth.codex_account_source import NoCandidateError
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory, patch(
+        "lingtai.auth.codex_account_source.WeightedAccountSource.select",
+        side_effect=NoCandidateError("empty pool"),
+    ), patch(
+        "lingtai.auth.codex_pool.load_codex_auth_pool",
+        return_value=[],
+    ):
+        agent = make_mock_agent(tmp_path)
+        agent.service.provider = "codex-pool"
+        agent.service._model = "gpt-5.6-sol"
+        agent.service._base_url = "https://codex-pool.example/backend-api/codex"
+        agent.service._provider_defaults = {"codex-pool": {"codex_auth_pool_path": "pool.json"}}
+        mgr = setup(agent, provider="codex")
+
+    mock_factory.assert_not_called()
+    assert mgr._vision_service is None
+    assert "no selected current OAuth identity" in mgr._manual_reason
+    assert "Exception" not in mgr._manual_reason
+
+
 @pytest.mark.parametrize(
     ("provider", "model", "base_url", "expects_base_url"),
     [
@@ -864,8 +952,17 @@ def test_create_vision_service_codex_uses_explicit_path_and_filters_extra_kwargs
 
 def test_codex_vision_service_streams_responses_api(monkeypatch, tmp_path):
     """CodexVisionService should parse streaming output_text deltas without network calls."""
+    import base64
+
+    # A genuinely valid 1x1 truecolor PNG (stdlib base64 decode; no external
+    # dependency, file fixture, or network). This exercises the direct Codex
+    # request seam with real image bytes rather than a non-PNG placeholder.
+    valid_png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+    )
+    assert valid_png.startswith(b"\x89PNG\r\n\x1a\n")
     img_path = tmp_path / "chart.png"
-    img_path.write_bytes(b"fake png bytes")
+    img_path.write_bytes(valid_png)
 
     events = [
         SimpleNamespace(type="response.created"),
@@ -902,7 +999,10 @@ def test_codex_vision_service_streams_responses_api(monkeypatch, tmp_path):
     content = kwargs["input"][0]["content"]
     assert content[0] == {"type": "input_text", "text": "What is shown?"}
     assert content[1]["type"] == "input_image"
-    assert content[1]["image_url"].startswith("data:image/png;base64,")
+    image_url = content[1]["image_url"]
+    assert image_url.startswith("data:image/png;base64,")
+    # The direct seam must carry the exact valid PNG, not a mangled placeholder.
+    assert base64.b64decode(image_url.split(",", 1)[1]) == valid_png
 
 
 def test_openai_responses_vision_sends_exact_request_shape(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fix generic `vision.provider=codex` resolution when the active service route is `codex-pool` / `codex_pool`.

The previous setup treated generic `codex` and an active Codex pool as different provider identities. That withheld the active model/base URL/selected OAuth token path, then forced the generic request down the direct `codex_auth_path` branch. The capability therefore failed before sending a vision request even though the active pool had a valid current model and credential.

## What changed

- Add an explicit Codex active-route resolver:
  - generic `codex` follows the active direct or pool sub-route;
  - explicit pool aliases share only an active pool identity;
  - inverse and unrelated-provider inheritance remain fail-closed.
- For an active pool, select the exact current-model candidate from `WeightedAccountSource` and pass that candidate's `auth_ref` token path.
- Keep the direct Codex auth-path behavior unchanged.
- Document the route/identity boundary in the paired vision `CONTRACT.md` and `ANATOMY.md`.
- Add regression coverage for both pool spellings, missing candidates, inverse pool-over-direct isolation, and the exact request path using a genuinely valid 1×1 PNG.

## Validation

```text
PYTHONPATH=src python -m pytest -q \
  tests/test_vision_capability.py \
  tests/test_vision_services.py \
  tests/test_architecture_documents.py \
  tests/test_docs_governance.py
# 192 passed
```

Also passed:

- `python -m py_compile` for the implementation and capability tests
- seven-case import/route smoke for direct, pool aliases, inverse, and unrelated routes
- `git diff --check`
- self-contained local PR explainer validation (not committed)

## Safety boundaries

- No silent credential/model fallback was added.
- Missing model/candidate/identity, unsupported providers, and request failures retain the existing sanitized/manual fail-closed behavior.
- This PR does not install or refresh any live runtime.
