### PR TITLE
chore(release): bump kernel to 0.18.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.18.0"
+version = "0.18.1"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump the kernel package version from `0.18.0` to `0.18.1`
- prepare the exact merged hotfix main for the authorized emergency release

## Validation
- parsed `pyproject.toml` and confirmed exact version `0.18.1`
- PEP 440 `packaging.version.Version` check passed when available
- `git diff --check`

No release machinery, runtime behavior, or unrelated source is changed.