### PR TITLE
feat(edit): adopt canonical action/input contract

### DIFF
--- a/src/lingtai/intrinsic_skills/file-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/file-manual/SKILL.md
@@ -105,6 +105,15 @@ ambiguous. That failure is a feature: it prevents accidental broad changes.
 Use `replace_all=true` only when every occurrence is supposed to change and you
 have checked the match set with `grep` first.
 
+### The `edit` action/input contract
+
+The public `edit` call is explicit: set the root `action` to `"edit"` and put
+`file_path`, `old_string`, `new_string`, and `replace_all` in its nested `input`.
+`replace_all` is a required nullable boolean for strict providers; `null` means
+false. The direct handler also treats an omitted `replace_all` as false. The
+manual route is `action="manual"` with `input={}` and performs no edit. Do not
+use the removed flat or omitted-action forms.
+
 ## Search workflow
 
 Start broad with `glob` (file names), narrow with `grep` (file contents), then
@@ -125,16 +134,16 @@ content or attach/export a file through the appropriate communication channel.
 
 ## Manual versus ordinary calls
 
-Normal file work is primary. Each file tool has two explicit modes:
+Normal file work is primary. Follow each tool's current public schema. The
+`edit` tool has two explicit root actions: use `action="edit"` with the nested
+ordinary input described above, or use `action="manual"` with `input={}` for
+this guide. Its removed flat and omitted-action forms are not supported.
 
-- **Ordinary work:** for backward compatibility, omit `action` or set it to the
-  tool name: `action="read"`, `"write"`, `"edit"`, `"glob"`, or `"grep"`.
-  Supply the ordinary arguments shown in that tool's schema.
-- **Manual lookup:** use `action="manual"` as a one-time entry when you need the
-  installed workflow guide. It returns documentation and performs no file
-  operation. `write`, `edit`, `glob`, and `grep` return this manual; `read`
-  returns `read-manual`.
+Other file tools may document their own ordinary arguments. A manual lookup is
+always an explicit `action="manual"` one-time entry when that tool exposes it;
+it returns documentation and performs no file operation. `write`, `edit`, `glob`,
+and `grep` return this manual; `read` returns `read-manual`.
 
-After a manual result, continue the original task with an ordinary call. Do not
-request the same manual again. Repeating an identical manual call is an error loop,
-not progress.
+After a manual result, continue the original task with the ordinary action. Do
+not request the same manual again. Repeating an identical manual call is an
+error loop, not progress.

--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -36,6 +36,7 @@ Safety properties:
 from __future__ import annotations
 
 import datetime as _dt
+from collections.abc import Mapping
 from typing import Any, Callable
 
 from .meta_block import formal_tool_result_content, formal_tool_result_visible_len
@@ -147,15 +148,21 @@ def is_apriori_summary(content: Any) -> bool:
     )
 
 
-def summary_requested(args: dict | None) -> bool:
-    """Return True iff the normalized tool args opt into a-priori summary.
+def summary_requested(args: Mapping | None) -> bool:
+    """Return True iff tool args opt into a-priori summary.
 
-    The flag is the boolean ``summary`` field on the tool call. Anything other
-    than a literal ``True`` (missing, ``False``, ``None``, truthy-but-not-True)
-    preserves current behavior exactly.
+    The presence of ``input`` selects canonical mode: only a Mapping-valued
+    ``input`` whose ``summary`` is exactly ``True`` requests summarization.
+    Root ``summary`` is ignored in canonical mode, including when ``input`` is
+    malformed or its nested flag is absent/invalid. When ``input`` is absent,
+    legacy mode reads only root ``summary``. Both modes require identity with
+    the boolean singleton ``True``; no truthy coercion is performed.
     """
-    if not isinstance(args, dict):
+    if not isinstance(args, Mapping):
         return False
+    if "input" in args:
+        payload = args["input"]
+        return isinstance(payload, Mapping) and payload.get("summary") is True
     return args.get("summary") is True
 
 
@@ -395,13 +402,19 @@ def maybe_summarize_result(
     and BEFORE the result is turned into the model-visible wire message.
 
     Contract:
+    - Summary control is canonical-first: when ``input`` is present, only
+      ``input.summary is True`` on a Mapping payload requests; root ``summary``
+      is never inspected or used as fallback. When ``input`` is absent, legacy
+      calls use root ``summary is True``. This exact-boolean discriminator is
+      applied without flattening or mutating the original args.
     - ``summary != true`` → returns *result* unchanged (current behavior).
     - ``summary == true`` but no ``summarizer_fn`` wired (e.g. service without a
       one-shot generate gateway) → **fails closed**: returns a summary-layer
       error (with the raw-retrieval locator), NOT the raw result. ``summary=true``
       is a request to keep the raw out of context; honoring it must not depend on
       whether a summarizer happens to be configured. The raw is already durably
-      logged before this point, so it remains retrievable by ``tool_call_id``.
+      logged before either the legacy or canonical predicate is applied, so it
+      remains retrievable by ``tool_call_id``.
     - Already an a-priori summary (defensive) → returned unchanged.
     - Error results (the tool itself failed) are NOT summarized: the agent needs
       the exact error text to recover. Returned unchanged.

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
@@ -35,6 +36,10 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_settings.py` — private Agent-owned placeholder-settings reader and
+  secret-free current-setting diagnostic. It strictly validates the exact
+  versioned no-op schema, rereads `settings/<bounded tool_name>.json` per call,
+  and never supplies action, input, reasoning, or tool behavior.
 
 ## Connections
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -40,6 +40,33 @@ There is no fourth public metadata block. Existing tools retain their current
 explicit schemas until a scoped migration changes their code, tests, manual, and
 contract together.
 
+### A-priori summary transition
+
+The shared kernel summary predicate uses the presence of the `input` key as the
+mode discriminator. A canonical call requests a summary only when `input` is a
+Mapping/object and `input.summary` is exactly the boolean `true`; once `input` is
+present, root `summary` is ignored and is never a fallback, even when `input` is
+malformed, missing `summary`, or carries a false/non-boolean value. No truthy
+coercion, flattening, or argument mutation is permitted. A call with no `input`
+key remains in legacy mode and requests only when root `summary` is exactly
+`true`.
+
+This is a transitional compatibility rule, not a second public schema: migrated
+capabilities that support a-priori summary advertise that flag only as nested
+`input.summary`, while unmigrated legacy advertisers retain their root flag until
+their own vertical migration. Tool errors continue to bypass summarization. The
+raw result is durably recorded before either nested or legacy summary control is
+applied; generated, refusal, and fail-closed no-gateway replacements are
+model-visible substitutes with the
+existing raw locator and metadata.
+
+The root-summary branch may be removed only in the commit that migrates the last
+currently legacy root-summary advertiser (including shell's historical `bash`
+rolling alias and daemon), and only after a registry-wide test proves that no
+provider-facing schema advertises root `summary`, no migrated handler accepts
+flat fields, and no supported pending legacy call relies on the root shape. Until
+that final removal gate, root lookup is permitted solely when `input` is absent.
+
 ## Port
 
 The provider-neutral boundary is the final `FunctionSchema` assembled by the

--- a/src/lingtai/tools/_settings.py
+++ b/src/lingtai/tools/_settings.py
@@ -1,0 +1,156 @@
+"""Private shared reader for Agent-owned no-op tool settings placeholders.
+
+The placeholder file is deliberately metadata-only.  A present, valid v1 file
+proves that an Agent-owned settings snapshot was read, but it cannot select or
+enable any tool behavior.  Individual tools may later add their own real
+settings reader when a configurable choice is actually authorized.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MAX_SETTINGS_BYTES = 64 * 1024
+SETTINGS_SCHEMA_VERSION = 1
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class SettingsError(ValueError):
+    """A placeholder settings snapshot was malformed or unsafe to use."""
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsSnapshot:
+    """Immutable evidence for one reread of one tool's settings file."""
+
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def valid_tool_name(value: Any) -> bool:
+    """Return whether *value* is safe as one bounded settings path component."""
+    return isinstance(value, str) and _TOOL_NAME.fullmatch(value) is not None
+
+
+def settings_path(agent: Any, tool_name: str) -> Path:
+    """Return the fixed Agent-owned ``settings/<tool_name>.json`` path."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return Path(agent._working_dir) / "settings" / f"{tool_name}.json"
+
+
+def _bounded_error(exc: Exception) -> str:
+    """Render a bounded diagnostic without echoing host paths or file content."""
+    if isinstance(exc, OSError):
+        return f"settings file could not be read ({type(exc).__name__})"
+    text = str(exc).replace("\n", " ").strip()
+    return (text or "invalid settings")[:240]
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject duplicate JSON object members instead of accepting last-wins data."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SettingsError("duplicate settings field")
+        result[key] = value
+    return result
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    """Read one bounded regular-file snapshot and its content revision."""
+    try:
+        first = path.lstat()
+    except FileNotFoundError:
+        return b"", "missing"
+    except OSError:
+        raise
+
+    if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
+        raise SettingsError("settings file must be a regular file")
+    if first.st_size > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings file exceeds the bounded size")
+
+    # Open by path only after lstat, then compare the path identity and metadata
+    # again.  Replacements, symlink swaps, growth, and ordinary in-place writes
+    # are therefore rejected rather than partially accepted.
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_SETTINGS_BYTES + 1)
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    try:
+        second = path.lstat()
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    if stat.S_ISLNK(second.st_mode) or not stat.S_ISREG(second.st_mode):
+        raise SettingsError("settings snapshot changed during read")
+    if (
+        len(raw) > MAX_SETTINGS_BYTES
+        or first.st_dev != second.st_dev
+        or first.st_ino != second.st_ino
+        or first.st_size != second.st_size
+        or first.st_mtime_ns != second.st_mtime_ns
+    ):
+        raise SettingsError("settings snapshot changed during read")
+    return raw, hashlib.sha256(raw).hexdigest()[:32]
+
+
+def read_settings(agent: Any, tool_name: str) -> SettingsSnapshot:
+    """Reread and strictly validate one tool's placeholder settings snapshot.
+
+    Missing is a normal placeholder state.  A valid file contributes only its
+    source/revision/hash evidence; it never changes behavior.  Every invocation
+    performs a fresh filesystem read and does not cache a prior snapshot.
+    """
+    path = settings_path(agent, tool_name)
+    digest: str | None = None
+    try:
+        raw, revision = _read_stable(path)
+        if revision == "missing":
+            return SettingsSnapshot("missing", "missing", None)
+        digest = revision
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        if not isinstance(value, dict) or set(value) != {"schema_version"}:
+            raise SettingsError("settings schema must contain only schema_version")
+        if type(value["schema_version"]) is not int or value["schema_version"] != SETTINGS_SCHEMA_VERSION:
+            raise SettingsError("settings schema_version must be integer 1")
+        return SettingsSnapshot(f"settings/{tool_name}.json", revision, digest)
+    except (OSError, UnicodeError, json.JSONDecodeError, SettingsError) as exc:
+        # Malformed data is never silently converted to the missing state.  The
+        # digest from a bounded stable read is retained as evidence when safe.
+        return SettingsSnapshot(
+            "settings_error",
+            digest or "error",
+            digest,
+            _bounded_error(exc if isinstance(exc, Exception) else SettingsError("invalid settings")),
+        )
+
+
+def current_setting(snapshot: SettingsSnapshot, tool_name: str) -> dict[str, Any]:
+    """Build the bounded, secret-free current-setting diagnostic for a tool."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return_value: dict[str, Any] = {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": snapshot.source,
+        "settings_revision": snapshot.revision,
+        "settings_hash": snapshot.digest,
+        "change_hint": (
+            f"Edit settings/{tool_name}.json; changes apply on the next {tool_name} "
+            "call; this no-op placeholder never changes tool behavior."
+        ),
+    }
+    if snapshot.error:
+        return_value["settings_error"] = snapshot.error
+    return return_value

