### PR TITLE
feat(knowledge): adopt action input tool contract

### DIFF
--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
@@ -35,6 +36,10 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_settings.py` — private Agent-owned placeholder-settings reader and
+  secret-free current-setting diagnostic. It strictly validates the exact
+  versioned no-op schema, rereads `settings/<bounded tool_name>.json` per call,
+  and never supplies action, input, reasoning, or tool behavior.
 
 ## Connections
 

--- a/src/lingtai/tools/_settings.py
+++ b/src/lingtai/tools/_settings.py
@@ -1,0 +1,156 @@
+"""Private shared reader for Agent-owned no-op tool settings placeholders.
+
+The placeholder file is deliberately metadata-only.  A present, valid v1 file
+proves that an Agent-owned settings snapshot was read, but it cannot select or
+enable any tool behavior.  Individual tools may later add their own real
+settings reader when a configurable choice is actually authorized.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MAX_SETTINGS_BYTES = 64 * 1024
+SETTINGS_SCHEMA_VERSION = 1
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class SettingsError(ValueError):
+    """A placeholder settings snapshot was malformed or unsafe to use."""
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsSnapshot:
+    """Immutable evidence for one reread of one tool's settings file."""
+
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def valid_tool_name(value: Any) -> bool:
+    """Return whether *value* is safe as one bounded settings path component."""
+    return isinstance(value, str) and _TOOL_NAME.fullmatch(value) is not None
+
+
+def settings_path(agent: Any, tool_name: str) -> Path:
+    """Return the fixed Agent-owned ``settings/<tool_name>.json`` path."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return Path(agent._working_dir) / "settings" / f"{tool_name}.json"
+
+
+def _bounded_error(exc: Exception) -> str:
+    """Render a bounded diagnostic without echoing host paths or file content."""
+    if isinstance(exc, OSError):
+        return f"settings file could not be read ({type(exc).__name__})"
+    text = str(exc).replace("\n", " ").strip()
+    return (text or "invalid settings")[:240]
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject duplicate JSON object members instead of accepting last-wins data."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SettingsError("duplicate settings field")
+        result[key] = value
+    return result
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    """Read one bounded regular-file snapshot and its content revision."""
+    try:
+        first = path.lstat()
+    except FileNotFoundError:
+        return b"", "missing"
+    except OSError:
+        raise
+
+    if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
+        raise SettingsError("settings file must be a regular file")
+    if first.st_size > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings file exceeds the bounded size")
+
+    # Open by path only after lstat, then compare the path identity and metadata
+    # again.  Replacements, symlink swaps, growth, and ordinary in-place writes
+    # are therefore rejected rather than partially accepted.
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_SETTINGS_BYTES + 1)
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    try:
+        second = path.lstat()
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    if stat.S_ISLNK(second.st_mode) or not stat.S_ISREG(second.st_mode):
+        raise SettingsError("settings snapshot changed during read")
+    if (
+        len(raw) > MAX_SETTINGS_BYTES
+        or first.st_dev != second.st_dev
+        or first.st_ino != second.st_ino
+        or first.st_size != second.st_size
+        or first.st_mtime_ns != second.st_mtime_ns
+    ):
+        raise SettingsError("settings snapshot changed during read")
+    return raw, hashlib.sha256(raw).hexdigest()[:32]
+
+
+def read_settings(agent: Any, tool_name: str) -> SettingsSnapshot:
+    """Reread and strictly validate one tool's placeholder settings snapshot.
+
+    Missing is a normal placeholder state.  A valid file contributes only its
+    source/revision/hash evidence; it never changes behavior.  Every invocation
+    performs a fresh filesystem read and does not cache a prior snapshot.
+    """
+    path = settings_path(agent, tool_name)
+    digest: str | None = None
+    try:
+        raw, revision = _read_stable(path)
+        if revision == "missing":
+            return SettingsSnapshot("missing", "missing", None)
+        digest = revision
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        if not isinstance(value, dict) or set(value) != {"schema_version"}:
+            raise SettingsError("settings schema must contain only schema_version")
+        if type(value["schema_version"]) is not int or value["schema_version"] != SETTINGS_SCHEMA_VERSION:
+            raise SettingsError("settings schema_version must be integer 1")
+        return SettingsSnapshot(f"settings/{tool_name}.json", revision, digest)
+    except (OSError, UnicodeError, json.JSONDecodeError, SettingsError) as exc:
+        # Malformed data is never silently converted to the missing state.  The
+        # digest from a bounded stable read is retained as evidence when safe.
+        return SettingsSnapshot(
+            "settings_error",
+            digest or "error",
+            digest,
+            _bounded_error(exc if isinstance(exc, Exception) else SettingsError("invalid settings")),
+        )
+
+
+def current_setting(snapshot: SettingsSnapshot, tool_name: str) -> dict[str, Any]:
+    """Build the bounded, secret-free current-setting diagnostic for a tool."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return_value: dict[str, Any] = {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": snapshot.source,
+        "settings_revision": snapshot.revision,
+        "settings_hash": snapshot.digest,
+        "change_hint": (
+            f"Edit settings/{tool_name}.json; changes apply on the next {tool_name} "
+            "call; this no-op placeholder never changes tool behavior."
+        ),
+    }
+    if snapshot.error:
+        return_value["settings_error"] = snapshot.error
+    return return_value

--- a/src/lingtai/tools/knowledge/ANATOMY.md
+++ b/src/lingtai/tools/knowledge/ANATOMY.md
@@ -32,16 +32,20 @@ the regular `read` tool.
   imports shared Markdown-catalog scanning/rendering from `core/_catalog.py`.
 - `core/_catalog.py` — shared frontmatter parser, recursive Markdown catalog
   scanner, and YAML catalog renderer used by both `knowledge` and `skills`.
-- `knowledge/CONTRACT.md` — public behavior contract: tool surface, on-disk
-  layout, prompt injection, knowledge/skill directionality, anchored claims,
-  and verification matrix.
+- `knowledge/CONTRACT.md` — public behavior contract: closed nested
+  `action`/`input` tool surface, settings diagnostics, on-disk layout, prompt
+  injection, knowledge/skill directionality, anchored claims, and verification
+  matrix.
 
 ## Connections
 
 - `lingtai.tools.registry` maps builtin capability name `knowledge` here. Former
   `library` and `codex` capability names are not registered.
-- `setup()` registers exactly one tool, `knowledge`, with a single `info`
-  action. The historical `knowledge_limit` kwarg is accepted and ignored.
+- `setup()` registers exactly one tool, `knowledge`, with `info` and `manual`
+  actions behind a closed root `action`/empty nested `input` schema. BaseAgent
+  adds root-only `reasoning`; the handler accepts that metadata (or executor
+  `_reasoning`) without placing it in action input. The historical
+  `knowledge_limit` kwarg is accepted and ignored.
 - `_reconcile()` writes protected prompt section `knowledge`.
 - `skills/` is the structurally isomorphic, physically separate sibling
   capability — it owns `<agent>/.library/{intrinsic,custom}/<name>/SKILL.md`,
@@ -56,6 +60,10 @@ the regular `read` tool.
 - Required frontmatter: `name`, `description`. Optional: `version`.
 - Prompt state: protected `knowledge` section holds the preamble + YAML catalog
   (one `- name:` block per entry, with `location:` and `description:` fields).
+- Each handler invocation rereads the Agent-owned `settings/knowledge.json`
+  placeholder and attaches the resulting `current_setting` diagnostic to every
+  action, malformed-input, degraded, and unknown result. The exact valid schema
+  is `{ "schema_version": 1 }`; it is no-op metadata and never selects behavior.
 - No JSON store and no per-entry size cap. A one-time legacy migration
   converts `knowledge/knowledge.json` and old `codex/codex.json` entries into `KNOWLEDGE.md` folders, writes old `supplementary` text to `references/supplementary.md`, and renames the source JSON to `<name>.json.migrated`.
 

--- a/src/lingtai/tools/knowledge/CONTRACT.md
+++ b/src/lingtai/tools/knowledge/CONTRACT.md
@@ -1,10 +1,11 @@
 ---
 name: knowledge-contract
 tool: knowledge
-contract_version: 1
+contract_version: 2
 related_files:
   - src/lingtai/tools/knowledge/__init__.py
   - src/lingtai/tools/knowledge/ANATOMY.md
+  - src/lingtai/tools/knowledge/manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -61,7 +62,7 @@ The two capabilities are structurally isomorphic but physically separate:
 | Root directory | `<agent>/.library/{intrinsic,custom}/` | `<agent>/knowledge/` |
 | Manifest file | `SKILL.md` | `KNOWLEDGE.md` |
 | Tool name | `skills` | `knowledge` |
-| Tool surface | `info` | `info` |
+| Tool surface | `info`, `manual` | `info`, `manual` with required nested `input: {}` |
 | Prompt section | protected `skills` (YAML catalog) | protected `knowledge` (YAML catalog) |
 | Extra path sources | `manifest.capabilities.skills.paths` | none — strictly per-agent |
 | Visibility | portable / shareable | private / agent-owned |
@@ -74,18 +75,42 @@ does not leak into the public skill catalog.
 
 ## Tool surface
 
-The schema requires `action` and accepts exactly one action:
+The model-facing schema is a closed object with required root `action` and
+`input` properties. `input.anyOf` contains exactly two strict empty-object
+branches titled `info input` and `manual input`; the root rejects flat payload
+fields and any other properties. BaseAgent adds the root-only `reasoning`
+property to the model-facing schema. Direct handlers may receive either
+`reasoning` or executor-normalized `_reasoning` metadata, but neither belongs in
+`input` and neither is dispatched as action data.
+
+Use the canonical calls:
+
+```text
+knowledge(action="info", input={}, reasoning="refresh the catalog")
+knowledge(action="manual", input={}, reasoning="load knowledge guidance")
+```
 
 | Action | Required fields | Optional fields | Return on success |
 |---|---|---|---|
-| `info` | — | — | `{status: "ok", knowledge_dir, catalog_size, problems}` |
+| `info` | `input: {}` | root reasoning metadata | `{status: "ok", knowledge_dir, catalog_size, problems, current_setting}` |
+| `manual` | `input: {}` | root reasoning metadata | `{status: "ok", knowledge_manual, manual_path, current_setting}` |
+
+Every action result, including malformed-input, degraded-manual, and
+unknown-action errors, carries a truthful `current_setting`. It is read afresh
+on every invocation from the Agent-owned `settings/knowledge.json` placeholder
+and reports the exact `source`, revision/hash, and any bounded validation error.
+The placeholder schema is exactly `{ "schema_version": 1 }`; missing, valid,
+hot-changed, and invalid files remain diagnostic only and never alter catalog,
+manual, migration, or dispatch behavior. `info` reconciles the catalog;
+`manual` reads only the installed manual and does not refresh it.
 
 Unknown actions return `{status: "error", message: ...}` and do not mutate
-state. The previous JSON-database actions (`submit`, `view`, `consolidate`,
-`delete`) are intentionally removed: knowledge is now authored by writing
-`KNOWLEDGE.md` files with the regular `write`/`edit` tools, just like skills.
-There is no in-tool capacity limit; the historical `knowledge_limit` kwarg is
-accepted but ignored.
+state. The existing exact message is
+`unknown action: <repr>, only 'info' or 'manual' is supported`. The previous
+JSON-database actions (`submit`, `view`, `consolidate`, `delete`) are
+intentionally removed: knowledge is authored by writing `KNOWLEDGE.md` files
+with the regular `write`/`edit` tools, just like skills. There is no in-tool
+capacity limit; the historical `knowledge_limit` kwarg is accepted but ignored.
 
 Only `knowledge(...)` is registered. There is no `library(...)` or `codex(...)`
 alias.

--- a/src/lingtai/tools/knowledge/__init__.py
+++ b/src/lingtai/tools/knowledge/__init__.py
@@ -30,12 +30,14 @@ import logging
 import os
 import re
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lingtai.kernel.tool_dispatch import dispatch_action
 
 from .._catalog import build_catalog_yaml, scan_markdown_catalog
+from .._settings import read_settings, current_setting
 from lingtai.kernel.i18n import t
 
 if TYPE_CHECKING:
@@ -282,20 +284,49 @@ def _knowledge_manual(agent: "BaseAgent") -> dict:
 
 
 def get_description(lang: str = "en") -> str:
-    return "SIGNPOST ONLY: this tool does not create, edit, search, or load knowledge entries; `info` only re-scans the knowledge catalog and reports health; `manual` returns the knowledge-manual body. Your private durable knowledge catalog across molts — what you've learned, decided, and discovered. Each entry is a folder at knowledge/<name>/ containing KNOWLEDGE.md (YAML frontmatter with name + description) and any supporting files (scripts, assets, notes, raw logs). The knowledge catalog in your system prompt is a YAML list — each entry is a `- name:` block with `location:` and `description:` — bodies load on demand via the read tool, just like skills. Knowledge is private and agent-owned: entries may reference local paths, mail ids, and logs that skills must not depend on. Author new entries by writing knowledge/<name>/KNOWLEDGE.md with write/edit; revise the same way. Call info to refresh the catalog and inspect health. Before using this tool, read the `knowledge-manual` skill — no exceptions."
+    return (
+        "SIGNPOST ONLY: this tool does not create, edit, search, or load knowledge entries; "
+        "use knowledge(action=\"info\", input={}, reasoning=\"refresh the catalog\") "
+        "to re-scan the knowledge catalog and report health, or "
+        "knowledge(action=\"manual\", input={}, reasoning=\"load knowledge guidance\") "
+        "to return the knowledge-manual body. Your private durable knowledge catalog "
+        "across molts — what you've learned, decided, and discovered. Each entry is a folder "
+        "at knowledge/<name>/ containing KNOWLEDGE.md (YAML frontmatter with name + description) "
+        "and any supporting files (scripts, assets, notes, raw logs). The knowledge catalog in "
+        "your system prompt is a YAML list — each entry is a `- name:` block with `location:` "
+        "and `description:` — bodies load on demand via the read tool, just like skills. "
+        "Knowledge is private and agent-owned: entries may reference local paths, mail ids, and "
+        "logs that skills must not depend on. Author new entries by writing knowledge/<name>/"
+        "KNOWLEDGE.md with write/edit; revise the same way. Every action result includes the "
+        "truthful `current_setting` diagnostic from a fresh no-op `settings/knowledge.json` "
+        "placeholder read; a missing, valid, hot-changed, or invalid placeholder never changes "
+        "knowledge behavior. Before using this tool, read the `knowledge-manual` skill — no exceptions."
+    )
 
 
 def get_schema(lang: str = "en") -> dict:
+    def empty_input(title: str) -> dict:
+        return {
+            "title": title,
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": False,
+        }
     return {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
                 "enum": ["info", "manual"],
-                "description": 'info: re-scan knowledge/ and return runtime health (catalog size, resolved root path, malformed entries) without the manual body. manual: return only the knowledge-manual skill body.',
+                "description": "Required operation: info or manual.",
+            },
+            "input": {
+                "anyOf": [empty_input("info input"), empty_input("manual input")],
             },
         },
-        "required": ["action"],
+        "required": ["action", "input"],
+        "additionalProperties": False,
     }
 
 
@@ -312,8 +343,46 @@ def setup(agent: "BaseAgent", **_ignored) -> None:
     _reconcile(agent)
 
     def handle_knowledge(args: dict) -> dict:
-        return dispatch_action(
-            args,
+        settings_snapshot = read_settings(agent, "knowledge")
+        setting = current_setting(settings_snapshot, "knowledge")
+
+        def with_setting(result: dict) -> dict:
+            result = dict(result)
+            result["current_setting"] = setting
+            return result
+
+        allowed_keys = {"action", "input", "reasoning", "_reasoning"}
+        if not isinstance(args, Mapping):
+            return with_setting({
+                "status": "error",
+                "message": "invalid knowledge arguments: expected an object with action and input",
+            })
+        unexpected = set(args) - allowed_keys
+        if unexpected:
+            return with_setting({
+                "status": "error",
+                "message": "invalid knowledge arguments: only action, input, and reasoning metadata are supported",
+            })
+        if "input" not in args:
+            return with_setting({
+                "status": "error",
+                "message": "invalid knowledge arguments: input is required and must be an empty object",
+            })
+        raw_input = args["input"]
+        if not isinstance(raw_input, Mapping):
+            return with_setting({
+                "status": "error",
+                "message": "invalid knowledge arguments: input must be a mapping",
+            })
+        action_input = dict(raw_input)
+        if action_input:
+            return with_setting({
+                "status": "error",
+                "message": "invalid knowledge arguments: input must be an empty object",
+            })
+
+        result = dispatch_action(
+            {"action": args.get("action", "")},
             {
                 "info": lambda _args: _reconcile(agent),
                 "manual": lambda _args: _knowledge_manual(agent),
@@ -323,6 +392,7 @@ def setup(agent: "BaseAgent", **_ignored) -> None:
                 "message": f"unknown action: {action!r}, only 'info' or 'manual' is supported",
             },
         )
+        return with_setting(result)
 
     agent.add_tool(
         "knowledge",

--- a/src/lingtai/tools/knowledge/glossary-en.md
+++ b/src/lingtai/tools/knowledge/glossary-en.md
@@ -10,6 +10,6 @@ related_files:
 - src/lingtai/tools/knowledge/glossary-zh.md
 - src/lingtai/tools/knowledge/glossary-wen.md
 maintenance: |
-  English glossary for the `knowledge` tool package (lingtai.tools.knowledge); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when knowledge's public tool schema changes.
+  English glossary for the `knowledge` tool package (lingtai.tools.knowledge); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when knowledge's public tool schema changes. The current closed surface requires root `action` + nested empty `input`; `current_setting` is a result diagnostic, not a localized alias.
   Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
 ---

--- a/src/lingtai/tools/knowledge/glossary-wen.md
+++ b/src/lingtai/tools/knowledge/glossary-wen.md
@@ -16,4 +16,6 @@ maintenance: |
 **名相对照**
 
 - `knowledge`：【路标之器】此器不代汝造经、修经、搜经或载经；`info` 唯重扫 knowledge 之目录并还康状；`manual` 方还 knowledge-manual 之文。汝跨凝蜕长存之私有知识目录——所习、所断、所悟之记。每经卷皆为 knowledge/<名>/ 一匣，内置 KNOWLEDGE.md（YAML frontmatter 须有 name 与 description），可附副件（script、素材、笔记、原始日志）。系统提示中之知识典为 YAML 之列——每经一 `- name:` 块，附 `location:` 与 `description:` 之目；正文按需以 read 工具取之，与 skills 同律。知识乃汝私藏：经卷可引本地之路、邮件之 id、日志之记——此皆 skills 所不可依也。新经以 write/edit 直书 knowledge/<名>/KNOWLEDGE.md；修订同此。呼 info 可重扫目录、验其康。用此器前，必先读 `knowledge-manual` 一技，无所例外。
-- `action`：info：重扫 knowledge/，返当时之康状（卷数、根径、损经之记），不载 manual 全文。manual：唯还 knowledge-manual 之文。
+- `action`：info：重扫 knowledge/，返当时之康状（卷数、根径、损经之记），不载 manual 全文；manual：唯还 knowledge-manual 之文。
+- `input`：必备之嵌套空对象 `{}`；不得省之，亦不得以扁平字段代之。
+- `current_setting`：每呼皆自 settings/knowledge.json 热读之真实诊断；惟记其况，不移 knowledge 之行。

--- a/src/lingtai/tools/knowledge/glossary-zh.md
+++ b/src/lingtai/tools/knowledge/glossary-zh.md
@@ -16,4 +16,6 @@ maintenance: |
 **术语对照**
 
 - `knowledge`：【路标工具】此工具不会创建、编辑、搜索或加载知识条目；`info` 只重新扫描 knowledge 目录并返回健康状态；`manual` 才返回 knowledge-manual 正文。你的跨凝蜕长存私有知识目录——所学、所断、所悟之记。每条目皆为 knowledge/<名>/ 下之一夹，内含 KNOWLEDGE.md（YAML frontmatter 须有 name 与 description），可附脚本、素材、笔记、原始日志等支撑文件。系统提示中之知识目录为 YAML 列表——每条目为一 `- name:` 块，附 `location:` 与 `description:` 字段；正文按需以 read 工具取之，与 skills 同。知识为汝私有：条目可引本地路径、邮件 ID、日志——此皆为 skills 所不可依赖之物。新条目以 write/edit 直接写入 knowledge/<名>/KNOWLEDGE.md；修订同法。调 info 可刷新目录并查看健康状态。用此工具前，必先读 `knowledge-manual` 技能，无例外。
-- `action`：info：重新扫描 knowledge/ 并返回运行时健康快照（目录大小、根路径、损坏条目），不带 manual 正文。manual：只返回 knowledge-manual 技能正文。
+- `action`：info：重新扫描 knowledge/ 并返回运行时健康快照（目录大小、根路径、损坏条目），不带 manual 正文；manual：只返回 knowledge-manual 技能正文。
+- `input`：必填的嵌套空对象 `{}`；不得改用扁平字段或省略 input。
+- `current_setting`：每次调用从 settings/knowledge.json 热重读所得的真实诊断；仅供观察，不改变 knowledge 行为。

--- a/src/lingtai/tools/knowledge/manual/SKILL.md
+++ b/src/lingtai/tools/knowledge/manual/SKILL.md
@@ -82,7 +82,25 @@ Required fields are `name` and `description`. Supporting files are optional and 
 
 The system prompt only receives a compact catalog: each entry's `name`, `description`, and `location`. The body of `KNOWLEDGE.md` and supporting files stay on disk until you explicitly read them. This keeps the prompt small while still making the memory discoverable.
 
-Call `knowledge({"action": "info"})` to rescan the catalog and refresh the prompt section, then use `read` on the listed `location` when an entry becomes relevant.
+Call `knowledge(action="info", input={}, reasoning="refresh the catalog")` to rescan the catalog and refresh the prompt section, then use `read` on the listed `location` when an entry becomes relevant. For the manual itself, call `knowledge(action="manual", input={}, reasoning="load knowledge guidance")`. The root `input` is required and must be exactly `{}`; do not use a flat payload or an action-only call.
+
+## Settings diagnostic
+
+Every `knowledge` invocation rereads the Agent-owned `settings/knowledge.json`
+file and includes the resulting `current_setting` object in its result, including
+malformed, degraded, and unknown-action results. The only valid placeholder file
+shape is:
+
+```json
+{"schema_version": 1}
+```
+
+The placeholder is deliberately diagnostic and no-op: missing, valid, hot-changed,
+or invalid settings report their truthful source/revision/hash/error, but never
+change knowledge catalog, migration, manual, or dispatch behavior. A hot edit is
+observed on the next call; the reader is not cached. `reasoning` is model-facing
+root metadata injected by BaseAgent and is not part of `input`; direct callers may
+use `_reasoning` after executor normalization.
 
 ## Nesting and sub-knowledge
 
@@ -166,4 +184,4 @@ PY
 Recommended cadence: before molt if knowledge sprawl is confusing, after major
 projects, and monthly for long-lived agents. If cleanup is approved with explicit user consent, record the
 entries consolidated/removed in `logs/cleanup.jsonl` and update the catalog with
-`knowledge(action="info")`.
+`knowledge(action="info", input={}, reasoning="refresh the catalog")`.

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -87,7 +87,7 @@ def test_legacy_knowledge_limit_kwarg_is_ignored(tmp_path):
     agent, _ = _mk_agent(tmp_path, {"knowledge_limit": 50})
     try:
         assert "knowledge" in agent._tool_handlers
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["status"] == "ok"
     finally:
         agent.stop(timeout=1.0)
@@ -101,11 +101,67 @@ def test_legacy_knowledge_limit_kwarg_is_ignored(tmp_path):
 def test_info_returns_runtime_snapshot(tmp_path):
     agent, workdir = _mk_agent(tmp_path)
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["status"] == "ok"
         assert result["knowledge_dir"] == str(workdir / "knowledge")
         assert result["catalog_size"] == 0
         assert result["problems"] == []
+        assert result["current_setting"]["source"] == "missing"
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_manual_returns_body_and_current_setting(tmp_path):
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        result = agent._tool_handlers["knowledge"](
+            {"action": "manual", "input": {}, "_reasoning": "load guidance"}
+        )
+        assert result["status"] == "ok"
+        assert "# The Knowledge Capability" in result["knowledge_manual"]
+        assert result["current_setting"]["source"] == "missing"
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_handler_rereads_settings_and_passes_exact_diagnostic_to_every_result(tmp_path, monkeypatch):
+    from lingtai.tools import knowledge as knowledge_module
+
+    agent, _ = _mk_agent(tmp_path)
+    snapshots = [object() for _ in range(5)]
+    settings = [{"call": index} for index in range(5)]
+    reads = []
+
+    def fake_read(current_agent, tool_name):
+        reads.append((current_agent, tool_name))
+        return snapshots.pop(0)
+
+    def fake_current(snapshot, tool_name):
+        assert tool_name == "knowledge"
+        return settings[len(reads) - 1]
+
+    monkeypatch.setattr(knowledge_module, "read_settings", fake_read)
+    monkeypatch.setattr(knowledge_module, "current_setting", fake_current)
+    monkeypatch.setattr(
+        knowledge_module,
+        "_knowledge_manual",
+        lambda _agent: {"status": "degraded", "knowledge_manual": "", "error": "missing"},
+    )
+    try:
+        handler = agent._tool_handlers["knowledge"]
+        calls = [
+            ({"action": "info", "input": {}}, "ok"),
+            ({"action": "manual", "input": {}}, "degraded"),
+            ({"action": "info"}, "error"),
+            ({"action": "submit", "input": {}}, "error"),
+            ({"action": "info", "input": {"title": "flat"}}, "error"),
+        ]
+        results = [handler(args) for args, _ in calls]
+        assert [result["status"] for result in results] == [expected for _, expected in calls]
+        assert [result["current_setting"] for result in results] == settings
+        assert [result["current_setting"] is setting for result, setting in zip(results, settings)] == [True] * 5
+        assert len(reads) == 5
+        assert all(tool_name == "knowledge" and current_agent is agent for current_agent, tool_name in reads)
     finally:
         agent.stop(timeout=1.0)
 
@@ -124,7 +180,7 @@ def test_info_picks_up_authored_entry(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["catalog_size"] == 1
         assert result["problems"] == []
     finally:
@@ -136,30 +192,49 @@ def test_unknown_action_returns_error(tmp_path):
     agent, _ = _mk_agent(tmp_path)
     try:
         for action in ("submit", "view", "consolidate", "delete", "filter", "export"):
-            result = agent._tool_handlers["knowledge"]({"action": action})
+            result = agent._tool_handlers["knowledge"]({"action": action, "input": {}})
             assert result["status"] == "error", f"{action!r} should be rejected"
             assert "unknown action" in result["message"].lower()
-        # Exact model-visible envelope must survive the dispatch-helper
-        # migration (issue #513): wording, quoting, and key names verbatim.
-        assert agent._tool_handlers["knowledge"]({"action": "submit"}) == {
+            assert "current_setting" in result
+        setting = agent._tool_handlers["knowledge"]({"action": "submit", "input": {}})["current_setting"]
+        # Exact model-visible wording remains unchanged; only the truthful
+        # settings diagnostic is added at the outer result boundary.
+        assert agent._tool_handlers["knowledge"]({"action": "submit", "input": {}}) == {
             "status": "error",
             "message": "unknown action: 'submit', only 'info' or 'manual' is supported",
+            "current_setting": setting,
         }
-        # A missing action key renders the empty-string default, not None.
-        assert agent._tool_handlers["knowledge"]({}) == {
+        # A missing action key renders the empty-string default, not None, when
+        # the required nested input is present.
+        assert agent._tool_handlers["knowledge"]({"input": {}}) == {
             "status": "error",
             "message": "unknown action: '', only 'info' or 'manual' is supported",
+            "current_setting": agent._tool_handlers["knowledge"]({"input": {}})["current_setting"],
         }
-        # Invalid JSON can make `action` unhashable (issue #513 blocker): the
-        # router must render the unknown-action envelope, not raise TypeError.
-        assert agent._tool_handlers["knowledge"]({"action": []}) == {
-            "status": "error",
-            "message": "unknown action: [], only 'info' or 'manual' is supported",
-        }
-        assert agent._tool_handlers["knowledge"]({"action": {}}) == {
-            "status": "error",
-            "message": "unknown action: {}, only 'info' or 'manual' is supported",
-        }
+        # Invalid JSON can make `action` unhashable: the router must render the
+        # unknown-action envelope, not raise TypeError.
+        for action, rendered in (([], "[]"), ({}, "{}")):
+            result = agent._tool_handlers["knowledge"]({"action": action, "input": {}})
+            assert result["message"] == f"unknown action: {rendered}, only 'info' or 'manual' is supported"
+            assert "current_setting" in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_handler_rejects_action_only_flat_and_nonempty_input(tmp_path):
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        handler = agent._tool_handlers["knowledge"]
+        for args in (
+            {"action": "info"},
+            {"action": "info", "title": "flat payload"},
+            {"action": "info", "input": {"title": "non-empty"}},
+            {"action": "info", "input": []},
+        ):
+            result = handler(args)
+            assert result["status"] == "error"
+            assert "current_setting" in result
+            assert "knowledge" in result["message"]
     finally:
         agent.stop(timeout=1.0)
 
@@ -171,13 +246,69 @@ def test_unknown_action_returns_error(tmp_path):
 
 def test_schema_has_info_and_manual_actions():
     from lingtai.tools.knowledge import get_schema
-    SCHEMA = get_schema("en")
-    actions = SCHEMA["properties"]["action"]["enum"]
-    assert actions == ["info", "manual"]
-    # Old JSON-store properties are gone — these fields no longer have any code path.
-    props = SCHEMA["properties"]
-    for removed in ("title", "summary", "content", "supplementary", "ids", "include_supplementary"):
-        assert removed not in props, f"{removed!r} must be removed from schema"
+
+    schema = get_schema("en")
+    assert set(schema["properties"]) == {"action", "input"}
+    assert schema["required"] == ["action", "input"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["action"]["enum"] == ["info", "manual"]
+    branches = schema["properties"]["input"]["anyOf"]
+    assert [branch["title"] for branch in branches] == ["info input", "manual input"]
+    for branch in branches:
+        assert branch == {
+            "title": branch["title"],
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": False,
+        }
+    # The raw capability schema deliberately does not include Agent-injected
+    # reasoning, and no branch may smuggle it in.
+    assert "reasoning" not in schema["properties"]
+    assert all("reasoning" not in branch["properties"] for branch in branches)
+
+
+def test_actual_agent_inventory_prompt_and_batches_keep_reasoning_root_only(tmp_path):
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        schema = next(item for item in agent._build_tool_schemas() if item.name == "knowledge")
+        params = schema.parameters
+        assert set(params["properties"]) == {"action", "input", "reasoning"}
+        assert params["required"] == ["action", "input"]
+        assert params["additionalProperties"] is False
+        branches = params["properties"]["input"]["anyOf"]
+        assert all("reasoning" not in branch["properties"] for branch in branches)
+
+        full_prompt = agent._build_system_prompt()
+        batches = agent._build_system_prompt_batches()
+        assert full_prompt == "\\n\\n".join(batch for batch in batches if batch)
+        assert "knowledge(action=\"info\", input={}, reasoning=" in full_prompt
+        assert "knowledge(action=\"manual\", input={}, reasoning=" in full_prompt
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_knowledge_schema_survives_openai_and_anthropic_envelopes():
+    from lingtai.kernel.llm.base import WIRE_TOOL_DESCRIPTION, FunctionSchema
+    from lingtai.llm.anthropic.adapter import _build_tools as build_anthropic_tools
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+    from lingtai.tools.knowledge import get_description, get_schema
+
+    raw = get_schema()
+    schema = FunctionSchema(name="knowledge", description=get_description(), parameters=raw)
+    chat = _build_tools([schema])[0]
+    responses = _build_responses_tools([schema])[0]
+    anthropic = build_anthropic_tools([schema])[0]
+    for envelope, parameters in (
+        (chat["function"]["parameters"], chat["function"]["parameters"]),
+        (responses["parameters"], responses["parameters"]),
+        (anthropic["input_schema"], anthropic["input_schema"]),
+    ):
+        assert envelope == raw
+        assert parameters["properties"]["input"]["anyOf"][0]["additionalProperties"] is False
+    assert chat["function"]["description"] == WIRE_TOOL_DESCRIPTION
+    assert responses["description"] == WIRE_TOOL_DESCRIPTION
+    assert anthropic["description"] == WIRE_TOOL_DESCRIPTION
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +370,7 @@ def test_catalog_refreshes_on_info(tmp_path):
             "late-arrival",
             "Added after agent boot.",
         )
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["catalog_size"] == 1
 
         prompt = agent._prompt_manager.read_section("knowledge") or ""
@@ -277,7 +408,7 @@ def test_knowledge_md_convention_distinct_from_skill_md(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["catalog_size"] == 1
         prompt = agent._prompt_manager.read_section("knowledge") or ""
         assert "real-entry" in prompt
@@ -316,7 +447,7 @@ def test_entries_may_have_scripts_and_assets(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["status"] == "ok"
         assert result["catalog_size"] == 1
         assert result["problems"] == []
@@ -349,7 +480,7 @@ def test_entry_may_reference_local_paths_in_body(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["catalog_size"] == 1
         prompt = agent._prompt_manager.read_section("knowledge") or ""
         # Body (and its private references) stays out of the prompt catalog.
@@ -377,7 +508,7 @@ def test_info_surfaces_missing_frontmatter(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         problem_folders = [p["folder"] for p in result["problems"]]
         assert any("missing-desc" in f for f in problem_folders)
         assert result["catalog_size"] == 0
@@ -408,7 +539,7 @@ def test_legacy_knowledge_json_migrates_to_knowledge_md(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["catalog_size"] == 1
         assert result["problems"] == []
 
@@ -456,7 +587,7 @@ def test_legacy_knowledge_json_migration_uses_unique_slugs(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["catalog_size"] == 2
         assert (legacy_dir / "duplicate" / "KNOWLEDGE.md").is_file()
         assert (legacy_dir / "duplicate-b2" / "KNOWLEDGE.md").is_file()
@@ -487,7 +618,7 @@ def test_legacy_codex_json_migrates_to_knowledge_md(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["catalog_size"] == 1
         assert result["problems"] == []
 

--- a/tests/test_tool_settings.py
+++ b/tests/test_tool_settings.py
@@ -1,0 +1,154 @@
+"""Focused tests for the private no-op placeholder-settings foundation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools._settings import (
+    MAX_SETTINGS_BYTES,
+    current_setting,
+    read_settings,
+    settings_path,
+    valid_tool_name,
+)
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+
+def _write(root: Path, tool_name: str, payload: str | bytes) -> Path:
+    path = root / "settings" / f"{tool_name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def test_missing_is_a_normal_noop_placeholder_state(tmp_path):
+    snapshot = read_settings(_Agent(tmp_path), "example")
+    setting = current_setting(snapshot, "example")
+    assert setting == {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": "missing",
+        "settings_revision": "missing",
+        "settings_hash": None,
+        "change_hint": (
+            "Edit settings/example.json; changes apply on the next example call; "
+            "this no-op placeholder never changes tool behavior."
+        ),
+    }
+
+
+def test_valid_v1_only_changes_source_revision_and_hash(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "example", '{"schema_version": 1}')
+    snapshot = read_settings(agent, "example")
+    setting = current_setting(snapshot, "example")
+    assert snapshot.error is None
+    assert setting["configurable"] is False
+    assert setting["placeholder"] == "no-op"
+    assert setting["source"] == "settings/example.json"
+    assert setting["settings_revision"] == setting["settings_hash"]
+    assert setting["settings_hash"]
+
+
+def test_reader_rereads_hot_changes_without_cache(tmp_path):
+    agent = _Agent(tmp_path)
+    path = _write(tmp_path, "example", '{"schema_version": 1}')
+    first = read_settings(agent, "example")
+    path.write_text('{ "schema_version": 1 }', encoding="utf-8")
+    second = read_settings(agent, "example")
+    assert first.digest != second.digest
+    assert second.source == "settings/example.json"
+
+
+def test_duplicate_and_extra_fields_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    duplicate = _write(tmp_path, "duplicate", '{"schema_version": 1, "schema_version": 1}')
+    duplicate_snapshot = read_settings(agent, "duplicate")
+    assert duplicate_snapshot.source == "settings_error"
+    assert "duplicate" in (duplicate_snapshot.error or "")
+
+    extra = _write(tmp_path, "extra", '{"schema_version": 1, "future": false}')
+    extra_snapshot = read_settings(agent, "extra")
+    assert extra_snapshot.source == "settings_error"
+    assert "only schema_version" in (extra_snapshot.error or "")
+
+
+def test_bool_and_other_schema_versions_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    for name, version in (("bool", True), ("float", 1.0), ("other", 2)):
+        _write(tmp_path, name, json.dumps({"schema_version": version}))
+        snapshot = read_settings(agent, name)
+        assert snapshot.source == "settings_error"
+        assert "integer 1" in (snapshot.error or "")
+
+
+def test_invalid_encoding_and_json_are_truthful_bounded_errors(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "encoding", b'{"schema_version": 1}\xff')
+    encoding_snapshot = read_settings(agent, "encoding")
+    assert encoding_snapshot.source == "settings_error"
+    assert encoding_snapshot.error
+
+    _write(tmp_path, "json", "{not-json")
+    json_snapshot = read_settings(agent, "json")
+    assert json_snapshot.source == "settings_error"
+    assert json_snapshot.error
+    assert len(json_snapshot.error) <= 240
+
+
+def test_symlink_non_regular_and_oversized_files_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text('{"schema_version": 1}', encoding="utf-8")
+    symlink = tmp_path / "settings" / "symlink.json"
+    symlink.parent.mkdir()
+    symlink.symlink_to(target)
+    symlink_snapshot = read_settings(agent, "symlink")
+    assert symlink_snapshot.source == "settings_error"
+    assert "regular file" in (symlink_snapshot.error or "")
+
+    non_regular = tmp_path / "settings" / "directory.json"
+    non_regular.mkdir()
+    directory_snapshot = read_settings(agent, "directory")
+    assert directory_snapshot.source == "settings_error"
+    assert "regular file" in (directory_snapshot.error or "")
+
+    _write(tmp_path, "large", b"{" + b"x" * MAX_SETTINGS_BYTES + b"}")
+    large_snapshot = read_settings(agent, "large")
+    assert large_snapshot.source == "settings_error"
+    assert "bounded size" in (large_snapshot.error or "")
+
+
+def test_unstable_snapshot_is_not_treated_as_missing(tmp_path, monkeypatch):
+    import lingtai.tools._settings as settings_module
+
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "unstable", '{"schema_version": 1}')
+
+    def raise_unstable(_path):
+        raise settings_module.SettingsError("settings snapshot changed during read")
+
+    monkeypatch.setattr(settings_module, "_read_stable", raise_unstable)
+    snapshot = read_settings(agent, "unstable")
+    assert snapshot.source == "settings_error"
+    assert snapshot.revision == "error"
+    assert snapshot.error == "settings snapshot changed during read"
+
+
+def test_tool_names_are_bounded_path_components(tmp_path):
+    assert valid_tool_name("web_search")
+    assert not valid_tool_name("../escape")
+    assert not valid_tool_name("nested/name")
+    assert not valid_tool_name("\\escape")
+    assert not valid_tool_name("x" * 65)
+    with pytest.raises(ValueError):
+        settings_path(_Agent(tmp_path), "../escape")


### PR DESCRIPTION
## Summary

- migrate the public `knowledge` schema to required root `action` + strict nested `input`; BaseAgent remains the sole owner of optional root `reasoning`
- add exact empty `info input` and `manual input` branches, reject action-only/flat/non-mapping/non-empty payloads, and preserve existing unknown-action wording
- reread Agent-owned `settings/knowledge.json` on every invocation and attach truthful no-op `current_setting` diagnostics to every success, degraded, malformed, and unknown-action result
- keep catalog reconciliation, legacy migration, manual loading, prompt refresh, and result fields unchanged
- synchronize the knowledge manual, contract v2, anatomy, three glossaries, and focused tests

## Validation

- parent no-pytest actual-Agent harness: **PASS**
  - raw module schema properties: `action`, `input`
  - fresh Agent / OpenAI Chat / OpenAI Responses / Anthropic properties: `action`, `input`, `reasoning`
  - required fields remain `action`, `input`; reasoning stays root-only
  - full prompt equals joined prompt batches and contains canonical knowledge call examples
  - info/manual/unknown/action-only/flat/non-empty paths validated; malformed paths retain `current_setting`
  - missing → valid → hot-changed → invalid settings reread validated; invalid placeholder remains diagnostic-only and a sentinel value did not leak
- exact worktree compile/import-origin assertions: **PASS**
- anatomy drift: **PASS** (`No anatomy drift found across 53 file(s).`)
- glossary validator: **PASS** (`57` resources across `19` packages)
- `git diff --check`: **PASS**
- canonical Git/GitHub identity: `huangzesen <hzsbazinga@outlook.com>` / `huangzesen`

Local pytest was intentionally not run because this task's strict no-deletion boundary forbids local harness cleanup. Focused pytest coverage is included for GitHub CI.

## Stack / review notes

- **base dependency:** draft foundation PR #1038 (`feat/tool-settings-foundation`, exact base `752e279e`)
- this PR's independently reviewable delta is the single knowledge commit `67c9fa73`
- no registry, BaseAgent, executor, provider adapter, shared web, auth/config, or unrelated tool change
- no merge is authorized; this remains a draft for Jason's morning review
