### PR TITLE
feat(shell): adopt canonical action-input contract

### DIFF
--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -217,7 +217,7 @@ If you wake up after a *system-performed* molt (triggered by karma, `.clear`, or
 2. `email(check)` — see what arrived while you were down
 3. Check `knowledge/session-journal/KNOWLEDGE.md` — your session history index
 4. `skills(action="info")` — confirm which skills you have
-5. `shell({"command": "tail -n 200 logs/events.jsonl | grep ..."})` — surgical reads if needed
+5. `shell(action="run", input={"command": "tail -n 200 logs/events.jsonl | grep ..."})` — surgical reads if needed
 
 Reconstruct your situation from these sources.
 

--- a/src/lingtai/intrinsic_skills/soul-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/soul-manual/SKILL.md
@@ -104,7 +104,7 @@ switch.
   means enabled, `status: disabled` means the env var is not set. You can also
   run `soul(action='config', ...)` and read `soul_flow_enabled` in the result.
 - **Check the env from a shell:**
-  `shell({"command": "printenv LINGTAI_SOUL_FLOW_ENABLED"})` — empty output
+  `shell(action="run", input={"command": "printenv LINGTAI_SOUL_FLOW_ENABLED"})` — empty output
   means unset (disabled).
 - **Enabled but no fires?** Fires only happen while you are IDLE and only after
   `delay_seconds` elapses. Confirm `delay_seconds` is a small, sane value and

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -210,7 +210,7 @@ a default wait loop. If waiting for a human or peer, ensure the current state is
 in pad/knowledge and then sleep or stop the turn.
 
 **Idle care for unverified long-running work.** Before entering idle, if you have
-launched any async/long-running child — a backgrounded `shell(async=true)` agent
+launched any async/long-running child — a backgrounded `shell(action="run", input={"async": true, ...})` agent
 CLI, a daemon emanation, a scheduled job, a PR/CI run — whose health you have not
 just verified, do **not** hand yourself entirely to its completion/IDLE
 notification. Arm at least one self-wake (a `.notification/cron.json` reminder or

--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -36,6 +36,7 @@ Safety properties:
 from __future__ import annotations
 
 import datetime as _dt
+from collections.abc import Mapping
 from typing import Any, Callable
 
 from .meta_block import formal_tool_result_content, formal_tool_result_visible_len
@@ -147,15 +148,21 @@ def is_apriori_summary(content: Any) -> bool:
     )
 
 
-def summary_requested(args: dict | None) -> bool:
-    """Return True iff the normalized tool args opt into a-priori summary.
+def summary_requested(args: Mapping | None) -> bool:
+    """Return True iff tool args opt into a-priori summary.
 
-    The flag is the boolean ``summary`` field on the tool call. Anything other
-    than a literal ``True`` (missing, ``False``, ``None``, truthy-but-not-True)
-    preserves current behavior exactly.
+    The presence of ``input`` selects canonical mode: only a Mapping-valued
+    ``input`` whose ``summary`` is exactly ``True`` requests summarization.
+    Root ``summary`` is ignored in canonical mode, including when ``input`` is
+    malformed or its nested flag is absent/invalid. When ``input`` is absent,
+    legacy mode reads only root ``summary``. Both modes require identity with
+    the boolean singleton ``True``; no truthy coercion is performed.
     """
-    if not isinstance(args, dict):
+    if not isinstance(args, Mapping):
         return False
+    if "input" in args:
+        payload = args["input"]
+        return isinstance(payload, Mapping) and payload.get("summary") is True
     return args.get("summary") is True
 
 
@@ -395,13 +402,19 @@ def maybe_summarize_result(
     and BEFORE the result is turned into the model-visible wire message.
 
     Contract:
+    - Summary control is canonical-first: when ``input`` is present, only
+      ``input.summary is True`` on a Mapping payload requests; root ``summary``
+      is never inspected or used as fallback. When ``input`` is absent, legacy
+      calls use root ``summary is True``. This exact-boolean discriminator is
+      applied without flattening or mutating the original args.
     - ``summary != true`` → returns *result* unchanged (current behavior).
     - ``summary == true`` but no ``summarizer_fn`` wired (e.g. service without a
       one-shot generate gateway) → **fails closed**: returns a summary-layer
       error (with the raw-retrieval locator), NOT the raw result. ``summary=true``
       is a request to keep the raw out of context; honoring it must not depend on
       whether a summarizer happens to be configured. The raw is already durably
-      logged before this point, so it remains retrievable by ``tool_call_id``.
+      logged before either the legacy or canonical predicate is applied, so it
+      remains retrievable by ``tool_call_id``.
     - Already an a-priori summary (defensive) → returned unchanged.
     - Error results (the tool itself failed) are NOT summarized: the agent needs
       the exact error text to recover. Returned unchanged.

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/_settings.py
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
@@ -35,6 +36,10 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
+- `_settings.py` — private Agent-owned placeholder-settings reader and
+  secret-free current-setting diagnostic. It strictly validates the exact
+  versioned no-op schema, rereads `settings/<bounded tool_name>.json` per call,
+  and never supplies action, input, reasoning, or tool behavior.
 
 ## Connections
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -40,6 +40,33 @@ There is no fourth public metadata block. Existing tools retain their current
 explicit schemas until a scoped migration changes their code, tests, manual, and
 contract together.
 
+### A-priori summary transition
+
+The shared kernel summary predicate uses the presence of the `input` key as the
+mode discriminator. A canonical call requests a summary only when `input` is a
+Mapping/object and `input.summary` is exactly the boolean `true`; once `input` is
+present, root `summary` is ignored and is never a fallback, even when `input` is
+malformed, missing `summary`, or carries a false/non-boolean value. No truthy
+coercion, flattening, or argument mutation is permitted. A call with no `input`
+key remains in legacy mode and requests only when root `summary` is exactly
+`true`.
+
+This is a transitional compatibility rule, not a second public schema: migrated
+capabilities that support a-priori summary advertise that flag only as nested
+`input.summary`, while unmigrated legacy advertisers retain their root flag until
+their own vertical migration. Tool errors continue to bypass summarization. The
+raw result is durably recorded before either nested or legacy summary control is
+applied; generated, refusal, and fail-closed no-gateway replacements are
+model-visible substitutes with the
+existing raw locator and metadata.
+
+The root-summary branch may be removed only in the commit that migrates the last
+currently legacy root-summary advertiser (including shell's historical `bash`
+rolling alias and daemon), and only after a registry-wide test proves that no
+provider-facing schema advertises root `summary`, no migrated handler accepts
+flat fields, and no supported pending legacy call relies on the root shape. Until
+that final removal gate, root lookup is permitted solely when `input` is absent.
+
 ## Port
 
 The provider-neutral boundary is the final `FunctionSchema` assembled by the

--- a/src/lingtai/tools/_settings.py
+++ b/src/lingtai/tools/_settings.py
@@ -1,0 +1,156 @@
+"""Private shared reader for Agent-owned no-op tool settings placeholders.
+
+The placeholder file is deliberately metadata-only.  A present, valid v1 file
+proves that an Agent-owned settings snapshot was read, but it cannot select or
+enable any tool behavior.  Individual tools may later add their own real
+settings reader when a configurable choice is actually authorized.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MAX_SETTINGS_BYTES = 64 * 1024
+SETTINGS_SCHEMA_VERSION = 1
+_TOOL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+class SettingsError(ValueError):
+    """A placeholder settings snapshot was malformed or unsafe to use."""
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsSnapshot:
+    """Immutable evidence for one reread of one tool's settings file."""
+
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def valid_tool_name(value: Any) -> bool:
+    """Return whether *value* is safe as one bounded settings path component."""
+    return isinstance(value, str) and _TOOL_NAME.fullmatch(value) is not None
+
+
+def settings_path(agent: Any, tool_name: str) -> Path:
+    """Return the fixed Agent-owned ``settings/<tool_name>.json`` path."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return Path(agent._working_dir) / "settings" / f"{tool_name}.json"
+
+
+def _bounded_error(exc: Exception) -> str:
+    """Render a bounded diagnostic without echoing host paths or file content."""
+    if isinstance(exc, OSError):
+        return f"settings file could not be read ({type(exc).__name__})"
+    text = str(exc).replace("\n", " ").strip()
+    return (text or "invalid settings")[:240]
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject duplicate JSON object members instead of accepting last-wins data."""
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SettingsError("duplicate settings field")
+        result[key] = value
+    return result
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    """Read one bounded regular-file snapshot and its content revision."""
+    try:
+        first = path.lstat()
+    except FileNotFoundError:
+        return b"", "missing"
+    except OSError:
+        raise
+
+    if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
+        raise SettingsError("settings file must be a regular file")
+    if first.st_size > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings file exceeds the bounded size")
+
+    # Open by path only after lstat, then compare the path identity and metadata
+    # again.  Replacements, symlink swaps, growth, and ordinary in-place writes
+    # are therefore rejected rather than partially accepted.
+    try:
+        with path.open("rb") as handle:
+            raw = handle.read(MAX_SETTINGS_BYTES + 1)
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    try:
+        second = path.lstat()
+    except FileNotFoundError as exc:
+        raise SettingsError("settings snapshot changed during read") from exc
+
+    if stat.S_ISLNK(second.st_mode) or not stat.S_ISREG(second.st_mode):
+        raise SettingsError("settings snapshot changed during read")
+    if (
+        len(raw) > MAX_SETTINGS_BYTES
+        or first.st_dev != second.st_dev
+        or first.st_ino != second.st_ino
+        or first.st_size != second.st_size
+        or first.st_mtime_ns != second.st_mtime_ns
+    ):
+        raise SettingsError("settings snapshot changed during read")
+    return raw, hashlib.sha256(raw).hexdigest()[:32]
+
+
+def read_settings(agent: Any, tool_name: str) -> SettingsSnapshot:
+    """Reread and strictly validate one tool's placeholder settings snapshot.
+
+    Missing is a normal placeholder state.  A valid file contributes only its
+    source/revision/hash evidence; it never changes behavior.  Every invocation
+    performs a fresh filesystem read and does not cache a prior snapshot.
+    """
+    path = settings_path(agent, tool_name)
+    digest: str | None = None
+    try:
+        raw, revision = _read_stable(path)
+        if revision == "missing":
+            return SettingsSnapshot("missing", "missing", None)
+        digest = revision
+        value = json.loads(raw.decode("utf-8"), object_pairs_hook=_pairs)
+        if not isinstance(value, dict) or set(value) != {"schema_version"}:
+            raise SettingsError("settings schema must contain only schema_version")
+        if type(value["schema_version"]) is not int or value["schema_version"] != SETTINGS_SCHEMA_VERSION:
+            raise SettingsError("settings schema_version must be integer 1")
+        return SettingsSnapshot(f"settings/{tool_name}.json", revision, digest)
+    except (OSError, UnicodeError, json.JSONDecodeError, SettingsError) as exc:
+        # Malformed data is never silently converted to the missing state.  The
+        # digest from a bounded stable read is retained as evidence when safe.
+        return SettingsSnapshot(
+            "settings_error",
+            digest or "error",
+            digest,
+            _bounded_error(exc if isinstance(exc, Exception) else SettingsError("invalid settings")),
+        )
+
+
+def current_setting(snapshot: SettingsSnapshot, tool_name: str) -> dict[str, Any]:
+    """Build the bounded, secret-free current-setting diagnostic for a tool."""
+    if not valid_tool_name(tool_name):
+        raise ValueError("tool name must be a bounded path component")
+    return_value: dict[str, Any] = {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": snapshot.source,
+        "settings_revision": snapshot.revision,
+        "settings_hash": snapshot.digest,
+        "change_hint": (
+            f"Edit settings/{tool_name}.json; changes apply on the next {tool_name} "
+            "call; this no-op placeholder never changes tool behavior."
+        ),
+    }
+    if snapshot.error:
+        return_value["settings_error"] = snapshot.error
+    return return_value

--- a/src/lingtai/tools/bash/ANATOMY.md
+++ b/src/lingtai/tools/bash/ANATOMY.md
@@ -43,7 +43,7 @@ be explicitly opted into.
 
 ## Components
 
-- `bash/__init__.py` — public schema/setup plus policy, sync execution, and durable async manager orchestration. `get_description` (`__init__.py:195`), `get_schema` (`__init__.py:199`), and `setup` (`__init__.py:1416`) define the public capability surface. `BashManager` owns validation, manager semantics, durable-state rehydration, notification publication, and poll/cancel consumption (`__init__.py:338`). `_augment_command_result` adds `ok`/`command_status`/`warning` fidelity fields (`__init__.py:141`).
+- `bash/__init__.py` — public canonical action/input schema/setup plus policy, sync execution, and durable async manager orchestration. `get_description`, `get_schema`, and `setup` define the public capability surface. `ShellManager` owns strict nested-input validation, manager semantics, durable-state rehydration, notification publication, poll/cancel consumption, and fresh `settings/shell.json` diagnostics. `_augment_command_result` adds `ok`/`command_status`/`warning` fidelity fields.
 - `bash/_shell_dialect.py` — the Bash-local `ShellDialect` port and serializable `ShellInvocation`; the POSIX extraction helper preserves the existing policy grammar.
 - `adapters/posix/bash.py` — `PosixBashDialect`, the first production adapter; it provides POSIX policy extraction and script-form shell invocation.
 - `adapters/shell.py` — `select_shell_dialect`, the outer selector for POSIX and PowerShell dialects; `adapters/bash.py` remains a private compatibility selector.
@@ -56,21 +56,23 @@ be explicitly opted into.
 
 ## Public API
 
-The canonical `shell` tool supports synchronous and asynchronous execution:
+The canonical `shell` tool supports synchronous and asynchronous execution through
+one strict root object: `{"action": "...", "input": {...}}`. `action` and
+`input` are the only shell-owned root properties; each input branch is closed.
+`run` requires `input.command` and accepts `timeout`, `working_dir`, `async`,
+`reminder`, and executor-owned a-priori `summary`; `poll`/`cancel` require only
+`input.job_id`; `manual` requires
+`input={}`. There are no flat aliases. BaseAgent injects optional root
+`reasoning` into the provider-facing schema and strips it before dispatch. Each
+result also carries a fresh no-op `current_setting` diagnostic loaded from the
+Agent-owned `settings/shell.json` snapshot; it does not fabricate shell options.
+`input.summary` is accepted only on `run`; exact boolean `true` selects the
+shared ToolExecutor a-priori summary path after raw-result logging, while root
+`reasoning` supplies the retention contract. Root `summary` is rejected.
 
-| Parameter      | Type     | Description |
-|----------------|----------|-------------|
-| `command`      | string   | Shell command to execute (required for `run`) |
-| `timeout`      | number   | Timeout in seconds (default: 30, sync only) |
-| `working_dir`  | string   | Working directory for execution (default: agent's working dir) |
-| `action`       | string   | `run` (default), `poll`, or `cancel` |
-| `async`        | boolean  | If true, run in background and return job_id immediately (default: false) |
-| `reminder`     | number   | Top-level schema-required field; provider calls carry it for every action, but runtime consumes/validates it only for async `run` (default 1800) |
-| `job_id`       | string   | Job ID for `poll` and `cancel` actions |
+**Sync mode** (`input.async=false`, default): Returns `{status, exit_code, stdout, stderr, ok, command_status[, warning], current_setting}` once the command completes, or `{status: "error", message, current_setting}` only when the shell itself could not run it (empty command, policy denial, timeout, spawn failure).
 
-**Sync mode** (`async=false`, default): Returns `{status, exit_code, stdout, stderr, ok, command_status[, warning]}` once the command completes, or `{status: "error", message}` only when the shell itself could not run it (empty command, policy denial, timeout, spawn failure).
-
-**Async mode** (`async=true`): Returns `{status: "ok", job_id, pid, message}` immediately. Initial durable state carries both a tokenized finite supervisor-start lease and a bounded `return_handoff`. The supervisor must claim/recheck the start lease before adapter spawn; the parent then atomically replaces the crash-fallback reminder deadline with `returned_at + reminder` and arms the return handoff before returning. `status: ok` requires winning that valid pending-to-armed transition (or exact completed/failed truth under the still-valid guard); a late owner after expiry returns a pollable error with `job_id`/`pid` instead of false success. Any rehydrated old timer defers while that handoff is pending. The detached supervisor owns durable lease/cancellation/terminal policy and selects the Bash-local process Port; the POSIX adapter owns the command handle, spawn, exact wait, and process-tree cancellation. The supervisor atomically records `{cwd, started_at, finished_at, exit_status_known, exit_code}` from that exact owned wait. A fresh manager never consumes unknown merely because a command process ref vanished: it waits/reloads while the recorded supervisor can still commit, marks unknown only after an expired start lease or a definitively gone supervisor, and otherwise returns recoverable `running`. Terminal poll is a conditional one-shot claim. `cancel` persists a request only after the selected adapter verifies the neutral supervisor ref as the same incarnation; unknown identity is never cancellation authority. The POSIX adapter retains the direct child unreaped through TERM grace, KILLs the original group, proves live-member quiescence, and returns exact terminal truth for the supervisor to commit before cancellation can atomically consume/suppress the job. Async run validates `reminder` as a finite non-negative number bounded by `threading.TIMEOUT_MAX` and defaults omitted direct calls to 1800 seconds.
+**Async mode** (`input.async=true`): Returns `{status: "ok", job_id, pid, message, current_setting}` immediately. Initial durable state carries both a tokenized finite supervisor-start lease and a bounded `return_handoff`. The supervisor must claim/recheck the start lease before adapter spawn; the parent then atomically replaces the crash-fallback reminder deadline with `returned_at + input.reminder` and arms the return handoff before returning. `status: ok` requires winning that valid pending-to-armed transition (or exact completed/failed truth under the still-valid guard); a late owner after expiry returns a pollable error with `job_id`/`pid` instead of false success. Any rehydrated old timer defers while that handoff is pending. The detached supervisor owns durable lease/cancellation/terminal policy and selects the Bash-local process Port; the POSIX adapter owns the command handle, spawn, exact wait, and process-tree cancellation. The supervisor atomically records `{cwd, started_at, finished_at, exit_status_known, exit_code}` from that exact owned wait. A fresh manager never consumes unknown merely because a command process ref vanished: it waits/reloads while the recorded supervisor can still commit, marks unknown only after an expired start lease or a definitively gone supervisor, and otherwise returns recoverable `running`. Terminal poll is a conditional one-shot claim. `cancel` persists a request only after the selected adapter verifies the neutral supervisor ref as the same incarnation; unknown identity is never cancellation authority. The POSIX adapter retains the direct child unreaped through TERM grace, KILLs the original group, proves live-member quiescence, and returns exact terminal truth for the supervisor to commit before cancellation can atomically consume/suppress the job. Async run validates `input.reminder` as a finite non-negative number bounded by `threading.TIMEOUT_MAX` and defaults omitted calls to 1800 seconds.
 
 **Result fidelity — top-level `status` vs. inner command success.** The top-level `status` (`ok`/`done`) reflects only that the shell *spawned* the command; it stays `ok`/`done` even when the inner command exits nonzero. To make inner failures impossible to skim past *without* changing the `status` contract that downstream recovery/telemetry branch on (`tool_executor.py` enriches/logs/collects on `status == "error"`), `_augment_command_result` (`__init__.py`) adds three additive, model-visible fields keyed off `exit_code`:
 

--- a/src/lingtai/tools/bash/CONTRACT.md
+++ b/src/lingtai/tools/bash/CONTRACT.md
@@ -58,7 +58,7 @@ invariants.
 ## Scope
 
 - Canonical tool name: `shell` (the retained implementation package is `lingtai.tools.bash`).
-- One public tool exposes three actions: `run` (default), `poll`, `cancel`.
+- One public tool exposes four actions: `run`, `poll`, `cancel`, and read-only `manual`. All calls use explicit `action` plus nested `input`; there is no implicit default action on the raw wire.
 - Policy is file-based (`bash_policy.json` is the POSIX default; Windows selects the reviewed `powershell_policy.json`). `yolo=True` at setup
   installs an allow-everything policy (unsandboxed command set) and is the
   documented default for trusted agents. Two policy modes exist: **allowlist**
@@ -71,20 +71,24 @@ does not stream output incrementally (async jobs are polled, not streamed).
 
 ## Tool surface
 
-`get_schema` marks `reminder` required at the top schema level to satisfy the
-provider-facing required-option contract. Provider-validated sync `run`,
-`poll`, and `cancel` calls therefore also carry `reminder` on the wire, but the
-handler consumes and validates it only for async `run`; sync `run`, `poll`, and
-`cancel` ignore it. Direct async runtime calls that omit it still default to
-1800 seconds for compatibility. The handler enforces per-action requirements
-for `command` and `job_id`. `action` defaults to `run`.
+`get_schema` is the canonical strict root contract: exactly `action` and
+`input` are public properties, both are required, and root/input objects reject
+unknown fields. The `input.anyOf` branches are closed action-specific objects:
+`run` requires `input.command` and admits `timeout`, `working_dir`, `async`,
+`reminder`, and the executor-owned a-priori `summary` control; `poll` and
+`cancel` require only `input.job_id`; `manual` requires
+an empty `input` object. There are no flat compatibility aliases. BaseAgent
+adds its optional root `reasoning` property to the provider-facing copy and
+strips it before dispatch; it is not shell-owned. Every handler result carries a
+fresh `current_setting` diagnostic from Agent-owned `settings/shell.json`.
 
-| Action | Required inputs | Optional inputs | Success output | Error shapes |
+| Action | Required nested input | Optional nested input | Success output | Error shapes |
 |---|---|---|---|---|
-| `run` (sync) | Provider schema: `command`, `reminder`; runtime consumes `command` only | `working_dir`, `timeout` (default 30), `summary` | `{status: "ok", exit_code, stdout, stderr, ok, command_status, warning?}` | `{status: "error", message}` — empty command, policy-denied, cwd outside sandbox, timeout (with broad-scan hint), or spawn failure |
-| `run` (async) | Provider/runtime: `command`, `async: true`, `reminder` | `working_dir`, `summary` | `{status: "ok", job_id, pid, message, handoff}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally says that if Telegram is connected and a Task Card is available for the current turn, the model should use it to report progress via `telegram(action='manual')` and that manual's `Programmable Task Card` section; read `shell-manual` and `notification-manual` for details | `{status: "error", message}` — same validation errors, invalid boolean/non-numeric/non-finite/negative/too-large `reminder`, plus `Failed to start async job: ...` |
-| `poll` | Provider schema: `job_id`, `reminder`; runtime consumes `job_id` only | — | running: `{status: "running", job_id, pid?}` while the recorded supervisor may still commit; known finished: `{status: "done", exit_status_known: true, exit_code, stdout, stderr, ok, command_status, warning?}`; unrecoverable/legacy terminal: `{status: "done", exit_status_known: false, exit_code: null, stdout, stderr}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or an already terminal-consumed job |
-| `cancel` | Provider schema: `job_id`, `reminder`; runtime consumes `job_id` only | — | `{status: "cancelled", job_id}` only after the supervisor has committed the held child's exact terminal status and cancellation atomically consumes/suppresses the job | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, terminal job, legacy job, or a durable cancellation request still awaiting a terminal commit (which remains pollable/remindable) |
+| `run` (sync) | `{"action":"run","input":{"command":"..."}}` | `timeout` (default 30), `working_dir`, `async` (false), `reminder`, `summary` (false) | `{status: "ok", exit_code, stdout, stderr, ok, command_status, warning?, current_setting}` | `{status: "error", message, current_setting}` — empty command, policy-denied, cwd outside sandbox, timeout (with broad-scan hint), or spawn failure |
+| `run` (async) | `input.command`, `input.async: true` | `input.working_dir`, `input.reminder` (default 1800), `input.summary` (false) | `{status: "ok", job_id, pid, message, handoff, current_setting}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally says that if Telegram is connected and a Task Card is available for the current turn, the model should use it to report progress via `telegram(action='manual')` and that manual's `Programmable Task Card` section; read `shell-manual` and `notification-manual` for details | `{status: "error", message, current_setting}` — same validation errors, invalid boolean/non-numeric/non-finite/negative/too-large `input.reminder`, plus `Failed to start async job: ...` |
+| `poll` | `{"action":"poll","input":{"job_id":"..."}}` | none | running: `{status: "running", job_id, pid?, current_setting}` while the recorded supervisor may still commit; known finished: `{status: "done", exit_status_known: true, exit_code, stdout, stderr, ok, command_status, warning?, current_setting}`; unrecoverable/legacy terminal: `{status: "done", exit_status_known: false, exit_code: null, stdout, stderr, current_setting}` | `{status: "error", message, current_setting}` — missing/invalid `job_id`, `Job not found`, or an already terminal-consumed job |
+| `cancel` | `{"action":"cancel","input":{"job_id":"..."}}` | none | `{status: "cancelled", job_id, current_setting}` only after the supervisor has committed the held child's exact terminal status and cancellation atomically consumes/suppresses the job | `{status: "error", message, current_setting}` — missing/invalid `job_id`, `Job not found`, terminal job, legacy job, or a durable cancellation request still awaiting a terminal commit (which remains pollable/remindable) |
+| `manual` | `{"action":"manual","input":{}}` | none | `{status: "ok", manual, manual_path, current_setting}` from the initialized installed shell manual; this is read-only | `{status: "degraded", manual: "", manual_path, error, current_setting}` if the installed manual is missing |
 
 Fidelity fields are additive and keyed off `exit_code`: `ok` is `True` only when
 `exit_code == 0`; `command_status` is `"success"`/`"failed"`; `warning` is
@@ -96,12 +100,18 @@ inner failure is surfaced through the additive fields, not by changing `status`.
 Unknown/invalid `job_id` values containing `/`, `\`, or `..` are rejected before
 any filesystem access (path-traversal guard).
 
-`reminder` is a finite non-negative number of seconds used only for async
-`run`; booleans, non-numeric values, non-finite values (`NaN`, `Infinity`),
+`input.reminder` is a finite non-negative number of seconds used only for
+async `run`; booleans, non-numeric values, non-finite values (`NaN`, `Infinity`),
 negative values, and values larger than `threading.TIMEOUT_MAX` are rejected
-because the timer backend cannot accept them safely. The schema default is 1800
-seconds. Direct runtime calls that omit it still get 1800 seconds, so older
-callers keep working even though providers see the field as required.
+because the timer backend cannot accept them safely. The nested schema default is
+1800 seconds and omitted direct canonical calls also get 1800 seconds. `poll`
+and `cancel` do not accept a reminder field.
+
+`input.summary` is an optional boolean on `run`. Only the exact value `true`
+requests the executor's a-priori model-visible summary; the raw shell result is
+still logged first and root `reasoning` drives what the summary retains. Because
+this is a migrated canonical tool, root `summary` is not accepted or consulted.
+`poll`, `cancel`, and `manual` do not admit a summary field.
 
 Agents following an async success `handoff` MUST treat Task Card guidance as
 conditional: use the Task Card only when Telegram is connected and a Task Card
@@ -292,7 +302,9 @@ for cancellation correctness.
 | Policy is enforced on async runs too | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_policy_applies_to_async` |
 | Neutral process refs are strict/JSON-safe, unknown identity is never same, and the POSIX adapter owns spawn plus exact wait | `src/lingtai/tools/bash/_async_process.py`, `src/lingtai/adapters/posix/bash_process.py` | `tests/test_bash_async_process_contract.py` |
 | Manager policy consumes neutral refs before v3 compatibility fields and refuses unverifiable cancellation | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_running_result_prefers_neutral_command_ref_over_legacy_fields`, `::test_cancel_refuses_unverifiable_neutral_supervisor_ref` |
-| Async `reminder` defaults to 1800 for omitted direct calls while schema marks it required | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_schema_requires_reminder_with_runtime_default` |
+| Canonical root is exactly `action` + strict nested `input`, with closed run/poll/cancel/manual branches and BaseAgent-owned reasoning injection | `src/lingtai/tools/bash/__init__.py`, `src/lingtai/kernel/base_agent/tools.py` | `tests/test_shell_action_input_candidate.py` |
+| Every result fresh-reads strict v1 Agent-owned `settings/shell.json` and reports no-op `current_setting`; no adjustable shell options are fabricated | `src/lingtai/tools/_settings.py`, `src/lingtai/tools/bash/__init__.py` | `tests/test_shell_action_input_candidate.py` |
+| `manual` reads the installed shell skill through the real read-only loader | `src/lingtai/tools/bash/__init__.py`, `src/lingtai/tools/_manual.py` | `tests/test_intrinsic_manual_actions.py`, `tests/test_shell_action_input_candidate.py` |
 | Last-resort deadlines are measured from successful async return, and a bounded durable handoff blocks both pre-adapter-spawn and durable-`running` pre-return publication windows while retaining crash fallback | `src/lingtai/tools/bash/__init__.py`, `_async_supervisor.py` | `tests/test_bash_async.py::test_reminder_deadline_starts_at_successful_async_return`, `::test_return_handoff_blocks_fallback_while_parent_popen_is_delayed`, `::test_return_handoff_blocks_fallback_after_running_before_return_arm`, `::test_owner_resuming_after_handoff_expiry_cannot_report_start_success`, `::test_stale_pre_return_reminder_timer_defers_to_latest_deadline` |
 | Supervisor terminal truth, bounded start-lease recovery, parent-reaper/fresh-manager handling of an actual preclaim supervisor exit, PID identity refusal, and sink-idempotent completion wake survive manager loss | `src/lingtai/tools/bash/_async_supervisor.py`, `__init__.py` | `tests/test_bash_async.py::TestBashAsyncRelaunchDurability`, `::test_owned_parent_reaps_actual_supervisor_exit_before_start_claim`, `::test_fresh_manager_recovers_actual_preclaim_exit_after_owner_loss`, `::test_legacy_live_pid_remains_running_and_uncancellable` |
 | Reminder validation rejects non-finite and backend-unsafe delays | `src/lingtai/tools/bash/__init__.py` | `tests/test_bash_async.py::test_async_reminder_rejects_invalid_values` |

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 
 from ._shell_dialect import ShellDialect, ShellInvocation, extract_posix_commands
 from .._manual import load_installed_manual
+from .._settings import current_setting, read_settings
 
 from ._async_supervisor import (
     load_state,
@@ -249,53 +250,94 @@ def get_description(
             "Returns exit_code, stdout, stderr, plus ok (bool) and command_status ('success'/'failed'). IMPORTANT: top-level status stays 'ok' even when the command FAILS — it only means the shell ran. "
             "Always check exit_code/ok and read the warning field (it names nonzero exits, Python tracebacks, and missing modules); never assume success from status alone. "
             "Avoid broad recursive scans (find … -name, rglob, os.walk, glob('**')) — they time out; prefer `rg --files`. Parse JSONL line-by-line, not as one JSON blob. "
-            "Supports async mode (async=true → job_id, then poll/cancel). Call shell(action='manual') to return the installed shell-manual skill. Before ordinary shell work, read that manual — it covers async hygiene and advanced usage; no exceptions.")
+            "Use shell(action='run', input={'command': '...'}) for ordinary work. Supports async mode (input.async=true → job_id, then action='poll'/'cancel' with input.job_id). Use input.summary=true for an a-priori summary when exact raw output is unnecessary. Call shell(action='manual', input={}) to return the installed shell-manual skill. Before ordinary shell work, read that manual — it covers async hygiene and advanced usage; no exceptions.")
 
 
 def get_schema(lang: str = "en") -> dict:
+    """Return the strict public ``shell(action, input)`` contract.
+
+    The action-specific payloads are intentionally closed.  ``reasoning`` is
+    injected by ``BaseAgent`` into the provider-facing copy of this schema; it
+    is not a shell-owned parameter and therefore does not appear here.
+    """
+    run_input = {
+        "title": "run input",
+        "type": "object",
+        "properties": {
+            "command": {"type": "string", "description": "Shell command to execute."},
+            "timeout": {
+                "type": "number",
+                "description": "Timeout in seconds (default: 30, only for synchronous execution).",
+                "default": 30,
+            },
+            "working_dir": {
+                "type": "string",
+                "description": "Working directory for the command (optional). Leave it out (or pass an empty string) to use the agent working directory. Must be inside the agent working directory sandbox; paths outside it are rejected. For external repos/paths, keep working_dir at the agent dir and put an explicit cd in command, e.g. cd /absolute/path && ...",
+            },
+            "async": {
+                "type": "boolean",
+                "description": "Run in the background and return a durable job_id (default: false).",
+                "default": False,
+            },
+            "reminder": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Async last-resort wake delay in seconds (default: 1800).",
+                "default": _DEFAULT_ASYNC_REMINDER_SECONDS,
+            },
+            "summary": {
+                "type": "boolean",
+                "description": (
+                    "Optional a-priori summary control. Default false; when true, "
+                    "preserve the raw result before replacing the model-visible "
+                    "result with a generated summary driven by root reasoning."
+                ),
+                "default": False,
+            },
+        },
+        "required": ["command"],
+        "additionalProperties": False,
+    }
+    poll_input = {
+        "title": "poll input",
+        "type": "object",
+        "properties": {
+            "job_id": {"type": "string", "description": "Durable job ID returned by an async run."},
+        },
+        "required": ["job_id"],
+        "additionalProperties": False,
+    }
+    cancel_input = {
+        "title": "cancel input",
+        "type": "object",
+        "properties": {
+            "job_id": {"type": "string", "description": "Durable job ID returned by an async run."},
+        },
+        "required": ["job_id"],
+        "additionalProperties": False,
+    }
+    manual_input = {
+        "title": "manual input",
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": False,
+    }
     return {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
                 "enum": ["run", "poll", "cancel", "manual"],
-                "description": "Action to perform: 'run' (default) executes a command, 'poll' checks async job status, 'cancel' kills an async job, 'manual' returns the installed shell-manual skill",
-                "default": "run",
+                "description": "Action to perform: run, poll, cancel, or the read-only installed manual.",
             },
-            "command": {
-                "type": "string",
-                "description": 'The shell command to execute',
-            },
-            "timeout": {
-                "type": "number",
-                "description": 'Timeout in seconds (default: 30, only for sync execution)',
-                "default": 30,
-            },
-            "working_dir": {
-                "type": "string",
-                "description": 'Working directory for the command (optional). Leave it out (or pass an empty string) to use the agent working directory. Must be inside the agent working directory sandbox; paths outside it are rejected. For external repos/paths, keep working_dir at the agent dir and put an explicit cd in command, e.g. cd /absolute/path && ...',
-            },
-            "async": {
-                "type": "boolean",
-                "description": "Run command in background and return immediately with a job_id (default: false, only for action='run')",
-                "default": False,
-            },
-            "reminder": {
-                "type": "number",
-                "description": "Last-resort async wake delay in seconds (default: 1800). For async run only: if the job is still non-terminal when the durable deadline expires, publish a system notification reminding you to poll it; exact completion suppresses this stale watchdog and publishes the shell completion wake instead.",
-                "default": _DEFAULT_ASYNC_REMINDER_SECONDS,
-            },
-            "job_id": {
-                "type": "string",
-                "description": 'Job ID for poll/cancel actions (returned by async run)',
-            },
-            "summary": {
-                "type": "boolean",
-                "description": 'Optional. Default false. When true, this tool runs normally and the raw result is preserved in the durable log (retrievable by tool_call_id), but before the result enters your context it is replaced by an LLM-generated summary driven by your `reasoning` field — so make `reasoning` specific about what to retain. Set true only when the output is expected to be large (>10k chars) and you do NOT need the exact raw text. Leave false when you need exact line/file/diff/stderr text. The summary is non-canonical; if the raw exceeds 500,000 chars no summary is generated and you get a refusal pointing at the preserved raw.',
-                "default": False,
+            "input": {
+                "anyOf": [run_input, poll_input, cancel_input, manual_input],
+                "description": "Strict action-specific input object.",
             },
         },
-        "required": [],  # action-specific inputs are enforced by the handler; manual needs none
+        "required": ["action", "input"],
+        "additionalProperties": False,
     }
 
 