--- a/src/lingtai/tools/edit/CONTRACT.md
+++ b/src/lingtai/tools/edit/CONTRACT.md
@@ -1,10 +1,11 @@
 ---
 name: edit-contract
 tool: edit
-contract_version: 2
+contract_version: 3
 related_files:
   - src/lingtai/tools/edit/__init__.py
   - src/lingtai/tools/_file_paths.py
+  - src/lingtai/tools/_settings.py
   - src/lingtai/services/file_io_sidecar.py
   - src/lingtai/intrinsic_skills/file-manual/SKILL.md
 maintenance: |
@@ -23,17 +24,18 @@ lives in `src/lingtai/tools/edit/__init__.py`; the code is the source of truth.
 ## Routing Card
 
 **Use this when:**
-- You are editing the match-count / `replace_all` guard logic.
+- You are editing the action/input schema or its strict root/branch validation.
 - You need the exact ambiguity rule (what happens when `old_string` appears more
-  than once) or the "not found" behavior.
+  than once) or the `replace_all` rule.
+- You need the per-call settings diagnostic contract.
 
 **Do not use this for:**
 - Full-file replacement or new files: read `src/lingtai/tools/write/CONTRACT.md`.
 - Reading content: read `src/lingtai/tools/read/CONTRACT.md`.
 - The byte-level read/write: `src/lingtai/services/file_io.py`.
 
-**Fast paths:** tool schema -> §Tool surface; ambiguity / `replace_all` rule ->
-§Tool surface; read-then-write flow -> §State & storage.
+**Fast paths:** tool schema → §Tool surface; ambiguity / `replace_all` rule →
+§Tool surface; read-then-write flow → §State & storage.
 
 ## Scope
 
@@ -42,44 +44,53 @@ lives in `src/lingtai/tools/edit/__init__.py`; the code is the source of truth.
 - Non-goals: no regex, no fuzzy matching, no multi-file edits, no file creation
   (the target must already exist). Matching is literal substring counting via
   `str.count` / `str.replace`.
+- Public compatibility with omitted-action or flat arguments is removed.
 
 ## Tool surface
 
-`handle_edit` has two modes:
+The raw tool-owned schema is a closed root object with required `action` and
+required nested `input`, and no other root fields. `BaseAgent` adds optional root
+`reasoning` only to the model-facing schema. The handler also accepts executor
+metadata `_reasoning`; neither metadata field enters action dispatch.
 
-- **Ordinary:** omit `action` (backward compatible) or set
-  `action="edit"`; both forms run the same edit operation.
-- **Manual:** `action="manual"` returns the installed `file-manual` without
-  attempting to edit a file.
+`action` is exactly one of `edit` or `manual`:
 
-The schema lists `edit` before `manual`. Any other explicit action
-returns a plain error before file I/O. After a manual response, the caller
-continues the original task with an ordinary call rather than repeating the
-manual.
+- `edit` uses a closed input object requiring `file_path: string`,
+  `old_string: string`, `new_string: string`, and `replace_all: boolean | null`.
+  Strict providers therefore always send `replace_all`; `null` means false.
+  Direct handler calls that omit it also preserve the historical false default.
+- `manual` uses a closed empty input object and returns the real installed
+  `file-manual` body without attempting an edit.
 
