### PR TITLE
feat(skills): adopt action input tool contract

### DIFF
--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
@@ -35,6 +36,10 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_settings.py` — private Agent-owned placeholder-settings reader and
+  secret-free current-setting diagnostic. It strictly validates the exact
+  versioned no-op schema, rereads `settings/<bounded tool_name>.json` per call,
+  and never supplies action, input, reasoning, or tool behavior.
 
 ## Connections
 

--- a/src/lingtai/tools/_settings.py
+++ b/src/lingtai/tools/_settings.py
@@ -1,0 +1,156 @@
+"""Private shared reader for Agent-owned no-op tool settings placeholders.
+
+The placeholder file is deliberately metadata-only.  A present, valid v1 file
+proves that an Agent-owned settings snapshot was read, but it cannot select or
+enable any tool behavior.  Individual tools may later add their own real
+settings reader when a configurable choice is actually authorized.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MAX_SETTINGS_BYTES = 64 * 1024
+SETTINGS_SCHEMA_VERSION = 1
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class SettingsError(ValueError):
+    """A placeholder settings snapshot was malformed or unsafe to use."""
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsSnapshot:
+    """Immutable evidence for one reread of one tool's settings file."""
+
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def valid_tool_name(value: Any) -> bool:
+    """Return whether *value* is safe as one bounded settings path component."""
+    return isinstance(value, str) and _TOOL_NAME.fullmatch(value) is not None
+
+
+def settings_path(agent: Any, tool_name: str) -> Path:
+    """Return the fixed Agent-owned ``settings/<tool_name>.json`` path."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return Path(agent._working_dir) / "settings" / f"{tool_name}.json"
+
+
+def _bounded_error(exc: Exception) -> str:
+    """Render a bounded diagnostic without echoing host paths or file content."""
+    if isinstance(exc, OSError):
+        return f"settings file could not be read ({type(exc).__name__})"
+    text = str(exc).replace("\n", " ").strip()
+    return (text or "invalid settings")[:240]
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject duplicate JSON object members instead of accepting last-wins data."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SettingsError("duplicate settings field")
+        result[key] = value
+    return result
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    """Read one bounded regular-file snapshot and its content revision."""
+    try:
+        first = path.lstat()
+    except FileNotFoundError:
+        return b"", "missing"
+    except OSError:
+        raise
+
+    if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
+        raise SettingsError("settings file must be a regular file")
+    if first.st_size > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings file exceeds the bounded size")
+
+    # Open by path only after lstat, then compare the path identity and metadata
+    # again.  Replacements, symlink swaps, growth, and ordinary in-place writes
+    # are therefore rejected rather than partially accepted.
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_SETTINGS_BYTES + 1)
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    try:
+        second = path.lstat()
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    if stat.S_ISLNK(second.st_mode) or not stat.S_ISREG(second.st_mode):
+        raise SettingsError("settings snapshot changed during read")
+    if (
+        len(raw) > MAX_SETTINGS_BYTES
+        or first.st_dev != second.st_dev
+        or first.st_ino != second.st_ino
+        or first.st_size != second.st_size
+        or first.st_mtime_ns != second.st_mtime_ns
+    ):
+        raise SettingsError("settings snapshot changed during read")
+    return raw, hashlib.sha256(raw).hexdigest()[:32]
+
+
+def read_settings(agent: Any, tool_name: str) -> SettingsSnapshot:
+    """Reread and strictly validate one tool's placeholder settings snapshot.
+
+    Missing is a normal placeholder state.  A valid file contributes only its
+    source/revision/hash evidence; it never changes behavior.  Every invocation
+    performs a fresh filesystem read and does not cache a prior snapshot.
+    """
+    path = settings_path(agent, tool_name)
+    digest: str | None = None
+    try:
+        raw, revision = _read_stable(path)
+        if revision == "missing":
+            return SettingsSnapshot("missing", "missing", None)
+        digest = revision
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        if not isinstance(value, dict) or set(value) != {"schema_version"}:
+            raise SettingsError("settings schema must contain only schema_version")
+        if type(value["schema_version"]) is not int or value["schema_version"] != SETTINGS_SCHEMA_VERSION:
+            raise SettingsError("settings schema_version must be integer 1")
+        return SettingsSnapshot(f"settings/{tool_name}.json", revision, digest)
+    except (OSError, UnicodeError, json.JSONDecodeError, SettingsError) as exc:
+        # Malformed data is never silently converted to the missing state.  The
+        # digest from a bounded stable read is retained as evidence when safe.
+        return SettingsSnapshot(
+            "settings_error",
+            digest or "error",
+            digest,
+            _bounded_error(exc if isinstance(exc, Exception) else SettingsError("invalid settings")),
+        )
+
+
+def current_setting(snapshot: SettingsSnapshot, tool_name: str) -> dict[str, Any]:
+    """Build the bounded, secret-free current-setting diagnostic for a tool."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return_value: dict[str, Any] = {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": snapshot.source,
+        "settings_revision": snapshot.revision,
+        "settings_hash": snapshot.digest,
+        "change_hint": (
+            f"Edit settings/{tool_name}.json; changes apply on the next {tool_name} "
+            "call; this no-op placeholder never changes tool behavior."
+        ),
+    }
+    if snapshot.error:
+        return_value["settings_error"] = snapshot.error
+    return return_value

--- a/src/lingtai/tools/skills/ANATOMY.md
+++ b/src/lingtai/tools/skills/ANATOMY.md
@@ -4,8 +4,10 @@ related_files:
   - src/lingtai/agent.py
   - src/lingtai/tools/daemon/__init__.py
   - src/lingtai/tools/skills/__init__.py
+  - src/lingtai/tools/skills/CONTRACT.md
   - src/lingtai/tools/skills/manual/SKILL.md
   - src/lingtai/init_schema.py
+  - src/lingtai/tools/_settings.py
   - tests/test_skills.py
   - tests/test_validate_skill.py
   - src/lingtai/tools/skills/glossary-en.md
@@ -20,37 +22,91 @@ maintenance: |
 ---
 # core/skills
 
-Skills capability — per-agent skill catalog and skill-manual surface. This is the renamed successor of the old `library` capability. It scans the existing `.library/` directory plus configured extra paths, renders a YAML catalog (one `- name:` block per skill with `location:` and a `description:` block scalar), and injects it into the `skills` prompt section. It never writes skill files; installation remains the Agent initializer's job.
+Skills capability — per-agent skill catalog and skill-manual surface. This is the
+renamed successor of the old `library` capability. It scans the existing
+`.library/` directory plus configured extra paths, renders a YAML catalog (one
+`- name:` block per skill with `location:` and a `description:` block scalar), and
+injects it into the `skills` prompt section. It never writes skill files;
+installation remains the Agent initializer's job.
 
 ## Components
 
-- `skills/__init__.py` — the capability implementation. `get_description` (`__init__.py:166-167`), `get_schema` (`__init__.py:170-181`), `setup` (`__init__.py:184-219`), `_reconcile` (`__init__.py:75-159`), and path/scanner helpers (`__init__.py:50-68`).
-- `skills/manual/` — `skills-manual` skill documentation, template assets, and validator script. The validator can optionally require `last_changed_at` for LingTai-maintained skill bundles.
+- `skills/__init__.py` — capability implementation. `_resolve_path`
+  (`__init__.py:52-62`) handles absolute, relative, and tilde paths; `_scan`
+  (`__init__.py:69-70`) delegates Markdown catalog parsing; `_reconcile`
+  (`__init__.py:77-161`) scans `.library/` and Tier-1 paths, injects the protected
+  catalog, and reports health while preserving all compatibility response keys.
+- `get_description` (`__init__.py:196-205`) documents the two nested calls with
+  root `action`, empty `input`, and Agent-injected `reasoning`; `get_schema`
+  (`__init__.py:208-241`) is the closed raw schema with required `action` +
+  `input.anyOf` branches titled `info input` and `manual input`.
+- `setup` (`__init__.py:244-322`) preserves setup-time reconciliation and the
+  initializer boundary, then registers `handle_skills` with catalog path
+  injection unchanged. The handler (`__init__.py:263-314`) rereads foundation
+  settings before every invocation, accepts root `action`, `input`, canonical
+  `reasoning`, and executor `_reasoning`, validates an empty mapping input,
+  dispatches only `action` and `input` without flat compatibility, and attaches
+  `current_setting` to every outcome.
+- `skills/manual/` — `skills-manual` skill documentation, template assets, and
+  validator script. The validator can optionally require `last_changed_at` for
+  LingTai-maintained skill bundles.
 
 ## Connections
 
-- `lingtai.tools.registry` maps canonical `skills` here. Former skill-catalog `library.paths` compatibility is removed in the clean rename.
-- `Agent._install_intrinsic_manuals()` copies every capability `manual/` bundle into `.library/intrinsic/capabilities/<name>/`, then re-runs `skills._reconcile()` for first-turn catalog freshness when `skills` is loaded (`src/lingtai/agent.py:256`).
-- The daemon capability blacklists `skills` so emanations do not recursively receive the skill catalog tool (`../daemon/__init__.py:34`).
+- `lingtai.tools.registry` maps canonical `skills` here. Former skill-catalog
+  `library.paths` compatibility is removed in the clean rename.
+- `Agent._install_intrinsic_manuals()` copies every capability `manual/` bundle into
+  `.library/intrinsic/capabilities/<name>/`, then re-runs `skills._reconcile()` for
+  first-turn catalog freshness when `skills` is loaded (`src/lingtai/agent.py:256`).
+- The daemon capability blacklists `skills` so emanations do not recursively
+  receive the skill catalog tool (`../daemon/__init__.py:34`).
+- The handler reads the shared no-op settings foundation
+  (`src/lingtai/tools/_settings.py:108-156`) but settings never select or alter
+  skills behavior; the `settings/skills.json` evidence is surfaced as
+  `current_setting` only.
 
 ## Public API
 
-The `skills` tool exposes two signpost actions:
+The `skills` tool exposes two signpost actions using a required nested empty
+input. The raw module schema has only `action` and `input`; it has no metadata
+properties. After registration, `BaseAgent` adds optional root `reasoning` to
+form the final Agent/model-facing schema, and `ToolExecutor` may pass that
+metadata internally as `_reasoning`. The direct handler accepts either root
+metadata spelling, and neither belongs inside `input` or reaches dispatch.
 
 | Action | Description |
 |---|---|
-| `info` | Refresh/reconcile the skills catalog and return runtime health (catalog size, paths report, problems) without manual bodies |
-| `manual` | Return the skills manual body plus the library manual body on demand |
+| `info` | `skills(action="info", input={}, reasoning="refresh the catalog")` refreshes/reconciles the skills catalog and returns runtime health (catalog size, paths report, problems) without manual bodies |
+| `manual` | `skills(action="manual", input={}, reasoning="read skills guidance")` returns the installed skills manual body plus `library_manual` on demand |
+
+Direct action-only, flat, non-object, or non-empty-input calls are malformed
+errors. Unknown actions retain the historical exact message text, but not the entire
+response envelope because `current_setting` is now attached. All success, degraded,
+malformed, and unknown results include the truthful per-call `current_setting` value.
 
 ## State
 
-- Skill storage remains `<agent>/.library/` for compatibility: `intrinsic/` is CLI-managed and `custom/` is agent-authored (`__init__.py:87-90`).
-- Config path source is canonical `manifest.capabilities.skills.paths` (`src/lingtai/init_schema.py:403-421`).
-- Prompt state is the `skills` section (`__init__.py:125-131`).
-- Health check expects `.library/intrinsic/capabilities/skills/SKILL.md` and reports `skills_manual`, with `library_manual` retained as a response compatibility key (`__init__.py:133-152`).
+- Skill storage remains `<agent>/.library/` for compatibility: `intrinsic/` is
+  CLI-managed and `custom/` is agent-authored (`__init__.py:89-92`).
+- Config path source is canonical `manifest.capabilities.skills.paths`
+  (`src/lingtai/init_schema.py:403-421`).
+- Prompt state is the protected `skills` section (`__init__.py:127-133`).
+- Health check expects `.library/intrinsic/capabilities/skills/SKILL.md` and reports
+  `skills_manual`, with `library_manual` retained as a response compatibility key
+  (`__init__.py:135-160`).
+- The settings placeholder is Agent-owned at `settings/skills.json`; the reader
+  rereads it on every handler invocation and reports missing/valid/invalid states
+  without changing scanner, path resolution, reconciliation, catalog injection,
+  or manual behavior.
 
 ## Notes
 
-- The `.library/` directory name and `.library_shared/` convention are intentionally preserved in this rename-only change; they are storage compatibility names, not the user-facing capability name.
-- New callers should use `skills({"action":"info"})`; old `library({"action":"info"})` is not registered because private durable memory is now `knowledge` and `library` is not registered.
-- LingTai-maintained `SKILL.md` files carry `last_changed_at` in frontmatter, initialized from git history for metadata-only backfills and updated on substantive skill edits.
+- The `.library/` directory name and `.library_shared/` convention are intentionally
+  preserved in this rename-only change; they are storage compatibility names, not
+  the user-facing capability name.
+- New callers should use `skills(action="info", input={}, reasoning="refresh the catalog")`;
+  old `library({"action":"info"})` is not registered because private durable memory
+  is now `knowledge` and `library` is not registered.
+- LingTai-maintained `SKILL.md` files carry `last_changed_at` in frontmatter,
+  initialized from git history for metadata-only backfills and updated on
+  substantive skill edits.

--- a/src/lingtai/tools/skills/CONTRACT.md
+++ b/src/lingtai/tools/skills/CONTRACT.md
@@ -1,10 +1,14 @@
 ---
 name: skills-contract
 tool: skills
-contract_version: 1
+contract_version: 2
 related_files:
   - src/lingtai/tools/skills/__init__.py
   - src/lingtai/tools/skills/ANATOMY.md
+  - src/lingtai/tools/skills/manual/SKILL.md
+  - src/lingtai/tools/skills/glossary-en.md
+  - src/lingtai/tools/skills/glossary-zh.md
+  - src/lingtai/tools/skills/glossary-wen.md
   - src/lingtai/tools/_catalog.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
@@ -27,6 +31,8 @@ in `src/lingtai/tools/skills/__init__.py`; the code is the source of truth.
   `info` / `manual` action split.
 - You need to verify the skills/knowledge boundary (portable procedures vs.
   private durable memory).
+- You need to verify the nested model-facing `action`/`input` contract or its
+  per-call settings diagnostic.
 
 **Do not use this for:**
 - Private durable memory: read `src/lingtai/tools/knowledge/CONTRACT.md` (the
@@ -54,22 +60,73 @@ in `src/lingtai/tools/skills/__init__.py`; the code is the source of truth.
 
 ## Tool surface
 
-Schema requires `action`; the handler is `handle_skills` (dispatched via
-`dispatch_action`). Exactly two actions.
+The raw module schema returned by `get_schema()` is a closed object with exactly root
+`action` and `input`:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "action": {"type": "string", "enum": ["info", "manual"]},
+    "input": {
+      "anyOf": [
+        {"title": "info input", "type": "object", "properties": {},
+         "required": [], "additionalProperties": false},
+        {"title": "manual input", "type": "object", "properties": {},
+         "required": [], "additionalProperties": false}
+      ]
+    }
+  },
+  "required": ["action", "input"],
+  "additionalProperties": false
+}
+```
+
+This raw schema is not the final Agent/model-facing schema. The module owns no
+`reasoning` property; after registration, `BaseAgent` adds optional root
+`reasoning`, so the final model-facing properties are `action`, `input`, and
+`reasoning`. `ToolExecutor` may remove that public field and pass it internally as
+`_reasoning`. Neither metadata form belongs inside an `input` branch. Direct handler
+calls accept root `action`, `input`, `reasoning`, and `_reasoning`; only `action` and
+`input` are dispatched. Root action-only, flat payloads, non-object input, and
+non-empty input are rejected rather than routed through a compatibility path.
 
 | Action | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|