@@ -493,14 +535,75 @@ class ShellManager:
         return delay, None
 
     def handle(self, args: dict) -> dict:
-        action = args.get("action", "run")
+        """Dispatch one strict canonical call and attach a fresh setting snapshot.
+
+        The provider schema owns the canonical shape, but this boundary also
+        validates it for direct/in-process callers.  Only BaseAgent's private
+        runtime fields may accompany the two public root fields; flat command,
+        job, timeout, and reminder aliases are deliberately not accepted.
+        """
+        snapshot = read_settings(self._agent, "shell")
+        diagnostic = current_setting(snapshot, "shell")
+
+        def finish(result: dict) -> dict:
+            value = dict(result)
+            value["current_setting"] = dict(diagnostic)
+            return value
+
+        if not isinstance(args, dict):
+            return finish({"status": "error", "message": "shell arguments must be an object"})
+        unknown_root = set(args) - {"action", "input", "_reasoning", "_tc_id"}
+        if unknown_root:
+            return finish({
+                "status": "error",
+                "message": f"Unsupported shell argument(s): {', '.join(sorted(map(str, unknown_root)))}",
+            })
+        action = args.get("action")
+        if not isinstance(action, str) or action not in {"run", "poll", "cancel", "manual"}:
+            return finish({"status": "error", "message": "action must be one of: run, poll, cancel, manual"})
+        payload = args.get("input")
+        if not isinstance(payload, dict):
+            return finish({"status": "error", "message": "input is required and must be an object"})
+
+        allowed = {
+            "run": {"command", "timeout", "working_dir", "async", "reminder", "summary"},
+            "poll": {"job_id"},
+            "cancel": {"job_id"},
+            "manual": set(),
+        }[action]
+        unknown_input = set(payload) - allowed
+        if unknown_input:
+            return finish({
+                "status": "error",
+                "message": f"Unsupported {action} input field(s): {', '.join(sorted(map(str, unknown_input)))}",
+            })
+        if action == "run":
+            command = payload.get("command")
+            if not isinstance(command, str):
+                return finish({"status": "error", "message": "command is required and must be a string"})
+            timeout = payload.get("timeout", 30)
+            if isinstance(timeout, bool) or not isinstance(timeout, (int, float)) or not math.isfinite(timeout):
+                return finish({"status": "error", "message": "timeout must be a finite number of seconds"})
+            if "working_dir" in payload and not isinstance(payload["working_dir"], str):
+                return finish({"status": "error", "message": "working_dir must be a string"})
+            if "async" in payload and not isinstance(payload["async"], bool):
+                return finish({"status": "error", "message": "async must be a boolean"})
+            if "summary" in payload and not isinstance(payload["summary"], bool):
+                return finish({"status": "error", "message": "summary must be a boolean"})
+            if payload.get("async", False) and "reminder" in payload:
+                reminder = payload["reminder"]
+                if isinstance(reminder, bool) or not isinstance(reminder, (int, float)):
+                    return finish({"status": "error", "message": "reminder must be a finite non-negative number of seconds"})
+                _, reminder_error = self._validate_reminder(reminder)
+                if reminder_error:
+                    return finish(reminder_error)
         if action == "manual":