-| Call | Required inputs | Optional inputs | Success output | Error shapes |
-|---|---|---|---|---|
-| `edit` | `file_path: string`, `old_string: string`, `new_string: string` | `replace_all: bool` (default false) | `{status: "ok", replacements}` (`count` when `replace_all`, else `1`) | see below |
+| Call | Required inputs | Success output | Error shapes |
+|---|---|---|---|
+| `edit` | `file_path`, `old_string`, `new_string`, `replace_all` (nullable boolean) | `{status: "ok", replacements}` (`count` when true, else `1`) | plain `{status: "error", message: "...", current_setting}` dict; see below |
+| `manual` | empty `input` | installed manual result plus `current_setting` | degraded manual result plus `current_setting` if unavailable |
+
+Every result, including malformed, unknown-action, manual, and file-I/O results,
+contains `current_setting`. The first operation of every call is a strict fresh
+`read_settings(agent, "edit")`. The Agent-owned settings placeholder accepts
+only `{schema_version: 1}`; missing, valid, hot-changed, or invalid settings
+produce evidence only and never change path resolution, matching, counts,
+ambiguity, replacement, or FileIO behavior.
 
 **Error shapes** (plain dicts, not exceptions):
-- `{"status": "error", "message": "file_path is required"}` — empty/missing path.
-- `{"status": "error", "message": "File not found: <path>"}` — `FileNotFoundError`
-  on the initial read.
-- `{"status": "error", "message": "Cannot read <path>: <exc>"}` — other read
-  failure.
-- `{"status": "error", "message": "old_string not found in <path>"}` — zero
-  matches.
-- `{"status": "error", "message": "old_string found <count> times — use replace_all=true or provide more context"}`
-  — more than one match without `replace_all`.
-- `{"status": "error", "message": "Cannot write <path>: <exc>"}` — write-back
-  failure.
+- `{"status": "error", "message": "edit requires root action and input", ...}` —
+  missing required root fields.
+- `{"status": "error", "message": "file_path is required", ...}` — empty/missing path.
+- `{"status": "error", "message": "File not found: <path>", ...}` —
+  `FileNotFoundError` on the initial read.
+- `{"status": "error", "message": "Cannot read <path>: <exc>", ...}` — other read failure.
+- `{"status": "error", "message": "old_string not found in <path>", ...}` — zero matches.
+- `{"status": "error", "message": "old_string found <count> times — use replace_all=true or provide more context", ...}` — more than one match without `replace_all`.
+- `{"status": "error", "message": "Cannot write <path>: <exc>", ...}` — write-back failure.
 
 ## State & storage
 
 None owned. `edit` does its own read→replace→write against the target file via
 `agent._file_io.read` then `agent._file_io.write`; it holds no persistent state.
-When `replace_all` is false the replacement is `content.replace(old, new, 1)`;
-when true it replaces every occurrence.
+When `replace_all` is false (including null or direct omission), the replacement
+is `content.replace(old, new, 1)`; when true it replaces every occurrence.
 
 ## Cross-platform invariants
 
@@ -98,27 +109,27 @@ Do not change any of the following; documented for reviewers only.
 
 | Claim | Source `src/lingtai/tools/edit/...` | Test |
 |---|---|---|
-| Exact string replacement works through the capability | `__init__.py` (`handle_edit`) | `tests/test_layers_file.py::test_edit_via_capability` |
-| Edit surfaces a `{status: error}` dict on failure | `__init__.py` (`handle_edit`) | `tests/test_layers_file.py::test_edit_error_shape` |
-| Relative paths resolve under the agent workdir | `__init__.py` (`resolve_workdir_path`) | `tests/test_layers_file.py::test_file_capability_relative_paths_resolve_under_workdir` |
-| Edit routes through the injected FileIOService | `__init__.py` (`handle_edit`) | `tests/test_layers_file.py::test_file_capability_uses_file_io_service` |
-| `file` sugar registers edit alongside the other four file tools | `src/lingtai/tools/registry.py` | `tests/test_layers_file.py::test_file_sugar_expands_to_five` |
+| Raw schema is closed action/input with strict edit/manual branches | `__init__.py` (`get_schema`) | `tests/test_edit_capability.py::test_raw_schema_is_closed_action_input` |
+| Agent schema adds only root reasoning metadata | `__init__.py`, BaseAgent schema builder | `tests/test_edit_capability.py::test_agent_schema_has_only_action_input_reasoning` |
+| Exact replacement and legacy false defaults work only under explicit edit action | `__init__.py` (`handle_edit`) | `tests/test_edit_capability.py::test_edit_replacement_and_defaults` |
+| Manual returns installed canonical body | `__init__.py` (`load_installed_manual`) | `tests/test_edit_capability.py::test_manual_returns_installed_body` |
+| Settings are fresh evidence and behavior-invariant | `__init__.py` / `_settings.py` | `tests/test_edit_capability.py::test_settings_are_attached_and_invariant` |
+| Envelope schemas expose only action/input/reasoning | BaseAgent schema and provider adapters | `tests/test_edit_capability.py::test_provider_envelopes_keep_public_fields` |
 
 ## Verification matrix
 
 | Invariant | Automated test | Manual check | Risk if broken |
 |---|---|---|---|
-| Single replacement round-trips | `tests/test_layers_file.py::test_edit_via_capability` | `edit` a unique substring, `read` the result | Silent corruption / wrong content |
-| Ambiguous match is refused without `replace_all` | `__init__.py` count guard | `edit` a substring that appears twice without `replace_all` | Unintended mass replacement |
-| Missing file / missing substring reported clearly | `tests/test_layers_file.py::test_edit_error_shape` | `edit` a nonexistent file or absent substring | Executor crash or silent no-op |
-| Relative paths stay in workdir | `tests/test_layers_file.py::test_file_capability_relative_paths_resolve_under_workdir` | `edit` a relative path from a known workdir | Edits escape the sandbox |
-| Edit routes through FileIOService | `tests/test_layers_file.py::test_file_capability_uses_file_io_service` | Boot with `capabilities=["edit"]` and confirm `agent._file_io` is used | Backend selection / sandbox bypassed |
+| Single replacement round-trips | `tests/test_edit_capability.py::test_edit_replacement_and_defaults` | edit a unique substring, then read the result | Silent corruption / wrong content |
+| Ambiguous match is refused without `replace_all` | `__init__.py` count guard | edit a substring that appears twice without `replace_all` | Unintended mass replacement |
+| Missing file / missing substring reported clearly | `__init__.py` structured errors | edit a nonexistent file or absent substring | Executor crash or silent no-op |
+| Relative paths stay in workdir | `__init__.py` `resolve_workdir_path` | edit a relative path from a known workdir | Edits escape the sandbox |
+| Edit routes through FileIOService | `__init__.py` (`handle_edit`) | boot with `capabilities=["edit"]` and inspect the injected service | Backend selection / sandbox bypassed |
+| Settings never select behavior | `_settings.py` plus handler | repeat after missing/valid/hot/invalid settings changes | Configuration leaks into edits |
 
-Run before merging:
-
-```bash
-python -m pytest tests/test_layers_file.py -q
-```
+Validation uses the repository's no-bytecode compile harness and the glossary
+validator; do not substitute a schema or manual copy for the installed canonical
+manual.
 
 ## Schema and glossary ownership
 

--- a/src/lingtai/tools/edit/__init__.py
+++ b/src/lingtai/tools/edit/__init__.py
@@ -4,73 +4,192 @@ Usage: Agent(capabilities=["edit"]) or capabilities=["file"]
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
 
 from .._file_paths import resolve_workdir_path
 from .._manual import load_installed_manual
+from .._settings import current_setting, read_settings
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
 
 
+_ACTION_FIELDS = {
+    "edit": ("file_path", "old_string", "new_string", "replace_all"),
+    "manual": (),
+}
+_ALLOWED_ROOT_FIELDS = ("action", "input", "reasoning", "_reasoning")
+
+
 def get_description(lang: str = "en") -> str:
-    return "Replace an exact string in a file. Normal edits are the primary operation: omit action for the legacy ordinary call or use action='edit' explicitly. Fails if old_string is not found or is ambiguous. Use action='manual' once to return the installed file-manual skill; after the manual result, continue the original ordinary edit instead of repeating manual, because repeated identical manual calls are an error loop."
+    return (
+        "Replace an exact string in a file with action='edit' and a nested input "
+        "object. The edit input requires file_path, old_string, new_string, and "
+        "replace_all (a boolean or null; null means false). Fails if old_string "
+        "is not found or is ambiguous. Use action='manual' with input={} once "
+        "to return the installed file-manual skill; after the manual result, "
+        "continue the original edit instead of repeating manual."
+    )
 
 
 def get_schema(lang: str = "en") -> dict:
+    """Return the raw closed action/input schema.
+
+    ``BaseAgent`` adds the optional root ``reasoning`` property when it builds
+    the model-facing schema. It is metadata, not an edit action input.
+    """
     return {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "enum": ["edit", "manual"], "description": "Omit action for the legacy ordinary edit, use action='edit' for an explicit ordinary edit, or use action='manual' once for the installed file-manual skill."},
-            "file_path": {"type": "string", "description": "Absolute path to the file to edit. Required for ordinary edits; omit for action='manual'."},
-            "old_string": {"type": "string", "description": "The exact text to find and replace. Required for ordinary edits; omit for action='manual'."},
-            "new_string": {"type": "string", "description": "The replacement text. Required for ordinary edits; omit for action='manual'."},
-            "replace_all": {"type": "boolean", "description": 'Replace all occurrences', "default": False},
+            "action": {
+                "type": "string",
+                "enum": ["edit", "manual"],
+                "description": "Required operation: edit a file or return the installed manual.",
+            },
+            "input": {
+                "description": "Strict action-specific edit input.",
+                "anyOf": [
+                    {
+                        "title": "edit input",
+                        "type": "object",
+                        "properties": {
+                            "file_path": {
+                                "type": "string",
+                                "description": "Path to the existing file to edit.",
+                            },
+                            "old_string": {
+                                "type": "string",
+                                "description": "Exact text to find.",
+                            },
+                            "new_string": {
+                                "type": "string",
+                                "description": "Replacement text.",
+                            },
+                            "replace_all": {
+                                "type": ["boolean", "null"],
+                                "description": "Replace every match; null preserves the historical false default.",
+                            },
+                        },
+                        # Strict providers require the semantic optional field to
+                        # be present while nullable. Direct calls may omit it.
+                        "required": ["file_path", "old_string", "new_string", "replace_all"],
+                        "additionalProperties": False,
+                    },
+                    {
+                        "title": "manual input",
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                        "additionalProperties": False,
+                    },
+                ],
+            },
         },
-        "required": [],
+        "required": ["action", "input"],
+        "additionalProperties": False,
     }
 
+
+def _with_setting(result: Mapping[str, Any], diagnostic: dict[str, Any]) -> dict[str, Any]:
+    """Attach one fresh settings diagnostic to every public result."""
+    value = dict(result)
+    value["current_setting"] = diagnostic
+    return value
 
 
 def setup(agent: "BaseAgent") -> None:
     """Set up the edit capability on an agent."""
 
-    def handle_edit(args: dict) -> dict:
-        action = args.get("action")
+    def handle_edit(args: Any) -> dict:
+        # This must remain the first operation for every call, including
+        # malformed, unknown, manual, and failed edit calls. Settings are
+        # evidence only and never select edit behavior.
+        snapshot = read_settings(agent, "edit")
+        diagnostic = current_setting(snapshot, "edit")
+
+        def error(message: str) -> dict:
+            return _with_setting({"status": "error", "message": message}, diagnostic)
+
+        if not isinstance(args, Mapping):
+            return error("edit arguments must be an object")
+
+        if any(key not in _ALLOWED_ROOT_FIELDS for key in args):
+            return error("edit accepts only root action, input, reasoning, and _reasoning")
+        if "action" not in args or "input" not in args:
+            return error("edit requires root action and input")
+
+        action = args["action"]
+        if not isinstance(action, str) or action not in _ACTION_FIELDS:
+            return error(f"Unsupported action for edit: {action!r}")
+
+        raw_input = args["input"]
+        if not isinstance(raw_input, Mapping):
+            return error("edit input must be an object")
+        action_input = dict(raw_input)
+        allowed_fields = _ACTION_FIELDS[action]
+        if any(key not in allowed_fields for key in action_input):
+            return error(f"unsupported edit input field for action {action!r}")
+
         if action == "manual":
-            return load_installed_manual(agent, "file-manual")
-        if action is not None and action != "edit":
-            return {"status": "error", "message": f"Unsupported action for edit: {action!r}"}
-        path = args.get("file_path", "")
-        if not path:
-            return {"status": "error", "message": "file_path is required"}
-        if "old_string" not in args:
-            return {"status": "error", "message": "old_string is required"}
-        if "new_string" not in args:
-            return {"status": "error", "message": "new_string is required"}
-        path = resolve_workdir_path(agent, path)
-        old = args["old_string"]
-        new = args["new_string"]
-        replace_all = args.get("replace_all", False)
+            if action_input:
+                # Kept separate from the unknown-field check so manual's closed
+                # empty object remains explicit even for unusual Mapping types.
+                return error("manual input must be an empty object")
+            return _with_setting(load_installed_manual(agent, "file-manual"), diagnostic)
+
+        for field in ("file_path", "old_string", "new_string"):
+            if field not in action_input:
+                return error(f"{field} is required")
+            if not isinstance(action_input[field], str):
+                return error(f"{field} must be a string")
+
+        if "replace_all" in action_input:
+            raw_replace_all = action_input["replace_all"]
+            if raw_replace_all is not None and type(raw_replace_all) is not bool:
+                return error("replace_all must be a boolean or null")
+            replace_all = raw_replace_all is True
+        else:
+            # Direct handler calls may omit the strict-provider field; preserve
+            # the historical false behavior while the public schema requires it.
+            replace_all = False
+
+        path_value = action_input["file_path"]
+        if not path_value:
+            return error("file_path is required")
+        path = resolve_workdir_path(agent, path_value)
+        old = action_input["old_string"]
+        new = action_input["new_string"]
         try:
             content = agent._file_io.read(path)
         except FileNotFoundError:
-            return {"status": "error", "message": f"File not found: {path}"}
-        except Exception as e:
-            return {"status": "error", "message": f"Cannot read {path}: {e}"}
+            return error(f"File not found: {path}")
+        except Exception as exc:
+            return error(f"Cannot read {path}: {exc}")
         count = content.count(old)
         if count == 0:
-            return {"status": "error", "message": f"old_string not found in {path}"}
+            return error(f"old_string not found in {path}")
         if count > 1 and not replace_all:
-            return {"status": "error", "message": f"old_string found {count} times — use replace_all=true or provide more context"}
+            return error(
+                f"old_string found {count} times — use replace_all=true or provide more context"
+            )
         if replace_all:
             updated = content.replace(old, new)
         else:
             updated = content.replace(old, new, 1)
         try:
             agent._file_io.write(path, updated)
-        except Exception as e:
-            return {"status": "error", "message": f"Cannot write {path}: {e}"}
-        return {"status": "ok", "replacements": count if replace_all else 1}
+        except Exception as exc:
+            return error(f"Cannot write {path}: {exc}")
+        return _with_setting(
+            {"status": "ok", "replacements": count if replace_all else 1},
+            diagnostic,
+        )
 
