### PR TITLE
fix(web): classify undecodable browse bodies as typed extract failures

### DIFF
--- a/src/lingtai/tools/browser/ANATOMY.md
+++ b/src/lingtai/tools/browser/ANATOMY.md
@@ -25,13 +25,14 @@ public `web` manager. It is deliberately not registered independently.
 ## Components
 
 - `BrowserEngine` — bounded fetch, extraction, provenance, snapshots, cursors,
-  refs, and typed result envelopes (`src/lingtai/tools/browser/core.py:119-315`).
+  refs, and typed result envelopes (`src/lingtai/tools/browser/core.py:126-327`).
 - `BrowserPort` and transport value types — technology-neutral outbound boundary
   (`src/lingtai/tools/browser/port.py:14-64`).
 - `netpolicy`, `fetcher`, and `extractor` — SSRF, deadline, redirect, decode,
-  and static text policy (`src/lingtai/tools/browser/netpolicy.py:43-224`,
+  undecodable-content, and static text policy
+  (`src/lingtai/tools/browser/netpolicy.py:43-224`,
   `src/lingtai/tools/browser/fetcher.py:56-136`,
-  `src/lingtai/tools/browser/extractor.py:145-220`).
+  `src/lingtai/tools/browser/extractor.py:175-268`).
 - `CursorCodec`, snapshot store, and `RefStore` — bounded same-Agent state
   (`src/lingtai/tools/browser/cursor.py:22-143`,
   `src/lingtai/tools/browser/snapshots.py:33-86`,

--- a/src/lingtai/tools/browser/CONTRACT.md
+++ b/src/lingtai/tools/browser/CONTRACT.md
@@ -53,7 +53,13 @@ inject a fake BrowserPort. No adapter registers a model-facing tool.
 
 Only public HTTP(S) destinations are accepted. Existing DNS/SSRF, redirect,
 content, charset, byte, link, snapshot, ref, cursor, timeout, and typed-error
-bounds remain normative. SearchService is not imported or called by this Core.
+bounds remain normative. A transport success whose body does not decode to
+readable text is not usable content: when a decode-replacement warning applies
+and the extracted text is large enough to judge, dominated by replacement
+characters, and carries raw control bytes, extraction yields no blocks and the
+existing `NO_TEXT_BLOCKS` extract failure is raised with HTTP provenance and a
+decode-specific recovery. Cleanly decoded text is never reclassified.
+SearchService is not imported or called by this Core.
 Refresh/reconstruction must use fresh per-Agent state; no filesystem snapshot,
 credential, cookie, or hidden fallback is part of this subcomponent.
 

--- a/src/lingtai/tools/browser/core.py
+++ b/src/lingtai/tools/browser/core.py
@@ -9,7 +9,7 @@ from typing import Any, Mapping
 
 from . import netpolicy
 from .cursor import CursorCodec, CursorError, CursorPayload, paginate_blocks, validate_max_chars
-from .extractor import extract_html, extract_plain_text
+from .extractor import UNDECODABLE_CONTENT_WARNING, extract_html, extract_plain_text
 from .fetcher import FetchError, FetchLimits, fetch
 from .port import BrowserPort
 from .refstore import RefStore
@@ -34,6 +34,7 @@ class BrowserFailure(Exception):
         retryable: bool = False,
         http_status: int | None = None,
         snapshot_id: str | None = None,
+        detail: str | None = None,
     ) -> None:
         super().__init__(error_code)
         self.stage = stage
@@ -41,6 +42,7 @@ class BrowserFailure(Exception):
         self.retryable = retryable
         self.http_status = http_status
         self.snapshot_id = snapshot_id
+        self.detail = detail
 
     def to_dict(self, request_id: str) -> dict[str, Any]:
         message = _MESSAGES.get(self.error_code, "The browser request failed safely.")
@@ -49,6 +51,11 @@ class BrowserFailure(Exception):
         recommended = "Retry once if the destination is expected to be temporary." if self.retryable else "Check the URL and stop if the failure persists."
         if self.stage == "policy":
             recommended = "Use a public, direct HTTP(S) URL; do not retry an unsafe destination."