-            return load_installed_manual(self._agent, "shell")
+            return finish(load_installed_manual(self._agent, "shell"))
         if action == "poll":
-            return self._handle_poll(args)
+            return finish(self._handle_poll(payload))
         if action == "cancel":
-            return self._handle_cancel(args)
-        return self._handle_run(args)
+            return finish(self._handle_cancel(payload))
+        return finish(self._handle_run(payload))
 
     def _handle_run(self, args: dict) -> dict:
         command = args.get("command", "")
@@ -817,7 +920,7 @@ class ShellManager:
                     }
                 return {
                     "status": "ok", "job_id": job_id, "pid": pid,
-                    "message": f'Job started. Use shell(action="poll", job_id="{job_id}") to check.',
+                    "message": f'Job started. Use shell(action="poll", input={{"job_id": "{job_id}"}}) to check.',
                     "handoff": "While waiting, go idle or call system(action='sleep'); the terminal result will arrive and wake you as a notification; read shell-manual and notification-manual for details. If Telegram is connected and a Task Card is available for the current turn, use it to report progress; call `telegram(action='manual')` and follow its `Programmable Task Card` section for details.",
                 }
             if state and self._terminal(state.get("status")):
@@ -1011,7 +1114,7 @@ class ShellManager:
     def _publish_async_reminder(self, job_id: str) -> bool:
         body = (
             f"Shell async job {job_id} may still be running. "
-            f"Poll it with shell(action=\"poll\", job_id=\"{job_id}\")."
+            f"Poll it with shell(action=\"poll\", input={{\"job_id\": \"{job_id}\"}})."
         )
         agent = self._agent
         if hasattr(agent, "_enqueue_system_notification"):

--- a/src/lingtai/tools/bash/glossary-wen.md
+++ b/src/lingtai/tools/bash/glossary-wen.md
@@ -15,12 +15,12 @@ maintenance: |
 ---
 **名相对照**
 
-- `shell`：执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。返 exit_code、stdout、stderr，兼附 ok（真伪）与 command_status（'success'/'failed'）。须知：命令虽败，顶层 status 仍作 'ok'——此仅言 shell 已运，非言命令已成。必察 exit_code/ok，且阅 warning 一字（标非零之退、Python 之回溯、缺失之模块）；勿独凭 status 而断其成。忌大范围递归之扫（find … -name、rglob、os.walk、glob('**')）——易致超时；宜先用 `rg --files`。JSONL 当逐行而解，勿混作一 JSON。支持异步：设 async=true 取 job_id，后以 poll/cancel 查之。用此器前，必先读 `shell-manual` 一技（含定时之设、异步之规、进阶之用），无所例外。
-- `action`：所行之事：'run'（默认）执行指令，'poll' 查异步任务之状，'cancel' 斩异步任务
+- `shell`：执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。返 exit_code、stdout、stderr，兼附 ok（真伪）与 command_status（'success'/'failed'）。须知：命令虽败，顶层 status 仍作 'ok'——此仅言 shell 已运，非言命令已成。必察 exit_code/ok，且阅 warning 一字（标非零之退、Python 之回溯、缺失之模块）；勿独凭 status 而断其成。忌大范围递归之扫（find … -name、rglob、os.walk、glob('**')）——易致超时；宜先用 `rg --files`。JSONL 当逐行而解，勿混作一 JSON。支持异步：设 action='run' 且 input.async=true 取 job_id，后以 action='poll'/'cancel' 与 input.job_id 查之。用此器前，必先读 `shell-manual` 一技（含定时之设、异步之规、进阶之用），无所例外。
+- `action`：必明择所行之事：'run' 执行指令，'poll' 查异步任务之状，'cancel' 斩异步任务，'manual' 读已装手册
 - `command`：欲执行之指令
 - `timeout`：超时秒数（默认：30，唯同步执行时生效）
-- `working_dir`：指令之工作目录（可选）。留空或传空字符串即用 agent 工作目录。须在 agent 工作目录沙箱之内；沙箱外路径会被拒。若需操作外部仓库/路径，请令 working_dir 保持为 agent 目录，并在 command 中显式 cd，如 cd /absolute/path && ...
-- `async`：后台运行指令，即返 job_id（默认：false，唯 action='run' 时生效）
-- `reminder`：异步兜底唤醒之延迟秒数（默认 1800）。顶层 schema 要求此字段，故经 provider 校验之同步 run、poll、cancel 亦携之；运行时唯异步 run 用且校验之，余动作忽略。初期之限，惟崩溃兜底；有界且持久之 return-handoff，禁次 manager 于首 manager 尚未毕成功返转之际先发旧限。惟守尚有效而原子书 `returned_at + reminder`（或精确成败已于有效守内落盘），方报启成；守既逾期，后复之 owner 携 `job_id/pid` 明告“犹可 poll”之误，且存崩溃兜底。终限届而任务仍非终态，方发 system 通知促 poll。取消中之持久 suppressing 亦有界，逾期可复告。若已得精确终态，则抑“或仍在行”之旧告，改由 Bash completion 唤醒。
-- `job_id`：异步任务之号，用于 poll/cancel（由异步 run 所返）
-- `summary`：可选。默认 false。设 true 时，此 tool 照常运行，原始结果完存于持久日志（可凭 tool_call_id 取回）；然结果入尔上下文前，先以尔 `reasoning` 字段所驱之 LLM 摘要代之——故 `reasoning` 当明言所欲存者。唯料输出甚巨（逾一万字符）且无需精确原文时，方设 true。需精确之行/文件/diff/stderr 原文者，留 false。摘要非权威；原始结果逾五十万字符，则不生摘要，尔得一拒辞，指向所存之原始结果。
+- `working_dir`：居于 input 对象；命令之工作目录（可选），留空即用 agent 工作目录，须在沙箱之内。
+- `async`：居于 run 之 input；后台运行指令，立即返 job_id（默认 false）。
+- `reminder`：居于 run 之 input；异步兜底唤醒延迟（默认 1800），仅 async run 校验使用；poll/cancel 不受此字段。
+- `job_id`：居于 poll/cancel 之 input；异步任务之号（由异步 run 所返）。
+- `input.summary`：可选。默认 false。设 true 时，此 tool 照常运行，原始结果完存于持久日志（可凭 tool_call_id 取回）；然结果入尔上下文前，先以尔 `reasoning` 字段所驱之 LLM 摘要代之——故 `reasoning` 当明言所欲存者。唯料输出甚巨（逾一万字符）且无需精确原文时，方设 true。需精确之行/文件/diff/stderr 原文者，留 false。摘要非权威；原始结果逾五十万字符，则不生摘要，尔得一拒辞，指向所存之原始结果。

--- a/src/lingtai/tools/bash/glossary-zh.md
+++ b/src/lingtai/tools/bash/glossary-zh.md
@@ -15,12 +15,12 @@ maintenance: |
 ---
 **术语对照**
 
-- `shell`：执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。返回 exit_code、stdout、stderr，并附 ok（布尔）与 command_status（'success'/'failed'）。要点：即便命令失败，顶层 status 仍为 'ok'——它仅表示 shell 已执行。务必检查 exit_code/ok 并阅读 warning 字段（标明非零退出、Python 回溯、缺失模块）；切勿仅凭 status 断定成功。避免大范围递归扫描（find … -name、rglob、os.walk、glob('**')）——易超时；优先用 `rg --files`。JSONL 须逐行解析，勿当作单个 JSON。支持异步：async=true 获取 job_id，再用 poll/cancel 查之。用此工具前，必先读 `shell-manual` 技能（涵盖定时任务、异步规范与进阶用法），无例外。
-- `action`：执行动作：'run'（默认）执行命令，'poll' 查询异步任务状态，'cancel' 终止异步任务
+- `shell`：执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。返回 exit_code、stdout、stderr，并附 ok（布尔）与 command_status（'success'/'failed'）。要点：即便命令失败，顶层 status 仍为 'ok'——它仅表示 shell 已执行。务必检查 exit_code/ok 并阅读 warning 字段（标明非零退出、Python 回溯、缺失模块）；切勿仅凭 status 断定成功。避免大范围递归扫描（find … -name、rglob、os.walk、glob('**')）——易超时；优先用 `rg --files`。JSONL 须逐行解析，勿当作单个 JSON。支持异步：action='run' 且 input.async=true 获取 job_id，再用 action='poll'/'cancel' 与 input.job_id 查之。用此工具前，必先读 `shell-manual` 技能（涵盖定时任务、异步规范与进阶用法），无例外。
+- `action`：必填且必须显式选择：'run' 执行命令，'poll' 查询异步任务状态，'cancel' 终止异步任务，'manual' 读取已安装手册
 - `command`：要执行的 shell 命令
 - `timeout`：超时秒数（默认：30，仅同步执行时生效）
-- `working_dir`：命令的工作目录（可选）。留空或传空字符串即使用 agent 工作目录。必须位于 agent 工作目录沙箱内；沙箱外路径会被拒绝。若要操作外部仓库/路径，请将 working_dir 保持为 agent 目录，并在 command 中显式 cd，例如 cd /absolute/path && ...
-- `async`：后台运行命令并立即返回 job_id（默认：false，仅 action='run' 时生效）
-- `reminder`：兜底异步唤醒延迟秒数（默认 1800）。顶层 schema 要求提供此字段，所以 provider 校验过的同步 run、poll、cancel 也会携带它；运行时只在异步 run 中使用并校验它，其他动作忽略。初始期限仅作崩溃兜底；有界的持久 return-handoff 会阻止第二个 manager 在首个 manager 尚未完成成功返回转换时提前发布旧期限。只有在守卫仍有效时原子写入 `returned_at + reminder`（或精确完成/失败已在有效守卫内落盘）才返回成功；过期后恢复的 owner 会携 `job_id/pid` 返回“仍可 poll”的显式错误，且保留崩溃兜底。若最终到期时任务仍非终态，则发布 system 通知提醒 poll。取消期间的持久 suppressing 状态同样有界，超时后可恢复提醒。精确完成会抑制这条过时的“仍可能运行”提醒，改由 Bash completion 通知唤醒。
-- `job_id`：异步任务 ID，用于 poll/cancel（由异步 run 返回）
-- `summary`：可选。默认 false。为 true 时，该 tool 照常执行，原始结果会完整保存到持久日志（可按 tool_call_id 取回），但在结果进入你的上下文之前，会被一段由你的 `reasoning` 字段驱动的 LLM 生成摘要替换——所以请在 `reasoning` 中明确说明要保留什么。仅当预期输出很大（>10k 字符）且你不需要精确原文时才设为 true。需要精确的行/文件/diff/stderr 原文时请保持 false。摘要非权威；若原始结果超过 500,000 字符则不生成摘要，你会收到一条指向已保存原始结果的拒绝信息。
+- `working_dir`：位于 input 对象内；命令工作目录（可选），留空即使用 agent 工作目录，必须在沙箱内。
+- `async`：位于 run 的 input 内；后台运行命令并立即返回 job_id（默认 false）。
+- `reminder`：位于 run 的 input 内；异步兜底唤醒延迟（默认 1800），仅 async run 校验和使用；poll/cancel 不接受此字段。
+- `job_id`：位于 poll/cancel 的 input 内；异步任务 ID（由异步 run 返回）。
+- `input.summary`：可选。默认 false。为 true 时，该 tool 照常执行，原始结果会完整保存到持久日志（可按 tool_call_id 取回），但在结果进入你的上下文之前，会被一段由你的 `reasoning` 字段驱动的 LLM 生成摘要替换——所以请在 `reasoning` 中明确说明要保留什么。仅当预期输出很大（>10k 字符）且你不需要精确原文时才设为 true。需要精确的行/文件/diff/stderr 原文时请保持 false。摘要非权威；若原始结果超过 500,000 字符则不生成摘要，你会收到一条指向已保存原始结果的拒绝信息。

--- a/src/lingtai/tools/bash/manual/SKILL.md
+++ b/src/lingtai/tools/bash/manual/SKILL.md
@@ -141,7 +141,7 @@ below; the page itself carries only what is specific to that CLI.
 2. **Long-running agent/coding CLI** (`claude -p`, `codex exec`, `opencode run`,
    Cursor Agent, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, Gemini CLI, Aider,
    Goose, OpenHands, Crush, or any sub-agent that may think/run tools for minutes)?
-   **Never run it synchronously.** Use `shell(async=true)` and poll — see the
+   **Never run it synchronously.** Use `shell(action="run", input={"command": "...", "async": true})` and poll — see the
    resident rule below.
 3. **Time itself is the trigger?** Read `reference/scheduled-work/SKILL.md`.
 4. **You only need a single future nudge?** Read
@@ -168,6 +168,10 @@ common way agents corrupt their own downstream work.
   run through the kernel's secret redactor, so secret-shaped lines are masked in
   `warning`; the raw `stderr` field is unchanged. If `warning` is present, stop
   and read it before acting on the output.
+- **Use `input.summary=true` only when raw exact output is unnecessary.** It is
+  available only on `action="run"`. The executor logs the raw result first, then
+  uses root `reasoning` as the retention contract for the generated model-visible
+  summary. Root `summary` is legacy syntax and is rejected by canonical shell.
 - **Use the venv interpreter for project code.** Bare `python3` lacks
   third-party packages and LingTai's own modules (`lingtai`, `lingtai.kernel`).
   A `No module named …` / `missing_module` warning usually means you ran the
@@ -203,7 +207,7 @@ reading the whole file when you only need recent events.
 - **Synchronous `shell` is only for short, deterministic commands.** A long-running
   agent/coding CLI session — `claude -p`, `codex exec`, `opencode run`, the Cursor
   agent CLI, or any sub-agent that may think and run tools for minutes — must
-  **never** be a synchronous `shell` call. Run it with `shell(async=true)` and poll
+  **never** be a synchronous `shell` call. Run it with `shell(action="run", input={"command": "...", "async": true})` and poll
   the returned `job_id`. A synchronous call blocks the whole turn until the child
   exits: you stay `ACTIVE` and stop seeing channel notifications (mail, refresh,
   interrupts) for the entire duration. Async + poll keeps you responsive and
@@ -211,18 +215,18 @@ reading the whole file when you only need recent events.
 
   ```text
   # Start the child agent in the background — returns immediately with a job_id:
-  shell(async=true, reminder=1800, command="claude -p 'refactor the auth module' --output-format json")
+  shell(action="run", input={"async": true, "reminder": 1800, "command": "claude -p 'refactor the auth module' --output-format json"})
   # → {"status": "ok", "job_id": "job-a1b2c3d4e5f678901234567890abcdef", "pid": 4321}
 
   # Later turns: poll until done (handle mail/other work between polls):
-  shell(action="poll", job_id="job-a1b2c3d4e5f678901234567890abcdef", reminder=1800)
+  shell(action="poll", input={"job_id": "job-a1b2c3d4e5f678901234567890abcdef"})
   # → {"status": "running", …}   then eventually
   # → {"status": "done", "exit_code": 0, "ok": true, "command_status": "success", "stdout": "…", "stderr": "…"}
   #   On failure: {"status": "done", "exit_code": 1, "ok": false,
   #                "command_status": "failed", "warning": "command exited with code 1; …"}
 
   # Abandon it if needed:
-  shell(action="cancel", job_id="job-a1b2c3d4e5f678901234567890abcdef", reminder=1800)
+  shell(action="cancel", input={"job_id": "job-a1b2c3d4e5f678901234567890abcdef"})
   ```
 
 - **Use a Task Card for progress when one is available for this turn.**
@@ -234,7 +238,7 @@ reading the whole file when you only need recent events.
   background command lifecycle and notification behavior unchanged while giving
   Telegram-originated turns a better progress surface.
 
