### PR TITLE
feat(read): adopt canonical action/input contract

### DIFF
--- a/src/lingtai/intrinsic_skills/file-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/file-manual/SKILL.md
@@ -74,17 +74,30 @@ committing or storing it as a durable LingTai asset.
 
 ## Reading safely
 
-Prefer `read` for known text files; its line numbers make later edits and
-citations easier. If a file may be generated, minified, huge, or noisy, search
-first and read only the relevant region:
+Prefer the strict nested `read` action for known text files; its line numbers
+make later edits and citations easier. If a file may be generated, minified,
+huge, or noisy, search first and read only the relevant region:
 
 ```python
 grep({"pattern": "class Agent|def handle", "path": "/abs/path/src", "glob": "*.py", "max_matches": 50})
-read({"file_path": "/abs/path/src/module.py", "offset": 40, "limit": 80})
+read({"action": "read", "input": {"file_path": "/abs/path/src/module.py", "offset": 40, "limit": 80, "summary": False}, "reasoning": "inspect the relevant source window"})
 ```
 
 For the cap model, continuation via `next_offset`, and `line_truncated`
-handling, read `read-manual` rather than improvising.
+handling, read `read-manual` rather than improvising. The public `read` call is
+closed: use `action="read"` with nested `input`, or `action="manual"` with
+`input={}` for the installed read guide; do not use omitted-action or flat-root
+forms.
+
+### The `read` action/input contract
+
+The public `read` call requires root `action` and nested `input`. A normal read
+requires nested `file_path`; `offset`, `limit`, `max_chars`, and exact-boolean
+`summary` remain nested read options, with defaults documented by `read-manual`.
+The manual route is `action="manual"` with an empty `input` and performs no
+file-target read. `BaseAgent` may add root `reasoning` as metadata, but reasoning
+is not a nested read field. Do not add compatibility aliases or flatten the
+input.
 
 ## Writing and editing safely
 
@@ -125,16 +138,18 @@ content or attach/export a file through the appropriate communication channel.
 
 ## Manual versus ordinary calls
 
-Normal file work is primary. Each file tool has two explicit modes:
+Normal file work is primary. Follow each tool's current public schema. The
+migrated `read` tool has two explicit root actions: use `action="read"` with the
+nested ordinary input described above, or use `action="manual"` with `input={}`
+for the installed read guide. Its omitted-action and flat-root forms are not
+supported.
 
-- **Ordinary work:** for backward compatibility, omit `action` or set it to the
-  tool name: `action="read"`, `"write"`, `"edit"`, `"glob"`, or `"grep"`.
-  Supply the ordinary arguments shown in that tool's schema.
-- **Manual lookup:** use `action="manual"` as a one-time entry when you need the
-  installed workflow guide. It returns documentation and performs no file
-  operation. `write`, `edit`, `glob`, and `grep` return this manual; `read`
-  returns `read-manual`.
+Other file tools may document their own ordinary arguments and rollout state.
+A manual lookup is always an explicit `action="manual"` one-time entry when that
+tool exposes it; it returns documentation and performs no file operation.
+`write`, `edit`, `glob`, and `grep` return this manual; `read` returns
+`read-manual`.
 
-After a manual result, continue the original task with an ordinary call. Do not
-request the same manual again. Repeating an identical manual call is an error loop,
-not progress.
+After a manual result, continue the original task with the tool's documented
+ordinary action. Do not request the same manual again. Repeating an identical
+manual call is an error loop, not progress.

--- a/src/lingtai/intrinsic_skills/read-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/read-manual/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: read-manual
-description: "Complete guide for the read tool: continuation workflow, next_offset pagination, line_truncated handling, runtime tool-result spill vs read-level pagination, 100k read default / 200k runtime hard cap, and when to use bash/grep/sed for truncated lines. Use when implementing complete file-read workflows, handling large files, or understanding cap and truncation semantics."
-version: 0.1.0
+description: "Complete guide for the read tool: strict action/input calls, continuation workflow, next_offset pagination, line_truncated handling, runtime tool-result spill vs read-level pagination, 100k read default / 200k runtime hard cap, and when to use bash/grep/sed for truncated lines."
+version: 0.2.0
 tags: [read, files, continuation, truncation, cap, pagination]
-last_changed_at: "2026-07-19T00:00:00Z"
+last_changed_at: "2026-07-26T00:00:00Z"
 related_files:
 - src/lingtai/tools/read/__init__.py
+- src/lingtai/tools/read/CONTRACT.md
 - src/lingtai/intrinsic_skills/file-manual/SKILL.md
 maintenance: |
   Tracks the tool/capability behavior it teaches; update when that tool's behavior changes.
@@ -13,26 +14,57 @@ maintenance: |
 
 # Read Manual
 
-Complete workflow for reading files with the `read` tool. Load it for large
-files, complete-content workflows, truncation, or `line_truncated` results.
+Complete guide for the public `read` capability. The raw tool-owned schema is a
+closed root object with required `action` and required nested `input`; `BaseAgent`
+adds optional root `reasoning` to the model-facing call shown here:
 
-For basic tool choice (read vs write vs edit vs grep vs glob), UTF-8 policy, and
-the shared `action="manual"` versus ordinary-call rule, see the `file-manual`
-skill — including that repeating an identical manual call is an error loop, not
-progress. After this manual returns, continue the original task with an ordinary
-read.
+```json
+{
+  "action": "read",
+  "input": {
+    "file_path": "src/example.py",
+    "offset": 1,
+    "limit": 200,
+    "max_chars": 100000,
+    "summary": false
+  },
+  "reasoning": "inspect the requested source window"
+}
+```
+
+`action` is exactly `read` or `manual`. The `read` input is closed and requires
+`file_path`; it preserves the optional `offset` (default `1`, 1-based), `limit`
+(default `2000` lines), `max_chars` (per-call character budget), and exact
+boolean `summary` (default `false`). `manual` requires the closed empty input
+object:
+
+```json
+{"action": "manual", "input": {}, "reasoning": "load the installed read guide"}
+```
+
+Do not use omitted-action, flat-root, nested `reasoning`, or compatibility-alias
+forms. `BaseAgent` may add optional root `reasoning` as call metadata; it is not
+part of this tool's nested input. `ToolExecutor` may normalize that metadata to
+`_reasoning` for the handler. Neither form changes read behavior.
+
+Every invocation first rereads strict Agent-owned `settings/read.json` and every
+result includes a secret-free `current_setting` placeholder diagnostic. The
+settings file has no genuine read option: only `{"schema_version": 1}` is valid,
+and missing, valid, hot, or invalid settings never change schema, prompts,
+path resolution, pagination, caps, or file behavior.
 
 ## Two caps
 
 | Cap | Value | Configurable |
 |---|---|---|
-| `read` per-call page budget | **100 000 chars** (default) | yes, via per-call `max_chars` |
+| `read` per-call page budget | **100 000 chars** (default) | yes, via nested `input.max_chars` |
 | Runtime tool-result hard ceiling | **200 000 chars** | no — not by agents or prompts |
 
-`max_chars` requests a smaller or larger chunk for one call. Values above the
-hard ceiling are clamped to 200 000; the effective value appears as `cap_chars`
-when the result is truncated. Do not assume the old 10 000- or 8 000-character
-limits from earlier versions.
+`input.max_chars` requests a smaller or larger chunk for one call. Positive
+integer values above the hard ceiling are clamped to 200 000; the existing read
+cap resolver uses the 100 000 default when the value is absent or otherwise does
+not select a positive cap. The runtime hard cap remains the ceiling that prevents
+provider-visible tool-result blowups.
 
 These two caps act at different layers:
 
@@ -46,13 +78,13 @@ These two caps act at different layers:
 
 A well-formed `read` result normally stays under the outer ceiling because
 `max_chars` is clamped to 200k. If you still see a spill manifest from `read`,
-inspect the `spill_path` artifact, then re-call `read` with a smaller
-`limit`/`max_chars` or process the artifact via `bash`/`grep`/Python.
+inspect the `spill_path` artifact, then re-call `read` with a smaller `limit` or
+`max_chars`, or process the artifact via `bash`/`grep`/Python.
 
 ## Metadata/stats preflight
 
 For unknown or large files, inspect cheap metadata before reading big chunks.
-This replaces a dedicated `read(dry_run=true)` mode.
+This replaces a dedicated dry-run action; there is no `dry_run` read input.
 
 ```bash
 python - <<'PY'
@@ -71,29 +103,41 @@ PY
 
 Use the result to choose the window:
 
-- `offset` — where to begin or resume (1-based).
-- `limit` — how many lines to request; a tight `limit` (e.g. `50`) narrows the
-  window, and a large `offset` with a small `limit` reads an arbitrary slice.
-- `max_chars` — per-call character budget (default 100k, max 200k).
+- `input.offset` — where to begin or resume (1-based; default `1`).
+- `input.limit` — how many lines to request (default `2000`); a tight `limit`
+  (e.g. `50`) narrows the window, and a large offset with a small limit reads an
+  arbitrary slice.
+- `input.max_chars` — per-call character budget (default 100k, max 200k).
+- `input.summary` — exact boolean control metadata only; it does not select a
+  different read range or alter the handler's file operation.
 
 ## Complete-content workflow
 
 For any file that may exceed the cap:
 
-1. Call `read` with the desired `offset` (default 1) and `limit`.
+1. Call `read` with the desired nested input offset and limit.
 2. If `truncated` is absent or `false`, the whole requested range was returned —
    done. If `true`, continue.
-3. Re-call with `offset=next_offset`, keeping the same `limit`, until
-   `truncated` is absent or `false`.
+3. Re-call with `offset=next_offset`, keeping the same `limit` and `max_chars`.
 
 ```python
 offset = 1
 while True:
-    r = read({"file_path": path, "offset": offset, "limit": 200})
-    process(r["content"])
-    if not r.get("truncated"):
+    result = read({
+        "action": "read",
+        "input": {
+            "file_path": path,
+            "offset": offset,
+            "limit": 200,
+            "max_chars": 100000,
+            "summary": False,
+        },
+        "reasoning": "read the next text window",
+    })
+    process(result["content"])
+    if not result.get("truncated"):
         break
