### PR TITLE
feat(tools): migrate Avatar to the action-separated ToolFamily envelope

### DIFF
--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -152,14 +152,15 @@ def is_apriori_summary(content: Any) -> bool:
 # unmigrated tool's own domain field literally named ``summarize`` is never
 # silently reinterpreted as this cross-cutting control (see
 # ``src/lingtai/tools/CONTRACT.md`` Contract rules > Envelope).
-_LTP_V2_MIGRATED_FAMILIES = frozenset({"web"})
+_LTP_V2_MIGRATED_FAMILIES = frozenset({"web", "avatar"})
 
 
 def summary_requested(args: dict | None, tool_name: str | None = None) -> bool:
     """Return True iff the normalized tool args opt into a-priori summary.
 
     The legacy flag is the boolean ``summary`` field on the tool call, honored
-    for every caller. A migrated LTP v2 family (currently only ``web``) may
+    for every caller. A migrated LTP v2 family (see
+    ``_LTP_V2_MIGRATED_FAMILIES``) may
     instead set the canonical root ``summarize`` boolean; that spelling is
     recognized only when ``tool_name`` names a migrated family, so an
     unmigrated tool's own ``summarize``-named domain field is never

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -9,6 +9,8 @@ related_files:
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/tools/tool_family/CONTRACT.md
+  - src/lingtai/tools/avatar/ANATOMY.md
+  - src/lingtai/tools/avatar/CONTRACT.md
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
   - src/lingtai/tools/glossary_validator.py
@@ -40,8 +42,8 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `tool_family/` — generic, optional ToolFamily/ChildTool schema-composition
   and dispatch infrastructure implementing the LTP v2 envelope, and the
-  reusable ManualTool builder; `web` is its first real consumer
-  (`src/lingtai/tools/tool_family/ANATOMY.md`).
+  reusable ManualTool builder; `web` is its first real consumer and `avatar`
+  its second (`src/lingtai/tools/tool_family/ANATOMY.md`).
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -9,15 +9,18 @@ related_files:
   - src/lingtai/kernel/tool_executor.py
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/avatar/CONTRACT.md
+  - src/lingtai/tools/avatar/__init__.py
   - src/lingtai/tools/tool_family/CONTRACT.md
+  - src/lingtai/kernel/tool_result_summary.py
   - tests/test_browser_capability.py
   - tests/test_wire_tool_description.py
 maintenance: |
   This component contract is governed by the root CONTRACT.md and owns the
   LingTai Tool Protocol (LTP). Keep the paired tools Anatomy and cross-contract
   links reciprocal. Update Agent schema composition, ToolExecutor normalization,
-  the migrated family, and this contract together when the canonical call
-  boundary changes. LTP alignment is documentary — this pair is the source of
+  each migrated family, the `_LTP_V2_MIGRATED_FAMILIES` allowlist, and this
+  contract together when the canonical call boundary changes. LTP alignment is documentary — this pair is the source of
   truth, not a central validator. Migrate one real family at a time; do not
   claim legacy tools already conform.
 ---
@@ -235,22 +238,40 @@ documents. `web` (`search | browse | manual`) is the first family migrated to
 this contract: its final model-facing root is exactly `action`, `input`,
 `reasoning`, and `summarize`; its `search` action reads the action-owned
 `settings/web.search.json` (see `src/lingtai/tools/web_search/CONTRACT.md`).
+
+`avatar` (`spawn | rules | manual`) is the second family migrated, keeping its
+public name and action values unchanged (see
+`src/lingtai/tools/avatar/CONTRACT.md`, contract_version 4). It owns no
+settings file at either level, and its manual says so explicitly. Two
+avatar-specific facts are worth naming here because they are envelope
+consequences, not local details: its `spawn` mission brief is root `reasoning`
+(never an `input` property, per "Envelope"), and its `rules` action is
+karma-gated while `spawn` and `manual` are not — a family must not hide a
+stronger child action behind a weaker family posture.
+
 The legacy a-priori result-summarization flag under the literal key `summary`
 (`src/lingtai/kernel/tool_result_summary.py:172`) remains honored for every
 still-unmigrated caller; `src/lingtai/kernel/tool_result_summary.py` recognizes
 the canonical `summarize` spelling only when the calling tool is a migrated LTP
-v2 family (currently only `web`), so an unmigrated tool's own field literally
-named `summarize` is never reinterpreted as this control. Every other
-LingTai-owned family remains unmigrated and keeps its existing schema and
-settings surface unchanged by this file.
+v2 family (`_LTP_V2_MIGRATED_FAMILIES`, currently `web` and `avatar`), so an
+unmigrated tool's own field literally named `summarize` is never reinterpreted
+as this control. A family adopting this envelope MUST join that allowlist in the
+same change, or the root `summarize` it advertises to the model would be
+silently ignored. Every other LingTai-owned family remains unmigrated and keeps
+its existing schema and settings surface unchanged by this file.
 
 `src/lingtai/tools/tool_family/` is optional, generic composition
 infrastructure implementing this envelope (schema composition from a
 `ChildTool` registry, dispatch-validation boilerplate, and a reusable
 ManualTool builder) that a family MAY adopt instead of hand-writing the
-equivalent code; `web` is its first consumer, using it for schema composition
-and dispatch while retaining its own outer `handle()` for family-specific
-diagnostics. Using it is never required — see its own
+equivalent code; `web` is its first consumer and `avatar` its second, each
+using it for schema composition and dispatch while retaining its own outer
+`handle()` for family-specific diagnostics (`web` stamps `current_setting`;
+`avatar` restores its pinned unknown-action error envelope). `avatar` reuses
+`ToolFamily` but not `build_manual_child`, because its manual ships inside its
+own package rather than the agent's installed `.library` catalog — adopting
+part of the infrastructure is conforming. Using it is never required — see its
+own
 `src/lingtai/tools/tool_family/CONTRACT.md` "Implementation independence" is
 binding on it exactly as it is on every family.
 
@@ -291,6 +312,17 @@ action-owned `settings/web.search.json` surface (see
 `src/lingtai/tools/web_search/CONTRACT.md` Contract tests). They remain one
 family's local evidence, not a conformance suite, and no such suite is required
 to exist.
+
+`tests/test_tool_family_avatar_migration.py` is `avatar`'s own local evidence
+for the same rules, chosen for that family's risk: the closed root, per-action
+child inputs, root `allOf` correlation surviving both wires, cross-action and
+unknown-root-field rejection *before* any handler I/O, `summarize` never
+reaching a child handler and `avatar` actually being on the kernel allowlist,
+the preserved unknown-action envelope, spawn's dry-run/mission-guard/identity
+and path validation, the karma gate and distribution for `rules`, and `manual`
+performing no spawn or rules I/O. Every test there builds its own isolated
+temporary network and fakes the launcher Port, so it neither creates a live
+avatar nor writes a live `.rules` signal.
 
 ## Maintenance
 

--- a/src/lingtai/tools/avatar/ANATOMY.md
+++ b/src/lingtai/tools/avatar/ANATOMY.md
@@ -8,7 +8,9 @@ related_files:
   - src/lingtai/adapters/posix/ANATOMY.md
   - src/lingtai/adapters/posix/avatar_launcher.py
   - src/lingtai/tools/avatar/manual/SKILL.md
+  - src/lingtai/tools/tool_family/ANATOMY.md
   - tests/test_avatar_rules.py
+  - tests/test_tool_family_avatar_migration.py
   - src/lingtai/tools/avatar/glossary-en.md
   - src/lingtai/tools/avatar/glossary-zh.md
   - src/lingtai/tools/avatar/glossary-wen.md
@@ -42,37 +44,60 @@ independent life — its existence does not depend on yours.
 
 ## Public API
 
-The capability exposes one public tool, `avatar`, dispatched by an `action`
-enum:
+The capability exposes one public tool, `avatar`, an LTP v2 action-separated
+family (`src/lingtai/tools/CONTRACT.md`) whose actions are canonical children:
 
-| Action | Description |
-|------|-------------|
-| `spawn` | Spawn a new avatar agent (shallow or deep) with a given name, optional type, and optional comment. Accepts `dry_run` (preview-only) and `confirm` (acknowledge mission-quality gate). |
-| `rules` | Set rules content and distribute via `.rules` signal files to self + all descendants. |
-| `manual` | Read-only: returns the exact `manual/SKILL.md` body. No mutation. |
+| Action | Own strict `input` | Description |
+|------|------|-------------|
+| `spawn` | `name`, `type`, `comment`, `dry_run`, `confirm` | Spawn a new avatar agent (shallow or deep). `dry_run` previews only; `confirm` acknowledges the mission-quality gate. |
+| `rules` | `rules_content` | Set rules content and distribute via `.rules` signal files to self + all descendants. Karma-gated. |
+| `manual` | *(empty)* | Read-only: returns the exact `manual/SKILL.md` body plus its host-local `manual_path`. No spawn or rules I/O. |
 
-`action` has no default — it is required both by the schema
-(`"required": ["action"]`) and at runtime, matching the established action-tool
-convention already used by `knowledge`, `mcp`, `skills`, `notification`,
-`system`, `soul`, and `daemon`. Omitting `action` fails deterministically via
-the same `dispatch_action` unknown-action envelope as an unrecognized value;
-it never falls through to `spawn`.
+The model-facing root is exactly `action` + `input` + required `reasoning` +
+optional `summarize`, `additionalProperties: false`. Each action owns exactly
+its own fields, so a key from another action's branch is rejected *before* any
+handler I/O. The child canonical name equals the public action value equals the
+dispatch key — there is no mapping layer.
 
-`avatar` uses a single plain top-level `type: object` schema with an explicit
-`action` enum, not a top-level `allOf`/`oneOf` combinator — some
-OpenAI-compatible strict tool validators reject top-level JSON Schema
-combinators. Action-specific required inputs beyond `action` itself (`name`
-for spawn, `rules_content` for rules) are validated in the handler, not the
-schema.
+`action` has no default — it is required both by the schema and at runtime,
+matching the established action-tool convention already used by `knowledge`,
+`mcp`, `skills`, `notification`, `system`, `soul`, and `daemon`. Omitting
+`action` fails deterministically with avatar's own pinned unknown-action
+envelope; it never falls through to `spawn`.
+
+**Mission brief.** The spawn mission is root `reasoning` (normalized to
+`_reasoning` by ToolExecutor), never an `input` property — nested `input` must
+never carry `reasoning`/`_reasoning`/`summarize`. `handle()` captures it from
+the envelope and hands it to `_spawn` out-of-band, clearing it in `finally` so
+no later call can inherit a previous call's mission.
+
+Schema composition and envelope dispatch are delegated to the generic, optional
+`tool_family` infrastructure (`../tool_family/ANATOMY.md`); `handle()` is
+retained as avatar's own outer layer solely to normalize the generic
+`ACTION_REQUIRED` envelope failure back to avatar's exact pinned
+unknown-action error string.
 
 ## Internal Module Layout
 
 ```
 avatar/__init__.py
-  ├── AvatarManager.__init__        — stores parent agent ref
-  ├── handle()                      — public dispatcher for the avatar tool
-  │                                    (action: spawn | rules | manual)
+  ├── _SPAWN/_RULES_INPUT_SCHEMA    — canonical strict per-action inputs
+  │                                    (manual reuses the generic
+  │                                    tool_family.manual.MANUAL_INPUT_SCHEMA)
+  ├── _CHILD_SPECS                  — the one (action, schema) source both
+  │                                    family listings are built from
+  ├── _build_family() / _FAMILY     — import-time registry validation;
+  │                                    get_schema() composes from _FAMILY
+  ├── AvatarManager.__init__        — parent agent ref + per-instance ToolFamily
+  ├── handle()                      — envelope entry: captures root _reasoning,
+  │                                    delegates to ToolFamily.handle(), then
+  │                                    normalizes ACTION_REQUIRED back to
+  │                                    avatar's pinned unknown-action error
+  ├── _dispatch_spawn/_rules/_manual — child handlers; strip nulls, thread
+  │                                    the mission brief to _spawn
+  ├── _strip_nulls()                — nullable-optional → absent
   ├── _manual()                     — reads the packaged manual/SKILL.md body
+  │                                    and reports its host-local path
   │
   │  Spawn pipeline:
   ├── _spawn()                      — validates name, checks liveness, prepares working dir, launches process
@@ -116,7 +141,7 @@ avatar/__init__.py
 
 - **Parent:** `src/lingtai/tools/` (tool package).
 - **Siblings:** `daemon/`, `mcp/`, `knowledge/` (private durable memory), `skills/` (skill catalog), `bash/`.
-- **Kernel hooks:** `setup()` is called during capability initialization; `AvatarManager.handle()` is registered as the single `avatar` tool handler, internally dispatching `spawn`/`rules`/`manual` via `lingtai.kernel.tool_dispatch.dispatch_action`. The daemon capability blacklists `avatar` to prevent avatar-in-daemon recursion and rules mutation from emanations.
+- **Kernel hooks:** `setup()` is called during capability initialization; `AvatarManager.handle()` is registered as the single `avatar` tool handler, internally dispatching `spawn`/`rules`/`manual` through its own `tool_family.ToolFamily`. `avatar` is on the kernel's `_LTP_V2_MIGRATED_FAMILIES` allowlist (`src/lingtai/kernel/tool_result_summary.py`), so the root `summarize` boolean it advertises is actually honored by the single central summarizer. The daemon capability blacklists `avatar` to prevent avatar-in-daemon recursion and rules mutation from emanations.
 
 Platform process mechanics are in `adapters/avatar_launcher.py` and the
 POSIX reference adapter. Unsupported Windows selection fails loudly; a future

--- a/src/lingtai/tools/avatar/CONTRACT.md
+++ b/src/lingtai/tools/avatar/CONTRACT.md
@@ -1,7 +1,7 @@
 ---
 name: avatar-contract
 tool: avatar
-contract_version: 3
+contract_version: 4
 related_files:
   - src/lingtai/tools/avatar/__init__.py
   - src/lingtai/tools/avatar/_launcher.py
@@ -10,6 +10,10 @@ related_files:
   - src/lingtai/adapters/avatar_launcher.py
   - src/lingtai/adapters/posix/avatar_launcher.py
   - src/lingtai/adapters/windows/avatar_launcher.py
+  - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/tool_family/CONTRACT.md
+  - src/lingtai/kernel/tool_result_summary.py
+  - tests/test_tool_family_avatar_migration.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -35,9 +39,42 @@ defaults to `spawn`. This aligns `avatar` with the established action-tool
 contract already followed by `knowledge`, `mcp`, `skills`, `notification`,
 `system`, `soul`, and `daemon`: every action tool in this repository requires
 an explicit `action`, with no implicit default action. A missing `action`
-returns the same deterministic `dispatch_action` unknown-action error envelope
-as any other unrecognized action value, and performs no spawn, rules, or
-manual side effect.
+returns the same deterministic unknown-action error envelope as any other
+unrecognized action value, and performs no spawn, rules, or manual side effect.
+
+**contract_version 4** (breaking): `avatar` is migrated to the LTP v2
+action-separated envelope (`src/lingtai/tools/CONTRACT.md`). The former flat
+property bag is gone: action-specific fields now live inside a strict, closed
+per-action `input` object, and the model-facing root is exactly `action`,
+`input`, required `reasoning`, and optional `summarize`, with
+`additionalProperties: false`.
+
+- Public tool name and action values are **unchanged**: `avatar` with
+  `spawn | rules | manual`.
+- `spawn` owns `name`, `type`, `comment`, `dry_run`, `confirm`. `rules` owns
+  `rules_content`. `manual` has strict empty input. A key belonging to another
+  action's branch, an unknown root field, a non-boolean `summarize`, or a
+  missing/non-object `input` is rejected **before any handler I/O** with the
+  generic typed failure (`{"status": "failed", "error_code":
+  "INVALID_ARGUMENT", ...}`), performing no spawn, ledger, `.rules`, or process
+  side effect. Previously an unrecognized extra key (e.g. the retired `dir`)
+  was silently ignored; it now fails loudly.
+- The spawn mission brief remains root `reasoning` (injected as `_reasoning`),
+  **not** an `input` property, and is captured per call — it never leaks from
+  one call into the next.
+- The unknown/omitted-`action` error envelope is **preserved exactly** (see
+  §Invalid or missing `action`).
+- `manual`'s result gains `manual_path` (the host-local packaged resource
+  path) alongside the unchanged `status`, `action`, and exact `manual` body.
+- `avatar` joins the kernel's `_LTP_V2_MIGRATED_FAMILIES` allowlist so the
+  root `summarize` boolean it advertises is honored by the single central
+  summarizer rather than silently ignored.
+
+Schema composition and envelope dispatch are delegated to the optional generic
+`src/lingtai/tools/tool_family/` infrastructure. That is an implementation
+choice, not a contract requirement: per that package's "Implementation
+independence" rule, avatar could hand-write an equivalent `handle()` without
+changing any promise in this file.
 
 ## Routing Card
 
@@ -59,14 +96,19 @@ storage; detached-process launch -> §Cross-platform invariants.
 
 ## Scope
 
-- Canonical tool name: `avatar`. It is registered as a single tool with a plain
-  top-level object schema (deliberately no `allOf`/`oneOf` combinator, which
-  some strict OpenAI-compatible validators reject) and an explicit `action`
-  enum (`spawn` | `rules` | `manual`). `action` is schema-required
-  (`"required": ["action"]`) — the same convention as `knowledge`, `mcp`,
-  `skills`, `notification`, `system`, `soul`, and `daemon`. Action-specific
-  required inputs beyond `action` itself (`name` for spawn, `rules_content`
-  for rules) are validated in the handler, not the schema.
+- Canonical tool name: `avatar`. It is registered as a single model-facing tool
+  whose root property set is exactly `action`, `input`, `reasoning`, and
+  `summarize`, with `additionalProperties: false` and
+  `required: ["action", "input", "reasoning"]`. `action` is the enum
+  (`spawn` | `rules` | `manual`) — schema-required, the same convention as
+  `knowledge`, `mcp`, `skills`, `notification`, `system`, `soul`, and `daemon`.
+  Each action's own strict, closed `input` schema is exposed to the model
+  before invocation two ways, both generated from the one child registry: an
+  `input.oneOf` disclosure branch per action, and one root `allOf`/`if`/`then`
+  condition per action correlating that action's `const` with that exact input
+  shape. Dispatch re-validates independently and is always authoritative.
+- Action-specific required inputs (`name` for spawn, `rules_content` for rules)
+  are enforced both by the child schema and again in the handler.
 - `action="spawn"` (must be passed explicitly — there is no default action)
   creates a sibling agent directory named after the avatar and launches it via
   the global venv. Shallow copies only `init.json` (no identity/pad/history);
@@ -75,8 +117,13 @@ storage; detached-process launch -> §Cross-platform invariants.
   so each agent refreshes its own `system/rules.md`-derived prompt. It carries
   its own admin gate, independent of `spawn` — spawning never requires admin.
 - `action="manual"` is read-only: it returns the exact packaged
-  `src/lingtai/tools/avatar/manual/SKILL.md` body and performs no filesystem
-  mutation (no spawn, no ledger write, no `.rules` write).
+  `src/lingtai/tools/avatar/manual/SKILL.md` body plus its host-local
+  `manual_path`, and performs no filesystem mutation (no spawn, no ledger
+  write, no `.rules` write). Avatar's manual ships inside this package rather
+  than being installed into the agent's `.library` intrinsic catalog, so this
+  action owns its own loader instead of the shared
+  `load_installed_manual`/`build_manual_child` pair — that builder would
+  report a `.library` path this family never reads.
 
 **Non-goals:** the parent holds no in-process handle to the avatar — liveness is
 checked purely via the filesystem handshake. The tool does not manage the
@@ -84,14 +131,32 @@ avatar's ongoing lifecycle after boot (mail/system intrinsics do that).
 
 ## Tool surface
 
+### Envelope
+
+Every call is `avatar(action=..., input={...}, reasoning="...", summarize?=bool)`.
+
+| Root field | Required | Meaning |
+|---|---|---|
+| `action` | yes | One of `spawn` \| `rules` \| `manual`. No default. |
+| `input` | yes | The selected action's own strict, closed object. |
+| `reasoning` | yes | Cross-cutting rationale. For `spawn` this **is** the mission brief and becomes the avatar's first prompt. Never an `input` property. |
+| `summarize` | no | Root-only result post-processing control, absent/false by default. Never action input, never reaches a handler. |
+
+Rejected before any handler I/O, with no spawn/ledger/`.rules`/process side
+effect: an unknown `action` (see below), a missing or non-object `input`, an
+unknown root field, a non-boolean `summarize`, and any `input` key belonging to
+another action's branch (`{"status": "failed", "error_code":
+"INVALID_ARGUMENT", "message": "unsupported avatar input field"}`).
+
 ### `avatar` — `action="spawn"`
 
-Requires `name`. The mission/task brief arrives via the injected `_reasoning`
-field (becomes the avatar's first prompt), not a schema property.
+`input` owns exactly `name`, `type`, `comment`, `dry_run`, `confirm`. The
+mission/task brief is root `reasoning` (injected as `_reasoning`), not an
+`input` property, and is scoped to the single call that carried it.
 
-| Inputs | Optional inputs | Success output | Error / gate shapes |
+| Input | Optional input | Success output | Error / gate shapes |
 |---|---|---|---|
-| `name` (required) | `type` (`shallow`\|`deep`, default `shallow`), `comment`, `dry_run`, `confirm` | `{status: "ok", address, agent_name, type, pid, warning?}` (`warning` when boot is `slow`) | `{error: ...}` — missing/invalid name, bad type, missing parent `init.json`, path escapes network root, dir exists, or boot `failed` (with stderr tail); `{status: "confirmation_needed", warning, reason, preview}` on the mission-quality gate; `{status: "already_active", working_dir, message}` if a live peer of that name exists; `{status: "dry_run", preview, message}` when `dry_run=true` |
+| `name` (required) | `type` (`shallow`\|`deep`, default `shallow`), `comment`, `dry_run`, `confirm` — nullable; null means absent | `{status: "ok", address, agent_name, type, pid, warning?}` (`warning` when boot is `slow`) | `{error: ...}` — missing/invalid name, bad type, missing parent `init.json`, path escapes network root, dir exists, or boot `failed` (with stderr tail); `{status: "confirmation_needed", warning, reason, preview}` on the mission-quality gate; `{status: "already_active", working_dir, message}` if a live peer of that name exists; `{status: "dry_run", preview, message}` when `dry_run=true` |
 
 The mission-quality gate refuses empty / very short (<20 chars) / debug-placeholder
 missions unless `confirm=true`; `dry_run` is exempt. Avatar names must match
@@ -100,20 +165,29 @@ slash, or leading `.` — the name doubles as the working-dir basename.
 
 ### `avatar` — `action="rules"`
 
-| Inputs | Optional inputs | Success output | Error shapes |
+`input` owns exactly `rules_content`. A `spawn`-branch key (e.g. `name`,
+`dry_run`) in this action's `input` is rejected before the authorization check
+and before any write.
+
+| Input | Optional input | Success output | Error shapes |
 |---|---|---|---|
 | `rules_content` (required) | — | `{status: "ok", message, distributed_to: [...]}` | `{error: ...}` — empty `rules_content`, no admin privilege, or failure writing the self `.rules` signal |
 
-`action="rules"` requires at least one truthy admin privilege on the caller.
-This gate applies only to `rules`; `spawn` never checks admin.
+`action="rules"` requires at least one truthy admin privilege (karma) on the
+caller. This gate applies only to `rules`; `spawn` never checks admin. The
+family must not hide this stronger action behind a weaker family posture.
 
 ### `avatar` — `action="manual"`
 
-No inputs consumed beyond `action`.
+Strict empty `input` (`{}`); any field is rejected. Performs no spawn or rules
+I/O of any kind.
 
-| Inputs | Optional inputs | Success output | Error shapes |
+| Input | Optional input | Success output | Error shapes |
 |---|---|---|---|
-| — | — | `{status: "ok", action: "manual", manual: <exact SKILL.md body>}` | `{status: "degraded", action: "manual", manual: "", error: ...}` if the packaged manual file is missing |
+| `{}` | — | `{status: "ok", action: "manual", manual: <exact SKILL.md body>, manual_path: <host-local packaged path>}` | `{status: "degraded", action: "manual", manual: "", manual_path: ..., error: "avatar manual missing"}` if the packaged manual file is missing |
+
+The result is avatar's own canonical shape, returned verbatim — it is never
+nested inside another action's result envelope and never double-wrapped.
 
 ### Invalid or missing `action`
 
@@ -124,6 +198,12 @@ omitted `action` key — returns
 ledger, `.rules`, or launching any process. There is no default action: a
 `name`- or `rules_content`-shaped payload with `action` omitted still fails
 this way rather than being inferred as `spawn` or `rules`.
+
+This exact envelope is a pinned public promise that predates the LTP v2
+migration. The generic dispatcher's own `ACTION_REQUIRED` failure shape is
+deliberately generic, so `AvatarManager.handle()` normalizes it back to the
+string above strictly *after* dispatch returns — never by changing the generic
+dispatcher's canonical error shape.
 
 ## State & storage
 
@@ -212,7 +292,7 @@ live descendant.
 | `_prepare_deep` refuses a non-sibling destination | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::test_prepare_deep_refuses_non_sibling_dst` |
 | `action="manual"` returns the exact packaged manual body and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` |
 | Invalid `action` fails deterministically without touching other actions | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_invalid_action_fails_deterministically`, `::test_spawn_missing_name_fails_without_affecting_other_actions` |
-| `action` is schema-required (`required: ["action"]`) and runtime-required — a missing `action` never defaults to `spawn`, `rules`, or `manual`, regardless of which action's fields are present, and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_omitted_action_fails_deterministically_and_does_not_default_to_spawn`, `::test_missing_action_fails_deterministically_regardless_of_payload_shape`; `tests/test_avatar_rules.py::TestAvatarRulesAction::test_explicit_spawn_action_required` |
+| `action` is schema-required (root `required: ["action", "input", "reasoning"]`) and runtime-required — a missing `action` never defaults to `spawn`, `rules`, or `manual`, regardless of which action's fields are present, and mutates nothing | `src/lingtai/tools/avatar/__init__.py` | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_omitted_action_fails_deterministically_and_does_not_default_to_spawn`, `::test_missing_action_fails_deterministically_regardless_of_payload_shape`; `tests/test_avatar_rules.py::TestAvatarRulesAction::test_explicit_spawn_action_required` |
 | The daemon blacklists the canonical `avatar` name (not the retired two-tool names) | `src/lingtai/tools/daemon/__init__.py` | `tests/test_daemon.py::test_build_tool_surface_blacklist`, `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_daemon_excludes_avatar_from_child_surface` |
 
 ## Verification matrix
@@ -221,17 +301,20 @@ live descendant.
 |---|---|---|---|
 | Exactly one tool registers on setup | `tests/test_layers_avatar.py::test_setup_avatar` | Boot with `capabilities={"avatar": {}}` and inspect tools | Rules distribution or spawning silently unavailable |
 | Spawn is ledgered with boot status | `tests/test_layers_avatar.py::test_ledger_records_spawn` | Spawn an avatar, inspect `delegates/ledger.jsonl` | No audit trail; duplicate/liveness checks break |
-| Mission gate stops accidental spawns | `tests/test_layers_avatar.py::test_helper_rejects_short` | `avatar(action="spawn", name="x")` with a 5-char mission, confirm gate | Stray detached processes from batched calls |
+| Mission gate stops accidental spawns | `tests/test_layers_avatar.py::test_helper_rejects_short` | `avatar(action="spawn", input={"name": "x"}, reasoning="short")` with a 5-char mission, confirm gate | Stray detached processes from batched calls |
 | Name validation / path-scope guard holds | `tests/test_layers_avatar.py::test_spawn_rejects_unsafe_name` | Spawn with `name="../x"`, confirm refusal | Avatar dir escapes the network root |
 | Boot verification catches early child exit | `tests/test_avatar_launcher.py::test_manager_boot_policy_uses_opaque_port_and_preserves_precedence` | Corrupt an avatar `init.json`, spawn, confirm `failed` + stderr | Parent thinks a crashed avatar is alive |
-| Omitted `action` never defaults to spawn | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_omitted_action_fails_deterministically_and_does_not_default_to_spawn` | Call `avatar(name="x", confirm=true)` with no `action`, confirm error + no spawned process | A model omitting `action` could accidentally spawn an untracked process |
+| Omitted `action` never defaults to spawn | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_omitted_action_fails_deterministically_and_does_not_default_to_spawn` | Call `avatar(input={"name": "x", "confirm": true}, reasoning="...")` with no `action`, confirm error + no spawned process | A model omitting `action` could accidentally spawn an untracked process |
 | Rules propagate to the whole subtree | `tests/test_avatar_rules.py::test_rules_distributes_recursively` | Set rules on a root, confirm `.rules` on each descendant | Descendants run stale/ungoverned rules |
-| `manual` action is read-only | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` | Call `avatar(action="manual")`, confirm no new files | A "manual" call could accidentally spawn or mutate rules |
+| `manual` action is read-only | `tests/test_layers_avatar.py::TestUnifiedAvatarTool::test_manual_returns_exact_body_and_performs_no_mutation` | Call `avatar(action="manual", input={}, reasoning="...")`, confirm no new files | A "manual" call could accidentally spawn or mutate rules |
 
 Run before merging avatar changes:
 
 ```bash
-python -m pytest tests/test_avatar_launcher.py tests/test_layers_avatar.py tests/test_avatar_rules.py tests/test_avatar_preset_inheritance.py tests/test_avatar_timezone_inheritance.py -q
+python -m pytest tests/test_avatar_launcher.py tests/test_layers_avatar.py \
+  tests/test_avatar_rules.py tests/test_avatar_preset_inheritance.py \
+  tests/test_avatar_timezone_inheritance.py \
+  tests/test_tool_family_avatar_migration.py -q
 ```
 
 ## Schema and glossary ownership

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -15,12 +15,15 @@ The avatar is an independent life — its existence does not depend on yours.
 Maintains an append-only ledger (delegates/ledger.jsonl) that records
 every spawn event.
 
-Usage:
+Usage (LTP v2 envelope — one action, one strict child input):
     Agent(capabilities=["avatar"])
-    # avatar(action="spawn", name="researcher")              — shallow (初生)
-    # avatar(action="spawn", name="clone", type="deep")      — deep (二重身)
-    # avatar(action="rules", rules_content="...")            — distribute rules
-    # avatar(action="manual")                                — read the avatar manual
+    # avatar(action="spawn", input={"name": "researcher"}, reasoning="...")
+    # avatar(action="spawn", input={"name": "clone", "type": "deep"}, reasoning="...")
+    # avatar(action="rules", input={"rules_content": "..."}, reasoning="...")
+    # avatar(action="manual", input={}, reasoning="...")
+
+The spawn mission brief is root ``reasoning`` (normalized to ``_reasoning`` by
+ToolExecutor), never an ``input`` property — see ``handle()``.
 """
 from __future__ import annotations
 
