### PR TITLE
fix(nudge): externalize oversized inline findings

### DIFF
--- a/src/lingtai/CONTRACT.md
+++ b/src/lingtai/CONTRACT.md
@@ -12,11 +12,13 @@ related_files:
   - src/lingtai/agent.py
   - src/lingtai/kernel/workdir.py
   - src/lingtai/kernel/nudge/ANATOMY.md
+  - src/lingtai/kernel/nudge/__init__.py
   - src/lingtai/kernel/nudge/init_config.py
   - src/lingtai/intrinsic_skills/system-manual/reference/environment-variables/SKILL.md
   - tests/test_init_reader.py
   - tests/test_cli.py
   - tests/test_deep_refresh.py
+  - tests/test_nudge_inline_cap.py
 maintenance: |
   Keep related_files complete and repo-relative: the paired ANATOMY.md, the
   canonical init.jsonc, real reader/writer/validator code, affected composition
@@ -100,6 +102,28 @@ constructs a migration workspace, or performs a second notification path.
    `LINGTAI_NUDGE_ENABLED` / `LINGTAI_NUDGE_REPEAT_INTERVAL` policy. The goal
    reminder is explicitly a separate protected-goal system notification, not a
    declared Nudge kind, and is therefore not part of Nudge dispatch/docs.
+7. Every declared Nudge kind is additionally bound by the shared
+   `nudge.upsert` hard inline cap: the fully assembled entry (producer body
+   plus `kind` and the policy fields from rule 6) may be at most
+   `INLINE_MAX_CHARS=10_000` characters on the wire. A finding that would
+   exceed this — including the init/config-shape finding's
+   `effective_outcome` payload on a large or non-canonical `init.json` — is
+   never truncated and never left inline oversized; the complete original is
+   persisted verbatim to a content-addressed, owner-only sidecar file under
+   `<working_dir>/tmp/nudge-findings/` (the ordinary agent temp namespace,
+   consistent with `tmp/tool-results/` — not `.notification/`), and the wire
+   entry is replaced with a compact summary carrying the sidecar's absolute
+   path, exact character/byte counts, and a SHA-256 of the exact persisted
+   bytes. `kind` is validated against a bounded filesystem-safe shape before
+   any file naming. Externalization is fail-loud: if `kind` is invalid or the
+   sidecar write does not durably succeed, `upsert` raises
+   `NudgeExternalizationError` (a bounded static message that never echoes
+   producer content) instead of writing any compact placeholder, and does
+   not mutate `.notification/nudge.json` or `.notification/.nudge_state.json`
+   at all — both are left completely untouched for a later heartbeat retry.
+   This is a Nudge-transport concern, not an `init_reader` concern: no
+   producer, including `nudge/init_config.py`, individually re-implements
+   truncation, externalization, or kind validation.
 
 ## Contract tests
 
@@ -108,6 +132,16 @@ outcomes, ignored-path reporting, structured parse/validation failure evidence,
 secret-redacted effective-manifest use, and the no-auto-mutation invariant.
 Focused Nudge tests prove defaults, invalid-value fallback, self-describing
 messages, global suppression, and dismiss/repeat semantics.
+`tests/test_nudge_inline_cap.py` proves the exact 10,000/10,001-char boundary,
+Unicode character-vs-byte counting, exact sidecar content/hash/path/
+permissions under `tmp/nudge-findings/`, directory-permission enforcement even
+when the directory pre-existed with looser permissions, stable
+content-addressed reuse across repeated upserts of the same finding, no
+cap-bookkeeping leakage into an ordinary uncapped entry, fail-loud
+`NudgeExternalizationError` (bounded message, no mutation of either
+`.notification/nudge.json` or `.notification/.nudge_state.json`) both when
+the sidecar write fails and when `kind` is oversized or escape-heavy, and
+dismissal/repeat semantics for a capped finding.
 
 ## Maintenance
 

--- a/src/lingtai/kernel/nudge/ANATOMY.md
+++ b/src/lingtai/kernel/nudge/ANATOMY.md
@@ -11,6 +11,7 @@ related_files:
   - src/lingtai/kernel/nudge/prompts.py
   - src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
   - src/lingtai/kernel/notifications.py
+  - src/lingtai/kernel/workdir.py
   - src/lingtai/CONTRACT.md
   - tests/test_nudge_prompts.py
   - tests/test_kernel_version_nudge.py
@@ -33,9 +34,23 @@ the ordinary Notification Store channel; it does not create a second transport.
 - `__init__.py` — `run_checks`, `upsert`, `remove`, `effective_policy`, and
   `record_dismissal` provide the shared policy, finding identity, dismissal mute,
   and `.notification/nudge.json` mutation (`src/lingtai/kernel/nudge/__init__.py:1-360`).
+  `upsert` also enforces the hard `INLINE_MAX_CHARS=10_000` inline-payload cap
+  via `_cap_inline_payload`: at or below the cap the assembled entry (producer
+  body plus shared policy fields and `kind`) is unchanged; above it, the full
+  entry is written verbatim to a content-addressed sidecar file under
+  `WorkdirLayout.nudge_findings_dir` (an ordinary agent temp path,
+  `<working_dir>/tmp/nudge-findings/`) and the wire entry is replaced with a
+  compact summary plus the sidecar's absolute path, exact char/byte counts,
+  and SHA-256. `kind` is validated against a bounded filesystem-safe pattern
+  before any file naming; an invalid `kind` or a sidecar write that does not
+  durably succeed raises `NudgeExternalizationError` (bounded static message,
+  never producer content) instead of ever persisting the oversized body or a
+  compact placeholder — `upsert` calls this before its `.notification/nudge.json`
+  mutation, so a raise leaves prior notification state untouched for retry on
+  a later heartbeat (`src/lingtai/kernel/nudge/__init__.py:295-488`).
 - `init_config.py` — consumes the last structured real-reader outcome and
   publishes/clears the typed configuration-shape finding; it never reads
-  `init.json` independently (`src/lingtai/kernel/nudge/init_config.py:1-80`).
+  `init.json` independently (`src/lingtai/kernel/nudge/init_config.py:1-74`).
 - `kernel_version.py` — read-only installed/running observation plus bounded
   GitHub/Gitee release-manifest comparison; it does not own a product repeat
   cadence (`src/lingtai/kernel/nudge/kernel_version.py:91-229`).
@@ -76,6 +91,18 @@ bounded implementation cost only; global enabled/repeat values are product
 semantics. Goal source state remains protected `.notification/goal.json` and its
 reminder remains in `system.json`.
 
+Findings that exceed `INLINE_MAX_CHARS` also persist their complete original
+body to `<working_dir>/tmp/nudge-findings/<kind>-<sha256>.json`
+(`WorkdirLayout.nudge_findings_dir`, `src/lingtai/kernel/workdir.py`) — the
+ordinary agent temp namespace, not `.notification/`, matching the existing
+`tmp/tool-results/` spill convention exactly. Owner-only (`0o700` dir, `0o600`
+file) is (re-)enforced on every write, including when the directory
+pre-existed with looser permissions, and the write is atomic
+sibling-temp-then-replace. The filename is content-addressed by the SHA-256
+of the exact persisted UTF-8 bytes, so re-upserting the same finding on a
+later heartbeat reuses the file instead of writing a new one every cycle.
+These sidecar files are local to one agent run and are not auto-cleaned.
+
 ## Notes
 
 Every emitted entry includes the effective `LINGTAI_NUDGE_ENABLED` and
@@ -93,3 +120,28 @@ artifact-hash digest must agree before an update version is considered. A local
 mismatch recommends refresh only when the installed PEP 440 version is
 semantically newer than the running version; reverse, invalid, and unknown pairs
 remain local diagnostics for interpreter/import-path inspection.
+
+Dismissal-fingerprint identity is computed once in `upsert`, before capping,
+from the full pre-cap entry facts (`title`/`detail`/`source`/etc.), then
+stamped onto a capped entry as `_dismiss_fingerprint` so `record_dismissal`
+recovers the same identity from the persisted compact shape rather than
+re-deriving it from the rewritten compact `title`/`detail`. An uncapped small
+entry never carries `_dismiss_fingerprint` — the wire shape for the common
+case is unchanged from before the cap existed.
+
+Externalization is fail-loud, not fail-open: an invalid `kind` (bounded
+filesystem-safe pattern, checked before any file naming) or a sidecar write
+that does not durably succeed raises `NudgeExternalizationError` from inside
+`upsert`, before either persistent side effect of a successful upsert runs —
+its `.notification/nudge.json` mutation and its `.notification/.nudge_state.json`
+dismissal-clear (`_clear_dismissal`) both happen only after externalization
+has completed (or determined no externalization is needed). The oversized
+body is never persisted inline as a fallback, and no compact placeholder with
+a null path is written either — prior state in both files is left completely
+untouched so a later heartbeat can retry. The exception message is a bounded
+static string; it never includes the producer's `kind`, title, detail, or any
+finding content, so a caller that logs `str(exc)` cannot leak the oversized
+body or an escape-heavy `kind`. `run_checks`' existing per-producer
+`_run_one` try/except already catches, bounds (`str(e)[:200]`), and logs any
+producer exception, so this raise surfaces as the existing
+`nudge_check_error` diagnostic rather than crashing the heartbeat.

