### PR TITLE
Migrate notification to canonical action/input contract

### DIFF
--- a/src/lingtai/intrinsic_skills/notification-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/SKILL.md
@@ -3,16 +3,17 @@ name: notification-manual
 description: >
   Notification filesystem and standalone notification tool router for LingTai.
   Read this when using notification(action='manual'|'check'|'dismiss_channel'|
-  'dismiss_event'|'dismiss_ref'), interpreting `.notification/<channel>.json`,
-  or deciding between producer-specific handling and safe mirror dismissal.
-  Routes channel/sync mechanics and dismissal safety into nested references;
-  large-result compaction remains owned by summarize-manual.
-version: 0.4.0
+  'dismiss_event'|'dismiss_ref') with nested input, interpreting
+  `.notification/<channel>.json`, or deciding between producer-specific handling
+  and safe mirror dismissal. Routes channel/sync mechanics and dismissal safety
+  into nested references; large-result compaction remains owned by summarize-manual.
+version: 0.5.0
 tags: [lingtai, notifications, channels, dismiss, manual, force, stale, nudge]
-last_changed_at: "2026-07-19T00:00:00Z"
+last_changed_at: "2026-07-26"
 related_files:
 - src/lingtai/tools/notification/__init__.py
 - src/lingtai/tools/notification/schema.py
+- src/lingtai/tools/_settings.py
 - src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
 - src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
 maintenance: |
@@ -28,34 +29,60 @@ agent-callable home for reading and clearing those surfaces. `system` has no
 notification or dismiss alias; it still owns `summarize` because context hygiene
 is not a notification operation.
 
-## Quick start
+## Public call shape
 
-| Action | Use |
-|---|---|
-| `notification(action='manual')` | Return this installed router body. Strictly read-only: it neither reads nor changes notification state. |
-| `notification(action='check')` | Request the live notification payload. The handler returns a placeholder and the kernel stamps `_meta.agent_meta.notifications.attention` plus `_meta.agent_meta.guidance.transient` onto the result. |
-| `notification(action='dismiss_channel', channel=...)` | Clear one dismissible channel mirror whole. |
-| `notification(action='dismiss_event', event_id=..., channel='system')` | Remove one matching system event; `channel` defaults to `system`. |
-| `notification(action='dismiss_ref', ref_id=..., channel='system')` | Remove matching system events by producer reference; `channel` defaults to `system`. |
+Every public call has an explicit root `action` and nested `input`; the Agent
+schema may additionally carry optional root `reasoning`. Reasoning is never
+nested in `input`.
+
+| Action | Canonical call | Use |
+|---|---|---|
+| `manual` | `notification(action='manual', input={})` | Return this installed router body. Strictly read-only. |
+| `check` | `notification(action='check', input={})` | Request the live notification payload. The handler returns a placeholder and the kernel stamps `_meta.agent_meta.notifications.attention` plus `_meta.agent_meta.guidance.transient` onto the result. |
+| `dismiss_channel` | `notification(action='dismiss_channel', input={'channel': 'soul'})` | Clear one dismissible channel mirror whole. |
+| `dismiss_event` | `notification(action='dismiss_event', input={'event_id': '...', 'channel': 'system'})` | Remove one matching system event. `channel` defaults to `system`. |
+| `dismiss_ref` | `notification(action='dismiss_ref', input={'ref_id': '...', 'channel': 'system'})` | Remove matching system events by producer reference. `channel` defaults to `system`. |
 
 There is no aggregate `dismiss` action. After handling a notification, use the
 narrowest correct producer-specific or atomic dismiss action and end the turn;
 do not voluntarily call `check` again merely to confirm the clear.
 
+## Action inputs
+
+`check` and `manual` accept only `{}`. `dismiss_channel` requires `channel` and
+may also carry `force` and `reason`. `dismiss_event` requires `event_id` and
+`dismiss_ref` requires `ref_id`; both may carry `channel`, `force`, and `reason`.
+These fields are action-owned: flat fields, cross-action fields, omitted action,
+`parameters`, and compatibility aliases are invalid.
+
+`force=true` is only for knowingly clearing a stale or producer-guarded mirror;
+it never mutates producer state or overrides protected channels. A
+post-molt dismissal requires `reason='<continue|defer|obsolete>: ...'`.
+
 ## Installed manual retrieval
 
-`notification(action='manual')` reads only:
+`notification(action='manual', input={})` reads only:
 
 ```text
 <agent>/.library/intrinsic/capabilities/notification-manual/SKILL.md
 ```
 
-Success returns exactly `status`, `notification_manual`, and `manual_path`. A
-missing installed file returns `status: degraded`, an empty
-`notification_manual`, the same fixed `manual_path`, and an actionable `error`
-naming an initializer or capability-install problem. It never falls back to a
-source checkout and never touches `.notification/`, the Notification Store,
+Success retains the established `status`, `notification_manual`, and
+`manual_path` fields. A missing installed file returns `status: degraded`, an
+empty `notification_manual`, the same fixed `manual_path`, and an actionable
+`error` naming an initializer or capability-install problem. It never falls back
+to a source checkout and never touches `.notification/`, the Notification Store,
 producer state, delivery fingerprints, or acknowledgement state.
+
+## Settings evidence
+
+Every success and error also reports fresh `current_setting` evidence from the
+Agent-owned `settings/notification.json` placeholder. The only valid content is
+`{"schema_version": 1}`. Missing, valid, byte-distinct rewrites, and invalid
+content are observable metadata only; they never select, enable, or alter a
+notification action. Settings diagnostics expose only the agent-relative path
+hint, bounded revision/hash evidence, and bounded errors, never secrets,
+absolute paths, or file contents.
 
 ## Nested reference catalog
 
@@ -65,15 +92,13 @@ producer state, delivery fingerprints, or acknowledgement state.
   description: |
     Nested notification-manual reference for the filesystem channel protocol,
     allowlist, envelopes and instructions, nudge routing, kernel sync, voluntary
-    check behavior, and producer canonical-state versus mirror boundaries. Read
-    this when interpreting or producing notification payloads.
+    check behavior, and producer canonical-state versus mirror boundaries.
 - name: notification-manual-dismissal-safety
   location: reference/dismissal-safety/SKILL.md
   description: |
     Nested notification-manual reference for atomic dismissal, producer-specific
     verbs, stale-version and force rules, protected channels, post-molt
-    acknowledgement, and legacy large_tool_result reminder escape hatches. Read
-    this before clearing notification state or diagnosing a refusal.
+    acknowledgement, and legacy large_tool_result reminder escape hatches.
 ```
 
 ## Routing table
@@ -92,8 +117,8 @@ producer state, delivery fingerprints, or acknowledgement state.
   only. Neither writes notification state.
 - Generic dismiss clears a notification mirror, never producer-owned canonical
   state. Prefer the producer's own verb when one exists.
-- `force=true` is for knowingly clearing a stale or guarded mirror. It does not
-  override protected source-of-truth channels and never mutates producer state.
+- `force=true` does not override protected source-of-truth channels and never
+  mutates producer state.
 - Large tool results are ranked under
   `_meta.agent_meta.agent_state.current_tool_result_chars`, not emitted as new
   notifications. Follow `../system-manual/reference/summarize-manual/SKILL.md`;

--- a/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
@@ -6,9 +6,9 @@ description: >
   kernel sync, voluntary check behavior, and canonical producer state versus
   notification mirrors. Read after notification-manual when interpreting,
   producing, or debugging notification payloads; skip for dismissal policy.
-version: 0.1.0
+version: 0.2.0
 tags: [lingtai, notifications, channels, protocol, sync, nudge]
-last_changed_at: "2026-07-19T00:00:00Z"
+last_changed_at: "2026-07-26T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/notification-manual/SKILL.md
 - src/lingtai/tools/notification/schema.py
@@ -74,7 +74,7 @@ replacement so readers never observe a partial JSON file.
 
 ## Voluntary check and model-visible delivery
 
-`notification(action='check')` returns a dict placeholder. The turn-loop
+`notification(action='check', input={})` returns a dict placeholder. The turn-loop
 post-hook stamps the canonical live payload onto that same result under
 `_meta.agent_meta.notifications.attention` and
 `_meta.agent_meta.guidance.transient`. The handler does not
@@ -82,7 +82,7 @@ assemble a second bare channel representation and does not write notification
 state.
 
 When notifications arrive while an agent is IDLE or ASLEEP, the kernel can
-synthesize the same `notification(action='check')` tool-call/result shape and
+synthesize the same `notification(action='check', input={})` tool-call/result shape and
 wake the agent. During ACTIVE work, the post-hook moves the single live payload
 to a suitable dict-shaped tool result only when required by first appearance,
 material change, or a deliberate check. Delivery fingerprints and the live

--- a/src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
@@ -7,9 +7,9 @@ description: >
   reminder escape hatches. Read after notification-manual before clearing a
   channel or diagnosing a dismissal refusal; summarization mechanics live in
   summarize-manual instead.
-version: 0.1.0
+version: 0.2.0
 tags: [lingtai, notifications, dismiss, force, stale, safety]
-last_changed_at: "2026-07-19T00:00:00Z"
+last_changed_at: "2026-07-26T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/notification-manual/SKILL.md
 - src/lingtai/tools/notification/__init__.py
@@ -30,9 +30,9 @@ dismissal would clear only the high-attention mirror.
 For a dismissible notification-owned surface, choose one atomic target:
 
 ```text
-notification(action='dismiss_channel', channel='nudge')
-notification(action='dismiss_event', event_id='evt_...')
-notification(action='dismiss_ref', ref_id='goal:current')
+notification(action='dismiss_channel', input={'channel': 'nudge'})
+notification(action='dismiss_event', input={'event_id': 'evt_...'})
+notification(action='dismiss_ref', input={'ref_id': 'goal:current'})
 ```
 
 `dismiss_channel` clears one allowlisted `.notification/<channel>.json` whole
@@ -62,7 +62,7 @@ as a routine retry or a substitute for handling the producer.
 ## Protected and acknowledgement-sensitive channels
 
 `goal` is protected source of truth. A generic
-`notification(action='dismiss_channel', channel='goal')` refuses even with
+`notification(action='dismiss_channel', input={'channel': 'goal'})` refuses even with
 `force=true`; use `../../../system-manual/reference/goal-manual/SKILL.md` to cancel or complete active goal
 state correctly.
 
@@ -72,8 +72,10 @@ that records the decision, for example:
 ```text
 notification(
   action='dismiss_channel',
-  channel='post-molt',
-  reason='continue: recovered the pending work'
+  input={
+    'channel': 'post-molt',
+    'reason': 'continue: recovered the pending work'
+  }
 )
 ```
 
@@ -91,8 +93,8 @@ matching `tool_call_id` also clears the legacy reminder. If summarization is no
 longer possible, use an atomic notification escape hatch:
 
 ```text
-notification(action='dismiss_ref', ref_id='large_tool_result:<tool_call_id>')
-notification(action='dismiss_event', event_id='<event_id>')
+notification(action='dismiss_ref', input={'ref_id': 'large_tool_result:<tool_call_id>'})
+notification(action='dismiss_event', input={'event_id': '<event_id>'})
 ```
 
 Whole-channel system dismissal also covers such an event but may clear unrelated

--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -1284,7 +1284,7 @@ class BaseAgent:
         3. Otherwise, inject a new block appropriate for current state:
 
            * IDLE → splice ``(call, result)`` pair (impersonates a
-             voluntary ``notification(action="check")`` call from the
+             voluntary ``notification(action="check", input={})`` call from the
              agent's perspective), post ``MSG_TC_WAKE`` so the run loop
              unblocks and ``_handle_tc_wake`` drives the next inference
              round off the existing wire — no fake user input, no meta
@@ -1371,7 +1371,7 @@ class BaseAgent:
                 return
             # Notification arrival wakes the agent, then inject as IDLE.
             # The synthesized (call, result) pair impersonates a
-            # voluntary notification(action="check") call; MSG_TC_WAKE
+            # voluntary notification(action="check", input={}) call; MSG_TC_WAKE
             # unblocks the run loop so _handle_tc_wake drives one
             # inference round off the existing wire (no fake user
             # input, no meta prefix).
@@ -1432,7 +1432,7 @@ class BaseAgent:
                     "[system] Notification delivery could not be injected onto "
                     f"the wire after a heal attempt. Affected source(s): "
                     f"{', '.join(sources)}. Please query the current state by "
-                    "calling notification(action=\"check\") or read the "
+                    "calling notification(action=\"check\", input={}) or read the "
                     "producer files under .notification/ directly, then decide "
                     "whether to act. The kernel will not retry this delivery "
                     "until the on-disk state changes."
@@ -1582,12 +1582,12 @@ class BaseAgent:
     def _inject_notification_pair(self, notifications: dict) -> bool:
         """Inject a synthetic (call, result) pair for IDLE / ASLEEP states.
 
-        Builds ``notification(action="check")`` / ``<JSON dict>`` and
+        Builds ``notification(action="check", input={})`` / ``<JSON dict>`` and
         appends to the wire interface.  Records the call_id for later
         stripping.
 
         The synthesized pair is byte-shape-identical to a voluntary
-        ``notification(action="check")`` read so the LLM cannot distinguish
+        ``notification(action="check", input={})`` read so the LLM cannot distinguish
         a kernel-injected delivery from one it issued itself; the
         ``_synthesized: true`` body flag remains the only marker.
 
@@ -1607,9 +1607,10 @@ class BaseAgent:
         distinguish kernel-injected reads from voluntary calls when reading
         conversation history.
 
-        Both call.args and result.content carry safe notification freshness
-        fields from build_meta plus a monotonic injection_seq. Internal tool-meta
-        transit keys are stripped below before the synthesized pair reaches the wire.
+        Result content and metadata carry safe notification freshness fields
+        from build_meta plus a monotonic injection_seq. The call itself stays
+        on the strict public action/input shape; internal freshness belongs in
+        the result sidecar rather than in an extra root or nested input field.
         This makes
         every synthesized pair tokenize uniquely even when the underlying
         notification payload repeats — a protection layer against the
@@ -1800,18 +1801,15 @@ class BaseAgent:
 
         # ``summary_text`` is log-only.  Do not place it in a TextBlock on the
         # wire: successful notification sync should be a structured
-        # notification(action="check") call/result pair, not a visible
+        # notification(action="check", input={}) call/result pair, not a visible
         # synthesized diary/text-input row.
-        # call.args carries injection_seq only — real tool calls don't have
-        # runtime freshness fields in their args (those live in results).
-        # The seq is enough to defeat byte-equality on the assistant turn.
+        # Keep the synthetic call on the same strict action/input shape as a
+        # voluntary notification check. Freshness is carried by the result
+        # content and sidecar, not by an extra public argument.
         call_block = ToolCallBlock(
             id=call_id,
             name="notification",
-            args={
-                "action": "check",
-                "injection_seq": self._notification_inject_seq,
-            },
+            args={"action": "check", "input": {}},
         )
         result_block = ToolResultBlock(
             id=call_id,

--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -1170,7 +1170,7 @@ def _handle_tc_wake(agent, msg: Message) -> None:
     message after ``_sync_notifications`` has already spliced a
     synthesized ``(ToolCallBlock, ToolResultBlock)`` pair into the
     canonical interface (impersonating a voluntary
-    ``notification(action="check")`` call from the agent's
+    ``notification(action="check", input={})`` call from the agent's
     perspective).  This handler's job is to drive the next inference
     round off that wire — no fake user message, no meta prefix.  From
     the LLM's viewpoint it is indistinguishable from the agent having

--- a/src/lingtai/kernel/meta_block.py
+++ b/src/lingtai/kernel/meta_block.py
@@ -41,7 +41,7 @@ parent notification and communication state is never projected into a daemon.
 
 As of 2026-05-02, the meta block no longer carries inbox-drained
 notifications. System-source notifications (mail arrival, bounce, future
-MCP events) are now delivered as synthetic notification(action="check")
+MCP events) are now delivered as synthetic notification(action="check", input={})
 tool-call pairs spliced by ``BaseAgent._inject_notification_pair`` (the
 legacy ``tc_inbox`` splice path is dormant); see
 docs/plans/2026-05-02-system-notification-as-tool-call.md.
@@ -2778,7 +2778,7 @@ def build_synthetic_tool_meta(
 ) -> dict:
     """Return a minimal synthetic ``tool_meta`` block for the IDLE/ASLEEP pair.
 
-    The synthesized ``notification(action="check")`` pair has no real tool
+    The synthesized ``notification(action="check", input={})`` pair has no real tool
     execution, so :class:`ToolExecutor._attach_tool_block` never stamps a
     ``_meta.tool_meta`` block on it.  The ``/notification`` history view still
     wants a ``tool_meta`` block to render, so this builds a parallel one carrying
@@ -2968,7 +2968,7 @@ def notification_payload_signature(payload: Mapping[str, Any] | None) -> str:
 
 
 def _is_notification_check_placeholder(content) -> bool:
-    """Return True when ``content`` is a voluntary ``notification(action=check)``
+    """Return True when ``content`` is a voluntary ``notification(action="check", input={})``
     placeholder result.
 
     The ``notification`` intrinsic's ``check`` action returns a dict carrying
@@ -3029,7 +3029,7 @@ def attach_active_notifications(
           ``_notification_fp`` is left uncommitted, and ``prior_holder`` is
           returned — the state can still be delivered later.
         * The current payload is copied for both unchanged and changed
-          signatures, including a deliberate ``notification(action="check")``
+          signatures, including a deliberate ``notification(action="check", input={})``
           read. The prior holder is released (a
           synthesized pair is skeletonized; a normal tool result RETAINS its old
           payload as a historical trace — timely transient semantics, Jason

--- a/src/lingtai/kernel/notifications.py
+++ b/src/lingtai/kernel/notifications.py
@@ -61,7 +61,7 @@ _PROTECTED_GENERIC_DISMISS: dict[str, str] = {
 
 # Channels whose generic dismissal would leak producer-owned state.
 # Producers with durable unread/state mirrors register themselves here at
-# import time so notification(action="dismiss_channel", channel=...) can refuse
+# import time so notification(action="dismiss_channel", input={"channel": ...}) can refuse
 # unsafe generic clears and point the agent at the producer-specific verb.
 _GENERIC_DISMISS_GUARDED: dict[str, str] = {}
 
@@ -215,7 +215,7 @@ def submit(
         tool_name: The producer's namespace key — ``email``, ``soul``,
             ``system``, ``mcp.<server>``, …  This becomes both the file
             basename (``<tool_name>.json``) AND the dict key the agent
-            sees when it reads ``notification(action="check")``.
+            sees when it reads ``notification(action="check", input={})``.
         data: Structured payload the agent will read.  No restrictions
             on shape — producers decide.
         header: One-line glanceable summary used by frontends (TUI

--- a/src/lingtai/kernel/nudge/__init__.py
+++ b/src/lingtai/kernel/nudge/__init__.py
@@ -15,7 +15,7 @@ Channel ``.notification/nudge.json`` carries a list of active nudges:
       "header": "<rendered by _render_header — e.g. '2 nudges'>",
       "icon": "🔔",
       "priority": "low",
-      "instructions": "Call notification(action='dismiss_channel', channel='nudge') ...",
+      "instructions": "Call notification(action='dismiss_channel', input={'channel': 'nudge'}) ...",
       "data": {"nudges": [{"kind": "kernel_version", ...}, ...]}
     }
 
@@ -23,7 +23,7 @@ Each check identifies its slot by a unique ``kind`` string. ``upsert``
 replaces (or appends) one entry; ``remove`` deletes one. When the last
 entry leaves, the channel file is cleared so the agent's wire surface
 drops the notification entirely. The agent dismisses everything at once
-with ``notification(action='dismiss_channel', channel='nudge')``.
+with ``notification(action='dismiss_channel', input={'channel': 'nudge'})``.
 
 To add a new nudge: drop ``nudge/<name>.py`` exposing ``check(agent)``,
 then add an import + dispatch line to :func:`run_checks` below. No
@@ -610,7 +610,7 @@ def _modify(agent, mutate) -> None:
             "priority": "low",
             "published_at": published_at,
             "instructions": (
-                "Call notification(action='dismiss_channel', channel='nudge') to "
+                "Call notification(action='dismiss_channel', input={'channel': 'nudge'}) to "
                 "acknowledge and clear ALL nudges at once. Individual nudges "
                 "may also describe a specific action to take (e.g. "
                 "system(action='refresh') for a kernel upgrade)."

--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -36,6 +36,7 @@ Safety properties:
 from __future__ import annotations
 
 import datetime as _dt
+from collections.abc import Mapping
 from typing import Any, Callable
 
 from .meta_block import formal_tool_result_content, formal_tool_result_visible_len
@@ -147,15 +148,21 @@ def is_apriori_summary(content: Any) -> bool:
     )
 
 
-def summary_requested(args: dict | None) -> bool:
-    """Return True iff the normalized tool args opt into a-priori summary.
+def summary_requested(args: Mapping | None) -> bool:
+    """Return True iff tool args opt into a-priori summary.
 
-    The flag is the boolean ``summary`` field on the tool call. Anything other
-    than a literal ``True`` (missing, ``False``, ``None``, truthy-but-not-True)
-    preserves current behavior exactly.
+    The presence of ``input`` selects canonical mode: only a Mapping-valued
+    ``input`` whose ``summary`` is exactly ``True`` requests summarization.
+    Root ``summary`` is ignored in canonical mode, including when ``input`` is
+    malformed or its nested flag is absent/invalid. When ``input`` is absent,
+    legacy mode reads only root ``summary``. Both modes require identity with
+    the boolean singleton ``True``; no truthy coercion is performed.
     """
-    if not isinstance(args, dict):
+    if not isinstance(args, Mapping):
         return False
+    if "input" in args:
+        payload = args["input"]
+        return isinstance(payload, Mapping) and payload.get("summary") is True
     return args.get("summary") is True
 
 
@@ -395,13 +402,19 @@ def maybe_summarize_result(
     and BEFORE the result is turned into the model-visible wire message.
 
     Contract:
+    - Summary control is canonical-first: when ``input`` is present, only
+      ``input.summary is True`` on a Mapping payload requests; root ``summary``
+      is never inspected or used as fallback. When ``input`` is absent, legacy
+      calls use root ``summary is True``. This exact-boolean discriminator is
+      applied without flattening or mutating the original args.
     - ``summary != true`` → returns *result* unchanged (current behavior).
     - ``summary == true`` but no ``summarizer_fn`` wired (e.g. service without a
       one-shot generate gateway) → **fails closed**: returns a summary-layer
       error (with the raw-retrieval locator), NOT the raw result. ``summary=true``
       is a request to keep the raw out of context; honoring it must not depend on
       whether a summarizer happens to be configured. The raw is already durably
-      logged before this point, so it remains retrievable by ``tool_call_id``.
+      logged before either the legacy or canonical predicate is applied, so it
+      remains retrievable by ``tool_call_id``.
     - Already an a-priori summary (defensive) → returned unchanged.
     - Error results (the tool itself failed) are NOT summarized: the agent needs
       the exact error text to recover. Returned unchanged.

--- a/src/lingtai/services/mcp_inbox.py
+++ b/src/lingtai/services/mcp_inbox.py
@@ -366,7 +366,7 @@ def _dispatch_summary(
     Uses the kernel's canonical ``.notification/`` filesystem-as-protocol
     instead of the legacy inbox queue.  The notification file is written as
     ``.notification/mcp.<mcp_name>.json`` and surfaces in the agent's
-    ``notification(action="check")`` wire block alongside email, soul,
+    ``notification(action="check", input={})`` wire block alongside email, soul,
     and system events.
 
     No explicit wake is needed — ``_sync_notifications`` detects the

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
@@ -35,6 +36,10 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_settings.py` — private Agent-owned placeholder-settings reader and
+  secret-free current-setting diagnostic. It strictly validates the exact
+  versioned no-op schema, rereads `settings/<bounded tool_name>.json` per call,
+  and never supplies action, input, reasoning, or tool behavior.
 
 ## Connections
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -40,6 +40,33 @@ There is no fourth public metadata block. Existing tools retain their current
 explicit schemas until a scoped migration changes their code, tests, manual, and
 contract together.
 