-    agent.add_tool("edit", schema=get_schema(), handler=handle_edit, description=get_description(), glossary_package=__package__)
+    agent.add_tool(
+        "edit",
+        schema=get_schema(),
+        handler=handle_edit,
+        description=get_description(),
+        glossary_package=__package__,
+    )

--- a/src/lingtai/tools/edit/glossary-wen.md
+++ b/src/lingtai/tools/edit/glossary-wen.md
@@ -15,8 +15,9 @@ maintenance: |
 ---
 **名相对照**
 
-- `edit`：精确替换文中之字。若 old_string 未见或有歧义则不成。
-- `file_path`：文卷之绝对路径
-- `old_string`：欲查且替之精确文字
-- `new_string`：替换后之文字
-- `replace_all`：替换所有匹配
+- `action`：所行之名；唯 `edit`、`manual` 二值
+- `input`：封闭之行参；`manual` 之参当为空
+- `replace_all`：严式字段，可为 `boolean` 或 `null`；`null` 即 false
+- `current_setting`：每次结果所附之设置快照，仅为证据而不改编辑
+
+`file_path`、`old_string`、`new_string` 皆守英文名相，不设省略 `action` 或扁平参之别名。

--- a/src/lingtai/tools/edit/glossary-zh.md
+++ b/src/lingtai/tools/edit/glossary-zh.md
@@ -15,8 +15,9 @@ maintenance: |
 ---
 **术语对照**
 
-- `edit`：精确替换文件中的字符串。如果 old_string 未找到或存在歧义则失败。
-- `file_path`：文件的绝对路径
-- `old_string`：要查找并替换的精确文本
-- `new_string`：替换后的文本
-- `replace_all`：替换所有匹配项
+- `action`：明确的操作名；值为 `edit` 或 `manual`
+- `input`：封闭的操作输入对象；`manual` 的输入为空
+- `replace_all`：可为 `boolean` 或 `null` 的严格字段；`null` 表示 false
+- `current_setting`：每次结果附带的设置快照诊断，不改变编辑行为
+
+`file_path`、`old_string`、`new_string` 保持英文标识，不提供省略 `action` 或扁平输入别名。

--- a/tests/test_apriori_summary_executor.py
+++ b/tests/test_apriori_summary_executor.py
@@ -21,10 +21,12 @@ from lingtai.kernel.tool_executor import ToolExecutor
 from lingtai.kernel.tool_result_summary import (
     APRIORI_SUMMARY_CAP,
     APRIORI_SUMMARY_MARKER,
+    summary_requested,
 )
 
 
-def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
+def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path,
+                   parallel_safe_tools=None):
     """Construct a ToolExecutor that records durable log events into *events*."""
 
     def logger_fn(event_type, **fields):
@@ -43,6 +45,7 @@ def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
         logger_fn=logger_fn,
         working_dir=tmp_path,
         summarizer_fn=summarizer_fn,
+        parallel_safe_tools=parallel_safe_tools or set(),
     )
 
 
@@ -64,6 +67,14 @@ def _event_fields(events, event_type):
     for et, fields in events:
         if et == event_type:
             return fields
+    return None
+
+
+def _event_index(events, event_type, *, tool_call_id):
+    """Return the first matching event index for ordering assertions."""
+    for index, (et, fields) in enumerate(events):
+        if et == event_type and fields.get("tool_call_id") == tool_call_id:
+            return index
     return None
 
 
@@ -161,6 +172,274 @@ def test_summary_true_under_cap_replaces_with_summary_and_preserves_raw(tmp_path
     assert gen["tool_call_id"] == "t3"
     assert gen["tool_name"] == "bash"
     assert "RAWSECRET" not in str(gen)
+
+
+def test_summary_requested_uses_input_presence_precedence_and_exact_bool():
+    """Canonical input wins; only a literal bool True opts in."""
+    assert summary_requested({"summary": True}) is True  # legacy compatibility
+    assert summary_requested({"input": {"summary": True}, "summary": False}) is True
+
+    # Once input is present, root summary is never a fallback, including when
+    # nested summary is absent, false, malformed, or input is not an object.
+    nested_values = [False, 1, "true", None, {}, []]
+    for nested in nested_values:
+        assert summary_requested({"input": {"summary": nested}, "summary": True}) is False
+    assert summary_requested({"input": {}, "summary": True}) is False
+    for malformed_input in (None, [], "payload", 1):
+        assert summary_requested({"input": malformed_input, "summary": True}) is False
+
+    # Legacy mode has the same exact-boolean rule and does not mutate args.
+    for root in (False, 1, "true", None, {}, []):
+        assert summary_requested({"summary": root}) is False
+    original = {"input": {"summary": True}, "summary": "ignored"}
+    snapshot = {"input": dict(original["input"]), "summary": original["summary"]}
+    assert summary_requested(original) is True
+    assert original == snapshot
+
+
+def test_nested_summary_true_serial_preserves_reasoning_and_raw_first(tmp_path):
+    raw = {"stdout": "NESTED-SERIAL-RAW"}
+    nested_input = {"command": "echo nested", "summary": True}
+    call_args = {
+        "input": nested_input,
+        "summary": False,  # root is ignored in canonical mode
+        "reasoning": "Retain the nested serial marker",
+    }
+    seen = {}
+    events = []
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen["prompt"] = user_prompt
+        return "NESTED-SERIAL-SUMMARY"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute(
+        [ToolCall(name="bash", args=call_args, id="nested-serial")]
+    )
+
+    content = _wire_content(results[0])
+    assert content["artifact"] == APRIORI_SUMMARY_MARKER
+    assert content["generated_summary"] == "NESTED-SERIAL-SUMMARY"
+    assert "Retain the nested serial marker" in seen["prompt"]
+    assert nested_input == {"command": "echo nested", "summary": True}
+
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-serial")
+    generated_index = _event_index(
+        events, "apriori_summary_generated", tool_call_id="nested-serial"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-serial"
+    )
+    assert raw_index is not None and generated_index is not None and visible_index is not None
+    assert raw_index < generated_index < visible_index
+    raw_event = events[raw_index][1]
+    assert "NESTED-SERIAL-RAW" in str(raw_event["result"])
+    assert "NESTED-SERIAL-SUMMARY" not in str(raw_event["result"])
+    assert raw_event["tool_args"]["_reasoning"] == "Retain the nested serial marker"
+
+
+def test_nested_summary_true_parallel_path_preserves_raw_before_each_replacement(tmp_path):
+    raw_by_id = {
+        "nested-parallel-1": {"stdout": "NESTED-PARALLEL-RAW-1"},
+        "nested-parallel-2": {"stdout": "NESTED-PARALLEL-RAW-2"},
+    }
+    events = []
+    seen = []
+
+    def dispatch(tc):
+        return raw_by_id[tc.id]
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen.append((tool_call_id, user_prompt))
+        return f"NESTED-PARALLEL-SUMMARY-{tool_call_id}"
+
+    ex = _make_executor(
+        dispatch_fn=dispatch,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+        parallel_safe_tools={"bash", "grep"},
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "one", "summary": True},
+                  "reasoning": "Keep parallel result one"},
+            id="nested-parallel-1",
+        ),
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "two", "summary": True},
+                  "reasoning": "Keep parallel result two"},
+            id="nested-parallel-2",
+        ),
+    ])
+
+    assert len(seen) == 2
+    for result_msg, call_id in zip(results, ("nested-parallel-1", "nested-parallel-2")):
+        content = _wire_content(result_msg)
+        assert content["artifact"] == APRIORI_SUMMARY_MARKER
+        assert content["generated_summary"] == f"NESTED-PARALLEL-SUMMARY-{call_id}"
+        raw_index = _event_index(events, "tool_result", tool_call_id=call_id)
+        generated_index = _event_index(
+            events, "apriori_summary_generated", tool_call_id=call_id
+        )
+        visible_index = _event_index(
+            events, "tool_result_model_visible", tool_call_id=call_id
+        )
+        assert raw_index is not None and generated_index is not None and visible_index is not None
+        assert raw_index < generated_index < visible_index
+        raw_event = events[raw_index][1]
+        suffix = call_id.rsplit("-", 1)[-1]
+        assert f"NESTED-PARALLEL-RAW-{suffix}" in str(raw_event["result"])
+        assert f"NESTED-PARALLEL-SUMMARY-{call_id}" not in str(raw_event["result"])
+
+
+def test_nested_false_absent_and_malformed_ignore_root_true_in_executor(tmp_path):
+    cases = [
+        ("nested-false", {"summary": False}),
+        ("nested-absent", {}),
+        ("nested-one", {"summary": 1}),
+        ("nested-string", {"summary": "true"}),
+        ("nested-null", {"summary": None}),
+        ("nested-object", {"summary": {"truthy": True}}),
+        ("nested-list", {"summary": [True]}),
+        ("input-null", None),
+        ("input-list", []),
+        ("input-string", "payload"),
+    ]
+    for call_id, nested_input in cases:
+        events = []
+        called = []
+        raw = {"stdout": f"RAW-{call_id}"}
+
+        def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+            called.append(tool_call_id)
+            return "SHOULD NOT RUN"
+
+        ex = _make_executor(
+            dispatch_fn=lambda tc, raw=raw: raw,
+            summarizer_fn=summarizer,
+            events=events,
+            tmp_path=tmp_path,
+        )
+        results, _, _ = ex.execute([
+            ToolCall(
+                name="grep",
+                args={"input": nested_input, "summary": True},
+                id=call_id,
+            )
+        ])
+        content = _wire_content(results[0])
+        assert "SHOULD NOT RUN" not in str(content)
+        assert "RAW-" + call_id in str(content)
+        assert not (isinstance(content, dict) and content.get("artifact") == APRIORI_SUMMARY_MARKER)
+        assert called == []
+
+
+def test_nested_summary_true_cap_refusal_logs_raw_before_replacement(tmp_path):
+    raw = {"stdout": "NESTED-CAP-RAW-" + "z" * (APRIORI_SUMMARY_CAP + 100)}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="read",
+            args={"input": {"file_path": "/big", "summary": True},
+                  "reasoning": "Avoid oversized raw"},
+            id="nested-cap",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert called == []
+    assert content["summary_kind"] == "apriori_cap_refused"
+    assert "NESTED-CAP-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-cap")
+    refusal_index = _event_index(
+        events, "apriori_summary_cap_refused", tool_call_id="nested-cap"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-cap"
+    )
+    assert raw_index is not None and refusal_index is not None and visible_index is not None
+    assert raw_index < refusal_index < visible_index
+    assert "NESTED-CAP-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_without_gateway_fails_closed_after_raw_log(tmp_path):
+    raw = {"stdout": "NESTED-NOGATEWAY-RAW"}
+    events = []
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=None,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "echo no gateway", "summary": True}},
+            id="nested-no-gateway",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["summary_kind"] == "apriori_error"
+    assert "NESTED-NOGATEWAY-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-no-gateway")
+    error_index = _event_index(
+        events, "apriori_summary_no_summarizer", tool_call_id="nested-no-gateway"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-no-gateway"
+    )
+    assert raw_index is not None and error_index is not None and visible_index is not None
+    assert raw_index < error_index < visible_index
+    assert "NESTED-NOGATEWAY-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_preserves_tool_error_bypass(tmp_path):
+    raw = {"status": "error", "message": "EXACT-TOOL-ERROR"}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "error", "summary": True}},
+            id="nested-error",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["status"] == "error"
+    assert "EXACT-TOOL-ERROR" in str(content)
+    assert called == []
+    assert _event_index(events, "tool_result", tool_call_id="nested-error") is not None
+    assert _event_index(events, "apriori_summary_generated", tool_call_id="nested-error") is None
 
 
 def test_summary_true_over_cap_refuses_without_llm_and_hides_raw(tmp_path):