@@ -32,11 +35,12 @@ import sys
 import time
 from importlib import resources
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Mapping
 
 from lingtai.kernel.agent_presence import observe_alive as _presence_observe_alive
 from lingtai.kernel.i18n import t
-from lingtai.kernel.tool_dispatch import dispatch_action
+from ..tool_family import ChildTool, ToolFamily
+from ..tool_family.manual import MANUAL_INPUT_SCHEMA
 from ._launcher import AvatarLaunchReceipt, AvatarLaunchRequest, AvatarLauncherPort
 
 
@@ -95,69 +99,129 @@ if TYPE_CHECKING:
 
 PROVIDERS = {"providers": [], "default": "builtin"}
 
+# Canonical, strict per-action input schemas. Optionals are expressed as
+# nullable required properties because that is what strict OpenAI-style
+# validators demand of a closed object; null means "absent" to the action
+# implementations (see ``_strip_nulls``).
+#
+# The spawn mission brief is deliberately NOT a property here: it is root
+# ``reasoning``, and nested ``input`` must never carry
+# ``reasoning``/``_reasoning``/``summarize``.
+_SPAWN_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": (
+                "True name for the avatar. Also the working-directory basename "
+                "under .lingtai/. Single segment: letters/digits/underscore/"
+                "hyphen, max 64 chars."
+            ),
+        },
+        "type": {
+            "type": ["string", "null"],
+            "enum": ["shallow", "deep", None],
+            "description": (
+                "'shallow' (default): blank slate — init.json only. 'deep': "
+                "full copy of character, pad, and codex. Null for the default."
+            ),
+        },
+        "comment": {
+            "type": ["string", "null"],
+            "description": (
+                "Persistent system note in the avatar's prompt (survives molt/"
+                "refresh/wake). Not inherited. Null or empty unless you have "
+                "something the avatar must never forget."
+            ),
+        },
+        "dry_run": {
+            "type": ["boolean", "null"],
+            "description": (
+                "Preview the spawn without creating a process. Use to "
+                "sanity-check before committing. Null for the default false."
+            ),
+        },
+        "confirm": {
+            "type": ["boolean", "null"],
+            "description": (
+                "Confirm you have reviewed the mission and intend to spawn. "
+                "Required when the mission looks empty/short/test-like. Null "
+                "for the default false."
+            ),
+        },
+    },
+    "required": ["name", "type", "comment", "dry_run", "confirm"],
+    "additionalProperties": False,
+}
+
+_RULES_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rules_content": {
+            "type": "string",
+            "description": (
+                "Plain text, one rule per line. Non-negotiable constraints "
+                "distributed to self and all descendants. Requires karma."
+            ),
+        },
+    },
+    "required": ["rules_content"],
+    "additionalProperties": False,
+}
+
+# The one child spec: canonical action name → its own strict input schema, in
+# model-facing enum order. Both the module-level schema-only family and each
+# manager's handler-bound family are built from this single source by
+# ``_build_family`` below, so the two listings cannot drift apart.
+_CHILD_SPECS: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("spawn", _SPAWN_INPUT_SCHEMA),
+    ("rules", _RULES_INPUT_SCHEMA),
+    ("manual", MANUAL_INPUT_SCHEMA),
+)
+
+
+def _build_family(handlers: Mapping[str, Any]) -> ToolFamily:
+    """Build avatar's family, binding each spec'd action to *handlers[name]*.
+
+    Construction validates the registry, so a duplicate or reserved-name
+    collision raises ``ToolFamilyError`` here — at import time for ``_FAMILY``
+    — rather than shipping silently.
+    """
+    return ToolFamily(
+        "avatar",
+        [
+            ChildTool(name, schema, handlers[name], title=f"{name} input")
+            for name, schema in _CHILD_SPECS
+        ],
+    )
+
+
+def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
+    raise AssertionError("the module-level schema-only ToolFamily never dispatches")
+
+
+# Composes the model-facing schema only; ``AvatarManager`` builds its own
+# per-instance family with real handlers bound to that instance.
+_FAMILY = _build_family({name: _unused for name, _ in _CHILD_SPECS})
+
+
 def get_description(lang: str = "en") -> str:
     return (
         "Spawn an independent agent (他我), set network rules for descendants, "
         "or read the avatar manual. Requires an explicit action — no default. "
-        "action='spawn': inherits init.json, boots on default preset — requires "
-        "'name'. action='rules': distribute rules_content to self + all "
-        "descendants (requires karma). action='manual': return the "
+        "avatar(action='spawn', input={'name': 'researcher', ...}, "
+        "reasoning='<the avatar's mission>'): inherits init.json, boots on "
+        "default preset; your reasoning becomes the avatar's first prompt. "
+        "avatar(action='rules', input={'rules_content': '...'}, reasoning='...'): "
+        "distribute rules to self + all descendants (requires karma). "
+        "avatar(action='manual', input={}, reasoning='...'): return the "
         "avatar-manual skill body. See avatar-manual skill for full guidance."
     )
 
 