--- a/src/lingtai/kernel/nudge/__init__.py
+++ b/src/lingtai/kernel/nudge/__init__.py
@@ -51,6 +51,30 @@ ENABLED_ENV = "LINGTAI_NUDGE_ENABLED"
 REPEAT_INTERVAL_ENV = "LINGTAI_NUDGE_REPEAT_INTERVAL"
 ENVIRONMENT_MANUAL = "system-manual/reference/environment-variables/SKILL.md"
 
+# Hard maximum for one nudge entry's inline, model-visible JSON serialization.
+# Entries at or below this size are unchanged; entries above it are
+# externalized to a sidecar file under the agent's working directory and
+# replaced on the wire by a compact summary (see `_cap_inline_payload`).
+INLINE_MAX_CHARS = 10_000
+
+# Bounded shape a `kind` must satisfy before it can participate in
+# externalization filename construction. Current built-in kinds
+# ("kernel_version", "source_drift", "init_config_shape", …) are short
+# identifiers well within this bound; only a pathological/programming-error
+# `kind` would ever trip it.
+_MAX_KIND_LEN = 100
+_KIND_RE = re.compile(r"^[A-Za-z0-9_.-]{1,%d}$" % _MAX_KIND_LEN)
+
+
+class NudgeExternalizationError(RuntimeError):
+    """Raised when an oversized finding cannot be safely externalized.
+
+    Carries a bounded, static message only — never the producer's `kind`,
+    title, detail, or any oversized payload content — so a caller that logs
+    ``str(exc)`` cannot leak the finding body or an escape-heavy producer
+    string.
+    """
+
 
 @dataclass(frozen=True, slots=True)
 class NudgePolicy:
@@ -150,6 +174,8 @@ __all__ = [
     "DEFAULT_REPEAT_INTERVAL_SECONDS",
     "ENABLED_ENV",
     "ENVIRONMENT_MANUAL",
+    "INLINE_MAX_CHARS",
+    "NudgeExternalizationError",
     "NudgePolicy",
     "REPEAT_INTERVAL_ENV",
     "effective_policy",
@@ -207,14 +233,23 @@ def upsert(agent, kind: str, body: dict) -> None:
         return
 
     entry = dict(body)
+    entry["kind"] = kind
     entry["policy"] = policy.payload()
     entry["policy_message"] = policy.message()
     entry["detail"] = (
         f"{entry.get('detail', '')}\n\n{policy.message()}".strip()
     )
+    # Fingerprint identity is computed on the full pre-cap entry so dismissal
+    # muting is a property of the finding's facts, not of whether the wire
+    # copy happened to be externalized this heartbeat.
     fingerprint = _finding_fingerprint(kind, entry)
     if _dismissed_until(agent, fingerprint) > time.time():
         return
+    # Externalization must complete (or return the entry unchanged) before
+    # ANY state mutates. If it raises, neither `.notification/nudge.json`
+    # nor `.notification/.nudge_state.json` may be touched, so a later
+    # heartbeat retry sees byte-for-byte the same prior state.
+    entry = _cap_inline_payload(agent, kind, entry, fingerprint=fingerprint)
     _clear_dismissal(agent, fingerprint)
     _modify(agent, lambda entries: _replace_kind(entries, kind, entry))
 
@@ -266,7 +301,20 @@ _STATE_FILE = Path(".notification") / ".nudge_state.json"
 
 
 def _finding_fingerprint(kind: str, body: dict) -> str:
-    """Hash stable finding facts, excluding policy display bookkeeping."""
+    """Hash stable finding facts, excluding policy display bookkeeping.
+
+    When an entry carries a stamped ``_dismiss_fingerprint`` (written by
+    :func:`upsert` before inline-cap externalization may rewrite ``title``/
+    ``detail``/``source``), that stamped value is authoritative — it is the
+    fingerprint of the complete original finding. This keeps dismissal
+    identity a property of the finding's facts, not of the persisted
+    (possibly capped) wire shape, so a capped finding's dismiss/repeat
+    semantics stay correct whether recomputed at upsert time or read back
+    from a persisted compact entry.
+    """
+    stamped = body.get("_dismiss_fingerprint")
+    if isinstance(stamped, str) and stamped:
+        return stamped
     stable = {
         "kind": kind,
         "title": body.get("title"),
@@ -279,6 +327,189 @@ def _finding_fingerprint(kind: str, body: dict) -> str:
     }
     raw = json.dumps(stable, ensure_ascii=False, sort_keys=True, default=str)
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _entry_inline_chars(entry: dict) -> tuple[str, int]:
+    """Return the canonical wire serialization and its character count.
+
+    This is the exact JSON text that would be persisted into
+    ``.notification/nudge.json`` for this one entry, measured *after* the
+    shared policy fields (``policy``, ``policy_message``, policy-appended
+    ``detail``) are already present — so cap enforcement sees what a reader
+    actually receives, not the producer's raw pre-policy body.
+    """
+    text = json.dumps(entry, ensure_ascii=False, sort_keys=True, default=str)
+    return text, len(text)
+
+
+def _findings_dir(agent) -> Path | None:
+    working_dir = getattr(agent, "_working_dir", None)
+    if working_dir is None:
+        return None
+    from .. import workdir
+
+    return workdir.workdir_layout(Path(working_dir)).nudge_findings_dir
+
+
+def _write_sidecar_atomic(target: Path, text: str) -> None:
+    """Write ``text`` to a sibling temp file and atomically replace ``target``.
+
+    Narrow, private I/O seam so a test can inject a write failure without
+    manipulating real filesystem permissions (which production's own
+    directory-permission repair, ``os.chmod(findings_dir, 0o700)``, would
+    otherwise undo before the write is attempted).
+
+    The temp file is created owner-only (``0o600``) from the moment it is
+    opened — via ``os.open`` with an explicit ``mode``, not ``open()`` at the
+    process umask followed by a later ``chmod`` — so the oversized finding
+    body is never briefly readable at a broader mode. Content is written as
+    exact UTF-8 bytes and flushed/fsynced before the atomic ``os.replace``,
+    so a crash between write and replace cannot leave a target that looks
+    complete but is actually truncated.
+
+    On any failure the caller is responsible for translating the raised
+    ``OSError`` into a bounded ``NudgeExternalizationError``; this helper
+    itself never logs or otherwise persists ``text``. No temp-file cleanup is
+    performed here — a failed write's partial temp file, already owner-only,
+    is left on disk as forensic evidence rather than being deleted.
+    """
+    tmp = target.with_name(f".{target.name}.{os.getpid()}.tmp")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(text)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(str(tmp), str(target))
+
+
+def _cap_inline_payload(agent, kind: str, entry: dict, *, fingerprint: str) -> dict:
+    """Enforce the hard inline-payload cap for one fully-assembled entry.
+
+    At or below :data:`INLINE_MAX_CHARS`, ``entry`` is returned completely
+    unchanged — no ``_dismiss_fingerprint`` or other cap bookkeeping is
+    added, so the ordinary small-finding wire shape is byte-for-byte the
+    same as before this cap existed.
+
+    Above the cap, the complete original entry (including policy fields) is
+    persisted verbatim as UTF-8 JSON to a content-addressed sidecar file
+    under ``<working_dir>/tmp/nudge-findings/`` (an ordinary agent temp
+    location, consistent with ``tmp/tool-results/``), and this function
+    returns a small compact entry: a bounded ``title``, a short bounded
+    ``detail``, the policy fields (so policy display stays intact), and an
+    ``externalized`` block naming the absolute file path, its exact
+    character/byte counts, and its SHA-256. The caller (``upsert``) stamps
+    ``kind`` back onto whatever this returns via ``_replace_kind``.
+
+    Content addressing (filename = ``sha256(bytes)``) means an unchanged
+    finding does not create a new sidecar file every heartbeat — the same
+    bytes hash to the same path and the write is a cheap no-op check.
+
+    Fail LOUD, not fail-open: if ``kind`` is not a bounded, filesystem-safe
+    identifier, or the sidecar write does not durably succeed, this raises
+    :class:`NudgeExternalizationError` with a bounded static message. The
+    caller (``upsert``) has not yet mutated ``.notification/nudge.json`` at
+    the point this is called, so a raise here leaves prior notification
+    state completely untouched for a later heartbeat retry. The oversized
+    body is never persisted inline as a fallback.
+    """
+    if not _KIND_RE.match(kind):
+        raise NudgeExternalizationError(
+            "nudge finding kind failed bounded validation "
+            f"(must match {_KIND_RE.pattern!r}); refusing to externalize or "
+            "persist this finding"
+        )
+
+    text, char_count = _entry_inline_chars(entry)
+    if char_count <= INLINE_MAX_CHARS:
+        return entry
+
+    raw_bytes = text.encode("utf-8")
+    digest = hashlib.sha256(raw_bytes).hexdigest()
+    byte_count = len(raw_bytes)
+
+    findings_dir = _findings_dir(agent)
+    if findings_dir is None:
+        raise NudgeExternalizationError(
+            "no working_dir configured; cannot durably externalize an "
+            "oversized nudge finding"
+        )
+
+    target = findings_dir / f"{kind}-{digest}.json"
+    if not target.is_file():
+        try:
+            findings_dir.mkdir(parents=True, exist_ok=True)
+            # Always enforce owner-only, even when the directory pre-existed
+            # with looser permissions (e.g. created before this cap existed,
+            # or by an external process) — a sidecar containing the full
+            # oversized finding must never be group/world-readable.
+            os.chmod(findings_dir, 0o700)
+            _write_sidecar_atomic(target, text)
+        except OSError as exc:
+            raise NudgeExternalizationError(
+                f"failed to durably write nudge finding sidecar file: "
+                f"{type(exc).__name__}"
+            ) from exc
+
+    # Bound every field sourced from producer-controlled text (title, source)
+    # so a pathological producer value cannot itself blow the compact entry
+    # past the cap; the fixed-shape fields below (policy, sha256, counts) are
+    # small by construction.
+    title = str(entry.get("title") or kind)[:200]
+    source = entry.get("source")
+    if isinstance(source, str):
+        source = source[:200]
+    file_path = str(target)
+    compact: dict[str, Any] = {
+        "kind": kind,
+        "title": title,
+        "source": source,
+        "policy": entry.get("policy"),
+        "policy_message": entry.get("policy_message"),
+        # Stamped only on the capped/compact shape, never on an ordinary
+        # unchanged small entry, so `record_dismissal` can recover the exact
+        # pre-cap fingerprint later without recomputing it from the
+        # (necessarily different) compact title/detail/source.
+        "_dismiss_fingerprint": fingerprint,
+        "externalized": {
+            "reason": (
+                f"Full finding is {char_count} chars, over the "
+                f"{INLINE_MAX_CHARS}-char inline Nudge cap."
+            ),
+            "path": file_path,
+            "original_char_count": char_count,
+            "original_byte_count": byte_count,
+            "sha256": digest,
+        },
+        "detail": (
+            f"{title} — full finding exceeds the {INLINE_MAX_CHARS}-char inline "
+            f"cap ({char_count} chars). The complete original is at {file_path} "
+            f"(SHA-256 {digest}); read that file directly for full detail."
+        ),
+    }
+
+    # Defensive: even the bounded fields above could combine to exceed the
+    # cap in a degenerate case. Shrink detail/title first — this is
+    # defence-in-depth, not a routine path, so a small bounded loop suffices.
+    for _ in range(4):
+        _, compact_chars = _entry_inline_chars(compact)
+        if compact_chars <= INLINE_MAX_CHARS:
+            break
+        if len(compact.get("detail", "")) > 100:
+            compact["detail"] = compact["detail"][:100] + "…"
+        elif len(compact.get("title", "")) > 50:
+            compact["title"] = compact["title"][:50] + "…"
+        else:
+            break
+
+    _safe_log(
+        agent,
+        "nudge_finding_externalized",
+        kind=kind,
+        original_char_count=char_count,
+        cap_chars=INLINE_MAX_CHARS,
+        sha256=digest,
+    )
+    return compact
 
 
 def _state_path(agent) -> Path | None:

--- a/src/lingtai/kernel/workdir.py
+++ b/src/lingtai/kernel/workdir.py
@@ -39,8 +39,9 @@ class WorkdirLayout:
     (agent-presence adapters/policy, ``notifications.validate_allowed_channel``, …).
     The point is a single discoverable surface for the agent workdir
     filesystem protocol (``.agent.json``, ``.agent.heartbeat``,
-    ``.notification/<channel>.json``, ``tmp/tool-results/``, …) so the same
-    relative names are not retyped across runtime modules and tests.
+    ``.notification/<channel>.json``, ``tmp/tool-results/``,
+    ``tmp/nudge-findings/``, …) so the same relative names are not retyped
+    across runtime modules and tests.
 
     Internal by convention: import from ``lingtai.kernel.workdir``; not
     re-exported from ``lingtai.kernel.__init__``.
