### PR TITLE
fix(codex): tighten empty pools and terminal no-candidate

### DIFF
--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -688,6 +688,28 @@ def _run_loop(agent) -> None:
 
                     err_desc = str(e) or repr(e)
 
+                    # Account selection has already exhausted the configured
+                    # Codex candidates. This is deterministic for this turn,
+                    # so do not rebuild/replay the session or spend AED
+                    # attempts on the same selection failure.
+                    from ...auth.codex_account_source import NoCandidateError
+
+                    if isinstance(e, NoCandidateError):
+                        agent._log(
+                            "no_candidate_terminal",
+                            error=err_desc[:300],
+                            exception=type(e).__name__,
+                        )
+                        logger.warning(
+                            f"[{agent.agent_name}] No Codex account candidate: {err_desc}"
+                        )
+                        _report_api_error_to_task_card(
+                            agent, e, terminal=True
+                        )
+                        sleep_state = AgentState.ASLEEP
+                        agent._asleep.set()
+                        break
+
                     if getattr(e, "_lingtai_partial_stream", False):
                         # Provider output has already reached the human-facing
                         # stream. Replaying this turn through transient retry or

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -5246,7 +5246,12 @@ class CodexOpenAIAdapter(OpenAIAdapter):
                     pool_size = len(snapshot)
             except Exception:
                 # Only a truly empty configured pool may use the legacy account.
-                if self._codex_fallback_auth_path is None or snapshot != []:
+                if (
+                    self._codex_fallback_auth_path is None
+                    or snapshot is None
+                    or not isinstance(snapshot, (list, tuple))
+                    or snapshot
+                ):
                     raise
                 from lingtai.auth.codex_account_source import FixedAccountSource
                 fallback = FixedAccountSource(self._codex_fallback_auth_path)

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -23,6 +23,7 @@ from lingtai.kernel.llm.base import UsageMetadata
 from lingtai.kernel.llm_utils import WorkerStillRunningError
 from lingtai.kernel.message import _make_message, MSG_REQUEST
 from lingtai.kernel.state import AgentState
+from lingtai.auth.codex_account_source import NoCandidateError
 
 
 @dataclass
@@ -238,6 +239,60 @@ def test_partial_stream_marker_stops_before_transient_or_aed_retry(tmp_path, mon
     assert any(name == "llm_partial_stream_terminal" for name, _ in agent._logs)
     assert not any(name == "aed_transient_retry" for name, _ in agent._logs)
     assert not any(name == "aed_attempt" for name, _ in agent._logs)
+
+
+def test_no_candidate_error_is_terminal_without_aed_retry(tmp_path, monkeypatch):
+    agent = _make_run_loop_agent(tmp_path)
+    agent.reports = []
+    agent._report_task_card_api_error = lambda exc, **kw: agent.reports.append((exc, kw))
+    calls = {"n": 0}
+
+    def fake_handle(_agent, _msg):
+        calls["n"] += 1
+        _agent._shutdown.set()
+        raise NoCandidateError("No eligible account remaining")
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    assert calls["n"] == 1
+    assert getattr(agent, "rebuilds", 0) == 0
+    assert agent._asleep.is_set()
+    assert [name for name, _ in agent._logs].count("no_candidate_terminal") == 1
+    assert not any(name == "aed_attempt" for name, _ in agent._logs)
+    assert len(agent.reports) == 1
+    assert agent.reports[0][0].args == ("No eligible account remaining",)
+    assert agent.reports[0][1] == {
+        "attempt": None,
+        "max_attempts": None,
+        "terminal": True,
+    }
+
+
+def test_ordinary_exception_keeps_aed_rebuild_behavior(tmp_path, monkeypatch):
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 3
+    calls = {"n": 0}
+
+    def fake_handle(_agent, _msg):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            _agent._shutdown.set()
+            return
+        raise ValueError("ordinary failure")
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: None)
+
+    turn._run_loop(agent)
+
+    assert calls["n"] == 3
+    assert getattr(agent, "rebuilds", 0) == 2
+    assert [name for name, _ in agent._logs].count("aed_attempt") == 2
 
 
 def test_transient_provider_error_retries_before_aed_count(tmp_path, monkeypatch):

--- a/tests/test_codex_native_multiaccount.py
+++ b/tests/test_codex_native_multiaccount.py
@@ -82,6 +82,11 @@ class _SequenceSource:
         ]
 
 
