### PR TITLE
chore(release): bump kernel to 0.18.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.18.1"
+version = "0.18.2"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the kernel package version from `0.18.1` to `0.18.2`
- prepare the current `main` release window for the authorized complete kernel release

## Scope

Release metadata only: one line in `pyproject.toml`. No runtime behavior, workflow, auth, or configuration change.

## Validation

- `git diff --check`
- parsed `pyproject.toml` with `tomllib`; project version is exactly `0.18.2`
- `PYTHONDONTWRITEBYTECODE=1 python3 tests/test_wheels_workflow_publish_gating.py`

Broader candidate tests/builds run after the reviewable PR is visible, before the public tag/release.