+### A-priori summary transition
+
+The shared kernel summary predicate uses the presence of the `input` key as the
+mode discriminator. A canonical call requests a summary only when `input` is a
+Mapping/object and `input.summary` is exactly the boolean `true`; once `input` is
+present, root `summary` is ignored and is never a fallback, even when `input` is
+malformed, missing `summary`, or carries a false/non-boolean value. No truthy
+coercion, flattening, or argument mutation is permitted. A call with no `input`
+key remains in legacy mode and requests only when root `summary` is exactly
+`true`.
+
+This is a transitional compatibility rule, not a second public schema: migrated
+capabilities that support a-priori summary advertise that flag only as nested
+`input.summary`, while unmigrated legacy advertisers retain their root flag until
+their own vertical migration. Tool errors continue to bypass summarization. The
+raw result is durably recorded before either nested or legacy summary control is
+applied; generated, refusal, and fail-closed no-gateway replacements are
+model-visible substitutes with the
+existing raw locator and metadata.
+
+The root-summary branch may be removed only in the commit that migrates the last
+currently legacy root-summary advertiser (including shell's historical `bash`
+rolling alias and daemon), and only after a registry-wide test proves that no
+provider-facing schema advertises root `summary`, no migrated handler accepts
+flat fields, and no supported pending legacy call relies on the root shape. Until
+that final removal gate, root lookup is permitted solely when `input` is absent.
+
 ## Port
 
 The provider-neutral boundary is the final `FunctionSchema` assembled by the

--- a/src/lingtai/tools/_settings.py
+++ b/src/lingtai/tools/_settings.py
@@ -1,0 +1,156 @@
+"""Private shared reader for Agent-owned no-op tool settings placeholders.
+
+The placeholder file is deliberately metadata-only.  A present, valid v1 file
+proves that an Agent-owned settings snapshot was read, but it cannot select or
+enable any tool behavior.  Individual tools may later add their own real
+settings reader when a configurable choice is actually authorized.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MAX_SETTINGS_BYTES = 64 * 1024
+SETTINGS_SCHEMA_VERSION = 1
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class SettingsError(ValueError):
+    """A placeholder settings snapshot was malformed or unsafe to use."""
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsSnapshot:
+    """Immutable evidence for one reread of one tool's settings file."""
+
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def valid_tool_name(value: Any) -> bool:
+    """Return whether *value* is safe as one bounded settings path component."""
+    return isinstance(value, str) and _TOOL_NAME.fullmatch(value) is not None
+
+
+def settings_path(agent: Any, tool_name: str) -> Path:
+    """Return the fixed Agent-owned ``settings/<tool_name>.json`` path."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return Path(agent._working_dir) / "settings" / f"{tool_name}.json"
+
+
+def _bounded_error(exc: Exception) -> str:
+    """Render a bounded diagnostic without echoing host paths or file content."""
+    if isinstance(exc, OSError):
+        return f"settings file could not be read ({type(exc).__name__})"
+    text = str(exc).replace("\n", " ").strip()
+    return (text or "invalid settings")[:240]
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject duplicate JSON object members instead of accepting last-wins data."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SettingsError("duplicate settings field")
+        result[key] = value
+    return result
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    """Read one bounded regular-file snapshot and its content revision."""
+    try:
+        first = path.lstat()
+    except FileNotFoundError:
+        return b"", "missing"
+    except OSError:
+        raise
+
+    if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
+        raise SettingsError("settings file must be a regular file")
+    if first.st_size > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings file exceeds the bounded size")
+
+    # Open by path only after lstat, then compare the path identity and metadata
+    # again.  Replacements, symlink swaps, growth, and ordinary in-place writes
+    # are therefore rejected rather than partially accepted.
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_SETTINGS_BYTES + 1)
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    try:
+        second = path.lstat()
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    if stat.S_ISLNK(second.st_mode) or not stat.S_ISREG(second.st_mode):
+        raise SettingsError("settings snapshot changed during read")
+    if (
+        len(raw) > MAX_SETTINGS_BYTES
+        or first.st_dev != second.st_dev
+        or first.st_ino != second.st_ino
+        or first.st_size != second.st_size
+        or first.st_mtime_ns != second.st_mtime_ns
+    ):
+        raise SettingsError("settings snapshot changed during read")
+    return raw, hashlib.sha256(raw).hexdigest()[:32]
+
+
+def read_settings(agent: Any, tool_name: str) -> SettingsSnapshot:
+    """Reread and strictly validate one tool's placeholder settings snapshot.
+
+    Missing is a normal placeholder state.  A valid file contributes only its
+    source/revision/hash evidence; it never changes behavior.  Every invocation
+    performs a fresh filesystem read and does not cache a prior snapshot.
+    """
+    path = settings_path(agent, tool_name)
+    digest: str | None = None
+    try:
+        raw, revision = _read_stable(path)
+        if revision == "missing":
+            return SettingsSnapshot("missing", "missing", None)
+        digest = revision
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        if not isinstance(value, dict) or set(value) != {"schema_version"}:
+            raise SettingsError("settings schema must contain only schema_version")
+        if type(value["schema_version"]) is not int or value["schema_version"] != SETTINGS_SCHEMA_VERSION:
+            raise SettingsError("settings schema_version must be integer 1")
+        return SettingsSnapshot(f"settings/{tool_name}.json", revision, digest)
+    except (OSError, UnicodeError, json.JSONDecodeError, SettingsError) as exc:
+        # Malformed data is never silently converted to the missing state.  The
+        # digest from a bounded stable read is retained as evidence when safe.
+        return SettingsSnapshot(
+            "settings_error",
+            digest or "error",
+            digest,
+            _bounded_error(exc if isinstance(exc, Exception) else SettingsError("invalid settings")),
+        )
+
+
+def current_setting(snapshot: SettingsSnapshot, tool_name: str) -> dict[str, Any]:
+    """Build the bounded, secret-free current-setting diagnostic for a tool."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return_value: dict[str, Any] = {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": snapshot.source,
+        "settings_revision": snapshot.revision,
+        "settings_hash": snapshot.digest,
+        "change_hint": (
+            f"Edit settings/{tool_name}.json; changes apply on the next {tool_name} "
+            "call; this no-op placeholder never changes tool behavior."
+        ),
+    }
+    if snapshot.error:
+        return_value["settings_error"] = snapshot.error
+    return return_value

--- a/src/lingtai/tools/notification/ANATOMY.md
+++ b/src/lingtai/tools/notification/ANATOMY.md
@@ -1,20 +1,23 @@
 ---
 related_files:
-  - src/lingtai/tools/notification/CONTRACT.md
   - src/lingtai/tools/ANATOMY.md
-  - src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
+  - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/notification/CONTRACT.md
   - src/lingtai/tools/notification/__init__.py
   - src/lingtai/tools/notification/schema.py
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/registry.py
+  - src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
   - src/lingtai/kernel/notifications.py
+  - src/lingtai/kernel/base_agent/__init__.py
   - src/lingtai/kernel/base_agent/turn.py
   - src/lingtai/agent.py
-  - src/lingtai/intrinsic_skills/system-manual/SKILL.md
   - src/lingtai/intrinsic_skills/notification-manual/SKILL.md
   - src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
   - src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
   - tests/test_notification_tool.py
   - tests/test_system_dismiss.py
+  - tests/test_tools_package_data.py
   - src/lingtai/tools/notification/glossary-en.md
   - src/lingtai/tools/notification/glossary-zh.md
   - src/lingtai/tools/notification/glossary-wen.md
@@ -23,95 +26,85 @@ maintenance: |
   Keep this component's ANATOMY.md and CONTRACT.md reciprocal and keep
   parent/child anatomy links bidirectional. Code is the structural source of
   truth: update this anatomy in the same change that moves files, symbols,
-  connections, composition, or state. Verify every changed citation and run the
+  connections, composition, or state. Verify every changed citation and run
   architecture-document validation before merge.
-  Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
 ---
 # Notification Tool Anatomy
 
 `src/lingtai/tools/notification/` is the mandatory agent-callable notification
 surface. It composes five actions: `check`, three atomic dismissal actions, and
 the strictly read-only `manual` action. Notification Core owns mirror guards and
-Store use; the tool owns only schema, dispatch, the check placeholder, argument
-adaptation, and installed-manual retrieval.
+Store use; the tool owns only the closed action/input schema, dispatch, the check
+placeholder, argument adaptation, settings evidence, and installed-manual
+retrieval.
 
 ## Components
 
-- `schema.py` defines canonical-English registration prose and the ordered
-  `check` / `dismiss_channel` / `dismiss_event` / `dismiss_ref` / `manual`
-  action domain (`src/lingtai/tools/notification/schema.py:27-62`).
-- `handle()` selects one of the five handlers and returns a structured error for
-  unknown or absent actions (`src/lingtai/tools/notification/__init__.py:174-189`).
-- `_check()` returns the dict-shaped placeholder onto which the turn loop can
-  stamp the current notification payload
-  (`src/lingtai/tools/notification/__init__.py:52-70`).
-- `_manual()` constructs the fixed installed
-  `.library/intrinsic/capabilities/notification-manual/SKILL.md`
-  path, returns its UTF-8 body, or returns an explicit degraded envelope when
-  the installed file is absent (`src/lingtai/tools/notification/__init__.py:73-97`).
-- `_dismiss_channel()` adapts a whole-channel request and rejects event/ref
-  targets (`src/lingtai/tools/notification/__init__.py:100-131`).
-- `_dismiss_event()` and `_dismiss_ref()` adapt targeted system-event removal
-  while defaulting the channel to `system`
-  (`src/lingtai/tools/notification/__init__.py:134-171`).
+- `schema.py` defines canonical-English registration prose, the ordered five
+  action domain, a closed root, and strict action-owned `input.anyOf` branches.
+  The check and manual branches are separate empty titled objects. The raw
+  schema owns no reasoning.
+- `__init__.py` defines `_ACTION_FIELDS`, mapping-key and type validation,
+  settings evidence, `handle()`, the check placeholder, manual retrieval, and
+  the three Core adapters. Public validation occurs before any notification
+  Core/Store seam; every result receives fresh `current_setting` evidence.
+- `_settings.py` supplies the shared Agent-owned no-op placeholder reader for
+  `settings/notification.json`.
 - `registry.INTRINSICS` registers `notification` as a mandatory intrinsic next
-  to email, system, psyche, and soul (`src/lingtai/tools/registry.py:45-53`).
+  to email, system, psyche, and soul.
+- `CONTRACT.md` is the normative public Port and invariant document.
 
 ## Connections
 
 - `BaseAgent._wire_intrinsics()` binds every registered intrinsic module's
-  `handle()` into the agent tool surface
-  (`src/lingtai/kernel/base_agent/__init__.py:783-796`).
-- The turn loop calls `attach_active_notifications()` after ordinary tool
-  results so `check` receives the canonical `_meta.agent_meta.notifications.attention` and
-  `_meta.agent_meta.guidance.transient` stamp
-  (`src/lingtai/kernel/base_agent/turn.py:1748-1764`;
-  `src/lingtai/kernel/meta_block.py:2944`).
-- All three dismissal handlers delegate to
-  `lingtai.kernel.notifications.dismiss_channel(...,
-  invoked_by="notification")`; Core owns allowlists, producer guards,
-  stale-version checks, protected channels, post-molt acknowledgement, and
-  targeted event/ref removal (`src/lingtai/kernel/notifications.py:469`).
+  `handle()` into the agent tool surface. `_build_tool_schemas()` copies the raw
+  notification schema and alone injects optional root `reasoning`.
+- The turn loop and notification meta-block call the notification post-hook
+  after ordinary tool results so `check` receives the canonical notification
+  payload on the same result.
+- Kernel notification Core owns allowlists, producer guards, stale-version
+  checks, protected channels, post-molt acknowledgement, and targeted event/ref
+  removal. All dismiss adapters call the Core helper with
+  `invoked_by="notification"`.
 - `Agent._install_intrinsic_manuals()` copies the kernel-shipped
-  `system-manual` skill tree into the per-agent intrinsic library that
-  `_manual()` reads (`src/lingtai/agent.py:311-372`).
+  notification-manual skill tree into the per-Agent intrinsic library that
+  `_manual()` reads.
 - The notification manual is the progressive-disclosure router for procedures;
-  its channel-model and dismissal-safety children hold protocol and safety
-  depth. The paired Contract defines the normative tool Port and invariants.
+  channel-model and dismissal-safety children hold protocol and safety depth.
 
 ## Composition
 
