### PR TITLE
refactor(config): remove dead config resolve residue

### DIFF
--- a/src/lingtai/kernel/config_resolve.py
+++ b/src/lingtai/kernel/config_resolve.py
@@ -7,12 +7,6 @@ import re
 from pathlib import Path
 
 
-# Module-level: pre-compiled regex for JSONC string literals (matches "..."
-# with escape sequences). Used by load_jsonc to skip over string contents
-# when stripping // comments.
-_JSONC_STRING_RE = re.compile(r'"(?:[^"\\]|\\.)*"')
-
-
 def parse_jsonc(text: str) -> dict:
     """Parse JSON or JSONC text (strips // comments and trailing commas).
 
@@ -122,16 +116,6 @@ def _resolve_env_fields(d: dict) -> dict:
     for env_key in env_keys:
         base_key = env_key[: -len("_env")]
         result[base_key] = resolve_env(result.get(base_key), result.pop(env_key))
-    return result
-
-
-def _resolve_file_fields(d: dict) -> dict:
-    """Resolve ``*_file`` keys in a dict using ``resolve_file``."""
-    result = dict(d)
-    file_keys = [k for k in result if k.endswith("_file")]
-    for file_key in file_keys:
-        base_key = file_key[: -len("_file")]
-        result[base_key] = resolve_file(result.get(base_key), result.pop(file_key))
     return result
 
 


### PR DESCRIPTION
## Summary

- remove the unused `_JSONC_STRING_RE` constant and its now-false ownership comment
- remove the unused `_resolve_file_fields` helper
- leave every live config-resolution function byte-for-byte unchanged, including the JSONC state machine, `resolve_file`, environment/capability resolution, paths, schema behavior, and Agent integration

`_resolve_file_fields`'s blanket `*_file` sweep is not only unreferenced; it would conflict with the current explicit allowlist that deliberately excludes retired prompt-override file fields. It should not be restored merely for symmetry with `_resolve_env_fields`.

## Validation

- `git diff --check`
- `python -m py_compile src/lingtai/kernel/config_resolve.py`
- zero repo-wide references to both deleted symbols
- differential JSONC smoke/parity checks, including URLs, quotes, escapes, comments, and trailing commas
- parent focused config/preset/migration gate: 163 passed
- Sonnet implementation gate: 200 passed
- independent Opus 5 exact-diff final: APPROVE / no blockers; 583 passed with one unrelated `msal` dependency failure reproduced unchanged on pristine base
- anatomy drift check: no drift across 52 files

No merge is requested or authorized by this PR creation.