+class _NoneSnapshotSource(_SequenceSource):
+    def snapshot(self):
+        return None
+
+
 class _Responses:
     def __init__(self, events_or_errors):
         self.events_or_errors = list(events_or_errors)
@@ -457,6 +462,37 @@ def test_native_codex_nonempty_exhausted_pool_never_falls_back():
     responses = _Responses([_success_events])
     adapter = _adapter(source, _managers("one.json", "a.json"), responses)
     adapter._codex_excluded_accounts.add(source._candidates[0].auth_path_sha8)
+    chat = adapter.create_chat("gpt-5.5", "system")
+
+    with pytest.raises(RuntimeError, match="no candidate"):
+        chat.send("hello")
+
+    assert source.calls == []
+    assert responses.calls == []
+
+
+def test_native_codex_none_snapshot_never_falls_back():
+    source = _NoneSnapshotSource()
+    responses = _Responses([_success_events])
+    adapter = _adapter(source, _managers("a.json"), responses)
+    chat = adapter.create_chat("gpt-5.5", "system")
+
+    with pytest.raises(RuntimeError, match="no candidate"):
+        chat.send("hello")
+
+    assert source.calls == []
+    assert responses.calls == []
+
+
+@pytest.mark.parametrize("snapshot", ["", {}])
+def test_native_codex_non_collection_falsy_snapshot_never_falls_back(snapshot):
+    class _FalsySnapshotSource(_SequenceSource):
+        def snapshot(self):
+            return snapshot
+
+    source = _FalsySnapshotSource()
+    responses = _Responses([_success_events])
+    adapter = _adapter(source, _managers("a.json"), responses)
     chat = adapter.create_chat("gpt-5.5", "system")
 
     with pytest.raises(RuntimeError, match="no candidate"):

--- a/tests/test_codex_native_multiaccount.py
+++ b/tests/test_codex_native_multiaccount.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from lingtai.auth.codex_account_source import AccountCandidate
+from lingtai.auth.codex_account_source import AccountCandidate, WeightedAccountSource
 from lingtai.kernel.llm.interface import ChatInterface
 from lingtai.llm.openai.adapter import CodexOpenAIAdapter
 
@@ -453,6 +453,20 @@ def test_native_codex_empty_pool_falls_back_to_legacy_account():
 
     assert response.text == "ok"
     assert source.calls == []
+    assert responses.calls[0]["extra_headers"]["ChatGPT-Account-ID"] == "acct-a.json"
+    assert chat.codex_pool_selection["fallback"] == "legacy_default"
+
+
+def test_native_codex_weighted_empty_tuple_falls_back_to_legacy_account(tmp_path):
+    source = WeightedAccountSource(tmp_path / "codex-auth-pool.json", tmp_path)
+    assert source.snapshot() == ()
+    responses = _Responses([_success_events])
+    adapter = _adapter(source, _managers("a.json"), responses)
+    chat = adapter.create_chat("gpt-5.5", "system")
+
+    response = chat.send("hello")
+
+    assert response.text == "ok"
     assert responses.calls[0]["extra_headers"]["ChatGPT-Account-ID"] == "acct-a.json"
     assert chat.codex_pool_selection["fallback"] == "legacy_default"
 


### PR DESCRIPTION
## Summary

- Restore the documented legacy-account fallback only when `WeightedAccountSource.snapshot()` is an actual empty list or tuple, including the production tuple shape.
- Preserve loud failure for `None`, non-collection falsy values, and nonempty unavailable/exhausted/ineligible pools.
- Treat typed `NoCandidateError` from Codex account selection as a terminal configuration/account-exhaustion result that surfaces once without generic AED replay.
- Preserve ordinary exception handling, transient AED retry behavior, max-AED exhaustion behavior, and preset fallback behavior outside the typed no-candidate path.

Exact base: `3e59c41b40b15198ca902dbe6541520194a21c39`.

Folded PR #1017 commit: `caf2a48a16176c431193fd7af3a2e42dfc0ad820` -> `98063fcc004d99c8450fd0b4b393eaaf759d9ad9`.

## Validation

- `git diff --check` - passed.
- `PYTHONDONTWRITEBYTECODE=1 pytest -q tests/test_codex_native_multiaccount.py tests/test_codex_account_source.py tests/test_aed_recovery.py` - 75 passed, 1 warning.

Preserved old behavior: `snapshot is None`, other falsy non-list/tuple snapshots, nonempty pools whose candidates are unavailable/exhausted/ineligible, ordinary exceptions, transient AED retries, generic AED exhaustion, and preset fallback handling remain unchanged.