### PR TITLE
feat(grep): adopt canonical action/input contract

### DIFF
--- a/src/lingtai/intrinsic_skills/file-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/file-manual/SKILL.md
@@ -79,7 +79,7 @@ citations easier. If a file may be generated, minified, huge, or noisy, search
 first and read only the relevant region:
 
 ```python
-grep({"pattern": "class Agent|def handle", "path": "/abs/path/src", "glob": "*.py", "max_matches": 50})
+grep({"action": "grep", "input": {"pattern": "class Agent|def handle", "path": "/abs/path/src", "glob": "*.py", "max_matches": 50, "summary": False}, "reasoning": "locate the handler before reading it"})
 read({"file_path": "/abs/path/src/module.py", "offset": 40, "limit": 80})
 ```
 
@@ -112,7 +112,7 @@ inspect with `read`.
 
 ```python
 glob({"pattern": "**/*.py", "path": "/abs/path/project"})
-grep({"pattern": "read_text\\(", "path": "/abs/path/project/src", "glob": "*.py", "max_matches": 100})
+grep({"action": "grep", "input": {"pattern": "read_text\\(", "path": "/abs/path/project/src", "glob": "*.py", "max_matches": 100, "summary": False}, "reasoning": "find Python text reads before inspecting matches"})
 ```
 
 ## File paths and privacy
@@ -125,16 +125,21 @@ content or attach/export a file through the appropriate communication channel.
 
 ## Manual versus ordinary calls
 
-Normal file work is primary. Each file tool has two explicit modes:
+Normal file work is primary. Follow each tool's current public schema. The
+migrated `grep` tool has two explicit root actions: use
+`{"action":"grep","input":{"pattern":"TODO","summary":false},"reasoning":"find pending work"}`
+for an ordinary search, or
+`{"action":"manual","input":{},"reasoning":"load the installed file guide"}`
+for this installed manual. Its omitted-action and flat-root forms are not
+supported; Agent-injected `reasoning` stays at the root and exact-boolean
+`summary` stays inside `input`.
 
-- **Ordinary work:** for backward compatibility, omit `action` or set it to the
-  tool name: `action="read"`, `"write"`, `"edit"`, `"glob"`, or `"grep"`.
-  Supply the ordinary arguments shown in that tool's schema.
-- **Manual lookup:** use `action="manual"` as a one-time entry when you need the
-  installed workflow guide. It returns documentation and performs no file
-  operation. `write`, `edit`, `glob`, and `grep` return this manual; `read`
-  returns `read-manual`.
+Other file tools may document their own ordinary arguments and rollout state. A
+manual lookup is always a one-time explicit `action="manual"` entry when that
+tool exposes it; it returns documentation and performs no file operation.
+`write`, `edit`, `glob`, and `grep` return this manual; `read` returns
+`read-manual`.
 
-After a manual result, continue the original task with an ordinary call. Do not
-request the same manual again. Repeating an identical manual call is an error loop,
-not progress.
+After a manual result, continue the original task with the tool's documented
+ordinary action. Do not request the same manual again. Repeating an identical
+manual call is an error loop, not progress.

--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -36,6 +36,7 @@ Safety properties:
 from __future__ import annotations
 
 import datetime as _dt
+from collections.abc import Mapping
 from typing import Any, Callable
 
 from .meta_block import formal_tool_result_content, formal_tool_result_visible_len
@@ -147,15 +148,21 @@ def is_apriori_summary(content: Any) -> bool:
     )
 
 
-def summary_requested(args: dict | None) -> bool:
-    """Return True iff the normalized tool args opt into a-priori summary.
+def summary_requested(args: Mapping | None) -> bool:
+    """Return True iff tool args opt into a-priori summary.
 
-    The flag is the boolean ``summary`` field on the tool call. Anything other
-    than a literal ``True`` (missing, ``False``, ``None``, truthy-but-not-True)
-    preserves current behavior exactly.
+    The presence of ``input`` selects canonical mode: only a Mapping-valued
+    ``input`` whose ``summary`` is exactly ``True`` requests summarization.
+    Root ``summary`` is ignored in canonical mode, including when ``input`` is
+    malformed or its nested flag is absent/invalid. When ``input`` is absent,
+    legacy mode reads only root ``summary``. Both modes require identity with
+    the boolean singleton ``True``; no truthy coercion is performed.
     """
-    if not isinstance(args, dict):
+    if not isinstance(args, Mapping):
         return False
+    if "input" in args:
+        payload = args["input"]
+        return isinstance(payload, Mapping) and payload.get("summary") is True
     return args.get("summary") is True
 
 
@@ -395,13 +402,19 @@ def maybe_summarize_result(
     and BEFORE the result is turned into the model-visible wire message.
 
     Contract:
+    - Summary control is canonical-first: when ``input`` is present, only
+      ``input.summary is True`` on a Mapping payload requests; root ``summary``
+      is never inspected or used as fallback. When ``input`` is absent, legacy
+      calls use root ``summary is True``. This exact-boolean discriminator is
+      applied without flattening or mutating the original args.
     - ``summary != true`` → returns *result* unchanged (current behavior).
     - ``summary == true`` but no ``summarizer_fn`` wired (e.g. service without a
       one-shot generate gateway) → **fails closed**: returns a summary-layer
       error (with the raw-retrieval locator), NOT the raw result. ``summary=true``
       is a request to keep the raw out of context; honoring it must not depend on
       whether a summarizer happens to be configured. The raw is already durably
-      logged before this point, so it remains retrievable by ``tool_call_id``.
+      logged before either the legacy or canonical predicate is applied, so it
+      remains retrievable by ``tool_call_id``.
     - Already an a-priori summary (defensive) → returned unchanged.
     - Error results (the tool itself failed) are NOT summarized: the agent needs
       the exact error text to recover. Returned unchanged.

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
@@ -35,6 +36,10 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_settings.py` — private Agent-owned placeholder-settings reader and
+  secret-free current-setting diagnostic. It strictly validates the exact
+  versioned no-op schema, rereads `settings/<bounded tool_name>.json` per call,
+  and never supplies action, input, reasoning, or tool behavior.
 
 ## Connections
 

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -8,6 +8,7 @@ related_files:
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/_settings.py
   - src/lingtai/tools/browser/ANATOMY.md
+  - src/lingtai/tools/grep/ANATOMY.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
   - src/lingtai/tools/glossary_validator.py

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -40,6 +40,33 @@ There is no fourth public metadata block. Existing tools retain their current
 explicit schemas until a scoped migration changes their code, tests, manual, and
 contract together.
 
+### A-priori summary transition
+
+The shared kernel summary predicate uses the presence of the `input` key as the
+mode discriminator. A canonical call requests a summary only when `input` is a
+Mapping/object and `input.summary` is exactly the boolean `true`; once `input` is
+present, root `summary` is ignored and is never a fallback, even when `input` is
+malformed, missing `summary`, or carries a false/non-boolean value. No truthy
+coercion, flattening, or argument mutation is permitted. A call with no `input`
+key remains in legacy mode and requests only when root `summary` is exactly
+`true`.
+
+This is a transitional compatibility rule, not a second public schema: migrated
+capabilities that support a-priori summary advertise that flag only as nested
+`input.summary`, while unmigrated legacy advertisers retain their root flag until
+their own vertical migration. Tool errors continue to bypass summarization. The
+raw result is durably recorded before either nested or legacy summary control is
+applied; generated, refusal, and fail-closed no-gateway replacements are
+model-visible substitutes with the
+existing raw locator and metadata.
+
+The root-summary branch may be removed only in the commit that migrates the last
+currently legacy root-summary advertiser (including shell's historical `bash`
+rolling alias and daemon), and only after a registry-wide test proves that no
+provider-facing schema advertises root `summary`, no migrated handler accepts
+flat fields, and no supported pending legacy call relies on the root shape. Until
+that final removal gate, root lookup is permitted solely when `input` is absent.
+
 ## Port
 
 The provider-neutral boundary is the final `FunctionSchema` assembled by the

--- a/src/lingtai/tools/_settings.py
+++ b/src/lingtai/tools/_settings.py
@@ -1,0 +1,156 @@
+"""Private shared reader for Agent-owned no-op tool settings placeholders.
+
+The placeholder file is deliberately metadata-only.  A present, valid v1 file
+proves that an Agent-owned settings snapshot was read, but it cannot select or
+enable any tool behavior.  Individual tools may later add their own real
+settings reader when a configurable choice is actually authorized.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MAX_SETTINGS_BYTES = 64 * 1024
+SETTINGS_SCHEMA_VERSION = 1
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class SettingsError(ValueError):
+    """A placeholder settings snapshot was malformed or unsafe to use."""
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsSnapshot:
+    """Immutable evidence for one reread of one tool's settings file."""
+
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def valid_tool_name(value: Any) -> bool:
+    """Return whether *value* is safe as one bounded settings path component."""
+    return isinstance(value, str) and _TOOL_NAME.fullmatch(value) is not None
+
+
+def settings_path(agent: Any, tool_name: str) -> Path:
+    """Return the fixed Agent-owned ``settings/<tool_name>.json`` path."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return Path(agent._working_dir) / "settings" / f"{tool_name}.json"
+
+
+def _bounded_error(exc: Exception) -> str:
+    """Render a bounded diagnostic without echoing host paths or file content."""
+    if isinstance(exc, OSError):
+        return f"settings file could not be read ({type(exc).__name__})"
+    text = str(exc).replace("\n", " ").strip()
+    return (text or "invalid settings")[:240]
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject duplicate JSON object members instead of accepting last-wins data."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SettingsError("duplicate settings field")
+        result[key] = value
+    return result
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    """Read one bounded regular-file snapshot and its content revision."""
+    try:
+        first = path.lstat()
+    except FileNotFoundError:
+        return b"", "missing"
+    except OSError:
+        raise
+
+    if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
+        raise SettingsError("settings file must be a regular file")
+    if first.st_size > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings file exceeds the bounded size")
+
+    # Open by path only after lstat, then compare the path identity and metadata
+    # again.  Replacements, symlink swaps, growth, and ordinary in-place writes
+    # are therefore rejected rather than partially accepted.
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_SETTINGS_BYTES + 1)
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    try:
+        second = path.lstat()
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    if stat.S_ISLNK(second.st_mode) or not stat.S_ISREG(second.st_mode):
+        raise SettingsError("settings snapshot changed during read")
+    if (
+        len(raw) > MAX_SETTINGS_BYTES
+        or first.st_dev != second.st_dev
+        or first.st_ino != second.st_ino
+        or first.st_size != second.st_size
+        or first.st_mtime_ns != second.st_mtime_ns
+    ):
+        raise SettingsError("settings snapshot changed during read")
+    return raw, hashlib.sha256(raw).hexdigest()[:32]
+
+
+def read_settings(agent: Any, tool_name: str) -> SettingsSnapshot:
+    """Reread and strictly validate one tool's placeholder settings snapshot.
+
+    Missing is a normal placeholder state.  A valid file contributes only its
+    source/revision/hash evidence; it never changes behavior.  Every invocation
+    performs a fresh filesystem read and does not cache a prior snapshot.
+    """
+    path = settings_path(agent, tool_name)
+    digest: str | None = None
+    try:
+        raw, revision = _read_stable(path)
+        if revision == "missing":
+            return SettingsSnapshot("missing", "missing", None)
+        digest = revision
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        if not isinstance(value, dict) or set(value) != {"schema_version"}:
+            raise SettingsError("settings schema must contain only schema_version")
+        if type(value["schema_version"]) is not int or value["schema_version"] != SETTINGS_SCHEMA_VERSION:
+            raise SettingsError("settings schema_version must be integer 1")
+        return SettingsSnapshot(f"settings/{tool_name}.json", revision, digest)
+    except (OSError, UnicodeError, json.JSONDecodeError, SettingsError) as exc:
+        # Malformed data is never silently converted to the missing state.  The
+        # digest from a bounded stable read is retained as evidence when safe.
+        return SettingsSnapshot(
+            "settings_error",
+            digest or "error",
+            digest,
+            _bounded_error(exc if isinstance(exc, Exception) else SettingsError("invalid settings")),
+        )
+
+
+def current_setting(snapshot: SettingsSnapshot, tool_name: str) -> dict[str, Any]:
+    """Build the bounded, secret-free current-setting diagnostic for a tool."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return_value: dict[str, Any] = {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": snapshot.source,
+        "settings_revision": snapshot.revision,
+        "settings_hash": snapshot.digest,
+        "change_hint": (
+            f"Edit settings/{tool_name}.json; changes apply on the next {tool_name} "
+            "call; this no-op placeholder never changes tool behavior."
+        ),
+    }
+    if snapshot.error:
+        return_value["settings_error"] = snapshot.error
+    return return_value