@@ -95,6 +96,10 @@ class WorkdirLayout:
     @property
     def tool_results_dir(self) -> Path:
         return self.root / "tmp" / "tool-results"
+
+    @property
+    def nudge_findings_dir(self) -> Path:
+        return self.root / "tmp" / "nudge-findings"
 
     @property
     def resolved_manifest(self) -> Path:

--- a/tests/test_nudge_inline_cap.py
+++ b/tests/test_nudge_inline_cap.py
@@ -1,0 +1,476 @@
+"""Regression tests for the hard 10,000-char inline Nudge payload cap.
+
+Product contract (2026-07-24 forward fix after v0.18.2, repaired 2026-07-24):
+
+1. Nudge's inline model-visible payload has a hard maximum of 10,000 chars.
+2. At or below 10,000 chars, existing inline behavior is unchanged.
+3. Above 10,000 chars, the full original payload is externalized to an
+   agent-readable file under ``<working_dir>/tmp/nudge-findings/`` (the
+   ordinary agent temp namespace, consistent with ``tmp/tool-results/``);
+   the persisted ``.notification/nudge.json`` entry carries only a compact
+   summary plus the original character count, an absolute usable file path,
+   and a SHA-256.
+4. Failure to durably externalize never falls back to persisting the
+   oversized body inline. It fails LOUD: ``upsert`` raises
+   ``NudgeExternalizationError`` (a bounded static message, never the
+   producer body or an escape-heavy kind) and does not mutate
+   ``.notification/nudge.json`` at all, leaving prior state untouched for a
+   later heartbeat retry.
+5. A pathological (oversized or escape-heavy) ``kind`` is rejected before
+   any file naming or persistence, with the same fail-loud, bounded-message,
+   state-untouched behavior.
+6. The sidecar directory is always owner-only (0700) after ``upsert``
+   returns, even if it pre-existed with looser permissions.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from lingtai.kernel.nudge import (
+    INLINE_MAX_CHARS,
+    NudgeExternalizationError,
+    effective_policy,
+    record_dismissal,
+    upsert,
+)
+from lingtai.kernel.notifications import dismiss_channel
+from lingtai.kernel.workdir import workdir_layout
+from tests._notification_store_helpers import notification_store_for, snapshot_notifications
+
+
+class _Agent:
+    def __init__(self, workdir):
+        self._working_dir = workdir
+        self._notification_store = notification_store_for(workdir)
+        self._notification_fp = ()
+        self.logs = []
+
+    def _log(self, event, **fields):
+        self.logs.append((event, fields))
+
+
+def _entry(workdir):
+    payload = snapshot_notifications(workdir).get("nudge", {})
+    entries = payload.get("data", {}).get("nudges", [])
+    assert len(entries) == 1
+    return entries[0]
+
+
+def _entry_chars(entry: dict) -> int:
+    return len(json.dumps(entry, ensure_ascii=False, sort_keys=True, default=str))
+
+
+def _pre_cap_chars(kind: str, title: str, detail: str, source: str) -> int:
+    """Chars of the fully-assembled entry BEFORE cap enforcement — matches
+    the exact quantity `upsert`/`_cap_inline_payload` compare against
+    INLINE_MAX_CHARS (kind + policy fields added, cap not yet applied)."""
+    policy = effective_policy()
+    entry = {
+        "kind": kind,
+        "title": title,
+        "detail": f"{detail}\n\n{policy.message()}".strip(),
+        "source": source,
+        "policy": policy.payload(),
+        "policy_message": policy.message(),
+    }
+    return len(json.dumps(entry, ensure_ascii=False, sort_keys=True, default=str))
+
+
+def test_entry_at_exactly_10000_chars_is_not_externalized(tmp_path):
+    agent = _Agent(tmp_path)
+    # Binary-search the detail length so the fully assembled PRE-CAP entry
+    # (post-policy-fields, before cap enforcement) lands at exactly
+    # INLINE_MAX_CHARS chars — the exact quantity the cap compares against.
+    lo, hi = 0, INLINE_MAX_CHARS
+    best_len = 0
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        chars = _pre_cap_chars("boundary", "t", "x" * mid, "s")
+        if chars <= INLINE_MAX_CHARS:
+            best_len = mid
+            lo = mid + 1
+        else:
+            hi = mid - 1
+
+    assert _pre_cap_chars("boundary", "t", "x" * best_len, "s") == INLINE_MAX_CHARS
+
+    upsert(agent, "boundary", {"title": "t", "detail": "x" * best_len, "source": "s"})
+    entry = _entry(tmp_path)
+    assert _entry_chars(entry) == INLINE_MAX_CHARS
+    assert "externalized" not in entry
+    assert entry["detail"].startswith("x")
+    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+    assert not findings_dir.exists()
+
+
+def test_entry_at_10001_chars_is_externalized(tmp_path):
+    agent = _Agent(tmp_path)
+    lo, hi = 0, INLINE_MAX_CHARS
+    best_len = 0
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        chars = _pre_cap_chars("boundary2", "t", "x" * mid, "s")
+        if chars <= INLINE_MAX_CHARS:
+            best_len = mid
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    over_len = best_len + 1
+    assert _pre_cap_chars("boundary2", "t", "x" * over_len, "s") == INLINE_MAX_CHARS + 1
+
+    upsert(agent, "boundary2", {"title": "t", "detail": "x" * over_len, "source": "s"})
+    entry = _entry(tmp_path)
+    assert "externalized" in entry
+    assert entry["externalized"]["original_char_count"] == INLINE_MAX_CHARS + 1
+    assert _entry_chars(entry) <= INLINE_MAX_CHARS
+
+
+def test_entry_over_10000_chars_is_externalized_with_full_content_preserved(tmp_path):
+    agent = _Agent(tmp_path)
+    big_detail = "y" * 50_000
+    upsert(agent, "oversized", {"title": "Oversized finding", "detail": big_detail, "source": "producer"})
+
+    entry = _entry(tmp_path)
+    assert _entry_chars(entry) <= INLINE_MAX_CHARS
+    assert "externalized" in entry
+    ext = entry["externalized"]
+    assert ext["path"] is not None
+    assert ext["original_char_count"] > INLINE_MAX_CHARS
+    assert "error" not in ext
+
+    # The persisted compact entry must not leak the oversized body anywhere.
+    persisted_text = json.dumps(entry, ensure_ascii=False, default=str)
+    assert big_detail not in persisted_text
+
+    # The sidecar file is directly readable and contains the FULL original,
+    # including the pre-cap detail text — nothing lost, not truncated.
+    sidecar_path = ext["path"]
+    full_text = open(sidecar_path, encoding="utf-8").read()
+    full = json.loads(full_text)
+    assert full["detail"].startswith(big_detail)
+    assert full["title"] == "Oversized finding"
+
+    # Exact character count and SHA-256 of exact persisted UTF-8 bytes.
+    assert ext["original_char_count"] == len(full_text)
+    raw_bytes = full_text.encode("utf-8")
+    assert ext["original_byte_count"] == len(raw_bytes)
+    assert ext["sha256"] == hashlib.sha256(raw_bytes).hexdigest()
+
+
+def test_unicode_multibyte_chars_use_character_count_not_byte_count(tmp_path):
+    agent = _Agent(tmp_path)
+    # Each CJK char is 1 Python `str` character but 3 UTF-8 bytes, so a
+    # detail of ~9000 chars stays *under* the char cap while its UTF-8 byte
+    # count would be ~27000 — proving the cap counts characters, not bytes.
+    detail = "中" * 9000
+    upsert(agent, "unicode-small", {"title": "t", "detail": detail, "source": "s"})
+    entry = _entry(tmp_path)
+    assert "externalized" not in entry
+    assert entry["detail"].startswith("中")
+
+    # Now push the character count itself over the cap.
+    big_detail = "中" * 20_000
+    upsert(agent, "unicode-big", {"title": "t2", "detail": big_detail, "source": "s"})
+    entries = snapshot_notifications(tmp_path)["nudge"]["data"]["nudges"]
+    big_entry = next(e for e in entries if e["kind"] == "unicode-big")
+    assert "externalized" in big_entry
+    ext = big_entry["externalized"]
+    sidecar_text = open(ext["path"], encoding="utf-8").read()
+    full = json.loads(sidecar_text)
+    assert full["detail"].startswith(big_detail)
+    # Char count in the manifest is Python str length, byte count is UTF-8.
+    assert ext["original_char_count"] == len(sidecar_text)
+    assert ext["original_byte_count"] == len(sidecar_text.encode("utf-8"))
+    assert ext["original_byte_count"] > ext["original_char_count"]
+
+
+def test_sidecar_file_permissions_are_owner_only(tmp_path):
+    agent = _Agent(tmp_path)
+    upsert(agent, "perm-check", {"title": "t", "detail": "z" * 20_000, "source": "s"})
+    entry = _entry(tmp_path)
+    sidecar_path = Path(entry["externalized"]["path"])
+    file_mode = stat.S_IMODE(sidecar_path.stat().st_mode)
+    assert file_mode == 0o600
+
+    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+    dir_mode = stat.S_IMODE(findings_dir.stat().st_mode)
+    assert dir_mode == 0o700
+
+
+def test_stable_content_addressed_reuse_same_finding_no_new_file_each_heartbeat(tmp_path):
+    agent = _Agent(tmp_path)
+    body = {"title": "Repeated finding", "detail": "w" * 20_000, "source": "producer"}
+
+    upsert(agent, "repeated", dict(body))
+    entry1 = _entry(tmp_path)
+    path1 = entry1["externalized"]["path"]
+    sha1 = entry1["externalized"]["sha256"]
+
+    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+    files_after_first = sorted(findings_dir.iterdir())
+    assert len(files_after_first) == 1
+
+    # Simulate the next heartbeat re-upserting the SAME finding facts.
+    upsert(agent, "repeated", dict(body))
+    entry2 = _entry(tmp_path)
+    assert entry2["externalized"]["path"] == path1
+    assert entry2["externalized"]["sha256"] == sha1
+
+    files_after_second = sorted(findings_dir.iterdir())
+    assert files_after_second == files_after_first, "same finding must not create a new sidecar file"
+
+
+def test_different_findings_get_distinct_content_addressed_files(tmp_path):
+    agent = _Agent(tmp_path)
+    upsert(agent, "kind-a", {"title": "A", "detail": "a" * 20_000, "source": "s"})
+    upsert(agent, "kind-b", {"title": "B", "detail": "b" * 20_000, "source": "s"})
+
+    entries = snapshot_notifications(tmp_path)["nudge"]["data"]["nudges"]
+    paths = {e["kind"]: e["externalized"]["path"] for e in entries}
+    assert paths["kind-a"] != paths["kind-b"]
+
+    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+    assert len(list(findings_dir.iterdir())) == 2
+
+
+def test_externalization_failure_raises_and_leaves_notification_state_unchanged(tmp_path, monkeypatch):
+    agent = _Agent(tmp_path)
+
+    # Seed a prior, unrelated small finding so there is real persisted
+    # notification state to prove untouched byte-for-byte after the failure.
+    upsert(agent, "prior-finding", {"title": "Prior", "detail": "unrelated", "source": "s"})
+
+    # Also seed an EXPIRED dismissal record for the exact finding that is
+    # about to fail to externalize. `_dismissed_until(...) > time.time()` is
+    # False for an expired record, so `upsert` proceeds past the mute guard
+    # and reaches `_clear_dismissal` — exactly the internal step whose
+    # ordering relative to `_cap_inline_payload` this test protects. If
+    # `_clear_dismissal` ran BEFORE externalization (the pre-fix ordering),
+    # this record would be popped even though the upsert ultimately raises;
+    # with the fix, a raised `NudgeExternalizationError` must leave it
+    # completely untouched.
+    from lingtai.kernel import nudge as nudge_module
+
+    kind = "fails-to-write"
+    big_detail = "q" * 30_000
+    # Must match exactly what `upsert` builds before fingerprinting: the
+    # producer detail with the policy message appended, not the raw detail.
+    policy_for_probe = effective_policy()
+    probe_entry = {
+        "kind": kind,
+        "title": "t",
+        "detail": f"{big_detail}\n\n{policy_for_probe.message()}".strip(),
+        "source": "s",
+    }
+    fingerprint = nudge_module._finding_fingerprint(kind, probe_entry)
+    state_path = tmp_path / ".notification" / ".nudge_state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    seeded_state = {
+        "dismissed": {
+            fingerprint: {
+                "kind": kind,
+                "dismissed_at": 1.0,
+                "until": 2.0,  # far in the past — expired, so the mute guard does not short-circuit
+            }
+        }
+    }
+    state_path.write_text(json.dumps(seeded_state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    before_notification_raw = notification_store_for(tmp_path).snapshot(lambda _c: True)
+    before_state_raw = state_path.read_bytes()
+
+    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+
+    # Inject the write failure through the narrow private I/O seam instead of
+    # real directory permissions: production's own directory-permission
+    # repair (`os.chmod(findings_dir, 0o700)` in `_cap_inline_payload`) would
+    # otherwise re-loosen a chmodded-read-only directory before the write is
+    # even attempted, making a permission-based injection unreliable.
+    def _raise_injected(target, text):
+        raise OSError("injected")
+
+    monkeypatch.setattr(nudge_module, "_write_sidecar_atomic", _raise_injected)
+
+    with pytest.raises(NudgeExternalizationError) as excinfo:
+        upsert(agent, kind, {"title": "t", "detail": big_detail, "source": "s"})
+
+    # Bounded, static message: no oversized body, no producer-controlled
+    # text (title/detail/source) leaked into the exception.
+    message = str(excinfo.value)
+    assert len(message) < 300
+    assert big_detail not in message
+    assert "t" != message  # sanity: not accidentally the raw title
+    assert kind not in message  # kind itself not required in message
+
+    # `.notification/nudge.json` (and every other channel) must be
+    # byte-for-byte identical to before the failed upsert — no partial
+    # write, no compact-with-path=None fallback, nothing persisted.
+    after_notification_raw = notification_store_for(tmp_path).snapshot(lambda _c: True)
+    assert after_notification_raw == before_notification_raw
+
+    # `.notification/.nudge_state.json` (the dismissal-mute state) must
+    # ALSO be byte-for-byte identical — `_clear_dismissal` must not have
+    # run, since it now only runs after externalization succeeds.
+    after_state_raw = state_path.read_bytes()
+    assert after_state_raw == before_state_raw
+
+    # No FINAL content-addressed sidecar file exists for the failed finding
+    # — the injected helper raised before any bytes were written, so there
+    # is nothing at the content-addressed target path to read back.
+    if findings_dir.exists():
+        assert list(findings_dir.glob(f"{kind}-*.json")) == []
+
+
+def test_ordinary_small_nudge_behavior_is_unchanged(tmp_path):
+    agent = _Agent(tmp_path)
+    upsert(agent, "small", {"title": "Small finding", "detail": "short detail", "source": "producer"})
+    entry = _entry(tmp_path)
+    assert entry["title"] == "Small finding"
+    assert "short detail" in entry["detail"]
+    assert "externalized" not in entry
+    assert entry["kind"] == "small"
+    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+    assert not findings_dir.exists()
+
+
+def test_dismissal_mutes_capped_finding_using_stable_fingerprint(tmp_path, monkeypatch):
+    agent = _Agent(tmp_path)
+    monkeypatch.setenv("LINGTAI_NUDGE_REPEAT_INTERVAL", "0.001s")
+    body = {"title": "Capped finding", "detail": "r" * 30_000, "source": "s"}
+
+    upsert(agent, "capped-dismiss", dict(body))
+    entry = _entry(tmp_path)
+    assert "externalized" in entry
+
+    result = dismiss_channel(agent, "nudge", invoked_by="notification", force=True)
+    assert result["status"] == "ok"
+    assert snapshot_notifications(tmp_path).get("nudge", {}) in ({}, None) or \
+        snapshot_notifications(tmp_path)["nudge"].get("data", {}).get("nudges") in (None, [])
+
+    # Dismissal is mute: re-upserting the SAME finding must not recreate it
+    # immediately, exactly as for an ordinary (non-capped) finding.
+    upsert(agent, "capped-dismiss", dict(body))
+    entries = snapshot_notifications(tmp_path).get("nudge", {}).get("data", {}).get("nudges", [])
+    assert entries == []
+
+    import time
+    time.sleep(0.01)
+    upsert(agent, "capped-dismiss", dict(body))
+    entries = snapshot_notifications(tmp_path).get("nudge", {}).get("data", {}).get("nudges", [])
+    assert len(entries) == 1
+
+
+def test_no_dismiss_fingerprint_sentinel_leaks_into_persisted_meta_visible_payload(tmp_path):
+    agent = _Agent(tmp_path)
+    upsert(agent, "small-fp", {"title": "t", "detail": "short", "source": "s"})
+    entry = _entry(tmp_path)
+    # The internal bookkeeping fingerprint field must never reach the
+    # model/meta-visible persisted payload for an ordinary small finding.
+    assert "_dismiss_fingerprint" not in entry
+
+
+def test_record_dismissal_reads_capped_entry_without_crashing(tmp_path):
+    agent = _Agent(tmp_path)
+    upsert(agent, "capped-record", {"title": "t", "detail": "s" * 30_000, "source": "s"})
+    # record_dismissal is called by notifications.dismiss_channel before it
+    # clears the channel; call it directly to prove it tolerates a capped
+    # (compact) persisted entry shape.
+    record_dismissal(agent)
+
+
+def test_oversized_kind_raises_and_leaves_state_untouched_and_writes_no_sidecar(tmp_path):
+    agent = _Agent(tmp_path)
+    upsert(agent, "prior", {"title": "Prior", "detail": "unrelated", "source": "s"})
+    before = notification_store_for(tmp_path).snapshot(lambda _c: True)
+
+    pathological_kind = "k" * 5000
+    with pytest.raises(NudgeExternalizationError) as excinfo:
+        upsert(agent, pathological_kind, {"title": "t", "detail": "d" * 20_000, "source": "s"})
+
+    message = str(excinfo.value)
+    assert len(message) < 300
+    assert pathological_kind not in message
+
+    after = notification_store_for(tmp_path).snapshot(lambda _c: True)
+    assert after == before
+
+    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+    assert not findings_dir.exists() or list(findings_dir.iterdir()) == []
+
+
+def test_escape_heavy_kind_raises_and_leaves_state_untouched_and_writes_no_sidecar(tmp_path):
+    agent = _Agent(tmp_path)
+    upsert(agent, "prior2", {"title": "Prior", "detail": "unrelated", "source": "s"})
+    before = notification_store_for(tmp_path).snapshot(lambda _c: True)
+
+    escape_heavy_kind = "../../../etc/passwd\x00\n\r;rm -rf /"
+    with pytest.raises(NudgeExternalizationError) as excinfo:
+        upsert(agent, escape_heavy_kind, {"title": "t", "detail": "d" * 20_000, "source": "s"})
+
+    message = str(excinfo.value)
+    assert len(message) < 300
+    assert escape_heavy_kind not in message
+    assert "/etc/passwd" not in message
+    assert "rm -rf" not in message
+
+    after = notification_store_for(tmp_path).snapshot(lambda _c: True)
+    assert after == before
+
+    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+    assert not findings_dir.exists() or list(findings_dir.iterdir()) == []
+
+
+def test_short_escape_heavy_kind_also_raises_even_when_finding_is_small(tmp_path):
+    # Kind validation happens before the size check, so even a SMALL finding
+    # body with a malformed kind is rejected rather than silently accepted.
+    agent = _Agent(tmp_path)
+    before = notification_store_for(tmp_path).snapshot(lambda _c: True)
+    with pytest.raises(NudgeExternalizationError):
+        upsert(agent, "bad kind!", {"title": "t", "detail": "short", "source": "s"})
+    after = notification_store_for(tmp_path).snapshot(lambda _c: True)
+    assert after == before
+
+
+def test_builtin_kind_shapes_remain_valid(tmp_path):
+    # Current short built-in kinds must be unaffected by the new validation.
+    agent = _Agent(tmp_path)
+    for kind in ("kernel_version", "source_drift", "init_config_shape"):
+        upsert(agent, kind, {"title": "t", "detail": "short detail", "source": "s"})
+    entries = snapshot_notifications(tmp_path)["nudge"]["data"]["nudges"]
+    assert {e["kind"] for e in entries} == {"kernel_version", "source_drift", "init_config_shape"}
+
+
+def test_findings_dir_permissions_enforced_even_when_preexisting_and_loose(tmp_path):
+    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+    findings_dir.mkdir(parents=True)
+    # Simulate a directory that pre-existed with looser permissions (e.g.
+    # created before this cap existed, or by an external process).
+    findings_dir.chmod(0o755)
+    assert stat.S_IMODE(findings_dir.stat().st_mode) == 0o755
+
+    agent = _Agent(tmp_path)
+    upsert(agent, "loose-dir", {"title": "t", "detail": "z" * 20_000, "source": "s"})
+
+    # After upsert, the directory must be owner-only regardless of the
+    # looser permissions it started with.
+    assert stat.S_IMODE(findings_dir.stat().st_mode) == 0o700
+    entry = _entry(tmp_path)
+    sidecar_path = Path(entry["externalized"]["path"])
+    assert stat.S_IMODE(sidecar_path.stat().st_mode) == 0o600
+
+
+def test_sidecar_path_is_under_tmp_nudge_findings_not_notification_dir(tmp_path):
+    agent = _Agent(tmp_path)
+    upsert(agent, "path-shape", {"title": "t", "detail": "v" * 20_000, "source": "s"})
+    entry = _entry(tmp_path)
+    sidecar_path = Path(entry["externalized"]["path"])
+    assert sidecar_path.is_absolute()
+    assert sidecar_path.is_file()
+    relative = sidecar_path.relative_to(Path(tmp_path))
+    assert relative.parts[:2] == ("tmp", "nudge-findings")
+    assert ".notification" not in relative.parts

--- a/tests/test_nudge_inline_cap.py
+++ b/tests/test_nudge_inline_cap.py
@@ -1,32 +1,18 @@
 """Regression tests for the hard 10,000-char inline Nudge payload cap.
 
