### PR TITLE
Migrate avatar to the canonical action/input contract

### DIFF
--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -36,6 +36,7 @@ Safety properties:
 from __future__ import annotations
 
 import datetime as _dt
+from collections.abc import Mapping
 from typing import Any, Callable
 
 from .meta_block import formal_tool_result_content, formal_tool_result_visible_len
@@ -147,15 +148,21 @@ def is_apriori_summary(content: Any) -> bool:
     )
 
 
-def summary_requested(args: dict | None) -> bool:
-    """Return True iff the normalized tool args opt into a-priori summary.
+def summary_requested(args: Mapping | None) -> bool:
+    """Return True iff tool args opt into a-priori summary.
 
-    The flag is the boolean ``summary`` field on the tool call. Anything other
-    than a literal ``True`` (missing, ``False``, ``None``, truthy-but-not-True)
-    preserves current behavior exactly.
+    The presence of ``input`` selects canonical mode: only a Mapping-valued
+    ``input`` whose ``summary`` is exactly ``True`` requests summarization.
+    Root ``summary`` is ignored in canonical mode, including when ``input`` is
+    malformed or its nested flag is absent/invalid. When ``input`` is absent,
+    legacy mode reads only root ``summary``. Both modes require identity with
+    the boolean singleton ``True``; no truthy coercion is performed.
     """
-    if not isinstance(args, dict):
+    if not isinstance(args, Mapping):
         return False
+    if "input" in args:
+        payload = args["input"]
+        return isinstance(payload, Mapping) and payload.get("summary") is True
     return args.get("summary") is True
 
 
@@ -395,13 +402,19 @@ def maybe_summarize_result(
     and BEFORE the result is turned into the model-visible wire message.
 
     Contract:
+    - Summary control is canonical-first: when ``input`` is present, only
+      ``input.summary is True`` on a Mapping payload requests; root ``summary``
+      is never inspected or used as fallback. When ``input`` is absent, legacy
+      calls use root ``summary is True``. This exact-boolean discriminator is
+      applied without flattening or mutating the original args.
     - ``summary != true`` → returns *result* unchanged (current behavior).
     - ``summary == true`` but no ``summarizer_fn`` wired (e.g. service without a
       one-shot generate gateway) → **fails closed**: returns a summary-layer
       error (with the raw-retrieval locator), NOT the raw result. ``summary=true``
       is a request to keep the raw out of context; honoring it must not depend on
       whether a summarizer happens to be configured. The raw is already durably
-      logged before this point, so it remains retrievable by ``tool_call_id``.
+      logged before either the legacy or canonical predicate is applied, so it
+      remains retrievable by ``tool_call_id``.
     - Already an a-priori summary (defensive) → returned unchanged.
     - Error results (the tool itself failed) are NOT summarized: the agent needs
       the exact error text to recover. Returned unchanged.

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
@@ -35,6 +36,10 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_settings.py` — private Agent-owned placeholder-settings reader and
+  secret-free current-setting diagnostic. It strictly validates the exact
+  versioned no-op schema, rereads `settings/<bounded tool_name>.json` per call,
+  and never supplies action, input, reasoning, or tool behavior.
 
 ## Connections
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -40,6 +40,33 @@ There is no fourth public metadata block. Existing tools retain their current
 explicit schemas until a scoped migration changes their code, tests, manual, and
 contract together.
 
+### A-priori summary transition
+
+The shared kernel summary predicate uses the presence of the `input` key as the
+mode discriminator. A canonical call requests a summary only when `input` is a
+Mapping/object and `input.summary` is exactly the boolean `true`; once `input` is
+present, root `summary` is ignored and is never a fallback, even when `input` is
+malformed, missing `summary`, or carries a false/non-boolean value. No truthy
+coercion, flattening, or argument mutation is permitted. A call with no `input`
+key remains in legacy mode and requests only when root `summary` is exactly
+`true`.
+
+This is a transitional compatibility rule, not a second public schema: migrated
+capabilities that support a-priori summary advertise that flag only as nested
+`input.summary`, while unmigrated legacy advertisers retain their root flag until
+their own vertical migration. Tool errors continue to bypass summarization. The
+raw result is durably recorded before either nested or legacy summary control is
+applied; generated, refusal, and fail-closed no-gateway replacements are
+model-visible substitutes with the
+existing raw locator and metadata.
+
+The root-summary branch may be removed only in the commit that migrates the last
+currently legacy root-summary advertiser (including shell's historical `bash`
+rolling alias and daemon), and only after a registry-wide test proves that no
+provider-facing schema advertises root `summary`, no migrated handler accepts
+flat fields, and no supported pending legacy call relies on the root shape. Until
+that final removal gate, root lookup is permitted solely when `input` is absent.
+
 ## Port
 
 The provider-neutral boundary is the final `FunctionSchema` assembled by the

--- a/src/lingtai/tools/_settings.py
+++ b/src/lingtai/tools/_settings.py
@@ -1,0 +1,156 @@
+"""Private shared reader for Agent-owned no-op tool settings placeholders.
+
+The placeholder file is deliberately metadata-only.  A present, valid v1 file
+proves that an Agent-owned settings snapshot was read, but it cannot select or
+enable any tool behavior.  Individual tools may later add their own real
+settings reader when a configurable choice is actually authorized.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MAX_SETTINGS_BYTES = 64 * 1024
+SETTINGS_SCHEMA_VERSION = 1
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class SettingsError(ValueError):
+    """A placeholder settings snapshot was malformed or unsafe to use."""
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsSnapshot:
+    """Immutable evidence for one reread of one tool's settings file."""
+
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def valid_tool_name(value: Any) -> bool:
+    """Return whether *value* is safe as one bounded settings path component."""
+    return isinstance(value, str) and _TOOL_NAME.fullmatch(value) is not None
+
+
+def settings_path(agent: Any, tool_name: str) -> Path:
+    """Return the fixed Agent-owned ``settings/<tool_name>.json`` path."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return Path(agent._working_dir) / "settings" / f"{tool_name}.json"
+
+
+def _bounded_error(exc: Exception) -> str:
+    """Render a bounded diagnostic without echoing host paths or file content."""
+    if isinstance(exc, OSError):
+        return f"settings file could not be read ({type(exc).__name__})"
+    text = str(exc).replace("\n", " ").strip()
+    return (text or "invalid settings")[:240]
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject duplicate JSON object members instead of accepting last-wins data."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SettingsError("duplicate settings field")
+        result[key] = value
+    return result
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    """Read one bounded regular-file snapshot and its content revision."""
+    try:
+        first = path.lstat()
+    except FileNotFoundError:
+        return b"", "missing"
+    except OSError:
+        raise
+
+    if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
+        raise SettingsError("settings file must be a regular file")
+    if first.st_size > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings file exceeds the bounded size")
+
+    # Open by path only after lstat, then compare the path identity and metadata
+    # again.  Replacements, symlink swaps, growth, and ordinary in-place writes
+    # are therefore rejected rather than partially accepted.
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_SETTINGS_BYTES + 1)
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    try:
+        second = path.lstat()
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    if stat.S_ISLNK(second.st_mode) or not stat.S_ISREG(second.st_mode):
+        raise SettingsError("settings snapshot changed during read")
+    if (
+        len(raw) > MAX_SETTINGS_BYTES
+        or first.st_dev != second.st_dev
+        or first.st_ino != second.st_ino
+        or first.st_size != second.st_size
+        or first.st_mtime_ns != second.st_mtime_ns
+    ):
+        raise SettingsError("settings snapshot changed during read")
+    return raw, hashlib.sha256(raw).hexdigest()[:32]
+
+
+def read_settings(agent: Any, tool_name: str) -> SettingsSnapshot:
+    """Reread and strictly validate one tool's placeholder settings snapshot.
+
+    Missing is a normal placeholder state.  A valid file contributes only its
+    source/revision/hash evidence; it never changes behavior.  Every invocation
+    performs a fresh filesystem read and does not cache a prior snapshot.
+    """
+    path = settings_path(agent, tool_name)
+    digest: str | None = None
+    try:
+        raw, revision = _read_stable(path)
+        if revision == "missing":
+            return SettingsSnapshot("missing", "missing", None)
+        digest = revision
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        if not isinstance(value, dict) or set(value) != {"schema_version"}:
+            raise SettingsError("settings schema must contain only schema_version")
+        if type(value["schema_version"]) is not int or value["schema_version"] != SETTINGS_SCHEMA_VERSION:
+            raise SettingsError("settings schema_version must be integer 1")
+        return SettingsSnapshot(f"settings/{tool_name}.json", revision, digest)
+    except (OSError, UnicodeError, json.JSONDecodeError, SettingsError) as exc:
+        # Malformed data is never silently converted to the missing state.  The
+        # digest from a bounded stable read is retained as evidence when safe.
+        return SettingsSnapshot(
+            "settings_error",
+            digest or "error",
+            digest,
+            _bounded_error(exc if isinstance(exc, Exception) else SettingsError("invalid settings")),
+        )
+
+
+def current_setting(snapshot: SettingsSnapshot, tool_name: str) -> dict[str, Any]:
+    """Build the bounded, secret-free current-setting diagnostic for a tool."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return_value: dict[str, Any] = {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": snapshot.source,
+        "settings_revision": snapshot.revision,
+        "settings_hash": snapshot.digest,
+        "change_hint": (
+            f"Edit settings/{tool_name}.json; changes apply on the next {tool_name} "
+            "call; this no-op placeholder never changes tool behavior."
+        ),
+    }
+    if snapshot.error:
+        return_value["settings_error"] = snapshot.error
+    return return_value

--- a/src/lingtai/tools/avatar/ANATOMY.md
+++ b/src/lingtai/tools/avatar/ANATOMY.md
@@ -4,120 +4,129 @@ related_files:
   - src/lingtai/tools/avatar/__init__.py
   - src/lingtai/tools/avatar/_launcher.py
   - src/lingtai/tools/avatar/CONTRACT.md
-  - src/lingtai/adapters/avatar_launcher.py
-  - src/lingtai/adapters/posix/ANATOMY.md
-  - src/lingtai/adapters/posix/avatar_launcher.py
   - src/lingtai/tools/avatar/manual/SKILL.md
-  - tests/test_avatar_rules.py
   - src/lingtai/tools/avatar/glossary-en.md
   - src/lingtai/tools/avatar/glossary-zh.md
   - src/lingtai/tools/avatar/glossary-wen.md
+  - src/lingtai/tools/_manual.py
+  - src/lingtai/tools/_settings.py
+  - src/lingtai/adapters/avatar_launcher.py
+  - src/lingtai/adapters/posix/ANATOMY.md
+  - src/lingtai/adapters/posix/avatar_launcher.py
+  - src/lingtai/adapters/windows/ANATOMY.md
+  - src/lingtai/adapters/windows/avatar_launcher.py
+  - tests/test_avatar_rules.py
+  - tests/test_layers_avatar.py
+  - tests/test_avatar_action_input_candidate.py
 maintenance: |
-  Keep related_files as repo-relative paths to real files. Include neighboring
-  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
-  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
-  maintenance field. If you notice drift between this anatomy and the code,
-  report it. See lingtai-dev-guide for details.
+  Keep related_files as repo-relative paths to real files and keep this anatomy
+  connected to neighboring anatomy/manual/contract authorities. If code drifts,
+  update the authoritative source and this map together.
 ---
 # core/avatar
 
-Avatar capability — spawn independent peer agents (分身) as fully detached
-processes. Two modes:
+Avatar is the durable peer-agent capability. It exposes exactly one public tool,
+`avatar`, with a closed root `action` plus required nested `input`. Every
+avatar-owned public example is explicit and includes Agent-injected root
+`reasoning`:
 
-- **Shallow (初生):** Copy `init.json` to a new working dir, strip identity,
-  launch. The avatar gets the same LLM config + capabilities but no history.
-- **Deep (二重身):** Copy identity and durable knowledge (`system/`, `knowledge/`, `exports/`)
-  plus `init.json`, strip name + history. The avatar is a doppelgänger — same
-  character, pad, knowledge — but starts a fresh conversation.
+```text
+avatar(action="spawn", input={"name": "researcher"}, reasoning="...")
+avatar(action="rules", input={"rules_content": "..."}, reasoning="...")
+avatar(action="manual", input={}, reasoning="load guidance")
+```
 
-Both modes launch `lingtai-agent run <dir>` as a detached process. The avatar is an
-independent life — its existence does not depend on yours.
+The raw avatar `get_schema()` contains only `action` and `input`. `BaseAgent`
+adds optional root `reasoning` when it constructs the model-facing
+`FunctionSchema.parameters`; reasoning never enters an input branch.
+Avatar-owned prose does not describe flat or omitted-action forms. Sibling tools
+remain outside this migration boundary.
 
 ## Components
 
-- `avatar/__init__.py` — validation, preparation, boot policy, ledger, rules,
-  schemas, and setup. The core class is `AvatarManager`.
-- `avatar/_launcher.py` — immutable launch request/receipt and the avatar-local
-  opaque-handle Port.
+- `avatar/__init__.py` — strict action/input schema and runtime validation,
+  settings evidence, installed-manual route, spawn preparation/boot/ledger,
+  rules distribution, and setup. `AvatarManager` is the core class.
+- `avatar/_launcher.py` — immutable launch request/receipt and the opaque
+  launcher Port.
+- `avatar/manual/SKILL.md` — installed avatar-manual source body and public
+  operational guidance.
+- `CONTRACT.md` — canonical public contract and provider-envelope notes.
+- `adapters/avatar_launcher.py` — launcher selection boundary.
+- `adapters/posix/avatar_launcher.py` and `adapters/windows/avatar_launcher.py`
+  — platform-specific process/session ownership. Their neighboring anatomy files
+  define the platform edges; core avatar code must not duplicate them.
 
-## Public API
+## Preserved runtime edges
 
-The capability exposes one public tool, `avatar`, dispatched by an `action`
-enum:
+The public schema change does not alter the existing lifecycle graph:
 
