### PR TITLE
refactor(daemon): delegate detached tool expansion

### DIFF
--- a/src/lingtai/tools/daemon/execution_host.py
+++ b/src/lingtai/tools/daemon/execution_host.py
@@ -132,19 +132,11 @@ class DetachedDaemonExecutionHost:
         # Reconstruct the ordinary host tool floor through the same registry
         # setup used by the parent manager.  No full Agent/workdir lease is
         # constructed in this process.
-        from lingtai.tools.daemon import EMANATION_BLACKLIST, _ToolCollector
-        from lingtai.tools.registry import BUILTIN_TOOLS, canonical_capability_name, setup_capability
+        from lingtai.tools.daemon import _ToolCollector
+        from lingtai.tools.registry import BUILTIN_TOOLS, setup_capability
         collector = _ToolCollector(self._agent)
-        names = set()
-        for name in manifest.get("tools", []):
-            name = canonical_capability_name(name)
-            if name in EMANATION_BLACKLIST:
-                continue
-            names.add(name)
+        expanded = DaemonManager._expand_requested_tools(self, manifest.get("tools", []))
         from lingtai.tools.registry import _GROUPS
-        expanded = set()
-        for name in names:
-            expanded.update(_GROUPS.get(name, [name]))
         if expanded.intersection(_GROUPS.get("file", ())):
             # File handlers dereference the agent-shaped host's injected
             # FileIOService at execution time. Mirror ordinary Agent


### PR DESCRIPTION
## Summary

- delegate detached execution-host tool expansion to the existing `DaemonManager._expand_requested_tools` owner
- remove the duplicate alias canonicalization, emanation blacklist filtering, and capability-group expansion block
- preserve constructor initialization order, the `FileIOService` gate, sorted capability setup, schemas, and handlers unchanged

This is a behavior-neutral one-source-of-truth cleanup. It does not change the daemon tool surface, refusal semantics, or any public contract.

## Validation

- `git diff --check` — passed
- `python -m py_compile src/lingtai/tools/daemon/execution_host.py` — passed
- in-memory old-inline vs canonical-owner parity harness — 194 cases, 0 mismatches
- base/current `FileIOService` gate comparison — byte-identical
- `python -m pytest tests/test_daemon_detached_supervisor.py tests/test_daemon_preset_capabilities.py tests/test_layers_avatar.py tests/test_daemon_windows_supervisor.py -q` — 115 passed, 2 skipped (native-Windows platform gates)
- independent Claude Opus final review — APPROVE; 78 passed, 2 native-Windows skips; no blockers

## Scope

One production file only: 3 insertions, 11 deletions. No test, ANATOMY, CONTRACT, or documentation change is required because ownership and documented contracts are unchanged.
