### PR TITLE
fix(shell): fail loudly on unsupported platforms

### DIFF
--- a/src/lingtai/adapters/shell_process.py
+++ b/src/lingtai/adapters/shell_process.py
@@ -15,7 +15,4 @@ def select_shell_async_process() -> BashAsyncProcessPort:
     if os.name == "nt":
         from .windows.powershell_process import WindowsShellAsyncProcessAdapter
         return WindowsShellAsyncProcessAdapter()
-    if sys.platform == "win32":
-        from lingtai.adapters.windows.powershell_process import WindowsPowerShellAsyncProcess
-        return WindowsPowerShellAsyncProcess()
     raise NotImplementedError(f"shell async process supervision is unsupported on {os.name!r}")

--- a/src/lingtai/adapters/shell_state_lock.py
+++ b/src/lingtai/adapters/shell_state_lock.py
@@ -15,7 +15,4 @@ def select_shell_state_lock() -> BashStateLockPort:
     if os.name == "nt":
         from .windows.powershell_state_lock import WindowsShellStateLockAdapter
         return WindowsShellStateLockAdapter()
-    if sys.platform == "win32":
-        from lingtai.adapters.windows.powershell_state_lock import WindowsPowerShellStateLock
-        return WindowsPowerShellStateLock()
     raise NotImplementedError(f"shell async state locking is unsupported on {os.name!r}")

--- a/tests/test_shell_pr1_contract.py
+++ b/tests/test_shell_pr1_contract.py
@@ -237,6 +237,19 @@ def test_windows_selector_modules_are_real_adapter_composition_points(monkeypatc
     assert isinstance(lock_selector.select_shell_state_lock(), WindowsShellStateLockAdapter)
 
 
+def test_unsupported_os_name_fails_loud_not_with_name_error(monkeypatch):
+    import lingtai.adapters.shell_process as process_selector
+    import lingtai.adapters.shell_state_lock as lock_selector
+
+    monkeypatch.setattr(process_selector.os, "name", "java")
+    with pytest.raises(NotImplementedError, match="unsupported on 'java'"):
+        process_selector.select_shell_async_process()
+
+    monkeypatch.setattr(lock_selector.os, "name", "java")
+    with pytest.raises(NotImplementedError, match="unsupported on 'java'"):
+        lock_selector.select_shell_state_lock()
+
+
 def test_windows_resume_uses_retained_process_handle_not_a_missing_thread(monkeypatch):
     import lingtai.adapters.windows.powershell_process as process_adapter
 


### PR DESCRIPTION
## Summary

- remove two impossible `sys.platform == "win32"` fallback branches from the canonical shell process/state-lock selectors
- preserve the supported POSIX and native Windows (`os.name == "nt"`) composition paths and final fail-loud messages verbatim
- add one focused regression proving an unsupported `os.name` raises the intended `NotImplementedError` instead of the current `NameError`

This is the report's separate six-line bugfix, not a broader Bash adapter simplification. The deleted fallbacks were dominated by the earlier Windows returns, referenced `sys` without importing it, and named classes that do not exist.

## Validation

- `git diff --check` and py_compile
- selector regression fails on base with `NameError` and passes on the fix with `NotImplementedError`
- `tests/test_shell_pr1_contract.py`: 20 passed
- parent selector/Windows/async-contract/anatomy gate: 37 passed
- independent Opus 5 exact-diff final: APPROVE / no code blockers; monkeypatch restoration/order checks passed

`tests/test_bash_async.py` currently has 27 unrelated failures; the same set was reproduced unchanged on the pristine base and does not exercise these selector branches.

No merge is requested or authorized by this PR creation.