-| Action | Description |
-|------|-------------|
-| `spawn` | Spawn a new avatar agent (shallow or deep) with a given name, optional type, and optional comment. Accepts `dry_run` (preview-only) and `confirm` (acknowledge mission-quality gate). |
-| `rules` | Set rules content and distribute via `.rules` signal files to self + all descendants. |
-| `manual` | Read-only: returns the exact `manual/SKILL.md` body. No mutation. |
-
-`action` has no default — it is required both by the schema
-(`"required": ["action"]`) and at runtime, matching the established action-tool
-convention already used by `knowledge`, `mcp`, `skills`, `notification`,
-`system`, `soul`, and `daemon`. Omitting `action` fails deterministically via
-the same `dispatch_action` unknown-action envelope as an unrecognized value;
-it never falls through to `spawn`.
-
-`avatar` uses a single plain top-level `type: object` schema with an explicit
-`action` enum, not a top-level `allOf`/`oneOf` combinator — some
-OpenAI-compatible strict tool validators reject top-level JSON Schema
-combinators. Action-specific required inputs beyond `action` itself (`name`
-for spawn, `rules_content` for rules) are validated in the handler, not the
-schema.
-
-## Internal Module Layout
-
-```
-avatar/__init__.py
-  ├── AvatarManager.__init__        — stores parent agent ref
-  ├── handle()                      — public dispatcher for the avatar tool
-  │                                    (action: spawn | rules | manual)
-  ├── _manual()                     — reads the packaged manual/SKILL.md body
-  │
-  │  Spawn pipeline:
-  ├── _spawn()                      — validates name, checks liveness, prepares working dir, launches process
-  ├── _make_avatar_init()           — builds avatar's init.json from parent's (strips identity, reroots paths)
-  ├── _prepare_deep()               — copies system/ + knowledge/ + exports/ + combo.json for deep mode
-  ├── _launch()                     — resolves argv and delegates to the launcher Port
-  ├── _wait_for_boot()              — polls .agent.heartbeat or Port exit truth
-  │
-  │  Ledger:
-  ├── _append_ledger()              — appends spawn event to delegates/ledger.jsonl
-  ├── _read_ledger()                — reads all ledger records
-  │
-  │  Rules distribution:
-  ├── _rules()                      — admin-gated rules update, distributes via .rules signal files
-  ├── _walk_avatar_tree()           — recursively discovers all descendants from ledger files
-  └── _distribute_rules_to_descendants() — writes .rules signal file to every descendant
+```text
+validated spawn input + root reasoning
+  → safe sibling destination and composed init
+  → optional shallow/deep durable copy and identity/history stripping
+  → LaunchRequest through injected AvatarLauncher Port
+  → heartbeat/boot decision
+  → release opaque process handle
+  → append registration outcome in delegates/ledger.jsonl
+  → propagate existing .rules signal through the ledger tree
 ```
 
-## Key Invariants
+`dry_run` stops before directory/process/ledger side effects. Platform-specific
+process APIs remain below the POSIX/Windows launcher adapters. Confirmation,
+duplicate/liveness, boot-failure, and admin-rule gates remain owned by the
+existing manager methods and their tests; only the public argument envelope and
+settings evidence change here.
 
-- **Name validation:** Avatar names must match `^[\w-]+$` (Unicode-aware), max 64 chars, no dots or path separators. The name doubles as the working directory basename.
-- **Path scope:** The avatar's working directory must be a direct sibling of the parent's (same parent directory). Resolved path is checked against the network root to prevent escape.
-- **No identity inheritance:** Avatars get no name (`agent_name` is set to the avatar name), no admin privileges, no comment, no brief, no addons (IMAP/Telegram). The inherited `lingtai` seed is blanked; the first turn still arrives via a separate `.prompt` signal file.
-- **Preset stability:** Avatars always spawn on the parent's DEFAULT preset, not its currently-active one. Materialized `llm` + `capabilities` are stripped so the avatar re-materializes from the preset on first boot.
-- **Relative path re-rooting:** Preset paths (`default`, `active`, `allowed`) that are relative are re-rooted against the parent's working dir so they remain valid from the avatar's different directory.
-- **Liveness check:** Before spawning, existing ledger entries are observed through a target-bound `PosixAgentPresenceStoreAdapter` and Core `observe_alive()` policy. If a live avatar with the same name exists, the spawn is refused with `already_active`.
-- **Boot verification:** After launching, `_wait_for_boot()` polls for `.agent.heartbeat` or Port exit truth within 5 seconds. If the process exits before handshaking, stderr is captured and the failure is reported. Port release after observation never kills a live slow avatar.
-- **Deep copy scope guard:** `_prepare_deep()` asserts `dst.parent == src.parent` to prevent rmtree from reaching outside the network root.
-- **Mission-quality gate (issue #33):** Before any filesystem mutation, `_spawn` runs `_mission_looks_unsafe(reasoning)` — empty / sub-20-char / debug-placeholder missions return `{"status": "confirmation_needed", ...}` unless `confirm=true`. The dry-run path is exempt (its purpose is preview without commitment).
-- **Dry-run (issue #33):** `dry_run=true` short-circuits after parent `init.json` is loaded and before any working dir is created or process launched, returning `{"status": "dry_run", "preview": {...}}`. The preview includes whether the mission would have tripped the quality gate.
+## Dispatch anatomy
 
-## Dependencies
+```text
+AvatarManager.handle(args)
+  ├─ read settings/avatar.json (fresh v1 placeholder snapshot)
+  ├─ validate root mapping/action/input and action-owned nested keys
+  ├─ action=manual → load_installed_manual(agent, "avatar")
+  ├─ action=spawn  → _spawn({nested fields, _reasoning})
+  └─ action=rules  → _rules({rules_content})
+      └─ every result gets secret-free current_setting evidence
+```
 
-- `lingtai.i18n` — `t()` for localized strings
-- `lingtai.kernel.agent_presence` + `lingtai.adapters.posix.agent_presence` — ordered Core liveness policy and the target-bound production presence adapter
-- `lingtai.kernel.handshake` — `resolve_address()` for ledger-based tree walking
-- `lingtai.venv_resolve` — `resolve_venv()`, `venv_python()` for resolving the Python executable to launch the avatar
-- `lingtai.agent.Agent` — parent agent type (TYPE_CHECKING only)
+The strict checks happen before `_spawn`, `_rules`, launcher calls, or rules
+writes. Manual is read-only. A malformed or cross-action call cannot reach an
+avatar service seam.
 
-## Composition
+## Action ownership
 
-- **Parent:** `src/lingtai/tools/` (tool package).
-- **Siblings:** `daemon/`, `mcp/`, `knowledge/` (private durable memory), `skills/` (skill catalog), `bash/`.
-- **Kernel hooks:** `setup()` is called during capability initialization; `AvatarManager.handle()` is registered as the single `avatar` tool handler, internally dispatching `spawn`/`rules`/`manual` via `lingtai.kernel.tool_dispatch.dispatch_action`. The daemon capability blacklists `avatar` to prevent avatar-in-daemon recursion and rules mutation from emanations.
+| Action | Required nested input | Owned optional nested input |
+|---|---|---|
+| `spawn` | `name` | `type`, `comment`, `dry_run`, `confirm` |
+| `rules` | `rules_content` | none |
+| `manual` | empty object | none |
 
-Platform process mechanics are in `adapters/avatar_launcher.py` and the
-POSIX reference adapter. Unsupported Windows selection fails loudly; a future
-Windows adapter and native acceptance remain outside this re-cut.
+Spawn retains shallow/deep copy, mission-quality gate, duplicate liveness,
+path-scope, dry-run, boot heartbeat, detached launcher, ledger, and descendant
+rule propagation semantics. Rules retains its independent admin gate and
+signal-file distribution. No unlisted action input is introduced.
+
+## Settings evidence
+
+`read_settings(agent, "avatar")` rereads the fixed Agent-owned
+`settings/avatar.json` on every call. The strict v1 placeholder is metadata-only:
+missing, valid, byte-distinct revisions, and invalid content cannot change
+behavior or prompt text. All success/manual/malformed/service-error results
+carry `current_setting`; invalid content contributes only a bounded,
+secret-free error marker.
+
+## Installed manual edge
+
+`action="manual"` reads the actual initialized agent path
+`<agent>/.library/intrinsic/capabilities/avatar/SKILL.md` through the
+shared installed-manual loader. It does not substitute the source package body,
+construct a launcher, write a signal, or mutate the agent.
+
+## Side-effect boundary
+
+The production spawn and rules paths can have live effects. Focused tests must
+inject deterministic fake launchers/services and prove malformed calls make
+zero service calls. Never invoke real avatar spawning, rules distribution,
+process creation, network modification, or descendant config writing during
+validation.

--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -1,258 +1,186 @@
 ---
 name: avatar-contract
 tool: avatar
-contract_version: 3
+contract_version: 4
 related_files:
   - src/lingtai/tools/avatar/__init__.py
   - src/lingtai/tools/avatar/_launcher.py
   - src/lingtai/tools/avatar/ANATOMY.md
   - src/lingtai/tools/avatar/manual/SKILL.md
+  - src/lingtai/tools/_settings.py
   - src/lingtai/adapters/avatar_launcher.py
   - src/lingtai/adapters/posix/avatar_launcher.py
   - src/lingtai/adapters/windows/avatar_launcher.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
-  contract disagree, the code is the source of truth — fix the contract in the
-  same change and bump contract_version on breaking contract edits.
+  contract disagree, the code is the source of truth; fix both in the same
+  change and bump contract_version on breaking public edits.
 ---
 
 # Avatar capability contract
 
-`avatar` spawns independent peer agents (分身) as fully detached processes, and
-distributes shared rules across the avatar subtree. It registers **one** public
-tool, `avatar`, dispatched by an `action` enum (`spawn` | `rules` | `manual`).
-The implementation lives in `src/lingtai/tools/avatar/`; the code is the source
-of truth.
+`avatar` is one public tool for independent peer-agent spawning, descendant
+rules distribution, and installed-manual lookup. This document owns the avatar
+surface only; sibling tools may be at different migration stages.
 
-**contract_version 2** (breaking): the former two-tool surface (`avatar_spawn`,
-`avatar_rules`) was merged into the single `avatar` tool below. `avatar_spawn`
-and `avatar_rules` are no longer registered as model-facing tools; there is no
-compatibility alias.
+**contract_version 4** is the closed action/input migration. The raw public
+parameters are a closed object requiring both root `action` and nested `input`.
+The three action branches are `spawn`, `rules`, and `manual`. There is no
+avatar-owned flat-argument or omitted-action compatibility path.
 
-**contract_version 3** (breaking): `action` is now schema-required
-(`"required": ["action"]`) and runtime-required — omitting `action` no longer
-defaults to `spawn`. This aligns `avatar` with the established action-tool
-contract already followed by `knowledge`, `mcp`, `skills`, `notification`,
-`system`, `soul`, and `daemon`: every action tool in this repository requires
-an explicit `action`, with no implicit default action. A missing `action`
-returns the same deterministic `dispatch_action` unknown-action error envelope
-as any other unrecognized action value, and performs no spawn, rules, or
-manual side effect.
+## Public calls
 
-## Routing Card
-
-**Use this when:**
-- You are editing avatar spawning (shallow 初生 / deep 二重身), the spawn ledger,
-  boot verification, or rules distribution.
-- You are reviewing the mission-quality gate, avatar-name validation, the
-  init.json rewrite for a newborn avatar, or the `.prompt` / `.rules` signal
-  files.
-
-**Do not use this for:**
-- Ephemeral in-process subagents/emanations: use `daemon` (see
-  `src/lingtai/tools/daemon/CONTRACT.md`). An avatar is an *independent life* whose
-  existence does not depend on the parent; a daemon does.
-- Code navigation only: read `src/lingtai/tools/avatar/ANATOMY.md`.
-
-**Fast paths:** tool schemas -> §Tool surface; on-disk layout -> §State &
-storage; detached-process launch -> §Cross-platform invariants.
-
-## Scope
-
-- Canonical tool name: `avatar`. It is registered as a single tool with a plain
-  top-level object schema (deliberately no `allOf`/`oneOf` combinator, which
-  some strict OpenAI-compatible validators reject) and an explicit `action`
-  enum (`spawn` | `rules` | `manual`). `action` is schema-required
-  (`"required": ["action"]`) — the same convention as `knowledge`, `mcp`,
-  `skills`, `notification`, `system`, `soul`, and `daemon`. Action-specific
-  required inputs beyond `action` itself (`name` for spawn, `rules_content`
-  for rules) are validated in the handler, not the schema.
-- `action="spawn"` (must be passed explicitly — there is no default action)
-  creates a sibling agent directory named after the avatar and launches it via
-  the global venv. Shallow copies only `init.json` (no identity/pad/history);
-  deep also copies `system/`, `knowledge/`, `exports/`, and `combo.json`.
-- `action="rules"` writes a `.rules` signal to the caller and every descendant
-  so each agent refreshes its own `system/rules.md`-derived prompt. It carries
-  its own admin gate, independent of `spawn` — spawning never requires admin.
-- `action="manual"` is read-only: it returns the exact packaged
-  `src/lingtai/tools/avatar/manual/SKILL.md` body and performs no filesystem
-  mutation (no spawn, no ledger write, no `.rules` write).
-
-**Non-goals:** the parent holds no in-process handle to the avatar — liveness is
-checked purely via the filesystem handshake. The tool does not manage the
-avatar's ongoing lifecycle after boot (mail/system intrinsics do that).
-
-## Tool surface
-
-### `avatar` — `action="spawn"`
-
-Requires `name`. The mission/task brief arrives via the injected `_reasoning`
-field (becomes the avatar's first prompt), not a schema property.
-
-| Inputs | Optional inputs | Success output | Error / gate shapes |
-|---|---|---|---|
-| `name` (required) | `type` (`shallow`\|`deep`, default `shallow`), `comment`, `dry_run`, `confirm` | `{status: "ok", address, agent_name, type, pid, warning?}` (`warning` when boot is `slow`) | `{error: ...}` — missing/invalid name, bad type, missing parent `init.json`, path escapes network root, dir exists, or boot `failed` (with stderr tail); `{status: "confirmation_needed", warning, reason, preview}` on the mission-quality gate; `{status: "already_active", working_dir, message}` if a live peer of that name exists; `{status: "dry_run", preview, message}` when `dry_run=true` |
-
-The mission-quality gate refuses empty / very short (<20 chars) / debug-placeholder
-missions unless `confirm=true`; `dry_run` is exempt. Avatar names must match
-`^[\w-]+$` (Unicode letters, digits, `_`, `-`), be ≤64 chars, and carry no dot,
-slash, or leading `.` — the name doubles as the working-dir basename.
-
-### `avatar` — `action="rules"`
-
-| Inputs | Optional inputs | Success output | Error shapes |
-|---|---|---|---|
-| `rules_content` (required) | — | `{status: "ok", message, distributed_to: [...]}` | `{error: ...}` — empty `rules_content`, no admin privilege, or failure writing the self `.rules` signal |
-
-`action="rules"` requires at least one truthy admin privilege on the caller.
-This gate applies only to `rules`; `spawn` never checks admin.
-
-### `avatar` — `action="manual"`
-
-No inputs consumed beyond `action`.
-
-| Inputs | Optional inputs | Success output | Error shapes |
-|---|---|---|---|
-| — | — | `{status: "ok", action: "manual", manual: <exact SKILL.md body>}` | `{status: "degraded", action: "manual", manual: "", error: ...}` if the packaged manual file is missing |
-
-### Invalid or missing `action`
-
-An `action` value outside `spawn`/`rules`/`manual` — including an entirely
-omitted `action` key — returns
-`{error: "unknown action: <repr>, only 'spawn', 'rules', or 'manual' is supported"}`
-(for the omitted case, `<repr>` is `''`) without touching the filesystem, the
-ledger, `.rules`, or launching any process. There is no default action: a
-`name`- or `rules_content`-shaped payload with `action` omitted still fails
-this way rather than being inferred as `spawn` or `rules`.
-
-## State & storage
-
-All paths are relative to the parent agent working directory (`<parent>/`) and
-the network root (`<parent>/..`):
+Every avatar-owned public example uses explicit root `action`, nested `input`,
+and an Agent-injected root `reasoning` field:
 
 ```text
