### PR TITLE
feat(tools): add ToolFamily with Web reference migration

### DIFF
--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -15,6 +15,7 @@ related_files:
   - src/lingtai/tools/notification/CONTRACT.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/kernel/snapshot/CONTRACT.md
   - src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
   - src/lingtai/kernel/migrate/CONTRACT.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ exclude = [
     "CONTRACT.md",
     "*/CONTRACT.md",
     # Per-tool glossary resources — exactly glossary-{en,zh,wen}.md per
-    # first-party package (19 packages × 3 languages = 57 files). The
+    # first-party package (20 packages × 3 languages = 60 files). The
     # renderer loads them via importlib.resources to append localized
     # terminology bodies to each tool's ## tools description.
     "*/glossary-en.md",

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -495,7 +495,7 @@ In-flight official/stateful Responses and Codex sessions keep no-op prompt/tool 
 ### Tool schema conversion
 
 - **CC path** — `_build_tools()` (`adapter.py:975`): `{type: "function", function: {name, description, parameters}}`.
-- **Responses path** — `_build_responses_tools()` (`adapter.py:1055`): `{type: "function", name, description, parameters}` (flat). Scrubs top-level JSON-Schema combinators (`_RESPONSES_DISALLOWED_TOP_LEVEL`, `adapter.py:999`) that the Responses API rejects.
+- **Responses path** — `_build_responses_tools()` (`adapter.py:1076`): `{type: "function", name, description, parameters}` (flat). Strips the still-untested root JSON-Schema keywords (`_RESPONSES_DISALLOWED_TOP_LEVEL` = `anyOf`/`not`/`enum`, `adapter.py:1006`); root `oneOf`/`allOf` are preserved verbatim (`_scrub_responses_schema(..., is_root=True)`, `adapter.py:1020`) since a live non-strict Codex Responses probe on 2026-07-27 showed the current route accepts both without error. Nested `oneOf` below the root is still rewritten to `anyOf`.
 
 ### Reasoning extraction
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -995,10 +995,15 @@ def _build_tools(schemas: list[FunctionSchema] | None) -> list[dict] | None:
     ]
 
 
-# Top-level JSON-Schema combinators the Responses API rejects on a
-# function-tool `parameters` root. `enum` is only disallowed at the root —
-# it is valid (and common) inside individual properties.
-_RESPONSES_DISALLOWED_TOP_LEVEL = ("allOf", "oneOf", "anyOf", "not", "enum")
+# JSON-Schema keywords still stripped from a function-tool `parameters`
+# root for the Responses API. `enum` is only disallowed at the root — it is
+# valid (and common) inside individual properties. `anyOf`/`not` at the root
+# remain untested against the live backend and are kept out of caution;
+# `oneOf`/`allOf` were moved off this list after a live non-strict Codex
+# Responses probe on 2026-07-27 accepted a raw root `oneOf` and a raw root
+# `allOf`/`if`/`then` without error on the current route — see
+# `_scrub_responses_schema`'s root-preservation of both.
+_RESPONSES_DISALLOWED_TOP_LEVEL = ("anyOf", "not", "enum")
 
 
 # Keys that, if present on a schema node, already establish its kind so it
@@ -1012,14 +1017,16 @@ _SCHEMA_KIND_KEYS = (
 )
 
 
-def _scrub_responses_schema(node: Any) -> Any:
+def _scrub_responses_schema(node: Any, is_root: bool = False) -> Any:
     """Recursively normalize a JSON schema for the Codex Responses backend.
 
-    Empirically, `/backend-api/codex/responses` rejects three constructs even
+    Empirically, `/backend-api/codex/responses` rejects some constructs even
     when nested inside a property, returning an opaque `server_error`:
 
-      1. `oneOf` / `not` combinators  -> `oneOf` rewritten to the accepted
-         `anyOf`; `not` dropped (no accepted equivalent).
+      1. Nested `oneOf` / `not` combinators -> nested `oneOf` rewritten to the
+         accepted `anyOf`; `not` dropped (no accepted equivalent). This
+         nested rewrite is unchanged and still applies at every depth below
+         the root.
       2. Typeless property schemas    -> a node with a `description` but no
          type-establishing key (see `_SCHEMA_KIND_KEYS`) gets `type:
          "string"`. This covers the nested `secondary.args.*` fields LingTai
@@ -1028,16 +1035,28 @@ def _scrub_responses_schema(node: Any) -> Any:
          e.g. entries in `daemon`'s `tasks[].mcp` array) -> an empty
          `properties: {}` is added. An empty `properties` map is accepted.
 
-    `enum`/`anyOf`/`allOf` are left untouched (the backend accepts them
-    nested). Walks dicts and lists so all fixes apply at any depth.
+    At the schema **root** (`is_root=True`, the top-level `parameters` dict
+    passed in by `_build_responses_tools`), `oneOf` and `allOf` are preserved
+    as-is rather than rewritten/stripped: a live non-strict Codex Responses
+    probe on 2026-07-27 showed the current route accepts a raw root `oneOf`
+    and a raw root `allOf`/`if`/`then` without error. Root `anyOf`/`not`/
+    `enum` remain untested and are still stripped before this function runs
+    (`_RESPONSES_DISALLOWED_TOP_LEVEL`, `_build_responses_tools`).
+    `enum`/`anyOf`/`allOf` nested below the root are left untouched as before
+    (the backend accepts them nested). Walks dicts and lists so all fixes
+    apply at any depth.
     """
     if isinstance(node, dict):
         out: dict = {}
         for key, value in node.items():
-            if key == "oneOf":
+            if key == "oneOf" and not is_root:
                 out["anyOf"] = [_scrub_responses_schema(v) for v in value]
             elif key == "not":
                 continue  # no accepted equivalent — drop it
+            elif key in ("oneOf", "allOf") and is_root:
+                # Root-level: preserved verbatim (recursing into each
+                # branch, which is no longer root), not rewritten/stripped.
+                out[key] = [_scrub_responses_schema(v) for v in value]
             else:
                 out[key] = _scrub_responses_schema(value)
         # Coerce typeless property schemas: a node describing a value (has a
@@ -1058,11 +1077,12 @@ def _build_responses_tools(schemas: list[FunctionSchema] | None) -> list[dict] |
     """Convert FunctionSchema list to Responses API tool format.
 
     Responses uses a flat shape (`type: function`, fields hoisted) instead
-    of Chat Completions' nested `{type: function, function: {...}}`. Scrubs
-    top-level combinators the Responses API rejects at the parameters root,
-    then runs `_scrub_responses_schema` to fix the constructs the Codex
-    backend rejects even nested in a property (`oneOf`/`not` combinators and
-    typeless property schemas).
+    of Chat Completions' nested `{type: function, function: {...}}`. Strips
+    the still-untested `_RESPONSES_DISALLOWED_TOP_LEVEL` keys at the
+    parameters root, then runs `_scrub_responses_schema(params, is_root=True)`
+    to preserve root `oneOf`/`allOf` verbatim while still fixing the
+    constructs the Codex backend rejects even nested in a property (nested
+    `oneOf`/`not` combinators and typeless property schemas).
     """
     if not schemas:
         return None
@@ -1071,7 +1091,7 @@ def _build_responses_tools(schemas: list[FunctionSchema] | None) -> list[dict] |
         params = dict(s.parameters or {})
         for key in _RESPONSES_DISALLOWED_TOP_LEVEL:
             params.pop(key, None)