-    offset = r["next_offset"]
+    offset = result["next_offset"]
 ```
 
 ## Continuation metadata fields
@@ -108,11 +152,11 @@ When `truncated=true` the result includes:
 | `requested_offset` | 1-based start line you passed |
 | `requested_limit` | line limit you passed |
 | `last_returned_line` | 1-based line number of the last line shown |
-| `next_offset` | pass this as `offset` on the next call to continue |
+| `next_offset` | pass this as `input.offset` on the next call to continue |
 | `remaining_lines_estimate` | approximate lines still unread |
 | `line_truncated` | `true` only when a single physical line exceeded the cap |
 
-## Handling line_truncated=true
+## Handling `line_truncated=true`
 
 `line_truncated=true` appears when a single physical line is longer than the cap.
 Then:
@@ -143,15 +187,14 @@ PY
 
 Before calling `read`:
 
+- Use `{"action":"read","input":{...},"reasoning":"describe the read"}`; never flatten the input or nest reasoning.
 - Large file? Probe with `limit=100`–`200`, or run the preflight above.
 - Need the whole file? Use the continuation loop.
 - `line_truncated=true`? Switch to `bash`/`grep`/`sed`/Python.
-- `status=spilled`? Read the `spill_path` artifact or reduce `limit`.
-- Need a specific region? Pass `offset` and a tight `limit`.
+- `status="spilled"`? Read the `spill_path` artifact or reduce `limit`.
+- Need a specific region? Pass `offset` and a tight `limit` inside `input`.
+- Need the installed guide? Use `{"action":"manual","input":{},"reasoning":"load the installed read guide"}` once.
 
-## Manual versus ordinary reads
-
-For backward compatibility, an ordinary read may omit `action` or set
-`action="read"`. Use `action="manual"` only as a one-time entry to this guide.
-After the manual returns, continue the original task with an ordinary read; do
-not repeat the same manual call. Repeating it is an error loop, not progress.
+The raw result is preserved before any `summary=true` replacement. Set nested
+`summary` to `true` only when a lossy generated summary is acceptable; keep it
+`false` when exact line/file content is required.

--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -36,6 +36,7 @@ Safety properties:
 from __future__ import annotations
 
 import datetime as _dt
+from collections.abc import Mapping
 from typing import Any, Callable
 
 from .meta_block import formal_tool_result_content, formal_tool_result_visible_len
@@ -147,15 +148,21 @@ def is_apriori_summary(content: Any) -> bool:
     )
 
 
-def summary_requested(args: dict | None) -> bool:
-    """Return True iff the normalized tool args opt into a-priori summary.
+def summary_requested(args: Mapping | None) -> bool:
+    """Return True iff tool args opt into a-priori summary.
 
-    The flag is the boolean ``summary`` field on the tool call. Anything other
-    than a literal ``True`` (missing, ``False``, ``None``, truthy-but-not-True)
-    preserves current behavior exactly.
+    The presence of ``input`` selects canonical mode: only a Mapping-valued
+    ``input`` whose ``summary`` is exactly ``True`` requests summarization.
+    Root ``summary`` is ignored in canonical mode, including when ``input`` is
+    malformed or its nested flag is absent/invalid. When ``input`` is absent,
+    legacy mode reads only root ``summary``. Both modes require identity with
+    the boolean singleton ``True``; no truthy coercion is performed.
     """
-    if not isinstance(args, dict):
+    if not isinstance(args, Mapping):
         return False
+    if "input" in args:
+        payload = args["input"]
+        return isinstance(payload, Mapping) and payload.get("summary") is True
     return args.get("summary") is True
 
 
@@ -395,13 +402,19 @@ def maybe_summarize_result(
     and BEFORE the result is turned into the model-visible wire message.
 
     Contract:
+    - Summary control is canonical-first: when ``input`` is present, only
+      ``input.summary is True`` on a Mapping payload requests; root ``summary``
+      is never inspected or used as fallback. When ``input`` is absent, legacy
+      calls use root ``summary is True``. This exact-boolean discriminator is
+      applied without flattening or mutating the original args.
     - ``summary != true`` → returns *result* unchanged (current behavior).
     - ``summary == true`` but no ``summarizer_fn`` wired (e.g. service without a
       one-shot generate gateway) → **fails closed**: returns a summary-layer
       error (with the raw-retrieval locator), NOT the raw result. ``summary=true``
       is a request to keep the raw out of context; honoring it must not depend on
       whether a summarizer happens to be configured. The raw is already durably
-      logged before this point, so it remains retrievable by ``tool_call_id``.
+      logged before either the legacy or canonical predicate is applied, so it
+      remains retrievable by ``tool_call_id``.
     - Already an a-priori summary (defensive) → returned unchanged.
     - Error results (the tool itself failed) are NOT summarized: the agent needs
       the exact error text to recover. Returned unchanged.

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
@@ -35,6 +36,10 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_settings.py` — private Agent-owned placeholder-settings reader and
+  secret-free current-setting diagnostic. It strictly validates the exact
+  versioned no-op schema, rereads `settings/<bounded tool_name>.json` per call,
+  and never supplies action, input, reasoning, or tool behavior.
 
 ## Connections
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -40,6 +40,33 @@ There is no fourth public metadata block. Existing tools retain their current
 explicit schemas until a scoped migration changes their code, tests, manual, and
 contract together.
 
+### A-priori summary transition
+
+The shared kernel summary predicate uses the presence of the `input` key as the
+mode discriminator. A canonical call requests a summary only when `input` is a
+Mapping/object and `input.summary` is exactly the boolean `true`; once `input` is
+present, root `summary` is ignored and is never a fallback, even when `input` is
+malformed, missing `summary`, or carries a false/non-boolean value. No truthy
+coercion, flattening, or argument mutation is permitted. A call with no `input`
+key remains in legacy mode and requests only when root `summary` is exactly
+`true`.
+
+This is a transitional compatibility rule, not a second public schema: migrated
+capabilities that support a-priori summary advertise that flag only as nested
+`input.summary`, while unmigrated legacy advertisers retain their root flag until
+their own vertical migration. Tool errors continue to bypass summarization. The
+raw result is durably recorded before either nested or legacy summary control is
+applied; generated, refusal, and fail-closed no-gateway replacements are
+model-visible substitutes with the
+existing raw locator and metadata.
+
+The root-summary branch may be removed only in the commit that migrates the last
+currently legacy root-summary advertiser (including shell's historical `bash`
+rolling alias and daemon), and only after a registry-wide test proves that no
+provider-facing schema advertises root `summary`, no migrated handler accepts
+flat fields, and no supported pending legacy call relies on the root shape. Until
+that final removal gate, root lookup is permitted solely when `input` is absent.
+
 ## Port
 
 The provider-neutral boundary is the final `FunctionSchema` assembled by the

--- a/src/lingtai/tools/_settings.py
+++ b/src/lingtai/tools/_settings.py
@@ -1,0 +1,156 @@
+"""Private shared reader for Agent-owned no-op tool settings placeholders.
+
+The placeholder file is deliberately metadata-only.  A present, valid v1 file
+proves that an Agent-owned settings snapshot was read, but it cannot select or
+enable any tool behavior.  Individual tools may later add their own real
+settings reader when a configurable choice is actually authorized.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MAX_SETTINGS_BYTES = 64 * 1024
+SETTINGS_SCHEMA_VERSION = 1
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class SettingsError(ValueError):
+    """A placeholder settings snapshot was malformed or unsafe to use."""
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsSnapshot:
+    """Immutable evidence for one reread of one tool's settings file."""
+
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def valid_tool_name(value: Any) -> bool:
+    """Return whether *value* is safe as one bounded settings path component."""
+    return isinstance(value, str) and _TOOL_NAME.fullmatch(value) is not None
+
+
+def settings_path(agent: Any, tool_name: str) -> Path:
+    """Return the fixed Agent-owned ``settings/<tool_name>.json`` path."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return Path(agent._working_dir) / "settings" / f"{tool_name}.json"
+
+
+def _bounded_error(exc: Exception) -> str:
+    """Render a bounded diagnostic without echoing host paths or file content."""
+    if isinstance(exc, OSError):
+        return f"settings file could not be read ({type(exc).__name__})"
+    text = str(exc).replace("\n", " ").strip()
+    return (text or "invalid settings")[:240]
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject duplicate JSON object members instead of accepting last-wins data."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SettingsError("duplicate settings field")
+        result[key] = value
+    return result
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    """Read one bounded regular-file snapshot and its content revision."""
+    try:
+        first = path.lstat()
+    except FileNotFoundError:
+        return b"", "missing"
+    except OSError:
+        raise
+
+    if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
+        raise SettingsError("settings file must be a regular file")
+    if first.st_size > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings file exceeds the bounded size")
+
+    # Open by path only after lstat, then compare the path identity and metadata
+    # again.  Replacements, symlink swaps, growth, and ordinary in-place writes
+    # are therefore rejected rather than partially accepted.
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_SETTINGS_BYTES + 1)
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    try:
+        second = path.lstat()
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    if stat.S_ISLNK(second.st_mode) or not stat.S_ISREG(second.st_mode):
+        raise SettingsError("settings snapshot changed during read")
+    if (
+        len(raw) > MAX_SETTINGS_BYTES
+        or first.st_dev != second.st_dev
+        or first.st_ino != second.st_ino
+        or first.st_size != second.st_size
+        or first.st_mtime_ns != second.st_mtime_ns
+    ):
+        raise SettingsError("settings snapshot changed during read")
+    return raw, hashlib.sha256(raw).hexdigest()[:32]
+
+
+def read_settings(agent: Any, tool_name: str) -> SettingsSnapshot:
+    """Reread and strictly validate one tool's placeholder settings snapshot.
+
+    Missing is a normal placeholder state.  A valid file contributes only its
+    source/revision/hash evidence; it never changes behavior.  Every invocation
+    performs a fresh filesystem read and does not cache a prior snapshot.
+    """
+    path = settings_path(agent, tool_name)
+    digest: str | None = None
+    try:
+        raw, revision = _read_stable(path)
+        if revision == "missing":
+            return SettingsSnapshot("missing", "missing", None)
+        digest = revision
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        if not isinstance(value, dict) or set(value) != {"schema_version"}:
+            raise SettingsError("settings schema must contain only schema_version")
+        if type(value["schema_version"]) is not int or value["schema_version"] != SETTINGS_SCHEMA_VERSION:
+            raise SettingsError("settings schema_version must be integer 1")
+        return SettingsSnapshot(f"settings/{tool_name}.json", revision, digest)
+    except (OSError, UnicodeError, json.JSONDecodeError, SettingsError) as exc:
+        # Malformed data is never silently converted to the missing state.  The
+        # digest from a bounded stable read is retained as evidence when safe.
+        return SettingsSnapshot(
+            "settings_error",
+            digest or "error",
+            digest,
+            _bounded_error(exc if isinstance(exc, Exception) else SettingsError("invalid settings")),
+        )
+
+
+def current_setting(snapshot: SettingsSnapshot, tool_name: str) -> dict[str, Any]:
+    """Build the bounded, secret-free current-setting diagnostic for a tool."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return_value: dict[str, Any] = {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": snapshot.source,
+        "settings_revision": snapshot.revision,
+        "settings_hash": snapshot.digest,
+        "change_hint": (
+            f"Edit settings/{tool_name}.json; changes apply on the next {tool_name} "
+            "call; this no-op placeholder never changes tool behavior."
+        ),
+    }
+    if snapshot.error:
+        return_value["settings_error"] = snapshot.error
+    return return_value

--- a/src/lingtai/tools/read/CONTRACT.md
+++ b/src/lingtai/tools/read/CONTRACT.md
@@ -1,10 +1,11 @@
 ---
 name: read-contract
 tool: read
-contract_version: 2
+contract_version: 3
 related_files:
   - src/lingtai/tools/read/__init__.py
   - src/lingtai/tools/_file_paths.py
+  - src/lingtai/tools/_settings.py
   - src/lingtai/services/file_io_sidecar.py
   - src/lingtai/intrinsic_skills/file-manual/SKILL.md
   - src/lingtai/intrinsic_skills/read-manual/SKILL.md
@@ -18,17 +19,17 @@ maintenance: |
 
 `read` returns numbered, character-capped windows of a single text file. It is a
 stateless, read-only wrapper over the injected `FileIOService` (`agent._file_io`).
-The implementation lives in `src/lingtai/tools/read/__init__.py`; the code is the source
-of truth.
+The implementation lives in `src/lingtai/tools/read/__init__.py`; the code is the
+source of truth.
 
 ## Routing Card
 
 **Use this when:**
-- You are editing the paging / truncation math (`_apply_cap`) or the per-call
-  character cap resolution (`_resolve_call_cap`).
+- You are editing the closed action/input schema or its strict dispatch checks.
 - You need the exact continuation contract (`truncated`, `next_offset`,
   `line_truncated`) that callers rely on to resume a long read.
-- You are reviewing how `read` resolves relative paths or reports missing files.
+- You are reviewing relative path resolution, settings diagnostics, or missing
+  file errors.
 
 **Do not use this for:**
 - Writing / mutating files: read `src/lingtai/tools/write/CONTRACT.md` or
@@ -38,9 +39,9 @@ of truth.
 - The underlying byte I/O, sidecar, or traversal budgets: those live in
   `src/lingtai/services/file_io.py` and `file_io_sidecar.py`.
 
-**Fast paths:** tool schema -> §Tool surface; cap constants -> §Scope; resume /
-continuation fields -> §Tool surface; path & encoding handling -> §Cross-platform
-invariants.
+**Fast paths:** tool schema → §Tool surface; cap constants → §Scope; resume /
+continuation fields → §Tool surface; settings evidence → §Settings; path &
+encoding handling → §Cross-platform invariants.
 
 ## Scope
 