--- a/src/lingtai/tools/grep/ANATOMY.md
+++ b/src/lingtai/tools/grep/ANATOMY.md
@@ -1,0 +1,59 @@
+---
+related_files:
+  - src/lingtai/tools/ANATOMY.md
+  - src/lingtai/tools/grep/__init__.py
+  - src/lingtai/tools/grep/CONTRACT.md
+  - src/lingtai/tools/grep/glossary-en.md
+  - src/lingtai/tools/grep/glossary-zh.md
+  - src/lingtai/tools/grep/glossary-wen.md
+  - src/lingtai/tools/_file_paths.py
+  - src/lingtai/tools/_manual.py
+  - src/lingtai/tools/_settings.py
+  - src/lingtai/services/file_io.py
+  - src/lingtai/intrinsic_skills/file-manual/SKILL.md
+  - tests/test_grep_action_input.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files and keep this anatomy
+  connected to src/lingtai/tools/ANATOMY.md. The public grep schema and examples
+  are canonical action/input calls; do not reintroduce flat or omitted-action
+  compatibility. If source and anatomy drift, report and repair both.
+---
+# src/lingtai/tools/grep/
+
+The public `grep` capability searches text by regular expression through the
+injected `FileIOService`. Its migration-owned surface is a closed root object
+with required `action` and `input`; `BaseAgent` adds only optional root
+`reasoning` for model-facing calls.
+
+## Components
+
+- `__init__.py` — owns `get_schema`, `get_description`, registration, strict
+  action/input validation, manual dispatch, settings evidence, FileIO mapping,
+  and traversal-stat projection.
+- `CONTRACT.md` — canonical public contract, provider envelope boundaries,
+  settings placeholder evidence, and verification matrix.
+- `glossary-*.md` — concise terminology resources; English remains empty and
+  localized bodies name canonical identifiers only.
+- `intrinsic_skills/file-manual/SKILL.md` — installed shared file guide; grep
+  examples use `action`, nested `input`, and visible Agent-injected `reasoning`.
+
+## Public shape
+
+Ordinary calls use
+`{"action":"grep","input":{"pattern":"...","path":"...","glob":"*.py","max_matches":200,"summary":false},"reasoning":"..."}`.
+Manual calls use
+`{"action":"manual","input":{},"reasoning":"..."}`. `input.summary` is
+an exact-boolean orchestration hint consumed by `ToolExecutor`, not a FileIO
+setting. Flat fields, omitted action/input, unknown keys, and root summary are
+not public grep compatibility.
+
+## Connections and invariants
+
+`setup()` registers the handler on `Agent`; relative input paths resolve against
+`agent._working_dir`. `LocalFileIOService.grep` owns regex matching, basename
+glob pruning before reads, traversal budgets, size/binary skips, and match
+ordering. `read_settings` rereads only the Agent-owned v1 no-op placeholder and
+`current_setting` reports bounded secret-free evidence; it never supplies grep
+behavior. Provider adapters preserve named schema envelopes: Chat
+`function.parameters`, Responses `parameters`, Anthropic `input_schema`, and
+internal `FunctionSchema.parameters`.

--- a/src/lingtai/tools/grep/CONTRACT.md
+++ b/src/lingtai/tools/grep/CONTRACT.md
@@ -1,147 +1,184 @@
 ---
 name: grep-contract
 tool: grep
-contract_version: 2
+contract_version: 3
 related_files:
   - src/lingtai/tools/grep/__init__.py
+  - src/lingtai/tools/grep/ANATOMY.md
   - src/lingtai/tools/_file_paths.py
+  - src/lingtai/tools/_settings.py
+  - src/lingtai/services/file_io.py
   - src/lingtai/services/file_io_sidecar.py
   - src/lingtai/intrinsic_skills/file-manual/SKILL.md
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
-  contract disagree, the code is the source of truth — fix the contract in the
-  same change and bump contract_version on breaking contract edits.
+  contract disagree, the code is the source of truth; fix both in one change and
+  bump contract_version on breaking public edits.
 ---
 
 # Grep capability contract
 
-`grep` searches file contents by regex under a search root, pushing the glob
-filter into the injected `FileIOService` (`agent._file_io.grep`) so excluded files
-are pruned before read. The implementation lives in `src/lingtai/tools/grep/__init__.py`;
-the code is the source of truth.
+`grep` searches file contents by regex under a search root, pushing the basename
+`glob` filter into the injected `FileIOService` (`agent._file_io.grep`) so
+excluded files are pruned before read. The implementation lives in
+`src/lingtai/tools/grep/__init__.py`; the code is the source of truth.
 
 ## Routing Card
 
 **Use this when:**