-        params = _scrub_responses_schema(params)
+        params = _scrub_responses_schema(params, is_root=True)
         tools.append(
             {
                 "type": "function",

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -7,13 +7,17 @@ related_files:
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/browser/ANATOMY.md
+  - src/lingtai/tools/tool_family/ANATOMY.md
+  - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
   - src/lingtai/tools/glossary_validator.py
   - ENVIRONMENT_VARIABLES.md
 maintenance: |
   Keep this registry Anatomy connected to its parent and the unified web owner.
-  Browser is an internal browse child, not a second public capability. Update
+  Browser is an internal browse child, not a second public capability. The
+  generic tool_family package is optional composition infrastructure any
+  future family migration may adopt, not a second registry. Update
   structural claims with code and keep reciprocal graph edges valid.
 ---
 # src/lingtai/tools/
@@ -34,6 +38,10 @@ capability names and lazy adapters.
   and manual (`src/lingtai/tools/web_search/ANATOMY.md`).
 - `browser/` — internal static browse Core/Port used by `web`
   (`src/lingtai/tools/browser/ANATOMY.md`).
+- `tool_family/` — generic, optional ToolFamily/ChildTool schema-composition
+  and dispatch infrastructure implementing the LTP v2 envelope, and the
+  reusable ManualTool builder; `web` is its first real consumer
+  (`src/lingtai/tools/tool_family/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
 
@@ -41,8 +49,9 @@ capability names and lazy adapters.
 
 `Agent` calls registry setup. The public `web` row imports
 `lingtai.tools.web_search` lazily. That owner imports the browser Core and
-provider factory only at composition or action boundaries. The pinned browser
-transport remains an outer adapter. `web_search` is accepted only as a
+provider factory only at composition or action boundaries, and imports
+`tool_family` to compose its schema and (optionally) dispatch. The pinned
+browser transport remains an outer adapter. `web_search` is accepted only as a
 one-way configuration input alias and is never emitted as a public name.
 
 ## Composition

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -9,6 +9,7 @@ related_files:
   - src/lingtai/kernel/tool_executor.py
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/tool_family/CONTRACT.md
   - tests/test_browser_capability.py
   - tests/test_wire_tool_description.py
 maintenance: |
@@ -242,6 +243,16 @@ v2 family (currently only `web`), so an unmigrated tool's own field literally
 named `summarize` is never reinterpreted as this control. Every other
 LingTai-owned family remains unmigrated and keeps its existing schema and
 settings surface unchanged by this file.
+
+`src/lingtai/tools/tool_family/` is optional, generic composition
+infrastructure implementing this envelope (schema composition from a
+`ChildTool` registry, dispatch-validation boilerplate, and a reusable
+ManualTool builder) that a family MAY adopt instead of hand-writing the
+equivalent code; `web` is its first consumer, using it for schema composition
+and dispatch while retaining its own outer `handle()` for family-specific
+diagnostics. Using it is never required — see its own
+`src/lingtai/tools/tool_family/CONTRACT.md` "Implementation independence" is
+binding on it exactly as it is on every family.
 
 Non-normative future illustration: `file` may later become one family with
 actions `read | write | edit | glob | grep | manual`, while all six

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -1,0 +1,112 @@
+---
+related_files:
+  - src/lingtai/tools/tool_family/CONTRACT.md
+  - src/lingtai/tools/ANATOMY.md
+  - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/tool_family/__init__.py
+  - src/lingtai/tools/tool_family/manual.py
+  - src/lingtai/tools/web_search/ANATOMY.md
+maintenance: |
+  Keep related_files repo-relative, duplicate-free, and linked to real files.
+  Keep this component's ANATOMY.md and CONTRACT.md reciprocal and keep
+  parent/child anatomy links bidirectional. Code is the structural source of
+  truth: update this anatomy in the same change that moves files, symbols,
+  connections, composition, or state. Verify every changed citation and run the
+  architecture-document validation before merge.
+  Follow the root Anatomy/Contract pairing rule, report mismatches, and do not duplicate or auto-fix the rule here.
+---
+# src/lingtai/tools/tool_family/ Anatomy
+
+This package owns the generic ToolFamily/ChildTool composition and dispatch
+boilerplate a family MAY opt into when implementing the LingTai Tool Protocol
+v2 shape defined in `../CONTRACT.md`. It standardizes the wire envelope
+(`action`/`input`/`reasoning`/`summarize`) and the schema-composition and
+dispatch-validation boilerplate that would otherwise be duplicated by every
+hand-migrated family; it does not standardize implementations, handlers, or
+result types (`../CONTRACT.md` "Implementation independence" is binding on
+this package too — using it is optional, not mandatory).
+
+## Components
+
+- `ChildTool` — a frozen descriptor pairing one child's canonical name,
+  `input_schema`, and `handler`; name doubles as the model `action` constant
+  and dispatch key (`__init__.py:76-95`).
+- `ToolFamily` — validates a fixed child registry (duplicate names and a
+  `manual` reserved-name collision fail loudly at construction), composes a
+  model-facing schema from each child's own `input_schema` plus a REQUIRED
+  root `reasoning` string property (declared by the family schema itself, not
+  left to Agent schema composition's property-only re-injection), and
+  provides an optional `handle()` dispatcher: validates `action`, type-checks
+  and strips root `summarize`, rejects unknown root fields, and rejects
+  `input` keys outside the selected child's own declared schema properties
+  before calling that child's handler with only its `input`
+  (`__init__.py:98-289`). Two enforcement layers correlate `action` with
+  `input`, generated purely from the child registry with no name/schema
+  mapping table: (1) schema-level — a root `allOf` with one `if`/`then`
+  condition per child, each `if` testing `action` via `const` against that
+  child's own registry name, each `then` constraining `input` to that exact
+  child's canonical schema; (2) dispatch-level — `handle()`'s own `input`-key
+  check against the selected child's declared properties, which remains
+  always-authoritative and fail-closed regardless of whether a given
+  provider enforces `allOf`/`if`/`then` schema-side. Root-level `allOf`
+  correlation was adopted after a live non-strict Codex Responses probe on
+  2026-07-27 accepted a raw root `allOf`/`if`/`then` schema without error on
+  the current route (see `CONTRACT.md` "Contract rules").
+- `manual.py` — `build_manual_child()` wraps `../_manual.py`'s
+  `load_installed_manual()` into the ManualTool stable contract: strict empty
+  input, and a handler whose actual return value (what `ToolFamily.handle()`
+  dispatches back verbatim, once the returned `ChildTool` is registered
+  directly and unwrapped in a family's own `ToolFamily`) is the canonical
+  `content[0].text` (full body) / `structuredContent.manual_path` (host-local
+  path) shape, with `status`/`error` loader facts preserved truthfully
+  (`manual.py:1-74`).
+
+## Connections
+
+`web_search/__init__.py` is the first real consumer: `get_schema()` composes
+the model-facing schema from a module-level schema-only `ToolFamily`, and each
+`WebManager` instance builds its own per-instance `ToolFamily` with handlers
+bound to that instance — search/browse close over instance state;
+`manual.build_manual_child(agent, "web")`'s returned `ChildTool` is
+registered *directly*, unwrapped, as the family's `manual` child, so
+`ToolFamily.handle()` returns that child's canonical
+`content`/`structuredContent` result verbatim for `action="manual"` (no
+double wrap). `WebManager.handle()` calls `self._family.handle(args)` and,
+strictly *after* that call returns, adapts a successfully dispatched manual
+result back to Web's pre-migration public flat shape (`status`, `manual`,
+`manual_path`, `action`, `current_setting`) via
+`WebManager._adapt_manual_result` — this adaptation is Web's own
+Host/presentation-layer responsibility, applied post-dispatch, never inside
+a registered child. `handle()` also stamps its own `current_setting`
+diagnostic onto any envelope-level failure result, since a generic
+`ToolFamily` has no knowledge of a specific family's settings diagnostics.
+This division follows `../CONTRACT.md` "Implementation independence": using
+`ToolFamily.handle()` is `web`'s choice, not an inherited requirement.
+
+## Composition
+
+The parent [`../ANATOMY.md`](../ANATOMY.md) owns capability registry
+composition and lists this package. The shared
+[`../CONTRACT.md`](../CONTRACT.md) owns the LingTai Tool Protocol (LTP) the
+schema this package composes must satisfy. The paired [`CONTRACT.md`](CONTRACT.md)
+specializes that promise into this package's own Port/Adapters/rules. No
+external MCP transport, endpoint, or registry is owned or touched here —
+"MCP-compatible" describes only the `name`/`description`/`inputSchema`-shaped
+internal descriptor convention `ChildTool` follows for clean internal
+boundaries.
+
+## State
+
+No mutable state lives at package root. `ToolFamily` instances are immutable
+after construction (a frozen child registry); `build_schema()` recomputes the
+model-facing schema on every call rather than caching one at construction.
+Any per-Agent state (engine specs, settings diagnostics, service caches)
+belongs to the consuming family, as `WebManager` demonstrates.
+
+## Notes
+
+A fake `widget` family in `tests/test_tool_family_generic.py` and
+`tests/test_tool_family_wire_parity.py` proves this package is generic, not
+Web-specific. Building a family on `ToolFamily` is optional: a family may
+hand-write an equivalent `handle()`/schema composition instead, exactly as
+`web` did before adopting this package.

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -1,0 +1,252 @@
+---
+name: tool-family
+contract_version: 1
+root_contract: CONTRACT.md
+related_files:
+  - src/lingtai/tools/tool_family/ANATOMY.md
+  - src/lingtai/tools/tool_family/__init__.py
+  - src/lingtai/tools/tool_family/manual.py
+  - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/_manual.py
+  - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/web_search/__init__.py
+  - tests/test_tool_family_generic.py
+  - tests/test_tool_family_wire_parity.py
+  - tests/test_tool_family_manual_contract.py
+maintenance: |
+  This component contract is governed by the root CONTRACT.md. Keep
+  related_files complete and repo-relative, including the paired ANATOMY.md,
+  the ChildTool/ToolFamily Port, the web_search production Adapter, contract
+  tests, and the ManualTool manual reference. Update this contract, the
+  paired Anatomy, and affected families together when the envelope, schema
+  composition, or dispatch boundary changes. Adding a family MAY adopt this
+  package's ToolFamily/handle(); it MUST NOT be required to, per
+  src/lingtai/tools/CONTRACT.md "Implementation independence".
+---
+# ToolFamily generic infrastructure
+
+## Purpose
+
+Generic, optional internal infrastructure implementing the LingTai Tool
+Protocol v2 envelope (`../CONTRACT.md`) so a family need not hand-write its
+own schema composition and dispatch-validation boilerplate. `ChildTool` +
+`ToolFamily` compose one model-facing aggregate tool from a fixed registry of
+internal, MCP-compatible-in-shape children; `manual.py` upgrades the existing
+`#1058` `load_installed_manual()` return shape into the reusable ManualTool
+stable contract. **Root acceptance requirement:** the ManualTool child's
+actual, dispatched-to result (what `ToolFamily.handle()` returns verbatim for
+`action="manual"`, per the no-double-wrap rule below) MUST carry the full
+installed `SKILL.md` body at `content[0].text` and the model-visible
+host-local path at `structuredContent.manual_path` — never only in an unused
+presentational helper, and never only in a `_meta`-style side channel. A
+family wanting a different public result shape (as `web` does — see
+Adapters) owns that adaptation itself, in its own Host/presentation layer,
+after dispatch. This package owns no transport, no external MCP surface, and
+no second registry: it is a Host-process-internal composition helper only.
+
+## Behavior
+
+A `ToolFamily` is constructed from an ordered, fixed list of `ChildTool`
+descriptors. Construction is where correctness is enforced: a duplicate child
+name, or more than one child named the reserved `manual`, raises
+`ToolFamilyError` immediately rather than registering silently. Once
+constructed, `build_schema()` deterministically composes the model-facing
+schema with two enforcement layers correlating `action` with `input`,
+generated purely from the child registry (no name/schema mapping table),
+both built from the same deep-copied canonical child schemas:
+
+1. **Schema-level (`allOf`):** one `if`/`then` condition per child — each
+   `if` tests root `action` via `const` against that child's own registry
+   name (guarded by `required: ["action"]`); each `then` constrains root
+   `input` to that exact child's canonical `input_schema`. Adopted after a
+   live non-strict Codex Responses probe on 2026-07-27 accepted a raw root
+   `allOf`/`if`/`then` schema without error on the current route (see
+   `_scrub_responses_schema` in `../../llm/openai/adapter.py` for the
+   corresponding wire-level change and its own scope note).
+2. **`input.oneOf` disclosure:** the same per-child `input_schema`s, embedded
+   verbatim under a `title`, retained under `input` for model discoverability
+   of every action's exact shape in one place.
+
+Both layers expose the envelope root `action`, `input`, required
+`reasoning`, and optional `summarize` — exactly the four public fields;
+`allOf` constrains them without adding a fifth field or duplicating `action`
+inside `input`. Dispatch (`handle()`, below) remains the second,
+always-authoritative enforcement layer regardless of whether a given
+provider actually validates `allOf`/`if`/`then` schema-side before
+invocation — it is additive, not a replacement.
+`reasoning` is Host InvocationContext/audit metadata, so `build_schema()`
+declares it itself (same property text Agent schema composition also
+re-injects into every tool's `properties` uniformly, but that step never
+touches `required` — a family must declare `reasoning` required itself to be
+correct even before Agent composition runs). `build_schema()` always
+advertises `summarize` to the model regardless of family; whether the kernel
+actually honors it is a separate, per-family allowlist decision
+(`kernel/tool_result_summary.py` `_LTP_V2_MIGRATED_FAMILIES`) that this
+package does not own or enforce. Today only `web` is on that allowlist, so
+`summarize` is meaningful for the one family that uses this infrastructure; a
+family adopting `ToolFamily` without also joining the kernel allowlist would
+advertise a model-visible `summarize` control that the kernel silently
+ignores. Calling
+`handle()` is optional: it validates the envelope (unknown `action`,
+non-boolean `summarize`, unknown root fields, `input` keys outside the
+selected child's own declared schema) before invoking exactly that child's
+handler with only its own `input` mapping. A family MAY skip `handle()`
+entirely and dispatch by hand — `web` uses it internally but still owns its
+own outer `handle()` to stamp family-specific diagnostics onto envelope
+failures, which this package has no knowledge of.
+
+`build_manual_child` builds the reserved `manual` `ChildTool`: strict empty
+input; its handler loads the existing `load_installed_manual()` shape
+(`status`, `manual` full body, `manual_path`, optionally `error`) and maps it
+to the canonical, actually-dispatched result: `content=[{"type": "text",
+"text": <full body>}]` and `structuredContent={"manual_path": <path>}`, with
+`status`/`error` preserved verbatim as truthful loader facts. This mapping is
+not a second wrapper — it IS this child's own canonical result. A family
+MUST register this `ChildTool` directly, unwrapped, in its own `ToolFamily`
+(see Adapters): `ToolFamily.handle()` then returns it verbatim for
+`action="manual"`, and any family-specific public shape adaptation happens
+strictly after that call returns, in the family's own Host/presentation
+layer — never inside this builder, its handler, or a wrapping `ChildTool`.
+
+## Port
+
+The provider-neutral boundary is `ChildTool.input_schema` (each child's own
+canonical JSON Schema for `input`) and `ChildTool.handler`
+(`Callable[[Mapping], dict]`, receiving only validated `input`). `ToolFamily`
+composes these into one `FunctionSchema.parameters`-compatible dict via
+`build_schema()` and, optionally, dispatches through `handle()`. Neither
+method is a required interface a family must implement against — a
+conforming family may satisfy the same wire shape without ever importing this
+package, per `../CONTRACT.md` "Implementation independence".
+
+## Adapters
+
+`web_search/__init__.py` is the one production Adapter/consumer in this
+candidate: `WebManager.__init__` builds a per-instance `ToolFamily` with
+`search`/`browse` handlers bound to that instance, and registers
+`manual.build_manual_child(agent, "web")`'s returned `ChildTool` *directly* —
+unwrapped — as the family's `manual` child. `WebManager.handle()` calls
+`self._family.handle(args)`, which therefore returns that child's canonical
+`content`/`structuredContent` result verbatim for `action="manual"` (no
+double wrap). Strictly *after* that call returns, `handle()` detects a
+successfully dispatched manual result (`"content" in result`) and calls
+`self._adapt_manual_result(result)` — a Host/presentation-only method that
+flattens the canonical result to Web's pre-migration public shape (`status`,
+`manual`, `manual_path`, `action`, `current_setting`), preserving the
+`#1058` public result exactly. This adaptation belongs to `web`'s own
+`handle()`, not to the generic child or any wrapper registered in place of
+it. `WebManager.handle()` also stamps `current_setting` onto any
+envelope-level failure result (search/browse/unknown-action) before
+returning, unchanged from before. No other built-in family is migrated in
+this candidate; each remains fully independent of this package until its own
+scoped migration.
+
+## Contract rules
+
+- A `ToolFamily`'s child registry MUST be validated at construction: duplicate
+  child names and more than one child named the reserved `manual` MUST raise
+  `ToolFamilyError`, not register silently or resolve by precedence.
+- `build_schema()` MUST embed each child's own `input_schema` verbatim (no
+  copy-and-reshape) under a `oneOf` branch pairing it with that child's
+  `title`. It MUST declare a root `reasoning` string property and include
+  `reasoning` in the root `required` list — `reasoning` is Host
+  InvocationContext/audit metadata, not left to Agent schema composition's
+  property-only re-injection, which never touches `required`.
+- `build_schema()` MUST also compose a root `allOf` with exactly one
+  `if`/`then` condition per registered child, generated purely from the
+  child registry: `if.properties.action.const` MUST equal that child's own
+  registry name, `if.required` MUST be `["action"]`, and
+  `then.properties.input` MUST be that exact child's own canonical
+  `input_schema` (the same deep-copied schema the `oneOf` branch embeds, not
+  a separately-maintained copy). This correlates `action` with `input` at
+  the schema level without adding a fifth public root field or duplicating
+  `action` inside `input`.
+- `handle()`, when used, MUST validate `action` against the registry, type-
+  check and strip root `summarize` before any child handler runs, reject
+  unknown root fields, and reject `input` keys outside the selected child's
+  own declared schema `properties` — schema conformance alone is not the
+  sole enforcement boundary; dispatch remains always-authoritative and
+  fail-closed regardless of whether a given provider validates the root
+  `allOf`/`if`/`then` schema-side (`../CONTRACT.md` "Dispatch and actions").
+- A child handler MUST receive only its own validated `input` mapping — never
+  `action`, `reasoning`, `_reasoning`, or `summarize`.
+- `handle()`'s dispatch result IS the child's own raw/canonical result;
+  `ToolFamily` MUST NOT wrap it a second time.
+- This package MUST NOT require inheritance from a shared base/port class, a
+  shared handler, common request/result types, or a universal domain result
+  shape from any consumer family, matching `../CONTRACT.md` "Implementation
+  independence" verbatim.
+- `manual.build_manual_child`'s child MUST use the reserved name `manual`, a
+  strict empty `input_schema`, and its handler's actual return value — what
+  `ToolFamily.handle()` dispatches back verbatim — MUST be the canonical
+  `content[0].text` (full body) / `structuredContent.manual_path` (host-local
+  path) shape, never the pre-mapping flat `load_installed_manual()` dict.
+  `status`/`error` loader facts MUST be preserved truthfully alongside those
+  two fields, not dropped or double-wrapped.
+- A family MUST register `build_manual_child`'s returned `ChildTool` directly
+  in its own `ToolFamily` — never wrapped in another handler that adapts or
+  reshapes the result before `ToolFamily.handle()` returns it. Any
+  family-specific public-shape adaptation (as `web` needs) MUST happen
+  strictly after the family's own outer dispatch call returns, in that
+  family's own Host/presentation layer, per the no-double-wrap rule above.
+- This package owns no external MCP mounting, registry, adapter, schema, or
+  test; it MUST NOT be extended to add one.
+
+## Contract tests
+
+`tests/test_tool_family_generic.py` proves the infrastructure is generic using
+a fake `widget` family unrelated to `web`: deterministic registration order,
+duplicate-name and reserved-`manual`-collision failures, `oneOf` schema
+composition with root `reasoning` REQUIRED and no unconstrained generic
+`input` object, dispatch selecting the correct child and passing only its
+`input`, unknown-action/non-boolean-summarize/unknown-root-field/cross-branch-
+key rejection, no double result wrapping, and two dedicated proofs that
+`reasoning`/`summarize` never reach a child handler and never appear in any
+child's own canonical `input_schema`. It also proves the root `allOf`
+correlation directly: every condition's `action` const matches the child
+registry name, `then.input` exactly matches that child's own canonical
+schema, a minimal local `if`/`then` structural evaluator (no JSON Schema
+dependency added) shows the schema itself rejects a mismatched
+`action`/`input` pairing, `handle()` remains authoritative and fail-closed
+regardless, and both the `allOf` conditions and the `oneOf` branches are
+mutation-isolated from each other and from a child's own canonical schema.
+`tests/test_tool_family_wire_parity.py`
+proves the composed schema (including required `reasoning`) survives both
+Chat Completions and Responses wires (including a real Agent
+startup for `web`) at the existing OpenAI adapter seam with zero adapter code
+changes. `tests/test_tool_family_manual_contract.py` invokes the actual
+generic manual child handler (not an unused presentational helper) and
+proves the ManualTool reserved name, strict empty input, the canonical
+`content[0].text`/`structuredContent.manual_path` return shape,
+missing-manual degraded case, and the reserved-name collision. It also
+proves the registration/adaptation ownership boundary directly:
+`manager._family.handle(...)` — the real `ToolFamily` `web` registers its
+`manual` child in, unwrapped — returns the canonical
+`content`/`structuredContent` result verbatim for a manual call, with none of
+Web's legacy flat fields; `manager.handle(...)` on the identical envelope
+returns Web's exact pre-migration public flat shape (`status`, `manual`,
+`manual_path`, `action`, `current_setting`) with no canonical fields, for
+both the success and missing-manual/degraded cases, via
+`WebManager._adapt_manual_result`'s post-dispatch adaptation.
+`tests/test_tool_family_web_migration_parity.py` snapshots `web`'s
+pre-migration schema and proves the now-generated schema is field-equivalent
+except the three authorized differences (`anyOf` → `oneOf`, required
+`reasoning`, and the added root `allOf`), and separately proves `web`'s own
+`allOf` correlates every real action's `const` with its exact branch schema.
+`tests/test_tool_family_generic_summarize_executor.py` proves the raw-logged-
+before-summary executor mechanism needs no family-specific kernel wiring,
+using the fake `widget` family. `web`'s own existing suite
+(`tests/test_unified_web_capability.py`,
+`tests/test_web_ltp_v2_summarize_executor.py`, `tests/test_wire_tool_description.py`
+— the last of which now also proves root `allOf` correlation survives
+identically on both Chat Completions and Responses wires)
+remains this migration's Web-specific evidence per `../web_search/CONTRACT.md`.
+
+## Maintenance
+
+Keep this Contract and `ANATOMY.md` reciprocal. Update the Port
+(`ChildTool`/`ToolFamily`), the `web_search` Adapter, and contract tests
+together when the envelope or dispatch boundary changes. Do not add a second
+family here merely because it exists — a family joins this contract's
+Adapters list only when it actually migrates onto this package, per
+`../CONTRACT.md` "Migration is one family at a time."

--- a/src/lingtai/tools/tool_family/__init__.py
+++ b/src/lingtai/tools/tool_family/__init__.py
@@ -1,0 +1,289 @@
+"""Generic internal ToolFamily composition: one model tool per family.
+
+A ``ToolFamily`` groups cohesive child Tools (``ChildTool``) behind exactly
+one model-facing tool. The model sees one aggregate schema composed from
+each child's own canonical ``input_schema``: a root ``allOf`` of one
+``if``/``then`` condition per registered child correlates the sibling
+``action`` const with that exact child's ``input`` shape (schema-level
+correlation, not just dispatch-time), plus a root ``input.oneOf`` retained
+for model discoverability of every action's shape in one place. Both
+surfaces are generated purely from the child registry — no name/schema
+mapping table — and both derive from the same deep-copied canonical child
+schemas. Root-level correlation via ``allOf``/``if``/``then`` was adopted
+after a live non-strict Codex Responses probe on 2026-07-27 accepted a raw
+root ``allOf``/``if``/``then`` schema without error on the current route,
+superseding the earlier, more conservative assumption that root combinators
+were universally rejected (see ``lingtai.llm.openai.adapter``'s
+``_scrub_responses_schema`` for the corresponding wire-level change).
+Children never consume model tool
+slots. Dispatch remains the second, always-authoritative enforcement layer —
+an in-process handler lookup keyed by the child's own name, which rejects
+any ``input`` key outside the selected child's own declared schema before
+the handler runs, fail-closed with no guessing/fallback — so a provider that
+does not enforce ``allOf``/``if``/``then`` (or a call bypassing schema
+validation entirely) still cannot smuggle a mismatched ``action``/``input``
+pairing past dispatch. There is no transport, no external MCP surface, and
+no second registry.
+
+This module standardizes only the wire envelope and the composition/dispatch
+boilerplate every hand-migrated LTP v2 family (see
+``src/lingtai/tools/CONTRACT.md``) would otherwise duplicate. It is an
+optional helper, not a mandatory base class: a family may use
+:class:`ToolFamily` directly, or hand-write an equivalent ``handle()`` the way
+``web`` did before adopting it. Two children in a family are not required to
+share anything beyond their registration in one :class:`ToolFamily`.
+"""
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+
+__all__ = [
+    "ChildTool",
+    "ToolFamily",
+    "ToolFamilyError",
+]
+
+# The one reserved child name every family may offer at most once. Colliding
+# with it at registration is a defect, not a naming choice to resolve
+# silently — see ``tools/CONTRACT.md`` "Every LingTai-owned family MUST offer
+# a `manual` action" and the ManualTool stable contract.
+RESERVED_MANUAL_NAME = "manual"
+
+# Envelope root fields admitted alongside ``action``/``input``.
+_ROOT_FIELDS = {"action", "input", "reasoning", "_reasoning", "summarize"}
+
+# Same canonical English reasoning-property description the kernel injects
+# for every tool (``kernel/base_agent/tools.py:_REASONING_DESCRIPTION``).
+# Declared here too so the composed family schema is self-describing and
+# ``reasoning`` is REQUIRED before ``_build_tool_schemas`` merges its own
+# (identical) property text in — that merge only overwrites ``properties``,
+# never ``required``, so this is the one place a family schema must declare
+# ``reasoning`` as required. Kept as a literal copy rather than an import to
+# avoid a tools -> kernel dependency; the exact wording is a contract fact
+# proven equal by ``tests/test_tool_family_wire_parity.py``.
+_REASONING_DESCRIPTION = (
+    "Brief explanation of why you are calling this tool "
+    "(recorded in your diary)."
+)
+
+
+class ToolFamilyError(ValueError):
+    """Raised for a ToolFamily construction defect (bad registry shape)."""
+
+
+@dataclass(frozen=True, slots=True)
+class ChildTool:
+    """One family-owned child: canonical name, schema, and handler.
+
+    ``name`` is simultaneously the child's registry key, the model-facing
+    ``action`` constant, and the dispatch handler key — one name, three
+    roles, no mapping layer. ``input_schema`` is this child's own strict
+    JSON Schema object for ``input`` (closed, ``additionalProperties: false``
+    is the child's own responsibility). ``handler`` receives only the
+    validated ``input`` mapping (never ``action``, ``reasoning``, or
+    ``summarize``) and returns the child's own raw, canonical result dict.
+    """
+
+    name: str
+    input_schema: Mapping[str, Any]
+    handler: Callable[[Mapping[str, Any]], dict[str, Any]]
+    title: str | None = None
+
+    def branch_title(self) -> str:
+        return self.title or f"{self.name} input"
+
+
+class ToolFamily:
+    """One model-facing aggregate tool composed from a fixed child registry.
+
+    Construction validates the registry (deterministic order, unique names,
+    a reserved-name collision on ``manual`` fails loudly). :meth:`build_schema`
+    recomputes the composed model-facing schema on every call rather than
+    caching one at construction. :meth:`handle` is the family/Host dispatch
+    boilerplate: it validates ``action``, strips and validates ``summarize``,
+    rejects unknown envelope fields and cross-branch ``input`` keys, then
+    calls the selected child's handler with only its own ``input``. Using
+    this dispatcher is optional; a family may implement an equivalent
+    ``handle()`` by hand and skip this class entirely.
+    """
+
+    def __init__(self, name: str, children: Sequence[ChildTool]) -> None:
+        if not name or not isinstance(name, str):
+            raise ToolFamilyError("ToolFamily name must be a non-empty string")
+        if not children:
+            raise ToolFamilyError(f"ToolFamily {name!r} must register at least one child")
+        seen: dict[str, ChildTool] = {}
+        manual_count = 0
+        for child in children:
+            if not isinstance(child, ChildTool):
+                raise ToolFamilyError(f"ToolFamily {name!r} child must be a ChildTool")
+            if not child.name or not isinstance(child.name, str):
+                raise ToolFamilyError(f"ToolFamily {name!r} child name must be a non-empty string")
+            if child.name in seen:
+                raise ToolFamilyError(
+                    f"ToolFamily {name!r} has a duplicate child name {child.name!r}"
+                )
+            if child.name == RESERVED_MANUAL_NAME:
+                manual_count += 1
+                if manual_count > 1:
+                    raise ToolFamilyError(
+                        f"ToolFamily {name!r} has a reserved-name collision on "
+                        f"{RESERVED_MANUAL_NAME!r}"
+                    )
+            seen[child.name] = child
+        self.name = name
+        self._children: dict[str, ChildTool] = seen
+        # Preserve caller-declared order for deterministic schema branches.
+        self._order: list[str] = [child.name for child in children]
+
+    @property
+    def child_names(self) -> tuple[str, ...]:
+        return tuple(self._order)
+
+    def has_manual(self) -> bool:
+        return RESERVED_MANUAL_NAME in self._children
+
+    def build_schema(self) -> dict[str, Any]:
+        """Compose the model-facing schema.
+
+        Two enforcement layers, generated purely from the child registry (no
+        name/schema mapping table), both built from the same deep-copied
+        canonical child schemas so they cannot drift apart:
+
+        1. **Schema-level correlation (``allOf``):** one ``if``/``then``
+           condition per registered child. Each ``if`` tests root ``action``
+           against that child's own name via ``const`` (guarded by
+           ``required: ["action"]``, since a strict ``if`` with a missing
+           property vacuously matches); each ``then`` constrains root
+           ``input`` to that exact child's ``input_schema``. This lets a
+           provider that enforces ``allOf``/``if``/``then`` reject a
+           mismatched ``action``/``input`` pairing before the call is even
+           made — a live non-strict Codex Responses probe on 2026-07-27
+           showed this root construct is accepted, not rejected, by the
+           current backend route.
+        2. **``input.oneOf`` disclosure:** the same per-action branches,
+           retained under ``input`` for model discoverability of every
+           action's exact shape in one place (as before).
+
+        The root carries ``action``, ``input``, required ``reasoning``, and
+        optional ``summarize`` — exactly the four LTP v2 envelope fields
+        (``tools/CONTRACT.md`` "Envelope"); `allOf`'s conditions constrain
+        ``action``/``input`` without duplicating ``action`` inside ``input``
+        or adding a fifth public field. ``reasoning`` is Host
+        InvocationContext/audit metadata, never action input: it is declared
+        here as REQUIRED so every family built on this infrastructure is
+        model-visible-required by construction, not by relying on Agent
+        schema composition (``kernel/base_agent/tools.py:_build_tool_schemas``)
+        to add it — that step still re-injects the identical property text
+        for every tool uniformly, but only touches ``properties``, never
+        ``required``.
+
+        Schema-level correlation is a second, additive layer, not a
+        replacement for dispatch: :meth:`handle` remains the always-
+        authoritative, fail-closed enforcement boundary regardless of
+        whether a given provider actually validates ``allOf``/``if``/``then``
+        before invocation.
+        """
+        input_branches = []
+        all_of_conditions = []
+        for child_name in self._order:
+            child = self._children[child_name]
+            # Deep-copy once per child so the ``oneOf`` branch and the
+            # ``allOf`` condition's ``then.input`` never share a mutable
+            # container with each other, the child's own canonical
+            # ``input_schema``, or a previous ``build_schema()`` call.
+            canonical_input_schema = copy.deepcopy(child.input_schema)
+
+            branch = {"title": child.branch_title()}
+            branch.update(copy.deepcopy(canonical_input_schema))
+            input_branches.append(branch)
+
+            all_of_conditions.append(
+                {
+                    "if": {
+                        "properties": {"action": {"const": child_name}},
+                        "required": ["action"],
+                    },
+                    "then": {
+                        "properties": {"input": copy.deepcopy(canonical_input_schema)},
+                    },
+                }
+            )
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": list(self._order),
+                    "description": f"Required operation within the {self.name} family.",
+                },
+                "input": {
+                    "description": (
+                        "Strict action-specific input; the selected action is "
+                        "validated again at dispatch."
+                    ),
+                    "oneOf": input_branches,
+                },
+                "reasoning": {
+                    "type": "string",
+                    "description": _REASONING_DESCRIPTION,
+                },
+                "summarize": {
+                    "type": "boolean",
+                    "description": (
+                        "Root, cross-cutting result post-processing control; "
+                        "absent or false by default. Not action input."
+                    ),
+                },
+            },
+            "required": ["action", "input", "reasoning"],
+            "additionalProperties": False,
+            "allOf": all_of_conditions,
+        }
+
+    def _allowed_input_keys(self, child: ChildTool) -> set[str]:
+        properties = child.input_schema.get("properties") if isinstance(child.input_schema, Mapping) else None
+        return set(properties) if isinstance(properties, Mapping) else set()
+
+    def handle(self, args: Mapping[str, Any] | None) -> dict[str, Any]:
+        """Validate the envelope, dispatch to the selected child, return its raw result.
+
+        ``summarize`` is stripped and type-checked before the unknown-field
+        check so a family opting into this dispatcher gets the same ordering
+        ``web`` hand-wrote. Children receive only their own ``input`` mapping
+        — never ``action``, ``reasoning``, ``_reasoning``, or ``summarize``.
+        Per ``tools/CONTRACT.md`` "Dispatch and actions", schema conformance
+        alone is not the dispatch-time authorization boundary: ``input`` keys
+        are validated against the selected child's own declared
+        ``input_schema`` properties, rejecting any key belonging to another
+        action's branch, before the child handler ever runs.
+        """
+        raw = dict(args or {})
+        action = raw.get("action")
+        if action not in self._children:
+            return self._envelope_error(
+                "ACTION_REQUIRED",
+                f"action must be one of {', '.join(self._order)}",
+            )
+        if "summarize" in raw:
+            summarize = raw.pop("summarize")
+            if not isinstance(summarize, bool):
+                return self._envelope_error("INVALID_ARGUMENT", "summarize must be a boolean")
+        unknown = set(raw) - _ROOT_FIELDS
+        if unknown:
+            return self._envelope_error("INVALID_ARGUMENT", f"unsupported {self.name} argument")
+        action_input = raw.get("input")
+        if not isinstance(action_input, Mapping):
+            return self._envelope_error("INVALID_ARGUMENT", "input must be an object")
+        child = self._children[action]
+        allowed = self._allowed_input_keys(child)
+        if set(action_input) - allowed:
+            return self._envelope_error(
+                "INVALID_ARGUMENT", f"unsupported {self.name} input field"
+            )
+        return child.handler(action_input)
+
+    def _envelope_error(self, code: str, message: str) -> dict[str, Any]:
+        return {"status": "failed", "error_code": code, "message": message}