@@ -49,32 +50,45 @@ invariants.
   (`capabilities=["file"]`) which expands to all five file tools.
 - Non-goals: no writing, no globbing, no recursive scan, no directory listing,
   no cross-file operations. One file, one window per call.
+- Public compatibility with omitted-action or flat arguments is removed.
 - Cap constants (source of truth is `src/lingtai/tools/read/__init__.py`):
   - `DEFAULT_READ_CAP_CHARS = 100_000` — everyday per-call page budget.
   - `READ_HARD_CAP_CHARS = PREVENTIVE_MAX_CHARS` — non-configurable ceiling
     (imported from `lingtai.kernel.tool_result_artifacts`).
   - The active runtime cap is `min(executor._max_result_chars, READ_HARD_CAP_CHARS)`
     when the executor exposes a positive cap, else `READ_HARD_CAP_CHARS`.
-  - Per-call `max_chars` is clamped to that runtime cap; invalid values fall back
-    to the read default.
+  - Per-call positive `max_chars` is clamped to that runtime cap; the existing
+    source fallback applies when the direct value is absent or not a positive int.
 
 ## Tool surface
 
-`handle_read` has two modes:
+The raw tool-owned schema is a closed root object containing exactly the required
+`action` and required nested `input` fields. `BaseAgent` adds only optional root
+`reasoning` to the final model-facing schema. The handler also accepts executor
+metadata `_reasoning`; neither metadata field enters the nested read input or
+changes read behavior.
 
-- **Ordinary:** omit `action` (backward compatible) or set
-  `action="read"`; both forms run the same read operation.
-- **Manual:** `action="manual"` returns the installed `read-manual` without
-  attempting to read a target file.
+`action` is exactly one of `read` or `manual`:
 
-The schema lists `read` before `manual`. Any other explicit action
-returns a plain error before file I/O. After a manual response, the caller
-continues the original task with an ordinary call rather than repeating the
-manual.
+- `read` uses a closed input object requiring `file_path: string` and preserving
+  the existing options: `offset: integer` (default `1`, 1-based), `limit:
+  integer` (default `2000` lines), `max_chars: integer` (optional per-call
+  character budget), and `summary: boolean` (default `false`). No other nested
+  field is admitted. The read handler validates declared values before target
+  FileIO and does not pass `summary` to FileIO.
+- `manual` uses a closed empty input object and returns the real installed
+  `read-manual` body and path without attempting a target read.
 
-| Call | Required inputs | Optional inputs | Success output | Error shapes |
-|---|---|---|---|---|
-| `read` | `file_path: string` | `offset: int` (default 1, 1-based), `limit: int` (default 2000 lines), `max_chars: int`, `summary: bool` (default false) | `{content, total_lines, lines_shown}` plus continuation fields when truncated | see below |
+A nested `summary: true` is a-priori control metadata for `ToolExecutor`: the raw
+result is logged before a replacement is generated, and the handler itself still
+performs the ordinary read. It never changes offset, limit, cap, path resolution,
+or the returned read fields. Summary selection is exact-boolean; root summary
+and any compatibility alias are not part of this tool's public contract.
+
+| Call | Required inputs | Success output | Error shapes |
+|---|---|---|---|
+| `read` | `file_path` | `{content, total_lines, lines_shown}` plus continuation fields when truncated and `current_setting` | plain `{status: "error", message: "...", current_setting}` dict; see below |
+| `manual` | empty `input` | installed manual result plus `current_setting` | degraded manual result plus `current_setting` if unavailable |
 
 `content` is `cat -n`-style: each kept line is `"{lineno}\t{line}"`. When the
 window is capped mid-way, the extra fields are added:
@@ -84,19 +98,46 @@ last_returned_line, next_offset, remaining_lines_estimate}` and, when a single
 line alone exceeds the cap, `line_truncated: true` (a bounded prefix of that line
 is returned). Callers resume by re-calling with `offset = next_offset`.
 
-**Error shapes** (all are plain dicts, not exceptions):
-- `{"status": "error", "message": "file_path is required"}` — empty/missing path.
-- `{"status": "error", "message": "File not found: <path>"}` — `FileNotFoundError`.
-- Spill-aware variant: if the missing path is under `tmp/tool-results/` (after
-  `..` normalization), the message is the "Spill artifact expired: …" hint
+## Settings
+
+Every invocation first performs a fresh strict `read_settings(agent, "read")`
+read of Agent-owned `settings/read.json`, then attaches a bounded, secret-free
+`current_setting` diagnostic to every success, manual, malformed-input, and
+FileIO-error result. The exact placeholder schema is only
+`{"schema_version": 1}`; it is not a read option and never changes schema,
+prompt, path resolution, pagination, cap calculation, manual selection, or
+FileIO behavior.
+
+The diagnostic is immutable per invocation and has the shared placeholder shape:
+`configurable: false`, `placeholder: "no-op"`, `source`, `settings_revision`,
+`settings_hash`, and a `change_hint` naming `settings/read.json`; invalid files
+also carry only a bounded `settings_error`. Missing, valid, hot-changed, and
+invalid settings are all truthful evidence states. Secrets, settings content,
+and absolute host paths are never exposed.
+
+## Error shapes
+
+All public errors are plain dicts, not exceptions, and include `current_setting`:
+
+- `{"status": "error", "message": "read requires root action and input", ...}` —
+  missing required root fields.
+- `{"status": "error", "message": "file_path is required", ...}` — empty or
+  missing path.
+- `{"status": "error", "message": "File not found: <path>", ...}` —
+  `FileNotFoundError`.
+- Spill-aware variant: if the missing path is under `tmp/tool-results/` after
+  `..` normalization, the message is the `Spill artifact expired: ...` hint
   instead of the generic not-found string.
-- `{"status": "error", "message": "Cannot read <path>: <exc>"}` — any other read
-  exception.
+- `{"status": "error", "message": "Cannot read <path>: <exc>", ...}` — any
+  other target read exception.
+- Wrong root/input/action/option types and unknown fields are rejected before
+  target FileIO and return the same plain error envelope.
 
 ## State & storage
 
-None. `read` is read-only and holds no persistent state. It only reads the
-target file through `agent._file_io.read(path)`.
+None. `read` is read-only and holds no persistent state. It only reads the target
+file through `agent._file_io.read(path)` after settings and validation. The
+nested input mapping and metadata fields are not mutated.
 
 ## Cross-platform invariants
 
@@ -105,10 +146,10 @@ Do not change any of the following; documented for reviewers only.
 - **Path handling:** relative `file_path` is resolved against `agent._working_dir`
   via `resolve_workdir_path` (`src/lingtai/tools/_file_paths.py`); absolute paths pass
   through unchanged to preserve historical error strings.
-- **Byte I/O / sidecar:** all reads go through the injected `FileIOService`.
-  The Rust search sidecar delegates read/write/edit verbatim to
-  `LocalFileIOBackend`; `default_file_io_service` selects Rust vs. a
-  Python-backed fallback per `LINGTAI_FILE_IO_BACKEND` (see
+- **Byte I/O / sidecar:** all target reads go through the injected
+  `FileIOService`. The Rust search sidecar delegates read/write/edit verbatim to
+  `LocalFileIOBackend`; `default_file_io_service` selects Rust vs. a Python-backed
+  fallback per `LINGTAI_FILE_IO_BACKEND` (see
   `src/lingtai/services/file_io_sidecar.py` resolution order). `read` itself is
   backend-agnostic.
 - **Encoding:** the service reads text as UTF-8; the source module pins UTF-8
@@ -120,29 +161,30 @@ Do not change any of the following; documented for reviewers only.
 
 | Claim | Source `src/lingtai/tools/read/...` | Test |
 |---|---|---|
-| Default per-call cap is 100k and the hard cap is 200k | `__init__.py` (`DEFAULT_READ_CAP_CHARS`, `READ_HARD_CAP_CHARS`) | `tests/test_read_continuation.py::test_read_cap_default_is_100k_and_hard_cap_is_200k` |
-| Missing `max_chars` uses the read default | `__init__.py` (`_resolve_call_cap`) | `tests/test_read_continuation.py::test_resolve_call_cap_defaults_to_read_default` |
-| Per-call `max_chars` is clamped to the runtime hard cap | `__init__.py` (`_resolve_call_cap`) | `tests/test_read_continuation.py::test_resolve_call_cap_clamps_to_runtime_hard_cap` |
-| Handler honors a per-call `max_chars` and emits continuation fields | `__init__.py` (`handle_read`, `_apply_cap`) | `tests/test_read_continuation.py::test_read_handler_uses_per_call_max_chars` |
-| `read` reaches files through the injected FileIOService | `__init__.py` (`handle_read`) | `tests/test_layers_file.py::test_file_capability_uses_file_io_service` |
-| Missing-file error is a `{status: error}` dict | `__init__.py` (`handle_read`) | `tests/test_layers_file.py::test_read_error_shape` |
-| Source pins UTF-8 and parses as Python 3.11 | `__init__.py` | `tests/test_utf8_read_text.py::test_source_read_text_calls_pin_utf8_encoding` |
+| Raw schema is closed action/input with strict read/manual branches | `__init__.py` (`get_schema`) | `tests/test_read_action_input.py::test_raw_schema_is_closed_action_input` |
+| Agent schema adds only root reasoning metadata | `__init__.py`, BaseAgent schema builder | `tests/test_read_action_input.py::test_agent_schema_has_only_action_input_reasoning_and_real_origin` |
+| Provider envelopes preserve action/input/reasoning | BaseAgent schema and provider adapters | `tests/test_read_action_input.py::test_provider_envelopes_keep_public_fields_and_wire_description` |
+| Default per-call cap is 100k and hard cap is 200k | `__init__.py` (`DEFAULT_READ_CAP_CHARS`, `READ_HARD_CAP_CHARS`) | `tests/test_read_continuation.py::test_read_cap_default_is_100k_and_hard_cap_is_200k` |
+| Handler honors offset/limit/max_chars and continuation fields | `__init__.py` (`handle_read`, `_apply_cap`) | `tests/test_read_action_input.py::test_pagination_max_chars_and_truncation_metadata` |
+| `read` reaches targets through the injected FileIOService | `__init__.py` (`handle_read`) | `tests/test_read_action_input.py::test_file_io_delegation_uses_relative_workdir_path` |
+| Every public result carries current_setting | `__init__.py` / `_settings.py` | `tests/test_read_action_input.py::test_settings_missing_valid_hot_invalid_and_behavior_prompt_invariance` |
+| Manual returns the installed canonical body | `__init__.py` (`load_installed_manual`) | `tests/test_read_action_input.py::test_manual_returns_real_installed_body_and_current_setting` |
+| Nested summary control preserves raw-before-replacement ordering | ToolExecutor and `tool_result_summary.py` | `tests/test_read_action_input.py::test_nested_summary_true_serial_uses_actual_handler_and_logs_raw_first` and `::test_nested_summary_true_parallel_reads_replace_after_each_raw_log` |
 
 ## Verification matrix
 
 | Invariant | Automated test | Manual check | Risk if broken |
 |---|---|---|---|
-| Cap constants stay 100k / 200k | `tests/test_read_continuation.py::test_read_cap_default_is_100k_and_hard_cap_is_200k` | `read` a large file and inspect `cap_chars` | Provider-visible tool-result blowups |
-| Continuation fields let callers resume | `tests/test_read_continuation.py::test_read_handler_uses_per_call_max_chars` | `read` with small `max_chars`, re-call with `next_offset` | Callers loop or drop tail content |
-| Relative paths resolve under workdir | `tests/test_layers_file.py::test_file_capability_relative_paths_resolve_under_workdir` | `read` a relative path from a known workdir | Reads escape / miss the sandbox |
-| Errors are dicts, not exceptions | `tests/test_layers_file.py::test_read_error_shape` | `read` a nonexistent path | Executor crashes instead of surfacing a message |
-| Reads route through FileIOService | `tests/test_layers_file.py::test_file_capability_uses_file_io_service` | Boot with `capabilities=["read"]` and confirm `agent._file_io` is used | Backend selection / sandbox bypassed |
+| Schema has no flat or omitted-action surface | focused read action/input tests | inspect `get_schema()` and an Agent-built schema | model sends rejected legacy shape or aliases leak |
+| Continuation fields let callers resume | focused pagination test plus `test_read_continuation.py` | read with a small `max_chars`, re-call with `next_offset` | callers loop or drop tail content |
+| Relative paths stay in workdir | focused FileIO test | read a relative path from a known workdir | reads escape / miss the sandbox |
+| Errors are dicts and settings remain truthful | focused malformed/settings tests | read a nonexistent path and change settings/read.json | executor crashes or diagnostics lie |
+| Reads route through FileIOService | focused delegation test | boot with `capabilities=["read"]` and inspect the injected service | backend selection / sandbox bypassed |
+| Summary control is nested and raw is preserved first | focused serial/parallel executor test | use a retained harness with a recording summarizer | raw leaks before replacement or root fallback wins |
 
-Run before merging:
-
-```bash
-python -m pytest tests/test_read_continuation.py tests/test_layers_file.py tests/test_utf8_read_text.py -q
-```
+Validation uses the repository's no-bytecode compile harness and the glossary
+validator; do not substitute a copied schema or manual for the installed
+canonical manual.
 
 ## Schema and glossary ownership
 
@@ -152,8 +194,8 @@ python -m pytest tests/test_read_continuation.py tests/test_layers_file.py tests
   language-independent; the optional `lang` argument is accepted for source
   compatibility but ignored.
 - **Provider wire:** provider adapters send the global `WIRE_TOOL_DESCRIPTION`
-  constant as the top-level tool description; `FunctionSchema.description`
-  holds the full canonical prose rendered into `## tools`.
+  constant as the top-level tool description; `FunctionSchema.description` holds
+  the full canonical prose rendered into `## tools`.
 - **Glossary resources:** this package owns `glossary-en.md`, `glossary-zh.md`,
   and `glossary-wen.md`. Each has strict YAML frontmatter
   (`kind: tool-glossary`, `schema_version: 1`, `tool_package: tools.<pkg>`,

--- a/src/lingtai/tools/read/__init__.py
+++ b/src/lingtai/tools/read/__init__.py
@@ -4,13 +4,15 @@ Usage: Agent(capabilities=["read"]) or capabilities=["file"]
 """
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lingtai.kernel.tool_result_artifacts import PREVENTIVE_MAX_CHARS
 
 from .._file_paths import resolve_workdir_path
 from .._manual import load_installed_manual
+from .._settings import current_setting, read_settings
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
@@ -22,6 +24,12 @@ PROVIDERS = {"providers": [], "default": "builtin"}
 # ``max_chars`` per read call; values above the runtime ceiling are clamped.
 DEFAULT_READ_CAP_CHARS: int = 100_000
 READ_HARD_CAP_CHARS: int = PREVENTIVE_MAX_CHARS
+
+_ACTION_FIELDS = {
+    "read": ("file_path", "offset", "limit", "max_chars", "summary"),
+    "manual": (),
+}
+_ALLOWED_ROOT_FIELDS = ("action", "input", "reasoning", "_reasoning")
 
 
 def _valid_cap(value: object) -> int | None:
@@ -42,7 +50,7 @@ def _resolve_call_cap(agent: "BaseAgent", requested_max_chars: object) -> int:
     ``max_chars`` lets the caller intentionally ask for smaller or larger chunks
     than the read default while the runtime hard cap remains the ceiling that
     prevents provider-visible tool-result blowups. Invalid per-call values are
-    ignored and use the 50k read default.
+    ignored and use the read default, preserving the pre-migration read math.
     """
     runtime_cap = _runtime_hard_cap(agent)
     requested_cap = _valid_cap(requested_max_chars)
@@ -52,22 +60,97 @@ def _resolve_call_cap(agent: "BaseAgent", requested_max_chars: object) -> int:
 
 
 def get_description(lang: str = "en") -> str:
-    return "Read the contents of a text file. Normal reads are the primary operation: omit action for the legacy ordinary call or use action='read' explicitly. Returns numbered lines. Text files only — cannot read binary, images, or audio. Use action='manual' once to return the installed read-manual skill; after the manual result, continue the original ordinary read instead of repeating manual, because repeated identical manual calls are an error loop. Before using read for ordinary reads, especially for large files, complete-content workflows, truncation, or line_truncated handling, read that manual. If the file is non-UTF-8 or needs careful search/edit workflow, read file-manual first. Use offset/limit for line windows and optional max_chars to choose the per-call character budget. Default read budget is 100 000 characters; max_chars can raise/lower that per call but is clamped by the non-configurable runtime hard cap of 200 000 characters. A successful read can still be truncated: check truncated=true, cap_chars, returned_chars, next_offset, remaining_lines_estimate, and line_truncated. Continue with next_offset until done. If line_truncated=true, the shown physical line is only a prefix; next_offset skips to the next line and does not recover the hidden tail. Use the read-manual's bash/Python metadata/stats workflow (file size, line count, longest line) and targeted grep/sed/Python processing for such content."
+    return (
+        "Read the contents of a text file. Use read(action='read', input={'file_path': "
+        "'...', 'offset': 1, 'limit': 2000, 'max_chars': 100000, 'summary': False}, "
+        "reasoning='...') for an ordinary text read. The nested input is strict and "
+        "closed; file_path is required, offset is 1-based with default 1, limit "
+        "defaults to 2000 lines, and max_chars is clamped by the 200 000 runtime "
+        "hard cap. Returns numbered lines and continuation metadata when capped; "
+        "check truncated, cap_chars, returned_chars, next_offset, "
+        "remaining_lines_estimate, and line_truncated. Before large or continued "
+        "reads, load the installed guide with read(action='manual', input={}, "
+        "reasoning='...'). This tool reads text files only and cannot read binary, "
+        "images, or audio."
+    )
 
 
 def get_schema(lang: str = "en") -> dict:
+    """Return the raw closed action/input schema.
+
+    ``BaseAgent`` adds the optional root ``reasoning`` property when it builds
+    the model-facing schema. It is metadata, not a read action input.
+    """
     return {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "enum": ["read", "manual"], "description": "Omit action for the legacy ordinary read, use action='read' for an explicit ordinary read, or use action='manual' once for the installed read-manual skill."},
-            "file_path": {"type": "string", "description": "Absolute path to the file to read. Required for ordinary reads; omit for action='manual'."},
-            "offset": {"type": "integer", "description": 'Line number to start from (1-based)', "default": 1},
-            "limit": {"type": "integer", "description": 'Max lines to read', "default": 2000},
-            "max_chars": {"type": "integer", "description": 'Optional per-call character budget for read content. Defaults to 100 000; values above the runtime hard cap are clamped to 200 000. Use read-manual before setting this for large files.'},
-            "summary": {"type": "boolean", "description": 'Optional. Default false. When true, this tool runs normally and the raw result is preserved in the durable log (retrievable by tool_call_id), but before the result enters your context it is replaced by an LLM-generated summary driven by your `reasoning` field — so make `reasoning` specific about what to retain. Set true only when the output is expected to be large (>10k chars) and you do NOT need the exact raw text. Leave false when you need exact line/file/diff/stderr text. The summary is non-canonical; if the raw exceeds 500,000 chars no summary is generated and you get a refusal pointing at the preserved raw.', "default": False},
+            "action": {
+                "type": "string",
+                "enum": ["read", "manual"],
+                "description": "Required operation: read a file or return the installed manual.",
+            },
+            "input": {
+                "description": "Strict action-specific read input.",
+                "anyOf": [
+                    {
+                        "title": "read input",
+                        "type": "object",
+                        "properties": {
+                            "file_path": {
+                                "type": "string",
+                                "description": "Path to the text file to read.",
+                            },
+                            "offset": {
+                                "type": "integer",
+                                "description": "Line number to start from (1-based).",
+                                "default": 1,
+                            },
+                            "limit": {
+                                "type": "integer",
+                                "description": "Maximum number of lines to read.",
+                                "default": 2000,
+                            },
+                            "max_chars": {
+                                "type": "integer",
+                                "description": (
+                                    "Optional per-call character budget for read content. "
+                                    "Defaults to 100 000; values above the runtime hard cap "
+                                    "are clamped to 200 000."
+                                ),
+                            },
+                            "summary": {
+                                "type": "boolean",
+                                "description": (
+                                    "Optional a-priori summary control. Default false; when "
+                                    "true, preserve the raw result before replacing the "
+                                    "model-visible result with a generated summary."
+                                ),
+                                "default": False,
+                            },
+                        },
+                        "required": ["file_path"],
+                        "additionalProperties": False,
+                    },
+                    {
+                        "title": "manual input",
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                        "additionalProperties": False,
+                    },
+                ],
+            },
         },
-        "required": [],
+        "required": ["action", "input"],
+        "additionalProperties": False,
     }