-- You are editing the grep wrapper's argument handling, its glob-filter
-  pass-through, or the truncation / traversal-stats surfacing (Issue #164).
-- You need the exact match shape and how the `truncated` signal is computed.
+- Editing the closed action/input routing, strict validation, or settings
+  diagnostic for the grep wrapper.
+- Reviewing glob-filter pass-through or truncation/traversal-stat surfacing.
 
 **Do not use this for:**
 - Finding files by name/pattern: read `src/lingtai/tools/glob/CONTRACT.md`.
-- Reading a specific file: read `src/lingtai/tools/read/CONTRACT.md`.
-- The regex engine, traversal budgets, or size/binary skips: those live in
+- Reading one file: read `src/lingtai/tools/read/CONTRACT.md`.
+- Regex engine, traversal budgets, or size/binary skips: read
   `src/lingtai/services/file_io.py` / `file_io_sidecar.py`.
 
-**Fast paths:** tool schema -> §Tool surface; match shape & `truncated` ->
-§Tool surface; glob-filter semantics -> §Tool surface.
+**Fast paths:** schema and routing → §Tool surface; settings evidence → §Settings;
+match shape and truncation → §Tool surface; FileIO semantics → §Cross-platform
+invariants.
 
 ## Scope
 
 - Canonical tool name: `grep`.
 - Registered via `capabilities=["grep"]` or the `file` sugar.
-- Non-goals: no file writes, no filename-only search, no context lines beyond the
-  matched line. Returns matching `{file, line, text}` records.
+- Non-goals: no file writes, no filename-only search, and no context lines beyond
+  matched lines. Returns `{file, line, text}` records.
+- Public compatibility with omitted `action`, omitted `input`, flat arguments, and
+  aliases is intentionally removed.
 
 ## Tool surface
 
-`handle_grep` has two modes:
+The raw tool-owned schema is a closed root object with exactly the required root
+keys `action` and `input`. `BaseAgent` alone adds optional root `reasoning` to the
+model-facing schema; the executor may pass that same metadata to the direct
+handler as `_reasoning`. Neither metadata field enters `input` or FileIO.
 
-- **Ordinary:** omit `action` (backward compatible) or set
-  `action="grep"`; both forms run the same grep operation.
-- **Manual:** `action="manual"` returns the installed `file-manual` without
-  attempting to search file content.
+`action` is exactly one of `grep` and `manual`, and `input` is a closed,
+action-specific object:
 
-The schema lists `grep` before `manual`. Any other explicit action
-returns a plain error before file I/O. After a manual response, the caller
-continues the original task with an ordinary call rather than repeating the
-manual.
+- **Ordinary:**
+  `{"action":"grep","input":{"pattern":"TODO","path":"src","glob":"*.py","max_matches":200,"summary":false},"reasoning":"find pending Python TODOs"}`
+  searches under the agent workdir by default. `input.pattern` is a non-empty
+  regex string; `input.path` is an optional file/directory root; `input.glob` is
+  an optional basename filter defaulting to `"*"`; `input.max_matches` defaults
+  to `200`; and nested `input.summary` is an exact-boolean a-priori summary
+  control defaulting to `false`.
+- **Manual:**
+  `{"action":"manual","input":{},"reasoning":"load the installed file guide"}`
+  returns the real installed `file-manual` body and path without searching.
 
-The tool-facing names differ from the service kwargs: the schema exposes
-`glob` and `max_matches`, which the handler maps to the service's
-`glob_filter` and `max_results`.
+The raw schema has no root `reasoning` property; BaseAgent's model-facing schema
+adds it without changing the root required list. No flat arguments, omitted
+`action`/`input`, unknown keys, compatibility aliases, malformed/non-mapping
+payloads, or unhashable action values are accepted. These errors are returned
+before target FileIO.
 
-| Call | Required inputs | Optional inputs | Success output | Error shapes |
+| Call | Required inputs | Optional inputs | Success output | Error shape |
 |---|---|---|---|---|
-| `grep` | `pattern: string` | `path: string` (defaults to `agent._working_dir`), `glob: string` (default `"*"`), `max_matches: int` (default 200), `summary: bool` (default false) | `{matches: [{file, line, text}], count, truncated}` plus traversal fields when the walk was cut short | see below |
+| `grep` | `input.pattern: string` | `input.path: string`, `input.glob: string` (default `"*"`), `input.max_matches: integer` (default `200`), `input.summary: boolean` (default `false`) | `{matches: [{file, line, text}], count, truncated}` plus traversal fields when partial, and `current_setting` | `{status: "error", message: "...", current_setting}` |
+| `manual` | empty `input` | none | installed manual result plus `current_setting` | same settings-bearing error envelope if loading fails |
 
-Glob-filter semantics: `glob` values `None`, `""`, or `"*"` mean "no filter"
-(the handler passes `glob_filter=None`); any other value is pushed into the
-service so non-matching files are pruned before stat/read. `truncated` is `true`
-when the (already glob-pruned) scan returned at least `max_matches` results, and
-is additionally forced `true` (with `truncated_reason` and a `traversal` block of
-`{visited, elapsed_ms, dirs_pruned, files_skipped_size, files_skipped_binary}`)
-when the service's `last_traversal.truncated_reason` is set.
+Nested `input.summary=true` is orchestration metadata only. The handler still
+performs the ordinary search; `ToolExecutor` logs the raw result first and then
+may replace what the model sees with a reasoning-guided summary. It never changes
+path, regex, glob filtering, max-match behavior, or returned raw fields. Root
+`summary` is not in the canonical schema and is never a summary opt-in.
 
-**Error shapes** (plain dicts, not exceptions):
-- `{"status": "error", "message": "pattern is required"}` — empty/missing pattern.
-- `{"status": "error", "message": "Grep failed: <exc>"}` — any search error.
+`glob` values `"*"` and `""` mean no basename filter and are passed to FileIO as
+`None`; any other string is passed as `glob_filter`. `truncated` is true when the
+service returns at least `max_matches` records, and is also forced true when the
+service reports a traversal truncation reason. In the latter case the result
+carries `truncated_reason` and `traversal` with `visited`, `elapsed_ms`,
+`dirs_pruned`, `files_skipped_size`, and `files_skipped_binary`.
+
+## Settings
+
+Every invocation rereads the strict Agent-owned `settings/grep.json` placeholder
+before validating, loading the manual, resolving a path, or calling FileIO. The
+only valid file content is the JSON object `{"schema_version": 1}`. This v1
+placeholder is metadata-only: it selects no backend, regex mode, filter, cap,
+manual, or other behavior. There are no fabricated grep settings or options.
+
+Every success, manual, malformed-input, and FileIO-error result carries a fresh,
+secret-free `current_setting` snapshot. It truthfully reports `source` as
+`missing`, `settings/grep.json`, or `settings_error`; a bounded
+`settings_revision` and `settings_hash`; `configurable: false`, `placeholder:
+"no-op"`, and a `change_hint` naming `settings/grep.json`. Invalid files carry
+only a bounded `settings_error`; settings contents, secrets, and absolute host
+paths are never disclosed. Changing a valid file changes only this diagnostic,
+not grep behavior or prompt/schema text.
+
+## Error shapes
+
+All public errors are plain dictionaries, never raised by the handler:
+
+- Missing/empty pattern: `{"status":"error","message":"pattern is required",...}`.
+- Wrong root/input/action/field/type: a strict routing/type message with
+  `current_setting`; no target FileIO call has occurred.
+- Search/path failure: `{"status":"error","message":"Grep failed: <exc>",...}`.
 
 ## State & storage
 
 None owned. `grep` is read-only over the filesystem and holds no persistent state.
-It reads `agent._file_io.last_traversal` only to surface truncation metadata.
+It reads `agent._file_io.last_traversal` only to surface service statistics and
+rereads the Agent-owned settings placeholder per invocation.
 
 ## Cross-platform invariants
 
-Do not change any of the following; documented for reviewers only.
+Do not change these source-truth behaviors:
 
-- **Path handling:** relative `path` (search root) is resolved against
-  `agent._working_dir` via `resolve_workdir_path` (`src/lingtai/tools/_file_paths.py`);
-  absolute roots pass through unchanged. Default root is the workdir.
-- **Sidecar resolution:** recursive `grep` is one of the two operations routed
-  through the Rust search sidecar when present; `default_file_io_service`
-  autodiscovers a packaged/dev-tree binary and soft-falls back to the Python
-  backend (see `src/lingtai/services/file_io_sidecar.py` resolution order). Both
-  backends share traversal / size / exclusion defaults.
-- **Encoding / skips:** oversized and binary files are skipped by the service and
-  counted in `files_skipped_size` / `files_skipped_binary`.
+- **Path handling:** relative `input.path` resolves against `agent._working_dir`
+  through `resolve_workdir_path`; absolute roots pass through unchanged. The
+  default root is the workdir.
+- **FileIO routing:** all searches use the injected `FileIOService`; the optional
+  Rust sidecar and Python backend share the public contract.
+- **Filter ordering:** non-matching basenames are pruned before stat/read by the
+  service; the wrapper does not post-filter results.
+- **Encoding/skips:** UTF-8 text is searched; oversized and binary/unreadable
+  files are skipped and counted in traversal stats.
+- **Ordering and shape:** the service owns match ordering; the wrapper maps each
+  result to `{"file": path, "line": line_number, "text": line}` unchanged.
 
 ## Anchored claims
 
-| Claim | Source `src/lingtai/tools/grep/...` | Test |
+| Claim | Source | Focused validation |
 |---|---|---|
-| Grep returns matching lines through the capability | `__init__.py` (`handle_grep`) | `tests/test_layers_file.py::test_grep_via_capability` |
-| Grep failures return a `{status: error}` dict | `__init__.py` (`handle_grep`) | `tests/test_layers_file.py::test_grep_error_shape` |
-| The glob filter prunes non-matching files before read | `__init__.py` (`handle_grep`, `service_glob`) | `tests/test_services_file_io.py::TestFileIOService::test_glob_filter_via_tool_wrapper_prunes_before_read` |
-| `max_matches` caps results at the service layer | `__init__.py` (`max_matches` → `max_results`) | `tests/test_services_file_io.py::TestFileIOService::test_grep_max_results` |
-| Grep routes through the injected FileIOService | `__init__.py` (`handle_grep`) | `tests/test_layers_file.py::test_file_capability_uses_file_io_service` |
+| Raw schema is closed action/input and has ordinary/manual branches | `__init__.py:get_schema` | `tests/test_grep_action_input.py` |
+| BaseAgent adds only root reasoning | `kernel/base_agent/tools.py` + grep schema | focused Agent schema test |
+| Provider envelopes preserve named parameters/input_schema | provider adapters + `FunctionSchema` | focused envelope test |
+| Description, prompt section, and installed manual show canonical reasoning examples | `get_description`, file manual | focused prompt/manual test |
+| Malformed and unhashable calls fail before FileIO | `handle_grep` | strict handler test |
+| Real LocalFileIO regex/filter/skip/error semantics remain source-truth | `services/file_io.py` | LocalFileIO focused test |
+| Settings are reread, strict, secret-free, and behavior/prompt invariant | `_settings.py`, `handle_grep` | settings focused test |
+| Nested summary is raw-first; root summary is rejected/ignored | `tool_result_summary.py`, executor | serial/parallel summary tests |
 
 ## Verification matrix
 
-| Invariant | Automated test | Manual check | Risk if broken |
-|---|---|---|---|
-| Regex matching returns expected lines | `tests/test_layers_file.py::test_grep_via_capability` | `grep` a known token under a tree | Missed or spurious matches |
-| Glob filter prunes before read | `tests/test_services_file_io.py::TestFileIOService::test_glob_filter_via_tool_wrapper_prunes_before_read` | `grep` with `glob="*.py"` on a mixed tree | Wasted reads / wrong scope |
-| `max_matches` cap and `truncated` flag | `tests/test_services_file_io.py::TestFileIOService::test_grep_max_results` | `grep` a common token with a low `max_matches` | Callers assume results are complete |
-| Oversized / binary files skipped | `tests/test_services_file_io.py::TestFileIOService::test_grep_skips_oversized_files` | `grep` a tree with a large binary | Budget exhaustion / crashes |
-| Grep routes through FileIOService | `tests/test_layers_file.py::test_file_capability_uses_file_io_service` | Boot with `capabilities=["grep"]` and confirm `agent._file_io` is used | Sidecar/backend selection bypassed |
+| Invariant | Validation | Risk if broken |
+|---|---|---|
+| Exact-candidate imports and filenames are used | `sys.path.insert(0, candidate/src)` plus `__file__` assertions | sibling source accidentally tested |
+| Provider schema boundaries remain stable | Chat, Responses, Anthropic envelope assertions | provider drift or nested reasoning leak |
+| Local search preserves regex/filter/truncation/error behavior | actual `LocalFileIOService` tree and invalid regex calls | incorrect matches or hidden partial results |
+| Strict calls do not touch FileIO | recording service and malformed/unhashable inputs | malformed model calls read files |
+| Settings missing/valid/hot/invalid are truthful and inert | retained workspaces and sentinel nonleak checks | secret leakage or fabricated behavior |
+| Summary semantics are nested, exact, raw-first, and tool-error bypassed | retained serial/parallel executor calls | raw loss, wrong summary, or error masking |
 
-Run before merging:
-
-```bash
-python -m pytest tests/test_layers_file.py tests/test_services_file_io.py -q
-```
+Use direct `unittest` or retained harnesses for this candidate. Do not use pytest,
+bytecode compilation, automatic cleanup, or temporary-file lifecycles.
 
 ## Schema and glossary ownership
 
-- **Canonical identifiers:** function names, JSON property names, action/enum
-  values, required fields, defaults, and bounds are canonical English literals.
-  The schema (`get_schema()`) and description (`get_description()`) are
-  language-independent; the optional `lang` argument is accepted for source
-  compatibility but ignored.
-- **Provider wire:** provider adapters send the global `WIRE_TOOL_DESCRIPTION`
-  constant as the top-level tool description; `FunctionSchema.description`
-  holds the full canonical prose rendered into `## tools`.
-- **Glossary resources:** this package owns `glossary-en.md`, `glossary-zh.md`,
-  and `glossary-wen.md`. Each has strict YAML frontmatter
-  (`kind: tool-glossary`, `schema_version: 1`, `tool_package: tools.<pkg>`,
-  `language: <lang>`). English body is empty; zh/wen bodies contain concise
-  terminology mappings that quote immutable English identifiers and never offer
-  localized aliases.
-- **Fallback:** exact normalized language lookup, then English, then no
-  appendix. Fail-closed for localized text; fail-open for tool availability.
-- **Update triggers:** changing a function name, action/enum value, property
-  name, or user-visible concept requires reviewing all three glossary files in
-  the same PR.
-- **Validation:** `python -m lingtai.tools.glossary_validator --check`.
+- Canonical identifiers, property names, action values, required fields, and
+  defaults are English literals owned by `get_schema()` and this contract.
+- Provider adapters preserve named envelopes: Chat uses
+  `function.parameters`, Responses uses `parameters`, Anthropic uses
+  `input_schema`, and internal `FunctionSchema` uses `parameters`.
+- This package owns `glossary-en.md`, `glossary-zh.md`, and `glossary-wen.md`.
+  English body remains empty; zh/wen provide concise terminology mappings only.
+- The shared installed `file-manual` is the manual returned by grep; grep-owned
+  examples in it use canonical nested input and visibly include root reasoning.
+- Validate glossary resources with `python -m lingtai.tools.glossary_validator --check`
+  when performing the parent validation (without pytest).

--- a/src/lingtai/tools/grep/__init__.py
+++ b/src/lingtai/tools/grep/__init__.py
@@ -4,76 +4,214 @@ Usage: Agent(capabilities=["grep"]) or capabilities=["file"]
 """
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from .._file_paths import resolve_workdir_path
 from .._manual import load_installed_manual
+from .._settings import current_setting, read_settings
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
 
 
+_SUMMARY_DESCRIPTION = (
+    "Optional. Default false. When true, the raw result is preserved in the "
+    "durable log and replaced before entering context by a reasoning-guided "
+    "summary; set it only when exact matches are not needed."
+)
+_ACTION_FIELDS = {
+    "grep": ("pattern", "path", "glob", "max_matches", "summary"),
+    "manual": (),
+}
+_ALLOWED_ROOT_FIELDS = ("action", "input", "reasoning", "_reasoning")
+
+
 def get_description(lang: str = "en") -> str:
-    return "Search file contents for lines matching a regex pattern. Normal searches are the primary operation: omit action for the legacy ordinary call or use action='grep' explicitly. Returns matching lines with file path and line number. Searches recursively when given a directory. Use the glob filter to narrow to specific file types. Use action='manual' once to return the installed file-manual skill; after the manual result, continue the original ordinary grep instead of repeating manual, because repeated identical manual calls are an error loop."
+    return (
+        "Search file contents for lines matching a regex pattern. Use grep(action='grep', "
+        "input={'pattern': '...', 'path': '...', 'glob': '*.py', "
+        "'max_matches': 200, 'summary': False}, reasoning='...') for an ordinary "
+        "search; input.path defaults to the agent workdir, input.glob filters "
+        "basenames before reads, and input.max_matches caps returned matches. "
+        "Results contain file path, line number, and matched text, with traversal "
+        "metadata when the scan is truncated. Load the installed guide once with "
+        "grep(action='manual', input={}, reasoning='...'); after the manual result, "
+        "continue with the canonical ordinary grep call instead of repeating manual."
+    )
 
 
 def get_schema(lang: str = "en") -> dict:
+    """Return the raw closed action/input schema.
+
+    ``BaseAgent`` adds the optional root ``reasoning`` property when it builds
+    the model-facing schema. Reasoning is metadata, not nested grep input.
+    """
     return {
         "type": "object",
         "properties": {
-            "action": {"type": "string", "enum": ["grep", "manual"], "description": "Omit action for the legacy ordinary grep, use action='grep' for an explicit ordinary search, or use action='manual' once for the installed file-manual skill."},
-            "pattern": {"type": "string", "description": "Regex pattern to search for. Required for ordinary searches; omit for action='manual'."},
-            "path": {"type": "string", "description": 'File or directory to search in'},
-            "glob": {"type": "string", "description": "File glob filter (e.g., '*.py')", "default": "*"},
-            "max_matches": {"type": "integer", "description": 'Maximum matches to return', "default": 200},
-            "summary": {"type": "boolean", "description": 'Optional. Default false. When true, this tool runs normally and the raw result is preserved in the durable log (retrievable by tool_call_id), but before the result enters your context it is replaced by an LLM-generated summary driven by your `reasoning` field — so make `reasoning` specific about what to retain. Set true only when the output is expected to be large (>10k chars) and you do NOT need the exact raw text. Leave false when you need exact line/file/diff/stderr text. The summary is non-canonical; if the raw exceeds 500,000 chars no summary is generated and you get a refusal pointing at the preserved raw.', "default": False},
+            "action": {
+                "type": "string",
+                "enum": ["grep", "manual"],
+                "description": "Required operation: search content or return the installed manual.",
+            },
+            "input": {
+                "description": "Strict action-specific grep or manual input.",
+                "anyOf": [
+                    {
+                        "title": "grep input",
+                        "type": "object",
+                        "properties": {
+                            "pattern": {
+                                "type": "string",
+                                "description": "Regular expression pattern to search for.",
+                            },
+                            "path": {
+                                "type": "string",
+                                "description": "File or directory to search; defaults to the agent workdir.",
+                            },
+                            "glob": {
+                                "type": "string",
+                                "description": "Basename glob filter applied before reads.",
+                                "default": "*",
+                            },
+                            "max_matches": {
+                                "type": "integer",
+                                "description": "Maximum matching lines to return.",
+                                "default": 200,
+                            },
+                            "summary": {
+                                "type": "boolean",
+                                "description": _SUMMARY_DESCRIPTION,
+                                "default": False,
+                            },
+                        },
+                        "required": ["pattern"],
+                        "additionalProperties": False,
+                    },
+                    {
+                        "title": "manual input",
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                        "additionalProperties": False,
+                    },
+                ],
+            },
         },
-        "required": [],
+        "required": ["action", "input"],
+        "additionalProperties": False,
     }
 
+
+def _with_setting(result: Mapping[str, Any], diagnostic: dict[str, Any]) -> dict[str, Any]:
+    """Attach one fresh, secret-free settings diagnostic to a public result."""
+    value = dict(result)
+    value["current_setting"] = dict(diagnostic)
+    return value
 
 
 def setup(agent: "BaseAgent") -> None:
     """Set up the grep capability on an agent."""
 
-    def handle_grep(args: dict) -> dict:
-        action = args.get("action")
-        if action == "manual":
-            return load_installed_manual(agent, "file-manual")
-        if action is not None and action != "grep":
-            return {"status": "error", "message": f"Unsupported action for grep: {action!r}"}
-        pattern = args.get("pattern", "")
-        if not pattern:
-            return {"status": "error", "message": "pattern is required"}
-        search_path = args.get("path", str(agent._working_dir))
-        search_path = resolve_workdir_path(agent, search_path)
-        max_matches = args.get("max_matches", 200)
-        glob_filter = args.get("glob", "*")
+    def handle_grep(args: Any) -> dict:
+        # Settings are evidence only, but are reread before every operation,
+        # including malformed and manual calls. No FileIO operation occurs
+        # before the canonical action/input checks below.
+        snapshot = read_settings(agent, "grep")
+        diagnostic = current_setting(snapshot, "grep")
+
+        def error(message: str) -> dict:
+            return _with_setting({"status": "error", "message": message}, diagnostic)
+
+        if not isinstance(args, Mapping):
+            return error("grep arguments must be an object")
         try:
-            # Push the glob filter into the service so excluded files are
-            # pruned *before* stat / read, instead of scanning every file
-            # under the search root and post-filtering the matches. ``"*"``
-            # is the schema default and means "no filter".
-            service_glob = None if glob_filter in (None, "", "*") else glob_filter
+            root_keys = list(args.keys())
+        except Exception:
+            return error("grep arguments must be an object")
+        if any(not isinstance(key, str) or key not in _ALLOWED_ROOT_FIELDS for key in root_keys):
+            return error("grep accepts only root action, input, reasoning, and _reasoning")
+        if "action" not in root_keys or "input" not in root_keys:
+            return error("grep requires root action and input")
+
+        try:
+            action = args["action"]
+            raw_input = args["input"]
+        except Exception:
+            return error("grep arguments are malformed")
+        if type(action) is not str or action not in _ACTION_FIELDS:
+            return error(f"Unsupported action for grep: {action!r}")
+
+        if not isinstance(raw_input, Mapping):
+            return error("grep input must be an object")
+        try:
+            action_input = dict(raw_input)
+        except Exception:
+            return error("grep input must be an object")
+        if any(not isinstance(key, str) for key in action_input):
+            return error("grep input field names must be strings")
+        allowed_fields = _ACTION_FIELDS[action]
+        if any(key not in allowed_fields for key in action_input):
+            return error(f"unsupported grep input field for action {action!r}")
+
+        if action == "manual":
+            if action_input:
+                return error("manual input must be an empty object")
+            try:
+                manual = load_installed_manual(agent, "file-manual")
+            except Exception as exc:
+                return error(f"Grep manual failed: {exc}")
+            return _with_setting(manual, diagnostic)
+
+        if "pattern" not in action_input:
+            return error("pattern is required")
+        pattern = action_input["pattern"]
+        if not isinstance(pattern, str):
+            return error("pattern must be a string")
+        if not pattern:
+            return error("pattern is required")
+
+        if "path" in action_input and not isinstance(action_input["path"], str):
+            return error("path must be a string")
+        if "glob" in action_input and not isinstance(action_input["glob"], str):
+            return error("glob must be a string")
+        if "max_matches" in action_input and type(action_input["max_matches"]) is not int:
+            return error("max_matches must be an integer")
+        if "summary" in action_input and type(action_input["summary"]) is not bool:
+            return error("summary must be a boolean")
+
+        search_path = action_input.get("path", str(agent._working_dir))
+        glob_filter = action_input.get("glob", "*")
+        max_matches = action_input.get("max_matches", 200)
+        try:
+            search_path = resolve_workdir_path(agent, search_path)
+        except Exception as exc:
+            return error(f"Grep failed: {exc}")
+
+        try:
+            # Push the basename glob into the service so excluded files are
+            # pruned before stat / read, instead of scanning every file under
+            # the search root and post-filtering the matches. ``*`` (and the
+            # empty string, as owned by the source service) means no filter.
+            service_glob = None if glob_filter in ("", "*") else glob_filter
             raw_results = agent._file_io.grep(
                 pattern,
                 path=search_path,
                 max_results=max_matches,
                 glob_filter=service_glob,
             )
-            matches = [{"file": r.path, "line": r.line_number, "text": r.line} for r in raw_results]
-            # truncated: true when the (already glob-pruned) scan hit its
-            # cap — there may be more matching files beyond what was
-            # scanned.
-            truncated = len(raw_results) >= max_matches
+            matches = [
+                {"file": result.path, "line": result.line_number, "text": result.line}
+                for result in raw_results
+            ]
             result: dict[str, Any] = {
                 "matches": matches,
                 "count": len(matches),
-                "truncated": truncated,
+                "truncated": len(raw_results) >= max_matches,
             }
-            # Issue #164: surface traversal budget / exclusion info so the
-            # LLM can react to partial results instead of treating them
-            # as definitive ("no matches found anywhere").
+            # Surface traversal budget / exclusion metadata so partial results
+            # are not mistaken for a definitive search result.
             stats = getattr(agent._file_io, "last_traversal", None)
             if stats is not None and stats.truncated_reason is not None:
                 result["truncated"] = True
@@ -85,8 +223,14 @@ def setup(agent: "BaseAgent") -> None:
                     "files_skipped_size": stats.files_skipped_size,
                     "files_skipped_binary": stats.files_skipped_binary,
                 }
-            return result
-        except Exception as e:
-            return {"status": "error", "message": f"Grep failed: {e}"}
+            return _with_setting(result, diagnostic)
+        except Exception as exc:
+            return error(f"Grep failed: {exc}")
 
-    agent.add_tool("grep", schema=get_schema(), handler=handle_grep, description=get_description(), glossary_package=__package__)
+    agent.add_tool(
+        "grep",
+        schema=get_schema(),
+        handler=handle_grep,
+        description=get_description(),
+        glossary_package=__package__,
+    )

--- a/src/lingtai/tools/grep/glossary-wen.md
+++ b/src/lingtai/tools/grep/glossary-wen.md
@@ -15,9 +15,12 @@ maintenance: |
 ---
 **名相对照**
 
-- `grep`：以正则式搜寻文中之字。返匹配之行及其文卷路径与行号。对目录递归搜寻。以 glob 过滤器限定文卷类型。
+- `grep`：以正则式搜寻文中之字；其公开调用以严整 `action` 与内嵌 `input` 为式。
+- `action`：择 `grep` 普通搜寻，或 `manual` 已装之手册。
+- `input`：普通输入之主，含 `pattern`、`path`、`glob`、`max_matches`，及内嵌 `summary`。
+- `reasoning`：Agent 所注之根级调用理由；非 `input` 所有，亦不入 FileIO。
 - `pattern`：欲搜之正则式
 - `path`：欲搜之文卷或目录
 - `glob`：文卷 glob 过滤器（如'*.py'）
 - `max_matches`：至多返回之匹配数
-- `summary`：可选。默认 false。设 true 时，此 tool 照常运行，原始结果完存于持久日志（可凭 tool_call_id 取回）；然结果入尔上下文前，先以尔 `reasoning` 字段所驱之 LLM 摘要代之——故 `reasoning` 当明言所欲存者。唯料输出甚巨（逾一万字符）且无需精确原文时，方设 true。需精确之行/文件/diff/stderr 原文者，留 false。摘要非权威；原始结果逾五十万字符，则不生摘要，尔得一拒辞，指向所存之原始结果。
+- `summary`：`input` 中之精确布尔摘要控；默认 false。

--- a/src/lingtai/tools/grep/glossary-zh.md
+++ b/src/lingtai/tools/grep/glossary-zh.md
@@ -15,9 +15,12 @@ maintenance: |
 ---
 **术语对照**
 
-- `grep`：在文件内容中搜索匹配正则表达式的行。返回匹配行及其文件路径和行号。对目录进行递归搜索。使用 glob 过滤器限定特定文件类型。
+- `grep`：在文件内容中搜索匹配正则表达式的行；其公开调用采用严格的 `action` 与嵌套 `input`。
+- `action`：选择 `grep` 普通搜索或 `manual` 已安装手册。
+- `input`：拥有 `pattern`、`path`、`glob`、`max_matches` 与嵌套 `summary` 的普通输入对象。
+- `reasoning`：由 Agent 注入的根级调用理由；不属于 `input`，也不送入 FileIO。
 - `pattern`：要搜索的正则表达式模式
 - `path`：要搜索的文件或目录
 - `glob`：文件 glob 过滤器（例如 '*.py'）
 - `max_matches`：最大返回匹配数
-- `summary`：可选。默认 false。为 true 时，该 tool 照常执行，原始结果会完整保存到持久日志（可按 tool_call_id 取回），但在结果进入你的上下文之前，会被一段由你的 `reasoning` 字段驱动的 LLM 生成摘要替换——所以请在 `reasoning` 中明确说明要保留什么。仅当预期输出很大（>10k 字符）且你不需要精确原文时才设为 true。需要精确的行/文件/diff/stderr 原文时请保持 false。摘要非权威；若原始结果超过 500,000 字符则不生成摘要，你会收到一条指向已保存原始结果的拒绝信息。
+- `summary`：`input` 内的精确布尔摘要控制；默认 false。

--- a/tests/test_apriori_summary_executor.py
+++ b/tests/test_apriori_summary_executor.py
@@ -21,10 +21,12 @@ from lingtai.kernel.tool_executor import ToolExecutor
 from lingtai.kernel.tool_result_summary import (
     APRIORI_SUMMARY_CAP,
     APRIORI_SUMMARY_MARKER,
+    summary_requested,
 )
 
 
-def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
+def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path,
+                   parallel_safe_tools=None):
     """Construct a ToolExecutor that records durable log events into *events*."""
 
     def logger_fn(event_type, **fields):
@@ -43,6 +45,7 @@ def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
         logger_fn=logger_fn,
         working_dir=tmp_path,
         summarizer_fn=summarizer_fn,
+        parallel_safe_tools=parallel_safe_tools or set(),
     )
 
 
@@ -64,6 +67,14 @@ def _event_fields(events, event_type):
     for et, fields in events:
         if et == event_type:
             return fields
+    return None
+
+
+def _event_index(events, event_type, *, tool_call_id):
+    """Return the first matching event index for ordering assertions."""
+    for index, (et, fields) in enumerate(events):
+        if et == event_type and fields.get("tool_call_id") == tool_call_id:
+            return index
     return None
 
 
@@ -161,6 +172,274 @@ def test_summary_true_under_cap_replaces_with_summary_and_preserves_raw(tmp_path
     assert gen["tool_call_id"] == "t3"
     assert gen["tool_name"] == "bash"
     assert "RAWSECRET" not in str(gen)
+
+
+def test_summary_requested_uses_input_presence_precedence_and_exact_bool():
+    """Canonical input wins; only a literal bool True opts in."""
+    assert summary_requested({"summary": True}) is True  # legacy compatibility
+    assert summary_requested({"input": {"summary": True}, "summary": False}) is True
+
+    # Once input is present, root summary is never a fallback, including when
+    # nested summary is absent, false, malformed, or input is not an object.
+    nested_values = [False, 1, "true", None, {}, []]
+    for nested in nested_values:
+        assert summary_requested({"input": {"summary": nested}, "summary": True}) is False
+    assert summary_requested({"input": {}, "summary": True}) is False
+    for malformed_input in (None, [], "payload", 1):
+        assert summary_requested({"input": malformed_input, "summary": True}) is False
+
+    # Legacy mode has the same exact-boolean rule and does not mutate args.
+    for root in (False, 1, "true", None, {}, []):
+        assert summary_requested({"summary": root}) is False
+    original = {"input": {"summary": True}, "summary": "ignored"}
+    snapshot = {"input": dict(original["input"]), "summary": original["summary"]}
+    assert summary_requested(original) is True
+    assert original == snapshot
+
+
+def test_nested_summary_true_serial_preserves_reasoning_and_raw_first(tmp_path):
+    raw = {"stdout": "NESTED-SERIAL-RAW"}
+    nested_input = {"command": "echo nested", "summary": True}
+    call_args = {
+        "input": nested_input,
+        "summary": False,  # root is ignored in canonical mode
+        "reasoning": "Retain the nested serial marker",
+    }
+    seen = {}
+    events = []
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen["prompt"] = user_prompt
+        return "NESTED-SERIAL-SUMMARY"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute(
+        [ToolCall(name="bash", args=call_args, id="nested-serial")]
+    )
+
+    content = _wire_content(results[0])
+    assert content["artifact"] == APRIORI_SUMMARY_MARKER
+    assert content["generated_summary"] == "NESTED-SERIAL-SUMMARY"
+    assert "Retain the nested serial marker" in seen["prompt"]
+    assert nested_input == {"command": "echo nested", "summary": True}
+
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-serial")
+    generated_index = _event_index(
+        events, "apriori_summary_generated", tool_call_id="nested-serial"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-serial"
+    )
+    assert raw_index is not None and generated_index is not None and visible_index is not None
+    assert raw_index < generated_index < visible_index
+    raw_event = events[raw_index][1]
+    assert "NESTED-SERIAL-RAW" in str(raw_event["result"])
+    assert "NESTED-SERIAL-SUMMARY" not in str(raw_event["result"])
+    assert raw_event["tool_args"]["_reasoning"] == "Retain the nested serial marker"
+
+
+def test_nested_summary_true_parallel_path_preserves_raw_before_each_replacement(tmp_path):
+    raw_by_id = {
+        "nested-parallel-1": {"stdout": "NESTED-PARALLEL-RAW-1"},
+        "nested-parallel-2": {"stdout": "NESTED-PARALLEL-RAW-2"},
+    }
+    events = []
+    seen = []
+
+    def dispatch(tc):
+        return raw_by_id[tc.id]
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen.append((tool_call_id, user_prompt))
+        return f"NESTED-PARALLEL-SUMMARY-{tool_call_id}"
+
+    ex = _make_executor(
+        dispatch_fn=dispatch,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+        parallel_safe_tools={"bash", "grep"},
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "one", "summary": True},
+                  "reasoning": "Keep parallel result one"},
+            id="nested-parallel-1",
+        ),
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "two", "summary": True},
+                  "reasoning": "Keep parallel result two"},
+            id="nested-parallel-2",
+        ),
+    ])
+
+    assert len(seen) == 2
+    for result_msg, call_id in zip(results, ("nested-parallel-1", "nested-parallel-2")):
+        content = _wire_content(result_msg)
+        assert content["artifact"] == APRIORI_SUMMARY_MARKER
+        assert content["generated_summary"] == f"NESTED-PARALLEL-SUMMARY-{call_id}"
+        raw_index = _event_index(events, "tool_result", tool_call_id=call_id)
+        generated_index = _event_index(
+            events, "apriori_summary_generated", tool_call_id=call_id
+        )
+        visible_index = _event_index(
+            events, "tool_result_model_visible", tool_call_id=call_id
+        )
+        assert raw_index is not None and generated_index is not None and visible_index is not None
+        assert raw_index < generated_index < visible_index
+        raw_event = events[raw_index][1]
+        suffix = call_id.rsplit("-", 1)[-1]
+        assert f"NESTED-PARALLEL-RAW-{suffix}" in str(raw_event["result"])
+        assert f"NESTED-PARALLEL-SUMMARY-{call_id}" not in str(raw_event["result"])
+
+
+def test_nested_false_absent_and_malformed_ignore_root_true_in_executor(tmp_path):
+    cases = [
+        ("nested-false", {"summary": False}),
+        ("nested-absent", {}),
+        ("nested-one", {"summary": 1}),
+        ("nested-string", {"summary": "true"}),
+        ("nested-null", {"summary": None}),
+        ("nested-object", {"summary": {"truthy": True}}),
+        ("nested-list", {"summary": [True]}),
+        ("input-null", None),
+        ("input-list", []),
+        ("input-string", "payload"),
+    ]
+    for call_id, nested_input in cases:
+        events = []
+        called = []
+        raw = {"stdout": f"RAW-{call_id}"}
+
+        def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+            called.append(tool_call_id)
+            return "SHOULD NOT RUN"
+
+        ex = _make_executor(
+            dispatch_fn=lambda tc, raw=raw: raw,
+            summarizer_fn=summarizer,
+            events=events,
+            tmp_path=tmp_path,
+        )
+        results, _, _ = ex.execute([
+            ToolCall(
+                name="grep",
+                args={"input": nested_input, "summary": True},
+                id=call_id,
+            )
+        ])
+        content = _wire_content(results[0])
+        assert "SHOULD NOT RUN" not in str(content)
+        assert "RAW-" + call_id in str(content)
+        assert not (isinstance(content, dict) and content.get("artifact") == APRIORI_SUMMARY_MARKER)
+        assert called == []
+
+
+def test_nested_summary_true_cap_refusal_logs_raw_before_replacement(tmp_path):
+    raw = {"stdout": "NESTED-CAP-RAW-" + "z" * (APRIORI_SUMMARY_CAP + 100)}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="read",
+            args={"input": {"file_path": "/big", "summary": True},
+                  "reasoning": "Avoid oversized raw"},
+            id="nested-cap",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert called == []
+    assert content["summary_kind"] == "apriori_cap_refused"
+    assert "NESTED-CAP-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-cap")
+    refusal_index = _event_index(
+        events, "apriori_summary_cap_refused", tool_call_id="nested-cap"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-cap"
+    )
+    assert raw_index is not None and refusal_index is not None and visible_index is not None
+    assert raw_index < refusal_index < visible_index
+    assert "NESTED-CAP-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_without_gateway_fails_closed_after_raw_log(tmp_path):
+    raw = {"stdout": "NESTED-NOGATEWAY-RAW"}
+    events = []
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=None,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "echo no gateway", "summary": True}},
+            id="nested-no-gateway",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["summary_kind"] == "apriori_error"
+    assert "NESTED-NOGATEWAY-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-no-gateway")
+    error_index = _event_index(
+        events, "apriori_summary_no_summarizer", tool_call_id="nested-no-gateway"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-no-gateway"
+    )
+    assert raw_index is not None and error_index is not None and visible_index is not None
+    assert raw_index < error_index < visible_index
+    assert "NESTED-NOGATEWAY-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_preserves_tool_error_bypass(tmp_path):
+    raw = {"status": "error", "message": "EXACT-TOOL-ERROR"}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "error", "summary": True}},
+            id="nested-error",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["status"] == "error"
+    assert "EXACT-TOOL-ERROR" in str(content)
+    assert called == []
+    assert _event_index(events, "tool_result", tool_call_id="nested-error") is not None
+    assert _event_index(events, "apriori_summary_generated", tool_call_id="nested-error") is None
 
 
 def test_summary_true_over_cap_refuses_without_llm_and_hides_raw(tmp_path):

--- a/tests/test_grep_action_input.py
+++ b/tests/test_grep_action_input.py
@@ -1,0 +1,482 @@
+"""Focused canonical grep action/input tests.
+
+This module is intentionally self-contained and imports the exact candidate
+source tree before any LingTai import. It uses retained work directories under
+artifacts/grep-action-input-worker/test-work; tests never remove them.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+CANDIDATE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CANDIDATE / "src"))
+
+import lingtai  # noqa: E402
+from lingtai.agent import Agent  # noqa: E402
+from lingtai.kernel.llm.base import FunctionSchema, ToolCall  # noqa: E402
+from lingtai.kernel.loop_guard import LoopGuard  # noqa: E402
+from lingtai.kernel.tool_executor import ToolExecutor  # noqa: E402
+from lingtai.kernel.tool_result_summary import (  # noqa: E402
+    APRIORI_SUMMARY_CAP,
+    APRIORI_SUMMARY_MARKER,
+    summary_requested,
+)
+from lingtai.llm.anthropic.adapter import _build_tools as build_anthropic_tools  # noqa: E402
+from lingtai.llm.openai.adapter import (  # noqa: E402
+    _build_responses_tools,
+    _build_tools as build_chat_tools,
+)
+from lingtai.services.file_io import GrepMatch, LocalFileIOService, TraversalStats  # noqa: E402
+from lingtai.tools import grep as grep_module  # noqa: E402
+
+
+WORK_ROOT = CANDIDATE / "artifacts" / "grep-action-input-worker" / "test-work"
+WORK_ROOT.mkdir(parents=True, exist_ok=True)
+
+
+class RecordingFileIO:
+    """Recording service used to prove malformed calls never reach FileIO."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+        self.last_traversal = TraversalStats()
+
+    def grep(self, pattern, *, path, max_results, glob_filter):
+        self.calls.append((pattern, path, max_results, glob_filter))
+        return [GrepMatch(path=str(path) + "/hit.py", line_number=1, line="needle")]
+
+
+def _new_workdir(label: str) -> Path:
+    path = WORK_ROOT / f"{label}-{time.time_ns()}"
+    path.mkdir(parents=True, exist_ok=False)
+    return path
+
+
+def _service() -> MagicMock:
+    service = MagicMock()
+    service.provider = "gemini"
+    service.model = "grep-test"
+    service.get_adapter.return_value = MagicMock()
+    return service
+
+
+def _agent(label: str, *, file_io=None) -> Agent:
+    return Agent(
+        service=_service(),
+        agent_name=f"grep-{label}",
+        working_dir=_new_workdir(label),
+        capabilities=["grep"],
+        disable=["read", "write", "edit", "glob"],
+        file_io=file_io,
+    )
+
+
+def _handler(agent: Agent):
+    handler = agent._tool_handlers["grep"]
+    candidate_source = CANDIDATE / "src"
+    assert Path(lingtai.__file__).resolve().is_relative_to(candidate_source)
+    assert Path(grep_module.__file__).resolve().is_relative_to(candidate_source)
+    assert Path(handler.__code__.co_filename).resolve() == candidate_source / "lingtai/tools/grep/__init__.py"
+    return handler
+
+
+class GrepActionInputTests(unittest.TestCase):
+    def test_raw_agent_schema_provider_envelopes_and_prompt(self):
+        agent = _agent("schema")
+        try:
+            handler = _handler(agent)
+            raw = grep_module.get_schema()
+            self.assertEqual(raw["required"], ["action", "input"])
+            self.assertFalse(raw["additionalProperties"])
+            self.assertEqual(set(raw["properties"]), {"action", "input"})
+            self.assertNotIn("reasoning", raw["properties"])
+
+            model_schema = next(s for s in agent._build_tool_schemas() if s.name == "grep")
+            self.assertEqual(model_schema.parameters["required"], ["action", "input"])
+            self.assertEqual(
+                set(model_schema.parameters["properties"]), {"action", "input", "reasoning"}
+            )
+            self.assertFalse(model_schema.parameters["additionalProperties"])
+            branches = model_schema.parameters["properties"]["input"]["anyOf"]
+            self.assertEqual(branches[0]["required"], ["pattern"])
+            self.assertEqual(branches[1]["required"], [])
+            self.assertTrue(
+                all("reasoning" not in branch.get("properties", {}) for branch in branches)
+            )
+
+            schema = FunctionSchema("grep", grep_module.get_description(), model_schema.parameters)
+            chat = build_chat_tools([schema])
+            responses = _build_responses_tools([schema])
+            anthropic = build_anthropic_tools([schema])
+            self.assertEqual(chat[0]["function"]["parameters"], model_schema.parameters)
+            self.assertEqual(responses[0]["parameters"], model_schema.parameters)
+            self.assertEqual(anthropic[0]["input_schema"], model_schema.parameters)
+            self.assertEqual(schema.to_dict()["parameters"], model_schema.parameters)
+
+            prompt = agent._build_system_prompt()
+            self.assertIn("### grep", prompt)
+            grep_section = prompt.split("### grep\n", 1)[1].split("\n\n### ", 1)[0]
+            self.assertNotIn("omit action", grep_section)
+            self.assertIn("grep(action='grep'", grep_section)
+            self.assertIn("reasoning='...')", grep_section)
+
+            manual = handler({"action": "manual", "input": {}, "reasoning": "load the guide"})
+            self.assertEqual(manual["status"], "ok")
+            self.assertIn(
+                'grep({"action": "grep", "input": {"pattern": "class Agent|def handle"',
+                manual["manual"],
+            )
+            self.assertIn('"reasoning": "locate the handler before reading it"', manual["manual"])
+            self.assertIn(
+                '{"action":"manual","input":{},"reasoning":"load the installed file guide"}',
+                manual["manual"],
+            )
+            self.assertNotIn(
+                'tool name: `action="read"`, `"write"`, `"edit"`, `"glob"`, or `"grep"`',
+                manual["manual"],
+            )
+            self.assertTrue(manual["manual_path"].endswith("capabilities/file-manual/SKILL.md"))
+            self.assertEqual(manual["current_setting"]["source"], "missing")
+            self.assertTrue(Path(manual["manual_path"]).is_file())
+        finally:
+            agent.stop(timeout=1.0)
+
+    def test_strict_malformed_and_unhashable_calls_precede_file_io(self):
+        recording = RecordingFileIO()
+        agent = _agent("strict", file_io=recording)
+        try:
+            handler = _handler(agent)
+            malformed = [
+                None,
+                [],
+                {},
+                {"action": "grep"},
+                {"input": {"pattern": "needle"}},
+                {"action": [], "input": {}},
+                {1: "root-key", "action": "grep", "input": {"pattern": "needle"}},
+                {"action": "grep", "input": []},
+                {"action": "grep", "input": {1: "input-key"}},
+                {"action": "grep", "input": {"pattern": "needle", "summary": 1}},
+                {"action": "grep", "input": {"pattern": "needle", "unknown": []}},
+                {"action": "grep", "input": {"pattern": "needle"}, "summary": True},
+                {"action": "manual", "input": {"pattern": "needle"}},
+            ]
+            for args in malformed:
+                result = handler(args)
+                self.assertEqual(result["status"], "error", args)
+                self.assertIn("current_setting", result)
+            self.assertEqual(recording.calls, [])
+
+            result = handler({"action": "grep", "input": {"pattern": "needle"}, "reasoning": "find it"})
+            self.assertEqual(result["count"], 1)
+            self.assertEqual(len(recording.calls), 1)
+            self.assertIsNone(recording.calls[0][3])
+        finally:
+            agent.stop(timeout=1.0)
+
+    def test_local_file_io_semantics_and_error_paths(self):
+        root = _new_workdir("local")
+        service = LocalFileIOService(root=root)
+        agent = Agent(
+            service=_service(), agent_name="grep-local", working_dir=root,
+            capabilities=["grep"], disable=["read", "write", "edit", "glob"], file_io=service,
+        )
+        try:
+            handler = _handler(agent)
+            (root / "one.py").write_text("needle\nother\n", encoding="utf-8")
+            (root / "two.txt").write_text("needle\n", encoding="utf-8")
+            (root / "broken.py").write_bytes(bytes([255, 254, 0]))
+            # A non-capped service call reaches the invalid UTF-8 file and records
+            # the binary skip; the public cap is checked separately below.
+            all_matches = service.grep("needle", path=str(root), max_results=200, glob_filter="*.py")
+            self.assertEqual(len(all_matches), 1)
+            self.assertEqual(service.last_traversal.files_skipped_binary, 1)
+
+            result = handler({
+                "action": "grep",
+                "input": {"pattern": "needle", "path": ".", "glob": "*.py", "max_matches": 1, "summary": False},
+                "reasoning": "find one Python match",
+            })
+            self.assertEqual(result["count"], 1)
+            self.assertTrue(all(match["file"].endswith(".py") for match in result["matches"]))
+            self.assertTrue(result["truncated"])
+
+            invalid = handler({"action": "grep", "input": {"pattern": "[", "path": "."}})
+            self.assertEqual(invalid["status"], "error")
+            self.assertIn("Grep failed", invalid["message"])
+        finally:
+            agent.stop(timeout=1.0)
+
+    def test_settings_missing_valid_hot_reload_invalid_secret_free_and_inert(self):
+        agent = _agent("settings")
+        try:
+            handler = _handler(agent)
+            target = agent.working_dir / "settings"
+            target.mkdir(parents=True, exist_ok=True)
+            (agent.working_dir / "match.py").write_text("needle\n", encoding="utf-8")
+            args = {"action": "grep", "input": {"pattern": "needle", "path": "."}}
+            missing = handler(args)
+            self.assertEqual(missing["current_setting"]["source"], "missing")
+            baseline = dict(missing)
+            baseline.pop("current_setting")
+            prompt = agent._build_system_prompt()
+            schema = copy.deepcopy(grep_module.get_schema())
+
+            settings_file = target / "grep.json"
+            settings_file.write_bytes(b'{"schema_version":1}')
+            valid = handler(args)
+            self.assertEqual(valid["current_setting"]["source"], "settings/grep.json")
+            self.assertNotEqual(missing["current_setting"]["settings_hash"], valid["current_setting"]["settings_hash"])
+            value = dict(valid)
+            value.pop("current_setting")
+            self.assertEqual(value, baseline)
+            self.assertEqual(agent._build_system_prompt(), prompt)
+            self.assertEqual(grep_module.get_schema(), schema)
+
+            settings_file.write_bytes(b'{ "schema_version" : 1 }\n')
+            hot = handler(args)
+            self.assertNotEqual(valid["current_setting"]["settings_hash"], hot["current_setting"]["settings_hash"])
+            self.assertNotEqual(
+                valid["current_setting"]["settings_revision"],
+                hot["current_setting"]["settings_revision"],
+            )
+            hot_value = dict(hot)
+            hot_value.pop("current_setting")
+            self.assertEqual(hot_value, baseline)
+            self.assertEqual(agent._build_system_prompt(), prompt)
+
+            sentinel = "SECRET-GREP-SENTINEL"
+            settings_file.write_text(json.dumps({"schema_version": 1, "secret": sentinel}), encoding="utf-8")
+            invalid = handler(args)
+            self.assertEqual(invalid["current_setting"]["source"], "settings_error")
+            self.assertIn("settings_error", invalid["current_setting"])
+            self.assertNotIn(sentinel, json.dumps(invalid, sort_keys=True))
+            self.assertNotIn(sentinel, agent._build_system_prompt())
+            invalid_value = dict(invalid)
+            invalid_value.pop("current_setting")
+            self.assertEqual(invalid_value, baseline)
+            self.assertEqual(agent._build_system_prompt(), prompt)
+        finally:
+            agent.stop(timeout=1.0)
+
+    def test_actual_handler_executor_serial_parallel_and_root_rejection(self):
+        recording = RecordingFileIO()
+        agent = _agent("summary-actual", file_io=recording)
+        events: list[tuple[str, dict]] = []
+        prompts: list[tuple[str, str]] = []
+
+        def logger(event_type, **fields):
+            events.append((event_type, fields))
+
+        def make_tool_result(name, result, **fields):
+            return {"role": "tool", "name": name, "content": result, **fields}
+
+        def summarizer(_system, prompt, _tool_name, tool_call_id):
+            prompts.append((tool_call_id, prompt))
+            return f"actual-summary-{tool_call_id}"
+
+        try:
+            _handler(agent)
+            executor = ToolExecutor(
+                dispatch_fn=agent._dispatch_tool,
+                make_tool_result_fn=make_tool_result,
+                guard=LoopGuard(),
+                known_tools={"grep"},
+                parallel_safe_tools={"grep"},
+                logger_fn=logger,
+                working_dir=agent.working_dir,
+                summarizer_fn=summarizer,
+            )
+            serial, intercepted, _ = executor.execute([
+                ToolCall(
+                    name="grep",
+                    args={
+                        "action": "grep",
+                        "input": {"pattern": "needle", "summary": True},
+                        "reasoning": "retain the exact grep hit",
+                    },
+                    id="actual-serial",
+                )
+            ])
+            self.assertFalse(intercepted)
+            self.assertEqual(
+                serial[0]["content"]["generated_summary"],
+                "actual-summary-actual-serial",
+            )
+            self.assertEqual(prompts[0][0], "actual-serial")
+            self.assertIn("hit.py", prompts[0][1])
+            serial_raw = next(
+                i for i, (kind, fields) in enumerate(events)
+                if kind == "tool_result" and fields.get("tool_call_id") == "actual-serial"
+            )
+            serial_generated = next(
+                i for i, (kind, fields) in enumerate(events)
+                if kind == "apriori_summary_generated" and fields.get("tool_call_id") == "actual-serial"
+            )
+            serial_visible = next(
+                i for i, (kind, fields) in enumerate(events)
+                if kind == "tool_result_model_visible" and fields.get("tool_call_id") == "actual-serial"
+            )
+            self.assertLess(serial_raw, serial_generated)
+            self.assertLess(serial_generated, serial_visible)
+            self.assertIn("current_setting", events[serial_raw][1]["result"])
+
+            parallel, intercepted, _ = executor.execute([
+                ToolCall(
+                    name="grep",
+                    args={
+                        "action": "grep",
+                        "input": {"pattern": "one", "summary": True},
+                        "reasoning": "retain parallel one",
+                    },
+                    id="actual-parallel-1",
+                ),
+                ToolCall(
+                    name="grep",
+                    args={
+                        "action": "grep",
+                        "input": {"pattern": "two", "summary": True},
+                        "reasoning": "retain parallel two",
+                    },
+                    id="actual-parallel-2",
+                ),
+            ])
+            self.assertFalse(intercepted)
+            self.assertEqual(
+                [item["content"]["generated_summary"] for item in parallel],
+                [
+                    "actual-summary-actual-parallel-1",
+                    "actual-summary-actual-parallel-2",
+                ],
+            )
+            for call_id in ("actual-parallel-1", "actual-parallel-2"):
+                raw_index = next(
+                    i for i, (kind, fields) in enumerate(events)
+                    if kind == "tool_result" and fields.get("tool_call_id") == call_id
+                )
+                generated_index = next(
+                    i for i, (kind, fields) in enumerate(events)
+                    if kind == "apriori_summary_generated" and fields.get("tool_call_id") == call_id
+                )
+                visible_index = next(
+                    i for i, (kind, fields) in enumerate(events)
+                    if kind == "tool_result_model_visible" and fields.get("tool_call_id") == call_id
+                )
+                self.assertLess(raw_index, generated_index)
+                self.assertLess(generated_index, visible_index)
+                self.assertIn("current_setting", events[raw_index][1]["result"])
+
+            prompt_count = len(prompts)
+            rejected, _, _ = executor.execute([
+                ToolCall(
+                    name="grep",
+                    args={
+                        "action": "grep",
+                        "input": {"pattern": "needle", "summary": False},
+                        "summary": True,
+                    },
+                    id="actual-root-rejected",
+                )
+            ])
+            self.assertEqual(rejected[0]["content"]["status"], "error")
+            self.assertIn("only root action, input", rejected[0]["content"]["message"])
+            self.assertEqual(len(prompts), prompt_count)
+        finally:
+            agent.stop(timeout=1.0)
+
+    def test_summary_executor_serial_parallel_raw_first_and_strict_nested_true(self):
+        events: list[tuple[str, dict]] = []
+
+        def logger(event_type, **fields):
+            events.append((event_type, fields))
+
+        def make_tool_result(name, result, **fields):
+            return {"role": "tool", "name": name, "content": result, **fields}
+
+        raw_by_id = {
+            "serial": {"matches": [{"file": "serial.py"}]},
+            "parallel-1": {"matches": [{"file": "one.py"}]},
+            "parallel-2": {"matches": [{"file": "two.py"}]},
+        }
+        seen: list[str] = []
+
+        def summarizer(_system, prompt, _tool_name, tool_call_id):
+            seen.append(prompt)
+            return f"summary-{tool_call_id}"
+
+        executor = ToolExecutor(
+            dispatch_fn=lambda tc: raw_by_id[tc.id],
+            make_tool_result_fn=make_tool_result,
+            guard=LoopGuard(), known_tools={"grep"}, logger_fn=logger,
+            working_dir=WORK_ROOT, summarizer_fn=summarizer,
+            parallel_safe_tools={"grep"},
+        )
+        serial_results, _, _ = executor.execute([ToolCall(
+            name="grep",
+            args={"action": "grep", "input": {"pattern": "x", "summary": True}, "reasoning": "retain serial"},
+            id="serial",
+        )])
+        self.assertEqual(serial_results[0]["content"]["artifact"], APRIORI_SUMMARY_MARKER)
+        self.assertIn("retain serial", seen[0])
+        serial_raw = next(i for i, (kind, fields) in enumerate(events) if kind == "tool_result" and fields.get("tool_call_id") == "serial")
+        serial_visible = next(i for i, (kind, fields) in enumerate(events) if kind == "tool_result_model_visible" and fields.get("tool_call_id") == "serial")
+        self.assertLess(serial_raw, serial_visible)
+
+        parallel_results, _, _ = executor.execute([
+            ToolCall(name="grep", args={"action": "grep", "input": {"pattern": "x", "summary": True}, "reasoning": "retain one"}, id="parallel-1"),
+            ToolCall(name="grep", args={"action": "grep", "input": {"pattern": "x", "summary": True}, "reasoning": "retain two"}, id="parallel-2"),
+        ])
+        self.assertEqual([r["content"]["generated_summary"] for r in parallel_results], ["summary-parallel-1", "summary-parallel-2"])
+        for call_id in ("parallel-1", "parallel-2"):
+            raw_index = next(i for i, (kind, fields) in enumerate(events) if kind == "tool_result" and fields.get("tool_call_id") == call_id)
+            visible_index = next(i for i, (kind, fields) in enumerate(events) if kind == "tool_result_model_visible" and fields.get("tool_call_id") == call_id)
+            self.assertLess(raw_index, visible_index)
+
+        self.assertTrue(summary_requested({"input": {"summary": True}, "summary": False}))
+        self.assertFalse(summary_requested({"input": {"summary": False}, "summary": True}))
+        self.assertFalse(summary_requested({"input": {"summary": 1}, "summary": True}))
+        self.assertFalse(summary_requested({"input": None, "summary": True}))
+
+        errors = []
+        no_gateway = ToolExecutor(
+            dispatch_fn=lambda _tc: {"status": "error", "message": "EXACT-ERROR"},
+            make_tool_result_fn=make_tool_result,
+            guard=LoopGuard(), known_tools={"grep"}, logger_fn=lambda e, **f: errors.append((e, f)),
+            working_dir=WORK_ROOT, summarizer_fn=summarizer,
+        )
+        error_result, _, _ = no_gateway.execute([ToolCall(
+            name="grep", args={"action": "grep", "input": {"pattern": "x", "summary": True}}, id="error",
+        )])
+        self.assertEqual(error_result[0]["content"]["message"], "EXACT-ERROR")
+        self.assertNotIn(APRIORI_SUMMARY_MARKER, error_result[0]["content"])
+
+        closed = ToolExecutor(
+            dispatch_fn=lambda _tc: {"matches": []}, make_tool_result_fn=make_tool_result,
+            guard=LoopGuard(), known_tools={"grep"}, logger_fn=lambda *_a, **_k: None,
+            working_dir=WORK_ROOT, summarizer_fn=None,
+        )
+        no_gateway_result, _, _ = closed.execute([ToolCall(
+            name="grep", args={"action": "grep", "input": {"pattern": "x", "summary": True}}, id="nogateway",
+        )])
+        self.assertEqual(no_gateway_result[0]["content"]["summary_kind"], "apriori_error")
+
+        too_big = ToolExecutor(
+            dispatch_fn=lambda _tc: {"matches": "z" * (APRIORI_SUMMARY_CAP + 1)}, make_tool_result_fn=make_tool_result,
+            guard=LoopGuard(), known_tools={"grep"}, logger_fn=lambda *_a, **_k: None,
+            working_dir=WORK_ROOT, summarizer_fn=summarizer,
+        )
+        cap_result, _, _ = too_big.execute([ToolCall(
+            name="grep", args={"action": "grep", "input": {"pattern": "x", "summary": True}}, id="cap",
+        )])
+        self.assertEqual(cap_result[0]["content"]["summary_kind"], "apriori_cap_refused")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_settings.py
+++ b/tests/test_tool_settings.py
@@ -1,0 +1,154 @@
+"""Focused tests for the private no-op placeholder-settings foundation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools._settings import (
+    MAX_SETTINGS_BYTES,
+    current_setting,
+    read_settings,
+    settings_path,
+    valid_tool_name,
+)
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+
+def _write(root: Path, tool_name: str, payload: str | bytes) -> Path:
+    path = root / "settings" / f"{tool_name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def test_missing_is_a_normal_noop_placeholder_state(tmp_path):
+    snapshot = read_settings(_Agent(tmp_path), "example")
+    setting = current_setting(snapshot, "example")
+    assert setting == {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": "missing",
+        "settings_revision": "missing",
+        "settings_hash": None,
+        "change_hint": (
+            "Edit settings/example.json; changes apply on the next example call; "
+            "this no-op placeholder never changes tool behavior."
+        ),
+    }
+
+
+def test_valid_v1_only_changes_source_revision_and_hash(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "example", '{"schema_version": 1}')
+    snapshot = read_settings(agent, "example")
+    setting = current_setting(snapshot, "example")
+    assert snapshot.error is None
+    assert setting["configurable"] is False
+    assert setting["placeholder"] == "no-op"
+    assert setting["source"] == "settings/example.json"
+    assert setting["settings_revision"] == setting["settings_hash"]
+    assert setting["settings_hash"]
+
+
+def test_reader_rereads_hot_changes_without_cache(tmp_path):
+    agent = _Agent(tmp_path)
+    path = _write(tmp_path, "example", '{"schema_version": 1}')
+    first = read_settings(agent, "example")
+    path.write_text('{ "schema_version": 1 }', encoding="utf-8")
+    second = read_settings(agent, "example")
+    assert first.digest != second.digest
+    assert second.source == "settings/example.json"
+
+
+def test_duplicate_and_extra_fields_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    duplicate = _write(tmp_path, "duplicate", '{"schema_version": 1, "schema_version": 1}')
+    duplicate_snapshot = read_settings(agent, "duplicate")
+    assert duplicate_snapshot.source == "settings_error"
+    assert "duplicate" in (duplicate_snapshot.error or "")
+
+    extra = _write(tmp_path, "extra", '{"schema_version": 1, "future": false}')
+    extra_snapshot = read_settings(agent, "extra")
+    assert extra_snapshot.source == "settings_error"
+    assert "only schema_version" in (extra_snapshot.error or "")
+
+
+def test_bool_and_other_schema_versions_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    for name, version in (("bool", True), ("float", 1.0), ("other", 2)):
+        _write(tmp_path, name, json.dumps({"schema_version": version}))
+        snapshot = read_settings(agent, name)
+        assert snapshot.source == "settings_error"
+        assert "integer 1" in (snapshot.error or "")
+
+
+def test_invalid_encoding_and_json_are_truthful_bounded_errors(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "encoding", b'{"schema_version": 1}\xff')
+    encoding_snapshot = read_settings(agent, "encoding")
+    assert encoding_snapshot.source == "settings_error"
+    assert encoding_snapshot.error
+
+    _write(tmp_path, "json", "{not-json")
+    json_snapshot = read_settings(agent, "json")
+    assert json_snapshot.source == "settings_error"
+    assert json_snapshot.error
+    assert len(json_snapshot.error) <= 240
+
+
+def test_symlink_non_regular_and_oversized_files_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text('{"schema_version": 1}', encoding="utf-8")
+    symlink = tmp_path / "settings" / "symlink.json"
+    symlink.parent.mkdir()
+    symlink.symlink_to(target)
+    symlink_snapshot = read_settings(agent, "symlink")
+    assert symlink_snapshot.source == "settings_error"
+    assert "regular file" in (symlink_snapshot.error or "")
+
+    non_regular = tmp_path / "settings" / "directory.json"
+    non_regular.mkdir()
+    directory_snapshot = read_settings(agent, "directory")
+    assert directory_snapshot.source == "settings_error"
+    assert "regular file" in (directory_snapshot.error or "")
+
+    _write(tmp_path, "large", b"{" + b"x" * MAX_SETTINGS_BYTES + b"}")
+    large_snapshot = read_settings(agent, "large")
+    assert large_snapshot.source == "settings_error"
+    assert "bounded size" in (large_snapshot.error or "")
+
+
+def test_unstable_snapshot_is_not_treated_as_missing(tmp_path, monkeypatch):
+    import lingtai.tools._settings as settings_module
+
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "unstable", '{"schema_version": 1}')
+
+    def raise_unstable(_path):
+        raise settings_module.SettingsError("settings snapshot changed during read")
+
+    monkeypatch.setattr(settings_module, "_read_stable", raise_unstable)
+    snapshot = read_settings(agent, "unstable")
+    assert snapshot.source == "settings_error"
+    assert snapshot.revision == "error"
+    assert snapshot.error == "settings snapshot changed during read"
+
+
+def test_tool_names_are_bounded_path_components(tmp_path):
+    assert valid_tool_name("web_search")
+    assert not valid_tool_name("../escape")
+    assert not valid_tool_name("nested/name")
+    assert not valid_tool_name("\\escape")
+    assert not valid_tool_name("x" * 65)
+    with pytest.raises(ValueError):
+        settings_path(_Agent(tmp_path), "../escape")