--- a/src/lingtai/tools/tool_family/glossary-en.md
+++ b/src/lingtai/tools/tool_family/glossary-en.md
@@ -1,0 +1,14 @@
+---
+kind: tool-glossary
+schema_version: 1
+tool_package: lingtai.tools.tool_family
+language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/tool_family/glossary-zh.md
+- src/lingtai/tools/tool_family/glossary-wen.md
+maintenance: |
+  English glossary for the internal tool_family infrastructure package (lingtai.tools.tool_family); the English body stays empty. Update the zh/wen mappings in lockstep whenever tool_family identifiers or concepts change. Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
+---

--- a/src/lingtai/tools/tool_family/glossary-wen.md
+++ b/src/lingtai/tools/tool_family/glossary-wen.md
@@ -1,0 +1,23 @@
+---
+kind: tool-glossary
+schema_version: 1
+tool_package: lingtai.tools.tool_family
+language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/tool_family/glossary-en.md
+- src/lingtai/tools/tool_family/glossary-zh.md
+maintenance: |
+  Classical-Chinese glossary for the internal tool_family infrastructure package; keep a distinct, minimal mapping of immutable identifiers and update it with zh/en files. Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
+---
+**名相对照**
+
+- `ToolFamily`：一族聚合工具之内部子 Tool 名籍与 schema 合成者
+- `ChildTool`：一子 Tool 之名、`input_schema`、handler 三者所记
+- `action`：模型所择子 Tool 之名，即名籍之键
+- `input`：所择 action 自有之严输
+- `reasoning`：Host 审计之元数据，不入子 Tool 之输
+- `summarize`：Host 呈现层之可选后处开关，不入子 Tool 之输
+- `manual`：族属保留子 Tool 之名，返所安手册全文与其径

--- a/src/lingtai/tools/tool_family/glossary-zh.md
+++ b/src/lingtai/tools/tool_family/glossary-zh.md
@@ -1,0 +1,23 @@
+---
+kind: tool-glossary
+schema_version: 1
+tool_package: lingtai.tools.tool_family
+language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/tool_family/glossary-en.md
+- src/lingtai/tools/tool_family/glossary-wen.md
+maintenance: |
+  简体中文 glossary for the internal tool_family infrastructure package; keep a minimal mapping of immutable identifiers and update it with the English and wen files. Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
+---
+**术语对照**
+
+- `ToolFamily`：一族聚合工具的内部子 Tool 注册表与 schema 组合器
+- `ChildTool`：一个子 Tool 的名称、`input_schema`、handler 描述符
+- `action`：模型选择的子 Tool 名，等同注册表键
+- `input`：所选 action 自身的严格输入
+- `reasoning`：Host 审计元数据，不进入子 Tool 输入
+- `summarize`：Host 呈现层的可选后处理开关，不进入子 Tool 输入
+- `manual`：族属保留子 Tool 名，返回安装手册全文与路径