-| `info` | `action="info"` | — | reconciles catalog, re-injects prompt, returns `{status, skills_dir, library_dir, catalog_size, paths, problems}` (manual body omitted) | see below |
-| `manual` | `action="manual"` | — | `{status: "ok", skills_manual, library_manual, manual_path}` — manual body without refreshing catalog | degraded shape below |
+| `info` | `action="info"`, `input={}` | root `reasoning` or `_reasoning` | reconciles catalog, re-injects prompt, returns `{status, skills_dir, library_dir, catalog_size, paths, problems, current_setting}` (manual body omitted) | degraded shape below |
+| `manual` | `action="manual"`, `input={}` | root `reasoning` or `_reasoning` | `{status: "ok", skills_manual, library_manual, manual_path, current_setting}` — manual body without refreshing catalog | degraded shape below |
 
-Status is `"ok"` normally; `info` and `manual` return `status: "degraded"` (with
-an `error` string and empty manual body) when the skills manual
-(`.library/intrinsic/capabilities/skills/SKILL.md`) is missing. `library_manual`
+Status is `"ok"` normally. When the skills manual
+(`.library/intrinsic/capabilities/skills/SKILL.md`) is missing, a degraded `info`
+result carries an `error` string and omits manual-body keys; only a degraded
+`manual` result returns empty `skills_manual`/`library_manual` values. `library_manual`
 and `library_dir` are back-compat keys mirroring the `skills_*` keys; the on-disk
 directory remains `.library`.
 