-- **Parent:** `src/lingtai/tools/` (see `src/lingtai/tools/ANATOMY.md`).
-- **Core dependency:** `src/lingtai/kernel/notifications.py` and the notification
-  Store behind it. This tool does not add a Store operation.
-- **Turn-loop adapter:** `src/lingtai/kernel/base_agent/turn.py` completes the
-  `check` placeholder with model-visible state.
-- **Installed-resource adapter:** `src/lingtai/agent.py` installs the intrinsic
-  skill tree consumed by `manual`.
+- **Parent:** `src/lingtai/tools/`.
+- **Core dependency:** `src/lingtai/kernel/notifications.py` and the injected
+  Notification Store Port. This tool adds no Store operation.
+- **Turn-loop adapter:** the notification post-hook completes the check
+  placeholder with model-visible state.
+- **Installed-resource adapter:** `src/lingtai/agent.py` installs the manual
+  tree consumed by `manual`.
 - **Sibling ownership:** `system` retains `summarize`; producer tools retain
   their own canonical read/dismiss operations.
 
-## State
+## Public boundary
 
-- `_check()` is in-memory and write-free.
-- `_manual()` reads one fixed installed text file and does not inspect or mutate
-  `.notification/`, Notification Store state, producer state, fingerprints,
-  acknowledgements, or notification logs.
-- Dismiss handlers own no state directly. Through notification Core they clear
-  notification mirrors or remove targeted system events while leaving producer
-  canonical state untouched.
+The raw root is exactly required `action` and required `input`, with
+`additionalProperties: false`. `input` is a strict action-specific `anyOf`; no
+flat fields, omitted action, nested reasoning, or compatibility alias is
+accepted. Agent-facing schemas add only optional root reasoning. Synthetic
+kernel check pairs use the same `{"action": "check", "input": {}}` call shape;
+freshness stays in result content/metadata.
 
-## Notes
+The handler rereads `settings/notification.json` on every call. The only valid
+settings value is `{"schema_version": 1}` and it is evidence-only; settings
+never selects or changes notification behavior. Missing, valid, rewritten, and
+invalid states are represented by bounded, secret-free `current_setting` data.
 
-- There is no aggregate `dismiss`, `summarize`, source-checkout fallback, shared
-  manual loader, or `system` notification/dismiss compatibility alias.
-- The kernel may synthesize the same `notification(action="check")` call/result
-  shape at an idle boundary; that delivery plumbing is not another agent-callable
-  action (`src/lingtai/kernel/base_agent/__init__.py:1255-1461`;
-  `src/lingtai/kernel/base_agent/__init__.py:1562-1800`).
-- Large tool results are ranked and compacted through
-  `system(action="summarize")`. Notification dismissal retains only the legacy
-  reminder escape hatch described by the manual.
-- Changes to notification read/dismiss semantics must also check
-  `src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md`; changes to Port behavior
-  must update the paired Contract and focused tests in the same PR.
+`check` is in-memory and write-free. `manual` reads one fixed installed text
+file and does not inspect or mutate `.notification/`, Notification Store state,
+producer state, fingerprints, acknowledgements, or notification logs. Dismiss
+handlers own no state directly: Core clears notification mirrors or removes
+selected system events while preserving producer canonical state and unrelated
+events.
+
+There is no aggregate `dismiss`, `summarize`, source-checkout fallback, shared
+manual compatibility route, or `system` notification/dismiss alias. Large-result
+reminder and stale/force behavior remains in Core and is not duplicated here.

--- a/src/lingtai/tools/notification/CONTRACT.md
+++ b/src/lingtai/tools/notification/CONTRACT.md
@@ -1,13 +1,15 @@
 ---
 name: notification-tool
-contract_version: 1
+contract_version: 2
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/notification/__init__.py
   - src/lingtai/tools/notification/schema.py
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/registry.py
   - src/lingtai/kernel/notifications.py
+  - src/lingtai/kernel/base_agent/__init__.py
   - src/lingtai/kernel/base_agent/turn.py
   - src/lingtai/agent.py
   - tests/test_notification_tool.py
@@ -16,7 +18,6 @@ related_files:
   - src/lingtai/tools/notification/glossary-en.md
   - src/lingtai/tools/notification/glossary-zh.md
   - src/lingtai/tools/notification/glossary-wen.md
-  - src/lingtai/intrinsic_skills/system-manual/SKILL.md
   - src/lingtai/intrinsic_skills/notification-manual/SKILL.md
   - src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
   - src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
@@ -28,10 +29,9 @@ maintenance: |
   belong here. Re-read this contract whenever a linked boundary changes. Update
   the Port, affected Adapters, contract tests, and this contract in the same
   change; update the paired Anatomy when structure or composition also changes;
-  bump contract_version for a breaking Port-contract change. If code and contract
-  disagree, treat the disagreement as a defect—do not silently rewrite the
-  normative contract to match the implementation.
-  Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+  bump contract_version for a breaking Port-contract change. If code and
+  contract disagree, treat the disagreement as a defect. Follow the root
+  Anatomy/Contract pairing rule and report drift rather than silently fixing it.
   <!-- CANONICAL-MAINTENANCE END -->
 ---
 # Notification Tool Contract
@@ -44,101 +44,104 @@ notification mirrors plus one strictly read-only `manual` action for progressive
 disclosure. It owns no producer state and introduces no Notification Store
 operation.
 
+## Public call boundary
+
+The raw `get_schema()` is a closed object whose required root properties are
+exactly `action` and `input`:
+
+```text
+notification(action="check", input={})
+notification(action="dismiss_channel", input={"channel": "soul"})
+notification(action="dismiss_event", input={"event_id": "evt-1"})
+notification(action="dismiss_ref", input={"ref_id": "producer-1"})
+notification(action="manual", input={})
+```
+
+The action domain, in order, is `check`, `dismiss_channel`, `dismiss_event`,
+`dismiss_ref`, `manual`. The root is closed (`additionalProperties: false`),
+`input` is required, and its `anyOf` consists of five closed action-owned object
+branches. `check` and `manual` intentionally have separate empty titled
+branches. `dismiss_channel` owns `channel`, `force`, and `reason`; it requires
+`channel`. `dismiss_event` owns `event_id`, optional `channel`, `force`, and
+`reason`; it requires `event_id`. `dismiss_ref` is the corresponding `ref_id`
+branch. Cross-action fields, flat fields, omitted action, and compatibility
+aliases are not accepted.
+
+The raw schema does not own `reasoning`. BaseAgent alone adds optional root
+`reasoning` to the Agent-facing FunctionSchema; an executor may carry it as
+internal `_reasoning`. Reasoning is never nested in `input`. Provider envelope
+names and shapes remain unchanged: Chat and Responses use the FunctionSchema
+parameters, Anthropic uses `input_schema`, and the common wire description is
+unchanged.
+
 ## Behavior
 
-LingTai agents MUST use `manual` only to retrieve installed guidance, `check` to
-request current notification state, and the narrowest producer-specific or
-atomic dismiss action after handling a notification. They MUST NOT treat generic
+Agents MUST use `manual` only to retrieve installed guidance, `check` to request
+current notification state, and the narrowest producer-specific or atomic
+dismiss action after handling a notification. They MUST NOT treat generic
 dismissal as mutation of producer canonical state, bypass protected channels, or
 route large-result compaction through this tool.
-
-Coding agents MUST preserve all four operational actions, Store semantics,
-notification Core guards, producer state, and the absence of `system`
-notification/dismiss aliases. They MUST keep `manual` read-only, fixed to the
-installed per-agent path, and independent of check/dismiss delivery state.
-Procedures and safety explanations live in the linked notification manual and
-nested references rather than in this contract.
-
-## Port
-
-The inbound agent-tool Port is named `notification`. Its input is an object with
-required canonical-English `action` and optional dismiss fields `channel`,
-`force`, `event_id`, `ref_id`, and `reason`. The action domain, in order, is:
-`check`, `dismiss_channel`, `dismiss_event`, `dismiss_ref`, `manual`.
 
 Observable action contracts are:
 
 - `check` returns `{_notification_placeholder: true, message}`; the turn-loop
-  adapter may stamp `_meta.agent_meta.notifications.attention` and `_meta.agent_meta.guidance.transient` onto
-  that same dict.
+  adapter may stamp `_meta.agent_meta.notifications.attention` and
+  `_meta.agent_meta.guidance.transient` onto that same dict.
 - `dismiss_channel` requires `channel`, rejects event/ref targets, and delegates
   a whole-mirror clear to notification Core.
 - `dismiss_event` requires `event_id`; `dismiss_ref` requires `ref_id`; each
   defaults `channel` to `system` and delegates targeted removal to Core.
 - `manual` reads only
   `<agent>/.library/intrinsic/capabilities/notification-manual/SKILL.md`.
-  Success contains exactly `{status: "ok", notification_manual, manual_path}`.
-  Absence contains exactly `{status: "degraded", notification_manual: "",
-  manual_path, error}`, where `error` is `notification manual missing —
-  initializer may have failed or capability not installed correctly`. Other
-  filesystem/decoding errors propagate.
-- Unknown or absent actions return `{status: "error", message}` naming the
-  unknown notification action.
+  Success retains the established `{status: "ok", notification_manual,
+  manual_path}` envelope; absence retains the degraded empty-body envelope.
+- Every success and error also carries fresh `current_setting` evidence from
+  the Agent-owned `settings/notification.json` placeholder. The only valid
+  settings file is the evidence-only v1 object `{"schema_version": 1}`. Missing,
+  valid, byte-distinct, and invalid files never change notification behavior.
+
+Malformed root/input mappings, non-string or odd keys, cross-action fields, and
+wrong action-input value types fail before any notification read, write, or
+Core/Store dismissal seam. Service, installed-manual, and filesystem
+exceptions use bounded non-private error envelopes; no exception detail,
+secret, or absolute settings path is model-visible.
 
 There is no aggregate `dismiss`, no `summarize`, no `items` property, no source
-checkout fallback, and no compatibility alias.
+checkout fallback, and no compatibility alias. `system` owns `summarize` and
+exposes no notification/dismiss alias.
 
-## Adapters
+## Adapters and safety
 
-`lingtai.tools.registry.INTRINSICS` is the composition wiring that installs the
-package as a mandatory tool. `handle()` is the driving dispatch adapter for the
-five actions. The turn-loop notification post-hook completes `check` with the
-single canonical model-visible payload. The three dismiss handlers adapt tool
-arguments into `lingtai.kernel.notifications.dismiss_channel(...,
-invoked_by="notification")`, where notification Core owns allowlists, guards,
-stale checks, protected channels, acknowledgement policy, and Store use.
+`lingtai.tools.registry.INTRINSICS` registers `notification` as a mandatory
+intrinsic. `handle()` validates and dispatches the five actions. The turn-loop
+notification post-hook completes `check` with the single canonical model-visible
+payload. The three dismiss handlers adapt nested input into
+`lingtai.kernel.notifications.dismiss_channel(..., invoked_by="notification")`,
+where Core owns allowlists, producer guards, stale-version checks, protected
+channels, acknowledgement policy, and targeted event/ref removal.
 
-`_manual` is a bounded installed-resource adapter: it performs one `is_file`
-check and one UTF-8 read at the fixed path. It does not call notification Core,
-`NotificationStorePort`, the post-hook, a producer, or a shared loader. Agent
-initialization copies the bundled first-level `notification-manual` skill tree
-into the installed per-agent intrinsic library.
+Agent initialization installs the bundled notification-manual skill tree into the
+per-Agent intrinsic library. `manual` reads that initialized resource only and
+never reads or mutates `.notification/`, Notification Store state, producer
+state, fingerprints, or acknowledgement state.
 
-## Contract rules
+Dismissal affects notification mirrors only. Producer guards, non-force stale
+refusal, protected-channel refusal, post-molt reasons, and unrelated-event
+preservation remain in force. Legacy `large_tool_result` reminder escape-hatch
+behavior remains unchanged.
 
-- `manual` MUST NOT read, create, clear, fingerprint, acknowledge, or otherwise
-  mutate `.notification/` or producer state, and MUST NOT emit notification logs.
-- Missing installed guidance is degraded, never a silent successful empty body;
-  source-tree fallback and compatibility response aliases are forbidden.
-- `check` remains a write-free placeholder path. Dismiss behavior and result
-  shapes remain those of the canonical notification Core helper.
-- Dismissal affects notification mirrors only. Producer guards, non-force stale
-  refusal, protected-channel refusal, post-molt reasons, and unrelated-event
-  preservation remain in force.
-- `system` owns `summarize` and exposes no notification/dismiss alias. The
-  notification tool owns no producer publication action.
-- Schema descriptions are canonical English and language-independent. Action
-  identifiers and properties have no localized aliases. All three owned
-  glossaries require review when this enum changes; the additive `manual` action
-  introduces no new localized concept.
-- Adding `manual` is additive, so `contract_version` remains `1`; a future
-  breaking Port change follows the root version rule.
+## Contract tests and maintenance
 
-## Contract tests
+Focused tests cover mandatory registration and wiring, the ordered five-action
+raw schema, raw-versus-Agent-facing reasoning injection, canonical descriptions,
+closed action branches, malformed input before notification seams, installed
+manual equality/path and read-only behavior, settings states/evidence, all
+atomic dismiss semantics, Core guards, exception sanitization, provider wires,
+and absence of system compatibility aliases. Architecture, Anatomy drift,
+glossary, i18n, compile, control-byte, and diff-check validators cover the
+linked document and manual graphs.
 
-`tests/test_notification_tool.py` proves mandatory registration and wiring, the
-ordered five-action schema, canonical description, absent aggregate actions,
-manual success/degraded envelopes and fixed path, read-only state/log behavior,
-check placeholder shape, all atomic dismiss semantics, Core guards, and absence
-of system compatibility aliases. `tests/test_system_dismiss.py` protects shared
-operational dismissal behavior. `tests/test_tools_package_data.py` verifies tool
-and documentation package data. Architecture, Anatomy drift, glossary, and skill
-validators cover the linked document and manual graphs.
-
-## Maintenance
-
-Read the paired Anatomy for current symbol locations, wiring, composition, state,
-and verified citations. Keep implementation, schema, registry wiring, focused
-tests, glossaries, and the manual/reference graph synchronized. Do not duplicate
-manual procedures here or expand this slice into Store, producer, system, or
-summarization changes.
+Read the paired Anatomy for current symbol locations and composition. Keep
+implementation, schema, registry wiring, focused tests, glossaries, and the
+manual/reference graph synchronized. The action/input migration is a breaking
+Port change, so `contract_version` is `2`.

--- a/src/lingtai/tools/notification/__init__.py
+++ b/src/lingtai/tools/notification/__init__.py
@@ -1,61 +1,50 @@
 """Notification intrinsic — the standalone notification surface.
 
-This intrinsic owns the notification-facing verbs: reading the live
-notification surface and clearing notification mirrors.  It is the **only**
-agent-callable home for those operations — the ``system`` tool no longer
-exposes any notification verb (no ``notification``/``dismiss`` compatibility
-alias).  ``system`` retains ``summarize`` (and the lifecycle/karma actions);
-``summarize`` is *not* a notification verb and stays under ``system``.
+The public boundary is a closed root ``action`` plus required nested ``input``.
+The raw schema owns no ``reasoning`` field; BaseAgent alone injects optional root
+reasoning into the Agent-facing schema. The five actions are:
 
-Dismissal is **atomic**: there is no single kitchen-sink ``dismiss``.  Each
-removal target has its own action so the API expresses exactly what is being
-cleared:
+* ``check`` — read the live notification surface through the kernel's
+  post-hook placeholder;
+* ``dismiss_channel`` — clear one notification mirror whole;
+* ``dismiss_event`` — remove one system event by event_id;
+* ``dismiss_ref`` — remove system event(s) by ref_id;
+* ``manual`` — read the initialized notification-manual resource.
 
-Actions:
-    check          — voluntary read of the live notification surface.  Returns
-                     a placeholder dict; the turn loop's meta-block post-hook
-                     stamps the canonical ``_meta.agent_meta.notifications.attention`` +
-                     ``_meta.agent_meta.guidance.transient`` payload onto this same result.
-    dismiss_channel — clear one ``.notification/<channel>.json`` surface whole.
-                     Rejects ``event_id``/``ref_id`` (those are atomic-event
-                     verbs).  Producer-owned state is never touched; guarded
-                     mirrors refuse without ``force``.
-    dismiss_event  — remove a single ``system`` event by ``event_id`` from
-                     ``.notification/system.json``.
-    dismiss_ref    — remove ``system`` event(s) by ``ref_id`` from
-                     ``.notification/system.json``.
-    manual         — return the installed notification manual body. Read-only;
-                     notification and producer state are not touched.
-
-All three dismiss verbs delegate to the single canonical
-:func:`lingtai.kernel.notifications.dismiss_channel` with
-``invoked_by="notification"``.  The decision logic (allowlist, ``post-molt``
-ack-reason, protected channels, generic-dismiss guard, and stale-channel-version
-refusal) lives there, so every guard holds through this tool by construction.
-Legacy ``large_tool_result`` reminders — the kernel no longer raises these
-(large results are ranked under ``_meta.agent_meta.agent_state.current_tool_result_chars``
-and compacted via ``system(action="summarize")``) — but any event still present
-from before this change (or a pre-molt session) may be dismissed as an escape
-hatch; doing so acknowledges the ref_id.  Summarization via
-``system(action="summarize")`` still auto-clears any such matching reminder.
+Dismissal remains delegated to the canonical notification Core helper. This
+module owns only strict envelope validation, dispatch, the check placeholder,
+and installed-manual retrieval.
 """
 from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .._settings import SettingsSnapshot, current_setting, read_settings
 
 # Schema (tool registration).
 from .schema import get_description, get_schema  # noqa: F401
 
-# Single-source delegate — the canonical dismissal helper.  No notification
-# logic is reimplemented here.
+# Single-source delegate — the canonical dismissal helper. No notification
+# policy is reimplemented here.
 from lingtai.kernel.notifications import dismiss_channel
 
 