-- **If repeated-call `_advisory` appears on `shell(action="poll")`, stop
+- **If repeated-call `_advisory` appears on `shell(action="poll", input={"job_id": "..."})`, stop
   tight polling.** The poll already executed; the advisory is not a block. If
   the job is still running and nothing meaningful changed, handle any human
   messages, do other work, or set one future reminder (`bash` notification
@@ -243,12 +247,10 @@ reading the whole file when you only need recent events.
   reason to expect new state.
 
 - **Idle care: set an async `reminder` that matches the expected duration.**
-  Every `shell(async=true)` call has a last-resort `reminder` delay, required in
-  the top-level provider schema and defaulted by the runtime to 1800 seconds
-  when omitted by older direct callers. Provider-facing sync commands, `poll`,
-  and `cancel` also carry `reminder` because of that schema shape, but the field
-  is meaningful and runtime-validated only for async `run`; sync commands,
-  `poll`, and `cancel` ignore it.
+  Every `shell(action="run", input={"async": true, ...})` call has a last-resort
+  `input.reminder` delay, defaulted by the runtime to 1800 seconds when omitted.
+  The field is meaningful and runtime-validated only for async `run`; synchronous
+  commands, `poll`, and `cancel` do not accept or use it.
   The initial durable deadline is a crash fallback while the supervisor starts.
   A bounded durable return-handoff guard prevents a relaunched/second manager from
   publishing that fallback while the first manager is still before supervisor
@@ -337,7 +339,7 @@ dispatched worker with its own worktree, branch, and context window.
 
 When in doubt for non-trivial work: daemon. A CLI has **no LingTai job protocol
 of its own** — "async" always means a LingTai or OS wrapper around it
-(`shell(async=true)`, a supervised background job, or a daemon backend), and
+(`shell(action="run", input={"async": true, ...})`, a supervised background job, or a daemon backend), and
 that wrapper owns logs, timeout, cancellation, and recovery notes. Keep
 synchronous inline calls short and explicitly timed (for example a 300 s bash
 timeout); do not solve a long task by raising the synchronous timeout to 15+

--- a/src/lingtai/tools/daemon/manual/reference/inspection/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/inspection/SKILL.md
@@ -110,11 +110,11 @@ read("daemons/em-3-20260427-094215-abc123/daemon.json")
 # → state=running, turn=8, current_tool=null, tool_call_count=15, tokens.input=22000
 
 # Last few lines of the transcript
-shell("tail -n 20 daemons/em-3-20260427-094215-abc123/history/chat_history.jsonl")
+shell(action="run", input={"command": "tail -n 20 daemons/em-3-20260427-094215-abc123/history/chat_history.jsonl"})
 # → assistant: "Found a potential SQL injection in db.py:42. Continuing..."
 
 # Recent tool activity
-shell("tail -n 10 daemons/em-3-20260427-094215-abc123/logs/events.jsonl")
+shell(action="run", input={"command": "tail -n 10 daemons/em-3-20260427-094215-abc123/logs/events.jsonl"})
 # → series of read/grep events on src/db/, src/auth/
 ```
 

--- a/src/lingtai/tools/email/manual/SKILL.md
+++ b/src/lingtai/tools/email/manual/SKILL.md
@@ -165,7 +165,7 @@ Use this for: TODOs you want to remember after a memory rotation, breadcrumbs ab
 
 Add `delay=<seconds>` to defer delivery. The outbox entry is written immediately; the `_mailman` daemon thread sleeps until the deadline, then dispatches. Combined with self-send this gives you cheap one-shot alarms without standing up a cron; the notification is delivered exactly once.
 
-Use delayed self-send as a **future nudge**, not delayed tool execution. The message should tell the future you what to inspect and why, then let that future turn decide with current context whether to run `shell(action="poll")`, `daemon(check)`, a channel read, or nothing at all. It is one of the escape hatches when a repeated-call `_advisory` says you may be polling the same thing: write one concrete reminder, then yield/idle.
+Use delayed self-send as a **future nudge**, not delayed tool execution. The message should tell the future you what to inspect and why, then let that future turn decide with current context whether to run `shell(action="poll", input={"job_id": "..."})`, `daemon(check)`, a channel read, or nothing at all. It is one of the escape hatches when a repeated-call `_advisory` says you may be polling the same thing: write one concrete reminder, then yield/idle.
 
 **Recurring work is not an email feature.** The internal `email` tool has no recurring scheduling API. For repeating reminders or agent-side scheduled work, use a host scheduler (cron, launchd, systemd, or an event watcher) via `shell-manual` → `reference/scheduled-work/SKILL.md`; for a single lightweight wakeup that does not need mailbox state, `shell-manual` → `reference/notification-reminders/SKILL.md` owns the `.notification/cron.json` pattern.
 

--- a/src/lingtai/tools/skills/manual/SKILL.md
+++ b/src/lingtai/tools/skills/manual/SKILL.md
@@ -163,7 +163,7 @@ load-bearing — the catalog still finds skills without them.
 catalog:
 
 ```
-shell({"command": "grep -rh '^name:' .library/ ~/.lingtai-tui/utilities/ 2>/dev/null"})
+shell(action="run", input={"command": "grep -rh '^name:' .library/ ~/.lingtai-tui/utilities/ 2>/dev/null"})
 ```
 
 On a hit: rename, or adapt the existing skill instead of forking a second one.

--- a/tests/test_apriori_summary_executor.py
+++ b/tests/test_apriori_summary_executor.py
@@ -21,10 +21,12 @@ from lingtai.kernel.tool_executor import ToolExecutor
 from lingtai.kernel.tool_result_summary import (
     APRIORI_SUMMARY_CAP,
     APRIORI_SUMMARY_MARKER,
+    summary_requested,
 )
 
 
-def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
+def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path,
+                   parallel_safe_tools=None):
     """Construct a ToolExecutor that records durable log events into *events*."""
 
     def logger_fn(event_type, **fields):
@@ -43,6 +45,7 @@ def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
         logger_fn=logger_fn,
         working_dir=tmp_path,
         summarizer_fn=summarizer_fn,
+        parallel_safe_tools=parallel_safe_tools or set(),
     )
 
 
@@ -64,6 +67,14 @@ def _event_fields(events, event_type):
     for et, fields in events:
         if et == event_type:
             return fields
+    return None
+
+
+def _event_index(events, event_type, *, tool_call_id):
+    """Return the first matching event index for ordering assertions."""
+    for index, (et, fields) in enumerate(events):
+        if et == event_type and fields.get("tool_call_id") == tool_call_id:
+            return index
     return None
 
 
@@ -161,6 +172,274 @@ def test_summary_true_under_cap_replaces_with_summary_and_preserves_raw(tmp_path
     assert gen["tool_call_id"] == "t3"
     assert gen["tool_name"] == "bash"
     assert "RAWSECRET" not in str(gen)
+
+
+def test_summary_requested_uses_input_presence_precedence_and_exact_bool():
+    """Canonical input wins; only a literal bool True opts in."""
+    assert summary_requested({"summary": True}) is True  # legacy compatibility
+    assert summary_requested({"input": {"summary": True}, "summary": False}) is True
+
+    # Once input is present, root summary is never a fallback, including when
+    # nested summary is absent, false, malformed, or input is not an object.
+    nested_values = [False, 1, "true", None, {}, []]
+    for nested in nested_values:
+        assert summary_requested({"input": {"summary": nested}, "summary": True}) is False
+    assert summary_requested({"input": {}, "summary": True}) is False
+    for malformed_input in (None, [], "payload", 1):
+        assert summary_requested({"input": malformed_input, "summary": True}) is False
+
+    # Legacy mode has the same exact-boolean rule and does not mutate args.
+    for root in (False, 1, "true", None, {}, []):
+        assert summary_requested({"summary": root}) is False
+    original = {"input": {"summary": True}, "summary": "ignored"}
+    snapshot = {"input": dict(original["input"]), "summary": original["summary"]}
+    assert summary_requested(original) is True
+    assert original == snapshot
+
+
+def test_nested_summary_true_serial_preserves_reasoning_and_raw_first(tmp_path):
+    raw = {"stdout": "NESTED-SERIAL-RAW"}
+    nested_input = {"command": "echo nested", "summary": True}
+    call_args = {
+        "input": nested_input,
+        "summary": False,  # root is ignored in canonical mode
+        "reasoning": "Retain the nested serial marker",
+    }
+    seen = {}
+    events = []
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen["prompt"] = user_prompt
+        return "NESTED-SERIAL-SUMMARY"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute(
+        [ToolCall(name="bash", args=call_args, id="nested-serial")]
+    )
+
+    content = _wire_content(results[0])
+    assert content["artifact"] == APRIORI_SUMMARY_MARKER
+    assert content["generated_summary"] == "NESTED-SERIAL-SUMMARY"
+    assert "Retain the nested serial marker" in seen["prompt"]
+    assert nested_input == {"command": "echo nested", "summary": True}
+
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-serial")
+    generated_index = _event_index(
+        events, "apriori_summary_generated", tool_call_id="nested-serial"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-serial"
+    )
+    assert raw_index is not None and generated_index is not None and visible_index is not None
+    assert raw_index < generated_index < visible_index
+    raw_event = events[raw_index][1]
+    assert "NESTED-SERIAL-RAW" in str(raw_event["result"])
+    assert "NESTED-SERIAL-SUMMARY" not in str(raw_event["result"])
+    assert raw_event["tool_args"]["_reasoning"] == "Retain the nested serial marker"
+
+
+def test_nested_summary_true_parallel_path_preserves_raw_before_each_replacement(tmp_path):
+    raw_by_id = {
+        "nested-parallel-1": {"stdout": "NESTED-PARALLEL-RAW-1"},
+        "nested-parallel-2": {"stdout": "NESTED-PARALLEL-RAW-2"},
+    }
+    events = []
+    seen = []
+
+    def dispatch(tc):
+        return raw_by_id[tc.id]
+
+    def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+        seen.append((tool_call_id, user_prompt))
+        return f"NESTED-PARALLEL-SUMMARY-{tool_call_id}"
+
+    ex = _make_executor(
+        dispatch_fn=dispatch,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+        parallel_safe_tools={"bash", "grep"},
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "one", "summary": True},
+                  "reasoning": "Keep parallel result one"},
+            id="nested-parallel-1",
+        ),
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "two", "summary": True},
+                  "reasoning": "Keep parallel result two"},
+            id="nested-parallel-2",
+        ),
+    ])
+
+    assert len(seen) == 2
+    for result_msg, call_id in zip(results, ("nested-parallel-1", "nested-parallel-2")):
+        content = _wire_content(result_msg)
+        assert content["artifact"] == APRIORI_SUMMARY_MARKER
+        assert content["generated_summary"] == f"NESTED-PARALLEL-SUMMARY-{call_id}"
+        raw_index = _event_index(events, "tool_result", tool_call_id=call_id)
+        generated_index = _event_index(
+            events, "apriori_summary_generated", tool_call_id=call_id
+        )
+        visible_index = _event_index(
+            events, "tool_result_model_visible", tool_call_id=call_id
+        )
+        assert raw_index is not None and generated_index is not None and visible_index is not None
+        assert raw_index < generated_index < visible_index
+        raw_event = events[raw_index][1]
+        suffix = call_id.rsplit("-", 1)[-1]
+        assert f"NESTED-PARALLEL-RAW-{suffix}" in str(raw_event["result"])
+        assert f"NESTED-PARALLEL-SUMMARY-{call_id}" not in str(raw_event["result"])
+
+
+def test_nested_false_absent_and_malformed_ignore_root_true_in_executor(tmp_path):
+    cases = [
+        ("nested-false", {"summary": False}),
+        ("nested-absent", {}),
+        ("nested-one", {"summary": 1}),
+        ("nested-string", {"summary": "true"}),
+        ("nested-null", {"summary": None}),
+        ("nested-object", {"summary": {"truthy": True}}),
+        ("nested-list", {"summary": [True]}),
+        ("input-null", None),
+        ("input-list", []),
+        ("input-string", "payload"),
+    ]
+    for call_id, nested_input in cases:
+        events = []
+        called = []
+        raw = {"stdout": f"RAW-{call_id}"}
+
+        def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+            called.append(tool_call_id)
+            return "SHOULD NOT RUN"
+
+        ex = _make_executor(
+            dispatch_fn=lambda tc, raw=raw: raw,
+            summarizer_fn=summarizer,
+            events=events,
+            tmp_path=tmp_path,
+        )
+        results, _, _ = ex.execute([
+            ToolCall(
+                name="grep",
+                args={"input": nested_input, "summary": True},
+                id=call_id,
+            )
+        ])
+        content = _wire_content(results[0])
+        assert "SHOULD NOT RUN" not in str(content)
+        assert "RAW-" + call_id in str(content)
+        assert not (isinstance(content, dict) and content.get("artifact") == APRIORI_SUMMARY_MARKER)
+        assert called == []
+
+
+def test_nested_summary_true_cap_refusal_logs_raw_before_replacement(tmp_path):
+    raw = {"stdout": "NESTED-CAP-RAW-" + "z" * (APRIORI_SUMMARY_CAP + 100)}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="read",
+            args={"input": {"file_path": "/big", "summary": True},
+                  "reasoning": "Avoid oversized raw"},
+            id="nested-cap",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert called == []
+    assert content["summary_kind"] == "apriori_cap_refused"
+    assert "NESTED-CAP-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-cap")
+    refusal_index = _event_index(
+        events, "apriori_summary_cap_refused", tool_call_id="nested-cap"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-cap"
+    )
+    assert raw_index is not None and refusal_index is not None and visible_index is not None
+    assert raw_index < refusal_index < visible_index
+    assert "NESTED-CAP-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_without_gateway_fails_closed_after_raw_log(tmp_path):
+    raw = {"stdout": "NESTED-NOGATEWAY-RAW"}
+    events = []
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=None,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="bash",
+            args={"input": {"command": "echo no gateway", "summary": True}},
+            id="nested-no-gateway",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["summary_kind"] == "apriori_error"
+    assert "NESTED-NOGATEWAY-RAW" not in str(content)
+    raw_index = _event_index(events, "tool_result", tool_call_id="nested-no-gateway")
+    error_index = _event_index(
+        events, "apriori_summary_no_summarizer", tool_call_id="nested-no-gateway"
+    )
+    visible_index = _event_index(
+        events, "tool_result_model_visible", tool_call_id="nested-no-gateway"
+    )
+    assert raw_index is not None and error_index is not None and visible_index is not None
+    assert raw_index < error_index < visible_index
+    assert "NESTED-NOGATEWAY-RAW" in str(events[raw_index][1]["result"])
+
+
+def test_nested_summary_true_preserves_tool_error_bypass(tmp_path):
+    raw = {"status": "error", "message": "EXACT-TOOL-ERROR"}
+    called = []
+    events = []
+
+    def summarizer(*args):
+        called.append(args)
+        return "SHOULD NOT RUN"
+
+    ex = _make_executor(
+        dispatch_fn=lambda tc: raw,
+        summarizer_fn=summarizer,
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(
+            name="grep",
+            args={"input": {"pattern": "error", "summary": True}},
+            id="nested-error",
+        )
+    ])
+    content = _wire_content(results[0])
+    assert content["status"] == "error"
+    assert "EXACT-TOOL-ERROR" in str(content)
+    assert called == []
+    assert _event_index(events, "tool_result", tool_call_id="nested-error") is not None
+    assert _event_index(events, "apriori_summary_generated", tool_call_id="nested-error") is None
 
 
 def test_summary_true_over_cap_refuses_without_llm_and_hides_raw(tmp_path):

--- a/tests/test_bash_async.py
+++ b/tests/test_bash_async.py
@@ -21,7 +21,7 @@ class TestBashAsync:
     """Tests for async run / poll / cancel."""
 
     def _make_manager(self, tmp_path: Path) -> BashManager:
-        agent = SimpleNamespace(_notification_store=notification_store_for(tmp_path))
+        agent = SimpleNamespace(_notification_store=notification_store_for(tmp_path), _working_dir=tmp_path)
         return BashManager(
             policy=BashPolicy.yolo(), working_dir=str(tmp_path), agent=agent
         )
@@ -88,7 +88,7 @@ class TestBashAsync:
     # 1. async run returns job_id and pid
     def test_async_run_returns_job_id_and_pid(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "echo hello", "async": True})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo hello', 'async': True}})
         assert result["status"] == "ok"
         assert result["job_id"].startswith("job-")
         assert isinstance(result["pid"], int)
@@ -99,26 +99,26 @@ class TestBashAsync:
     # 2. poll returns 'running' while command is executing
     def test_poll_returns_running(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "sleep 5", "async": True})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'sleep 5', 'async': True}})
         job_id = result["job_id"]
 
-        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        poll = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "running"
         assert poll["job_id"] == job_id
 
         # Clean up
-        mgr.handle({"action": "cancel", "command": "", "job_id": job_id})
+        mgr.handle({'action': 'cancel', 'input': {'job_id': job_id}})
 
     # 3. poll returns 'done' with output after command finishes
     def test_poll_returns_done_with_output(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "echo async-output", "async": True})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo async-output', 'async': True}})
         job_id = result["job_id"]
 
         # Wait for the fast command to finish
         time.sleep(0.5)
 
-        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        poll = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "done"
         assert "async-output" in poll["stdout"]
         assert "exit_code" in poll
@@ -129,12 +129,12 @@ class TestBashAsync:
     # 3b. poll on a failed async job surfaces the failure explicitly
     def test_poll_nonzero_exit_is_flagged_failed(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "exit 7", "async": True})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'exit 7', 'async': True}})
         job_id = result["job_id"]
 
         time.sleep(0.5)
 
-        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        poll = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "done"
         assert poll["exit_code"] == 7
         assert poll["ok"] is False
@@ -144,24 +144,24 @@ class TestBashAsync:
     # 3c. a still-running poll has no exit_code, so no fidelity fields
     def test_poll_running_has_no_fidelity_fields(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "sleep 5", "async": True})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'sleep 5', 'async': True}})
         job_id = result["job_id"]
 
-        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        poll = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "running"
         assert "ok" not in poll
         assert "command_status" not in poll
 
-        mgr.handle({"action": "cancel", "command": "", "job_id": job_id})
+        mgr.handle({'action': 'cancel', 'input': {'job_id': job_id}})
 
     # 4. cancel kills the process
     def test_cancel_kills_process(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "sleep 60", "async": True})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'sleep 60', 'async': True}})
         job_id = result["job_id"]
         pid = result["pid"]
 
-        cancel = mgr.handle({"action": "cancel", "command": "", "job_id": job_id})
+        cancel = mgr.handle({'action': 'cancel', 'input': {'job_id': job_id}})
         assert cancel["status"] == "cancelled"
         assert cancel["job_id"] == job_id
 
@@ -176,99 +176,98 @@ class TestBashAsync:
         policy_file = tmp_path / "policy.json"
         policy_file.write_text(json.dumps({"deny": ["rm"]}))
         policy = BashPolicy.from_file(str(policy_file))
-        agent = SimpleNamespace(_notification_store=notification_store_for(tmp_path))
+        agent = SimpleNamespace(_notification_store=notification_store_for(tmp_path), _working_dir=tmp_path)
         mgr = BashManager(policy=policy, working_dir=str(tmp_path), agent=agent)
 
-        result = mgr.handle({"command": "rm -rf /", "async": True})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'rm -rf /', 'async': True}})
         assert result["status"] == "error"
         assert "not allowed" in result["message"]
 
     # 6. working_dir validation still applies
     def test_working_dir_validation_applies_to_async(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({
-            "command": "echo hi",
-            "async": True,
-            "working_dir": "/etc",
-        })
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo hi', 'async': True, 'working_dir': '/etc'}})
         assert result["status"] == "error"
         assert "working_dir" in result["message"]
 
     # 7. missing job_id returns error
     def test_poll_missing_job_id(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"action": "poll", "command": ""})
+        result = mgr.handle({'action': 'poll', 'input': {}})
         assert result["status"] == "error"
         assert "job_id is required" in result["message"]
 
     def test_cancel_missing_job_id(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"action": "cancel", "command": ""})
+        result = mgr.handle({'action': 'cancel', 'input': {}})
         assert result["status"] == "error"
         assert "job_id is required" in result["message"]
 
     # 8. double-poll after completion returns error (durable record is consumed)
     def test_double_poll_after_completion(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "echo done", "async": True})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo done', 'async': True}})
         job_id = result["job_id"]
 
         time.sleep(0.5)
 
         # First poll succeeds and durably marks the terminal result consumed.
-        poll1 = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        poll1 = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll1["status"] == "done"
 
         # The record remains for relaunch evidence, but the public result is one-shot.
-        poll2 = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        poll2 = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll2["status"] == "error"
         assert "already finished" in poll2["message"].lower()
 
     def test_poll_nonexistent_job(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"action": "poll", "command": "", "job_id": "job-ffffffffffffffffffffffffffffffff"})
+        result = mgr.handle({'action': 'poll', 'input': {'job_id': 'job-ffffffffffffffffffffffffffffffff'}})
         assert result["status"] == "error"
         assert "not found" in result["message"].lower()
 
     def test_cancel_nonexistent_job(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"action": "cancel", "command": "", "job_id": "job-ffffffffffffffffffffffffffffffff"})
+        result = mgr.handle({'action': 'cancel', 'input': {'job_id': 'job-ffffffffffffffffffffffffffffffff'}})
         assert result["status"] == "error"
         assert "not found" in result["message"].lower()
 
     # Sync path unchanged — default action='run', async=false
     def test_sync_path_unchanged(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "echo sync-test"})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo sync-test'}})
         assert result["status"] == "ok"
         assert result["exit_code"] == 0
         assert "sync-test" in result["stdout"]
 
     def test_sync_ignores_reminder_field(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "echo sync-test", "reminder": float("nan")})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo sync-test', 'reminder': float('nan')}})
         assert result["status"] == "ok"
         assert result["exit_code"] == 0
         assert "sync-test" in result["stdout"]
 
     def test_async_stderr_captured(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "echo err >&2", "async": True})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo err >&2', 'async': True}})
         job_id = result["job_id"]
 
         time.sleep(0.5)
 
-        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        poll = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "done"
         assert "err" in poll["stderr"]
 
-    def test_schema_requires_reminder_with_runtime_default(self, tmp_path):
+    def test_schema_is_canonical_nested_and_reminder_is_run_input(self, tmp_path):
         schema = get_schema()
-        assert "reminder" not in schema["required"]  # manual has no action-specific inputs
-        assert schema["properties"]["reminder"]["default"] == 1800.0
+        assert schema["required"] == ["action", "input"]
+        assert set(schema["properties"]) == {"action", "input"}
+        run_input = schema["properties"]["input"]["anyOf"][0]
+        assert run_input["properties"]["reminder"]["default"] == 1800.0
+        assert run_input["additionalProperties"] is False
 
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "echo compat", "async": True})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo compat', 'async': True}})
         assert result["status"] == "ok"
         assert result["handoff"] == (
             "While waiting, go idle or call system(action='sleep'); the terminal result "
@@ -278,7 +277,7 @@ class TestBashAsync:
             "`telegram(action='manual')` and follow its `Programmable Task Card` "
             "section for details."
         )
-        mgr.handle({"action": "cancel", "command": "", "job_id": result["job_id"]})
+        mgr.handle({'action': 'cancel', 'input': {'job_id': result['job_id']}})
 
     def test_reminder_deadline_starts_at_successful_async_return(self, tmp_path, monkeypatch):
         mgr = self._make_manager(tmp_path)
@@ -291,7 +290,7 @@ class TestBashAsync:
             return real_popen(*args, **kwargs)
 
         monkeypatch.setattr("lingtai.tools.bash.subprocess.Popen", delayed_supervisor_start)
-        started = mgr.handle({"command": "sleep 5", "async": True, "reminder": reminder})
+        started = mgr.handle({'action': 'run', 'input': {'command': 'sleep 5', 'async': True, 'reminder': reminder}})
         returned_at = time.time()
         assert started["status"] == "ok"
 
@@ -303,7 +302,7 @@ class TestBashAsync:
         # return gives the caller the requested interval after supervisor startup.
         assert deadline - state["created_at"] >= startup_delay + reminder * 0.5
         assert deadline - returned_at >= reminder * 0.5
-        mgr.handle({"action": "cancel", "job_id": started["job_id"]})
+        mgr.handle({'action': 'cancel', 'input': {'job_id': started['job_id']}})
 
     @pytest.mark.parametrize(
         "value",
@@ -320,13 +319,13 @@ class TestBashAsync:
     )
     def test_async_reminder_rejects_invalid_values(self, tmp_path, value):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "echo nope", "async": True, "reminder": value})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo nope', 'async': True, 'reminder': value}})
         assert result["status"] == "error"
         assert "reminder" in result["message"]
 
     def test_completed_unpolled_job_uses_completion_wake_without_stale_reminder(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "echo finished", "async": True, "reminder": 0.05})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo finished', 'async': True, 'reminder': 0.05}})
         job_id = result["job_id"]
 
         time.sleep(0.3)
@@ -336,13 +335,13 @@ class TestBashAsync:
         assert notifications["bash"]["data"]["job_id"] == job_id
         assert notifications["bash"]["data"]["exit_code"] == 0
 
-        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        poll = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "done"
 
     def test_async_reminder_does_not_overwrite_close_due_jobs(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        first = mgr.handle({"command": "sleep 1", "async": True, "reminder": 0.05})
-        second = mgr.handle({"command": "sleep 1", "async": True, "reminder": 0.05})
+        first = mgr.handle({'action': 'run', 'input': {'command': 'sleep 1', 'async': True, 'reminder': 0.05}})
+        second = mgr.handle({'action': 'run', 'input': {'command': 'sleep 1', 'async': True, 'reminder': 0.05}})
         job_ids = {first["job_id"], second["job_id"]}
 
         time.sleep(0.3)
@@ -355,15 +354,15 @@ class TestBashAsync:
         assert len({event["event_id"] for event in events}) == 2
 
         for job_id in job_ids:
-            mgr.handle({"action": "cancel", "command": "", "job_id": job_id})
+            mgr.handle({'action': 'cancel', 'input': {'job_id': job_id}})
 
     def test_terminal_poll_suppresses_async_reminder(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "echo handled", "async": True, "reminder": 0.3})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo handled', 'async': True, 'reminder': 0.3}})
         job_id = result["job_id"]
 
         time.sleep(0.1)
-        poll = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        poll = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "done"
         time.sleep(0.3)
 
@@ -371,17 +370,12 @@ class TestBashAsync:
 
     def test_successful_cancel_suppresses_async_reminder(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "sleep 5", "async": True, "reminder": 0.2})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'sleep 5', 'async': True, 'reminder': 0.2}})
         job_id = result["job_id"]
 
-        cancel = mgr.handle({
-            "action": "cancel",
-            "command": "",
-            "job_id": job_id,
-            "reminder": float("nan"),
-        })
+        cancel = mgr.handle({'action': 'cancel', 'input': {'job_id': job_id}})
         assert cancel["status"] == "cancelled"
-        consumed = mgr.handle({"action": "poll", "command": "", "job_id": job_id})
+        consumed = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert consumed["status"] == "error"
         assert "cancelled" in consumed["message"].lower()
         time.sleep(0.3)
@@ -390,18 +384,13 @@ class TestBashAsync:
 
     def test_poll_ignores_reminder_field(self, tmp_path):
         mgr = self._make_manager(tmp_path)
-        result = mgr.handle({"command": "sleep 5", "async": True, "reminder": 10})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'sleep 5', 'async': True, 'reminder': 10}})
         job_id = result["job_id"]
 
-        poll = mgr.handle({
-            "action": "poll",
-            "command": "",
-            "job_id": job_id,
-            "reminder": float("nan"),
-        })
+        poll = mgr.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "running"
 
-        mgr.handle({"action": "cancel", "command": "", "job_id": job_id})
+        mgr.handle({'action': 'cancel', 'input': {'job_id': job_id}})
 
     def test_terminal_pop_before_deadline_claim_suppresses_reminder(self, tmp_path, monkeypatch):
         mgr = self._make_manager(tmp_path)
@@ -445,7 +434,7 @@ class TestBashAsync:
 
     def test_agent_exception_fallback_uses_injected_store(self, tmp_path):
         store = notification_store_for(tmp_path)
-        agent = SimpleNamespace(_notification_store=store)
+        agent = SimpleNamespace(_notification_store=store, _working_dir=tmp_path)
 
         def failing_enqueue(**_kwargs):
             raise RuntimeError("boom")
@@ -463,7 +452,7 @@ class TestBashAsync:
         assert events[0]["ref_id"] == "bash.reminder:job-fallback"
 
     def test_direct_manager_fallback_is_serialized_by_shared_store(self, tmp_path):
-        agent = SimpleNamespace(_notification_store=notification_store_for(tmp_path))
+        agent = SimpleNamespace(_notification_store=notification_store_for(tmp_path), _working_dir=tmp_path)
         first = BashManager(
             policy=BashPolicy.yolo(), working_dir=str(tmp_path), agent=agent
         )
@@ -523,7 +512,7 @@ class TestBashAsyncRelaunchDurability:
         return BashManager(
             policy=BashPolicy.yolo(),
             working_dir=str(tmp_path),
-            agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path)),
+            agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path), _working_dir=tmp_path),
         )
 
     @staticmethod
@@ -582,7 +571,7 @@ class TestBashAsyncRelaunchDurability:
         self, tmp_path, command, expected
     ):
         first = self._manager(tmp_path)
-        started = first.handle({"command": command, "async": True, "reminder": 30})
+        started = first.handle({'action': 'run', 'input': {'command': command, 'async': True, 'reminder': 30}})
         job_id = started["job_id"]
         job_dir = tmp_path / "system" / "jobs" / job_id
 
@@ -594,7 +583,7 @@ class TestBashAsyncRelaunchDurability:
         # A new manager has no Popen handle and must use the supervisor's durable
         # terminal result rather than inferring a false -1 failure from a dead PID.
         relaunched = self._manager(tmp_path)
-        poll = relaunched.handle({"action": "poll", "job_id": job_id})
+        poll = relaunched.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "done"
         assert poll["exit_status_known"] is True
         assert poll["exit_code"] == expected
@@ -614,12 +603,15 @@ root = Path(sys.argv[1])
 manager = BashManager(
     policy=BashPolicy.yolo(),
     working_dir=str(root),
-    agent=SimpleNamespace(_notification_store=notification_store_for(root)),
+    agent=SimpleNamespace(_notification_store=notification_store_for(root), _working_dir=root),
 )
 print(json.dumps(manager.handle({
-    "command": "sleep 0.2; exit 17",
-    "async": True,
-    "reminder": 30,
+    "action": "run",
+    "input": {
+        "command": "sleep 0.2; exit 17",
+        "async": True,
+        "reminder": 30,
+    },
 })), flush=True)
 """
         launched = subprocess.run(
@@ -638,7 +630,7 @@ print(json.dumps(manager.handle({
         )
 
         relaunched = self._manager(tmp_path)
-        poll = relaunched.handle({"action": "poll", "job_id": job_id})
+        poll = relaunched.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "done"
         assert poll["exit_status_known"] is True
         assert poll["exit_code"] == 17
@@ -672,8 +664,8 @@ print(json.dumps(manager.handle({
 
     def test_rehydrated_terminal_poll_and_cancel_suppress_reminders(self, tmp_path):
         first = self._manager(tmp_path)
-        completed = first.handle({"command": "exit 0", "async": True, "reminder": 0.2})
-        cancelled = first.handle({"command": "sleep 5", "async": True, "reminder": 0.2})
+        completed = first.handle({'action': 'run', 'input': {'command': 'exit 0', 'async': True, 'reminder': 0.2}})
+        cancelled = first.handle({'action': 'run', 'input': {'command': 'sleep 5', 'async': True, 'reminder': 0.2}})
         completed_dir = tmp_path / "system" / "jobs" / completed["job_id"]
 
         self._wait_for(
@@ -682,9 +674,9 @@ print(json.dumps(manager.handle({
         )
 
         relaunched = self._manager(tmp_path)
-        poll = relaunched.handle({"action": "poll", "job_id": completed["job_id"]})
+        poll = relaunched.handle({'action': 'poll', 'input': {'job_id': completed['job_id']}})
         assert poll["status"] == "done"
-        cancel = relaunched.handle({"action": "cancel", "job_id": cancelled["job_id"]})
+        cancel = relaunched.handle({'action': 'cancel', 'input': {'job_id': cancelled['job_id']}})
         assert cancel["status"] == "cancelled"
 
         time.sleep(0.3)
@@ -704,7 +696,7 @@ print(json.dumps(manager.handle({
         (job_dir / "stdout.log").write_text("")
         (job_dir / "stderr.log").write_text("")
 
-        poll = self._manager(tmp_path).handle({"action": "poll", "job_id": job_id})
+        poll = self._manager(tmp_path).handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert poll["status"] == "done"
         assert poll["exit_status_known"] is False
         assert poll["exit_code"] is None
@@ -726,12 +718,12 @@ print(json.dumps(manager.handle({
             (job_dir / "stderr.log").write_text("")
 
             manager = self._manager(tmp_path)
-            poll = manager.handle({"action": "poll", "job_id": job_id})
+            poll = manager.handle({'action': 'poll', 'input': {'job_id': job_id}})
             assert poll["status"] == "running"
             assert poll["pid"] == proc.pid
             assert "cancellation is unavailable" in poll["message"]
 
-            cancel = manager.handle({"action": "cancel", "job_id": job_id})
+            cancel = manager.handle({'action': 'cancel', 'input': {'job_id': job_id}})
             assert cancel["status"] == "error"
             assert "legacy" in cancel["message"].lower()
             os.kill(proc.pid, 0)
@@ -758,7 +750,7 @@ print(json.dumps(manager.handle({
             (job_dir / "status").write_text("running")
             (job_dir / "pid").write_text(str(proc.pid))
 
-            result = self._manager(tmp_path).handle({"action": "cancel", "job_id": job_id})
+            result = self._manager(tmp_path).handle({'action': 'cancel', 'input': {'job_id': job_id}})
             assert result["status"] == "error"
             assert "identity" in result["message"].lower()
             os.kill(proc.pid, 0)
@@ -778,7 +770,7 @@ print(json.dumps(manager.handle({
         manager = BashManager(
             policy=BashPolicy.yolo(),
             working_dir=str(tmp_path),
-            agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path)),
+            agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path), _working_dir=tmp_path),
             async_process=RecordingProcessPort(),
         )
         neutral = ProcessRef(77, "adapter-owned-incarnation")
@@ -799,7 +791,7 @@ print(json.dumps(manager.handle({
         manager = BashManager(
             policy=BashPolicy.yolo(),
             working_dir=str(tmp_path),
-            agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path)),
+            agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path), _working_dir=tmp_path),
             async_process=UnknownProcessPort(),
         )
         job_id = "job-11111111111111111111111111111112"
@@ -814,7 +806,7 @@ print(json.dumps(manager.handle({
         })
         _async_supervisor.write_initial_state(job_dir, state)
 
-        result = manager.handle({"action": "cancel", "job_id": job_id})
+        result = manager.handle({'action': 'cancel', 'input': {'job_id': job_id}})
         assert result["status"] == "error"
         assert "cannot be verified" in result["message"]
         recovered = json.loads((job_dir / "state.json").read_text())
@@ -850,7 +842,7 @@ print(json.dumps(manager.handle({
         manager = BashManager(
             policy=BashPolicy.yolo(),
             working_dir=str(tmp_path),
-            agent=SimpleNamespace(_notification_store=store),
+            agent=SimpleNamespace(_notification_store=store, _working_dir=tmp_path),
         )
         assert store.writes == 1
 
@@ -869,7 +861,7 @@ class TestBashAsyncTerminalRaces:
         return BashManager(
             policy=BashPolicy.yolo(),
             working_dir=str(tmp_path),
-            agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path)),
+            agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path), _working_dir=tmp_path),
         )
 
     @staticmethod
@@ -920,29 +912,27 @@ class TestBashAsyncTerminalRaces:
         # The command has exited, but its live recorded supervisor is paused before
         # the exact wait status commit.  This must remain recoverable, not consume
         # an unknown terminal response.
-        pending = manager.handle({"action": "poll", "job_id": job_id})
+        pending = manager.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert pending["status"] == "running"
         assert json.loads((job_dir / "state.json").read_text())["terminal_polled"] is False
 
         release_commit.set()
         worker.join(timeout=2)
         assert not worker.is_alive()
-        terminal = manager.handle({"action": "poll", "job_id": job_id})
+        terminal = manager.handle({'action': 'poll', 'input': {'job_id': job_id}})
         assert terminal["status"] == "done"
         assert terminal["exit_status_known"] is True
         assert terminal["exit_code"] == 23
 
     def test_term_ignoring_group_is_killed_by_supervisor_before_cancelled(self, tmp_path):
         manager = self._manager(tmp_path)
-        started = manager.handle({
-            "command": "trap '' TERM; while :; do sleep 1; done",
-            "async": True,
-            "reminder": 30,
-        })
+        started = manager.handle({'action': 'run', 'input': {'command': "trap '' TERM; while :; do sleep 1; done", 'async': True, 'reminder': 30}})
         began = time.monotonic()
-        cancelled = manager.handle({"action": "cancel", "job_id": started["job_id"]})
+        cancelled = manager.handle({'action': 'cancel', 'input': {'job_id': started['job_id']}})
         elapsed = time.monotonic() - began
-        assert cancelled == {"status": "cancelled", "job_id": started["job_id"]}
+        assert cancelled["status"] == "cancelled"
+        assert cancelled["job_id"] == started["job_id"]
+        assert cancelled["current_setting"]["source"] == "missing"
         # The supervisor grants TERM a bounded interval before escalating to KILL.
         assert elapsed >= 0.35
         state = json.loads(
@@ -955,14 +945,7 @@ class TestBashAsyncTerminalRaces:
 
     def test_outer_shell_exit_does_not_leave_term_ignoring_descendant(self, tmp_path):
         manager = self._manager(tmp_path)
-        started = manager.handle({
-            "command": (
-                "sh -c 'trap \"\" TERM; echo $$ > descendant.pid; "
-                ": > descendant.ready; while :; do sleep 1; done' & wait $!"
-            ),
-            "async": True,
-            "reminder": 30,
-        })
+        started = manager.handle({'action': 'run', 'input': {'command': 'sh -c \'trap "" TERM; echo $$ > descendant.pid; : > descendant.ready; while :; do sleep 1; done\' & wait $!', 'async': True, 'reminder': 30}})
         descendant_file = tmp_path / "descendant.pid"
         descendant_ready = tmp_path / "descendant.ready"
         deadline = time.monotonic() + 2
@@ -974,8 +957,10 @@ class TestBashAsyncTerminalRaces:
         assert descendant_file.exists()
         descendant_pid = int(descendant_file.read_text().strip())
 
-        cancelled = manager.handle({"action": "cancel", "job_id": started["job_id"]})
-        assert cancelled == {"status": "cancelled", "job_id": started["job_id"]}
+        cancelled = manager.handle({'action': 'cancel', 'input': {'job_id': started['job_id']}})
+        assert cancelled["status"] == "cancelled"
+        assert cancelled["job_id"] == started["job_id"]
+        assert cancelled["current_setting"]["source"] == "missing"
         deadline = time.monotonic() + 2
         while _posix_process_is_alive(descendant_pid) and time.monotonic() < deadline:
             time.sleep(0.01)
@@ -1024,9 +1009,7 @@ class TestBashAsyncTerminalRaces:
         monkeypatch.setattr(
             "lingtai.tools.bash.subprocess.Popen", launch_with_wrong_start_token
         )
-        started = manager.handle({
-            "command": "echo must-not-run", "async": True, "reminder": 30,
-        })
+        started = manager.handle({'action': 'run', 'input': {'command': 'echo must-not-run', 'async': True, 'reminder': 30}})
         assert started["status"] == "error"
         job_dirs = list((tmp_path / "system" / "jobs").iterdir())
         assert len(job_dirs) == 1
@@ -1208,9 +1191,7 @@ class TestBashAsyncTerminalRaces:
         outcome = {}
 
         def start_job():
-            outcome["result"] = manager_a.handle({
-                "command": "sleep 5", "async": True, "reminder": reminder,
-            })
+            outcome["result"] = manager_a.handle({'action': 'run', 'input': {'command': 'sleep 5', 'async': True, 'reminder': reminder}})
             outcome["returned_at"] = time.time()
 
         starter = threading.Thread(target=start_job)
@@ -1242,7 +1223,7 @@ class TestBashAsyncTerminalRaces:
             returned_at + reminder
         )
         assert returned_at <= outcome["returned_at"]
-        manager_a.handle({"action": "cancel", "job_id": outcome["result"]["job_id"]})
+        manager_a.handle({'action': 'cancel', 'input': {'job_id': outcome['result']['job_id']}})
 
     def test_return_handoff_blocks_fallback_after_running_before_return_arm(
         self, tmp_path, monkeypatch
@@ -1278,9 +1259,7 @@ class TestBashAsyncTerminalRaces:
         outcome = {}
 
         def start_job():
-            outcome["result"] = manager_a.handle({
-                "command": "sleep 5", "async": True, "reminder": reminder,
-            })
+            outcome["result"] = manager_a.handle({'action': 'run', 'input': {'command': 'sleep 5', 'async': True, 'reminder': reminder}})
             outcome["returned_at"] = time.time()
 
         starter = threading.Thread(target=start_job)
@@ -1314,7 +1293,7 @@ class TestBashAsyncTerminalRaces:
             returned_at + reminder
         )
         assert returned_at <= outcome["returned_at"]
-        manager_a.handle({"action": "cancel", "job_id": outcome["result"]["job_id"]})
+        manager_a.handle({'action': 'cancel', 'input': {'job_id': outcome['result']['job_id']}})
 
     def test_owner_resuming_after_handoff_expiry_cannot_report_start_success(
         self, tmp_path, monkeypatch
@@ -1346,9 +1325,7 @@ class TestBashAsyncTerminalRaces:
         outcome = {}
 
         def start_job():
-            outcome["result"] = manager_a.handle({
-                "command": "sleep 5", "async": True, "reminder": 0.02,
-            })
+            outcome["result"] = manager_a.handle({'action': 'run', 'input': {'command': 'sleep 5', 'async': True, 'reminder': 0.02}})
 
         starter = threading.Thread(target=start_job)
         starter.start()
@@ -1388,7 +1365,7 @@ class TestBashAsyncTerminalRaces:
         assert final["return_handoff"]["state"] == "expired"
         assert final["reminder"]["state"] == "published"
         assert published == [job_dir.name]
-        manager_a.handle({"action": "cancel", "job_id": job_dir.name})
+        manager_a.handle({'action': 'cancel', 'input': {'job_id': job_dir.name}})
 
     def test_expired_suppressing_reminder_recovers_after_manager_crash(
         self, tmp_path, monkeypatch
@@ -1434,7 +1411,7 @@ class TestBashAsyncTerminalRaces:
 
         with ThreadPoolExecutor(max_workers=2) as pool:
             results = list(pool.map(
-                lambda manager: manager.handle({"action": "poll", "job_id": job_id}),
+                lambda manager: manager.handle({'action': 'poll', 'input': {'job_id': job_id}}),
                 managers,
             ))
 
@@ -1477,7 +1454,7 @@ class TestBashAsyncTerminalRaces:
         values = iter((SimpleNamespace(hex=existing), SimpleNamespace(hex=replacement)))
         monkeypatch.setattr("lingtai.tools.bash.uuid.uuid4", lambda: next(values))
 
-        started = manager.handle({"command": "exit 0", "async": True, "reminder": 30})
+        started = manager.handle({'action': 'run', 'input': {'command': 'exit 0', 'async': True, 'reminder': 30}})
         assert started["job_id"] == f"job-{replacement}"
         assert len(started["job_id"]) == 36
         assert manager._validate_job_id(started["job_id"]) is None

--- a/tests/test_bash_shell_dialect.py
+++ b/tests/test_bash_shell_dialect.py
@@ -26,7 +26,7 @@ def manager(tmp_path, dialect=None, policy=None):
     return BashManager(
         policy=policy or BashPolicy.yolo(),
         working_dir=str(tmp_path),
-        agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path)),
+        agent=SimpleNamespace(_notification_store=notification_store_for(tmp_path), _working_dir=tmp_path),
         dialect=dialect,
     )
 
@@ -114,14 +114,14 @@ def test_selected_dialect_drives_policy_and_sync_execution(tmp_path):
     dialect = MarkerDialect()
     policy = BashPolicy(deny=["blocked"])
     mgr = manager(tmp_path, dialect=dialect, policy=policy)
-    assert mgr.handle({"command": "marker"})["status"] == "error"
-    result = mgr.handle({"command": "echo"})
+    assert mgr.handle({'action': 'run', 'input': {'command': 'marker'}})["status"] == "error"
+    result = mgr.handle({'action': 'run', 'input': {'command': 'echo'}})
     assert result["stdout"] == "dialect-marker"
 
 
 def test_async_state_persists_dialect_invocation_and_raw_command(tmp_path):
     mgr = manager(tmp_path, dialect=MarkerDialect())
-    started = mgr.handle({"command": "echo original", "async": True, "reminder": 30})
+    started = mgr.handle({'action': 'run', 'input': {'command': 'echo original', 'async': True, 'reminder': 30}})
     assert started["status"] == "ok"
     state_path = tmp_path / "system" / "jobs" / started["job_id"] / "state.json"
     state = json.loads(state_path.read_text())
@@ -133,7 +133,7 @@ def test_async_state_persists_dialect_invocation_and_raw_command(tmp_path):
         if json.loads(state_path.read_text()).get("status") == "completed":
             break
         time.sleep(0.02)
-    result = mgr.handle({"action": "poll", "job_id": started["job_id"]})
+    result = mgr.handle({'action': 'poll', 'input': {'job_id': started['job_id']}})
     assert result["status"] == "done"
     assert result["stdout"] == "dialect-marker"
 

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -71,7 +71,7 @@ def test_manual_actions_return_their_installed_skills(tmp_path: Path) -> None:
     web_manager = web_tool.setup(agent)
 
     calls = {
-        "shell": ("shell", lambda: shell_manager.handle({"action": "manual"})),
+        "shell": ("shell", lambda: shell_manager.handle({"action": "manual", "input": {}})),
         "daemon": ("daemon", lambda: daemon_manager.handle({"action": "manual"})),
         "email": ("email", lambda: email_tool.handle(agent, {"action": "manual"})),
         "psyche": ("psyche-manual", lambda: psyche_tool.handle(agent, {"action": "manual"})),
@@ -94,6 +94,11 @@ def test_manual_actions_return_their_installed_skills(tmp_path: Path) -> None:
             assert result["manual"] == body
             assert result["manual_path"] == str(path)
             assert isinstance(result["current_setting"], dict)
+        elif tool_name == "shell":
+            assert result["status"] == "ok"
+            assert result["manual"] == body
+            assert result["manual_path"] == str(path)
+            assert result["current_setting"]["source"] == "missing"
         else:
             assert result == {
                 "status": "ok",
@@ -124,7 +129,10 @@ def test_manual_schemas_preserve_runtime_checks_for_ordinary_file_calls(
         action = schema["properties"]["action"]
         assert "manual" in action.get("enum", ()) or "manual" in action["description"]
 
-    assert shell_tool.get_schema()["required"] == []
+    shell_schema = shell_tool.get_schema()
+    assert shell_schema["required"] == ["action", "input"]
+    assert set(shell_schema["properties"]) == {"action", "input"}
+    assert len(shell_schema["properties"]["input"]["anyOf"]) == 4
     assert psyche_tool.get_schema()["required"] == ["action"]
     web_schema = web_tool.get_schema()
     assert web_schema["required"] == ["action", "input"]

--- a/tests/test_layers_bash.py
+++ b/tests/test_layers_bash.py
@@ -20,6 +20,9 @@ from lingtai.tools.bash import (
 class _SyncOnlyAgent:
     """Strict stand-in for manager tests that exercise only synchronous runs."""
 
+    def __init__(self, working_dir: Path | str = "/tmp"):
+        self._working_dir = Path(working_dir)
+
 
 # ---------------------------------------------------------------------------
 # BashPolicy
@@ -104,14 +107,14 @@ class TestBashPolicy:
 class TestBashManager:
     def test_echo(self):
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
-        result = mgr.handle({"command": "echo hello"})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo hello'}})
         assert result["status"] == "ok"
         assert result["exit_code"] == 0
         assert "hello" in result["stdout"]
 
     def test_nonexistent_command(self):
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
-        result = mgr.handle({"command": "definitely_not_a_real_command_xyz"})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'definitely_not_a_real_command_xyz'}})
         # status stays "ok" — it reflects that the shell spawned, not that the
         # inner command succeeded (preserving the existing executor contract).
         assert result["status"] == "ok"
@@ -121,7 +124,7 @@ class TestBashManager:
 
     def test_success_is_marked_ok(self):
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
-        result = mgr.handle({"command": "echo hi"})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo hi'}})
         assert result["exit_code"] == 0
         assert result["ok"] is True
         assert result["command_status"] == "success"
@@ -130,7 +133,7 @@ class TestBashManager:
 
     def test_nonzero_exit_is_flagged_failed_with_warning(self):
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
-        result = mgr.handle({"command": "exit 3"})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'exit 3'}})
         # status unchanged, but the failure is now impossible to miss.
         assert result["status"] == "ok"
         assert result["exit_code"] == 3
@@ -141,7 +144,7 @@ class TestBashManager:
     def test_warning_includes_stderr_tail(self):
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
         result = mgr.handle(
-            {"command": "echo boom-marker 1>&2; exit 1"}
+            {'action': 'run', 'input': {'command': 'echo boom-marker 1>&2; exit 1'}}
         )
         assert result["ok"] is False
         assert "boom-marker" in result["warning"]
@@ -150,7 +153,7 @@ class TestBashManager:
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
         # A real interpreter traceback exits nonzero and prints to stderr.
         result = mgr.handle(
-            {"command": "python3 -c 'raise ValueError(\"x\")'"}
+            {'action': 'run', 'input': {'command': 'python3 -c \'raise ValueError("x")\''}}
         )
         assert result["ok"] is False
         assert result["command_status"] == "failed"
@@ -159,7 +162,7 @@ class TestBashManager:
     def test_missing_module_is_detected(self):
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
         result = mgr.handle(
-            {"command": "python3 -c 'import lingtai.kernel_does_not_exist_xyz'"}
+            {'action': 'run', 'input': {'command': "python3 -c 'import lingtai.kernel_does_not_exist_xyz'"}}
         )
         assert result["ok"] is False
         assert "missing_module" in result["warning"]
@@ -169,9 +172,7 @@ class TestBashManager:
         # stdout — flag it as suspicious without claiming the command failed.
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
         result = mgr.handle(
-            {
-                "command": "python3 -c 'raise ValueError(1)' 2>&1 | cat; true"
-            }
+            {'action': 'run', 'input': {'command': "python3 -c 'raise ValueError(1)' 2>&1 | cat; true"}}
         )
         assert result["exit_code"] == 0
         assert result["ok"] is True
@@ -181,12 +182,12 @@ class TestBashManager:
 
     def test_empty_command(self):
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
-        result = mgr.handle({"command": ""})
+        result = mgr.handle({'action': 'run', 'input': {'command': ''}})
         assert result["status"] == "error"
 
     def test_timeout(self):
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
-        result = mgr.handle({"command": "sleep 10", "timeout": 0.5})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'sleep 10', 'timeout': 0.5}})
         assert result["status"] == "error"
         assert "timed out" in result["message"]
         # A plain sleep is not a broad scan — no recipe hint appended.
@@ -195,12 +196,7 @@ class TestBashManager:
     def test_timeout_on_broad_find_appends_rg_hint(self):
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp")
         result = mgr.handle(
-            {
-                "command": (
-                    "sleep 10; find /Users/x/work -name '*.py' -type f"
-                ),
-                "timeout": 0.5,
-            }
+            {'action': 'run', 'input': {'command': "sleep 10; find /Users/x/work -name '*.py' -type f", 'timeout': 0.5}}
         )
         assert result["status"] == "error"
         assert "timed out" in result["message"]
@@ -211,7 +207,7 @@ class TestBashManager:
         policy_file.write_text(json.dumps({"deny": ["rm"]}))
         policy = BashPolicy.from_file(str(policy_file))
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=policy, working_dir="/tmp")
-        result = mgr.handle({"command": "rm -rf /"})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'rm -rf /'}})
         assert result["status"] == "error"
         assert "not allowed" in result["message"]
 
@@ -220,27 +216,27 @@ class TestBashManager:
         policy_file.write_text(json.dumps({"allow": ["echo", "ls"]}))
         policy = BashPolicy.from_file(str(policy_file))
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=policy, working_dir="/tmp")
-        result = mgr.handle({"command": "echo ok"})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'echo ok'}})
         assert result["status"] == "ok"
 
     def test_working_dir(self, tmp_path):
-        mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir=str(tmp_path))
-        result = mgr.handle({"command": "pwd"})
+        mgr = BashManager(agent=_SyncOnlyAgent(tmp_path), policy=BashPolicy.yolo(), working_dir=str(tmp_path))
+        result = mgr.handle({'action': 'run', 'input': {'command': 'pwd'}})
         assert result["status"] == "ok"
         assert str(tmp_path) in result["stdout"]
 
     def test_working_dir_empty_string_defaults_to_agent_dir(self, tmp_path):
         # An empty-string working_dir is treated as unset and runs in the
         # agent working directory rather than failing the sandbox check.
-        mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir=str(tmp_path))
-        result = mgr.handle({"command": "pwd", "working_dir": ""})
+        mgr = BashManager(agent=_SyncOnlyAgent(tmp_path), policy=BashPolicy.yolo(), working_dir=str(tmp_path))
+        result = mgr.handle({'action': 'run', 'input': {'command': 'pwd', 'working_dir': ''}})
         assert result["status"] == "ok"
         assert str(tmp_path) in result["stdout"]
 
     def test_working_dir_whitespace_only_defaults_to_agent_dir(self, tmp_path):
         # Whitespace-only working_dir is also treated as unset.
-        mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir=str(tmp_path))
-        result = mgr.handle({"command": "pwd", "working_dir": "   "})
+        mgr = BashManager(agent=_SyncOnlyAgent(tmp_path), policy=BashPolicy.yolo(), working_dir=str(tmp_path))
+        result = mgr.handle({'action': 'run', 'input': {'command': 'pwd', 'working_dir': '   '}})
         assert result["status"] == "ok"
         assert str(tmp_path) in result["stdout"]
 
@@ -249,9 +245,9 @@ class TestBashManager:
         external = tmp_path / "external"
         sandbox.mkdir()
         external.mkdir()
-        mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir=str(sandbox))
+        mgr = BashManager(agent=_SyncOnlyAgent(sandbox), policy=BashPolicy.yolo(), working_dir=str(sandbox))
 
-        result = mgr.handle({"command": "pwd", "working_dir": str(external)})
+        result = mgr.handle({'action': 'run', 'input': {'command': 'pwd', 'working_dir': str(external)}})
 
         assert result["status"] == "error"
         assert "under agent working directory" in result["message"]
@@ -259,7 +255,7 @@ class TestBashManager:
         assert str(external.resolve()) in result["message"]
 
     def test_schema_documents_working_dir_sandbox_and_cd_workaround(self):
-        desc = get_schema("en")["properties"]["working_dir"]["description"]
+        desc = get_schema("en")["properties"]["input"]["anyOf"][0]["properties"]["working_dir"]["description"]
 
         assert "agent working directory sandbox" in desc
         assert "paths outside" in desc
@@ -267,7 +263,7 @@ class TestBashManager:
 
     def test_output_truncation(self):
         mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir="/tmp", max_output=20)
-        result = mgr.handle({"command": "echo 'a very long output string that exceeds the limit'"})
+        result = mgr.handle({'action': 'run', 'input': {'command': "echo 'a very long output string that exceeds the limit'"}})
         assert "truncated" in result["stdout"]
 
 

--- a/tests/test_shell_action_input_candidate.py
+++ b/tests/test_shell_action_input_candidate.py
@@ -1,0 +1,331 @@
+"""Independent candidate contract tests for the canonical ``shell`` tool.
+
+The suite exercises the raw schema, actual Agent/provider surfaces, real manual
+and settings readers, strict direct-call validation, and ToolExecutor's nested
+summary boundary. Run/poll/cancel implementation seams are always patched: this
+module never launches a child, supervisor, timer, scheduler, or notification.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+from uuid import uuid4
+
+_ROOT = Path(__file__).resolve().parents[1]
+_CANDIDATE_SRC = (_ROOT / "src").resolve()
+sys.path.insert(0, str(_CANDIDATE_SRC))
+for _module_name in tuple(sys.modules):
+    if _module_name == "lingtai" or _module_name.startswith("lingtai."):
+        del sys.modules[_module_name]
+
+from lingtai.agent import Agent
+from lingtai.kernel.llm.base import WIRE_TOOL_DESCRIPTION, ToolCall
+from lingtai.kernel.loop_guard import LoopGuard
+from lingtai.kernel.tool_executor import ToolExecutor
+from lingtai.llm.anthropic.adapter import _build_tools as build_anthropic_tools
+from lingtai.llm.openai.adapter import (
+    _build_responses_tools,
+    _build_tools as build_chat_tools,
+)
+from lingtai.tools import registry as tool_registry
+from lingtai.tools.bash import ShellManager, get_description, get_schema
+from tests._service_helpers import make_gemini_mock_service
+
+
+_ARTIFACT_ROOT = _ROOT / "artifacts" / "shell-action-input-parent" / "committed-test-runs"
+
+
+def _persistent_root(label: str) -> Path:
+    root = _ARTIFACT_ROOT / f"{label}-{uuid4().hex}"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _agent(label: str) -> Agent:
+    root = _persistent_root(label)
+    return Agent(
+        service=make_gemini_mock_service(),
+        agent_name="shell-action-input-test",
+        working_dir=root / "agent",
+        capabilities={"shell": {"yolo": True}},
+    )
+
+
+def _manager(agent: Agent) -> ShellManager:
+    manager = agent.get_capability("shell")
+    assert isinstance(manager, ShellManager)
+    return manager
+
+
+def _write_manual(agent: Agent, marker: str = "# Shell Manual\ncanonical-shell-manual-marker\n") -> Path:
+    path = agent.working_dir / ".library" / "intrinsic" / "capabilities" / "shell" / "SKILL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(marker, encoding="utf-8")
+    return path
+
+
+def _write_settings(agent: Agent, text: str) -> Path:
+    path = agent.working_dir / "settings" / "shell.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _without_setting(value: dict) -> dict:
+    return {key: item for key, item in value.items() if key != "current_setting"}
+
+
+def _make_executor(agent: Agent, *, events, summarizer):
+    def logger(event_type, **fields):
+        events.append((event_type, fields))
+
+    def make_tool_result(name, result, **kwargs):
+        return {"role": "tool", "name": name, "content": result, **kwargs}
+
+    return ToolExecutor(
+        dispatch_fn=agent._dispatch_tool,
+        make_tool_result_fn=make_tool_result,
+        guard=LoopGuard(),
+        known_tools={"shell"},
+        logger_fn=logger,
+        working_dir=agent.working_dir,
+        summarizer_fn=summarizer,
+        parallel_safe_tools=set(),
+    )
+
+
+def _event_index(events, event_type: str, call_id: str) -> int | None:
+    for index, (kind, fields) in enumerate(events):
+        if kind == event_type and fields.get("tool_call_id") == call_id:
+            return index
+    return None
+
+
+class TestShellActionInputCandidate(unittest.TestCase):
+    def test_raw_schema_is_closed_and_preserves_nested_summary(self):
+        schema = get_schema()
+        self.assertEqual(set(schema), {"type", "properties", "required", "additionalProperties"})
+        self.assertEqual(set(schema["properties"]), {"action", "input"})
+        self.assertEqual(schema["required"], ["action", "input"])
+        self.assertIs(schema["additionalProperties"], False)
+        self.assertEqual(schema["properties"]["action"]["enum"], ["run", "poll", "cancel", "manual"])
+        self.assertNotIn("reasoning", schema["properties"])
+        self.assertNotIn("summary", schema["properties"])
+
+        branches = {branch["title"]: branch for branch in schema["properties"]["input"]["anyOf"]}
+        self.assertEqual(set(branches), {"run input", "poll input", "cancel input", "manual input"})
+        run = branches["run input"]
+        self.assertEqual(
+            set(run["properties"]),
+            {"command", "timeout", "working_dir", "async", "reminder", "summary"},
+        )
+        self.assertEqual(run["required"], ["command"])
+        self.assertIs(run["additionalProperties"], False)
+        self.assertEqual(run["properties"]["summary"]["type"], "boolean")
+        self.assertIs(run["properties"]["summary"]["default"], False)
+        self.assertEqual(branches["poll input"]["required"], ["job_id"])
+        self.assertEqual(branches["cancel input"]["required"], ["job_id"])
+        self.assertEqual(branches["manual input"]["properties"], {})
+        for branch in branches.values():
+            self.assertIs(branch["additionalProperties"], False)
+
+    def test_actual_agent_origin_schema_prompt_and_provider_envelopes(self):
+        agent = _agent("agent-surface")
+        try:
+            manager = _manager(agent)
+            schema = next(item for item in agent._build_tool_schemas() if item.name == "shell")
+            self.assertEqual(tool_registry.BUILTIN_TOOLS["shell"], "lingtai.tools.bash")
+            self.assertEqual(set(schema.parameters["properties"]), {"action", "input", "reasoning"})
+            self.assertEqual(schema.parameters["required"], ["action", "input"])
+            self.assertIs(schema.parameters["additionalProperties"], False)
+            self.assertEqual(Path(sys.modules["lingtai.tools.bash"].__file__).resolve(), (_ROOT / "src/lingtai/tools/bash/__init__.py").resolve())
+            self.assertEqual(manager.handle.__code__.co_filename, str((_ROOT / "src/lingtai/tools/bash/__init__.py").resolve()))
+
+            prompt = agent._build_system_prompt()
+            self.assertIn("### shell", prompt)
+            self.assertIn("Execute a shell command and return stdout/stderr.", prompt)
+            self.assertIn("input.summary=true", prompt)
+            self.assertIn("input.summary=true", get_description())
+
+            chat = build_chat_tools([schema])[0]
+            responses = _build_responses_tools([schema])[0]
+            anthropic = build_anthropic_tools([schema], cache_tools=False)[0]
+            self.assertEqual(chat["function"]["name"], "shell")
+            self.assertEqual(responses["name"], "shell")
+            self.assertEqual(anthropic["name"], "shell")
+            self.assertEqual(chat["function"]["description"], WIRE_TOOL_DESCRIPTION)
+            self.assertEqual(responses["description"], WIRE_TOOL_DESCRIPTION)
+            self.assertEqual(anthropic["description"], WIRE_TOOL_DESCRIPTION)
+            for parameters in (
+                chat["function"]["parameters"],
+                responses["parameters"],
+                anthropic["input_schema"],
+            ):
+                self.assertEqual(set(parameters["properties"]), {"action", "input", "reasoning"})
+                self.assertEqual(parameters["required"], ["action", "input"])
+                self.assertIs(parameters["additionalProperties"], False)
+        finally:
+            agent.stop(timeout=1.0)
+
+    def test_real_manual_fake_routes_and_authoritative_current_setting(self):
+        agent = _agent("routes")
+        try:
+            manager = _manager(agent)
+            manual_path = _write_manual(agent)
+            manual = manager.handle({"action": "manual", "input": {}})
+            self.assertEqual(manual["status"], "ok")
+            self.assertIn("canonical-shell-manual-marker", manual["manual"])
+            self.assertEqual(Path(manual["manual_path"]).resolve(), manual_path.resolve())
+            self.assertEqual(manual["current_setting"]["source"], "missing")
+
+            with (
+                patch.object(manager, "_handle_run", return_value={"status": "ok", "route": "run", "current_setting": {"source": "forged"}}) as run,
+                patch.object(manager, "_handle_poll", return_value={"status": "running", "route": "poll"}) as poll,
+                patch.object(manager, "_handle_cancel", return_value={"status": "cancelled", "route": "cancel"}) as cancel,
+            ):
+                run_result = manager.handle({"action": "run", "input": {"command": "not-executed", "summary": True}})
+                poll_result = manager.handle({"action": "poll", "input": {"job_id": "job-12345678"}})
+                cancel_result = manager.handle({"action": "cancel", "input": {"job_id": "job-12345678"}})
+                self.assertEqual(run_result["route"], "run")
+                self.assertEqual(run_result["current_setting"]["source"], "missing")
+                self.assertEqual(poll_result["route"], "poll")
+                self.assertEqual(cancel_result["route"], "cancel")
+                run.assert_called_once_with({"command": "not-executed", "summary": True})
+                poll.assert_called_once_with({"job_id": "job-12345678"})
+                cancel.assert_called_once_with({"job_id": "job-12345678"})
+        finally:
+            agent.stop(timeout=1.0)
+
+    def test_strict_malformed_calls_never_reach_execution_routes(self):
+        agent = _agent("reject")
+        try:
+            manager = _manager(agent)
+            bad_calls = [
+                None,
+                [],
+                {},
+                {"command": "flat"},
+                {"action": ["run"], "input": {}},
+                {"action": "run", "input": {"command": 3}},
+                {"action": "run", "input": {"command": "x", "timeout": "3"}},
+                {"action": "run", "input": {"command": "x", "working_dir": 3}},
+                {"action": "run", "input": {"command": "x", "async": 1}},
+                {"action": "run", "input": {"command": "x", "async": True, "reminder": "3"}},
+                {"action": "run", "input": {"command": "x", "summary": 1}},
+                {"action": "run", "input": {"command": "x", "unknown": True}},
+                {"action": "poll", "input": {"job_id": "job-12345678", "summary": True}},
+                {"action": "manual", "input": {"command": "x"}},
+                {"action": "manual", "input": {}, "summary": True},
+            ]
+            with (
+                patch.object(manager, "_handle_run", side_effect=AssertionError("live run route reached")) as run,
+                patch.object(manager, "_handle_poll", side_effect=AssertionError("live poll route reached")) as poll,
+                patch.object(manager, "_handle_cancel", side_effect=AssertionError("live cancel route reached")) as cancel,
+            ):
+                for payload in bad_calls:
+                    with self.subTest(payload=payload):
+                        result = manager.handle(payload)
+                        self.assertEqual(result["status"], "error")
+                        self.assertIn("current_setting", result)
+                run.assert_not_called()
+                poll.assert_not_called()
+                cancel.assert_not_called()
+        finally:
+            agent.stop(timeout=1.0)
+
+    def test_settings_missing_valid_hot_invalid_and_behavior_invariance(self):
+        agent = _agent("settings")
+        try:
+            manager = _manager(agent)
+            _write_manual(agent)
+            prompt_before = agent._build_system_prompt()
+            with patch.object(manager, "_handle_run", return_value={"status": "ok", "marker": "same"}):
+                missing = manager.handle({"action": "run", "input": {"command": "not-executed"}})
+                self.assertEqual(missing["current_setting"]["source"], "missing")
+                baseline = _without_setting(missing)
+
+                _write_settings(agent, '{"schema_version": 1}')
+                valid = manager.handle({"action": "run", "input": {"command": "not-executed"}})
+                self.assertEqual(valid["current_setting"]["source"], "settings/shell.json")
+                self.assertEqual(_without_setting(valid), baseline)
+
+                _write_settings(agent, '{ "schema_version": 1 }')
+                hot = manager.handle({"action": "run", "input": {"command": "not-executed"}})
+                self.assertNotEqual(hot["current_setting"]["settings_revision"], valid["current_setting"]["settings_revision"])
+                self.assertEqual(_without_setting(hot), baseline)
+
+                ignored_reminder = manager.handle({
+                    "action": "run",
+                    "input": {"command": "not-executed", "reminder": float("nan")},
+                })
+                self.assertEqual(_without_setting(ignored_reminder), baseline)
+
+                _write_settings(agent, '{"schema_version": 1, "future": true}')
+                invalid = manager.handle({"action": "run", "input": {"command": "not-executed"}})
+                self.assertEqual(invalid["current_setting"]["source"], "settings_error")
+                self.assertTrue(invalid["current_setting"]["settings_error"])
+                self.assertEqual(_without_setting(invalid), baseline)
+                self.assertEqual(agent._build_system_prompt(), prompt_before)
+
+                valid["current_setting"]["source"] = "tampered"
+                again = manager.handle({"action": "run", "input": {"command": "not-executed"}})
+                self.assertEqual(again["current_setting"]["source"], "settings_error")
+        finally:
+            agent.stop(timeout=1.0)
+
+    def test_nested_summary_true_uses_fake_handler_and_logs_raw_first(self):
+        agent = _agent("summary")
+        try:
+            manager = _manager(agent)
+            events = []
+            seen = {}
+
+            def summarizer(system_prompt, user_prompt, tool_name, tool_call_id):
+                seen["prompt"] = user_prompt
+                return "SHELL-GENERATED-SUMMARY"
+
+            executor = _make_executor(agent, events=events, summarizer=summarizer)
+            raw_result = {
+                "status": "ok",
+                "exit_code": 0,
+                "stdout": "raw-shell-marker",
+                "stderr": "",
+                "ok": True,
+                "command_status": "success",
+            }
+            with patch.object(manager, "_handle_run", return_value=raw_result) as run:
+                results, intercepted, _ = executor.execute([
+                    ToolCall(
+                        name="shell",
+                        args={
+                            "action": "run",
+                            "input": {"command": "not-executed", "summary": True},
+                            "reasoning": "retain the raw shell marker",
+                        },
+                        id="shell-summary",
+                    )
+                ])
+            self.assertIs(intercepted, False)
+            run.assert_called_once_with({"command": "not-executed", "summary": True})
+            content = results[0]["content"]
+            self.assertEqual(content["summary_kind"], "apriori_generated")
+            self.assertEqual(content["generated_summary"], "SHELL-GENERATED-SUMMARY")
+            self.assertIn("raw-shell-marker", seen["prompt"])
+            raw_index = _event_index(events, "tool_result", "shell-summary")
+            generated_index = _event_index(events, "apriori_summary_generated", "shell-summary")
+            visible_index = _event_index(events, "tool_result_model_visible", "shell-summary")
+            self.assertIsNotNone(raw_index)
+            self.assertIsNotNone(generated_index)
+            self.assertIsNotNone(visible_index)
+            self.assertLess(raw_index, generated_index)
+            self.assertLess(generated_index, visible_index)
+            self.assertIn("raw-shell-marker", str(events[raw_index][1]["result"]))
+        finally:
+            agent.stop(timeout=1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shell_pr1_contract.py
+++ b/tests/test_shell_pr1_contract.py
@@ -111,10 +111,10 @@ def test_powershell_parenthesized_policy_rejects_before_invocation(tmp_path, pol
     manager = ShellManager(
         policy=policy,
         working_dir=str(tmp_path),
-        agent=SimpleNamespace(),
+        agent=SimpleNamespace(_working_dir=tmp_path),
         dialect=dialect,
     )
-    denied = manager.handle({"command": r"Write-Output (Remove-Item -LiteralPath .\victim)"})
+    denied = manager.handle({'action': 'run', 'input': {'command': 'Write-Output (Remove-Item -LiteralPath .\\victim)'}})
     assert denied["status"] == "error"
     assert "not allowed" in denied["message"]
     assert "Remove-Item" in denied["message"]
@@ -142,10 +142,10 @@ def test_powershell_backtick_escaped_command_fails_closed_before_invocation(
     manager = ShellManager(
         policy=policy,
         working_dir=str(tmp_path),
-        agent=SimpleNamespace(),
+        agent=SimpleNamespace(_working_dir=tmp_path),
         dialect=dialect,
     )
-    denied = manager.handle({"command": command})
+    denied = manager.handle({'action': 'run', 'input': {'command': command}})
     assert denied["status"] == "error"
     assert "does not support this syntax" in denied["message"]
     assert "refusing to run" in denied["message"]
@@ -157,19 +157,19 @@ def test_powershell_policy_is_case_insensitive_and_dynamic_syntax_fails_closed(t
     manager = ShellManager(
         policy=policy,
         working_dir=str(tmp_path),
-        agent=SimpleNamespace(),
+        agent=SimpleNamespace(_working_dir=tmp_path),
         dialect=PowerShellDialect(executable="pwsh"),
     )
-    denied = manager.handle({"command": "remove-item file.txt"})
+    denied = manager.handle({'action': 'run', 'input': {'command': 'remove-item file.txt'}})
     assert denied["status"] == "error"
     assert "not allowed" in denied["message"]
-    dynamic = manager.handle({"command": "& $command"})
+    dynamic = manager.handle({'action': 'run', 'input': {'command': '& $command'}})
     assert dynamic["status"] == "error"
-    expandable = manager.handle({"command": '& "$command" victim'})
+    expandable = manager.handle({'action': 'run', 'input': {'command': '& "$command" victim'}})
     assert expandable["status"] == "error"
-    static = manager.handle({"command": "& Remove-Item victim"})
+    static = manager.handle({'action': 'run', 'input': {'command': '& Remove-Item victim'}})
     assert static["status"] == "error"
-    quoted_static = manager.handle({"command": "& 'Remove-Item' victim"})
+    quoted_static = manager.handle({'action': 'run', 'input': {'command': "& 'Remove-Item' victim"}})
     assert quoted_static["status"] == "error"
 
 

--- a/tests/test_shell_sandbox_containment.py
+++ b/tests/test_shell_sandbox_containment.py
@@ -20,6 +20,9 @@ from lingtai.tools.bash import BashManager, BashPolicy, _working_dir_contained
 class _SyncOnlyAgent:
     """Stand-in agent for synchronous manager runs."""
 
+    def __init__(self):
+        self._working_dir = None
+
 
 # ---------------------------------------------------------------------------
 # Direct unit tests of the module-level helper
@@ -73,8 +76,10 @@ def test_nested_working_dir_is_accepted(tmp_path):
     sandbox = tmp_path / "agent"
     nested = sandbox / "sub" / "deep"
     nested.mkdir(parents=True)
-    mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir=str(sandbox))
-    result = mgr.handle({"command": "pwd", "working_dir": str(nested)})
+    agent = _SyncOnlyAgent()
+    agent._working_dir = sandbox
+    mgr = BashManager(agent=agent, policy=BashPolicy.yolo(), working_dir=str(sandbox))
+    result = mgr.handle({"action": "run", "input": {"command": "pwd", "working_dir": str(nested)}})
     assert result["status"] == "ok"
     assert str(nested.resolve()) in result["stdout"]
 
@@ -87,7 +92,9 @@ def test_sibling_prefix_dir_is_rejected(tmp_path):
     sibling = tmp_path / "agent-bb"
     sandbox.mkdir()
     sibling.mkdir()
-    mgr = BashManager(agent=_SyncOnlyAgent(), policy=BashPolicy.yolo(), working_dir=str(sandbox))
-    result = mgr.handle({"command": "pwd", "working_dir": str(sibling)})
+    agent = _SyncOnlyAgent()
+    agent._working_dir = sandbox
+    mgr = BashManager(agent=agent, policy=BashPolicy.yolo(), working_dir=str(sandbox))
+    result = mgr.handle({"action": "run", "input": {"command": "pwd", "working_dir": str(sibling)}})
     assert result["status"] == "error"
     assert "under agent working directory" in result["message"]

--- a/tests/test_shell_windows_native.py
+++ b/tests/test_shell_windows_native.py
@@ -41,7 +41,7 @@ class _NotificationSink:
 
 
 def _manager(root: Path) -> ShellManager:
-    agent = SimpleNamespace(_notification_store=_NotificationSink())
+    agent = SimpleNamespace(_notification_store=_NotificationSink(), _working_dir=root)
     return ShellManager(
         policy=ShellPolicy.yolo(),
         working_dir=str(root),
@@ -53,7 +53,7 @@ def _poll_terminal(manager: ShellManager, job_id: str, timeout: float = 15.0) ->
     deadline = time.monotonic() + timeout
     latest: dict = {"status": "not-polled"}
     while time.monotonic() < deadline:
-        latest = manager.handle({"action": "poll", "job_id": job_id})
+        latest = manager.handle({'action': 'poll', 'input': {'job_id': job_id}})
         if latest.get("status") == "done":
             return latest
         assert latest.get("status") == "running", latest
@@ -76,14 +76,7 @@ def _ps_literal(path: Path) -> str:
 
 def test_native_powershell_sync_captures_streams_and_exact_native_exit(tmp_path):
     manager = _manager(tmp_path)
-    result = manager.handle({
-        "command": (
-            "Write-Output 'native-stdout'; "
-            "[Console]::Error.WriteLine('native-stderr'); "
-            "& $env:ComSpec /d /c exit 7"
-        ),
-        "timeout": 10,
-    })
+    result = manager.handle({'action': 'run', 'input': {'command': "Write-Output 'native-stdout'; [Console]::Error.WriteLine('native-stderr'); & $env:ComSpec /d /c exit 7", 'timeout': 10}})
 
     assert result["status"] == "ok"
     assert result["exit_code"] == 7
@@ -96,45 +89,28 @@ def test_native_powershell_sync_captures_streams_and_exact_native_exit(tmp_path)
 def test_native_powershell_failure_and_sync_timeout_are_explicit(tmp_path):
     manager = _manager(tmp_path)
 
-    failed = manager.handle({"command": "Write-Error 'powershell-failure'", "timeout": 10})
+    failed = manager.handle({'action': 'run', 'input': {'command': "Write-Error 'powershell-failure'", 'timeout': 10}})
     assert failed["status"] == "ok"
     assert failed["exit_code"] == 1
     assert failed["ok"] is False
     assert "powershell-failure" in failed["stderr"]
 
-    sticky_native_then_powershell = manager.handle({
-        "command": (
-            "& $env:ComSpec /d /c exit 7; "
-            "Write-Error 'final-powershell-failure'"
-        ),
-        "timeout": 10,
-    })
+    sticky_native_then_powershell = manager.handle({'action': 'run', 'input': {'command': "& $env:ComSpec /d /c exit 7; Write-Error 'final-powershell-failure'", 'timeout': 10}})
     assert sticky_native_then_powershell["status"] == "ok"
     assert sticky_native_then_powershell["exit_code"] == 1
 
-    native_then_success = manager.handle({
-        "command": "& $env:ComSpec /d /c exit 7; Write-Output 'final-success'",
-        "timeout": 10,
-    })
+    native_then_success = manager.handle({'action': 'run', 'input': {'command': "& $env:ComSpec /d /c exit 7; Write-Output 'final-success'", 'timeout': 10}})
     assert native_then_success["status"] == "ok"
     assert native_then_success["exit_code"] == 0
 
-    timed_out = manager.handle({"command": "Start-Sleep -Seconds 10", "timeout": 0.5})
+    timed_out = manager.handle({'action': 'run', 'input': {'command': 'Start-Sleep -Seconds 10', 'timeout': 0.5}})
     assert timed_out["status"] == "error"
     assert "timed out" in timed_out["message"].lower()
 
 
 def test_native_powershell_async_poll_preserves_streams_and_exit_code(tmp_path):
     manager = _manager(tmp_path)
-    started = manager.handle({
-        "command": (
-            "Write-Output 'async-stdout'; "
-            "[Console]::Error.WriteLine('async-stderr'); "
-            "& $env:ComSpec /d /c exit 7"
-        ),
-        "async": True,
-        "reminder": 30,
-    })
+    started = manager.handle({'action': 'run', 'input': {'command': "Write-Output 'async-stdout'; [Console]::Error.WriteLine('async-stderr'); & $env:ComSpec /d /c exit 7", 'async': True, 'reminder': 30}})
 
     assert started["status"] == "ok", started
     terminal = _poll_terminal(manager, started["job_id"])
@@ -200,15 +176,13 @@ def test_native_job_object_cancel_after_root_exit_terminates_descendant_tree(tmp
         "exit 0"
     )
 
-    started = manager.handle({
-        "command": parent_script,
-        "async": True,
-        "reminder": 30,
-    })
+    started = manager.handle({'action': 'run', 'input': {'command': parent_script, 'async': True, 'reminder': 30}})
     assert started["status"] == "ok", started
     _wait_for_file(ready)
-    cancelled = manager.handle({"action": "cancel", "job_id": started["job_id"]})
-    assert cancelled == {"status": "cancelled", "job_id": started["job_id"]}
+    cancelled = manager.handle({'action': 'cancel', 'input': {'job_id': started['job_id']}})
+    assert cancelled["status"] == "cancelled"
+    assert cancelled["job_id"] == started["job_id"]
+    assert cancelled["current_setting"]["source"] == "missing"
 
     state_path = tmp_path / "system" / "jobs" / started["job_id"] / "state.json"
     state = json.loads(state_path.read_text(encoding="utf-8"))
@@ -237,16 +211,14 @@ def test_native_job_object_cancel_terminates_descendant_tree(tmp_path):
         "Wait-Process -Id $child.Id"
     )
 
-    started = manager.handle({
-        "command": parent_script,
-        "async": True,
-        "reminder": 30,
-    })
+    started = manager.handle({'action': 'run', 'input': {'command': parent_script, 'async': True, 'reminder': 30}})
     assert started["status"] == "ok", started
     _wait_for_file(ready)
 
-    cancelled = manager.handle({"action": "cancel", "job_id": started["job_id"]})
-    assert cancelled == {"status": "cancelled", "job_id": started["job_id"]}
+    cancelled = manager.handle({'action': 'cancel', 'input': {'job_id': started['job_id']}})
+    assert cancelled["status"] == "cancelled"
+    assert cancelled["job_id"] == started["job_id"]
+    assert cancelled["current_setting"]["source"] == "missing"
 
     state_path = tmp_path / "system" / "jobs" / started["job_id"] / "state.json"
     state = json.loads(state_path.read_text(encoding="utf-8"))

--- a/tests/test_tool_settings.py
+++ b/tests/test_tool_settings.py
@@ -1,0 +1,154 @@
+"""Focused tests for the private no-op placeholder-settings foundation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools._settings import (
+    MAX_SETTINGS_BYTES,
+    current_setting,
+    read_settings,
+    settings_path,
+    valid_tool_name,
+)
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+
+def _write(root: Path, tool_name: str, payload: str | bytes) -> Path:
+    path = root / "settings" / f"{tool_name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, bytes):
+        path.write_bytes(payload)
+    else:
+        path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def test_missing_is_a_normal_noop_placeholder_state(tmp_path):
+    snapshot = read_settings(_Agent(tmp_path), "example")
+    setting = current_setting(snapshot, "example")
+    assert setting == {
+        "configurable": False,
+        "placeholder": "no-op",
+        "source": "missing",
+        "settings_revision": "missing",
+        "settings_hash": None,
+        "change_hint": (
+            "Edit settings/example.json; changes apply on the next example call; "
+            "this no-op placeholder never changes tool behavior."
+        ),
+    }
+
+
+def test_valid_v1_only_changes_source_revision_and_hash(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "example", '{"schema_version": 1}')
+    snapshot = read_settings(agent, "example")
+    setting = current_setting(snapshot, "example")
+    assert snapshot.error is None
+    assert setting["configurable"] is False
+    assert setting["placeholder"] == "no-op"
+    assert setting["source"] == "settings/example.json"
+    assert setting["settings_revision"] == setting["settings_hash"]
+    assert setting["settings_hash"]
+
+
+def test_reader_rereads_hot_changes_without_cache(tmp_path):
+    agent = _Agent(tmp_path)
+    path = _write(tmp_path, "example", '{"schema_version": 1}')
+    first = read_settings(agent, "example")
+    path.write_text('{ "schema_version": 1 }', encoding="utf-8")
+    second = read_settings(agent, "example")
+    assert first.digest != second.digest
+    assert second.source == "settings/example.json"
+
+
+def test_duplicate_and_extra_fields_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    duplicate = _write(tmp_path, "duplicate", '{"schema_version": 1, "schema_version": 1}')
+    duplicate_snapshot = read_settings(agent, "duplicate")
+    assert duplicate_snapshot.source == "settings_error"
+    assert "duplicate" in (duplicate_snapshot.error or "")
+
+    extra = _write(tmp_path, "extra", '{"schema_version": 1, "future": false}')
+    extra_snapshot = read_settings(agent, "extra")
+    assert extra_snapshot.source == "settings_error"
+    assert "only schema_version" in (extra_snapshot.error or "")
+
+
+def test_bool_and_other_schema_versions_are_invalid(tmp_path):
+    agent = _Agent(tmp_path)
+    for name, version in (("bool", True), ("float", 1.0), ("other", 2)):
+        _write(tmp_path, name, json.dumps({"schema_version": version}))
+        snapshot = read_settings(agent, name)
+        assert snapshot.source == "settings_error"
+        assert "integer 1" in (snapshot.error or "")
+
+
+def test_invalid_encoding_and_json_are_truthful_bounded_errors(tmp_path):
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "encoding", b'{"schema_version": 1}\xff')
+    encoding_snapshot = read_settings(agent, "encoding")
+    assert encoding_snapshot.source == "settings_error"
+    assert encoding_snapshot.error
+
+    _write(tmp_path, "json", "{not-json")
+    json_snapshot = read_settings(agent, "json")
+    assert json_snapshot.source == "settings_error"
+    assert json_snapshot.error
+    assert len(json_snapshot.error) <= 240
+
+
+def test_symlink_non_regular_and_oversized_files_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    target = tmp_path / "outside.json"
+    target.write_text('{"schema_version": 1}', encoding="utf-8")
+    symlink = tmp_path / "settings" / "symlink.json"
+    symlink.parent.mkdir()
+    symlink.symlink_to(target)
+    symlink_snapshot = read_settings(agent, "symlink")
+    assert symlink_snapshot.source == "settings_error"
+    assert "regular file" in (symlink_snapshot.error or "")
+
+    non_regular = tmp_path / "settings" / "directory.json"
+    non_regular.mkdir()
+    directory_snapshot = read_settings(agent, "directory")
+    assert directory_snapshot.source == "settings_error"
+    assert "regular file" in (directory_snapshot.error or "")
+
+    _write(tmp_path, "large", b"{" + b"x" * MAX_SETTINGS_BYTES + b"}")
+    large_snapshot = read_settings(agent, "large")
+    assert large_snapshot.source == "settings_error"
+    assert "bounded size" in (large_snapshot.error or "")
+
+
+def test_unstable_snapshot_is_not_treated_as_missing(tmp_path, monkeypatch):
+    import lingtai.tools._settings as settings_module
+
+    agent = _Agent(tmp_path)
+    _write(tmp_path, "unstable", '{"schema_version": 1}')
+
+    def raise_unstable(_path):
+        raise settings_module.SettingsError("settings snapshot changed during read")
+
+    monkeypatch.setattr(settings_module, "_read_stable", raise_unstable)
+    snapshot = read_settings(agent, "unstable")
+    assert snapshot.source == "settings_error"
+    assert snapshot.revision == "error"
+    assert snapshot.error == "settings snapshot changed during read"
+
+
+def test_tool_names_are_bounded_path_components(tmp_path):
+    assert valid_tool_name("web_search")
+    assert not valid_tool_name("../escape")
+    assert not valid_tool_name("nested/name")
+    assert not valid_tool_name("\\escape")
+    assert not valid_tool_name("x" * 65)
+    with pytest.raises(ValueError):
+        settings_path(_Agent(tmp_path), "../escape")


### PR DESCRIPTION
## Summary

- migrate the public `shell` tool to the canonical required root `action` plus strict nested `input` contract, with closed `run`, `poll`, `cancel`, and read-only `manual` branches and no flat compatibility aliases
- preserve the existing executor-owned a-priori summary path as `run`-only `input.summary`; BaseAgent alone injects optional root `reasoning`, and provider names/envelopes remain unchanged
- attach a fresh authoritative no-op `current_setting` snapshot from strict Agent-owned `settings/shell.json` to every result, and load the real installed shell manual for `manual`
- migrate owning tests and all discovered source/manual call sites, and update the shell contract, anatomy, manual, and zh/wen glossaries in lockstep

The candidate keeps the existing sync/async process, durable job, reminder, poll/cancel, notification, PowerShell, and sandbox implementations unchanged behind the new dispatch boundary. Parent review additionally restored `input.summary`, preserved the established invariant that sync runs ignore `reminder`, removed ephemeral worker-artifact references from the source contract, and fixed stale implicit-run glossary language.

## Validation

- parent final gate: **PASS**, 44 checks / 0 failures
- exact committed candidate suite: **6/6 PASS** with `$LINGTAI_RUNTIME_PYTHON`, candidate `src` forced to import, actual Agent + full prompt, raw/Agent-facing/Chat/Responses/Anthropic schemas, real manual/settings, strict malformed calls, fake run/poll/cancel, sync-reminder compatibility, and raw-first nested summary
- all tracked `src/` + `tests/` Python: **703 files compiled in memory**, 0 errors
- repository closure audit: **1,083 files**, 21 shell text records / 0 stale, 123 literal handles, 1 exact dynamic allowlist, 2 exact negative fixtures, 1 `ToolCall`, 0 parse/handle/tool-call violations
- established-test semantic control: **114 foundation calls = 114 candidate calls = 114 normalized matches**, 0 violations across seven owning test files
- worker event audit: **2,125/2,125 records parsed**, 193 received / 193 dispatched / 193 results, no pairing gaps or duplicates, no writes/cwds outside the candidate, and no deletion, network/package, pytest/temp, signal/process-kill, or live candidate-shell lifecycle calls
- exact commit parent: `80d5c7d4e99c7de147ccb4dda4642a177842f47f`; `git diff --check` PASS; tracked worktree clean after commit

Repository-wide pytest was intentionally not run locally because the active no-deletion/no-cleanup boundary forbids pytest lifecycle cleanup. Parent validation never launched a candidate shell child, supervisor, scheduler, job-store lifecycle, or notification; exact platform lifecycle coverage is delegated to GitHub CI.

## Stack integration

This draft is based directly on foundation PR #1038 (`feat/tool-settings-foundation`). Read-only merge-tree checks against the thirteen published sibling draft heads found:

- clean with knowledge #1039, skills #1040, MCP #1041, vision #1042, edit #1043, write #1044, read #1045, glob #1046, grep #1047, avatar #1048, and notification #1050
- conflicts with soul #1049 in `src/lingtai/intrinsic_skills/soul-manual/SKILL.md` and `tests/test_intrinsic_manual_actions.py`
- conflicts with system #1051 in `src/lingtai/tools/bash/CONTRACT.md` and `src/lingtai/tools/bash/__init__.py`

Those four paths require explicit resolution in stack integration; this draft does not merge or resolve sibling branches.

## Attribution

A single bounded `gpt-5.6-luna` worker produced the initial candidate. The parent audited all worker events, reviewed and repaired the candidate, added the committed regression suite and independent gates, and owns this submitted commit.