-Product contract (2026-07-24 forward fix after v0.18.2, repaired 2026-07-24):
-
-1. Nudge's inline model-visible payload has a hard maximum of 10,000 chars.
-2. At or below 10,000 chars, existing inline behavior is unchanged.
-3. Above 10,000 chars, the full original payload is externalized to an
-   agent-readable file under ``<working_dir>/tmp/nudge-findings/`` (the
-   ordinary agent temp namespace, consistent with ``tmp/tool-results/``);
-   the persisted ``.notification/nudge.json`` entry carries only a compact
-   summary plus the original character count, an absolute usable file path,
-   and a SHA-256.
-4. Failure to durably externalize never falls back to persisting the
-   oversized body inline. It fails LOUD: ``upsert`` raises
-   ``NudgeExternalizationError`` (a bounded static message, never the
-   producer body or an escape-heavy kind) and does not mutate
-   ``.notification/nudge.json`` at all, leaving prior state untouched for a
-   later heartbeat retry.
-5. A pathological (oversized or escape-heavy) ``kind`` is rejected before
-   any file naming or persistence, with the same fail-loud, bounded-message,
-   state-untouched behavior.
-6. The sidecar directory is always owner-only (0700) after ``upsert``
-   returns, even if it pre-existed with looser permissions.
+Contract: inline model-visible Nudge payload is capped at INLINE_MAX_CHARS;
+above it, the full body is externalized to a content-addressed file under
+``<working_dir>/tmp/nudge-findings/`` and the persisted entry carries only a
+summary, char/byte counts, path and SHA-256. Externalization failure is
+fail-loud (``NudgeExternalizationError``, bounded message) and must never
+partially persist or fall back to inline. See ``lingtai.kernel.nudge``.
 """
 from __future__ import annotations
 
 import hashlib
 import json
 import stat
+import time
 from pathlib import Path
 
 import pytest
@@ -54,21 +40,25 @@ class _Agent:
         self.logs.append((event, fields))
 
 
-def _entry(workdir):
+def _entry(workdir, kind=None):
     payload = snapshot_notifications(workdir).get("nudge", {})
     entries = payload.get("data", {}).get("nudges", [])
-    assert len(entries) == 1
-    return entries[0]
+    if kind is None:
+        assert len(entries) == 1
+        return entries[0]
+    return next(e for e in entries if e["kind"] == kind)
 
 
 def _entry_chars(entry: dict) -> int:
     return len(json.dumps(entry, ensure_ascii=False, sort_keys=True, default=str))
 
 
+def _findings_dir(workdir) -> Path:
+    return workdir_layout(workdir).nudge_findings_dir
+
+
 def _pre_cap_chars(kind: str, title: str, detail: str, source: str) -> int:
-    """Chars of the fully-assembled entry BEFORE cap enforcement — matches
-    the exact quantity `upsert`/`_cap_inline_payload` compare against
-    INLINE_MAX_CHARS (kind + policy fields added, cap not yet applied)."""
+    """Chars of the assembled entry before cap enforcement (what upsert compares to INLINE_MAX_CHARS)."""
     policy = effective_policy()
     entry = {
         "kind": kind,
@@ -81,58 +71,51 @@ def _pre_cap_chars(kind: str, title: str, detail: str, source: str) -> int:
     return len(json.dumps(entry, ensure_ascii=False, sort_keys=True, default=str))
 
 
-def test_entry_at_exactly_10000_chars_is_not_externalized(tmp_path):
-    agent = _Agent(tmp_path)
-    # Binary-search the detail length so the fully assembled PRE-CAP entry
-    # (post-policy-fields, before cap enforcement) lands at exactly
-    # INLINE_MAX_CHARS chars — the exact quantity the cap compares against.
-    lo, hi = 0, INLINE_MAX_CHARS
+def _detail_len_for_pre_cap_chars(kind: str, target_chars: int) -> int:
+    """Binary-search a detail length landing the pre-cap entry at exactly target_chars."""
+    lo, hi = 0, target_chars
     best_len = 0
     while lo <= hi:
         mid = (lo + hi) // 2
-        chars = _pre_cap_chars("boundary", "t", "x" * mid, "s")
-        if chars <= INLINE_MAX_CHARS:
+        chars = _pre_cap_chars(kind, "t", "x" * mid, "s")
+        if chars <= target_chars:
             best_len = mid
             lo = mid + 1
         else:
             hi = mid - 1
+    assert _pre_cap_chars(kind, "t", "x" * best_len, "s") == target_chars
+    return best_len
 
-    assert _pre_cap_chars("boundary", "t", "x" * best_len, "s") == INLINE_MAX_CHARS
 
-    upsert(agent, "boundary", {"title": "t", "detail": "x" * best_len, "source": "s"})
-    entry = _entry(tmp_path)
+def test_entry_at_10000_chars_inline_boundary_vs_10001_externalized(tmp_path):
+    agent = _Agent(tmp_path)
+
+    at_cap_len = _detail_len_for_pre_cap_chars("boundary", INLINE_MAX_CHARS)
+    upsert(agent, "boundary", {"title": "t", "detail": "x" * at_cap_len, "source": "s"})
+    entry = _entry(tmp_path, "boundary")
     assert _entry_chars(entry) == INLINE_MAX_CHARS
     assert "externalized" not in entry
     assert entry["detail"].startswith("x")
-    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
-    assert not findings_dir.exists()
+    assert not _findings_dir(tmp_path).exists()
+
+    over_cap_len = _detail_len_for_pre_cap_chars("boundary2", INLINE_MAX_CHARS) + 1
+    assert _pre_cap_chars("boundary2", "t", "x" * over_cap_len, "s") == INLINE_MAX_CHARS + 1
+    upsert(agent, "boundary2", {"title": "t", "detail": "x" * over_cap_len, "source": "s"})
+    entry2 = _entry(tmp_path, "boundary2")
+    assert "externalized" in entry2
+    assert entry2["externalized"]["original_char_count"] == INLINE_MAX_CHARS + 1
+    assert _entry_chars(entry2) <= INLINE_MAX_CHARS
 
 
-def test_entry_at_10001_chars_is_externalized(tmp_path):
+@pytest.mark.parametrize(
+    "label, detail_char, byte_count_exceeds_char_count",
+    [("ascii", "y", False), ("unicode", "中", True)],
+)
+def test_externalization_preserves_full_content_and_metadata(
+    tmp_path, label, detail_char, byte_count_exceeds_char_count
+):
     agent = _Agent(tmp_path)
-    lo, hi = 0, INLINE_MAX_CHARS
-    best_len = 0
-    while lo <= hi:
-        mid = (lo + hi) // 2
-        chars = _pre_cap_chars("boundary2", "t", "x" * mid, "s")
-        if chars <= INLINE_MAX_CHARS:
-            best_len = mid
-            lo = mid + 1
-        else:
-            hi = mid - 1
-    over_len = best_len + 1
-    assert _pre_cap_chars("boundary2", "t", "x" * over_len, "s") == INLINE_MAX_CHARS + 1
-
-    upsert(agent, "boundary2", {"title": "t", "detail": "x" * over_len, "source": "s"})
-    entry = _entry(tmp_path)
-    assert "externalized" in entry
-    assert entry["externalized"]["original_char_count"] == INLINE_MAX_CHARS + 1
-    assert _entry_chars(entry) <= INLINE_MAX_CHARS
-
-
-def test_entry_over_10000_chars_is_externalized_with_full_content_preserved(tmp_path):
-    agent = _Agent(tmp_path)
-    big_detail = "y" * 50_000
+    big_detail = detail_char * 20_000
     upsert(agent, "oversized", {"title": "Oversized finding", "detail": big_detail, "source": "producer"})
 
     entry = _entry(tmp_path)
@@ -143,123 +126,78 @@ def test_entry_over_10000_chars_is_externalized_with_full_content_preserved(tmp_
     assert ext["original_char_count"] > INLINE_MAX_CHARS
     assert "error" not in ext
 
-    # The persisted compact entry must not leak the oversized body anywhere.
     persisted_text = json.dumps(entry, ensure_ascii=False, default=str)
     assert big_detail not in persisted_text
 
-    # The sidecar file is directly readable and contains the FULL original,
-    # including the pre-cap detail text — nothing lost, not truncated.
-    sidecar_path = ext["path"]
-    full_text = open(sidecar_path, encoding="utf-8").read()
+    sidecar_path = Path(ext["path"])
+    assert sidecar_path.is_absolute()
+    assert sidecar_path.is_file()
+    relative = sidecar_path.relative_to(Path(tmp_path))
+    assert relative.parts[:2] == ("tmp", "nudge-findings")
+    assert ".notification" not in relative.parts
+
+    full_text = sidecar_path.read_text(encoding="utf-8")
     full = json.loads(full_text)
     assert full["detail"].startswith(big_detail)
     assert full["title"] == "Oversized finding"
 
-    # Exact character count and SHA-256 of exact persisted UTF-8 bytes.
-    assert ext["original_char_count"] == len(full_text)
     raw_bytes = full_text.encode("utf-8")
+    assert ext["original_char_count"] == len(full_text)
     assert ext["original_byte_count"] == len(raw_bytes)
     assert ext["sha256"] == hashlib.sha256(raw_bytes).hexdigest()
+    assert (ext["original_byte_count"] > ext["original_char_count"]) == byte_count_exceeds_char_count
 
 
-def test_unicode_multibyte_chars_use_character_count_not_byte_count(tmp_path):
+def test_content_addressed_reuse_and_distinct_files(tmp_path):
     agent = _Agent(tmp_path)
-    # Each CJK char is 1 Python `str` character but 3 UTF-8 bytes, so a
-    # detail of ~9000 chars stays *under* the char cap while its UTF-8 byte
-    # count would be ~27000 — proving the cap counts characters, not bytes.
-    detail = "中" * 9000
-    upsert(agent, "unicode-small", {"title": "t", "detail": detail, "source": "s"})
-    entry = _entry(tmp_path)
-    assert "externalized" not in entry
-    assert entry["detail"].startswith("中")
+    findings_dir = _findings_dir(tmp_path)
 
-    # Now push the character count itself over the cap.
-    big_detail = "中" * 20_000
-    upsert(agent, "unicode-big", {"title": "t2", "detail": big_detail, "source": "s"})
-    entries = snapshot_notifications(tmp_path)["nudge"]["data"]["nudges"]
-    big_entry = next(e for e in entries if e["kind"] == "unicode-big")
-    assert "externalized" in big_entry
-    ext = big_entry["externalized"]
-    sidecar_text = open(ext["path"], encoding="utf-8").read()
-    full = json.loads(sidecar_text)
-    assert full["detail"].startswith(big_detail)
-    # Char count in the manifest is Python str length, byte count is UTF-8.
-    assert ext["original_char_count"] == len(sidecar_text)
-    assert ext["original_byte_count"] == len(sidecar_text.encode("utf-8"))
-    assert ext["original_byte_count"] > ext["original_char_count"]
-
-
-def test_sidecar_file_permissions_are_owner_only(tmp_path):
-    agent = _Agent(tmp_path)
-    upsert(agent, "perm-check", {"title": "t", "detail": "z" * 20_000, "source": "s"})
-    entry = _entry(tmp_path)
-    sidecar_path = Path(entry["externalized"]["path"])
-    file_mode = stat.S_IMODE(sidecar_path.stat().st_mode)
-    assert file_mode == 0o600
-
-    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
-    dir_mode = stat.S_IMODE(findings_dir.stat().st_mode)
-    assert dir_mode == 0o700
-
-
-def test_stable_content_addressed_reuse_same_finding_no_new_file_each_heartbeat(tmp_path):
-    agent = _Agent(tmp_path)
     body = {"title": "Repeated finding", "detail": "w" * 20_000, "source": "producer"}
-
     upsert(agent, "repeated", dict(body))
-    entry1 = _entry(tmp_path)
+    entry1 = _entry(tmp_path, "repeated")
     path1 = entry1["externalized"]["path"]
     sha1 = entry1["externalized"]["sha256"]
-
-    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
     files_after_first = sorted(findings_dir.iterdir())
     assert len(files_after_first) == 1
 
-    # Simulate the next heartbeat re-upserting the SAME finding facts.
     upsert(agent, "repeated", dict(body))
-    entry2 = _entry(tmp_path)
+    entry2 = _entry(tmp_path, "repeated")
     assert entry2["externalized"]["path"] == path1
     assert entry2["externalized"]["sha256"] == sha1
+    assert sorted(findings_dir.iterdir()) == files_after_first, \
+        "same finding must not create a new sidecar file"
 
-    files_after_second = sorted(findings_dir.iterdir())
-    assert files_after_second == files_after_first, "same finding must not create a new sidecar file"
-
-
-def test_different_findings_get_distinct_content_addressed_files(tmp_path):
-    agent = _Agent(tmp_path)
-    upsert(agent, "kind-a", {"title": "A", "detail": "a" * 20_000, "source": "s"})
-    upsert(agent, "kind-b", {"title": "B", "detail": "b" * 20_000, "source": "s"})
-
-    entries = snapshot_notifications(tmp_path)["nudge"]["data"]["nudges"]
-    paths = {e["kind"]: e["externalized"]["path"] for e in entries}
-    assert paths["kind-a"] != paths["kind-b"]
-
-    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+    upsert(agent, "distinct", {"title": "B", "detail": "b" * 20_000, "source": "s"})
+    entry3 = _entry(tmp_path, "distinct")
+    assert entry3["externalized"]["path"] != path1
     assert len(list(findings_dir.iterdir())) == 2
+
+
+def test_sidecar_and_dir_permissions_owner_only_including_preexisting_loose_dir(tmp_path):
+    findings_dir = _findings_dir(tmp_path)
+
+    # Pre-existing looser-permission dir must be re-tightened, not just newly-created dirs.
+    findings_dir.mkdir(parents=True)
+    findings_dir.chmod(0o755)
+    assert stat.S_IMODE(findings_dir.stat().st_mode) == 0o755
+
+    agent = _Agent(tmp_path)
+    upsert(agent, "loose-dir", {"title": "t", "detail": "z" * 20_000, "source": "s"})
+
+    assert stat.S_IMODE(findings_dir.stat().st_mode) == 0o700
+    entry = _entry(tmp_path)
+    sidecar_path = Path(entry["externalized"]["path"])
+    assert stat.S_IMODE(sidecar_path.stat().st_mode) == 0o600
 
 
 def test_externalization_failure_raises_and_leaves_notification_state_unchanged(tmp_path, monkeypatch):
     agent = _Agent(tmp_path)
-
-    # Seed a prior, unrelated small finding so there is real persisted
-    # notification state to prove untouched byte-for-byte after the failure.
     upsert(agent, "prior-finding", {"title": "Prior", "detail": "unrelated", "source": "s"})
 
-    # Also seed an EXPIRED dismissal record for the exact finding that is
-    # about to fail to externalize. `_dismissed_until(...) > time.time()` is
-    # False for an expired record, so `upsert` proceeds past the mute guard
-    # and reaches `_clear_dismissal` — exactly the internal step whose
-    # ordering relative to `_cap_inline_payload` this test protects. If
-    # `_clear_dismissal` ran BEFORE externalization (the pre-fix ordering),
-    # this record would be popped even though the upsert ultimately raises;
-    # with the fix, a raised `NudgeExternalizationError` must leave it
-    # completely untouched.
     from lingtai.kernel import nudge as nudge_module
 
     kind = "fails-to-write"
     big_detail = "q" * 30_000
-    # Must match exactly what `upsert` builds before fingerprinting: the
-    # producer detail with the policy message appended, not the raw detail.
     policy_for_probe = effective_policy()
     probe_entry = {
         "kind": kind,
@@ -270,27 +208,21 @@ def test_externalization_failure_raises_and_leaves_notification_state_unchanged(
     fingerprint = nudge_module._finding_fingerprint(kind, probe_entry)
     state_path = tmp_path / ".notification" / ".nudge_state.json"
     state_path.parent.mkdir(parents=True, exist_ok=True)
+    # Expired dismissal (until in the past) lets upsert pass the mute guard and
+    # reach _clear_dismissal — proving that step now runs only AFTER a successful
+    # externalization, not before, so a raised error leaves it untouched.
     seeded_state = {
-        "dismissed": {
-            fingerprint: {
-                "kind": kind,
-                "dismissed_at": 1.0,
-                "until": 2.0,  # far in the past — expired, so the mute guard does not short-circuit
-            }
-        }
+        "dismissed": {fingerprint: {"kind": kind, "dismissed_at": 1.0, "until": 2.0}}
     }
     state_path.write_text(json.dumps(seeded_state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     before_notification_raw = notification_store_for(tmp_path).snapshot(lambda _c: True)
     before_state_raw = state_path.read_bytes()
+    findings_dir = _findings_dir(tmp_path)
 
-    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
-
-    # Inject the write failure through the narrow private I/O seam instead of
-    # real directory permissions: production's own directory-permission
-    # repair (`os.chmod(findings_dir, 0o700)` in `_cap_inline_payload`) would
-    # otherwise re-loosen a chmodded-read-only directory before the write is
-    # even attempted, making a permission-based injection unreliable.
+    # Inject failure via the private write seam: production's own chmod(0o700)
+    # repair would re-loosen a chmodded-read-only dir before the write is even
+    # attempted, so a permissions-based injection would be unreliable here.
     def _raise_injected(target, text):
         raise OSError("injected")
 
@@ -299,29 +231,17 @@ def test_externalization_failure_raises_and_leaves_notification_state_unchanged(
     with pytest.raises(NudgeExternalizationError) as excinfo:
         upsert(agent, kind, {"title": "t", "detail": big_detail, "source": "s"})
 
-    # Bounded, static message: no oversized body, no producer-controlled
-    # text (title/detail/source) leaked into the exception.
     message = str(excinfo.value)
     assert len(message) < 300
     assert big_detail not in message
-    assert "t" != message  # sanity: not accidentally the raw title
-    assert kind not in message  # kind itself not required in message
+    assert "t" != message
+    assert kind not in message
 
-    # `.notification/nudge.json` (and every other channel) must be
-    # byte-for-byte identical to before the failed upsert — no partial
-    # write, no compact-with-path=None fallback, nothing persisted.
     after_notification_raw = notification_store_for(tmp_path).snapshot(lambda _c: True)
     assert after_notification_raw == before_notification_raw
-
-    # `.notification/.nudge_state.json` (the dismissal-mute state) must
-    # ALSO be byte-for-byte identical — `_clear_dismissal` must not have
-    # run, since it now only runs after externalization succeeds.
     after_state_raw = state_path.read_bytes()
     assert after_state_raw == before_state_raw
 
-    # No FINAL content-addressed sidecar file exists for the failed finding
-    # — the injected helper raised before any bytes were written, so there
-    # is nothing at the content-addressed target path to read back.
     if findings_dir.exists():
         assert list(findings_dir.glob(f"{kind}-*.json")) == []
 
@@ -334,11 +254,18 @@ def test_ordinary_small_nudge_behavior_is_unchanged(tmp_path):
     assert "short detail" in entry["detail"]
     assert "externalized" not in entry
     assert entry["kind"] == "small"
-    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
-    assert not findings_dir.exists()
+    assert not _findings_dir(tmp_path).exists()
+    # Internal bookkeeping field must never leak into the persisted payload.
+    assert "_dismiss_fingerprint" not in entry
+
+    # Current short built-in kinds are unaffected by the new validation.
+    for kind in ("kernel_version", "source_drift", "init_config_shape"):
+        upsert(agent, kind, {"title": "t", "detail": "short detail", "source": "s"})
+    entries = snapshot_notifications(tmp_path)["nudge"]["data"]["nudges"]
+    assert {e["kind"] for e in entries} >= {"small", "kernel_version", "source_drift", "init_config_shape"}
 
 
-def test_dismissal_mutes_capped_finding_using_stable_fingerprint(tmp_path, monkeypatch):
+def test_dismissal_round_trip_for_capped_finding(tmp_path, monkeypatch):
     agent = _Agent(tmp_path)
     monkeypatch.setenv("LINGTAI_NUDGE_REPEAT_INTERVAL", "0.001s")
     body = {"title": "Capped finding", "detail": "r" * 30_000, "source": "s"}
@@ -347,130 +274,52 @@ def test_dismissal_mutes_capped_finding_using_stable_fingerprint(tmp_path, monke
     entry = _entry(tmp_path)
     assert "externalized" in entry
 
+    # Prove record_dismissal tolerates a capped (compact) persisted entry shape.
+    record_dismissal(agent)
+
     result = dismiss_channel(agent, "nudge", invoked_by="notification", force=True)
     assert result["status"] == "ok"
     assert snapshot_notifications(tmp_path).get("nudge", {}) in ({}, None) or \
         snapshot_notifications(tmp_path)["nudge"].get("data", {}).get("nudges") in (None, [])
 
-    # Dismissal is mute: re-upserting the SAME finding must not recreate it
-    # immediately, exactly as for an ordinary (non-capped) finding.
     upsert(agent, "capped-dismiss", dict(body))
     entries = snapshot_notifications(tmp_path).get("nudge", {}).get("data", {}).get("nudges", [])
     assert entries == []
 
-    import time
     time.sleep(0.01)
     upsert(agent, "capped-dismiss", dict(body))
     entries = snapshot_notifications(tmp_path).get("nudge", {}).get("data", {}).get("nudges", [])
     assert len(entries) == 1
 
 
-def test_no_dismiss_fingerprint_sentinel_leaks_into_persisted_meta_visible_payload(tmp_path):
-    agent = _Agent(tmp_path)
-    upsert(agent, "small-fp", {"title": "t", "detail": "short", "source": "s"})
-    entry = _entry(tmp_path)
-    # The internal bookkeeping fingerprint field must never reach the
-    # model/meta-visible persisted payload for an ordinary small finding.
-    assert "_dismiss_fingerprint" not in entry
-
-
-def test_record_dismissal_reads_capped_entry_without_crashing(tmp_path):
-    agent = _Agent(tmp_path)
-    upsert(agent, "capped-record", {"title": "t", "detail": "s" * 30_000, "source": "s"})
-    # record_dismissal is called by notifications.dismiss_channel before it
-    # clears the channel; call it directly to prove it tolerates a capped
-    # (compact) persisted entry shape.
-    record_dismissal(agent)
-
-
-def test_oversized_kind_raises_and_leaves_state_untouched_and_writes_no_sidecar(tmp_path):
+@pytest.mark.parametrize(
+    "label, kind, forbidden_substrings",
+    [
+        ("oversized", "k" * 5000, ["k" * 5000]),
+        (
+            "escape-heavy",
+            "../../../etc/passwd\x00\n\r;rm -rf /",
+            ["../../../etc/passwd\x00\n\r;rm -rf /", "/etc/passwd", "rm -rf"],
+        ),
+        ("short-but-malformed", "bad kind!", ["bad kind!"]),
+    ],
+)
+def test_invalid_producer_kind_families_are_rejected(tmp_path, label, kind, forbidden_substrings):
+    # Kind validation happens before size checks and any persistence, so even a
+    # small body with a malformed kind gets the same fail-loud/state-untouched behavior.
     agent = _Agent(tmp_path)
     upsert(agent, "prior", {"title": "Prior", "detail": "unrelated", "source": "s"})
     before = notification_store_for(tmp_path).snapshot(lambda _c: True)
 
-    pathological_kind = "k" * 5000
     with pytest.raises(NudgeExternalizationError) as excinfo:
-        upsert(agent, pathological_kind, {"title": "t", "detail": "d" * 20_000, "source": "s"})
+        upsert(agent, kind, {"title": "t", "detail": "d" * 20_000, "source": "s"})
 
     message = str(excinfo.value)
     assert len(message) < 300
-    assert pathological_kind not in message
+    for forbidden in forbidden_substrings:
+        assert forbidden not in message
 
     after = notification_store_for(tmp_path).snapshot(lambda _c: True)
     assert after == before
-
-    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
+    findings_dir = _findings_dir(tmp_path)
     assert not findings_dir.exists() or list(findings_dir.iterdir()) == []
-
-
-def test_escape_heavy_kind_raises_and_leaves_state_untouched_and_writes_no_sidecar(tmp_path):
-    agent = _Agent(tmp_path)
-    upsert(agent, "prior2", {"title": "Prior", "detail": "unrelated", "source": "s"})
-    before = notification_store_for(tmp_path).snapshot(lambda _c: True)
-
-    escape_heavy_kind = "../../../etc/passwd\x00\n\r;rm -rf /"
-    with pytest.raises(NudgeExternalizationError) as excinfo:
-        upsert(agent, escape_heavy_kind, {"title": "t", "detail": "d" * 20_000, "source": "s"})
-
-    message = str(excinfo.value)
-    assert len(message) < 300
-    assert escape_heavy_kind not in message
-    assert "/etc/passwd" not in message
-    assert "rm -rf" not in message
-
-    after = notification_store_for(tmp_path).snapshot(lambda _c: True)
-    assert after == before
-
-    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
-    assert not findings_dir.exists() or list(findings_dir.iterdir()) == []
-
-
-def test_short_escape_heavy_kind_also_raises_even_when_finding_is_small(tmp_path):
-    # Kind validation happens before the size check, so even a SMALL finding
-    # body with a malformed kind is rejected rather than silently accepted.
-    agent = _Agent(tmp_path)
-    before = notification_store_for(tmp_path).snapshot(lambda _c: True)
-    with pytest.raises(NudgeExternalizationError):
-        upsert(agent, "bad kind!", {"title": "t", "detail": "short", "source": "s"})
-    after = notification_store_for(tmp_path).snapshot(lambda _c: True)
-    assert after == before
-
-
-def test_builtin_kind_shapes_remain_valid(tmp_path):
-    # Current short built-in kinds must be unaffected by the new validation.
-    agent = _Agent(tmp_path)
-    for kind in ("kernel_version", "source_drift", "init_config_shape"):
-        upsert(agent, kind, {"title": "t", "detail": "short detail", "source": "s"})
-    entries = snapshot_notifications(tmp_path)["nudge"]["data"]["nudges"]
-    assert {e["kind"] for e in entries} == {"kernel_version", "source_drift", "init_config_shape"}
-
-
-def test_findings_dir_permissions_enforced_even_when_preexisting_and_loose(tmp_path):
-    findings_dir = workdir_layout(tmp_path).nudge_findings_dir
-    findings_dir.mkdir(parents=True)
-    # Simulate a directory that pre-existed with looser permissions (e.g.
-    # created before this cap existed, or by an external process).
-    findings_dir.chmod(0o755)
-    assert stat.S_IMODE(findings_dir.stat().st_mode) == 0o755
-
-    agent = _Agent(tmp_path)
-    upsert(agent, "loose-dir", {"title": "t", "detail": "z" * 20_000, "source": "s"})
-
-    # After upsert, the directory must be owner-only regardless of the
-    # looser permissions it started with.
-    assert stat.S_IMODE(findings_dir.stat().st_mode) == 0o700
-    entry = _entry(tmp_path)
-    sidecar_path = Path(entry["externalized"]["path"])
-    assert stat.S_IMODE(sidecar_path.stat().st_mode) == 0o600
-
-
-def test_sidecar_path_is_under_tmp_nudge_findings_not_notification_dir(tmp_path):
-    agent = _Agent(tmp_path)
-    upsert(agent, "path-shape", {"title": "t", "detail": "v" * 20_000, "source": "s"})
-    entry = _entry(tmp_path)
-    sidecar_path = Path(entry["externalized"]["path"])
-    assert sidecar_path.is_absolute()
-    assert sidecar_path.is_file()
-    relative = sidecar_path.relative_to(Path(tmp_path))
-    assert relative.parts[:2] == ("tmp", "nudge-findings")
-    assert ".notification" not in relative.parts


### PR DESCRIPTION
## What changed

- keep Nudge findings at or below 10,000 characters inline unchanged
- externalize larger complete findings to an owner-only, content-addressed file under the agent workdir
- retain only bounded metadata inline: summary, original character/byte counts, path, and SHA-256
- fail before notification or dismissal-state mutation if externalization cannot be completed
- validate producer kinds so the 10,000-character inline ceiling cannot be bypassed by pathological input
- document the runtime contract and ownership flow
- consolidate the new pytest surface around distinct failure invariants instead of one test per example

## Why

Oversized diagnostic payloads could be persisted into `.notification/nudge.json` and then replayed through tool-result `_meta` on every turn. A redacted effective-config finding demonstrated roughly 24k new cache-miss tokens per turn. The full body must remain recoverable without remaining inline in notification/history surfaces.

## Validation at current head

- current head: `6185c76b128e21e4d6f58428139262801f94b430`
- focused Nudge/workdir/contract/architecture gate: `108 passed`
- anatomy drift check: `0 across 52 files`
- `git diff --check`: pass
- new test file reduced from 476 lines / 18 top-level tests to 325 lines / 8 top-level tests (13 executed cases via parameterization); unrelated old Nudge coverage was not deleted
- production candidate at `9b5f8d73` received independent Claude Opus 4.8 APPROVE/no blockers; the later commit is test-only and was parent diff/test validated

## Scope

No release, version, workflow, installer, PyPI, daemon-reclaim, psyche, or system-prompt-threshold changes. The requested rendered-system-prompt `>45% context window` warning is intentionally deferred to the next standalone kernel PR. This PR is open for review; it is **not authorized to merge**.