+
+
+def _with_setting(result: Mapping[str, Any], diagnostic: dict[str, Any]) -> dict[str, Any]:
+    """Attach one fresh, secret-free settings diagnostic to a public result."""
+    value = dict(result)
+    value["current_setting"] = dict(diagnostic)
+    return value
 
 
 def _apply_cap(
@@ -130,25 +213,75 @@ def _apply_cap(
 def setup(agent: "BaseAgent") -> None:
     """Set up the read capability on an agent."""
 
-    def handle_read(args: dict) -> dict:
-        action = args.get("action")
+    def handle_read(args: Any) -> dict:
+        # Settings are evidence only, but must be reread before every operation,
+        # including malformed and manual calls. No target FileIO operation occurs
+        # before the canonical action/input checks below.
+        snapshot = read_settings(agent, "read")
+        diagnostic = current_setting(snapshot, "read")
+
+        def error(message: str) -> dict:
+            return _with_setting({"status": "error", "message": message}, diagnostic)
+
+        if not isinstance(args, Mapping):
+            return error("read arguments must be an object")
+        try:
+            root_keys = list(args.keys())
+        except Exception:
+            return error("read arguments must be an object")
+        if any(not isinstance(key, str) or key not in _ALLOWED_ROOT_FIELDS for key in root_keys):
+            return error("read accepts only root action, input, reasoning, and _reasoning")
+        if "action" not in root_keys or "input" not in root_keys:
+            return error("read requires root action and input")
+
+        action = args["action"]
+        if not isinstance(action, str) or action not in _ACTION_FIELDS:
+            return error(f"Unsupported action for read: {action!r}")
+
+        raw_input = args["input"]
+        if not isinstance(raw_input, Mapping):
+            return error("read input must be an object")
+        try:
+            action_input = dict(raw_input)
+        except Exception:
+            return error("read input must be an object")
+        if any(not isinstance(key, str) for key in action_input):
+            return error("read input field names must be strings")
+        allowed_fields = _ACTION_FIELDS[action]
+        if any(key not in allowed_fields for key in action_input):
+            return error(f"unsupported read input field for action {action!r}")
+
         if action == "manual":
-            return load_installed_manual(agent, "read-manual")
-        if action is not None and action != "read":
-            return {"status": "error", "message": f"Unsupported action for read: {action!r}"}
-        path = args.get("file_path", "")
-        if not path:
-            return {"status": "error", "message": "file_path is required"}
-        path = resolve_workdir_path(agent, path)
-        offset = args.get("offset", 1)
-        limit = args.get("limit", 2000)
-        max_chars = args.get("max_chars")
+            if action_input:
+                return error("manual input must be an empty object")
+            return _with_setting(load_installed_manual(agent, "read-manual"), diagnostic)
+
+        if "file_path" not in action_input:
+            return error("file_path is required")
+        file_path = action_input["file_path"]
+        if not isinstance(file_path, str):
+            return error("file_path must be a string")
+        if not file_path:
+            return error("file_path is required")
+
+        for field in ("offset", "limit"):
+            if field in action_input and type(action_input[field]) is not int:
+                return error(f"{field} must be an integer")
+        if "max_chars" in action_input and type(action_input["max_chars"]) is not int:
+            return error("max_chars must be an integer")
+        if "summary" in action_input and type(action_input["summary"]) is not bool:
+            return error("summary must be a boolean")
+
+        path = resolve_workdir_path(agent, file_path)
+        offset = action_input.get("offset", 1)
+        limit = action_input.get("limit", 2000)
+        max_chars = action_input.get("max_chars")
         try:
             content = agent._file_io.read(path)
         except FileNotFoundError:
             # Spill-aware messaging: if the missing file is under
             # tmp/tool-results/, it was an ephemeral sidecar artifact
-            # that has been cleaned up.  Give a specific hint instead
+            # that has been cleaned up. Give a specific hint instead
             # of the generic "File not found".
             # Normalize to collapse ".." components so that e.g.
             # tmp/tool-results/../not-a-spill.txt is NOT misclassified
@@ -161,18 +294,15 @@ def setup(agent: "BaseAgent") -> None:
                 rel = Path(path)
             parts = rel.parts
             if len(parts) >= 3 and parts[0] == "tmp" and parts[1] == "tool-results":
-                return {
-                    "status": "error",
-                    "message": (
-                        "Spill artifact expired: this tmp/tool-results/ sidecar file "
-                        "no longer exists. The original tool result content is "
-                        "unavailable. Use the preview from the manifest or rerun the "
-                        "source tool."
-                    ),
-                }
-            return {"status": "error", "message": f"File not found: {path}"}
-        except Exception as e:
-            return {"status": "error", "message": f"Cannot read {path}: {e}"}
+                return error(
+                    "Spill artifact expired: this tmp/tool-results/ sidecar file "
+                    "no longer exists. The original tool result content is "
+                    "unavailable. Use the preview from the manifest or rerun the "
+                    "source tool."
+                )
+            return error(f"File not found: {path}")
+        except Exception as exc:
+            return error(f"Cannot read {path}: {exc}")
         lines = content.splitlines(keepends=True)
         start = max(0, offset - 1)
         numbered, extra = _apply_cap(lines, start, limit, _resolve_call_cap(agent, max_chars))
@@ -182,6 +312,12 @@ def setup(agent: "BaseAgent") -> None:
             "lines_shown": len(numbered.splitlines()) if numbered else 0,
         }
         result.update(extra)
-        return result
+        return _with_setting(result, diagnostic)
 
-    agent.add_tool("read", schema=get_schema(), handler=handle_read, description=get_description(), glossary_package=__package__)
+    agent.add_tool(
+        "read",
+        schema=get_schema(),
+        handler=handle_read,
+        description=get_description(),
+        glossary_package=__package__,
+    )

--- a/src/lingtai/tools/read/glossary-wen.md
+++ b/src/lingtai/tools/read/glossary-wen.md
@@ -10,14 +10,14 @@ related_files:
 - src/lingtai/tools/read/glossary-en.md
 - src/lingtai/tools/read/glossary-zh.md
 maintenance: |
-  Classical-Chinese (wen) glossary for the `read` tool package (lingtai.tools.read); body must stay non-empty and distinct from glossary-zh.md — tests/test_tool_glossary.py::test_wen_uses_classical_chinese_not_zh exercises exactly this file. Update in lockstep with glossary-en.md/glossary-zh.md whenever read's public tool schema changes.
+  Classical-Chinese (wen) glossary for the `read` tool package (lingtai.tools.read); body must stay non-empty and distinct from glossary-zh.md. Update when read's public action/input schema or user-visible terminology changes.
   Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
 ---
-**名相对照**
+**名相對照**
 
-- `read`：阅文本卷，返带行号之文。唯文本可读，二进制、图像、音声不可。凡用 read，尤大卷、全卷续读、截断、line_truncated 之处置，必先读 read-manual 一技。若非 UTF-8 或须慎搜慎改，先读 file-manual。以 offset/limit 定行段；可以 max_chars 定此召字符之额。read 默额十万字；max_chars 可于一召增减，然不得逾 runtime 不可配置之硬限二十万字，逾则裁之。阅之虽成，犹或截断：当察 truncated=true、cap_chars、returned_chars、next_offset、remaining_lines_estimate、line_truncated；以 next_offset 续阅至尽。若 line_truncated=true，则所示物理行唯前缀；next_offset 越至下行，不复其隐尾。当循 read-manual，以 bash/Python 先察卷大、行数、最长行等 metadata/stats，再定 offset/limit/max_chars；长行则以 grep/sed/Python 等定向处之。
-- `file_path`：文卷之绝对路径
-- `offset`：起始行号（自一起算）
-- `limit`：至多读取之行数
-- `max_chars`：可选：此召 read 内容之字符额。默认十万；逾 runtime 硬限者裁至二十万。大卷设此参数前，先读 read-manual。
-- `summary`：可选。默认 false。设 true 时，此 tool 照常运行，原始结果完存于持久日志（可凭 tool_call_id 取回）；然结果入尔上下文前，先以尔 `reasoning` 字段所驱之 LLM 摘要代之——故 `reasoning` 当明言所欲存者。唯料输出甚巨（逾一万字符）且无需精确原文时，方设 true。需精确之行/文件/diff/stderr 原文者，留 false。摘要非权威；原始结果逾五十万字符，则不生摘要，尔得一拒辞，指向所存之原始结果。
+- `action`：所行之名；唯 `read`、`manual` 二值
+- `input`：封閉之行參；`manual` 之參必空
+- `summary`：`input` 中之精確布爾摘要控，默 false，且不改閱卷之行
+- `current_setting`：每召所附之嚴格設定快照，惟作證據而不改閱卷
+
+`file_path`、`offset`、`limit`、`max_chars`、`next_offset`、`line_truncated` 皆守英文名相；不設省略 `action`、扁平參數或兼容別名。

--- a/src/lingtai/tools/read/glossary-zh.md
+++ b/src/lingtai/tools/read/glossary-zh.md
@@ -10,14 +10,14 @@ related_files:
 - src/lingtai/tools/read/glossary-en.md
 - src/lingtai/tools/read/glossary-wen.md
 maintenance: |
-  Simplified-Chinese (zh) glossary for the `read` tool package (lingtai.tools.read); body must stay non-empty — tests/test_tool_glossary.py::test_chinese_body_is_non_empty exercises exactly this file. Update in lockstep with glossary-en.md/glossary-wen.md whenever read's public tool schema changes.
+  Simplified-Chinese (zh) glossary for the `read` tool package (lingtai.tools.read); body must stay non-empty. Update when read's public action/input schema or user-visible terminology changes.
   Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
 ---
 **术语对照**
 
-- `read`：读取文本文件的内容，返回带行号的文本。仅支持文本文件，不能读取二进制、图片或音频。使用 read 前，尤其是大文件、完整读取、截断或 line_truncated 处理，必须先读 read-manual skill。如遇非 UTF-8 或需要谨慎搜索/编辑，请先读 file-manual。用 offset/limit 控制行窗口，并可用可选 max_chars 控制单次字符预算。read 默认预算为 100 000 字符；max_chars 可在单次调用中放大/缩小，但会被不可配置的 runtime 硬上限 200 000 字符 clamp。读取成功仍可能截断：检查 truncated=true、cap_chars、returned_chars、next_offset、remaining_lines_estimate 和 line_truncated，并用 next_offset 续读至结束。若 line_truncated=true，所示物理行只是前缀；next_offset 会跳到下一行，不能恢复该行隐藏尾部。按 read-manual 推荐，先用 bash/Python 查看文件大小、总行数、最长行等 metadata/stats，再决定 offset/limit/max_chars；长行内容用 grep/sed/Python 等定向处理。
-- `file_path`：文件的绝对路径
-- `offset`：起始行号（从 1 开始）
-- `limit`：最大读取行数
-- `max_chars`：可选的单次读取字符预算。默认 100 000；超过 runtime 硬上限的值会被 clamp 到 200 000。大文件设置此参数前先读 read-manual。
-- `summary`：可选。默认 false。为 true 时，该 tool 照常执行，原始结果会完整保存到持久日志（可按 tool_call_id 取回），但在结果进入你的上下文之前，会被一段由你的 `reasoning` 字段驱动的 LLM 生成摘要替换——所以请在 `reasoning` 中明确说明要保留什么。仅当预期输出很大（>10k 字符）且你不需要精确原文时才设为 true。需要精确的行/文件/diff/stderr 原文时请保持 false。摘要非权威；若原始结果超过 500,000 字符则不生成摘要，你会收到一条指向已保存原始结果的拒绝信息。
+- `action`：明确操作名；仅为 `read` 或 `manual`
+- `input`：封闭的操作输入对象；`manual` 的输入必须为空
+- `summary`：嵌套于 `input` 的精确布尔摘要控制，默认 `false`，不改变读取行为
+- `current_setting`：每次结果附带的严格设置快照，仅作证据而不改变读取
+
+`file_path`、`offset`、`limit`、`max_chars`、`next_offset` 与 `line_truncated` 保持英文标识；不提供省略 `action`、扁平参数或兼容别名。

--- a/tests/test_apriori_summary_executor.py
+++ b/tests/test_apriori_summary_executor.py
@@ -21,10 +21,12 @@ from lingtai.kernel.tool_executor import ToolExecutor
 from lingtai.kernel.tool_result_summary import (
     APRIORI_SUMMARY_CAP,
     APRIORI_SUMMARY_MARKER,
+    summary_requested,
 )
 
 
-def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
+def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path,
+                   parallel_safe_tools=None):
     """Construct a ToolExecutor that records durable log events into *events*."""
 
     def logger_fn(event_type, **fields):
@@ -43,6 +45,7 @@ def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
         logger_fn=logger_fn,
         working_dir=tmp_path,
         summarizer_fn=summarizer_fn,
+        parallel_safe_tools=parallel_safe_tools or set(),
     )
 
 
@@ -64,6 +67,14 @@ def _event_fields(events, event_type):
     for et, fields in events:
         if et == event_type:
             return fields
+    return None
+
+
+def _event_index(events, event_type, *, tool_call_id):
+    """Return the first matching event index for ordering assertions."""
+    for index, (et, fields) in enumerate(events):
+        if et == event_type and fields.get("tool_call_id") == tool_call_id:
+            return index
     return None
 
 