### PR DESCRIPTION
## Summary

This stacked draft migrates the public `grep` tool to LingTai's future canonical model-facing contract:

- required root `action` plus required nested `input` in the raw tool-owned schema;
- actions exactly `grep` and `manual`;
- BaseAgent-injected root `reasoning`, with no nested reasoning alias;
- closed action-specific inputs and no omitted-action or flat-root compatibility;
- required non-empty `input.pattern`, optional string `input.path`, basename `input.glob`, integer `input.max_matches`, and nested exact-boolean `input.summary`;
- no root-summary fallback once `input` exists;
- strict per-call `settings/grep.json` v1 placeholder loading with truthful `current_setting` on success, manual, malformed-input, path-resolution, and FileIO-error paths;
- a real installed `file-manual` action plus synchronized grep contract, anatomy, shared-manual guidance, and glossaries;
- preserved relative-path resolution, injected FileIO delegation, regex matching, pre-read basename pruning, max-match truncation, binary/size skip source truth, and traversal metadata.

Provider wrappers remain unchanged: Chat uses `function.parameters`, Responses uses `parameters`, Anthropic uses `input_schema`, and internal `FunctionSchema` uses `parameters`.

## Stack

- Depends on foundation draft #1038 at exact foundation commit `80d5c7d4`.
- Base branch: `feat/tool-settings-foundation`.
- This PR is intentionally a draft and must not be merged independently of the stack review.