+        if self.detail == UNDECODABLE_CONTENT_WARNING:
+            # The transport succeeded, so URL-checking is the wrong advice: the
+            # body itself was not decodable text.
+            message = "The page returned bytes that are not decodable text, so it contained no readable content."
+            recommended = "The response body was not readable text; use the documented legacy extraction fallback for this URL."
         result: dict[str, Any] = {
             "status": "failed",
             "request_id": request_id,
@@ -216,7 +223,12 @@ class BrowserEngine:
             raise BrowserFailure("extract", "CONTENT_TYPE_UNSUPPORTED", http_status=fetched.http_status)
         extract_ms = max(0, int((time.monotonic() - extract_started) * 1000))
         if not extracted.blocks:
-            raise BrowserFailure("extract", "NO_TEXT_BLOCKS", http_status=fetched.http_status)
+            raise BrowserFailure(
+                "extract",
+                "NO_TEXT_BLOCKS",
+                http_status=fetched.http_status,
+                detail=UNDECODABLE_CONTENT_WARNING if UNDECODABLE_CONTENT_WARNING in extracted.warnings else None,
+            )
         links, links_truncated = self._bounded_links(extracted.links)
         warnings = list(content_warnings)
         warnings.extend(item for item in extracted.warnings if item not in warnings)

--- a/src/lingtai/tools/browser/extractor.py
+++ b/src/lingtai/tools/browser/extractor.py
@@ -3,10 +3,27 @@ from __future__ import annotations
 
 import codecs
 import re
+import unicodedata
 from dataclasses import dataclass
 from html.parser import HTMLParser
 
 from . import netpolicy
+
+# A body that failed to decode is only reclassified as unreadable when it is
+# large enough to judge and is dominated by undecodable characters.  Short
+# documents are excluded because a legitimately truncated multibyte tail can
+# reach an arbitrarily high replacement ratio (``b"\x82\xa0\x82"`` in shift_jis
+# is 50% replacement yet perfectly usable), so density alone is not evidence.
+_UNDECODABLE_MIN_CHARS = 512
+_UNDECODABLE_REPLACEMENT_RATIO = 0.30
+_UNDECODABLE_BINARY_RATIO = 0.01
+_REPLACEMENT_CHAR = "�"
+_DECODE_REPLACED_WARNINGS = {
+    "CHARSET_DECODE_ERROR_REPLACED",
+    "UNSUPPORTED_CHARSET_FALLBACK",
+    "INVALID_UTF8_REPLACED",
+}
+UNDECODABLE_CONTENT_WARNING = "UNDECODABLE_CONTENT"
 
 
 @dataclass(frozen=True, slots=True)
@@ -187,6 +204,27 @@ def _number_blocks(raw: list[tuple[str, str]]) -> list[Block]:
     return [Block(id=f"b{i:04d}", kind=kind, text=text) for i, (kind, text) in enumerate(raw, 1)]
 
 
+def _is_undecodable(blocks: list[Block], warnings: list[str]) -> bool:
+    """Report whether extracted text is replacement garbage rather than content.
+
+    Only bodies the decoder already had to repair are considered, so cleanly
+    decoded text — however exotic its script — is never reclassified.  Binary
+    payloads served under a text content type (an unnegotiated ``gzip``
+    response, for example) survive decoding as a dense mix of replacement
+    characters and raw control bytes; real prose carries neither.
+    """
+    if not any(warning in _DECODE_REPLACED_WARNINGS for warning in warnings):
+        return False
+    text = "".join(block.text for block in blocks)
+    if len(text) < _UNDECODABLE_MIN_CHARS:
+        return False
+    replacement = text.count(_REPLACEMENT_CHAR)
+    if replacement / len(text) < _UNDECODABLE_REPLACEMENT_RATIO:
+        return False
+    binary = sum(1 for char in text if unicodedata.category(char) in {"Cc", "Cf", "Co", "Cs", "Cn"} and char not in "\t\n\r")
+    return binary / len(text) >= _UNDECODABLE_BINARY_RATIO
+
+
 def extract_html(body: bytes, *, base_url: str, charset: str | None = None) -> ExtractedDocument:
     text, warnings = _decode(body, charset)
     parser = _Parser(base_url)
@@ -204,6 +242,13 @@ def extract_html(body: bytes, *, base_url: str, charset: str | None = None) -> E
             seen.add(key)
             links.append(link)
     blocks = _number_blocks(parser.blocks)
+    if _is_undecodable(blocks, warnings):
+        # Undecodable bytes are not usable page content; drop them so the
+        # caller raises its existing no-text failure instead of returning
+        # garbage under a success envelope.
+        blocks = []
+        links = []
+        warnings.append(UNDECODABLE_CONTENT_WARNING)
     if not blocks:
         warnings.append("NO_TEXT_BLOCKS")
     return ExtractedDocument(_clean("".join(parser.title_parts)), blocks, links, warnings)
@@ -215,6 +260,9 @@ def extract_plain_text(body: bytes, charset: str | None = None) -> ExtractedDocu
     if len(paragraphs) == 1 and "\n" in paragraphs[0]:
         paragraphs = [line.strip() for line in paragraphs[0].splitlines() if line.strip()]
     blocks = _number_blocks([("paragraph", _clean(part)) for part in paragraphs if _clean(part)])
+    if _is_undecodable(blocks, warnings):
+        blocks = []
+        warnings.append(UNDECODABLE_CONTENT_WARNING)
     if not blocks:
         warnings.append("NO_TEXT_BLOCKS")
     return ExtractedDocument("", blocks, [], warnings)

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -40,7 +40,7 @@ this package too — using it is optional, not mandatory).
   and strips root `summarize`, rejects unknown root fields, and rejects
   `input` keys outside the selected child's own declared schema properties
   before calling that child's handler with only its `input`
-  (`__init__.py:98-289`). Two enforcement layers correlate `action` with
+  (`__init__.py:98-281`). Two enforcement layers correlate `action` with
   `input`, generated purely from the child registry with no name/schema
   mapping table: (1) schema-level — a root `allOf` with one `if`/`then`
   condition per child, each `if` testing `action` via `const` against that
@@ -52,7 +52,9 @@ this package too — using it is optional, not mandatory).
   correlation was adopted after a live non-strict Codex Responses probe on
   2026-07-27 accepted a raw root `allOf`/`if`/`then` schema without error on
   the current route (see `CONTRACT.md` "Contract rules").