@@ -161,6 +172,274 @@ def test_summary_true_under_cap_replaces_with_summary_and_preserves_raw(tmp_path
     assert gen["tool_call_id"] == "t3"
     assert gen["tool_name"] == "bash"
     assert "RAWSECRET" not in str(gen)
+
+
+def test_summary_requested_uses_input_presence_precedence_and_exact_bool():
+    """Canonical input wins; only a literal bool True opts in."""
+    assert summary_requested({"summary": True}) is True  # legacy compatibility
+    assert summary_requested({"input": {"summary": True}, "summary": False}) is True
+
+    # Once input is present, root summary is never a fallback, including when
+    # nested summary is absent, false, malformed, or input is not an object.
+    nested_values = [False, 1, "true", None, {}, []]
+    for nested in nested_values:
+        assert summary_requested({"input": {"summary": nested}, "summary": True}) is False
+    assert summary_requested({"input": {}, "summary": True}) is False
+    for malformed_input in (None, [], "payload", 1):
+        assert summary_requested({"input": malformed_input, "summary": True}) is False
+
+    # Legacy mode has the same exact-boolean rule and does not mutate args.
+    for root in (False, 1, "true", None, {}, []):
+        assert summary_requested({"summary": root}) is False
+    original = {"input": {"summary": True}, "summary": "ignored"}
+    snapshot = {"input": dict(original["input"]), "summary": original["summary"]}
+    assert summary_requested(original) is True
+    assert original == snapshot
+
+
+def test_nested_summary_true_serial_preserves_reasoning_and_raw_first(tmp_path):
+    raw = {"stdout": "NESTED-SERIAL-RAW"}
+    nested_input = {"command": "echo nested", "summary": True}
+    call_args = {
+        "input": nested_input,
+        "summary": False,  # root is ignored in canonical mode
+        "reasoning": "Retain the nested serial marker",
+    }
+    seen = {}
+    events = []
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen["prompt"] = user_prompt
+        return "NESTED-SERIAL-SUMMARY"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute(
+        [ToolCall(name="bash", args=call_args, id="nested-serial")]
+    )
+
+    content = _wire_content(results[0])
+    assert content["artifact"] == APRIORI_SUMMARY_MARKER
+    assert content["generated_summary"] == "NESTED-SERIAL-SUMMARY"
+    assert "Retain the nested serial marker" in seen["prompt"]
+    assert nested_input == {"command": "echo nested", "summary": True}
+
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-serial")
+    generated_index = _event_index(
+        events, "apriori_summary_generated", tool_call_id="nested-serial"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-serial"
+    )
+    assert raw_index is not None and generated_index is not None and visible_index is not None
+    assert raw_index < generated_index < visible_index
+    raw_event = events[raw_index][1]
+    assert "NESTED-SERIAL-RAW" in str(raw_event["result"])
+    assert "NESTED-SERIAL-SUMMARY" not in str(raw_event["result"])
+    assert raw_event["tool_args"]["_reasoning"] == "Retain the nested serial marker"
+
+
+def test_nested_summary_true_parallel_path_preserves_raw_before_each_replacement(tmp_path):
+    raw_by_id = {
+        "nested-parallel-1": {"stdout": "NESTED-PARALLEL-RAW-1"},
+        "nested-parallel-2": {"stdout": "NESTED-PARALLEL-RAW-2"},
+    }
+    events = []
+    seen = []
+
+    def dispatch(tc):
+        return raw_by_id[tc.id]
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen.append((tool_call_id, user_prompt))
+        return f"NESTED-PARALLEL-SUMMARY-{tool_call_id}"
+
+    ex = _make_executor(
+        dispatch_fn=dispatch,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+        parallel_safe_tools={"bash", "grep"},
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "one", "summary": True},
+                  "reasoning": "Keep parallel result one"},
+            id="nested-parallel-1",
+        ),
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "two", "summary": True},
+                  "reasoning": "Keep parallel result two"},
+            id="nested-parallel-2",
+        ),
+    ])
+
+    assert len(seen) == 2
+    for result_msg, call_id in zip(results, ("nested-parallel-1", "nested-parallel-2")):
+        content = _wire_content(result_msg)
+        assert content["artifact"] == APRIORI_SUMMARY_MARKER
+        assert content["generated_summary"] == f"NESTED-PARALLEL-SUMMARY-{call_id}"
+        raw_index = _event_index(events, "tool_result", tool_call_id=call_id)
+        generated_index = _event_index(
+            events, "apriori_summary_generated", tool_call_id=call_id
+        )
+        visible_index = _event_index(
+            events, "tool_result_model_visible", tool_call_id=call_id
+        )
+        assert raw_index is not None and generated_index is not None and visible_index is not None
+        assert raw_index < generated_index < visible_index
+        raw_event = events[raw_index][1]
+        suffix = call_id.rsplit("-", 1)[-1]
+        assert f"NESTED-PARALLEL-RAW-{suffix}" in str(raw_event["result"])
+        assert f"NESTED-PARALLEL-SUMMARY-{call_id}" not in str(raw_event["result"])
+
+
+def test_nested_false_absent_and_malformed_ignore_root_true_in_executor(tmp_path):
+    cases = [
+        ("nested-false", {"summary": False}),
+        ("nested-absent", {}),
+        ("nested-one", {"summary": 1}),
+        ("nested-string", {"summary": "true"}),
+        ("nested-null", {"summary": None}),
+        ("nested-object", {"summary": {"truthy": True}}),
+        ("nested-list", {"summary": [True]}),
+        ("input-null", None),
+        ("input-list", []),
+        ("input-string", "payload"),
+    ]
+    for call_id, nested_input in cases:
+        events = []
+        called = []
+        raw = {"stdout": f"RAW-{call_id}"}
+
+        def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+            called.append(tool_call_id)
+            return "SHOULD NOT RUN"
+
+        ex = _make_executor(
+            dispatch_fn=lambda tc, raw=raw: raw,
+            summarizer_fn=summarizer,
+            events=events,
+            tmp_path=tmp_path,
+        )
+        results, _, _ = ex.execute([
+            ToolCall(
+                name="grep",
+                args={"input": nested_input, "summary": True},
+                id=call_id,
+            )
+        ])
+        content = _wire_content(results[0])
+        assert "SHOULD NOT RUN" not in str(content)
+        assert "RAW-" + call_id in str(content)
+        assert not (isinstance(content, dict) and content.get("artifact") == APRIORI_SUMMARY_MARKER)
+        assert called == []
+
+
+def test_nested_summary_true_cap_refusal_logs_raw_before_replacement(tmp_path):
+    raw = {"stdout": "NESTED-CAP-RAW-" + "z" * (APRIORI_SUMMARY_CAP + 100)}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="read",
+            args={"input": {"file_path": "/big", "summary": True},
+                  "reasoning": "Avoid oversized raw"},
+            id="nested-cap",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert called == []
+    assert content["summary_kind"] == "apriori_cap_refused"
+    assert "NESTED-CAP-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-cap")
+    refusal_index = _event_index(
+        events, "apriori_summary_cap_refused", tool_call_id="nested-cap"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-cap"
+    )
+    assert raw_index is not None and refusal_index is not None and visible_index is not None
+    assert raw_index < refusal_index < visible_index
+    assert "NESTED-CAP-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_without_gateway_fails_closed_after_raw_log(tmp_path):
+    raw = {"stdout": "NESTED-NOGATEWAY-RAW"}
+    events = []
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=None,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "echo no gateway", "summary": True}},
+            id="nested-no-gateway",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["summary_kind"] == "apriori_error"
+    assert "NESTED-NOGATEWAY-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-no-gateway")
+    error_index = _event_index(
+        events, "apriori_summary_no_summarizer", tool_call_id="nested-no-gateway"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-no-gateway"
+    )
+    assert raw_index is not None and error_index is not None and visible_index is not None
+    assert raw_index < error_index < visible_index
+    assert "NESTED-NOGATEWAY-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_preserves_tool_error_bypass(tmp_path):
+    raw = {"status": "error", "message": "EXACT-TOOL-ERROR"}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "error", "summary": True}},
+            id="nested-error",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["status"] == "error"
+    assert "EXACT-TOOL-ERROR" in str(content)
+    assert called == []
+    assert _event_index(events, "tool_result", tool_call_id="nested-error") is not None
+    assert _event_index(events, "apriori_summary_generated", tool_call_id="nested-error") is None
 
 
 def test_summary_true_over_cap_refuses_without_llm_and_hides_raw(tmp_path):