--- a/tests/test_edit_capability.py
+++ b/tests/test_edit_capability.py
@@ -113,10 +113,12 @@ def test_prompt_batches_and_canonical_description(tmp_path):
         batches = agent._build_system_prompt_batches()
         joined = "\n\n".join(batch for batch in batches if batch)
         assert prompt == joined
+        description = get_description()
         assert "### edit" in prompt
-        assert "action='edit'" in prompt
-        assert "nested input" in prompt
-        assert "omit action for the legacy" not in prompt
+        assert description in prompt
+        assert "action='edit'" in description
+        assert "nested input" in description
+        assert "omit action for the legacy" not in description
         assert "action='edit'" in joined
     finally:
         agent.stop(timeout=1.0)

--- a/tests/test_edit_capability.py
+++ b/tests/test_edit_capability.py
@@ -1,0 +1,294 @@
+"""Independent public action/input contract tests for the edit capability.
+
+These tests deliberately exercise the handler directly as well as the schema
+surfaces. They are edit-owned; shared file-capability compatibility tests are
+not changed by this migration.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.agent import Agent
+from lingtai.llm.anthropic.adapter import _build_tools as build_anthropic_tools
+from lingtai.llm.openai.adapter import (
+    _build_responses_tools,
+    _build_tools as build_chat_tools,
+)
+from lingtai.tools.edit import get_description, get_schema
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
+
+
+
+def _agent(tmp_path: Path) -> Agent:
+    return Agent(
+        service=make_mock_service(),
+        agent_name="edit-contract-test",
+        working_dir=tmp_path / "agent",
+        capabilities=["edit"],
+    )
+
+
+def _edit_call(agent: Agent, **payload):
+    return agent._tool_handlers["edit"](payload)
+
+
+def _explicit(path: str, old: str, new: str, replace_all=None) -> dict:
+    input_value = {"file_path": path, "old_string": old, "new_string": new}
+    if replace_all is not ...:
+        input_value["replace_all"] = replace_all
+    return {"action": "edit", "input": input_value}
+
+
+def _without_setting(value: dict) -> dict:
+    return {key: item for key, item in value.items() if key != "current_setting"}
+
+
+def test_raw_schema_is_closed_action_input():
+    schema = get_schema()
+    assert set(schema) == {"type", "properties", "required", "additionalProperties"}
+    assert set(schema["properties"]) == {"action", "input"}
+    assert schema["required"] == ["action", "input"]
+    assert schema["additionalProperties"] is False
+
+    branches = schema["properties"]["input"]["anyOf"]
+    edit_branch = next(branch for branch in branches if branch["title"] == "edit input")
+    manual_branch = next(branch for branch in branches if branch["title"] == "manual input")
+    assert set(edit_branch["properties"]) == {
+        "file_path", "old_string", "new_string", "replace_all"
+    }
+    assert edit_branch["required"] == [
+        "file_path", "old_string", "new_string", "replace_all"
+    ]
+    assert edit_branch["additionalProperties"] is False
+    assert edit_branch["properties"]["replace_all"]["type"] == ["boolean", "null"]
+    assert manual_branch["properties"] == {}
+    assert manual_branch["required"] == []
+    assert manual_branch["additionalProperties"] is False
+
+
+def test_agent_schema_has_only_action_input_reasoning(tmp_path):
+    agent = _agent(tmp_path)
+    try:
+        schema = next(item for item in agent._build_tool_schemas() if item.name == "edit")
+        assert set(schema.parameters["properties"]) == {"action", "input", "reasoning"}
+        assert schema.parameters["required"] == ["action", "input"]
+        assert schema.parameters["additionalProperties"] is False
+        for branch in schema.parameters["properties"]["input"]["anyOf"]:
+            assert "reasoning" not in branch.get("properties", {})
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_provider_envelopes_keep_public_fields(tmp_path):
+    agent = _agent(tmp_path)
+    try:
+        schema = next(item for item in agent._build_tool_schemas() if item.name == "edit")
+        chat = build_chat_tools([schema])[0]
+        responses = _build_responses_tools([schema])[0]
+        anthropic = build_anthropic_tools([schema], cache_tools=False)[0]
+
+        assert set(chat) == {"type", "function"}
+        assert set(chat["function"]) == {"name", "description", "parameters"}
+        assert set(responses) == {"type", "name", "description", "parameters"}
+        assert set(anthropic) == {"name", "description", "input_schema"}
+        for parameters in (
+            chat["function"]["parameters"],
+            responses["parameters"],
+            anthropic["input_schema"],
+        ):
+            assert set(parameters["properties"]) == {"action", "input", "reasoning"}
+            assert parameters["required"] == ["action", "input"]
+            assert parameters["additionalProperties"] is False
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_prompt_batches_and_canonical_description(tmp_path):
+    agent = _agent(tmp_path)
+    try:
+        prompt = agent._build_system_prompt()
+        batches = agent._build_system_prompt_batches()
+        joined = "\n\n".join(batch for batch in batches if batch)
+        assert prompt == joined
+        assert "### edit" in prompt
+        assert "action='edit'" in prompt
+        assert "nested input" in prompt
+        assert "omit action for the legacy" not in prompt
+        assert "action='edit'" in joined
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_edit_replacement_and_defaults(tmp_path):
+    agent = _agent(tmp_path)
+    try:
+        target = agent.working_dir / "replace.txt"
+        target.write_text("alpha beta alpha", encoding="utf-8")
+
+        ambiguous = _edit_call(agent, **_explicit(str(target), "alpha", "omega", None))
+        assert ambiguous["status"] == "error"
+        assert "2 times" in ambiguous["message"]
+        assert "current_setting" in ambiguous
+        assert target.read_text(encoding="utf-8") == "alpha beta alpha"
+
+        all_result = _edit_call(agent, **_explicit(str(target), "alpha", "omega", True))
+        assert _without_setting(all_result) == {"status": "ok", "replacements": 2}
+        assert target.read_text(encoding="utf-8") == "omega beta omega"
+
+        target.write_text("one two", encoding="utf-8")
+        omitted = _edit_call(agent, **_explicit(str(target), "one", "ONE", ...))
+        assert _without_setting(omitted) == {"status": "ok", "replacements": 1}
+        assert target.read_text(encoding="utf-8") == "ONE two"
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_null_replace_all_preserves_false_and_reasoning_is_metadata(tmp_path):
+    agent = _agent(tmp_path)
+    try:
+        target = agent.working_dir / "null.txt"
+        target.write_text("x x", encoding="utf-8")
+        result = _edit_call(
+            agent,
+            **_explicit(str(target), "x", "y", None),
+            reasoning="public explanation",
+            _reasoning="executor explanation",
+        )
+        assert result["status"] == "error"
+        assert "2 times" in result["message"]
+        assert target.read_text(encoding="utf-8") == "x x"
+    finally:
+        agent.stop(timeout=1.0)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"file_path": "x", "old_string": "a", "new_string": "b"},
+        {"action": "edit", "input": {"file_path": "x", "old_string": "a", "new_string": "b"}, "extra": 1},
+    ],
+)
+def test_missing_flat_and_unknown_root_calls_are_rejected(tmp_path, payload):
+    agent = _agent(tmp_path)
+    try:
+        result = _edit_call(agent, **payload)
+        assert result["status"] == "error"
+        assert "current_setting" in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+@pytest.mark.parametrize("bad_root", [None, [], "edit", 3])
+def test_nonmapping_root_is_structured_error(tmp_path, bad_root):
+    agent = _agent(tmp_path)
+    try:
+        result = agent._tool_handlers["edit"](bad_root)
+        assert result["status"] == "error"
+        assert "current_setting" in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"action": "edit", "input": []},
+        {"action": "edit", "input": {"file_path": 4, "old_string": "a", "new_string": "b", "replace_all": None}},
+        {"action": "edit", "input": {"file_path": "x", "old_string": "a", "new_string": "b", "replace_all": "yes"}},
+        {"action": "manual", "input": {"unexpected": True}},
+    ],
+)
+def test_wrong_input_types_and_closed_branches_are_rejected(tmp_path, payload):
+    agent = _agent(tmp_path)
+    try:
+        result = _edit_call(agent, **payload)
+        assert result["status"] == "error"
+        assert "current_setting" in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+@pytest.mark.parametrize("action", ["write", "", 4, [], {}])
+def test_unknown_and_unhashable_actions_are_safe(tmp_path, action):
+    agent = _agent(tmp_path)
+    try:
+        result = _edit_call(agent, action=action, input={})
+        assert result["status"] == "error"
+        assert "Unsupported action for edit" in result["message"]
+        assert "current_setting" in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_manual_returns_installed_body(tmp_path):
+    agent = _agent(tmp_path)
+    try:
+        result = _edit_call(agent, action="manual", input={})
+        assert result["status"] == "ok"
+        assert result["manual"]
+        assert "# File Manual" in result["manual"]
+        assert "The `edit` action/input contract" in result["manual"]
+        assert result["manual_path"].endswith("capabilities/file-manual/SKILL.md")
+        assert "current_setting" in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_settings_are_attached_and_invariant(tmp_path):
+    agent = _agent(tmp_path)
+    try:
+        target = agent.working_dir / "settings.txt"
+        target.write_text("old", encoding="utf-8")
+        settings = agent.working_dir / "settings" / "edit.json"
+        settings.parent.mkdir(parents=True, exist_ok=True)
+
+        missing = _edit_call(agent, **_explicit(str(target), "old", "missing", True))
+        assert missing["current_setting"]["source"] == "missing"
+
+        settings.write_text(json.dumps({"schema_version": 1}), encoding="utf-8")
+        valid = _edit_call(agent, **_explicit(str(target), "missing", "valid", True))
+        assert valid["current_setting"]["source"] == "settings/edit.json"
+        assert _without_setting(valid) == {"status": "ok", "replacements": 1}
+
+        settings.write_text(json.dumps({"schema_version": 1, "extra": False}), encoding="utf-8")
+        invalid = _edit_call(agent, **_explicit(str(target), "valid", "invalid", True))
+        assert invalid["current_setting"]["source"] == "settings_error"
+        assert invalid["current_setting"]["settings_error"]
+        assert _without_setting(invalid) == {"status": "ok", "replacements": 1}
+        assert target.read_text(encoding="utf-8") == "invalid"
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_file_io_delegation_and_structured_failures(tmp_path):
+    agent = _agent(tmp_path)
+    try:
+        calls = []
+        target = agent.working_dir / "delegated.txt"
+        target.write_text("old", encoding="utf-8")
+        real_io = agent._file_io
+
+        class SpyIO:
+            def read(self, path):
+                calls.append(("read", path))
+                return real_io.read(path)
+
+            def write(self, path, content):
+                calls.append(("write", path, content))
+                return real_io.write(path, content)
+
+        agent._file_io = SpyIO()
+        result = _edit_call(agent, **_explicit("delegated.txt", "old", "new", False))
+        assert result["status"] == "ok"
+        assert [call[0] for call in calls] == ["read", "write"]
+        assert calls[0][1] == agent.working_dir / "delegated.txt"
+
+        missing = _edit_call(agent, **_explicit("missing.txt", "old", "new", False))
+        assert missing["status"] == "error"
+        assert missing["message"].startswith("File not found:")
+    finally:
+        agent.stop(timeout=1.0)

--- a/tests/test_tool_settings.py
+++ b/tests/test_tool_settings.py
@@ -1,0 +1,154 @@
+"""Focused tests for the private no-op placeholder-settings foundation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools._settings import (
+    MAX_SETTINGS_BYTES,
+    current_setting,
+    read_settings,
+    settings_path,
+    valid_tool_name,
+)
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+
+def _write(root: Path, tool_name: str, payload: str | bytes) -> Path:
+    path = root / "settings" / f"{tool_name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def test_missing_is_a_normal_noop_placeholder_state(tmp_path):
+    snapshot = read_settings(_Agent(tmp_path), "example")
+    setting = current_setting(snapshot, "example")
+    assert setting == {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": "missing",
+        "settings_revision": "missing",
+        "settings_hash": None,
+        "change_hint": (
+            "Edit settings/example.json; changes apply on the next example call; "
+            "this no-op placeholder never changes tool behavior."
+        ),
+    }
+
+
+def test_valid_v1_only_changes_source_revision_and_hash(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "example", '{"schema_version": 1}')
+    snapshot = read_settings(agent, "example")
+    setting = current_setting(snapshot, "example")
+    assert snapshot.error is None
+    assert setting["configurable"] is False
+    assert setting["placeholder"] == "no-op"
+    assert setting["source"] == "settings/example.json"
+    assert setting["settings_revision"] == setting["settings_hash"]
+    assert setting["settings_hash"]
+
+
+def test_reader_rereads_hot_changes_without_cache(tmp_path):
+    agent = _Agent(tmp_path)
+    path = _write(tmp_path, "example", '{"schema_version": 1}')
+    first = read_settings(agent, "example")
+    path.write_text('{ "schema_version": 1 }', encoding="utf-8")
+    second = read_settings(agent, "example")
+    assert first.digest != second.digest
+    assert second.source == "settings/example.json"
+
+
+def test_duplicate_and_extra_fields_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    duplicate = _write(tmp_path, "duplicate", '{"schema_version": 1, "schema_version": 1}')
+    duplicate_snapshot = read_settings(agent, "duplicate")
+    assert duplicate_snapshot.source == "settings_error"
+    assert "duplicate" in (duplicate_snapshot.error or "")
+
+    extra = _write(tmp_path, "extra", '{"schema_version": 1, "future": false}')
+    extra_snapshot = read_settings(agent, "extra")
+    assert extra_snapshot.source == "settings_error"
+    assert "only schema_version" in (extra_snapshot.error or "")
+
+
+def test_bool_and_other_schema_versions_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    for name, version in (("bool", True), ("float", 1.0), ("other", 2)):
+        _write(tmp_path, name, json.dumps({"schema_version": version}))
+        snapshot = read_settings(agent, name)
+        assert snapshot.source == "settings_error"
+        assert "integer 1" in (snapshot.error or "")
+
+
+def test_invalid_encoding_and_json_are_truthful_bounded_errors(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "encoding", b'{"schema_version": 1}\xff')
+    encoding_snapshot = read_settings(agent, "encoding")
+    assert encoding_snapshot.source == "settings_error"
+    assert encoding_snapshot.error
+
+    _write(tmp_path, "json", "{not-json")
+    json_snapshot = read_settings(agent, "json")
+    assert json_snapshot.source == "settings_error"
+    assert json_snapshot.error
+    assert len(json_snapshot.error) <= 240
+
+
+def test_symlink_non_regular_and_oversized_files_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text('{"schema_version": 1}', encoding="utf-8")
+    symlink = tmp_path / "settings" / "symlink.json"
+    symlink.parent.mkdir()
+    symlink.symlink_to(target)
+    symlink_snapshot = read_settings(agent, "symlink")
+    assert symlink_snapshot.source == "settings_error"
+    assert "regular file" in (symlink_snapshot.error or "")
+
+    non_regular = tmp_path / "settings" / "directory.json"
+    non_regular.mkdir()
+    directory_snapshot = read_settings(agent, "directory")
+    assert directory_snapshot.source == "settings_error"
+    assert "regular file" in (directory_snapshot.error or "")
+
+    _write(tmp_path, "large", b"{" + b"x" * MAX_SETTINGS_BYTES + b"}")
+    large_snapshot = read_settings(agent, "large")
+    assert large_snapshot.source == "settings_error"
+    assert "bounded size" in (large_snapshot.error or "")
+
+
+def test_unstable_snapshot_is_not_treated_as_missing(tmp_path, monkeypatch):
+    import lingtai.tools._settings as settings_module
+
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "unstable", '{"schema_version": 1}')
+
+    def raise_unstable(_path):
+        raise settings_module.SettingsError("settings snapshot changed during read")
+
+    monkeypatch.setattr(settings_module, "_read_stable", raise_unstable)
+    snapshot = read_settings(agent, "unstable")
+    assert snapshot.source == "settings_error"
+    assert snapshot.revision == "error"
+    assert snapshot.error == "settings snapshot changed during read"
+
+
+def test_tool_names_are_bounded_path_components(tmp_path):
+    assert valid_tool_name("web_search")
+    assert not valid_tool_name("../escape")
+    assert not valid_tool_name("nested/name")
+    assert not valid_tool_name("\\escape")
+    assert not valid_tool_name("x" * 65)
+    with pytest.raises(ValueError):
+        settings_path(_Agent(tmp_path), "../escape")


