### PR TITLE
feat(vision): migrate vision to the action-separated ToolFamily shape

### DIFF
--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -152,15 +152,16 @@ def is_apriori_summary(content: Any) -> bool:
 # unmigrated tool's own domain field literally named ``summarize`` is never
 # silently reinterpreted as this cross-cutting control (see
 # ``src/lingtai/tools/CONTRACT.md`` Contract rules > Envelope).
-_LTP_V2_MIGRATED_FAMILIES = frozenset({"web"})
+_LTP_V2_MIGRATED_FAMILIES = frozenset({"web", "vision"})
 
 
 def summary_requested(args: dict | None, tool_name: str | None = None) -> bool:
     """Return True iff the normalized tool args opt into a-priori summary.
 
     The legacy flag is the boolean ``summary`` field on the tool call, honored
-    for every caller. A migrated LTP v2 family (currently only ``web``) may
-    instead set the canonical root ``summarize`` boolean; that spelling is
+    for every caller. A migrated LTP v2 family (currently ``web`` and
+    ``vision``) may instead set the canonical root ``summarize`` boolean; that
+    spelling is
     recognized only when ``tool_name`` names a migrated family, so an
     unmigrated tool's own ``summarize``-named domain field is never
     reinterpreted as this control. Anything other than a literal ``True``

--- a/src/lingtai/services/vision/openai.py
+++ b/src/lingtai/services/vision/openai.py
@@ -28,7 +28,9 @@ class OpenAIVisionService(VisionService):
             "responses",
         }:
             raise ValueError(
-                "Unsupported OpenAI vision wire; use vision(action='manual')."
+                "Unsupported OpenAI vision wire; use vision(action='manual', "
+                "input={}, reasoning='the active OpenAI vision wire is "
+                "unsupported')."
             )
 
         import openai as _openai

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -6,6 +6,8 @@ related_files:
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
+  - src/lingtai/tools/vision/ANATOMY.md
+  - src/lingtai/tools/vision/CONTRACT.md
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/tools/tool_family/CONTRACT.md
@@ -36,12 +38,15 @@ capability names and lazy adapters.
   (`src/lingtai/tools/registry.py:40-359`).
 - `web_search/` — public `web` composition owner for search, browse, settings,
   and manual (`src/lingtai/tools/web_search/ANATOMY.md`).
+- `vision/` — public `vision` composition owner: one action-separated family
+  with canonical `analyze`/`manual` children over the existing direct
+  provider routing (`src/lingtai/tools/vision/ANATOMY.md`).
 - `browser/` — internal static browse Core/Port used by `web`
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `tool_family/` — generic, optional ToolFamily/ChildTool schema-composition
   and dispatch infrastructure implementing the LTP v2 envelope, and the
-  reusable ManualTool builder; `web` is its first real consumer
-  (`src/lingtai/tools/tool_family/ANATOMY.md`).
+  reusable ManualTool builder; `web` is its first real consumer and `vision`
+  its second (`src/lingtai/tools/tool_family/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
 
@@ -50,9 +55,12 @@ capability names and lazy adapters.
 `Agent` calls registry setup. The public `web` row imports
 `lingtai.tools.web_search` lazily. That owner imports the browser Core and
 provider factory only at composition or action boundaries, and imports
-`tool_family` to compose its schema and (optionally) dispatch. The pinned
-browser transport remains an outer adapter. `web_search` is accepted only as a
-one-way configuration input alias and is never emitted as a public name.
+`tool_family` to compose its schema and (optionally) dispatch. The public
+`vision` row imports `lingtai.tools.vision`, which imports `tool_family` the
+same way and reaches `lingtai.services.vision` only on the selected direct
+route. The pinned browser transport remains an outer adapter. `web_search` is
+accepted only as a one-way configuration input alias and is never emitted as a
+public name.
 
 ## Composition
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -235,14 +235,19 @@ documents. `web` (`search | browse | manual`) is the first family migrated to
 this contract: its final model-facing root is exactly `action`, `input`,
 `reasoning`, and `summarize`; its `search` action reads the action-owned
 `settings/web.search.json` (see `src/lingtai/tools/web_search/CONTRACT.md`).
-The legacy a-priori result-summarization flag under the literal key `summary`
-(`src/lingtai/kernel/tool_result_summary.py:172`) remains honored for every
-still-unmigrated caller; `src/lingtai/kernel/tool_result_summary.py` recognizes
-the canonical `summarize` spelling only when the calling tool is a migrated LTP
-v2 family (currently only `web`), so an unmigrated tool's own field literally
-named `summarize` is never reinterpreted as this control. Every other
-LingTai-owned family remains unmigrated and keeps its existing schema and
-settings surface unchanged by this file.
+`vision` (`analyze | manual`) is the second: it keeps its public tool name and
+both public action values while moving to the same root envelope, with
+`analyze` owning the direct current-preset image request and `manual` the
+family-owned reserved child (see `src/lingtai/tools/vision/CONTRACT.md`). It
+owns no settings file, so the two-level settings addressing rules do not apply
+to it. The legacy a-priori result-summarization flag under the literal key
+`summary` (`src/lingtai/kernel/tool_result_summary.py:172`) remains honored for
+every still-unmigrated caller; `src/lingtai/kernel/tool_result_summary.py`
+recognizes the canonical `summarize` spelling only when the calling tool is a
+migrated LTP v2 family (currently `web` and `vision`), so an unmigrated tool's
+own field literally named `summarize` is never reinterpreted as this control.
+Every other LingTai-owned family remains unmigrated and keeps its existing
+schema and settings surface unchanged by this file.
 
 `src/lingtai/tools/tool_family/` is optional, generic composition
 infrastructure implementing this envelope (schema composition from a
@@ -250,7 +255,9 @@ infrastructure implementing this envelope (schema composition from a
 ManualTool builder) that a family MAY adopt instead of hand-writing the
 equivalent code; `web` is its first consumer, using it for schema composition
 and dispatch while retaining its own outer `handle()` for family-specific
-diagnostics. Using it is never required — see its own
+diagnostics, and `vision` its second, using it the same way while retaining its
+own outer `handle()` for the family's flat manual/error result shapes. Using it
+is never required — see its own
 `src/lingtai/tools/tool_family/CONTRACT.md` "Implementation independence" is
 binding on it exactly as it is on every family.
 

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -52,14 +52,18 @@ this package too — using it is optional, not mandatory).
   correlation was adopted after a live non-strict Codex Responses probe on
   2026-07-27 accepted a raw root `allOf`/`if`/`then` schema without error on
   the current route (see `CONTRACT.md` "Contract rules").
-- `manual.py` — `build_manual_child()` wraps `../_manual.py`'s
-  `load_installed_manual()` into the ManualTool stable contract: strict empty
-  input, and a handler whose actual return value (what `ToolFamily.handle()`
-  dispatches back verbatim, once the returned `ChildTool` is registered
-  directly and unwrapped in a family's own `ToolFamily`) is the canonical
-  `content[0].text` (full body) / `structuredContent.manual_path` (host-local
-  path) shape, with `status`/`error` loader facts preserved truthfully
-  (`manual.py:1-74`).
+- `manual.py` — exports `MANUAL_INPUT_SCHEMA`, the one canonical strict-empty
+  input schema every family's reserved `manual` child registers (so a family
+  composing a schema-only `ToolFamily` uses the same object dispatch validates
+  against instead of restating a drift-prone near-copy), and
+  `build_manual_child()`, which wraps `../_manual.py`'s
+  `load_installed_manual()` into the ManualTool stable contract: that strict
+  empty input, and a handler whose actual return value (what
+  `ToolFamily.handle()` dispatches back verbatim, once the returned `ChildTool`
+  is registered directly and unwrapped in a family's own `ToolFamily`) is the
+  canonical `content[0].text` (full body) / `structuredContent.manual_path`
+  (host-local path) shape, with `status`/`error` loader facts preserved
+  truthfully (`manual.py:1-84`).
 
 ## Connections
 

--- a/src/lingtai/tools/tool_family/manual.py
+++ b/src/lingtai/tools/tool_family/manual.py
@@ -22,7 +22,17 @@ from typing import Any, Mapping
 from .._manual import load_installed_manual
 from . import ChildTool
 
-__all__ = ["build_manual_child"]
+__all__ = ["MANUAL_INPUT_SCHEMA", "build_manual_child"]
+
+# The one canonical strict-empty input schema for every family's reserved
+# ``manual`` child. Exported so a family composing a schema-only ``ToolFamily``
+# registers the *same* object ``build_manual_child`` dispatches against,
+# instead of restating a near-copy that can drift from it.
+MANUAL_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
 
 
 def _to_mcp_result(loaded: Mapping[str, Any]) -> dict[str, Any]:
@@ -68,7 +78,7 @@ def build_manual_child(agent: Any, skill_name: str) -> ChildTool:
 
     return ChildTool(
         name="manual",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        input_schema=MANUAL_INPUT_SCHEMA,
         handler=handler,
         title="manual input",
     )

--- a/src/lingtai/tools/vision/ANATOMY.md
+++ b/src/lingtai/tools/vision/ANATOMY.md
@@ -7,27 +7,40 @@ related_files:
   - src/lingtai/tools/vision/glossary-zh.md
   - src/lingtai/tools/vision/glossary-wen.md
   - src/lingtai/tools/vision/manual/SKILL.md
+  - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/services/vision/ANATOMY.md
 maintenance: |
   Keep related_files as repo-relative paths to real files and keep anatomy links
   reciprocal. Update citations with structural code changes and run the document
-  validators after edits.
+  validators after edits. tool_family is generic optional infrastructure this
+  package composes onto; vision's own provider routing and result shapes stay
+  here.
 ---
 # src/lingtai/tools/vision/
 
-The `vision` tool registers direct current-preset image analysis plus a
-provider-neutral manual route when direct setup is unavailable.
+The `vision` tool registers one action-separated public family: direct
+current-preset image analysis (`analyze`) plus a provider-neutral, family-owned
+`manual` route when direct setup is unavailable. Schema composition and envelope
+dispatch delegate to the generic `tool_family` infrastructure; this package
+retains ownership of provider routing, identity resolution, and every action
+result shape.
 
 ## Components
 
-- `__init__.py:34-88` — Codex-family gate and bucket-driven route resolution plus the same-provider alias check; GLM/Zhipu and Codex spelling pairs share current identity, provider spelling is only a Codex-family compatibility gate, `_normalize_codex_auth_path` trims the bucket `codex_auth_path` once, and `_codex_bucket_route` picks direct (nonblank trimmed `codex_auth_path` in the active bucket) vs pool exactly as the canonical Codex factory does.
-- `__init__.py:108-125` — exact advertised provider registry; the local pseudo-provider remains explicit opt-in and intentionally excluded.
-- `__init__.py:127-152` — compatible tool schema; neither action requires an image path at schema level.
-- `__init__.py:154-203` — `VisionManager`; `manual` reads bundled guidance without a backend, while `analyze` validates and reads the image.
-- `__init__.py:205-494` — `setup`; resolves only the same current model/endpoint/credential/headers/wire, routes active Codex-family services by the bucket-driven direct (trimmed `codex_auth_path`) vs pool (pool-selected candidate token path) rule, creates supported services, fails closed to manual guidance when identity is incomplete, and always registers the tool.
+- `__init__.py:46-99` — Codex-family gate and bucket-driven route resolution plus the same-provider alias check; GLM/Zhipu and Codex spelling pairs share current identity, provider spelling is only a Codex-family compatibility gate, `_normalize_codex_auth_path` trims the bucket `codex_auth_path` once, and `_codex_bucket_route` picks direct (nonblank trimmed `codex_auth_path` in the active bucket) vs pool exactly as the canonical Codex factory does.
+- `__init__.py:120-128` — exact advertised provider registry; the local pseudo-provider remains explicit opt-in and intentionally excluded.
+- `__init__.py:130-150` — the two canonical child input schemas: `analyze` owns the strict `image_path`/nullable-`question` object, `manual` is strict empty.
+- `__init__.py:152-199` — `_build_family`, the one canonical child declaration consumed by both the module-level schema-only family and every `VisionManager`, plus `get_description`/`get_schema`; the reserved `manual` child registers the generic `tool_family.manual.MANUAL_INPUT_SCHEMA` rather than a local copy, and the composed root exposes both exact child inputs and correlates each `action` const with its own `input`.
+- `__init__.py:202-316` — `VisionManager`; builds its family through `_build_family` with the `analyze` handler bound to instance state and the reserved `manual` child from `tool_family.manual.build_manual_child`, `handle()` owns the canonical dispatch/presentation ordering and flattens the manual child's canonical result afterwards, `_dispatch_analyze` validates and reads the image.
+- `__init__.py:319-614` — `setup`; resolves only the same current model/endpoint/credential/headers/wire, routes active Codex-family services by the bucket-driven direct (trimmed `codex_auth_path`) vs pool (pool-selected candidate token path) rule, creates supported services, fails closed to manual guidance when identity is incomplete, and always registers the one public `vision` tool.
 
 ## Connections
 
+- Schema composition and envelope dispatch build on
+  [`src/lingtai/tools/tool_family/ANATOMY.md`](../tool_family/ANATOMY.md), which
+  knows nothing of vision's providers or identity rules.
+- The reserved `manual` child reads the installed capability manual through the
+  shared `_manual.py` loader, so `manual_path` is host-local and truthful.
 - Setup lazily reaches `lingtai.services.vision` and the Codex pool selector.
 - Direct compatible aliases (`openrouter`, `deepseek`, `zhipu`, `glm`, `grok`,
   `qwen`, `kimi`, `custom`) use current OpenAI/Anthropic-compatible identity.
@@ -36,14 +49,16 @@ provider-neutral manual route when direct setup is unavailable.
 
 ## Composition
 
-`VisionManager` owns the agent, optional service, and safe manual reason. The
-capability is registered by the built-in capability loader and registers one
-`vision` tool with the schema and glossary package.
+`VisionManager` owns the agent, optional service, safe manual reason, and its
+per-instance `ToolFamily`. The capability is registered by the built-in
+capability loader and registers exactly one `vision` tool with the composed
+schema and the glossary package.
 
 ## State
 
-Only the in-memory manager/service references persist. Manual content is bundled
-with the package; analyses are not persisted.
+Only the in-memory manager/service/family references persist. Manual content is
+bundled with the package and installed into the agent's intrinsic capability
+library; analyses are not persisted.
 
 ## Notes
 

--- a/src/lingtai/tools/vision/CONTRACT.md
+++ b/src/lingtai/tools/vision/CONTRACT.md
@@ -6,9 +6,14 @@ related_files:
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/ANATOMY.md
   - src/lingtai/tools/vision/manual/SKILL.md
+  - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/tool_family/CONTRACT.md
 maintenance: |
   Keep this contract aligned with the vision tool and its tests. Bump the
   version only for a repository-policy-required breaking contract change.
+  vision's schema composition and envelope dispatch build on the generic
+  tool_family package; keep that link current when either side's boundary
+  changes.
 ---
 # Vision capability contract
 
@@ -19,9 +24,33 @@ automatically invokes MCP.
 
 ## Scope and registry
 
-The schema has optional `image_path`, `question`, and `action`; `action` is
-`analyze` by default or `manual`. Manual works without `image_path`; analyze
-requires it and resolves relative paths against the agent working directory.
+`vision` is one action-separated family in the LingTai Tool Protocol v2 shape
+defined in `src/lingtai/tools/CONTRACT.md`, built on the generic
+`src/lingtai/tools/tool_family/` infrastructure (`ToolFamily`/`ChildTool` plus
+the reusable ManualTool builder). The public tool name stays `vision` and the
+public action values stay exactly `analyze` and `manual`; adopting the shared
+infrastructure changed no provider route, identity rule, or result shape in this
+file. Exactly one public model-facing `vision` root is registered; the two
+canonical children are not separate tools and consume no model tool slots.
+
+The model shape is the strict envelope `action` + `input` + `reasoning` +
+optional `summarize`, with `required: [action, input, reasoning]` and
+`additionalProperties: false`. The root exposes both children's exact input
+schemas before invocation (`input.oneOf`, one titled branch per action) and
+correlates each `action` const with that child's own `input` at the root
+(`allOf`/`if`/`then`), on both the Chat Completions and Responses wires.
+`reasoning` is required Host InvocationContext/audit metadata and `summarize` is
+Host presentation control; neither ever reaches child input. Child canonical
+name equals public action value equals dispatch key — there is no mapping layer.
+
+`analyze` owns a strict closed input of `image_path` (string) and `question`
+(nullable string; null means absent and applies the unchanged default prompt
+`Describe what you see in this image.`), both required as branch properties per
+the strict-object convention. `manual` is the family-owned reserved child with
+strict empty input. Analyze resolves relative `image_path` values against the
+agent working directory. Unknown actions and invalid or cross-action `input`
+fail at dispatch, before any handler runs and therefore before any provider I/O,
+credential read, or image read.
 
 `PROVIDERS["providers"]` is exactly: `gemini`, `anthropic`, `openai`,
 `openrouter`, `custom`, `deepseek`, `minimax`, `mimo`, `glm`, `zhipu`, `grok`,
@@ -33,7 +62,8 @@ native Codex Responses; MiniMax uses the Anthropic route. OpenRouter and custom
 deliberately try the current OpenAI-compatible model/endpoint/credential without
 preflighting image support; other compatible aliases use the current
 OpenAI/Anthropic identity. A real request failure is returned as a sanitized
-vision tool error that points to `vision(action="manual")` for explicit
+vision tool error that points to
+`vision(action="manual", input={}, reasoning="...")` for explicit
 alternatives, without silently switching model/provider or invoking MCP.
 
 ## Current identity and wires
@@ -73,15 +103,37 @@ manual-only.
 
 ## Tool behavior
 
-Success is `{status: "ok", analysis: text}`. Manual success is
-`{status: "ok", action: "manual", manual: body}`; missing manual is degraded.
+Analyze success is exactly `{status: "ok", analysis: text}`. Manual success is
+`{status: "ok", action: "manual", manual: body, manual_path: path}`, where
+`body` is the full installed capability manual and `path` is its host-local
+location; a missing installed manual is `degraded` with an empty body and the
+loader's error. Manual performs no analyze operation, constructs no provider,
+and reads no credential, even when the configured direct route is broken or
+absent. The `manual` child's canonical result is adapted once by the Host into
+that flat public shape after dispatch; it is never nested inside another action
+result and is never double wrapped.
+
 Missing image, empty response, setup failure, and request failure are structured
-errors pointing to `vision(action="manual")`. Exception messages are never
-returned; failures may include only the provider and exception type.
+errors pointing to the full accepted envelope
+`vision(action="manual", input={}, reasoning="...")` — every taught pointer
+carries `input` and a contextual `reasoning`, because the bare shorthand is
+rejected by the registered schema and the dispatcher. Envelope failures
+(unknown action,
+non-object `input`, unknown root field, non-boolean `summarize`, unknown or
+cross-action `input` field) return the same `{status: "error", message: ...}`
+shape. Exception messages are never returned; failures may include only the
+provider and exception type.
 
 ## Invariants and tests
 
-- `setup` always registers the tool: `tests/test_vision_capability.py`.
+- `setup` always registers exactly one public `vision` tool:
+  `tests/test_vision_capability.py`, `tests/test_tool_family_vision_migration.py`.
+- Both child schemas and handlers, invalid/cross-action rejection before
+  provider I/O, manual-without-provider-call, exact success/failure shapes, and
+  Chat/Responses wire parity with no double wrap:
+  `tests/test_tool_family_vision_migration.py`.
+- The installed manual body/path round-trip alongside every other manual-owning
+  tool: `tests/test_intrinsic_manual_actions.py`.
 - Endpoint identity is sanitized by `sanitize_endpoint` and drops userinfo,
   query, fragment, malformed ports, and non-URLs: `tests/test_agent_preset_manifest.py`.
 - Provider construction and exact OpenAI Responses shape are covered in
@@ -89,5 +141,6 @@ returned; failures may include only the provider and exception type.
 - Manual guidance is provider-neutral and kernel/TUI-independent in
   `manual/SKILL.md`.
 
-Run `python -m pytest tests/test_vision_capability.py tests/test_vision_services.py -q`
+Run `python -m pytest tests/test_vision_capability.py tests/test_vision_services.py
+tests/test_tool_family_vision_migration.py tests/test_intrinsic_manual_actions.py -q`
 and the glossary validator before merging.

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -10,12 +10,23 @@ Usage:
 The local mlx-vlm pseudo-provider remains available through explicit
 ``add_capability(..., provider="local")`` opt-in, but it is intentionally not
 advertised in ``PROVIDERS`` or first-run/check-caps surfaces yet.
+
+``vision`` is migrated to the LingTai Tool Protocol v2 action-separated shape
+(``src/lingtai/tools/CONTRACT.md``): one public ``vision`` tool whose canonical
+children are ``analyze`` and the family-owned reserved ``manual``, composed and
+dispatched by the generic ``lingtai.tools.tool_family`` infrastructure. The
+public tool name and both action values are unchanged; only the call envelope
+moved from flat arguments to ``action``/``input``/``reasoning``/``summarize``.
+Provider routing, credential/identity resolution, and every analyze/manual
+result shape are untouched by that migration.
 """
 from __future__ import annotations
 
 from pathlib import Path