-**Error shapes** (plain dicts):
-- Unknown action: `{"status": "error", "message": "unknown action: <action>, only 'info' or 'manual' is supported"}`.
+All action results, degraded results, malformed-input errors, and unknown-action
+errors include the exact `current_setting` value produced for that invocation.
+Malformed input uses a plain error dict with one of the bounded messages
+`input is required`, `input must be an object`, `input must be an empty object`,
+or `unsupported skills argument`. Unknown actions preserve the exact historical
+message text, but not the entire historical envelope: `current_setting` is now
+attached to every result.
+
+```json
+{"status": "error", "message": "unknown action: <action>, only 'info' or 'manual' is supported", "current_setting": {}}
+```
+
+## Settings placeholder and hot reread
+
+Before every handler invocation, the capability calls the foundation
+`read_settings(agent, "skills")` and `current_setting(snapshot, "skills")` helpers.
+The Agent-owned `settings/skills.json` file is a metadata-only v1 placeholder and
+must contain exactly `{"schema_version": 1}` when present. Missing, valid, and
+invalid settings states are reported truthfully in `current_setting`; invalid
+JSON, extra fields, wrong versions, unstable snapshots, non-regular files, and
+oversized files are not silently treated as missing. The reader is deliberately
+not cached: a file change is visible on the next call. The placeholder never
+selects, enables, or otherwise changes skills behavior, and `manual` always
+returns the installed canonical `SKILL.md` body rather than settings data.
 
 ## State & storage
 
@@ -101,17 +158,22 @@ Do not change any of the following; documented for reviewers only.
   via `agent.update_system_prompt("skills", ..., protected=True)`; empty catalog
   clears the section.
 - **Encoding:** `SKILL.md` bodies are read as UTF-8.
+- **Initializer boundary:** setup reconciles the installed store but does not
+  create, install, wipe, or rewrite `.library`; those remain Agent initializer
+  responsibilities.
 
 ## Anchored claims
 
 | Claim | Source `src/lingtai/tools/skills/...` | Test |
 |---|---|---|