-- `manual.py` — `build_manual_child()` wraps `../_manual.py`'s
+- `manual.py` — owns `MANUAL_INPUT_SCHEMA`, the single strict-empty `manual`
+  input schema every family reuses, and `build_manual_child()`, which wraps
+  `../_manual.py`'s
   `load_installed_manual()` into the ManualTool stable contract: strict empty
   input, and a handler whose actual return value (what `ToolFamily.handle()`
   dispatches back verbatim, once the returned `ChildTool` is registered

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -176,8 +176,10 @@ scoped migration.
   shared handler, common request/result types, or a universal domain result
   shape from any consumer family, matching `../CONTRACT.md` "Implementation
   independence" verbatim.
-- `manual.build_manual_child`'s child MUST use the reserved name `manual`, a
-  strict empty `input_schema`, and its handler's actual return value — what
+- `manual.build_manual_child`'s child MUST use the reserved name `manual`, the
+  exported `manual.MANUAL_INPUT_SCHEMA` strict-empty `input_schema` — the one
+  canonical spelling (`required: []` stated explicitly; families MUST NOT
+  restate it locally) — and its handler's actual return value — what
   `ToolFamily.handle()` dispatches back verbatim — MUST be the canonical
   `content[0].text` (full body) / `structuredContent.manual_path` (host-local
   path) shape, never the pre-mapping flat `load_installed_manual()` dict.

--- a/src/lingtai/tools/tool_family/__init__.py
+++ b/src/lingtai/tools/tool_family/__init__.py
@@ -98,8 +98,8 @@ class ChildTool:
 class ToolFamily:
     """One model-facing aggregate tool composed from a fixed child registry.
 
-    Construction validates the registry (deterministic order, unique names,
-    a reserved-name collision on ``manual`` fails loudly). :meth:`build_schema`
+    Construction validates the registry (deterministic order, unique names —
+    which also covers a repeated reserved ``manual`` child). :meth:`build_schema`
     recomputes the composed model-facing schema on every call rather than
     caching one at construction. :meth:`handle` is the family/Host dispatch
     boilerplate: it validates ``action``, strips and validates ``summarize``,
@@ -115,7 +115,6 @@ class ToolFamily:
         if not children:
             raise ToolFamilyError(f"ToolFamily {name!r} must register at least one child")
         seen: dict[str, ChildTool] = {}
-        manual_count = 0
         for child in children:
             if not isinstance(child, ChildTool):
                 raise ToolFamilyError(f"ToolFamily {name!r} child must be a ChildTool")
@@ -125,13 +124,6 @@ class ToolFamily:
                 raise ToolFamilyError(
                     f"ToolFamily {name!r} has a duplicate child name {child.name!r}"
                 )
-            if child.name == RESERVED_MANUAL_NAME:
-                manual_count += 1
-                if manual_count > 1:
-                    raise ToolFamilyError(
-                        f"ToolFamily {name!r} has a reserved-name collision on "
-                        f"{RESERVED_MANUAL_NAME!r}"
-                    )
             seen[child.name] = child
         self.name = name
         self._children: dict[str, ChildTool] = seen

--- a/src/lingtai/tools/tool_family/manual.py
+++ b/src/lingtai/tools/tool_family/manual.py
@@ -17,12 +17,25 @@ and actions"): the child's own canonical/raw result stays canonical.
 """
 from __future__ import annotations
 
+import copy
 from typing import Any, Mapping
 
 from .._manual import load_installed_manual
 from . import ChildTool
 
-__all__ = ["build_manual_child"]
+__all__ = ["MANUAL_INPUT_SCHEMA", "build_manual_child"]
+
+#: The one strict-empty ``manual`` input schema every family shares. ``required``
+#: is stated explicitly rather than left implicit: an empty ``properties`` map
+#: with ``additionalProperties: False`` already admits only ``{}``, so the key is
+#: semantically exact, and stating it keeps one canonical spelling for consumers
+#: that compare composed schemas byte-for-byte.
+MANUAL_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
 
 
 def _to_mcp_result(loaded: Mapping[str, Any]) -> dict[str, Any]:
@@ -68,7 +81,9 @@ def build_manual_child(agent: Any, skill_name: str) -> ChildTool:
 
     return ChildTool(
         name="manual",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        # Deep copy: a shallow one would share the nested ``properties`` map,
+        # letting one family's child mutate every other family's schema.
+        input_schema=copy.deepcopy(MANUAL_INPUT_SCHEMA),
         handler=handler,
         title="manual input",
     )

--- a/src/lingtai/tools/web_search/ANATOMY.md
+++ b/src/lingtai/tools/web_search/ANATOMY.md
@@ -45,7 +45,7 @@ action implementations, settings, and diagnostics.
   validation over the action-owned `settings/web.search.json`
   (`src/lingtai/tools/web_search/settings.py:49-182`).
 - `BrowserEngine` — internal static browse use case, provenance, refs, cursors,
-  SSRF policy, and typed failures (`src/lingtai/tools/browser/core.py:119-315`).
+  SSRF policy, and typed failures (`src/lingtai/tools/browser/core.py:126-327`).
 - `SearchService` adapters — provider implementations behind the internal
   service boundary (`src/lingtai/services/websearch/__init__.py:20-70`).
 - `manual/SKILL.md` — sole installed `web-manual` route

--- a/src/lingtai/tools/web_search/__init__.py
+++ b/src/lingtai/tools/web_search/__init__.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 from .._manual import load_installed_manual
 from ..browser.core import BrowserEngine
 from ..tool_family import ChildTool, ToolFamily
-from ..tool_family.manual import build_manual_child
+from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
 from .settings import SettingsSnapshot, current_setting, read_settings, valid_engine_name
 
 if TYPE_CHECKING:
@@ -68,12 +68,16 @@ _BROWSE_INPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
-_MANUAL_INPUT_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {},
-    "required": [],
-    "additionalProperties": False,
-}
+# The single source of truth for web's own children: one ``(name, schema,
+# title)`` triple per child, consumed both by the module-level schema-only
+# family below and by ``WebManager.__init__``, which binds real handlers to
+# the same specs. The reserved ``manual`` child is not listed here: its schema
+# is the owner-exported ``MANUAL_INPUT_SCHEMA`` and its real child comes from
+# ``build_manual_child``.
+_CHILD_SPECS: tuple[tuple[str, dict[str, Any], str], ...] = (
+    ("search", _SEARCH_INPUT_SCHEMA, "search input"),
+    ("browse", _BROWSE_INPUT_SCHEMA, "browse input"),
+)
 
 
 def _schema_only_family() -> ToolFamily:
@@ -89,9 +93,8 @@ def _schema_only_family() -> ToolFamily:
     return ToolFamily(
         "web",
         [
-            ChildTool("search", _SEARCH_INPUT_SCHEMA, _unused, title="search input"),
-            ChildTool("browse", _BROWSE_INPUT_SCHEMA, _unused, title="browse input"),
-            ChildTool("manual", _MANUAL_INPUT_SCHEMA, _unused, title="manual input"),
+            *(ChildTool(name, schema, _unused, title=title) for name, schema, title in _CHILD_SPECS),
+            ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused, title="manual input"),
         ],
     )
 
@@ -157,11 +160,14 @@ class WebManager:
         self._legacy_fallback_from = legacy_fallback_from
         self._services: dict[str, Any] = {}
         self._service_errors: dict[str, str] = {}
+        handlers = {"search": self._dispatch_search, "browse": self._dispatch_browse}
         self._family = ToolFamily(
             "web",
             [
-                ChildTool("search", _SEARCH_INPUT_SCHEMA, self._dispatch_search, title="search input"),
-                ChildTool("browse", _BROWSE_INPUT_SCHEMA, self._dispatch_browse, title="browse input"),
+                *(
+                    ChildTool(name, schema, handlers[name], title=title)
+                    for name, schema, title in _CHILD_SPECS
+                ),
                 # Registered directly, unwrapped: ``ToolFamily.handle()`` must
                 # dispatch this child's own canonical MCP-compatible result
                 # verbatim for ``action="manual"`` (no double wrap). Web's
@@ -387,10 +393,6 @@ class WebManager:
             result["action"] = action if isinstance(action, str) else "unknown"
             result["current_setting"] = self._no_settings_diagnostic()
         return result
-
-
-# Retained import compatibility for callers that imported the old class.
-WebSearchManager = WebManager
 
 
 def _specs_from_kwargs(

--- a/src/lingtai/tools/web_search/manual/SKILL.md
+++ b/src/lingtai/tools/web_search/manual/SKILL.md
@@ -3,8 +3,8 @@ name: web-manual
 description: >
   One web workflow: search first, browse a known result next, and use one
   explicit legacy fallback only when static browsing cannot serve the need.
-version: 7.0.0
-last_changed_at: "2026-07-26T00:00:00Z"
+version: 7.0.1
+last_changed_at: "2026-07-27T00:00:00Z"
 related_files:
   - src/lingtai/tools/web_search/__init__.py
   - src/lingtai/tools/web_search/settings.py
@@ -162,7 +162,9 @@ web(action='manual', input={}, reasoning='load web guidance') for schema.`
 ## 4. One explicit legacy fallback
 
 If browse returns a typed unsupported-content failure (for example PDF or a
-JavaScript-only page), choose exactly one legacy route and name it: use the
+JavaScript-only page), or a `NO_TEXT_BLOCKS` failure reporting that the body was
+not decodable text (an origin that returns compressed or binary bytes under a
+text content type), choose exactly one legacy route and name it: use the
 preserved `scripts/extract_page.py --tier 0` for a PDF, a source-specific API
 for structured data, or the documented Playwright/academic references under
 `reference/`. Do not advertise or invoke a second public tool; do not silently

--- a/tests/test_browser_policy_cursor_edges.py
+++ b/tests/test_browser_policy_cursor_edges.py
@@ -1,6 +1,8 @@
 """Deterministic browser Core policy, redirect, cap and state edge cases."""
 from __future__ import annotations
 
+import gzip
+
 from lingtai.tools.browser.core import BrowserEngine, _content_metadata
 from lingtai.tools.browser.cursor import paginate_blocks
 from lingtai.tools.browser.extractor import Block, extract_html, extract_plain_text
@@ -376,3 +378,91 @@ def test_continuation_refreshes_all_snapshot_link_refs_after_eviction():
         followed = engine.handle({"link_ref": link["ref"]})
         assert followed["status"] == "ok"
         assert followed["requested_url"].endswith(("/one", "/two"))
+
+
+class UndecodableBodyPort:
+    """Serves a text/html 200 whose body is not decodable text.
+
+    Reproduces the real ``python.org/downloads`` case: the origin answers an
+    unnegotiated ``Content-Encoding: gzip`` while still labelling the payload
+    ``text/html; charset=utf-8``, so Core receives compressed bytes.
+    """
+
+    def __init__(self, body: bytes, content_type: str = "text/html; charset=utf-8"):
+        self.body = body
+        self.content_type = content_type
+
+    def resolve(self, hostname: str, *, timeout_s: float):
+        return ("93.184.216.34",)
+
+    def request(self, url: str, *, resolved: ResolvedTarget, max_bytes: int, timeout_s: float):
+        return TransportResponse(200, {"Content-Type": self.content_type}, self.body, False, url)
+
+
+def _gzipped_page() -> bytes:
+    # Paragraphs vary so the compressed payload stays high-entropy and
+    # realistically sized, like the real origin response.
+    paragraphs = "".join(
+        f"<p>Python 3.{n}.{n % 7} was released on day {n}; download artifact {n * 7919}.</p>"
+        for n in range(400)
+    )
+    html = (
+        "<html><head><title>Download Python</title></head><body>"
+        f"<main>{paragraphs}</main></body></html>"
+    ).encode("utf-8")
+    return gzip.compress(html)
+
+
+def test_compressed_binary_body_is_a_typed_extract_failure_not_nominal_success():
+    """HTTP 200 whose extracted body is replacement garbage must not read as usable content."""
+    engine = BrowserEngine(UndecodableBodyPort(_gzipped_page()))
+    result = engine.handle({"url": "https://public.example/downloads/", "max_chars": 12_000})
+
+    assert result["status"] == "failed"
+    assert result["error_code"] == "NO_TEXT_BLOCKS"
+    assert result["stage"] == "extract"
+    # HTTP provenance survives the reclassification.
+    assert result["http_status"] == 200
+    assert result["retryable"] is False
+    # The diagnosis names the real cause instead of blaming the URL, and the
+    # recovery route is actionable.
+    assert "not decodable text" in result["message"]
+    assert "legacy extraction fallback" in result["recommended_action"]
+    # No garbage may reach the model as ordinary page content.
+    assert "blocks" not in result
+    assert result["partial"] is False
+
+
+def test_genuinely_empty_page_keeps_the_generic_no_text_diagnosis():
+    """Only undecodable bodies get the decode-specific message and recovery."""
+    engine = BrowserEngine(UndecodableBodyPort(b"<html><body><nav>menu</nav></body></html>"))
+    result = engine.handle({"url": "https://public.example/empty"})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "NO_TEXT_BLOCKS"
+    assert result["message"] == "The page contained no static text blocks."
+    assert "legacy extraction fallback" not in result["recommended_action"]
+
+
+def test_undecodable_detection_requires_an_actual_decode_failure():
+    """Cleanly decoded text is never reclassified, however unusual its characters."""
+    dense_unicode = ("<main><p>" + "中文内容\U0001f600" * 400 + "</p></main>").encode("utf-8")
+    engine = BrowserEngine(UndecodableBodyPort(dense_unicode))
+    result = engine.handle({"url": "https://public.example/cjk", "max_chars": 12_000})
+    assert result["status"] == "ok"
+    assert result["blocks"]
+
+
+def test_legitimate_partially_replaced_documents_stay_successful():
+    """A mostly-readable document with a few bad bytes keeps its usable content."""
+    body = ("café " * 200).encode("utf-8") + b"\xff\xfe"
+    engine = BrowserEngine(UndecodableBodyPort(body, content_type="text/plain; charset=utf-8"))
+    result = engine.handle({"url": "https://public.example/text", "max_chars": 12_000})
+    assert result["status"] == "ok"
+    assert "CHARSET_DECODE_ERROR_REPLACED" in result["warnings"]
+    assert "café" in result["blocks"][0]["text"]
+
+    # A short legitimately-truncated multibyte document is far too small to judge
+    # by replacement density alone; it must survive.
+    short = extract_plain_text(b"\x82\xa0\x82", charset="shift_jis")
+    assert short.blocks[0].text == "あ�"
+    assert "UNDECODABLE_CONTENT" not in short.warnings

--- a/tests/test_tool_family_generic.py
+++ b/tests/test_tool_family_generic.py
@@ -59,11 +59,13 @@ def test_registration_is_deterministic_and_ordered():
 
 def test_duplicate_child_name_fails_loudly():
     calls: list[dict] = []
-    with pytest.raises(ToolFamilyError):
+    with pytest.raises(ToolFamilyError, match="duplicate child name 'spin'"):
         ToolFamily("widget", [_spin_child(calls), _spin_child(calls)])
 
 
 def test_manual_reserved_name_collision_fails_loudly():
+    """A repeated reserved ``manual`` child is caught by the duplicate-name check."""
+
     def handler(_input):
         return {"status": "ok"}
 
@@ -72,7 +74,7 @@ def test_manual_reserved_name_collision_fails_loudly():
         input_schema={"type": "object", "properties": {}, "additionalProperties": False},
         handler=handler,
     )
-    with pytest.raises(ToolFamilyError):
+    with pytest.raises(ToolFamilyError, match=f"duplicate child name '{RESERVED_MANUAL_NAME}'"):
         ToolFamily("widget", [_manual_child(), second_manual])
 
 

--- a/tests/test_tool_family_manual_contract.py
+++ b/tests/test_tool_family_manual_contract.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from lingtai.tools.tool_family import RESERVED_MANUAL_NAME, ChildTool, ToolFamily, ToolFamilyError
-from lingtai.tools.tool_family.manual import build_manual_child
+from lingtai.tools.tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
 
 
 class _FakeAgent:
@@ -33,10 +33,34 @@ def test_manual_child_reserved_name_is_exactly_manual():
     assert child.name == RESERVED_MANUAL_NAME == "manual"
 
 
-def test_manual_child_input_schema_is_strict_empty():
+def test_manual_child_input_schema_is_the_one_canonical_strict_empty_schema():
+    """Every family's ``manual`` child uses the single exported schema.
+
+    ``required: []`` is stated explicitly and is semantically exact: empty
+    ``properties`` plus ``additionalProperties: False`` already admits only
+    ``{}``. Families must not restate this schema locally.
+    """
     agent = _FakeAgent(Path("/nonexistent"))
     child = build_manual_child(agent, "widget")
-    assert child.input_schema == {"type": "object", "properties": {}, "additionalProperties": False}
+    assert child.input_schema == MANUAL_INPUT_SCHEMA
+    assert MANUAL_INPUT_SCHEMA == {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": False,
+    }
+
+
+def test_manual_child_schema_is_deep_copied_so_families_cannot_mutate_each_other():
+    """One family's child must not be able to edit the shared canonical schema."""
+    agent = _FakeAgent(Path("/nonexistent"))
+    first = build_manual_child(agent, "widget")
+    second = build_manual_child(agent, "gadget")
+    first.input_schema["properties"]["injected"] = {"type": "string"}
+    first.input_schema["required"].append("injected")
+    assert MANUAL_INPUT_SCHEMA["properties"] == {}
+    assert MANUAL_INPUT_SCHEMA["required"] == []
+    assert second.input_schema == MANUAL_INPUT_SCHEMA
 
 
 def test_manual_child_actual_handler_returns_body_at_content_text_and_path_at_structured_content(tmp_path):

--- a/tests/test_unified_web_capability.py
+++ b/tests/test_unified_web_capability.py
@@ -1,6 +1,7 @@
 """Focused contract regressions for the single public ``web`` capability."""
 from __future__ import annotations
 
+import gzip
 import json
 import os
 from pathlib import Path
@@ -439,3 +440,34 @@ def test_search_caps_an_unbounded_provider_iterable(tmp_path):
     assert result["status"] == "ok"
     assert result["count"] == 20
     assert len(result["results"]) == 20
+
+
+class _CompressedPort:
+    """Origin that answers 200 text/html with an unnegotiated gzip payload."""
+
+    def resolve(self, hostname: str, *, timeout_s: float):
+        return ["93.184.216.34"]
+
+    def request(self, url: str, *, resolved, max_bytes: int, timeout_s: float):
+        paragraphs = "".join(
+            f"<p>Python 3.{n}.{n % 7} was released on day {n}; download artifact {n * 7919}.</p>"
+            for n in range(400)
+        )
+        html = f"<html><body><main>{paragraphs}</main></body></html>".encode("utf-8")
+        return TransportResponse(200, {"content-type": "text/html; charset=utf-8"}, gzip.compress(html), False, url)
+
+
+def test_undecodable_body_surfaces_as_typed_failure_on_the_public_web_result(tmp_path):
+    """Result/wire parity: degraded content is a typed failure, not usable page content."""
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_Search(), browser_port=_CompressedPort())
+    result = manager.handle(
+        {"action": "browse", "input": {"url": "https://public.example/downloads/", "max_chars": 12_000}}
+    )
+    assert result["status"] == "failed"
+    assert result["error_code"] == "NO_TEXT_BLOCKS"
+    assert result["stage"] == "extract"
+    assert result["http_status"] == 200
+    assert result["action"] == "browse"
+    assert "blocks" not in result
+    assert result["current_setting"]["source"] == "not_applicable"


### PR DESCRIPTION
> **Exact source head:** `e5cfa4a8218a6555b4697a8b360c06e35ece61a9`  
> **Exact base:** `4ad8b1555a5b0368af81aa57292438719a105052`  
> **dev4 exact-head live-use gate:** pending immediately after PR opening; this body will be updated with the durable receipt.

# fix(web): classify undecodable browse bodies as typed extract failures

## Summary

An HTTP 200 whose body does not decode to readable text was being returned as an ordinary successful page. Real case, from dev4's broader real-Agent Web cycle on #1059: browsing `python.org/downloads` produced `status: ok`, HTTP 200, an empty title, zero links, `partial: true`, and one 12k block of compressed/binary replacement garbage under the warning `CHARSET_DECODE_ERROR_REPLACED`. Nothing in that result told the Agent it had no usable evidence — it read as a successful fetch.

This PR makes that case fail truthfully, at the layer that owns the invariant, and folds in the obsolete-compatibility cleanup that #1059 left behind in the same owner.

**Invariant added:** a transport success whose extracted body is undecodable is not usable content. It yields no blocks and raises the **existing** typed `NO_TEXT_BLOCKS` extract failure, carrying HTTP provenance and a cause-specific recovery route.

### Root cause, confirmed

The origin returns **unnegotiated** `Content-Encoding: gzip` (the transport sends no `Accept-Encoding`) while still labelling the payload `text/html; charset=utf-8`. Core therefore decodes gzip bytes as UTF-8 with `errors="replace"`. Confirmed by one read-only GET to the public evidence URL: `HTTP/2 200`, `content-encoding: gzip`, `content-length: 19360`, body starting `1f 8b 08` (gzip magic). Replaying that exact captured body against the base reproduces the reported symptom precisely (replacement ratio 0.4382).

### Why classification, not decompression

Fixing the missing gzip decompression would make this one URL succeed but would **not** satisfy the invariant: any binary body under a text content type — brotli, zstd, a mislabeled image — reproduces the identical fake success. The invariant is first violated in extraction, so the fix lives there. Verified orthogonal: the classifier catches gzip, zlib/deflate, bz2, lzma, random bytes, and PNG-like binary alike.

**The transport `Accept-Encoding`/decompression gap is deliberately untouched and is a named follow-up.** `python.org/downloads` is still not *readable* through browse — it now fails honestly instead of returning garbage.

### No new status enum

`NO_TEXT_BLOCKS` already means "the page contained no static text blocks," already fires at the same raise site, and already carries the same HTTP metadata. Once garbage is defined as not-text, it is a true statement. Garbage was escaping only because bad bytes happened to form a non-empty block list. The parent `WebManager._dispatch_browse` passes engine failures through verbatim, so **no parent, schema, or wire change was required**.

Result on the real captured body:

```
status               failed
stage                extract
error_code           NO_TEXT_BLOCKS
http_status          200
retryable            False
message              The page returned bytes that are not decodable text, so it contained no readable content.
recommended_action   The response body was not readable text; use the documented legacy extraction fallback for this URL.
```

A genuinely empty page keeps the original generic message — the cause-specific wording is not a blanket rewrite, and that is regression-locked.

## Explicit no-scope-expansion statement

This PR does **not** touch, and explicitly does not expand into: Search ranking, relevance, or trust/suspicious-domain signalling; JS rendering; PDF or ICS handling; cache redesign; automatic second fetch or retry; broad content-quality heuristics; transport content negotiation or decompression; and it does **not** alter #1059's ToolFamily architecture or the public Web wire schema. The dev4 report enumerated six inherited Web follow-ups; this PR addresses exactly one of them and leaves the other five untracked here by design.

The detection is confined to bodies the decoder **already had to repair** — it never inspects cleanly decoded text — which is what keeps it a truthful classification rather than a general content-quality heuristic.

## #1059 obsolete-compatibility cleanup (same owner, authorized)

Bundled per maintainer direction; all verified obsolete, none behavior-changing:

1. **Dead reserved-manual branch** — `tool_family/__init__.py`: the `manual_count > 1` raise was unreachable, since the generic duplicate-name check fires first for any repeated name (proved by probe). Counter and branch deleted; `RESERVED_MANUAL_NAME` retained (live in `has_manual()`); class docstring corrected. Both registration tests tightened to assert the exact duplicate-name message, so the retained behavior is pinned.
2. **Duplicated Web child registry** — `web_search/__init__.py`: the schema-only family and `WebManager.__init__` each restated the `(name, schema, title)` triples. Collapsed to one `_CHILD_SPECS` source consumed by both, via a bound-handler map. Import-time collision validation retained (the schema-only family is still constructed). Removes the schema-drift risk between the two registries.
3. **Dead `WebSearchManager = WebManager` alias** — zero consumers across `src/`, `tests/`, `crates/`, `scripts/`, `docs/` (grep-verified twice). Removed.
4. **Duplicated strict-empty manual schema** — see below.

### Canonical `MANUAL_INPUT_SCHEMA` and the deep-copy invariant

Web restated the strict-empty `manual` input schema locally. It is now owned once, exported from `tool_family/manual.py`, with `required: []` stated **explicitly**: empty `properties` plus `additionalProperties: False` already admits only `{}`, so the key is semantically exact, and stating it keeps one canonical spelling for consumers that compare composed schemas byte-for-byte. CONTRACT and ANATOMY record the ownership rule — families MUST NOT restate it locally. **No helper or normalizer was added**; the constant is a plain module-level dict, imported directly.

**This dedup exposed a latent drift.** Before the change the two web families disagreed: the module-level schema-only family used web's local schema (with `required: []`) while the *real, dispatched* family used `build_manual_child`'s inline literal (without it). The composed schema was therefore not identical between the schema-only proof object and the live registered family. Single-sourcing collapsed both onto one spelling; the live family now matches the module-level baseline exactly. This was a real inconsistency, not cosmetic duplication.

**Deep-copy invariant.** `build_manual_child` returns `copy.deepcopy(MANUAL_INPUT_SCHEMA)`. The first cut used `dict(...)` — a shallow copy, so a child mutating `input_schema["properties"]` would reach into the shared constant and corrupt every other family's schema for the process lifetime. The new isolation test caught it via the classic shared-mutable-state signature: passing alone, poisoning a downstream parity test. The test now actively mutates one child's `properties` **and** `required` and asserts both the canonical constant and a second independently-built child are untouched.

## Validation

### Classifier evidence

- **Failing-first:** before implementation the two degraded-content regressions failed with `assert 'ok' == 'failed'`; the legitimate-document controls passed throughout.
- **Real captured body** → `failed | NO_TEXT_BLOCKS | http_status 200`, unchanged across every subsequent cleanup pass.
- **True positives 7/7:** real python.org body, gzip, zlib/deflate, bz2, lzma, random bytes, PNG-like binary.
- **False positives 0/10:** long English, long CJK, emoji-heavy, declared latin-1, long good shift_jis, shift_jis with truncated tail, large UTF-8 with a few bad bytes, Cyrillic, Arabic RTL, 25%-replaced mixed document.

**The finding that shaped the design.** A replacement-ratio threshold alone is unsafe: the legitimate 3-byte shift_jis document in an existing passing test scores **0.500**, *higher* than the real garbage at **0.441**. Any pure-ratio threshold catching the garbage would have broken that test and mangled real truncated multibyte documents. The 512-char floor and the binary-control-character axis are what separate them — both derived from measurement, not guessed. Thresholds: 512 chars / 0.30 replacement / 0.01 binary.

Reviewer-independent probes (Fable, not inherited) additionally cleared the most dangerous false-positive class — shift_jis and gb18030 bodies mis-declared as UTF-8 (classic mojibake: high replacement, zero control bytes), ZWJ-heavy emoji with a small decode error, and valid UTF-8 under an unsupported declared charset.

### Test and tooling evidence

- **Parent focused + generic suites: 136 passed** — 7-file Web suite plus `test_tool_family_generic`, `..._generic_summarize_executor`, `..._manual_contract`, `..._wire_parity`, `..._web_migration_parity`, `test_intrinsic_manual_actions`. (Reviewer reproduced a 9-file subset: 125 passed.)
- **Public Web schema byte-parity:** composed `_FAMILY.build_schema()` captured before the registry collapse and before the schema dedup, compared after each → **BYTE-IDENTICAL** both times. `get_schema()`'s manual branch remains `{"additionalProperties": false, "properties": {}, "required": [], "type": "object"}`. Web already carried `required: []`, so nothing moved on the wire.
- **`py_compile`** on all changed Python files → OK.
- **Anatomy drift checker** `--check` → clean across 54 files, exit 0. It caught one genuine drift introduced by the dead-branch deletion (`tool_family/ANATOMY.md` citing `:98-289` against a now-281-line file), fixed before this body was written.
- **Docs/glossary:** manual §4 routes the decode-failure case to the existing single legacy fallback — the same route `recommended_action` names. Manual frontmatter bumped to **7.0.1 / 2026-07-27**. No locale/glossary change warranted: no new public identifier, and `tool_family`/`web_search` glossaries carry schema identifiers only, no error codes (grep-verified).

### Broad differential

Full suite (excluding files that fail to collect on a pre-existing missing `msal` dependency): **6139 passed, 8 failed.**

Seven failures are pre-existing and verified as such by stashing the change and re-running on the clean base — `test_kernel_update_contract`, `test_mcp_capability`, `test_mcp_config_helper[imap]`, `test_mcp_server_scaffold[imap]`, `test_resolved_manifest_artifact`, `test_skills`, `test_wheel_sidecar_smoke`. None touch browser, Web, or ToolFamily.

The eighth, `test_retroactive_history_compaction::test_aed_transient_retry_compacts_history_before_backoff`, is **load-flaky, not caused by this diff**: it passes in isolation, its whole file passes 40/40 both with the change applied and on the stash-controlled clean base, and it exercises AED retry/backoff timing with threading events and monkeypatched `sleep` — no ToolFamily or Web code path.

### LOC — production separated from tests and docs

| Category | Added | Removed | Net |
|---|---|---|---|
| **Production `.py`** | 99 | 30 | **+69** |
| Tests `.py` | 153 | 5 | +148 |
| Docs `.md` | 25 | 12 | +13 |
| **Total** (15 files) | **277** | **47** | **+230** |

**Justifying the +69 production, honestly.** This PR adds a real classification invariant; it is not net-negative and was not padded with unrelated deletions to appear so.

- **Browser `+62/−2`** is the invariant itself: the three-gate classifier, its constants, the drop-and-mark in both extract paths, and the `detail` plumbing that carries cause to `to_dict`. Roughly a third is the rationale comment and docstring explaining *why* each gate exists — deliberately kept, because the comment is what stops a future reader from "simplifying" the binary-character gate away and reintroducing the mojibake false positive that gate exists to prevent.
- **Consolidation files land at `+37/−28`, net +9**, of which about half is docstring/comment stating the canonical-schema and single-registry ownership rules; executable additions are ≈17 lines (the constant, the spec tuple, generator plumbing).
- Two cleanup items **added** lines rather than removing them, and are reported as such rather than presented as reductions: the child-registry collapse removes the *duplication* but costs a spec tuple plus its comment, and the schema dedup costs an exported constant plus rationale to delete a 6-line local copy. The wins are single-source correctness and the closed live-vs-schema-only drift, not line count.
- All identified obsolete #1059 compatibility duplication — dead branch, duplicate registries, dead alias, restated schema — is gone, and **no new compatibility path or opt-out flag was introduced**.

## Review status

**Fable 5 independent review: ACCEPT on g2 `g2-b7688ebaa93c60d3`, zero blockers.** The reviewer verified failing-first independently (extracting the base package via `git show` into a temp dir rather than mutating git), re-ran the focused suite and drift checker, ran their own adversarial false-positive probes beyond the committed tests, and read the public-shape guarantees from code rather than from tests — confirming `UNDECODABLE_CONTENT` and the internal `detail` field never serialize, that no snapshot/cursor state is created for garbage pages (so no continuation into garbage is possible), and that statuses stay `ok|failed` with no new error code.

An earlier pass returned APPROVE_WITH_NONBLOCKING_NOTES; every recommendation from it was implemented and re-verified in the ACCEPT pass. The one note still outstanding at that time — the stale manual frontmatter — is now bumped.

**Process disclosure:** the `daemon_common` completion MCP server disconnected during both the reviewer's runs and the author's later passes, so the `finish` completion tool was unavailable. The written reports are the completion artifacts in each case. This does not affect the code, the test results, or the acceptance; it is disclosed so the evidence trail is not misread as incomplete.

Residual reviewer nit, non-gating and not addressed here: `_schema_only_family` passes the canonical dict by reference rather than a defensive copy. Safe today — `build_schema` deep-copies, nothing mutates registry schemas, and this matches the base's own by-reference sharing.

## Evidence provenance and what remains unrun

**Source of the defect:** dev4's broader real-Agent Web UX cycle on #1059 (`a2335219-broader-real-agent-web-ux-report.md`), tested head `a2335219be906f02de5bb733204d94e598d9c325`, authorized base `21bf4a3d12e0857510d96248179178ca3b36ff7e`, run via `codex-pool / gpt-5.6-sol / fast` on the Codex Responses WebSocket route. That cycle exercised **all three public Web actions** — `search`, `browse`, and `manual` — across 9 model-visible calls and 9 terminal results, including typed HTTP 404 recovery, a blocked-loopback policy failure, and root `summarize`. §5 of that report is the exact symptom this PR fixes; it concluded the defect was inherited browser behavior, not a #1059 migration regression, and recommended tracking it separately — which is what this PR is.

**Still unrun, stated plainly:** this PR's validation is fixture-based plus one read-only GET. **A live real-Agent cycle against this PR's exact head is pending** — the model-visible `web` tool has not been driven through a live provider on this candidate. No claim is made here about end-to-end agent experience on this head; the claims are about engine behavior, the public result shape, and the composed schema.

Other disclosed limits: thresholds are empirical constants tuned to fail toward preserving content, so a pathological sub-512-char or low-control-byte document could sit on the wrong side (measured: a 47-byte gzip body decodes to 43 garbage chars and stays `ok` — bounded harm); and a binary payload declared under a single-byte charset such as `iso-8859-1` decodes warning-free and is deliberately not classified, because without a decode failure there is no truthful signal and guessing would become the broad heuristic this PR excludes. `error_code` alone cannot distinguish undecodable-body from genuinely-empty page — that distinction rides on `message`/`recommended_action`, an accepted consequence of the scope-mandated enum reuse.

## Base and rollback

- **Base:** `4ad8b1555a5b0368af81aa57292438719a105052` (clean, exact). Worktree HEAD is unchanged at that commit; the candidate is uncommitted working-tree state across 15 files, zero untracked, zero staged.
- **Branch:** `fix/web-degraded-content-status-dev1-20260727`.
- **Rollback:** the change is confined to `tools/browser/`, `tools/tool_family/`, `tools/web_search/`, and four test files. Reverting the commit restores base behavior exactly — there is no migration, no persisted state, no config key, no schema version bump, and no wire change to unwind. Reverting only the cleanup hunks while keeping the classifier is also safe: the two concerns touch disjoint code paths, sharing only the `NO_TEXT_BLOCKS` raise site, which the cleanup does not modify.
- **Behavior change to expect on revert:** `python.org/downloads`-class pages return to reporting `status: ok` with garbage blocks.

## Suggested commit title

`fix(web): classify undecodable browse bodies as typed extract failures`
