### PR TITLE
fix(daemon): recover once from text-only completion

### DIFF
--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -8,7 +8,7 @@ description: >
   terminal notifications, and compaction boundaries.
 status: active
 contract_version: 6
-last_changed_at: "2026-07-24"
+last_changed_at: "2026-07-26"
 related_files:
   - src/lingtai/tools/daemon/ANATOMY.md
   - src/lingtai/tools/daemon/__init__.py
@@ -42,6 +42,7 @@ related_files:
   - tests/test_daemon_run_dir.py
   - tests/test_daemon_codex_usage.py
   - tests/test_codex_standalone_compaction.py
+  - tests/test_daemon_detached_supervisor.py
   - tests/test_daemon_windows_lock.py
   - tests/test_daemon_windows_process_port.py
   - tests/test_daemon_windows_supervisor.py
@@ -228,6 +229,14 @@ When `daemon_common` is loaded, a conversational final answer is not enough.
 Success requires a validated `finish(status="done")`; missing completion,
 invalid JSON, invalid status, run-id mismatch, `failed`, or `incomplete` must
 prevent terminal `done`.
+
+For LingTai-backend runs only, a nonblank text-only response with no valid
+completion may receive one same-session recovery prompt when enough turn budget
+remains to dispatch a returned tool batch. Recovery never synthesizes
+`daemon_completion.json`, never turns text into success, never reinterprets
+`failed`/`incomplete` as success, and does not change the detached execution
+host's local canonical `finish` surface or its filtering of the reserved
+external `daemon_common` registration.
 
 ### 4. Artifacts separate review evidence from secret-bearing config
 

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -141,6 +141,13 @@ DAEMON_MECHANICAL_COMPACT_RECOVERY = (
     "resume from that verified state. Do not assume erased context or repeat "
     "side effects without verification."
 )
+DAEMON_COMPLETION_RECOVERY_PROMPT = (
+    "Your last response was ordinary text, but this daemon run still has no "
+    "valid completion signal. Do not repeat tool calls that already succeeded. "
+    "If the task is complete, call finish(status=\"done\", summary=...). If it "
+    "is blocked, incomplete, or failed, call finish with the truthful terminal "
+    "status and required reason. Text alone cannot complete this daemon."
+)
 _DAEMON_SKILL_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?\n)---\s*\n", re.DOTALL)
 
 
@@ -3003,157 +3010,197 @@ class DaemonManager:
                 return _mark_cancelled_or_timeout(run_dir, timeout_event)
             turns = 0
             recovery_tool_batch_pending = False
+            completion_recovery_used = False
             run_dir.bump_turn(turn=turns + 1, response_text=response.text or "")
 
-            while response.tool_calls and (
-                turns < effective_max_turns or recovery_tool_batch_pending
-            ):
-                if cancel_event.is_set():
-                    return _mark_cancelled_or_timeout(run_dir, timeout_event)
+            while True:
+                while response.tool_calls and (
+                    turns < effective_max_turns or recovery_tool_batch_pending
+                ):
+                    if cancel_event.is_set():
+                        return _mark_cancelled_or_timeout(run_dir, timeout_event)
 
-                # Intermediate text is already persisted in chat_history via
-                # bump_turn(); do not inject daemon progress as parent requests.
+                    # Intermediate text is already persisted in chat_history via
+                    # bump_turn(); do not inject daemon progress as parent requests.
 