--- a/tests/test_read_action_input.py
+++ b/tests/test_read_action_input.py
@@ -1,0 +1,573 @@
+"""Independent public action/input contract tests for the ``read`` capability.
+
+This module is read-owned. It deliberately tests the raw capability schema, the
+actual Agent/provider surfaces, direct handler validation, settings evidence,
+read semantics, and the executor's nested a-priori summary boundary. Shared
+legacy file-tool tests are intentionally not rewritten here during rollout.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from lingtai.agent import Agent
+from lingtai.kernel.llm.base import WIRE_TOOL_DESCRIPTION, ToolCall
+from lingtai.kernel.loop_guard import LoopGuard
+from lingtai.kernel.tool_executor import ToolExecutor
+from lingtai.llm.anthropic.adapter import _build_tools as build_anthropic_tools
+from lingtai.llm.openai.adapter import (
+    _build_responses_tools,
+    _build_tools as build_chat_tools,
+)
+from lingtai.tools.read import get_description, get_schema
+from tests._service_helpers import make_gemini_mock_service
+
+
+class _UnhashableMapping(Mapping):
+    """Mapping-shaped bad input whose key cannot be hashed."""
+
+    def keys(self):
+        return [[]]
+
+    def __iter__(self):
+        return iter([[]])
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, key):
+        raise KeyError(key)
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_ARTIFACT_ROOT = _ROOT / "artifacts" / "read-action-input-worker" / "tests"
+
+
+def _persistent_root(label: str) -> Path:
+    """Return a unique retained test root; this suite never auto-cleans it."""
+    root = _ARTIFACT_ROOT / f"{label}-{uuid4().hex}"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _agent(label: str = "agent") -> Agent:
+    root = _persistent_root(label)
+    return Agent(
+        service=make_gemini_mock_service(),
+        agent_name="read-contract-test",
+        working_dir=root / "agent",
+        capabilities=["read"],
+    )
+
+
+def _read_call(agent: Agent, **payload):
+    return agent._tool_handlers["read"](payload)
+
+
+def _explicit(path: str, **options) -> dict:
+    value = {"file_path": path}
+    value.update(options)
+    return {"action": "read", "input": value}
+
+
+def _without_setting(value: dict) -> dict:
+    return {key: item for key, item in value.items() if key != "current_setting"}
+
+
+def _write_settings(agent: Agent, value: str) -> Path:
+    path = agent.working_dir / "settings" / "read.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value, encoding="utf-8")
+    return path
+
+
+def _make_executor(agent: Agent, *, events, summarizer, parallel_safe_tools=None):
+    def logger(event_type, **fields):
+        events.append((event_type, fields))
+
+    def make_tool_result(name, result, **kwargs):
+        return {"role": "tool", "name": name, "content": result, **kwargs}
+
+    return ToolExecutor(
+        dispatch_fn=agent._dispatch_tool,
+        make_tool_result_fn=make_tool_result,
+        guard=LoopGuard(),
+        known_tools={"read"},
+        logger_fn=logger,
+        working_dir=agent.working_dir,
+        summarizer_fn=summarizer,
+        parallel_safe_tools=parallel_safe_tools or set(),
+    )
+
+
+def _wire_content(result_message):
+    return result_message["content"]
+
+
+def _event_index(events, event_type: str, call_id: str) -> int | None:
+    for index, (kind, fields) in enumerate(events):
+        if kind == event_type and fields.get("tool_call_id") == call_id:
+            return index
+    return None
+
+
+def test_raw_schema_is_closed_action_input():
+    schema = get_schema()
+    assert set(schema) == {"type", "properties", "required", "additionalProperties"}
+    assert set(schema["properties"]) == {"action", "input"}
+    assert schema["required"] == ["action", "input"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["action"]["enum"] == ["read", "manual"]
+
+    branches = schema["properties"]["input"]["anyOf"]
+    read_branch = next(branch for branch in branches if branch["title"] == "read input")
+    manual_branch = next(branch for branch in branches if branch["title"] == "manual input")
+    assert set(read_branch["properties"]) == {
+        "file_path", "offset", "limit", "max_chars", "summary"
+    }
+    assert read_branch["required"] == ["file_path"]
+    assert read_branch["additionalProperties"] is False
+    assert read_branch["properties"]["offset"]["type"] == "integer"
+    assert read_branch["properties"]["offset"]["default"] == 1
+    assert read_branch["properties"]["limit"]["type"] == "integer"
+    assert read_branch["properties"]["limit"]["default"] == 2000
+    assert read_branch["properties"]["max_chars"]["type"] == "integer"
+    assert "default" not in read_branch["properties"]["max_chars"]
+    assert read_branch["properties"]["summary"]["type"] == "boolean"
+    assert read_branch["properties"]["summary"]["default"] is False
+    assert "reasoning" not in read_branch["properties"]
+    assert manual_branch["properties"] == {}
+    assert manual_branch["required"] == []
+    assert manual_branch["additionalProperties"] is False
+
+
+def test_agent_schema_has_only_action_input_reasoning_and_real_origin():
+    agent = _agent("schema")
+    try:
+        schema = next(item for item in agent._build_tool_schemas() if item.name == "read")
+        assert set(schema.parameters["properties"]) == {"action", "input", "reasoning"}
+        assert schema.parameters["required"] == ["action", "input"]
+        assert schema.parameters["additionalProperties"] is False
+        for branch in schema.parameters["properties"]["input"]["anyOf"]:
+            assert "reasoning" not in branch.get("properties", {})
+        assert Path(sys.modules["lingtai.tools.read"].__file__).resolve() == (
+            _ROOT / "src/lingtai/tools/read/__init__.py"
+        ).resolve()
+        assert agent._tool_handlers["read"].__code__.co_filename == str(
+            _ROOT / "src/lingtai/tools/read/__init__.py"
+        )
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_provider_envelopes_keep_public_fields_and_wire_description():
+    agent = _agent("envelopes")
+    try:
+        schema = next(item for item in agent._build_tool_schemas() if item.name == "read")
+        chat = build_chat_tools([schema])[0]
+        responses = _build_responses_tools([schema])[0]
+        anthropic = build_anthropic_tools([schema], cache_tools=False)[0]
+
+        assert set(chat) == {"type", "function"}
+        assert set(chat["function"]) == {"name", "description", "parameters"}
+        assert set(responses) == {"type", "name", "description", "parameters"}
+        assert set(anthropic) == {"name", "description", "input_schema"}
+        assert chat["function"]["description"] == WIRE_TOOL_DESCRIPTION
+        assert responses["description"] == WIRE_TOOL_DESCRIPTION
+        assert anthropic["description"] == WIRE_TOOL_DESCRIPTION
+        for parameters in (
+            chat["function"]["parameters"],
+            responses["parameters"],
+            anthropic["input_schema"],
+        ):
+            assert set(parameters["properties"]) == {"action", "input", "reasoning"}
+            assert parameters["required"] == ["action", "input"]
+            assert parameters["additionalProperties"] is False
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_prompt_batches_and_tool_owned_description_only():
+    agent = _agent("prompt")
+    try:
+        prompt = agent._build_system_prompt()
+        batches = agent._build_system_prompt_batches()
+        joined = "\n\n".join(batch for batch in batches if batch)
+        description = get_description()
+        assert prompt == joined
+        assert "### read" in prompt
+        assert description in prompt
+        assert "action='read'" in description
+        assert "input={'file_path':" in description
+        assert "reasoning='...'" in description
+        assert "nested input" in description
+        assert "omit action for the legacy" not in description
+        assert "flat" not in description
+        # The resident prompt also contains unmigrated sibling prose; only the
+        # read-owned section is canonicalized by this test.
+        read_section = prompt.split("### read", 1)[1]
+        assert description in read_section
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_canonical_handler_calls_and_direct_metadata_reasoning():
+    agent = _agent("canonical")
+    try:
+        target = agent.working_dir / "canonical.txt"
+        target.write_text("one\ntwo\n", encoding="utf-8")
+        direct = _read_call(agent, **_explicit("canonical.txt"), reasoning="why direct")
+        normalized = _read_call(agent, **_explicit("canonical.txt"), _reasoning="why executor")
+        assert _without_setting(direct)["content"] == _without_setting(normalized)["content"]
+        assert direct["total_lines"] == 2
+        assert direct["current_setting"]["source"] == "missing"
+
+        flat = _read_call(agent, file_path="canonical.txt")
+        assert flat["status"] == "error"
+        assert "current_setting" in flat
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_file_io_delegation_uses_relative_workdir_path():
+    agent = _agent("delegation")
+    try:
+        target = agent.working_dir / "delegated.txt"
+        target.write_text("delegated\n", encoding="utf-8")
+        calls = []
+        real_io = agent._file_io
+
+        class SpyIO:
+            def read(self, path):
+                calls.append(path)
+                return real_io.read(path)
+
+        agent._file_io = SpyIO()
+        result = _read_call(agent, **_explicit("delegated.txt"))
+        assert result.get("status") != "error"
+        assert calls == [str(agent.working_dir / "delegated.txt")]
+        assert result["content"].startswith("1\tdelegated")
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_manual_returns_real_installed_body_and_current_setting():
+    agent = _agent("manual")
+    try:
+        result = _read_call(agent, action="manual", input={})
+        assert result["status"] == "ok"
+        assert result["manual"]
+        assert "# Read Manual" in result["manual"]
+        assert '"action": "read"' in result["manual"]
+        assert '"reasoning": "inspect the requested source window"' in result["manual"]
+        assert '"action": "manual"' in result["manual"]
+        assert '"reasoning": "load the installed read guide"' in result["manual"]
+        assert "omit" in result["manual"]
+        assert result["manual_path"].endswith("capabilities/read-manual/SKILL.md")
+        assert result["current_setting"]["source"] == "missing"
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_pagination_max_chars_and_truncation_metadata():
+    agent = _agent("pagination")
+    try:
+        target = agent.working_dir / "pages.txt"
+        target.write_text("".join(f"line-{i:03d}-xxxxxxxxxxxxxxxx\n" for i in range(1, 40)), encoding="utf-8")
+        first = _read_call(agent, **_explicit("pages.txt", limit=39, max_chars=90))
+        assert first["truncated"] is True
+        assert first["cap_chars"] == 90
+        assert first["returned_chars"] <= 90
+        assert first["requested_offset"] == 1
+        assert first["requested_limit"] == 39
+        assert first["last_returned_line"] >= 1
+        assert first["next_offset"] == first["last_returned_line"] + 1
+        assert first["remaining_lines_estimate"] > 0
+        second = _read_call(
+            agent,
+            **_explicit("pages.txt", offset=first["next_offset"], limit=39, max_chars=90),
+        )
+        assert int(second["content"].split("\t", 1)[0]) == first["next_offset"]
+        assert second["current_setting"]["source"] == "missing"
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_line_truncated_is_bounded_and_advances_to_next_line():
+    agent = _agent("line-truncated")
+    try:
+        target = agent.working_dir / "long-line.txt"
+        target.write_text("A" * 500 + "\nsecond\n", encoding="utf-8")
+        result = _read_call(agent, **_explicit("long-line.txt", limit=2, max_chars=40))
+        assert result["truncated"] is True
+        assert result["line_truncated"] is True
+        assert result["returned_chars"] <= 40
+        assert result["last_returned_line"] == 1
+        assert result["next_offset"] == 2
+        assert "A" in result["content"]
+    finally:
+        agent.stop(timeout=1.0)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"file_path": "x"},
+        {"action": "read", "input": {"file_path": "x"}, "extra": 1},
+        {"action": "read", "input": {"file_path": "x", "unknown": 1}},
+        {"action": "manual", "input": {"unknown": 1}},
+        {"action": "read", "input": {"file_path": "x", "summary": 1}},
+        {"action": "read", "input": {"file_path": "x", "offset": "1"}},
+        {"action": "read", "input": {"file_path": "x", "limit": False}},
+        {"action": "read", "input": {"file_path": "x", "max_chars": None}},
+    ],
+)
+def test_strict_flat_unknown_and_malformed_calls_do_not_read_target(payload):
+    agent = _agent("reject")
+    try:
+        calls = []
+        real_io = agent._file_io
+
+        class SpyIO:
+            def read(self, path):
+                calls.append(path)
+                return real_io.read(path)
+
+        agent._file_io = SpyIO()
+        result = _read_call(agent, **payload)
+        assert result["status"] == "error"
+        assert "current_setting" in result
+        assert calls == []
+    finally:
+        agent.stop(timeout=1.0)
+
+
+@pytest.mark.parametrize("bad_root", [None, [], "read", 3, _UnhashableMapping()])
+def test_nonmapping_and_unhashable_roots_are_structured_rejections(bad_root):
+    agent = _agent("bad-root")
+    try:
+        calls = []
+        real_io = agent._file_io
+
+        class SpyIO:
+            def read(self, path):
+                calls.append(path)
+                return real_io.read(path)
+
+        agent._file_io = SpyIO()
+        result = agent._tool_handlers["read"](bad_root)
+        assert result["status"] == "error"
+        assert "current_setting" in result
+        assert calls == []
+    finally:
+        agent.stop(timeout=1.0)
+
+
+@pytest.mark.parametrize("bad_action", ["write", "", 4, [], {}])
+def test_unknown_and_unhashable_actions_are_safe(bad_action):
+    agent = _agent("bad-action")
+    try:
+        result = _read_call(agent, action=bad_action, input={})
+        assert result["status"] == "error"
+        assert "Unsupported action for read" in result["message"]
+        assert "current_setting" in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_settings_missing_valid_hot_invalid_and_behavior_prompt_invariance():
+    agent = _agent("settings")
+    try:
+        target = agent.working_dir / "settings-target.txt"
+        target.write_text("a\nb\nc\n", encoding="utf-8")
+        prompt_before = agent._build_system_prompt()
+
+        missing = _read_call(agent, **_explicit("settings-target.txt", limit=2))
+        assert missing["current_setting"]["source"] == "missing"
+        baseline = _without_setting(missing)
+
+        _write_settings(agent, '{"schema_version": 1}')
+        valid = _read_call(agent, **_explicit("settings-target.txt", limit=2))
+        assert valid["current_setting"]["source"] == "settings/read.json"
+        assert valid["current_setting"]["settings_hash"]
+        assert _without_setting(valid) == baseline
+
+        _write_settings(agent, '{ "schema_version": 1 }')
+        hot = _read_call(agent, **_explicit("settings-target.txt", limit=2))
+        assert hot["current_setting"]["source"] == "settings/read.json"
+        assert hot["current_setting"]["settings_revision"] != valid["current_setting"]["settings_revision"]
+        assert _without_setting(hot) == baseline
+
+        _write_settings(agent, '{"schema_version": 1, "future": true}')
+        invalid = _read_call(agent, **_explicit("settings-target.txt", limit=2))
+        assert invalid["current_setting"]["source"] == "settings_error"
+        assert invalid["current_setting"]["settings_error"]
+        assert _without_setting(invalid) == baseline
+        assert agent._build_system_prompt() == prompt_before
+
+        # A caller mutation cannot alter a later immutable snapshot.
+        valid["current_setting"]["source"] = "tampered"
+        again = _read_call(agent, **_explicit("settings-target.txt", limit=2))
+        assert again["current_setting"]["source"] == "settings_error"
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_file_io_and_runtime_errors_are_text_only_and_setting_bearing():
+    agent = _agent("errors")
+    try:
+        missing = _read_call(agent, **_explicit("missing.txt"))
+        assert missing["status"] == "error"
+        assert missing["message"].startswith("File not found:")
+        assert missing["current_setting"]["source"] == "missing"
+
+        class BrokenIO:
+            def read(self, path):
+                raise RuntimeError("backend exploded")
+
+        agent._file_io = BrokenIO()
+        failed = _read_call(agent, **_explicit("anything.txt"))
+        assert failed["status"] == "error"
+        assert failed["message"].startswith("Cannot read")
+        assert "backend exploded" in failed["message"]
+        assert failed["current_setting"]["source"] == "missing"
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_nested_summary_true_serial_uses_actual_handler_and_logs_raw_first():
+    agent = _agent("summary-serial")
+    try:
+        target = agent.working_dir / "summary.txt"
+        target.write_text("raw-file-marker\n", encoding="utf-8")
+        events = []
+        seen = {}
+
+        def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+            seen["prompt"] = user_prompt
+            return "SERIAL-READ-SUMMARY"
+
+        executor = _make_executor(agent, events=events, summarizer=summarizer)
+        results, intercepted, _ = executor.execute([
+            ToolCall(
+                name="read",
+                args={
+                    "action": "read",
+                    "input": {"file_path": "summary.txt", "summary": True},
+                    "reasoning": "retain the file marker",
+                },
+                id="read-serial",
+            )
+        ])
+        assert intercepted is False
+        content = _wire_content(results[0])
+        assert content["summary_kind"] == "apriori_generated"
+        assert content["generated_summary"] == "SERIAL-READ-SUMMARY"
+        assert "raw-file-marker" in seen["prompt"]
+        raw_index = _event_index(events, "tool_result", "read-serial")
+        generated_index = _event_index(events, "apriori_summary_generated", "read-serial")
+        visible_index = _event_index(events, "tool_result_model_visible", "read-serial")
+        assert raw_index is not None and generated_index is not None and visible_index is not None
+        assert raw_index < generated_index < visible_index
+        assert "raw-file-marker" in str(events[raw_index][1]["result"])
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_nested_summary_true_parallel_reads_replace_after_each_raw_log():
+    agent = _agent("summary-parallel")
+    try:
+        (agent.working_dir / "one.txt").write_text("parallel-one-marker\n", encoding="utf-8")
+        (agent.working_dir / "two.txt").write_text("parallel-two-marker\n", encoding="utf-8")
+        events = []
+        seen = []
+
+        def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+            seen.append((tool_call_id, user_prompt))
+            return f"PARALLEL-SUMMARY-{tool_call_id}"
+
+        executor = _make_executor(
+            agent,
+            events=events,
+            summarizer=summarizer,
+            parallel_safe_tools={"read"},
+        )
+        results, intercepted, _ = executor.execute([
+            ToolCall(
+                name="read",
+                args={"action": "read", "input": {"file_path": "one.txt", "summary": True}},
+                id="read-parallel-1",
+            ),
+            ToolCall(
+                name="read",
+                args={"action": "read", "input": {"file_path": "two.txt", "summary": True}},
+                id="read-parallel-2",
+            ),
+        ])
+        assert intercepted is False
+        assert len(seen) == 2
+        for result_message, call_id in zip(results, ("read-parallel-1", "read-parallel-2")):
+            content = _wire_content(result_message)
+            assert content["generated_summary"] == f"PARALLEL-SUMMARY-{call_id}"
+            raw_index = _event_index(events, "tool_result", call_id)
+            generated_index = _event_index(events, "apriori_summary_generated", call_id)
+            visible_index = _event_index(events, "tool_result_model_visible", call_id)
+            assert raw_index is not None and generated_index is not None and visible_index is not None
+            assert raw_index < generated_index < visible_index
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_nested_input_summary_false_ignores_root_summary_without_replacement():
+    """The shared canonical predicate never falls back to root summary."""
+    from lingtai.kernel.tool_result_summary import APRIORI_SUMMARY_MARKER
+
+    events = []
+    called = []
+
+    def logger(event_type, **fields):
+        events.append((event_type, fields))
+
+    def dispatch(_tool_call):
+        return {"stdout": "ROOT-IGNORED-RAW"}
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD-NOT-RUN"
+
+    executor = ToolExecutor(
+        dispatch_fn=dispatch,
+        make_tool_result_fn=lambda name, result, **kw: {"name": name, "content": result, **kw},
+        guard=LoopGuard(),
+        known_tools={"read"},
+        logger_fn=logger,
+        working_dir=_persistent_root("summary-root"),
+        summarizer_fn=summarizer,
+    )
+    results, _, _ = executor.execute([
+        ToolCall(
+            name="read",
+            args={
+                "input": {"file_path": "unused", "summary": False},
+                "summary": True,
+            },
+            id="read-root-ignored",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert "ROOT-IGNORED-RAW" in str(content)
+    assert not (isinstance(content, dict) and content.get("artifact") == APRIORI_SUMMARY_MARKER)
+    assert called == []
+
+
+def test_no_summary_root_fallback_when_nested_summary_is_absent():
+    from lingtai.kernel.tool_result_summary import summary_requested
+
+    assert summary_requested({"input": {"file_path": "x"}, "summary": True}) is False
+    assert summary_requested({"input": {"file_path": "x", "summary": False}, "summary": True}) is False

--- a/tests/test_tool_settings.py
+++ b/tests/test_tool_settings.py
@@ -1,0 +1,154 @@
+"""Focused tests for the private no-op placeholder-settings foundation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools._settings import (
+    MAX_SETTINGS_BYTES,
+    current_setting,
+    read_settings,
+    settings_path,
+    valid_tool_name,
+)
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+
+def _write(root: Path, tool_name: str, payload: str | bytes) -> Path:
+    path = root / "settings" / f"{tool_name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def test_missing_is_a_normal_noop_placeholder_state(tmp_path):
+    snapshot = read_settings(_Agent(tmp_path), "example")
+    setting = current_setting(snapshot, "example")
+    assert setting == {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": "missing",
+        "settings_revision": "missing",
+        "settings_hash": None,
+        "change_hint": (
+            "Edit settings/example.json; changes apply on the next example call; "
+            "this no-op placeholder never changes tool behavior."
+        ),
+    }
+
+
+def test_valid_v1_only_changes_source_revision_and_hash(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "example", '{"schema_version": 1}')
+    snapshot = read_settings(agent, "example")
+    setting = current_setting(snapshot, "example")
+    assert snapshot.error is None
+    assert setting["configurable"] is False
+    assert setting["placeholder"] == "no-op"
+    assert setting["source"] == "settings/example.json"
+    assert setting["settings_revision"] == setting["settings_hash"]
+    assert setting["settings_hash"]
+
+
+def test_reader_rereads_hot_changes_without_cache(tmp_path):
+    agent = _Agent(tmp_path)
+    path = _write(tmp_path, "example", '{"schema_version": 1}')
+    first = read_settings(agent, "example")
+    path.write_text('{ "schema_version": 1 }', encoding="utf-8")
+    second = read_settings(agent, "example")
+    assert first.digest != second.digest
+    assert second.source == "settings/example.json"
+
+
+def test_duplicate_and_extra_fields_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    duplicate = _write(tmp_path, "duplicate", '{"schema_version": 1, "schema_version": 1}')
+    duplicate_snapshot = read_settings(agent, "duplicate")
+    assert duplicate_snapshot.source == "settings_error"
+    assert "duplicate" in (duplicate_snapshot.error or "")
+
+    extra = _write(tmp_path, "extra", '{"schema_version": 1, "future": false}')
+    extra_snapshot = read_settings(agent, "extra")
+    assert extra_snapshot.source == "settings_error"
+    assert "only schema_version" in (extra_snapshot.error or "")
+
+
+def test_bool_and_other_schema_versions_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    for name, version in (("bool", True), ("float", 1.0), ("other", 2)):
+        _write(tmp_path, name, json.dumps({"schema_version": version}))
+        snapshot = read_settings(agent, name)
+        assert snapshot.source == "settings_error"
+        assert "integer 1" in (snapshot.error or "")
+
+
+def test_invalid_encoding_and_json_are_truthful_bounded_errors(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "encoding", b'{"schema_version": 1}\xff')
+    encoding_snapshot = read_settings(agent, "encoding")
+    assert encoding_snapshot.source == "settings_error"
+    assert encoding_snapshot.error
+
+    _write(tmp_path, "json", "{not-json")
+    json_snapshot = read_settings(agent, "json")
+    assert json_snapshot.source == "settings_error"
+    assert json_snapshot.error
+    assert len(json_snapshot.error) <= 240
+
+
+def test_symlink_non_regular_and_oversized_files_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text('{"schema_version": 1}', encoding="utf-8")
+    symlink = tmp_path / "settings" / "symlink.json"
+    symlink.parent.mkdir()
+    symlink.symlink_to(target)
+    symlink_snapshot = read_settings(agent, "symlink")
+    assert symlink_snapshot.source == "settings_error"
+    assert "regular file" in (symlink_snapshot.error or "")
+
+    non_regular = tmp_path / "settings" / "directory.json"
+    non_regular.mkdir()
+    directory_snapshot = read_settings(agent, "directory")
+    assert directory_snapshot.source == "settings_error"
+    assert "regular file" in (directory_snapshot.error or "")
+
+    _write(tmp_path, "large", b"{" + b"x" * MAX_SETTINGS_BYTES + b"}")
+    large_snapshot = read_settings(agent, "large")
+    assert large_snapshot.source == "settings_error"
+    assert "bounded size" in (large_snapshot.error or "")
+
+
+def test_unstable_snapshot_is_not_treated_as_missing(tmp_path, monkeypatch):
+    import lingtai.tools._settings as settings_module
+
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "unstable", '{"schema_version": 1}')
+
+    def raise_unstable(_path):
+        raise settings_module.SettingsError("settings snapshot changed during read")
+
+    monkeypatch.setattr(settings_module, "_read_stable", raise_unstable)
+    snapshot = read_settings(agent, "unstable")
+    assert snapshot.source == "settings_error"
+    assert snapshot.revision == "error"
+    assert snapshot.error == "settings snapshot changed during read"
+
+
+def test_tool_names_are_bounded_path_components(tmp_path):
+    assert valid_tool_name("web_search")
+    assert not valid_tool_name("../escape")
+    assert not valid_tool_name("nested/name")
+    assert not valid_tool_name("\\escape")
+    assert not valid_tool_name("x" * 65)
+    with pytest.raises(ValueError):
+        settings_path(_Agent(tmp_path), "../escape")