-<parent>/delegates/ledger.jsonl   # append-only spawn ledger (one JSON record/line)
-<parent>/system/rules.md          # canonical rules; auto-distributed on spawn
-<parent>/.rules                   # self rules signal (consumed by heartbeat)
-
-<network-root>/<avatar-name>/     # sibling of the parent
-  init.json                       # rewritten copy of parent's init.json
-  .prompt                         # first-turn brief (parent identity + reasoning), consumed once
-  .rules                          # distributed rules signal
-  logs/spawn.stderr               # captured child stderr for boot diagnosis
-  system/ knowledge/ exports/ combo.json   # deep mode only
+avatar(action="spawn", input={"name": "researcher"}, reasoning="...mission...")
+avatar(action="spawn", input={"name": "clone", "type": "deep", "comment": "", "dry_run": true, "confirm": false}, reasoning="preview this reviewed mission")
+avatar(action="rules", input={"rules_content": "Always report findings."}, reasoning="distribute the reviewed rule")
+avatar(action="manual", input={}, reasoning="load avatar guidance")
 ```
 
-The avatar's `init.json` is a deep copy of the parent's with: `agent_name` set,
-`lingtai` seed blanked, `admin` cleared, `comment` reset, kernel/secretary
-prompt-override fields and `addons` stripped, relative preset paths re-rooted,
-and the avatar pinned to the parent's **default** preset. The spawn brief is
-delivered out-of-band via the `.prompt` signal file, not the `lingtai` seed.
+`reasoning` is optional metadata injected at the root by `BaseAgent`; it is not
+nested action input and is not part of `get_schema()`. The tool executor passes
+it internally as `_reasoning`, where spawn uses it as the first-prompt mission.
 
-Each spawn appends a ledger record (`event: "avatar"`, `name`, `working_dir`,
-`mission`, `type`, `pid`, `boot_status`, optional `boot_error`). Rules
-distribution walks the ledger tree (cycle-guarded) and writes `.rules` to each
-live descendant.
+The raw schema is:
 
-## Cross-platform launcher contract
+- root `type: object`
+- root properties exactly `action` and `input`
+- root `required: ["action", "input"]`
+- root `additionalProperties: false`
+- `action` is the string enum `spawn | rules | manual`
+- `input` is an `anyOf` of strict object branches, each with
+  `additionalProperties: false`
 
-- `AvatarManager` resolves the existing interpreter policy and submits the
-  exact argv `[python, "-m", "lingtai", "run", <dir>]` plus
-  `logs/spawn.stderr` to the avatar-local Port. Cwd and environment are
-  inherited; the Port does not add a cwd or environment override.
-- The Port returns a positive PID and an opaque adapter handle. `poll()` is
-  nonblocking and returns the exact integer child return code or `None`.
-- Production adapters disconnect stdin/stdout and own a binary-write stderr
-  file, closing the parent descriptor after launch. `release()` performs a
-  best-effort, non-raising final observation and never terminates a live avatar.
-- POSIX (`src/lingtai/adapters/posix/avatar_launcher.py`) uses
-  `start_new_session=True`; `terminate()` is one-process TERM and
-  `force_terminate()` is one-process KILL. Neither operation claims tree
-  management.
-- Windows (`src/lingtai/adapters/windows/avatar_launcher.py`,
-  `WindowsAvatarLauncherAdapter`) uses
-  `creationflags=_win32.DETACHED_CREATIONFLAGS` (new process group + no window,
-  from the shared `lingtai.adapters.windows._win32` surface) plus
-  `close_fds=True` in place of `start_new_session`. It keeps the same
-  stdin/stdout-disconnect, owned binary-write stderr file, PID/exit-code, and
-  non-killing `release()` contracts. Honest termination tier (owner decision
-  U7): on Windows `Popen.terminate()` and `Popen.kill()` **both** call
-  `TerminateProcess` — there is no graceful signal. The Windows adapter does not
-  pretend a graceful tier exists: `terminate()` and `force_terminate()` are
-  **both** forceful, immediate termination of exactly the owned process, never a
-  tree kill.
-- The selector `select_avatar_launcher()` returns the Windows adapter when
-  `os.name == "nt"` (lazy import) and the POSIX adapter when `os.name ==
-  "posix"`, both via lazy imports so each mechanism module loads only on its
-  own platform. Any other `os.name` still fails loudly with `NotImplementedError`.
-- `python` is resolved lazily via `lingtai.venv_resolve.resolve_venv` /
-  `venv_python` from the avatar's `init.json` → global runtime. The
-  `lingtai.tools → lingtai` import edge is allowed only inside setup/handlers.
-- Boot verification polls for the avatar's `.agent.heartbeat` handshake file (up
-  to `_BOOT_WAIT_SECS = 5.0s`, 0.1s interval). If the child exits first, spawn
-  is `failed` and a bounded stderr tail is returned; if neither happens in the
-  window, boot is `slow` and a warning is attached.
+`get_schema()` remains the raw action/input-only schema. `BaseAgent` adds
+optional root `reasoning` when it constructs the Agent-facing
+`FunctionSchema.parameters`; no reasoning field is added inside any input
+branch. Provider envelope names remain unchanged: Chat uses
+`function.parameters`, Responses uses flat function `parameters`, and
+Anthropic uses `input_schema`.
 
-## Anchored claims
+## Action ownership
 
-| Claim | Source | Test |
-|---|---|---|
-| The POSIX launcher preserves exact detached launch, PID/exit truth, one-process termination, and non-killing release contracts; unrecognized platforms fail loudly | `src/lingtai/adapters/posix/avatar_launcher.py`, `src/lingtai/adapters/avatar_launcher.py` | `tests/test_avatar_launcher.py::test_posix_launch_contract_and_release`, `::test_selector_selects_posix_and_fails_loud_for_unsupported` |
-| The Windows launcher uses `DETACHED_CREATIONFLAGS` + `close_fds` (no `start_new_session`), keeps the same disconnect/stderr/PID/exit/non-killing-release contracts, and maps both `terminate` and `force_terminate` to forceful `TerminateProcess`; the selector routes `os.name == "nt"` to it | `src/lingtai/adapters/windows/avatar_launcher.py`, `src/lingtai/adapters/avatar_launcher.py` | `tests/test_avatar_launcher_windows.py::test_selector_returns_windows_adapter_when_os_name_is_nt`, `::test_windows_launch_uses_detached_flags_and_disconnects_streams`, `::test_windows_terminate_and_force_terminate_both_forceful`, `::test_windows_release_never_raises_and_never_terminates` |
-| Boot policy keeps heartbeat-first precedence, exact early-exit truth, and a live-process slow path without termination | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_launcher.py::test_manager_boot_policy_uses_opaque_port_and_preserves_precedence`, `::test_manager_slow_observation_does_not_terminate_child` |
-| `setup` registers exactly one public tool, `avatar`, and no old public names | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_setup_avatar`, `::test_add_capability_avatar`, `::TestUnifiedAvatarTool::test_setup_registers_exactly_one_public_tool` |
-| Each spawn appends a ledger record | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_ledger_records_spawn` |
-| `dry_run` previews without spawning and does not require `confirm` | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_dry_run_returns_preview_without_spawning`, `::test_dry_run_does_not_require_confirm` |
-| The mission-quality gate rejects empty/short/placeholder missions | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_helper_rejects_empty`, `::test_helper_rejects_short`, `::test_helper_rejects_test_word`, `::test_helper_rejects_test_prefix` |
-| Unsafe / duplicate avatar names are rejected | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_spawn_rejects_unsafe_name`, `::test_spawn_duplicate_name_error` |
-| Shallow spawn does not copy identity files | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_spawn_does_not_copy_identity_files` |
-| `action="rules"` requires admin and non-empty content; `spawn` does not inherit that gate | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_rules_requires_admin`, `::test_rules_requires_content`; `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_spawn_does_not_inherit_rules_permission_gate` |
-| Rules are distributed recursively to descendants (cycle-safe) | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_rules_distributes_recursively`, `::test_rules_root_not_duplicated_via_cycle` |
-| Spawning distributes existing rules to the newborn | `src/lingtai/tools/avatar/__init__.py` | `tests/test_avatar_rules.py::test_spawn_distributes_existing_rules`, `::test_spawn_deep_clone_also_gets_rules_signal` |
-| `_prepare_deep` refuses a non-sibling destination | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_prepare_deep_refuses_non_sibling_dst` |
-| `action="manual"` returns the exact packaged manual body and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` |
-| Invalid `action` fails deterministically without touching other actions | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_invalid_action_fails_deterministically`, `::test_spawn_missing_name_fails_without_affecting_other_actions` |
-| `action` is schema-required (`required: ["action"]`) and runtime-required — a missing `action` never defaults to `spawn`, `rules`, or `manual`, regardless of which action's fields are present, and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_omitted_action_fails_deterministically_and_does_not_default_to_spawn`, `::test_missing_action_fails_deterministically_regardless_of_payload_shape`; `tests/test_avatar_rules.py::TestAvatarRulesAction::test_explicit_spawn_action_required` |
-| The daemon blacklists the canonical `avatar` name (not the retired two-tool names) | `src/lingtai/tools/daemon/__init__.py` | `tests/test_daemon.py::test_build_tool_surface_blacklist`, `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_daemon_excludes_avatar_from_child_surface` |
+### `action="spawn"`
 
-## Verification matrix
+`input` requires `name` and owns only these fields:
 
-| Invariant | Automated test | Manual check | Risk if broken |
-|---|---|---|---|
-| Exactly one tool registers on setup | `tests/test_layers_avatar.py::test_setup_avatar` | Boot with `capabilities={"avatar": {}}` and inspect tools | Rules distribution or spawning silently unavailable |
-| Spawn is ledgered with boot status | `tests/test_layers_avatar.py::test_ledger_records_spawn` | Spawn an avatar, inspect `delegates/ledger.jsonl` | No audit trail; duplicate/liveness checks break |
-| Mission gate stops accidental spawns | `tests/test_layers_avatar.py::test_helper_rejects_short` | `avatar(action="spawn", name="x")` with a 5-char mission, confirm gate | Stray detached processes from batched calls |
-| Name validation / path-scope guard holds | `tests/test_layers_avatar.py::test_spawn_rejects_unsafe_name` | Spawn with `name="../x"`, confirm refusal | Avatar dir escapes the network root |
-| Boot verification catches early child exit | `tests/test_avatar_launcher.py::test_manager_boot_policy_uses_opaque_port_and_preserves_precedence` | Corrupt an avatar `init.json`, spawn, confirm `failed` + stderr | Parent thinks a crashed avatar is alive |
-| Omitted `action` never defaults to spawn | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_omitted_action_fails_deterministically_and_does_not_default_to_spawn` | Call `avatar(name="x", confirm=true)` with no `action`, confirm error + no spawned process | A model omitting `action` could accidentally spawn an untracked process |
-| Rules propagate to the whole subtree | `tests/test_avatar_rules.py::test_rules_distributes_recursively` | Set rules on a root, confirm `.rules` on each descendant | Descendants run stale/ungoverned rules |
-| `manual` action is read-only | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` | Call `avatar(action="manual")`, confirm no new files | A "manual" call could accidentally spawn or mutate rules |
+- `name` (required string): one bare sibling-directory name, Unicode letters,
+  digits, underscore, or hyphen; no dots, slashes, spaces, or leading dot; at
+  most 64 characters.
+- `type` (optional `shallow` or `deep`, default `shallow`)
+- `comment` (optional persistent avatar system note)
+- `dry_run` (optional boolean)
+- `confirm` (optional boolean)
 
-Run before merging avatar changes:
+The spawn action never accepts `rules_content`. Its mission is the injected
+root `reasoning` value. Empty, short (<20 characters), or debug/test-like
+missions require `confirm=true` unless `dry_run=true`. A dry run validates and
+returns a preview without writing a directory, ledger, signal, or process.
+Normal success, duplicate/live-peer, gate, and boot-failure semantics remain
+those implemented by `AvatarManager._spawn`.
 
-```bash
-python -m pytest tests/test_avatar_launcher.py tests/test_layers_avatar.py tests/test_avatar_rules.py tests/test_avatar_preset_inheritance.py tests/test_avatar_timezone_inheritance.py -q
+### `action="rules"`
+
+`input` requires `rules_content` and owns no spawn-only field. It requires an
+admin privilege, writes the self `.rules` signal, and distributes the same
+signal to live descendants discovered through the ledger tree. `name`, `type`,
+`comment`, `dry_run`, and `confirm` are rejected for this action before any
+rules service or filesystem side effect.
+
+### `action="manual"`
+
+`input` must be exactly `{}`. The action is read-only and loads the real
+installed `avatar` manual at:
+
+```text
+<agent>/.library/intrinsic/capabilities/avatar/SKILL.md
 ```
 
-## Schema and glossary ownership
+It does not read the source-package manual as a substitute and does not spawn,
+write rules, or append a ledger event.
 
-- **Canonical identifiers:** function names, JSON property names, action/enum
-  values, required fields, defaults, and bounds are canonical English literals.
-  The schema (`get_schema()`) and description (`get_description()`) are
-  language-independent; the optional `lang` argument is accepted for source
-  compatibility but ignored.
-- **Provider wire:** provider adapters send the global `WIRE_TOOL_DESCRIPTION`
-  constant as the top-level tool description; `FunctionSchema.description`
-  holds the full canonical prose rendered into `## tools`.
-- **Glossary resources:** this package owns `glossary-en.md`, `glossary-zh.md`,
-  and `glossary-wen.md`. Each has strict YAML frontmatter
-  (`kind: tool-glossary`, `schema_version: 1`, `tool_package: tools.<pkg>`,
-  `language: <lang>`). English body is empty; zh/wen bodies contain concise
-  terminology mappings that quote immutable English identifiers and never offer
-  localized aliases.
-- **Fallback:** exact normalized language lookup, then English, then no
-  appendix. Fail-closed for localized text; fail-open for tool availability.
-- **Update triggers:** changing a function name, action/enum value, property
-  name, or user-visible concept requires reviewing all three glossary files in
-  the same PR.
-- **Validation:** `python -m lingtai.tools.glossary_validator --check`.
+## Validation and settings evidence
+
+Every handler call first rereads the Agent-owned `settings/avatar.json` through
+the strict shared v1 placeholder reader. Missing, valid, byte-distinct hot
+revision, and invalid files are evidence only: `current_setting` never selects
+or changes avatar behavior. The file is reread on every call, including
+malformed, manual, and service-error paths.
+
+Every returned result contains a fresh secret-free `current_setting` block with
+`configurable: false`, `placeholder: "no-op"`, source, revision, bounded hash,
+and a no-op change hint. Invalid settings may add a bounded `settings_error`;
+raw bytes, secret sentinels, and host paths are never returned. Settings
+behavior and prompt text are invariant across missing/valid/revised/invalid
+snapshots.
+
+Root and nested mappings are checked strictly before dispatch. Non-mapping
+arguments, missing root keys, unsupported root keys, non-string/unhashable
+keys, non-string or unsupported action values, non-mapping input, non-string
+nested keys, missing action-required fields, and action-crossed fields return a
+bounded error with `current_setting` and make zero avatar service calls.
+
+## State and side effects
+
+All paths are relative to the parent agent directory and its network root:
+
+```text
+<parent>/delegates/ledger.jsonl
+<parent>/.rules
+<network-root>/<avatar-name>/
+```
+
+A real spawn is a detached process and may copy/write files, launch a child,
+and distribute existing rules. A real rules call writes signals. Validation,
+manual, and dry-run paths do not perform those live side effects. Tests and
+harnesses must inject a deterministic launcher/service seam; never call the
+public tool against a live network or real avatar process.
+
+The launch Port remains responsible for platform mechanics. Spawn keeps the
+existing exact argv, boot heartbeat, ledger, deep-copy, path-scope, and
+cross-platform launcher semantics described by the source and adapter
+contracts.
+
+## Preserved runtime and platform invariants
+
+This schema migration does not move platform mechanics into the core manager or
+weaken the existing launch contract:
+
+- avatar names remain one safe sibling segment and the resolved destination must
+  stay directly under the network root;
+- shallow spawn copies the parent configuration through the existing composition
+  and identity-stripping path; deep spawn also copies the durable roots selected
+  by the existing implementation and starts with fresh conversation history;
+- `dry_run` performs validation and returns the existing preview without creating
+  the avatar directory, launching a process, or appending a success ledger row;
+- the manager prepares a `LaunchRequest`, calls the injected launcher Port, waits
+  for the existing heartbeat/boot condition, and releases the opaque process
+  handle after the boot decision;
+- POSIX and Windows process/session details remain owned by their adapter
+  launchers. Core code must not branch on platform-specific process APIs;
+- successful spawn registration and rules propagation continue through
+  `delegates/ledger.jsonl` and the existing `.rules` signal protocol. Failed
+  launch/boot paths must not be reported as successful registrations;
+- confirmation, duplicate/liveness, admin, and boot-failure outputs keep their
+  established machine-readable shapes; this migration only nests public inputs
+  and adds settings evidence.
+
+The cross-platform and state invariants remain mechanically anchored by
+`tests/test_layers_avatar.py`, `tests/test_avatar_rules.py`, the platform
+launcher test suites, and `tests/test_avatar_action_input_candidate.py`. Tests
+for this public migration must patch candidate-owned launch/boot/rules seams and
+must never start a real descendant process or distribute rules to a live
+network.
+
+## Documentation and glossary ownership
+
+`get_description()`, this contract, `ANATOMY.md`, and the installed manual must
+keep avatar-owned public examples in root-action/nested-input/reasoning form.
+Do not rewrite sibling-tool prose merely because it still shows another shape.
+Canonical identifiers (`avatar`, `action`, `input`, `spawn`, `rules`, `manual`,
+`name`, `type`, `comment`, `dry_run`, `confirm`, `rules_content`, and
+`reasoning`) remain English literals. The zh/wen glossaries map terms only and
+do not invent aliases or options.

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -17,10 +17,13 @@ every spawn event.
 
 Usage:
     Agent(capabilities=["avatar"])
-    # avatar(action="spawn", name="researcher")              — shallow (初生)
-    # avatar(action="spawn", name="clone", type="deep")      — deep (二重身)
-    # avatar(action="rules", rules_content="...")            — distribute rules
-    # avatar(action="manual")                                — read the avatar manual
+    # avatar(action="spawn", input={"name": "researcher"}, reasoning="...")
+    # avatar(action="spawn", input={"name": "clone", "type": "deep"}, reasoning="...")
+    # avatar(action="rules", input={"rules_content": "..."}, reasoning="...")
+    # avatar(action="manual", input={}, reasoning="read the avatar manual")
+
+The public schema is a closed root ``action`` + required nested ``input``;
+``BaseAgent`` injects optional root ``reasoning`` for model-facing calls.
 """
 from __future__ import annotations
 
@@ -28,15 +31,15 @@ import json
 import os
 import re
 import shutil
-import sys
 import time
-from importlib import resources
+from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lingtai.kernel.agent_presence import observe_alive as _presence_observe_alive
 from lingtai.kernel.i18n import t
-from lingtai.kernel.tool_dispatch import dispatch_action
+from .._manual import load_installed_manual
+from .._settings import current_setting, read_settings
 from ._launcher import AvatarLaunchReceipt, AvatarLaunchRequest, AvatarLauncherPort
 
 
@@ -95,67 +98,98 @@ if TYPE_CHECKING:
 
 PROVIDERS = {"providers": [], "default": "builtin"}
 
+_ACTION_FIELDS = {
+    "spawn": ("name", "type", "comment", "dry_run", "confirm"),
+    "rules": ("rules_content",),
+    "manual": (),
+}
+_ALLOWED_ROOT_FIELDS = ("action", "input", "reasoning", "_reasoning")
+
+
 def get_description(lang: str = "en") -> str:
     return (
         "Spawn an independent agent (他我), set network rules for descendants, "
-        "or read the avatar manual. Requires an explicit action — no default. "
-        "action='spawn': inherits init.json, boots on default preset — requires "
-        "'name'. action='rules': distribute rules_content to self + all "
-        "descendants (requires karma). action='manual': return the "
-        "avatar-manual skill body. See avatar-manual skill for full guidance."
+        "or read the avatar manual. Use avatar(action='spawn', input={'name': "
+        "'researcher', 'type': 'shallow', 'comment': '', 'dry_run': False, "
+        "'confirm': True}, reasoning='...') for spawn; spawn input.name is "
+        "required and owns only type/comment/dry_run/confirm. Use "
+        "avatar(action='rules', input={'rules_content': '...'}, reasoning='...') "
+        "to distribute rules, or avatar(action='manual', input={}, "
+        "reasoning='...') to load the installed avatar manual (avatar-manual). BaseAgent injects "
+        "optional root reasoning; action and input are always explicit."
     )
 
 
 def get_schema(lang: str = "en") -> dict:
-    """Schema for the single public ``avatar`` tool.
+    """Return the raw closed ``action`` + required nested ``input`` schema.
 
-    A plain top-level ``type: object`` with an explicit ``action`` enum —
-    deliberately no top-level ``allOf``/``oneOf`` combinator, which some
-    OpenAI-compatible strict tool validators reject. Action-specific required
-    inputs (``name`` for spawn, ``rules_content`` for rules) are validated in
-    the handler, not the schema, so all three actions share one flat property
-    bag.
+    ``BaseAgent`` alone adds the optional root ``reasoning`` property to the
+    model-facing schema. Provider adapters retain their own named envelopes;
+    this function returns only the provider-agnostic raw parameters.
     """