-def get_schema(lang: str = "en") -> dict:
-    """Schema for the single public ``avatar`` tool.
-
-    A plain top-level ``type: object`` with an explicit ``action`` enum —
-    deliberately no top-level ``allOf``/``oneOf`` combinator, which some
-    OpenAI-compatible strict tool validators reject. Action-specific required
-    inputs (``name`` for spawn, ``rules_content`` for rules) are validated in
-    the handler, not the schema, so all three actions share one flat property
-    bag.
-    """
-    return {
-        "type": "object",
-        "properties": {
-            "action": {
-                "type": "string",
-                "enum": ["spawn", "rules", "manual"],
-                "description": (
-                    "spawn: create a new avatar — requires 'name'. "
-                    "rules: distribute network rules to self + descendants — "
-                    "requires 'rules_content'. manual: return the avatar-manual "
-                    "skill body; no other inputs used. Required — no default."
-                ),
-            },
-            "name": {
-                "type": "string",
-                "description": 'True name for the avatar (required for action=spawn). Also the working-directory basename under .lingtai/. Single segment: letters/digits/underscore/hyphen, max 64 chars.',
-            },
-            "type": {
-                "type": "string",
-                "enum": ["shallow", "deep"],
-                "description": "'shallow' (default): blank slate — init.json only. 'deep': full copy of character, pad, and codex.",
-            },
-            "comment": {
-                "type": "string",
-                "description": "Persistent system note in the avatar's prompt (survives molt/refresh/wake). Not inherited. Leave empty unless you have something the avatar must never forget.",
-            },
-            "dry_run": {
-                "type": "boolean",
-                "description": 'Preview the spawn without creating a process. Use to sanity-check before committing.',
-            },
-            "confirm": {
-                "type": "boolean",
-                "description": 'Confirm you have reviewed the mission and intend to spawn. Required when the mission looks empty/short/test-like.',
-            },
-            "rules_content": {
-                "type": "string",
-                "description": 'Rules content for action=rules. Plain text, one rule per line. Non-negotiable constraints distributed to all descendants.',
-            },
-        },
-        "required": ["action"],
-    }
-
+def get_schema(lang: str = "en") -> dict[str, Any]:
+    """Compose the LTP v2 model-facing schema for the single public ``avatar`` tool."""
+    return _FAMILY.build_schema()
 
 
 class AvatarManager:
@@ -174,31 +238,93 @@ class AvatarManager:
             from lingtai.adapters.avatar_launcher import select_avatar_launcher
             launcher = select_avatar_launcher()
         self._launcher = launcher
+        # The spawn mission brief reaches ``_spawn`` out-of-band via
+        # ``self._pending_reasoning``, set by ``handle()`` (see ``handle``).
+        self._family = _build_family({
+            "spawn": self._dispatch_spawn,
+            "rules": self._dispatch_rules,
+            "manual": self._dispatch_manual,
+        })
+        self._pending_reasoning: str | None = None
 
     # ------------------------------------------------------------------
     # Handler
     # ------------------------------------------------------------------
 
-    def handle(self, args: dict) -> dict:
-        return dispatch_action(
-            args,
-            {
-                "spawn": self._spawn,
-                "rules": self._rules,
-                "manual": lambda _args: self._manual(),
-            },
-            unknown=lambda action: {
-                "error": f"unknown action: {action!r}, only 'spawn', 'rules', or 'manual' is supported",
-            },
-        )
+    def handle(self, args: dict | None) -> dict:
+        """Dispatch one action through the family, normalizing avatar's errors.
+
+        Root ``reasoning`` (normalized to ``_reasoning`` by ToolExecutor) is the
+        avatar's mission brief and becomes the newborn's first prompt. It is
+        envelope metadata, never action input, so it is captured here and handed
+        to ``_spawn`` out-of-band rather than smuggled into ``input``, and
+        cleared in ``finally`` so a later call cannot inherit a previous call's
+        mission.
+
+        Avatar's pre-migration unknown-action envelope is a pinned public
+        promise; the generic dispatcher's ``ACTION_REQUIRED`` shape is
+        deliberately generic, so it is normalized back here, after dispatch —
+        never by changing that dispatcher's own canonical error shape.
+        """
+        raw = args if isinstance(args, Mapping) else {}
+        reasoning = raw.get("_reasoning")
+        self._pending_reasoning = reasoning if isinstance(reasoning, str) else None
+        try:
+            result = self._family.handle(args)
+        finally:
+            self._pending_reasoning = None
+        if result.get("error_code") == "ACTION_REQUIRED":
+            action = raw.get("action", "")
+            return {
+                "error": (
+                    f"unknown action: {action!r}, only 'spawn', 'rules', or "
+                    f"'manual' is supported"
+                ),
+            }
+        return result
+
+    @staticmethod
+    def _strip_nulls(action_input: Mapping[str, Any]) -> dict[str, Any]:
+        # Strict OpenAI schemas express optional fields as required nullable
+        # properties. Null means absent to the internal action handlers, so
+        # every default below stays exactly the pre-migration default.
+        return {key: value for key, value in action_input.items() if value is not None}
+
+    def _dispatch_spawn(self, action_input: Mapping[str, Any]) -> dict:
+        return self._spawn(self._strip_nulls(action_input), self._pending_reasoning)
+
+    def _dispatch_rules(self, action_input: Mapping[str, Any]) -> dict:
+        return self._rules(self._strip_nulls(action_input))
+
+    def _dispatch_manual(self, _action_input: Mapping[str, Any]) -> dict:
+        return self._manual()
 
     def _manual(self) -> dict:
-        """Return the exact packaged avatar-manual body; performs no mutation."""
+        """Return the exact packaged avatar-manual body; performs no mutation.
+
+        Avatar's manual ships inside this package (``manual/SKILL.md``) rather
+        than in the agent's installed ``.library`` catalog, so this action owns
+        its own loader instead of the shared
+        ``load_installed_manual``/``build_manual_child`` pair — reusing that
+        builder here would report a ``.library`` path this family never reads.
+        """
+        resource = resources.files(__package__).joinpath("manual/SKILL.md")
         try:
-            body = resources.files(__package__).joinpath("manual/SKILL.md").read_text(encoding="utf-8")
-        except (FileNotFoundError, ModuleNotFoundError, AttributeError):
-            return {"status": "degraded", "action": "manual", "manual": "", "error": "avatar manual missing"}
-        return {"status": "ok", "action": "manual", "manual": body}
+            body = resource.read_text(encoding="utf-8")
+        except (FileNotFoundError, ModuleNotFoundError, AttributeError, OSError):
+            return {
+                "status": "degraded",
+                "action": "manual",
+                "manual": "",
+                "manual_path": str(resource),
+                "error": "avatar manual missing",
+            }
+        return {
+            "status": "ok",
+            "action": "manual",
+            "manual": body,
+            "manual_path": str(resource),
+        }
 
     # ------------------------------------------------------------------
     # Ledger (append-only JSONL log of avatar spawn events)
@@ -219,9 +345,11 @@ class AvatarManager:
     # Core spawn
     # ------------------------------------------------------------------
 
-    def _spawn(self, args: dict) -> dict:
+    def _spawn(self, args: dict, reasoning: str | None = None) -> dict:
+        """Create one avatar. ``reasoning`` is the mission brief from the root
+        envelope (``handle()``), not an ``input`` property — it becomes the
+        newborn's first prompt and gates the mission-quality check."""
         parent = self._agent
-        reasoning = args.get("_reasoning")
         peer_name = args.get("name")
         avatar_type = args.get("type", "shallow")
         dry_run = bool(args.get("dry_run", False))

--- a/src/lingtai/tools/avatar/glossary-wen.md
+++ b/src/lingtai/tools/avatar/glossary-wen.md
@@ -15,11 +15,14 @@ maintenance: |
 ---
 **名相对照**
 
-- `avatar`：唯一公开之器，以 `action` 分遣。详见 avatar-manual 技。
-- `action`：必填，无默认。`spawn`（化出独立他我，承 init.json，以默认预设启）｜`rules`（设网法以布一切后嗣，需 karma）｜`manual`（只读，还 avatar 手册全文）。
-- `name`：他我真名（action=spawn 时必填）。亦为 .lingtai/ 下目录之名。单段：字母/数/下划线/连字，至长六十四。
-- `type`：'shallow'（默认，初生）：白纸，仅 init.json。'deep'（二重身）：全拷灵台、简、典。
-- `comment`：他我提示之恒注（跨蜕/刷/眠不去）。不承自父。无事勿填。
-- `dry_run`：预览而不化。用于提交前省察。
-- `confirm`：确认已审任务且决意化。任务空/短/似试时必填。
-- `rules_content`：action=rules 所需法则之文。纯文每行一则。不可议之约束，布一切后嗣。
+- `avatar`：唯一公开之器，以 `action` 分遣，每遣各有严整自专之 `input`。详见 avatar-manual 技。
+- `action`：必填，无默认。`spawn`（化出独立他我，承 init.json，以默认预设启）｜`rules`（设网法以布一切后嗣，需 karma）｜`manual`（只读，还 avatar 手册全文及其 `manual_path`）。
+- `input`：必填，乃所遣一动作自专之严封之器。他遣分支之名，未及动手之先即斥。
+- `reasoning`：必填，居根，非动作之入。`action=spawn` 时即任务之书，为他我第一言。
+- `summarize`：可选，居根之布尔，默然为否。惟司果之后治，终不入动作之实。
+- `input.name`：他我真名（action=spawn 必填）。亦为 .lingtai/ 下目录之名。单段：字母/数/下划线/连字，至长六十四。
+- `input.type`：'shallow'（默认，初生）：白纸，仅 init.json。'deep'（二重身）：全拷灵台、简、典。
+- `input.comment`：他我提示之恒注（跨蜕/刷/眠不去）。不承自父。无事勿填。
+- `input.dry_run`：预览而不化。用于提交前省察。
+- `input.confirm`：确认已审任务且决意化。任务空/短/似试时必填。
+- `input.rules_content`：action=rules 所需法则之文。纯文每行一则。不可议之约束，布一切后嗣。

--- a/src/lingtai/tools/avatar/glossary-zh.md
+++ b/src/lingtai/tools/avatar/glossary-zh.md
@@ -15,11 +15,14 @@ maintenance: |
 ---
 **术语对照**
 