### PR DESCRIPTION
## Summary

This stacked draft migrates the public `edit` tool to LingTai's future canonical model-facing contract:

- required root `action` plus required nested `input` in the raw tool-owned schema;
- actions exactly `edit` and `manual`;
- BaseAgent-injected root `reasoning`, with no nested reasoning alias;
- closed action-specific inputs and no omitted-action or flat-root compatibility;
- strict per-call `settings/edit.json` v1 placeholder loading with truthful `current_setting` on success and failure paths;
- canonical installed file manual plus synchronized edit contract and glossaries.

The provider wrappers remain unchanged: Chat uses `function.parameters`, Responses uses `parameters`, and Anthropic uses `input_schema`.

## Stack

- Depends on foundation draft #1038.
- Base branch: `feat/tool-settings-foundation`.
- This PR is intentionally a draft and must not be merged independently of the stack review.

## Validation

- dedicated `tests/test_edit_capability.py` added;
- fresh persistent-path actual Agent schema and prompt construction passed;
- exact Agent-built schema passed unchanged through Chat, Responses, and Anthropic adapters;
- direct `reasoning` and executor `_reasoning` metadata paths passed;
- FileIO replacement and ambiguity behavior passed;
- malformed, unknown, and unhashable inputs failed safely without mutation;
- missing, valid, hot-reloaded, and invalid settings plus prompt/behavior invariance passed;
- installed manual body, anatomy drift (53 files), glossary resources (57 across 19 packages), and `git diff --check` passed.

No merge, release, deploy, tag, deletion, or cleanup is part of this draft.

## Follow-up after foundation advance

- non-force merged foundation head `80d5c7d4` into this stacked branch;
- repaired one test-only false assumption: the whole resident prompt legitimately still contains legacy prose for unmigrated sibling tools, so the stale-prose negative assertion now scopes to the edit-owned `get_description()` result;
- directly executed `test_prompt_batches_and_canonical_description` against the exact worktree Agent path with a persistent artifact root: **PASS**;
- production edit code and public schema were unchanged by this follow-up; #1043 is `CLEAN` against the advanced foundation base.