+    spawn_input = {
+        "title": "spawn input",
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "True avatar name and sibling working-directory basename; max 64 characters, no dots, slashes, spaces, or leading dot.",
+            },
+            "type": {
+                "type": "string",
+                "enum": ["shallow", "deep"],
+                "description": "shallow (default) copies init.json only; deep copies durable identity and knowledge.",
+            },
+            "comment": {
+                "type": "string",
+                "description": "Persistent system note for the avatar; not inherited.",
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "Preview without creating files or a process.",
+            },
+            "confirm": {
+                "type": "boolean",
+                "description": "Confirm a reviewed mission when the quality gate requires it.",
+            },
+        },
+        "required": ["name"],
+        "additionalProperties": False,
+    }
+    rules_input = {
+        "title": "rules input",
+        "type": "object",
+        "properties": {
+            "rules_content": {
+                "type": "string",
+                "description": "Plain-text rules distributed to the caller and descendants.",
+            },
+        },
+        "required": ["rules_content"],
+        "additionalProperties": False,
+    }
+    manual_input = {
+        "title": "manual input",
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": False,
+    }
     return {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
                 "enum": ["spawn", "rules", "manual"],
-                "description": (
-                    "spawn: create a new avatar — requires 'name'. "
-                    "rules: distribute network rules to self + descendants — "
-                    "requires 'rules_content'. manual: return the avatar-manual "
-                    "skill body; no other inputs used. Required — no default."
-                ),
+                "description": "Required operation: spawn, rules, or manual.",
             },
-            "name": {
-                "type": "string",
-                "description": 'True name for the avatar (required for action=spawn). Also the working-directory basename under .lingtai/. Single segment: letters/digits/underscore/hyphen, max 64 chars.',
-            },
-            "type": {
-                "type": "string",
-                "enum": ["shallow", "deep"],
-                "description": "'shallow' (default): blank slate — init.json only. 'deep': full copy of character, pad, and codex.",
-            },
-            "comment": {
-                "type": "string",
-                "description": "Persistent system note in the avatar's prompt (survives molt/refresh/wake). Not inherited. Leave empty unless you have something the avatar must never forget.",
-            },
-            "dry_run": {
-                "type": "boolean",
-                "description": 'Preview the spawn without creating a process. Use to sanity-check before committing.',
-            },
-            "confirm": {
-                "type": "boolean",
-                "description": 'Confirm you have reviewed the mission and intend to spawn. Required when the mission looks empty/short/test-like.',
-            },
-            "rules_content": {
-                "type": "string",
-                "description": 'Rules content for action=rules. Plain text, one rule per line. Non-negotiable constraints distributed to all descendants.',
+            "input": {
+                "description": "Strict action-specific avatar input.",
+                "anyOf": [spawn_input, rules_input, manual_input],
             },
         },
-        "required": ["action"],
+        "required": ["action", "input"],
+        "additionalProperties": False,
     }
 
 
@@ -179,26 +213,108 @@ class AvatarManager:
     # Handler
     # ------------------------------------------------------------------
 
-    def handle(self, args: dict) -> dict:
-        return dispatch_action(
-            args,
-            {
-                "spawn": self._spawn,
-                "rules": self._rules,
-                "manual": lambda _args: self._manual(),
-            },
-            unknown=lambda action: {
-                "error": f"unknown action: {action!r}, only 'spawn', 'rules', or 'manual' is supported",
-            },
-        )
+    @staticmethod
+    def _with_setting(result: Mapping[str, Any], diagnostic: dict[str, Any]) -> dict[str, Any]:
+        """Attach one fresh, secret-free settings diagnostic to a result."""
+        value = dict(result)
+        value["current_setting"] = dict(diagnostic)
+        return value
+
+    def handle(self, args: Any) -> dict:
+        """Validate the closed public action/input contract before any service call."""
+        snapshot = read_settings(self._agent, "avatar")
+        diagnostic = current_setting(snapshot, "avatar")
+
+        def error(message: str) -> dict:
+            return self._with_setting({"error": message}, diagnostic)
+
+        if not isinstance(args, Mapping):
+            return error("avatar arguments must be an object")
+        try:
+            root_keys = list(args.keys())
+        except Exception:
+            return error("avatar arguments must be an object")
+        if any(not isinstance(key, str) or key not in _ALLOWED_ROOT_FIELDS for key in root_keys):
+            return error("avatar accepts only root action, input, reasoning, and _reasoning")
+        if "action" not in root_keys or "input" not in root_keys:
+            return error("avatar requires root action and input")
+
+        try:
+            action = args["action"]
+            raw_input = args["input"]
+        except Exception:
+            return error("avatar arguments are malformed")
+        if type(action) is not str or action not in _ACTION_FIELDS:
+            return error(
+                f"unknown action: {action!r}, only 'spawn', 'rules', or 'manual' is supported"
+            )
+        if not isinstance(raw_input, Mapping):
+            return error("avatar input must be an object")
+        try:
+            action_input = dict(raw_input)
+        except Exception:
+            return error("avatar input must be an object")
+        if any(not isinstance(key, str) for key in action_input):
+            return error("avatar input field names must be strings")
+        allowed_fields = _ACTION_FIELDS[action]
+        if any(key not in allowed_fields for key in action_input):
+            return error(f"unsupported avatar input field for action {action!r}")
+
+        if action == "manual":
+            if action_input:
+                return error("manual input must be an empty object")
+            try:
+                result = self._manual()
+            except Exception:
+                result = {
+                    "status": "degraded",
+                    "action": "manual",
+                    "manual": "",
+                    "error": "avatar manual failed",
+                }
+            return self._with_setting(result, diagnostic)
+
+        required = "name" if action == "spawn" else "rules_content"
+        if required not in action_input:
+            return error(f"{required} is required")
+        if action == "rules" and not isinstance(action_input["rules_content"], str):
+            return error("rules_content must be a string")
+        if action == "spawn":
+            if not isinstance(action_input["name"], str):
+                return error("name must be a string")
+            if "type" in action_input and type(action_input["type"]) is not str:
+                return error("type must be a string")
+            if "comment" in action_input and not isinstance(action_input["comment"], str):
+                return error("comment must be a string")
+            if "dry_run" in action_input and type(action_input["dry_run"]) is not bool:
+                return error("dry_run must be a boolean")
+            if "confirm" in action_input and type(action_input["confirm"]) is not bool:
+                return error("confirm must be a boolean")
+
+        # ``ToolExecutor`` removes public root reasoning and preserves it as
+        # ``_reasoning``.  Accepting the plain key here only supports direct
+        # in-process callers; it is not part of the raw public schema.
+        try:
+            reasoning = args.get("_reasoning")
+            if reasoning is None:
+                reasoning = args.get("reasoning")
+        except Exception:
+            reasoning = None
+        if reasoning is not None and not isinstance(reasoning, str):
+            return error("reasoning must be a string")
+        dispatch_args = dict(action_input)
+        dispatch_args["_reasoning"] = reasoning
+        try:
+            result = self._spawn(dispatch_args) if action == "spawn" else self._rules(dispatch_args)
+        except Exception:
+            # Do not expose service exception text, paths, or secrets. The
+            # settings diagnostic remains the only configuration evidence.
+            result = {"error": "avatar service failed"}
+        return self._with_setting(result, diagnostic)
 
     def _manual(self) -> dict:
-        """Return the exact packaged avatar-manual body; performs no mutation."""
-        try:
-            body = resources.files(__package__).joinpath("manual/SKILL.md").read_text(encoding="utf-8")
-        except (FileNotFoundError, ModuleNotFoundError, AttributeError):
-            return {"status": "degraded", "action": "manual", "manual": "", "error": "avatar manual missing"}
-        return {"status": "ok", "action": "manual", "manual": body}
+        """Return the exact installed avatar-manual body; performs no mutation."""
+        return {"action": "manual", **load_installed_manual(self._agent, "avatar")}
 
     # ------------------------------------------------------------------
     # Ledger (append-only JSONL log of avatar spawn events)
@@ -256,8 +372,9 @@ class AvatarManager:
         # Mission-quality gate. The reasoning field becomes the avatar's first
         # prompt, so an empty / very-short / debug-placeholder mission almost
         # always means an accidental spawn (a real incident: an agent batched
-        # avatar_spawn into a parallel call with mission "test" and a process
-        # was created). Refuse unless the caller explicitly passes confirm=True.
+        # avatar(action="spawn", input={...}, reasoning="test") into a parallel
+        # call and a process was created). Refuse unless the caller explicitly
+        # passes confirm=True.
         # The dry-run path is exempt — its whole purpose is preview without
         # commitment, and forcing confirm=True there would defeat that.
         if not dry_run and not confirm:

--- a/src/lingtai/tools/avatar/glossary-wen.md
+++ b/src/lingtai/tools/avatar/glossary-wen.md
@@ -10,16 +10,18 @@ related_files:
 - src/lingtai/tools/avatar/glossary-en.md
 - src/lingtai/tools/avatar/glossary-zh.md
 maintenance: |
-  Classical-Chinese (wen) glossary for the `avatar` tool package (lingtai.tools.avatar); body must stay non-empty and distinct from glossary-zh.md (tool_glossary.py enforces both). Update in lockstep with glossary-en.md/glossary-zh.md whenever avatar's public tool schema changes.
+  Classical-Chinese (wen) glossary for the `avatar` tool package; body must stay non-empty and distinct from glossary-zh.md. Update when avatar's public identifiers change.
   Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
 ---
 **名相对照**
 
-- `avatar`：唯一公开之器，以 `action` 分遣。详见 avatar-manual 技。
-- `action`：必填，无默认。`spawn`（化出独立他我，承 init.json，以默认预设启）｜`rules`（设网法以布一切后嗣，需 karma）｜`manual`（只读，还 avatar 手册全文）。
-- `name`：他我真名（action=spawn 时必填）。亦为 .lingtai/ 下目录之名。单段：字母/数/下划线/连字，至长六十四。
-- `type`：'shallow'（默认，初生）：白纸，仅 init.json。'deep'（二重身）：全拷灵台、简、典。
-- `comment`：他我提示之恒注（跨蜕/刷/眠不去）。不承自父。无事勿填。
-- `dry_run`：预览而不化。用于提交前省察。
-- `confirm`：确认已审任务且决意化。任务空/短/似试时必填。
-- `rules_content`：action=rules 所需法则之文。纯文每行一则。不可议之约束，布一切后嗣。
+- `avatar`：唯一公开之器，以 `action` 分遣，根必具 `input`。
+- `action`：根必填，无默认。`spawn`｜`rules`｜`manual`。
+- `input`：根必填之严整动作输入，各动作各守其字段。
+- `reasoning`：Agent 所注之根级可选元数，非 `input` 所属；为 spawn 之使命简报。
+- `name`：他我真名（`spawn.input` 必填），亦为 .lingtai/ 下目录之名；单段字母/数/下划线/连字，至长六十四。
+- `type`：`spawn.input` 之 `shallow`（默认，初生）或 `deep`（二重身）。
+- `comment`：`spawn.input` 之恒注，不承自父。
+- `dry_run`：`spawn.input` 之预览，不化进程。
+- `confirm`：`spawn.input` 之任务确认。
+- `rules_content`：`rules.input` 所需法则之文；`spawn` 不属此字段。

--- a/src/lingtai/tools/avatar/glossary-zh.md
+++ b/src/lingtai/tools/avatar/glossary-zh.md
@@ -15,11 +15,13 @@ maintenance: |
 ---
 **术语对照**
 
-- `avatar`：唯一公开工具，以 `action` 分派。详见 avatar-manual 技能。
-- `action`：必填，无默认值。`spawn`（化出独立他我，继承 init.json，用默认预设启动）｜`rules`（设置网络法则并分发给所有后代，需 karma）｜`manual`（只读，返回 avatar 手册全文）。
-- `name`：他我之真名（action=spawn 时必填）。兼作 .lingtai/ 下目录名。单段：字母/数字/下划线/连字符，最长64字。
-- `type`：'shallow'（默认，初生）：白纸，仅 init.json。'deep'（二重身）：完整复制灵台、简、典。
-- `comment`：写入他我系统提示之持久注解（跨凝蜕/刷新/休眠不变）。不承自父。非必要勿填。
-- `dry_run`：预览化出而不生进程。用于提交前审查。
-- `confirm`：确认已审阅任务并决意化出。任务空白/过短/似试时必填。
-- `rules_content`：action=rules 所需之法则内容。纯文，每行一则。不可协商之约束，分发一切后代。
+- `avatar`：唯一公开工具，以 `action` 分派，根含必填 `input`。
+- `action`：根级必填，无默认值。`spawn`（化出独立他我）｜`rules`（设置网络法则）｜`manual`（只读，返回已安装手册）。
+- `input`：根级必填之严格动作输入；各动作只纳其所属字段。
+- `reasoning`：Agent 注入之可选根级元数据，非 `input` 字段；用于 spawn 任务简报。
+- `name`：他我之真名（`spawn` 的 `input` 中必填）。兼作 .lingtai/ 下目录名。单段：字母/数字/下划线/连字符，最长64字。
+- `type`：`spawn.input` 之 'shallow'（默认，初生）或 'deep'（二重身）。
+- `comment`：`spawn.input` 之持久系统注解。不承自父。
+- `dry_run`：`spawn.input` 之预览开关，不生进程。
+- `confirm`：`spawn.input` 之任务确认开关。
+- `rules_content`：`rules.input` 所需之法则内容；`spawn` 不拥有此字段。

--- a/src/lingtai/tools/avatar/manual/SKILL.md
+++ b/src/lingtai/tools/avatar/manual/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: avatar-manual
 description: |
-  Complete operational guide for the avatar tool — spawning, managing, and communicating with 他我 (alter-ego agents). Read this when: you are about to spawn an avatar; an avatar you spawned goes quiet; you need to decide between avatar, daemon, or bash; or you are an avatar and need to know how to escalate to your parent. Covers spawn types, naming rules, discipline, escalation protocol, and the parent_prompt contract.
-version: 1.0.0
-last_changed_at: 2026-07-19T00:00:00Z
+  Complete operational guide for the avatar tool — spawning, managing, and communicating with 他我 (alter-ego agents). Read this when you are about to spawn an avatar, an avatar goes quiet, you need to choose between avatar/daemon/bash, or you need escalation guidance.
+version: 2.0.0
+last_changed_at: 2026-07-26T00:00:00Z
 related_files:
 - src/lingtai/tools/avatar/__init__.py
 - src/lingtai/tools/avatar/ANATOMY.md
@@ -16,152 +16,136 @@ maintenance: |
 
 ## 1. What Is an Avatar
 
-An avatar (他我) is a **fully independent agent process** spawned from you. It:
+An avatar (他我) is a **fully independent agent process** spawned from you. It
+inherits the relevant `init.json` configuration, boots on your default preset,
+is recorded in `delegates/ledger.jsonl`, and communicates through mail or email.
+Once spawned it is detached, with its own working directory, history, and life.
 