-                daemon_meta_state.note_tool_batch(response.tool_calls)
-                compact_execution_calls = [
-                    tc for tc in response.tool_calls
-                    if tc.name == "compact" and (tc.args or {}).get("action") == "run"
-                ]
-                has_compact_call = bool(compact_execution_calls)
-                compact_batch_allowed = (
-                    len(compact_execution_calls) == 1
-                    and len(response.tool_calls) == 1
-                )
-                executor.guard.record_calls(len(response.tool_calls))
-                compact_reset_accepted = False
-                if has_compact_call and not compact_batch_allowed:
-                    result_payload = {
-                        "status": "error",
-                        "message": (
-                            "compact must be the only tool call in its assistant "
-                            "batch; no tools in this batch were executed"
-                        ),
-                    }
-                    tool_results = [
-                        service.make_tool_result(
-                            tc.name,
-                            dict(result_payload),
-                            tool_call_id=getattr(tc, "id", None),
-                        )
-                        for tc in response.tool_calls
+                    daemon_meta_state.note_tool_batch(response.tool_calls)
+                    compact_execution_calls = [
+                        tc for tc in response.tool_calls
+                        if tc.name == "compact" and (tc.args or {}).get("action") == "run"
                     ]
-                    intercepted = False
-                    intercept_text = ""
-                    executor.guard.clear_progress_notice()
-                else:
-                    tool_results, intercepted, intercept_text = executor.execute(
-                        response.tool_calls,
-                        api_call_id=getattr(response, "api_call_id", None),
+                    has_compact_call = bool(compact_execution_calls)
+                    compact_batch_allowed = (
+                        len(compact_execution_calls) == 1
+                        and len(response.tool_calls) == 1
                     )
-                    executor.guard.clear_progress_notice()
+                    executor.guard.record_calls(len(response.tool_calls))
+                    compact_reset_accepted = False
+                    if has_compact_call and not compact_batch_allowed:
+                        result_payload = {
+                            "status": "error",
+                            "message": (
+                                "compact must be the only tool call in its assistant "
+                                "batch; no tools in this batch were executed"
+                            ),
+                        }
+                        tool_results = [
+                            service.make_tool_result(
+                                tc.name,
+                                dict(result_payload),
+                                tool_call_id=getattr(tc, "id", None),
+                            )
+                            for tc in response.tool_calls
+                        ]
+                        intercepted = False
+                        intercept_text = ""
+                        executor.guard.clear_progress_notice()
+                    else:
+                        tool_results, intercepted, intercept_text = executor.execute(
+                            response.tool_calls,
+                            api_call_id=getattr(response, "api_call_id", None),
+                        )
+                        executor.guard.clear_progress_notice()
 
-                if not intercepted and compact_batch_allowed and compact_reset_accepted:
-                    if cancel_event.is_set():
-                        return _mark_cancelled_or_timeout(run_dir, timeout_event)
-                    from lingtai.kernel.llm.interface import ChatInterface
-                    history = session.interface.to_dict()
-                    compact_assistant = history[-1] if history else None
-                    if not (
-                        isinstance(compact_assistant, dict)
-                        and compact_assistant.get("role") == "assistant"
-                    ):
-                        raise RuntimeError("compact context reset requires an intact assistant compact call")
-                    system_entries = [e for e in history if e.get("role") == "system"]
-                    retained = ChatInterface.from_dict(
-                        ([system_entries[-1]] if system_entries else [])
-                        + [compact_assistant]
-                    )
-                    session = service.create_session(
-                        system_prompt=system_prompt,
-                        tools=schemas or None,
-                        model=effective_model,
-                        thinking="default",
-                        tracked=False,
-                        interface=retained,
-                    )
-                    # The compact result is the first carrier in the fresh context.
-                    # Clear pre-reset current-call state before stamping that carrier,
-                    # while preserving cumulative daemon totals and round identity.
-                    daemon_meta_state.note_compact_reset(session)
-
-                # Promote the daemon-local snapshot to the canonical final
-                # ToolResultBlock sidecar. The helper deliberately omits the
-                # parent-only notifications/communication axis. For an accepted
-                # compact reset, this now describes the fresh retained context.
-                attach_daemon_agent_meta(
-                    tool_results,
-                    agent_state=daemon_meta_state.snapshot(session),
-                )
-
-                if intercepted:
-                    # Preserve provider pairing by recording the synthesized tool
-                    # results, then terminate the daemon with the intercept text.
-                    run_dir.record_user_send(
-                        json.dumps([str(r) for r in tool_results], ensure_ascii=False),
-                        kind="tool_results",
-                    )
-                    text = intercept_text or "[intercepted]"
-                    self._require_done_completion(run_dir, text)
-                    run_dir.mark_done(text)
-                    return text
-
-                mechanically_compacted = False
-                if daemon_meta_state.compact_due:
-                    if cancel_event.is_set():
-                        return _mark_cancelled_or_timeout(run_dir, timeout_event)
-                    response = _mechanically_compact(tool_results)
-                    mechanically_compacted = True
-                if not mechanically_compacted:
-                    # Tool results are written to chat_history before sending.
-                    run_dir.record_user_send(
-                        json.dumps([str(r) for r in tool_results], ensure_ascii=False),
-                        kind="tool_results",
-                    )
-                    response = session.send(tool_results)
-                    daemon_meta_state.note_response(response, session)
-                    _accum(response)
-                turns += 1
-                run_dir.bump_turn(turn=turns + 1, response_text=response.text or "")
-                recovery_tool_batch_pending = mechanically_compacted and bool(
-                    response.tool_calls
-                )
-
-                # Inject follow-up as a separate user message — only safe when
-                # the response is text-only. If it carries new tool_calls, the
-                # canonical interface tail is assistant[tool_calls] and a user
-                # message here would violate the pairing invariant.
-                if not response.tool_calls:
-                    if not mechanically_compacted and daemon_meta_state.compact_due:
+                    if not intercepted and compact_batch_allowed and compact_reset_accepted:
                         if cancel_event.is_set():
                             return _mark_cancelled_or_timeout(run_dir, timeout_event)
-                        response = _mechanically_compact()
-                        turns += 1
-                        run_dir.bump_turn(
-                            turn=turns + 1, response_text=response.text or ""
+                        from lingtai.kernel.llm.interface import ChatInterface
+                        history = session.interface.to_dict()
+                        compact_assistant = history[-1] if history else None
+                        if not (
+                            isinstance(compact_assistant, dict)
+                            and compact_assistant.get("role") == "assistant"
+                        ):
+                            raise RuntimeError("compact context reset requires an intact assistant compact call")
+                        system_entries = [e for e in history if e.get("role") == "system"]
+                        retained = ChatInterface.from_dict(
+                            ([system_entries[-1]] if system_entries else [])
+                            + [compact_assistant]
                         )
-                        recovery_tool_batch_pending = bool(response.tool_calls)
-                        if response.tool_calls:
-                            # Recovery tool calls must complete before the
-                            # buffered follow-up is drained or sent.
-                            continue
-                    followup = self._drain_followup(em_id)
-                    if followup:
-                        run_dir.record_user_send(followup, kind="followup")
-                        response = session.send(followup)
+                        session = service.create_session(
+                            system_prompt=system_prompt,
+                            tools=schemas or None,
+                            model=effective_model,
+                            thinking="default",
+                            tracked=False,
+                            interface=retained,
+                        )
+                        # The compact result is the first carrier in the fresh context.
+                        # Clear pre-reset current-call state before stamping that carrier,
+                        # while preserving cumulative daemon totals and round identity.
+                        daemon_meta_state.note_compact_reset(session)
+
+                    # Promote the daemon-local snapshot to the canonical final
+                    # ToolResultBlock sidecar. The helper deliberately omits the
+                    # parent-only notifications/communication axis. For an accepted
+                    # compact reset, this now describes the fresh retained context.
+                    attach_daemon_agent_meta(
+                        tool_results,
+                        agent_state=daemon_meta_state.snapshot(session),
+                    )
+
+                    if intercepted:
+                        # Preserve provider pairing by recording the synthesized tool
+                        # results, then terminate the daemon with the intercept text.
+                        run_dir.record_user_send(
+                            json.dumps([str(r) for r in tool_results], ensure_ascii=False),
+                            kind="tool_results",
+                        )
+                        text = intercept_text or "[intercepted]"
+                        self._require_done_completion(run_dir, text)
+                        run_dir.mark_done(text)
+                        return text
+
+                    mechanically_compacted = False
+                    if daemon_meta_state.compact_due:
+                        if cancel_event.is_set():
+                            return _mark_cancelled_or_timeout(run_dir, timeout_event)
+                        response = _mechanically_compact(tool_results)
+                        mechanically_compacted = True
+                    if not mechanically_compacted:
+                        # Tool results are written to chat_history before sending.
+                        run_dir.record_user_send(
+                            json.dumps([str(r) for r in tool_results], ensure_ascii=False),
+                            kind="tool_results",
+                        )
+                        response = session.send(tool_results)
                         daemon_meta_state.note_response(response, session)
                         _accum(response)
-                        turns += 1
-                        run_dir.bump_turn(turn=turns + 1, response_text=response.text or "")
+                    turns += 1
+                    run_dir.bump_turn(turn=turns + 1, response_text=response.text or "")
+                    recovery_tool_batch_pending = mechanically_compacted and bool(
+                        response.tool_calls
+                    )
 
-            if response.tool_calls and turns >= effective_max_turns:
-                raise RuntimeError(
-                    "max_turns exhausted before the daemon completed its tool chain"
-                )
+                    # Inject follow-up as a separate user message — only safe when
+                    # the response is text-only. If it carries new tool_calls, the
+                    # canonical interface tail is assistant[tool_calls] and a user
+                    # message here would violate the pairing invariant.
+                    if not response.tool_calls:
+                        if not mechanically_compacted and daemon_meta_state.compact_due:
+                            if cancel_event.is_set():
+                                return _mark_cancelled_or_timeout(run_dir, timeout_event)
+                            response = _mechanically_compact()
+                            turns += 1
+                            run_dir.bump_turn(
+                                turn=turns + 1, response_text=response.text or ""
+                            )
+                            recovery_tool_batch_pending = bool(response.tool_calls)
+                            if response.tool_calls:
+                                # Recovery tool calls must complete before the
+                                # buffered follow-up is drained or sent.
+                                continue
+                        followup = self._drain_followup(em_id)
+                        if followup:
+                            run_dir.record_user_send(followup, kind="followup")
+                            response = session.send(followup)
+                            daemon_meta_state.note_response(response, session)
+                            _accum(response)
+                            turns += 1
+                            run_dir.bump_turn(turn=turns + 1, response_text=response.text or "")
+
+                if response.tool_calls and turns >= effective_max_turns:
+                    raise RuntimeError(
+                        "max_turns exhausted before the daemon completed its tool chain"
+                    )
+
+                text = response.text or "[no output]"
+                completion = self._read_daemon_completion(run_dir)
+                if (
+                    not completion_recovery_used
+                    and self._run_has_daemon_common_mcp(run_dir)
+                    and isinstance(response.text, str)
+                    and response.text.strip()
+                    and not completion.status
+                    and turns + 1 < effective_max_turns
+                ):
+                    if cancel_event.is_set():
+                        return _mark_cancelled_or_timeout(run_dir, timeout_event)
+                    completion_recovery_used = True
+                    run_dir.append_event(
+                        "daemon_completion_recovery",
+                        em_id=em_id,
+                        run_id=getattr(run_dir, "run_id", None),
+                        completion_error=completion.error,
+                    )
+                    run_dir.record_user_send(
+                        DAEMON_COMPLETION_RECOVERY_PROMPT,
+                        kind="completion_recovery",
+                    )
+                    response = session.send(DAEMON_COMPLETION_RECOVERY_PROMPT)
+                    daemon_meta_state.note_response(response, session)
+                    _accum(response)
+                    turns += 1
+                    run_dir.bump_turn(
+                        turn=turns + 1,
+                        response_text=response.text or "",
+                    )
+                    if cancel_event.is_set():
+                        return _mark_cancelled_or_timeout(run_dir, timeout_event)
+                    recovery_tool_batch_pending = bool(response.tool_calls)
+                    continue
+                break
+
             text = response.text or "[no output]"
             # The final terminal transition is serialized with cancellation:
             # a reclaim/deadline racing the last provider response wins over a

--- a/tests/_fake_llm_adapter.py
+++ b/tests/_fake_llm_adapter.py
@@ -16,7 +16,9 @@ deadline/reclaim watcher can interrupt an in-flight "LLM call".
 """
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
 import time
 
 from lingtai.kernel.llm.base import ChatSession, LLMResponse, ToolCall, UsageMetadata
@@ -35,6 +37,17 @@ class _FakeChatSession(ChatSession):
         # This proves the runtime received a value without persisting/printing it.
         self._has_runtime_key = has_runtime_key
 
+    def _record_send(self) -> None:
+        path = os.environ.get("LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_REPORT")
+        if not path:
+            return
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps({
+                "session_id": id(self),
+                "send_count": self._send_count,
+            }) + "\n")
+
     @property
     def interface(self):
         return self._interface
@@ -44,6 +57,7 @@ class _FakeChatSession(ChatSession):
         if sleep_s:
             time.sleep(float(sleep_s))
         self._send_count += 1
+        self._record_send()
         usage_extra = {
             "codex_auth_path_sha8": "a1b2c3d4",
             "codex_pool_source_index": 1,
@@ -79,6 +93,53 @@ class _FakeChatSession(ChatSession):
                                     thinking_tokens=3, cached_tokens=5,
                                     extra=usage_extra),
             )
+        if os.environ.get(
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO"
+        ) == "text-only-completion-recovery":
+            if self._send_count == 1:
+                return LLMResponse(text="Task done in words only.", tool_calls=[])
+            if self._send_count == 2:
+                sleep_s = os.environ.get(
+                    "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_RECOVERY_SLEEP"
+                )
+                if sleep_s:
+                    time.sleep(float(sleep_s))
+                return LLMResponse(
+                    text="Calling finish after recovery prompt.",
+                    tool_calls=[ToolCall(
+                        name="finish",
+                        args={"status": "done", "summary": "recovered completion"},
+                        id="fake-recovery-finish",
+                    )],
+                )
+            return LLMResponse(text="Recovered task done.", tool_calls=[])
+        if os.environ.get(
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO"
+        ) == "side-effect-completion-recovery":
+            if self._send_count == 1:
+                return LLMResponse(
+                    text="Writing side-effect probe.",
+                    tool_calls=[ToolCall(
+                        name="write",
+                        args={
+                            "file_path": "recovery-side-effect.txt",
+                            "content": "side-effect once\n",
+                        },
+                        id="fake-write-once",
+                    )],
+                )
+            if self._send_count == 2:
+                return LLMResponse(text="Done in text after side effect.", tool_calls=[])
+            if self._send_count == 3:
+                return LLMResponse(
+                    text="Calling finish after side-effect recovery.",
+                    tool_calls=[ToolCall(
+                        name="finish",
+                        args={"status": "done", "summary": "side effect recovered"},
+                        id="fake-side-effect-finish",
+                    )],
+                )
+            return LLMResponse(text="Side-effect recovery done.", tool_calls=[])
         if (
             os.environ.get("LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_FINISH") == "1"
             and self._has_runtime_key

--- a/tests/_fake_llm_adapter.py
+++ b/tests/_fake_llm_adapter.py
@@ -115,6 +115,31 @@ class _FakeChatSession(ChatSession):
             return LLMResponse(text="Recovered task done.", tool_calls=[])
         if os.environ.get(
             "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO"
+        ) == "text-only-recovery-still-text":
+            if self._send_count == 1:
+                return LLMResponse(text="Task done in words only.", tool_calls=[])
+            return LLMResponse(text="Still only text after recovery.", tool_calls=[])
+        if os.environ.get(
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO"
+        ) == "completion-recovery-terminal-status":
+            status = os.environ.get(
+                "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_COMPLETION_STATUS",
+                "failed",
+            )
+            if self._send_count == 1:
+                return LLMResponse(text="Task done in words only.", tool_calls=[])
+            if self._send_count == 2:
+                return LLMResponse(
+                    text=f"Calling finish({status}) after recovery prompt.",
+                    tool_calls=[ToolCall(
+                        name="finish",
+                        args={"status": status, "reason": f"truthful {status}"},
+                        id=f"fake-recovery-{status}",
+                    )],
+                )
+            return LLMResponse(text=f"Recovered task reported {status}.", tool_calls=[])
+        if os.environ.get(
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO"
         ) == "side-effect-completion-recovery":
             if self._send_count == 1:
                 return LLMResponse(

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -43,6 +43,21 @@ from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdap
 FAKE_LLM_ENV = "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM"
 
 
+def _daemon_common_registration(run_dir: DaemonRunDir) -> dict:
+    return {
+        "name": "daemon_common",
+        "transport": "stdio",
+        "command": sys.executable,
+        "args": ["-m", "lingtai.mcp_servers.daemon_common"],
+        "env": {
+            "LINGTAI_DAEMON_COMPLETION_FILE": str(
+                run_dir.path / "daemon_completion.json"
+            ),
+            "LINGTAI_DAEMON_RUN_ID": run_dir.run_id,
+        },
+    }
+
+
 def _disk_state(run_dir: DaemonRunDir) -> dict:
     """Fresh disk read of *run_dir*'s daemon.json.
 
@@ -69,34 +84,56 @@ def _poll_until(predicate, *, timeout=15.0, interval=0.1):
     raise AssertionError(f"condition not met within {timeout}s")
 
 
-def _make_run_dir(tmp_path: Path, *, task="say hi", timeout_s=30.0, max_turns=5) -> DaemonRunDir:
+def _make_run_dir(
+    tmp_path: Path,
+    *,
+    task="say hi",
+    timeout_s=30.0,
+    max_turns=5,
+    tools=None,
+    mcp=None,
+) -> DaemonRunDir:
     parent = tmp_path / "agent"
     parent.mkdir(parents=True, exist_ok=True)
+    tools = list(tools or [])
+    call_parameters = {"task": task, "tools": tools}
+    if mcp is not None:
+        call_parameters["mcp"] = list(mcp)
     run_dir = DaemonRunDir(
         parent_working_dir=parent,
         handle="em-test",
         run_id="em-test",
         task=task,
-        tools=[],
+        tools=tools,
         model="fake-model",
         max_turns=max_turns,
         timeout_s=timeout_s,
         parent_addr=parent.name,
         parent_pid=os.getpid(),
         system_prompt=f"You are a test daemon.\n\nYour task:\n{task}",
-        call_parameters={"task": task, "tools": []},
+        call_parameters=call_parameters,
     )
     return run_dir
 
 
-def _spawn_lingtai_supervisor(run_dir: DaemonRunDir, *, task="say hi", timeout_s=30.0, max_turns=5, extra_env=None):
+def _spawn_lingtai_supervisor(
+    run_dir: DaemonRunDir,
+    *,
+    task="say hi",
+    timeout_s=30.0,
+    max_turns=5,
+    tools=None,
+    mcp=None,
+    extra_env=None,
+):
+    tools = list(tools or [])
     manifest = build_manifest(
         run_id=run_dir.run_id,
         backend="lingtai",
         parent_working_dir=str(run_dir.path.parent.parent),
         run_dir=str(run_dir.path),
         task=task,
-        tools=[],
+        tools=tools,
         max_turns=max_turns,
         timeout_s=timeout_s,
         group_id=None,
@@ -108,6 +145,7 @@ def _spawn_lingtai_supervisor(run_dir: DaemonRunDir, *, task="say hi", timeout_s
             "context_window": None,
             "provider_defaults": None,
         },
+        mcp=list(mcp or []),
     )
     write_manifest(run_dir.path, manifest)
     request = DaemonSupervisorRequest(
@@ -115,6 +153,15 @@ def _spawn_lingtai_supervisor(run_dir: DaemonRunDir, *, task="say hi", timeout_s
         manifest_path=str(manifest_path_for(run_dir.path)),
         python_executable=sys.executable,
     )
+    capsule = {"mcp": list(mcp or [])} if mcp else None
+    capsule_bytes = (
+        json.dumps(capsule, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        if capsule
+        else None
+    )
+    read_fd = write_fd = None
+    if capsule_bytes is not None:
+        read_fd, write_fd = os.pipe()
     env = dict(os.environ)
     env[FAKE_LLM_ENV] = "1"
     tests_dir = str(Path(__file__).parent)
@@ -125,18 +172,41 @@ def _spawn_lingtai_supervisor(run_dir: DaemonRunDir, *, task="say hi", timeout_s
     )
     if extra_env:
         env.update(extra_env)
+    pass_fds = ()
+    if read_fd is not None:
+        env["LINGTAI_DAEMON_CAPSULE_FD"] = str(read_fd)
+        pass_fds = (read_fd,)
     # Same mechanics as PosixDaemonSupervisorAdapter.spawn_detached, but with
     # an explicit env override for the test-only fake-LLM hook (the real
     # adapter always inherits full os.environ, no override point).
-    proc = subprocess.Popen(
-        [sys.executable, "-m", "lingtai.adapters.posix.daemon_supervisor_entrypoint",
-         __import__("lingtai.kernel.daemon_supervisor", fromlist=["encode_request"]).encode_request(request)],
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-        env=env,
-    )
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "lingtai.adapters.posix.daemon_supervisor_entrypoint",
+             __import__("lingtai.kernel.daemon_supervisor", fromlist=["encode_request"]).encode_request(request)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            env=env,
+            close_fds=True,
+            pass_fds=pass_fds,
+        )
+        if read_fd is not None:
+            os.close(read_fd)
+            read_fd = None
+            view = memoryview(capsule_bytes or b"")
+            while view:
+                written = os.write(write_fd, view)
+                view = view[written:]
+            os.close(write_fd)
+            write_fd = None
+    finally:
+        for fd in (read_fd, write_fd):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
     return proc
 
 
@@ -614,6 +684,185 @@ def test_detached_lingtai_surface_keeps_one_local_finish_without_external_common
     assert [schema.name for schema in schemas].count("finish") == 1
     assert list(dispatch).count("finish") == 1
     assert [registration["name"] for registration in connected] == ["parent-docs"]
+
+
+def test_detached_text_only_completion_recovery_uses_real_local_finish_once(tmp_path):
+    """Text-only LingTai output gets one same-session recovery and real finish."""
+    report = tmp_path / "fake-send-report.jsonl"
+    run_dir = _make_run_dir(tmp_path, task="text-only recovery", max_turns=4)
+    common = _daemon_common_registration(run_dir)
+    run_dir.update_state(call_parameters={
+        "task": "text-only recovery", "tools": [], "mcp": [common],
+    })
+    assert not (run_dir.path / "daemon_completion.json").exists()
+
+    proc = _spawn_lingtai_supervisor(
+        run_dir,
+        task="text-only recovery",
+        max_turns=4,
+        mcp=[common],
+        extra_env={
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO": "text-only-completion-recovery",
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_REPORT": str(report),
+        },
+    )
+    try:
+        _poll_until(lambda: _disk_state(run_dir).get("state") == "done", timeout=20)
+        proc.wait(timeout=5)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+    completion = json.loads(
+        (run_dir.path / "daemon_completion.json").read_text(encoding="utf-8")
+    )
+    assert completion["status"] == "done"
+    assert completion["run_id"] == run_dir.run_id
+    assert completion["summary"] == "recovered completion"
+    assert "Recovered task done." in run_dir.result_path.read_text(encoding="utf-8")
+
+    events = [
+        json.loads(line)
+        for line in run_dir.events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    recovery_events = [
+        event for event in events if event.get("event") == "daemon_completion_recovery"
+    ]
+    assert len(recovery_events) == 1
+    assert recovery_events[0]["completion_error"] == "missing completion MCP finish signal"
+    assert [
+        event for event in events
+        if event.get("event") == "tool_call" and event.get("name") == "finish"
+    ]
+    assert len([
+        event for event in events
+        if event.get("event") == "tool_result" and event.get("name") == "finish"
+    ]) == 1
+
+    chat = [
+        json.loads(line)
+        for line in run_dir.chat_path.read_text(encoding="utf-8").splitlines()
+    ]
+    recovery_chat = [
+        entry for entry in chat
+        if entry.get("role") == "user" and entry.get("kind") == "completion_recovery"
+    ]
+    assert len(recovery_chat) == 1
+    assert "Text alone cannot complete this daemon." in recovery_chat[0]["text"]
+
+    sends = [
+        json.loads(line)
+        for line in report.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["send_count"] for row in sends] == [1, 2, 3]
+    assert len({row["session_id"] for row in sends}) == 1
+
+
+def test_detached_recovery_after_side_effect_does_not_replay_tool(tmp_path):
+    """Recovery dispatches finish without repeating an earlier side effect."""
+    run_dir = _make_run_dir(
+        tmp_path,
+        task="side-effect recovery",
+        tools=["file"],
+        max_turns=5,
+    )
+    common = _daemon_common_registration(run_dir)
+    run_dir.update_state(
+        call_parameters={
+            "task": "side-effect recovery", "tools": ["file"], "mcp": [common],
+        }
+    )
+    proc = _spawn_lingtai_supervisor(
+        run_dir,
+        task="side-effect recovery",
+        tools=["file"],
+        max_turns=5,
+        mcp=[common],
+        extra_env={
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO": "side-effect-completion-recovery",
+        },
+    )
+    try:
+        _poll_until(lambda: _disk_state(run_dir).get("state") == "done", timeout=20)
+        proc.wait(timeout=5)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+    assert (
+        run_dir.path.parent.parent / "recovery-side-effect.txt"
+    ).read_text(encoding="utf-8") == "side-effect once\n"
+    events = [
+        json.loads(line)
+        for line in run_dir.events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len([
+        event for event in events
+        if event.get("event") == "tool_call" and event.get("name") == "write"
+    ]) == 1
+    assert len([
+        event for event in events
+        if event.get("event") == "tool_call" and event.get("name") == "finish"
+    ]) == 1
+    assert len([
+        event for event in events
+        if event.get("event") == "daemon_completion_recovery"
+    ]) == 1
+
+
+def test_detached_reclaim_during_completion_recovery_cancels_without_done(tmp_path):
+    """Explicit reclaim during recovery wins over a late completion attempt."""
+    from lingtai.kernel.daemon_supervisor import control
+
+    report = tmp_path / "fake-send-report.jsonl"
+    run_dir = _make_run_dir(tmp_path, task="cancel recovery", max_turns=4, timeout_s=60)
+    common = _daemon_common_registration(run_dir)
+    run_dir.update_state(call_parameters={
+        "task": "cancel recovery", "tools": [], "mcp": [common],
+    })
+    proc = _spawn_lingtai_supervisor(
+        run_dir,
+        task="cancel recovery",
+        max_turns=4,
+        timeout_s=60,
+        mcp=[common],
+        extra_env={
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO": "text-only-completion-recovery",
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_RECOVERY_SLEEP": "10",
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_REPORT": str(report),
+        },
+    )
+    try:
+        _poll_until(
+            lambda: report.exists()
+            and len(report.read_text(encoding="utf-8").splitlines()) >= 2,
+            timeout=10,
+        )
+        control.submit_request(run_dir.path, "reclaim", {})
+        _poll_until(lambda: _disk_state(run_dir).get("state") == "cancelled", timeout=15)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+    state = _disk_state(run_dir)
+    assert state["state"] == "cancelled"
+    assert not (run_dir.path / "daemon_completion.json").exists()
+    assert not run_dir.result_path.exists()
+    events = [
+        json.loads(line)
+        for line in run_dir.events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len([
+        event for event in events
+        if event.get("event") == "daemon_completion_recovery"
+    ]) == 1
+    assert all(
+        not (event.get("event") == "tool_call" and event.get("name") == "finish")
+        for event in events
+    )
 
 
 def test_codex_detached_reclaim_kills_exact_own_process_group_only(tmp_path):

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -210,6 +210,69 @@ def _spawn_lingtai_supervisor(
     return proc
 
 
+def _spawn_lingtai_supervisor_via_adapter(
+    run_dir: DaemonRunDir,
+    *,
+    task="say hi",
+    timeout_s=30.0,
+    max_turns=5,
+    tools=None,
+    mcp=None,
+    extra_env=None,
+) -> None:
+    tools = list(tools or [])
+    manifest = build_manifest(
+        run_id=run_dir.run_id,
+        backend="lingtai",
+        parent_working_dir=str(run_dir.path.parent.parent),
+        run_dir=str(run_dir.path),
+        task=task,
+        tools=tools,
+        max_turns=max_turns,
+        timeout_s=timeout_s,
+        group_id=None,
+        llm={
+            "provider": "lingtai-supervisor-test-fake",
+            "model": "fake-model",
+            "api_key": None,
+            "base_url": None,
+            "context_window": None,
+            "provider_defaults": None,
+        },
+        mcp=list(mcp or []),
+    )
+    write_manifest(run_dir.path, manifest)
+    request = DaemonSupervisorRequest(
+        run_id=run_dir.run_id,
+        manifest_path=str(manifest_path_for(run_dir.path)),
+        python_executable=sys.executable,
+    )
+    capsule = {"mcp": list(mcp or [])} if mcp else None
+    tests_dir = str(Path(__file__).parent)
+    repo_src = str(Path(__file__).parent.parent / "src")
+    existing_pp = os.environ.get("PYTHONPATH", "")
+    env_updates = {
+        FAKE_LLM_ENV: "1",
+        "PYTHONPATH": os.pathsep.join(
+            dict.fromkeys(
+                [tests_dir, repo_src]
+                + [p for p in existing_pp.split(os.pathsep) if p]
+            )
+        ),
+        **(extra_env or {}),
+    }
+    old_env = {name: os.environ.get(name) for name in env_updates}
+    try:
+        os.environ.update(env_updates)
+        PosixDaemonSupervisorAdapter().spawn_detached(request, capsule=capsule)
+    finally:
+        for name, value in old_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+
 def test_posix_adapter_spawns_real_detached_process(tmp_path):
     """The production Port/adapter actually launches a real OS process."""
     run_dir = _make_run_dir(tmp_path, task="say hi", timeout_s=30.0)
@@ -686,7 +749,7 @@ def test_detached_lingtai_surface_keeps_one_local_finish_without_external_common
     assert [registration["name"] for registration in connected] == ["parent-docs"]
 
 
-def test_detached_text_only_completion_recovery_uses_real_local_finish_once(tmp_path):
+def test_detached_text_only_completion_recovery_uses_production_adapter_and_real_local_finish_once(tmp_path):
     """Text-only LingTai output gets one same-session recovery and real finish."""
     report = tmp_path / "fake-send-report.jsonl"
     run_dir = _make_run_dir(tmp_path, task="text-only recovery", max_turns=4)
@@ -696,7 +759,7 @@ def test_detached_text_only_completion_recovery_uses_real_local_finish_once(tmp_
     })
     assert not (run_dir.path / "daemon_completion.json").exists()
 
-    proc = _spawn_lingtai_supervisor(
+    _spawn_lingtai_supervisor_via_adapter(
         run_dir,
         task="text-only recovery",
         max_turns=4,
@@ -706,13 +769,7 @@ def test_detached_text_only_completion_recovery_uses_real_local_finish_once(tmp_
             "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_REPORT": str(report),
         },
     )
-    try:
-        _poll_until(lambda: _disk_state(run_dir).get("state") == "done", timeout=20)
-        proc.wait(timeout=5)
-    finally:
-        if proc.poll() is None:
-            proc.terminate()
-            proc.wait(timeout=5)
+    _poll_until(lambda: _disk_state(run_dir).get("state") == "done", timeout=20)
 
     completion = json.loads(
         (run_dir.path / "daemon_completion.json").read_text(encoding="utf-8")
@@ -750,6 +807,16 @@ def test_detached_text_only_completion_recovery_uses_real_local_finish_once(tmp_
     ]
     assert len(recovery_chat) == 1
     assert "Text alone cannot complete this daemon." in recovery_chat[0]["text"]
+    assert [(entry["role"], entry.get("kind")) for entry in chat] == [
+        ("user", "kickoff"),
+        ("assistant", None),
+        ("user", "completion_recovery"),
+        ("assistant", None),
+        ("user", "tool_results"),
+        ("assistant", None),
+    ]
+    assert chat[2]["text"] == recovery_chat[0]["text"]
+    assert "fake-recovery-finish" in chat[4]["text"]
 
     sends = [
         json.loads(line)
@@ -757,6 +824,172 @@ def test_detached_text_only_completion_recovery_uses_real_local_finish_once(tmp_
     ]
     assert [row["send_count"] for row in sends] == [1, 2, 3]
     assert len({row["session_id"] for row in sends}) == 1
+
+
+def test_detached_preexisting_malformed_completion_fails_closed(tmp_path):
+    """A malformed completion artifact cannot satisfy the final gate."""
+    run_dir = _make_run_dir(
+        tmp_path,
+        task="pre-existing malformed completion",
+        max_turns=1,
+    )
+    common = _daemon_common_registration(run_dir)
+    run_dir.update_state(call_parameters={
+        "task": "pre-existing malformed completion", "tools": [], "mcp": [common],
+    })
+    completion_path = run_dir.path / "daemon_completion.json"
+    completion_path.write_text("{malformed", encoding="utf-8")
+
+    _spawn_lingtai_supervisor_via_adapter(
+        run_dir,
+        task="pre-existing malformed completion",
+        max_turns=1,
+        mcp=[common],
+    )
+    _poll_until(lambda: _disk_state(run_dir).get("state") == "failed", timeout=20)
+
+    assert completion_path.read_text(encoding="utf-8") == "{malformed"
+    state = _disk_state(run_dir)
+    assert "invalid completion signal" in state["error"]["message"]
+    assert "fake-response: task complete" in run_dir.result_path.read_text(
+        encoding="utf-8"
+    )
+    events = [
+        json.loads(line)
+        for line in run_dir.events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    contract_failures = [
+        event for event in events
+        if event.get("event") == "daemon_completion_contract_failed"
+    ]
+    assert len(contract_failures) == 1
+    assert "invalid completion signal" in contract_failures[0]["error"]
+    assert not [
+        event for event in events
+        if event.get("event") == "daemon_completion_recovery"
+    ]
+
+
+def test_detached_text_only_completion_recovery_is_one_shot(tmp_path):
+    """A second text-only response after recovery fails without another prompt."""
+    report = tmp_path / "fake-send-report.jsonl"
+    run_dir = _make_run_dir(tmp_path, task="second text-only recovery", max_turns=4)
+    common = _daemon_common_registration(run_dir)
+    run_dir.update_state(call_parameters={
+        "task": "second text-only recovery", "tools": [], "mcp": [common],
+    })
+
+    _spawn_lingtai_supervisor_via_adapter(
+        run_dir,
+        task="second text-only recovery",
+        max_turns=4,
+        mcp=[common],
+        extra_env={
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO": "text-only-recovery-still-text",
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_REPORT": str(report),
+        },
+    )
+    _poll_until(lambda: _disk_state(run_dir).get("state") == "failed", timeout=20)
+
+    assert not (run_dir.path / "daemon_completion.json").exists()
+    assert "Still only text after recovery." in run_dir.result_path.read_text(
+        encoding="utf-8"
+    )
+    events = [
+        json.loads(line)
+        for line in run_dir.events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len([
+        event for event in events
+        if event.get("event") == "daemon_completion_recovery"
+    ]) == 1
+    chat = [
+        json.loads(line)
+        for line in run_dir.chat_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len([
+        entry for entry in chat
+        if entry.get("role") == "user" and entry.get("kind") == "completion_recovery"
+    ]) == 1
+    sends = [
+        json.loads(line)
+        for line in report.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["send_count"] for row in sends] == [1, 2]
+
+
+@pytest.mark.parametrize("status", ["failed", "incomplete"])
+def test_detached_completion_recovery_rejects_non_done_finish_status(tmp_path, status):
+    """Recovery may record truthful non-done completion, but cannot mark done."""
+    run_dir = _make_run_dir(tmp_path, task=f"{status} recovery", max_turns=4)
+    common = _daemon_common_registration(run_dir)
+    run_dir.update_state(call_parameters={
+        "task": f"{status} recovery", "tools": [], "mcp": [common],
+    })
+
+    _spawn_lingtai_supervisor_via_adapter(
+        run_dir,
+        task=f"{status} recovery",
+        max_turns=4,
+        mcp=[common],
+        extra_env={
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO": "completion-recovery-terminal-status",
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_COMPLETION_STATUS": status,
+        },
+    )
+    _poll_until(lambda: _disk_state(run_dir).get("state") == "failed", timeout=20)
+
+    completion = json.loads(
+        (run_dir.path / "daemon_completion.json").read_text(encoding="utf-8")
+    )
+    assert completion["status"] == status
+    assert completion["run_id"] == run_dir.run_id
+    assert completion["reason"] == f"truthful {status}"
+    state = _disk_state(run_dir)
+    assert state["state"] == "failed"
+    assert f"finish status was {status!r}" in state["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    ("max_turns", "expected_state", "expected_recoveries"),
+    [(1, "failed", 0), (2, "done", 1)],
+)
+def test_detached_completion_recovery_respects_max_turn_headroom(
+    tmp_path, max_turns, expected_state, expected_recoveries
+):
+    """Recovery needs one counted turn for the returned finish batch."""
+    run_dir = _make_run_dir(
+        tmp_path,
+        task=f"max-turn recovery {max_turns}",
+        max_turns=max_turns,
+    )
+    common = _daemon_common_registration(run_dir)
+    run_dir.update_state(call_parameters={
+        "task": f"max-turn recovery {max_turns}", "tools": [], "mcp": [common],
+    })
+
+    _spawn_lingtai_supervisor_via_adapter(
+        run_dir,
+        task=f"max-turn recovery {max_turns}",
+        max_turns=max_turns,
+        mcp=[common],
+        extra_env={
+            "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO": "text-only-completion-recovery",
+        },
+    )
+    _poll_until(lambda: _disk_state(run_dir).get("state") == expected_state, timeout=20)
+
+    events = [
+        json.loads(line)
+        for line in run_dir.events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len([
+        event for event in events
+        if event.get("event") == "daemon_completion_recovery"
+    ]) == expected_recoveries
+    assert (run_dir.path / "daemon_completion.json").exists() is (
+        expected_state == "done"
+    )
 
 
 def test_detached_recovery_after_side_effect_does_not_replay_tool(tmp_path):
@@ -773,7 +1006,7 @@ def test_detached_recovery_after_side_effect_does_not_replay_tool(tmp_path):
             "task": "side-effect recovery", "tools": ["file"], "mcp": [common],
         }
     )
-    proc = _spawn_lingtai_supervisor(
+    _spawn_lingtai_supervisor_via_adapter(
         run_dir,
         task="side-effect recovery",
         tools=["file"],
@@ -783,13 +1016,7 @@ def test_detached_recovery_after_side_effect_does_not_replay_tool(tmp_path):
             "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_SCENARIO": "side-effect-completion-recovery",
         },
     )
-    try:
-        _poll_until(lambda: _disk_state(run_dir).get("state") == "done", timeout=20)
-        proc.wait(timeout=5)
-    finally:
-        if proc.poll() is None:
-            proc.terminate()
-            proc.wait(timeout=5)
+    _poll_until(lambda: _disk_state(run_dir).get("state") == "done", timeout=20)
 
     assert (
         run_dir.path.parent.parent / "recovery-side-effect.txt"
@@ -822,7 +1049,7 @@ def test_detached_reclaim_during_completion_recovery_cancels_without_done(tmp_pa
     run_dir.update_state(call_parameters={
         "task": "cancel recovery", "tools": [], "mcp": [common],
     })
-    proc = _spawn_lingtai_supervisor(
+    _spawn_lingtai_supervisor_via_adapter(
         run_dir,
         task="cancel recovery",
         max_turns=4,
@@ -834,18 +1061,13 @@ def test_detached_reclaim_during_completion_recovery_cancels_without_done(tmp_pa
             "LINGTAI_DAEMON_SUPERVISOR_TEST_FAKE_LLM_REPORT": str(report),
         },
     )
-    try:
-        _poll_until(
-            lambda: report.exists()
-            and len(report.read_text(encoding="utf-8").splitlines()) >= 2,
-            timeout=10,
-        )
-        control.submit_request(run_dir.path, "reclaim", {})
-        _poll_until(lambda: _disk_state(run_dir).get("state") == "cancelled", timeout=15)
-    finally:
-        if proc.poll() is None:
-            proc.terminate()
-            proc.wait(timeout=5)
+    _poll_until(
+        lambda: report.exists()
+        and len(report.read_text(encoding="utf-8").splitlines()) >= 2,
+        timeout=10,
+    )
+    control.submit_request(run_dir.path, "reclaim", {})
+    _poll_until(lambda: _disk_state(run_dir).get("state") == "cancelled", timeout=15)
 
     state = _disk_state(run_dir)
     assert state["state"] == "cancelled"


### PR DESCRIPTION
## Summary

- add one bounded same-session recovery when a LingTai daemon returns non-empty text, no tool call, and no valid current-run `daemon_common.finish` record
- preserve the existing strict completion gate: only a validated current-run `finish(status="done")` can mark the daemon done
- preserve failure evidence and existing max-turn/cancellation/explicit `failed` or `incomplete` behavior
- document the recovery event/chat record and add focused regression coverage

## Why

Three observed MiMo daemon runs reached a milestone, emitted a non-empty progress sentence, and returned no tool calls. The LingTai loop therefore left `while response.tool_calls`; the existing strict completion gate then correctly rejected success because no current-run `finish` artifact existed.

The failure gate is doing the right thing. The missing behavior is one bounded opportunity for the same session to continue from its durable state and call the already-required completion tool.

## Behavior

The recovery is eligible only when:

- the response has non-empty text and zero tool calls
- no valid completion status is present
- `daemon_common` is registered for the run
- cancellation is not set
- an ordinary continuation slot remains
- the invocation-local latch has not already been used

The latch is set before the recovery send. The runtime records one `daemon_completion_recovery` event and one `completion_recovery` chat entry, names the current run ID, tells the model not to repeat successful tool calls, and requires exactly one `finish` signal after continuing.

A second text-only response receives no second recovery. Blank text, valid `done`, explicit `failed`/`incomplete`, cancellation, missing `daemon_common`, and turn-ceiling cases keep their existing fail-closed paths. This patch does not grant an unbounded or free turn at the ceiling.

## Validation

Fresh official-main base: `67fbf5aea631f22a0719ec7c26e47638b3a5fc0a`

- 11/11 focused recovery regressions pass, including the two post-review ToolExecutor/max-turn boundary pins
- failing-first check on the unpatched base: 6 new-behavior tests fail and 3 existing-boundary regression pins pass
- daemon contract + architecture-document tests: 7 passed
- focused daemon-family subset: 312 passed
- full `tests/test_daemon*.py tests/test_lifecycle_daemon_shutdown.py tests/test_architecture_documents.py`: **718 passed, 7 skipped** (the skips are native-Windows-only)
- `git diff --check`: pass
- exact scope: five files only

## Evidence boundary

A real MiMo prompt-level harness reproduced text-only output and showed that the recovery prompt can elicit `finish(done)` in the same LLM session. That harness did **not** execute this patched `DaemonManager`, so it is evidence for prompt efficacy, not a full runtime integration proof. Its attempted second-text-only negative case was inconclusive because MiMo called `finish` instead.

Two deterministic post-review tests now exercise the candidate `DaemonManager` and real `ToolExecutor` loop with a fake task-MCP surface: an in-budget recovery-generated `finish` dispatches exactly once without replaying a prior successful tool, while a final-slot recovery tool batch is not dispatched and the existing max-turn failure wins. A proof with a separately started local `daemon_common` MCP process remains valuable follow-up evidence. The raw provider stop/status fields are also not currently persisted, so natural model stop versus a provider/wire-side stop remains unknown; provider observability is intentionally outside this patch.

This PR does not merge or apply the change to a running LingTai runtime.

