### PR TITLE
fix(notification): preserve concurrent daemon terminal wakes

### DIFF
--- a/src/lingtai/adapters/notification_store_lock.py
+++ b/src/lingtai/adapters/notification_store_lock.py
@@ -1,0 +1,28 @@
+"""Platform selector for Notification Store mutation serialization."""
+
+from __future__ import annotations
+
+import os
+
+from lingtai.kernel.notification_store._mutation_lock import (
+    NotificationMutationLockPort,
+)
+
+
+def select_notification_store_lock() -> NotificationMutationLockPort:
+    """Return the native cross-process lock for this platform."""
+    if os.name == "posix":
+        from .posix.notification_store_lock import (
+            PosixNotificationStoreLockAdapter,
+        )
+
+        return PosixNotificationStoreLockAdapter()
+    if os.name == "nt":
+        from .windows.notification_store_lock import (
+            WindowsNotificationStoreLockAdapter,
+        )
+
+        return WindowsNotificationStoreLockAdapter()
+    raise NotImplementedError(
+        f"notification Store mutation locking is unsupported on {os.name!r}"
+    )

--- a/src/lingtai/adapters/posix/notification_store.py
+++ b/src/lingtai/adapters/posix/notification_store.py
@@ -5,11 +5,13 @@ It provides atomic file replacement and Store-owned mutation serialization.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import threading
 from pathlib import Path
 