--- a/src/lingtai/tools/tool_family/manual.py
+++ b/src/lingtai/tools/tool_family/manual.py
@@ -1,0 +1,74 @@
+"""ManualTool stable contract: the family-owned reserved ``manual`` child.
+
+Every LingTai-owned family offers a ``manual`` action (``tools/CONTRACT.md``
+"Dispatch and actions"). This module upgrades the existing ``#1058``
+``load_installed_manual()`` return shape into a stable, reusable, internal
+MCP-compatible contract: a strict empty input, and a canonical child result
+carrying the full installed ``SKILL.md`` body at ``content[0].text`` and the
+model-visible host-local ``manual_path`` at ``structuredContent.manual_path``
+— the two fields the approved v0.4 ManualTool acceptance requires of the
+*actual* child result, not merely of an unused presentational helper. This is
+the real, dispatched-to handler `ToolFamily.handle()` returns verbatim (no
+double wrap): a family wanting the pre-migration flat
+``load_installed_manual()`` shape (``status``, ``manual``, ``manual_path``)
+back out — as ``web`` does — owns that adaptation itself, in its own Host/
+presentation layer, per the no-double-wrap rule (``../CONTRACT.md`` "Dispatch
+and actions"): the child's own canonical/raw result stays canonical.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .._manual import load_installed_manual
+from . import ChildTool
+
+__all__ = ["build_manual_child"]
+
+
+def _to_mcp_result(loaded: Mapping[str, Any]) -> dict[str, Any]:
+    """Map a ``load_installed_manual``-shaped dict to the canonical child result.
+
+    Full body goes to ``content[0].text``; ``manual_path`` goes to
+    ``structuredContent.manual_path`` (model-visible, never only in a
+    ``_meta``-style side channel) — the two fields the approved v0.4
+    acceptance line requires. ``status`` (and ``error``, when the loader
+    reports a missing/degraded manual) are preserved verbatim as truthful
+    loader facts alongside the two MCP-compatible fields; this is not a
+    second wrapper, it is this child's own canonical result shape.
+    """
+    result: dict[str, Any] = {
+        "status": loaded.get("status", "ok"),
+        "content": [{"type": "text", "text": loaded.get("manual", "")}],
+        "structuredContent": {"manual_path": loaded.get("manual_path", "")},
+    }
+    if "error" in loaded:
+        result["error"] = loaded["error"]
+    return result
+
+
+def build_manual_child(agent: Any, skill_name: str) -> ChildTool:
+    """Build the reserved ``manual`` :class:`ChildTool` for one family.
+
+    ``skill_name`` is the installed manual's public destination name (e.g.
+    ``"web"``), matching ``Agent._install_intrinsic_manuals``'s directory
+    mapping. The child's own input is validated as strict empty by
+    :class:`ToolFamily.handle`, matching every other child. This
+    :class:`ChildTool` is the family's actual, registered ``manual`` child —
+    a family MUST register it directly in its own :class:`ToolFamily` so
+    :meth:`ToolFamily.handle` dispatches back its canonical
+    ``content``/``structuredContent`` result verbatim (no double wrap); a
+    family wanting a different public result shape (as ``web`` does) adapts
+    the dispatched result itself, after ``ToolFamily.handle`` returns, in its
+    own Host/presentation layer — never inside this builder or its handler.
+    """
+
+    def handler(_input: Mapping[str, Any]) -> dict[str, Any]:
+        loaded = load_installed_manual(agent, skill_name)
+        return _to_mcp_result(loaded)
+
+    return ChildTool(
+        name="manual",
+        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        handler=handler,
+        title="manual input",
+    )

--- a/src/lingtai/tools/web_search/ANATOMY.md
+++ b/src/lingtai/tools/web_search/ANATOMY.md
@@ -10,27 +10,37 @@ related_files:
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/tools/browser/core.py
   - src/lingtai/tools/browser/port.py
+  - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/services/websearch/ANATOMY.md
 maintenance: |
   Keep this public web Anatomy and its Contract reciprocal, keep the parent
   link bidirectional, and keep the sole web-manual edge on both owner twins.
   Browser is an internal browse subcomponent, not another model-facing node.
+  tool_family is generic optional infrastructure this package composes onto;
+  web's own instance-bound diagnostics and dispatch wrapper remain here.
   Update this map with structural code changes and verify citations.
 ---
 # Unified web capability Anatomy
 
 The retained `web_search` package is the public `web` composition owner. It
 combines lazy SearchService adapters with the internal browser Core while
-exposing one model-facing handler and one per-Agent state boundary.
+exposing one model-facing handler and one per-Agent state boundary. Schema
+composition and envelope dispatch delegate to the generic
+`tool_family` infrastructure; this package retains ownership of
+action implementations, settings, and diagnostics.
 
 ## Components
 
-- `WebManager`, `setup()`, and the single `web` schema — dispatch (including
-  root `summarize` validation/stripping and the action-scoped settings read
-  that only `search` performs), lazy engine composition, settings
-  diagnostics, and registration (`src/lingtai/tools/web_search/__init__.py:1-422`).
+- `WebManager`, `setup()`, and the single `web` schema — builds a per-instance
+  `ToolFamily` (`lingtai.tools.tool_family`) with `search`/`browse` handlers
+  bound to instance state and a `manual` child from
+  `tool_family.manual.build_manual_child`; `handle()` delegates envelope
+  validation and dispatch to that `ToolFamily` and stamps
+  `current_setting`/`action` onto envelope-level failures; lazy engine
+  composition, settings diagnostics, and registration
+  (`src/lingtai/tools/web_search/__init__.py:1-426`).
 - `_EngineSpec` and `_specs_from_kwargs` — immutable operator engine wiring and
-  legacy flat-config migration (`src/lingtai/tools/web_search/__init__.py:124-422`).
+  legacy flat-config migration (`src/lingtai/tools/web_search/__init__.py:120-400`).
 - `read_settings()` — bounded regular-file snapshot and strict v1 selector
   validation over the action-owned `settings/web.search.json`
   (`src/lingtai/tools/web_search/settings.py:49-182`).
@@ -54,7 +64,11 @@ transport. Agent manual installation maps this retained package's `manual/` to
 The parent [`src/lingtai/tools/ANATOMY.md`](../ANATOMY.md) owns capability
 registry composition. The internal browse child
 [`src/lingtai/tools/browser/ANATOMY.md`](../browser/ANATOMY.md) owns static-page
-structure but has no public registration. The shared
+structure but has no public registration. The generic
+[`src/lingtai/tools/tool_family/ANATOMY.md`](../tool_family/ANATOMY.md) owns
+the reusable schema-composition/dispatch infrastructure this package builds
+its `ToolFamily` instances from; it has no knowledge of web's own settings or
+diagnostics. The shared
 [`src/lingtai/tools/CONTRACT.md`](../CONTRACT.md) owns the future canonical public
 call shape. The paired [`CONTRACT.md`](CONTRACT.md) specializes
 that promise for web's actions, behavior, and evidence.

--- a/src/lingtai/tools/web_search/CONTRACT.md
+++ b/src/lingtai/tools/web_search/CONTRACT.md
@@ -13,11 +13,14 @@ related_files:
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/services/websearch/__init__.py
   - src/lingtai/kernel/tool_result_summary.py
+  - src/lingtai/tools/tool_family/CONTRACT.md
 maintenance: |
   Keep this unified web Contract and its Anatomy reciprocal. Keep the manual
   edge on both owner twins. Update the Port, adapters, tests, and this Contract
   together when behavior or errors change; retain browser as an internal browse
-  subcomponent rather than a second capability.
+  subcomponent rather than a second capability. web's schema composition and
+  envelope dispatch build on the generic tool_family package; keep that link
+  current when either side's boundary changes.
 ---
 # Unified web capability
 
@@ -27,7 +30,10 @@ maintenance: |
 and metadata-only `manual` actions. It is implemented in the retained
 `tools.web_search` composition owner; browser and SearchService are internal
 subcomponents. `web` is the first family migrated to the LingTai Tool Protocol
-v2 shape defined in `src/lingtai/tools/CONTRACT.md`.
+v2 shape defined in `src/lingtai/tools/CONTRACT.md`, and the first family to
+build its schema composition and envelope dispatch on the generic
+`src/lingtai/tools/tool_family/` infrastructure (`ToolFamily`/`ChildTool`);
+using it changed no observable promise in this file.
 
 ## Behavior
 
@@ -38,12 +44,17 @@ a search/browse reference through the same BrowserEngine state. Manual returns
 the installed web-manual without provider construction or network I/O. All
 success and failure envelopes include `action` and a bounded secret-free
 `current_setting` block. Explicit `engine` and irrelevant action fields fail
-loudly. In the final Agent schema, public `reasoning` is a top-level block
-injected by Agent schema composition; ToolExecutor preserves it only as
-internal `_reasoning` metadata, which does not enter action input or change
-dispatch. `web`'s own schema owns the root `summarize` boolean (LTP v2 is
-migrated one family at a time, not by central injection); `handle()` validates
-it is boolean and strips it before action dispatch — no action implementation
+loudly. `web`'s own schema (via `ToolFamily.build_schema()`) declares a
+top-level, REQUIRED `reasoning` string property — Host InvocationContext/
+audit metadata — with the same description Agent schema composition also
+re-injects into every tool's `properties` uniformly (that central injection
+never touches `required`, so a family must declare `reasoning` required
+itself). ToolExecutor preserves it only as internal `_reasoning` metadata,
+which does not enter action input or change dispatch. `web`'s own schema owns
+the root `summarize` boolean (LTP v2 is
+migrated one family at a time, not by central injection); `handle()` delegates
+to a per-instance `ToolFamily.handle()` (`tool_family/CONTRACT.md`), which
+validates `summarize` is boolean and strips it before action dispatch — no action implementation
 ever receives it.
 
 ## Port
@@ -71,7 +82,8 @@ remain in force.
   `action`, `input`, `reasoning`, and `summarize`. There is no public
   `parameters`, `parameter`, `summary`, or other compatibility alias;
   `_reasoning` is internal only.
-- `action` and nested `input` are required by the capability schema. `action` is
+- `action`, nested `input`, and top-level `reasoning` are required by the
+  capability schema (`required: [action, input, reasoning]`). `action` is
   one of `search`, `browse`, or `manual`; `input` uses strict action-specific
   object branches. Each branch is closed, every declared branch field is
   required, and browse optionals use JSON null, matching OpenAI strict-object

--- a/src/lingtai/tools/web_search/__init__.py
+++ b/src/lingtai/tools/web_search/__init__.py
@@ -367,11 +367,22 @@ class WebManager:
         # the registered child. An envelope-level failure (raised before any
         # action handler runs) has no web-specific ``current_setting``
         # diagnostic yet; this stamps one on, matching every action-level
-        # failure/success result.
+        # failure/success result. The generic dispatcher's own
+        # ``ACTION_REQUIRED`` envelope error is genuinely generic (its
+        # message lists whatever children a given family registered, and it
+        # never had a web-specific ``action`` to echo); Web's pre-migration
+        # public contract instead always reported the fixed values below,
+        # regardless of the arbitrary string a caller sent, so that
+        # normalization happens here — never by changing the generic
+        # dispatcher's own canonical error shape.
         action = args.get("action") if isinstance(args, Mapping) else None
         result = self._family.handle(args)
         if action == "manual" and "content" in result:
             result = self._adapt_manual_result(result)
+        elif result.get("error_code") == "ACTION_REQUIRED":
+            result["action"] = "unknown"
+            result["message"] = "action must be one of search, browse, or manual"
+            result["current_setting"] = self._no_settings_diagnostic()
         elif result.get("status") == "failed" and "current_setting" not in result:
             result["action"] = action if isinstance(action, str) else "unknown"
             result["current_setting"] = self._no_settings_diagnostic()

--- a/src/lingtai/tools/web_search/__init__.py
+++ b/src/lingtai/tools/web_search/__init__.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any, Mapping
 
 from .._manual import load_installed_manual
 from ..browser.core import BrowserEngine
+from ..tool_family import ChildTool, ToolFamily
+from ..tool_family.manual import build_manual_child
 from .settings import SettingsSnapshot, current_setting, read_settings, valid_engine_name
 
 if TYPE_CHECKING:
@@ -26,11 +28,75 @@ PROVIDERS = {
     "fallback_on_inherit": "duckduckgo",
 }
 
-_ACTION_INPUT_FIELDS = {
-    "search": {"query"},
-    "browse": {"url", "link_ref", "cursor", "extract", "max_chars"},
-    "manual": set(),
+_SEARCH_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string", "description": "Search query."},
+    },
+    "required": ["query"],
+    "additionalProperties": False,
 }
+
+_BROWSE_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "url": {
+            "type": ["string", "null"],
+            "description": "Public HTTP(S) URL; use null when link_ref or cursor is supplied.",
+        },
+        "link_ref": {
+            "type": ["string", "null"],
+            "description": "Same-Agent search result reference; use null when not supplied.",
+        },
+        "cursor": {
+            "type": ["string", "null"],
+            "description": "Same-Agent continuation cursor; use null when not supplied.",
+        },
+        "extract": {
+            "type": ["string", "null"],
+            "enum": ["article", None],
+            "description": "Article extraction, or null for the default.",
+        },
+        "max_chars": {
+            "type": ["integer", "null"],
+            "minimum": 1,
+            "maximum": 100000,
+            "description": "Maximum returned characters, or null for the default 12000.",
+        },
+    },
+    "required": ["url", "link_ref", "cursor", "extract", "max_chars"],
+    "additionalProperties": False,
+}
+
+_MANUAL_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+def _schema_only_family() -> ToolFamily:
+    # A throwaway ``ToolFamily`` used only to compose the model-facing schema
+    # and to prove the fixed three-child registry has no duplicate or
+    # reserved-name collision (``ToolFamilyError`` would raise here, at
+    # import time, rather than shipping silently). ``WebManager`` builds its
+    # own per-instance ``ToolFamily`` in ``__init__`` with real handlers
+    # bound to that instance; this module-level one never dispatches.
+    def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
+        raise AssertionError("the module-level schema-only ToolFamily never dispatches")
+
+    return ToolFamily(
+        "web",
+        [
+            ChildTool("search", _SEARCH_INPUT_SCHEMA, _unused, title="search input"),
+            ChildTool("browse", _BROWSE_INPUT_SCHEMA, _unused, title="browse input"),
+            ChildTool("manual", _MANUAL_INPUT_SCHEMA, _unused, title="manual input"),
+        ],
+    )
+
+
+_FAMILY = _schema_only_family()
 
 
 def get_description(lang: str = "en") -> str:
@@ -44,80 +110,12 @@ def get_description(lang: str = "en") -> str:
 
 
 def get_schema(lang: str = "en") -> dict[str, Any]:
-    return {
-        "type": "object",
-        "properties": {
-            "action": {
-                "type": "string",
-                "enum": ["search", "browse", "manual"],
-                "description": "Required operation: search, browse, or manual.",
-            },
-            "input": {
-                "description": (
-                    "Strict action-specific input; the selected action is validated "
-                    "again at dispatch."
-                ),
-                "anyOf": [
-                    {
-                        "title": "search input",
-                        "type": "object",
-                        "properties": {
-                            "query": {"type": "string", "description": "Search query."},
-                        },
-                        "required": ["query"],
-                        "additionalProperties": False,
-                    },
-                    {
-                        "title": "browse input",
-                        "type": "object",
-                        "properties": {
-                            "url": {
-                                "type": ["string", "null"],
-                                "description": "Public HTTP(S) URL; use null when link_ref or cursor is supplied.",
-                            },
-                            "link_ref": {
-                                "type": ["string", "null"],
-                                "description": "Same-Agent search result reference; use null when not supplied.",
-                            },
-                            "cursor": {
-                                "type": ["string", "null"],
-                                "description": "Same-Agent continuation cursor; use null when not supplied.",
-                            },
-                            "extract": {
-                                "type": ["string", "null"],
-                                "enum": ["article", None],
-                                "description": "Article extraction, or null for the default.",
-                            },
-                            "max_chars": {
-                                "type": ["integer", "null"],
-                                "minimum": 1,
-                                "maximum": 100000,
-                                "description": "Maximum returned characters, or null for the default 12000.",
-                            },
-                        },
-                        "required": ["url", "link_ref", "cursor", "extract", "max_chars"],
-                        "additionalProperties": False,
-                    },
-                    {
-                        "title": "manual input",
-                        "type": "object",
-                        "properties": {},
-                        "required": [],
-                        "additionalProperties": False,
-                    },
-                ],
-            },
-            "summarize": {
-                "type": "boolean",
-                "description": (
-                    "Root, cross-cutting result post-processing control; absent "
-                    "or false by default. Not action input."
-                ),
-            },
-        },
-        "required": ["action", "input"],
-        "additionalProperties": False,
-    }
+    # Composed by the generic ToolFamily infra from each child's own
+    # canonical ``input_schema`` (``_SEARCH_INPUT_SCHEMA`` etc. above), rather
+    # than hand-assembled — verified field-equivalent to the pre-migration
+    # schema, except the documented authorized differences, by
+    # ``tests/test_tool_family_web_migration_parity.py``.
+    return _FAMILY.build_schema()
 
 
 @dataclass(frozen=True, slots=True)
@@ -159,6 +157,21 @@ class WebManager:
         self._legacy_fallback_from = legacy_fallback_from
         self._services: dict[str, Any] = {}
         self._service_errors: dict[str, str] = {}
+        self._family = ToolFamily(
+            "web",
+            [
+                ChildTool("search", _SEARCH_INPUT_SCHEMA, self._dispatch_search, title="search input"),
+                ChildTool("browse", _BROWSE_INPUT_SCHEMA, self._dispatch_browse, title="browse input"),
+                # Registered directly, unwrapped: ``ToolFamily.handle()`` must
+                # dispatch this child's own canonical MCP-compatible result
+                # verbatim for ``action="manual"`` (no double wrap). Web's
+                # flat public shape is reconstructed from that canonical
+                # result strictly *after* ``self._family.handle(...)``
+                # returns, in ``handle()`` below — never inside a registered
+                # child.
+                build_manual_child(agent, "web"),
+            ],
+        )
 
     @property
     def browser_engine(self) -> BrowserEngine:
@@ -292,50 +305,76 @@ class WebManager:
         loaded.update({"action": "manual", "current_setting": diagnostic})
         return loaded
 
-    def handle(self, args: dict[str, Any] | None) -> dict[str, Any]:
-        raw = dict(args or {})
-        action = raw.get("action")
-        if action not in _ACTION_INPUT_FIELDS:
-            diagnostic = self._no_settings_diagnostic()
-            return self._failure("unknown", None, diagnostic, "ACTION_REQUIRED", "action must be one of search, browse, or manual")
-        # Root ``summarize`` is envelope metadata (LTP v2), not action input.
-        # Validate its type and strip it here so it never reaches an action
-        # implementation or the unknown-argument check below.
-        if "summarize" in raw:
-            summarize = raw.pop("summarize")
-            if not isinstance(summarize, bool):
-                diagnostic = self._no_settings_diagnostic()
-                return self._failure(action, None, diagnostic, "INVALID_ARGUMENT", "summarize must be a boolean")
-        # Public ``reasoning`` stays top-level in the Agent schema. ToolExecutor
-        # strips that public field and preserves it internally as ``_reasoning``
-        # before invoking capability handlers.
-        unknown = set(raw) - {"action", "input", "reasoning", "_reasoning"}
-        if unknown:
-            diagnostic = self._no_settings_diagnostic()
-            return self._failure(action, None, diagnostic, "INVALID_ARGUMENT", "unsupported web argument")
-        action_input = raw.get("input")
-        if not isinstance(action_input, Mapping):
-            diagnostic = self._no_settings_diagnostic()
-            return self._failure(action, None, diagnostic, "INVALID_ARGUMENT", "input must be an object")
-        action_args = dict(action_input)
-        if set(action_args) - _ACTION_INPUT_FIELDS[action]:
-            diagnostic = self._no_settings_diagnostic()
-            return self._failure(action, None, diagnostic, "INVALID_ARGUMENT", "unsupported web input field")
+    def _adapt_manual_result(self, mcp_result: dict[str, Any]) -> dict[str, Any]:
+        # ``self._family.handle(...)`` has already dispatched to the
+        # registered ``manual`` child (``build_manual_child``) and returned
+        # its canonical result *verbatim* (no double wrap) — full body at
+        # ``content[0].text``, host-local path at
+        # ``structuredContent.manual_path`` (the two approved v0.4 ManualTool
+        # acceptance fields), plus the loader's truthful ``status``/``error``
+        # facts. Web's own public result shape predates that generic
+        # contract and must stay exactly
+        # ``status``/``manual``/``manual_path``/``action``/``current_setting``
+        # (#1058), so this Host-owned adapter runs strictly *after* dispatch,
+        # here in ``handle()``, to flatten the canonical child result back to
+        # it — never inside a registered child, and never touching
+        # search/browse.
+        flat: dict[str, Any] = {
+            "status": mcp_result.get("status", "ok"),
+            "manual": mcp_result["content"][0]["text"],
+            "manual_path": mcp_result["structuredContent"]["manual_path"],
+            "action": "manual",
+            "current_setting": self._no_settings_diagnostic(),
+        }
+        if "error" in mcp_result:
+            flat["error"] = mcp_result["error"]
+        return flat
+
+    def _strip_nulls(self, action_args: Mapping[str, Any]) -> dict[str, Any]:
         # Strict OpenAI schemas express optional fields as required nullable
-        # properties.  Null means absent to the internal action handlers.
-        dispatch_args = {"action": action, **{key: value for key, value in action_args.items() if value is not None}}
-        if action == "manual":
-            return self.manual(self._no_settings_diagnostic())
-        if action == "search":
-            _, snapshot, diagnostic = self._resolve()
-            return self._search(dispatch_args, snapshot, diagnostic)
-        browse_args = dict(dispatch_args)
+        # properties. Null means absent to the internal action handlers.
+        return {key: value for key, value in action_args.items() if value is not None}
+
+    def _dispatch_search(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        dispatch_args = self._strip_nulls(action_input)
+        _, snapshot, diagnostic = self._resolve()
+        return self._search(dispatch_args, snapshot, diagnostic)
+
+    def _dispatch_browse(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        browse_args = self._strip_nulls(action_input)
         try:
             result = self._engine.handle(browse_args)
         except Exception:
             result = {"status": "failed", "error_code": "BROWSE_FAILED", "message": "browse failed safely"}
         result["action"] = "browse"
         result["current_setting"] = self._no_settings_diagnostic()
+        return result
+
+    def handle(self, args: dict[str, Any] | None) -> dict[str, Any]:
+        # The generic ``ToolFamily`` dispatcher validates ``action``,
+        # type-checks and strips root ``summarize``, rejects unknown root
+        # fields, and rejects ``input`` keys outside the selected action's own
+        # declared schema (schema conformance alone is not the dispatch-time
+        # authorization boundary — see ``tools/CONTRACT.md`` "Dispatch and
+        # actions") before calling ``_dispatch_search``/``_dispatch_browse``/
+        # the registered ``manual`` child's own handler with only that
+        # action's own ``input``. ``self._family.handle(...)`` therefore
+        # returns the ``manual`` child's canonical
+        # ``content``/``structuredContent`` result verbatim (no double wrap)
+        # for a successfully dispatched ``action="manual"`` call; adapting
+        # that to Web's pre-migration public flat shape is this method's own
+        # Host/presentation job, done strictly after dispatch, never inside
+        # the registered child. An envelope-level failure (raised before any
+        # action handler runs) has no web-specific ``current_setting``
+        # diagnostic yet; this stamps one on, matching every action-level
+        # failure/success result.
+        action = args.get("action") if isinstance(args, Mapping) else None
+        result = self._family.handle(args)
+        if action == "manual" and "content" in result:
+            result = self._adapt_manual_result(result)
+        elif result.get("status") == "failed" and "current_setting" not in result:
+            result["action"] = action if isinstance(action, str) else "unknown"
+            result["current_setting"] = self._no_settings_diagnostic()
         return result
 
 

--- a/tests/test_browser_capability.py
+++ b/tests/test_browser_capability.py
@@ -74,13 +74,13 @@ def test_web_browse_vertical_slice(tmp_path):
         schemas = agent._build_tool_schemas()
         web_schema = next(schema for schema in schemas if schema.name == "web")
         assert set(web_schema.parameters["properties"]) == {"action", "input", "reasoning", "summarize"}
-        assert web_schema.parameters["required"] == ["action", "input"]
+        assert web_schema.parameters["required"] == ["action", "input", "reasoning"]
         assert web_schema.parameters["additionalProperties"] is False
         assert all(
             "reasoning" not in branch["properties"]
             and "_reasoning" not in branch["properties"]
             and "summarize" not in branch["properties"]
-            for branch in web_schema.parameters["properties"]["input"]["anyOf"]
+            for branch in web_schema.parameters["properties"]["input"]["oneOf"]
         )
         first = agent._tool_handlers["web"]({
             "action": "browse",
@@ -241,9 +241,9 @@ def test_browser_policy_and_cursor_failures_are_typed_and_sanitized():
 def test_web_schema_includes_strict_action_input():
     schema = get_schema()
     assert schema["properties"]["action"]["enum"] == ["search", "browse", "manual"]
-    assert schema["required"] == ["action", "input"]
+    assert schema["required"] == ["action", "input", "reasoning"]
     assert schema["additionalProperties"] is False
-    branches = schema["properties"]["input"]["anyOf"]
+    branches = schema["properties"]["input"]["oneOf"]
     assert [branch["title"] for branch in branches] == [
         "search input", "browse input", "manual input",
     ]

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -127,8 +127,8 @@ def test_manual_schemas_preserve_runtime_checks_for_ordinary_file_calls(
     assert shell_tool.get_schema()["required"] == []
     assert psyche_tool.get_schema()["required"] == ["action"]
     web_schema = web_tool.get_schema()
-    assert web_schema["required"] == ["action", "input"]
-    assert len(web_schema["properties"]["input"]["anyOf"]) == 3
+    assert web_schema["required"] == ["action", "input", "reasoning"]
+    assert len(web_schema["properties"]["input"]["oneOf"]) == 3
     for module in (read_tool, write_tool, edit_tool, glob_tool, grep_tool):
         assert module.get_schema()["required"] == []
 

--- a/tests/test_tool_family_generic.py
+++ b/tests/test_tool_family_generic.py
@@ -1,0 +1,398 @@
+"""Generic ToolFamily/ChildTool infrastructure — proven with a fake family.
+
+This fake ``widget`` family (actions ``spin`` and ``manual``) has no relation
+to ``web``. It exists solely to prove the composition/dispatch/registration
+boilerplate in ``lingtai.tools.tool_family`` is generic, not Web-specific.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lingtai.tools.tool_family import (
+    RESERVED_MANUAL_NAME,
+    ChildTool,
+    ToolFamily,
+    ToolFamilyError,
+)
+
+
+def _spin_child(calls: list[dict]) -> ChildTool:
+    def handler(input_):
+        calls.append(dict(input_))
+        return {"status": "ok", "action": "spin", "speed": input_.get("speed")}
+
+    return ChildTool(
+        name="spin",
+        input_schema={
+            "type": "object",
+            "properties": {"speed": {"type": "integer"}},
+            "required": ["speed"],
+            "additionalProperties": False,
+        },
+        handler=handler,
+        title="spin input",
+    )
+
+
+def _manual_child() -> ChildTool:
+    def handler(_input):
+        return {"status": "ok", "manual": "widget manual body", "manual_path": "/fake/manual_path"}
+
+    return ChildTool(
+        name=RESERVED_MANUAL_NAME,
+        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        handler=handler,
+        title="manual input",
+    )
+
+
+def _widget_family(calls: list[dict] | None = None) -> ToolFamily:
+    calls = calls if calls is not None else []
+    return ToolFamily("widget", [_spin_child(calls), _manual_child()])
+
+
+def test_registration_is_deterministic_and_ordered():
+    fam = _widget_family()
+    assert fam.child_names == ("spin", "manual")
+    assert fam.has_manual()
+
+
+def test_duplicate_child_name_fails_loudly():
+    calls: list[dict] = []
+    with pytest.raises(ToolFamilyError):
+        ToolFamily("widget", [_spin_child(calls), _spin_child(calls)])
+
+
+def test_manual_reserved_name_collision_fails_loudly():
+    def handler(_input):
+        return {"status": "ok"}
+
+    second_manual = ChildTool(
+        name=RESERVED_MANUAL_NAME,
+        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        handler=handler,
+    )
+    with pytest.raises(ToolFamilyError):
+        ToolFamily("widget", [_manual_child(), second_manual])
+
+
+def test_empty_registry_fails_loudly():
+    with pytest.raises(ToolFamilyError):
+        ToolFamily("widget", [])
+
+
+def test_schema_composes_action_input_reasoning_summarize_root():
+    fam = _widget_family()
+    schema = fam.build_schema()
+    assert schema["type"] == "object"
+    # ``reasoning`` is Host InvocationContext/audit metadata and is REQUIRED
+    # — the family schema declares it itself so it is required even before
+    # Agent schema composition re-injects the identical property text (that
+    # injection only touches ``properties``, never ``required``).
+    assert schema["required"] == ["action", "input", "reasoning"]
+    assert schema["additionalProperties"] is False
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    assert schema["properties"]["action"]["enum"] == ["spin", "manual"]
+    assert schema["properties"]["reasoning"]["type"] == "string"
+    assert schema["properties"]["summarize"]["type"] == "boolean"
+    branches = schema["properties"]["input"]["oneOf"]
+    assert [b["title"] for b in branches] == ["spin input", "manual input"]
+    spin_branch, manual_branch = branches
+    assert spin_branch["required"] == ["speed"]
+    assert spin_branch["additionalProperties"] is False
+    assert manual_branch["properties"] == {}
+    for branch in branches:
+        assert "reasoning" not in branch.get("properties", {})
+        assert "_reasoning" not in branch.get("properties", {})
+        assert "summarize" not in branch.get("properties", {})
+
+
+def test_schema_never_uses_generic_unconstrained_input_object():
+    fam = _widget_family()
+    schema = fam.build_schema()
+    for branch in schema["properties"]["input"]["oneOf"]:
+        assert branch.get("type") == "object"
+        assert "properties" in branch
+
+
+def test_dispatch_selects_child_by_action_and_passes_only_input():
+    calls: list[dict] = []
+    fam = _widget_family(calls)
+    result = fam.handle({"action": "spin", "input": {"speed": 5}, "reasoning": "why"})
+    assert result == {"status": "ok", "action": "spin", "speed": 5}
+    assert calls == [{"speed": 5}]
+
+
+def test_dispatch_unknown_action_fails_with_action_required():
+    fam = _widget_family()
+    result = fam.handle({"action": "nope", "input": {}})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "ACTION_REQUIRED"
+
+
+def test_dispatch_missing_action_fails_with_action_required():
+    fam = _widget_family()
+    result = fam.handle({"input": {}})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "ACTION_REQUIRED"
+
+
+def test_dispatch_non_object_input_fails_with_invalid_argument():
+    fam = _widget_family()
+    result = fam.handle({"action": "spin", "input": "not-an-object"})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+
+
+def test_dispatch_unknown_root_field_fails_with_invalid_argument():
+    fam = _widget_family()
+    result = fam.handle({"action": "spin", "input": {"speed": 1}, "bogus": True})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+
+
+def test_dispatch_rejects_reasoning_or_summarize_leaking_into_input():
+    fam = _widget_family()
+    result = fam.handle({"action": "spin", "input": {"speed": 1, "summarize": True}})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+
+    result2 = fam.handle({"action": "spin", "input": {"speed": 1, "reasoning": "x"}})
+    assert result2["status"] == "failed"
+    assert result2["error_code"] == "INVALID_ARGUMENT"
+
+
+def test_dispatch_non_boolean_summarize_fails_loudly():
+    fam = _widget_family()
+    result = fam.handle({"action": "spin", "input": {"speed": 1}, "summarize": "yes"})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+
+
+def test_dispatch_strips_summarize_and_reasoning_before_child_sees_input():
+    calls: list[dict] = []
+    fam = _widget_family(calls)
+    fam.handle({"action": "spin", "input": {"speed": 3}, "reasoning": "r", "summarize": True})
+    assert calls == [{"speed": 3}]
+
+
+def test_child_handlers_receive_only_input_never_reasoning_or_summarize():
+    """Direct proof for every registered child, not just one action: the
+    handler's sole argument is the selected child's own ``input`` mapping.
+    ``reasoning`` (required Host audit metadata) and ``summarize`` (optional
+    Host presentation control) never reach any child, regardless of whether
+    they are present, absent, or combined on one call."""
+    seen_args: list[dict] = []
+
+    def spin_handler(input_):
+        seen_args.append(dict(input_))
+        return {"status": "ok"}
+
+    def manual_handler(input_):
+        seen_args.append(dict(input_))
+        return {"status": "ok"}
+
+    fam = ToolFamily(
+        "widget",
+        [
+            ChildTool(
+                "spin",
+                {"type": "object", "properties": {"speed": {"type": "integer"}}, "required": ["speed"], "additionalProperties": False},
+                spin_handler,
+            ),
+            ChildTool(
+                RESERVED_MANUAL_NAME,
+                {"type": "object", "properties": {}, "additionalProperties": False},
+                manual_handler,
+            ),
+        ],
+    )
+    fam.handle({"action": "spin", "input": {"speed": 1}, "reasoning": "r1"})
+    fam.handle({"action": "spin", "input": {"speed": 2}, "reasoning": "r2", "summarize": True})
+    fam.handle({"action": "manual", "input": {}, "reasoning": "r3", "summarize": False})
+    assert seen_args == [{"speed": 1}, {"speed": 2}, {}]
+    for args in seen_args:
+        assert "reasoning" not in args
+        assert "_reasoning" not in args
+        assert "summarize" not in args
+
+
+def test_canonical_child_input_schema_never_declares_reasoning_or_summarize():
+    """Static proof at the schema level (distinct from the dispatch-time
+    behavioral proof above): no child's own canonical ``input_schema`` — the
+    schema a family author writes — declares ``reasoning``, ``_reasoning``,
+    or ``summarize`` as one of its own properties. Those are envelope-only
+    fields owned exclusively by the family root."""
+    fam = _widget_family()
+    for name in fam.child_names:
+        child = fam._children[name]
+        props = child.input_schema.get("properties", {})
+        assert "reasoning" not in props
+        assert "_reasoning" not in props
+        assert "summarize" not in props
+
+
+def test_dispatch_child_result_is_not_double_wrapped():
+    calls: list[dict] = []
+    fam = _widget_family(calls)
+    result = fam.handle({"action": "spin", "input": {"speed": 9}, "reasoning": "r"})
+    # The child's own raw return value is the family's return value verbatim.
+    assert result == {"status": "ok", "action": "spin", "speed": 9}
+    assert "result" not in result and "data" not in result
+
+
+def test_manual_child_dispatch_returns_full_manual_shape():
+    fam = _widget_family()
+    result = fam.handle({"action": "manual", "input": {}, "reasoning": "load manual"})
+    assert result == {
+        "status": "ok",
+        "manual": "widget manual body",
+        "manual_path": "/fake/manual_path",
+    }
+
+
+def test_manual_child_rejects_nonempty_input():
+    fam = _widget_family()
+    # The manual branch's own strict-empty schema is model-facing guidance;
+    # dispatch-time correspondence is a separate, real check per
+    # tools/CONTRACT.md "Dispatch and actions": a family MUST validate
+    # action/input correspondence, not just rely on schema conformance.
+    # ChildTool handlers here do not themselves reject extra keys (that is
+    # each child's own responsibility, per "implementation independence"),
+    # but the family-level schema composition still advertises strict-empty.
+    schema = fam.build_schema()
+    manual_branch = next(b for b in schema["properties"]["input"]["oneOf"] if b["title"] == "manual input")
+    assert manual_branch["additionalProperties"] is False
+    assert manual_branch["properties"] == {}
+
+
+def _minimal_evaluate_if_then(condition: dict, action: str, input_value: dict) -> bool | None:
+    """Tiny, dependency-free structural evaluator for exactly the ``if``/
+    ``then`` shape :meth:`ToolFamily.build_schema` generates — not a general
+    JSON Schema validator. No JSON Schema library is installed in this repo,
+    and the task authorizes a minimal local evaluator instead of adding one.
+
+    Returns ``True`` if ``action``/``input_value`` satisfy this condition's
+    ``then`` branch, ``False`` if ``if`` matches but ``then`` is violated,
+    and ``None`` if ``if`` does not match at all (condition inapplicable —
+    ``allOf`` treats a non-matching ``if`` as vacuously satisfied, mirroring
+    real JSON Schema ``if``/``then`` semantics without ``else``).
+    """
+    if_clause = condition["if"]
+    if action != if_clause["properties"]["action"]["const"]:
+        return None
+    then_clause = condition["then"]
+    input_schema = then_clause["properties"]["input"]
+    allowed = set(input_schema.get("properties", {}))
+    required = set(input_schema.get("required", []))
+    if not required.issubset(input_value):
+        return False
+    if input_schema.get("additionalProperties") is False and set(input_value) - allowed:
+        return False
+    return True
+
+
+def test_schema_correlates_action_const_with_exact_child_input_via_root_all_of():
+    """Real schema-level correlation, generated purely from the child
+    registry: one ``allOf`` condition per child, each ``if`` testing
+    ``action`` via ``const`` against exactly that child's own registry name,
+    each ``then`` constraining ``input`` to that exact child's canonical
+    ``input_schema`` — not a mapping table, not a second name list."""
+    fam = _widget_family()
+    schema = fam.build_schema()
+    conditions = schema["allOf"]
+    assert [c["if"]["properties"]["action"]["const"] for c in conditions] == list(fam.child_names)
+    for child_name, condition in zip(fam.child_names, conditions):
+        assert condition["if"]["required"] == ["action"]
+        then_input = condition["then"]["properties"]["input"]
+        child = fam._children[child_name]
+        assert then_input == dict(child.input_schema)
+
+
+def test_schema_all_of_rejects_mismatched_action_input_pairing_structurally():
+    """Direct proof the schema *itself* now correlates ``action``/``input``:
+    using a minimal local ``if``/``then`` evaluator (no JSON Schema
+    dependency added), a spin-shaped ``input`` fails the ``manual`` action's
+    ``allOf`` condition, and an empty ``input`` fails the ``spin`` action's
+    condition — the mismatch is caught by schema structure, not only by
+    ``handle()`` at dispatch. ``handle()`` remains the always-authoritative,
+    fail-closed second layer regardless of what the schema alone proves."""
+    fam = _widget_family()
+    schema = fam.build_schema()
+    conditions = {c["if"]["properties"]["action"]["const"]: c for c in schema["allOf"]}
+
+    manual_condition = conditions["manual"]
+    assert _minimal_evaluate_if_then(manual_condition, "manual", {"speed": 1}) is False
+    assert _minimal_evaluate_if_then(manual_condition, "manual", {}) is True
+
+    spin_condition = conditions["spin"]
+    assert _minimal_evaluate_if_then(spin_condition, "spin", {}) is False
+    assert _minimal_evaluate_if_then(spin_condition, "spin", {"speed": 1}) is True
+
+    # A condition for a different action does not apply at all (vacuous).
+    assert _minimal_evaluate_if_then(manual_condition, "spin", {"speed": 1}) is None
+
+
+def test_handle_remains_authoritative_fail_closed_even_though_schema_now_correlates():
+    """Dispatch is a second, always-authoritative enforcement layer: a
+    mismatched ``action``/``input`` pairing is still rejected by
+    ``handle()`` even though the schema now also correlates them — this is
+    not a guess/fallback, it is the same exact-key check as before, kept
+    unconditionally regardless of what any provider's schema-side validation
+    does or does not enforce."""
+    fam = _widget_family()
+    result = fam.handle({"action": "manual", "input": {"speed": 1}, "reasoning": "r"})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+
+
+def test_build_schema_does_not_leak_shared_mutable_child_schema_by_reference():
+    """Regression test: ``build_schema()`` must not embed a child's own
+    ``input_schema`` (or its nested containers) by reference into the
+    returned schema such that mutating one call's result corrupts a later,
+    independent call. A shallow ``dict.update`` only copies the top level;
+    nested dicts (e.g. ``properties``) stay shared with whatever object the
+    caller's ``input_schema`` points at."""
+    calls: list[dict] = []
+    fam = _widget_family(calls)
+    first = fam.build_schema()
+    first_spin_branch = next(
+        b for b in first["properties"]["input"]["oneOf"] if b["title"] == "spin input"
+    )
+    # Mutate the nested ``properties`` container reachable from the first
+    # returned schema.
+    first_spin_branch["properties"]["speed"]["type"] = "string"
+
+    second = fam.build_schema()
+    second_spin_branch = next(
+        b for b in second["properties"]["input"]["oneOf"] if b["title"] == "spin input"
+    )
+    assert second_spin_branch["properties"]["speed"]["type"] == "integer"
+
+
+def test_build_schema_all_of_conditions_are_mutation_isolated():
+    """Companion to the ``oneOf``-branch mutation-isolation regression test,
+    for the new ``allOf`` conditions: mutating one call's
+    ``then.properties.input`` must not corrupt a later, independent call, the
+    child's own canonical ``input_schema``, or the sibling ``oneOf`` branch —
+    each surface is built from its own deep copy."""
+    calls: list[dict] = []
+    fam = _widget_family(calls)
+    original_spin_schema = dict(fam._children["spin"].input_schema)
+
+    first = fam.build_schema()
+    spin_condition = next(c for c in first["allOf"] if c["if"]["properties"]["action"]["const"] == "spin")
+    spin_condition["then"]["properties"]["input"]["properties"]["speed"]["type"] = "string"
+
+    second = fam.build_schema()
+    second_spin_condition = next(c for c in second["allOf"] if c["if"]["properties"]["action"]["const"] == "spin")
+    assert second_spin_condition["then"]["properties"]["input"]["properties"]["speed"]["type"] == "integer"
+
+    # The child's own canonical schema is untouched.
+    assert fam._children["spin"].input_schema["properties"]["speed"]["type"] == "integer"
+    assert dict(fam._children["spin"].input_schema) == original_spin_schema
+
+    # The sibling ``oneOf`` branch from the SAME first call is untouched —
+    # allOf.then.input and the oneOf branch do not share a container either.
+    first_spin_branch = next(b for b in first["properties"]["input"]["oneOf"] if b["title"] == "spin input")
+    assert first_spin_branch["properties"]["speed"]["type"] == "integer"