-- Inherits your `init.json` (model config, capabilities, covenant, language)
-- Boots on your **default** preset (not your active preset — this keeps the avatar's "home" stable in the network)
-- Is recorded in `delegates/ledger.jsonl`
-- Communicates with you via `mail` or `email`
+Use avatar only for work that needs persistence and learning. Use `daemon` when
+you need only an ephemeral conclusion, and `bash` for one-off commands.
 
-Once spawned, it is **detached** — a new life. It has its own working directory, its own conversation history, its own molts. It does not share your context window.
+## 2. The public call shape
 
-### Avatar vs Daemon vs Bash
+The avatar-owned public call is always a closed root `action` plus nested `input`,
+with optional root `reasoning` injected by `BaseAgent`:
 
-Pick avatar only for work that needs *persistence and learning* — a specialist
-that accumulates knowledge across sessions and survives until sleep/suspend.
-Use `daemon` when you only need the *conclusion* (ephemeral, fire-and-forget)
-and `bash` for one-off commands. The full body-selection model lives in
-`system-manual` → `reference/substrate-manual/SKILL.md` §1.
-
-## 2. Spawn Types
-
-| Type | What it gets | When to use |
-|------|-------------|-------------|
-| `shallow` (default, 初生) | `init.json` only — blank slate | Most tasks. The avatar starts clean and learns what it needs. |
-| `deep` (二重身) | Full copy of your lingtai (character), pad, and knowledge | When the avatar needs to hit the ground running with your accumulated knowledge. |
-
-## 3. Naming Rules
-
-The `name` field (required) doubles as the avatar's working-directory basename under `.lingtai/`. Constraints:
-
-- Single bare segment: letters (any script), digits, underscore, hyphen only
-- No slashes, no dots, no spaces, no leading `.`
-- Max 64 characters
-
-The avatar's display name (nickname) can be set separately via `psyche(name, nickname, ...)` and has no such constraints.
-
-## 4. The `reasoning` Field — Mission Briefing
-
-The `reasoning` parameter you write on the `avatar(action="spawn")` call **automatically becomes the avatar's first prompt**. Write it as a thorough mission briefing, not just a one-liner rationale. Include:
-
-- What the task is
-- Why it matters
-- What files/paths/resources are relevant
-- Who to contact (parent address, collaborators)
-- What "done" looks like
-- Any constraints or gotchas
-
-This is the most important part of the spawn. A vague briefing produces a confused avatar.
-
-## 5. Spawn Discipline
-
-Every `avatar(action="spawn")` call creates an independent process that consumes resources until `system(sleep)` or `system(suspend)`. Treat spawns as expensive:
-
-1. **Never include `avatar(action="spawn")` in a parallel batch** with unrelated tool calls.
-2. **Re-read your `reasoning` field before invoking** (§4).
-3. **For inspection or one-off commands, use `bash` or `system`** — not `avatar`.
-4. **Use `dry_run=true` to preview** a spawn without creating a process. Sanity-check the name, type, working directory, and mission before committing.
-5. **Use `confirm=true`** to acknowledge you have double-checked the mission and intend to spawn. Required when the mission looks empty/very short/test-like.
-
-## 6. Caring for Avatars After Spawn
-
-### Record in pad
-
-After spawning, record the avatar's address (working-directory name), the
-mission you gave it, and why you delegated. Pad is the roster of delegations you
-are accountable for — update it when the avatar reports back or completes.
-(Pad practice itself: `psyche-manual` §5.)
-
-### When an avatar goes quiet
-
-**Do not send probe mails to check on it.** Instead, report upstream: email your own parent, who can decide whether to `system(cpr)` the avatar, escalate further, or accept the loss. Failures propagate up the delegation chain naturally.
-
-### The parent_prompt contract
-
-Every avatar receives this system-level prompt on spawn:
-
-> "[system] You are an avatar of {parent_name}, whose address is {parent_address}. Please keep this in your psyche memory so you remember who spawned you. When you complete your mission, encounter problems you cannot resolve, or need to report back, email your parent at the address above."
-
-This is automatic — you do not need to repeat it in your reasoning.
-
-## 7. Avatar Escalation (for Avatars)
-
-If you are an avatar (your `admin` block is empty or all admin privileges are false) and you hit a problem you cannot resolve, **mail your parent**. This is non-optional. Silence looks like success and starves your parent of signal.
-
-**What counts as "should report to parent":**
-
-- **Blocker you cannot unblock** — missing credentials, a tool that refuses you, an external service down, a dependency your parent owns
-- **Scope creep or ambiguity** — the task as written doesn't match what you're finding; you need a decision, not a guess
-- **Budget pressure** — you are close to a molt, context/tool budget is tight, or the task looks bigger than you were briefed for
-- **Broken peers** — another avatar in your sibling group is STUCK, unresponsive, or producing bad output that affects your work
-- **Security or safety concerns** — anything that smells wrong (suspicious file, unexpected credentials, destructive instruction from an unknown sender)
-- **Surprising findings the parent would want** — even good news counts if it changes the plan
-
-**Be concrete in your report:** what you were doing, what went wrong, what you tried, what you need from them. Then either continue on a safe fallback, go `system(sleep)`, or idle — whatever the parent's standing orders say. Do not silently retry forever and do not molt with an unreported blocker.
-
-## 8. The `comment` Field — Persistent System Note
-
-The `comment` parameter is a persistent system-level note injected into the avatar's system prompt (rendered last, after memory). Key properties:
-
-- **Not inherited from parent** — defaults to empty
-- **Survives everything**: molt, refresh, sleep/wake
-- Use ONLY for instructions the avatar must **always** remember — critical constraints, environment setup notes, safety rules
-
-Leave empty unless you have something the avatar should never forget.
-
-## 9. Network Rules (`avatar(action="rules")`)
-
-The `rules` action writes a `.rules` file to your directory and distributes it to **all descendants** in the avatar tree. Properties:
-
-- Requires **karma** privilege (admin)
-- Rules are injected into the system prompt (after covenant, before tools)
-- Persist across molts
-- Plain text — one rule per line
-- These are **non-negotiable constraints**, not suggestions
-
-Example:
-```
-Always report findings via email.
-Do not spawn more than 3 avatars.
+```text
+avatar(action="spawn", input={"name": "researcher"}, reasoning="...mission briefing...")
+avatar(action="spawn", input={"name": "clone", "type": "deep", "comment": "", "dry_run": true, "confirm": false}, reasoning="preview this reviewed mission")
+avatar(action="rules", input={"rules_content": "Always report findings."}, reasoning="distribute the reviewed rule")
+avatar(action="manual", input={}, reasoning="load the installed avatar manual")
 ```
 
-## Cleanup / Footprint
+`action` and `input` are both required. Do not omit `action`, flatten nested
+fields, or move `reasoning` into `input`. Avatar-owned prose uses no flat or
+omitted-action compatibility form. `reasoning` is Agent metadata, not a nested
+avatar option; for `spawn` it becomes the avatar's first mission prompt.
 
-Avatars leave independent agent directories under the `.lingtai/` network plus
-parent-side delegation records such as `delegates/ledger.jsonl`. These are lives,
-not cache files. Do not delete an avatar directory directly unless the user has
-explicitly approved retiring that avatar and you have captured any handoff,
-knowledge, or files worth preserving. Prefer lifecycle tools (`lull`, `suspend`,
-`nirvana` when appropriate and authorized) over filesystem deletion.
+## 3. Spawn types and input ownership
 
-Footprint check (read-only, records the audit from the parent agent directory):
+`avatar(action="spawn", input={...}, reasoning="...")` requires
+`input.name`. Spawn owns only these nested fields:
 
-```bash
-python3 - <<'PY'
-import json, time
-from pathlib import Path
-agent = Path.cwd(); network = agent.parent if agent.parent.name == ".lingtai" else agent / ".lingtai"
-avatars = [p for p in network.iterdir() if p.is_dir() and (p / ".agent.json").exists()] if network.is_dir() else []
-def size(p): return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
-rows = [(p, size(p)) for p in avatars]
-total = sum(s for _, s in rows)
-print(f"agent dirs: {len(rows)}; bytes: {total}")
-for p, s in sorted(rows, key=lambda r: r[1], reverse=True): print(f"{s:>12}  {p.name}")
-log = agent / "logs" / "cleanup.jsonl"; log.parent.mkdir(parents=True, exist_ok=True)
-log.open("a", encoding="utf-8").write(json.dumps({"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "tool": "avatar", "dry_run": True, "candidates": len(rows), "bytes": total, "human_approved": False, "summary": "avatar network footprint audit"}) + "\n")
-PY
+- `name`: a single bare sibling-directory segment; letters (any script),
+  digits, underscore, and hyphen only; no dots, slashes, spaces, or leading
+  dot; maximum 64 characters.
+- `type`: `shallow` (default, `初生`) copies `init.json` only; `deep`
+  (`二重身`) copies durable identity and knowledge.
+- `comment`: optional persistent system note, not inherited.
+- `dry_run`: optional preview with no directory, files, or process.
+- `confirm`: optional acknowledgement for the mission-quality gate.
+
+`rules_content` belongs only to the `rules` action. Do not include it in a
+spawn input.
+
+## 4. The root `reasoning` field — mission briefing
+
+The root `reasoning` metadata on
+`avatar(action="spawn", input={"name": "..."}, reasoning="...")` becomes the
+avatar's first prompt. Write a thorough mission briefing: task, importance,
+relevant paths/resources, parent/collaborator contact, done criteria, and
+constraints. Re-read it before invoking the tool.
+
+The mission-quality gate refuses empty, very short (<20 characters), or
+placeholder/debug-like missions unless `confirm=true`; `dry_run=true` is exempt.
+
+## 5. Spawn discipline
+
+Every ordinary spawn call creates an independent process and consumes resources
+until lifecycle management sleeps or suspends it. Therefore:
+
+1. Never put `avatar(action="spawn", input={...}, reasoning="...")` in a
+   parallel batch with unrelated calls.
+2. Re-read the root `reasoning` mission before invoking.
+3. Use `bash` or `system` for inspection and one-off commands.
+4. Use `avatar(action="spawn", input={"name": "...", "dry_run": true}, reasoning="...")`
+   to preview without creating a process.
+5. Use `confirm=true` only after reviewing the mission and intending to spawn.
+
+## 6. Caring for avatars
+
+After a spawn, record its address, mission, and delegation purpose in your pad.
+If an avatar goes quiet, do not send probe mails: report upstream so the parent
+can decide whether to use lifecycle tools or accept the loss.
+
+Every avatar receives a system-level parent prompt identifying its parent address.
+The avatar should email its parent when it completes, encounters an unresolved
+problem, or needs to report back.
+
+## 7. Escalation for avatars
+
+If your admin block is empty or all privileges are false and you hit a blocker,
+mail your parent. Report concrete facts: what you were doing, what failed, what
+you tried, and what decision or help you need. Report ambiguity, budget
+pressure, broken peers, safety concerns, and surprising findings rather than
+silently retrying forever.
+
+## 8. Persistent `comment`
+
+`comment` is a persistent system-level note injected into the avatar prompt. It
+is not inherited and survives molt, refresh, sleep, and wake. Use it only for
+instructions the avatar must always remember.
+
+## 9. Network rules
+
+`avatar(action="rules", input={"rules_content": "..."}, reasoning="...")` requires
+at least one truthy admin privilege. Its input owns only `rules_content`.
+The action writes a `.rules` signal to the caller and distributes it to all
+ledger-discovered descendants. Rules are non-negotiable plain-text constraints,
+not suggestions. This is a live filesystem side effect; use a deterministic
+fake service in tests and never point validation at a live network.
+
+## 10. Manual action and installed content
+
+`avatar(action="manual", input={}, reasoning="load guidance")` is read-only. It
+loads the real installed `avatar-manual` file from the current agent:
+
+```text
+<agent>/.library/intrinsic/capabilities/avatar/SKILL.md
 ```
 
-Recommended cadence: after spawning new specialists, before pruning a network,
-and monthly for busy orchestrators. Any destructive cleanup requires explicit
-user consent after a dry-run list of avatars and sizes.
+It does not spawn, write rules, or append a ledger entry. If the installed file
+is missing, the result is degraded and includes the installed path so the
+initializer problem is visible.
+
+## 11. Settings evidence
+
+Every avatar call rereads the Agent-owned `settings/avatar.json` v1 placeholder.
+Missing, valid, byte-distinct revisions, and invalid content are evidence only;
+they never select behavior or change this manual/prompt. Every success, manual,
+malformed, and service-error result includes secret-free `current_setting`
+evidence. Secret values, raw bytes, and host paths are not returned.
+
+## 12. Safety and footprint
+
+Avatars create independent directories and records; do not delete them directly
+without explicit retirement authority. Production spawn and rules operations
+have real side effects. Tests and harnesses must patch a candidate-owned fake
+launcher/service and prove malformed action/input calls make zero service calls.
+
+Before any separately authorized retirement or cleanup, audit the footprint
+read-only: the sibling agent directory, the parent's `delegates/ledger.jsonl`
+rows, live heartbeat/process evidence, `.rules` propagation state, and any
+shared-artifact references. Record what was inspected and the exact paths an
+operator authorized. A completed task, a failed boot, a dry-run preview, or the
+fact that an avatar directory looks temporary is never deletion permission.

--- a/tests/test_apriori_summary_executor.py
+++ b/tests/test_apriori_summary_executor.py
@@ -21,10 +21,12 @@ from lingtai.kernel.tool_executor import ToolExecutor
 from lingtai.kernel.tool_result_summary import (
     APRIORI_SUMMARY_CAP,
     APRIORI_SUMMARY_MARKER,
+    summary_requested,
 )
 
 
-def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
+def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path,
+                   parallel_safe_tools=None):
     """Construct a ToolExecutor that records durable log events into *events*."""
 
     def logger_fn(event_type, **fields):
@@ -43,6 +45,7 @@ def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
         logger_fn=logger_fn,
         working_dir=tmp_path,
         summarizer_fn=summarizer_fn,
+        parallel_safe_tools=parallel_safe_tools or set(),
     )
 
 
@@ -64,6 +67,14 @@ def _event_fields(events, event_type):
     for et, fields in events:
         if et == event_type:
             return fields
+    return None
+
+
+def _event_index(events, event_type, *, tool_call_id):
+    """Return the first matching event index for ordering assertions."""
+    for index, (et, fields) in enumerate(events):
+        if et == event_type and fields.get("tool_call_id") == tool_call_id:
+            return index
     return None
 
 
@@ -161,6 +172,274 @@ def test_summary_true_under_cap_replaces_with_summary_and_preserves_raw(tmp_path
     assert gen["tool_call_id"] == "t3"
     assert gen["tool_name"] == "bash"
     assert "RAWSECRET" not in str(gen)
+
+
+def test_summary_requested_uses_input_presence_precedence_and_exact_bool():
+    """Canonical input wins; only a literal bool True opts in."""
+    assert summary_requested({"summary": True}) is True  # legacy compatibility
+    assert summary_requested({"input": {"summary": True}, "summary": False}) is True
+
+    # Once input is present, root summary is never a fallback, including when
+    # nested summary is absent, false, malformed, or input is not an object.
+    nested_values = [False, 1, "true", None, {}, []]
+    for nested in nested_values:
+        assert summary_requested({"input": {"summary": nested}, "summary": True}) is False
+    assert summary_requested({"input": {}, "summary": True}) is False
+    for malformed_input in (None, [], "payload", 1):
+        assert summary_requested({"input": malformed_input, "summary": True}) is False
+
+    # Legacy mode has the same exact-boolean rule and does not mutate args.
+    for root in (False, 1, "true", None, {}, []):
+        assert summary_requested({"summary": root}) is False
+    original = {"input": {"summary": True}, "summary": "ignored"}
+    snapshot = {"input": dict(original["input"]), "summary": original["summary"]}
+    assert summary_requested(original) is True
+    assert original == snapshot
+
+
+def test_nested_summary_true_serial_preserves_reasoning_and_raw_first(tmp_path):
+    raw = {"stdout": "NESTED-SERIAL-RAW"}
+    nested_input = {"command": "echo nested", "summary": True}
+    call_args = {
+        "input": nested_input,
+        "summary": False,  # root is ignored in canonical mode
+        "reasoning": "Retain the nested serial marker",
+    }
+    seen = {}
+    events = []
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen["prompt"] = user_prompt
+        return "NESTED-SERIAL-SUMMARY"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute(
+        [ToolCall(name="bash", args=call_args, id="nested-serial")]
+    )
+
+    content = _wire_content(results[0])
+    assert content["artifact"] == APRIORI_SUMMARY_MARKER
+    assert content["generated_summary"] == "NESTED-SERIAL-SUMMARY"
+    assert "Retain the nested serial marker" in seen["prompt"]
+    assert nested_input == {"command": "echo nested", "summary": True}
+
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-serial")
+    generated_index = _event_index(
+        events, "apriori_summary_generated", tool_call_id="nested-serial"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-serial"
+    )
+    assert raw_index is not None and generated_index is not None and visible_index is not None
+    assert raw_index < generated_index < visible_index
+    raw_event = events[raw_index][1]
+    assert "NESTED-SERIAL-RAW" in str(raw_event["result"])
+    assert "NESTED-SERIAL-SUMMARY" not in str(raw_event["result"])
+    assert raw_event["tool_args"]["_reasoning"] == "Retain the nested serial marker"
+
+
+def test_nested_summary_true_parallel_path_preserves_raw_before_each_replacement(tmp_path):
+    raw_by_id = {
+        "nested-parallel-1": {"stdout": "NESTED-PARALLEL-RAW-1"},
+        "nested-parallel-2": {"stdout": "NESTED-PARALLEL-RAW-2"},
+    }
+    events = []
+    seen = []
+
+    def dispatch(tc):
+        return raw_by_id[tc.id]
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen.append((tool_call_id, user_prompt))
+        return f"NESTED-PARALLEL-SUMMARY-{tool_call_id}"
+
+    ex = _make_executor(
+        dispatch_fn=dispatch,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+        parallel_safe_tools={"bash", "grep"},
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "one", "summary": True},
+                  "reasoning": "Keep parallel result one"},
+            id="nested-parallel-1",
+        ),
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "two", "summary": True},
+                  "reasoning": "Keep parallel result two"},
+            id="nested-parallel-2",
+        ),
+    ])
+
+    assert len(seen) == 2
+    for result_msg, call_id in zip(results, ("nested-parallel-1", "nested-parallel-2")):
+        content = _wire_content(result_msg)
+        assert content["artifact"] == APRIORI_SUMMARY_MARKER
+        assert content["generated_summary"] == f"NESTED-PARALLEL-SUMMARY-{call_id}"
+        raw_index = _event_index(events, "tool_result", tool_call_id=call_id)
+        generated_index = _event_index(
+            events, "apriori_summary_generated", tool_call_id=call_id
+        )
+        visible_index = _event_index(
+            events, "tool_result_model_visible", tool_call_id=call_id
+        )
+        assert raw_index is not None and generated_index is not None and visible_index is not None
+        assert raw_index < generated_index < visible_index
+        raw_event = events[raw_index][1]
+        suffix = call_id.rsplit("-", 1)[-1]
+        assert f"NESTED-PARALLEL-RAW-{suffix}" in str(raw_event["result"])
+        assert f"NESTED-PARALLEL-SUMMARY-{call_id}" not in str(raw_event["result"])
+
+
+def test_nested_false_absent_and_malformed_ignore_root_true_in_executor(tmp_path):
+    cases = [
+        ("nested-false", {"summary": False}),
+        ("nested-absent", {}),
+        ("nested-one", {"summary": 1}),
+        ("nested-string", {"summary": "true"}),
+        ("nested-null", {"summary": None}),
+        ("nested-object", {"summary": {"truthy": True}}),
+        ("nested-list", {"summary": [True]}),
+        ("input-null", None),
+        ("input-list", []),
+        ("input-string", "payload"),
+    ]
+    for call_id, nested_input in cases:
+        events = []
+        called = []
+        raw = {"stdout": f"RAW-{call_id}"}
+
+        def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+            called.append(tool_call_id)
+            return "SHOULD NOT RUN"
+
+        ex = _make_executor(
+            dispatch_fn=lambda tc, raw=raw: raw,
+            summarizer_fn=summarizer,
+            events=events,
+            tmp_path=tmp_path,
+        )
+        results, _, _ = ex.execute([
+            ToolCall(
+                name="grep",
+                args={"input": nested_input, "summary": True},
+                id=call_id,
+            )
+        ])
+        content = _wire_content(results[0])
+        assert "SHOULD NOT RUN" not in str(content)
+        assert "RAW-" + call_id in str(content)
+        assert not (isinstance(content, dict) and content.get("artifact") == APRIORI_SUMMARY_MARKER)
+        assert called == []
+
+
+def test_nested_summary_true_cap_refusal_logs_raw_before_replacement(tmp_path):
+    raw = {"stdout": "NESTED-CAP-RAW-" + "z" * (APRIORI_SUMMARY_CAP + 100)}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="read",
+            args={"input": {"file_path": "/big", "summary": True},
+                  "reasoning": "Avoid oversized raw"},
+            id="nested-cap",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert called == []
+    assert content["summary_kind"] == "apriori_cap_refused"
+    assert "NESTED-CAP-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-cap")
+    refusal_index = _event_index(
+        events, "apriori_summary_cap_refused", tool_call_id="nested-cap"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-cap"
+    )
+    assert raw_index is not None and refusal_index is not None and visible_index is not None
+    assert raw_index < refusal_index < visible_index
+    assert "NESTED-CAP-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_without_gateway_fails_closed_after_raw_log(tmp_path):
+    raw = {"stdout": "NESTED-NOGATEWAY-RAW"}
+    events = []
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=None,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "echo no gateway", "summary": True}},
+            id="nested-no-gateway",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["summary_kind"] == "apriori_error"
+    assert "NESTED-NOGATEWAY-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-no-gateway")
+    error_index = _event_index(
+        events, "apriori_summary_no_summarizer", tool_call_id="nested-no-gateway"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-no-gateway"
+    )
+    assert raw_index is not None and error_index is not None and visible_index is not None
+    assert raw_index < error_index < visible_index
+    assert "NESTED-NOGATEWAY-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_preserves_tool_error_bypass(tmp_path):
+    raw = {"status": "error", "message": "EXACT-TOOL-ERROR"}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "error", "summary": True}},
+            id="nested-error",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["status"] == "error"
+    assert "EXACT-TOOL-ERROR" in str(content)
+    assert called == []
+    assert _event_index(events, "tool_result", tool_call_id="nested-error") is not None
+    assert _event_index(events, "apriori_summary_generated", tool_call_id="nested-error") is None
 
 
 def test_summary_true_over_cap_refuses_without_llm_and_hides_raw(tmp_path):