## Parent review repairs

The worker candidate was not accepted unchanged. Parent review made five material validation/documentation repairs:

- replaced the shared file manual's remaining false statement that `grep` still accepted omitted-action/flat calls, and added exact canonical ordinary/manual examples with root `reasoning`;
- hardened actual-Agent tests to verify exact final/provider schemas, root-only reasoning, scoped prompt prose, real installed manual content/path/current settings, and exact candidate origins;
- made settings tests prove byte-distinct `settings_revision` changes plus whole-result and prompt secret non-leakage;
- expanded malformed-input coverage to non-mappings and non-string root/input keys before FileIO;
- added actual-handler ToolExecutor coverage for serial and parallel raw-first summary replacement, current-setting preservation, and strict rejection of root `summary` without fallback.

As in the preceding glob review, every final test process explicitly places this candidate's `src` first and mechanically checks the `lingtai`, `grep`, and handler origins; `PYTHONPATH` alone is not trusted on this shared machine.

## Validation

- exact repaired owning module executed with `unittest` (not pytest): all 6 tests passed;
- fresh retained independent parent gate passed 110 checks across raw and actual-Agent schemas, Chat/Responses/Anthropic envelopes, prompt/manual/root reasoning, exact source origins, strict malformed no-FileIO behavior, relative/default path and glob/max mapping, traversal fields, missing/valid/hot/invalid settings, secret non-leakage, behavior/prompt invariance, real LocalFileIO regex/filter/binary/cap/error semantics, and actual serial/parallel nested-summary raw-before-generated-before-visible ordering;
- all 1,334 durable worker events were parsed with zero errors into 121 normalized calls and 121 results: compact 2, edit 12, finish 1, glob 7, grep 21, read 38, shell 32, write 8;
- all non-empty direct writes/edits stayed inside the authorized candidate; shell calls outside it were manual actions or read-only inspection of the explicitly authorized read/glob reference worktrees;
- no deletion, pytest, pycompile/compileall, Git/GitHub mutation, network, process-signal, or temp-lifecycle category was found;
- two focused unittest iterations failed because a max-match cap short-circuited before a binary file, and one exact glossary edit failed on a stale old string; these iterations are retained/disclosed and superseded by corrected successful gates;
- anatomy drift check passed across 54 anatomy files; glossary validation passed for 57 resources across 19 packages; in-memory compile, control-character scan, and `git diff --check` passed.

Repository-wide pytest was intentionally not executed under the current no-cleanup boundary. Pre-existing flat grep-handler expectations remain in `tests/test_layers_file.py`, `tests/test_intrinsic_manual_actions.py`, and `tests/test_services_file_io.py`; they are explicit stacked integration debt and must be canonicalized before merge. No merge, release, deploy, tag, deletion, or cleanup is part of this draft.