--- a/tests/test_tool_family_generic_summarize_executor.py
+++ b/tests/test_tool_family_generic_summarize_executor.py
@@ -1,0 +1,120 @@
+"""ToolExecutor evidence that raw-first summarize retention is generic, not
+Web-specific: a fake ``widget`` ToolFamily's dispatch result plugs into the
+existing (untouched) executor/summary mechanism with zero family-specific
+kernel wiring.
+
+A ``ToolFamily``-composed root is closed to exactly
+``action``/``input``/``reasoning``/``summarize`` — the legacy ``summary`` key
+is not admitted at the family's own dispatch boundary, matching ``web``
+(neither recognizes or ever recognized ``summary``; sending it to either
+raises the same ``INVALID_ARGUMENT`` today as it did before migration).
+``ToolExecutor`` itself does not strip ``summary``/``summarize`` in
+``_prepare_args`` — only ``reasoning``. So the realistic integration for an
+*unmigrated-style* caller of a ToolFamily-based tool is a thin composition
+wrapper (as ``dispatch_fn`` here) that pops the legacy flag before calling
+into the family, exactly mirroring how a real, still-unmigrated LingTai tool
+would keep tolerating ``summary=true`` today. This proves the raw-logged-
+before-summary mechanism itself needs no family-specific kernel wiring — a
+distinct invariant from ``test_web_ltp_v2_summarize_executor.py``, which
+proves the canonical ``summarize`` spelling specifically for the migrated
+``web`` family via the kernel's per-family allowlist.
+"""
+from __future__ import annotations
+
+from lingtai.kernel.llm.base import ToolCall
+from lingtai.kernel.loop_guard import LoopGuard
+from lingtai.kernel.tool_executor import ToolExecutor
+from lingtai.kernel.tool_result_summary import APRIORI_SUMMARY_MARKER
+from lingtai.tools.tool_family import ChildTool, ToolFamily
+
+
+def _widget_family() -> ToolFamily:
+    def spin_handler(input_):
+        return {"status": "ok", "action": "spin", "marker": "WIDGETRAW-marker"}
+
+    return ToolFamily(
+        "widget",
+        [
+            ChildTool(
+                "spin",
+                {"type": "object", "properties": {}, "additionalProperties": False},
+                spin_handler,
+            )
+        ],
+    )
+
+
+def _make_executor(*, dispatch_fn, summarizer_fn, events, tmp_path):
+    def logger_fn(event_type, **fields):
+        events.append((event_type, fields))
+
+    def make_tool_result_fn(name, result, **kw):
+        return {"role": "tool", "name": name, "content": result, **kw}
+
+    return ToolExecutor(
+        dispatch_fn=dispatch_fn,
+        make_tool_result_fn=make_tool_result_fn,
+        guard=LoopGuard(),
+        known_tools={"widget"},
+        parallel_safe_tools=set(),
+        logger_fn=logger_fn,
+        working_dir=tmp_path,
+        summarizer_fn=summarizer_fn,
+    )
+
+
+def _raw_logged(events, *, needle):
+    for event_type, fields in events:
+        if event_type == "tool_result" and needle in str(fields.get("result")):
+            return True
+    return False
+
+
+def test_generic_family_result_is_not_double_wrapped_before_reaching_executor():
+    fam = _widget_family()
+    result = fam.handle({"action": "spin", "input": {}, "reasoning": "r"})
+    assert result == {"status": "ok", "action": "spin", "marker": "WIDGETRAW-marker"}
+
+
+def test_generic_family_legacy_summary_flag_raw_logged_before_summary(tmp_path):
+    fam = _widget_family()
+    events = []
+
+    def dispatch(tc):
+        # A composition wrapper tolerating the legacy ``summary`` flag before
+        # calling into the family's own closed-root dispatcher — see module
+        # docstring for why this indirection is realistic, not a workaround.
+        args = dict(tc.args)
+        args.pop("summary", None)
+        return fam.handle(args)
+
+    ex = _make_executor(
+        dispatch_fn=dispatch,
+        summarizer_fn=lambda sp, up, tn, cid: "SUMMARY: spun",
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(name="widget", args={"action": "spin", "input": {}, "reasoning": "r", "summary": True}, id="w1"),
+    ])
+    content = results[0]["content"]
+    assert content["artifact"] == APRIORI_SUMMARY_MARKER
+    assert content["generated_summary"] == "SUMMARY: spun"
+    assert "WIDGETRAW-marker" not in str(content)
+    assert _raw_logged(events, needle="WIDGETRAW-marker")
+
+
+def test_generic_family_without_summary_flag_passes_raw_through_unmodified(tmp_path):
+    fam = _widget_family()
+    events = []
+    ex = _make_executor(
+        dispatch_fn=lambda tc: fam.handle(tc.args),
+        summarizer_fn=lambda sp, up, tn, cid: (_ for _ in ()).throw(AssertionError("must not summarize without opt-in")),
+        events=events,
+        tmp_path=tmp_path,
+    )
+    results, _, _ = ex.execute([
+        ToolCall(name="widget", args={"action": "spin", "input": {}, "reasoning": "r"}, id="w2"),
+    ])
+    content = results[0]["content"]
+    assert content == {"status": "ok", "action": "spin", "marker": "WIDGETRAW-marker"}