-from importlib import resources
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Mapping
+
+from ..tool_family import ChildTool, ToolFamily
+from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
 
 
 if TYPE_CHECKING:
@@ -27,7 +38,8 @@ def _setup_failure(provider: str, exc: BaseException) -> str:
     """Build explicit manual guidance without exposing exception contents."""
     return (
         f"Direct vision setup failed for provider {provider!r} "
-        f"({type(exc).__name__}); use vision(action='manual')."
+        f"({type(exc).__name__}); use vision(action='manual', input={{}}, "
+        f"reasoning='direct vision setup failed, load the manual route')."
     )
 
 
@@ -115,40 +127,76 @@ PROVIDERS = {
     "fallback_on_inherit": None,  # no agnostic fallback for vision
 }
 
+_ANALYZE_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "image_path": {
+            "type": "string",
+            "description": "Path to the image file",
+        },
+        "question": {
+            # Strict OpenAI object branches express an optional field as a
+            # required nullable property. Null means absent, and the analyze
+            # handler then applies the same default prompt it always has.
+            "type": ["string", "null"],
+            "description": (
+                "Question about the image, or null for the default "
+                "\"Describe what you see in this image.\""
+            ),
+        },
+    },
+    "required": ["image_path", "question"],
+    "additionalProperties": False,
+}
+
+def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
+    raise AssertionError("the module-level schema-only ToolFamily never dispatches")
+
+
+def _build_family(
+    analyze_handler: Any = _unused,
+    manual_child: ChildTool | None = None,
+) -> ToolFamily:
+    """Build vision's family from the one canonical child declaration.
+
+    The single source of truth for vision's children: both the module-level
+    schema-only family (which composes the model-facing schema and proves at
+    import time that the registry has no duplicate or reserved-name collision)
+    and each ``VisionManager``'s dispatching family come from here, so child
+    names, schemas, titles, and order cannot drift between the wire surface
+    and the dispatcher. Defaults build the non-dispatching variant; the
+    manager passes its bound ``analyze`` handler and the real reserved
+    ``manual`` child from ``build_manual_child``.
+    """
+    return ToolFamily(
+        "vision",
+        [
+            ChildTool("analyze", _ANALYZE_INPUT_SCHEMA, analyze_handler, title="analyze input"),
+            manual_child
+            or ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused, title="manual input"),
+        ],
+    )
+
+
+_FAMILY = _build_family()
+
+
 def get_description(lang: str = "en") -> str:
     return (
-        "Analyze an image with the active preset. OpenRouter/custom first try the "
-        "current OpenAI-compatible route; a real request failure returns a "
-        "sanitized error and points to action='manual' for read-only alternatives. "
+        "Analyze an image with the active preset. Use vision(action='analyze', "
+        "input={'image_path': '...', 'question': null}, reasoning='read the "
+        "image') for the direct request; OpenRouter/custom first try the "
+        "current OpenAI-compatible route. A real request failure returns a "
+        "sanitized error and points to vision(action='manual', input={}, "
+        "reasoning='load vision guidance') for read-only alternatives. "
         "No provider, model, credential, or MCP fallback is automatic."
     )
 
 
 def get_schema(lang: str = "en") -> dict:
