### PR TITLE
fix(feishu): keep SDK logs off MCP stdout

### DIFF
--- a/src/lingtai/mcp_servers/feishu/account.py
+++ b/src/lingtai/mcp_servers/feishu/account.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+import sys
 import tempfile
 import threading
 from datetime import datetime, timezone
@@ -28,6 +29,23 @@ lark: Any = None
 # SDK keeps its own module-level ``loop`` attribute that ``Client.start()`` uses
 # directly — see ``_ThreadLocalLoop`` and ``_ws_loop`` for why that matters.
 _sdk_ws_client_module: Any = None
+_sdk_logging_lock = threading.Lock()
+
+
+def _configure_lark_sdk_logging() -> None:
+    """Keep Lark SDK diagnostics off the MCP protocol's stdout stream."""
+    with _sdk_logging_lock:
+        sdk_logger = logging.getLogger("Lark")
+        stdout_streams = (sys.stdout, sys.__stdout__)
+        for handler in sdk_logger.handlers:
+            if not isinstance(handler, logging.StreamHandler):
+                continue
+            stream = getattr(handler, "stream", None)
+            if stream is not None and any(
+                stream is item for item in stdout_streams
+            ):
+                handler.setStream(sys.stderr)
+        sdk_logger.propagate = False
 
 
 def _import_lark() -> Any:
@@ -35,6 +53,7 @@ def _import_lark() -> Any:
     if lark is None:
         import lark_oapi as _lark
         lark = _lark
+    _configure_lark_sdk_logging()
     return lark
 
 

--- a/tests/test_feishu_stdio_logging.py
+++ b/tests/test_feishu_stdio_logging.py
@@ -1,0 +1,44 @@
+"""Regression tests for Feishu SDK logging on MCP stdio."""
+from __future__ import annotations
+
+import logging
+import sys
+
+from lingtai.mcp_servers.feishu import account as account_module
+
+
+def test_lark_sdk_logs_use_stderr_without_replacing_handlers(capsys, monkeypatch):
+    sdk_logger = logging.getLogger("Lark")
+    original_handlers = list(sdk_logger.handlers)
+    original_level = sdk_logger.level
+    original_propagate = sdk_logger.propagate
+    original_disabled = sdk_logger.disabled
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter("SDK %(levelname)s %(message)s"))
+    preserved_handler = logging.NullHandler()
+    fake_lark = object()
+
+    try:
+        sdk_logger.handlers = [stdout_handler, preserved_handler]
+        sdk_logger.setLevel(logging.INFO)
+        sdk_logger.propagate = True
+        sdk_logger.disabled = False
+        monkeypatch.setattr(account_module, "lark", fake_lark)
+
+        assert account_module._import_lark() is fake_lark
+        assert account_module._import_lark() is fake_lark
+
+        assert sdk_logger.handlers == [stdout_handler, preserved_handler]
+        assert stdout_handler.stream is sys.stderr
+        assert sdk_logger.propagate is False
+
+        sdk_logger.info("stdio invariant")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "SDK INFO stdio invariant" in captured.err
+    finally:
+        sdk_logger.handlers = original_handlers
+        sdk_logger.setLevel(original_level)
+        sdk_logger.propagate = original_propagate
+        sdk_logger.disabled = original_disabled


### PR DESCRIPTION
## Summary

- keep Feishu/Lark SDK log records off MCP stdout by retargeting SDK stdout handlers to stderr
- preserve handler order, formatter, filters, level, and other logger configuration
- make the adjustment idempotent and reapply it during lazy SDK import
- add regression coverage proving stdout remains clean while SDK diagnostics remain visible on stderr

## Validation

- `PYTHONPATH=src python -m pytest -q tests/test_feishu_stdio_logging.py tests/test_feishu_notification_metadata.py` — 6 passed
- `python -m py_compile src/lingtai/mcp_servers/feishu/account.py tests/test_feishu_stdio_logging.py`
- `git diff --check`

Fixes Lingtai-AI/lingtai#751