--- a/tests/test_tool_family_manual_contract.py
+++ b/tests/test_tool_family_manual_contract.py
@@ -1,0 +1,213 @@
+"""ManualTool stable contract: reserved name, strict empty input, dual return.
+
+Covers the generic ``lingtai.tools.tool_family.manual`` builder in isolation
+(fake agent, no real Web/browser wiring) plus its use as ``web``'s own
+``manual`` child, so both the infra and its first real consumer are proven.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools.tool_family import RESERVED_MANUAL_NAME, ChildTool, ToolFamily, ToolFamilyError
+from lingtai.tools.tool_family.manual import build_manual_child
+
+
+class _FakeAgent:
+    def __init__(self, working_dir: Path) -> None:
+        self._working_dir = working_dir
+
+
+def _install_manual(working_dir: Path, skill_name: str, body: str) -> Path:
+    manual_dir = working_dir / ".library" / "intrinsic" / "capabilities" / skill_name
+    manual_dir.mkdir(parents=True)
+    path = manual_dir / "SKILL.md"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_manual_child_reserved_name_is_exactly_manual():
+    agent = _FakeAgent(Path("/nonexistent"))
+    child = build_manual_child(agent, "widget")
+    assert child.name == RESERVED_MANUAL_NAME == "manual"
+
+
+def test_manual_child_input_schema_is_strict_empty():
+    agent = _FakeAgent(Path("/nonexistent"))
+    child = build_manual_child(agent, "widget")
+    assert child.input_schema == {"type": "object", "properties": {}, "additionalProperties": False}
+
+
+def test_manual_child_actual_handler_returns_body_at_content_text_and_path_at_structured_content(tmp_path):
+    """Invokes the ACTUAL generic manual child handler (not an unused
+    presentational helper) and proves the two fields the approved v0.4
+    ManualTool acceptance requires of the real, dispatched-to child result:
+    full body at ``content[0].text``, host-local path at
+    ``structuredContent.manual_path`` (model-visible, not only in a
+    ``_meta``-style side channel)."""
+    manual_path = _install_manual(tmp_path, "widget", "# Widget manual\nFull body here.")
+    agent = _FakeAgent(tmp_path)
+    child = build_manual_child(agent, "widget")
+    result = child.handler({})
+    assert result["status"] == "ok"
+    assert result["content"] == [{"type": "text", "text": "# Widget manual\nFull body here."}]
+    assert result["structuredContent"] == {"manual_path": str(manual_path)}
+    assert "error" not in result
+
+
+def test_manual_child_missing_manual_fails_honestly_no_io_error(tmp_path):
+    agent = _FakeAgent(tmp_path)  # no manual installed
+    child = build_manual_child(agent, "widget")
+    result = child.handler({})
+    assert result["status"] == "degraded"
+    assert result["content"] == [{"type": "text", "text": ""}]
+    assert "manual_path" in result["structuredContent"]
+    assert "error" in result
+
+
+def test_reserved_manual_name_collision_across_two_manual_children_fails_loudly(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    first = build_manual_child(agent, "widget")
+    second = build_manual_child(agent, "widget")  # a second, distinct manual child
+    with pytest.raises(ToolFamilyError):
+        ToolFamily("widget", [first, second])
+
+
+def test_a_family_without_any_manual_child_is_still_valid():
+    def handler(_input):
+        return {"status": "ok"}
+
+    fam = ToolFamily("widget", [ChildTool("spin", {"type": "object", "properties": {}, "additionalProperties": False}, handler)])
+    assert not fam.has_manual()
+
+
+def test_web_manual_child_shares_the_same_reserved_contract(tmp_path):
+    from lingtai.tools.web_search import setup
+
+    class _Agent:
+        def __init__(self, working_dir):
+            self._working_dir = working_dir
+
+        def add_tool(self, *args, **kwargs):
+            pass
+
+    class _Port:
+        def handle(self, args):
+            return {"status": "ok"}
+
+    manual_dir = tmp_path / ".library" / "intrinsic" / "capabilities" / "web"
+    manual_dir.mkdir(parents=True)
+    (manual_dir / "SKILL.md").write_text("web manual body", encoding="utf-8")
+
+    manager = setup(_Agent(tmp_path), browser_port=_Port())
+    result = manager.handle({"action": "manual", "input": {}, "reasoning": "load web guidance"})
+    assert result["status"] == "ok"
+    assert result["manual"] == "web manual body"
+    assert result["manual_path"] == str(manual_dir / "SKILL.md")
+    assert result["action"] == "manual"
+    assert "current_setting" in result
+    # The generic child's canonical MCP-compatible fields must not leak into
+    # Web's own pre-migration public flat shape — that adaptation is Web's
+    # own Host/presentation job (``WebManager._adapt_manual_result``),
+    # applied strictly after ``self._family.handle(...)`` dispatch.
+    assert "content" not in result
+    assert "structuredContent" not in result
+
+
+def test_web_family_handle_returns_canonical_manual_result_verbatim_before_host_adaptation(tmp_path):
+    """Proves the ownership boundary directly: ``manager._family.handle(...)``
+    — the real ``ToolFamily`` this family registers its ``manual`` child in —
+    returns the child's own canonical ``content``/``structuredContent``
+    result verbatim (no double wrap, no legacy flat fields), while
+    ``manager.handle(...)`` on the exact same envelope returns Web's
+    pre-migration public flat shape with no canonical fields. This is the
+    no-double-wrap/Host-owns-presentation contract: dispatch produces the
+    canonical result; Web's own Host layer adapts it strictly afterward."""
+    from lingtai.tools.web_search import setup
+
+    class _Agent:
+        def __init__(self, working_dir):
+            self._working_dir = working_dir
+
+        def add_tool(self, *args, **kwargs):
+            pass
+
+    class _Port:
+        def handle(self, args):
+            return {"status": "ok"}
+
+    manual_dir = tmp_path / ".library" / "intrinsic" / "capabilities" / "web"
+    manual_dir.mkdir(parents=True)
+    (manual_dir / "SKILL.md").write_text("web manual body", encoding="utf-8")
+
+    manager = setup(_Agent(tmp_path), browser_port=_Port())
+    envelope = {"action": "manual", "input": {}, "reasoning": "load web guidance"}
+
+    canonical = manager._family.handle(envelope)
+    assert canonical["status"] == "ok"
+    assert canonical["content"] == [{"type": "text", "text": "web manual body"}]
+    assert canonical["structuredContent"] == {"manual_path": str(manual_dir / "SKILL.md")}
+    assert "manual" not in canonical
+    assert "manual_path" not in canonical
+    assert "action" not in canonical
+    assert "current_setting" not in canonical
+
+    flat = manager.handle(envelope)
+    assert flat["status"] == "ok"
+    assert flat["manual"] == "web manual body"
+    assert flat["manual_path"] == str(manual_dir / "SKILL.md")
+    assert flat["action"] == "manual"
+    assert "current_setting" in flat
+    assert "content" not in flat
+    assert "structuredContent" not in flat
+
+
+def test_web_manual_missing_manual_keeps_exact_public_degraded_shape(tmp_path):
+    """Web's own public ``handle()`` result for a missing/degraded manual
+    keeps its exact pre-migration flat shape — this is the Host-side
+    adaptation of the generic canonical child result, proven for the
+    missing-manual case specifically (the success case is covered above)."""
+    from lingtai.tools.web_search import setup
+
+    class _Agent:
+        def __init__(self, working_dir):
+            self._working_dir = working_dir
+
+        def add_tool(self, *args, **kwargs):
+            pass
+
+    class _Port:
+        def handle(self, args):
+            return {"status": "ok"}
+
+    manager = setup(_Agent(tmp_path), browser_port=_Port())  # no manual installed
+    result = manager.handle({"action": "manual", "input": {}, "reasoning": "load web guidance"})
+    assert result["status"] == "degraded"
+    assert result["manual"] == ""
+    assert "manual_path" in result
+    assert result["action"] == "manual"
+    assert "current_setting" in result
+    assert "error" in result
+    assert "content" not in result
+    assert "structuredContent" not in result
+
+
+def test_web_manual_rejects_nonempty_input(tmp_path):
+    from lingtai.tools.web_search import setup
+
+    class _Agent:
+        def __init__(self, working_dir):
+            self._working_dir = working_dir
+
+        def add_tool(self, *args, **kwargs):
+            pass
+
+    class _Port:
+        def handle(self, args):
+            return {"status": "ok"}
+
+    manager = setup(_Agent(tmp_path), browser_port=_Port())
+    result = manager.handle({"action": "manual", "input": {"topic": "search"}, "reasoning": "x"})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"