### PR DESCRIPTION
## Summary

This stacked draft migrates the public `read` tool to LingTai's future canonical model-facing contract:

- required root `action` plus required nested `input` in the raw tool-owned schema;
- actions exactly `read` and `manual`;
- BaseAgent-injected root `reasoning`, with no nested reasoning alias;
- closed action-specific inputs and no omitted-action or flat-root compatibility;
- nested exact-boolean `input.summary`, with no root-summary fallback once `input` exists;
- strict per-call `settings/read.json` v1 placeholder loading with truthful `current_setting` on success, manual, malformed-input, and FileIO-error paths;
- the real installed `read-manual` plus synchronized read contract, shared read-owned file-manual guidance, and glossaries;
- preserved relative-path resolution, UTF-8 FileIO delegation, 1-based offset/limit semantics, 100k default / 200k hard cap behavior, continuation metadata, spill-aware errors, and `line_truncated` behavior.

Provider wrappers remain unchanged: Chat uses `function.parameters`, Responses uses `parameters`, and Anthropic uses `input_schema`.

## Stack

- Depends on foundation draft #1038 at exact foundation commit `80d5c7d4`.
- Base branch: `feat/tool-settings-foundation`.
- This PR is intentionally a draft and must not be merged independently of the stack review.

## Parent review repairs

The worker candidate was not accepted unchanged. Parent review found that the tool-owned description, primary read-manual examples, and shared read example did not visibly carry Agent-injected root `reasoning`, despite the final schema doing so. Those examples were repaired, raw-schema versus Agent-facing ownership was clarified, and the owning prompt/manual tests were hardened to prevent recurrence.

The worker's 121 normalized events were also audited: all 80 shell/write/edit records stayed inside the authorized read candidate and persistent artifact paths, with no explicit deletion, pytest, py_compile, temporary lifecycle, Git mutation, or GitHub mutation.

## Validation

- exact post-repair owning module executed directly without pytest lifecycle cleanup: 15 ordinary tests plus 19 parameterized rejection cases passed;
- fresh retained parent gate passed 95 checks across raw and actual-Agent schemas, Chat/Responses/Anthropic envelopes, prompt batches, installed manual, exact source origins, UTF-8/FileIO delegation, pagination, `max_chars`, `line_truncated`, strict malformed no-read behavior, missing/valid/hot/invalid settings, secret non-leakage, spill-aware errors, and serial/parallel nested-summary raw-before-visible ordering;
- nested absent/false/non-boolean summary values were verified never to fall back to root `summary`, and tool errors were verified to bypass summarization;
- anatomy drift (53 files), glossary resources (57 across 19 packages), in-memory compile, control-character scan, and `git diff --check` passed.

Repository-wide pytest was intentionally not executed under the current no-cleanup boundary. Pre-existing flat read-handler expectations outside the new read-owned module remain rollout debt and must be canonicalized in the stack integration before merge. No merge, release, deploy, tag, deletion, or cleanup is part of this draft.