-- `avatar`：唯一公开工具，以 `action` 分派。详见 avatar-manual 技能。
-- `action`：必填，无默认值。`spawn`（化出独立他我，继承 init.json，用默认预设启动）｜`rules`（设置网络法则并分发给所有后代，需 karma）｜`manual`（只读，返回 avatar 手册全文）。
-- `name`：他我之真名（action=spawn 时必填）。兼作 .lingtai/ 下目录名。单段：字母/数字/下划线/连字符，最长64字。
-- `type`：'shallow'（默认，初生）：白纸，仅 init.json。'deep'（二重身）：完整复制灵台、简、典。
-- `comment`：写入他我系统提示之持久注解（跨凝蜕/刷新/休眠不变）。不承自父。非必要勿填。
-- `dry_run`：预览化出而不生进程。用于提交前审查。
-- `confirm`：确认已审阅任务并决意化出。任务空白/过短/似试时必填。
-- `rules_content`：action=rules 所需之法则内容。纯文，每行一则。不可协商之约束，分发一切后代。
+- `avatar`：唯一公开工具，以 `action` 分派，每个动作各有严格独立的 `input`。详见 avatar-manual 技能。
+- `action`：必填，无默认值。`spawn`（化出独立他我，继承 init.json，用默认预设启动）｜`rules`（设置网络法则并分发给所有后代，需 karma）｜`manual`（只读，返回 avatar 手册全文及其 `manual_path`）。
+- `input`：必填，为所选 `action` 独有之严格封闭对象。属于他动作分支之字段一律在任何写入前拒斥。
+- `reasoning`：必填，根层字段，非动作输入。`action=spawn` 时即为任务书，成为他我第一道提示。
+- `summarize`：可选，根层布尔，默认为否。仅作结果后处理之开关，永不传入动作实现。
+- `input.name`：他我之真名（action=spawn 必填）。兼作 .lingtai/ 下目录名。单段：字母/数字/下划线/连字符，最长64字。
+- `input.type`：'shallow'（默认，初生）：白纸，仅 init.json。'deep'（二重身）：完整复制灵台、简、典。
+- `input.comment`：写入他我系统提示之持久注解（跨凝蜕/刷新/休眠不变）。不承自父。非必要勿填。
+- `input.dry_run`：预览化出而不生进程。用于提交前审查。
+- `input.confirm`：确认已审阅任务并决意化出。任务空白/过短/似试时必填。
+- `input.rules_content`：action=rules 所需之法则内容。纯文，每行一则。不可协商之约束，分发一切后代。

--- a/src/lingtai/tools/avatar/manual/SKILL.md
+++ b/src/lingtai/tools/avatar/manual/SKILL.md
@@ -2,17 +2,47 @@
 name: avatar-manual
 description: |
   Complete operational guide for the avatar tool — spawning, managing, and communicating with 他我 (alter-ego agents). Read this when: you are about to spawn an avatar; an avatar you spawned goes quiet; you need to decide between avatar, daemon, or bash; or you are an avatar and need to know how to escalate to your parent. Covers spawn types, naming rules, discipline, escalation protocol, and the parent_prompt contract.
-version: 1.0.0
-last_changed_at: 2026-07-19T00:00:00Z
+version: 1.1.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/avatar/__init__.py
 - src/lingtai/tools/avatar/ANATOMY.md
 - src/lingtai/tools/avatar/CONTRACT.md
+- src/lingtai/tools/CONTRACT.md
 maintenance: |
   Tracks the routed source/resources it summarizes; update when the underlying capability or its sub-references change.
 ---
 
 # Avatar Manual
+
+## 0. How to Call `avatar`
+
+One tool, three actions, each with its own strict `input` object:
+
+```
+avatar(action="spawn",  input={"name": "researcher"},        reasoning="<mission briefing>")
+avatar(action="spawn",  input={"name": "clone", "type": "deep"}, reasoning="<mission briefing>")
+avatar(action="rules",  input={"rules_content": "..."},      reasoning="why these rules")
+avatar(action="manual", input={},                            reasoning="load avatar guidance")
+```
+
+- `action` is **required** — there is no default. Omitting it never spawns.
+- `input` is **required** and closed. `spawn` owns `name`, `type`, `comment`,
+  `dry_run`, `confirm`; `rules` owns `rules_content`; `manual` takes `{}`.
+  Putting one action's field in another's `input` is rejected before anything
+  happens — no process, no ledger entry, no `.rules` write.
+- `reasoning` is **required** and lives at the root, never inside `input`. For
+  `spawn` it *is* the mission briefing (see §4).
+
+**Settings:** `avatar` has no settings file at either the family or action
+level. There is nothing to configure on disk.
+
+**`summarize` (short-result profile).** Every action here returns a small
+result — a spawn receipt, a distribution list, or a manual body you asked for
+verbatim. `summarize` is available but normally unnecessary: leave it false.
+Keep it false for `manual` in particular, so exact procedure and constraints
+are not summarized away, and for `spawn`, whose receipt carries the address,
+`agent_name`, and `pid` you need exactly.
 
 ## 1. What Is an Avatar
 
@@ -42,7 +72,7 @@ and `bash` for one-off commands. The full body-selection model lives in
 
 ## 3. Naming Rules
 
-The `name` field (required) doubles as the avatar's working-directory basename under `.lingtai/`. Constraints:
+The `input.name` field (required for `spawn`) doubles as the avatar's working-directory basename under `.lingtai/`. Constraints:
 
 - Single bare segment: letters (any script), digits, underscore, hyphen only
 - No slashes, no dots, no spaces, no leading `.`
@@ -52,7 +82,7 @@ The avatar's display name (nickname) can be set separately via `psyche(name, nic
 
 ## 4. The `reasoning` Field — Mission Briefing
 
-The `reasoning` parameter you write on the `avatar(action="spawn")` call **automatically becomes the avatar's first prompt**. Write it as a thorough mission briefing, not just a one-liner rationale. Include:
+The root `reasoning` parameter you write on the `avatar(action="spawn", input={...})` call **automatically becomes the avatar's first prompt**. It is a root envelope field, never part of `input`. Write it as a thorough mission briefing, not just a one-liner rationale. Include:
 
 - What the task is
 - Why it matters
@@ -65,13 +95,13 @@ This is the most important part of the spawn. A vague briefing produces a confus
 
 ## 5. Spawn Discipline
 
-Every `avatar(action="spawn")` call creates an independent process that consumes resources until `system(sleep)` or `system(suspend)`. Treat spawns as expensive:
+Every `avatar(action="spawn", ...)` call creates an independent process that consumes resources until `system(sleep)` or `system(suspend)`. Treat spawns as expensive:
 
-1. **Never include `avatar(action="spawn")` in a parallel batch** with unrelated tool calls.
+1. **Never include `avatar(action="spawn", ...)` in a parallel batch** with unrelated tool calls.
 2. **Re-read your `reasoning` field before invoking** (§4).
 3. **For inspection or one-off commands, use `bash` or `system`** — not `avatar`.
-4. **Use `dry_run=true` to preview** a spawn without creating a process. Sanity-check the name, type, working directory, and mission before committing.
-5. **Use `confirm=true`** to acknowledge you have double-checked the mission and intend to spawn. Required when the mission looks empty/very short/test-like.
+4. **Use `input={"name": ..., "dry_run": true}` to preview** a spawn without creating a process. Sanity-check the name, type, working directory, and mission before committing.
+5. **Use `input={"name": ..., "confirm": true}`** to acknowledge you have double-checked the mission and intend to spawn. Required when the mission looks empty/very short/test-like.
 
 ## 6. Caring for Avatars After Spawn
 
@@ -111,7 +141,7 @@ If you are an avatar (your `admin` block is empty or all admin privileges are fa
 
 ## 8. The `comment` Field — Persistent System Note
 
-The `comment` parameter is a persistent system-level note injected into the avatar's system prompt (rendered last, after memory). Key properties:
+The `input.comment` field (spawn only) is a persistent system-level note injected into the avatar's system prompt (rendered last, after memory). Key properties:
 
 - **Not inherited from parent** — defaults to empty
 - **Survives everything**: molt, refresh, sleep/wake
@@ -119,7 +149,7 @@ The `comment` parameter is a persistent system-level note injected into the avat
 
 Leave empty unless you have something the avatar should never forget.
 
-## 9. Network Rules (`avatar(action="rules")`)
+## 9. Network Rules (`avatar(action="rules", input={"rules_content": ...})`)
 
 The `rules` action writes a `.rules` file to your directory and distributes it to **all descendants** in the avatar tree. Properties:
 

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/tool_family/__init__.py
   - src/lingtai/tools/tool_family/manual.py
   - src/lingtai/tools/web_search/ANATOMY.md
+  - src/lingtai/tools/avatar/ANATOMY.md
 maintenance: |
   Keep related_files repo-relative, duplicate-free, and linked to real files.
   Keep this component's ANATOMY.md and CONTRACT.md reciprocal and keep
@@ -58,8 +59,10 @@ this package too — using it is optional, not mandatory).
   dispatches back verbatim, once the returned `ChildTool` is registered
   directly and unwrapped in a family's own `ToolFamily`) is the canonical
   `content[0].text` (full body) / `structuredContent.manual_path` (host-local
-  path) shape, with `status`/`error` loader facts preserved truthfully
-  (`manual.py:1-74`).
+  path) shape, with `status`/`error` loader facts preserved truthfully. It also
+  exports `MANUAL_INPUT_SCHEMA`, the canonical strict-empty `manual` input this
+  builder uses and a family supplying its own `manual` child can reference
+  instead of restating the literal — `avatar` does (`manual.py`).
 
 ## Connections
 
@@ -82,6 +85,23 @@ diagnostic onto any envelope-level failure result, since a generic
 `ToolFamily` has no knowledge of a specific family's settings diagnostics.
 This division follows `../CONTRACT.md` "Implementation independence": using
 `ToolFamily.handle()` is `web`'s choice, not an inherited requirement.
+
+`avatar/__init__.py` ([`../avatar/ANATOMY.md`](../avatar/ANATOMY.md)) is the
+second real consumer, and shows partial adoption is conforming: it reuses
+`ChildTool`/`ToolFamily` and the exported `MANUAL_INPUT_SCHEMA` for
+`spawn`/`rules`/`manual` schema composition and dispatch — deriving both its
+schema-only and handler-bound child listings from one `_CHILD_SPECS`
+`(action, schema)` source via its own `_build_family`, so they cannot drift
+apart — but supplies its **own** `manual` handler rather than
+`manual.build_manual_child`, because its manual ships inside its own package
+instead of the agent's installed `.library` catalog. `ToolFamily.handle()`
+returns that child's own canonical flat result verbatim — no double wrap, and
+no post-dispatch adaptation of a manual result at all. `AvatarManager.handle()`
+does two things after dispatch returns that this package deliberately cannot:
+it restores avatar's pinned unknown-action error string in place of the generic
+`ACTION_REQUIRED` envelope failure, and it threads root `_reasoning` (the spawn
+mission brief) to the `spawn` handler out-of-band, since `ToolFamily` correctly
+passes no envelope field to any child.
 
 ## Composition
 

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -10,6 +10,8 @@ related_files:
   - src/lingtai/tools/_manual.py
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/avatar/CONTRACT.md
+  - src/lingtai/tools/avatar/__init__.py
   - tests/test_tool_family_generic.py
   - tests/test_tool_family_wire_parity.py
   - tests/test_tool_family_manual_contract.py
@@ -95,8 +97,11 @@ entirely and dispatch by hand — `web` uses it internally but still owns its
 own outer `handle()` to stamp family-specific diagnostics onto envelope
 failures, which this package has no knowledge of.
 
-`build_manual_child` builds the reserved `manual` `ChildTool`: strict empty
-input; its handler loads the existing `load_installed_manual()` shape
+`build_manual_child` builds the reserved `manual` `ChildTool` with the
+exported `MANUAL_INPUT_SCHEMA` — the canonical strict-empty `input` schema for
+a family's `manual` child. It is exported so a family supplying its own
+`manual` handler (as `avatar` does) can reference it instead of restating the
+literal, and so the two cannot drift apart. Its handler loads the existing `load_installed_manual()` shape
 (`status`, `manual` full body, `manual_path`, optionally `error`) and maps it
 to the canonical, actually-dispatched result: `content=[{"type": "text",
 "text": <full body>}]` and `structuredContent={"manual_path": <path>}`, with
@@ -137,9 +142,30 @@ flattens the canonical result to Web's pre-migration public shape (`status`,
 `handle()`, not to the generic child or any wrapper registered in place of
 it. `WebManager.handle()` also stamps `current_setting` onto any
 envelope-level failure result (search/browse/unknown-action) before
-returning, unchanged from before. No other built-in family is migrated in
-this candidate; each remains fully independent of this package until its own
-scoped migration.
+returning, unchanged from before.
+
+`avatar/__init__.py` is the second production Adapter/consumer:
+`AvatarManager.__init__` builds a per-instance `ToolFamily` with
+`spawn`/`rules`/`manual` handlers bound to that instance, and
+`AvatarManager.handle()` calls `self._family.handle(args)`. It is a deliberate
+**partial** adoption, which this package permits: `avatar` reuses `ChildTool`
+and `ToolFamily` but *not* `build_manual_child`, because its manual ships inside
+its own package (`avatar/manual/SKILL.md`) rather than the agent's installed
+`.library` intrinsic catalog — `build_manual_child` would report a `.library`
+`manual_path` that family never reads. Its `manual` child is therefore its own
+`ChildTool` returning `avatar`'s own canonical flat result (`status`, `action`,
+`manual`, `manual_path`), which `ToolFamily.handle()` returns verbatim with no
+double wrap and no post-dispatch adaptation. Strictly *after* dispatch,
+`AvatarManager.handle()` normalizes this package's generic `ACTION_REQUIRED`
+envelope failure back to avatar's own pinned unknown-action error string — the
+same Host/presentation-layer ownership boundary `web` uses for
+`current_setting`, and never a change to this package's canonical error shape.
+`avatar` also threads its root `_reasoning` (the spawn mission brief) to its
+`spawn` handler out-of-band, because this package correctly refuses to pass any
+envelope field to a child.
+
+Every other built-in family remains unmigrated and fully independent of this
+package until its own scoped migration.
 
 ## Contract rules
 
@@ -176,8 +202,10 @@ scoped migration.
   shared handler, common request/result types, or a universal domain result
   shape from any consumer family, matching `../CONTRACT.md` "Implementation
   independence" verbatim.
-- `manual.build_manual_child`'s child MUST use the reserved name `manual`, a
-  strict empty `input_schema`, and its handler's actual return value — what
+- `manual.build_manual_child`'s child MUST use the reserved name `manual`, the
+  exported canonical `MANUAL_INPUT_SCHEMA` (a strict empty `input_schema`),
+  which any family supplying its own `manual` child SHOULD reference rather
+  than restate — and its handler's actual return value — what
   `ToolFamily.handle()` dispatches back verbatim — MUST be the canonical
   `content[0].text` (full body) / `structuredContent.manual_path` (host-local
   path) shape, never the pre-mapping flat `load_installed_manual()` dict.

--- a/src/lingtai/tools/tool_family/manual.py
+++ b/src/lingtai/tools/tool_family/manual.py
@@ -22,7 +22,19 @@ from typing import Any, Mapping
 from .._manual import load_installed_manual
 from . import ChildTool
 
-__all__ = ["build_manual_child"]
+__all__ = ["MANUAL_INPUT_SCHEMA", "build_manual_child"]
+
+# The one canonical strict-empty ``input`` schema every family's reserved
+# ``manual`` child uses — whether it registers ``build_manual_child`` below or,
+# like ``avatar``, supplies its own ``manual`` handler. Exported so a consumer
+# references this object instead of restating the literal, which is how the
+# three copies this replaced could have drifted apart on the wire.
+MANUAL_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
 
 
 def _to_mcp_result(loaded: Mapping[str, Any]) -> dict[str, Any]:
@@ -68,7 +80,7 @@ def build_manual_child(agent: Any, skill_name: str) -> ChildTool:
 
     return ChildTool(
         name="manual",
-        input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        input_schema=MANUAL_INPUT_SCHEMA,
         handler=handler,
         title="manual input",
     )

--- a/tests/test_avatar_rules.py
+++ b/tests/test_avatar_rules.py
@@ -165,7 +165,7 @@ class TestAvatarRulesAction:
         mgr = agent.get_capability("avatar")
         result = mgr.handle({
             "action": "rules",
-            "rules_content": "No deleting.",
+            "input": {"rules_content": "No deleting."},
         })
         assert "error" in result
 
