### PR TITLE
fix: forward resolved admin during CLI bootstrap

### DIFF
--- a/src/lingtai/cli.py
+++ b/src/lingtai/cli.py
@@ -108,6 +108,7 @@ def build_agent(data: dict, working_dir: Path) -> Agent:
     agent = Agent(
         service,
         agent_name=m.get("agent_name"),
+        admin=m.get("admin", {}),
         working_dir=working_dir,
         workdir_lease=select_workdir_lease(working_dir),
         notification_store=PosixNotificationStoreAdapter(working_dir),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,6 +108,7 @@ def test_build_agent_constructs_correctly(mock_mail, mock_agent, mock_llm, tmp_p
     mock_agent.assert_called_once()
     call_kwargs = mock_agent.call_args
     assert call_kwargs.kwargs["agent_name"] == "test-agent"
+    assert call_kwargs.kwargs["admin"] == {"karma": True}
     assert call_kwargs.kwargs["working_dir"] == tmp_path
     assert call_kwargs.kwargs["streaming"] is False
     # covenant, memory, capabilities, addons no longer passed to constructor —
@@ -585,6 +586,22 @@ def test_check_duplicate_process_ignores_shell_wrapper(tmp_path):
     wrapper = f"67192 /bin/zsh -ic 'lingtai run {codex.resolve()} && echo done'"
     with _posix_scan_pinned(), patch("subprocess.check_output", return_value=wrapper + "\n"):
         _check_duplicate_process(codex)
+
+
+@patch("lingtai.cli.LLMService")
+@patch("lingtai.cli.Agent")
+@patch("lingtai.cli.PosixFilesystemMailAdapter")
+def test_build_agent_forwards_empty_admin(mock_mail, mock_agent, mock_llm, tmp_path):
+    """Empty admin {} from manifest must reach Agent, not be promoted to karma."""
+    from lingtai.cli import load_init, build_agent
+
+    _write_init(tmp_path, overrides={"manifest": {"admin": {}}})
+    data = load_init(tmp_path)
+    build_agent(data, tmp_path)
+
+    call_kwargs = mock_agent.call_args.kwargs
+    assert "admin" in call_kwargs, "admin must be forwarded to Agent constructor"
+    assert call_kwargs["admin"] == {}
 
 
 def test_check_duplicate_process_excludes_own_pid(tmp_path):


### PR DESCRIPTION
## Summary

- forward the resolved manifest's `admin` mapping during the CLI's initial `Agent(...)` construction
- preserve the existing default for direct primary-Agent callers
- cover both configured non-admin `{}` and valid `{"karma": true}` mappings at the composition root

## Validation

- [x] `git diff --check`
- [x] Relevant tests or documentation checks:
  - `python -m pytest -q tests/test_cli.py::test_build_agent_constructs_correctly tests/test_cli.py::test_build_agent_forwards_empty_admin` (`2 passed`)
  - `python -m pytest -q tests/test_cli.py` (`28 passed`)
  - `python -m py_compile src/lingtai/cli.py tests/test_cli.py`

## Notes

- Fixes #1014.
- No Anatomy or Contract update is needed: this only forwards an already-resolved manifest field at the existing CLI composition root; it does not change the init reader, `Agent` interface, or direct-call default.
- Logs and examples were reviewed and contain no credentials, machine-specific paths, agent identities, or communication records.
