### PR TITLE
refactor(knowledge): separate info and manual actions

### DIFF
--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -152,15 +152,16 @@ def is_apriori_summary(content: Any) -> bool:
 # unmigrated tool's own domain field literally named ``summarize`` is never
 # silently reinterpreted as this cross-cutting control (see
 # ``src/lingtai/tools/CONTRACT.md`` Contract rules > Envelope).
-_LTP_V2_MIGRATED_FAMILIES = frozenset({"web"})
+_LTP_V2_MIGRATED_FAMILIES = frozenset({"web", "knowledge"})
 
 
 def summary_requested(args: dict | None, tool_name: str | None = None) -> bool:
     """Return True iff the normalized tool args opt into a-priori summary.
 
     The legacy flag is the boolean ``summary`` field on the tool call, honored
-    for every caller. A migrated LTP v2 family (currently only ``web``) may
-    instead set the canonical root ``summarize`` boolean; that spelling is
+    for every caller. A migrated LTP v2 family (currently ``web`` and
+    ``knowledge``) may instead set the canonical root ``summarize`` boolean;
+    that spelling is
     recognized only when ``tool_name`` names a migrated family, so an
     unmigrated tool's own ``summarize``-named domain field is never
     reinterpreted as this control. Anything other than a literal ``True``
@@ -423,8 +424,8 @@ def maybe_summarize_result(
     - Error results (the tool itself failed) are NOT summarized: the agent needs
       the exact error text to recover. Returned unchanged. This covers the
       kernel-wide ``status == "error"`` convention and, scoped to migrated LTP
-      v2 families only, that family's own canonical error status (``web``'s is
-      exactly ``"failed"``).
+      v2 families only, that family's own canonical error status (``web``'s and
+      ``knowledge``'s envelope failures are exactly ``"failed"``).
     - Visible payload > cap → refusal dict (no LLM call).
     - Otherwise → generated summary dict; on summarizer exception, an error dict.
 
@@ -437,7 +438,8 @@ def maybe_summarize_result(
     # Do not summarize tool-level errors — the agent needs the exact error to
     # recover. ``status == "error"`` is the kernel-wide tool-error convention.
     # A migrated LTP v2 family may instead use its own canonical error status
-    # (``web``'s is exactly ``"failed"``); recognizing it here is scoped to
+    # (``web``'s and ``knowledge``'s envelope failures are exactly
+    # ``"failed"``); recognizing it here is scoped to
     # migrated families only, so an unrelated tool's non-error ``"failed"``-
     # named domain value is never reinterpreted as an error result.
     if isinstance(result, dict):

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -9,6 +9,8 @@ related_files:
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/tools/tool_family/CONTRACT.md
+  - src/lingtai/tools/knowledge/ANATOMY.md
+  - src/lingtai/tools/knowledge/CONTRACT.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
   - src/lingtai/tools/glossary_validator.py
@@ -40,8 +42,12 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `tool_family/` — generic, optional ToolFamily/ChildTool schema-composition
   and dispatch infrastructure implementing the LTP v2 envelope, and the
-  reusable ManualTool builder; `web` is its first real consumer
+  reusable ManualTool builder; `web` is its first real consumer and
+  `knowledge` its second
   (`src/lingtai/tools/tool_family/ANATOMY.md`).
+- `knowledge/` — private durable knowledge catalog, migrated to the LTP v2
+  family envelope with the unchanged public actions `info`/`manual`
+  (`src/lingtai/tools/knowledge/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -9,6 +9,8 @@ related_files:
   - src/lingtai/kernel/tool_executor.py
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/knowledge/CONTRACT.md
+  - src/lingtai/tools/knowledge/__init__.py
   - src/lingtai/tools/tool_family/CONTRACT.md
   - tests/test_browser_capability.py
   - tests/test_wire_tool_description.py
@@ -235,12 +237,17 @@ documents. `web` (`search | browse | manual`) is the first family migrated to
 this contract: its final model-facing root is exactly `action`, `input`,
 `reasoning`, and `summarize`; its `search` action reads the action-owned
 `settings/web.search.json` (see `src/lingtai/tools/web_search/CONTRACT.md`).
+`knowledge` (`info | manual`) is the second: the migration is envelope-only —
+its public tool name and both public action values are unchanged, both children
+take the canonical strict-empty `input`, and it supports no settings file (see
+`src/lingtai/tools/knowledge/CONTRACT.md`). It remains a signpost capability
+with no authoring, search, or edit action.
 The legacy a-priori result-summarization flag under the literal key `summary`
 (`src/lingtai/kernel/tool_result_summary.py:172`) remains honored for every
 still-unmigrated caller; `src/lingtai/kernel/tool_result_summary.py` recognizes
 the canonical `summarize` spelling only when the calling tool is a migrated LTP
-v2 family (currently only `web`), so an unmigrated tool's own field literally
-named `summarize` is never reinterpreted as this control. Every other
+v2 family (currently `web` and `knowledge`), so an unmigrated tool's own field
+literally named `summarize` is never reinterpreted as this control. Every other
 LingTai-owned family remains unmigrated and keeps its existing schema and
 settings surface unchanged by this file.
 
@@ -250,7 +257,9 @@ infrastructure implementing this envelope (schema composition from a
 ManualTool builder) that a family MAY adopt instead of hand-writing the
 equivalent code; `web` is its first consumer, using it for schema composition
 and dispatch while retaining its own outer `handle()` for family-specific
-diagnostics. Using it is never required — see its own
+diagnostics; `knowledge` is its second, using it the same way with its own
+outer `handle()` preserving that family's exact pre-migration unknown-action
+result. Using it is never required — see its own
 `src/lingtai/tools/tool_family/CONTRACT.md` "Implementation independence" is
 binding on it exactly as it is on every family.
 

--- a/src/lingtai/tools/knowledge/ANATOMY.md
+++ b/src/lingtai/tools/knowledge/ANATOMY.md
@@ -5,7 +5,11 @@ related_files:
   - src/lingtai/tools/knowledge/CONTRACT.md
   - src/lingtai/tools/knowledge/__init__.py
   - src/lingtai/tools/knowledge/manual/SKILL.md
+  - src/lingtai/tools/tool_family/ANATOMY.md
+  - src/lingtai/tools/tool_family/CONTRACT.md
+  - src/lingtai/tools/CONTRACT.md
   - tests/test_knowledge.py
+  - tests/test_tool_family_knowledge_migration_parity.py
   - src/lingtai/tools/knowledge/glossary-en.md
   - src/lingtai/tools/knowledge/glossary-zh.md
   - src/lingtai/tools/knowledge/glossary-wen.md
@@ -28,8 +32,13 @@ the regular `read` tool.
 ## Components
 
 - `knowledge/__init__.py` — the capability implementation. It owns legacy JSON
-  migration, `_reconcile`, `get_description`, `get_schema`, and `setup`, and
-  imports shared Markdown-catalog scanning/rendering from `core/_catalog.py`.
+  migration, `_reconcile`, `_knowledge_manual`, the `ToolFamily` composition
+  (`_EMPTY_INPUT_SCHEMA`, `_CHILD_SPECS`, one `_build_family(agent | None)`),
+  `get_description`, `get_schema`, `handle`, and `setup`, and imports shared
+  Markdown-catalog scanning/rendering from `core/_catalog.py`.
+- `tools/tool_family/` — the generic, optional LTP v2 composition/dispatch
+  infrastructure this capability adopts for its schema and dispatch
+  (`src/lingtai/tools/tool_family/ANATOMY.md`).
 - `core/_catalog.py` — shared frontmatter parser, recursive Markdown catalog
   scanner, and YAML catalog renderer used by both `knowledge` and `skills`.
 - `knowledge/CONTRACT.md` — public behavior contract: tool surface, on-disk
@@ -40,9 +49,17 @@ the regular `read` tool.
 
 - `lingtai.tools.registry` maps builtin capability name `knowledge` here. Former
   `library` and `codex` capability names are not registered.
-- `setup()` registers exactly one tool, `knowledge`, with a single `info`
-  action. The historical `knowledge_limit` kwarg is accepted and ignored.
+- `setup()` registers exactly one tool, `knowledge`, as one LTP v2 family with
+  the two public actions `info` and `manual`. The historical `knowledge_limit`
+  kwarg is accepted and ignored.
+- `handle()` is the Host layer: it dispatches through the family and normalizes
+  the generic `ACTION_REQUIRED` envelope failure back to knowledge's exact
+  pre-migration unknown-action result.
 - `_reconcile()` writes protected prompt section `knowledge`.
+- `kernel/tool_result_summary.py` lists `knowledge` in
+  `_LTP_V2_MIGRATED_FAMILIES`, so root `summarize` is the canonical a-priori
+  summary control for this tool and its `status: "failed"` envelope errors are
+  never summarized.
 - `skills/` is the structurally isomorphic, physically separate sibling
   capability — it owns `<agent>/.library/{intrinsic,custom}/<name>/SKILL.md`,
   knowledge owns `<agent>/knowledge/<name>/KNOWLEDGE.md`. Two separate
@@ -63,6 +80,12 @@ the regular `read` tool.
 
 - `knowledge` is private, agent-owned memory. It is not the public skill
   catalog.
+- The tool is a signpost only: no action creates, edits, searches, or loads
+  knowledge entries. Both children declare a strict-empty `input`, so there is
+  no field through which an authoring payload could be smuggled.
+- `info` re-scans/reconciles the catalog and returns health
+  (`knowledge_dir`/`catalog_size`/`problems`) without loading bodies. `manual`
+  returns the current manual body/path and never rescans or mutates.
 - `library` and `codex` are gone as durable-memory aliases. This is a breaking
   rename by design.
 - The catalog injects only `name`/`description`/`path`. Bodies and supporting

--- a/src/lingtai/tools/knowledge/CONTRACT.md
+++ b/src/lingtai/tools/knowledge/CONTRACT.md
@@ -1,10 +1,13 @@
 ---
 name: knowledge-contract
 tool: knowledge
-contract_version: 1
+contract_version: 2
 related_files:
   - src/lingtai/tools/knowledge/__init__.py
   - src/lingtai/tools/knowledge/ANATOMY.md
+  - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/tool_family/CONTRACT.md
+  - tests/test_tool_family_knowledge_migration_parity.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -61,7 +64,7 @@ The two capabilities are structurally isomorphic but physically separate:
 | Root directory | `<agent>/.library/{intrinsic,custom}/` | `<agent>/knowledge/` |
 | Manifest file | `SKILL.md` | `KNOWLEDGE.md` |
 | Tool name | `skills` | `knowledge` |
-| Tool surface | `info` | `info` |
+| Tool surface | `info`, `manual` (unmigrated flat schema) | `info`, `manual` (LTP v2 family envelope) |
 | Prompt section | protected `skills` (YAML catalog) | protected `knowledge` (YAML catalog) |
 | Extra path sources | `manifest.capabilities.skills.paths` | none — strictly per-agent |
 | Visibility | portable / shareable | private / agent-owned |
@@ -74,18 +77,64 @@ does not leak into the public skill catalog.
 
 ## Tool surface
 
-The schema requires `action` and accepts exactly one action:
+`knowledge` is a migrated **LTP v2 family** (`src/lingtai/tools/CONTRACT.md`).
+Its public name and its two public action values are unchanged by that
+migration; the root envelope is what changed. The model-facing root is the
+closed object `{action, input, reasoning, summarize}` with
+`additionalProperties: false` and `required: [action, input, reasoning]`.
+`summarize` is the optional root-only Host presentation control and is never
+action input.
 
-| Action | Required fields | Optional fields | Return on success |
-|---|---|---|---|
-| `info` | — | — | `{status: "ok", knowledge_dir, catalog_size, problems}` |
+`action` selects one child; `input` is that child's own strict object. Both
+children take the canonical **strict-empty** input
+(`{"type": "object", "properties": {}, "required": [], "additionalProperties": false}`)
+because neither operation ever took an argument:
 
-Unknown actions return `{status: "error", message: ...}` and do not mutate
-state. The previous JSON-database actions (`submit`, `view`, `consolidate`,
-`delete`) are intentionally removed: knowledge is now authored by writing
-`KNOWLEDGE.md` files with the regular `write`/`edit` tools, just like skills.
-There is no in-tool capacity limit; the historical `knowledge_limit` kwarg is
-accepted but ignored.
+| Action | `input` | Return on success |
+|---|---|---|
+| `info` | `{}` (strict empty) | `{status: "ok", knowledge_dir, catalog_size, problems}` |
+| `manual` | `{}` (strict empty) | `{status: "ok", knowledge_manual, manual_path}` |
+
+The composed schema correlates each action `const` with its exact `input`
+schema at the root (`allOf`/`if`/`then`) and additionally discloses every
+action's shape under `input.oneOf`. Both surfaces reach the Chat Completions
+and Responses wires; the Responses builder rewrites nested `oneOf` to `anyOf`
+but preserves the root correlation.
+
+Behavior is preserved exactly across the migration:
+
+- `info` re-scans and reconciles the private knowledge catalog, rewrites the
+  protected prompt section, and returns health only. It never loads entry
+  bodies into its result and never mutates entries.
+- `manual` returns the current knowledge-manual body at `knowledge_manual` and
+  its host-local path at `manual_path`. It performs no scan, no reconciliation,
+  and no mutation. A missing manual returns `status: "degraded"` with an empty
+  `knowledge_manual`, the resolved `manual_path`, and an `error`. This result
+  is the child's own canonical shape, returned verbatim by the dispatcher with
+  no double wrap.
+
+Neither action creates, edits, searches, or loads knowledge entries; the tool
+remains a signpost. Because both child inputs are strict-empty, *any* `input`
+key — including an authoring or search field — is rejected at dispatch before
+the handler runs, with `{status: "failed", error_code: "INVALID_ARGUMENT"}`.
+Unknown root fields and a non-boolean `summarize` fail the same way.
+
+Unknown actions return knowledge's exact pre-migration envelope,
+`{status: "error", message: "unknown action: <repr>, only 'info' or 'manual' is
+supported"}`, and do not mutate state; a missing `action` renders the
+empty-string default and an unhashable `action` (invalid JSON, issue #513)
+renders its repr rather than raising. That shape is preserved by knowledge's
+own Host layer after dispatch, not by altering the generic dispatcher's
+canonical `ACTION_REQUIRED` failure.
+
+The family supports no settings files at either LTP settings level; there is
+nothing to configure and no file is ever read.
+
+The previous JSON-database actions (`submit`, `view`, `consolidate`, `delete`)
+are intentionally removed: knowledge is now authored by writing `KNOWLEDGE.md`
+files with the regular `write`/`edit` tools, just like skills. There is no
+in-tool capacity limit; the historical `knowledge_limit` kwarg is accepted but
+ignored.
 
 Only `knowledge(...)` is registered. There is no `library(...)` or `codex(...)`
 alias.
@@ -163,7 +212,14 @@ skill -> private knowledge.
 | Claim | Source | Test |
 |---|---|---|
 | `knowledge` is the only private durable memory capability in the builtin registry | `src/lingtai/tools/registry.py` | `tests/test_check_caps.py::test_get_all_providers_includes_expected_capabilities` |
-| `knowledge` setup registers only the `knowledge` tool | `src/lingtai/tools/knowledge/__init__.py` | `tests/test_knowledge.py::test_knowledge_setup_registers_only_knowledge_tool` |
+| `knowledge` setup registers only the `knowledge` tool | `src/lingtai/tools/knowledge/__init__.py` | `tests/test_knowledge.py::test_knowledge_setup_registers_only_knowledge_tool`, `tests/test_tool_family_knowledge_migration_parity.py::test_setup_registers_one_knowledge_tool_with_the_family_schema` |
+| The root envelope is the closed `action`/`input`/`reasoning`/`summarize` object with required `reasoning` | `src/lingtai/tools/knowledge/__init__.py` | `tests/test_tool_family_knowledge_migration_parity.py::test_schema_root_is_closed_action_input_reasoning_summarize` |
+| Public action values are unchanged (`info`, `manual`) and no authoring/search/edit action exists | `src/lingtai/tools/knowledge/__init__.py` | `tests/test_tool_family_knowledge_migration_parity.py::test_public_action_values_are_unchanged_by_the_migration`, `::test_family_has_no_authoring_search_or_edit_capability` |
+| Both child inputs are canonical strict-empty objects, correlated to their action const on both wires | `src/lingtai/tools/knowledge/__init__.py` | `tests/test_tool_family_knowledge_migration_parity.py::test_child_inputs_are_canonical_strict_empty_objects`, `::test_root_allof_correlates_each_action_const_with_its_input_schema`, `::test_knowledge_family_schema_survives_chat_and_responses_wires` |
+| Missing or extra `input` fails before any handler I/O | `src/lingtai/tools/tool_family/__init__.py` | `tests/test_tool_family_knowledge_migration_parity.py::test_missing_input_is_rejected_before_any_io`, `::test_extra_input_field_is_rejected_before_any_io` |
+| `info` re-scans and returns exact count/problems without loading bodies or mutating entries | `src/lingtai/tools/knowledge/__init__.py` | `tests/test_tool_family_knowledge_migration_parity.py::test_info_rescans_and_reports_exact_count_and_problems`, `::test_info_does_not_load_bodies_or_mutate_entries` |
+| `manual` returns the current body/path and never rescans or mutates | `src/lingtai/tools/knowledge/__init__.py` | `tests/test_tool_family_knowledge_migration_parity.py::test_manual_returns_body_and_path_without_rescanning`, `::test_manual_missing_is_degraded_and_still_no_rescan` |
+| The exact pre-migration unknown-action envelope survives the migration | `src/lingtai/tools/knowledge/__init__.py` | `tests/test_knowledge.py::test_unknown_action_returns_error` |
 | Legacy `knowledge/knowledge.json` and `codex/codex.json` entries migrate once into `KNOWLEDGE.md` folders; `supplementary` becomes `references/supplementary.md` | `src/lingtai/tools/knowledge/__init__.py` | `tests/test_knowledge.py::test_legacy_knowledge_json_migrates_to_knowledge_md`, `tests/test_knowledge.py::test_legacy_codex_json_migrates_to_knowledge_md` |
 | Manager-style lookup is exact: `knowledge` resolves and former names do not | `src/lingtai/agent.py` | `tests/test_knowledge.py::test_former_alias_capabilities_do_not_register_knowledge` |
 | Catalog reads `<agent>/knowledge/<name>/KNOWLEDGE.md` and excludes `SKILL.md` entries | `src/lingtai/tools/knowledge/__init__.py` | `tests/test_knowledge.py::test_knowledge_md_convention_distinct_from_skill_md` |
@@ -179,11 +235,14 @@ skill -> private knowledge.
 | Skills do not depend on private knowledge | documented invariant; enforce by review | Check shared skill docs for private paths/ids | Shared skills become non-portable |
 | Knowledge and skills use distinct manifest filenames | `tests/test_knowledge.py::test_knowledge_md_convention_distinct_from_skill_md` | Drop a `SKILL.md` into `<agent>/knowledge/foo/` and confirm it is not picked up | Physical separation collapses; private/public boundary blurs |
 | Body content stays out of prompt catalog | `tests/test_knowledge.py::test_prompt_catalog_only_metadata_not_body` | Author an entry with a long body and inspect the prompt section | Prompt bloat / private detail leakage |
+| LTP v2 envelope: closed root, strict-empty child inputs, pre-I/O rejection | `tests/test_tool_family_knowledge_migration_parity.py` | Call with an extra `input` field and confirm no rescan happens | Invalid calls reach handlers; the signpost boundary weakens |
+| `manual` performs no catalog scan or mutation | `tests/test_tool_family_knowledge_migration_parity.py::test_manual_returns_body_and_path_without_rescanning` | Author an entry, call `manual`, confirm the prompt section is unchanged | Reading guidance silently rewrites prompt state |
 
 Run before merging knowledge changes:
 
 ```bash
-python -m pytest tests/test_knowledge.py tests/test_skills.py tests/test_check_caps.py tests/test_daemon_preset_capabilities.py -q
+python -m pytest tests/test_knowledge.py tests/test_tool_family_knowledge_migration_parity.py \
+  tests/test_skills.py tests/test_check_caps.py tests/test_daemon_preset_capabilities.py -q
 ```
 
 ## Schema and glossary ownership

--- a/src/lingtai/tools/knowledge/__init__.py
+++ b/src/lingtai/tools/knowledge/__init__.py
@@ -16,9 +16,11 @@ Knowledge is structurally isomorphic to skills but physically separate:
   private, agent-owned, and may reference agent-local paths, mail ids, and
   logs that skills must not depend on.
 
-Tool surface: ``info`` returns a runtime health snapshot (catalog size,
-problems) without the manual body; ``manual`` returns the knowledge-manual body
-on demand. Knowledge entry bodies are read via the ``read`` tool, the same way
+Tool surface (LTP v2 family; see ``src/lingtai/tools/CONTRACT.md``): the public
+tool stays ``knowledge`` with the same two action values. ``info`` returns a
+runtime health snapshot (catalog size, problems) without the manual body;
+``manual`` returns the knowledge-manual body on demand. Both take a strict empty
+``input``. Knowledge entry bodies are read via the ``read`` tool, the same way
 the agent opens a ``SKILL.md``.
 
 Usage: ``Agent(capabilities={"knowledge": {}})`` or via init.json.
@@ -31,11 +33,10 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-from lingtai.kernel.tool_dispatch import dispatch_action
+from typing import TYPE_CHECKING, Any, Callable, Mapping
 
 from .._catalog import build_catalog_yaml, scan_markdown_catalog
+from ..tool_family import ChildTool, ToolFamily
 from lingtai.kernel.i18n import t
 
 if TYPE_CHECKING:
@@ -281,48 +282,126 @@ def _knowledge_manual(agent: "BaseAgent") -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# LTP v2 family composition
+# ---------------------------------------------------------------------------
+
+# Neither action ever took an argument, so both children share the canonical
+# strict-empty input. That is what mechanically enforces the signpost contract:
+# with no declared property, *every* ``input`` key is an unknown key and is
+# rejected before the handler runs.
+_EMPTY_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
+
+# The one source of truth for knowledge's children: name -> the operation that
+# child performs on a bound agent. Both share ``_EMPTY_INPUT_SCHEMA`` and the
+# ``"<name> input"`` title, so the spec carries only what differs. Each
+# operation is a lambda rather than a direct function reference so the
+# module-level global is resolved when the child runs, not when this tuple is
+# built at import — the no-rescan/pre-I/O tests patch those globals to prove a
+# handler never ran.
+#
+# ``manual`` is this package's own child rather than the generic
+# ``build_manual_child`` because knowledge's public result is keyed
+# ``knowledge_manual``, not the generic ``content``/``structuredContent`` shape.
+# Using the generic builder would mean wrapping into a shape this family never
+# exposes only to flatten it back in a Host adapter; registering our own child
+# satisfies no-double-wrap without that round trip.
+_CHILD_SPECS: tuple[tuple[str, Callable[["BaseAgent"], dict]], ...] = (
+    ("info", lambda agent: _reconcile(agent)),
+    ("manual", lambda agent: _knowledge_manual(agent)),
+)
+
+
+def _build_family(agent: "BaseAgent | None") -> ToolFamily:
+    """Build one ``knowledge`` :class:`ToolFamily` from :data:`_CHILD_SPECS`.
+
+    With an ``agent``, children dispatch that agent's real operations. With
+    ``None`` — the module-level :data:`_FAMILY` backing ``get_schema()`` — they
+    raise if invoked, since a schema-only family never dispatches. Either way
+    construction validates the registry, so a duplicate or reserved-name
+    collision raises :class:`ToolFamilyError` at import time.
+    """
+
+    def bind(operation: "Callable[[BaseAgent], dict]") -> Callable[[Mapping[str, Any]], dict]:
+        if agent is None:
+            def unused(_input: Mapping[str, Any]) -> dict:
+                raise AssertionError("the module-level schema-only ToolFamily never dispatches")
+            return unused
+        return lambda _input: operation(agent)
+
+    return ToolFamily(
+        "knowledge",
+        [
+            ChildTool(name, _EMPTY_INPUT_SCHEMA, bind(operation), title=f"{name} input")
+            for name, operation in _CHILD_SPECS
+        ],
+    )
+
+
+_FAMILY = _build_family(None)
+
+
 def get_description(lang: str = "en") -> str:
-    return "SIGNPOST ONLY: this tool does not create, edit, search, or load knowledge entries; `info` only re-scans the knowledge catalog and reports health; `manual` returns the knowledge-manual body. Your private durable knowledge catalog across molts — what you've learned, decided, and discovered. Each entry is a folder at knowledge/<name>/ containing KNOWLEDGE.md (YAML frontmatter with name + description) and any supporting files (scripts, assets, notes, raw logs). The knowledge catalog in your system prompt is a YAML list — each entry is a `- name:` block with `location:` and `description:` — bodies load on demand via the read tool, just like skills. Knowledge is private and agent-owned: entries may reference local paths, mail ids, and logs that skills must not depend on. Author new entries by writing knowledge/<name>/KNOWLEDGE.md with write/edit; revise the same way. Call info to refresh the catalog and inspect health. Before using this tool, read the `knowledge-manual` skill — no exceptions."
+    return "SIGNPOST ONLY: this tool does not create, edit, search, or load knowledge entries; `info` only re-scans the knowledge catalog and reports health; `manual` returns the knowledge-manual body. Your private durable knowledge catalog across molts — what you've learned, decided, and discovered. Each entry is a folder at knowledge/<name>/ containing KNOWLEDGE.md (YAML frontmatter with name + description) and any supporting files (scripts, assets, notes, raw logs). The knowledge catalog in your system prompt is a YAML list — each entry is a `- name:` block with `location:` and `description:` — bodies load on demand via the read tool, just like skills. Knowledge is private and agent-owned: entries may reference local paths, mail ids, and logs that skills must not depend on. Author new entries by writing knowledge/<name>/KNOWLEDGE.md with write/edit; revise the same way. Call knowledge(action='info', input={}, reasoning='refresh the knowledge catalog') to refresh the catalog and inspect health, and knowledge(action='manual', input={}, reasoning='load knowledge guidance') for the manual body. Before using this tool, read the `knowledge-manual` skill — no exceptions."
 
 
 def get_schema(lang: str = "en") -> dict:
-    return {
-        "type": "object",
-        "properties": {
-            "action": {
-                "type": "string",
-                "enum": ["info", "manual"],
-                "description": 'info: re-scan knowledge/ and return runtime health (catalog size, resolved root path, malformed entries) without the manual body. manual: return only the knowledge-manual skill body.',
-            },
-        },
-        "required": ["action"],
-    }
+    # Composed by the generic ToolFamily infra from each child's own canonical
+    # ``input_schema`` rather than hand-assembled. The public action values are
+    # unchanged (``info``, ``manual``); what changes is the root envelope, which
+    # is now the closed LTP v2 ``action``/``input``/``reasoning``/``summarize``
+    # shape with per-action ``input`` correlation on both provider wires.
+    return _FAMILY.build_schema()
+
+
+def handle(family: ToolFamily, args: dict | None) -> dict:
+    """Dispatch one ``knowledge`` family call and normalize its envelope error.
+
+    ``family`` is the per-agent :class:`ToolFamily` ``setup()`` builds once at
+    registration. Dispatch itself lives entirely in the generic
+    ``ToolFamily.handle``; the only thing this Host layer adds is the
+    unknown-action normalization below.
+
+    Knowledge's pre-migration public unknown-action result was
+    ``{"status": "error", "message": "unknown action: ..., only 'info' or
+    'manual' is supported"}`` for any bad action value, including an unhashable
+    one such as ``[]`` or ``{}``, and rendering a *missing* ``action`` as the
+    empty-string default (``kernel/tool_dispatch.py``'s ``default=""``). That
+    exact shape — including that default — is preserved here, after dispatch,
+    rather than by changing the generic dispatcher's own canonical
+    ``ACTION_REQUIRED`` envelope error.
+    """
+    action = args.get("action", "") if isinstance(args, Mapping) else ""
+    result = family.handle(args)
+    if result.get("error_code") == "ACTION_REQUIRED":
+        return {
+            "status": "error",
+            "message": f"unknown action: {action!r}, only 'info' or 'manual' is supported",
+        }
+    return result
 
 
 def setup(agent: "BaseAgent", **_ignored) -> None:
     """Set up the knowledge capability.
 
     Scans ``<agent>/knowledge/`` for ``<name>/KNOWLEDGE.md`` entries and
-    injects the catalog into the system prompt. Registers ``info`` for
-    runtime health and ``manual`` for the progressive-disclosure manual body.
+    injects the catalog into the system prompt. Registers the ``knowledge``
+    family with ``info`` for runtime health and ``manual`` for the
+    progressive-disclosure manual body.
 
     Unknown kwargs (e.g. the historical ``knowledge_limit``) are accepted and
     ignored — the file-backed catalog has no fixed-size limit.
     """
     _reconcile(agent)
+    family = _build_family(agent)
 
     def handle_knowledge(args: dict) -> dict:
-        return dispatch_action(
-            args,
-            {
-                "info": lambda _args: _reconcile(agent),
-                "manual": lambda _args: _knowledge_manual(agent),
-            },
-            unknown=lambda action: {
-                "status": "error",
-                "message": f"unknown action: {action!r}, only 'info' or 'manual' is supported",
-            },
-        )
+        return handle(family, args)
 
     agent.add_tool(
         "knowledge",

--- a/src/lingtai/tools/knowledge/glossary-wen.md
+++ b/src/lingtai/tools/knowledge/glossary-wen.md
@@ -15,5 +15,8 @@ maintenance: |
 ---
 **名相对照**
 
-- `knowledge`：【路标之器】此器不代汝造经、修经、搜经或载经；`info` 唯重扫 knowledge 之目录并还康状；`manual` 方还 knowledge-manual 之文。汝跨凝蜕长存之私有知识目录——所习、所断、所悟之记。每经卷皆为 knowledge/<名>/ 一匣，内置 KNOWLEDGE.md（YAML frontmatter 须有 name 与 description），可附副件（script、素材、笔记、原始日志）。系统提示中之知识典为 YAML 之列——每经一 `- name:` 块，附 `location:` 与 `description:` 之目；正文按需以 read 工具取之，与 skills 同律。知识乃汝私藏：经卷可引本地之路、邮件之 id、日志之记——此皆 skills 所不可依也。新经以 write/edit 直书 knowledge/<名>/KNOWLEDGE.md；修订同此。呼 info 可重扫目录、验其康。用此器前，必先读 `knowledge-manual` 一技，无所例外。
-- `action`：info：重扫 knowledge/，返当时之康状（卷数、根径、损经之记），不载 manual 全文。manual：唯还 knowledge-manual 之文。
+- `knowledge`：【路标之器】此器不代汝造经、修经、搜经或载经；`info` 唯重扫 knowledge 之目录并还康状；`manual` 方还 knowledge-manual 之文。汝跨凝蜕长存之私有知识目录——所习、所断、所悟之记。每经卷皆为 knowledge/<名>/ 一匣，内置 KNOWLEDGE.md（YAML frontmatter 须有 name 与 description），可附副件（script、素材、笔记、原始日志）。系统提示中之知识典为 YAML 之列——每经一 `- name:` 块，附 `location:` 与 `description:` 之目；正文按需以 read 工具取之，与 skills 同律。知识乃汝私藏：经卷可引本地之路、邮件之 id、日志之记——此皆 skills 所不可依也。新经以 write/edit 直书 knowledge/<名>/KNOWLEDGE.md；修订同此。呼 `knowledge(action='info', input={}, reasoning='...')` 可重扫目录、验其康；呼 `knowledge(action='manual', input={}, reasoning='...')` 以取手册之文。用此器前，必先读 `knowledge-manual` 一技，无所例外。
+- `action`：info：重扫 knowledge/，返当时之康状（卷数、根径、损经之记），不载 manual 全文。manual：唯还 knowledge-manual 之文，且不重扫。
+- `input`：所择 action 独有之入参。info 与 manual 二者皆严格空器（strict-empty），不纳一字；有余字者，未及行事而先见拒。
+- `reasoning`：根上必具之由，乃宿主稽核之属，终不入 input 之内。
+- `summarize`：根上可有之果后处置之钥，默为否；非动作之入参。knowledge 之果本简，寻常不必启之。

--- a/src/lingtai/tools/knowledge/glossary-zh.md
+++ b/src/lingtai/tools/knowledge/glossary-zh.md
@@ -15,5 +15,8 @@ maintenance: |
 ---
 **术语对照**
 
-- `knowledge`：【路标工具】此工具不会创建、编辑、搜索或加载知识条目；`info` 只重新扫描 knowledge 目录并返回健康状态；`manual` 才返回 knowledge-manual 正文。你的跨凝蜕长存私有知识目录——所学、所断、所悟之记。每条目皆为 knowledge/<名>/ 下之一夹，内含 KNOWLEDGE.md（YAML frontmatter 须有 name 与 description），可附脚本、素材、笔记、原始日志等支撑文件。系统提示中之知识目录为 YAML 列表——每条目为一 `- name:` 块，附 `location:` 与 `description:` 字段；正文按需以 read 工具取之，与 skills 同。知识为汝私有：条目可引本地路径、邮件 ID、日志——此皆为 skills 所不可依赖之物。新条目以 write/edit 直接写入 knowledge/<名>/KNOWLEDGE.md；修订同法。调 info 可刷新目录并查看健康状态。用此工具前，必先读 `knowledge-manual` 技能，无例外。
-- `action`：info：重新扫描 knowledge/ 并返回运行时健康快照（目录大小、根路径、损坏条目），不带 manual 正文。manual：只返回 knowledge-manual 技能正文。
+- `knowledge`：【路标工具】此工具不会创建、编辑、搜索或加载知识条目；`info` 只重新扫描 knowledge 目录并返回健康状态；`manual` 才返回 knowledge-manual 正文。你的跨凝蜕长存私有知识目录——所学、所断、所悟之记。每条目皆为 knowledge/<名>/ 下之一夹，内含 KNOWLEDGE.md（YAML frontmatter 须有 name 与 description），可附脚本、素材、笔记、原始日志等支撑文件。系统提示中之知识目录为 YAML 列表——每条目为一 `- name:` 块，附 `location:` 与 `description:` 字段；正文按需以 read 工具取之，与 skills 同。知识为汝私有：条目可引本地路径、邮件 ID、日志——此皆为 skills 所不可依赖之物。新条目以 write/edit 直接写入 knowledge/<名>/KNOWLEDGE.md；修订同法。调 `knowledge(action='info', input={}, reasoning='...')` 可刷新目录并查看健康状态；调 `knowledge(action='manual', input={}, reasoning='...')` 取手册正文。用此工具前，必先读 `knowledge-manual` 技能，无例外。
+- `action`：info：重新扫描 knowledge/ 并返回运行时健康快照（目录大小、根路径、损坏条目），不带 manual 正文。manual：只返回 knowledge-manual 技能正文，且不重新扫描。
+- `input`：所选 action 之专属入参对象。info 与 manual 皆为严格空对象（strict-empty）：不接受任何字段，多余字段在动作执行前即被拒。
+- `reasoning`：必填的根级调用理由，属宿主审计元数据，绝不下沉入 input。
+- `summarize`：可选的根级结果后处理开关，默认为假；非动作入参。knowledge 结果本就短小，通常无需开启。

--- a/src/lingtai/tools/knowledge/manual/SKILL.md
+++ b/src/lingtai/tools/knowledge/manual/SKILL.md
@@ -82,7 +82,37 @@ Required fields are `name` and `description`. Supporting files are optional and 
 
 The system prompt only receives a compact catalog: each entry's `name`, `description`, and `location`. The body of `KNOWLEDGE.md` and supporting files stay on disk until you explicitly read them. This keeps the prompt small while still making the memory discoverable.
 
-Call `knowledge({"action": "info"})` to rescan the catalog and refresh the prompt section, then use `read` on the listed `location` when an entry becomes relevant.
+Call `knowledge(action="info", input={}, reasoning="rescan the knowledge catalog")` to rescan the catalog and refresh the prompt section, then use `read` on the listed `location` when an entry becomes relevant.
+
+## Call shape
+
+`knowledge` is one tool family with two actions. Every call carries exactly
+four root fields — `action`, `input`, `reasoning` (all required) and the
+optional `summarize`:
+
+- `knowledge(action="info", input={}, reasoning="...")` — rescan the catalog
+  and return health only: `knowledge_dir`, `catalog_size`, and `problems`.
+- `knowledge(action="manual", input={}, reasoning="...")` — return this
+  manual's body and its path. It does **not** rescan the catalog.
+
+Both actions take a strict-empty `input`: there is no argument to pass, and any
+field you put inside `input` is rejected before the action runs. This tool is a
+signpost — it never creates, edits, searches, or loads entries. Author and
+revise entries by writing `knowledge/<name>/KNOWLEDGE.md` with `write`/`edit`,
+and load bodies with `read`.
+
+### `summarize`
+
+`knowledge` is a **short-result** family: both actions return small results, so
+root `summarize` is available but normally unnecessary — leave it false. Keep it
+false for `manual` in particular, so exact procedure and constraints are not
+summarized away. `summarize` is a root field; it is never part of `input`.
+
+### Settings
+
+`knowledge` supports no settings surface: there is no `settings/knowledge.json`
+and no `settings/knowledge.<action>.json`; nothing in this family reads
+settings.
 
 ## Nesting and sub-knowledge
 
@@ -166,4 +196,4 @@ PY
 Recommended cadence: before molt if knowledge sprawl is confusing, after major
 projects, and monthly for long-lived agents. If cleanup is approved with explicit user consent, record the
 entries consolidated/removed in `logs/cleanup.jsonl` and update the catalog with
-`knowledge(action="info")`.
+`knowledge(action="info", input={}, reasoning="refresh after cleanup")`.

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/tool_family/__init__.py
   - src/lingtai/tools/tool_family/manual.py
   - src/lingtai/tools/web_search/ANATOMY.md
+  - src/lingtai/tools/knowledge/ANATOMY.md
 maintenance: |
   Keep related_files repo-relative, duplicate-free, and linked to real files.
   Keep this component's ANATOMY.md and CONTRACT.md reciprocal and keep
@@ -82,6 +83,19 @@ diagnostic onto any envelope-level failure result, since a generic
 `ToolFamily` has no knowledge of a specific family's settings diagnostics.
 This division follows `../CONTRACT.md` "Implementation independence": using
 `ToolFamily.handle()` is `web`'s choice, not an inherited requirement.
+
+`knowledge/__init__.py` is the second real consumer
+(`src/lingtai/tools/knowledge/ANATOMY.md`): one `_build_family(agent | None)`
+is the single builder — `_FAMILY = _build_family(None)` backs `get_schema()`
+with non-dispatching handlers, and `_build_family(agent)` binds the
+`info`/`manual` operations named in `_CHILD_SPECS` per agent. Both children declare the canonical strict-empty
+`input_schema`, so every `input` key is a cross-branch/unknown key rejected
+before handler I/O. It registers its own `manual` child rather than
+`build_manual_child`, because knowledge's public manual result is keyed
+`knowledge_manual` — the child's canonical result is returned verbatim, so no
+Host-layer flattening is needed. Its outer `handle()` normalizes only the
+generic `ACTION_REQUIRED` envelope failure back to knowledge's exact
+pre-migration unknown-action result.
 
 ## Composition
 

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -82,8 +82,9 @@ correct even before Agent composition runs). `build_schema()` always
 advertises `summarize` to the model regardless of family; whether the kernel
 actually honors it is a separate, per-family allowlist decision
 (`kernel/tool_result_summary.py` `_LTP_V2_MIGRATED_FAMILIES`) that this
-package does not own or enforce. Today only `web` is on that allowlist, so
-`summarize` is meaningful for the one family that uses this infrastructure; a
+package does not own or enforce. Today `web` and `knowledge` are on that
+allowlist, so `summarize` is meaningful for the families that use this
+infrastructure; a
 family adopting `ToolFamily` without also joining the kernel allowlist would
 advertise a model-visible `summarize` control that the kernel silently
 ignores. Calling
@@ -121,8 +122,8 @@ package, per `../CONTRACT.md` "Implementation independence".
 
 ## Adapters
 
-`web_search/__init__.py` is the one production Adapter/consumer in this
-candidate: `WebManager.__init__` builds a per-instance `ToolFamily` with
+`web_search/__init__.py` is the first production Adapter/consumer:
+`WebManager.__init__` builds a per-instance `ToolFamily` with
 `search`/`browse` handlers bound to that instance, and registers
 `manual.build_manual_child(agent, "web")`'s returned `ChildTool` *directly* —
 unwrapped — as the family's `manual` child. `WebManager.handle()` calls
@@ -137,9 +138,23 @@ flattens the canonical result to Web's pre-migration public shape (`status`,
 `handle()`, not to the generic child or any wrapper registered in place of
 it. `WebManager.handle()` also stamps `current_setting` onto any
 envelope-level failure result (search/browse/unknown-action) before
-returning, unchanged from before. No other built-in family is migrated in
-this candidate; each remains fully independent of this package until its own
-scoped migration.
+returning, unchanged from before.
+
+`knowledge/__init__.py` is the second production Adapter/consumer:
+one `_build_family(agent | None)` registers `info` and `manual` children from a
+single `_CHILD_SPECS` source, both with the canonical strict-empty
+`input_schema`; passing `None` yields the module-level schema-only family
+behind `get_schema()`. It does **not** use
+`manual.build_manual_child`, because knowledge's public manual result has
+always been keyed `knowledge_manual` rather than the generic
+`content`/`structuredContent` shape; registering its own `manual` child means
+`ToolFamily.handle()` returns that family's canonical result verbatim with no
+double wrap and no round-trip through a shape it never exposes — the same
+no-double-wrap rule, satisfied without a Host adapter. Its outer `handle()`
+normalizes only the generic `ACTION_REQUIRED` envelope failure back to
+knowledge's exact pre-migration unknown-action result. No other built-in
+family is migrated; each remains fully independent of this package until its
+own scoped migration.
 
 ## Contract rules
 
@@ -168,6 +183,11 @@ scoped migration.
   sole enforcement boundary; dispatch remains always-authoritative and
   fail-closed regardless of whether a given provider validates the root
   `allOf`/`if`/`then` schema-side (`../CONTRACT.md` "Dispatch and actions").
+- `handle()` MUST treat an unhashable `action` (e.g. `[]` or `{}`, reachable
+  when invalid JSON survives to dispatch — the issue #513 blocker class) as
+  simply matching no child, rendering the stable typed `ACTION_REQUIRED`
+  envelope failure exactly as `kernel/tool_dispatch.py` does, rather than
+  raising `TypeError` out of the dispatcher.
 - A child handler MUST receive only its own validated `input` mapping — never
   `action`, `reasoning`, `_reasoning`, or `summarize`.
 - `handle()`'s dispatch result IS the child's own raw/canonical result;

--- a/src/lingtai/tools/tool_family/__init__.py
+++ b/src/lingtai/tools/tool_family/__init__.py
@@ -259,10 +259,20 @@ class ToolFamily:
         are validated against the selected child's own declared
         ``input_schema`` properties, rejecting any key belonging to another
         action's branch, before the child handler ever runs.
+
+        Invalid JSON can make ``action`` an unhashable value (e.g. ``[]`` or
+        ``{}``) — the issue #513 blocker class. Such an ``action`` simply
+        matches no child and renders the stable typed envelope failure below,
+        exactly as ``kernel/tool_dispatch.py`` does, rather than raising
+        ``TypeError`` out of the dispatcher.
         """
         raw = dict(args or {})
         action = raw.get("action")
-        if action not in self._children:
+        try:
+            known_action = action in self._children
+        except TypeError:
+            known_action = False
+        if not known_action:
             return self._envelope_error(
                 "ACTION_REQUIRED",
                 f"action must be one of {', '.join(self._order)}",

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -87,7 +87,7 @@ def test_legacy_knowledge_limit_kwarg_is_ignored(tmp_path):
     agent, _ = _mk_agent(tmp_path, {"knowledge_limit": 50})
     try:
         assert "knowledge" in agent._tool_handlers
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         assert result["status"] == "ok"
     finally:
         agent.stop(timeout=1.0)
@@ -101,7 +101,7 @@ def test_legacy_knowledge_limit_kwarg_is_ignored(tmp_path):
 def test_info_returns_runtime_snapshot(tmp_path):
     agent, workdir = _mk_agent(tmp_path)
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         assert result["status"] == "ok"
         assert result["knowledge_dir"] == str(workdir / "knowledge")
         assert result["catalog_size"] == 0
@@ -124,7 +124,7 @@ def test_info_picks_up_authored_entry(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         assert result["catalog_size"] == 1
         assert result["problems"] == []
     finally:
@@ -132,16 +132,26 @@ def test_info_picks_up_authored_entry(tmp_path):
 
 
 def test_unknown_action_returns_error(tmp_path):
-    """Removed JSON-store actions (submit/view/etc.) must be rejected."""
+    """Removed JSON-store actions (submit/view/etc.) must be rejected.
+
+    The exact pre-ToolFamily model-visible unknown-action envelope is preserved
+    by knowledge's own Host-layer normalization, not by the generic
+    dispatcher's canonical ``ACTION_REQUIRED`` failure.
+    """
     agent, _ = _mk_agent(tmp_path)
     try:
         for action in ("submit", "view", "consolidate", "delete", "filter", "export"):
-            result = agent._tool_handlers["knowledge"]({"action": action})
+            result = agent._tool_handlers["knowledge"](
+                {"action": action, "input": {}, "reasoning": "probe a removed action"}
+            )
             assert result["status"] == "error", f"{action!r} should be rejected"
             assert "unknown action" in result["message"].lower()
         # Exact model-visible envelope must survive the dispatch-helper
-        # migration (issue #513): wording, quoting, and key names verbatim.
-        assert agent._tool_handlers["knowledge"]({"action": "submit"}) == {
+        # migration (issue #513) and the ToolFamily migration: wording,
+        # quoting, and key names verbatim.
+        assert agent._tool_handlers["knowledge"](
+            {"action": "submit", "input": {}, "reasoning": "probe a removed action"}
+        ) == {
             "status": "error",
             "message": "unknown action: 'submit', only 'info' or 'manual' is supported",
         }
@@ -152,11 +162,15 @@ def test_unknown_action_returns_error(tmp_path):
         }
         # Invalid JSON can make `action` unhashable (issue #513 blocker): the
         # router must render the unknown-action envelope, not raise TypeError.
-        assert agent._tool_handlers["knowledge"]({"action": []}) == {
+        assert agent._tool_handlers["knowledge"](
+            {"action": [], "input": {}, "reasoning": "unhashable action"}
+        ) == {
             "status": "error",
             "message": "unknown action: [], only 'info' or 'manual' is supported",
         }
-        assert agent._tool_handlers["knowledge"]({"action": {}}) == {
+        assert agent._tool_handlers["knowledge"](
+            {"action": {}, "input": {}, "reasoning": "unhashable action"}
+        ) == {
             "status": "error",
             "message": "unknown action: {}, only 'info' or 'manual' is supported",
         }
@@ -239,7 +253,7 @@ def test_catalog_refreshes_on_info(tmp_path):
             "late-arrival",
             "Added after agent boot.",
         )
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         assert result["catalog_size"] == 1
 
         prompt = agent._prompt_manager.read_section("knowledge") or ""
@@ -277,7 +291,7 @@ def test_knowledge_md_convention_distinct_from_skill_md(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         assert result["catalog_size"] == 1
         prompt = agent._prompt_manager.read_section("knowledge") or ""
         assert "real-entry" in prompt
@@ -316,7 +330,7 @@ def test_entries_may_have_scripts_and_assets(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         assert result["status"] == "ok"
         assert result["catalog_size"] == 1
         assert result["problems"] == []
@@ -349,7 +363,7 @@ def test_entry_may_reference_local_paths_in_body(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         assert result["catalog_size"] == 1
         prompt = agent._prompt_manager.read_section("knowledge") or ""
         # Body (and its private references) stays out of the prompt catalog.
@@ -377,7 +391,7 @@ def test_info_surfaces_missing_frontmatter(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         problem_folders = [p["folder"] for p in result["problems"]]
         assert any("missing-desc" in f for f in problem_folders)
         assert result["catalog_size"] == 0
@@ -408,7 +422,7 @@ def test_legacy_knowledge_json_migrates_to_knowledge_md(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         assert result["catalog_size"] == 1
         assert result["problems"] == []
 
@@ -456,7 +470,7 @@ def test_legacy_knowledge_json_migration_uses_unique_slugs(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         assert result["catalog_size"] == 2
         assert (legacy_dir / "duplicate" / "KNOWLEDGE.md").is_file()
         assert (legacy_dir / "duplicate-b2" / "KNOWLEDGE.md").is_file()
@@ -487,7 +501,7 @@ def test_legacy_codex_json_migrates_to_knowledge_md(tmp_path):
         capabilities={"knowledge": {}},
     )
     try:
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"]({"action": "info", "input": {}, "reasoning": "check knowledge catalog health"})
         assert result["catalog_size"] == 1
         assert result["problems"] == []
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -935,7 +935,9 @@ def test_new_knowledge_and_skills_config_registers_both(tmp_path):
         (entry_dir / "KNOWLEDGE.md").write_text(
             "---\nname: new-entry\ndescription: A freshly authored knowledge entry.\n---\nBody.\n"
         )
-        result = agent._tool_handlers["knowledge"]({"action": "info"})
+        result = agent._tool_handlers["knowledge"](
+            {"action": "info", "input": {}, "reasoning": "refresh after authoring"}
+        )
         assert result["status"] == "ok"
         assert result["catalog_size"] == 1
         assert "new-entry" in (agent._prompt_manager.read_section("knowledge") or "")

--- a/tests/test_tool_family_generic.py
+++ b/tests/test_tool_family_generic.py
@@ -137,6 +137,22 @@ def test_dispatch_missing_action_fails_with_action_required():
     assert result["error_code"] == "ACTION_REQUIRED"
 
 
+def test_dispatch_unhashable_action_fails_without_raising():
+    """Invalid JSON can make ``action`` unhashable (issue #513 blocker class).
+
+    Such an action matches no child and must render the stable typed envelope
+    failure, exactly as ``kernel/tool_dispatch.py`` does — not raise
+    ``TypeError`` out of the dispatcher.
+    """
+    calls: list[dict] = []
+    fam = _widget_family(calls)
+    for unhashable in ([], {}, ["spin"], {"spin": 1}, set()):
+        result = fam.handle({"action": unhashable, "input": {}, "reasoning": "why"})
+        assert result["status"] == "failed", unhashable
+        assert result["error_code"] == "ACTION_REQUIRED", unhashable
+    assert calls == []
+
+
 def test_dispatch_non_object_input_fails_with_invalid_argument():
     fam = _widget_family()
     result = fam.handle({"action": "spin", "input": "not-an-object"})

--- a/tests/test_tool_family_knowledge_migration_parity.py
+++ b/tests/test_tool_family_knowledge_migration_parity.py
@@ -1,0 +1,443 @@
+"""Knowledge LTP v2 family migration parity and wire correlation.
+
+``knowledge`` keeps its exact public name and its two public action values
+(``info``, ``manual``); what the migration changes is the root envelope, which
+is now the closed LTP v2 ``action``/``input``/``reasoning``/``summarize`` shape
+with per-action ``input`` correlation on both provider wires.
+
+The behavioral point of these tests is that the migration is envelope-only:
+``info`` still re-scans and reconciles the private catalog and returns health
+(root/count/problems) without loading bodies or mutating entries, and ``manual``
+still returns the current manual body/path without rescanning or mutating
+anything.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lingtai.agent import Agent
+from lingtai.tools import knowledge as knowledge_tool
+from tests._service_helpers import make_gemini_mock_service as make_mock_service
+
+
+def _mk_agent(tmp_path: Path):
+    workdir = tmp_path / "agent"
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="knowledge-family-test",
+        working_dir=workdir,
+        capabilities={"knowledge": {}},
+    )
+    return agent, workdir
+
+
+def _dispatch(agent, args: dict) -> dict:
+    """Call the Host layer with an explicitly built family, as ``setup`` does.
+
+    ``knowledge.handle`` takes the family the caller owns — there is no
+    build-on-demand fallback in production, so tests build one the same way
+    ``setup()`` does rather than relying on a test-only convenience branch.
+    """
+    return knowledge_tool.handle(knowledge_tool._build_family(agent), args)
+
+
+def _write_entry(folder: Path, name: str, desc: str = "an entry", body: str = "Body.") -> Path:
+    folder.mkdir(parents=True, exist_ok=True)
+    path = folder / "KNOWLEDGE.md"
+    path.write_text(f"---\nname: {name}\ndescription: {desc}\n---\n\n{body}\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Schema: closed root envelope, strict-empty child inputs, action parity
+# ---------------------------------------------------------------------------
+
+
+def test_schema_root_is_closed_action_input_reasoning_summarize():
+    schema = knowledge_tool.get_schema()
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    # ``reasoning`` is REQUIRED Host InvocationContext/audit metadata declared
+    # by the family schema itself, not left to Agent schema composition (which
+    # only re-injects the identical property text and never touches
+    # ``required``).
+    assert schema["required"] == ["action", "input", "reasoning"]
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    assert schema["properties"]["reasoning"]["type"] == "string"
+    assert schema["properties"]["summarize"]["type"] == "boolean"
+
+
+def test_public_action_values_are_unchanged_by_the_migration():
+    """The migration is envelope-only: the public action vocabulary is exactly
+    the pre-migration ``info``/``manual``, with no authoring/search/edit
+    action added."""
+    schema = knowledge_tool.get_schema()
+    assert schema["properties"]["action"]["enum"] == ["info", "manual"]
+
+
+def test_child_inputs_are_canonical_strict_empty_objects():
+    schema = knowledge_tool.get_schema()
+    branches = schema["properties"]["input"]["oneOf"]
+    assert [b["title"] for b in branches] == ["info input", "manual input"]
+    for branch in branches:
+        assert branch["type"] == "object"
+        assert branch["properties"] == {}
+        assert branch["required"] == []
+        assert branch["additionalProperties"] is False
+        # Envelope controls never leak into a child's own input.
+        assert "reasoning" not in branch["properties"]
+        assert "_reasoning" not in branch["properties"]
+        assert "summarize" not in branch["properties"]
+
+
+def test_root_allof_correlates_each_action_const_with_its_input_schema():
+    schema = knowledge_tool.get_schema()
+    conditions = schema["allOf"]
+    assert len(conditions) == 2
+    seen = {}
+    for condition in conditions:
+        const = condition["if"]["properties"]["action"]["const"]
+        assert condition["if"]["required"] == ["action"]
+        seen[const] = condition["then"]["properties"]["input"]
+    assert set(seen) == {"info", "manual"}
+    for action, input_schema in seen.items():
+        assert input_schema["additionalProperties"] is False, action
+        assert input_schema["properties"] == {}, action
+
+
+# ---------------------------------------------------------------------------
+# Wire correlation: Chat Completions and Responses
+# ---------------------------------------------------------------------------
+
+
+def test_knowledge_family_schema_survives_chat_and_responses_wires(tmp_path):
+    from lingtai.kernel.base_agent.tools import _build_tool_schemas
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        schemas = _build_tool_schemas(agent)
+        knowledge = next(s for s in schemas if s.name == "knowledge")
+        chat = _build_tools([knowledge])[0]["function"]["parameters"]
+        responses = _build_responses_tools([knowledge])[0]["parameters"]
+
+        for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+            assert wire["type"] == "object"
+            assert wire["required"] == ["action", "input", "reasoning"]
+            assert wire["additionalProperties"] is False
+            assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
+            branches = wire["properties"]["input"][combinator]
+            assert [b["title"] for b in branches] == ["info input", "manual input"]
+            for branch in branches:
+                assert branch["additionalProperties"] is False
+                assert "reasoning" not in branch["properties"]
+                assert "_reasoning" not in branch["properties"]
+                assert "summarize" not in branch["properties"]
+
+        # Root ``allOf`` action/input correlation reaches both wires. Chat
+        # keeps it verbatim; the Responses builder preserves a root ``allOf``
+        # rather than stripping it.
+        for wire in (chat, responses):
+            consts = [c["if"]["properties"]["action"]["const"] for c in wire["allOf"]]
+            assert consts == ["info", "manual"]
+    finally:
+        agent.stop(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch: pre-I/O rejection
+# ---------------------------------------------------------------------------
+
+
+def test_missing_input_is_rejected_before_any_io(tmp_path, monkeypatch):
+    """A call with no ``input`` fails at the envelope, before either action's
+    handler runs — no rescan, no manual read."""
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        calls: list[str] = []
+        monkeypatch.setattr(
+            knowledge_tool, "_reconcile", lambda _agent: calls.append("reconcile") or {},
+        )
+        monkeypatch.setattr(
+            knowledge_tool,
+            "_knowledge_manual",
+            lambda _agent: calls.append("manual") or {},
+        )
+        for action in ("info", "manual"):
+            result = _dispatch(agent, {"action": action, "reasoning": "no input"})
+            assert result["status"] == "failed"
+            assert result["error_code"] == "INVALID_ARGUMENT"
+        assert calls == []
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_extra_input_field_is_rejected_before_any_io(tmp_path, monkeypatch):
+    """Both children declare a strict-empty input, so ANY input key is a
+    cross-branch/unknown key and is rejected at dispatch before handler I/O."""
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        calls: list[str] = []
+        monkeypatch.setattr(
+            knowledge_tool, "_reconcile", lambda _agent: calls.append("reconcile") or {},
+        )
+        monkeypatch.setattr(
+            knowledge_tool,
+            "_knowledge_manual",
+            lambda _agent: calls.append("manual") or {},
+        )
+        # Exercise the registered handler (the family ``setup`` built once),
+        # not just the module-level ``handle`` helper.
+        registered = agent._tool_handlers["knowledge"]
+        for dispatch in (lambda a: _dispatch(agent, a), registered):
+            for action in ("info", "manual"):
+                result = dispatch(
+                    {
+                        "action": action,
+                        "input": {"query": "find something"},
+                        "reasoning": "smuggle an authoring/search field",
+                    }
+                )
+                assert result["status"] == "failed"
+                assert result["error_code"] == "INVALID_ARGUMENT"
+                assert "unsupported knowledge input field" in result["message"]
+        assert calls == []
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_unknown_root_field_and_non_boolean_summarize_are_rejected(tmp_path):
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        unknown_root = _dispatch(
+            agent,
+            {"action": "info", "input": {}, "reasoning": "r", "parameters": {}},
+        )
+        assert unknown_root["status"] == "failed"
+        assert unknown_root["error_code"] == "INVALID_ARGUMENT"
+
+        bad_summarize = _dispatch(
+            agent,
+            {"action": "info", "input": {}, "reasoning": "r", "summarize": "yes"},
+        )
+        assert bad_summarize["status"] == "failed"
+        assert bad_summarize["error_code"] == "INVALID_ARGUMENT"
+        assert "summarize must be a boolean" in bad_summarize["message"]
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_reasoning_and_summarize_never_reach_a_child_handler(tmp_path):
+    """Children receive only their own ``input`` mapping — never ``action``,
+    ``reasoning``, ``_reasoning``, or ``summarize``."""
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        assert set(knowledge_tool._build_family(agent).child_names) == {"info", "manual"}
+
+        seen: list[dict] = []
+
+        def record(input_mapping):
+            seen.append(dict(input_mapping))
+            return {"status": "ok"}
+
+        recording = knowledge_tool.ToolFamily(
+            "knowledge",
+            [
+                knowledge_tool.ChildTool(
+                    "info", knowledge_tool._EMPTY_INPUT_SCHEMA, record, title="info input",
+                ),
+                knowledge_tool.ChildTool(
+                    "manual", knowledge_tool._EMPTY_INPUT_SCHEMA, record, title="manual input",
+                ),
+            ],
+        )
+        recording.handle(
+            {
+                "action": "info",
+                "input": {},
+                "reasoning": "why",
+                "_reasoning": "internal",
+                "summarize": True,
+            }
+        )
+        assert seen == [{}]
+    finally:
+        agent.stop(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Preserved semantics: info scans, manual does not
+# ---------------------------------------------------------------------------
+
+
+def test_info_rescans_and_reports_exact_count_and_problems(tmp_path):
+    """``info`` re-scans and reconciles the catalog: an entry authored after
+    setup is picked up on the next call, and a malformed entry is reported in
+    ``problems`` — the exact pre-migration behavior."""
+    agent, workdir = _mk_agent(tmp_path)
+    try:
+        first = _dispatch(
+            agent, {"action": "info", "input": {}, "reasoning": "initial health"}
+        )
+        assert first["status"] == "ok"
+        assert first["knowledge_dir"] == str(workdir / "knowledge")
+        assert first["catalog_size"] == 0
+        assert first["problems"] == []
+
+        _write_entry(workdir / "knowledge" / "alpha", "alpha")
+        _write_entry(workdir / "knowledge" / "beta", "beta")
+        # A folder whose KNOWLEDGE.md lacks required frontmatter is a problem,
+        # not an entry.
+        broken = workdir / "knowledge" / "broken"
+        broken.mkdir(parents=True, exist_ok=True)
+        (broken / "KNOWLEDGE.md").write_text("no frontmatter here\n")
+
+        second = _dispatch(
+            agent, {"action": "info", "input": {}, "reasoning": "rescan after authoring"}
+        )
+        assert second["status"] == "ok"
+        assert second["catalog_size"] == 2
+        assert len(second["problems"]) == 1
+        assert set(second) == {"status", "knowledge_dir", "catalog_size", "problems"}
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_info_does_not_load_bodies_or_mutate_entries(tmp_path):
+    agent, workdir = _mk_agent(tmp_path)
+    try:
+        secret = "SENTINEL-BODY-must-not-be-returned"
+        path = _write_entry(workdir / "knowledge" / "alpha", "alpha", body=secret)
+        before = path.read_bytes()
+
+        result = _dispatch(
+            agent, {"action": "info", "input": {}, "reasoning": "health only"}
+        )
+        assert result["catalog_size"] == 1
+        assert secret not in repr(result)
+        # No entry mutation: the capability is pure presentation.
+        assert path.read_bytes() == before
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_manual_returns_body_and_path_without_rescanning(tmp_path, monkeypatch):
+    """``manual`` returns the current manual body/path and performs no catalog
+    scan or reconciliation."""
+    agent, workdir = _mk_agent(tmp_path)
+    try:
+        manual_path = (
+            workdir / ".library" / "intrinsic" / "capabilities" / "knowledge" / "SKILL.md"
+        )
+        manual_path.parent.mkdir(parents=True, exist_ok=True)
+        body = "---\nname: knowledge\n---\n\n# knowledge manual sentinel\n"
+        manual_path.write_text(body, encoding="utf-8")
+
+        scans: list[str] = []
+        monkeypatch.setattr(
+            knowledge_tool,
+            "_reconcile",
+            lambda _agent: scans.append("scan") or {"status": "ok"},
+        )
+        # Authoring an entry after setup would change catalog_size if manual
+        # rescanned; it must not.
+        _write_entry(workdir / "knowledge" / "late-entry", "late-entry")
+
+        result = _dispatch(
+            agent, {"action": "manual", "input": {}, "reasoning": "load guidance"}
+        )
+        assert scans == []
+        assert result["status"] == "ok"
+        assert result["knowledge_manual"] == body
+        assert result["manual_path"] == str(manual_path)
+        # No double wrap: the child's canonical result is returned verbatim.
+        assert set(result) == {"status", "knowledge_manual", "manual_path"}
+        assert "content" not in result
+        assert "structuredContent" not in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_manual_missing_is_degraded_and_still_no_rescan(tmp_path, monkeypatch):
+    agent, workdir = _mk_agent(tmp_path)
+    try:
+        manual_path = (
+            workdir / ".library" / "intrinsic" / "capabilities" / "knowledge" / "SKILL.md"
+        )
+        if manual_path.is_file():
+            manual_path.unlink()
+
+        scans: list[str] = []
+        monkeypatch.setattr(
+            knowledge_tool,
+            "_reconcile",
+            lambda _agent: scans.append("scan") or {"status": "ok"},
+        )
+        result = _dispatch(
+            agent, {"action": "manual", "input": {}, "reasoning": "load guidance"}
+        )
+        assert scans == []
+        assert result["status"] == "degraded"
+        assert result["knowledge_manual"] == ""
+        assert result["manual_path"] == str(manual_path)
+        assert "error" in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Registration wiring
+# ---------------------------------------------------------------------------
+
+
+def test_setup_registers_one_knowledge_tool_with_the_family_schema(tmp_path):
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        assert "knowledge" in agent._tool_handlers
+        # No duplicate/old model root sneaks in alongside the family.
+        assert "knowledge_info" not in agent._tool_handlers
+        assert "knowledge_manual" not in agent._tool_handlers
+
+        from lingtai.kernel.base_agent.tools import _build_tool_schemas
+
+        schemas = [s for s in _build_tool_schemas(agent) if s.name == "knowledge"]
+        assert len(schemas) == 1
+        params = schemas[0].parameters
+        assert params["properties"]["action"]["enum"] == ["info", "manual"]
+        assert params["required"] == ["action", "input", "reasoning"]
+
+        # The registered handler is the family handler: it dispatches the same
+        # envelope the schema advertises.
+        result = agent._tool_handlers["knowledge"](
+            {"action": "info", "input": {}, "reasoning": "wired handler"}
+        )
+        assert result["status"] == "ok"
+        assert "catalog_size" in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_knowledge_is_a_registered_ltp_v2_family_for_summarize(tmp_path):
+    """Root ``summarize`` is the canonical control for this migrated family,
+    and its envelope failures are not summarized away."""
+    from lingtai.kernel.tool_result_summary import summary_requested
+
+    assert summary_requested({"summarize": True}, tool_name="knowledge") is True
+    # An unmigrated tool's own field named ``summarize`` is still not this control.
+    assert summary_requested({"summarize": True}, tool_name="some_other_tool") is False
+
+
+def test_family_has_no_authoring_search_or_edit_capability():
+    """The signpost contract holds after migration: no action creates, edits,
+    searches, or loads knowledge entries."""
+    schema = knowledge_tool.get_schema()
+    actions = set(schema["properties"]["action"]["enum"])
+    forbidden = {
+        "create", "write", "edit", "update", "delete", "search", "query",
+        "load", "view", "submit", "consolidate",
+    }
+    assert actions.isdisjoint(forbidden)
+    # And no child accepts an input field at all, so no authoring payload can
+    # be smuggled through one.
+    for branch in schema["properties"]["input"]["oneOf"]:
+        assert branch["properties"] == {}


### PR DESCRIPTION
## Decision

Migrate the public signpost-only `knowledge` tool to one action-separated ToolFamily while preserving the public root and actions:

```text
knowledge
├── info
└── manual
```

Calls now use the strict family envelope `action + input + reasoning`, with optional Host `summarize`. This does not add authoring, search, edit, or settings behavior.

## Behavior

- `info` still re-scans/reconciles the private knowledge catalogue and returns the exact health shape without loading entry bodies or mutating entries;
- `manual` still reads only the installed Knowledge manual, performs no scan/reconcile/mutation, and returns the exact `knowledge_manual + manual_path` result without double wrapping;
- both children have canonical strict-empty inputs;
- unknown, missing and unhashable actions retain Knowledge's established error result;
- invalid/cross-action input fails before handler I/O;
- Chat and Responses preserve root action↔input correlation;
- `reasoning` and `summarize` remain Host controls and never enter child arguments;
- the family uses the existing raw-first summarizer allowlist; no second summarizer or cap is introduced.

The manual and CONTRACT now state explicitly that Knowledge has no settings surface or settings file.

## One-time cleanup / no compatibility shim

- removed the hand-written flat root schema;
- removed Knowledge's `dispatch_action` route and import;
- old flat calls fail closed; there is no legacy-call alias or opt-out;
- collapsed schema-only/runtime construction to one `_CHILD_SPECS` + `_build_family(agent | None)` source;
- removed `_schema_only_family()`, the duplicate `ChildTool` list, the production test-only `family=None` branch, and the now-dead `agent` parameter;
- kept only the short Host-owned result-error normalization required by the existing public error contract;
- corrected the stale Skills action reference to `info|manual`.

## LOC accounting

Exact diff against `4ad8b1555a5b0368af81aa57292438719a105052` after the repair/simplification pass:

| Bucket | Added | Removed | Net |
|---|---:|---:|---:|
| Production Python | 129 | 38 | **+91 raw** |
| Production executable lines | — | — | **+19** |
| Tests | 493 | 18 | +475 |
| Docs / contracts / manuals / i18n | 202 | 35 | +167 |

The remaining executable delta is the strict registry/envelope, root wire correlation, pre-I/O cross-branch validation, summarize wiring and shared unhashable-action hardening. Every owner-local flat schema/router and duplicate child registry is removed.

## Validation

- Opus 5 author gate after repair: **449 passed**, plus one exact byte-identical base failure on an untouched environment-variable manual timestamp.
- Fable 5 independent review found all behavior/no-shim gates green and one documentation blocker; the exact no-settings sentences are now applied.
- Parent gate: **470 passed, 1 exact-base deselected** across 18 Knowledge/ToolFamily/manual/summarizer/wire/Skills/docs/glossary/anatomy suites.
- `py_compile`: pass.
- glossary validator: **60 resources across 20 packages**, pass.
- docs governance: **294 documents + docs.yaml**, pass.
- anatomy drift: clean across **54 files**.
- `git diff --check`: clean.

The dev4 exact-head checkout/refresh/model-visible Manual + `info` experience remains the required post-open gate. Its receipt will be appended before merge consideration.

## Scope boundaries

- no Knowledge entry write/edit/search capability is introduced;
- no settings, shared config, merge, release or cleanup is part of this PR;
- parallel family PRs touch shared ToolFamily documentation and the migrated-family allowlist; group integration must reconcile those lists deliberately.

## Rollback

Revert this commit to restore the previous flat schema/router/manual call shape atomically with its tests and documentation.