--- a/tests/test_avatar_action_input_candidate.py
+++ b/tests/test_avatar_action_input_candidate.py
@@ -1,0 +1,339 @@
+"""Focused avatar canonical-contract checks with no live avatar/rules effects.
+
+Run directly with ``python tests/test_avatar_action_input_candidate.py``.  The
+candidate source is inserted at sys.path[0] before any LingTai import.  Each run
+uses a new retained candidate-owned artifact directory and never cleans it up.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import sys
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+sys.path.insert(0, str(SRC))
+assert Path(sys.path[0]).resolve() == SRC.resolve()
+
+import lingtai  # noqa: E402
+import lingtai.tools.avatar as avatar_module  # noqa: E402
+from lingtai.agent import Agent  # noqa: E402
+from lingtai.kernel.llm.base import FunctionSchema, WIRE_TOOL_DESCRIPTION  # noqa: E402
+from lingtai.llm.anthropic.adapter import _build_tools as build_anthropic_tools  # noqa: E402
+from lingtai.llm.openai.adapter import (  # noqa: E402
+    _build_responses_tools,
+    _build_tools as build_chat_tools,
+)
+from lingtai.tools.avatar import AvatarManager  # noqa: E402
+from lingtai.tools.avatar._launcher import AvatarLaunchReceipt  # noqa: E402
+
+
+ARTIFACT_ROOT = ROOT / "artifacts" / "avatar-action-input-worker"
+
+
+class _Service:
+    provider = "gemini"
+    model = "candidate-test"
+
+    def get_adapter(self):
+        return object()
+
+
+class _FakeLauncher:
+    def __init__(self):
+        self.launch_calls = []
+        self.release_calls = []
+
+    def launch(self, request):
+        self.launch_calls.append(request)
+        return AvatarLaunchReceipt(42000 + len(self.launch_calls), object())
+
+    def poll(self, handle):
+        return None
+
+    def terminate(self, handle):
+        raise AssertionError("test must not terminate a fake avatar")
+
+    def force_terminate(self, handle):
+        raise AssertionError("test must not force-terminate a fake avatar")
+
+    def release(self, handle):
+        self.release_calls.append(handle)
+
+
+class _UnhashableKeys(Mapping):
+    def __getitem__(self, key):
+        return None
+
+    def __iter__(self):
+        return iter(([],))
+
+    def __len__(self):
+        return 1
+
+    def keys(self):
+        return [[]]
+
+
+class _RootWithUnhashableInput(Mapping):
+    def __init__(self):
+        self.values = {"action": "manual", "input": _UnhashableKeys()}
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+    def __iter__(self):
+        return iter(self.values)
+
+    def __len__(self):
+        return len(self.values)
+
+
+class AvatarActionInputCandidate(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # PID names avoid collisions while keeping all evidence under the
+        # explicitly retained candidate artifact directory.
+        cls.workdir = ARTIFACT_ROOT / f"fresh-agent-{os.getpid()}"
+        cls.workdir.mkdir(parents=True, exist_ok=False)
+        cls.settings_dir = cls.workdir / "settings"
+        cls.settings_dir.mkdir(parents=True, exist_ok=True)
+        cls.agent = Agent(
+            service=_Service(),
+            agent_name="avatar-contract-agent",
+            working_dir=cls.workdir,
+            capabilities=["avatar"],
+            admin={"karma": True},
+        )
+        cls.manager = cls.agent.get_capability("avatar")
+        cls.fake_launcher = _FakeLauncher()
+        cls.manager._launcher = cls.fake_launcher
+        # Spawn's parent-init precondition is deliberately satisfied in this
+        # fresh candidate-owned agent; no production spawn is ever attempted.
+        (cls.workdir / "init.json").write_text(
+            json.dumps({"manifest": {"agent_name": "avatar-contract-agent"}, "lingtai": ""}),
+            encoding="utf-8",
+        )
+
+    def test_import_identity_and_raw_schema(self):
+        self.assertEqual(Path(lingtai.__file__).resolve(), (SRC / "lingtai" / "__init__.py").resolve())
+        self.assertEqual(Path(avatar_module.__file__).resolve(), (SRC / "lingtai" / "tools" / "avatar" / "__init__.py").resolve())
+        raw = avatar_module.get_schema()
+        self.assertEqual(set(raw), {"type", "properties", "required", "additionalProperties"})
+        self.assertEqual(set(raw["properties"]), {"action", "input"})
+        self.assertEqual(raw["required"], ["action", "input"])
+        self.assertFalse(raw["additionalProperties"])
+        branches = raw["properties"]["input"]["anyOf"]
+        self.assertEqual([b["title"] for b in branches], ["spawn input", "rules input", "manual input"])
+        self.assertEqual(branches[0]["required"], ["name"])
+        self.assertEqual(set(branches[0]["properties"]), {"name", "type", "comment", "dry_run", "confirm"})
+        self.assertEqual(branches[1]["required"], ["rules_content"])
+        self.assertEqual(set(branches[1]["properties"]), {"rules_content"})
+        self.assertEqual(branches[2]["properties"], {})
+
+    def test_agent_schema_prompt_handler_and_provider_envelopes(self):
+        facing = next(s for s in self.agent._build_tool_schemas() if s.name == "avatar")
+        self.assertEqual(facing.parameters["required"], ["action", "input"])
+        self.assertEqual(set(facing.parameters["properties"]), {"action", "input", "reasoning"})
+        self.assertFalse(facing.parameters["additionalProperties"])
+        self.assertNotIn("reasoning", avatar_module.get_schema()["properties"])
+        self.assertTrue(
+            all(
+                "reasoning" not in branch.get("properties", {})
+                for branch in facing.parameters["properties"]["input"]["anyOf"]
+            )
+        )
+        prompt_tools = self.agent._prompt_manager.read_section("tools")
+        avatar_section = prompt_tools.split("### avatar\n", 1)[1].split("\n\n### ", 1)[0]
+        self.assertIn("avatar(action='spawn', input={'name': 'researcher'", avatar_section)
+        self.assertIn("reasoning", avatar_section)
+        self.assertIn("action and input are always explicit", avatar_section)
+        self.assertNotIn("omit `action`", avatar_section)
+        handler_filename = Path(self.agent._tool_handlers["avatar"].__code__.co_filename).resolve()
+        self.assertEqual(handler_filename, (SRC / "lingtai" / "tools" / "avatar" / "__init__.py").resolve())
+        self.assertIs(inspect.getmodule(self.agent._tool_handlers["avatar"]), avatar_module)
+
+        function_schema = next(s for s in self.agent._build_tool_schemas() if s.name == "avatar")
+        self.assertEqual(function_schema.parameters, facing.parameters)
+        chat = build_chat_tools([function_schema])[0]
+        responses = _build_responses_tools([function_schema])[0]
+        anthropic = build_anthropic_tools([function_schema])[0]
+        self.assertEqual(set(chat), {"type", "function"})
+        self.assertEqual(set(chat["function"]), {"name", "description", "parameters"})
+        self.assertEqual(set(responses), {"type", "name", "description", "parameters"})
+        self.assertEqual(set(anthropic), {"name", "description", "input_schema"})
+        self.assertEqual(chat["function"]["parameters"], function_schema.parameters)
+        self.assertEqual(responses["parameters"], function_schema.parameters)
+        self.assertEqual(anthropic["input_schema"], function_schema.parameters)
+        self.assertEqual(chat["function"]["description"], WIRE_TOOL_DESCRIPTION)
+        self.assertEqual(responses["description"], WIRE_TOOL_DESCRIPTION)
+        self.assertEqual(anthropic["description"], WIRE_TOOL_DESCRIPTION)
+        self.assertEqual(chat["function"]["name"], responses["name"])
+        self.assertEqual(chat["function"]["name"], anthropic["name"])
+
+    def test_manual_is_installed_and_settings_are_evidence_only(self):
+        prompt_before = self.agent._prompt_manager.read_section("tools")
+        manual = self.manager.handle({"action": "manual", "input": {}, "reasoning": "load guidance"})
+        self.assertEqual(manual["status"], "ok")
+        installed = self.workdir / ".library" / "intrinsic" / "capabilities" / "avatar" / "SKILL.md"
+        self.assertEqual(Path(manual["manual_path"]).resolve(), installed.resolve())
+        self.assertEqual(manual["manual"], installed.read_text(encoding="utf-8"))
+        self.assertIn(
+            'avatar(action="spawn", input={"name": "researcher"}, reasoning="...mission briefing...")',
+            manual["manual"],
+        )
+        self.assertIn(
+            'avatar(action="rules", input={"rules_content": "Always report findings."}, reasoning="distribute the reviewed rule")',
+            manual["manual"],
+        )
+        self.assertIn(
+            'avatar(action="manual", input={}, reasoning="load the installed avatar manual")',
+            manual["manual"],
+        )
+        self.assertIn("Do not omit `action`, flatten nested", manual["manual"])
+        self.assertIn("uses no flat or\nomitted-action compatibility form", manual["manual"])
+        self.assertEqual(manual["current_setting"]["source"], "missing")
+
+        settings = self.settings_dir / "avatar.json"
+        settings.write_bytes(b'{"schema_version":1}')
+        valid = self.manager.handle({"action": "manual", "input": {}, "reasoning": "load guidance"})
+        self.assertEqual(valid["current_setting"]["source"], "settings/avatar.json")
+        settings.write_bytes(b'{ "schema_version" : 1 }\n')
+        hot = self.manager.handle({"action": "manual", "input": {}, "reasoning": "load guidance"})
+        self.assertEqual(hot["current_setting"]["source"], "settings/avatar.json")
+        self.assertNotEqual(
+            valid["current_setting"]["settings_revision"],
+            hot["current_setting"]["settings_revision"],
+        )
+        self.assertNotEqual(
+            valid["current_setting"]["settings_hash"],
+            hot["current_setting"]["settings_hash"],
+        )
+        self.assertEqual(valid["manual"], hot["manual"])
+
+        sentinel = "AVATAR_SECRET_SENTINEL"
+        settings.write_text(
+            json.dumps({"schema_version": 1, "secret": sentinel}), encoding="utf-8"
+        )
+        invalid = self.manager.handle({"action": "manual", "input": {}, "reasoning": "load guidance"})
+        self.assertEqual(invalid["current_setting"]["source"], "settings_error")
+        self.assertTrue(invalid["current_setting"]["settings_error"])
+        self.assertNotIn(sentinel, json.dumps(invalid, sort_keys=True))
+        self.assertNotIn(sentinel, self.agent._prompt_manager.read_section("tools"))
+        self.assertEqual(prompt_before, self.agent._prompt_manager.read_section("tools"))
+        self.assertEqual(valid["manual"], invalid["manual"])
+
+    def test_malformed_calls_are_strict_and_do_not_reach_services(self):
+        before_launch = len(self.fake_launcher.launch_calls)
+        malformed = [
+            None,
+            {},
+            {"action": "spawn", "input": {"name": "x", "rules_content": "wrong"}},
+            {"action": "rules", "input": {"rules_content": "x", "dry_run": True}},
+            {"action": "manual", "input": {"name": "wrong"}},
+            {"action": [], "input": {}},
+            {"action": "manual"},
+            {"action": "manual", "input": []},
+            {"action": "manual", "input": _UnhashableKeys()},
+            {"action": "spawn", "input": {"name": "x"}, "_reasoning": []},
+            _RootWithUnhashableInput(),
+            {1: "manual", "input": {}},
+        ]
+        for args in malformed:
+            result = self.manager.handle(args)
+            self.assertIn("current_setting", result)
+            self.assertIn("error", result)
+        self.assertEqual(len(self.fake_launcher.launch_calls), before_launch)
+
+    def test_spawn_gate_dry_run_success_boot_error_and_no_live_process(self):
+        gate = self.manager.handle({
+            "action": "spawn",
+            "input": {"name": "gated"},
+            "_reasoning": "short",
+        })
+        self.assertEqual(gate["status"], "confirmation_needed")
+        self.assertEqual(len(self.fake_launcher.launch_calls), 0)
+
+        dry = self.manager.handle({
+            "action": "spawn",
+            "input": {"name": "preview", "dry_run": True},
+            "_reasoning": "short preview",
+        })
+        self.assertEqual(dry["status"], "dry_run")
+        self.assertEqual(len(self.fake_launcher.launch_calls), 0)
+
+        self.manager._launch = lambda working_dir: (
+            AvatarLaunchReceipt(43001, object()), working_dir / "spawn.stderr"
+        )
+        self.manager._wait_for_boot = lambda working_dir, proc, stderr: ("ok", None)
+        success_name = f"fake-success-{os.getpid()}"
+        success = self.manager.handle({
+            "action": "spawn",
+            "input": {"name": success_name, "type": "shallow", "comment": "", "confirm": True},
+            "_reasoning": "A reviewed mission that is intentionally long enough.",
+        })
+        self.assertEqual(success["status"], "ok")
+        self.assertEqual(success["type"], "shallow")
+        self.assertEqual(len(self.fake_launcher.release_calls), 1)
+
+        self.manager._wait_for_boot = lambda working_dir, proc, stderr: ("failed", "fake boot failure")
+        failed_name = f"fake-failed-{os.getpid()}"
+        failed = self.manager.handle({
+            "action": "spawn",
+            "input": {"name": failed_name, "confirm": True},
+            "_reasoning": "A reviewed mission that is intentionally long enough.",
+        })
+        self.assertIn("error", failed)
+        self.assertIn("current_setting", failed)
+        self.assertEqual(len(self.fake_launcher.release_calls), 2)
+
+    def test_rules_success_and_admin_error_are_owned_by_rules(self):
+        self.manager._distribute_rules_to_descendants = lambda content, root: ["fake-child"]
+        success = self.manager.handle({
+            "action": "rules",
+            "input": {"rules_content": "Always report findings."},
+            "_reasoning": "distribute reviewed rule",
+        })
+        self.assertEqual(success["status"], "ok")
+        self.assertEqual(success["distributed_to"], [self.workdir.name, "fake-child"])
+
+        old_admin = self.agent._admin
+        self.agent._admin = {}
+        denied = self.manager.handle({
+            "action": "rules",
+            "input": {"rules_content": "No live distribution."},
+            "_reasoning": "test admin gate",
+        })
+        self.agent._admin = old_admin
+        self.assertIn("error", denied)
+        self.assertIn("current_setting", denied)
+
+    def test_unexpected_service_errors_are_bounded_and_keep_settings(self):
+        with patch.object(self.manager, "_spawn", side_effect=RuntimeError("PRIVATE-SPAWN-DETAIL")):
+            failed_spawn = self.manager.handle({
+                "action": "spawn",
+                "input": {"name": "bounded", "confirm": True},
+                "reasoning": "A reviewed mission that is intentionally long enough.",
+            })
+        self.assertEqual(failed_spawn["error"], "avatar service failed")
+        self.assertIn("current_setting", failed_spawn)
+        self.assertNotIn("PRIVATE-SPAWN-DETAIL", repr(failed_spawn))
+
+        with patch.object(self.manager, "_rules", side_effect=RuntimeError("PRIVATE-RULES-DETAIL")):
+            failed_rules = self.manager.handle({
+                "action": "rules",
+                "input": {"rules_content": "Bound unexpected errors."},
+                "reasoning": "exercise the bounded rules error path",
+            })
+        self.assertEqual(failed_rules["error"], "avatar service failed")
+        self.assertIn("current_setting", failed_rules)
+        self.assertNotIn("PRIVATE-RULES-DETAIL", repr(failed_rules))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_avatar_rules.py
+++ b/tests/test_avatar_rules.py
@@ -165,7 +165,7 @@ class TestAvatarRulesAction:
         mgr = agent.get_capability("avatar")
         result = mgr.handle({
             "action": "rules",
-            "rules_content": "No deleting.",
+            "input": {"rules_content": "No deleting.",}
         })
         assert "error" in result
 
@@ -189,7 +189,7 @@ class TestAvatarRulesAction:
         mgr = agent.get_capability("avatar")
         result = mgr.handle({
             "action": "rules",
-            "rules_content": "Always log actions.",
+            "input": {"rules_content": "Always log actions.",}
         })
         assert result["status"] == "ok"
 
@@ -243,7 +243,7 @@ class TestAvatarRulesAction:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "rules",
-            "rules_content": "No external API calls.",
+            "input": {"rules_content": "No external API calls.",}
         })
         assert result["status"] == "ok"
         # Self + descendants uniformly get .rules signal files
@@ -288,7 +288,7 @@ class TestAvatarRulesAction:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "rules",
-            "rules_content": "Be concise.",
+            "input": {"rules_content": "Be concise.",}
         })
         assert result["status"] == "ok"
         # All descendants get .rules signal files
@@ -307,7 +307,7 @@ class TestAvatarRulesAction:
             admin={"karma": True},
         )
         mgr = agent.get_capability("avatar")
-        result = mgr.handle({"action": "rules"})
+        result = mgr.handle({"action": "rules", "input": {}})
         assert "error" in result
 
     def test_explicit_spawn_action_required(self, tmp_path):
@@ -322,7 +322,7 @@ class TestAvatarRulesAction:
         so the unified 'avatar' tool matches the schema-and-runtime-required
         'action' contract every other canonical action tool (knowledge, mcp,
         skills, notification, system, soul, daemon) already follows — see
-        avatar CONTRACT.md contract_version 3.
+        avatar CONTRACT.md contract_version 4.
         """
         from lingtai.agent import Agent
 