@@ -189,7 +189,7 @@ class TestAvatarRulesAction:
         mgr = agent.get_capability("avatar")
         result = mgr.handle({
             "action": "rules",
-            "rules_content": "Always log actions.",
+            "input": {"rules_content": "Always log actions."},
         })
         assert result["status"] == "ok"
 
@@ -243,7 +243,7 @@ class TestAvatarRulesAction:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "rules",
-            "rules_content": "No external API calls.",
+            "input": {"rules_content": "No external API calls."},
         })
         assert result["status"] == "ok"
         # Self + descendants uniformly get .rules signal files
@@ -288,7 +288,7 @@ class TestAvatarRulesAction:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "rules",
-            "rules_content": "Be concise.",
+            "input": {"rules_content": "Be concise."},
         })
         assert result["status"] == "ok"
         # All descendants get .rules signal files
@@ -307,7 +307,7 @@ class TestAvatarRulesAction:
             admin={"karma": True},
         )
         mgr = agent.get_capability("avatar")
-        result = mgr.handle({"action": "rules"})
+        result = mgr.handle({"action": "rules", "input": {}})
         assert "error" in result
 
     def test_explicit_spawn_action_required(self, tmp_path):
@@ -322,7 +322,7 @@ class TestAvatarRulesAction:
         so the unified 'avatar' tool matches the schema-and-runtime-required
         'action' contract every other canonical action tool (knowledge, mcp,
         skills, notification, system, soul, daemon) already follows — see
-        avatar CONTRACT.md contract_version 3.
+        avatar CONTRACT.md contract_version 4.
         """
         from lingtai.agent import Agent
 
@@ -349,7 +349,7 @@ class TestAvatarRulesAction:
             assert not (parent_dir.parent / "child").exists()
 
             # Explicit action='spawn' behaves exactly as before.
-            result = mgr.handle({"action": "spawn", "name": "child", "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": "child", "confirm": True}})
         assert result["status"] == "ok"
         assert result["agent_name"] == "child"
         assert result["address"] == "child"  # relative name (current convention)
@@ -388,7 +388,7 @@ class TestAvatarRulesAction:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "rules",
-            "rules_content": "Cycle test.",
+            "input": {"rules_content": "Cycle test."},
         })
         assert result["status"] == "ok"
         # Both self and child receive .rules signals
@@ -435,7 +435,7 @@ class TestAutoDistributeAfterSpawn:
 
         mgr = parent.get_capability("avatar")
         with _patch_avatar_launch():
-            result = mgr.handle({"action": "spawn", "name": "child", "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": "child", "confirm": True}})
         assert result["status"] == "ok"
 
         # Child dir is a sibling of parent_dir (avatar_working_dir = parent.parent / name)
@@ -449,7 +449,7 @@ class TestAutoDistributeAfterSpawn:
 
         mgr = parent.get_capability("avatar")
         with _patch_avatar_launch():
-            result = mgr.handle({"action": "spawn", "name": "child", "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": "child", "confirm": True}})
         assert result["status"] == "ok"
 
         child_dir = parent_dir.parent / "child"
@@ -463,7 +463,7 @@ class TestAutoDistributeAfterSpawn:
 
         mgr = parent.get_capability("avatar")
         with _patch_avatar_launch():
-            result = mgr.handle({"action": "spawn", "name": "clone", "type": "deep", "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": "clone", "type": "deep", "confirm": True}})
         assert result["status"] == "ok"
 
         clone_dir = parent_dir.parent / "clone"
@@ -515,7 +515,7 @@ class TestSpawnNameValidation:
         mgr = parent.get_capability("avatar")
 
         with _patch_avatar_launch() as launch:
-            result = mgr.handle({"action": "spawn", "name": bad_name})
+            result = mgr.handle({"action": "spawn", "input": {"name": bad_name}})
 
         assert "error" in result, f"name={bad_name!r} should have been rejected but got {result}"
         # No subprocess launched
@@ -540,26 +540,44 @@ class TestSpawnNameValidation:
         mgr = parent.get_capability("avatar")
 
         with _patch_avatar_launch():
-            result = mgr.handle({"action": "spawn", "name": good_name, "confirm": True})
+            result = mgr.handle({"action": "spawn", "input": {"name": good_name, "confirm": True}})
 
         assert result.get("status") == "ok", f"name={good_name!r} should have been accepted but got {result}"
         assert (parent_dir.parent / good_name).is_dir()
 
-    def test_legacy_dir_argument_is_ignored(self, tmp_path):
-        """Pre-fix callers may still pass `dir=...`. It's no longer in the
-        schema, but the handler must not crash on unknown kwargs — it should
-        fall through to `name`-driven placement."""
+    def test_legacy_dir_argument_is_rejected_before_any_io(self, tmp_path):
+        """Pre-fix callers may still pass `dir=...` inside the spawn input.
+
+        Before the LTP v2 migration `dir` was merely absent from the schema and
+        silently ignored, so a call carrying it still spawned at the
+        `name`-driven location. The strict per-action input schema is now the
+        dispatch-time authorization boundary: an unknown input key is rejected
+        outright, before any filesystem mutation or subprocess launch. The
+        malicious `dir` still cannot place anything — and now neither can the
+        otherwise-valid `name`.
+        """
         parent, parent_dir = self._spawnable_parent(tmp_path)
         mgr = parent.get_capability("avatar")
 
-        with _patch_avatar_launch():
-            # Pass both a safe name and a malicious legacy dir; name wins.
-            result = mgr.handle({"action": "spawn", "name": "safe", "dir": "avatars/evil", "confirm": True})
+        with _patch_avatar_launch() as launch:
+            # Pass both a safe name and a malicious legacy dir; the whole call
+            # is refused because `dir` is not a declared spawn input field.
+            result = mgr.handle({
+                "action": "spawn",
+                "input": {"name": "safe", "dir": "avatars/evil", "confirm": True},
+            })
 
-        assert result.get("status") == "ok"
-        assert (parent_dir.parent / "safe").is_dir()
+        assert result == {
+            "status": "failed",
+            "error_code": "INVALID_ARGUMENT",
+            "message": "unsupported avatar input field",
+        }
+        # Rejected before any I/O: no subprocess, no directory, no ledger.
+        launch.assert_not_called()
+        assert not (parent_dir.parent / "safe").exists()
         # The malicious dir was NOT honored
         assert not (parent_dir.parent / "avatars").exists()
+        assert not (parent_dir / "delegates" / "ledger.jsonl").exists()
 
     def test_prepare_deep_refuses_non_sibling_dst(self, tmp_path):
         """Defense-in-depth: even if _prepare_deep is called directly with a

--- a/tests/test_layers_avatar.py
+++ b/tests/test_layers_avatar.py
@@ -74,7 +74,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert result["status"] == "ok"
         assert "address" in result
         assert result["address"]  # filesystem path (non-empty string)
@@ -86,7 +86,7 @@ class TestAvatarManager:
         from lingtai.agent import Agent
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities={"bash": {"yolo": True}, "avatar": {}})
-        result = parent._tool_handlers["avatar"]({"action": "spawn", "name": "child", "confirm": True})
+        result = parent._tool_handlers["avatar"]({"action": "spawn", "input": {"name": "child", "confirm": True}})
         assert result["status"] == "ok"
         # New architecture: avatars run as their own processes; introspection
         # is via the avatar's on-disk init.json, not an in-process _peers map.
@@ -104,7 +104,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"], covenant="Be helpful and concise.")
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert result["status"] == "ok"
 
     def test_spawn_no_admin(self, tmp_path):
@@ -113,7 +113,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"], admin={"karma": True})
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert result["status"] == "ok"
         child_init = json.loads((parent._working_dir.parent / "helper" / "init.json").read_text())
         child_admin = child_init.get("manifest", {}).get("admin", {})
@@ -133,9 +133,9 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        r1 = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        r1 = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert r1["status"] == "ok"
-        r2 = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        r2 = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert "error" in r2 or r2.get("status") == "already_active"
 
     def test_spawn_does_not_copy_identity_files(self, tmp_path):
@@ -154,7 +154,7 @@ class TestAvatarManager:
         (knowledge_dir / "knowledge.json").write_text('{"entries": []}')
 
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "blank", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "blank", "confirm": True}})
         assert result["status"] == "ok"
         child_dir = parent._working_dir.parent / "blank"
         # Character and knowledge should NOT be copied
@@ -167,7 +167,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "clone", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "clone", "confirm": True}})
         assert result["status"] == "ok"
 
     def test_ledger_records_spawn(self, tmp_path):
@@ -176,7 +176,7 @@ class TestAvatarManager:
         parent = Agent(service=make_mock_service(), agent_name="parent", working_dir=tmp_path / "test",
                             capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        mgr.handle({"action": "spawn", "name": "clone", "confirm": True})
+        mgr.handle({"action": "spawn", "input": {"name": "clone", "confirm": True}})
         ledger = (parent._working_dir / "delegates" / "ledger.jsonl").read_text().strip()
         record = json.loads(ledger)
         assert record["name"] == "clone"
@@ -230,7 +230,7 @@ class TestMissionQualityGate:
         """Spawn with no _reasoning and no confirm should be refused with a preview."""
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper"})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper"}})
         assert result["status"] == "confirmation_needed"
         assert "warning" in result
         assert "preview" in result
@@ -243,7 +243,7 @@ class TestMissionQualityGate:
     def test_spawn_with_short_mission_returns_confirmation_needed(self, tmp_path):
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "_reasoning": "test"})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper"}, "_reasoning": "test"})
         assert result["status"] == "confirmation_needed"
         assert result["preview"]["mission"] == "test"
         assert result["preview"]["mission_chars"] == 4
@@ -252,7 +252,7 @@ class TestMissionQualityGate:
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
         # No mission, but confirm=True acknowledges the risk.
-        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert result["status"] == "ok"
         assert (parent._working_dir.parent / "helper").is_dir()
 
@@ -261,7 +261,7 @@ class TestMissionQualityGate:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "spawn",
-            "name": "helper",
+            "input": {"name": "helper"},
             "_reasoning": "Investigate the heartbeat regression and report back via mail",
         })
         assert result["status"] == "ok"
@@ -269,7 +269,7 @@ class TestMissionQualityGate:
     def test_dry_run_returns_preview_without_spawning(self, tmp_path):
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "dry_run": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "dry_run": True}})
         assert result["status"] == "dry_run"
         assert result["preview"]["name"] == "helper"
         assert result["preview"]["type"] == "shallow"
@@ -285,7 +285,7 @@ class TestMissionQualityGate:
         parent = self._parent(tmp_path)
         mgr = parent.get_capability("avatar")
         # Empty mission + no confirm + dry_run=True → returns dry_run, not confirmation_needed.
-        result = mgr.handle({"action": "spawn", "name": "helper", "dry_run": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "dry_run": True}})
         assert result["status"] == "dry_run"
 
     def test_dry_run_preview_reports_real_mission_safe(self, tmp_path):
@@ -293,8 +293,7 @@ class TestMissionQualityGate:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "spawn",
-            "name": "helper",
-            "dry_run": True,
+            "input": {"name": "helper", "dry_run": True},
             "_reasoning": "Investigate the heartbeat regression and report back via mail",
         })
         assert result["status"] == "dry_run"
@@ -302,15 +301,23 @@ class TestMissionQualityGate:
         assert result["preview"]["mission_reason"] == ""
 
     def test_schema_exposes_dry_run_and_confirm(self):
+        """The dry_run/confirm gates stay model-visible after the LTP v2 migration.
+
+        Under the action-separated envelope they live inside the ``spawn``
+        branch of ``input.oneOf`` (and ``rules_content`` inside the ``rules``
+        branch) rather than at the root, but they must still be declared with
+        their gate types so the model can actually reach them.
+        """
         from lingtai.tools.avatar import get_schema
         sch = get_schema("en")
-        assert "dry_run" in sch["properties"]
-        assert sch["properties"]["dry_run"]["type"] == "boolean"
-        assert "confirm" in sch["properties"]
-        assert sch["properties"]["confirm"]["type"] == "boolean"
-        assert "rules_content" in sch["properties"]
-        assert sch["required"] == ["action"]
-        assert not {"oneOf", "anyOf", "allOf", "not"} & set(sch)
+        branches = {b["title"]: b for b in sch["properties"]["input"]["oneOf"]}
+        spawn_props = branches["spawn input"]["properties"]
+        assert "dry_run" in spawn_props
+        assert spawn_props["dry_run"]["type"] == ["boolean", "null"]
+        assert "confirm" in spawn_props
+        assert spawn_props["confirm"]["type"] == ["boolean", "null"]
+        assert "rules_content" in branches["rules input"]["properties"]
+        assert sch["required"] == ["action", "input", "reasoning"]
         assert sch["properties"]["action"]["enum"] == ["spawn", "rules", "manual"]
 
     def test_description_points_to_avatar_manual_after_prompt_compaction(self):
@@ -318,16 +325,20 @@ class TestMissionQualityGate:
 
         Prompt-token compaction moved verbose WARNING copy out of the always-on
         tool description and into avatar-manual. The safety contract now lives