-    return {
-        "type": "object",
-        "properties": {
-            "image_path": {"type": "string", "description": 'Path to the image file'},
-            "question": {
-                "type": "string",
-                "description": 'Question about the image',
-                "default": "Describe this image.",
-            },
-            "action": {
-                "type": "string",
-                "enum": ["analyze", "manual"],
-                "default": "analyze",
-                "description": (
-                    "analyze performs the direct request; OpenRouter/custom try the "
-                    "current OpenAI-compatible route even when downstream image "
-                    "support is unknown. On real failure the sanitized tool result "
-                    "points to manual, which returns bundled read-only alternatives."
-                ),
-            },
-        },
-        "required": [],
-    }
-
+    # Composed by the generic ToolFamily infra from ``_build_family``'s child
+    # declaration, never hand-assembled.
+    return _FAMILY.build_schema()
 
 
 class VisionManager:
@@ -163,14 +211,33 @@ class VisionManager:
         self._agent = agent
         self._vision_service = vision_service
         self._manual_reason = manual_reason
+        # Same canonical child declaration the module-level schema-only family
+        # uses, with this instance's bound analyze handler and the real
+        # reserved ``manual`` child registered directly (unwrapped).
+        self._family = _build_family(
+            self._dispatch_analyze, build_manual_child(agent, "vision")
+        )
 
-    def handle(self, args: dict) -> dict:
-        if args.get("action", "analyze") == "manual":
-            return self.manual()
+    def _dispatch_analyze(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        """Run the one direct analyze operation on already-validated input.
+
+        The body is the pre-migration ``handle()`` analyze path unchanged:
+        same missing-service guard, relative-path resolution, existence check,
+        default prompt, and success/failure result shapes.
+        """
         if self._vision_service is None:
-            return {"status": "error", "message": self._manual_reason or "Direct vision is unavailable; call vision(action='manual')."}
-        image_path = args.get("image_path", "")
-        question = args.get("question", "Describe what you see in this image.")
+            return {
+                "status": "error",
+                "message": self._manual_reason or (
+                    "Direct vision is unavailable; call vision(action='manual', "
+                    "input={}, reasoning='no direct vision route, load the "
+                    "manual alternatives')."
+                ),
+            }
+        image_path = action_input.get("image_path") or ""
+        question = action_input.get("question")
+        if question is None:
+            question = "Describe what you see in this image."
 
         if not image_path:
             return {"status": "error", "message": "Provide image_path"}
@@ -191,15 +258,62 @@ class VisionManager:
                 }
             return {"status": "ok", "analysis": analysis}
         except Exception as e:
-            return {"status": "error", "message": f"Vision analysis failed ({type(e).__name__}). Call vision(action='manual') for the explicit manual route."}
+            return {
+                "status": "error",
+                "message": (
+                    f"Vision analysis failed ({type(e).__name__}). Call "
+                    "vision(action='manual', input={}, reasoning='the direct "
+                    "vision request failed, load the explicit manual route') "
+                    "for the explicit manual route."
+                ),
+            }
+
+    def _adapt_manual_result(self, mcp_result: dict[str, Any]) -> dict[str, Any]:
+        # Host-owned flattening of the manual child's canonical result into
+        # vision's pre-migration ``status``/``action``/``manual`` shape (plus
+        # the loader's ``manual_path``). See ``handle()`` for the ordering rule.
+        flat: dict[str, Any] = {
+            "status": mcp_result.get("status", "ok"),
+            "action": "manual",
+            "manual": mcp_result["content"][0]["text"],
+            "manual_path": mcp_result["structuredContent"]["manual_path"],
+        }
+        if "error" in mcp_result:
+            flat["error"] = mcp_result["error"]
+        return flat
 
     def manual(self) -> dict:
-        """Return only bundled guidance; never inspect config or invoke a backend."""
-        try:
-            body = resources.files(__package__).joinpath("manual/SKILL.md").read_text(encoding="utf-8")
-        except (FileNotFoundError, ModuleNotFoundError, AttributeError):
-            return {"status": "degraded", "action": "manual", "manual": "", "error": "vision manual missing"}
-        return {"status": "ok", "action": "manual", "manual": body}
+        """Return only installed guidance; never inspect config or invoke a backend.
+
+        Retained as the family's own public manual entry point (callers and
+        tests use it directly). Performs no provider construction, no
+        credential read, and no analyze operation.
+        """
+        return self._adapt_manual_result(self._family.handle({"action": "manual", "input": {}}))
+
+    def handle(self, args: dict | None) -> dict:
+        # Canonical statement of this family's dispatch/presentation ordering.
+        # The generic ``ToolFamily`` dispatcher validates ``action``,
+        # type-checks and strips root ``summarize``, rejects unknown root
+        # fields, and rejects ``input`` keys outside the selected action's own
+        # declared schema (schema conformance alone is not the dispatch-time
+        # authorization boundary — see ``tools/CONTRACT.md`` "Dispatch and
+        # actions") before ``_dispatch_analyze`` or the registered ``manual``
+        # child's handler ever runs, so every envelope failure lands before any
+        # provider I/O. ``self._family.handle`` returns the ``manual`` child's
+        # canonical ``content``/``structuredContent`` result verbatim (no double
+        # wrap); flattening it to vision's public shape is this method's own
+        # Host job, done strictly after dispatch, never inside a registered
+        # child. Envelope failures are normalized to vision's long-standing
+        # ``{"status": "error", "message": ...}`` shape here, rather than by
+        # changing the generic dispatcher's canonical error result.
+        action = args.get("action") if isinstance(args, Mapping) else None
+        result = self._family.handle(args)
+        if action == "manual" and "content" in result:
+            return self._adapt_manual_result(result)
+        if result.get("status") == "failed" and "error_code" in result:
+            return {"status": "error", "message": result["message"]}
+        return result
 
 
 def setup(
@@ -300,11 +414,11 @@ def setup(
                 if cap_max_tokens is not None:
                     svc_kwargs["max_tokens"] = cap_max_tokens
                 if wire_api is None:
-                    manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual')."
+                    manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual', input={}, reasoning='the active OpenAI-compatible wire has no direct vision route')."
                 elif not llm_model:
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
                 elif not api_key:
-                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current credential for direct vision')."
                 else:
                     try:
                         vision_service = OpenAIVisionService(**svc_kwargs)
@@ -322,16 +436,16 @@ def setup(
                 if cap_max_tokens is not None:
                     svc_kwargs["max_tokens"] = cap_max_tokens
                 if not llm_model:
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
                 elif not api_key:
-                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current credential for direct vision')."
                 else:
                     try:
                         vision_service = AnthropicVisionService(**svc_kwargs)
                     except Exception as exc:
                         manual_reason = _setup_failure(provider, exc)
             else:
-                manual_reason = f"No direct vision route is supported for provider {provider!r}; use vision(action='manual')."
+                manual_reason = f"No direct vision route is supported for provider {provider!r}; use vision(action='manual', input={{}}, reasoning='this provider has no supported direct vision route')."
         else:
             if provider_key in _CODEX_FAMILY:
                 # Codex vision is a standalone Responses request. It may share
@@ -366,7 +480,7 @@ def setup(
                 if explicit_token_path:
                     kwargs["token_path"] = explicit_token_path
                 if not kwargs.get("model"):
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
                 elif codex_route == "direct":
                     # A whitespace-only explicit ``token_path`` is not an identity;
                     # normalize both it and the inherited bucket path once so the
@@ -378,7 +492,7 @@ def setup(
                     if token_path:
                         kwargs["token_path"] = token_path
                     else:
-                        manual_reason = "Codex vision has no explicit current OAuth identity; use vision(action='manual')."
+                        manual_reason = "Codex vision has no explicit current OAuth identity; use vision(action='manual', input={}, reasoning='Codex vision has no explicit current OAuth identity')."
                 else:
                     # Pool route (bucket has no nonblank ``codex_auth_path``).
                     # WeightedAccountSource selects an account from the pool file
@@ -408,7 +522,7 @@ def setup(
                         except NoCandidateError:
                             pass
                     if not kwargs.get("token_path"):
-                        manual_reason = "Codex pool vision has no selected current OAuth identity; use vision(action='manual')."
+                        manual_reason = "Codex pool vision has no selected current OAuth identity; use vision(action='manual', input={}, reasoning='Codex pool vision has no selected current OAuth identity')."
                 kwargs.pop("api_compat", None)
                 kwargs.pop("base_url", None)
                 if codex_base_url:
@@ -452,11 +566,11 @@ def setup(
                 if service_provider == "mimo" and same_provider and active_base_url:
                     kwargs.setdefault("base_url", active_base_url)
                 if service_provider in {"openai", "mimo"} and wire_api is None:
-                    manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual')."
+                    manual_reason = "The active OpenAI-compatible wire is not implemented by the direct vision service; use vision(action='manual', input={}, reasoning='the active OpenAI-compatible wire has no direct vision route')."
                 elif service_provider == "mimo" and wire_api != "chat_completions":
-                    manual_reason = "The active MiMo wire is not implemented by the direct vision service; use vision(action='manual')."
+                    manual_reason = "The active MiMo wire is not implemented by the direct vision service; use vision(action='manual', input={}, reasoning='the active MiMo wire has no direct vision route')."
                 if service_provider in {"openai", "mimo"} and active_compat == "anthropic":
-                    manual_reason = "The active preset uses an Anthropic wire that this vision route cannot safely adapt; use vision(action='manual')."
+                    manual_reason = "The active preset uses an Anthropic wire that this vision route cannot safely adapt; use vision(action='manual', input={}, reasoning='the active Anthropic wire cannot be safely adapted for direct vision')."
                     vision_service = None
                 if service_provider == "anthropic" and active_headers:
                     kwargs.setdefault("default_headers", active_headers)
@@ -473,9 +587,9 @@ def setup(
                     kwargs.pop("wire_api", None)
                 resolved_api_key = api_key or active_api_key
                 if service_provider not in {"codex", "local"} and not kwargs.get("model"):
-                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current model for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current model for direct vision')."
                 elif service_provider not in {"codex", "local"} and not resolved_api_key:
-                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual')."
+                    manual_reason = f"Provider {provider!r} has no resolved current credential for direct vision; use vision(action='manual', input={{}}, reasoning='no resolved current credential for direct vision')."
                 # Dedicated vision services do not consume the LLM adapter's
                 # transport selector.
                 kwargs.pop("api_compat", None)
@@ -493,7 +607,7 @@ def setup(
                     except Exception as exc:
                         manual_reason = _setup_failure(provider, exc)
     elif vision_service is None:
-        manual_reason = "No direct vision provider was configured; use vision(action='manual')."
+        manual_reason = "No direct vision provider was configured; use vision(action='manual', input={}, reasoning='no direct vision provider is configured')."
 
     mgr = VisionManager(agent, vision_service=vision_service, manual_reason=manual_reason)
     agent.add_tool("vision", schema=get_schema(), handler=mgr.handle, description=get_description(), glossary_package=__package__)

--- a/src/lingtai/tools/vision/glossary-wen.md
+++ b/src/lingtai/tools/vision/glossary-wen.md
@@ -16,7 +16,10 @@ maintenance: |
 **名相对照**
 
 - `vision`：观象之器——以 LLM 之视觉能力析图。支 JPEG、PNG 与 WebP。可对图发任何问——述其内容、识其文字、解其图表、辨其物象、评其风格与气韵。结合绘相可先生图再析之。
-- `image_path`：图像之路径
-- `question`：关于图像之问
-- `action`：`analyze` 直析，`manual` 惟返只读指引
-- `manual`：使 agent 察当前 preset 身份，于自身 skill catalog 寻相应手册；不自动召 MCP
+- `action`：所择子 Tool 之名，`analyze` 直析，`manual` 惟返只读指引
+- `input`：所择 action 自有之严输
+- `image_path`：`analyze` 之输中图像之路径
+- `question`：`analyze` 之输中关于图像之问，`null` 则用默问
+- `reasoning`：Host 审计之元数据，不入 action 之输
+- `summarize`：Host 呈现层之可选后处开关，不入 action 之输
+- `manual`：族属保留子 Tool 之名，返所安手册全文与其径；使 agent 察当前 preset 身份，于自身 skill catalog 寻相应手册；不自动召 MCP

--- a/src/lingtai/tools/vision/glossary-zh.md
+++ b/src/lingtai/tools/vision/glossary-zh.md
@@ -16,7 +16,10 @@ maintenance: |
 **术语对照**
 
 - `vision`：使用 LLM 的视觉能力分析图像。支持 JPEG、PNG 和 WebP。可以对图像提出任何问题——描述内容、识别文字、解读图表、识别物体、评估风格或氛围。结合 draw 可以先生成图像再分析。
-- `image_path`：图像文件路径
-- `question`：关于图像的问题
-- `action`：`analyze` 直接分析，`manual` 仅返回只读指引
-- `manual`：引导 agent 查看当前 preset 身份并在自身 skill catalog 中查找匹配手册；不自动调用 MCP
+- `action`：所选子 Tool 名，`analyze` 直接分析，`manual` 仅返回只读指引
+- `input`：所选 action 自身的严格输入
+- `image_path`：`analyze` 输入中的图像文件路径
+- `question`：`analyze` 输入中关于图像的问题，`null` 表示使用默认提问
+- `reasoning`：Host 审计元数据，不进入 action 输入
+- `summarize`：Host 呈现层的可选后处理开关，不进入 action 输入
+- `manual`：族属保留子 Tool 名，返回安装手册全文与路径；引导 agent 查看当前 preset 身份并在自身 skill catalog 中查找匹配手册；不自动调用 MCP

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Use this manual when the vision capability has no usable provider route or
   reports a direct setup/request failure and needs safe, provider-neutral
   troubleshooting guidance.
-last_changed_at: 2026-07-19T00:00:00Z
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
   - src/lingtai/tools/vision/__init__.py
   - src/lingtai/tools/vision/ANATOMY.md
@@ -18,14 +18,29 @@ maintenance: |
 This is the provider-neutral fallback for `vision`. It contains guidance only;
 it does not discover, install, start, or invoke a backend.
 
+## Call shape
+
+`vision` is one action-separated tool with exactly two actions:
+
+- `vision(action="analyze", input={"image_path": "...", "question": null},
+  reasoning="...")` — the direct image request. `question` is optional: send
+  `null` to use the default "Describe what you see in this image."
+- `vision(action="manual", input={}, reasoning="...")` — this guidance. Its
+  input is strictly empty and it performs no analyze operation.
+
+`reasoning` is required on both actions and is recorded in your diary; it never
+becomes part of the image request. Optional `summarize` is a root presentation
+control, not action input. An unknown action, or an input field belonging to the
+other action, is rejected before anything is sent to a provider.
+
 ## Route behavior and failures
 
-For OpenRouter and custom OpenAI-compatible presets, `vision(action="analyze")`
-first tries the current endpoint, model, and credential. It does not reject the
-route merely because downstream image support cannot be known in advance. Any
-direct setup or request failure returns a sanitized vision tool result that
-reports the failure type and points here for explicit alternatives; it never
-exposes exception contents.
+For OpenRouter and custom OpenAI-compatible presets, `analyze` first tries the
+current endpoint, model, and credential. It does not reject the route merely
+because downstream image support cannot be known in advance. Any direct setup or
+request failure returns a sanitized vision tool result that reports the failure
+type and points here for explicit alternatives; it never exposes exception
+contents.
 
 ## Stay on the active preset
 

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -13,6 +13,7 @@ from lingtai.tools import read as read_tool
 from lingtai.tools import soul as soul_tool
 from lingtai.tools import system as system_tool
 from lingtai.tools import write as write_tool
+from lingtai.tools import vision as vision_tool
 from lingtai.tools import web_search as web_tool
 from lingtai.tools import bash as shell_tool
 
@@ -54,6 +55,7 @@ def test_manual_actions_return_their_installed_skills(tmp_path: Path) -> None:
             "soul-manual",
             "system-manual",
             "web",
+            "vision",
             "file-manual",
         )
     }
@@ -69,6 +71,7 @@ def test_manual_actions_return_their_installed_skills(tmp_path: Path) -> None:
     daemon_manager = daemon_tool.DaemonManager.__new__(daemon_tool.DaemonManager)
     daemon_manager._agent = agent
     web_manager = web_tool.setup(agent)
+    vision_manager = vision_tool.setup(agent)
 
     calls = {
         "shell": ("shell", lambda: shell_manager.handle({"action": "manual"})),
@@ -79,6 +82,7 @@ def test_manual_actions_return_their_installed_skills(tmp_path: Path) -> None:
         "soul": ("soul-manual", lambda: soul_tool.handle(agent, {"action": "manual"})),
         "system": ("system-manual", lambda: system_tool.handle(agent, {"action": "manual"})),
         "web": ("web", lambda: web_manager.handle({"action": "manual", "input": {}})),
+        "vision": ("vision", lambda: vision_manager.handle({"action": "manual", "input": {}})),
         "write": ("file-manual", lambda: agent.handlers["write"]({"action": "manual"})),
         "edit": ("file-manual", lambda: agent.handlers["edit"]({"action": "manual"})),
         "glob": ("file-manual", lambda: agent.handlers["glob"]({"action": "manual"})),
@@ -94,6 +98,15 @@ def test_manual_actions_return_their_installed_skills(tmp_path: Path) -> None:
             assert result["manual"] == body
             assert result["manual_path"] == str(path)
             assert isinstance(result["current_setting"], dict)
+        elif tool_name == "vision":
+            # vision's family-owned manual keeps its pre-migration
+            # status/action/manual shape and adds the loader's manual_path.
+            assert result == {
+                "status": "ok",
+                "action": "manual",
+                "manual": body,
+                "manual_path": str(path),
+            }
         else:
             assert result == {
                 "status": "ok",
@@ -114,6 +127,7 @@ def test_manual_schemas_preserve_runtime_checks_for_ordinary_file_calls(
         soul_tool,
         system_tool,
         web_tool,
+        vision_tool,
         write_tool,
         edit_tool,
         glob_tool,
@@ -129,6 +143,9 @@ def test_manual_schemas_preserve_runtime_checks_for_ordinary_file_calls(
     web_schema = web_tool.get_schema()
     assert web_schema["required"] == ["action", "input", "reasoning"]
     assert len(web_schema["properties"]["input"]["oneOf"]) == 3
+    vision_schema = vision_tool.get_schema()
+    assert vision_schema["required"] == ["action", "input", "reasoning"]
+    assert len(vision_schema["properties"]["input"]["oneOf"]) == 2
     for module in (read_tool, write_tool, edit_tool, glob_tool, grep_tool):
         assert module.get_schema()["required"] == []
 

--- a/tests/test_tool_family_vision_migration.py
+++ b/tests/test_tool_family_vision_migration.py
@@ -1,0 +1,596 @@
+"""Focused acceptance for the action-separated public ``vision`` family.
+
+``vision`` keeps its public tool name and both public action values
+(``analyze``/``manual``) while moving to the LTP v2 envelope
+(``action``/``input``/``reasoning``/``summarize``) composed and dispatched by
+the generic ``lingtai.tools.tool_family`` infrastructure. These tests pin the
+migration's own promises: exactly one public model root, both child schemas and
+handlers, envelope/cross-action rejection strictly *before* any provider I/O,
+a manual route that constructs and calls no provider, the exact preserved
+success/failure result shapes, and Chat/Responses wire parity with no double
+wrapping of the manual child's canonical result.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lingtai.services.vision import VisionService
+from lingtai.tools import vision as vision_tool
+from lingtai.tools.vision import VisionManager, get_schema, setup
+
+
+class _StubAgent:
+    """Minimal agent surface: a working dir plus one recorded ``add_tool``."""
+
+    def __init__(self, working_dir: Path):
+        self._working_dir = working_dir
+        self.tools: dict[str, dict] = {}
+
+    def add_tool(self, name: str, **kwargs) -> None:
+        self.tools[name] = kwargs
+
+
+def _install_manual(workdir: Path) -> tuple[str, Path]:
+    path = workdir / ".library" / "intrinsic" / "capabilities" / "vision" / "SKILL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = "---\nname: vision-manual\n---\n\n# vision sentinel\n"
+    path.write_text(body, encoding="utf-8")
+    return body, path
+
+
+def _never_called_service() -> MagicMock:
+    """A vision service that fails the test if any provider I/O is attempted."""
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.side_effect = AssertionError(
+        "provider I/O must not run for this call"
+    )
+    return svc
+
+
+def _manager(tmp_path: Path, service=None) -> VisionManager:
+    return VisionManager(_StubAgent(tmp_path), vision_service=service)
+
+
+# ---------------------------------------------------------------------------
+# Public registration: one model root, unchanged public name
+# ---------------------------------------------------------------------------
+
+
+def test_setup_registers_exactly_one_public_vision_root(tmp_path):
+    agent = _StubAgent(tmp_path)
+    setup(agent, vision_service=MagicMock(spec=VisionService))
+
+    assert list(agent.tools) == ["vision"]
+    assert agent.tools["vision"]["schema"] == get_schema()
+    assert agent.tools["vision"]["glossary_package"] == "lingtai.tools.vision"
+
+
+def test_public_actions_are_exactly_analyze_and_manual():
+    schema = get_schema()
+    assert schema["properties"]["action"]["enum"] == ["analyze", "manual"]
+
+
+# ---------------------------------------------------------------------------
+# Root schema: strict envelope with action <-> input correlation
+# ---------------------------------------------------------------------------
+
+
+def test_root_schema_is_the_strict_ltp_v2_envelope():
+    schema = get_schema()
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert schema["required"] == ["action", "input", "reasoning"]
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    assert schema["properties"]["reasoning"]["type"] == "string"
+    assert schema["properties"]["summarize"]["type"] == "boolean"
+
+
+def test_root_schema_correlates_each_action_const_with_its_own_input():
+    schema = get_schema()
+    conditions = {
+        cond["if"]["properties"]["action"]["const"]: cond["then"]["properties"]["input"]
+        for cond in schema["allOf"]
+    }
+    assert set(conditions) == {"analyze", "manual"}
+    assert set(conditions["analyze"]["properties"]) == {"image_path", "question"}
+    assert conditions["manual"]["properties"] == {}
+    for cond in schema["allOf"]:
+        # A strict ``if`` with a missing property matches vacuously; the guard
+        # keeps each branch scoped to its own action.
+        assert cond["if"]["required"] == ["action"]
+
+
+def test_both_child_input_schemas_are_exposed_before_invocation():
+    branches = get_schema()["properties"]["input"]["oneOf"]
+    assert [b["title"] for b in branches] == ["analyze input", "manual input"]
+
+    analyze_branch, manual_branch = branches
+    assert analyze_branch["required"] == ["image_path", "question"]
+    assert analyze_branch["additionalProperties"] is False
+    assert analyze_branch["properties"]["image_path"]["type"] == "string"
+    # Optional ``question`` is a required nullable property, matching the
+    # strict-object convention the other migrated families use.
+    assert analyze_branch["properties"]["question"]["type"] == ["string", "null"]
+
+    assert manual_branch["properties"] == {}
+    assert manual_branch["additionalProperties"] is False
+
+
+def test_reasoning_and_summarize_never_leak_into_child_input():
+    schema = get_schema()
+    for branch in schema["properties"]["input"]["oneOf"]:
+        assert not {"reasoning", "_reasoning", "summarize", "action"} & set(
+            branch["properties"]
+        )
+    for cond in schema["allOf"]:
+        assert not {"reasoning", "_reasoning", "summarize", "action"} & set(
+            cond["then"]["properties"]["input"]["properties"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch: envelope/cross-action failures land before any provider I/O
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        pytest.param({"reasoning": "r"}, id="missing-action"),
+        pytest.param({"action": "look", "input": {}, "reasoning": "r"}, id="unknown-action"),
+        pytest.param(
+            {"action": "analyze", "input": "not-an-object", "reasoning": "r"},
+            id="input-not-object",
+        ),
+        pytest.param(
+            {"action": "analyze", "input": {"image_path": "x.png", "question": None}, "reasoning": "r", "engine": "x"},
+            id="unknown-root-field",
+        ),
+        pytest.param(
+            {"action": "analyze", "input": {"image_path": "x.png", "question": None}, "reasoning": "r", "summarize": "yes"},
+            id="non-boolean-summarize",
+        ),
+    ],
+)
+def test_invalid_envelope_fails_before_provider_io(tmp_path, args):
+    mgr = _manager(tmp_path, _never_called_service())
+    result = mgr.handle(args)
+    assert result["status"] == "error"
+    assert isinstance(result["message"], str) and result["message"]
+
+
+def test_cross_action_input_is_rejected_before_provider_io(tmp_path):
+    """``manual``'s strict-empty input cannot smuggle in analyze's fields."""
+    mgr = _manager(tmp_path, _never_called_service())
+    result = mgr.handle(
+        {"action": "manual", "input": {"image_path": "x.png"}, "reasoning": "r"}
+    )
+    assert result["status"] == "error"
+    assert "manual" not in result  # never reached the manual child either
+
+
+def test_unknown_analyze_input_field_is_rejected_before_provider_io(tmp_path):
+    mgr = _manager(tmp_path, _never_called_service())
+    result = mgr.handle(
+        {
+            "action": "analyze",
+            "input": {"image_path": "x.png", "question": None, "action": "manual"},
+            "reasoning": "r",
+        }
+    )
+    assert result["status"] == "error"
+
+
+def test_root_summarize_is_stripped_and_never_reaches_the_child(tmp_path):
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.return_value = "a chart"
+    img = tmp_path / "chart.png"
+    img.write_bytes(b"\x89PNG fake")
+
+    mgr = _manager(tmp_path, svc)
+    result = mgr.handle(
+        {
+            "action": "analyze",
+            "input": {"image_path": str(img), "question": "What is this?"},
+            "reasoning": "read the chart",
+            "summarize": True,
+        }
+    )
+    assert result == {"status": "ok", "analysis": "a chart"}
+    svc.analyze_image.assert_called_once_with(str(img), prompt="What is this?")
+
+
+# ---------------------------------------------------------------------------
+# analyze: exact preserved success/failure shapes and routing
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_success_shape_is_exact(tmp_path):
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.return_value = "A dog in the park"
+    img = tmp_path / "dog.jpg"
+    img.write_bytes(b"\xff\xd8\xff fake jpeg")
+
+    result = _manager(tmp_path, svc).handle(
+        {
+            "action": "analyze",
+            "input": {"image_path": str(img), "question": "What animal?"},
+            "reasoning": "identify the animal",
+        }
+    )
+    assert result == {"status": "ok", "analysis": "A dog in the park"}
+
+
+def test_analyze_null_question_uses_the_unchanged_default_prompt(tmp_path):
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.return_value = "An image"
+    img = tmp_path / "photo.png"
+    img.write_bytes(b"\x89PNG fake")
+
+    _manager(tmp_path, svc).handle(
+        {
+            "action": "analyze",
+            "input": {"image_path": "photo.png", "question": None},
+            "reasoning": "describe it",
+        }
+    )
+    svc.analyze_image.assert_called_once_with(
+        str(img), prompt="Describe what you see in this image."
+    )
+
+
+@pytest.mark.parametrize(
+    ("image_path", "expected_fragment"),
+    [
+        pytest.param("", "Provide image_path", id="empty-path"),
+        pytest.param("/nonexistent/img.png", "Image file not found", id="missing-file"),
+    ],
+)
+def test_analyze_input_failures_keep_their_exact_messages(
+    tmp_path, image_path, expected_fragment
+):
+    svc = _never_called_service()
+    result = _manager(tmp_path, svc).handle(
+        {
+            "action": "analyze",
+            "input": {"image_path": image_path, "question": None},
+            "reasoning": "r",
+        }
+    )
+    assert result["status"] == "error"
+    assert expected_fragment in result["message"]
+
+
+def test_analyze_request_failure_is_sanitized_and_points_to_manual(tmp_path):
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.side_effect = RuntimeError(
+        "token=secret https://user:pw@example.test/v1"
+    )
+    img = tmp_path / "x.png"
+    img.write_bytes(b"fake")
+
+    result = _manager(tmp_path, svc).handle(
+        {"action": "analyze", "input": {"image_path": str(img), "question": None}, "reasoning": "r"}
+    )
+    assert result["status"] == "error"
+    assert "RuntimeError" in result["message"]
+    # The taught pointer must be the full accepted envelope, not the
+    # pre-migration bare shorthand the dispatcher now rejects.
+    assert "vision(action='manual', input={}" in result["message"]
+    assert "reasoning=" in result["message"]
+    assert "secret" not in result["message"]
+    assert "example.test" not in result["message"]
+
+
+def test_analyze_empty_response_is_an_error(tmp_path):
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.return_value = ""
+    img = tmp_path / "x.png"
+    img.write_bytes(b"fake")
+
+    result = _manager(tmp_path, svc).handle(
+        {"action": "analyze", "input": {"image_path": str(img), "question": None}, "reasoning": "r"}
+    )
+    assert result == {
+        "status": "error",
+        "message": "Vision analysis returned no response.",
+    }
+
+
+def test_analyze_without_a_direct_route_returns_the_setup_manual_reason(tmp_path):
+    reason = (
+        "No direct vision provider was configured; use vision(action='manual', "
+        "input={}, reasoning='no direct vision provider is configured')."
+    )
+    mgr = VisionManager(_StubAgent(tmp_path), vision_service=None, manual_reason=reason)
+    result = mgr.handle(
+        {"action": "analyze", "input": {"image_path": "x.png", "question": None}, "reasoning": "r"}
+    )
+    assert result == {"status": "error", "message": reason}
+
+
+# ---------------------------------------------------------------------------
+# manual: family-owned, no provider construction or call, exact body/path
+# ---------------------------------------------------------------------------
+
+
+def test_manual_returns_the_exact_installed_body_and_path(tmp_path):
+    body, path = _install_manual(tmp_path)
+    mgr = _manager(tmp_path, _never_called_service())
+
+    result = mgr.handle({"action": "manual", "input": {}, "reasoning": "load guidance"})
+    assert result == {
+        "status": "ok",
+        "action": "manual",
+        "manual": body,
+        "manual_path": str(path),
+    }
+
+
+def test_manual_result_is_not_double_wrapped(tmp_path):
+    _install_manual(tmp_path)
+    result = _manager(tmp_path, _never_called_service()).handle(
+        {"action": "manual", "input": {}, "reasoning": "r"}
+    )
+    # The canonical MCP child result is adapted, never nested inside another
+    # action result.
+    assert "content" not in result
+    assert "structuredContent" not in result
+    assert not any(isinstance(value, dict) for value in result.values())
+
+
+def test_missing_installed_manual_degrades_without_side_effects(tmp_path):
+    expected = tmp_path / ".library" / "intrinsic" / "capabilities" / "vision" / "SKILL.md"
+    result = _manager(tmp_path, _never_called_service()).handle(
+        {"action": "manual", "input": {}, "reasoning": "r"}
+    )
+    assert result == {
+        "status": "degraded",
+        "action": "manual",
+        "manual": "",
+        "manual_path": str(expected),
+        "error": (
+            "vision manual missing — initializer may have failed or "
+            "capability not installed correctly"
+        ),
+    }
+    assert not (tmp_path / ".library").exists()
+
+
+def test_manual_constructs_no_provider_and_calls_no_service(tmp_path):
+    _install_manual(tmp_path)
+    agent = _StubAgent(tmp_path)
+    with patch("lingtai.services.vision.create_vision_service") as mock_factory:
+        mgr = setup(agent, provider="not-a-real-provider")
+        result = agent.tools["vision"]["handler"](
+            {"action": "manual", "input": {}, "reasoning": "r"}
+        )
+    mock_factory.assert_not_called()
+    assert mgr._vision_service is None
+    assert result["status"] == "ok"
+    assert result["action"] == "manual"
+
+
+def test_manual_works_even_when_a_configured_service_would_fail(tmp_path):
+    """Manual performs no analyze operation, so a broken provider is irrelevant."""
+    body, path = _install_manual(tmp_path)
+    svc = _never_called_service()
+    result = _manager(tmp_path, svc).handle(
+        {"action": "manual", "input": {}, "reasoning": "r"}
+    )
+    assert result["manual"] == body
+    assert result["manual_path"] == str(path)
+    svc.analyze_image.assert_not_called()
+
+
+def test_manual_method_matches_the_dispatched_manual_action(tmp_path):
+    _install_manual(tmp_path)
+    mgr = _manager(tmp_path, _never_called_service())
+    assert mgr.manual() == mgr.handle(
+        {"action": "manual", "input": {}, "reasoning": "r"}
+    )
+
+
+def test_every_taught_manual_pointer_round_trips_through_the_dispatcher(tmp_path):
+    """The guidance strings must teach a call the dispatcher actually accepts.
+
+    Before the envelope migration, `vision(action='manual')` was a complete
+    valid call. It no longer is — `input` is required — so any in-result string
+    still teaching the bare shorthand would send an agent into a rejection loop.
+    This walks every guidance string vision can emit, extracts the taught call,
+    and proves the literal shape it teaches dispatches successfully.
+    """
+    import re
+
+    _install_manual(tmp_path)
+    mgr = _manager(tmp_path, _never_called_service())
+
+    # Collect the guidance strings from every source that emits one: the
+    # setup-failure builder, both analyze failure paths, and every
+    # `manual_reason` literal assigned in setup().
+    source = Path("src/lingtai/tools/vision/__init__.py").read_text(encoding="utf-8")
+    taught = re.findall(r"vision\(action='manual'([^)]*)\)", source)
+    assert len(taught) >= 18, f"expected every guidance string, found {len(taught)}"
+
+    for suffix in taught:
+        assert "input={}" in suffix.replace("{{}}", "{}"), (
+            f"taught pointer omits input: vision(action='manual'{suffix})"
+        )
+        assert "reasoning=" in suffix, (
+            f"taught pointer omits reasoning: vision(action='manual'{suffix})"
+        )
+
+    # The taught shape, executed literally, must succeed through dispatch.
+    assert mgr.handle(
+        {"action": "manual", "input": {}, "reasoning": "load vision guidance"}
+    )["status"] == "ok"
+    # ...and the pre-migration bare shorthand must NOT, which is exactly why
+    # the strings had to change.
+    assert mgr.handle({"action": "manual"})["status"] == "error"
+
+
+def test_no_bare_manual_pointer_survives_in_any_vision_owned_surface():
+    """No `vision(action='manual')` without `input=` anywhere vision owns."""
+    import re
+
+    owned = [
+        Path("src/lingtai/tools/vision/__init__.py"),
+        Path("src/lingtai/tools/vision/CONTRACT.md"),
+        Path("src/lingtai/tools/vision/manual/SKILL.md"),
+        Path("src/lingtai/services/vision/openai.py"),
+    ]
+    bare = re.compile(r"vision\(action=[\"']manual[\"']\s*\)")
+    for path in owned:
+        text = path.read_text(encoding="utf-8")
+        assert not bare.search(text), f"stale bare manual pointer in {path}"
+
+
+def test_family_registers_the_reserved_manual_child_once(tmp_path):
+    mgr = _manager(tmp_path)
+    assert mgr._family.child_names == ("analyze", "manual")
+    assert mgr._family.has_manual()
+
+
+def test_wire_and_dispatch_families_come_from_one_child_declaration(tmp_path):
+    """The schema-only family and the manager's family cannot drift apart.
+
+    Both are built by `_build_family`, so child names, order, and per-action
+    input schemas are identical objects/values on the wire surface and at the
+    dispatch boundary — the duplication that a second hand-written registry
+    would allow is structurally impossible.
+    """
+    from lingtai.tools.vision import _FAMILY
+
+    mgr = _manager(tmp_path, _never_called_service())
+    assert mgr._family.child_names == _FAMILY.child_names
+    assert mgr._family.build_schema() == _FAMILY.build_schema() == get_schema()
+
+
+def test_manual_child_input_schema_is_the_generic_owners_object(tmp_path):
+    """Vision registers the generic manual schema, never a local near-copy.
+
+    A restated copy previously carried `"required": []` while the generic
+    owner's omitted the key, so the wire schema and the dispatch-side schema
+    for the same child were two different objects.
+    """
+    from lingtai.tools.tool_family.manual import MANUAL_INPUT_SCHEMA
+
+    manual_branch = get_schema()["properties"]["input"]["oneOf"][1]
+    assert manual_branch["properties"] == MANUAL_INPUT_SCHEMA["properties"]
+    assert manual_branch["additionalProperties"] is False
+    assert "required" not in MANUAL_INPUT_SCHEMA
+
+
+# ---------------------------------------------------------------------------
+# Wire parity: Chat Completions and Responses
+# ---------------------------------------------------------------------------
+
+
+def test_vision_schema_survives_both_provider_wires():
+    from lingtai.kernel.llm.base import FunctionSchema
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+    schema = FunctionSchema(
+        name="vision",
+        description=vision_tool.get_description(),
+        parameters=get_schema(),
+    )
+    chat = _build_tools([schema])[0]["function"]["parameters"]
+    responses = _build_responses_tools([schema])[0]["parameters"]
+
+    for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+        assert wire["type"] == "object"
+        assert wire["required"] == ["action", "input", "reasoning"]
+        assert wire["additionalProperties"] is False
+        assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert wire["properties"]["action"]["enum"] == ["analyze", "manual"]
+        branches = wire["properties"]["input"][combinator]
+        assert [b["title"] for b in branches] == ["analyze input", "manual input"]
+        for branch in branches:
+            assert branch["additionalProperties"] is False
+            assert not {"reasoning", "_reasoning", "summarize"} & set(
+                branch["properties"]
+            )
+        # Root action<->input correlation must survive the wire, not just the
+        # composed schema: each action const keeps its own `then.input`.
+        correlated = {
+            cond["if"]["properties"]["action"]["const"]: cond["then"]["properties"]["input"]
+            for cond in wire["allOf"]
+        }
+        assert set(correlated) == {"analyze", "manual"}
+        assert set(correlated["analyze"]["properties"]) == {"image_path", "question"}
+        assert correlated["manual"]["properties"] == {}
+
+
+def test_root_summarize_reaches_the_single_centralized_summarizer(tmp_path):
+    """``vision`` is a migrated LTP v2 family, so its canonical root
+    ``summarize`` boolean is recognized by the one existing centralized
+    a-priori summarizer — no second summarizer, and the raw result is still
+    durably logged before the visible replacement."""
+    from lingtai.kernel.llm.base import ToolCall
+    from lingtai.kernel.loop_guard import LoopGuard
+    from lingtai.kernel.tool_executor import ToolExecutor
+    from lingtai.kernel.tool_result_summary import (
+        APRIORI_SUMMARY_MARKER,
+        summary_requested,
+    )
+
+    assert summary_requested({"summarize": True}, "vision") is True
+    # An unmigrated tool's own ``summarize``-named field is still never
+    # reinterpreted as this cross-cutting control.
+    assert summary_requested({"summarize": True}, "some_unmigrated_tool") is False
+
+    events: list[tuple] = []
+    raw = {"status": "ok", "analysis": "VISIONRAW-marker long description"}
+    executor = ToolExecutor(
+        dispatch_fn=lambda tc: raw,
+        make_tool_result_fn=lambda name, result, **kw: {"content": result, **kw},
+        guard=LoopGuard(),
+        known_tools={"vision"},
+        parallel_safe_tools=set(),
+        logger_fn=lambda event_type, **fields: events.append((event_type, fields)),
+        working_dir=tmp_path,
+        summarizer_fn=lambda sp, up, tn, cid: "SUMMARY: a chart",
+    )
+    results, _, _ = executor.execute(
+        [
+            ToolCall(
+                name="vision",
+                args={
+                    "action": "analyze",
+                    "input": {"image_path": "x.png", "question": None},
+                    "reasoning": "read the chart",
+                    "summarize": True,
+                },
+                id="v1",
+            )
+        ]
+    )
+    content = results[0]["content"]
+    assert content["artifact"] == APRIORI_SUMMARY_MARKER
+    assert content["generated_summary"] == "SUMMARY: a chart"
+    assert "VISIONRAW-marker" not in str(content)
+    assert any(
+        event_type == "tool_result" and "VISIONRAW-marker" in str(fields.get("result"))
+        for event_type, fields in events
+    )
+
+
+def test_dispatch_is_identical_regardless_of_originating_wire(tmp_path):
+    """Dispatch depends only on the normalized args dict both wires converge to."""
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.return_value = "same answer"
+    img = tmp_path / "x.png"
+    img.write_bytes(b"fake")
+    mgr = _manager(tmp_path, svc)
+
+    chat_call = mgr.handle(
+        {"action": "analyze", "input": {"image_path": str(img), "question": "Q"}, "reasoning": "chat-wire"}
+    )
+    responses_call = mgr.handle(
+        {"action": "analyze", "input": {"image_path": str(img), "question": "Q"}, "reasoning": "responses-wire"}
+    )
+    assert chat_call == responses_call == {"status": "ok", "analysis": "same answer"}

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -13,6 +13,23 @@ from lingtai.tools.vision import PROVIDERS, VisionManager, setup
 from lingtai.services.vision import VisionService, create_vision_service
 
 
+def analyze(image_path: str = "", question=None) -> dict:
+    """Build one LTP v2 ``analyze`` envelope for the public ``vision`` family.
+
+    ``vision`` is action-separated (``analyze``/``manual``): the model sends
+    ``action`` + strict per-action ``input`` + required ``reasoning``. Optional
+    ``question`` is a required nullable branch property, so absent is ``None``.
+    """
+    return {
+        "action": "analyze",
+        "input": {"image_path": image_path, "question": question},
+        "reasoning": "analyze the test image",
+    }
+
+
+MANUAL_CALL = {"action": "manual", "input": {}, "reasoning": "load vision guidance"}
+
+
 def make_mock_service():
     svc = MagicMock()
     svc.provider = "gemini"
@@ -69,7 +86,7 @@ def test_vision_with_dedicated_service(tmp_path):
 
     img_path = tmp_path / "test.jpg"
     img_path.write_bytes(b"\xff\xd8\xff fake jpeg")
-    result = mgr.handle({"image_path": str(img_path)})
+    result = mgr.handle(analyze(str(img_path)))
     assert result["status"] == "ok"
     assert "dog" in result["analysis"]
     mock_vision_svc.analyze_image.assert_called_once()
@@ -80,7 +97,7 @@ def test_vision_missing_image(tmp_path):
     mock_vision_svc = MagicMock(spec=VisionService)
     agent = make_mock_agent(tmp_path)
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
-    result = mgr.handle({"image_path": "/nonexistent/image.png"})
+    result = mgr.handle(analyze("/nonexistent/image.png"))
     assert result.get("status") == "error"
 
 
@@ -93,7 +110,7 @@ def test_vision_relative_path(tmp_path):
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
     img_path = tmp_path / "photo.png"
     img_path.write_bytes(b"\x89PNG fake")
-    result = mgr.handle({"image_path": "photo.png"})
+    result = mgr.handle(analyze("photo.png"))
     assert result["status"] == "ok"
     mock_vision_svc.analyze_image.assert_called_once_with(str(img_path), prompt="Describe what you see in this image.")
 
@@ -107,7 +124,7 @@ def test_vision_service_error_handled(tmp_path):
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
     img_path = tmp_path / "test.png"
     img_path.write_bytes(b"\x89PNG fake")
-    result = mgr.handle({"image_path": str(img_path)})
+    result = mgr.handle(analyze(str(img_path)))
     assert result["status"] == "error"
     assert "API down" not in result["message"]
     assert "RuntimeError" in result["message"]
@@ -122,7 +139,7 @@ def test_vision_service_error_does_not_echo_secret_or_url(tmp_path):
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
     img_path = tmp_path / "test.png"
     img_path.write_bytes(b"fake")
-    result = mgr.handle({"image_path": str(img_path)})
+    result = mgr.handle(analyze(str(img_path)))
     assert result["status"] == "error"
     assert "secret" not in result["message"]
     assert "example.test" not in result["message"]
@@ -205,7 +222,7 @@ def test_openai_unknown_wire_remains_manual_without_factory_call(tmp_path):
 
     mock_factory.assert_not_called()
     assert mgr._vision_service is None
-    result = mgr.handle({})
+    result = mgr.handle(analyze())
     assert result["status"] == "error"
     assert "manual" in result["message"]
     assert "unproven_wire" not in result["message"]
@@ -233,7 +250,7 @@ def test_generic_openai_compatible_unknown_wire_remains_manual(tmp_path):
 
     mock_cls.assert_not_called()
     assert mgr._vision_service is None
-    result = mgr.handle({})
+    result = mgr.handle(analyze())
     assert result["status"] == "error"
     assert "manual" in result["message"]
     assert "unproven_wire" not in result["message"]
@@ -257,7 +274,7 @@ def test_vision_empty_response_is_error(tmp_path):
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
     img_path = tmp_path / "test.png"
     img_path.write_bytes(b"\x89PNG fake")
-    result = mgr.handle({"image_path": str(img_path)})
+    result = mgr.handle(analyze(str(img_path)))
     assert result["status"] == "error"
 
 
@@ -355,7 +372,7 @@ def test_mimo_responses_wire_is_manual_only(tmp_path):
     )
     mgr = setup(agent, provider="mimo", api_key="sk-test")
     assert mgr._vision_service is None
-    assert mgr.handle({})["status"] == "error"
+    assert mgr.handle(analyze())["status"] == "error"
 
 
 def test_vision_setup_resolves_api_key_env(tmp_path, monkeypatch):
@@ -1071,7 +1088,7 @@ def test_registered_adapters_remain_callable_with_manual_route(tmp_path, provide
     assert isinstance(result, VisionManager)
     agent.add_tool.assert_called_once()
     handler = agent.add_tool.call_args.kwargs["handler"]
-    assert handler({"action": "manual"})["status"] in {"ok", "degraded"}
+    assert handler(MANUAL_CALL)["status"] in {"ok", "degraded"}
 
 
 def test_vision_setup_unsupported_provider_keeps_manual_route(tmp_path):
@@ -1096,7 +1113,7 @@ def test_setup_failure_retains_safe_manual_reason(tmp_path):
         )
         (tmp_path / "x.png").write_bytes(b"fake")
         mgr = setup(agent, provider="openai", api_key="sk-test")
-    result = mgr.handle({"image_path": "x.png"})
+    result = mgr.handle(analyze("x.png"))
     assert result["status"] == "error"
     assert "RuntimeError" in result["message"]
     assert "secret" not in result["message"]
@@ -1306,7 +1323,7 @@ def test_vision_empty_image_path(tmp_path):
     mock_vision_svc = MagicMock(spec=VisionService)
     agent = make_mock_agent(tmp_path)
     mgr = VisionManager(agent, vision_service=mock_vision_svc)
-    result = mgr.handle({"image_path": ""})
+    result = mgr.handle(analyze(""))
     assert result["status"] == "error"
     assert "image_path" in result["message"].lower() or "provide" in result["message"].lower()
 


### PR DESCRIPTION
> **Exact source head:** `f41d7b57eb6e6d0d1882c467e56c5ce96c4f6efd`  
> **Exact base:** `4ad8b1555a5b0368af81aa57292438719a105052`  
> **dev4 exact-head live-use gate:** pending immediately after PR opening; this body will be updated with the durable receipt.

feat(vision): migrate vision to the action-separated ToolFamily shape

## Summary

Migrates the public `vision` tool to the LingTai Tool Protocol v2
action-separated shape defined in `src/lingtai/tools/CONTRACT.md`, making it the
second family (after `web`) to build on the generic
`src/lingtai/tools/tool_family/` infrastructure.

The public tool name stays `vision` and the public action values stay exactly
`analyze` and `manual`. Only the call envelope changed. Provider routing,
identity/credential resolution, the Codex direct-vs-pool bucket rule, wire
selection, and every analyze result shape are byte-identical to base.

Exactly one public model-facing `vision` root is registered. The two canonical
children are not separate tools and consume no model tool slots; child canonical
name equals public action value equals dispatch key, with no mapping layer.

### Exact envelope

Root model shape is strict `action` + `input` + `reasoning` + optional
`summarize`, with `required: ["action", "input", "reasoning"]` and
`additionalProperties: false`. The root exposes both children's exact input
schemas before invocation (`input.oneOf`, one titled branch per action) and
correlates each `action` const with that child's own `input` at the root
(`allOf` / `if` / `then`, each `if` guarded by `required: ["action"]`), on both
the Chat Completions and Responses wires.

```jsonc
// analyze — the direct current-preset image request
{
  "action": "analyze",
  "input": {
    "image_path": "chart.png",   // string, required
    "question": null             // string|null, required; null = default prompt
  },
  "reasoning": "read the chart"  // required Host audit metadata
}

// manual — the family-owned reserved child
{
  "action": "manual",
  "input": {},                   // strict empty
  "reasoning": "load vision guidance"
}
```

`question` is a required nullable branch property per the strict-object
convention `web` uses; `null` means absent and applies the unchanged default
prompt `Describe what you see in this image.`. `reasoning` and `summarize` are
Host-owned and never reach child input. Unknown actions and invalid or
cross-action `input` fail at dispatch — before any handler runs, and therefore
before any provider I/O, credential read, or image read.

## Agent-facing guidance repair (20 pointers)

Every in-result guidance string that taught the pre-migration shorthand
`vision(action='manual')` now teaches the full accepted envelope with a
**contextual** `reasoning` matching the failure it reports. Under the old flat
schema (`required: []`) the shorthand was a complete valid call; after this PR
registers the envelope it fails before dispatch with
`{'status': 'error', 'message': 'input must be an object'}`, so leaving these
strings would have sent an agent that just made a schema-valid call into a
rejection loop.

Repaired across four owned surfaces:

- `tools/vision/__init__.py` — 18 strings: `_setup_failure`, the analyze
  no-service message, the sanitized analyze exception message, and all 16
  `manual_reason` assignments in `setup()`.
- `tools/vision/__init__.py` — `get_description` (2 taught call shapes).
- `services/vision/openai.py:31` — the `OpenAIVisionService` constructor
  `ValueError`; same defect class, found during repair rather than in the
  original review.
- `tools/vision/CONTRACT.md` — both sentences that codified the stale shorthand.

Nine distinct contextual reasonings are emitted, e.g.
`reasoning='no resolved current credential for direct vision'`,
`reasoning='Codex pool vision has no selected current OAuth identity'`,
`reasoning='the active MiMo wire has no direct vision route'`.

Two tests lock the class permanently:
`test_every_taught_manual_pointer_round_trips_through_the_dispatcher` extracts
every taught pointer from the source, asserts each carries `input={}` **and**
`reasoning=`, executes the taught shape, and asserts the bare shorthand still
fails; `test_no_bare_manual_pointer_survives_in_any_vision_owned_surface` sweeps
all four owned files.

## Duplication cleanup

- **Single child registry.** `_build_family()` is the one canonical child
  declaration. The module-level schema-only `_FAMILY` and every
  `VisionManager._family` are both built from it (the manager passes its bound
  analyze handler plus the real `build_manual_child`). Child names, schemas,
  titles, and order can no longer drift between the wire surface and the
  dispatcher — `mgr._family.build_schema() == _FAMILY.build_schema() ==
  get_schema()`, pinned by
  `test_wire_and_dispatch_families_come_from_one_child_declaration`.
- **Canonical manual schema at its owner.** `tool_family/manual.py` now exports
  `MANUAL_INPUT_SCHEMA`, and `build_manual_child` consumes it. Vision's local
  `_MANUAL_INPUT_SCHEMA` copy is deleted. This eliminates a real
  wire-vs-dispatch mismatch: the local copy carried `"required": []` while the
  owner's omitted the key, so the same child had two different schema objects.
- **Comment collapse.** The no-double-wrap / adapt-after-dispatch rule was
  stated four times in full prose; it is now stated once canonically on
  `handle()` (which owns the behavior), with short pointers at
  `_adapt_manual_result`, `manual()`, and the registration site.

Deleted symbols: `_schema_only_family()`, `_MANUAL_INPUT_SCHEMA` (vision-local),
the inline manual schema literal in `build_manual_child`, the second
hand-written `ToolFamily(...)` child list in `VisionManager.__init__`, and four
full-prose comment blocks.

## No aliases, no shims, no fallbacks

The legacy flat surface is fully replaced with no compatibility layer:

- The hand-written flat `get_schema` is deleted; the schema is composed from the
  child declaration.
- The flat `handle()` action branch (`args.get("action", "analyze")`) is
  deleted. The analyze body moved verbatim into `_dispatch_analyze`.
- Old flat calls fail closed —
  `{'status': 'error', 'message': 'action must be one of analyze, manual'}`.
  **No acceptance shim, no alias, and no default-action fallback survives.**
- No provider, model, credential, or MCP fallback was added anywhere.
  `PROVIDERS` (`fallback_on_inherit: None`) and every `setup()` routing branch
  are byte-identical to base.

## LOC

Production is reported separately from tests and docs.

| Category | Raw added | Raw removed | Raw net |
|---|---|---|---|
| **Production** (`vision/__init__.py`, `tool_result_summary.py`, `services/vision/openai.py`, `tool_family/manual.py`) | 192 | 65 | **+127** |
| Tests (new 596-line migration file, `test_vision_capability.py`, `test_intrinsic_manual_actions.py`) | 642 | 12 | +630 |
| Docs (3× ANATOMY, 2× CONTRACT, manual SKILL.md, zh/wen glossaries) | 161 | 55 | +106 |

**Executable production** (blank / comment / docstring excluded, measured with
`ast` + `tokenize` on base vs head):

| File | Base | Head | Net |
|---|---|---|---|
| `tools/vision/__init__.py` | 359 | 407 | +48 |
| `kernel/tool_result_summary.py` | 343 | 343 | 0 |
| `services/vision/openai.py` | 63 | 65 | +2 |
| `tools/tool_family/manual.py` | 24 | 29 | +5 |
| **TOTAL** | **789** | **844** | **+55** |

Production net-negative is arithmetically unreachable for this migration: the
entire legacy flat surface was 44 lines, and a strict envelope carrying two
disclosed child schemas, root correlation, and dispatch delegation cannot be
expressed in fewer. The reviewer independently derived the same conclusion and
reproduced the +55 figure exactly, noting it lands **below** the +65–80 floor
their first review called the honest minimum.

## Preserved behavior

- **Provider routing unchanged**: all direct-native, OpenAI-compatible,
  Anthropic-compatible, MiniMax, MiMo, and Codex-family routes; the
  bucket-driven direct (trimmed `codex_auth_path`) vs pool (pool-selected
  candidate token path) rule; same-provider identity inheritance including the
  GLM/Zhipu and codex-pool spelling pairs; fail-closed on missing model,
  credential, or OAuth identity.
- **Analyze results exact**: `{status: "ok", analysis: text}` on success;
  unchanged messages for missing `image_path`, file-not-found, and empty
  response; sanitized request failures that expose only the exception type and
  never secrets, URLs, or exception contents.
- **Manual degraded behavior preserved**: a missing installed manual returns
  `status: "degraded"` with an empty body, the host-local `manual_path`, and the
  loader's error, with no side effects — the `.library` tree is not created.
  Manual constructs no provider, reads no credential, and performs no analyze
  operation.
- **Summarizer single-source**: `_LTP_V2_MIGRATED_FAMILIES` extends to
  `{"web", "vision"}` so vision's root `summarize` reaches the one existing
  centralized a-priori summarizer. No second summarizer; the raw-first 500k cap
  and the legacy `summary` spelling for unmigrated tools are untouched.

One intentional behavior delta: reusing the approved ManualTool builder means
`manual` reads the installed catalog copy (`.library/intrinsic/capabilities/
vision/SKILL.md`) rather than the package resource, and returns a `manual_path`
key. The bodies are byte-identical — `_install_intrinsic_manuals` copies the
package `manual/` bundle verbatim and `vision` is not name-remapped. The
observable deltas are the new `manual_path` key and a different degraded error
string; both are documented in CONTRACT.md and covered by exact-shape tests.

## Validation

| Gate | Result |
|---|---|
| Author focused suites (23 selections: vision, all `tool_family_*`, web, summarizer, docs, glossary, services) | **601 passed** |
| Parent gate suites | **187 passed** |
| Reviewer independent selection (migration + capability + intrinsic-manual, then 13 adjacent suites) | 141 + 316 = **457 passed** |
| `tests/test_tool_family_vision_migration.py` | **35 tests** |
| `py_compile` (all 4 production files) | clean |
| `git diff --check` | clean |
| `check_anatomy_drift.py` | No drift across 54 files |
| ANATOMY citations | all 6 vision ranges + `manual.py:1-84` verified accurate |

The author's 601 and the reviewer's 457 are independently chosen selections over
the same tree, not a discrepancy. Zero failures in any selection.

Known unrelated pre-existing failure, present identically at base and not
touched by this PR: `test_skills.py::test_lingtai_owned_skill_frontmatter_has_
last_changed_at`, caused by `intrinsic_skills/system-manual/reference/
environment-variables/SKILL.md` carrying a date-only `2026-07-24`.

Full-suite differential vs a clean `git archive` of the base: worktree
**8 failed / 6185 passed**, base **9 failed / 6153 passed**. Every failure traced
to the `msal` environment gap, pre-existing base failures, or order-dependent
nudge flakes that this diff does not touch.

## Review status

**Fable 5 independent review: ACCEPT** (final re-review, same day, after the
authorized repair round). The reviewer verified every fix against the live
worktree module rather than the report, and confirmed that no old call shape,
dual registry, manual-schema copy, or shim survives. Both original BLOCK
findings — the 20 stale taught pointers and the duplication/LOC gate — are
closed, and all rider notes from the first review were delivered (manual
frontmatter bumped, manual prose shorthand replaced, root `allOf` wire-parity
assertion added).

Reviewer's summary: *"the cleanest of the family migrations I have reviewed in
this round: every legacy path deleted with replacement proof, executable
production +55 with nothing left I can soundly remove, and the taught-shape
regression class is locked by tests so it cannot recur silently."*

## Outstanding before merge

**dev4 exact-head live exercise is PENDING.** Step 5 of the review contract — an
isolated runtime exercise at the exact head confirming the real public action
count, a live `analyze` call, and Manual usability — has not been run. All
provider paths in this PR are mock-covered only; no network call was made at any
point. This PR should not merge until that exercise reports.

## Base and rollback

- Exact base: `4ad8b1555a5b0368af81aa57292438719a105052`
  (`feat(tools): add ToolFamily with Web reference migration (#1059)`).
- Self-contained and independently revertible: reverting this PR restores the
  flat vision schema and handler wholesale. No other family depends on anything
  it adds. The only cross-cutting production line is the one-token addition of
  `"vision"` to `_LTP_V2_MIGRATED_FAMILIES`, which reverts cleanly and affects
  no other tool.
- No data migration, no settings file, no persisted state: vision owns no
  settings surface, so the two-level settings addressing rules do not apply and
  there is nothing to roll forward or back on disk.

## Disclosure — shared generic file overlap

This PR modifies **`src/lingtai/tools/tool_family/manual.py`**, a generic file
outside the vision owner. Both changes are additive: a new exported
`MANUAL_INPUT_SCHEMA` constant, and a one-line substitution making
`build_manual_child` consume it instead of an inline literal. No dispatch logic
was touched, and the dead `manual_count` branch in `tool_family/__init__.py`
was deliberately left alone (it belongs to the Web cleanup).

**Known group-merge conflict.** The authorized Web cleanup also touches
`tool_family/manual.py` and specifies this same export as its resolution shape,
so both PRs land on that file. The content converges — resolve once at group
merge. No other family worktree has created the export yet (checked Web, Avatar,
MCP, Knowledge, Shell, Notification, Skills, Soul, File), so **parent action is
required**: point the remaining families at this canonical export and delete
their local `_MANUAL_INPUT_SCHEMA` copies.

Consequence until that happens: vision's `manual` wire branch omits
`"required": []` (the canonical schema has no such key) while web's at-base
branch still carries it, so the two families differ on the wire until web
consumes the same export. No provider on either wire validates that difference,
and it converges at group merge.

Two further parent-owned reconciliations, unchanged from prior reviews and
deliberately not done here because every family PR would collide on the same
lines: `tool_family/CONTRACT.md:124` still names `web_search` the "one
production Adapter/consumer", and `tool_family/ANATOMY.md`'s consumer prose
needs one pass once the group lands.

## Files changed

```
 src/lingtai/kernel/tool_result_summary.py  |   4 +-
 src/lingtai/services/vision/openai.py      |   3 +-
 src/lingtai/tools/ANATOMY.md               |  13 +-
 src/lingtai/tools/CONTRACT.md              |  16 +-
 src/lingtai/tools/tool_family/ANATOMY.md   |  12 +-
 src/lingtai/tools/tool_family/manual.py    |  12 +-
 src/lingtai/tools/vision/ANATOMY.md        |  28 +-
 src/lingtai/tools/vision/CONTRACT.md       |  63 +-
 src/lingtai/tools/vision/__init__.py       | 173 +++--
 src/lingtai/tools/vision/glossary-wen.md   |   7 +-
 src/lingtai/tools/vision/glossary-zh.md    |   7 +-
 src/lingtai/tools/vision/manual/SKILL.md   |  22 +-
 tests/test_intrinsic_manual_actions.py     |  17 +
 tests/test_vision_capability.py            |  29 +-
 tests/test_tool_family_vision_migration.py | 596 +++++++++++++ (new)
```