@@ -342,14 +342,14 @@ class TestAvatarRulesAction:
         mgr = agent.get_capability("avatar")
         with _patch_avatar_launch() as launch:
             # Omitted action must fail deterministically and spawn nothing.
-            omitted = mgr.handle({"name": "child", "confirm": True})
+            omitted = mgr.handle({"input": {"name": "child", "confirm": True}})
             assert "error" in omitted
-            assert omitted["error"] == "unknown action: '', only 'spawn', 'rules', or 'manual' is supported"
+            assert omitted["error"] == "avatar requires root action and input"
             launch.assert_not_called()
             assert not (parent_dir.parent / "child").exists()
 
             # Explicit action='spawn' behaves exactly as before.
-            result = mgr.handle({"action": "spawn", "name": "child", "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": "child", "confirm": True}})
         assert result["status"] == "ok"
         assert result["agent_name"] == "child"
         assert result["address"] == "child"  # relative name (current convention)
@@ -388,7 +388,7 @@ class TestAvatarRulesAction:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "rules",
-            "rules_content": "Cycle test.",
+            "input": {"rules_content": "Cycle test.",}
         })
         assert result["status"] == "ok"
         # Both self and child receive .rules signals
@@ -435,7 +435,7 @@ class TestAutoDistributeAfterSpawn:
 
         mgr = parent.get_capability("avatar")
         with _patch_avatar_launch():
-            result = mgr.handle({"action": "spawn", "name": "child", "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": "child", "confirm": True}})
         assert result["status"] == "ok"
 
         # Child dir is a sibling of parent_dir (avatar_working_dir = parent.parent / name)
@@ -449,7 +449,7 @@ class TestAutoDistributeAfterSpawn:
 
         mgr = parent.get_capability("avatar")
         with _patch_avatar_launch():
-            result = mgr.handle({"action": "spawn", "name": "child", "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": "child", "confirm": True}})
         assert result["status"] == "ok"
 
         child_dir = parent_dir.parent / "child"
@@ -463,7 +463,7 @@ class TestAutoDistributeAfterSpawn:
 
         mgr = parent.get_capability("avatar")
         with _patch_avatar_launch():
-            result = mgr.handle({"action": "spawn", "name": "clone", "type": "deep", "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": "clone", "type": "deep", "confirm": True}})
         assert result["status"] == "ok"
 
         clone_dir = parent_dir.parent / "clone"
@@ -515,7 +515,7 @@ class TestSpawnNameValidation:
         mgr = parent.get_capability("avatar")
 
         with _patch_avatar_launch() as launch:
-            result = mgr.handle({"action": "spawn", "name": bad_name})
+            result = mgr.handle({"action": "spawn", "input": {"name": bad_name}})
 
         assert "error" in result, f"name={bad_name!r} should have been rejected but got {result}"
         # No subprocess launched
@@ -540,25 +540,23 @@ class TestSpawnNameValidation:
         mgr = parent.get_capability("avatar")
 
         with _patch_avatar_launch():
-            result = mgr.handle({"action": "spawn", "name": good_name, "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": good_name, "confirm": True}})
 
         assert result.get("status") == "ok", f"name={good_name!r} should have been accepted but got {result}"
         assert (parent_dir.parent / good_name).is_dir()
 
-    def test_legacy_dir_argument_is_ignored(self, tmp_path):
-        """Pre-fix callers may still pass `dir=...`. It's no longer in the
-        schema, but the handler must not crash on unknown kwargs — it should
-        fall through to `name`-driven placement."""
+    def test_spawn_only_owns_declared_input_fields(self, tmp_path):
+        """An undeclared spawn input field is rejected; no compatibility option is invented."""
         parent, parent_dir = self._spawnable_parent(tmp_path)
         mgr = parent.get_capability("avatar")
 
         with _patch_avatar_launch():
             # Pass both a safe name and a malicious legacy dir; name wins.
-            result = mgr.handle({"action": "spawn", "name": "safe", "dir": "avatars/evil", "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": "safe", "dir": "avatars/evil", "confirm": True}})
 
-        assert result.get("status") == "ok"
-        assert (parent_dir.parent / "safe").is_dir()
-        # The malicious dir was NOT honored
+        assert "error" in result
+        assert "unsupported avatar input field" in result["error"]
+        assert not (parent_dir.parent / "safe").exists()
         assert not (parent_dir.parent / "avatars").exists()
 
     def test_prepare_deep_refuses_non_sibling_dst(self, tmp_path):

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -74,7 +74,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert result["status"] == "ok"
         assert "address" in result
         assert result["address"]  # filesystem path (non-empty string)
@@ -86,7 +86,7 @@ class TestAvatarManager:
         from lingtai.agent import Agent
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities={"bash": {"yolo": True}, "avatar": {}})
-        result = parent._tool_handlers["avatar"]({"action": "spawn", "name": "child", "confirm": True})
+        result = parent._tool_handlers["avatar"]({"action": "spawn", "input": {"name": "child", "confirm": True}})
         assert result["status"] == "ok"
         # New architecture: avatars run as their own processes; introspection
         # is via the avatar's on-disk init.json, not an in-process _peers map.
@@ -104,7 +104,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"], covenant="Be helpful and concise.")
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert result["status"] == "ok"
 
     def test_spawn_no_admin(self, tmp_path):
@@ -113,7 +113,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"], admin={"karma": True})
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert result["status"] == "ok"
         child_init = json.loads((parent._working_dir.parent / "helper" / "init.json").read_text())
         child_admin = child_init.get("manifest", {}).get("admin", {})
@@ -133,9 +133,9 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        r1 = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        r1 = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert r1["status"] == "ok"
-        r2 = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        r2 = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert "error" in r2 or r2.get("status") == "already_active"
 
     def test_spawn_does_not_copy_identity_files(self, tmp_path):
@@ -154,7 +154,7 @@ class TestAvatarManager:
         (knowledge_dir / "knowledge.json").write_text('{"entries": []}')
 
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "blank", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "blank", "confirm": True}})
         assert result["status"] == "ok"
         child_dir = parent._working_dir.parent / "blank"
         # Character and knowledge should NOT be copied
@@ -167,7 +167,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "clone", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "clone", "confirm": True}})
         assert result["status"] == "ok"
 
     def test_ledger_records_spawn(self, tmp_path):
@@ -176,7 +176,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        mgr.handle({"action": "spawn", "name": "clone", "confirm": True})
+        mgr.handle({"action": "spawn", "input": {"name": "clone", "confirm": True}})
         ledger = (parent._working_dir / "delegates" / "ledger.jsonl").read_text().strip()
         record = json.loads(ledger)
         assert record["name"] == "clone"
@@ -230,7 +230,7 @@ class TestMissionQualityGate:
         """Spawn with no _reasoning and no confirm should be refused with a preview."""
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper"})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper"}})
         assert result["status"] == "confirmation_needed"
         assert "warning" in result
         assert "preview" in result
@@ -243,7 +243,7 @@ class TestMissionQualityGate:
     def test_spawn_with_short_mission_returns_confirmation_needed(self, tmp_path):
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "_reasoning": "test"})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper"}, "_reasoning": "test"})
         assert result["status"] == "confirmation_needed"
         assert result["preview"]["mission"] == "test"
         assert result["preview"]["mission_chars"] == 4
@@ -252,7 +252,7 @@ class TestMissionQualityGate:
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
         # No mission, but confirm=True acknowledges the risk.
-        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert result["status"] == "ok"
         assert (parent._working_dir.parent / "helper").is_dir()
 
@@ -261,7 +261,7 @@ class TestMissionQualityGate:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "spawn",
-            "name": "helper",
+            "input": {"name": "helper"},
             "_reasoning": "Investigate the heartbeat regression and report back via mail",
         })
         assert result["status"] == "ok"
@@ -269,7 +269,7 @@ class TestMissionQualityGate:
     def test_dry_run_returns_preview_without_spawning(self, tmp_path):
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "dry_run": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "dry_run": True}})
         assert result["status"] == "dry_run"
         assert result["preview"]["name"] == "helper"
         assert result["preview"]["type"] == "shallow"
@@ -285,7 +285,7 @@ class TestMissionQualityGate:
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
         # Empty mission + no confirm + dry_run=True → returns dry_run, not confirmation_needed.
-        result = mgr.handle({"action": "spawn", "name": "helper", "dry_run": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "dry_run": True}})
         assert result["status"] == "dry_run"
 
     def test_dry_run_preview_reports_real_mission_safe(self, tmp_path):
@@ -293,8 +293,7 @@ class TestMissionQualityGate:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "spawn",
-            "name": "helper",
-            "dry_run": True,
+            "input": {"name": "helper", "dry_run": True},
             "_reasoning": "Investigate the heartbeat regression and report back via mail",
         })
         assert result["status"] == "dry_run"
@@ -304,14 +303,14 @@ class TestMissionQualityGate:
     def test_schema_exposes_dry_run_and_confirm(self):
         from lingtai.tools.avatar import get_schema
         sch = get_schema("en")
-        assert "dry_run" in sch["properties"]
-        assert sch["properties"]["dry_run"]["type"] == "boolean"
-        assert "confirm" in sch["properties"]
-        assert sch["properties"]["confirm"]["type"] == "boolean"
-        assert "rules_content" in sch["properties"]
-        assert sch["required"] == ["action"]
-        assert not {"oneOf", "anyOf", "allOf", "not"} & set(sch)
+        branches = sch["properties"]["input"]["anyOf"]
+        spawn_props = branches[0]["properties"]
+        assert "dry_run" in spawn_props and spawn_props["dry_run"]["type"] == "boolean"
+        assert "confirm" in spawn_props and spawn_props["confirm"]["type"] == "boolean"
+        assert "rules_content" in branches[1]["properties"]
+        assert sch["required"] == ["action", "input"]
         assert sch["properties"]["action"]["enum"] == ["spawn", "rules", "manual"]