-| Unknown actions return a `{status: error}` dict | `__init__.py` (`handle_skills`) | `tests/test_skills.py::test_unknown_action_returns_error` |
+| Unknown actions return a `{status: error}` dict with the historical wording | `__init__.py` (`handle_skills`) | `tests/test_skills.py::test_unknown_action_returns_error` |
+| Root and nested input are closed and empty | `__init__.py` (`get_schema`, `handle_skills`) | `tests/test_skills.py::test_schema_requires_closed_nested_empty_input`, `::test_handler_rejects_action_only_flat_and_nonempty_input` |
 | `info` omits the manual body | `__init__.py` (`_skills_info`) | `tests/test_skills.py::test_info_omits_skills_manual_body` |
 | `manual` returns the skills manual body | `__init__.py` (`_skills_manual`) | `tests/test_skills.py::test_manual_returns_skills_manual_body` |
 | Missing intrinsic manual reports `degraded` | `__init__.py` (`_reconcile`) | `tests/test_skills.py::test_info_reports_degraded_when_intrinsic_missing` |
 | Declared paths resolve (absolute / relative / `~`) | `__init__.py` (`_resolve_path`) | `tests/test_skills.py::test_skills_scans_absolute_path`, `::test_skills_resolves_relative_path_from_working_dir`, `::test_skills_expands_tilde` |
 | Catalog is injected into the `skills` prompt section | `__init__.py` (`_reconcile`) | `tests/test_skills.py::test_catalog_injected_into_skills_section` |
+| Settings are reread and attached to every outcome | `__init__.py` (`handle_skills`) | `tests/test_skills.py::test_settings_are_reread_and_attached_to_every_result` |
 | Former `library`/`codex` configs do not register legacy tools | `__init__.py` / registry | `tests/test_skills.py::test_former_library_config_does_not_register_library_tool` |
 | Catalog scan/parse helpers behave per spec | `src/lingtai/tools/_catalog.py` | `tests/test_catalog_helpers.py::test_scan_recurses_and_sorts` |
 | `SKILL.md` frontmatter validation | `src/lingtai/tools/_catalog.py` | `tests/test_validate_skill.py` |
@@ -120,10 +182,11 @@ Do not change any of the following; documented for reviewers only.
 
 | Invariant | Automated test | Manual check | Risk if broken |
 |---|---|---|---|
-| Only `info` / `manual` are accepted | `tests/test_skills.py::test_unknown_action_returns_error` | Call `skills(action="foo")` | Silent mis-dispatch |
+| Only nested empty `info` / `manual` calls are accepted | `tests/test_skills.py::test_handler_rejects_action_only_flat_and_nonempty_input` | Call `skills(action="foo", input={}, reasoning="check routing")` | Silent mis-dispatch |
 | Catalog reaches the prompt | `tests/test_skills.py::test_catalog_injected_into_skills_section` | Boot with a custom skill, inspect `skills` prompt section | Skills invisible to the model |
 | Body stays out of prompt | `tests/test_catalog_helpers.py::test_build_catalog_yaml_golden` | Author a long-body skill, inspect prompt | Prompt bloat |
-| Missing manual is degraded not fatal | `tests/test_skills.py::test_info_reports_degraded_when_intrinsic_missing` | Remove the intrinsic manual, call `info` | Boot failure vs. graceful degrade |
+| Missing manual is degraded not fatal | `tests/test_skills.py::test_info_reports_degraded_when_intrinsic_missing` | Remove the intrinsic manual, call nested `info` | Boot failure vs. graceful degrade |
+| Settings are truthful and hot-reread | `tests/test_skills.py::test_settings_are_reread_and_attached_to_every_result` | Edit `settings/skills.json`, call again | Stale or fabricated diagnostics |
 | Legacy names do not register | `tests/test_skills.py::test_former_library_config_does_not_register_library_tool` | Boot an old `library` manifest, inspect tools | Half-applied rename confuses model |
 
 Run before merging:
@@ -140,8 +203,8 @@ python -m pytest tests/test_skills.py tests/test_validate_skill.py tests/test_ca
   language-independent; the optional `lang` argument is accepted for source
   compatibility but ignored.
 - **Provider wire:** provider adapters send the global `WIRE_TOOL_DESCRIPTION`
-  constant as the top-level tool description; `FunctionSchema.description`
-  holds the full canonical prose rendered into `## tools`.
+  constant as the top-level tool description; `FunctionSchema.description` holds
+  the full canonical prose rendered into `## tools`.
 - **Glossary resources:** this package owns `glossary-en.md`, `glossary-zh.md`,
   and `glossary-wen.md`. Each has strict YAML frontmatter
   (`kind: tool-glossary`, `schema_version: 1`, `tool_package: tools.<pkg>`,

--- a/src/lingtai/tools/skills/__init__.py
+++ b/src/lingtai/tools/skills/__init__.py
@@ -27,10 +27,12 @@ Usage: ``Agent(capabilities={"skills": {"paths": [...]}})`` or via init.json.
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lingtai.kernel.tool_dispatch import dispatch_action
+from .._settings import current_setting, read_settings
 
 from .._catalog import build_catalog_yaml, scan_markdown_catalog
 from lingtai.kernel.i18n import t
@@ -192,7 +194,15 @@ def _skills_manual(agent: "BaseAgent") -> dict:
 # ---------------------------------------------------------------------------
 
 def get_description(lang: str = "en") -> str:
-    return 'SIGNPOST ONLY: this tool does not author, pin, publish, install, or execute skills; `info` only refreshes/reconciles the skills catalog and returns health without the manual body; `manual` returns the skills-manual body. Your per-agent skill catalog. The skills section of your system prompt is a YAML list — one `- name:` block per skill with `location:` and `description:` — covering every skill reachable right now. Before using this tool (authoring, pinning, publishing, or managing skills), read the `skills-manual` skill — call `manual` for its body and `info` for a runtime health snapshot; no exceptions.'
+    return (
+        "SIGNPOST ONLY: this tool does not author, pin, publish, install, or execute skills. "
+        "Use skills(action=\"info\", input={}, reasoning=\"refresh the catalog\") to "
+        "refresh/reconcile the per-agent skills catalog and return runtime health without "
+        "the manual body. Use skills(action=\"manual\", input={}, "
+        "reasoning=\"read skills guidance\") to return the installed skills-manual body. "
+        "The skills section of your system prompt is a YAML list — one `- name:` block per "
+        "reachable skill with `location:` and `description:`."
+    )
 
 
 def get_schema(lang: str = "en") -> dict:
@@ -202,10 +212,32 @@ def get_schema(lang: str = "en") -> dict:
             "action": {
                 "type": "string",
                 "enum": ["info", "manual"],
-                "description": 'info: refresh/reconcile the skills catalog and return runtime health (catalog size, resolved paths, problems) without the manual body. manual: return only the skills-manual skill body.',
+                "description": (
+                    "Required operation: info refreshes the catalog; manual returns "
+                    "the installed skills-manual body."
+                ),
+            },
+            "input": {
+                "anyOf": [
+                    {
+                        "title": "info input",
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                        "additionalProperties": False,
+                    },
+                    {
+                        "title": "manual input",
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                        "additionalProperties": False,
+                    },
+                ],
             },
         },
-        "required": ["action"],
+        "required": ["action", "input"],
+        "additionalProperties": False,
     }
 
 
@@ -229,8 +261,47 @@ def setup(agent: "BaseAgent", paths: list[str] | None = None, **_ignored) -> Non
 
     # Register signpost actions. `info` refreshes health; `manual` returns the large manual body.
     def handle_skills(args: dict) -> dict:
-        return dispatch_action(
-            args,
+        setting = current_setting(read_settings(agent, "skills"), "skills")
+
+        def with_setting(result: dict) -> dict:
+            result["current_setting"] = setting
+            return result
+
+        if not isinstance(args, Mapping):
+            return with_setting({
+                "status": "error",
+                "message": "skills arguments must be an object",
+            })
+
+        raw = dict(args)
+        if set(raw) - {"action", "input", "reasoning", "_reasoning"}:
+            return with_setting({
+                "status": "error",
+                "message": "unsupported skills argument",
+            })
+        if "input" not in raw:
+            return with_setting({
+                "status": "error",
+                "message": "input is required",
+            })
+        if not isinstance(raw["input"], Mapping):
+            return with_setting({
+                "status": "error",
+                "message": "input must be an object",
+            })
+
+        # The public schema has two exact empty input branches. Unwrap the
+        # mapping once, but never merge it with root fields or accept a flat
+        # compatibility payload.
+        action_input = dict(raw["input"])
+        if action_input:
+            return with_setting({
+                "status": "error",
+                "message": "input must be an empty object",
+            })
+
+        result = dispatch_action(
+            {"action": raw.get("action", ""), "input": action_input},
             {
                 "info": lambda _args: _skills_info(agent, path_list),
                 "manual": lambda _args: _skills_manual(agent),
@@ -240,6 +311,7 @@ def setup(agent: "BaseAgent", paths: list[str] | None = None, **_ignored) -> Non
                 "message": f"unknown action: {action!r}, only 'info' or 'manual' is supported",
             },
         )
+        return with_setting(result)
 
     agent.add_tool(
         "skills",

--- a/src/lingtai/tools/skills/glossary-en.md
+++ b/src/lingtai/tools/skills/glossary-en.md
@@ -10,6 +10,6 @@ related_files:
 - src/lingtai/tools/skills/glossary-zh.md
 - src/lingtai/tools/skills/glossary-wen.md
 maintenance: |
-  English glossary for the `skills` tool package (lingtai.tools.skills); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when skills's public tool schema changes.
+  English glossary for the `skills` tool package (lingtai.tools.skills); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when skills's public tool schema changes. The current public shape has root `action` + `input`, while Agent-injected `reasoning` remains root-only.
   Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
 ---

--- a/src/lingtai/tools/skills/glossary-wen.md
+++ b/src/lingtai/tools/skills/glossary-wen.md
@@ -10,10 +10,12 @@ related_files:
 - src/lingtai/tools/skills/glossary-en.md
 - src/lingtai/tools/skills/glossary-zh.md
 maintenance: |
-  Classical-Chinese (wen) glossary for the `skills` tool package (lingtai.tools.skills); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever skills's public tool schema changes.
+  Classical-Chinese (wen) glossary for the `skills` tool package (lingtai.tools.skills); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever skills's public tool schema changes. The public root uses `action` and `input`; Agent-injected `reasoning` remains root-only.
   Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
 ---
 **名相对照**
 
-- `skills`：【路标之器】此器不代汝书技、固技、发布、安装或施技；`info` 唯重校/重扫技典并还康状，不载 manual 全文；`manual` 方还 skills-manual 之文。尔之器灵技能目录。系统之中技能典为 YAML 之列——每技一 `- name:` 块，附 `location:` 与 `description:` 之目——所列皆此时可取之技。用此器前（凡藏用、固定、出新、料理技能之事），必先读 `skills-manual` 一技——呼 `info` 即得其文与当时之康状，无所例外。
+- `skills`：【路标之器】此器不代汝书技、固技、发布、安装或施技；`info` 唯重校/重扫技典并还康状，不载 manual 全文；`manual` 方还 skills-manual 之文。尔之器灵技能目录。系统之中技能典为 YAML 之列——每技一 `- name:` 块，附 `location:` 与 `description:` 之目——所列皆此时可取之技。用此器前（凡藏用、固定、出新、料理技能之事），必先读 `skills-manual` 一技——呼 `info` 乃得当时之康状，呼 `manual` 方得其文，无所例外。
 - `action`：info：重校/重扫技能目录，并还当时之康状（技数、解径、患记），不载 manual 全文。manual：唯还 skills-manual 之文。
+- `input`：二 action 皆受之空对象；路径、目录限及他参，不可平列于根。
+- `reasoning`：Agent 所注之根级调用由；非 `input` 分支所有。

--- a/src/lingtai/tools/skills/glossary-zh.md
+++ b/src/lingtai/tools/skills/glossary-zh.md
@@ -10,10 +10,12 @@ related_files:
 - src/lingtai/tools/skills/glossary-en.md
 - src/lingtai/tools/skills/glossary-wen.md
 maintenance: |
-  Simplified-Chinese (zh) glossary for the `skills` tool package (lingtai.tools.skills); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever skills's public tool schema changes.
+  Simplified-Chinese (zh) glossary for the `skills` tool package (lingtai.tools.skills); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever skills's public tool schema changes. The public root uses `action` and `input`; Agent-injected `reasoning` remains root-only.
   Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
 ---
 **术语对照**
 
-- `skills`：【路标工具】此工具不会编写、固定、发布、安装或执行技能；`info` 只重新协调/扫描技能目录并返回健康状态，不带 manual 正文；`manual` 才返回 skills-manual 正文。你的器灵专属技能目录。系统提示词中的技能目录为 YAML 列表——每项技能为一 `- name:` 块，附 `location:` 与 `description:` 字段——涵盖当前所有可用的技能。用此工具前（编写、固定、发布或管理技能），必先读 `skills-manual` 技能——调用 `info` 即可获取其正文与运行时健康快照，无例外。
+- `skills`：【路标工具】此工具不会编写、固定、发布、安装或执行技能；`info` 只重新协调/扫描技能目录并返回健康状态，不带 manual 正文；`manual` 才返回 skills-manual 正文。你的器灵专属技能目录。系统提示词中的技能目录为 YAML 列表——每项技能为一 `- name:` 块，附 `location:` 与 `description:` 字段——涵盖当前所有可用的技能。用此工具前（编写、固定、发布或管理技能），必先读 `skills-manual` 技能——调用 `info` 获取运行时健康快照，调用 `manual` 获取其正文，无例外。
 - `action`：info：刷新/协调技能目录并返回运行时健康快照（目录规模、解析后的路径、问题列表），不带 manual 正文。manual：只返回 skills-manual 技能正文。
+- `input`：两种 action 的严格空对象输入；不得把路径、目录限制或其他参数平铺到根对象。
+- `reasoning`：Agent 注入的根级调用理由；不属于 `input` 分支。

--- a/src/lingtai/tools/skills/manual/SKILL.md
+++ b/src/lingtai/tools/skills/manual/SKILL.md
@@ -71,14 +71,33 @@ The `skills` section of your system prompt is a YAML list. Each skill is one
 `SKILL.md`) and a `description:` block scalar. To read a skill's body, `read` the
 file at its `location`.
 
-`skills({"action": "info"})` refreshes/reconciles the catalog and returns a
-runtime snapshot — `skills_dir`/`library_dir`, `catalog_size`, resolved paths
-with exist/skill-count info, and any `problems` (invalid frontmatter, unreadable
-folders) — without the manual body. Use it first when a skill you expect is
-missing. `skills({"action": "manual"})` returns this SKILL.md body instead. A
-`status` of `"degraded"` carries an error message naming the fix — typically a
-missing manual under `intrinsic/capabilities/skills/`, meaning the initializer
-did not install manuals correctly.
+`skills(action="info", input={}, reasoning="refresh the catalog")` refreshes/reconciles
+the catalog and returns a runtime snapshot — `skills_dir`/`library_dir`,
+`catalog_size`, resolved paths with exist/skill-count info, and any `problems`
+(invalid frontmatter, unreadable folders) — without the manual body. Use it first
+when a skill you expect is missing. `skills(action="manual", input={},
+reasoning="read skills guidance")` returns this SKILL.md body instead. A `status`
+of `"degraded"` carries an error message naming the fix — typically a missing
+manual under `intrinsic/capabilities/skills/`, meaning the initializer did not
+install manuals correctly. An `info` result never includes manual-body keys, even
+when degraded; only `manual` can return those keys, with empty strings when its
+installed manual is missing.
+
+## Settings placeholder and current setting
+
+Each `skills` invocation rereads the Agent-owned `settings/skills.json` file before
+validating or dispatching the request. The file is an exact v1 placeholder:
+`{"schema_version": 1}` and no other fields. A missing file is a normal
+placeholder state; a valid file contributes only its source/revision/hash
+metadata; malformed, unstable, non-regular, or oversized files report a bounded
+`settings_error`. None of these states changes catalog scanning, reconciliation,
+manual loading, or any other skills behavior.
+
+Every `info`, `manual`, degraded, malformed-input, and unknown-action result
+contains the truthful `current_setting` returned for that invocation. The reader
+is not cached: edits to `settings/skills.json` are visible on the next call, and
+`current_setting.change_hint` names this hot-reread behavior. `manual` remains the
+installed canonical `SKILL.md` body; settings metadata never replaces it.
 
 To pin a skill's body into your pad so it survives a molt and rides in the cached
 system-prompt prefix:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -64,33 +64,159 @@ def _write_skill(folder: Path, name: str, desc: str = "test skill"):
 
 
 def test_unknown_action_returns_error(tmp_path):
-    """Only `info` is supported; the exact error envelope is model-visible.
-
-    Locks the unknown-action envelope through the issue #513 dispatch-helper
-    migration: wording, quoting, and key names must stay verbatim.
-    """
+    """Only nested empty inputs are accepted; unknown wording stays exact."""
     agent, _ = _mk_agent(tmp_path)
     try:
         handler = agent._tool_handlers["skills"]
-        assert handler({"action": "list"}) == {
-            "status": "error",
-            "message": "unknown action: 'list', only 'info' or 'manual' is supported",
-        }
+        result = handler({"action": "list", "input": {}})
+        assert result["status"] == "error"
+        assert result["message"] == (
+            "unknown action: 'list', only 'info' or 'manual' is supported"
+        )
+        assert "current_setting" in result
+
         # Missing action key renders the empty-string default, not None.
-        assert handler({}) == {
-            "status": "error",
-            "message": "unknown action: '', only 'info' or 'manual' is supported",
+        result = handler({"input": {}})
+        assert result["message"] == (
+            "unknown action: '', only 'info' or 'manual' is supported"
+        )
+        # Invalid JSON can make `action` unhashable: the router still renders
+        # the unknown-action envelope instead of raising TypeError.
+        for action, rendered in (([], "[]"), ({}, "{}")):
+            result = handler({"action": action, "input": {}})
+            assert result["message"] == (
+                f"unknown action: {rendered}, only 'info' or 'manual' is supported"
+            )
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_schema_requires_closed_nested_empty_input(tmp_path):
+    from lingtai.tools.skills import get_schema
+
+    schema = get_schema()
+    assert set(schema["properties"]) == {"action", "input"}
+    assert schema["required"] == ["action", "input"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["action"]["enum"] == ["info", "manual"]
+    branches = schema["properties"]["input"]["anyOf"]
+    assert [branch["title"] for branch in branches] == ["info input", "manual input"]
+    for branch in branches:
+        assert branch == {
+            "title": branch["title"],
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": False,
         }
-        # Invalid JSON can make `action` unhashable (issue #513 blocker): the
-        # router must render the unknown-action envelope, not raise TypeError.
-        assert handler({"action": []}) == {
-            "status": "error",
-            "message": "unknown action: [], only 'info' or 'manual' is supported",
-        }
-        assert handler({"action": {}}) == {
-            "status": "error",
-            "message": "unknown action: {}, only 'info' or 'manual' is supported",
-        }
+
+
+def test_handler_rejects_action_only_flat_and_nonempty_input(tmp_path, monkeypatch):
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        handler = agent._tool_handlers["skills"]
+        for args, message in (
+            ({"action": "info"}, "input is required"),
+            ({"action": "info", "paths": []}, "unsupported skills argument"),
+            ({"action": "info", "input": {"paths": []}}, "input must be an empty object"),
+            ({"action": "info", "input": None}, "input must be an object"),
+        ):
+            result = handler(args)
+            assert result["status"] == "error"
+            assert result["message"] == message
+            assert isinstance(result["current_setting"], dict)
+
+        import lingtai.tools.skills as skills_module
+
+        dispatched = []
+
+        def fake_dispatch(args, actions, *, unknown):
+            dispatched.append(args)
+            return {"status": "ok"}
+
+        monkeypatch.setattr(skills_module, "dispatch_action", fake_dispatch)
+        for metadata_key in ("reasoning", "_reasoning"):
+            result = handler(
+                {"action": "info", "input": {}, metadata_key: "refresh the catalog"}
+            )
+            assert result["status"] == "ok"
+            assert dispatched[-1] == {"action": "info", "input": {}}
+            assert metadata_key not in dispatched[-1]
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_agent_inventory_and_prompt_use_root_reasoning_only(tmp_path):
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        schemas = {schema.name: schema for schema in agent._build_tool_schemas()}
+        params = schemas["skills"].parameters
+        assert set(params["properties"]) == {"action", "input", "reasoning"}
+        assert params["required"] == ["action", "input"]
+        assert params["additionalProperties"] is False
+        for branch in params["properties"]["input"]["anyOf"]:
+            assert "reasoning" not in branch["properties"]
+
+        full_prompt = agent._build_system_prompt()
+        batches = agent._build_system_prompt_batches()
+        assert 'skills(action="info", input={}, reasoning=' in full_prompt
+        assert any("skills(action=\"manual\", input={}, reasoning=" in batch for batch in batches)
+
+        from lingtai.llm.anthropic.adapter import _build_tools as anthropic_tools
+        from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+        schema = schemas["skills"]
+        chat = _build_tools([schema])[0]["function"]["parameters"]
+        responses = _build_responses_tools([schema])[0]["parameters"]
+        anthropic = anthropic_tools([schema])[0]["input_schema"]
+        assert chat == params == responses == anthropic
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_settings_are_reread_and_attached_to_every_result(tmp_path, monkeypatch):
+    import lingtai.tools.skills as skills_module
+    from lingtai.tools._settings import SettingsSnapshot
+
+    agent, workdir = _mk_agent(tmp_path)
+    try:
+        reads = []
+        attached = []
+
+        def fake_read(current_agent, tool_name):
+            assert current_agent is agent
+            assert tool_name == "skills"
+            revision = f"sentinel-{len(reads)}"
+            reads.append(revision)
+            return SettingsSnapshot("sentinel", revision, revision)
+
+        def fake_current(snapshot, tool_name):
+            assert tool_name == "skills"
+            value = {"revision": snapshot.revision}
+            attached.append(value)
+            return value
+
+        monkeypatch.setattr(skills_module, "read_settings", fake_read)
+        monkeypatch.setattr(skills_module, "current_setting", fake_current)
+        handler = agent._tool_handlers["skills"]
+        calls = [
+            {"action": "info", "input": {}},
+            {"action": "manual", "input": {}},
+            {"action": "unknown", "input": {}},
+            {"action": "info"},
+        ]
+        manual_path = (
+            workdir / ".library" / "intrinsic" / "capabilities" / "skills" / "SKILL.md"
+        )
+        for call in calls:
+            result = handler(call)
+            assert result["current_setting"] is attached[-1]
+            assert result["current_setting"]["revision"] == reads[-1]
+        manual_path.unlink()
+        result = handler({"action": "info", "input": {}})
+        assert result["status"] == "degraded"
+        assert result["current_setting"] is attached[-1]
+        assert len(reads) == len(calls) + 1
     finally:
         agent.stop(timeout=1.0)
 
@@ -593,7 +719,7 @@ def test_skills_scans_absolute_path(tmp_path):
 
     agent, _ = _mk_agent(tmp_path, {"paths": [str(extra)]})
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}})
         assert result["status"] == "ok"
         assert result["paths"][str(extra)]["skills"] == 1
         assert result["catalog_size"] >= 2  # skills-manual + shared-skill
