### PR TITLE
feat(vision): migrate public contract to action and input

### DIFF
--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
@@ -35,6 +36,10 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_settings.py` — private Agent-owned placeholder-settings reader and
+  secret-free current-setting diagnostic. It strictly validates the exact
+  versioned no-op schema, rereads `settings/<bounded tool_name>.json` per call,
+  and never supplies action, input, reasoning, or tool behavior.
 
 ## Connections
 

--- a/src/lingtai/tools/_settings.py
+++ b/src/lingtai/tools/_settings.py
@@ -1,0 +1,156 @@
+"""Private shared reader for Agent-owned no-op tool settings placeholders.
+
+The placeholder file is deliberately metadata-only.  A present, valid v1 file
+proves that an Agent-owned settings snapshot was read, but it cannot select or
+enable any tool behavior.  Individual tools may later add their own real
+settings reader when a configurable choice is actually authorized.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MAX_SETTINGS_BYTES = 64 * 1024
+SETTINGS_SCHEMA_VERSION = 1
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class SettingsError(ValueError):
+    """A placeholder settings snapshot was malformed or unsafe to use."""
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsSnapshot:
+    """Immutable evidence for one reread of one tool's settings file."""
+
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def valid_tool_name(value: Any) -> bool:
+    """Return whether *value* is safe as one bounded settings path component."""
+    return isinstance(value, str) and _TOOL_NAME.fullmatch(value) is not None
+
+
+def settings_path(agent: Any, tool_name: str) -> Path:
+    """Return the fixed Agent-owned ``settings/<tool_name>.json`` path."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return Path(agent._working_dir) / "settings" / f"{tool_name}.json"
+
+
+def _bounded_error(exc: Exception) -> str:
+    """Render a bounded diagnostic without echoing host paths or file content."""
+    if isinstance(exc, OSError):
+        return f"settings file could not be read ({type(exc).__name__})"
+    text = str(exc).replace("\n", " ").strip()
+    return (text or "invalid settings")[:240]
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject duplicate JSON object members instead of accepting last-wins data."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SettingsError("duplicate settings field")
+        result[key] = value
+    return result
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    """Read one bounded regular-file snapshot and its content revision."""
+    try:
+        first = path.lstat()
+    except FileNotFoundError:
+        return b"", "missing"
+    except OSError:
+        raise
+
+    if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
+        raise SettingsError("settings file must be a regular file")
+    if first.st_size > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings file exceeds the bounded size")
+
+    # Open by path only after lstat, then compare the path identity and metadata
+    # again.  Replacements, symlink swaps, growth, and ordinary in-place writes
+    # are therefore rejected rather than partially accepted.
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_SETTINGS_BYTES + 1)
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    try:
+        second = path.lstat()
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    if stat.S_ISLNK(second.st_mode) or not stat.S_ISREG(second.st_mode):
+        raise SettingsError("settings snapshot changed during read")
+    if (
+        len(raw) > MAX_SETTINGS_BYTES
+        or first.st_dev != second.st_dev
+        or first.st_ino != second.st_ino
+        or first.st_size != second.st_size
+        or first.st_mtime_ns != second.st_mtime_ns
+    ):
+        raise SettingsError("settings snapshot changed during read")
+    return raw, hashlib.sha256(raw).hexdigest()[:32]
+
+
+def read_settings(agent: Any, tool_name: str) -> SettingsSnapshot:
+    """Reread and strictly validate one tool's placeholder settings snapshot.
+
+    Missing is a normal placeholder state.  A valid file contributes only its
+    source/revision/hash evidence; it never changes behavior.  Every invocation
+    performs a fresh filesystem read and does not cache a prior snapshot.
+    """
+    path = settings_path(agent, tool_name)
+    digest: str | None = None
+    try:
+        raw, revision = _read_stable(path)
+        if revision == "missing":
+            return SettingsSnapshot("missing", "missing", None)
+        digest = revision
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        if not isinstance(value, dict) or set(value) != {"schema_version"}:
+            raise SettingsError("settings schema must contain only schema_version")
+        if type(value["schema_version"]) is not int or value["schema_version"] != SETTINGS_SCHEMA_VERSION:
+            raise SettingsError("settings schema_version must be integer 1")
+        return SettingsSnapshot(f"settings/{tool_name}.json", revision, digest)
+    except (OSError, UnicodeError, json.JSONDecodeError, SettingsError) as exc:
+        # Malformed data is never silently converted to the missing state.  The
+        # digest from a bounded stable read is retained as evidence when safe.
+        return SettingsSnapshot(
+            "settings_error",
+            digest or "error",
+            digest,
+            _bounded_error(exc if isinstance(exc, Exception) else SettingsError("invalid settings")),
+        )
+
+
+def current_setting(snapshot: SettingsSnapshot, tool_name: str) -> dict[str, Any]:
+    """Build the bounded, secret-free current-setting diagnostic for a tool."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return_value: dict[str, Any] = {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": snapshot.source,
+        "settings_revision": snapshot.revision,
+        "settings_hash": snapshot.digest,
+        "change_hint": (
+            f"Edit settings/{tool_name}.json; changes apply on the next {tool_name} "
+            "call; this no-op placeholder never changes tool behavior."
+        ),
+    }
+    if snapshot.error:
+        return_value["settings_error"] = snapshot.error
+    return return_value

--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -22,9 +22,9 @@ provider-neutral manual route when direct setup is unavailable.
 
 - `__init__.py:34-88` — Codex-family gate and bucket-driven route resolution plus the same-provider alias check; GLM/Zhipu and Codex spelling pairs share current identity, provider spelling is only a Codex-family compatibility gate, `_normalize_codex_auth_path` trims the bucket `codex_auth_path` once, and `_codex_bucket_route` picks direct (nonblank trimmed `codex_auth_path` in the active bucket) vs pool exactly as the canonical Codex factory does.
 - `__init__.py:108-125` — exact advertised provider registry; the local pseudo-provider remains explicit opt-in and intentionally excluded.
-- `__init__.py:127-152` — compatible tool schema; neither action requires an image path at schema level.
-- `__init__.py:154-203` — `VisionManager`; `manual` reads bundled guidance without a backend, while `analyze` validates and reads the image.
-- `__init__.py:205-494` — `setup`; resolves only the same current model/endpoint/credential/headers/wire, routes active Codex-family services by the bucket-driven direct (trimmed `codex_auth_path`) vs pool (pool-selected candidate token path) rule, creates supported services, fails closed to manual guidance when identity is incomplete, and always registers the tool.
+- `__init__.py:129-192` — raw closed action/input schema: `analyze input` requires `image_path` and nullable `question`, while `manual input` is empty; the final Agent schema adds only optional root `reasoning`.
+- `__init__.py:194-332` — `VisionManager`; every handler call rereads the shared metadata-only `vision` settings snapshot before strict root/branch validation, attaches `current_setting` to every result, strips nullable defaults, and then preserves the existing image/manual behavior.
+- `__init__.py:334-629` — `setup`; resolves only the same current model/endpoint/credential/headers/wire, routes active Codex-family services by the bucket-driven direct (trimmed `codex_auth_path`) vs pool (pool-selected candidate token path) rule, creates supported services, fails closed to manual guidance when identity is incomplete, and always registers the tool.
 
 ## Connections
 

--- a/src/lingtai/tools/vision/CONTRACT.md
+++ b/src/lingtai/tools/vision/CONTRACT.md
@@ -1,7 +1,7 @@
 ---
 name: vision-contract
 tool: vision
-contract_version: 1
+contract_version: 2
 related_files:
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/ANATOMY.md
@@ -17,23 +17,45 @@ If direct setup is absent, unsupported, or fails, setup still registers the tool
 and preserves a read-only `action="manual"` route. It never changes provider or
 automatically invokes MCP.
 
-## Scope and registry
+## Public schema and registry
 
-The schema has optional `image_path`, `question`, and `action`; `action` is
-`analyze` by default or `manual`. Manual works without `image_path`; analyze
-requires it and resolves relative paths against the agent working directory.
+The raw tool schema is a closed object with exactly `action` and `input`, both
+required. `action` is `analyze` or `manual`; `input` is an action-specific closed
+object. The `analyze input` branch requires `image_path: string` and a required
+nullable `question: string | null`; the `manual input` branch is exactly empty.
+The strict nullable `question` representation allows providers to omit a
+semantic optional value by sending `null`; the handler removes null (and accepts
+direct-call omission) before applying the historical default
+`Describe what you see in this image.`. `BaseAgent` adds only optional root
+`reasoning` to the final Agent-facing schema; it is metadata, not nested input.
+
+Canonical calls are:
+
+```text
+vision(action="analyze", input={"image_path": "photo.png", "question": null}, reasoning="inspect the image")
+vision(action="manual", input={}, reasoning="load the read-only procedure")
+```
+
+Flat root `image_path`/`question`, action-only calls, unknown root keys, unknown
+input keys, and mismatched action/input branches are rejected by the handler
+before image/provider work. Manual works without an image and never starts a
+backend, inspects settings for behavior, or invokes MCP. Relative image paths
+resolve against the agent working directory.
 
 `PROVIDERS["providers"]` is exactly: `gemini`, `anthropic`, `openai`,
 `openrouter`, `custom`, `deepseek`, `minimax`, `mimo`, `glm`, `zhipu`, `grok`,
 `qwen`, `kimi`, `codex`, `codex-pool`, `codex_pool`, `claude-code`, and
 `claude_code`. The local mlx-vlm pseudo-provider remains available only through
 explicit `add_capability(..., provider="local")` opt-in and is intentionally not
-advertised to wizards/check-caps. Claude Code is manual-only; Codex aliases use
-native Codex Responses; MiniMax uses the Anthropic route. OpenRouter and custom
+advertised to wizards/check-caps.
+
+Claude Code is manual-only;
+Codex aliases use native Codex Responses; MiniMax uses the Anthropic route.
+OpenRouter and custom
 deliberately try the current OpenAI-compatible model/endpoint/credential without
 preflighting image support; other compatible aliases use the current
 OpenAI/Anthropic identity. A real request failure is returned as a sanitized
-vision tool error that points to `vision(action="manual")` for explicit
+vision tool error that points to `vision(action="manual", input={})` for explicit
 alternatives, without silently switching model/provider or invoking MCP.
 
 ## Current identity and wires
@@ -71,13 +93,24 @@ URL/max tokens: blank/auto resolves to its current Chat Completions route, which
 constructs without headers/wire kwargs, while an active unsupported wire remains
 manual-only.
 
-## Tool behavior
+## Tool behavior and settings evidence
 
-Success is `{status: "ok", analysis: text}`. Manual success is
-`{status: "ok", action: "manual", manual: body}`; missing manual is degraded.
-Missing image, empty response, setup failure, and request failure are structured
-errors pointing to `vision(action="manual")`. Exception messages are never
-returned; failures may include only the provider and exception type.
+Success is `{status: "ok", analysis: text, current_setting: {...}}`. Manual success
+is `{status: "ok", action: "manual", manual: body, current_setting: {...}}`;
+missing manual is degraded with the same diagnostic. Missing image, empty response,
+setup failure, request failure, malformed/unknown input, and unknown action are
+structured errors with `current_setting` and (where applicable) a pointer to
+`vision(action="manual", input={})`. Exception messages are never returned; failures may
+include only the provider and exception type.
+
+Every handler call rereads `settings/vision.json` through the shared settings
+reader before validation or behavior. Missing is normal; exact `{"schema_version": 1}`
+is a valid metadata-only v1 snapshot. A valid snapshot is diagnostic-only and
+cannot choose a provider/model/credential, enable a route, or alter defaults.
+Malformed, unstable, non-regular, or oversized settings are reported as
+`current_setting.source == "settings_error"` while existing behavior remains
+unchanged. The revision/hash and source therefore prove hot rereads without
+making the placeholder a configuration mechanism.
 
 ## Invariants and tests
 

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 from pathlib import Path
 from importlib import resources
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Mapping
+
+from lingtai.tools._settings import current_setting, read_settings
 
 
 if TYPE_CHECKING:
@@ -27,7 +29,7 @@ def _setup_failure(provider: str, exc: BaseException) -> str:
     """Build explicit manual guidance without exposing exception contents."""
     return (
         f"Direct vision setup failed for provider {provider!r} "
-        f"({type(exc).__name__}); use vision(action='manual')."
+        f"({type(exc).__name__}); use vision(action='manual', input={{}})."
     )
 
 
@@ -125,30 +127,68 @@ def get_description(lang: str = "en") -> str:
 
 
 def get_schema(lang: str = "en") -> dict:
+    """Return the raw, closed action/input schema owned by this tool.
+
+    ``BaseAgent`` adds the optional root ``reasoning`` property when it builds
+    the model-facing schema.  Keeping it out of this raw schema is deliberate:
+    reasoning is metadata, never an action input.
+    """
     return {
         "type": "object",
         "properties": {
-            "image_path": {"type": "string", "description": 'Path to the image file'},
-            "question": {
-                "type": "string",
-                "description": 'Question about the image',
-                "default": "Describe this image.",
-            },
             "action": {
                 "type": "string",
                 "enum": ["analyze", "manual"],
-                "default": "analyze",
                 "description": (
-                    "analyze performs the direct request; OpenRouter/custom try the "
-                    "current OpenAI-compatible route even when downstream image "
-                    "support is unknown. On real failure the sanitized tool result "
-                    "points to manual, which returns bundled read-only alternatives."
+                    "Required operation: analyze the image or return the read-only manual."
                 ),
             },
+            "input": {
+                "description": "Strict action-specific vision input.",
+                "anyOf": [
+                    {
+                        "title": "analyze input",
+                        "type": "object",
+                        "properties": {
+                            "image_path": {
+                                "type": "string",
+                                "description": "Path to the image file.",
+                            },
+                            "question": {
+                                "type": ["string", "null"],
+                                "description": (
+                                    "Question about the image, or null for the "
+                                    "existing default description."
+                                ),
+                            },
+                        },
+                        # Strict providers require semantically optional fields to
+                        # be required nullable properties.  The handler treats
+                        # null (and direct-call omission) as the old default.
+                        "required": ["image_path", "question"],
+                        "additionalProperties": False,
+                    },
+                    {
+                        "title": "manual input",
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                        "additionalProperties": False,
+                    },
+                ],
+            },
         },
-        "required": [],
+        "required": ["action", "input"],
+        "additionalProperties": False,
     }
 
+
+_ACTION_INPUT_FIELDS = {
+    "analyze": {"image_path", "question"},
+    "manual": set(),
+}
+_ALLOWED_ROOT_FIELDS = {"action", "input", "reasoning", "_reasoning"}
+_DEFAULT_QUESTION = "Describe what you see in this image."
 
 
 class VisionManager:
@@ -164,42 +204,131 @@ class VisionManager:
         self._vision_service = vision_service
         self._manual_reason = manual_reason
 
+    def _diagnostic(self) -> dict[str, Any]:
+        """Read the Agent-owned placeholder settings for this call only."""
+        snapshot = read_settings(self._agent, "vision")
+        return current_setting(snapshot, "vision")
+
+    @staticmethod
+    def _with_setting(result: dict[str, Any], diagnostic: dict[str, Any]) -> dict[str, Any]:
+        result["current_setting"] = diagnostic
+        return result
+
+    def _manual_result(self, diagnostic: dict[str, Any]) -> dict:
+        """Return bundled guidance without config, a backend, or MCP."""
+        try:
+            body = resources.files(__package__).joinpath("manual/SKILL.md").read_text(encoding="utf-8")
+        except (FileNotFoundError, ModuleNotFoundError, AttributeError):
+            return self._with_setting(
+                {"status": "degraded", "action": "manual", "manual": "", "error": "vision manual missing"},
+                diagnostic,
+            )
+        return self._with_setting(
+            {"status": "ok", "action": "manual", "manual": body}, diagnostic
+        )
+
     def handle(self, args: dict) -> dict:
-        if args.get("action", "analyze") == "manual":
-            return self.manual()
+        """Dispatch one strict action/input call after one settings reread.
+
+        The schema is model-facing validation, not an authorization boundary;
+        repeat the root/branch correspondence checks here before touching an
+        image or provider.  ToolExecutor removes public ``reasoning`` and
+        supplies internal ``_reasoning``; both are accepted metadata keys only.
+        """
+        diagnostic = self._diagnostic()
+        raw = dict(args) if isinstance(args, Mapping) else {}
+
+        unknown = set(raw) - _ALLOWED_ROOT_FIELDS
+        if unknown:
+            return self._with_setting(
+                {"status": "error", "message": "unsupported vision argument"}, diagnostic
+            )
+
+        action = raw.get("action")
+        if not isinstance(action, str) or action not in _ACTION_INPUT_FIELDS:
+            return self._with_setting(
+                {
+                    "status": "error",
+                    "message": "action must be one of analyze or manual",
+                },
+                diagnostic,
+            )
+
+        action_input = raw.get("input")
+        if not isinstance(action_input, Mapping):
+            return self._with_setting(
+                {"status": "error", "message": "input must be an object"}, diagnostic
+            )
+        action_args = dict(action_input)
+        if set(action_args) - _ACTION_INPUT_FIELDS[action]:
+            return self._with_setting(
+                {"status": "error", "message": "unsupported vision input field"}, diagnostic
+            )
+
+        if action == "manual":
+            return self._manual_result(diagnostic)
+
+        image_path = action_args.get("image_path", "")
+        if not isinstance(image_path, str):
+            return self._with_setting(
+                {"status": "error", "message": "image_path must be a string"}, diagnostic
+            )
+        question = action_args.get("question")
+        if question is not None and not isinstance(question, str):
+            return self._with_setting(
+                {"status": "error", "message": "question must be a string or null"}, diagnostic
+            )
+        # Strict schemas encode this optional field as required nullable.  Direct
+        # calls may omit it; null and omission preserve the historical default.
+        if question is None:
+            question = _DEFAULT_QUESTION
+
         if self._vision_service is None:
-            return {"status": "error", "message": self._manual_reason or "Direct vision is unavailable; call vision(action='manual')."}
-        image_path = args.get("image_path", "")
-        question = args.get("question", "Describe what you see in this image.")
+            return self._with_setting(
+                {
+                    "status": "error",
+                    "message": self._manual_reason or "Direct vision is unavailable; call vision(action='manual', input={}).",
+                },
+                diagnostic,
+            )
 
         if not image_path:
-            return {"status": "error", "message": "Provide image_path"}
+            return self._with_setting(
+                {"status": "error", "message": "Provide image_path"}, diagnostic
+            )
 
         path = Path(image_path)
         if not path.is_absolute():
             path = self._agent._working_dir / path
 
         if not path.is_file():
-            return {"status": "error", "message": f"Image file not found: {path}"}
+            return self._with_setting(
+                {"status": "error", "message": f"Image file not found: {path}"}, diagnostic
+            )
 
         try:
             analysis = self._vision_service.analyze_image(str(path), prompt=question)
             if not analysis:
-                return {
-                    "status": "error",
-                    "message": "Vision analysis returned no response.",
-                }
-            return {"status": "ok", "analysis": analysis}
+                return self._with_setting(
+                    {
+                        "status": "error",
+                        "message": "Vision analysis returned no response.",
+                    },
+                    diagnostic,
+                )
+            return self._with_setting({"status": "ok", "analysis": analysis}, diagnostic)
         except Exception as e:
-            return {"status": "error", "message": f"Vision analysis failed ({type(e).__name__}). Call vision(action='manual') for the explicit manual route."}
+            return self._with_setting(
+                {
+                    "status": "error",
+                    "message": f"Vision analysis failed ({type(e).__name__}). Call vision(action='manual', input={{}}) for the explicit manual route.",
+                },
+                diagnostic,
+            )
 
     def manual(self) -> dict:
-        """Return only bundled guidance; never inspect config or invoke a backend."""
-        try:
-            body = resources.files(__package__).joinpath("manual/SKILL.md").read_text(encoding="utf-8")
-        except (FileNotFoundError, ModuleNotFoundError, AttributeError):
-            return {"status": "degraded", "action": "manual", "manual": "", "error": "vision manual missing"}
-        return {"status": "ok", "action": "manual", "manual": body}
+        """Return only bundled guidance; reread diagnostics, never behavior config."""
+        return self._manual_result(self._diagnostic())
 
 
 def setup(
@@ -300,11 +429,11 @@ def setup(
                 if cap_max_tokens is not None:
                     svc_kwargs["max_tokens"] = cap_max_tokens
                 if wire_api is None:
-                    manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual')."
+                    manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual', input={})."
                 elif not llm_model:
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}})."
                 elif not api_key:
-                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}})."
                 else:
                     try:
                         vision_service = OpenAIVisionService(**svc_kwargs)
@@ -322,16 +451,16 @@ def setup(
                 if cap_max_tokens is not None:
                     svc_kwargs["max_tokens"] = cap_max_tokens
                 if not llm_model:
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}})."
                 elif not api_key:
-                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}})."
                 else:
                     try:
                         vision_service = AnthropicVisionService(**svc_kwargs)
                     except Exception as exc:
                         manual_reason = _setup_failure(provider, exc)
             else:
-                manual_reason = f"No direct vision route is supported for provider {provider!r}; use vision(action='manual')."
+                manual_reason = f"No direct vision route is supported for provider {provider!r}; use vision(action='manual', input={{}})."
         else:
             if provider_key in _CODEX_FAMILY:
                 # Codex vision is a standalone Responses request. It may share
@@ -366,7 +495,7 @@ def setup(
                 if explicit_token_path:
                     kwargs["token_path"] = explicit_token_path
                 if not kwargs.get("model"):
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}})."
                 elif codex_route == "direct":
                     # A whitespace-only explicit ``token_path`` is not an identity;
                     # normalize both it and the inherited bucket path once so the
@@ -378,7 +507,7 @@ def setup(
                     if token_path:
                         kwargs["token_path"] = token_path
                     else:
-                        manual_reason = "Codex vision has no explicit current OAuth identity; use vision(action='manual')."
+                        manual_reason = "Codex vision has no explicit current OAuth identity; use vision(action='manual', input={})."
                 else:
                     # Pool route (bucket has no nonblank ``codex_auth_path``).
                     # WeightedAccountSource selects an account from the pool file
@@ -408,7 +537,7 @@ def setup(
                         except NoCandidateError:
                             pass
                     if not kwargs.get("token_path"):
-                        manual_reason = "Codex pool vision has no selected current OAuth identity; use vision(action='manual')."
+                        manual_reason = "Codex pool vision has no selected current OAuth identity; use vision(action='manual', input={})."
                 kwargs.pop("api_compat", None)
                 kwargs.pop("base_url", None)
                 if codex_base_url:
@@ -452,11 +581,11 @@ def setup(
                 if service_provider == "mimo" and same_provider and active_base_url:
                     kwargs.setdefault("base_url", active_base_url)
                 if service_provider in {"openai", "mimo"} and wire_api is None:
-                    manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual')."
+                    manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual', input={})."
                 elif service_provider == "mimo" and wire_api != "chat_completions":
-                    manual_reason = "The active MiMo wire is not implemented by the direct vision service; use vision(action='manual')."
+                    manual_reason = "The active MiMo wire is not implemented by the direct vision service; use vision(action='manual', input={})."
                 if service_provider in {"openai", "mimo"} and active_compat == "anthropic":
-                    manual_reason = "The active preset uses an Anthropic wire that this vision route cannot safely adapt; use vision(action='manual')."
+                    manual_reason = "The active preset uses an Anthropic wire that this vision route cannot safely adapt; use vision(action='manual', input={})."
                     vision_service = None
                 if service_provider == "anthropic" and active_headers:
                     kwargs.setdefault("default_headers", active_headers)
@@ -473,9 +602,9 @@ def setup(
                     kwargs.pop("wire_api", None)
                 resolved_api_key = api_key or active_api_key
                 if service_provider not in {"codex", "local"} and not kwargs.get("model"):
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}})."
                 elif service_provider not in {"codex", "local"} and not resolved_api_key:
-                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}})."
                 # Dedicated vision services do not consume the LLM adapter's
                 # transport selector.
                 kwargs.pop("api_compat", None)
@@ -493,7 +622,7 @@ def setup(
                     except Exception as exc:
                         manual_reason = _setup_failure(provider, exc)
     elif vision_service is None:
-        manual_reason = "No direct vision provider was configured; use vision(action='manual')."
+        manual_reason = "No direct vision provider was configured; use vision(action='manual', input={})."
 
     mgr = VisionManager(agent, vision_service=vision_service, manual_reason=manual_reason)
     agent.add_tool("vision", schema=get_schema(), handler=mgr.handle, description=get_description(), glossary_package=__package__)

--- a/src/lingtai/tools/vision/glossary-wen.md
+++ b/src/lingtai/tools/vision/glossary-wen.md
@@ -18,5 +18,5 @@ maintenance: |
 - `vision`：观象之器——以 LLM 之视觉能力析图。支 JPEG、PNG 与 WebP。可对图发任何问——述其内容、识其文字、解其图表、辨其物象、评其风格与气韵。结合绘相可先生图再析之。
 - `image_path`：图像之路径
 - `question`：关于图像之问
-- `action`：`analyze` 直析，`manual` 惟返只读指引
-- `manual`：使 agent 察当前 preset 身份，于自身 skill catalog 寻相应手册；不自动召 MCP
+- `action`：所行之名；`input`：随所行而定之结构容器
+- `manual`：只读指引之名，不自动召 MCP

--- a/src/lingtai/tools/vision/glossary-zh.md
+++ b/src/lingtai/tools/vision/glossary-zh.md
@@ -18,5 +18,5 @@ maintenance: |
 - `vision`：使用 LLM 的视觉能力分析图像。支持 JPEG、PNG 和 WebP。可以对图像提出任何问题——描述内容、识别文字、解读图表、识别物体、评估风格或氛围。结合 draw 可以先生成图像再分析。
 - `image_path`：图像文件路径
 - `question`：关于图像的问题
-- `action`：`analyze` 直接分析，`manual` 仅返回只读指引
-- `manual`：引导 agent 查看当前 preset 身份并在自身 skill catalog 中查找匹配手册；不自动调用 MCP
+- `action`：操作名；`input`：与操作对应的结构化输入容器
+- `manual`：只读指引名，不自动调用 MCP

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -20,7 +20,11 @@ it does not discover, install, start, or invoke a backend.
 
 ## Route behavior and failures
 
-For OpenRouter and custom OpenAI-compatible presets, `vision(action="analyze")`
+The canonical calls are `vision(action="analyze", input={"image_path":
+"photo.png", "question": null}, reasoning="inspect the image")` and
+`vision(action="manual", input={}, reasoning="load the read-only procedure")`.
+The nullable question preserves the historical default when it is null or omitted.
+For OpenRouter and custom OpenAI-compatible presets, the analyze call
 first tries the current endpoint, model, and credential. It does not reject the
 route merely because downstream image support cannot be known in advance. Any
 direct setup or request failure returns a sanitized vision tool result that
@@ -44,6 +48,17 @@ present, report that no discoverable vision method is available.
 An optional MCP or other skill may be described by that preset manual, but it
 is always an explicit operator/agent action. This manual never auto-loads or
 auto-invokes MCP.
+
+## Settings evidence
+
+The handler rereads the Agent-owned `settings/vision.json` file on every call.
+The only valid v1 content is exactly `{"schema_version": 1}`; it is a metadata-only
+placeholder and never selects a route or changes defaults. The result's
+`current_setting` reports the source, revision/hash, and the next-call change hint.
+Missing settings are normal. Invalid, unstable, non-regular, or oversized settings
+are reported as `settings_error` evidence while the direct/manual behavior remains
+unchanged. Do not treat this diagnostic as permission to invent a provider, model,
+credential, or fallback.
 
 ## Safety
 

--- a/tests/test_tool_settings.py
+++ b/tests/test_tool_settings.py
@@ -1,0 +1,154 @@
+"""Focused tests for the private no-op placeholder-settings foundation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools._settings import (
+    MAX_SETTINGS_BYTES,
+    current_setting,
+    read_settings,
+    settings_path,
+    valid_tool_name,
+)
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+
+def _write(root: Path, tool_name: str, payload: str | bytes) -> Path:
+    path = root / "settings" / f"{tool_name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def test_missing_is_a_normal_noop_placeholder_state(tmp_path):
+    snapshot = read_settings(_Agent(tmp_path), "example")
+    setting = current_setting(snapshot, "example")
+    assert setting == {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": "missing",
+        "settings_revision": "missing",
+        "settings_hash": None,
+        "change_hint": (
+            "Edit settings/example.json; changes apply on the next example call; "
+            "this no-op placeholder never changes tool behavior."
+        ),
+    }
+
+
+def test_valid_v1_only_changes_source_revision_and_hash(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "example", '{"schema_version": 1}')
+    snapshot = read_settings(agent, "example")
+    setting = current_setting(snapshot, "example")
+    assert snapshot.error is None
+    assert setting["configurable"] is False
+    assert setting["placeholder"] == "no-op"
+    assert setting["source"] == "settings/example.json"
+    assert setting["settings_revision"] == setting["settings_hash"]
+    assert setting["settings_hash"]
+
+
+def test_reader_rereads_hot_changes_without_cache(tmp_path):
+    agent = _Agent(tmp_path)
+    path = _write(tmp_path, "example", '{"schema_version": 1}')
+    first = read_settings(agent, "example")
+    path.write_text('{ "schema_version": 1 }', encoding="utf-8")
+    second = read_settings(agent, "example")
+    assert first.digest != second.digest
+    assert second.source == "settings/example.json"
+
+
+def test_duplicate_and_extra_fields_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    duplicate = _write(tmp_path, "duplicate", '{"schema_version": 1, "schema_version": 1}')
+    duplicate_snapshot = read_settings(agent, "duplicate")
+    assert duplicate_snapshot.source == "settings_error"
+    assert "duplicate" in (duplicate_snapshot.error or "")
+
+    extra = _write(tmp_path, "extra", '{"schema_version": 1, "future": false}')
+    extra_snapshot = read_settings(agent, "extra")
+    assert extra_snapshot.source == "settings_error"
+    assert "only schema_version" in (extra_snapshot.error or "")
+
+
+def test_bool_and_other_schema_versions_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    for name, version in (("bool", True), ("float", 1.0), ("other", 2)):
+        _write(tmp_path, name, json.dumps({"schema_version": version}))
+        snapshot = read_settings(agent, name)
+        assert snapshot.source == "settings_error"
+        assert "integer 1" in (snapshot.error or "")
+
+
+def test_invalid_encoding_and_json_are_truthful_bounded_errors(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "encoding", b'{"schema_version": 1}\xff')
+    encoding_snapshot = read_settings(agent, "encoding")
+    assert encoding_snapshot.source == "settings_error"
+    assert encoding_snapshot.error
+
+    _write(tmp_path, "json", "{not-json")
+    json_snapshot = read_settings(agent, "json")
+    assert json_snapshot.source == "settings_error"
+    assert json_snapshot.error
+    assert len(json_snapshot.error) <= 240
+
+
+def test_symlink_non_regular_and_oversized_files_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text('{"schema_version": 1}', encoding="utf-8")
+    symlink = tmp_path / "settings" / "symlink.json"
+    symlink.parent.mkdir()
+    symlink.symlink_to(target)
+    symlink_snapshot = read_settings(agent, "symlink")
+    assert symlink_snapshot.source == "settings_error"
+    assert "regular file" in (symlink_snapshot.error or "")
+
+    non_regular = tmp_path / "settings" / "directory.json"
+    non_regular.mkdir()
+    directory_snapshot = read_settings(agent, "directory")
+    assert directory_snapshot.source == "settings_error"
+    assert "regular file" in (directory_snapshot.error or "")
+
+    _write(tmp_path, "large", b"{" + b"x" * MAX_SETTINGS_BYTES + b"}")
+    large_snapshot = read_settings(agent, "large")
+    assert large_snapshot.source == "settings_error"
+    assert "bounded size" in (large_snapshot.error or "")
+
+
+def test_unstable_snapshot_is_not_treated_as_missing(tmp_path, monkeypatch):
+    import lingtai.tools._settings as settings_module
+
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "unstable", '{"schema_version": 1}')
+
+    def raise_unstable(_path):
+        raise settings_module.SettingsError("settings snapshot changed during read")
+
+    monkeypatch.setattr(settings_module, "_read_stable", raise_unstable)
+    snapshot = read_settings(agent, "unstable")
+    assert snapshot.source == "settings_error"
+    assert snapshot.revision == "error"
+    assert snapshot.error == "settings snapshot changed during read"
+
+
+def test_tool_names_are_bounded_path_components(tmp_path):
+    assert valid_tool_name("web_search")
+    assert not valid_tool_name("../escape")
+    assert not valid_tool_name("nested/name")
+    assert not valid_tool_name("\\escape")
+    assert not valid_tool_name("x" * 65)
+    with pytest.raises(ValueError):
+        settings_path(_Agent(tmp_path), "../escape")

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -49,6 +49,101 @@ def make_provider_agent(
     return make_mock_agent(tmp_path, svc=svc)
 
 
+def test_vision_schema_is_closed_nested_action_input():
+    from lingtai.tools.vision import get_schema
+
+    schema = get_schema()
+    assert schema["type"] == "object"
+    assert set(schema["properties"]) == {"action", "input"}
+    assert schema["required"] == ["action", "input"]
+    assert schema["additionalProperties"] is False
+    assert "reasoning" not in schema["properties"]
+
+    branches = schema["properties"]["input"]["anyOf"]
+    assert [branch["title"] for branch in branches] == ["analyze input", "manual input"]
+    analyze, manual = branches
+    assert set(analyze["properties"]) == {"image_path", "question"}
+    assert analyze["required"] == ["image_path", "question"]
+    assert analyze["properties"]["question"]["type"] == ["string", "null"]
+    assert analyze["additionalProperties"] is False
+    assert manual["properties"] == {}
+    assert manual["required"] == []
+    assert manual["additionalProperties"] is False
+
+
+def test_vision_handler_requires_nested_input_and_preserves_metadata(tmp_path):
+    service = MagicMock(spec=VisionService)
+    agent = make_mock_agent(tmp_path)
+    mgr = VisionManager(agent, vision_service=service)
+
+    flat = mgr.handle({"action": "analyze", "image_path": "photo.png"})
+    assert flat["status"] == "error"
+    assert "current_setting" in flat
+    assert service.analyze_image.call_count == 0
+
+    wrong_branch = mgr.handle({"action": "manual", "input": {"image_path": "photo.png"}})
+    assert wrong_branch["status"] == "error"
+    assert "current_setting" in wrong_branch
+    assert service.analyze_image.call_count == 0
+
+    unknown = mgr.handle({"action": "sideways", "input": {}})
+    assert unknown["status"] == "error"
+    assert "current_setting" in unknown
+
+    for unhashable_action in ([], {}):
+        bounded = mgr.handle({"action": unhashable_action, "input": {}})
+        assert bounded["status"] == "error"
+        assert "current_setting" in bounded
+
+    public_reasoning = mgr.handle(
+        {"action": "manual", "input": {}, "reasoning": "read the fallback"}
+    )
+    executor_reasoning = mgr.handle(
+        {"action": "manual", "input": {}, "_reasoning": "executor metadata"}
+    )
+    assert public_reasoning["status"] == "ok"
+    assert executor_reasoning["status"] == "ok"
+    assert service.analyze_image.call_count == 0
+
+
+def test_vision_handler_null_or_omitted_question_keeps_existing_default(tmp_path):
+    service = MagicMock(spec=VisionService)
+    service.analyze_image.return_value = "A dog"
+    agent = make_mock_agent(tmp_path)
+    mgr = VisionManager(agent, vision_service=service)
+    image = tmp_path / "photo.png"
+    image.write_bytes(b"fake")
+
+    for action_input in (
+        {"image_path": str(image), "question": None},
+        {"image_path": str(image)},
+    ):
+        result = mgr.handle({"action": "analyze", "input": action_input, "_reasoning": "inspect"})
+        assert result["status"] == "ok"
+    assert service.analyze_image.call_args.kwargs["prompt"] == "Describe what you see in this image."
+
+
+def test_vision_settings_are_hot_reread_and_attached_to_every_path(tmp_path):
+    import json
+
+    service = MagicMock(spec=VisionService)
+    service.analyze_image.return_value = "A dog"
+    agent = make_mock_agent(tmp_path, svc=service)
+    mgr = VisionManager(agent, vision_service=service)
+    settings = tmp_path / "settings" / "vision.json"
+    settings.parent.mkdir()
+    settings.write_text(json.dumps({"schema_version": 1}), encoding="utf-8")
+    image = tmp_path / "photo.png"
+    image.write_bytes(b"fake")
+
+    first = mgr.handle({"action": "manual", "input": {}})
+    settings.write_text("{not-json", encoding="utf-8")
+    second = mgr.handle({"action": "analyze", "input": {"image_path": str(image)}})
+    assert first["current_setting"]["source"] == "settings/vision.json"
+    assert second["current_setting"]["source"] == "settings_error"
+    assert "settings_error" in second["current_setting"]
+
+
 def test_vision_added_by_setup(tmp_path):
     """setup() should register the vision tool on the agent."""
     mock_svc = MagicMock(spec=VisionService)
@@ -69,7 +164,7 @@ def test_vision_with_dedicated_service(tmp_path):
 
     img_path = tmp_path / "test.jpg"
     img_path.write_bytes(b"\xff\xd8\xff fake jpeg")
-    result = mgr.handle({"image_path": str(img_path)})
+    result = mgr.handle({"action": "analyze", "input": {"image_path": str(img_path)}})
     assert result["status"] == "ok"
     assert "dog" in result["analysis"]
     mock_vision_svc.analyze_image.assert_called_once()
@@ -80,7 +175,7 @@ def test_vision_missing_image(tmp_path):
     mock_vision_svc = MagicMock(spec=VisionService)
     agent = make_mock_agent(tmp_path)
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
-    result = mgr.handle({"image_path": "/nonexistent/image.png"})
+    result = mgr.handle({"action": "analyze", "input": {"image_path": "/nonexistent/image.png"}})
     assert result.get("status") == "error"
 
 
@@ -93,7 +188,7 @@ def test_vision_relative_path(tmp_path):
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
     img_path = tmp_path / "photo.png"
     img_path.write_bytes(b"\x89PNG fake")
-    result = mgr.handle({"image_path": "photo.png"})
+    result = mgr.handle({"action": "analyze", "input": {"image_path": "photo.png"}})
     assert result["status"] == "ok"
     mock_vision_svc.analyze_image.assert_called_once_with(str(img_path), prompt="Describe what you see in this image.")
 
@@ -107,7 +202,7 @@ def test_vision_service_error_handled(tmp_path):
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
     img_path = tmp_path / "test.png"
     img_path.write_bytes(b"\x89PNG fake")
-    result = mgr.handle({"image_path": str(img_path)})
+    result = mgr.handle({"action": "analyze", "input": {"image_path": str(img_path)}})
     assert result["status"] == "error"
     assert "API down" not in result["message"]
     assert "RuntimeError" in result["message"]
@@ -122,7 +217,7 @@ def test_vision_service_error_does_not_echo_secret_or_url(tmp_path):
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
     img_path = tmp_path / "test.png"
     img_path.write_bytes(b"fake")
-    result = mgr.handle({"image_path": str(img_path)})
+    result = mgr.handle({"action": "analyze", "input": {"image_path": str(img_path)}})
     assert result["status"] == "error"
     assert "secret" not in result["message"]
     assert "example.test" not in result["message"]
@@ -205,7 +300,7 @@ def test_openai_unknown_wire_remains_manual_without_factory_call(tmp_path):
 
     mock_factory.assert_not_called()
     assert mgr._vision_service is None
-    result = mgr.handle({})
+    result = mgr.handle({"action": "analyze", "input": {"image_path": "missing.png"}})
     assert result["status"] == "error"
     assert "manual" in result["message"]
     assert "unproven_wire" not in result["message"]
@@ -233,7 +328,7 @@ def test_generic_openai_compatible_unknown_wire_remains_manual(tmp_path):
 
     mock_cls.assert_not_called()
     assert mgr._vision_service is None
-    result = mgr.handle({})
+    result = mgr.handle({"action": "analyze", "input": {"image_path": "missing.png"}})
     assert result["status"] == "error"
     assert "manual" in result["message"]
     assert "unproven_wire" not in result["message"]
@@ -257,7 +352,7 @@ def test_vision_empty_response_is_error(tmp_path):
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
     img_path = tmp_path / "test.png"
     img_path.write_bytes(b"\x89PNG fake")
-    result = mgr.handle({"image_path": str(img_path)})
+    result = mgr.handle({"action": "analyze", "input": {"image_path": str(img_path)}})
     assert result["status"] == "error"
 
 
@@ -355,7 +450,7 @@ def test_mimo_responses_wire_is_manual_only(tmp_path):
     )
     mgr = setup(agent, provider="mimo", api_key="sk-test")
     assert mgr._vision_service is None
-    assert mgr.handle({})["status"] == "error"
+    assert mgr.handle({"action": "analyze", "input": {"image_path": "missing.png"}})["status"] == "error"
 
 
 def test_vision_setup_resolves_api_key_env(tmp_path, monkeypatch):
@@ -1096,7 +1191,7 @@ def test_setup_failure_retains_safe_manual_reason(tmp_path):
         )
         (tmp_path / "x.png").write_bytes(b"fake")
         mgr = setup(agent, provider="openai", api_key="sk-test")
-    result = mgr.handle({"image_path": "x.png"})
+    result = mgr.handle({"action": "analyze", "input": {"image_path": "x.png"}})
     assert result["status"] == "error"
     assert "RuntimeError" in result["message"]
     assert "secret" not in result["message"]
@@ -1306,7 +1401,7 @@ def test_vision_empty_image_path(tmp_path):
     mock_vision_svc = MagicMock(spec=VisionService)
     agent = make_mock_agent(tmp_path)
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
-    result = mgr.handle({"image_path": ""})
+    result = mgr.handle({"action": "analyze", "input": {"image_path": ""}})
     assert result["status"] == "error"
     assert "image_path" in result["message"].lower() or "provide" in result["message"].lower()
 


### PR DESCRIPTION
## Summary

Migrates the public `vision` tool to the canonical model-facing contract while preserving its existing active-preset routing:

- raw closed root `action` + nested `input`;
- Agent-owned optional root `reasoning` in final model/provider schemas;
- `analyze input` requires `image_path` plus a required-nullable `question`;
- `manual input` is exactly empty;
- no action-only, flat-root, or mismatched-branch compatibility route;
- strict per-call `settings/vision.json` placeholder reread and truthful `current_setting` on every result.

This draft is intentionally stacked on #1038 (`feat/tool-settings-foundation`) and contains only the vision vertical slice.

## Behavior preserved

- The existing default prompt remains `Describe what you see in this image.` when `question` is null or a direct caller omits it.
- Relative image paths still resolve against the Agent working directory.
- Direct success, missing image, empty response, setup failure, and request failure remain structured and sanitized.
- `manual` still returns only the bundled provider-neutral guidance and never invokes MCP or switches provider/model/credential.
- All existing Gemini/Anthropic/OpenAI/OpenRouter/custom/DeepSeek/MiniMax/MiMo/GLM/Zhipu/Grok/Qwen/Kimi/Codex routing remains in `setup`; the settings placeholder is diagnostic-only and cannot change it.
- Every fallback hint now teaches the valid nested `vision(action='manual', input={})` call instead of the obsolete action-only form.

## Parent review repairs

The initial worker candidate was not accepted unchanged. Parent review found and repaired:

1. unhashable non-string actions (`[]` / `{}`) could raise before returning a bounded error;
2. 20 contract/code fallback hints still taught an invalid action-only manual call;
3. manual examples omitted Agent-owned root `reasoning`;
4. anatomy line ownership was stale after the expanded manager;
5. the retained validation probe over-constrained settings-path prose and misread Git's collapsed `?? artifacts/` status.

The committed regression now covers both public `reasoning` and executor `_reasoning`, plus bounded unhashable actions.

## Validation

A fresh independent persistent-path parent harness passed with the actual worktree module and runtime interpreter:

- raw schema properties: `action`, `input`;
- final Agent / Chat / Responses / Anthropic properties: `action`, `input`, `reasoning`;
- provider envelopes unchanged: Chat `function.parameters`, Responses `parameters`, Anthropic `input_schema`;
- full prompt equals joined prompt batches;
- real local fixture analysis through an in-memory vision stub;
- public/executor reasoning metadata, manual, malformed/flat/wrong-branch/type/unknown/unhashable paths;
- missing -> valid -> hot reread -> invalid settings, behavior/prompt invariance, and sentinel non-leakage;
- only canonical nested manual hints remain.

Evidence: `artifacts/vision-parent-validation-202607260310b/validation.json` in the local worktree (intentionally not committed).

The repaired retained worker probe also passes 7/7 without network, provider, pytest, py_compile, temporary-directory cleanup, or image-library side effects.

Additional gates:

```text
No anatomy drift found across 53 file(s).
OK: 57 glossary resources across 19 packages validated.
git diff --check: PASS
```

The local pytest suite was not run under the current strict no-deletion validation boundary; CI remains the broader suite gate.

## Review focus

1. Is required-nullable `question` the correct strict-provider representation of the historical optional default?
2. Does handler validation enforce action/input correspondence before image/provider work?
3. Does `current_setting` remain evidence-only across all provider/manual/error paths?
4. Are active-preset identity, wire, credential, and fail-closed manual semantics unchanged?