--- a/tests/test_tool_family_web_migration_parity.py
+++ b/tests/test_tool_family_web_migration_parity.py
@@ -1,0 +1,191 @@
+"""``web``'s migration onto the generic ToolFamily infra changes nothing the
+model or a caller can observe, except three documented, authorized
+differences:
+
+1. the ``anyOf`` -> ``oneOf`` combinator swap for the ``input`` discriminated
+   union (locked decision L3 in the design record this candidate implements);
+2. ``get_schema()`` alone now declares a REQUIRED ``reasoning`` property
+   itself, rather than relying solely on Agent schema composition
+   (``_build_tool_schemas``) to inject it into ``properties`` (never
+   ``required``) at Agent-build time. Pre-migration, ``get_schema()`` in
+   isolation never mentioned ``reasoning`` at all; the real final Agent-built
+   schema always ended up with the ``reasoning`` *property* either way, but
+   never had it in ``required`` until this repair. Making the family's own
+   schema self-describing and REQUIRED-correct even before Agent composition
+   is the exact fix for the reported blocker (real ``PYTHONPATH=src`` import
+   of ``get_schema()`` previously showed ``reasoning`` entirely absent);
+3. a root ``allOf`` was added: one ``if``/``then`` condition per action,
+   correlating the sibling ``action`` const with that exact action's
+   ``input`` shape at the schema level (adopted after a live non-strict
+   Codex Responses probe on 2026-07-27 accepted a raw root ``allOf``/``if``/
+   ``then`` schema without error on the current route). The public root's
+   four fields (``action``, ``input``, ``reasoning``, ``summarize``) and their
+   requiredness are unchanged; ``allOf`` constrains them without adding a
+   fifth field or duplicating ``action`` inside ``input``.
+
+This module snapshots the true pre-migration schema shape (as it existed at
+this worktree's exact clean base, commit
+21bf4a3d12e0857510d96248179178ca3b36ff7e, before this candidate's changes)
+and diffs it against the now-generated schema, proving equivalence
+field-by-field rather than merely re-asserting individual properties as the
+other web test files already do.
+"""
+from __future__ import annotations
+
+from lingtai.tools.web_search import get_schema
+
+
+def _pre_migration_schema() -> dict:
+    # Verbatim copy of the schema ``web_search/__init__.py::get_schema()``
+    # hand-built before this candidate, at commit
+    # 21bf4a3d12e0857510d96248179178ca3b36ff7e, with only ``anyOf`` swapped to
+    # ``oneOf`` per the authorized design decision.
+    return {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["search", "browse", "manual"],
+                "description": "Required operation: search, browse, or manual.",
+            },
+            "input": {
+                "description": (
+                    "Strict action-specific input; the selected action is validated "
+                    "again at dispatch."
+                ),
+                "oneOf": [
+                    {
+                        "title": "search input",
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string", "description": "Search query."},
+                        },
+                        "required": ["query"],
+                        "additionalProperties": False,
+                    },
+                    {
+                        "title": "browse input",
+                        "type": "object",
+                        "properties": {
+                            "url": {
+                                "type": ["string", "null"],
+                                "description": "Public HTTP(S) URL; use null when link_ref or cursor is supplied.",
+                            },
+                            "link_ref": {
+                                "type": ["string", "null"],
+                                "description": "Same-Agent search result reference; use null when not supplied.",
+                            },
+                            "cursor": {
+                                "type": ["string", "null"],
+                                "description": "Same-Agent continuation cursor; use null when not supplied.",
+                            },
+                            "extract": {
+                                "type": ["string", "null"],
+                                "enum": ["article", None],
+                                "description": "Article extraction, or null for the default.",
+                            },
+                            "max_chars": {
+                                "type": ["integer", "null"],
+                                "minimum": 1,
+                                "maximum": 100000,
+                                "description": "Maximum returned characters, or null for the default 12000.",
+                            },
+                        },
+                        "required": ["url", "link_ref", "cursor", "extract", "max_chars"],
+                        "additionalProperties": False,
+                    },
+                    {
+                        "title": "manual input",
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                        "additionalProperties": False,
+                    },
+                ],
+            },
+            "summarize": {
+                "type": "boolean",
+                "description": (
+                    "Root, cross-cutting result post-processing control; absent "
+                    "or false by default. Not action input."
+                ),
+            },
+        },
+        "required": ["action", "input"],
+        "additionalProperties": False,
+    }
+
+
+def test_generated_schema_is_field_equivalent_to_pre_migration_schema_except_authorized_differences():
+    generated = get_schema()
+    pre = _pre_migration_schema()
+
+    # The action enum's description text became a generic template as part of
+    # generalizing schema composition (an explicitly authorized ownership
+    # change, not accidental drift).
+    normalized = dict(generated)
+    normalized["properties"] = dict(generated["properties"])
+    normalized["properties"]["action"] = dict(generated["properties"]["action"])
+    normalized["properties"]["action"]["description"] = pre["properties"]["action"]["description"]
+
+    # ``reasoning`` is the second authorized difference (the repaired
+    # blocker): ``get_schema()`` alone now declares it, required, itself.
+    # Strip it back out before comparing against the true pre-migration
+    # fixture (which never mentioned ``reasoning`` at the ``get_schema()``
+    # level at all), and assert its presence/requiredness separately below.
+    assert "reasoning" in normalized["properties"]
+    assert normalized["required"] == ["action", "input", "reasoning"]
+    del normalized["properties"]["reasoning"]
+    normalized["required"] = ["action", "input"]
+
+    # ``allOf`` is the third authorized difference (root action/input
+    # correlation). Assert its shape/correctness separately below, then
+    # strip it before comparing the rest of the schema field-by-field
+    # against the true pre-migration fixture (which never had ``allOf``).
+    assert "allOf" in normalized
+    del normalized["allOf"]
+
+    assert normalized == pre
+
+
+def test_all_of_correlates_action_const_with_exact_child_schema_for_every_web_action():
+    """The new root ``allOf`` is checked on its own: one condition per web
+    action, each ``if`` testing ``action`` via ``const`` against the real
+    action enum values, each ``then`` constraining ``input`` to exactly that
+    action's own branch schema from ``input.oneOf`` — both surfaces must
+    derive from the same canonical child schema, never drift apart."""
+    generated = get_schema()
+    conditions = generated["allOf"]
+    branches = generated["properties"]["input"]["oneOf"]
+    assert [c["if"]["properties"]["action"]["const"] for c in conditions] == ["search", "browse", "manual"]
+    for condition, branch in zip(conditions, branches):
+        assert condition["if"]["required"] == ["action"]
+        then_input = condition["then"]["properties"]["input"]
+        # The oneOf branch is the same input schema plus a "title" key; strip
+        # it before comparing to the allOf condition's own copy.
+        branch_without_title = {k: v for k, v in branch.items() if k != "title"}
+        assert then_input == branch_without_title
+
+
+def test_reasoning_is_required_and_absent_from_pre_migration_fixture():
+    # The pre-migration fixture is the true historical shape: no ``reasoning``
+    # property at the ``get_schema()`` level, matching the exact blocker
+    # evidence (``PYTHONPATH=src python`` import previously showed properties
+    # == {action, input, summarize} with no reasoning, required ==
+    # [action, input]). The now-generated schema must differ exactly here.
+    pre = _pre_migration_schema()
+    assert "reasoning" not in pre["properties"]
+    assert pre["required"] == ["action", "input"]
+
+    generated = get_schema()
+    assert generated["properties"]["reasoning"]["type"] == "string"
+    assert generated["required"] == ["action", "input", "reasoning"]
+
+
+def test_action_enum_values_and_order_unchanged():
+    assert get_schema()["properties"]["action"]["enum"] == ["search", "browse", "manual"]
+
+
+def test_input_branch_order_and_titles_unchanged():
+    branches = get_schema()["properties"]["input"]["oneOf"]
+    assert [b["title"] for b in branches] == ["search input", "browse input", "manual input"]

--- a/tests/test_tool_family_web_migration_parity.py
+++ b/tests/test_tool_family_web_migration_parity.py
@@ -32,7 +32,19 @@ other web test files already do.
 """
 from __future__ import annotations
 
-from lingtai.tools.web_search import get_schema
+from pathlib import Path
+
+from lingtai.tools.web_search import get_schema, setup
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+    def add_tool(self, *args, **kwargs) -> None:
+        self.tool_name = args[0]
+        self.schema = kwargs["schema"]
+        self.handler = kwargs["handler"]
 
 
 def _pre_migration_schema() -> dict:
@@ -189,3 +201,25 @@ def test_action_enum_values_and_order_unchanged():
 def test_input_branch_order_and_titles_unchanged():
     branches = get_schema()["properties"]["input"]["oneOf"]
     assert [b["title"] for b in branches] == ["search input", "browse input", "manual input"]
+
+
+def test_unknown_action_matches_pre_migration_public_shape(tmp_path):
+    # At the true pre-migration base (21bf4a3d), an arbitrary invalid
+    # ``action`` string always produced ``action: "unknown"`` and the exact
+    # message ``"action must be one of search, browse, or manual"`` — never
+    # an echo of the caller's own invalid string, and never missing the
+    # "or". The generic ``ToolFamily`` dispatcher's own envelope error is
+    # deliberately generic (a bare comma-joined child list with no "or",
+    # keyed only by ``error_code == "ACTION_REQUIRED"``); ``WebManager``
+    # must restore Web's own pre-migration public values at its
+    # post-dispatch boundary without changing that generic shape.
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=object())
+
+    result = manager.handle({"action": "not-a-real-action", "input": {}})
+
+    assert result["action"] == "unknown"
+    assert result["message"] == "action must be one of search, browse, or manual"
+    assert result["status"] == "failed"
+    assert result["error_code"] == "ACTION_REQUIRED"
+    assert "current_setting" in result

--- a/tests/test_tool_family_wire_parity.py
+++ b/tests/test_tool_family_wire_parity.py
@@ -1,0 +1,111 @@
+"""Chat Completions / Responses wire parity for the generic ToolFamily schema.
+
+Proves the composed ``oneOf``-over-``input`` schema survives both
+provider wire shapes at the smallest existing adapter seam
+(``lingtai.llm.openai.adapter._build_tools`` /
+``_build_responses_tools``) without any adapter code change — a fake
+``widget`` family, unrelated to ``web``, is the fixture.
+"""
+from __future__ import annotations
+
+from lingtai.kernel.llm.base import FunctionSchema
+from lingtai.tools.tool_family import ChildTool, ToolFamily
+
+
+def _widget_family() -> ToolFamily:
+    def spin_handler(input_):
+        return {"status": "ok", "action": "spin", "speed": input_.get("speed")}
+
+    def manual_handler(_input):
+        return {"status": "ok", "manual": "widget manual", "manual_path": "/fake/manual_path"}
+
+    return ToolFamily(
+        "widget",
+        [
+            ChildTool(
+                "spin",
+                {
+                    "type": "object",
+                    "properties": {"speed": {"type": "integer"}},
+                    "required": ["speed"],
+                    "additionalProperties": False,
+                },
+                spin_handler,
+                title="spin input",
+            ),
+            ChildTool(
+                "manual",
+                {"type": "object", "properties": {}, "additionalProperties": False},
+                manual_handler,
+                title="manual input",
+            ),
+        ],
+    )
+
+
+def test_generic_family_schema_survives_chat_and_responses_wires():
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+    fam = _widget_family()
+    schema = FunctionSchema(name="widget", description="widget", parameters=fam.build_schema())
+    chat = _build_tools([schema])[0]["function"]["parameters"]
+    responses = _build_responses_tools([schema])[0]["parameters"]
+
+    for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+        assert wire["type"] == "object"
+        # ``reasoning`` is REQUIRED Host InvocationContext/audit metadata,
+        # declared by the family schema itself (see ToolFamily.build_schema).
+        assert wire["required"] == ["action", "input", "reasoning"]
+        assert wire["additionalProperties"] is False
+        assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert wire["properties"]["reasoning"]["type"] == "string"
+        branches = wire["properties"]["input"][combinator]
+        assert [b["title"] for b in branches] == ["spin input", "manual input"]
+        for branch in branches:
+            assert branch["additionalProperties"] is False
+            assert "reasoning" not in branch["properties"]
+            assert "_reasoning" not in branch["properties"]
+            assert "summarize" not in branch["properties"]
+
+
+def test_generic_family_handler_parity_across_dispatch_and_child_registry():
+    """The same family instance dispatches identically regardless of which
+    provider wire the call arrived from — dispatch does not depend on wire
+    shape, only on the normalized ``{action, input, ...}`` args dict every
+    provider adapter converges to before ``ToolExecutor`` dispatch."""
+    fam = _widget_family()
+    result = fam.handle({"action": "spin", "input": {"speed": 4}, "reasoning": "chat-wire-call"})
+    assert result == {"status": "ok", "action": "spin", "speed": 4}
+    result2 = fam.handle({"action": "spin", "input": {"speed": 4}, "reasoning": "responses-wire-call"})
+    assert result2 == {"status": "ok", "action": "spin", "speed": 4}
+
+
+def test_real_agent_startup_builds_web_family_schema_on_both_wires(tmp_path):
+    """Integration proof at the real Agent composition boundary (not just the
+    unit-level FunctionSchema construction above): a fresh Agent with the web
+    capability produces one ``web`` tool whose schema composes correctly and
+    reaches both provider builders unchanged from ``_build_tool_schemas``."""
+    from lingtai.agent import Agent
+    from lingtai.kernel.base_agent.tools import _build_tool_schemas
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+    from tests._service_helpers import make_gemini_mock_service as make_mock_service
+
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="wire-parity-test",
+        working_dir=tmp_path,
+        capabilities={"web": {"provider": "duckduckgo"}},
+    )
+    try:
+        schemas = _build_tool_schemas(agent)
+        web = next(s for s in schemas if s.name == "web")
+        chat = _build_tools([web])[0]["function"]["parameters"]
+        responses = _build_responses_tools([web])[0]["parameters"]
+        assert set(chat["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert set(responses["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert chat["required"] == ["action", "input", "reasoning"]
+        assert responses["required"] == ["action", "input", "reasoning"]
+        assert len(chat["properties"]["input"]["oneOf"]) == 3
+        assert len(responses["properties"]["input"]["anyOf"]) == 3
+    finally:
+        agent.stop(timeout=1.0)

--- a/tests/test_tool_glossary.py
+++ b/tests/test_tool_glossary.py
@@ -641,6 +641,7 @@ class TestSourceValidation:
 
     def test_validator_passes(self):
         """The validator module should pass on the current source tree."""
+        import re
         import subprocess
         import sys
         from pathlib import Path
@@ -658,7 +659,7 @@ class TestSourceValidation:
             env={"PYTHONPATH": str(repo_root / "src"), "PATH": ""},
         )
         assert result.returncode == 0, f"Validator failed:\n{result.stderr}"
-        assert "57" in result.stdout
+        assert re.search(r"OK: \d+ glossary resources across \d+ packages", result.stdout)
 
     def test_no_repo_root_tools_directory(self):
         """Root tools/ directory must not exist (anatomy hygiene)."""

--- a/tests/test_tools_package_data.py
+++ b/tests/test_tools_package_data.py
@@ -30,7 +30,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-# The nineteen built-in tools, each owning a top-level CONTRACT.md.
+# The twenty built-in tools, each owning a top-level CONTRACT.md.
 _BUILTIN_TOOLS = [
     "avatar",
     "bash",
@@ -51,6 +51,7 @@ _BUILTIN_TOOLS = [
     "web_search",
     "browser",
     "write",
+    "tool_family",
 ]
 
 # The nine daemon CLI-backend manuals that must continue to ship unchanged.
@@ -210,7 +211,7 @@ def test_wheel_ships_complete_web_search_manual_bundle(wheel_entries: set[str]):
 
 
 def test_wheel_ships_exact_expected_tool_contracts(wheel_entries: set[str]):
-    # Keep the manifest closed: the shared tools contract, nineteen top-level
+    # Keep the manifest closed: the shared tools contract, twenty top-level
     # built-in tool contracts, and one intentional daemon component contract.
     # No other nested/manual contract may sneak in through an over-broad glob.
     expected = {
@@ -245,7 +246,7 @@ def test_wheel_ships_first_level_notification_manual(wheel_entries: set[str]):
 
 
 # ---------------------------------------------------------------------------
-# Glossary resources (57 files: 19 packages × 3 languages)
+# Glossary resources (60 files: 20 packages × 3 languages)
 # ---------------------------------------------------------------------------
 
 
@@ -259,8 +260,8 @@ def test_wheel_ships_every_glossary_resource(wheel_entries: set[str]):
     assert not missing, "glossary resources missing from wheel: %r" % missing
 
 
-def test_wheel_ships_exactly_57_glossary_resources(wheel_entries: set[str]):
-    # Exactly 19 packages × 3 languages = 57. The narrowed package-data globs
+def test_wheel_ships_exactly_60_glossary_resources(wheel_entries: set[str]):
+    # Exactly 20 packages × 3 languages = 60. The narrowed package-data globs
     # (glossary-en.md, glossary-zh.md, glossary-wen.md — not glossary-*.md)
     # must include exactly these files and nothing more.
     glossary_files = {
@@ -268,8 +269,8 @@ def test_wheel_ships_exactly_57_glossary_resources(wheel_entries: set[str]):
         for e in wheel_entries
         if e.startswith("lingtai/tools/") and "/glossary-" in e and e.endswith(".md")
     }
-    assert len(glossary_files) == 57, (
-        "expected exactly 57 glossary resources, wheel has %d: %r"
+    assert len(glossary_files) == 60, (
+        "expected exactly 60 glossary resources, wheel has %d: %r"
         % (len(glossary_files), sorted(glossary_files))
     )
 
@@ -309,7 +310,7 @@ def test_installed_wheel_validator_reads_package_resources(
         text=True,
     )
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "57 glossary resources across 19 packages" in result.stdout
+    assert "60 glossary resources across 20 packages" in result.stdout
 
 
 @pytest.fixture(scope="module")
@@ -367,12 +368,12 @@ def test_sdist_ships_complete_web_search_manual_bundle(sdist_entries: set[str]):
     assert not missing, "web_search manual files missing from sdist: %r" % missing
 
 
-def test_sdist_ships_exactly_57_glossary_resources(sdist_entries: set[str]):
+def test_sdist_ships_exactly_60_glossary_resources(sdist_entries: set[str]):
     glossary_files = {
         e
         for e in sdist_entries
         if e.startswith("lingtai/tools/") and "/glossary-" in e and e.endswith(".md")
     }
-    assert len(glossary_files) == 57, (
-        "expected exactly 57 glossary resources in sdist, got %d" % len(glossary_files)
+    assert len(glossary_files) == 60, (
+        "expected exactly 60 glossary resources in sdist, got %d" % len(glossary_files)
     )

--- a/tests/test_unified_web_capability.py
+++ b/tests/test_unified_web_capability.py
@@ -349,13 +349,20 @@ def test_schema_root_is_closed_action_input_reasoning_summarize(tmp_path):
 
     schema = get_schema()
     assert schema["additionalProperties"] is False
-    assert schema["required"] == ["action", "input"]
-    assert set(schema["properties"]) == {"action", "input", "summarize"}
+    # ``reasoning`` is REQUIRED Host InvocationContext/audit metadata; the
+    # family's own get_schema() declares it (and its required-ness) itself —
+    # this is not left to Agent schema composition, which only re-injects the
+    # identical property text into every tool's ``properties`` and never
+    # touches ``required``.
+    assert schema["required"] == ["action", "input", "reasoning"]
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    reasoning_prop = schema["properties"]["reasoning"]
+    assert reasoning_prop["type"] == "string"
     summarize_prop = schema["properties"]["summarize"]
     assert summarize_prop["type"] == "boolean"
     # No public `summary` alias, and no branch admits `reasoning`/`_reasoning`/
     # `summarize` inside its own input.
-    for branch in schema["properties"]["input"]["anyOf"]:
+    for branch in schema["properties"]["input"]["oneOf"]:
         assert "summary" not in branch["properties"]
         assert "summarize" not in branch["properties"]
         assert "reasoning" not in branch["properties"]

--- a/tests/test_wire_tool_description.py
+++ b/tests/test_wire_tool_description.py
@@ -141,13 +141,23 @@ def test_web_action_input_schema_survives_chat_and_responses_wires():
     schema = FunctionSchema(name="web", description="web", parameters=get_schema())
     chat = _build_tools([schema])[0]["function"]["parameters"]
     responses = _build_responses_tools([schema])[0]["parameters"]
-    for wire in (chat, responses):
+    # The family composes a nested ``oneOf`` under ``input``. Chat Completions
+    # passes it through unchanged; the Responses backend rewrites any nested
+    # ``oneOf`` to ``anyOf`` (``_scrub_responses_schema``), so each wire is
+    # checked under its own actual combinator key — the branches themselves
+    # stay identical either way.
+    for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
         assert wire["type"] == "object"
-        assert wire["required"] == ["action", "input"]
+        # ``reasoning`` is REQUIRED Host InvocationContext/audit metadata —
+        # the family schema declares it itself (not left to Agent schema
+        # composition's blanket property injection, which never touches
+        # ``required``) so it is required even from ``get_schema()`` alone.
+        assert wire["required"] == ["action", "input", "reasoning"]
         assert wire["additionalProperties"] is False
-        assert set(wire["properties"]) == {"action", "input", "summarize"}
+        assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert wire["properties"]["reasoning"]["type"] == "string"
         assert wire["properties"]["summarize"]["type"] == "boolean"
-        branches = wire["properties"]["input"]["anyOf"]
+        branches = wire["properties"]["input"][combinator]
         assert [branch["title"] for branch in branches] == [
             "search input", "browse input", "manual input",
         ]
@@ -161,11 +171,55 @@ def test_web_action_input_schema_survives_chat_and_responses_wires():
         assert branches[2]["properties"] == {}
 
 
+def test_web_root_all_of_correlation_survives_chat_and_responses_wires():
+    """Root ``allOf`` schema-level action/input correlation must survive on
+    BOTH wires — Chat Completions (which never strips any root key) and the
+    Responses adapter (which, after this candidate's live-evidence-driven
+    fix, preserves root ``allOf``/``oneOf`` instead of unconditionally
+    stripping them). Responses may still normalize the nested ``input``
+    disclosure surface's ``oneOf`` to ``anyOf``, but the root ``allOf``
+    condition itself — and its exact per-action correlation — must remain
+    identical on both wires, with no child leakage into the root."""
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+    from lingtai.tools.web_search import get_schema
+
+    schema = FunctionSchema(name="web", description="web", parameters=get_schema())
+    chat = _build_tools([schema])[0]["function"]["parameters"]
+    responses = _build_responses_tools([schema])[0]["parameters"]
+
+    for wire in (chat, responses):
+        assert "allOf" in wire
+        conditions = wire["allOf"]
+        assert [c["if"]["properties"]["action"]["const"] for c in conditions] == [
+            "search", "browse", "manual",
+        ]
+        for condition in conditions:
+            assert condition["if"]["required"] == ["action"]
+            then_input = condition["then"]["properties"]["input"]
+            assert then_input["additionalProperties"] is False
+            assert "reasoning" not in then_input.get("properties", {})
+            assert "_reasoning" not in then_input.get("properties", {})
+            assert "summarize" not in then_input.get("properties", {})
+        # No child leakage into the root: only the four public envelope
+        # fields, exactly as before this correlation was added.
+        assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert wire["required"] == ["action", "input", "reasoning"]
+
+    # The two wires' allOf conditions carry identical per-action correlation
+    # (Chat Completions' allOf is untouched; Responses' allOf is preserved
+    # verbatim by the root-aware scrub).
+    assert chat["allOf"] == responses["allOf"]
+
+
 def test_web_final_agent_schema_root_is_exactly_action_input_reasoning_summarize(tmp_path):
     """A real fresh ``Agent`` startup must prove the exact final closed root:
-    ``action | input | reasoning | summarize``. ``reasoning`` is injected by
-    Agent schema composition (``_build_tool_schemas``); ``summarize`` is owned
-    by web's own schema (LTP v2 is migrated per-family, not by central
+    ``action | input | reasoning | summarize``, with ``reasoning`` REQUIRED.
+    The family's own schema (``ToolFamily.build_schema()``) already declares
+    ``reasoning`` required and describes it identically to what Agent schema
+    composition (``_build_tool_schemas``) re-injects into every tool's
+    ``properties`` uniformly — that injection never touches ``required``, so
+    a family must declare ``reasoning`` required itself. ``summarize`` is
+    owned by web's own schema (LTP v2 is migrated per-family, not by central
     injection). No public ``summary`` alias and no nested branch admits
     ``reasoning``, ``_reasoning``, or ``summarize``.
     """
@@ -183,11 +237,11 @@ def test_web_final_agent_schema_root_is_exactly_action_input_reasoning_summarize
         schemas = _build_tool_schemas(agent)
         web = next(s for s in schemas if s.name == "web")
         params = web.parameters
-        assert params["required"] == ["action", "input"]
+        assert params["required"] == ["action", "input", "reasoning"]
         assert params["additionalProperties"] is False
         assert set(params["properties"]) == {"action", "input", "reasoning", "summarize"}
         assert "summary" not in params["properties"]
-        for branch in params["properties"]["input"]["anyOf"]:
+        for branch in params["properties"]["input"]["oneOf"]:
             assert "reasoning" not in branch["properties"]
             assert "_reasoning" not in branch["properties"]
             assert "summarize" not in branch["properties"]
@@ -215,6 +269,143 @@ def test_openai_responses_preserves_daemon_backend_options_passthrough_schema():
         option == {"type": "string"}
         for option in backend_options["additionalProperties"]["anyOf"]
     )
+
+
+def test_openai_responses_root_all_of_if_then_survives():
+    """A live non-strict Codex Responses probe on 2026-07-27 showed a raw
+    root ``allOf``/``if``/``then`` schema is accepted on the current route
+    without error. The adapter must preserve it verbatim rather than
+    stripping it."""
+    from lingtai.llm.openai.adapter import _build_responses_tools
+
+    params = {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["search", "manual"]},
+            "input": {"type": "object"},
+            "reasoning": {"type": "string"},
+        },
+        "required": ["action", "input", "reasoning"],
+        "additionalProperties": False,
+        "allOf": [
+            {
+                "if": {"properties": {"action": {"const": "search"}}, "required": ["action"]},
+                "then": {"properties": {"input": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"], "additionalProperties": False}}},
+            },
+            {
+                "if": {"properties": {"action": {"const": "manual"}}, "required": ["action"]},
+                "then": {"properties": {"input": {"type": "object", "properties": {}, "additionalProperties": False}}},
+            },
+        ],
+    }
+    tools = _build_responses_tools([FunctionSchema(name="web", description="web", parameters=params)])
+    out = tools[0]["parameters"]
+    assert "allOf" in out
+    assert len(out["allOf"]) == 2
+    assert out["allOf"][0]["if"]["properties"]["action"]["const"] == "search"
+    assert out["allOf"][0]["then"]["properties"]["input"]["properties"] == {"query": {"type": "string"}}
+    assert out["allOf"][1]["if"]["properties"]["action"]["const"] == "manual"
+    assert out["allOf"][1]["then"]["properties"]["input"]["properties"] == {}
+    # Ordinary root fields untouched by the root-combinator handling.
+    assert out["type"] == "object"
+    assert out["required"] == ["action", "input", "reasoning"]
+    assert out["additionalProperties"] is False
+    assert set(out["properties"]) == {"action", "input", "reasoning"}
+
+
+def test_openai_responses_root_one_of_survives_as_one_of():
+    """Companion to the ``allOf`` case: real backend evidence showed a raw
+    root ``oneOf`` is also accepted without error, so it must survive as
+    ``oneOf`` (not be rewritten to ``anyOf``, unlike a nested ``oneOf``)."""
+    from lingtai.llm.openai.adapter import _build_responses_tools
+
+    params = {
+        "type": "object",
+        "oneOf": [
+            {"properties": {"action": {"const": "search"}}},
+            {"properties": {"action": {"const": "manual"}}},
+        ],
+    }
+    tools = _build_responses_tools([FunctionSchema(name="web", description="web", parameters=params)])
+    out = tools[0]["parameters"]
+    assert "oneOf" in out
+    assert "anyOf" not in out
+    assert [branch["properties"]["action"]["const"] for branch in out["oneOf"]] == ["search", "manual"]
+
+
+def test_openai_responses_nested_one_of_still_becomes_any_of_even_with_root_all_of():
+    """A nested ``oneOf`` (e.g. inside an ``allOf`` branch's ``then``, or
+    under a property) must still be rewritten to ``anyOf`` exactly as before
+    — only the schema *root* gets the new preservation behavior."""
+    from lingtai.llm.openai.adapter import _build_responses_tools
+
+    params = {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string"},
+            "input": {
+                "oneOf": [
+                    {"type": "object", "properties": {"query": {"type": "string"}}},
+                    {"type": "object", "properties": {}},
+                ],
+            },
+        },
+        "allOf": [
+            {
+                "if": {"properties": {"action": {"const": "search"}}},
+                "then": {
+                    "oneOf": [
+                        {"properties": {"input": {"type": "string"}}},
+                        {"properties": {"input": {"type": "integer"}}},
+                    ],
+                },
+            },
+        ],
+    }
+    tools = _build_responses_tools([FunctionSchema(name="web", description="web", parameters=params)])
+    out = tools[0]["parameters"]
+    # Root allOf preserved as allOf.
+    assert "allOf" in out
+    # Nested oneOf under a property rewritten to anyOf.
+    assert "oneOf" not in out["properties"]["input"]
+    assert "anyOf" in out["properties"]["input"]
+    # Nested oneOf inside an allOf branch's "then" also rewritten to anyOf.
+    then_node = out["allOf"][0]["then"]
+    assert "oneOf" not in then_node
+    assert "anyOf" in then_node
+
+
+def test_openai_responses_root_any_of_not_and_enum_are_still_stripped():
+    """Root ``anyOf``, ``not``, and ``enum`` remain untested against the live
+    backend (only root ``oneOf``/``allOf`` were probed), so they are still
+    stripped from the schema root exactly as before this change — no
+    broadening beyond the evidenced keywords."""
+    from lingtai.llm.openai.adapter import _build_responses_tools
+
+    params = {
+        "type": "object",
+        "properties": {"action": {"type": "string"}},
+        "anyOf": [{"required": ["action"]}],
+        "not": {"required": ["forbidden"]},
+        "enum": ["a", "b"],
+    }
+    tools = _build_responses_tools([FunctionSchema(name="widget", description="widget", parameters=params)])
+    out = tools[0]["parameters"]
+    assert "anyOf" not in out
+    assert "not" not in out
+    assert "enum" not in out
+    assert out["type"] == "object"
+    assert out["properties"] == {"action": {"type": "string"}}
+
+
+def test_openai_responses_ordinary_schema_without_root_combinators_unchanged():
+    """An ordinary schema with none of the root-combinator keywords is
+    completely unaffected by this change — same as before."""
+    from lingtai.llm.openai.adapter import _build_responses_tools
+
+    schemas = _schemas()
+    tools = _build_responses_tools(schemas)
+    assert json.dumps(tools[0]["parameters"], sort_keys=True) == json.dumps(PARAMETERS, sort_keys=True)
 
 
 def test_anthropic_wire_description_and_cache_control():


### PR DESCRIPTION
## Summary

- add a generic internal `ToolFamily` child registry/dispatcher whose family-level schema is derived from canonical child schemas
- migrate Web as the first reference family while preserving the public `web` surface and existing result behavior
- make `manual` a reserved family-owned child with a strict empty input and canonical MCP-compatible result (`content[0].text` plus `structuredContent.manual_path`)
- preserve root action/input correlation on both Chat and Responses wire paths without changing external MCP insertion or any other built-in family

## Contract

The model still sees one aggregate `web` tool. Its root is exactly `action`, `input`, required host-level `reasoning`, and optional host-level `summarize`. Registry-generated root `allOf` clauses correlate each `action` constant with that child's exact input schema; the disclosed input branches come from the same deep-copied canonical schemas. Runtime dispatch remains action-authoritative and fail-closed.

Children return canonical/raw results. `ToolFamily.handle()` does not double-wrap them; `WebManager.handle()` is the Web compatibility boundary that presents the existing flat public result. Existing raw-first summarization, durable raw locator, 500k fail-closed cap, settings ownership, and Chat/Responses execution semantics remain centralized and unchanged.

## Responses compatibility evidence

A bounded live probe against the currently configured non-strict Codex Responses route sent five requests and produced zero tool calls. The normal adapter reproduced the old stripping behavior, while process-local raw bypass requests with minimal root `oneOf` and root `allOf + if/then` schemas were both accepted. This PR therefore preserves the root `oneOf`/`allOf` correlation forms needed by ToolFamily while retaining the existing nested compatibility rewrite and legacy stripping for other unsupported root forms. The claim is intentionally scoped to the current non-strict route.

## Validation

- Parent final focused gate after live-use repair: **66 passed**
- Final bounded relevant union after correlation repair: **1108 passed, 2 skipped, 0 failed**
- anatomy drift: clean across 54 files
- `py_compile`: clean for ToolFamily, OpenAI adapter, and Web entrypoint
- `git diff --check`: clean
- zero portable source/test references to private experiment artifact paths
- exact Huang GitHub and Git author identity verified before commit/push

A separate resolved-manifest metadata check still fails identically on the immutable base because an existing `last_changed_at: 2026-07-24` value lacks a time component; introduced failures are zero.

## Scope

This PR intentionally covers generic internal infrastructure plus Web only. It does **not** migrate other built-in families, change external MCP behavior, add transport/export surfaces, or authorize merge/release/cleanup.

## Live Agent validation and repair

Jason explicitly prioritized a real independent Agent checkout/refresh over more self-consistent review. dev4bot loaded exact PR head `621d2b342ce446664284ecbee59c448fa33fbdc0` through an agent-scoped reversible source hook and mechanically proved that `lingtai`, kernel, ToolFamily, and Web were imported from the clean detached PR worktree on `codex-pool / gpt-5.6-sol / Codex Responses WebSocket`.

Seven real calls covered `manual`, a network browse, cross-branch input, invalid summarize type, loopback blocking, unknown action, and a-priori browse summarization. All terminated without crash, hang, pending state, traceback, or double wrapping. The run found one PR-specific public parity drift: an invalid action was echoed instead of normalizing to base's `action: "unknown"` and exact allowed-action message.

Commit `a2335219be906f02de5bb733204d94e598d9c325` restores that Web-only post-dispatch compatibility behavior and locks both exact fields through the real manager path. dev4bot then fetched the new exact head, refreshed the same isolated runtime, mechanically re-proved the imports/head/tree, and repeated two real calls:

- unknown action: terminal `ACTION_REQUIRED`, exact `action: "unknown"`, exact `action must be one of search, browse, or manual`, with `current_setting`
- `manual {}`: terminal `status: ok`, flat `manual` + `manual_path`, no `content`/`structuredContent` leak and no double wrap

The refreshed segment had zero current `Traceback`/`ERROR`/`CRITICAL`/`Exception`/`pending`/WebManager/ToolFamily findings. The dev4 worktree, reversible hook, and evidence remain preserved; this PR does not authorize cleanup.

## Full all-action real UX cycle

A later Manual-first cycle used the same clean exact `a2335219be906f02de5bb733204d94e598d9c325` runtime through **9 model-visible `web` calls and 9 terminal results** on the exercised Codex Responses WebSocket route. This cycle counted actions rather than variants: `manual`, `search`, and `browse` all ran through real public calls.

- Manual body and returned `manual_path` file were byte-identical (7,566 bytes, SHA-256 `98544f53711c566dee9eae64cf38fb88f6884d1dd13d42bdc991ab3f2c3193df`). It was actionable enough to drive the subsequent workflow and retained the established flat Web result.
- A real DuckDuckGo-backed Search query returned five results and supported link-ref continuation. Ranking/trust quality was mediocre for an explicitly official query, including a suspicious typo-domain result.
- Following an official downloads link exposed a serious **inherited browser UX** issue: HTTP 200 / `status: ok` despite compressed/binary-looking replacement content, empty title/links, and `CHARSET_DECODE_ERROR_REPLACED`, without a typed degraded status or recovery guidance.
- Direct Browse to the official Python 3.14 What's New page succeeded with stable title, final URL, source hash, release evidence, links, cursor, and warnings. Its raw result was noisy (~52k visible chars); root `summarize: true` reduced 52,534 to 5,656 while preserving provenance, key facts, primary links, continuation, and limits.
- A real HTTP 404 returned a typed terminal error with actionable guidance; correcting the URL produced a successful follow-up call.
- Health inspection found 9/9 terminal Web results, zero residual unmatched calls, and no current crash, hang, traceback, or pending ToolFamily/Web event.

The final head showed **no remaining PR-specific blocker**. Search ranking/trust, nominal-success degraded-content classification, extraction/link bloat, and Manual copy density are meaningful inherited Web follow-ups, but the base→head diff does not touch browser internals and this PR should not absorb those product changes.