+        assert not {"oneOf", "allOf", "not"} & set(sch)
 
     def test_description_points_to_avatar_manual_after_prompt_compaction(self):
         """The terse tool description should route safety guidance to the manual.
@@ -326,9 +325,10 @@ class TestMissionQualityGate:
         schema = get_schema("en")
         assert "avatar-manual" in desc
         assert "WARNING" not in desc
-        assert "confirm" in schema["properties"]
-        assert "dry_run" in schema["properties"]
-        assert "action" in schema["properties"]
+        spawn_properties = schema["properties"]["input"]["anyOf"][0]["properties"]
+        assert "confirm" in spawn_properties
+        assert "dry_run" in spawn_properties
+        assert set(schema["properties"]) == {"action", "input"}
 
 
 class TestSetupAvatar:
@@ -420,7 +420,7 @@ class TestUnifiedAvatarTool:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "spawn",
-            "name": "helper",
+            "input": {"name": "helper"},
             "_reasoning": "Investigate the heartbeat regression and report back via mail",
         })
         assert result["status"] == "ok"
@@ -441,9 +441,9 @@ class TestUnifiedAvatarTool:
 
         # Even with a fully valid spawn payload (name + confirm), omitting
         # 'action' must fail deterministically rather than silently spawning.
-        result = mgr.handle({"name": "helper2", "confirm": True})
+        result = mgr.handle({"input": {"name": "helper2", "confirm": True}})
         assert "error" in result
-        assert result["error"] == "unknown action: '', only 'spawn', 'rules', or 'manual' is supported"
+        assert result["error"] == "avatar requires root action and input"
         assert result.get("status") != "ok"
 
         # No process/filesystem/ledger mutation happened.
@@ -457,17 +457,17 @@ class TestUnifiedAvatarTool:
         no_admin = Agent(service=make_mock_service(), agent_name="worker",
                           working_dir=tmp_path / "worker", capabilities=["avatar"], admin={})
         mgr = no_admin.get_capability("avatar")
-        result = mgr.handle({"action": "rules", "rules_content": "No deleting."})
+        result = mgr.handle({"action": "rules", "input": {"rules_content": "No deleting."}})
         assert "error" in result
 
         admin = Agent(service=make_mock_service(), agent_name="admin",
                        working_dir=tmp_path / "admin", capabilities=["avatar"],
                        admin={"karma": True})
         mgr2 = admin.get_capability("avatar")
-        empty_result = mgr2.handle({"action": "rules", "rules_content": ""})
+        empty_result = mgr2.handle({"action": "rules", "input": {"rules_content": ""}})
         assert "error" in empty_result
 
-        ok_result = mgr2.handle({"action": "rules", "rules_content": "Be concise."})
+        ok_result = mgr2.handle({"action": "rules", "input": {"rules_content": "Be concise."}})
         assert ok_result["status"] == "ok"
         assert (admin._working_dir / ".rules").read_text() == "Be concise."
 
@@ -477,7 +477,7 @@ class TestUnifiedAvatarTool:
         no_admin = Agent(service=make_mock_service(), agent_name="worker",
                           working_dir=tmp_path / "worker", capabilities=["avatar"], admin={})
         mgr = no_admin.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert result["status"] == "ok"
 
     def test_manual_returns_exact_body_and_performs_no_mutation(self, tmp_path):
@@ -492,7 +492,7 @@ class TestUnifiedAvatarTool:
             / "src" / "lingtai" / "tools" / "avatar" / "manual" / "SKILL.md"
         ).read_text(encoding="utf-8")
 
-        result = mgr.handle({"action": "manual"})
+        result = mgr.handle({"action": "manual", "input": {}})
         assert result["status"] == "ok"
         assert result["manual"] == manual_source
 
@@ -514,7 +514,7 @@ class TestUnifiedAvatarTool:
         parent = Agent(service=make_mock_service(), agent_name="parent",
                         working_dir=tmp_path / "test", capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "bogus"})
+        result = mgr.handle({"action": "bogus", "input": {}})
         assert "error" in result
         assert "bogus" in result["error"]
 
@@ -529,22 +529,22 @@ class TestUnifiedAvatarTool:
         mgr = parent.get_capability("avatar")
 
         # Payload shaped like a valid rules call, but action omitted.
-        rules_shaped = mgr.handle({"rules_content": "Be concise."})
+        rules_shaped = mgr.handle({"input": {"rules_content": "Be concise."}})
         assert "error" in rules_shaped
-        assert "unknown action: ''" in rules_shaped["error"]
+        assert "requires root action and input" in rules_shaped["error"]
         assert not (parent._working_dir / ".rules").exists()
 
         # Payload shaped like a valid spawn call, but action omitted.
-        spawn_shaped = mgr.handle({"name": "helper3", "confirm": True})
+        spawn_shaped = mgr.handle({"input": {"name": "helper3", "confirm": True}})
         assert "error" in spawn_shaped
-        assert "unknown action: ''" in spawn_shaped["error"]
+        assert "requires root action and input" in spawn_shaped["error"]
         assert not (parent._working_dir.parent / "helper3").exists()
         assert not (parent._working_dir / "delegates" / "ledger.jsonl").exists()
 
         # Entirely empty payload.
         empty = mgr.handle({})
         assert "error" in empty
-        assert "unknown action: ''" in empty["error"]
+        assert "requires root action and input" in empty["error"]
 
     def test_spawn_missing_name_fails_without_affecting_other_actions(self, tmp_path):
         from lingtai.agent import Agent
@@ -553,12 +553,12 @@ class TestUnifiedAvatarTool:
                         admin={"karma": True})
         mgr = parent.get_capability("avatar")
 
-        spawn_result = mgr.handle({"action": "spawn"})
+        spawn_result = mgr.handle({"action": "spawn", "input": {}})
         assert "error" in spawn_result
         assert "name is required" in spawn_result["error"]
 
-        rules_result = mgr.handle({"action": "rules", "rules_content": "Be concise."})
+        rules_result = mgr.handle({"action": "rules", "input": {"rules_content": "Be concise."}})
         assert rules_result["status"] == "ok"
 
-        manual_result = mgr.handle({"action": "manual"})
+        manual_result = mgr.handle({"action": "manual", "input": {}})
         assert manual_result["status"] == "ok"

--- a/tests/test_tool_settings.py
+++ b/tests/test_tool_settings.py
@@ -1,0 +1,154 @@
+"""Focused tests for the private no-op placeholder-settings foundation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools._settings import (
+    MAX_SETTINGS_BYTES,
+    current_setting,
+    read_settings,
+    settings_path,
+    valid_tool_name,
+)
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+
+def _write(root: Path, tool_name: str, payload: str | bytes) -> Path:
+    path = root / "settings" / f"{tool_name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def test_missing_is_a_normal_noop_placeholder_state(tmp_path):
+    snapshot = read_settings(_Agent(tmp_path), "example")
+    setting = current_setting(snapshot, "example")
+    assert setting == {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": "missing",
+        "settings_revision": "missing",
+        "settings_hash": None,
+        "change_hint": (
+            "Edit settings/example.json; changes apply on the next example call; "
+            "this no-op placeholder never changes tool behavior."
+        ),
+    }
+
+
+def test_valid_v1_only_changes_source_revision_and_hash(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "example", '{"schema_version": 1}')
+    snapshot = read_settings(agent, "example")
+    setting = current_setting(snapshot, "example")
+    assert snapshot.error is None
+    assert setting["configurable"] is False
+    assert setting["placeholder"] == "no-op"
+    assert setting["source"] == "settings/example.json"
+    assert setting["settings_revision"] == setting["settings_hash"]
+    assert setting["settings_hash"]
+
+
+def test_reader_rereads_hot_changes_without_cache(tmp_path):
+    agent = _Agent(tmp_path)
+    path = _write(tmp_path, "example", '{"schema_version": 1}')
+    first = read_settings(agent, "example")
+    path.write_text('{ "schema_version": 1 }', encoding="utf-8")
+    second = read_settings(agent, "example")
+    assert first.digest != second.digest
+    assert second.source == "settings/example.json"
+
+
+def test_duplicate_and_extra_fields_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    duplicate = _write(tmp_path, "duplicate", '{"schema_version": 1, "schema_version": 1}')
+    duplicate_snapshot = read_settings(agent, "duplicate")
+    assert duplicate_snapshot.source == "settings_error"
+    assert "duplicate" in (duplicate_snapshot.error or "")
+
+    extra = _write(tmp_path, "extra", '{"schema_version": 1, "future": false}')
+    extra_snapshot = read_settings(agent, "extra")
+    assert extra_snapshot.source == "settings_error"
+    assert "only schema_version" in (extra_snapshot.error or "")
+
+
+def test_bool_and_other_schema_versions_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    for name, version in (("bool", True), ("float", 1.0), ("other", 2)):
+        _write(tmp_path, name, json.dumps({"schema_version": version}))
+        snapshot = read_settings(agent, name)
+        assert snapshot.source == "settings_error"
+        assert "integer 1" in (snapshot.error or "")
+
+
+def test_invalid_encoding_and_json_are_truthful_bounded_errors(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "encoding", b'{"schema_version": 1}\xff')
+    encoding_snapshot = read_settings(agent, "encoding")
+    assert encoding_snapshot.source == "settings_error"
+    assert encoding_snapshot.error
+
+    _write(tmp_path, "json", "{not-json")
+    json_snapshot = read_settings(agent, "json")
+    assert json_snapshot.source == "settings_error"
+    assert json_snapshot.error
+    assert len(json_snapshot.error) <= 240
+
+
+def test_symlink_non_regular_and_oversized_files_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text('{"schema_version": 1}', encoding="utf-8")
+    symlink = tmp_path / "settings" / "symlink.json"
+    symlink.parent.mkdir()
+    symlink.symlink_to(target)
+    symlink_snapshot = read_settings(agent, "symlink")
+    assert symlink_snapshot.source == "settings_error"
+    assert "regular file" in (symlink_snapshot.error or "")
+
+    non_regular = tmp_path / "settings" / "directory.json"
+    non_regular.mkdir()
+    directory_snapshot = read_settings(agent, "directory")
+    assert directory_snapshot.source == "settings_error"
+    assert "regular file" in (directory_snapshot.error or "")
+
+    _write(tmp_path, "large", b"{" + b"x" * MAX_SETTINGS_BYTES + b"}")
+    large_snapshot = read_settings(agent, "large")
+    assert large_snapshot.source == "settings_error"
+    assert "bounded size" in (large_snapshot.error or "")
+
+
+def test_unstable_snapshot_is_not_treated_as_missing(tmp_path, monkeypatch):
+    import lingtai.tools._settings as settings_module
+
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "unstable", '{"schema_version": 1}')
+
+    def raise_unstable(_path):
+        raise settings_module.SettingsError("settings snapshot changed during read")
+
+    monkeypatch.setattr(settings_module, "_read_stable", raise_unstable)
+    snapshot = read_settings(agent, "unstable")
+    assert snapshot.source == "settings_error"
+    assert snapshot.revision == "error"
+    assert snapshot.error == "settings snapshot changed during read"
+
+
+def test_tool_names_are_bounded_path_components(tmp_path):
+    assert valid_tool_name("web_search")
+    assert not valid_tool_name("../escape")
+    assert not valid_tool_name("nested/name")
+    assert not valid_tool_name("\\escape")
+    assert not valid_tool_name("x" * 65)
+    with pytest.raises(ValueError):
+        settings_path(_Agent(tmp_path), "../escape")


### PR DESCRIPTION
## Summary

Migrate the public `avatar` tool onto the canonical tool contract introduced by the stacked foundation PR:

- raw schema: required root `action` plus required nested `input`;
- Agent-facing schema: `BaseAgent` injects optional root `reasoning`;
- actions: `spawn`, `rules`, and `manual`;
- strict action-owned input fields with no flat or omitted-action compatibility;
- real installed-manual lookup for `action="manual"`;
- fresh per-call `settings/avatar.json` v1 placeholder evidence in `current_setting`.

This keeps provider envelope names unchanged and preserves the existing avatar lifecycle, launcher, boot/heartbeat, ledger, path-scope, shallow/deep, dry-run, confirmation, and network-rules semantics.

## Public contract

Canonical examples are now:

```text
avatar(action="spawn", input={"name": "researcher"}, reasoning="...mission...")
avatar(action="rules", input={"rules_content": "Always report findings."}, reasoning="distribute the reviewed rule")
avatar(action="manual", input={}, reasoning="load avatar guidance")
```

`spawn.input` owns `name`, `type`, `comment`, `dry_run`, and `confirm`. `rules.input` owns only `rules_content`. `manual.input` must be empty. Malformed, crossed-action, non-mapping, non-string-key, and wrong-type calls return bounded errors with `current_setting` before any avatar service seam is reached.

The raw `get_schema()` remains action/input-only. `BaseAgent` adds optional root `reasoning` to the model-facing `FunctionSchema.parameters`; Chat, Responses, and Anthropic retain their existing `function.parameters`, `parameters`, and `input_schema` envelope names.

## Settings and manual behavior

Every call rereads the Agent-owned `settings/avatar.json` v1 placeholder. Missing, valid, byte-distinct hot revisions, and invalid content are evidence only: settings cannot change behavior or prompt text. Results expose bounded, secret-free `current_setting` metadata and never return raw settings bytes, secret values, or host paths.

`action="manual"` reads the actual initialized Agent copy at `.library/intrinsic/capabilities/avatar/SKILL.md`. It does not substitute the source resource and does not spawn, distribute rules, or append a ledger event.

## Parent review repairs

The candidate was not accepted unchanged. Parent review additionally repaired:

- false docs claiming Agent-facing `FunctionSchema.parameters` stayed raw action/input-only;
- the wrong anatomy manual-loader argument (`avatar-manual` instead of `avatar`);
- missing platform launcher, glossary, and test-graph links plus compressed lifecycle invariants;
- lost read-only retirement-footprint guidance;
- provider/prompt/manual/settings/secret-nonleakage coverage;
- three leftover flat spawn calls and two stale flat-root schema assertions in `tests/test_layers_avatar.py` found during final exact diff review.

A final AST audit now finds zero flat or action-without-input avatar handler calls across the 56 calls in the three intended avatar test files.

## Validation

Final retained validation on exact head `5b43c38dedc2da7996e42065d9f71601ed982687`:

- focused candidate unittest: **7/7 PASS**;
- fresh independent parent gate: **112 checks PASS**;
  - exact candidate import and handler origins;
  - raw and Agent-facing schemas;
  - Chat / Responses / Anthropic envelopes;
  - prompt and real installed manual;
  - malformed zero-service behavior;
  - missing / valid / byte-distinct hot / invalid settings;
  - whole-result and prompt secret non-leakage plus behavior invariance;
  - confirmation and dry-run;
  - deterministic fake launch success and fake boot failure;
  - candidate-owned fake rules/admin gate;
  - bounded unexpected service errors;
  - **0 live process launches and 0 live descendant rule writes**;
- repaired pure schema/description/setup assertions: PASS without pytest;
- AST call-shape audit across intended avatar tests: PASS;
- ANATOMY citation drift: **53 files, PASS**;
- glossary validation: **57 resources across 19 packages, PASS**;
- in-memory compile: **4 Python files, PASS**;
- UTF-8/control-character scan: **9 intended files, PASS**;
- front-matter related-file existence: PASS;
- `git diff --check`: PASS;
- exact committed file set: 9 intended source/docs/test files only.

Worker event truth was also audited completely: 1,388 event lines parsed into 126 calls and 126 exact results. All non-empty mutation paths and shell working directories stayed inside the candidate. The audit found no deletion/cleanup, pytest, `py_compile`/`compileall`, Git/GitHub mutation, network, signal, temporary-directory lifecycle, process-spawn API, or live avatar/rules/config-path invocation.

## Transparent caveats

- Repository-wide pytest was not run under the current no-cleanup boundary.
- The migrated existing avatar modules are pytest-based and use `tmp_path` lifecycle fixtures, so they were not executed through pytest. The active runtime interpreter also does not have pytest installed; one direct import attempt stopped with `ModuleNotFoundError: pytest` before test execution. No package installation was attempted. The repaired pure assertions, focused unittest, independent fake-service gate, and full AST call-shape audit were used instead.
- Iterative failures are retained rather than hidden: the worker had an initial 2/6 focused failure, one import-validation syntax error, one corrected glossary failure, and four superseded file-tool errors; the parent focused test failed three assertions, then one, before final 7/7. A final combined validator command also had one shell variable-ordering error after its anatomy half passed; the glossary half was rerun correctly and passed 57/19.
- Production spawn and rules paths have real side effects. No live public avatar/rules call was used for validation; all semantic validation used candidate-owned retained artifacts and deterministic fake seams.

## Stack and scope

- Base branch: `feat/tool-settings-foundation`
- Exact base: `80d5c7d4e99c7de147ccb4dda4642a177842f47f` (#1038)
- Exact head: `5b43c38dedc2da7996e42065d9f71601ed982687`
- One canonical commit by `huangzesen <hzsbazinga@outlook.com>`

This is a draft review candidate only. It does not merge, release, deploy, tag, or change runtime/auth configuration.