-        in the schema gates (dry_run/confirm) plus the manual pointer, not in a
-        long description string.
+        in the schema gates (dry_run/confirm, now inside the spawn branch of
+        ``input.oneOf``) plus the manual pointer, not in a long description
+        string.
         """
         from lingtai.tools.avatar import get_description, get_schema
         desc = get_description("en")
         schema = get_schema("en")
         assert "avatar-manual" in desc
         assert "WARNING" not in desc
-        assert "confirm" in schema["properties"]
-        assert "dry_run" in schema["properties"]
+        spawn_props = {
+            b["title"]: b for b in schema["properties"]["input"]["oneOf"]
+        }["spawn input"]["properties"]
+        assert "confirm" in spawn_props
+        assert "dry_run" in spawn_props
         assert "action" in schema["properties"]
 
 
@@ -404,13 +415,23 @@ class TestUnifiedAvatarTool:
         assert name == "avatar"
         assert kwargs["schema"]["properties"]["action"]["enum"] == ["spawn", "rules", "manual"]
 
-    def test_schema_is_plain_object_with_no_top_level_combinators(self):
+    def test_schema_is_ltp_v2_action_separated_envelope(self):
+        """The root is exactly the LTP v2 envelope, not the old flat object.
+
+        Pre-migration the schema was a plain object with every action's fields
+        merged at the root and no top-level combinators. It is now the
+        action-separated envelope: four root fields, three of them required,
+        closed to anything else, with one ``input.oneOf`` branch per action.
+        """
         from lingtai.tools.avatar import get_schema
         sch = get_schema("en")
         assert sch["type"] == "object"
-        assert not ({"allOf", "oneOf", "anyOf"} & set(sch))
+        assert set(sch["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert sch["required"] == ["action", "input", "reasoning"]
+        assert sch["additionalProperties"] is False
         assert sch["properties"]["action"]["type"] == "string"
         assert sch["properties"]["action"]["enum"] == ["spawn", "rules", "manual"]
+        assert len(sch["properties"]["input"]["oneOf"]) == 3
 
     def test_spawn_dispatch_preserves_behavior_and_reasoning(self, tmp_path, fake_avatar_launch):
         """action='spawn' preserves outputs and _reasoning → first-prompt propagation."""
@@ -420,7 +441,7 @@ class TestUnifiedAvatarTool:
         mgr = parent.get_capability("avatar")
         result = mgr.handle({
             "action": "spawn",
-            "name": "helper",
+            "input": {"name": "helper"},
             "_reasoning": "Investigate the heartbeat regression and report back via mail",
         })
         assert result["status"] == "ok"
@@ -457,17 +478,17 @@ class TestUnifiedAvatarTool:
         no_admin = Agent(service=make_mock_service(), agent_name="worker",
                           working_dir=tmp_path / "worker", capabilities=["avatar"], admin={})
         mgr = no_admin.get_capability("avatar")
-        result = mgr.handle({"action": "rules", "rules_content": "No deleting."})
+        result = mgr.handle({"action": "rules", "input": {"rules_content": "No deleting."}})
         assert "error" in result
 
         admin = Agent(service=make_mock_service(), agent_name="admin",
                        working_dir=tmp_path / "admin", capabilities=["avatar"],
                        admin={"karma": True})
         mgr2 = admin.get_capability("avatar")
-        empty_result = mgr2.handle({"action": "rules", "rules_content": ""})
+        empty_result = mgr2.handle({"action": "rules", "input": {"rules_content": ""}})
         assert "error" in empty_result
 
-        ok_result = mgr2.handle({"action": "rules", "rules_content": "Be concise."})
+        ok_result = mgr2.handle({"action": "rules", "input": {"rules_content": "Be concise."}})
         assert ok_result["status"] == "ok"
         assert (admin._working_dir / ".rules").read_text() == "Be concise."
 
@@ -477,7 +498,7 @@ class TestUnifiedAvatarTool:
         no_admin = Agent(service=make_mock_service(), agent_name="worker",
                           working_dir=tmp_path / "worker", capabilities=["avatar"], admin={})
         mgr = no_admin.get_capability("avatar")
-        result = mgr.handle({"action": "spawn", "name": "helper", "confirm": True})
+        result = mgr.handle({"action": "spawn", "input": {"name": "helper", "confirm": True}})
         assert result["status"] == "ok"
 
     def test_manual_returns_exact_body_and_performs_no_mutation(self, tmp_path):
@@ -492,7 +513,7 @@ class TestUnifiedAvatarTool:
             / "src" / "lingtai" / "tools" / "avatar" / "manual" / "SKILL.md"
         ).read_text(encoding="utf-8")
 
-        result = mgr.handle({"action": "manual"})
+        result = mgr.handle({"action": "manual", "input": {}})
         assert result["status"] == "ok"
         assert result["manual"] == manual_source
 
@@ -514,7 +535,7 @@ class TestUnifiedAvatarTool:
         parent = Agent(service=make_mock_service(), agent_name="parent",
                         working_dir=tmp_path / "test", capabilities=["avatar"])
         mgr = parent.get_capability("avatar")
-        result = mgr.handle({"action": "bogus"})
+        result = mgr.handle({"action": "bogus", "input": {}})
         assert "error" in result
         assert "bogus" in result["error"]
 
@@ -553,12 +574,12 @@ class TestUnifiedAvatarTool:
                         admin={"karma": True})
         mgr = parent.get_capability("avatar")
 
-        spawn_result = mgr.handle({"action": "spawn"})
+        spawn_result = mgr.handle({"action": "spawn", "input": {}})
         assert "error" in spawn_result
         assert "name is required" in spawn_result["error"]
 
-        rules_result = mgr.handle({"action": "rules", "rules_content": "Be concise."})
+        rules_result = mgr.handle({"action": "rules", "input": {"rules_content": "Be concise."}})
         assert rules_result["status"] == "ok"
 
-        manual_result = mgr.handle({"action": "manual"})
+        manual_result = mgr.handle({"action": "manual", "input": {}})
         assert manual_result["status"] == "ok"

--- a/tests/test_tool_family_avatar_migration.py
+++ b/tests/test_tool_family_avatar_migration.py
@@ -1,0 +1,615 @@
+"""Avatar's LTP v2 action-separated ToolFamily migration — focused evidence.
+
+Covers the acceptance surface for the `avatar` family specifically: the composed
+root/child schema and its wire correlation, dispatch of each action, the spawn
+dry-run and its guard/error envelopes, the rules authorization/distribution
+gate, manual's no-side-effect promise, cross-action input rejection *before* any
+handler I/O, and the fact that the family wires one public tool without double
+wrapping a child result.
+
+Every test here builds its own isolated agent network under `tmp_path` and
+monkeypatches the launcher Port, so no test creates a live avatar process and no
+test writes a `.rules` signal outside its own temporary tree.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from lingtai.tools import avatar as avatar_tool
+from lingtai.tools.avatar import AvatarManager
+from lingtai.tools.tool_family import ToolFamily, ToolFamilyError
+from lingtai.tools.tool_family.manual import MANUAL_INPUT_SCHEMA
+
+
+# ---------------------------------------------------------------------------
+# Isolated fixtures — no live avatar, no live network rules
+# ---------------------------------------------------------------------------
+
+
+class _FakeReceipt:
+    def __init__(self) -> None:
+        self.pid = 424242
+        self.handle = object()
+
+
+class _FakeLauncher:
+    """Launcher Port double: records launches, never creates a process.
+
+    ``launch`` writes the ``.agent.heartbeat`` handshake file the real child
+    would write, so ``_wait_for_boot`` observes a clean ``ok`` boot without any
+    sleeping or real process.
+    """
+
+    def __init__(self) -> None:
+        self.launched: list[Any] = []
+
+    def launch(self, request):
+        self.launched.append(request)
+        working_dir = Path(request.argv[-1])
+        (working_dir / ".agent.heartbeat").write_text("{}", encoding="utf-8")
+        return _FakeReceipt()
+
+    def poll(self, _handle):
+        return None
+
+    def release(self, _handle):
+        return None
+
+
+class _StubAgent:
+    """Minimal parent agent: a working dir, an admin block, and a name."""
+
+    def __init__(self, working_dir: Path, *, admin: dict | None = None) -> None:
+        self._working_dir = working_dir
+        self._admin = admin or {}
+        self.agent_name = working_dir.name
+        self._venv_path = None
+        self.added: dict[str, dict] = {}
+
+    def add_tool(self, name: str, **kwargs) -> None:
+        self.added[name] = kwargs
+
+
+@pytest.fixture
+def network(tmp_path: Path):
+    """One isolated `.lingtai`-shaped network root with a parent agent in it."""
+    root = tmp_path / "network"
+    parent_dir = root / "parent"
+    parent_dir.mkdir(parents=True)
+    (parent_dir / "init.json").write_text(
+        json.dumps({"manifest": {"agent_name": "parent", "language": "en"}, "lingtai": ""}),
+        encoding="utf-8",
+    )
+    return parent_dir
+
+
+@pytest.fixture
+def launcher():
+    return _FakeLauncher()
+
+
+def _manager(parent_dir: Path, launcher: _FakeLauncher, *, admin: dict | None = None):
+    agent = _StubAgent(parent_dir, admin=admin)
+    return AvatarManager(agent, launcher=launcher), agent
+
+
+# ---------------------------------------------------------------------------
+# Schema: root envelope, per-action children, wire correlation
+# ---------------------------------------------------------------------------
+
+
+class TestAvatarFamilySchema:
+    def test_root_is_exactly_action_input_reasoning_summarize(self):
+        schema = avatar_tool.get_schema()
+        assert schema["type"] == "object"
+        assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert schema["required"] == ["action", "input", "reasoning"]
+        assert schema["additionalProperties"] is False
+        # ``reasoning`` is required by the family itself, not left to Agent
+        # schema composition (which only ever merges ``properties``).
+        assert schema["properties"]["reasoning"]["type"] == "string"
+        assert schema["properties"]["summarize"]["type"] == "boolean"
+
+    def test_public_action_values_are_unchanged(self):
+        schema = avatar_tool.get_schema()
+        assert schema["properties"]["action"]["enum"] == ["spawn", "rules", "manual"]
+
+    def test_each_action_owns_exactly_its_own_canonical_input(self):
+        branches = {
+            branch["title"]: branch
+            for branch in avatar_tool.get_schema()["properties"]["input"]["oneOf"]
+        }
+        assert set(branches) == {"spawn input", "rules input", "manual input"}
+        assert set(branches["spawn input"]["properties"]) == {
+            "name", "type", "comment", "dry_run", "confirm",
+        }
+        assert set(branches["rules input"]["properties"]) == {"rules_content"}
+        assert branches["manual input"]["properties"] == {}
+        for branch in branches.values():
+            assert branch["additionalProperties"] is False
+
+    def test_no_child_input_leaks_reasoning_or_summarize(self):
+        for branch in avatar_tool.get_schema()["properties"]["input"]["oneOf"]:
+            assert not (
+                {"reasoning", "_reasoning", "summarize"} & set(branch["properties"])
+            ), branch["title"]
+
+    def test_root_allof_correlates_each_action_const_with_its_exact_input(self):
+        schema = avatar_tool.get_schema()
+        conditions = schema["allOf"]
+        assert len(conditions) == 3
+        by_action = {c["if"]["properties"]["action"]["const"]: c for c in conditions}
+        assert set(by_action) == {"spawn", "rules", "manual"}
+        expected = dict(avatar_tool._CHILD_SPECS)
+        for action, condition in by_action.items():
+            assert condition["if"]["required"] == ["action"]
+            assert condition["then"]["properties"]["input"] == expected[action]
+
+    def test_spawn_optionals_are_nullable_but_name_is_a_plain_string(self):
+        spawn = avatar_tool._SPAWN_INPUT_SCHEMA
+        assert spawn["properties"]["name"]["type"] == "string"
+        for optional in ("type", "comment", "dry_run", "confirm"):
+            assert None in spawn["properties"][optional]["type"] or "null" in (
+                spawn["properties"][optional]["type"]
+            ), optional
+        # Closed object: every declared field is required, optionality is
+        # carried by the nullable type, per the strict-provider convention.
+        assert spawn["required"] == ["name", "type", "comment", "dry_run", "confirm"]
+
+    def test_schema_only_and_runtime_families_derive_from_one_spec(self, network, launcher):
+        # Both listings are built by ``_build_family`` from ``_CHILD_SPECS``,
+        # so they cannot drift in name, order, or input schema.
+        mgr, _ = _manager(network, launcher)
+        assert avatar_tool._FAMILY.child_names == mgr._family.child_names
+        assert avatar_tool._FAMILY.build_schema() == mgr._family.build_schema()
+        assert avatar_tool._FAMILY.build_schema() == avatar_tool.get_schema()
+
+    def test_manual_child_uses_the_shared_generic_input_schema(self):
+        # The strict-empty manual input is the one exported generic constant,
+        # not a local restatement that could drift from it.
+        assert dict(avatar_tool._CHILD_SPECS)["manual"] is MANUAL_INPUT_SCHEMA
+
+    def test_module_level_registry_rejects_a_reserved_manual_collision(self):
+        from lingtai.tools.tool_family import ChildTool
+
+        def _unused(_input):
+            raise AssertionError("never dispatched")
+
+        with pytest.raises(ToolFamilyError):
+            ToolFamily(
+                "avatar",
+                [
+                    ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused),
+                    ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused),
+                ],
+            )
+
+
+class TestAvatarSchemaSurvivesBothWires:
+    """The composed schema must correlate action→input on Chat and Responses.
+
+    Chat Completions carries the schema through verbatim. The Responses wire
+    rewrites a *nested* ``oneOf`` to ``anyOf`` while preserving the root
+    ``allOf``, so the per-action correlation must survive on both wires even
+    though the disclosure combinator is spelled differently.
+    """
+
+    def test_chat_completions_carries_the_schema_verbatim(self):
+        schema = avatar_tool.get_schema()
+        assert len(schema["properties"]["input"]["oneOf"]) == 3
+        assert len(schema["allOf"]) == 3
+
+    def test_responses_wire_preserves_root_allof_correlation(self):
+        from lingtai.llm.openai.adapter import _scrub_responses_schema
+
+        scrubbed = _scrub_responses_schema(avatar_tool.get_schema(), is_root=True)
+        # Root ``allOf`` survives — this is what correlates action to input.
+        assert len(scrubbed["allOf"]) == 3
+        correlated = {
+            condition["if"]["properties"]["action"]["const"]: condition["then"]["properties"]["input"]
+            for condition in scrubbed["allOf"]
+        }
+        assert set(correlated) == {"spawn", "rules", "manual"}
+        assert set(correlated["spawn"]["properties"]) == {
+            "name", "type", "comment", "dry_run", "confirm",
+        }
+        assert set(correlated["rules"]["properties"]) == {"rules_content"}
+        assert correlated["manual"]["properties"] == {}
+
+    def test_responses_wire_rewrites_the_nested_disclosure_oneof_to_anyof(self):
+        from lingtai.llm.openai.adapter import _scrub_responses_schema
+
+        scrubbed = _scrub_responses_schema(avatar_tool.get_schema(), is_root=True)
+        nested = scrubbed["properties"]["input"]
+        assert "oneOf" not in nested
+        assert len(nested["anyOf"]) == 3
+        assert {branch["title"] for branch in nested["anyOf"]} == {
+            "spawn input", "rules input", "manual input",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Dispatch: one action, one child, no double wrap
+# ---------------------------------------------------------------------------
+
+
+class TestAvatarDispatch:
+    def test_setup_wires_exactly_one_public_tool_with_the_composed_schema(self):
+        agent = MagicMock()
+        avatar_tool.setup(agent)
+        assert agent.add_tool.call_count == 1
+        (name,), kwargs = agent.add_tool.call_args
+        assert name == "avatar"
+        assert kwargs["schema"] == avatar_tool.get_schema()
+        assert kwargs["schema"]["required"] == ["action", "input", "reasoning"]
+
+    def test_manual_result_is_not_double_wrapped(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({"action": "manual", "input": {}})
+        # Avatar's own canonical flat result — no generic envelope nested
+        # inside another action result.
+        assert result["status"] == "ok"
+        assert result["action"] == "manual"
+        assert "content" not in result
+        assert "structuredContent" not in result
+        assert not isinstance(result.get("manual"), dict)
+
+    def test_unknown_action_preserves_the_exact_legacy_error_envelope(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({"action": "bogus", "input": {}})
+        assert result == {
+            "error": "unknown action: 'bogus', only 'spawn', 'rules', or "
+                     "'manual' is supported",
+        }
+
+    def test_omitted_action_preserves_the_exact_legacy_error_envelope(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        assert mgr.handle({})["error"] == (
+            "unknown action: '', only 'spawn', 'rules', or 'manual' is supported"
+        )
+
+    def test_non_boolean_summarize_fails_before_any_action_runs(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper", "confirm": True},
+            "summarize": "yes",
+        })
+        assert result["status"] == "failed"
+        assert result["error_code"] == "INVALID_ARGUMENT"
+        assert not (network.parent / "helper").exists()
+        assert launcher.launched == []
+
+    def test_summarize_never_reaches_a_child_handler(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        seen: list[dict] = []
+        mgr._spawn = lambda args, reasoning=None: (seen.append(dict(args)), {"status": "ok"})[1]
+        mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper", "confirm": True},
+            "summarize": True,
+            "_reasoning": "a genuine mission brief, long enough to pass",
+        })
+        assert seen == [{"name": "helper", "confirm": True}]
+        assert "summarize" not in seen[0]
+        assert "_reasoning" not in seen[0]
+
+    def test_avatar_is_on_the_kernel_summarize_allowlist(self):
+        # A family advertising root ``summarize`` must actually be honored by
+        # the single central summarizer, or the control is a lie.
+        from lingtai.kernel.tool_result_summary import summary_requested
+
+        assert summary_requested({"summarize": True}, tool_name="avatar") is True
+        assert summary_requested({"summarize": True}, tool_name="knowledge") is False
+
+
+class TestCrossActionInputRejectedBeforeIO:
+    """A key from another action's branch must fail before any handler I/O."""
+
+    @pytest.mark.parametrize(
+        "action,bad_input",
+        [
+            ("spawn", {"name": "helper", "rules_content": "No deleting."}),
+            ("rules", {"rules_content": "No deleting.", "name": "helper"}),
+            ("rules", {"rules_content": "No deleting.", "dry_run": True}),
+            ("manual", {"name": "helper"}),
+            ("manual", {"rules_content": "No deleting."}),
+        ],
+    )
+    def test_cross_action_key_is_rejected_with_no_side_effects(
+        self, network, launcher, action, bad_input,
+    ):
+        mgr, _ = _manager(network, launcher, admin={"karma": True})
+        result = mgr.handle({
+            "action": action,
+            "input": bad_input,
+            "_reasoning": "a genuine mission brief, long enough to pass",
+        })
+        assert result["status"] == "failed"
+        assert result["error_code"] == "INVALID_ARGUMENT"
+        assert result["message"] == "unsupported avatar input field"
+        # No spawn, no rules, no ledger — the failure precedes all I/O.
+        assert launcher.launched == []
+        assert not (network / ".rules").exists()
+        assert not (network / "delegates" / "ledger.jsonl").exists()
+        assert not (network.parent / "helper").exists()
+
+    def test_unknown_root_field_is_rejected_before_io(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper", "confirm": True},
+            "dir": "somewhere",
+        })
+        assert result["status"] == "failed"
+        assert result["error_code"] == "INVALID_ARGUMENT"
+        assert launcher.launched == []
+        assert not (network.parent / "helper").exists()
+
+    def test_missing_input_object_is_rejected_before_io(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({"action": "spawn"})
+        assert result["status"] == "failed"
+        assert result["error_code"] == "INVALID_ARGUMENT"
+        assert result["message"] == "input must be an object"
+        assert launcher.launched == []
+
+
+# ---------------------------------------------------------------------------
+# Spawn: dry-run, mission guard, identity/path validation, receipts
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnThroughTheEnvelope:
+    def test_dry_run_previews_without_launching_or_writing(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper", "dry_run": True},
+            "_reasoning": "Investigate the heartbeat regression and report back",
+        })
+        assert result["status"] == "dry_run"
+        assert result["preview"]["name"] == "helper"
+        assert result["preview"]["type"] == "shallow"
+        assert "Investigate the heartbeat regression" in result["preview"]["mission"]
+        assert launcher.launched == []
+        assert not (network.parent / "helper").exists()
+        assert not (network / "delegates" / "ledger.jsonl").exists()
+
+    def test_dry_run_is_exempt_from_the_confirm_guard(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper", "dry_run": True},
+            "_reasoning": "test",
+        })
+        assert result["status"] == "dry_run"
+        assert result["preview"]["mission_unsafe"] is True
+
+    def test_short_mission_trips_the_confirm_guard_without_launching(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper"},
+            "_reasoning": "test",
+        })
+        assert result["status"] == "confirmation_needed"
+        assert "confirm=true" in result["warning"]
+        assert launcher.launched == []
+        assert not (network.parent / "helper").exists()
+
+    def test_confirm_overrides_the_mission_guard(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper", "confirm": True},
+            "_reasoning": "test",
+        })
+        assert result["status"] == "ok"
+        assert len(launcher.launched) == 1
+
+    def test_root_reasoning_becomes_the_avatar_first_prompt(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        mission = "Investigate the heartbeat regression and report back via mail"
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper"},
+            "_reasoning": mission,
+        })
+        assert result["status"] == "ok"
+        assert mission in (network.parent / "helper" / ".prompt").read_text(encoding="utf-8")
+
+    def test_reasoning_does_not_leak_across_calls(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        mission = "Investigate the heartbeat regression and report back via mail"
+        mgr.handle({"action": "spawn", "input": {"name": "first"}, "_reasoning": mission})
+        # A second call with no reasoning must trip the mission guard rather
+        # than silently inheriting the previous call's mission.
+        second = mgr.handle({"action": "spawn", "input": {"name": "second"}})
+        assert second["status"] == "confirmation_needed"
+        assert not (network.parent / "second").exists()
+
+    @pytest.mark.parametrize(
+        "bad_name", ["../evil", "foo/bar", "/etc/hacked", ".hidden", "foo.bar", "", "a" * 65],
+    )
+    def test_identity_and_path_validation_survive_the_envelope(
+        self, network, launcher, bad_name,
+    ):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": bad_name, "confirm": True},
+            "_reasoning": "a genuine mission brief, long enough to pass",
+        })
+        assert "error" in result
+        assert launcher.launched == []
+
+    def test_deep_type_reaches_the_spawn_implementation(self, network, launcher):
+        (network / "system").mkdir()
+        (network / "system" / "character.md").write_text("who I am", encoding="utf-8")
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "clone", "type": "deep", "confirm": True},
+            "_reasoning": "a genuine mission brief, long enough to pass",
+        })
+        assert result["status"] == "ok"
+        assert result["type"] == "deep"
+        assert (network.parent / "clone" / "system" / "character.md").is_file()
+
+    def test_shallow_default_does_not_copy_identity(self, network, launcher):
+        (network / "system").mkdir()
+        (network / "system" / "character.md").write_text("who I am", encoding="utf-8")
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper", "confirm": True},
+            "_reasoning": "a genuine mission brief, long enough to pass",
+        })
+        assert result["status"] == "ok"
+        assert result["type"] == "shallow"
+        assert not (network.parent / "helper" / "system").exists()
+
+    def test_comment_reaches_the_newborn_init(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper", "comment": "never forget this", "confirm": True},
+            "_reasoning": "a genuine mission brief, long enough to pass",
+        })
+        init = json.loads((network.parent / "helper" / "init.json").read_text(encoding="utf-8"))
+        assert init["comment"] == "never forget this"
+
+    def test_spawn_receipt_and_ledger_are_preserved(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper", "confirm": True},
+            "_reasoning": "a genuine mission brief, long enough to pass",
+        })
+        assert result["status"] == "ok"
+        assert result["address"] == "helper"
+        assert result["agent_name"] == "helper"
+        assert result["pid"] == 424242
+        ledger = (network / "delegates" / "ledger.jsonl").read_text(encoding="utf-8")
+        record = json.loads(ledger.strip())
+        assert record["event"] == "avatar"
+        assert record["name"] == "helper"
+        assert record["boot_status"] == "ok"
+
+    def test_spawn_never_requires_admin(self, network, launcher):
+        mgr, _ = _manager(network, launcher, admin={})
+        result = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "helper", "confirm": True},
+            "_reasoning": "a genuine mission brief, long enough to pass",
+        })
+        assert result["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Rules: authorization + distribution, on an isolated tree
+# ---------------------------------------------------------------------------
+
+
+class TestRulesThroughTheEnvelope:
+    def test_rules_requires_karma(self, network, launcher):
+        mgr, _ = _manager(network, launcher, admin={})
+        result = mgr.handle({"action": "rules", "input": {"rules_content": "No deleting."}})
+        assert "error" in result
+        assert "admin privilege required" in result["error"]
+        assert not (network / ".rules").exists()
+
+    def test_rules_requires_content(self, network, launcher):
+        mgr, _ = _manager(network, launcher, admin={"karma": True})
+        result = mgr.handle({"action": "rules", "input": {"rules_content": "   "}})
+        assert "error" in result
+        assert not (network / ".rules").exists()
+
+    def test_authorized_rules_write_self_signal(self, network, launcher):
+        mgr, _ = _manager(network, launcher, admin={"karma": True})
+        result = mgr.handle({"action": "rules", "input": {"rules_content": "Be concise."}})
+        assert result["status"] == "ok"
+        assert (network / ".rules").read_text() == "Be concise."
+        assert result["distributed_to"] == ["parent"]
+
+    def test_rules_distribute_to_descendants_in_the_isolated_tree(self, network, launcher):
+        # Spawn a real (faked-launch) child so the ledger is genuine, then
+        # distribute — both inside this test's own temp network only.
+        mgr, _ = _manager(network, launcher, admin={"karma": True})
+        spawned = mgr.handle({
+            "action": "spawn",
+            "input": {"name": "child", "confirm": True},
+            "_reasoning": "a genuine mission brief, long enough to pass",
+        })
+        assert spawned["status"] == "ok"
+
+        result = mgr.handle({"action": "rules", "input": {"rules_content": "Be kind."}})
+        assert result["status"] == "ok"
+        assert set(result["distributed_to"]) == {"parent", "child"}
+        assert (network.parent / "child" / ".rules").read_text() == "Be kind."
+
+
+# ---------------------------------------------------------------------------
+# Manual: no spawn/rules I/O, exact body and path
+# ---------------------------------------------------------------------------
+
+
+class TestManualThroughTheEnvelope:
+    def test_manual_returns_the_exact_packaged_body_and_path(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({"action": "manual", "input": {}})
+
+        source = (
+            Path(avatar_tool.__file__).resolve().parent / "manual" / "SKILL.md"
+        )
+        assert result["status"] == "ok"
+        assert result["action"] == "manual"
+        assert result["manual"] == source.read_text(encoding="utf-8")
+        assert Path(result["manual_path"]) == source
+
+    def test_manual_performs_no_spawn_or_rules_io(self, network, launcher):
+        mgr, _ = _manager(network, launcher, admin={"karma": True})
+        before = sorted(p.name for p in network.parent.iterdir())
+
+        result = mgr.handle({"action": "manual", "input": {}})
+        assert result["status"] == "ok"
+
+        assert launcher.launched == []
+        assert not (network / ".rules").exists()
+        assert not (network / "delegates").exists()
+        assert not (network / "logs").exists()
+        assert sorted(p.name for p in network.parent.iterdir()) == before
+
+    def test_manual_rejects_any_input_field(self, network, launcher):
+        mgr, _ = _manager(network, launcher)
+        result = mgr.handle({"action": "manual", "input": {"name": "helper"}})
+        assert result["status"] == "failed"
+        assert result["error_code"] == "INVALID_ARGUMENT"
+
+    def test_missing_packaged_manual_degrades_truthfully(self, network, launcher, monkeypatch):
+        mgr, _ = _manager(network, launcher)
+
+        class _Missing:
+            def joinpath(self, _name):
+                return self
+
+            def read_text(self, **_kwargs):
+                raise FileNotFoundError("gone")
+
+            def __str__(self) -> str:
+                return "<missing avatar manual>"
+
+        monkeypatch.setattr(
+            avatar_tool.resources, "files", lambda _pkg: _Missing(),
+        )
+        result = mgr.handle({"action": "manual", "input": {}})
+        assert result["status"] == "degraded"
+        assert result["manual"] == ""
+        assert result["error"] == "avatar manual missing"
+        assert result["manual_path"] == "<missing avatar manual>"

--- a/tests/test_tool_family_manual_contract.py
+++ b/tests/test_tool_family_manual_contract.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from lingtai.tools.tool_family import RESERVED_MANUAL_NAME, ChildTool, ToolFamily, ToolFamilyError
-from lingtai.tools.tool_family.manual import build_manual_child
+from lingtai.tools.tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
 
 
 class _FakeAgent:
@@ -36,7 +36,16 @@ def test_manual_child_reserved_name_is_exactly_manual():
 def test_manual_child_input_schema_is_strict_empty():
     agent = _FakeAgent(Path("/nonexistent"))
     child = build_manual_child(agent, "widget")
-    assert child.input_schema == {"type": "object", "properties": {}, "additionalProperties": False}
+    # Strict empty: no properties admitted, and closed. Pinned by identity with
+    # the exported canonical constant, so a consumer that references it (this
+    # builder; ``avatar``) cannot drift from a restated literal. This asserts
+    # only the generic constant — it makes no claim about how many families
+    # still keep a local copy, so a family collapsing onto the export is a
+    # separate, independently reviewable change.
+    assert child.input_schema is MANUAL_INPUT_SCHEMA
+    assert child.input_schema == {
+        "type": "object", "properties": {}, "required": [], "additionalProperties": False,
+    }
 
 
 def test_manual_child_actual_handler_returns_body_at_content_text_and_path_at_structured_content(tmp_path):


### PR DESCRIPTION
> **Exact source head:** `1c3dcaf4e2e57bde542301ffcddc6ccfa0c93ec7`  
> **Exact base:** `4ad8b1555a5b0368af81aa57292438719a105052`  
> **dev4 exact-head live-use gate:** pending immediately after PR opening; this body will be updated with the durable receipt.

# feat(tools): migrate Avatar to the action-separated ToolFamily envelope

## Summary

Migrates the public `avatar` tool to the LingTai Tool Protocol v2
action-separated shape, using the existing generic `tools/tool_family`
infrastructure — the same one `web` adopted in #1059. The spawn engine, ledger,
launcher Port, boot policy, and rules distribution are untouched; this changes
the model-facing surface and separates the three actions into canonical
children.

**Public tool name and action values are unchanged: `avatar` with
`spawn | rules | manual`.** No action was added, renamed, or removed.

### Public actions and envelope

Three canonical children where the child name is simultaneously the public
`action` value and the dispatch key, with no mapping layer.

The model-facing root is exactly four fields, strict and closed
(`additionalProperties: false`, `required: ["action", "input", "reasoning"]`):

| Root field | Required | Purpose |
|---|---|---|
| `action` | yes | one of `spawn`, `rules`, `manual`; no default |
| `input` | yes | strict, action-specific input object |
| `reasoning` | yes | Host InvocationContext/audit metadata; never forwarded into `input` |
| `summarize` | no | root cross-cutting result post-processing; never forwarded into `input` |

Field separation is enforced at two layers — schema and dispatch:

- `name`, `type`, `comment`, `dry_run`, `confirm` exist **only** in `spawn`'s `input`.
- `rules_content` exists **only** in `rules`'s `input`.
- `manual` takes a strict-empty `input`.

The root carries `allOf`/`if`/`then` correlating each `action` const to that
child's own input schema, plus `input.oneOf` disclosure of every branch.
Dispatch remains the authoritative fail-closed layer regardless of whether a
given provider validates the combinators: a key belonging to another action's
branch is rejected **before any handler I/O** with `INVALID_ARGUMENT` and the
message `unsupported avatar input field`, performing no spawn, no ledger write,
no `.rules` write, and no process launch.

Optional spawn fields follow the strict-schema convention already used by
`web`'s `browse`: declared REQUIRED but nullable, where `null` means *absent*
and the handler applies its own unchanged defaults (`type` shallow, `comment`
empty, `dry_run` false, `confirm` false).

### Why action-separated ToolFamily

The pre-migration schema was a single flat property bag: one `action` enum plus
six sibling root fields shared by all three actions, with action-specific
requirements enforced only inside the handler. That shape cannot express which
fields belong to which action, so the model saw `rules_content` as an available
field on a `spawn` call and `name` as available on `rules`. Separation makes the
action/input correspondence a schema fact and a dispatch-time authorization
boundary rather than a handler convention — which matters more for `avatar` than
for most families, because one of its actions creates a detached OS process and
another mutates governance for an entire descendant subtree.

### The spawn mission brief stays at the root (load-bearing)

`spawn`'s mission briefing is root `reasoning` — normalized to `_reasoning` by
ToolExecutor — and it becomes the newborn avatar's first prompt. It is **not**
an `input` property, because `tools/CONTRACT.md` forbids nested `input` from
carrying `reasoning`/`_reasoning`/`summarize`.

`ToolFamily.handle()` correctly passes no envelope field to any child, so
without explicit handling `_spawn` would have silently lost its mission and
every spawn would have degraded to the empty-mission confirm gate.
`AvatarManager.handle()` therefore captures root `_reasoning` per call, hands it
to `_spawn` as an explicit argument, and clears it in `finally` so a later call
can never inherit a previous call's mission. A non-string `_reasoning` coerces
to `None` and is treated as a missing mission — fail-closed into the confirm
gate. Both properties are regression-locked.

### The pinned unknown-action envelope is preserved byte-for-byte

An `action` outside `spawn`/`rules`/`manual` — including an entirely omitted
`action` — still returns exactly:

```
{"error": "unknown action: <repr>, only 'spawn', 'rules', or 'manual' is supported"}
```

with `''` for the omitted case, unchanged from base. The generic dispatcher's
`ACTION_REQUIRED` shape is deliberately generic, so `AvatarManager.handle()`
normalizes it back **strictly after dispatch returns** — never by changing the
generic dispatcher's own canonical error shape. Avatar's children never emit
`error_code`, so the remap cannot mis-fire on a child result.

### No flat compatibility

Per `tools/CONTRACT.md` and the `web` precedent, **no flat compatibility shim is
retained**. A flat call fails closed with a typed, recoverable error
(`INVALID_ARGUMENT`, `unsupported avatar argument`). Avatar's legacy is deleted
in place, not wrapped: there is no alias, no dual-shape acceptance, no branch on
caller vintage, and no dead path left inside avatar's ownership.

### Kernel `summarize` allowlist (required, not optional)

`avatar` is added to `_LTP_V2_MIGRATED_FAMILIES` in
`kernel/tool_result_summary.py`. `ToolFamily.build_schema()` advertises root
`summarize` to the model for *every* family unconditionally, so a family that
migrates without joining this single central allowlist would ship a
model-visible control the kernel silently ignores. This is a two-line additive
change; the summarizer logic, the raw-first cap, and the single-source
summarizer are untouched.

### Manual: own loader, not `build_manual_child`

Avatar's manual ships **inside its own package** (`avatar/manual/SKILL.md`)
rather than in the agent's installed `.library` intrinsic catalog that
`load_installed_manual` reads. Reusing `build_manual_child` would therefore
report a `.library` `manual_path` this family never reads — a false statement in
a model-visible field.

Avatar supplies its own `manual` child instead, returning its own canonical flat
result, which `ToolFamily.handle()` returns verbatim — no double wrap and, unlike
`web`, no post-dispatch manual adaptation at all. Partial adoption of the generic
infrastructure is explicitly conforming per `tool_family/CONTRACT.md`
"Implementation independence", and both that contract and its ANATOMY now
document Avatar reciprocally.

The served body is the exact packaged `SKILL.md`, unchanged. **`manual_path` is
new** — the pre-migration result carried no path — satisfying the common
contract's model-visible-path acceptance line.

## Owner-bounded scope

This candidate is **Avatar + one generic export**. It does not touch any other
family's implementation.

`src/lingtai/tools/web_search/__init__.py` was briefly modified during an
earlier revision to collapse Web onto the shared constant, then **restored
byte-for-byte to exact base** — verified by `git diff <base> -- <path>` being
empty and by direct base-vs-working content comparison. Web keeps its
pre-existing local `_MANUAL_INPUT_SCHEMA` and `_schema_only_family()`;
collapsing them belongs to the Web degraded-content PR, which already owns that
deletion. **See "Known limitations" #1 — that PR and this one both add
`MANUAL_INPUT_SCHEMA` to the same file and will conflict.**

## Removed/collapsed, with replacement proof

All owner-local. Repo-wide grep confirms zero dangling references in `src/` or
`tests/`.

| Removed | Location | Replaced by |
|---|---|---|
| flat `get_schema()` (~55-line property bag) | `tools/avatar/__init__.py` | `_FAMILY.build_schema()` composed from the child registry |
| `handle()` via `kernel.tool_dispatch.dispatch_action` | `tools/avatar/__init__.py` | per-instance `ToolFamily` dispatch + post-dispatch error normalization |
| `from lingtai.kernel.tool_dispatch import dispatch_action` | `tools/avatar/__init__.py` | dead after the above |
| `_MANUAL_INPUT_SCHEMA` local literal | `tools/avatar/__init__.py` | exported `tool_family.manual.MANUAL_INPUT_SCHEMA` |
| `_schema_only_family()` | `tools/avatar/__init__.py` | `_build_family()` over one `_CHILD_SPECS` source |
| `_ACTION_ORDER` | `tools/avatar/__init__.py` | unused after the collapse |
| `_spawn` reading `args["_reasoning"]` | `tools/avatar/__init__.py` | explicit `reasoning` argument threaded from the root envelope |

`kernel/tool_dispatch.dispatch_action` itself is **retained** — it still has
three live consumers (`mcp`, `knowledge`, `skills`) and is not Avatar's to
remove.

**Dual-listing collapse.** Avatar declares one `_CHILD_SPECS`
`(action, input_schema)` tuple in model-facing enum order; both the module-level
schema-only family and each manager's handler-bound family are built from it by
`_build_family`, so the two cannot drift in name, order, or schema. Locked by
`test_schema_only_and_runtime_families_derive_from_one_spec`.

## LOC accounting (against exact base `4ad8b155`)

| Bucket | Added | Removed | Net |
|---|---|---|---|
| **Production** (3 `.py` files) | 226 | 85 | **+141** |
| **Docs/manual/glossaries** (9 `.md`) | 327 | 101 | +226 |
| **Tests** (3 modified + 1 new 615-line file) | 728 | 65 | +663 |

Tracked diff **+666/−251** across 15 files, plus the untracked new test file.

**Executable Python is +29 AST statements** (443 → 472) and **+6 functions**
(39 → 45) — per file: `avatar/__init__.py` +28/+6,
`tool_family/manual.py` +1/+0, `kernel/tool_result_summary.py` +0/+0.

The gap between raw +141 and executable +29 is the three per-action JSON schemas
(one undifferentiated flat property bag becomes three closed schemas with
per-action `description` prose) plus comments/docstrings recording the migration's
judgment calls. **The line growth is the separation.** Net-negative production
LOC was not reachable owner-locally: the legacy is already deleted in place with
no shim, alias, or dead path remaining, and the only further candidates are
shared primitives outside this owner.

## Risk, security, and authorization semantics

**No new write paths.** The production diff adds zero filesystem writes. All
mutation still flows through the unchanged `_spawn`/`_rules` owners with their
pre-existing defenses intact: avatar-name regex `^[\w-]+$` + 64-char cap +
dot/slash/leading-`.` refusal, the resolved-parent == network-root scope check,
`_prepare_deep`'s sibling assertion guarding `rmtree`, the `already_active`
liveness refusal, and the append-only ledger.

| Action | Posture | Gate |
|---|---|---|
| `spawn` | **creates a detached OS process** | mission-quality gate (empty / <20 chars / debug-placeholder → `confirmation_needed` unless `confirm=true`); `dry_run` exempt and performs no I/O; never requires admin |
| `rules` | **mutates governance for the whole descendant subtree** | requires at least one truthy admin (karma) privilege; independent of `spawn` |
| `manual` | read-only | none; performs no spawn or rules I/O of any kind |

**The family must not hide a stronger child.** `rules`'s karma gate lives in the
action implementation and is unchanged by the migration, so it cannot be bypassed
by any envelope shape. A cross-action key in `rules`'s `input` is rejected
*before* the authorization check and before any write. `spawn` correctly does not
inherit the rules gate. `avatar/CONTRACT.md` now states this posture explicitly.

**ToolGuard** (`kernel/tool_call_guard.py`) is untouched and has no
avatar-specific rows. Dispatch remains the authoritative fail-closed layer, so a
provider that ignores `allOf`/`if`/`then` still cannot smuggle a cross-action key
or reach a handler with envelope fields.

**Fail-closed envelope.** Unknown root field, missing/non-object `input`,
non-boolean `summarize`, unknown action, and cross-action keys all fail before
any handler I/O — each covered by side-effect-asserting tests.

### Behavior changes (two, both intentional)

1. **Unknown input keys now fail loudly.** The retired `dir` argument was
   previously ignored silently; it now returns `INVALID_ARGUMENT` before any I/O.
   Required by the common contract's dispatch rule. The pre-existing test was
   renamed `test_legacy_dir_argument_is_rejected_before_any_io` and made strictly
   stronger.
2. **`_manual` also catches `OSError`.** A present-but-unreadable manual now
   returns the degraded envelope (`status: "degraded"`, empty `manual`, truthful
   `error`) instead of raising — consistent with the existing missing-file path,
   and honest rather than faking success.

`avatar/CONTRACT.md` is bumped to **contract_version 4** with a full
breaking-change entry covering both.

## Validation

**Exact base:** `4ad8b1555a5b0368af81aa57292438719a105052`.
All commands pinned with `PYTHONPATH=src` (the venv's editable install resolves
`lingtai` to a different worktree; unpinned runs validate the wrong tree).

| Gate | Result |
|---|---|
| Avatar suites (migration + layers + rules) | **128 passed** |
| Generic ToolFamily + Web wire/migration parity + manual contract + browser/intrinsic | **97 passed** |
| Safety/launcher/daemon/docs/anatomy/contracts/glossary/package-data | **580 passed, 1 skipped** |
| Parent post-trim focused suite | **188 passed, 1 skipped**, chained diff clean |
| `tests/test_tool_family_avatar_migration.py` | 52 tests, 615 lines |
| `py_compile` | clean |
| `git diff --check` | clean |
| `glossary_validator --check` | `OK: 60 glossary resources across 20 packages` |
| `check_docs_governance.py --check` | `OK: 294 documents` |
| `web_search/__init__.py` vs base | byte-identical (diff empty) |

Web's parity suites pass with Web's source restored to base, confirming the
generic export change is wire-invisible to Web.

**Full suite:** 6245 passed, 28 skipped, 5 failed — **all five proven
pre-existing** by extracting a pristine base tree (`git archive 4ad8b155`) and
reproducing each failure there:
`test_codex_standalone_compaction`, `test_kernel_update_contract`,
`test_resolved_manifest_artifact`, `test_skills` (a `last_changed_at` timestamp
on an unrelated `system-manual` file), and `test_wheel_sidecar_smoke` (no locally
built Rust sidecar). **Zero regressions.**

**Test isolation.** Every test in the new suite builds its own `tmp_path`
network with a faked launcher Port. **No live avatar was spawned and no live
`.rules` was written** at any point during authoring or review.

**Independent review:** Fable 5 — **g2 FINAL ACCEPT, no blockers**
(`scratch/avatar-toolfamily-fable-review-20260727.md`). Fable independently
re-derived the schema by real import pinned to this worktree, executed the
envelope edge behaviors by hand on an isolated temp network with a faked
launcher, and specifically hunted both soul-review failure classes (a
wire-visible flat-shape producer; a manual teaching the old shape) — neither
exists for Avatar. Fable also caught a real evidence-hygiene error in the author's
report (an unpinned validator run reporting 54/18 instead of the true 60/20);
that is corrected above and in the durable report.

## Known limitations

1. **Merge conflict with the Web degraded-content PR — coordinate before
   merging.** Both PRs add `MANUAL_INPUT_SCHEMA` to
   `src/lingtai/tools/tool_family/manual.py`. The Web PR's version is **strictly
   better and should win**: it returns `copy.deepcopy(MANUAL_INPUT_SCHEMA)` from
   `build_manual_child`, while this PR returns the shared object directly. That
   difference is a real latent hazard, reproduced in-process against this
   candidate: mutating one child's `input_schema["properties"]` pollutes the
   canonical constant *and* every other family's schema for the process lifetime.
   No current code mutates it, so nothing is broken today — but taking Web's
   `deepcopy` version at merge closes it. Avatar needs no change beyond accepting
   that resolution; its `_CHILD_SPECS` reference works identically either way.
2. **Production LOC is net-positive (+141 raw / +29 executable statements)**,
   explained above.
3. **`import sys` in `tools/avatar/__init__.py` is unused** — pre-existing at
   base, left as out-of-scope.
4. **The confirm-guard warning string** still reads `confirm=true` /
   `dry_run=true` rather than `input.confirm`. It is the pinned pre-migration
   string with test pins, notation-only, and carries no field-placement
   falsehood. Rewording it is a separate change with its own test updates.
5. **`tool_family/CONTRACT.md` and `ANATOMY.md` are edited by several parallel
   family PRs** on overlapping lines. This PR keeps its edits minimal and
   truthful about Web's actual (unchanged) state; the parent should reconcile
   the file once at group-merge.

## Rollback

Self-contained and low-risk. Reverting this commit restores the flat
`get_schema`, the `dispatch_action` handler, and the pre-migration manual result
in one step. **No migration, no data change, and no durable-state format change
is involved** — `delegates/ledger.jsonl`, the `.prompt` / `.rules` signal-file
protocol, `logs/spawn.stderr`, and the avatar working-directory layout are all
untouched, so already-spawned avatars and in-flight rules distribution are
unaffected in either direction.

The only cross-cutting production edits are two small additive ones, each
independently revertible: `kernel/tool_result_summary.py` adds `"avatar"` to the
existing `_LTP_V2_MIGRATED_FAMILIES` allowlist, and `tool_family/manual.py` adds
the exported constant. Reverting Avatar alone while leaving the export in place
is safe (the export would simply have one consumer, `build_manual_child`).

## Still pending — dev4 live exact-head exercise

**Step 5 of the review contract is NOT done and is required before merge
consideration.** It was correctly not performed during authoring or review,
because for `avatar` it necessarily means creating a real detached agent process
and/or distributing real network rules.

Requested plan for dev4 (or another agent) at the exact PR head:

1. **Isolated network.** Run from a disposable network root, not a live agent
   tree. Nothing below should touch a production avatar or a live `.rules`.
2. **Public action count.** Confirm the registered `avatar` tool exposes exactly
   three actions (`spawn`, `rules`, `manual`) and a root of exactly
   `action` / `input` / `reasoning` / `summarize`.
3. **`manual` first.** Call `avatar(action="manual", input={}, reasoning="...")`
   with `summarize=false`; confirm the body is usable, `manual_path` resolves,
   and no files are created.
4. **`spawn` dry-run.** `input={"name": "<disposable>", "dry_run": true}` — confirm
   the preview, and that no directory, ledger entry, or process appears.
5. **`spawn` real, once.** A genuine mission in `reasoning`; confirm the receipt
   (`address`, `agent_name`, `pid`), the ledger record, and that the mission text
   arrives as the newborn's first prompt. **Then retire that avatar via the
   documented lifecycle path** (`system` sleep/suspend), not filesystem deletion.
6. **Confirm gate.** A short/test-like mission returns `confirmation_needed` and
   spawns nothing.
7. **`rules` on the disposable tree only.** Confirm the karma gate refuses a
   non-admin caller, and that an authorized call distributes to the disposable
   descendants only.
8. **Cross-action rejection live.** Send `rules_content` inside a `spawn` input;
   confirm `INVALID_ARGUMENT` with no side effect.

Evidence to preserve: the exact composed schema as seen on the wire, each
terminal result, the ledger file, and confirmation that every spawned avatar was
retired.

Placeholders to fill after that run:

- Tested head: *(fill in — dev4 exact-head SHA)*
- dev4 report path: *(fill in)*
- Observed public action count: *(fill in — expected 3)*
- Manual usability verdict: *(fill in)*

---

## Placeholders to update before opening

- **Head:** *(fill in at push time — the candidate is uncommitted; `HEAD` in the
  worktree is still the exact base `4ad8b155`)*
- **PR number / branch name:** *(fill in at push time)*
- **Git author identity:** *(verify at commit time — Huang Git author and GitHub
  identity preflight is a parent gate per the review contract)*
- **Fable report link:** `scratch/avatar-toolfamily-fable-review-20260727.md`
  *(convert to a permanent link if the reports are published)*
- **Durable author report:**
  `scratch/avatar-toolfamily-opus-candidate-report-20260727.md` (rev 3)

Exact base: `4ad8b1555a5b0368af81aa57292438719a105052`
Head: *(fill in at push time)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