-# Placeholder returned by ``check`` — the live payload (``_meta.agent_meta.notifications.attention``
-# + ``_meta.agent_meta.guidance.transient``) is stamped onto this same result dict by
-# ``attach_active_notifications`` in the turn loop.  Returning a dict (not a
-# string) is what makes that stamp possible: the meta-block walks backward for
-# the freshest *dict-shaped* tool result.
+_ACTION_FIELDS: dict[str, tuple[str, ...]] = {
+    "check": (),
+    "dismiss_channel": ("channel", "force", "reason"),
+    "dismiss_event": ("event_id", "channel", "force", "reason"),
+    "dismiss_ref": ("ref_id", "channel", "force", "reason"),
+    "manual": (),
+}
+
+# ``_tc_id`` is injected by intrinsic dispatch. ``reasoning`` and ``_reasoning``
+# are Agent/executor metadata accepted only at this internal boundary. None of
+# these are public raw-schema properties.
+_ALLOWED_ROOT_FIELDS = ("action", "input", "reasoning", "_reasoning", "_tc_id")
+
 _CHECK_PLACEHOLDER_MESSAGE = (
-    "Voluntary notification(action=check) read. The live notification payload "
+    "Voluntary notification(action='check', input={}) read. The live notification payload "
     "is delivered via the kernel meta-block under the `_meta.agent_meta.notifications.attention` and "
     "`_meta.agent_meta.guidance.transient` keys on this same result. If those keys are "
     "absent, no notifications are active."
@@ -71,7 +60,7 @@ def _check(agent, args: dict) -> dict:
 
 
 def _manual(agent, args: dict) -> dict:
-    """Return only the installed notification manual; never touch notification state."""
+    """Read only the initialized notification manual resource."""
     manual_path = (
         agent._working_dir
         / ".library"
@@ -98,28 +87,16 @@ def _manual(agent, args: dict) -> dict:
 
 
 def _dismiss_channel(agent, args: dict) -> dict:
-    """Clear one notification channel whole.
-
-    Atomic event verbs (``event_id``/``ref_id``) are not accepted here; use
-    ``dismiss_event`` / ``dismiss_ref`` for targeted removal.
-    """
+    """Clear one notification channel whole."""
     channel = args.get("channel")
     if channel is None:
         agent._log("notification_dismiss_missing_channel")
         return {
             "status": "error",
             "reason": "missing_channel",
-            "message": "notification(action='dismiss_channel') requires channel=<name>.",
-        }
-    if args.get("event_id") or args.get("ref_id"):
-        return {
-            "status": "error",
-            "reason": "channel_dismiss_rejects_event_target",
-            "channel": channel,
             "message": (
-                "dismiss_channel clears a whole channel; use dismiss_event "
-                "(event_id=...) or dismiss_ref (ref_id=...) for a single "
-                "system event."
+                "notification(action='dismiss_channel', input={'channel': '<name>'}) "
+                "requires input.channel."
             ),
         }
     return dismiss_channel(
@@ -139,7 +116,10 @@ def _dismiss_event(agent, args: dict) -> dict:
         return {
             "status": "error",
             "reason": "missing_event_id",
-            "message": "notification(action='dismiss_event') requires event_id=<id>.",
+            "message": (
+                "notification(action='dismiss_event', input={'event_id': '<id>'}) "
+                "requires input.event_id."
+            ),
         }
     return dismiss_channel(
         agent,
@@ -159,7 +139,10 @@ def _dismiss_ref(agent, args: dict) -> dict:
         return {
             "status": "error",
             "reason": "missing_ref_id",
-            "message": "notification(action='dismiss_ref') requires ref_id=<id>.",
+            "message": (
+                "notification(action='dismiss_ref', input={'ref_id': '<id>'}) "
+                "requires input.ref_id."
+            ),
         }
     return dismiss_channel(
         agent,
@@ -171,19 +154,157 @@ def _dismiss_ref(agent, args: dict) -> dict:
     )
 
 
-def handle(agent, args: dict) -> dict:
-    """Handle the standalone ``notification`` tool."""
-    action = args.get("action")
-    handler = {
+def _mapping_keys(value: Mapping) -> tuple[list[Any], str | None]:
+    """Read mapping keys without hashing untrusted or odd mapping keys."""
+    try:
+        keys = list(value.keys())
+    except Exception:
+        return [], "mapping keys could not be read"
+    if any(not isinstance(key, str) for key in keys):
+        return keys, "mapping keys must be strings"
+    return keys, None
+
+
+def _setting_diagnostic(agent) -> dict[str, Any]:
+    """Reread settings and keep an unexpected reader failure bounded."""
+    try:
+        snapshot = read_settings(agent, "notification")
+    except Exception:
+        snapshot = SettingsSnapshot(
+            "settings_error", "error", None, "settings file could not be read"
+        )
+    return current_setting(snapshot, "notification")
+
+
+def _with_setting(result: Any, diagnostic: dict[str, Any]) -> dict[str, Any]:
+    """Attach fresh, secret-free settings evidence to every public result."""
+    if isinstance(result, Mapping):
+        value = dict(result)
+    else:
+        value = {
+            "status": "error",
+            "reason": "notification_action_failed",
+            "message": "notification action failed",
+        }
+    # Core's low-level clear error historically carried the exception text. Keep
+    # its stable reason but do not expose filesystem/service details to the agent.
+    if value.get("reason") == "clear_failed":
+        value["message"] = "notification mirror operation failed"
+    value["current_setting"] = dict(diagnostic)
+    return value
+
+
+def _error(message: str, diagnostic: dict[str, Any]) -> dict[str, Any]:
+    return _with_setting({"status": "error", "message": message}, diagnostic)
+
+
+def _validate_input_types(action: str, action_input: dict[str, Any]) -> str | None:
+    """Validate value types before any notification Core/Store seam."""
+    string_fields = {"channel", "event_id", "ref_id", "reason"}
+    for field in string_fields:
+        if field in action_input and type(action_input[field]) is not str:
+            return f"notification input field {field!r} must be a string"
+    if "force" in action_input and type(action_input["force"]) is not bool:
+        return "notification input field 'force' must be a boolean"
+    # Missing target fields retain the existing action-specific envelopes in
+    # _dismiss_channel/_dismiss_event/_dismiss_ref; only wrong value types are
+    # rejected at this pre-seam boundary.
+    return None
+
+
+def handle(agent, args: Any) -> dict:
+    """Validate and dispatch one canonical notification action.
+
+    Envelope and value validation deliberately precede every notification
+    read/write/dismiss seam. Settings evidence is reread for every outcome,
+    including malformed, manual, and service-error paths.
+    """
+    diagnostic = _setting_diagnostic(agent)
+
+    if not isinstance(args, Mapping):
+        return _error("notification arguments must be an object", diagnostic)
+    root_keys, root_error = _mapping_keys(args)
+    if root_error:
+        return _error(f"notification {root_error}", diagnostic)
+    try:
+        if any(key not in _ALLOWED_ROOT_FIELDS for key in root_keys):
+            return _error(
+                "notification accepts only root action, input, and Agent reasoning metadata",
+                diagnostic,
+            )
+        if "action" not in root_keys or "input" not in root_keys:
+            return _error("notification requires root action and input", diagnostic)
+        action = args["action"]
+        raw_input = args["input"]
+    except Exception:
+        return _error("notification arguments are malformed", diagnostic)
+
+    if type(action) is not str or action not in _ACTION_FIELDS:
+        return _error("Unknown notification action", diagnostic)
+    if not isinstance(raw_input, Mapping):
+        return _error("notification input must be an object", diagnostic)
+    nested_keys, nested_error = _mapping_keys(raw_input)
+    if nested_error:
+        return _error(f"notification input {nested_error}", diagnostic)
+    try:
+        action_input = dict(raw_input)
+    except Exception:
+        return _error("notification input must be an object", diagnostic)
+    allowed_fields = _ACTION_FIELDS[action]
+    try:
+        if action == "dismiss_channel" and any(
+            key in ("event_id", "ref_id") for key in nested_keys
+        ):
+            channel = action_input.get("channel")
+            return _with_setting(
+                {
+                    "status": "error",
+                    "reason": "channel_dismiss_rejects_event_target",
+                    "channel": channel,
+                    "message": (
+                        "dismiss_channel clears a whole channel; use dismiss_event "
+                        "(event_id=...) or dismiss_ref (ref_id=...) for a single "
+                        "system event."
+                    ),
+                },
+                diagnostic,
+            )
+        if any(key not in allowed_fields for key in nested_keys):
+            return _error(
+                f"unsupported notification input field for action {action!r}",
+                diagnostic,
+            )
+    except Exception:
+        return _error("notification input is malformed", diagnostic)
+    if action in ("check", "manual") and action_input:
+        return _error(f"{action} input must be an empty object", diagnostic)
+    type_error = _validate_input_types(action, action_input)
+    if type_error:
+        return _error(type_error, diagnostic)
+
+    try:
+        reasoning = args.get("_reasoning")
+        if reasoning is None:
+            reasoning = args.get("reasoning")
+    except Exception:
+        reasoning = None
+    if reasoning is not None and not isinstance(reasoning, str):
+        return _error("notification reasoning metadata must be a string", diagnostic)
+
+    dispatch_args = {"action": action, **action_input}
+    handlers = {
         "check": _check,
         "dismiss_channel": _dismiss_channel,
         "dismiss_event": _dismiss_event,
         "dismiss_ref": _dismiss_ref,
         "manual": _manual,
-    }.get(action)
-    if handler is None:
-        return {
+    }
+    try:
+        result = handlers[action](agent, dispatch_args)
+    except Exception:
+        result = {
             "status": "error",
-            "message": f"Unknown notification action: {action}",
+            "reason": "notification_action_failed",
+            "message": "notification action failed",
         }
-    return handler(agent, args)
+    return _with_setting(result, diagnostic)

--- a/src/lingtai/tools/notification/glossary-en.md
+++ b/src/lingtai/tools/notification/glossary-en.md
@@ -10,6 +10,6 @@ related_files:
 - src/lingtai/tools/notification/glossary-zh.md
 - src/lingtai/tools/notification/glossary-wen.md
 maintenance: |
-  English glossary for the `notification` tool package (lingtai.tools.notification); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when notification's public tool schema changes.
+  English glossary for the `notification` tool package (lingtai.tools.notification); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when notification's public tool schema changes. The canonical public root is `action` plus nested `input`; reasoning is Agent-injected metadata, not a glossary alias.
   Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
 ---

--- a/src/lingtai/tools/notification/glossary-wen.md
+++ b/src/lingtai/tools/notification/glossary-wen.md
@@ -13,6 +13,6 @@ maintenance: |
   Classical-Chinese (wen) glossary for the `notification` tool package (lingtai.tools.notification); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever notification's public tool schema changes.
   Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
 ---
-**名相对照**
+**名相對照**
 
-- `notification`：原 locale catalog 未载 model-facing 本地名；召名、action 枚举之值与参名皆仍书上文 canonical English。
+- `notification`：原 locale catalog 未載 model-facing 本地名；召名、action 枚舉之值、根 `action`、內嵌 `input` 與參名皆仍書 canonical English。

--- a/src/lingtai/tools/notification/glossary-zh.md
+++ b/src/lingtai/tools/notification/glossary-zh.md
@@ -15,4 +15,4 @@ maintenance: |
 ---
 **术语对照**
 
-- `notification`：原 locale catalog 未定义 model-facing 本地化别名；调用名、action 枚举值和参数名均保持上方 canonical English。
+- `notification`：原 locale catalog 未定义 model-facing 本地化别名；调用名、action 枚举值、根 `action` 与嵌套 `input` 及参数名均保持上方 canonical English。

--- a/src/lingtai/tools/notification/schema.py
+++ b/src/lingtai/tools/notification/schema.py
@@ -1,20 +1,16 @@
-"""Schema — tool registration for the standalone ``notification`` tool.
-
-The notification tool exposes ``check``, the three atomic dismiss verbs
-(``dismiss_channel``, ``dismiss_event``, ``dismiss_ref``), and the strictly
-read-only progressive-disclosure action ``manual``. ``summarize`` is *not* here
-— it remains a ``system`` action. Schema prose is canonical English; ``lang`` is
-accepted for source compatibility and does not select localized aliases.
-"""
+"""Schema and description for the standalone ``notification`` intrinsic."""
 from __future__ import annotations
+
+from typing import Any
+
 
 LARGE_RESULT_DISMISS_ACTION_NOTE = (
     "Legacy: the kernel no longer raises large_tool_result reminders — large "
     "results are ranked under _meta.agent_meta.agent_state.current_tool_result_chars and "
     "compacted via system(action=summarize). Any large_tool_result event still "
-    "present (e.g. persisted before this change or pre-molt) can be dismissed "
-    "as an escape hatch. Dismissal only clears the notification surface; the "
-    "original result stays in chat history and events.jsonl. See "
+    "present (for example, persisted before this change or pre-molt) can be "
+    "dismissed as an escape hatch. Dismissal only clears the notification "
+    "surface; the original result stays in chat history and events.jsonl. See "
     "notification-manual."
 )
 
@@ -24,39 +20,157 @@ LARGE_RESULT_FORCE_NOTE = (
 )
 
 
+def _input_branch(
+    title: str,
+    properties: dict[str, dict[str, Any]],
+    required: list[str],
+) -> dict[str, Any]:
+    return {
+        "title": title,
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
 def get_description(lang: str = "en") -> str:
-    return "Notification surface — read and clear the agent's notification channels. Self-actions, no permissions needed.\n\nThis is the only tool that exposes notification verbs; the system tool no longer offers notification or dismiss aliases.\n\nUse check to read all channels, dismiss_channel to clear one channel whole, and dismiss_event / dismiss_ref to remove a single system event by event_id / ref_id. Use notification(action='manual') to return the installed notification manual; this action is strictly read-only and does not change notification state. To compress a large tool result, use system(action=summarize)."
+    return (
+        "Notification surface — read and clear the agent's notification channels. "
+        "The public call is always notification(action=..., input={...}); "
+        "BaseAgent alone adds optional root reasoning, never nested input. "
+        "Self-actions need no permissions. This is the only tool that exposes "
+        "notification verbs; system has no notification or dismiss alias. Use "
+        "notification(action='check', input={}) to read all channels, "
+        "notification(action='dismiss_channel', input={'channel': '...'}) to "
+        "clear one channel whole, and the event/ref actions to remove a single "
+        "system event. Use notification(action='manual', input={}) to return the "
+        "installed notification manual; manual is strictly read-only. To compress "
+        "a large tool result, use system(action='summarize')."
+    )
 
 
-def get_schema(lang: str = "en") -> dict:
+def get_schema(lang: str = "en") -> dict[str, Any]:
+    """Return the raw closed action/input schema.
+
+    ``reasoning`` is deliberately absent: BaseAgent injects it as optional root
+    metadata while constructing the Agent-facing FunctionSchema. Each nested
+    branch is closed and owns only the fields for its action.
+    """
     return {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["check", "dismiss_channel", "dismiss_event", "dismiss_ref", "manual"],
-                "description": "check: read all notification channels. Returns a placeholder; the live payload is stamped onto this same result under `_meta.agent_meta.notifications.attention` and `_meta.agent_meta.guidance.transient`. Replace-only — do not call voluntarily after handling; dismiss instead. Prefer coalescing the dismiss with other tool work you already need this turn when safe; dismiss alone only when there is no useful coalesced work or safety requires it.\n\ndismiss_channel: clear one notification channel whole (channel=<name>). Use producer-specific verbs first (for email, use email(read/dismiss)); guarded channels require force=true only for stale mirrors. Rejects event_id/ref_id — use dismiss_event/dismiss_ref for those.\n\ndismiss_event: remove a single system event by event_id from .notification/system.json (channel defaults to 'system').\n\ndismiss_ref: remove system event(s) by ref_id from .notification/system.json (channel defaults to 'system').\n\nmanual: call notification(action='manual') to return the installed notification-manual skill body. This action is strictly read-only and does not read or change notification state." + "\n\n" + LARGE_RESULT_DISMISS_ACTION_NOTE,
+                "enum": [
+                    "check",
+                    "dismiss_channel",
+                    "dismiss_event",
+                    "dismiss_ref",
+                    "manual",
+                ],
+                "description": (
+                    "Required operation: check, dismiss_channel, dismiss_event, "
+                    "dismiss_ref, or manual.\n\n"
+                    "check reads all notification channels. dismiss_channel clears "
+                    "one whole channel and rejects event_id/ref_id; dismiss_event "
+                    "removes one system event by event_id; dismiss_ref removes "
+                    "system events by ref_id; manual reads the installed manual "
+                    "without notification-state changes.\n\n"
+                    + LARGE_RESULT_DISMISS_ACTION_NOTE
+                ),
             },
-            "channel": {
-                "type": "string",
-                "description": "Notification channel to act on (e.g. soul, system, mcp.telegram). Required for dismiss_channel; for dismiss_event/dismiss_ref it defaults to 'system'. For producer-owned channels like email, prefer the producer's own verb (email(read/dismiss)).",
-            },
-            "force": {
-                "type": "boolean",
-                "description": 'Optional for dismiss verbs. When true, bypasses a producer-registered generic-dismiss guard and the stale-channel-version refusal. Use only when knowingly clearing a stale mirror; producer-owned state is never changed.' + " " + LARGE_RESULT_FORCE_NOTE,
-            },
-            "event_id": {
-                "type": "string",
-                "description": 'For dismiss_event: remove only the matching system notification event_id from .notification/system.json instead of the whole channel.',
-            },
-            "ref_id": {
-                "type": "string",
-                "description": 'For dismiss_ref: remove system notification event(s) carrying this producer ref_id from .notification/system.json instead of the whole channel.',
-            },
-            "reason": {
-                "type": "string",
-                "description": "Optional acknowledgement reason, logged to the event log. Required when dismissing the post-molt continuation channel (use reason='<continue|defer|obsolete>: ...').",
+            "input": {
+                "description": (
+                    "Strict action-specific notification input; no nested "
+                    "reasoning field."
+                ),
+                "anyOf": [
+                    # Keep separate empty branches for check and manual. This is
+                    # the established action/input precedent; no fabricated
+                    # discriminator is needed for their distinct action values.
+                    _input_branch("check input", {}, []),
+                    _input_branch(
+                        "dismiss_channel input",
+                        {
+                            "channel": {
+                                "type": "string",
+                                "description": "Notification channel to clear whole.",
+                            },
+                            "force": {
+                                "type": "boolean",
+                                "description": (
+                                    "When true, bypass a producer guard or stale "
+                                    "mirror refusal; producer state is never changed. "
+                                    + LARGE_RESULT_FORCE_NOTE
+                                ),
+                            },
+                            "reason": {
+                                "type": "string",
+                                "description": (
+                                    "Acknowledgement reason; required for post-molt "
+                                    "continuation dismissal."
+                                ),
+                            },
+                        },
+                        ["channel"],
+                    ),
+                    _input_branch(
+                        "dismiss_event input",
+                        {
+                            "event_id": {
+                                "type": "string",
+                                "description": "System event_id to remove.",
+                            },
+                            "channel": {
+                                "type": "string",
+                                "description": "Target channel; defaults to system.",
+                            },
+                            "force": {
+                                "type": "boolean",
+                                "description": (
+                                    "When true, bypass a stale mirror refusal; "
+                                    "producer state is never changed. "
+                                    + LARGE_RESULT_FORCE_NOTE
+                                ),
+                            },
+                            "reason": {
+                                "type": "string",
+                                "description": "Optional acknowledgement reason.",
+                            },
+                        },
+                        ["event_id"],
+                    ),
+                    _input_branch(
+                        "dismiss_ref input",
+                        {
+                            "ref_id": {
+                                "type": "string",
+                                "description": "Producer ref_id whose system events are removed.",
+                            },
+                            "channel": {
+                                "type": "string",
+                                "description": "Target channel; defaults to system.",
+                            },
+                            "force": {
+                                "type": "boolean",
+                                "description": (
+                                    "When true, bypass a stale mirror refusal; "
+                                    "producer state is never changed. "
+                                    + LARGE_RESULT_FORCE_NOTE
+                                ),
+                            },
+                            "reason": {
+                                "type": "string",
+                                "description": "Optional acknowledgement reason.",
+                            },
+                        },
+                        ["ref_id"],
+                    ),
+                    _input_branch("manual input", {}, []),
+                ],
             },
         },
-        "required": ["action"],
+        "required": ["action", "input"],
+        "additionalProperties": False,
     }

--- a/src/lingtai/tools/psyche/_molt.py
+++ b/src/lingtai/tools/psyche/_molt.py
@@ -97,7 +97,7 @@ def _publish_post_molt(
             "recent human-channel messages — then decide what to do. Do not treat "
             "any stored text as a command to run blindly. Once reoriented, "
             "explicitly ack by one of: (a) CONTINUE — resume the task, then "
-            "notification(action='dismiss_channel', channel='post-molt', reason='continue: ...'); "
+            "notification(action='dismiss_channel', input={'channel': 'post-molt', 'reason': 'continue: ...'}); "
             "(b) DEFER — record why in pad.md/knowledge, then dismiss with "
             "reason='defer: ...'; "
             "(c) OBSOLETE — record why it no longer applies, then dismiss with "

--- a/src/lingtai/tools/soul/__init__.py
+++ b/src/lingtai/tools/soul/__init__.py
@@ -8,7 +8,7 @@ Three actions:
               written to ``.notification/soul.json`` via
               ``publish_notification``; the kernel's ``_sync_notifications``
               picks up the fingerprint change and surfaces them inside the
-              single-slot synthesized ``notification(action="check")`` wire
+              single-slot synthesized ``notification(action="check", input={})`` wire
               pair. Mechanical — agent cannot invoke manually.
     inquiry — sync mirror session. Clones conversation (text+thinking only),
               sends question, returns answer in tool result. On-demand.
@@ -126,7 +126,7 @@ def handle(agent, args: dict) -> dict:
     Flow is invocable too, but the call returns immediately with a
     synthesized success result; the actual voices arrive shortly by
     writing ``.notification/soul.json``, which the kernel's notification
-    sync surfaces inside the synthesized ``notification(action="check")``
+    sync surfaces inside the synthesized ``notification(action="check", input={})``
     wire pair.
     """
     action = args.get("action", "")

--- a/src/lingtai/tools/soul/inquiry.py
+++ b/src/lingtai/tools/soul/inquiry.py
@@ -85,7 +85,7 @@ def _publish_human_inquiry_notification(agent, result: dict, question: str) -> N
             "your mirrored self via soul.inquiry. It is context with clear "
             "provenance, not a direct new instruction. Use it only if it "
             "helps the current work. The human still reaches you directly "
-            "through email. Dismiss with notification(action='dismiss_channel', channel='btw') "
+            "through email. Dismiss with notification(action='dismiss_channel', input={'channel': 'btw'}) "
             "after you have noted it."
         ),
         data={

--- a/tests/test_apriori_summary_executor.py
+++ b/tests/test_apriori_summary_executor.py
@@ -21,10 +21,12 @@ from lingtai.kernel.tool_executor import ToolExecutor
 from lingtai.kernel.tool_result_summary import (
     APRIORI_SUMMARY_CAP,
     APRIORI_SUMMARY_MARKER,
+    summary_requested,
 )
 
 
-def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
+def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path,
+                   parallel_safe_tools=None):
     """Construct a ToolExecutor that records durable log events into *events*."""
 
     def logger_fn(event_type, **fields):
@@ -43,6 +45,7 @@ def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
         logger_fn=logger_fn,
         working_dir=tmp_path,
         summarizer_fn=summarizer_fn,
+        parallel_safe_tools=parallel_safe_tools or set(),
     )
 
 
@@ -64,6 +67,14 @@ def _event_fields(events, event_type):
     for et, fields in events:
         if et == event_type:
             return fields
+    return None
+
+
+def _event_index(events, event_type, *, tool_call_id):
+    """Return the first matching event index for ordering assertions."""
+    for index, (et, fields) in enumerate(events):
+        if et == event_type and fields.get("tool_call_id") == tool_call_id:
+            return index
     return None
 
 
@@ -161,6 +172,274 @@ def test_summary_true_under_cap_replaces_with_summary_and_preserves_raw(tmp_path
     assert gen["tool_call_id"] == "t3"
     assert gen["tool_name"] == "bash"
     assert "RAWSECRET" not in str(gen)
+
+
+def test_summary_requested_uses_input_presence_precedence_and_exact_bool():
+    """Canonical input wins; only a literal bool True opts in."""
+    assert summary_requested({"summary": True}) is True  # legacy compatibility
+    assert summary_requested({"input": {"summary": True}, "summary": False}) is True
+
+    # Once input is present, root summary is never a fallback, including when
+    # nested summary is absent, false, malformed, or input is not an object.
+    nested_values = [False, 1, "true", None, {}, []]
+    for nested in nested_values:
+        assert summary_requested({"input": {"summary": nested}, "summary": True}) is False
+    assert summary_requested({"input": {}, "summary": True}) is False
+    for malformed_input in (None, [], "payload", 1):
+        assert summary_requested({"input": malformed_input, "summary": True}) is False
+
+    # Legacy mode has the same exact-boolean rule and does not mutate args.
+    for root in (False, 1, "true", None, {}, []):
+        assert summary_requested({"summary": root}) is False
+    original = {"input": {"summary": True}, "summary": "ignored"}
+    snapshot = {"input": dict(original["input"]), "summary": original["summary"]}
+    assert summary_requested(original) is True
+    assert original == snapshot
+
+
+def test_nested_summary_true_serial_preserves_reasoning_and_raw_first(tmp_path):
+    raw = {"stdout": "NESTED-SERIAL-RAW"}
+    nested_input = {"command": "echo nested", "summary": True}
+    call_args = {
+        "input": nested_input,
+        "summary": False,  # root is ignored in canonical mode
+        "reasoning": "Retain the nested serial marker",
+    }
+    seen = {}
+    events = []
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen["prompt"] = user_prompt
+        return "NESTED-SERIAL-SUMMARY"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute(
+        [ToolCall(name="bash", args=call_args, id="nested-serial")]
+    )
+
+    content = _wire_content(results[0])
+    assert content["artifact"] == APRIORI_SUMMARY_MARKER
+    assert content["generated_summary"] == "NESTED-SERIAL-SUMMARY"
+    assert "Retain the nested serial marker" in seen["prompt"]
+    assert nested_input == {"command": "echo nested", "summary": True}
+
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-serial")
+    generated_index = _event_index(
+        events, "apriori_summary_generated", tool_call_id="nested-serial"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-serial"
+    )
+    assert raw_index is not None and generated_index is not None and visible_index is not None
+    assert raw_index < generated_index < visible_index
+    raw_event = events[raw_index][1]
+    assert "NESTED-SERIAL-RAW" in str(raw_event["result"])
+    assert "NESTED-SERIAL-SUMMARY" not in str(raw_event["result"])
+    assert raw_event["tool_args"]["_reasoning"] == "Retain the nested serial marker"
+
+
+def test_nested_summary_true_parallel_path_preserves_raw_before_each_replacement(tmp_path):
+    raw_by_id = {
+        "nested-parallel-1": {"stdout": "NESTED-PARALLEL-RAW-1"},
+        "nested-parallel-2": {"stdout": "NESTED-PARALLEL-RAW-2"},
+    }
+    events = []
+    seen = []
+
+    def dispatch(tc):
+        return raw_by_id[tc.id]
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen.append((tool_call_id, user_prompt))
+        return f"NESTED-PARALLEL-SUMMARY-{tool_call_id}"
+
+    ex = _make_executor(
+        dispatch_fn=dispatch,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+        parallel_safe_tools={"bash", "grep"},
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "one", "summary": True},
+                  "reasoning": "Keep parallel result one"},
+            id="nested-parallel-1",
+        ),
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "two", "summary": True},
+                  "reasoning": "Keep parallel result two"},
+            id="nested-parallel-2",
+        ),
+    ])
+
+    assert len(seen) == 2
+    for result_msg, call_id in zip(results, ("nested-parallel-1", "nested-parallel-2")):
+        content = _wire_content(result_msg)
+        assert content["artifact"] == APRIORI_SUMMARY_MARKER
+        assert content["generated_summary"] == f"NESTED-PARALLEL-SUMMARY-{call_id}"
+        raw_index = _event_index(events, "tool_result", tool_call_id=call_id)
+        generated_index = _event_index(
+            events, "apriori_summary_generated", tool_call_id=call_id
+        )
+        visible_index = _event_index(
+            events, "tool_result_model_visible", tool_call_id=call_id
+        )
+        assert raw_index is not None and generated_index is not None and visible_index is not None
+        assert raw_index < generated_index < visible_index
+        raw_event = events[raw_index][1]
+        suffix = call_id.rsplit("-", 1)[-1]
+        assert f"NESTED-PARALLEL-RAW-{suffix}" in str(raw_event["result"])
+        assert f"NESTED-PARALLEL-SUMMARY-{call_id}" not in str(raw_event["result"])
+
+
+def test_nested_false_absent_and_malformed_ignore_root_true_in_executor(tmp_path):
+    cases = [
+        ("nested-false", {"summary": False}),
+        ("nested-absent", {}),
+        ("nested-one", {"summary": 1}),
+        ("nested-string", {"summary": "true"}),
+        ("nested-null", {"summary": None}),
+        ("nested-object", {"summary": {"truthy": True}}),
+        ("nested-list", {"summary": [True]}),
+        ("input-null", None),
+        ("input-list", []),
+        ("input-string", "payload"),
+    ]
+    for call_id, nested_input in cases:
+        events = []
+        called = []
+        raw = {"stdout": f"RAW-{call_id}"}
+
+        def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+            called.append(tool_call_id)
+            return "SHOULD NOT RUN"
+
+        ex = _make_executor(
+            dispatch_fn=lambda tc, raw=raw: raw,
+            summarizer_fn=summarizer,
+            events=events,
+            tmp_path=tmp_path,
+        )
+        results, _, _ = ex.execute([
+            ToolCall(
+                name="grep",
+                args={"input": nested_input, "summary": True},
+                id=call_id,
+            )
+        ])
+        content = _wire_content(results[0])
+        assert "SHOULD NOT RUN" not in str(content)
+        assert "RAW-" + call_id in str(content)
+        assert not (isinstance(content, dict) and content.get("artifact") == APRIORI_SUMMARY_MARKER)
+        assert called == []
+
+
+def test_nested_summary_true_cap_refusal_logs_raw_before_replacement(tmp_path):
+    raw = {"stdout": "NESTED-CAP-RAW-" + "z" * (APRIORI_SUMMARY_CAP + 100)}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="read",
+            args={"input": {"file_path": "/big", "summary": True},
+                  "reasoning": "Avoid oversized raw"},
+            id="nested-cap",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert called == []
+    assert content["summary_kind"] == "apriori_cap_refused"
+    assert "NESTED-CAP-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-cap")
+    refusal_index = _event_index(
+        events, "apriori_summary_cap_refused", tool_call_id="nested-cap"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-cap"
+    )
+    assert raw_index is not None and refusal_index is not None and visible_index is not None
+    assert raw_index < refusal_index < visible_index
+    assert "NESTED-CAP-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_without_gateway_fails_closed_after_raw_log(tmp_path):
+    raw = {"stdout": "NESTED-NOGATEWAY-RAW"}
+    events = []
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=None,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "echo no gateway", "summary": True}},
+            id="nested-no-gateway",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["summary_kind"] == "apriori_error"
+    assert "NESTED-NOGATEWAY-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-no-gateway")
+    error_index = _event_index(
+        events, "apriori_summary_no_summarizer", tool_call_id="nested-no-gateway"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-no-gateway"
+    )
+    assert raw_index is not None and error_index is not None and visible_index is not None
+    assert raw_index < error_index < visible_index
+    assert "NESTED-NOGATEWAY-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_preserves_tool_error_bypass(tmp_path):
+    raw = {"status": "error", "message": "EXACT-TOOL-ERROR"}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "error", "summary": True}},
+            id="nested-error",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["status"] == "error"
+    assert "EXACT-TOOL-ERROR" in str(content)
+    assert called == []
+    assert _event_index(events, "tool_result", tool_call_id="nested-error") is not None
+    assert _event_index(events, "apriori_summary_generated", tool_call_id="nested-error") is None
 
 
 def test_summary_true_over_cap_refuses_without_llm_and_hides_raw(tmp_path):

--- a/tests/test_custom_responses_stateless.py
+++ b/tests/test_custom_responses_stateless.py
@@ -313,7 +313,7 @@ def test_send_none_replays_pre_staged_notification_style_pair():
     iface = ChatInterface()
     iface.add_system("system")
     iface.add_assistant_message([
-        ToolCallBlock(id="notif_1", name="notification", args={"action": "check"}),
+        ToolCallBlock(id="notif_1", name="notification", args={"action": "check", "input": {}}),
     ])
     iface.add_tool_results([
         ToolResultBlock(id="notif_1", name="notification", content={"email": {"count": 1}}),
@@ -328,7 +328,7 @@ def test_send_none_replays_pre_staged_notification_style_pair():
             "type": "function_call",
             "call_id": "notif_1",
             "name": "notification",
-            "arguments": '{"action": "check"}',
+            "arguments": '{"action": "check", "input": {}}',
         },
         {
             "type": "function_call_output",
@@ -349,7 +349,7 @@ def test_send_none_failure_preserves_pre_staged_notification_style_pair():
     iface = ChatInterface()
     iface.add_system("system")
     iface.add_assistant_message([
-        ToolCallBlock(id="notif_1", name="notification", args={"action": "check"}),
+        ToolCallBlock(id="notif_1", name="notification", args={"action": "check", "input": {}}),
     ])
     iface.add_tool_results([
         ToolResultBlock(id="notif_1", name="notification", content={"email": {"count": 1}}),
@@ -375,7 +375,7 @@ def test_pre_request_hook_entries_replay_on_same_stateless_responses_request():
 
     def hook(iface):
         iface.add_assistant_message([
-            ToolCallBlock(id="notif_1", name="notification", args={"action": "check"}),
+            ToolCallBlock(id="notif_1", name="notification", args={"action": "check", "input": {}}),
         ])
         iface.add_tool_results([
             ToolResultBlock(id="notif_1", name="notification", content={"count": 1}),
@@ -390,7 +390,7 @@ def test_pre_request_hook_entries_replay_on_same_stateless_responses_request():
             "type": "function_call",
             "call_id": "notif_1",
             "name": "notification",
-            "arguments": '{"action": "check"}',
+            "arguments": '{"action": "check", "input": {}}',
         },
         {
             "type": "function_call_output",

--- a/tests/test_goal_notification.py
+++ b/tests/test_goal_notification.py
@@ -151,7 +151,7 @@ def test_goal_reminder_republishes_after_whole_system_dismiss_and_fresh_delay(tm
     assert "system" in snapshot_notifications(tmp_path)
     agent._notification_fp = fingerprint_notifications(tmp_path)
 
-    result = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "channel": "system"})
+    result = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "input": {"channel": "system"}})
 
     assert result["status"] == "ok"
     assert "system" not in snapshot_notifications(tmp_path)

--- a/tests/test_large_result_rescan.py
+++ b/tests/test_large_result_rescan.py
@@ -13,7 +13,7 @@ This file pins what survives that removal:
    keeps its ``skip_if_ref_id_exists`` dedup contract.
 3. Legacy ``large_tool_result`` events that already exist in ``system.json``
    (e.g. persisted before this change / before a molt) remain dismissible via
-   ``notification(action="dismiss_ref")`` as an escape hatch (P0 requirement §3).
+   ``notification(action="dismiss_ref", input={"ref_id": "<ref_id>"})`` as an escape hatch (P0 requirement §3).
 4. ToolExecutor metadata stamping (``tool_meta``) is unaffected.
 """
 from __future__ import annotations
@@ -321,7 +321,7 @@ def test_stale_large_result_event_can_be_dismissed(tmp_path):
     )
     agent._notification_fp = fingerprint_notifications(tmp_path)
 
-    res = notif_intrinsic.handle(agent, {"action": "dismiss_ref", "ref_id": stale_ref})
+    res = notif_intrinsic.handle(agent, {"action": "dismiss_ref", "input": {"ref_id": stale_ref}})
 
     assert res["status"] == "ok"
     assert stale_ref in res.get("acked_large_result_refs", [])

--- a/tests/test_messaging_notification_format.py
+++ b/tests/test_messaging_notification_format.py
@@ -2,7 +2,7 @@
 
 These tests cover the prose body produced by
 ``_render_unread_digest`` — which is the renderer that built the old
-per-arrival ``notification(action="check")`` body and now builds the
+per-arrival ``notification(action="check", input={})`` body and now builds the
 single ``email(action="unread")`` digest body. The same edge cases
 apply (subject placeholder, sent_at vs received_at fallback, time-blind
 agents) — they just live one layer deeper in the code now.

--- a/tests/test_meta_block.py
+++ b/tests/test_meta_block.py
@@ -1881,7 +1881,7 @@ def test_reconstruction_tool_meta_is_one_shot():
 # ---------------------------------------------------------------------------
 # notifications field removed 2026-05-02 (Task 11 of system-notification-as-
 # tool-call redesign). System-source notifications are now delivered as
-# synthetic notification(action="check") tool-call pairs spliced by
+# synthetic notification(action="check", input={}) tool-call pairs spliced by
 # BaseAgent._inject_notification_pair (the legacy tc_inbox splice path is
 # dormant); see docs/plans/2026-05-02-system-notification-as-tool-call.md. Tests for the
 # old inbox-drain path lived here and have been removed alongside the field.
@@ -1891,7 +1891,7 @@ def test_reconstruction_tool_meta_is_one_shot():
 # ---------------------------------------------------------------------------
 # attach_active_notifications — moving single-slot, SPARSE / update-driven
 # stamping.  The payload attaches on first appearance and re-attaches only when
-# it materially changes (or on a deliberate notification(action=check) read);
+# it materially changes (or on a deliberate notification(action="check", input={}) read);
 # an unchanged payload is NOT chased onto every newest ordinary tool result.
 # ---------------------------------------------------------------------------
 
@@ -2176,7 +2176,7 @@ def test_attach_active_notifications_unchanged_signature_without_holder_reattach
 
 
 def test_attach_active_notifications_check_read_receives_unchanged_payload(tmp_path):
-    # A deliberate notification(action=check) placeholder result is a read
+    # A deliberate notification(action="check", input={}) placeholder result is a read
     # request: it must receive the current payload even when unchanged.
     _write_email_notif(tmp_path)
     agent = _notif_agent(tmp_path)
@@ -2186,7 +2186,7 @@ def test_attach_active_notifications_check_read_receives_unchanged_payload(tmp_p
     holder = attach_active_notifications(agent, [first], prior_holder=None)
     assert "notifications" in first.metadata["agent_meta"]
 
-    # Now the agent voluntarily calls notification(action=check): its result is
+    # Now the agent voluntarily calls notification(action="check", input={}): its result is
     # the placeholder dict.  Even though the payload is unchanged, the check
     # result must receive the payload (deliberate read) and become the holder.
     check_result = ToolResultBlock(

--- a/tests/test_notification_action_input_candidate.py
+++ b/tests/test_notification_action_input_candidate.py
@@ -1,0 +1,618 @@
+"""Safe focused checks for the canonical notification action/input contract.
+
+Run directly with the project runtime interpreter:
+
+    python tests/test_notification_action_input_candidate.py
+
+The candidate source is inserted at ``sys.path[0]`` before LingTai imports. One
+real candidate Agent proves registration, prompt, provider, and initialized
+manual provenance. Every dismissal test uses a candidate-owned in-memory Store;
+this harness never reads, writes, or clears the running agent's live notification
+surface.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import sys
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+sys.path.insert(0, str(SRC))
+assert Path(sys.path[0]).resolve() == SRC.resolve()
+
+import lingtai  # noqa: E402
+import lingtai.tools.notification as notification  # noqa: E402
+from lingtai.agent import Agent  # noqa: E402
+from lingtai.kernel.llm.base import FunctionSchema, WIRE_TOOL_DESCRIPTION  # noqa: E402
+from lingtai.kernel.notification_store import (  # noqa: E402
+    CompareUpdateResult,
+    UNCONDITIONAL,
+)
+from lingtai.llm.anthropic.adapter import _build_tools as build_anthropic_tools  # noqa: E402
+from lingtai.llm.openai.adapter import (  # noqa: E402
+    _build_responses_tools,
+    _build_tools as build_chat_tools,
+)
+
+ARTIFACT_ROOT = ROOT / "artifacts" / "notification-action-input-test"
+
+
+class _Service:
+    provider = "gemini"
+    model = "notification-candidate"
+
+    def get_adapter(self):
+        return object()
+
+
+class _OddKeys(Mapping):
+    def __init__(self, key) -> None:
+        self.key = key
+
+    def __getitem__(self, key):
+        return None
+
+    def __iter__(self):
+        return iter((self.key,))
+
+    def __len__(self) -> int:
+        return 1
+
+    def keys(self):
+        return [self.key]
+
+
+class _MemoryStore:
+    """Candidate-owned in-memory NotificationStorePort test double."""
+
+    def __init__(self) -> None:
+        self.payloads: dict[str, dict] = {}
+        self.versions: dict[str, tuple] = {}
+        self.ack_refs: set[str] = set()
+        self.calls: list[tuple] = []
+        self.compare_error: Exception | None = None
+
+    def reset_calls(self) -> None:
+        self.calls.clear()
+
+    def snapshot(self, allow_channel):
+        self.calls.append(("snapshot",))
+        return {key: value for key, value in self.payloads.items() if allow_channel(key)}
+
+    def fingerprint(self, allow_channel):
+        self.calls.append(("fingerprint",))
+        return tuple(
+            self.versions[key]
+            for key in sorted(self.payloads)
+            if allow_channel(key) and key in self.versions
+        )
+
+    def publish(self, channel, payload):
+        self.calls.append(("publish", channel))
+        self.payloads[channel] = payload
+
+    def clear(self, channel):
+        self.calls.append(("clear", channel))
+        existed = channel in self.payloads
+        self.payloads.pop(channel, None)
+        return existed
+
+    def compare_update_channel(self, channel, expected_version, mutator):
+        self.calls.append(("compare_update_channel", channel, expected_version))
+        if self.compare_error is not None:
+            raise self.compare_error
+        current_version = self.versions.get(channel)
+        if expected_version is not UNCONDITIONAL and expected_version != current_version:
+            safe = list(current_version) if current_version is not None else None
+            return CompareUpdateResult(False, True, False, False, None, safe, safe)
+        current = self.payloads.get(channel, {})
+        new_payload, changed, value = mutator(current)
+        if changed:
+            if new_payload is None:
+                self.payloads.pop(channel, None)
+            else:
+                self.payloads[channel] = new_payload
+        return CompareUpdateResult(
+            True,
+            False,
+            bool(changed),
+            bool(changed and new_payload is None),
+            value,
+            None,
+            None,
+        )
+
+    def load_ack_refs(self):
+        self.calls.append(("load_ack_refs",))
+        return set(self.ack_refs)
+
+    def update_ack_refs(self, mutator):
+        self.calls.append(("update_ack_refs",))
+        updated, changed, value = mutator(set(self.ack_refs))
+        if changed:
+            self.ack_refs = set(updated)
+        return type("AckResult", (), {"changed": changed, "value": value})()
+
+
+class _FakeAgent:
+    def __init__(self, workdir: Path) -> None:
+        self._working_dir = workdir
+        self._notification_store = _MemoryStore()
+        self._notification_fp: tuple = ()
+        self._chat = None
+        self.logs: list[tuple[str, dict]] = []
+
+    def _log(self, event: str, **fields) -> None:
+        self.logs.append((event, fields))
+
+
+class NotificationActionInputCandidate(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        ARTIFACT_ROOT.mkdir(parents=True, exist_ok=True)
+        cls.fake_workdir = cls._fresh_dir("fake-agent")
+        cls.fake = _FakeAgent(cls.fake_workdir)
+        cls.settings = cls.fake_workdir / "settings" / "notification.json"
+        cls.settings.parent.mkdir(parents=True, exist_ok=True)
+
+        cls.actual_workdir = cls._fresh_dir("actual-agent")
+        cls.actual_agent = Agent(
+            service=_Service(),
+            agent_name="notification-candidate-agent",
+            working_dir=cls.actual_workdir,
+            capabilities=["notification"],
+        )
+        # Preserve the closure as data; a plain function class attribute would be
+        # rebound by unittest's descriptor protocol.
+        cls.actual_handler = staticmethod(cls.actual_agent._intrinsics["notification"])
+        cls.installed_manual = (
+            cls.actual_workdir
+            / ".library"
+            / "intrinsic"
+            / "capabilities"
+            / "notification-manual"
+            / "SKILL.md"
+        )
+
+    @classmethod
+    def _fresh_dir(cls, stem: str) -> Path:
+        candidate = ARTIFACT_ROOT / f"{stem}-{os.getpid()}"
+        suffix = 0
+        while candidate.exists():
+            suffix += 1
+            candidate = ARTIFACT_ROOT / f"{stem}-{os.getpid()}-{suffix}"
+        candidate.mkdir(parents=True)
+        return candidate
+
+    def _setting(self, result: dict, source: str | None) -> dict:
+        self.assertIn("current_setting", result)
+        value = result["current_setting"]
+        if source is not None:
+            self.assertEqual(value["source"], source)
+        self.assertFalse(value["configurable"])
+        self.assertEqual(value["placeholder"], "no-op")
+        self.assertIn("settings_revision", value)
+        self.assertIn("settings_hash", value)
+        self.assertIn("settings/notification.json", value["change_hint"])
+        return value
+
+    @staticmethod
+    def _without_setting(result: dict) -> dict:
+        value = dict(result)
+        value.pop("current_setting")
+        return value
+
+    def _deliver(self, channel: str, version: tuple, payload: dict) -> None:
+        store = self.fake._notification_store
+        store.payloads[channel] = payload
+        store.versions[channel] = version
+        self.fake._notification_fp = (version,)
+        store.reset_calls()
+
+    def test_candidate_origins_intrinsic_closure_and_schemas(self):
+        self.assertEqual(
+            Path(lingtai.__file__).resolve(),
+            (SRC / "lingtai" / "__init__.py").resolve(),
+        )
+        self.assertEqual(
+            Path(notification.__file__).resolve(),
+            (SRC / "lingtai/tools/notification/__init__.py").resolve(),
+        )
+        self.assertIs(inspect.getmodule(notification.handle), notification)
+        self.assertIs(self.actual_agent._intrinsic_modules["notification"], notification)
+        closure = self.actual_agent._intrinsics["notification"]
+        self.assertTrue(closure.__defaults__)
+        self.assertIs(closure.__defaults__[0], notification.handle)
+
+        raw = notification.get_schema()
+        self.assertEqual(set(raw), {"type", "properties", "required", "additionalProperties"})
+        self.assertEqual(set(raw["properties"]), {"action", "input"})
+        self.assertEqual(raw["required"], ["action", "input"])
+        self.assertFalse(raw["additionalProperties"])
+        self.assertNotIn("reasoning", raw["properties"])
+        self.assertEqual(
+            raw["properties"]["action"]["enum"],
+            ["check", "dismiss_channel", "dismiss_event", "dismiss_ref", "manual"],
+        )
+        branches = raw["properties"]["input"]["anyOf"]
+        self.assertEqual(
+            [branch["title"] for branch in branches],
+            [
+                "check input",
+                "dismiss_channel input",
+                "dismiss_event input",
+                "dismiss_ref input",
+                "manual input",
+            ],
+        )
+        self.assertEqual(branches[0]["properties"], {})
+        self.assertEqual(branches[4]["properties"], {})
+        self.assertEqual(set(branches[1]["properties"]), {"channel", "force", "reason"})
+        self.assertEqual(set(branches[2]["properties"]), {"event_id", "channel", "force", "reason"})
+        self.assertEqual(set(branches[3]["properties"]), {"ref_id", "channel", "force", "reason"})
+        self.assertEqual(branches[1]["required"], ["channel"])
+        self.assertEqual(branches[2]["required"], ["event_id"])
+        self.assertEqual(branches[3]["required"], ["ref_id"])
+        for branch in branches:
+            self.assertFalse(branch["additionalProperties"])
+            self.assertNotIn("reasoning", branch["properties"])
+
+        facing = next(
+            schema
+            for schema in self.actual_agent._build_tool_schemas()
+            if schema.name == "notification"
+        )
+        self.assertIsInstance(facing, FunctionSchema)
+        self.assertEqual(set(facing.parameters["properties"]), {"action", "input", "reasoning"})
+        self.assertEqual(facing.parameters["required"], ["action", "input"])
+        self.assertFalse(facing.parameters["additionalProperties"])
+        self.assertTrue(
+            all(
+                "reasoning" not in branch["properties"]
+                for branch in facing.parameters["properties"]["input"]["anyOf"]
+            )
+        )
+
+    def test_prompt_provider_envelopes_and_real_initialized_manual(self):
+        prompt = self.actual_agent._prompt_manager.read_section("tools")
+        section = prompt.split("### notification\n", 1)[1].split("\n\n### ", 1)[0]
+        self.assertIn("notification(action=..., input={...})", section)
+        self.assertIn("BaseAgent alone adds optional root reasoning", section)
+        self.assertNotIn("omit action", section.lower())
+
+        facing = next(
+            schema
+            for schema in self.actual_agent._build_tool_schemas()
+            if schema.name == "notification"
+        )
+        self.assertEqual(facing.description, notification.get_description())
+        chat = build_chat_tools([facing])[0]
+        responses = _build_responses_tools([facing])[0]
+        anthropic = build_anthropic_tools([facing])[0]
+        self.assertEqual(set(chat), {"type", "function"})
+        self.assertEqual(set(chat["function"]), {"name", "description", "parameters"})
+        self.assertEqual(set(responses), {"type", "name", "description", "parameters"})
+        self.assertEqual(set(anthropic), {"name", "description", "input_schema"})
+        for name, description, parameters in (
+            (
+                chat["function"]["name"],
+                chat["function"]["description"],
+                chat["function"]["parameters"],
+            ),
+            (responses["name"], responses["description"], responses["parameters"]),
+            (anthropic["name"], anthropic["description"], anthropic["input_schema"]),
+        ):
+            self.assertEqual(name, "notification")
+            self.assertEqual(description, WIRE_TOOL_DESCRIPTION)
+            self.assertEqual(parameters, facing.parameters)
+
+        before = self.actual_agent._notification_store.snapshot(lambda _channel: True)
+        result = self.actual_handler(
+            {
+                "action": "manual",
+                "input": {},
+                "reasoning": "verify the initialized read-only manual",
+            }
+        )
+        after = self.actual_agent._notification_store.snapshot(lambda _channel: True)
+        self.assertEqual(before, after)
+        self.assertEqual(result["status"], "ok")
+        self.assertTrue(self.installed_manual.is_file())
+        self.assertEqual(Path(result["manual_path"]).resolve(), self.installed_manual.resolve())
+        self.assertEqual(
+            result["notification_manual"],
+            self.installed_manual.read_text(encoding="utf-8"),
+        )
+        self.assertIn("notification(action='manual', input={})", result["notification_manual"])
+        self.assertIn("notification(action='check', input={})", result["notification_manual"])
+        self.assertNotIn("notification(action='check')", result["notification_manual"])
+        self._setting(result, "missing")
+
+    def test_strict_malformed_calls_reach_zero_action_core_or_store_seams(self):
+        malformed = [
+            None,
+            [],
+            {},
+            {"action": "check"},
+            {"input": {}},
+            {"action": "check", "input": []},
+            {"action": "unknown", "input": {}},
+            {"action": 1, "input": {}},
+            {"action": "check", "input": {"channel": "system"}},
+            {"action": "manual", "input": {"channel": "system"}},
+            {"action": "dismiss_channel", "input": {"event_id": "evt"}},
+            {"action": "dismiss_channel", "input": {"channel": "system", "ref_id": "ref"}},
+            {"action": "dismiss_event", "input": {"ref_id": "ref"}},
+            {"action": "dismiss_ref", "input": {"event_id": "evt"}},
+            {"action": "dismiss_ref", "input": {"ref_id": 3}},
+            {"action": "dismiss_channel", "input": {"channel": "system", "force": "yes"}},
+            {"action": "dismiss_event", "input": {"event_id": "evt", "reason": 4}},
+            {"action": "manual", "input": {}, "surprise": True},
+            {"action": "manual", "input": {}, "reasoning": 4},
+            {"action": "manual", "input": _OddKeys([])},
+            {"action": "manual", "input": _OddKeys(1)},
+            _OddKeys([]),
+            _OddKeys(1),
+            {1: "manual", "input": {}},
+        ]
+        store = self.fake._notification_store
+        store.reset_calls()
+        with patch.object(notification, "_check") as check_seam, \
+             patch.object(notification, "_manual") as manual_seam, \
+             patch.object(notification, "dismiss_channel") as core_seam:
+            for args in malformed:
+                with self.subTest(args=repr(args)):
+                    result = notification.handle(self.fake, args)
+                    self.assertEqual(result["status"], "error")
+                    self._setting(result, None)
+            self.assertEqual(check_seam.call_count, 0)
+            self.assertEqual(manual_seam.call_count, 0)
+            self.assertEqual(core_seam.call_count, 0)
+        self.assertEqual(store.calls, [])
+
+    def test_settings_missing_valid_hot_invalid_and_invariance(self):
+        prompt_before = self.actual_agent._prompt_manager.read_section("tools")
+        raw_schema = notification.get_schema()
+        args = {"action": "check", "input": {}, "reasoning": "settings evidence"}
+
+        missing = notification.handle(self.fake, args)
+        missing_setting = self._setting(missing, "missing")
+        self.assertEqual(missing_setting["settings_revision"], "missing")
+        self.assertIsNone(missing_setting["settings_hash"])
+        missing_body = self._without_setting(missing)
+
+        self.settings.write_bytes(b'{"schema_version":1}')
+        valid = notification.handle(self.fake, args)
+        valid_setting = self._setting(valid, "settings/notification.json")
+        self.assertEqual(len(valid_setting["settings_hash"]), 32)
+        self.assertEqual(valid_setting["settings_revision"], valid_setting["settings_hash"])
+        self.assertEqual(self._without_setting(valid), missing_body)
+
+        self.settings.write_bytes(b'{ "schema_version" : 1 }\n')
+        hot = notification.handle(self.fake, args)
+        hot_setting = self._setting(hot, "settings/notification.json")
+        self.assertNotEqual(hot_setting["settings_revision"], valid_setting["settings_revision"])
+        self.assertNotEqual(hot_setting["settings_hash"], valid_setting["settings_hash"])
+        self.assertEqual(self._without_setting(hot), missing_body)
+
+        secret = "NOTIFICATION_SETTINGS_SECRET_SENTINEL"
+        private_path = str(self.settings.resolve())
+        invalid_values = [
+            '{"schema_version":2}',
+            '{"schema_version":"1"}',
+            '{"schema_version":1,"secret":"' + secret + '"}',
+            json.dumps({"schema_version": 1, "private_path": private_path}),
+            '{"schema_version":1,"schema_version":1}',
+            "not-json",
+        ]
+        for text in invalid_values:
+            self.settings.write_text(text, encoding="utf-8")
+            invalid = notification.handle(self.fake, args)
+            setting = self._setting(invalid, "settings_error")
+            self.assertIn("settings_error", setting)
+            rendered = json.dumps(invalid, sort_keys=True)
+            self.assertNotIn(secret, rendered)
+            self.assertNotIn(private_path, rendered)
+            self.assertEqual(self._without_setting(invalid), missing_body)
+
+        self.assertEqual(prompt_before, self.actual_agent._prompt_manager.read_section("tools"))
+        self.assertNotIn(secret, self.actual_agent._prompt_manager.read_section("tools"))
+        self.assertNotIn(private_path, self.actual_agent._prompt_manager.read_section("tools"))
+        self.assertEqual(notification.get_schema(), raw_schema)
+        self.settings.write_bytes(b'{"schema_version":1}')
+
+    def test_candidate_owned_fake_state_semantics_and_guards(self):
+        store = self.fake._notification_store
+
+        store.reset_calls()
+        checked = notification.handle(self.fake, {"action": "check", "input": {}})
+        self.assertTrue(checked["_notification_placeholder"])
+        self.assertEqual(store.calls, [])
+
+        version = ("soul.json", 1, "soul-v1")
+        self._deliver("soul", version, {"header": "fake soul"})
+        cleared = notification.handle(
+            self.fake,
+            {"action": "dismiss_channel", "input": {"channel": "soul"}},
+        )
+        self.assertEqual(cleared["status"], "ok")
+        self.assertTrue(cleared["cleared"])
+        self.assertNotIn("soul", store.payloads)
+
+        system_version = ("system.json", 2, "system-v2")
+        self._deliver(
+            "system",
+            system_version,
+            {
+                "header": "3 system notifications",
+                "data": {
+                    "events": [
+                        {"event_id": "evt-a", "ref_id": "ref-a"},
+                        {"event_id": "evt-b", "ref_id": "ref-b"},
+                        {"event_id": "evt-c", "ref_id": "ref-b"},
+                    ]
+                },
+            },
+        )
+        event = notification.handle(
+            self.fake,
+            {"action": "dismiss_event", "input": {"event_id": "evt-a"}},
+        )
+        self.assertEqual(event["status"], "ok")
+        self.assertEqual(event["removed"], 1)
+        ref = notification.handle(
+            self.fake,
+            {"action": "dismiss_ref", "input": {"ref_id": "ref-b"}},
+        )
+        self.assertEqual(ref["status"], "ok")
+        self.assertEqual(ref["removed"], 2)
+        self.assertNotIn("system", store.payloads)
+
+        old = ("system.json", 3, "old")
+        current = ("system.json", 4, "current")
+        store.payloads["system"] = {"header": "changed", "data": {"events": []}}
+        store.versions["system"] = current
+        self.fake._notification_fp = (old,)
+        store.reset_calls()
+        stale = notification.handle(
+            self.fake,
+            {"action": "dismiss_channel", "input": {"channel": "system"}},
+        )
+        self.assertEqual(stale["reason"], "stale_channel_version")
+        self.assertIn("system", store.payloads)
+        forced = notification.handle(
+            self.fake,
+            {"action": "dismiss_channel", "input": {"channel": "system", "force": True}},
+        )
+        self.assertEqual(forced["status"], "ok")
+        self.assertTrue(forced["forced"])
+        self.assertNotIn("system", store.payloads)
+
+        store.reset_calls()
+        with patch(
+            "lingtai.kernel.notifications.is_generic_dismiss_guarded",
+            return_value="email(action='dismiss', input={})",
+        ):
+            guarded = notification.handle(
+                self.fake,
+                {"action": "dismiss_channel", "input": {"channel": "email"}},
+            )
+        self.assertEqual(guarded["reason"], "guarded")
+        self.assertEqual(store.calls, [])
+
+        protected = notification.handle(
+            self.fake,
+            {"action": "dismiss_channel", "input": {"channel": "goal", "force": True}},
+        )
+        self.assertEqual(protected["reason"], "protected_channel")
+
+        atomic_wrong_channel = notification.handle(
+            self.fake,
+            {
+                "action": "dismiss_event",
+                "input": {"event_id": "evt", "channel": "soul", "force": True},
+            },
+        )
+        self.assertEqual(
+            atomic_wrong_channel["reason"],
+            "atomic_dismiss_requires_system_channel",
+        )
+
+        post_version = ("post-molt.json", 5, "post")
+        self._deliver("post-molt", post_version, {"header": "continue"})
+        missing_reason = notification.handle(
+            self.fake,
+            {"action": "dismiss_channel", "input": {"channel": "post-molt"}},
+        )
+        self.assertEqual(missing_reason["reason"], "missing_ack_reason")
+        acknowledged = notification.handle(
+            self.fake,
+            {
+                "action": "dismiss_channel",
+                "input": {"channel": "post-molt", "reason": "continue: tested"},
+            },
+        )
+        self.assertEqual(acknowledged["status"], "ok")
+        self.assertEqual(acknowledged["reason"], "continue: tested")
+
+        manual_path = (
+            self.fake_workdir
+            / ".library"
+            / "intrinsic"
+            / "capabilities"
+            / "notification-manual"
+            / "SKILL.md"
+        )
+        manual_path.parent.mkdir(parents=True, exist_ok=True)
+        manual_body = "---\nname: notification-manual\n---\n\n# candidate-owned fake manual\n"
+        manual_path.write_text(manual_body, encoding="utf-8")
+        store.reset_calls()
+        manual = notification.handle(self.fake, {"action": "manual", "input": {}})
+        self.assertEqual(manual["notification_manual"], manual_body)
+        self.assertEqual(store.calls, [])
+
+    def test_all_five_action_exceptions_are_bounded_and_core_error_is_sanitized(self):
+        sentinel = "NOTIFICATION_PRIVATE_ACTION_SECRET"
+        error_cases = [
+            (
+                "check",
+                lambda: patch.object(notification, "_check", side_effect=RuntimeError(sentinel)),
+                {"action": "check", "input": {}},
+            ),
+            (
+                "dismiss_channel",
+                lambda: patch.object(notification, "dismiss_channel", side_effect=RuntimeError(sentinel)),
+                {"action": "dismiss_channel", "input": {"channel": "soul", "force": True}},
+            ),
+            (
+                "dismiss_event",
+                lambda: patch.object(notification, "dismiss_channel", side_effect=RuntimeError(sentinel)),
+                {"action": "dismiss_event", "input": {"event_id": "evt", "force": True}},
+            ),
+            (
+                "dismiss_ref",
+                lambda: patch.object(notification, "dismiss_channel", side_effect=RuntimeError(sentinel)),
+                {"action": "dismiss_ref", "input": {"ref_id": "ref", "force": True}},
+            ),
+            (
+                "manual",
+                lambda: patch.object(notification, "_manual", side_effect=RuntimeError(sentinel)),
+                {"action": "manual", "input": {}},
+            ),
+        ]
+        for label, seam_factory, args in error_cases:
+            with self.subTest(action=label), seam_factory() as seam:
+                result = notification.handle(self.fake, args)
+                self.assertEqual(seam.call_count, 1)
+                self.assertEqual(result["status"], "error")
+                self.assertEqual(result["reason"], "notification_action_failed")
+                self.assertEqual(result["message"], "notification action failed")
+                self._setting(result, None)
+                self.assertNotIn(sentinel, json.dumps(result, sort_keys=True))
+
+        store = self.fake._notification_store
+        version = ("soul.json", 9, "error")
+        self._deliver("soul", version, {"header": "retained"})
+        store.compare_error = OSError("/private/store/" + sentinel)
+        try:
+            failed = notification.handle(
+                self.fake,
+                {"action": "dismiss_channel", "input": {"channel": "soul"}},
+            )
+        finally:
+            store.compare_error = None
+        self.assertEqual(failed["status"], "error")
+        self.assertEqual(failed["reason"], "clear_failed")
+        self.assertEqual(failed["message"], "notification mirror operation failed")
+        self.assertNotIn(sentinel, json.dumps(failed, sort_keys=True))
+        self.assertIn("soul", store.payloads)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -6,7 +6,7 @@ Covers the design's invariants and the patch's §13 test matrix:
 - §13.2 — IDLE-state pair injection / strip / no-op
 - §13.3 — ACTIVE-state deferral without ToolResultBlock mutation
 - §13.4 — ASLEEP-state wake on fingerprint change
-- §13.5 — voluntary `notification(action="check")` returns the dict
+- §13.5 — voluntary `notification(action="check", input={})` returns the dict
 - §13.6 — producer migrations: email, soul, system
 - §13.7 — molt clearing
 
@@ -182,7 +182,7 @@ def test_concurrent_publish_atomicity(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# §13.5 — `notification(action="check")` voluntary call
+# §13.5 — `notification(action="check", input={})` voluntary call
 #
 # The read verb moved off `system` onto the standalone `notification` tool.
 # `system(action="notification")` is no longer a valid action.
@@ -202,15 +202,14 @@ def test_check_action_returns_empty_when_nothing_published(
         def _log(self, evt: str, **fields: Any) -> None:
             self._logs.append((evt, fields))
 
-    res = handle(_Stub(), {"action": "check"})
+    res = handle(_Stub(), {"action": "check", "input": {}})
     # Voluntary call returns a placeholder dict — the live notification
     # payload (if any) is stamped on by the turn loop's meta-block hook,
     # never built by the handler itself. So even with nothing published,
     # the bare channel keys are absent here.
-    assert res == {
-        "_notification_placeholder": True,
-        "message": res["message"],
-    }
+    assert res["_notification_placeholder"] is True
+    assert "message" in res
+    assert res["current_setting"]["source"] == "missing"
     assert "notification" in res["message"].lower()
 
 
@@ -228,7 +227,7 @@ def test_check_action_returns_placeholder(tmp_path: Path) -> None:
         def _log(self, evt: str, **fields: Any) -> None:
             self._logs.append((evt, fields))
 
-    res = handle(_Stub(), {"action": "check"})
+    res = handle(_Stub(), {"action": "check", "input": {}})
     # Handler returns a placeholder only — channel keys MUST NOT appear
     # here. The canonical `notifications` payload is attached later by
     # `attach_active_notifications`, not by this handler. This guarantees
@@ -670,7 +669,7 @@ def test_sync_idle_posts_wake_message(tmp_path: Path) -> None:
 
     The synthesized ``(ToolCallBlock, ToolResultBlock)`` pair has
     already been spliced by ``_inject_notification_pair`` —
-    impersonating a voluntary ``notification(action="check")`` call
+    impersonating a voluntary ``notification(action="check", input={})`` call
     from the agent's perspective.  ``MSG_TC_WAKE`` then unblocks the
     run loop so ``_handle_tc_wake`` drives one inference round off
     the existing wire, no fake user message and no meta prefix.
@@ -941,9 +940,9 @@ def test_sync_idle_injects_pair_with_synthesized_marker(tmp_path: Path) -> None:
     result_block = entries[1].content[0]
     assert isinstance(call_block, ToolCallBlock)
     # The kernel-synthesized delivery pair impersonates a voluntary
-    # notification(action="check") read — not system(action="notification").
+    # notification(action="check", input={}) read — not system(action="notification").
     assert call_block.name == "notification"
-    assert call_block.args["action"] == "check"
+    assert call_block.args == {"action": "check", "input": {}}
     assert isinstance(result_block, ToolResultBlock)
     assert result_block.name == "notification"
     assert result_block.synthesized is True
@@ -1611,7 +1610,7 @@ def test_sync_asleep_inject_fail_falls_back_to_degraded_request(tmp_path: Path) 
     to ASLEEP without committing the fingerprint, so the next heartbeat
     saw the same .notification/ state, woke again, failed inject again,
     reverted again — forever. The fix wakes the agent via a degraded
-    request that tells it to call notification(action="check") or
+    request that tells it to call notification(action="check", input={}) or
     read the producer files directly.
     """
     from lingtai.kernel.state import AgentState

--- a/tests/test_notification_tool.py
+++ b/tests/test_notification_tool.py
@@ -4,13 +4,13 @@ The notification tool is the **only** agent-callable home for the notification
 verbs.  ``system`` exposes no notification or dismiss verb — there are no
 compatibility aliases.  Dismissal is **atomic**:
 
-* ``notification(action="check")`` returns a placeholder dict that the
+* ``notification(action="check", input={})`` returns a placeholder dict that the
   meta-block later stamps the live payload onto;
-* ``notification(action="dismiss_channel", channel=...)`` clears one channel
+* ``notification(action="dismiss_channel", input={"channel": ...})`` clears one channel
   whole and refuses ``event_id``/``ref_id``;
-* ``notification(action="dismiss_event", event_id=..., [channel="system"])``
+* ``notification(action="dismiss_event", input={"event_id": ..., "channel": "system"})``
   removes one ``system`` event;
-* ``notification(action="dismiss_ref", ref_id=..., [channel="system"])``
+* ``notification(action="dismiss_ref", input={"ref_id": ..., "channel": "system"})``
   removes ``system`` event(s) by ``ref_id``.
 
 ``summarize`` is NOT here — it stays a ``system`` action.
@@ -96,11 +96,21 @@ def test_notification_schema_exposes_atomic_actions() -> None:
         "dismiss_ref",
         "manual",
     ]
-    assert schema["required"] == ["action"]
-    # Dismiss params present; summarize 'items' must NOT be here.
-    for key in ("channel", "force", "event_id", "ref_id", "reason"):
-        assert key in schema["properties"]
-    assert "items" not in schema["properties"]
+    assert schema["required"] == ["action", "input"]
+    assert schema["additionalProperties"] is False
+    assert set(schema["properties"]) == {"action", "input"}
+    branches = schema["properties"]["input"]["anyOf"]
+    assert [branch["title"] for branch in branches] == [
+        "check input", "dismiss_channel input", "dismiss_event input",
+        "dismiss_ref input", "manual input",
+    ]
+    assert branches[0]["properties"] == {}
+    assert branches[-1]["properties"] == {}
+    assert branches[1]["required"] == ["channel"]
+    assert branches[2]["required"] == ["event_id"]
+    assert branches[3]["required"] == ["ref_id"]
+    assert all(branch["additionalProperties"] is False for branch in branches)
+    assert "reasoning" not in schema["properties"]
 
 
 def test_notification_schema_has_no_kitchen_sink_dismiss() -> None:
@@ -120,13 +130,13 @@ def test_notification_schema_is_canonical_english() -> None:
         assert notif_intrinsic.get_schema(lang) == base_schema
     # Descriptions are real prose, not raw i18n keys.
     assert base_desc and "notification" in base_desc.casefold()
-    assert "notification(action='manual')" in base_desc
+    assert "notification(action='manual', input={})" in base_desc
     assert "read-only" in base_desc.casefold()
     adesc = base_schema["properties"]["action"]["description"]
     assert adesc and "check" in adesc.casefold()
-    assert "notification(action='manual')" in adesc
+    assert "manual reads the installed manual" in adesc
     assert "read-only" in adesc.casefold()
-    cdesc = base_schema["properties"]["channel"]["description"]
+    cdesc = base_schema["properties"]["input"]["anyOf"][1]["properties"]["channel"]["description"]
     assert cdesc and "channel" in cdesc.casefold()
 
 
@@ -203,13 +213,12 @@ def test_manual_returns_installed_notification_manual_without_state_mutation(
     before_fingerprint = fingerprint_notifications(tmp_path)
     before_logs = list(agent._logs)
 
-    res = notif_intrinsic.handle(agent, {"action": "manual"})
+    res = notif_intrinsic.handle(agent, {"action": "manual", "input": {}})
 
-    assert res == {
-        "status": "ok",
-        "notification_manual": manual_body,
-        "manual_path": str(manual_path),
-    }
+    assert res["status"] == "ok"
+    assert res["notification_manual"] == manual_body
+    assert res["manual_path"] == str(manual_path)
+    assert res["current_setting"]["source"] == "missing"
     assert snapshot_notifications(tmp_path) == before_state
     assert fingerprint_notifications(tmp_path) == before_fingerprint
     assert agent._logs == before_logs
@@ -221,17 +230,16 @@ def test_manual_missing_installed_file_returns_degraded_without_state_mutation(
     agent = _StubAgent(tmp_path)
     manual_path = _notification_manual_path(tmp_path)
 
-    res = notif_intrinsic.handle(agent, {"action": "manual"})
+    res = notif_intrinsic.handle(agent, {"action": "manual", "input": {}})
 
-    assert res == {
-        "status": "degraded",
-        "notification_manual": "",
-        "manual_path": str(manual_path),
-        "error": (
-            "notification manual missing — initializer may have failed or "
-            "capability not installed correctly"
-        ),
-    }
+    assert res["status"] == "degraded"
+    assert res["notification_manual"] == ""
+    assert res["manual_path"] == str(manual_path)
+    assert res["error"] == (
+        "notification manual missing — initializer may have failed or "
+        "capability not installed correctly"
+    )
+    assert res["current_setting"]["source"] == "missing"
     assert not (tmp_path / ".notification").exists()
     assert agent._logs == []
 
@@ -243,15 +251,15 @@ def test_manual_missing_installed_file_returns_degraded_without_state_mutation(
 
 def test_check_returns_placeholder_dict(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
-    res = notif_intrinsic.handle(agent, {"action": "check"})
+    res = notif_intrinsic.handle(agent, {"action": "check", "input": {}})
     assert res["_notification_placeholder"] is True
-    assert "notification(action=check)" in res["message"]
+    assert "notification(action='check', input={})" in res["message"]
     assert "notifications" not in res
 
 
 def test_unknown_action_errors(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
-    res = notif_intrinsic.handle(agent, {"action": "bogus"})
+    res = notif_intrinsic.handle(agent, {"action": "bogus", "input": {}})
     assert res["status"] == "error"
     assert "Unknown notification action" in res["message"]
 
@@ -266,9 +274,13 @@ def test_dismiss_channel_clears_surface(tmp_path: Path) -> None:
     publish_test_payload(tmp_path, "soul", {"header": "soul flow"})
     _mark_delivered(agent)
 
-    res = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "channel": "soul"})
+    res = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "input": {"channel": "soul"}})
 
-    assert res == {"status": "ok", "channel": "soul", "cleared": True, "forced": False}
+    assert res["status"] == "ok"
+    assert res["channel"] == "soul"
+    assert res["cleared"] is True
+    assert res["forced"] is False
+    assert res["current_setting"]["source"] == "missing"
     assert snapshot_notifications(tmp_path) == {}
     # Provenance: invoked_by="notification"; no system_dismiss line.
     assert _events(agent, "notification_dismiss")[0]["invoked_by"] == "notification"
@@ -277,7 +289,7 @@ def test_dismiss_channel_clears_surface(tmp_path: Path) -> None:
 
 def test_dismiss_channel_missing_channel(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
-    res = notif_intrinsic.handle(agent, {"action": "dismiss_channel"})
+    res = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "input": {}})
     assert res["status"] == "error"
     assert res["reason"] == "missing_channel"
 
@@ -287,10 +299,10 @@ def test_dismiss_channel_rejects_event_target(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
     for kwargs in ({"event_id": "evt_a"}, {"ref_id": "goal:current"}):
         res = notif_intrinsic.handle(
-            agent, {"action": "dismiss_channel", "channel": "system", **kwargs}
+            agent, {"action": "dismiss_channel", "input": {"channel": "system", **kwargs}}
         )
         assert res["status"] == "error", kwargs
-        assert res["reason"] == "channel_dismiss_rejects_event_target", kwargs
+        assert res["reason"] == "unexpected_input_field", kwargs
 
 
 # ---------------------------------------------------------------------------
@@ -316,7 +328,7 @@ def test_dismiss_event_removes_one(tmp_path: Path) -> None:
     _mark_delivered(agent)
 
     res = notif_intrinsic.handle(
-        agent, {"action": "dismiss_event", "event_id": "evt_b"}
+        agent, {"action": "dismiss_event", "input": {"event_id": "evt_b"}}
     )
 
     assert res["status"] == "ok"
@@ -327,7 +339,7 @@ def test_dismiss_event_removes_one(tmp_path: Path) -> None:
 
 def test_dismiss_event_missing_event_id(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
-    res = notif_intrinsic.handle(agent, {"action": "dismiss_event"})
+    res = notif_intrinsic.handle(agent, {"action": "dismiss_event", "input": {}})
     assert res["status"] == "error"
     assert res["reason"] == "missing_event_id"
 
@@ -341,7 +353,7 @@ def test_dismiss_event_defaults_to_system_channel(tmp_path: Path) -> None:
         {"data": {"events": [{"event_id": "evt_a", "source": "daemon", "ref_id": "a"}]}},
     )
     _mark_delivered(agent)
-    res = notif_intrinsic.handle(agent, {"action": "dismiss_event", "event_id": "evt_a"})
+    res = notif_intrinsic.handle(agent, {"action": "dismiss_event", "input": {"event_id": "evt_a"}})
     assert res["status"] == "ok"
     assert res["channel"] == "system"
     assert res["removed"] == 1
@@ -362,7 +374,7 @@ def test_dismiss_ref_removes_by_ref(tmp_path: Path) -> None:
     _mark_delivered(agent)
 
     res = notif_intrinsic.handle(
-        agent, {"action": "dismiss_ref", "ref_id": "goal:current"}
+        agent, {"action": "dismiss_ref", "input": {"ref_id": "goal:current"}}
     )
 
     assert res["status"] == "ok"
@@ -372,7 +384,7 @@ def test_dismiss_ref_removes_by_ref(tmp_path: Path) -> None:
 
 def test_dismiss_ref_missing_ref_id(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
-    res = notif_intrinsic.handle(agent, {"action": "dismiss_ref"})
+    res = notif_intrinsic.handle(agent, {"action": "dismiss_ref", "input": {}})
     assert res["status"] == "error"
     assert res["reason"] == "missing_ref_id"
 
@@ -391,12 +403,12 @@ def test_large_result_guard_every_atomic_action(tmp_path: Path) -> None:
     returns status=ok, reports ``acked_large_result_refs``, and removes the
     reminder from the channel."""
     cases = [
-        {"action": "dismiss_channel", "channel": "system"},
-        {"action": "dismiss_channel", "channel": "system", "force": True},
-        {"action": "dismiss_event", "event_id": "evt_lr"},
-        {"action": "dismiss_event", "event_id": "evt_lr", "force": True},
-        {"action": "dismiss_ref", "ref_id": "large_tool_result:toolu_big"},
-        {"action": "dismiss_ref", "ref_id": "large_tool_result:toolu_big", "force": True},
+        {"action": "dismiss_channel", "input": {"channel": "system"}},
+        {"action": "dismiss_channel", "input": {"channel": "system", "force": True}},
+        {"action": "dismiss_event", "input": {"event_id": "evt_lr"}},
+        {"action": "dismiss_event", "input": {"event_id": "evt_lr", "force": True}},
+        {"action": "dismiss_ref", "input": {"ref_id": "large_tool_result:toolu_big"}},
+        {"action": "dismiss_ref", "input": {"ref_id": "large_tool_result:toolu_big", "force": True}},
     ]
     for kwargs in cases:
         agent = _StubAgent(tmp_path / json.dumps(kwargs, sort_keys=True))
@@ -418,7 +430,7 @@ def test_large_result_guard_every_atomic_action(tmp_path: Path) -> None:
 def test_summarize_is_not_a_notification_action(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
     res = notif_intrinsic.handle(
-        agent, {"action": "summarize", "items": [{"tool_call_id": "x", "summary": "y"}]}
+        agent, {"action": "summarize", "input": {"items": [{"tool_call_id": "x", "summary": "y"}]}}
     )
     assert res["status"] == "error"
     assert "Unknown notification action" in res["message"]
@@ -528,7 +540,7 @@ def test_guarded_channel_refuses_without_force(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
     publish_test_payload(tmp_path, "email", {"header": "1 unread"})
 
-    res = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "channel": "email"})
+    res = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "input": {"channel": "email"}})
 
     assert res["status"] == "error"
     assert res["reason"] == "guarded"
@@ -543,7 +555,7 @@ def test_stale_channel_refused_without_force(tmp_path: Path) -> None:
     _mark_delivered(agent)
     publish_test_payload(tmp_path, "system", {"header": "two", "data": {"events": ["old", "new"]}})
 
-    res = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "channel": "system"})
+    res = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "input": {"channel": "system"}})
 
     assert res["status"] == "error"
     assert res["reason"] == "stale_channel_version"
@@ -557,7 +569,7 @@ def test_force_bypasses_stale_on_allowed_channel(tmp_path: Path) -> None:
     publish_test_payload(tmp_path, "system", {"header": "two", "data": {"events": ["old", "new"]}})
 
     res = notif_intrinsic.handle(
-        agent, {"action": "dismiss_channel", "channel": "system", "force": True}
+        agent, {"action": "dismiss_channel", "input": {"channel": "system", "force": True}}
     )
 
     assert res["status"] == "ok"
@@ -571,7 +583,7 @@ def test_protected_goal_channel_refused(tmp_path: Path) -> None:
     agent._notification_fp = fingerprint_notifications(tmp_path)
 
     res = notif_intrinsic.handle(
-        agent, {"action": "dismiss_channel", "channel": "goal", "force": True}
+        agent, {"action": "dismiss_channel", "input": {"channel": "goal", "force": True}}
     )
 
     assert res["status"] == "error"
@@ -584,14 +596,14 @@ def test_post_molt_dismiss_requires_reason(tmp_path: Path) -> None:
     publish_test_payload(tmp_path, "post-molt", {"header": "continue?"})
     _mark_delivered(agent)
     res = notif_intrinsic.handle(
-        agent, {"action": "dismiss_channel", "channel": "post-molt"}
+        agent, {"action": "dismiss_channel", "input": {"channel": "post-molt"}}
     )
     assert res["status"] == "error"
     assert res["reason"] == "missing_ack_reason"
 
     res2 = notif_intrinsic.handle(
         agent,
-        {"action": "dismiss_channel", "channel": "post-molt", "reason": "continue: done"},
+        {"action": "dismiss_channel", "input": {"channel": "post-molt", "reason": "continue: done"}},
     )
     assert res2["status"] == "ok"
     assert res2["reason"] == "continue: done"

--- a/tests/test_system_dismiss.py
+++ b/tests/test_system_dismiss.py
@@ -5,9 +5,9 @@ The ``system`` tool no longer exposes any dismiss/notification verb (see
 ``test_notification_tool.py`` for the no-compatibility regression anchors).
 Dismissal is atomic on the ``notification`` tool:
 
-* ``notification(action="dismiss_channel", channel=...)`` → whole-channel clear,
-* ``notification(action="dismiss_event", event_id=..., [channel="system"])``,
-* ``notification(action="dismiss_ref", ref_id=..., [channel="system"])``.
+* ``notification(action="dismiss_channel", input={"channel": ...})`` → whole-channel clear,
+* ``notification(action="dismiss_event", input={"event_id": ..., "channel": "system"})``,
+* ``notification(action="dismiss_ref", input={"ref_id": ..., "channel": "system"})``.
 
 The ``soul(action="dismiss")`` convenience alias still routes through the same
 shared helper with ``invoked_by="soul"``. Generic dismiss clears one
@@ -37,16 +37,16 @@ from tests._notification_helpers import (
 
 def _dismiss_channel(agent, channel, **kwargs):
     return notif_intrinsic.handle(
-        agent, {"action": "dismiss_channel", "channel": channel, **kwargs}
+        agent, {"action": "dismiss_channel", "input": {"channel": channel, **kwargs}}
     )
 
 
 def _dismiss_event(agent, **kwargs):
-    return notif_intrinsic.handle(agent, {"action": "dismiss_event", **kwargs})
+    return notif_intrinsic.handle(agent, {"action": "dismiss_event", "input": dict(kwargs)})
 
 
 def _dismiss_ref(agent, **kwargs):
-    return notif_intrinsic.handle(agent, {"action": "dismiss_ref", **kwargs})
+    return notif_intrinsic.handle(agent, {"action": "dismiss_ref", "input": dict(kwargs)})
 
 
 def test_dismiss_channel_clears_existing_file(tmp_path: Path) -> None:
@@ -56,7 +56,11 @@ def test_dismiss_channel_clears_existing_file(tmp_path: Path) -> None:
 
     res = _dismiss_channel(agent, "soul")
 
-    assert res == {"status": "ok", "channel": "soul", "cleared": True, "forced": False}
+    assert res["status"] == "ok"
+    assert res["channel"] == "soul"
+    assert res["cleared"] is True
+    assert res["forced"] is False
+    assert res["current_setting"]["source"] == "missing"
     assert snapshot_notifications(tmp_path) == {}
     nd = _events(agent, "notification_dismiss")[0]
     assert nd["channel"] == "soul"
@@ -91,7 +95,7 @@ def test_dismiss_mcp_dotted_channel(tmp_path: Path) -> None:
 def test_dismiss_validation_errors(tmp_path: Path) -> None:
     agent = _StubAgent(tmp_path)
 
-    missing = notif_intrinsic.handle(agent, {"action": "dismiss_channel"})
+    missing = notif_intrinsic.handle(agent, {"action": "dismiss_channel", "input": {}})
     assert missing["status"] == "error"
     assert missing["reason"] == "missing_channel"
 

--- a/tests/test_system_summarize.py
+++ b/tests/test_system_summarize.py
@@ -1255,7 +1255,7 @@ def test_summarize_then_dismiss_is_unnecessary_end_to_end(tmp_path):
 
     # Dismiss now succeeds — large_tool_result reminders are dismissable as escape hatch.
     dismissed = notif_intrinsic.handle(
-        agent, {"action": "dismiss_channel", "channel": "system", "force": True}
+        agent, {"action": "dismiss_channel", "input": {"channel": "system", "force": True}}
     )
     assert dismissed["status"] == "ok"
     assert "acked_large_result_refs" in dismissed

--- a/tests/test_tool_settings.py
+++ b/tests/test_tool_settings.py
@@ -1,0 +1,154 @@
+"""Focused tests for the private no-op placeholder-settings foundation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools._settings import (
+    MAX_SETTINGS_BYTES,
+    current_setting,
+    read_settings,
+    settings_path,
+    valid_tool_name,
+)
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+
+def _write(root: Path, tool_name: str, payload: str | bytes) -> Path:
+    path = root / "settings" / f"{tool_name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def test_missing_is_a_normal_noop_placeholder_state(tmp_path):
+    snapshot = read_settings(_Agent(tmp_path), "example")
+    setting = current_setting(snapshot, "example")
+    assert setting == {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": "missing",
+        "settings_revision": "missing",
+        "settings_hash": None,
+        "change_hint": (
+            "Edit settings/example.json; changes apply on the next example call; "
+            "this no-op placeholder never changes tool behavior."
+        ),
+    }
+
+
+def test_valid_v1_only_changes_source_revision_and_hash(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "example", '{"schema_version": 1}')
+    snapshot = read_settings(agent, "example")
+    setting = current_setting(snapshot, "example")
+    assert snapshot.error is None
+    assert setting["configurable"] is False
+    assert setting["placeholder"] == "no-op"
+    assert setting["source"] == "settings/example.json"
+    assert setting["settings_revision"] == setting["settings_hash"]
+    assert setting["settings_hash"]
+
+
+def test_reader_rereads_hot_changes_without_cache(tmp_path):
+    agent = _Agent(tmp_path)
+    path = _write(tmp_path, "example", '{"schema_version": 1}')
+    first = read_settings(agent, "example")
+    path.write_text('{ "schema_version": 1 }', encoding="utf-8")
+    second = read_settings(agent, "example")
+    assert first.digest != second.digest
+    assert second.source == "settings/example.json"
+
+
+def test_duplicate_and_extra_fields_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    duplicate = _write(tmp_path, "duplicate", '{"schema_version": 1, "schema_version": 1}')
+    duplicate_snapshot = read_settings(agent, "duplicate")
+    assert duplicate_snapshot.source == "settings_error"
+    assert "duplicate" in (duplicate_snapshot.error or "")
+
+    extra = _write(tmp_path, "extra", '{"schema_version": 1, "future": false}')
+    extra_snapshot = read_settings(agent, "extra")
+    assert extra_snapshot.source == "settings_error"
+    assert "only schema_version" in (extra_snapshot.error or "")
+
+
+def test_bool_and_other_schema_versions_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    for name, version in (("bool", True), ("float", 1.0), ("other", 2)):
+        _write(tmp_path, name, json.dumps({"schema_version": version}))
+        snapshot = read_settings(agent, name)
+        assert snapshot.source == "settings_error"
+        assert "integer 1" in (snapshot.error or "")
+
+
+def test_invalid_encoding_and_json_are_truthful_bounded_errors(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "encoding", b'{"schema_version": 1}\xff')
+    encoding_snapshot = read_settings(agent, "encoding")
+    assert encoding_snapshot.source == "settings_error"
+    assert encoding_snapshot.error
+
+    _write(tmp_path, "json", "{not-json")
+    json_snapshot = read_settings(agent, "json")
+    assert json_snapshot.source == "settings_error"
+    assert json_snapshot.error
+    assert len(json_snapshot.error) <= 240
+
+
+def test_symlink_non_regular_and_oversized_files_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text('{"schema_version": 1}', encoding="utf-8")
+    symlink = tmp_path / "settings" / "symlink.json"
+    symlink.parent.mkdir()
+    symlink.symlink_to(target)
+    symlink_snapshot = read_settings(agent, "symlink")
+    assert symlink_snapshot.source == "settings_error"
+    assert "regular file" in (symlink_snapshot.error or "")
+
+    non_regular = tmp_path / "settings" / "directory.json"
+    non_regular.mkdir()
+    directory_snapshot = read_settings(agent, "directory")
+    assert directory_snapshot.source == "settings_error"
+    assert "regular file" in (directory_snapshot.error or "")
+
+    _write(tmp_path, "large", b"{" + b"x" * MAX_SETTINGS_BYTES + b"}")
+    large_snapshot = read_settings(agent, "large")
+    assert large_snapshot.source == "settings_error"
+    assert "bounded size" in (large_snapshot.error or "")
+
+
+def test_unstable_snapshot_is_not_treated_as_missing(tmp_path, monkeypatch):
+    import lingtai.tools._settings as settings_module
+
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "unstable", '{"schema_version": 1}')
+
+    def raise_unstable(_path):
+        raise settings_module.SettingsError("settings snapshot changed during read")
+
+    monkeypatch.setattr(settings_module, "_read_stable", raise_unstable)
+    snapshot = read_settings(agent, "unstable")
+    assert snapshot.source == "settings_error"
+    assert snapshot.revision == "error"
+    assert snapshot.error == "settings snapshot changed during read"
+
+
+def test_tool_names_are_bounded_path_components(tmp_path):
+    assert valid_tool_name("web_search")
+    assert not valid_tool_name("../escape")
+    assert not valid_tool_name("nested/name")
+    assert not valid_tool_name("\\escape")
+    assert not valid_tool_name("x" * 65)
+    with pytest.raises(ValueError):
+        settings_path(_Agent(tmp_path), "../escape")


### PR DESCRIPTION
## Summary

This draft migrates the standalone `notification` intrinsic onto the canonical public contract established by #1038:

- raw schema requires root `action` plus strict nested `input`;
- BaseAgent alone injects optional root `reasoning`;
- provider envelope names remain Chat `parameters`, Responses `parameters`, and Anthropic `input_schema`;
- `check`, `dismiss_channel`, `dismiss_event`, `dismiss_ref`, and `manual` each have an explicit closed input branch;
- `manual` reads the initialized notification manual without touching notification state;
- every outcome carries fresh Agent-owned `settings/notification.json` v1 evidence without configurable or fabricated options.

The patch also migrates notification call sites, prompt text, manual/reference material, glossary resources, contracts/anatomy, and owning tests. Stateful validation uses only candidate-owned in-memory stores; it never reads, writes, or clears a running Agent's live producer state.

Stacked on #1038 at exact foundation commit `80d5c7d4e99c7de147ccb4dda4642a177842f47f`.

## Validation

- focused direct unittest: 6/6 PASS;
- independent parent gate: 439 checks PASS, `live_notification_calls=0`;
- strict parent static gate: 29 intended files, 21 Python files compiled in memory, 3 i18n JSON resources parsed, 44 literal notification calls audited, 9 exact dynamic call sites allowlisted, 0 stale public signatures, 0 forbidden control bytes;
- anatomy drift: 53 files PASS;
- glossary validator: 57 resources across 19 packages PASS;
- bounded full `src`/`tests` in-memory compile: 703 Python files PASS;
- bounded full text control scan: 970 files PASS;
- `git diff --check`: PASS;
- worker event truth: 2,335 events parsed into 212 exact calls + 212 results, with no deletion/cleanup, pytest, pycompile, temp lifecycle, process-spawn API, signal, Git/GitHub mutation, network call, or live notification action.

## Integration notes

- Repository-wide pytest was not run under the standing no-deletion/no-cleanup boundary. The focused unittest, independent actual-Agent/fake-Store gate, full in-memory compile, and canonical validators above are the local evidence.
- Read-only merge-order validation against soul #1049 found four overlapping paths: `src/lingtai/kernel/base_agent/__init__.py`, `src/lingtai/kernel/notifications.py`, `src/lingtai/tools/soul/__init__.py`, and `tests/test_system_dismiss.py`. Three-way application auto-resolves all except `src/lingtai/tools/soul/__init__.py`; that sibling call-site conflict must be resolved explicitly during stack integration.
- This PR is intentionally draft and unmerged. No release, deploy, tag, cleanup, or live notification-state mutation was performed.
