### PR TITLE
fix(kernel): terminate Codex no-candidate turns

### DIFF
--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -688,6 +688,28 @@ def _run_loop(agent) -> None:
 
                     err_desc = str(e) or repr(e)
 
+                    # Account selection has already exhausted the configured
+                    # Codex candidates. This is deterministic for this turn,
+                    # so do not rebuild/replay the session or spend AED
+                    # attempts on the same selection failure.
+                    from ...auth.codex_account_source import NoCandidateError
+
+                    if isinstance(e, NoCandidateError):
+                        agent._log(
+                            "no_candidate_terminal",
+                            error=err_desc[:300],
+                            exception=type(e).__name__,
+                        )
+                        logger.warning(
+                            f"[{agent.agent_name}] No Codex account candidate: {err_desc}"
+                        )
+                        _report_api_error_to_task_card(
+                            agent, e, terminal=True
+                        )
+                        sleep_state = AgentState.ASLEEP
+                        agent._asleep.set()
+                        break
+
                     if getattr(e, "_lingtai_partial_stream", False):
                         # Provider output has already reached the human-facing
                         # stream. Replaying this turn through transient retry or

--- a/tests/test_aed_recovery.py
+++ b/tests/test_aed_recovery.py
@@ -23,6 +23,7 @@ from lingtai.kernel.llm.base import UsageMetadata
 from lingtai.kernel.llm_utils import WorkerStillRunningError
 from lingtai.kernel.message import _make_message, MSG_REQUEST
 from lingtai.kernel.state import AgentState
+from lingtai.auth.codex_account_source import NoCandidateError
 
 
 @dataclass
@@ -238,6 +239,60 @@ def test_partial_stream_marker_stops_before_transient_or_aed_retry(tmp_path, mon
     assert any(name == "llm_partial_stream_terminal" for name, _ in agent._logs)
     assert not any(name == "aed_transient_retry" for name, _ in agent._logs)
     assert not any(name == "aed_attempt" for name, _ in agent._logs)
+
+
+def test_no_candidate_error_is_terminal_without_aed_retry(tmp_path, monkeypatch):
+    agent = _make_run_loop_agent(tmp_path)
+    agent.reports = []
+    agent._report_task_card_api_error = lambda exc, **kw: agent.reports.append((exc, kw))
+    calls = {"n": 0}
+
+    def fake_handle(_agent, _msg):
+        calls["n"] += 1
+        _agent._shutdown.set()
+        raise NoCandidateError("No eligible account remaining")
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: _a._shutdown.set())
+
+    turn._run_loop(agent)
+
+    assert calls["n"] == 1
+    assert getattr(agent, "rebuilds", 0) == 0
+    assert agent._asleep.is_set()
+    assert [name for name, _ in agent._logs].count("no_candidate_terminal") == 1
+    assert not any(name == "aed_attempt" for name, _ in agent._logs)
+    assert len(agent.reports) == 1
+    assert agent.reports[0][0].args == ("No eligible account remaining",)
+    assert agent.reports[0][1] == {
+        "attempt": None,
+        "max_attempts": None,
+        "terminal": True,
+    }
+
+
+def test_ordinary_exception_keeps_aed_rebuild_behavior(tmp_path, monkeypatch):
+    agent = _make_run_loop_agent(tmp_path)
+    agent._config.max_aed_attempts = 3
+    calls = {"n": 0}
+
+    def fake_handle(_agent, _msg):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            _agent._shutdown.set()
+            return
+        raise ValueError("ordinary failure")
+
+    monkeypatch.setattr(turn, "_handle_message", fake_handle)
+    import lingtai.tools.soul.flow as soul_flow
+    monkeypatch.setattr(soul_flow, "_cancel_soul_timer", lambda _a: None)
+
+    turn._run_loop(agent)
+
+    assert calls["n"] == 3
+    assert getattr(agent, "rebuilds", 0) == 2
+    assert [name for name, _ in agent._logs].count("aed_attempt") == 2
 
 
 def test_transient_provider_error_retries_before_aed_count(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Treat the owning typed `NoCandidateError` as deterministic and terminal for the current turn.
- Surface its safe original message once, avoid AED state rebuild/retry, and preserve the existing session/state safety path.
- Keep transient provider retry, partial-stream, worker-running, over-window, ordinary-exception AED, and persisted/default/clamped `max_aed_attempts` behavior unchanged.
- Separate intentional behavior fix, following the dev-3 handoff and Fable review context where relevant.

Exact base: `3e59c41b40b15198ca902dbe6541520194a21c39`.

## Validation

- `pytest -q tests/test_aed_recovery.py` — 13 passed.
- `git diff --check` — passed before commit.
- Commit: `caf2a48a16176c431193fd7af3a2e42dfc0ad820`.

Preserved old behavior: all non-`NoCandidateError` exception classification and AED retry/rebuild paths remain unchanged; no new config or flag was added.