+from lingtai.adapters.notification_store_lock import select_notification_store_lock
 from lingtai.kernel._fsutil import atomic_write_json
 from lingtai.kernel.notification_store import (
     AllowPredicate,
@@ -22,6 +24,9 @@ from lingtai.kernel.notification_store import (
     UpdateAckRefsResult,
     _applied_result,
     _conflict_result,
+)
+from lingtai.kernel.notification_store._mutation_lock import (
+    NotificationMutationLockPort,
 )
 
 _LARGE_RESULT_ACK_FILE = "large_result_acks.json"
@@ -60,10 +65,22 @@ class PosixNotificationStoreAdapter(NotificationStorePort):
     One composed instance owns serialization; Core supplies channel policy.
     """
 
-    def __init__(self, workdir: Path):
+    def __init__(
+        self,
+        workdir: Path,
+        mutation_lock: NotificationMutationLockPort | None = None,
+    ):
         self._workdir = Path(workdir)
         self._lock = threading.Lock()
+        self._mutation_lock = mutation_lock or select_notification_store_lock()
 
+    @contextlib.contextmanager
+    def _exclusive_mutation(self):
+        # The thread lock prevents same-process lock re-entry while the native
+        # lock serializes independently composed producer/supervisor processes.
+        with self._lock:
+            with self._mutation_lock.exclusive(_notification_dir(self._workdir)):
+                yield
 
     def snapshot(self, allow_channel: AllowPredicate) -> dict[str, object]:
         notif_dir = _notification_dir(self._workdir)
@@ -108,13 +125,13 @@ class PosixNotificationStoreAdapter(NotificationStorePort):
         notif_dir = _notification_dir(self._workdir)
         notif_dir.mkdir(exist_ok=True)
         target = _channel_path(self._workdir, channel)
-        with self._lock:
+        with self._exclusive_mutation():
             atomic_write_json(target, payload, ensure_ascii=False, indent=None)
 
 
     def clear(self, channel: str) -> bool:
         target = _channel_path(self._workdir, channel)
-        with self._lock:
+        with self._exclusive_mutation():
             try:
                 target.unlink()
             except FileNotFoundError:
@@ -130,7 +147,7 @@ class PosixNotificationStoreAdapter(NotificationStorePort):
     ) -> CompareUpdateResult:
         target = _channel_path(self._workdir, channel)
 
-        with self._lock:
+        with self._exclusive_mutation():
             current_payload: dict = {}
             current_version: list | None = None
             try:
@@ -221,7 +238,7 @@ class PosixNotificationStoreAdapter(NotificationStorePort):
         self, pure_core_set_mutator: PureAckMutator
     ) -> UpdateAckRefsResult:
         ack_path = _ack_path(self._workdir)
-        with self._lock:
+        with self._exclusive_mutation():
             current = self.load_ack_refs()
             refs, requested_change, value = pure_core_set_mutator(set(current))
             if not requested_change:

--- a/src/lingtai/adapters/posix/notification_store_lock.py
+++ b/src/lingtai/adapters/posix/notification_store_lock.py
@@ -1,0 +1,24 @@
+"""POSIX cross-process mutation lock for the Notification Store."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+from pathlib import Path
+
+_LOCK_FILE = ".store.lock"
+
+
+class PosixNotificationStoreLockAdapter:
+    """Advisory ``flock`` held for one complete Store mutation."""
+
+    @contextlib.contextmanager
+    def exclusive(self, notification_dir: Path):
+        notification_dir.mkdir(parents=True, exist_ok=True)
+        handle = open(notification_dir / _LOCK_FILE, "a+b")
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            handle.close()

--- a/src/lingtai/adapters/posix/notification_store_lock.py
+++ b/src/lingtai/adapters/posix/notification_store_lock.py
@@ -16,9 +16,14 @@ class PosixNotificationStoreLockAdapter:
     def exclusive(self, notification_dir: Path):
         notification_dir.mkdir(parents=True, exist_ok=True)
         handle = open(notification_dir / _LOCK_FILE, "a+b")
+        locked = False
         try:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            locked = True
             yield
         finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-            handle.close()
+            try:
+                if locked:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            finally:
+                handle.close()

--- a/src/lingtai/adapters/windows/notification_store_lock.py
+++ b/src/lingtai/adapters/windows/notification_store_lock.py
@@ -20,6 +20,7 @@ class WindowsNotificationStoreLockAdapter:
 
         notification_dir.mkdir(parents=True, exist_ok=True)
         handle = open(notification_dir / _LOCK_FILE, "a+b")
+        locked = False
         try:
             if handle.seek(0, 2) == 0:
                 handle.write(b"\0")
@@ -28,6 +29,7 @@ class WindowsNotificationStoreLockAdapter:
             while True:
                 try:
                     msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                    locked = True
                     break
                 except OSError as exc:
                     if getattr(exc, "winerror", None) != 33 and exc.errno not in {
@@ -39,7 +41,8 @@ class WindowsNotificationStoreLockAdapter:
             yield
         finally:
             try:
-                handle.seek(0)
-                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                if locked:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
             finally:
                 handle.close()

--- a/src/lingtai/adapters/windows/notification_store_lock.py
+++ b/src/lingtai/adapters/windows/notification_store_lock.py
@@ -1,0 +1,45 @@
+"""Windows cross-process mutation lock for the Notification Store."""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from pathlib import Path
+
+_LOCK_FILE = ".store.lock"
+
+
+class WindowsNotificationStoreLockAdapter:
+    """Byte-range lock held for one complete Store mutation."""
+
+    @contextlib.contextmanager
+    def exclusive(self, notification_dir: Path):
+        if __import__("os").name != "nt":
+            raise OSError("Windows notification Store lock requires Windows")
+        import msvcrt
+
+        notification_dir.mkdir(parents=True, exist_ok=True)
+        handle = open(notification_dir / _LOCK_FILE, "a+b")
+        try:
+            if handle.seek(0, 2) == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            while True:
+                try:
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                    break
+                except OSError as exc:
+                    if getattr(exc, "winerror", None) != 33 and exc.errno not in {
+                        13,
+                        36,
+                    }:
+                        raise
+                    time.sleep(0.01)
+            yield
+        finally:
+            try:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            finally:
+                handle.close()

--- a/src/lingtai/kernel/notification_store/ANATOMY.md
+++ b/src/lingtai/kernel/notification_store/ANATOMY.md
@@ -73,8 +73,8 @@ Persistent protocol state is the existing `.notification/<channel>.json` plus
 `.notification/large_result_acks.json`. The adapter holds its workdir, an
 in-process mutex, and a platform-selected mutation lock. Native adapters lock
 `.notification/.store.lock` using `flock` on POSIX or byte 0 on Windows
-(`src/lingtai/adapters/posix/notification_store_lock.py:1-24`,
-`src/lingtai/adapters/windows/notification_store_lock.py:1-45`). Lock-file
+(`src/lingtai/adapters/posix/notification_store_lock.py:1-29`,
+`src/lingtai/adapters/windows/notification_store_lock.py:1-48`). Lock-file
 existence is not authority; OS lock ownership serializes complete mutation
 transactions and releases on process death. Core retains delivered fingerprints
 and policy state on the agent, not in the adapter.

--- a/src/lingtai/kernel/notification_store/ANATOMY.md
+++ b/src/lingtai/kernel/notification_store/ANATOMY.md
@@ -3,12 +3,18 @@ related_files:
   - src/lingtai/kernel/notification_store/CONTRACT.md
   - src/lingtai/kernel/ANATOMY.md
   - src/lingtai/kernel/notification_store/__init__.py
+  - src/lingtai/kernel/notification_store/_mutation_lock.py
+  - src/lingtai/adapters/notification_store_lock.py
   - src/lingtai/adapters/posix/notification_store.py
+  - src/lingtai/adapters/posix/notification_store_lock.py
+  - src/lingtai/adapters/windows/notification_store_lock.py
   - src/lingtai/kernel/notifications.py
   - src/lingtai/kernel/base_agent/__init__.py
   - src/lingtai/agent.py
   - src/lingtai/cli.py
   - src/lingtai/mcp_servers/telegram/server.py
+  - src/lingtai/tools/daemon/supervisor_runtime.py
+  - tests/test_notification_store.py
 maintenance: |
   Keep related_files repo-relative, duplicate-free, and linked to real files.
   Keep this component's ANATOMY.md and CONTRACT.md reciprocal and keep
@@ -30,9 +36,13 @@ The Notification Store is the Core-owned persistence boundary for current
   (`src/lingtai/kernel/notification_store/__init__.py:115-197`).
 - `CompareUpdateResult` and `UpdateAckRefsResult` carry typed operational and
   policy evidence (`src/lingtai/kernel/notification_store/__init__.py:59-75`).
+- `NotificationMutationLockPort` is the Store-private cross-process transaction
+  seam (`src/lingtai/kernel/notification_store/_mutation_lock.py:1-13`). Its
+  platform selector composes native POSIX and Windows implementations
+  (`src/lingtai/adapters/notification_store_lock.py:1-28`).
 - `PosixNotificationStoreAdapter` maps the Port onto the established
-  `.notification/` layout and owns mutation serialization
-  (`src/lingtai/adapters/posix/notification_store.py:57-240`).
+  `.notification/` layout and owns both in-process and native cross-process
+  mutation serialization (`src/lingtai/adapters/posix/notification_store.py:62-257`).
 - Notification Core owns channel policy, atomic acknowledgement union/purge, and
   current-payload dismiss decisions (`src/lingtai/kernel/notifications.py:129-186`,
   `src/lingtai/kernel/notifications.py:297-312`,
@@ -42,24 +52,32 @@ The Notification Store is the Core-owned persistence boundary for current
 
 `BaseAgent` receives the Port as a required constructor dependency and uses it
 for sync and delivery (`src/lingtai/kernel/base_agent/__init__.py:304-368`).
-`Agent` and the CLI construct the POSIX adapter at outer composition roots
+`Agent` and the CLI construct the filesystem adapter at outer composition roots
 (`src/lingtai/agent.py:142-151`, `src/lingtai/cli.py:127-140`). The Telegram MCP
-server separately composes one adapter for its manager
-(`src/lingtai/mcp_servers/telegram/server.py:655-663`).
+server and each detached daemon supervisor separately compose Store instances
+(`src/lingtai/mcp_servers/telegram/server.py:655-663`,
+`src/lingtai/tools/daemon/supervisor_runtime.py:600-620`). Those independent
+processes share the native mutation lock for each complete transaction.
 
 ## Composition
 
 The parent map is `src/lingtai/kernel/ANATOMY.md`; the paired normative interface
-is `src/lingtai/kernel/notification_store/CONTRACT.md`. Core depends inward on
-the Port. The POSIX adapter depends on that Port, and outer roots inject it.
+is `src/lingtai/kernel/notification_store/CONTRACT.md`. The Store and
+mutation-lock Port definitions are Core-owned. The filesystem Store adapter
+depends inward on both, composes the platform-selected POSIX or Windows lock,
+and outer roots inject the Store Port.
 
 ## State
 
-Persistent state is the existing `.notification/<channel>.json` protocol plus
-`.notification/large_result_acks.json`. The POSIX adapter holds only its workdir
-and an in-process mutation lock (`src/lingtai/adapters/posix/notification_store.py:63-66`).
-Core retains delivered fingerprints and policy state on the agent, not in the
-adapter.
+Persistent protocol state is the existing `.notification/<channel>.json` plus
+`.notification/large_result_acks.json`. The adapter holds its workdir, an
+in-process mutex, and a platform-selected mutation lock. Native adapters lock
+`.notification/.store.lock` using `flock` on POSIX or byte 0 on Windows
+(`src/lingtai/adapters/posix/notification_store_lock.py:1-24`,
+`src/lingtai/adapters/windows/notification_store_lock.py:1-45`). Lock-file
+existence is not authority; OS lock ownership serializes complete mutation
+transactions and releases on process death. Core retains delivered fingerprints
+and policy state on the agent, not in the adapter.
 
 ## Notes
 

--- a/src/lingtai/kernel/notification_store/CONTRACT.md
+++ b/src/lingtai/kernel/notification_store/CONTRACT.md
@@ -6,13 +6,18 @@ related_files:
   - src/lingtai/kernel/notification_store/ANATOMY.md
   - src/lingtai/kernel/base_agent/CONTRACT.md
   - src/lingtai/kernel/notification_store/__init__.py
+  - src/lingtai/kernel/notification_store/_mutation_lock.py
+  - src/lingtai/adapters/notification_store_lock.py
   - src/lingtai/adapters/posix/notification_store.py
+  - src/lingtai/adapters/posix/notification_store_lock.py
+  - src/lingtai/adapters/windows/notification_store_lock.py
   - src/lingtai/kernel/notifications.py
   - src/lingtai/kernel/base_agent/__init__.py
   - src/lingtai/agent.py
   - src/lingtai/cli.py
   - src/lingtai/mcp_servers/telegram/manager.py
   - src/lingtai/mcp_servers/telegram/server.py
+  - src/lingtai/tools/daemon/supervisor_runtime.py
   - tests/_notification_store_helpers.py
   - tests/test_notification_store.py
 maintenance: |
@@ -67,20 +72,26 @@ fingerprint tuple means the exact delivered version. Channel mutators return
 
 ## Adapters
 
-`PosixNotificationStoreAdapter` is the production adapter. One composed instance
-owns in-process serialization for channel and acknowledgement mutations. Agent,
-CLI, and Telegram server composition roots construct it and inject the Port.
-External LICC/direct `mcp.*` producers keep the same filesystem path and envelope.
+`PosixNotificationStoreAdapter` is the production filesystem adapter. Each
+instance owns an in-process mutex and composes the selected native
+`NotificationMutationLockPort`; together they serialize channel and
+acknowledgement mutations across threads and independently composed processes.
+The selector provides `flock` on POSIX and byte-range locking on Windows. Agent,
+CLI, daemon supervisor, and Telegram server composition roots construct the Store
+adapter. External LICC/direct `mcp.*` producers keep the same filesystem path and
+envelope.
 
 ## Contract rules
 
 - Snapshot and fingerprint skip missing, malformed, or unreadable entries and
   apply the live Core allow-predicate; fingerprints are sorted SHA-256 entries of
   filename, byte size, and bytes, not mtime.
-- Publish is atomic sibling-temp replacement. Clear returns `False` only for
+- Publish is atomic sibling-temp replacement. Publish and clear hold the Store's
+  in-process and cross-process mutation locks. Clear returns `False` only for
   absence; other clear and write errors propagate unless a Core best-effort
   wrapper explicitly preserves legacy suppression.
-- Compare-update reads payload and version under Store serialization. Only
+- Compare-update reads payload and version under the same whole-transaction
+  cross-process Store serialization. Only
   `FileNotFoundError` is absence; every other read error propagates. Readable
   malformed/non-dict JSON retains its version and presents `{}` to Core, so it
   cannot satisfy expected absence.
@@ -90,23 +101,29 @@ External LICC/direct `mcp.*` producers keep the same filesystem path and envelop
   report the resulting version and actual clear outcome, while `value` carries
   all Core response/log policy evidence.
 - Ack load preserves legacy best effort: absent, malformed, or unreadable state
-  yields an empty set. Atomic ack update holds one Store lock across that same
-  read, one pure Core set mutation, and store-or-clear. `changed=False` performs
+  yields an empty set. Atomic ack update holds the same in-process and
+  cross-process Store locks across that read, one pure Core set mutation, and
+  store-or-clear. `changed=False` performs
   no write. Non-empty write failures propagate. Empty-set clear preserves legacy
   best effort by swallowing every unlink `OSError`; typed `changed/value`
   evidence still returns, with `changed=False` when no unlink succeeds.
 - Core acknowledgement union and purge MUST use family 7, never split family 6
-  read from a later write. System, nudge, and Telegram mutations decide from the
-  current payload inside compare-update; force uses `UNCONDITIONAL`, while
-  non-force dismiss uses the delivered fingerprint entry including explicit
-  absence.
+  read from a later write. System, nudge, Telegram, and daemon-terminal mutations
+  decide from the current payload inside compare-update; force uses
+  `UNCONDITIONAL`, while non-force dismiss uses the delivered fingerprint entry
+  including explicit absence.
+- `.notification/.store.lock` is coordination metadata, not notification state or
+  authority. POSIX and Windows adapters MUST use native OS locks whose ownership,
+  not file existence, defines exclusion and whose release follows process death.
+  Snapshot and fingerprint continue to expose only allowed JSON channel files.
 
 ## Contract tests
 
 Shared conformance covers the seven-family surface, expected absence versus
 unconditional updates, malformed/unreadable/error behavior, typed policy values,
-atomic concurrent channel updates, atomic acknowledgement union/purge, required
-injection, outer composition, stale dismiss refusal, unrelated-event survival,
+atomic same-process and spawned-process channel updates, atomic acknowledgement
+union/purge, required injection, outer composition, stale dismiss refusal,
+unrelated-event survival,
 nudge updates, and Telegram current-mirror clearing. Production adapter tests
 must use only an explicitly authorized persistent scratch path when deletion is
 separately authorized.

--- a/src/lingtai/kernel/notification_store/_mutation_lock.py
+++ b/src/lingtai/kernel/notification_store/_mutation_lock.py
@@ -1,0 +1,13 @@
+"""Cross-process mutation lock Port for the Notification Store."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from pathlib import Path
+from typing import Protocol
+
+
+class NotificationMutationLockPort(Protocol):
+    """Serialize Store mutations across independently composed processes."""
+
+    def exclusive(self, notification_dir: Path) -> AbstractContextManager[None]: ...

--- a/tests/test_notification_store.py
+++ b/tests/test_notification_store.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import inspect
 import json
+import multiprocessing
 import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
@@ -45,6 +47,21 @@ def _allow_all(_channel: str) -> bool:
 def _posix_store(workdir: Path) -> PosixNotificationStoreAdapter:
     workdir.mkdir(parents=True, exist_ok=True)
     return PosixNotificationStoreAdapter(workdir)
+
+
+def _process_increment_channel(workdir: str, barrier) -> None:
+    store = PosixNotificationStoreAdapter(Path(workdir))
+    barrier.wait(timeout=30)
+
+    def increment(current: dict):
+        # Widen the read/modify/write race between independently composed
+        # Store instances without blocking inside the process lock itself.
+        time.sleep(0.1)
+        return ({"count": int(current.get("count", 0)) + 1}, True, None)
+
+    result = store.compare_update_channel("system", UNCONDITIONAL, increment)
+    if not result.applied:
+        raise RuntimeError(f"channel increment was not applied: {result!r}")
 
 
 @pytest.fixture(params=("fake", "posix"))
@@ -328,6 +345,30 @@ class TestAtomicCoreRedCounterexamples:
             thread.join(timeout=5)
             assert not thread.is_alive()
         assert store.snapshot(_allow_all)["system"]["count"] == 12
+
+    def test_real_adapter_cross_process_channel_updates_are_serialized(self, tmp_path):
+        workdir = tmp_path / "channel-process-concurrency"
+        workdir.mkdir()
+        context = multiprocessing.get_context("spawn")
+        barrier = context.Barrier(5)
+        processes = [
+            context.Process(
+                target=_process_increment_channel,
+                args=(str(workdir), barrier),
+            )
+            for _ in range(4)
+        ]
+
+        for process in processes:
+            process.start()
+        barrier.wait(timeout=30)
+        for process in processes:
+            process.join(timeout=30)
+        assert all(not process.is_alive() for process in processes)
+        assert [process.exitcode for process in processes] == [0, 0, 0, 0]
+
+        store = PosixNotificationStoreAdapter(workdir)
+        assert store.snapshot(_allow_all)["system"]["count"] == 4
 
     def test_concurrent_ack_unions_use_atomic_family_seven(self, tmp_path):
         store = _posix_store(tmp_path / "ack-unions")

--- a/tests/test_notification_store.py
+++ b/tests/test_notification_store.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import inspect
 import json
 import multiprocessing
+import os
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -369,6 +371,48 @@ class TestAtomicCoreRedCounterexamples:
 
         store = PosixNotificationStoreAdapter(workdir)
         assert store.snapshot(_allow_all)["system"]["count"] == 4
+
+    def test_posix_lock_preserves_acquisition_error(self, tmp_path, monkeypatch):
+        if os.name != "posix":
+            pytest.skip("POSIX flock adapter is unavailable")
+        from lingtai.adapters.posix import notification_store_lock as lock_module
+
+        calls = []
+
+        def fail_acquire(_fileno, operation):
+            calls.append(operation)
+            if operation == lock_module.fcntl.LOCK_EX:
+                raise OSError("acquisition failed")
+
+        monkeypatch.setattr(lock_module.fcntl, "flock", fail_acquire)
+        lock = lock_module.PosixNotificationStoreLockAdapter()
+        with pytest.raises(OSError, match="acquisition failed"):
+            with lock.exclusive(tmp_path):
+                pytest.fail("mutation body ran without the process lock")
+        assert calls == [lock_module.fcntl.LOCK_EX]
+
+    def test_windows_lock_preserves_acquisition_error(self, tmp_path, monkeypatch):
+        from lingtai.adapters.windows.notification_store_lock import (
+            WindowsNotificationStoreLockAdapter,
+        )
+
+        calls = []
+        fake_msvcrt = SimpleNamespace(LK_NBLCK=1, LK_UNLCK=2)
+
+        def fail_acquire(_fileno, operation, _size):
+            calls.append(operation)
+            if operation == fake_msvcrt.LK_NBLCK:
+                raise OSError(5, "acquisition failed")
+
+        fake_msvcrt.locking = fail_acquire
+        monkeypatch.setattr(os, "name", "nt")
+        monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+        lock = WindowsNotificationStoreLockAdapter()
+        with pytest.raises(OSError, match="acquisition failed"):
+            with lock.exclusive(tmp_path):
+                pytest.fail("mutation body ran without the process lock")
+        assert calls == [fake_msvcrt.LK_NBLCK]
 
     def test_concurrent_ack_unions_use_atomic_family_seven(self, tmp_path):
         store = _posix_store(tmp_path / "ack-unions")


### PR DESCRIPTION
## Summary

- serialize Notification Store mutations across independently composed processes
- use native `flock` on POSIX and byte-range `msvcrt.locking` on Windows
- preserve the existing seven-family Store Port and current `.notification/*.json` protocol
- add a Windows-compatible spawned-process regression that forces the former lost-update race

## Root cause

Each detached daemon supervisor creates its own Notification Store instance. The Store previously held only a per-instance `threading.Lock` around read -> pure mutation -> atomic replace.

Concurrent supervisors could both read the same `system.json`, append distinct terminal events, and successfully replace it with diverging successors. Last rename won, while both run receipts recorded terminal publication as complete. That could drop daemon completion wakes for every backend sharing this common terminal path.

This change keeps the in-process mutex and adds a Store-private platform lock around `publish`, `clear`, `compare_update_channel`, and acknowledgement updates for the complete transaction.

## Validation

- `tests/test_notification_store.py`
- `tests/test_daemon_detached_supervisor.py`
- `tests/test_architecture_documents.py`
- 77 tests passed
- Ruff passed on all changed Python files
- Black passed on all wholly new Python modules
- `git diff --check` passed

## Independent review

A bounded immutable-patch review returned **APPROVE** with no blocker/high finding. Its one medium exception-fidelity risk (cleanup could attempt unlock after acquisition failure) was resolved in `068315b` with POSIX and Windows regressions proving the original acquisition error survives and the mutation body never runs.

## Windows follow-up boundary

This focused PR repairs the proven cross-process terminal-wake race and gives Windows CI a native spawned-process regression. It does **not** claim to solve the separate larger Windows process-tree residuals:

- inherited execution scope currently owns exact children, not all PowerShell/CLI grandchildren
- detached supervisors do not yet prove breakaway from an enclosing kill-on-close host Job
- the full public `Agent -> daemon(emanate) -> PowerShell tool work -> wake/check` route still needs a real native Windows agent acceptance run

Those findings should remain explicit follow-up work rather than being hidden inside this small transaction-safety patch.