@@ -609,7 +735,7 @@ def test_skills_resolves_relative_path_from_working_dir(tmp_path):
 
     agent, _ = _mk_agent(tmp_path, {"paths": ["../.library_shared"]})
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}})
         assert result["status"] == "ok"
         assert result["paths"]["../.library_shared"]["exists"] is True
         assert result["paths"]["../.library_shared"]["skills"] == 1
@@ -626,7 +752,7 @@ def test_skills_expands_tilde(tmp_path, monkeypatch):
 
     agent, _ = _mk_agent(tmp_path, {"paths": ["~/my-utils"]})
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}})
         assert result["paths"]["~/my-utils"]["exists"] is True
     finally:
         agent.stop(timeout=1.0)
@@ -635,7 +761,7 @@ def test_skills_expands_tilde(tmp_path, monkeypatch):
 def test_skills_reports_missing_path_as_not_existing(tmp_path):
     agent, _ = _mk_agent(tmp_path, {"paths": ["/does/not/exist"]})
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}})
         assert result["paths"]["/does/not/exist"]["exists"] is False
         assert result["paths"]["/does/not/exist"]["skills"] == 0
     finally:
@@ -650,7 +776,7 @@ def test_skills_reports_missing_path_as_not_existing(tmp_path):
 def test_info_omits_skills_manual_body(tmp_path):
     agent, _ = _mk_agent(tmp_path)
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}})
         assert "skills_manual" not in result
         assert "library_manual" not in result
     finally:
@@ -660,7 +786,7 @@ def test_info_omits_skills_manual_body(tmp_path):
 def test_manual_returns_skills_manual_body(tmp_path):
     agent, _ = _mk_agent(tmp_path)
     try:
-        result = agent._tool_handlers["skills"]({"action": "manual"})
+        result = agent._tool_handlers["skills"]({"action": "manual", "input": {}})
         assert "skills_manual" in result
         assert "library_manual" in result
         assert "name: skills-manual" in result["skills_manual"]
@@ -671,7 +797,7 @@ def test_manual_returns_skills_manual_body(tmp_path):
 def test_info_reports_ok_when_healthy(tmp_path):
     agent, _ = _mk_agent(tmp_path)
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}})
         assert result["status"] == "ok"
         assert "error" not in result
     finally:
@@ -690,7 +816,7 @@ def test_info_reports_degraded_when_intrinsic_missing(tmp_path):
         assert manual_path.is_file(), "precondition: initializer installed manual"
         manual_path.unlink()
 
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}})
         assert result["status"] == "degraded"
         assert "error" in result
     finally:
@@ -711,7 +837,7 @@ def test_info_surfaces_problems(tmp_path):
         capabilities={"skills": {}},
     )
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}})
         problem_folders = [p["folder"] for p in result["problems"]]
         assert any("broken" in f for f in problem_folders)
     finally:
@@ -884,7 +1010,7 @@ def test_new_knowledge_and_skills_config_registers_both(tmp_path):
         (entry_dir / "KNOWLEDGE.md").write_text(
             "---\nname: new-entry\ndescription: A freshly authored knowledge entry.\n---\nBody.\n"
         )
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}})
         assert result["status"] == "ok"
         assert result["catalog_size"] == 1
         assert "new-entry" in (agent._prompt_manager.read_section("knowledge") or "")

--- a/tests/test_tool_settings.py
+++ b/tests/test_tool_settings.py
@@ -1,0 +1,154 @@
+"""Focused tests for the private no-op placeholder-settings foundation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools._settings import (
+    MAX_SETTINGS_BYTES,
+    current_setting,
+    read_settings,
+    settings_path,
+    valid_tool_name,
+)
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+
+def _write(root: Path, tool_name: str, payload: str | bytes) -> Path:
+    path = root / "settings" / f"{tool_name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def test_missing_is_a_normal_noop_placeholder_state(tmp_path):
+    snapshot = read_settings(_Agent(tmp_path), "example")
+    setting = current_setting(snapshot, "example")
+    assert setting == {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": "missing",
+        "settings_revision": "missing",
+        "settings_hash": None,
+        "change_hint": (
+            "Edit settings/example.json; changes apply on the next example call; "
+            "this no-op placeholder never changes tool behavior."
+        ),
+    }
+
+
+def test_valid_v1_only_changes_source_revision_and_hash(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "example", '{"schema_version": 1}')
+    snapshot = read_settings(agent, "example")
+    setting = current_setting(snapshot, "example")
+    assert snapshot.error is None
+    assert setting["configurable"] is False
+    assert setting["placeholder"] == "no-op"
+    assert setting["source"] == "settings/example.json"
+    assert setting["settings_revision"] == setting["settings_hash"]
+    assert setting["settings_hash"]
+
+
+def test_reader_rereads_hot_changes_without_cache(tmp_path):
+    agent = _Agent(tmp_path)
+    path = _write(tmp_path, "example", '{"schema_version": 1}')
+    first = read_settings(agent, "example")
+    path.write_text('{ "schema_version": 1 }', encoding="utf-8")
+    second = read_settings(agent, "example")
+    assert first.digest != second.digest
+    assert second.source == "settings/example.json"
+
+
+def test_duplicate_and_extra_fields_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    duplicate = _write(tmp_path, "duplicate", '{"schema_version": 1, "schema_version": 1}')
+    duplicate_snapshot = read_settings(agent, "duplicate")
+    assert duplicate_snapshot.source == "settings_error"
+    assert "duplicate" in (duplicate_snapshot.error or "")
+
+    extra = _write(tmp_path, "extra", '{"schema_version": 1, "future": false}')
+    extra_snapshot = read_settings(agent, "extra")
+    assert extra_snapshot.source == "settings_error"
+    assert "only schema_version" in (extra_snapshot.error or "")
+
+
+def test_bool_and_other_schema_versions_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    for name, version in (("bool", True), ("float", 1.0), ("other", 2)):
+        _write(tmp_path, name, json.dumps({"schema_version": version}))
+        snapshot = read_settings(agent, name)
+        assert snapshot.source == "settings_error"
+        assert "integer 1" in (snapshot.error or "")
+
+
+def test_invalid_encoding_and_json_are_truthful_bounded_errors(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "encoding", b'{"schema_version": 1}\xff')
+    encoding_snapshot = read_settings(agent, "encoding")
+    assert encoding_snapshot.source == "settings_error"
+    assert encoding_snapshot.error
+
+    _write(tmp_path, "json", "{not-json")
+    json_snapshot = read_settings(agent, "json")
+    assert json_snapshot.source == "settings_error"
+    assert json_snapshot.error
+    assert len(json_snapshot.error) <= 240
+
+
+def test_symlink_non_regular_and_oversized_files_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text('{"schema_version": 1}', encoding="utf-8")
+    symlink = tmp_path / "settings" / "symlink.json"
+    symlink.parent.mkdir()
+    symlink.symlink_to(target)
+    symlink_snapshot = read_settings(agent, "symlink")
+    assert symlink_snapshot.source == "settings_error"
+    assert "regular file" in (symlink_snapshot.error or "")
+
+    non_regular = tmp_path / "settings" / "directory.json"
+    non_regular.mkdir()
+    directory_snapshot = read_settings(agent, "directory")
+    assert directory_snapshot.source == "settings_error"
+    assert "regular file" in (directory_snapshot.error or "")
+
+    _write(tmp_path, "large", b"{" + b"x" * MAX_SETTINGS_BYTES + b"}")
+    large_snapshot = read_settings(agent, "large")
+    assert large_snapshot.source == "settings_error"
+    assert "bounded size" in (large_snapshot.error or "")
+
+
+def test_unstable_snapshot_is_not_treated_as_missing(tmp_path, monkeypatch):
+    import lingtai.tools._settings as settings_module
+
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "unstable", '{"schema_version": 1}')
+
+    def raise_unstable(_path):
+        raise settings_module.SettingsError("settings snapshot changed during read")
+
+    monkeypatch.setattr(settings_module, "_read_stable", raise_unstable)
+    snapshot = read_settings(agent, "unstable")
+    assert snapshot.source == "settings_error"
+    assert snapshot.revision == "error"
+    assert snapshot.error == "settings snapshot changed during read"
+
+
+def test_tool_names_are_bounded_path_components(tmp_path):
+    assert valid_tool_name("web_search")
+    assert not valid_tool_name("../escape")
+    assert not valid_tool_name("nested/name")
+    assert not valid_tool_name("\\escape")
+    assert not valid_tool_name("x" * 65)
+    with pytest.raises(ValueError):
+        settings_path(_Agent(tmp_path), "../escape")


### PR DESCRIPTION
## Summary

- migrate the public `skills` schema to required root `action` + strict nested `input`; BaseAgent remains the sole owner of optional root `reasoning`
- add exact empty `info input` and `manual input` branches, reject action-only/flat/non-mapping/non-empty payloads, and preserve existing unknown-action message text
- reread Agent-owned `settings/skills.json` on every invocation and attach truthful no-op `current_setting` diagnostics to every success, degraded, malformed, and unknown-action result
- preserve reconciliation, catalog injection, initializer boundaries, manual loading, path resolution, and existing result fields
- synchronize the skills manual, contract v2, anatomy, three glossaries, and focused tests

## Validation

- parent no-pytest actual-Agent harness: **PASS**
  - raw module properties: `action`, `input`
  - fresh Agent / OpenAI Chat / OpenAI Responses / Anthropic properties: `action`, `input`, `reasoning`
  - public `reasoning` and executor `_reasoning` direct paths both accepted and stripped before dispatch
  - full prompt equals joined batches with canonical skills examples
  - info/manual/unknown/action-only/flat/non-object/non-empty paths validated with exact messages and `current_setting`
  - missing → valid → hot-changed → invalid settings reread validated; catalog/status/path results remained invariant and a sentinel value did not leak
- exact worktree compile/import-origin assertions: **PASS**
- anatomy drift: **PASS** (`No anatomy drift found across 53 file(s).`)
- glossary validator: **PASS** (`57` resources across `19` packages)
- `git diff --check`: **PASS**
- canonical Git/GitHub identity: `huangzesen <hzsbazinga@outlook.com>` / `huangzesen`

Local pytest was intentionally not run because this task's strict no-deletion boundary forbids local harness cleanup. Focused pytest coverage is included for GitHub CI.

## Stack / review notes

- **base dependency:** draft foundation PR #1038 (`feat/tool-settings-foundation`, exact base `752e279e`)
- this PR's independently reviewable delta is the single skills commit `d949a4ef`
- parent review found and repaired four pre-PR defects: public reasoning rejection, flat-argument expected message, raw-vs-final schema wording, and info/manual glossary contradictions
- no registry, BaseAgent, executor, provider adapter, shared web, auth/config, or unrelated tool change
- no merge is authorized; this remains a draft for Jason's morning review
