### PR TITLE
refactor(shell): separate run, poll, cancel, and manual actions

### DIFF
--- a/src/lingtai/kernel/llm/interface.py
+++ b/src/lingtai/kernel/llm/interface.py
@@ -85,6 +85,15 @@ def _tool_call_context(tool_call: "ToolCallBlock | None") -> str:
     if tool_call.name in {"shell", "bash"}:
         action = args.get("action", "run")
         lines.append(f"shell action: {action}")
+        # ``shell`` is a migrated LTP v2 family: the action's own fields live
+        # under the root ``input`` object, not at the root. A historical/
+        # pending flat call (or the ``bash`` compatibility alias) may still
+        # carry them at the root, so read whichever shape this call actually
+        # has — a recovery notice that silently lost the command preview on
+        # the new envelope would be the failure this helper exists to prevent.
+        action_input = args.get("input")
+        if isinstance(action_input, dict):
+            args = action_input
         if "working_dir" in args:
             lines.append(f"shell working_dir: {args.get('working_dir')}")
         if "timeout" in args:

--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -152,15 +152,22 @@ def is_apriori_summary(content: Any) -> bool:
 # unmigrated tool's own domain field literally named ``summarize`` is never
 # silently reinterpreted as this cross-cutting control (see
 # ``src/lingtai/tools/CONTRACT.md`` Contract rules > Envelope).
-_LTP_V2_MIGRATED_FAMILIES = frozenset({"web"})
+_LTP_V2_MIGRATED_FAMILIES = frozenset({"web", "shell"})
 
 
 def summary_requested(args: dict | None, tool_name: str | None = None) -> bool:
     """Return True iff the normalized tool args opt into a-priori summary.
 
     The legacy flag is the boolean ``summary`` field on the tool call, honored
-    for every caller. A migrated LTP v2 family (currently only ``web``) may
-    instead set the canonical root ``summarize`` boolean; that spelling is
+    unconditionally for every caller. ``shell``'s pre-migration ``summary``
+    boolean is still accepted through that spelling by any historical/pending
+    call that carries it, but the migrated public ``shell`` schema
+    (``tools/bash/_tool_family.py::get_schema``) no longer advertises it — the
+    legacy flat ``tools/bash/__init__.py::get_schema`` that still declares
+    ``summary`` is retained only as the internal ``ShellManager`` shape and is
+    not the registered model-facing schema. A migrated LTP v2 family
+    (``web``, ``shell``) sets the canonical root ``summarize`` boolean
+    instead; that spelling is
     recognized only when ``tool_name`` names a migrated family, so an
     unmigrated tool's own ``summarize``-named domain field is never
     reinterpreted as this control. Anything other than a literal ``True``

--- a/src/lingtai/tools/ANATOMY.md
+++ b/src/lingtai/tools/ANATOMY.md
@@ -9,6 +9,9 @@ related_files:
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/tools/tool_family/CONTRACT.md
+  - src/lingtai/tools/bash/ANATOMY.md
+  - src/lingtai/tools/bash/CONTRACT.md
+  - src/lingtai/tools/bash/_tool_family.py
   - src/lingtai/adapters/browser_transport.py
   - src/lingtai/tools/registry.py
   - src/lingtai/tools/glossary_validator.py
@@ -40,8 +43,13 @@ capability names and lazy adapters.
   (`src/lingtai/tools/browser/ANATOMY.md`).
 - `tool_family/` — generic, optional ToolFamily/ChildTool schema-composition
   and dispatch infrastructure implementing the LTP v2 envelope, and the
-  reusable ManualTool builder; `web` is its first real consumer
+  reusable ManualTool builder; `web` and `shell` are its consumers
   (`src/lingtai/tools/tool_family/ANATOMY.md`).
+- `bash/` — public `shell` composition owner for run/poll/cancel/manual
+  (`src/lingtai/tools/bash/ANATOMY.md`); the public model-facing schema is
+  the ToolFamily-composed LTP v2 envelope (`bash/_tool_family.py`) and is the
+  package's only schema/description pair, while `ShellManager` remains the
+  unchanged execution engine behind an internal-only flat call shape.
 - `_manual.py` — bounded installed-manual loader
   (`src/lingtai/tools/_manual.py:1-29`).
 
@@ -53,6 +61,13 @@ provider factory only at composition or action boundaries, and imports
 `tool_family` to compose its schema and (optionally) dispatch. The pinned
 browser transport remains an outer adapter. `web_search` is accepted only as a
 one-way configuration input alias and is never emitted as a public name.
+The public `shell` row imports `lingtai.tools.bash` lazily; `bash/__init__.py`
+imports `tool_family` (via `bash/_tool_family.py`) to compose the public
+action-separated schema (re-exported as the package's canonical
+`get_schema`/`get_description`) and to translate `action`/`input` calls into the
+internal flat shape `ShellManager.handle` consumes. `bash` is the
+one-way legacy input alias for `shell` (`registry.py`) and is never emitted
+as a public name or a second schema.
 
 ## Composition
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -235,12 +235,19 @@ documents. `web` (`search | browse | manual`) is the first family migrated to
 this contract: its final model-facing root is exactly `action`, `input`,
 `reasoning`, and `summarize`; its `search` action reads the action-owned
 `settings/web.search.json` (see `src/lingtai/tools/web_search/CONTRACT.md`).
+`shell` (`run | poll | cancel | manual`) is the second: its final model-facing
+root is likewise exactly `action`, `input`, `reasoning`, and `summarize`, its
+run-only fields live only in `run`'s `input` and `job_id` only in
+`poll`/`cancel`'s, and its unchanged `ShellManager` engine — sync execution,
+the working-directory sandbox, the durable async lifecycle, cancellation, and
+terminal receipts — keeps its historical flat shape as a purely internal
+interface (see `src/lingtai/tools/bash/CONTRACT.md`).
 The legacy a-priori result-summarization flag under the literal key `summary`
 (`src/lingtai/kernel/tool_result_summary.py:172`) remains honored for every
 still-unmigrated caller; `src/lingtai/kernel/tool_result_summary.py` recognizes
 the canonical `summarize` spelling only when the calling tool is a migrated LTP
-v2 family (currently only `web`), so an unmigrated tool's own field literally
-named `summarize` is never reinterpreted as this control. Every other
+v2 family (currently `web` and `shell`), so an unmigrated tool's own field
+literally named `summarize` is never reinterpreted as this control. Every other
 LingTai-owned family remains unmigrated and keeps its existing schema and
 settings surface unchanged by this file.
 
@@ -250,7 +257,9 @@ infrastructure implementing this envelope (schema composition from a
 ManualTool builder) that a family MAY adopt instead of hand-writing the
 equivalent code; `web` is its first consumer, using it for schema composition
 and dispatch while retaining its own outer `handle()` for family-specific
-diagnostics. Using it is never required — see its own
+diagnostics, and `shell` is its second, using it the same way while retaining a
+thin outer `handle()` that narrows the generic unknown-action message to its own
+four actions. Using it is never required — see its own
 `src/lingtai/tools/tool_family/CONTRACT.md` "Implementation independence" is
 binding on it exactly as it is on every family.
 

--- a/src/lingtai/tools/bash/ANATOMY.md
+++ b/src/lingtai/tools/bash/ANATOMY.md
@@ -3,6 +3,9 @@ related_files:
   - src/lingtai/ANATOMY.md
   - src/lingtai/adapters/posix/ANATOMY.md
   - src/lingtai/tools/bash/__init__.py
+  - src/lingtai/tools/bash/_tool_family.py
+  - src/lingtai/tools/tool_family/ANATOMY.md
+  - src/lingtai/tools/tool_family/CONTRACT.md
   - src/lingtai/tools/bash/_async_supervisor.py
   - src/lingtai/tools/bash/_async_process.py
   - src/lingtai/tools/bash/_state_lock.py
@@ -43,7 +46,8 @@ be explicitly opted into.
 
 ## Components
 
-- `bash/__init__.py` — public schema/setup plus policy, sync execution, and durable async manager orchestration. `get_description` (`__init__.py:195`), `get_schema` (`__init__.py:199`), and `setup` (`__init__.py:1416`) define the public capability surface. `BashManager` owns validation, manager semantics, durable-state rehydration, notification publication, and poll/cancel consumption (`__init__.py:338`). `_augment_command_result` adds `ok`/`command_status`/`warning` fidelity fields (`__init__.py:141`).
+- `bash/__init__.py` — the execution engine plus policy, sync execution, and durable async manager orchestration. It declares no schema or description of its own: the package's single public pair is re-exported from `_tool_family.py` at `__init__.py:43` under the canonical `get_schema`/`get_description` names, so there is exactly one model-facing surface and no second flat one to drift against. `setup` (`__init__.py:1470`) registers the public `shell` tool with that schema/description and the family dispatcher. `ShellManager` (`__init__.py:330`, aliased `BashManager` at `__init__.py:1467`) owns validation, manager semantics, durable-state rehydration, notification publication, and poll/cancel consumption; its `handle` dispatches `poll`/`cancel`/`run` only — `manual` is a family child and never reaches it. Its async start receipt and durable reminder body both teach the registered envelope call `shell(action="poll", input={"job_id": ...})`. `_augment_command_result` adds `ok`/`command_status`/`warning` fidelity fields (`__init__.py:191`).
+- `bash/_tool_family.py` — the public/model-facing `shell` tool's LTP v2 envelope. `RUN_INPUT_SCHEMA`/`POLL_INPUT_SCHEMA`/`CANCEL_INPUT_SCHEMA`/`MANUAL_INPUT_SCHEMA` are four strict per-action schemas (run-only fields — `command`, `timeout`, `working_dir`, `async`, `reminder` — live only in `run`'s branch; `job_id` lives only in `poll`/`cancel`'s); `get_schema()` composes them via the generic `tool_family.ToolFamily` (root `allOf` correlation plus `input.oneOf` disclosure, same infra `web` uses), and `get_description()` here is the registered model-facing text documenting that action-separated call shape. Optional run fields are declared required-but-nullable per the strict-schema convention; `_strip_nulls` drops `null` (meaning *absent*) so `ShellManager`'s own runtime defaults apply, while falsy-but-present values (`timeout: 0`, `async: false`) pass through verbatim. `ShellFamilyDispatcher` is the per-agent, per-`ShellManager` handler registered by `setup()`: its `run`/`poll`/`cancel` child handlers flatten their own validated `input` (re-adding the matching `action` key) and delegate to the unchanged `ShellManager.handle` — the async lifecycle, durable state, and every existing `ShellManager` test keep exercising that exact code path. Its thin outer `handle()` adds exactly one Host normalization: narrowing the generic dispatcher's unknown-action message to Shell's own four actions. `manual` is registered directly from `tool_family.manual.build_manual_child`, the shared reserved-name contract, so it returns the canonical `content`/`structuredContent` shape; `MANUAL_INPUT_SCHEMA` is sourced from that same builder rather than re-declared, so the schema the wire advertises and the schema dispatch validates against are one definition. The engine has no manual branch at all — `manual` performs no shell operation and never reaches `ShellManager`.
 - `bash/_shell_dialect.py` — the Bash-local `ShellDialect` port and serializable `ShellInvocation`; the POSIX extraction helper preserves the existing policy grammar.
 - `adapters/posix/bash.py` — `PosixBashDialect`, the first production adapter; it provides POSIX policy extraction and script-form shell invocation.
 - `adapters/shell.py` — `select_shell_dialect`, the outer selector for POSIX and PowerShell dialects; `adapters/bash.py` remains a private compatibility selector.
@@ -56,21 +60,33 @@ be explicitly opted into.
 
 ## Public API
 
-The canonical `shell` tool supports synchronous and asynchronous execution:
+The canonical `shell` tool is a migrated LTP v2 family (`src/lingtai/tools/CONTRACT.md`). Its model-facing root is exactly four fields, and the action's own inputs live under `input`:
 
-| Parameter      | Type     | Description |
-|----------------|----------|-------------|
-| `command`      | string   | Shell command to execute (required for `run`) |
-| `timeout`      | number   | Timeout in seconds (default: 30, sync only) |
-| `working_dir`  | string   | Working directory for execution (default: agent's working dir) |
-| `action`       | string   | `run` (default), `poll`, or `cancel` |
-| `async`        | boolean  | If true, run in background and return job_id immediately (default: false) |
-| `reminder`     | number   | Top-level schema-required field; provider calls carry it for every action, but runtime consumes/validates it only for async `run` (default 1800) |
-| `job_id`       | string   | Job ID for `poll` and `cancel` actions |
+| Root field   | Type    | Description |
+|--------------|---------|-------------|
+| `action`     | string  | Required. One of `run`, `poll`, `cancel`, `manual`. No default. |
+| `input`      | object  | Required. Strict, action-specific input; cross-action keys are rejected at dispatch. |
+| `reasoning`  | string  | Required. Host InvocationContext/audit metadata; never forwarded into `input`. |
+| `summarize`  | boolean | Optional root result post-processing control (default false); never forwarded into `input`. |
 
-**Sync mode** (`async=false`, default): Returns `{status, exit_code, stdout, stderr, ok, command_status[, warning]}` once the command completes, or `{status: "error", message}` only when the shell itself could not run it (empty command, policy denial, timeout, spawn failure).
+Per-action `input` (run-only fields exist only in `run`; `job_id` only in `poll`/`cancel`):
 
-**Async mode** (`async=true`): Returns `{status: "ok", job_id, pid, message}` immediately. Initial durable state carries both a tokenized finite supervisor-start lease and a bounded `return_handoff`. The supervisor must claim/recheck the start lease before adapter spawn; the parent then atomically replaces the crash-fallback reminder deadline with `returned_at + reminder` and arms the return handoff before returning. `status: ok` requires winning that valid pending-to-armed transition (or exact completed/failed truth under the still-valid guard); a late owner after expiry returns a pollable error with `job_id`/`pid` instead of false success. Any rehydrated old timer defers while that handoff is pending. The detached supervisor owns durable lease/cancellation/terminal policy and selects the Bash-local process Port; the POSIX adapter owns the command handle, spawn, exact wait, and process-tree cancellation. The supervisor atomically records `{cwd, started_at, finished_at, exit_status_known, exit_code}` from that exact owned wait. A fresh manager never consumes unknown merely because a command process ref vanished: it waits/reloads while the recorded supervisor can still commit, marks unknown only after an expired start lease or a definitively gone supervisor, and otherwise returns recoverable `running`. Terminal poll is a conditional one-shot claim. `cancel` persists a request only after the selected adapter verifies the neutral supervisor ref as the same incarnation; unknown identity is never cancellation authority. The POSIX adapter retains the direct child unreaped through TERM grace, KILLs the original group, proves live-member quiescence, and returns exact terminal truth for the supervisor to commit before cancellation can atomically consume/suppress the job. Async run validates `reminder` as a finite non-negative number bounded by `threading.TIMEOUT_MAX` and defaults omitted direct calls to 1800 seconds.
+| Action   | `input` field  | Type    | Description |
+|----------|----------------|---------|-------------|
+| `run`    | `command`      | string  | Shell command to execute (the one genuinely required, non-nullable field) |
+| `run`    | `timeout`      | number\|null | Timeout in seconds; `null` → default 30, sync only |
+| `run`    | `working_dir`  | string\|null | Working directory; `null`/`""` → the agent working dir, and it must stay inside that sandbox |
+| `run`    | `async`        | boolean\|null | `true` runs in background and returns `job_id` immediately; `null` → false |
+| `run`    | `reminder`     | number\|null | Last-resort async wake delay; `null` → default 1800. Consumed/validated only for async `run` |
+| `poll`   | `job_id`       | string  | Job ID returned by an async run |
+| `cancel` | `job_id`       | string  | Job ID returned by an async run |
+| `manual` | —              | —       | Strict empty `{}`; performs no shell operation |
+
+**Manual** (`action="manual"`): Returns the shared ManualTool contract result — full `shell-manual` body at `content[0].text`, host-local path at `structuredContent.manual_path` — verbatim, with no double wrapping. It reaches no execution engine, spawns no process, and touches no job state, and it serves the installed manual body/path unchanged (`.library/intrinsic/capabilities/shell/SKILL.md`).
+
+**Sync mode** (`input.async=false`, default): Returns `{status, exit_code, stdout, stderr, ok, command_status[, warning]}` once the command completes, or `{status: "error", message}` only when the shell itself could not run it (empty command, policy denial, timeout, spawn failure).
+
+**Async mode** (`input.async=true`): Returns `{status: "ok", job_id, pid, message}` immediately. Initial durable state carries both a tokenized finite supervisor-start lease and a bounded `return_handoff`. The supervisor must claim/recheck the start lease before adapter spawn; the parent then atomically replaces the crash-fallback reminder deadline with `returned_at + reminder` and arms the return handoff before returning. `status: ok` requires winning that valid pending-to-armed transition (or exact completed/failed truth under the still-valid guard); a late owner after expiry returns a pollable error with `job_id`/`pid` instead of false success. Any rehydrated old timer defers while that handoff is pending. The detached supervisor owns durable lease/cancellation/terminal policy and selects the Bash-local process Port; the POSIX adapter owns the command handle, spawn, exact wait, and process-tree cancellation. The supervisor atomically records `{cwd, started_at, finished_at, exit_status_known, exit_code}` from that exact owned wait. A fresh manager never consumes unknown merely because a command process ref vanished: it waits/reloads while the recorded supervisor can still commit, marks unknown only after an expired start lease or a definitively gone supervisor, and otherwise returns recoverable `running`. Terminal poll is a conditional one-shot claim. `cancel` persists a request only after the selected adapter verifies the neutral supervisor ref as the same incarnation; unknown identity is never cancellation authority. The POSIX adapter retains the direct child unreaped through TERM grace, KILLs the original group, proves live-member quiescence, and returns exact terminal truth for the supervisor to commit before cancellation can atomically consume/suppress the job. Async run validates `reminder` as a finite non-negative number bounded by `threading.TIMEOUT_MAX` and defaults omitted direct calls to 1800 seconds.
 
 **Result fidelity — top-level `status` vs. inner command success.** The top-level `status` (`ok`/`done`) reflects only that the shell *spawned* the command; it stays `ok`/`done` even when the inner command exits nonzero. To make inner failures impossible to skim past *without* changing the `status` contract that downstream recovery/telemetry branch on (`tool_executor.py` enriches/logs/collects on `status == "error"`), `_augment_command_result` (`__init__.py`) adds three additive, model-visible fields keyed off `exit_code`:
 

--- a/src/lingtai/tools/bash/CONTRACT.md
+++ b/src/lingtai/tools/bash/CONTRACT.md
@@ -1,9 +1,13 @@
 ---
 name: bash-contract
 tool: shell
-contract_version: 3
+contract_version: 4
 related_files:
   - src/lingtai/tools/bash/__init__.py
+  - src/lingtai/tools/bash/_tool_family.py
+  - src/lingtai/tools/tool_family/__init__.py
+  - src/lingtai/tools/tool_family/manual.py
+  - src/lingtai/tools/CONTRACT.md
   - src/lingtai/tools/bash/_async_supervisor.py
   - src/lingtai/tools/bash/_async_process.py
   - src/lingtai/tools/bash/_state_lock.py
@@ -71,20 +75,86 @@ does not stream output incrementally (async jobs are polled, not streamed).
 
 ## Tool surface
 
-`get_schema` marks `reminder` required at the top schema level to satisfy the
-provider-facing required-option contract. Provider-validated sync `run`,
-`poll`, and `cancel` calls therefore also carry `reminder` on the wire, but the
-handler consumes and validates it only for async `run`; sync `run`, `poll`, and
-`cancel` ignore it. Direct async runtime calls that omit it still default to
-1800 seconds for compatibility. The handler enforces per-action requirements
-for `command` and `job_id`. `action` defaults to `run`.
+`shell` is a migrated LingTai Tool Protocol v2 family (see
+`src/lingtai/tools/CONTRACT.md`). Its public/model-facing root is exactly
+`action`, `input`, `reasoning`, and `summarize`; `action`, `input`, and
+`reasoning` are required and the root is closed
+(`additionalProperties: false`). The four canonical children are
+`run | poll | cancel | manual`; each child name is simultaneously the public
+`action` value and the dispatch key, with no mapping layer. `action` has no
+default — it must be stated. The composed schema is built by the generic
+`tool_family` infrastructure in `src/lingtai/tools/bash/_tool_family.py`
+(`get_schema`), which correlates each `action` const to that child's own
+`input` schema at the root via `allOf`/`if`/`then` and additionally discloses
+every branch under `input.oneOf`.
 
-| Action | Required inputs | Optional inputs | Success output | Error shapes |
+Run-only fields (`command`, `timeout`, `working_dir`, `async`, `reminder`) exist
+only in `run`'s `input`; `job_id` exists only in `poll`'s and `cancel`'s.
+`manual` takes a strict empty `input`. Every child `input` is closed, and a key
+belonging to another action's branch is rejected at dispatch — before any
+handler I/O — with `{status: "failed", error_code: "INVALID_ARGUMENT",
+message: "unsupported shell input field"}`. An unknown `action` is rejected the
+same way with `error_code: "ACTION_REQUIRED"` and the message
+`action must be one of run, poll, cancel, or manual`.
+
+Following the strict-schema convention, optional run fields are declared
+REQUIRED but nullable: `null` means *absent* and is dropped before delegation,
+so `ShellManager` applies its own unchanged runtime defaults (`timeout` 30,
+`working_dir` = the agent sandbox, `async` false, `reminder` 1800). Only
+`command` is genuinely required and non-nullable. A falsy-but-present value
+(`timeout: 0`, `async: false`, `working_dir: ""`) is passed through verbatim.
+
+`reasoning` is Host InvocationContext/audit metadata and `summarize` is the
+root, cross-cutting result post-processing control; neither is ever forwarded
+into a child's `input`. `summarize` is honored by the single existing central
+summarizer (`src/lingtai/kernel/tool_result_summary.py`), which recognizes the
+canonical spelling only for a migrated family — there is no second summarizer
+and no shell-specific summarization mechanism. The pre-migration flat `summary`
+boolean is no longer advertised on the public schema, though the central
+summarizer still honors that spelling unconditionally for any historical or
+pending call that carries it.
+
+`ShellManager` is the unchanged execution engine. It still accepts the
+historical flat call shape (`{"action": "run", "command": ...}`, `action`
+defaulting to `run`) as its internal interface, and the async lifecycle,
+durable job state, leases, reminders, completion notifications, and
+cancellation semantics below are exactly as before; `_tool_family.py` only
+flattens a validated `input` back into that shape before delegating. That flat
+shape is purely internal and has no schema of its own: the package declares
+exactly one `get_schema`/`get_description` pair — the migrated family surface in
+`_tool_family.py`, re-exported from `__init__.py` under those canonical names —
+so no second, pre-migration public schema exists to drift against.
+
+The engine serves no documentation: `ShellManager.handle` dispatches only
+`poll`, `cancel`, and `run`. `manual` is owned solely by the family's reserved
+child and never reaches the engine.
+
+Each child returns `ShellManager`'s own raw, canonical result verbatim. There
+is no Host envelope wrapped around a child result, and no child result nested
+inside another action's result.
+
+| Action | Required `input` | Nullable-optional `input` | Success output | Error shapes |
 |---|---|---|---|---|
-| `run` (sync) | Provider schema: `command`, `reminder`; runtime consumes `command` only | `working_dir`, `timeout` (default 30), `summary` | `{status: "ok", exit_code, stdout, stderr, ok, command_status, warning?}` | `{status: "error", message}` — empty command, policy-denied, cwd outside sandbox, timeout (with broad-scan hint), or spawn failure |
-| `run` (async) | Provider/runtime: `command`, `async: true`, `reminder` | `working_dir`, `summary` | `{status: "ok", job_id, pid, message, handoff}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally says that if Telegram is connected and a Task Card is available for the current turn, the model should use it to report progress via `telegram(action='manual')` and that manual's `Programmable Task Card` section; read `shell-manual` and `notification-manual` for details | `{status: "error", message}` — same validation errors, invalid boolean/non-numeric/non-finite/negative/too-large `reminder`, plus `Failed to start async job: ...` |
-| `poll` | Provider schema: `job_id`, `reminder`; runtime consumes `job_id` only | — | running: `{status: "running", job_id, pid?}` while the recorded supervisor may still commit; known finished: `{status: "done", exit_status_known: true, exit_code, stdout, stderr, ok, command_status, warning?}`; unrecoverable/legacy terminal: `{status: "done", exit_status_known: false, exit_code: null, stdout, stderr}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or an already terminal-consumed job |
-| `cancel` | Provider schema: `job_id`, `reminder`; runtime consumes `job_id` only | — | `{status: "cancelled", job_id}` only after the supervisor has committed the held child's exact terminal status and cancellation atomically consumes/suppresses the job | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, terminal job, legacy job, or a durable cancellation request still awaiting a terminal commit (which remains pollable/remindable) |
+| `run` (sync) | `command` | `working_dir`, `timeout` (default 30), `async`, `reminder` | `{status: "ok", exit_code, stdout, stderr, ok, command_status, warning?}` | `{status: "error", message}` — empty command, policy-denied, cwd outside sandbox, timeout (with broad-scan hint), or spawn failure |
+| `run` (async) | `command`, `async: true` | `working_dir`, `timeout`, `reminder` | `{status: "ok", job_id, pid, message, handoff}`; `handoff` tells the model it may go idle or call `system(action='sleep')` while waiting for the terminal notification, and conditionally says that if Telegram is connected and a Task Card is available for the current turn, the model should use it to report progress via `telegram(action='manual')` and that manual's `Programmable Task Card` section; read `shell-manual` and `notification-manual` for details | `{status: "error", message}` — same validation errors, invalid boolean/non-numeric/non-finite/negative/too-large `reminder`, plus `Failed to start async job: ...` |
+| `poll` | `job_id` | — | running: `{status: "running", job_id, pid?}` while the recorded supervisor may still commit; known finished: `{status: "done", exit_status_known: true, exit_code, stdout, stderr, ok, command_status, warning?}`; unrecoverable/legacy terminal: `{status: "done", exit_status_known: false, exit_code: null, stdout, stderr}` | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, or an already terminal-consumed job |
+| `cancel` | `job_id` | — | `{status: "cancelled", job_id}` only after the supervisor has committed the held child's exact terminal status and cancellation atomically consumes/suppresses the job | `{status: "error", message}` — missing/invalid `job_id`, `Job not found`, terminal job, legacy job, or a durable cancellation request still awaiting a terminal commit (which remains pollable/remindable) |
+| `manual` | — (strict empty `{}`) | — | `{status, content: [{type: "text", text: <full shell-manual body>}], structuredContent: {manual_path}}` — the shared ManualTool contract, returned without double wrapping | `status: "degraded"` plus `error` when the installed manual is missing |
+
+`manual` performs no shell operation: it never reaches the execution engine,
+spawns no process, and touches no job state. It serves the installed manual body
+and its host-local `manual_path` unchanged
+(`.library/intrinsic/capabilities/shell/SKILL.md`, the destination
+`Agent._install_intrinsic_manuals` maps the retained `bash/manual/` bundle to).
+Its input schema is sourced from the shared `build_manual_child` builder, not
+re-declared, so the advertised and dispatch-validated shapes are one definition.
+
+The async start receipt (`run` async `message`) and the durable reminder
+notification body both hand the model a literal call, and both MUST teach the
+registered envelope — `shell(action="poll", input={"job_id": "..."})` — never a
+flat root `job_id`, which the public schema rejects before dispatch. A reminder
+may wake an agent hours later, possibly post-molt, so this is the recovery
+guidance for exactly the callers least able to re-derive the shape.
 
 Fidelity fields are additive and keyed off `exit_code`: `ok` is `True` only when
 `exit_code == 0`; `command_status` is `"success"`/`"failed"`; `warning` is
@@ -100,8 +170,9 @@ any filesystem access (path-traversal guard).
 `run`; booleans, non-numeric values, non-finite values (`NaN`, `Infinity`),
 negative values, and values larger than `threading.TIMEOUT_MAX` are rejected
 because the timer backend cannot accept them safely. The schema default is 1800
-seconds. Direct runtime calls that omit it still get 1800 seconds, so older
-callers keep working even though providers see the field as required.
+seconds. It now lives only in `run`'s `input`, so `poll` and `cancel` no longer
+carry it on the wire at all; a `run` call that passes `null` (or a direct
+runtime call that omits it) still gets 1800 seconds.
 
 Agents following an async success `handoff` MUST treat Task Card guidance as
 conditional: use the Task Card only when Telegram is connected and a Task Card

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -23,7 +23,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ._shell_dialect import ShellDialect, ShellInvocation, extract_posix_commands
-from .._manual import load_installed_manual
 
 from ._async_supervisor import (
     load_state,
@@ -37,6 +36,11 @@ from ._async_process import (
     ProcessRef,
     process_ref_from_state,
 )
+# The package's one and only public schema/description pair is the migrated
+# action-separated family surface, re-exported here under the canonical
+# duck-typed names (the same single-surface shape ``web`` has). There is no
+# second, flat, pre-migration pair to drift against.
+from ._tool_family import ShellFamilyDispatcher, get_description, get_schema
 
 
 if TYPE_CHECKING:
@@ -238,66 +242,6 @@ def _augment_command_result(result: dict) -> dict:
     result["warning"] = "; ".join(parts)
     return result
 
-def get_description(
-    lang: str = "en",
-    dialect: str = "posix",
-    host_os: str | None = None,
-) -> str:
-    host = f" Host OS: {host_os}." if host_os else ""
-    return (f"Execute a shell command and return stdout/stderr. Active shell dialect: {dialect}.{host} "
-            "The dialect and host OS are detected at setup time; calls cannot choose them. Any system program — scripts, git, curl, pip, data pipelines. "
-            "Returns exit_code, stdout, stderr, plus ok (bool) and command_status ('success'/'failed'). IMPORTANT: top-level status stays 'ok' even when the command FAILS — it only means the shell ran. "
-            "Always check exit_code/ok and read the warning field (it names nonzero exits, Python tracebacks, and missing modules); never assume success from status alone. "
-            "Avoid broad recursive scans (find … -name, rglob, os.walk, glob('**')) — they time out; prefer `rg --files`. Parse JSONL line-by-line, not as one JSON blob. "
-            "Supports async mode (async=true → job_id, then poll/cancel). Call shell(action='manual') to return the installed shell-manual skill. Before ordinary shell work, read that manual — it covers async hygiene and advanced usage; no exceptions.")
-
-
-def get_schema(lang: str = "en") -> dict:
-    return {
-        "type": "object",
-        "properties": {
-            "action": {
-                "type": "string",
-                "enum": ["run", "poll", "cancel", "manual"],
-                "description": "Action to perform: 'run' (default) executes a command, 'poll' checks async job status, 'cancel' kills an async job, 'manual' returns the installed shell-manual skill",
-                "default": "run",
-            },
-            "command": {
-                "type": "string",
-                "description": 'The shell command to execute',
-            },
-            "timeout": {
-                "type": "number",
-                "description": 'Timeout in seconds (default: 30, only for sync execution)',
-                "default": 30,
-            },
-            "working_dir": {
-                "type": "string",
-                "description": 'Working directory for the command (optional). Leave it out (or pass an empty string) to use the agent working directory. Must be inside the agent working directory sandbox; paths outside it are rejected. For external repos/paths, keep working_dir at the agent dir and put an explicit cd in command, e.g. cd /absolute/path && ...',
-            },
-            "async": {
-                "type": "boolean",
-                "description": "Run command in background and return immediately with a job_id (default: false, only for action='run')",
-                "default": False,
-            },
-            "reminder": {
-                "type": "number",
-                "description": "Last-resort async wake delay in seconds (default: 1800). For async run only: if the job is still non-terminal when the durable deadline expires, publish a system notification reminding you to poll it; exact completion suppresses this stale watchdog and publishes the shell completion wake instead.",
-                "default": _DEFAULT_ASYNC_REMINDER_SECONDS,
-            },
-            "job_id": {
-                "type": "string",
-                "description": 'Job ID for poll/cancel actions (returned by async run)',
-            },
-            "summary": {
-                "type": "boolean",
-                "description": 'Optional. Default false. When true, this tool runs normally and the raw result is preserved in the durable log (retrievable by tool_call_id), but before the result enters your context it is replaced by an LLM-generated summary driven by your `reasoning` field — so make `reasoning` specific about what to retain. Set true only when the output is expected to be large (>10k chars) and you do NOT need the exact raw text. Leave false when you need exact line/file/diff/stderr text. The summary is non-canonical; if the raw exceeds 500,000 chars no summary is generated and you get a refusal pointing at the preserved raw.',
-                "default": False,
-            },
-        },
-        "required": [],  # action-specific inputs are enforced by the handler; manual needs none
-    }
-
 
 
 class ShellPolicy:
@@ -493,9 +437,13 @@ class ShellManager:
         return delay, None
 
     def handle(self, args: dict) -> dict:
+        """Execute one already-validated action in the internal flat shape.
+
+        ``manual`` is not handled here: it is a no-I/O documentation action
+        owned by the family's reserved ``manual`` child
+        (``_tool_family.build_manual_child``), which never reaches this engine.
+        """
         action = args.get("action", "run")
-        if action == "manual":
-            return load_installed_manual(self._agent, "shell")
         if action == "poll":
             return self._handle_poll(args)
         if action == "cancel":
@@ -817,7 +765,13 @@ class ShellManager:
                     }
                 return {
                     "status": "ok", "job_id": job_id, "pid": pid,
-                    "message": f'Job started. Use shell(action="poll", job_id="{job_id}") to check.',
+                    # Teaches the registered public envelope, not the internal
+                    # flat shape: an agent that copies this receipt verbatim
+                    # must land a call the public ``shell`` schema accepts.
+                    "message": (
+                        'Job started. Use shell(action="poll", '
+                        f'input={{"job_id": "{job_id}"}}) to check.'
+                    ),
                     "handoff": "While waiting, go idle or call system(action='sleep'); the terminal result will arrive and wake you as a notification; read shell-manual and notification-manual for details. If Telegram is connected and a Task Card is available for the current turn, use it to report progress; call `telegram(action='manual')` and follow its `Programmable Task Card` section for details.",
                 }
             if state and self._terminal(state.get("status")):
@@ -1009,9 +963,12 @@ class ShellManager:
             cancel_event.set()
 
     def _publish_async_reminder(self, job_id: str) -> bool:
+        # Same envelope-teaching rule as the async start receipt: this durable
+        # watchdog may wake an agent hours later (possibly post-molt), so the
+        # call it hands over must be the one the public schema accepts.
         body = (
             f"Shell async job {job_id} may still be running. "
-            f"Poll it with shell(action=\"poll\", job_id=\"{job_id}\")."
+            f'Poll it with shell(action="poll", input={{"job_id": "{job_id}"}}).'
         )
         agent = self._agent
         if hasattr(agent, "_enqueue_system_notification"):
@@ -1543,11 +1500,19 @@ def setup(
         agent=agent,
         dialect=dialect,
     )
-    # Description is setup-time metadata derived from the injected adapter and host.
+    # Description is setup-time metadata derived from the injected adapter and
+    # host, documenting the registered action-separated call shape.
     desc = get_description(dialect=dialect.state_key(), host_os=_describe_host_os())
     policy_summary = policy.describe()
     if policy_summary:
         desc = f"{desc}\n\n{policy_summary}"
 
-    agent.add_tool("shell", schema=get_schema(), handler=mgr.handle, description=desc, glossary_package=__package__)
+    # The dispatcher validates the envelope and flattens each action's own
+    # ``input`` into the internal call shape ``ShellManager.handle`` consumes,
+    # so the async lifecycle and durable state stay one untouched code path.
+    dispatcher = ShellFamilyDispatcher(mgr, agent)
+    agent.add_tool(
+        "shell", schema=get_schema(), handler=dispatcher.handle,
+        description=desc, glossary_package=__package__,
+    )
     return mgr

--- a/src/lingtai/tools/bash/_tool_family.py
+++ b/src/lingtai/tools/bash/_tool_family.py
@@ -1,0 +1,249 @@
+"""ToolFamily envelope for the canonical ``shell`` tool.
+
+The public/model-facing ``shell`` tool is migrated to the LingTai Tool
+Protocol v2 action-separated shape (``action``/``input``/``reasoning``/
+``summarize``, see ``../CONTRACT.md``) using the generic, optional
+``tool_family`` infrastructure (``../tool_family/__init__.py``). ``run``,
+``poll``, ``cancel``, and the reserved ``manual`` become four ``ChildTool``s
+with their own strict per-action ``input`` schemas — run-only fields
+(``command``, ``timeout``, ``working_dir``, ``async``, ``reminder``) live only
+in ``run``'s branch; ``job_id`` lives only in ``poll``/``cancel``'s branches.
+
+``ShellManager`` (``__init__.py``) is the unchanged execution engine: its
+``handle()`` still accepts the historical flat legacy shape
+(``{"action": "run", "command": ..., ...}``, ``action`` defaulting to
+``"run"``) and its full async lifecycle (leases, durable state, reminders,
+completion notifications, cancellation) is untouched — this module only
+translates the new envelope into that flat shape before delegating, so every
+existing ``ShellManager`` test keeps exercising the exact same code path. That
+flat shape is internal only — this module owns the package's single public
+``get_schema``/``get_description`` pair, re-exported from ``__init__.py``.
+This is the same division ``web`` uses between
+``ToolFamily.handle()`` (envelope validation/dispatch) and its own
+Host/presentation adaptation, applied in the opposite direction: here the
+*inner* engine is the legacy shape and the *outer* envelope is new.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..tool_family import ChildTool, ToolFamily
+from ..tool_family.manual import build_manual_child
+
+_DEFAULT_TIMEOUT_SECONDS = 30
+_DEFAULT_ASYNC_REMINDER_SECONDS = 1800.0
+
+RUN_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "command": {
+            "type": "string",
+            "description": "The shell command to execute",
+        },
+        "timeout": {
+            "type": ["number", "null"],
+            "description": (
+                "Timeout in seconds, or null for the default 30. Only for sync "
+                "execution."
+            ),
+            "default": _DEFAULT_TIMEOUT_SECONDS,
+        },
+        "working_dir": {
+            "type": ["string", "null"],
+            "description": (
+                "Working directory for the command; use null (or an empty "
+                "string) to use the agent working directory. Must be inside "
+                "the agent working directory sandbox; paths outside it are "
+                "rejected. For external repos/paths, keep working_dir at the "
+                "agent dir and put an explicit cd in command, e.g. "
+                "cd /absolute/path && ..."
+            ),
+        },
+        "async": {
+            "type": ["boolean", "null"],
+            "description": (
+                "Run command in background and return immediately with a "
+                "job_id, or null for the default false."
+            ),
+            "default": False,
+        },
+        "reminder": {
+            "type": ["number", "null"],
+            "description": (
+                "Last-resort async wake delay in seconds, or null for the "
+                "default 1800. Only "
+                "meaningful when async is true: if the job is still non-terminal "
+                "when the durable deadline expires, publish a system "
+                "notification reminding you to poll it; exact completion "
+                "suppresses this stale watchdog and publishes the shell "
+                "completion wake instead."
+            ),
+            "default": _DEFAULT_ASYNC_REMINDER_SECONDS,
+        },
+    },
+    # Strict OpenAI schemas express an optional field as a REQUIRED nullable
+    # property (the same convention ``web``'s ``browse`` child uses): every
+    # run-only field is listed here, and null means "absent" to
+    # ``ShellManager``, which then applies its own unchanged runtime default
+    # (timeout 30, working_dir = the agent sandbox, async false, reminder
+    # 1800). ``command`` is the one genuinely required field and is
+    # non-nullable.
+    "required": ["command", "timeout", "working_dir", "async", "reminder"],
+    "additionalProperties": False,
+}
+
+POLL_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "job_id": {
+            "type": "string",
+            "description": "Job ID for the poll action (returned by an async run)",
+        },
+    },
+    "required": ["job_id"],
+    "additionalProperties": False,
+}
+
+CANCEL_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "job_id": {
+            "type": "string",
+            "description": "Job ID for the cancel action (returned by an async run)",
+        },
+    },
+    "required": ["job_id"],
+    "additionalProperties": False,
+}
+
+# Sourced from the shared reserved-``manual`` builder rather than re-declared,
+# so the schema the wire advertises and the schema the dispatcher validates
+# against are the same object by construction and cannot drift apart.
+MANUAL_INPUT_SCHEMA: dict[str, Any] = dict(
+    build_manual_child(None, "shell").input_schema
+)
+
+
+def get_description(
+    lang: str = "en",
+    dialect: str = "posix",
+    host_os: str | None = None,
+) -> str:
+    host = f" Host OS: {host_os}." if host_os else ""
+    return (
+        f"Execute a shell command and return stdout/stderr. Active shell dialect: {dialect}.{host} "
+        "The dialect and host OS are detected at setup time; calls cannot choose them. Any system program — scripts, git, curl, pip, data pipelines. "
+        "shell(action='run', input={'command': '...'}, reasoning='...') executes a command; "
+        "shell(action='poll', input={'job_id': '...'}, reasoning='...') checks an async job; "
+        "shell(action='cancel', input={'job_id': '...'}, reasoning='...') kills an async job; "
+        "shell(action='manual', input={}, reasoning='...') returns the installed shell-manual skill. "
+        "Returns exit_code, stdout, stderr, plus ok (bool) and command_status ('success'/'failed'). IMPORTANT: top-level status stays 'ok' even when the command FAILS — it only means the shell ran. "
+        "Always check exit_code/ok and read the warning field (it names nonzero exits, Python tracebacks, and missing modules); never assume success from status alone. "
+        "Avoid broad recursive scans (find … -name, rglob, os.walk, glob('**')) — they time out; prefer `rg --files`. Parse JSONL line-by-line, not as one JSON blob. "
+        "Supports async mode (input.async=true → job_id, then poll/cancel). Before ordinary shell work, read the manual — it covers async hygiene and advanced usage; no exceptions."
+    )
+
+
+def _schema_only_family() -> ToolFamily:
+    # A throwaway ``ToolFamily`` composing only the model-facing schema — the
+    # fixed four-child registry (no duplicate/reserved-name collision) is
+    # proven once, at import time, exactly as ``web_search`` does. The real
+    # per-agent dispatcher below builds its own ``ToolFamily`` with handlers
+    # bound to a live ``ShellManager`` instance.
+    def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
+        raise AssertionError("the module-level schema-only ToolFamily never dispatches")
+
+    return ToolFamily(
+        "shell",
+        [
+            ChildTool("run", RUN_INPUT_SCHEMA, _unused, title="run input"),
+            ChildTool("poll", POLL_INPUT_SCHEMA, _unused, title="poll input"),
+            ChildTool("cancel", CANCEL_INPUT_SCHEMA, _unused, title="cancel input"),
+            ChildTool("manual", MANUAL_INPUT_SCHEMA, _unused, title="manual input"),
+        ],
+    )
+
+
+_FAMILY = _schema_only_family()
+
+
+def get_schema(lang: str = "en") -> dict[str, Any]:
+    """Compose the action-separated public ``shell`` schema.
+
+    Generated purely from ``RUN_INPUT_SCHEMA``/``POLL_INPUT_SCHEMA``/
+    ``CANCEL_INPUT_SCHEMA``/``MANUAL_INPUT_SCHEMA`` by the generic
+    ``ToolFamily`` infra (root ``allOf`` correlation plus ``input.oneOf``
+    disclosure) — this is the schema registered for the public ``shell``
+    tool, and the only one the package defines. It is re-exported from
+    ``bash/__init__.py`` as that package's canonical ``get_schema``.
+    """
+    return _FAMILY.build_schema()
+
+
+class ShellFamilyDispatcher:
+    """Adapts the ``action``/``input`` envelope to ``ShellManager``'s legacy flat call shape.
+
+    Built per-agent, bound to one live ``ShellManager``. ``handle()`` is the
+    public ``shell`` tool's registered handler: ``ToolFamily.handle()``
+    validates the envelope and dispatches to exactly one of the four
+    ``ChildTool`` handlers below, each of which flattens its own validated
+    ``input`` mapping (injecting the matching ``action`` key, mirroring the
+    legacy dispatch contract in ``ShellManager.handle``) and calls
+    ``ShellManager.handle()`` unchanged. ``manual`` is registered directly,
+    unwrapped, from ``build_manual_child`` — the shared reserved-name
+    contract every LingTai family uses — so it returns the canonical
+    ``content``/``structuredContent`` shape. It is the family's sole manual
+    surface: ``ShellManager.handle`` has no ``action="manual"`` branch, so the
+    engine never serves documentation and ``manual`` performs no shell
+    operation.
+    """
+
+    def __init__(self, manager: Any, agent: Any) -> None:
+        self._manager = manager
+        self._family = ToolFamily(
+            "shell",
+            [
+                ChildTool("run", RUN_INPUT_SCHEMA, self._dispatch_run, title="run input"),
+                ChildTool("poll", POLL_INPUT_SCHEMA, self._dispatch_poll, title="poll input"),
+                ChildTool("cancel", CANCEL_INPUT_SCHEMA, self._dispatch_cancel, title="cancel input"),
+                build_manual_child(agent, "shell"),
+            ],
+        )
+
+    @staticmethod
+    def _strip_nulls(action_input: Mapping[str, Any]) -> dict[str, Any]:
+        # Strict schemas express optional fields as required nullable
+        # properties (see ``RUN_INPUT_SCHEMA``'s ``required`` note, and
+        # ``web``'s identical ``_strip_nulls``). Null means *absent* to
+        # ``ShellManager``, which then applies its own unchanged runtime
+        # default — dropping the key is what makes ``args.get("timeout", 30)``
+        # / ``args.get("working_dir") or self._working_dir`` behave exactly as
+        # they did for a legacy flat caller that simply omitted the field. A
+        # falsy-but-present value (``timeout: 0``, ``async: False``,
+        # ``working_dir: ""``) is preserved verbatim, never dropped.
+        return {key: value for key, value in action_input.items() if value is not None}
+
+    def _dispatch_run(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        flat = self._strip_nulls(action_input)
+        flat["action"] = "run"
+        flat.setdefault("command", "")
+        return self._manager.handle(flat)
+
+    def _dispatch_poll(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        return self._manager.handle({"action": "poll", "job_id": action_input.get("job_id", "")})
+
+    def _dispatch_cancel(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        return self._manager.handle({"action": "cancel", "job_id": action_input.get("job_id", "")})
+
+    def handle(self, args: Mapping[str, Any] | None) -> dict[str, Any]:
+        # ``ToolFamily.handle`` validates the envelope, strips/type-checks
+        # root ``summarize``, rejects unknown root fields and cross-action
+        # ``input`` keys, then returns the selected child's own raw canonical
+        # result verbatim — no double wrap, no Host envelope. The one Host
+        # normalization below narrows the generic dispatcher's action list to
+        # Shell's exact four; the generic canonical error shape
+        # (``status``/``error_code``/``message``) is left untouched.
+        result = self._family.handle(args)
+        if result.get("error_code") == "ACTION_REQUIRED":
+            result["message"] = "action must be one of run, poll, cancel, or manual"
+        return result

--- a/src/lingtai/tools/bash/glossary-wen.md
+++ b/src/lingtai/tools/bash/glossary-wen.md
@@ -15,12 +15,15 @@ maintenance: |
 ---
 **名相对照**
 
-- `shell`：执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。返 exit_code、stdout、stderr，兼附 ok（真伪）与 command_status（'success'/'failed'）。须知：命令虽败，顶层 status 仍作 'ok'——此仅言 shell 已运，非言命令已成。必察 exit_code/ok，且阅 warning 一字（标非零之退、Python 之回溯、缺失之模块）；勿独凭 status 而断其成。忌大范围递归之扫（find … -name、rglob、os.walk、glob('**')）——易致超时；宜先用 `rg --files`。JSONL 当逐行而解，勿混作一 JSON。支持异步：设 async=true 取 job_id，后以 poll/cancel 查之。用此器前，必先读 `shell-manual` 一技（含定时之设、异步之规、进阶之用），无所例外。
-- `action`：所行之事：'run'（默认）执行指令，'poll' 查异步任务之状，'cancel' 斩异步任务
-- `command`：欲执行之指令
-- `timeout`：超时秒数（默认：30，唯同步执行时生效）
-- `working_dir`：指令之工作目录（可选）。留空或传空字符串即用 agent 工作目录。须在 agent 工作目录沙箱之内；沙箱外路径会被拒。若需操作外部仓库/路径，请令 working_dir 保持为 agent 目录，并在 command 中显式 cd，如 cd /absolute/path && ...
-- `async`：后台运行指令，即返 job_id（默认：false，唯 action='run' 时生效）
-- `reminder`：异步兜底唤醒之延迟秒数（默认 1800）。顶层 schema 要求此字段，故经 provider 校验之同步 run、poll、cancel 亦携之；运行时唯异步 run 用且校验之，余动作忽略。初期之限，惟崩溃兜底；有界且持久之 return-handoff，禁次 manager 于首 manager 尚未毕成功返转之际先发旧限。惟守尚有效而原子书 `returned_at + reminder`（或精确成败已于有效守内落盘），方报启成；守既逾期，后复之 owner 携 `job_id/pid` 明告“犹可 poll”之误，且存崩溃兜底。终限届而任务仍非终态，方发 system 通知促 poll。取消中之持久 suppressing 亦有界，逾期可复告。若已得精确终态，则抑“或仍在行”之旧告，改由 Bash completion 唤醒。
-- `job_id`：异步任务之号，用于 poll/cancel（由异步 run 所返）
-- `summary`：可选。默认 false。设 true 时，此 tool 照常运行，原始结果完存于持久日志（可凭 tool_call_id 取回）；然结果入尔上下文前，先以尔 `reasoning` 字段所驱之 LLM 摘要代之——故 `reasoning` 当明言所欲存者。唯料输出甚巨（逾一万字符）且无需精确原文时，方设 true。需精确之行/文件/diff/stderr 原文者，留 false。摘要非权威；原始结果逾五十万字符，则不生摘要，尔得一拒辞，指向所存之原始结果。
+- `shell`：执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。返 exit_code、stdout、stderr，兼附 ok（真伪）与 command_status（'success'/'failed'）。须知：命令虽败，顶层 status 仍作 'ok'——此仅言 shell 已运，非言命令已成。必察 exit_code/ok，且阅 warning 一字（标非零之退、Python 之回溯、缺失之模块）；勿独凭 status 而断其成。忌大范围递归之扫（find … -name、rglob、os.walk、glob('**')）——易致超时；宜先用 `rg --files`。JSONL 当逐行而解，勿混作一 JSON。支持异步：设 input.async=true 取 job_id，后以 poll/cancel 查之。用此器前，必先读 `shell-manual` 一技（含定时之设、异步之规、进阶之用），无所例外。
+- `action`：必备。族中所行之事，四者择一：'run' 执行指令，'poll' 查异步任务之状，'cancel' 斩异步任务，'manual' 返已装之 shell-manual 一技。无默认。
+- `input`：必备。所择 action 专属之严格入参；诸动作之字段各不相通，跨动作之字段未及派发即被拒。
+- `reasoning`：必备。略述何以召此器（录于日记）。乃 Host 之元数据，不入 action 之参。
+- `summarize`：可选，默认 false。根层跨切之结果后处理，非 action 之参。设 true 时，此 tool 照常运行，原始结果完存于持久日志（可凭 tool_call_id 取回）；然结果入尔上下文前，先以尔 `reasoning` 字段所驱之 LLM 摘要代之——故 `reasoning` 当明言所欲存者。唯料输出甚巨（逾一万字符）且无需精确原文时，方设 true。需精确之行/文件/diff/stderr 原文者，留 false。摘要非权威；原始结果逾五十万字符，则不生摘要，尔得一拒辞，指向所存之原始结果。
+- `input.command`（唯 run）：欲执行之指令
+- `input.timeout`（唯 run）：超时秒数，传 null 即用默认三十；唯同步执行时生效
+- `input.working_dir`（唯 run）：指令之工作目录，传 null 或空字符串即用 agent 工作目录。须在 agent 工作目录沙箱之内；沙箱外路径会被拒。若需操作外部仓库/路径，请令 working_dir 保持为 agent 目录，并在 command 中显式 cd，如 cd /absolute/path && ...
+- `input.async`（唯 run）：后台运行指令，即返 job_id，传 null 即用默认 false
+- `input.reminder`（唯 run）：异步兜底唤醒之延迟秒数，传 null 即用默认一千八百。唯异步 run 用且校验之。初期之限，惟崩溃兜底；有界且持久之 return-handoff，禁次 manager 于首 manager 尚未毕成功返转之际先发旧限。惟守尚有效而原子书 `returned_at + reminder`（或精确成败已于有效守内落盘），方报启成；守既逾期，后复之 owner 携 `job_id/pid` 明告“犹可 poll”之误，且存崩溃兜底。终限届而任务仍非终态，方发 system 通知促 poll。取消中之持久 suppressing 亦有界，逾期可复告。若已得精确终态，则抑“或仍在行”之旧告，改由 shell completion 唤醒。
+- `input.job_id`（唯 poll/cancel）：异步任务之号（由异步 run 所返）
+- `manual`：其参乃严格空器 `{}`，不行任何 shell 之操，返 shell-manual 全文及其宿主本地之路。

--- a/src/lingtai/tools/bash/glossary-zh.md
+++ b/src/lingtai/tools/bash/glossary-zh.md
@@ -15,12 +15,15 @@ maintenance: |
 ---
 **术语对照**
 
-- `shell`：执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。返回 exit_code、stdout、stderr，并附 ok（布尔）与 command_status（'success'/'failed'）。要点：即便命令失败，顶层 status 仍为 'ok'——它仅表示 shell 已执行。务必检查 exit_code/ok 并阅读 warning 字段（标明非零退出、Python 回溯、缺失模块）；切勿仅凭 status 断定成功。避免大范围递归扫描（find … -name、rglob、os.walk、glob('**')）——易超时；优先用 `rg --files`。JSONL 须逐行解析，勿当作单个 JSON。支持异步：async=true 获取 job_id，再用 poll/cancel 查之。用此工具前，必先读 `shell-manual` 技能（涵盖定时任务、异步规范与进阶用法），无例外。
-- `action`：执行动作：'run'（默认）执行命令，'poll' 查询异步任务状态，'cancel' 终止异步任务
-- `command`：要执行的 shell 命令
-- `timeout`：超时秒数（默认：30，仅同步执行时生效）
-- `working_dir`：命令的工作目录（可选）。留空或传空字符串即使用 agent 工作目录。必须位于 agent 工作目录沙箱内；沙箱外路径会被拒绝。若要操作外部仓库/路径，请将 working_dir 保持为 agent 目录，并在 command 中显式 cd，例如 cd /absolute/path && ...
-- `async`：后台运行命令并立即返回 job_id（默认：false，仅 action='run' 时生效）
-- `reminder`：兜底异步唤醒延迟秒数（默认 1800）。顶层 schema 要求提供此字段，所以 provider 校验过的同步 run、poll、cancel 也会携带它；运行时只在异步 run 中使用并校验它，其他动作忽略。初始期限仅作崩溃兜底；有界的持久 return-handoff 会阻止第二个 manager 在首个 manager 尚未完成成功返回转换时提前发布旧期限。只有在守卫仍有效时原子写入 `returned_at + reminder`（或精确完成/失败已在有效守卫内落盘）才返回成功；过期后恢复的 owner 会携 `job_id/pid` 返回“仍可 poll”的显式错误，且保留崩溃兜底。若最终到期时任务仍非终态，则发布 system 通知提醒 poll。取消期间的持久 suppressing 状态同样有界，超时后可恢复提醒。精确完成会抑制这条过时的“仍可能运行”提醒，改由 Bash completion 通知唤醒。
-- `job_id`：异步任务 ID，用于 poll/cancel（由异步 run 返回）
-- `summary`：可选。默认 false。为 true 时，该 tool 照常执行，原始结果会完整保存到持久日志（可按 tool_call_id 取回），但在结果进入你的上下文之前，会被一段由你的 `reasoning` 字段驱动的 LLM 生成摘要替换——所以请在 `reasoning` 中明确说明要保留什么。仅当预期输出很大（>10k 字符）且你不需要精确原文时才设为 true。需要精确的行/文件/diff/stderr 原文时请保持 false。摘要非权威；若原始结果超过 500,000 字符则不生成摘要，你会收到一条指向已保存原始结果的拒绝信息。
+- `shell`：执行指令，返 stdout/stderr。可运行系统上一切可用之程——脚本、git、curl、pip、数据管道等。返回 exit_code、stdout、stderr，并附 ok（布尔）与 command_status（'success'/'failed'）。要点：即便命令失败，顶层 status 仍为 'ok'——它仅表示 shell 已执行。务必检查 exit_code/ok 并阅读 warning 字段（标明非零退出、Python 回溯、缺失模块）；切勿仅凭 status 断定成功。避免大范围递归扫描（find … -name、rglob、os.walk、glob('**')）——易超时；优先用 `rg --files`。JSONL 须逐行解析，勿当作单个 JSON。支持异步：input.async=true 获取 job_id，再用 poll/cancel 查之。用此工具前，必先读 `shell-manual` 技能（涵盖定时任务、异步规范与进阶用法），无例外。
+- `action`：必选。本族动作之一：'run' 执行命令，'poll' 查询异步任务状态，'cancel' 终止异步任务，'manual' 返回已安装的 shell-manual 技能。无默认值。
+- `input`：必选。所选 action 专属的严格入参对象；各动作的字段互不相通，跨动作字段会在派发前被拒绝。
+- `reasoning`：必选。简述调用本工具的缘由（记入日记）。属 Host 元数据，不会进入 action 入参。
+- `summarize`：可选，默认 false。根层跨切面的结果后处理开关，非 action 入参。为 true 时，该 tool 照常执行，原始结果会完整保存到持久日志（可按 tool_call_id 取回），但在结果进入你的上下文之前，会被一段由你的 `reasoning` 字段驱动的 LLM 生成摘要替换——所以请在 `reasoning` 中明确说明要保留什么。仅当预期输出很大（>10k 字符）且你不需要精确原文时才设为 true。需要精确的行/文件/diff/stderr 原文时请保持 false。摘要非权威；若原始结果超过 500,000 字符则不生成摘要，你会收到一条指向已保存原始结果的拒绝信息。
+- `input.command`（仅 run）：要执行的 shell 命令
+- `input.timeout`（仅 run）：超时秒数，传 null 即用默认 30；仅同步执行时生效
+- `input.working_dir`（仅 run）：命令的工作目录，传 null 或空字符串即使用 agent 工作目录。必须位于 agent 工作目录沙箱内；沙箱外路径会被拒绝。若要操作外部仓库/路径，请将 working_dir 保持为 agent 目录，并在 command 中显式 cd，例如 cd /absolute/path && ...
+- `input.async`（仅 run）：后台运行命令并立即返回 job_id，传 null 即用默认 false
+- `input.reminder`（仅 run）：兜底异步唤醒延迟秒数，传 null 即用默认 1800。仅在异步 run 中使用并校验。初始期限仅作崩溃兜底；有界的持久 return-handoff 会阻止第二个 manager 在首个 manager 尚未完成成功返回转换时提前发布旧期限。只有在守卫仍有效时原子写入 `returned_at + reminder`（或精确完成/失败已在有效守卫内落盘）才返回成功；过期后恢复的 owner 会携 `job_id/pid` 返回“仍可 poll”的显式错误，且保留崩溃兜底。若最终到期时任务仍非终态，则发布 system 通知提醒 poll。取消期间的持久 suppressing 状态同样有界，超时后可恢复提醒。精确完成会抑制这条过时的“仍可能运行”提醒，改由 shell completion 通知唤醒。
+- `input.job_id`（仅 poll/cancel）：异步任务 ID（由异步 run 返回）
+- `manual`：入参为严格空对象 `{}`，不执行任何 shell 操作，返回 shell-manual 全文与其宿主本地路径。

--- a/src/lingtai/tools/bash/manual/SKILL.md
+++ b/src/lingtai/tools/bash/manual/SKILL.md
@@ -141,7 +141,7 @@ below; the page itself carries only what is specific to that CLI.
 2. **Long-running agent/coding CLI** (`claude -p`, `codex exec`, `opencode run`,
    Cursor Agent, MiMo Code, Qwen Code, Oh-My-Pi, Kimi Code, Gemini CLI, Aider,
    Goose, OpenHands, Crush, or any sub-agent that may think/run tools for minutes)?
-   **Never run it synchronously.** Use `shell(async=true)` and poll — see the
+   **Never run it synchronously.** Use `input.async=true` and poll — see the
    resident rule below.
 3. **Time itself is the trigger?** Read `reference/scheduled-work/SKILL.md`.
 4. **You only need a single future nudge?** Read
@@ -203,26 +203,35 @@ reading the whole file when you only need recent events.
 - **Synchronous `shell` is only for short, deterministic commands.** A long-running
   agent/coding CLI session — `claude -p`, `codex exec`, `opencode run`, the Cursor
   agent CLI, or any sub-agent that may think and run tools for minutes — must
-  **never** be a synchronous `shell` call. Run it with `shell(async=true)` and poll
+  **never** be a synchronous `shell` call. Run it with `input.async=true` and poll
   the returned `job_id`. A synchronous call blocks the whole turn until the child
   exits: you stay `ACTIVE` and stop seeing channel notifications (mail, refresh,
   interrupts) for the entire duration. Async + poll keeps you responsive and
   prevents ACTIVE blockage while the child CLI works.
 
   ```text
-  # Start the child agent in the background — returns immediately with a job_id:
-  shell(async=true, reminder=1800, command="claude -p 'refactor the auth module' --output-format json")
+  # Start the child agent in the background — returns immediately with a job_id.
+  # Run-only fields (command, async, reminder, timeout, working_dir) live in input:
+  shell(action="run",
+        input={"command": "claude -p 'refactor the auth module' --output-format json",
+               "async": true, "reminder": 1800},
+        reasoning="start the refactor sub-agent in the background")
   # → {"status": "ok", "job_id": "job-a1b2c3d4e5f678901234567890abcdef", "pid": 4321}
 
-  # Later turns: poll until done (handle mail/other work between polls):
-  shell(action="poll", job_id="job-a1b2c3d4e5f678901234567890abcdef", reminder=1800)
+  # Later turns: poll until done (handle mail/other work between polls).
+  # poll takes job_id and nothing else — no reminder, no command:
+  shell(action="poll",
+        input={"job_id": "job-a1b2c3d4e5f678901234567890abcdef"},
+        reasoning="check whether the refactor sub-agent finished")
   # → {"status": "running", …}   then eventually
   # → {"status": "done", "exit_code": 0, "ok": true, "command_status": "success", "stdout": "…", "stderr": "…"}
   #   On failure: {"status": "done", "exit_code": 1, "ok": false,
   #                "command_status": "failed", "warning": "command exited with code 1; …"}
 
-  # Abandon it if needed:
-  shell(action="cancel", job_id="job-a1b2c3d4e5f678901234567890abcdef", reminder=1800)
+  # Abandon it if needed — cancel also takes job_id and nothing else:
+  shell(action="cancel",
+        input={"job_id": "job-a1b2c3d4e5f678901234567890abcdef"},
+        reasoning="the refactor is no longer needed")
   ```
 
 - **Use a Task Card for progress when one is available for this turn.**
@@ -242,13 +251,11 @@ reading the whole file when you only need recent events.
   a completion notification arrives, the reminder fires, or you have a concrete
   reason to expect new state.
 
-- **Idle care: set an async `reminder` that matches the expected duration.**
-  Every `shell(async=true)` call has a last-resort `reminder` delay, required in
-  the top-level provider schema and defaulted by the runtime to 1800 seconds
-  when omitted by older direct callers. Provider-facing sync commands, `poll`,
-  and `cancel` also carry `reminder` because of that schema shape, but the field
-  is meaningful and runtime-validated only for async `run`; sync commands,
-  `poll`, and `cancel` ignore it.
+- **Idle care: set an async `input.reminder` that matches the expected duration.**
+  Every async run has a last-resort `reminder` delay. It lives only in `run`'s
+  `input`, alongside the other run-only fields; `poll` and `cancel` take
+  `job_id` and nothing else, so they never carry it. Pass `null` (or omit it) to
+  get the runtime default of 1800 seconds.
   The initial durable deadline is a crash fallback while the supervisor starts.
   A bounded durable return-handoff guard prevents a relaunched/second manager from
   publishing that fallback while the first manager is still before supervisor
@@ -337,7 +344,8 @@ dispatched worker with its own worktree, branch, and context window.
 
 When in doubt for non-trivial work: daemon. A CLI has **no LingTai job protocol
 of its own** — "async" always means a LingTai or OS wrapper around it
-(`shell(async=true)`, a supervised background job, or a daemon backend), and
+(`shell` with `input.async=true`, a supervised background job, or a daemon
+backend), and
 that wrapper owns logs, timeout, cancellation, and recovery notes. Keep
 synchronous inline calls short and explicitly timed (for example a 300 s bash
 timeout); do not solve a long task by raising the synchronous timeout to 15+

--- a/tests/test_bash_async.py
+++ b/tests/test_bash_async.py
@@ -263,9 +263,15 @@ class TestBashAsync:
         assert "err" in poll["stderr"]
 
     def test_schema_requires_reminder_with_runtime_default(self, tmp_path):
-        schema = get_schema()
-        assert "reminder" not in schema["required"]  # manual has no action-specific inputs
-        assert schema["properties"]["reminder"]["default"] == 1800.0
+        # ``reminder`` is run-only: it exists solely in the ``run`` child's
+        # input on the migrated envelope, and never on poll/cancel.
+        branches = {
+            b["title"]: b for b in get_schema()["properties"]["input"]["oneOf"]
+        }
+        run_branch = branches["run input"]
+        assert run_branch["properties"]["reminder"]["default"] == 1800.0
+        for action in ("poll input", "cancel input"):
+            assert "reminder" not in branches[action]["properties"]
 
         mgr = self._make_manager(tmp_path)
         result = mgr.handle({"command": "echo compat", "async": True})

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -70,8 +70,18 @@ def test_manual_actions_return_their_installed_skills(tmp_path: Path) -> None:
     daemon_manager._agent = agent
     web_manager = web_tool.setup(agent)
 
+    # ``shell`` is a migrated LTP v2 family: its ``manual`` is the reserved
+    # family child dispatched through the registered envelope handler, not an
+    # engine branch. Build the same dispatcher ``setup`` registers.
+    shell_dispatcher = shell_tool.ShellFamilyDispatcher(shell_manager, agent)
+
     calls = {
-        "shell": ("shell", lambda: shell_manager.handle({"action": "manual"})),
+        "shell": (
+            "shell",
+            lambda: shell_dispatcher.handle(
+                {"action": "manual", "input": {}, "reasoning": "load shell guidance"}
+            ),
+        ),
         "daemon": ("daemon", lambda: daemon_manager.handle({"action": "manual"})),
         "email": ("email", lambda: email_tool.handle(agent, {"action": "manual"})),
         "psyche": ("psyche-manual", lambda: psyche_tool.handle(agent, {"action": "manual"})),
@@ -94,6 +104,13 @@ def test_manual_actions_return_their_installed_skills(tmp_path: Path) -> None:
             assert result["manual"] == body
             assert result["manual_path"] == str(path)
             assert isinstance(result["current_setting"], dict)
+        elif tool_name == "shell":
+            # Migrated family: the reserved ``manual`` child's canonical
+            # ManualTool result is returned verbatim (no double wrap) — full
+            # body at content[0].text, host-local path in structuredContent.
+            assert result["status"] == "ok"
+            assert result["content"][0]["text"] == body
+            assert result["structuredContent"]["manual_path"] == str(path)
         else:
             assert result == {
                 "status": "ok",
@@ -124,11 +141,14 @@ def test_manual_schemas_preserve_runtime_checks_for_ordinary_file_calls(
         action = schema["properties"]["action"]
         assert "manual" in action.get("enum", ()) or "manual" in action["description"]
 
-    assert shell_tool.get_schema()["required"] == []
     assert psyche_tool.get_schema()["required"] == ["action"]
     web_schema = web_tool.get_schema()
     assert web_schema["required"] == ["action", "input", "reasoning"]
     assert len(web_schema["properties"]["input"]["oneOf"]) == 3
+    # ``shell`` is migrated to the same LTP v2 envelope, with four children.
+    shell_schema = shell_tool.get_schema()
+    assert shell_schema["required"] == ["action", "input", "reasoning"]
+    assert len(shell_schema["properties"]["input"]["oneOf"]) == 4
     for module in (read_tool, write_tool, edit_tool, glob_tool, grep_tool):
         assert module.get_schema()["required"] == []
 

--- a/tests/test_layers_bash.py
+++ b/tests/test_layers_bash.py
@@ -259,7 +259,13 @@ class TestBashManager:
         assert str(external.resolve()) in result["message"]
 
     def test_schema_documents_working_dir_sandbox_and_cd_workaround(self):
-        desc = get_schema("en")["properties"]["working_dir"]["description"]
+        # ``working_dir`` is a run-only field, so it lives in the ``run``
+        # child's own input schema on the migrated envelope.
+        run_branch = next(
+            b for b in get_schema("en")["properties"]["input"]["oneOf"]
+            if b["title"] == "run input"
+        )
+        desc = run_branch["properties"]["working_dir"]["description"]
 
         assert "agent working directory sandbox" in desc
         assert "paths outside" in desc

--- a/tests/test_shell_tool_family_migration.py
+++ b/tests/test_shell_tool_family_migration.py
@@ -1,0 +1,737 @@
+"""Shell's LTP v2 action-separated migration: schema, dispatch, and lifecycle.
+
+Proves the public/model-facing ``shell`` tool is the ToolFamily-composed
+``action``/``input``/``reasoning``/``summarize`` envelope over the canonical
+children ``run | poll | cancel | manual``, while ``ShellManager`` — the sync
+execution path, the working-directory sandbox, the durable async lifecycle,
+cancellation, and terminal receipts — stays the exact, untouched engine the
+pre-migration suites (``test_bash_async.py``, ``test_layers_bash.py``,
+``test_shell_sandbox_containment.py``) already exercise through its legacy flat
+call shape.
+
+The invariants under test come from ``src/lingtai/tools/CONTRACT.md`` (Envelope,
+Dispatch and actions) and the overnight Shell-specific acceptance line:
+run-only fields live only in ``run``'s branch, ``job_id`` only in
+``poll``/``cancel``'s, the reserved ``manual`` performs no target operation, and
+every child result stays canonical/raw with no second envelope wrapped around
+it.
+"""
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests._notification_store_helpers import notification_store_for
+from lingtai.tools.bash import ShellManager, ShellPolicy, setup
+from lingtai.tools.bash._tool_family import (
+    CANCEL_INPUT_SCHEMA,
+    MANUAL_INPUT_SCHEMA,
+    POLL_INPUT_SCHEMA,
+    RUN_INPUT_SCHEMA,
+    ShellFamilyDispatcher,
+    get_schema,
+)
+
+_ACTIONS = ["run", "poll", "cancel", "manual"]
+
+
+def _make_manager(tmp_path: Path) -> ShellManager:
+    agent = SimpleNamespace(_notification_store=notification_store_for(tmp_path))
+    return ShellManager(
+        policy=ShellPolicy.yolo(), working_dir=str(tmp_path), agent=agent
+    )
+
+
+def _make_dispatcher(tmp_path: Path) -> tuple[ShellFamilyDispatcher, ShellManager]:
+    mgr = _make_manager(tmp_path)
+    return ShellFamilyDispatcher(mgr, mgr._agent), mgr
+
+
+def _install_shell_manual(working_dir: Path, body: str) -> Path:
+    """Install a shell manual exactly where the real initializer puts it.
+
+    ``Agent._install_intrinsic_manuals`` maps the retained implementation
+    directory ``bash/`` to the canonical model-facing destination name
+    ``shell`` under ``.library/intrinsic/capabilities/`` — so
+    ``build_manual_child(agent, "shell")`` reads the same body/path the
+    pre-migration ``ShellManager.handle({"action": "manual"})`` did.
+    """
+    manual_dir = working_dir / ".library" / "intrinsic" / "capabilities" / "shell"
+    manual_dir.mkdir(parents=True)
+    manual_path = manual_dir / "SKILL.md"
+    manual_path.write_text(body, encoding="utf-8")
+    return manual_path
+
+
+def _run(dispatcher: ShellFamilyDispatcher, **input_fields) -> dict:
+    return dispatcher.handle(
+        {"action": "run", "input": input_fields, "reasoning": "migration test"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public identity and root envelope
+# ---------------------------------------------------------------------------
+
+def test_public_model_facing_name_is_shell_with_the_family_schema(tmp_path):
+    """The registered public name stays exactly ``shell`` (``bash`` is only the
+    retained implementation package), and the registered schema is now the
+    action-separated family envelope, not the legacy flat shape."""
+    agent = MagicMock()
+    agent._working_dir = Path(tmp_path)
+
+    setup(agent, yolo=True)
+
+    assert agent.add_tool.call_args.args[0] == "shell"
+    schema = agent.add_tool.call_args.kwargs["schema"]
+    assert schema == get_schema()
+    # The legacy flat run-only fields are gone from the public root.
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    for legacy_flat_field in ("command", "timeout", "working_dir", "async", "reminder", "job_id"):
+        assert legacy_flat_field not in schema["properties"]
+
+
+def test_registered_description_documents_the_action_separated_call_shape(tmp_path):
+    """The model-facing description must teach the shape actually registered —
+    ``input.async`` / ``input={'job_id': ...}``, not the legacy flat fields."""
+    agent = MagicMock()
+    agent._working_dir = Path(tmp_path)
+
+    setup(agent, yolo=True)
+    description = agent.add_tool.call_args.kwargs["description"]
+
+    for action in _ACTIONS:
+        assert f"shell(action='{action}'" in description
+    assert "input.async=true" in description
+    # Setup-time adapter/host metadata and the failure-fidelity guidance the
+    # pre-migration description carried are retained.
+    assert "Active shell dialect:" in description
+    assert "Host OS:" in description
+    assert "exit_code" in description and "command_status" in description
+    assert "warning field" in description
+
+
+def test_root_is_strict_action_input_reasoning_summarize():
+    schema = get_schema()
+
+    assert schema["type"] == "object"
+    assert schema["required"] == ["action", "input", "reasoning"]
+    assert schema["additionalProperties"] is False
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    assert schema["properties"]["reasoning"]["type"] == "string"
+    assert schema["properties"]["summarize"]["type"] == "boolean"
+    assert schema["properties"]["action"]["enum"] == _ACTIONS
+
+
+def test_canonical_children_are_the_four_shell_actions():
+    branches = get_schema()["properties"]["input"]["oneOf"]
+    assert [b["title"] for b in branches] == [f"{a} input" for a in _ACTIONS]
+
+
+# ---------------------------------------------------------------------------
+# Per-action input separation
+# ---------------------------------------------------------------------------
+
+def test_run_only_fields_live_only_in_run_and_job_id_only_in_poll_cancel():
+    run_props = set(RUN_INPUT_SCHEMA["properties"])
+    assert run_props == {"command", "timeout", "working_dir", "async", "reminder"}
+    assert "job_id" not in run_props
+
+    assert set(POLL_INPUT_SCHEMA["properties"]) == {"job_id"}
+    assert set(CANCEL_INPUT_SCHEMA["properties"]) == {"job_id"}
+    for schema in (POLL_INPUT_SCHEMA, CANCEL_INPUT_SCHEMA):
+        assert schema["required"] == ["job_id"]
+        assert run_props.isdisjoint(schema["properties"])
+
+    # Manual is strict-empty: it takes no input at all. Its schema is sourced
+    # from the shared reserved-manual builder, so there is exactly one
+    # definition and the wire/dispatch views cannot drift.
+    assert MANUAL_INPUT_SCHEMA["properties"] == {}
+    assert MANUAL_INPUT_SCHEMA["additionalProperties"] is False
+    from lingtai.tools.tool_family.manual import build_manual_child
+
+    assert MANUAL_INPUT_SCHEMA == dict(build_manual_child(None, "shell").input_schema)
+
+
+def test_every_child_input_schema_is_closed_and_free_of_host_fields():
+    for schema in (RUN_INPUT_SCHEMA, POLL_INPUT_SCHEMA, CANCEL_INPUT_SCHEMA, MANUAL_INPUT_SCHEMA):
+        assert schema["additionalProperties"] is False
+        for host_field in ("action", "reasoning", "_reasoning", "summarize", "summary"):
+            assert host_field not in schema["properties"]
+
+
+def test_root_allof_correlates_each_action_const_to_its_own_input_schema():
+    schema = get_schema()
+    conditions = schema["allOf"]
+    assert len(conditions) == len(_ACTIONS)
+
+    expected = {
+        "run": RUN_INPUT_SCHEMA,
+        "poll": POLL_INPUT_SCHEMA,
+        "cancel": CANCEL_INPUT_SCHEMA,
+        "manual": MANUAL_INPUT_SCHEMA,
+    }
+    for condition in conditions:
+        action = condition["if"]["properties"]["action"]["const"]
+        assert condition["if"]["required"] == ["action"]
+        assert condition["then"]["properties"]["input"] == expected[action]
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-time rejection (before any handler I/O)
+# ---------------------------------------------------------------------------
+
+def test_unknown_action_fails_with_shells_own_four_action_message(tmp_path):
+    dispatcher, _ = _make_dispatcher(tmp_path)
+
+    result = dispatcher.handle({"action": "exec", "input": {}, "reasoning": "r"})
+
+    assert result["status"] == "failed"
+    assert result["error_code"] == "ACTION_REQUIRED"
+    assert result["message"] == "action must be one of run, poll, cancel, or manual"
+
+
+@pytest.mark.parametrize(
+    "action, action_input",
+    [
+        ("run", {"command": "echo hi", "job_id": "job-1"}),   # poll/cancel field in run
+        ("poll", {"job_id": "job-1", "command": "echo hi"}),  # run field in poll
+        ("cancel", {"job_id": "job-1", "async": True}),       # run field in cancel
+        ("manual", {"command": "echo hi"}),                   # manual takes nothing
+    ],
+    ids=["job_id-in-run", "command-in-poll", "async-in-cancel", "command-in-manual"],
+)
+def test_cross_action_input_fields_are_rejected_before_handler_io(tmp_path, action, action_input):
+    """A key belonging to another action's branch is refused at dispatch — the
+    engine is never reached, so no command runs and no job is touched."""
+    mgr = _make_manager(tmp_path)
+    mgr.handle = lambda args: pytest.fail("cross-action input reached ShellManager")
+    dispatcher = ShellFamilyDispatcher(mgr, mgr._agent)
+
+    result = dispatcher.handle({"action": action, "input": action_input, "reasoning": "r"})
+
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+    assert result["message"] == "unsupported shell input field"
+
+
+def test_unknown_root_field_and_non_object_input_are_rejected(tmp_path):
+    dispatcher, _ = _make_dispatcher(tmp_path)
+
+    unknown_root = dispatcher.handle(
+        {"action": "run", "input": {"command": "echo hi"}, "reasoning": "r", "command": "echo hi"}
+    )
+    assert unknown_root["error_code"] == "INVALID_ARGUMENT"
+    assert unknown_root["message"] == "unsupported shell argument"
+
+    bad_input = dispatcher.handle({"action": "run", "input": "echo hi", "reasoning": "r"})
+    assert bad_input["error_code"] == "INVALID_ARGUMENT"
+    assert bad_input["message"] == "input must be an object"
+
+
+def test_reasoning_and_summarize_never_reach_the_engine(tmp_path):
+    """Host envelope metadata is stripped before dispatch: the engine sees only
+    the action's own flattened input."""
+    seen: list[dict] = []
+    mgr = _make_manager(tmp_path)
+    mgr.handle = lambda args: seen.append(dict(args)) or {"status": "ok"}
+    dispatcher = ShellFamilyDispatcher(mgr, mgr._agent)
+
+    dispatcher.handle({
+        "action": "run",
+        "input": {"command": "echo hi"},
+        "reasoning": "why I am calling this",
+        "summarize": True,
+    })
+
+    assert seen == [{"action": "run", "command": "echo hi"}]
+
+
+def test_non_boolean_summarize_is_rejected(tmp_path):
+    dispatcher, _ = _make_dispatcher(tmp_path)
+
+    result = dispatcher.handle(
+        {"action": "run", "input": {"command": "echo hi"}, "reasoning": "r", "summarize": "yes"}
+    )
+
+    assert result["error_code"] == "INVALID_ARGUMENT"
+    assert result["message"] == "summarize must be a boolean"
+
+
+# ---------------------------------------------------------------------------
+# Null-as-absent translation into the unchanged engine defaults
+# ---------------------------------------------------------------------------
+
+def test_null_optionals_are_dropped_so_engine_defaults_apply(tmp_path):
+    """Strict schemas express optionals as required-nullable; null means absent,
+    so ``ShellManager`` applies its own unchanged runtime defaults."""
+    seen: list[dict] = []
+    mgr = _make_manager(tmp_path)
+    mgr.handle = lambda args: seen.append(dict(args)) or {"status": "ok"}
+    dispatcher = ShellFamilyDispatcher(mgr, mgr._agent)
+
+    dispatcher.handle({
+        "action": "run",
+        "input": {
+            "command": "echo hi", "timeout": None, "working_dir": None,
+            "async": None, "reminder": None,
+        },
+        "reasoning": "r",
+    })
+
+    assert seen == [{"action": "run", "command": "echo hi"}]
+
+
+def test_falsy_but_present_values_are_preserved_not_dropped(tmp_path):
+    seen: list[dict] = []
+    mgr = _make_manager(tmp_path)
+    mgr.handle = lambda args: seen.append(dict(args)) or {"status": "ok"}
+    dispatcher = ShellFamilyDispatcher(mgr, mgr._agent)
+
+    dispatcher.handle({
+        "action": "run",
+        "input": {
+            "command": "echo hi", "timeout": 0, "working_dir": "",
+            "async": False, "reminder": 0,
+        },
+        "reasoning": "r",
+    })
+
+    assert seen == [{
+        "action": "run", "command": "echo hi", "timeout": 0,
+        "working_dir": "", "async": False, "reminder": 0,
+    }]
+
+
+# ---------------------------------------------------------------------------
+# Sync execution through the envelope
+# ---------------------------------------------------------------------------
+
+def test_sync_success_returns_the_canonical_raw_result(tmp_path):
+    dispatcher, _ = _make_dispatcher(tmp_path)
+
+    result = _run(dispatcher, command="echo migrated")
+
+    assert result["status"] == "ok"
+    assert result["exit_code"] == 0
+    assert result["stdout"].strip() == "migrated"
+    assert result["ok"] is True
+    assert result["command_status"] == "success"
+    # Canonical/raw: the child result is returned verbatim, never nested in a
+    # second Host envelope.
+    assert "content" not in result
+    assert "result" not in result
+
+
+def test_sync_nonzero_failure_keeps_status_ok_with_fidelity_fields(tmp_path):
+    dispatcher, _ = _make_dispatcher(tmp_path)
+
+    result = _run(dispatcher, command="exit 7")
+
+    assert result["status"] == "ok"  # status means the shell ran, not that it succeeded
+    assert result["exit_code"] == 7
+    assert result["ok"] is False
+    assert result["command_status"] == "failed"
+    assert "command exited with code 7" in result["warning"]
+
+
+def test_working_dir_sandbox_is_enforced_through_the_envelope(tmp_path):
+    sandbox = tmp_path / "sandbox"
+    external = tmp_path / "external"
+    sandbox.mkdir()
+    external.mkdir()
+    agent = SimpleNamespace(_notification_store=notification_store_for(tmp_path))
+    mgr = ShellManager(policy=ShellPolicy.yolo(), working_dir=str(sandbox), agent=agent)
+    dispatcher = ShellFamilyDispatcher(mgr, agent)
+
+    result = _run(dispatcher, command="pwd", working_dir=str(external))
+
+    assert result["status"] == "error"
+    assert "under agent working directory" in result["message"]
+
+
+def test_timeout_is_honored_through_the_envelope(tmp_path):
+    dispatcher, _ = _make_dispatcher(tmp_path)
+
+    result = _run(dispatcher, command="sleep 5", timeout=0.3)
+
+    assert result["status"] == "error"
+    assert "timed out" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Async lifecycle: run -> poll -> terminal receipt
+# ---------------------------------------------------------------------------
+
+def test_async_run_then_terminal_poll_through_the_envelope(tmp_path):
+    dispatcher, _ = _make_dispatcher(tmp_path)
+
+    started = _run(dispatcher, command="echo async-migrated", **{"async": True})
+    job_id = started["job_id"]
+    assert started["status"] == "ok"
+    assert job_id
+    assert started["handoff"]  # async return-handoff guard preserved
+
+    deadline = time.time() + 20
+    while time.time() < deadline:
+        poll = dispatcher.handle(
+            {"action": "poll", "input": {"job_id": job_id}, "reasoning": "check"}
+        )
+        if poll["status"] == "done":
+            break
+        time.sleep(0.2)
+
+    assert poll["status"] == "done"
+    assert poll["exit_code"] == 0
+    assert "async-migrated" in poll["stdout"]
+
+
+def test_poll_is_one_shot_after_terminal_consumption(tmp_path):
+    """The second terminal poll must not re-serve the same completed job as if
+    it were fresh — the pre-migration one-shot semantics are unchanged."""
+    dispatcher, mgr = _make_dispatcher(tmp_path)
+
+    started = _run(dispatcher, command="echo once", **{"async": True})
+    job_id = started["job_id"]
+
+    deadline = time.time() + 20
+    while time.time() < deadline:
+        first = dispatcher.handle(
+            {"action": "poll", "input": {"job_id": job_id}, "reasoning": "check"}
+        )
+        if first["status"] == "done":
+            break
+        time.sleep(0.2)
+    assert first["status"] == "done"
+
+    second = dispatcher.handle(
+        {"action": "poll", "input": {"job_id": job_id}, "reasoning": "check again"}
+    )
+    # Whatever the engine's one-shot answer is, it is the engine's own — the
+    # envelope must reproduce it identically to the legacy flat call path.
+    assert second == mgr.handle({"action": "poll", "job_id": job_id})
+
+
+def test_cancel_through_the_envelope_terminates_the_job(tmp_path):
+    dispatcher, _ = _make_dispatcher(tmp_path)
+
+    started = _run(dispatcher, command="sleep 30", **{"async": True})
+    job_id = started["job_id"]
+    assert job_id
+
+    cancelled = dispatcher.handle(
+        {"action": "cancel", "input": {"job_id": job_id}, "reasoning": "stop it"}
+    )
+
+    assert cancelled["status"] in {"ok", "done", "cancelled"}
+    # No orphan: the job reaches a terminal state rather than staying live.
+    deadline = time.time() + 20
+    while time.time() < deadline:
+        poll = dispatcher.handle(
+            {"action": "poll", "input": {"job_id": job_id}, "reasoning": "confirm terminal"}
+        )
+        if poll["status"] in {"done", "error"}:
+            break
+        time.sleep(0.2)
+    assert poll["status"] in {"done", "error"}
+
+
+def test_async_reminder_default_and_explicit_value_reach_the_engine(tmp_path):
+    seen: list[dict] = []
+    mgr = _make_manager(tmp_path)
+    mgr.handle = lambda args: seen.append(dict(args)) or {"status": "ok", "job_id": "j"}
+    dispatcher = ShellFamilyDispatcher(mgr, mgr._agent)
+
+    dispatcher.handle({
+        "action": "run",
+        "input": {"command": "sleep 1", "async": True, "reminder": 42.0},
+        "reasoning": "r",
+    })
+    assert seen[-1]["reminder"] == 42.0
+
+    # Omitted/null reminder leaves the engine's own 1800s durable default.
+    dispatcher.handle({
+        "action": "run",
+        "input": {"command": "sleep 1", "async": True, "reminder": None},
+        "reasoning": "r",
+    })
+    assert "reminder" not in seen[-1]
+    assert RUN_INPUT_SCHEMA["properties"]["reminder"]["default"] == 1800.0
+
+
+# ---------------------------------------------------------------------------
+# Agent-facing guidance strings must teach the registered envelope
+# ---------------------------------------------------------------------------
+
+def _parse_taught_call(text: str) -> dict:
+    """Turn a taught ``shell(action="poll", input={"job_id": "..."})`` string
+    into the args dict an agent copying it verbatim would actually send."""
+    match = re.search(
+        r'shell\(action="(?P<action>\w+)",\s*input=\{"job_id":\s*"(?P<job_id>[^"]+)"\}\)',
+        text,
+    )
+    assert match, f"no envelope-shaped shell call found in: {text!r}"
+    return {
+        "action": match.group("action"),
+        "input": {"job_id": match.group("job_id")},
+        "reasoning": "following the taught call verbatim",
+    }
+
+
+def test_async_receipt_teaches_a_call_the_registered_schema_accepts(tmp_path):
+    """The async start receipt is instructional content. An agent that copies it
+    verbatim must land a call the public envelope accepts — not one rejected
+    before dispatch."""
+    dispatcher, _ = _make_dispatcher(tmp_path)
+
+    started = _run(dispatcher, command="echo receipt-round-trip", **{"async": True})
+    job_id = started["job_id"]
+    message = started["message"]
+
+    # The taught call names the envelope, not the flat root field.
+    assert f'shell(action="poll", input={{"job_id": "{job_id}"}})' in message
+    assert f'job_id="{job_id}"' not in message
+
+    taught = _parse_taught_call(message)
+    assert taught["input"]["job_id"] == job_id
+
+    # Round-trip: the exact taught call must survive dispatch, not fail closed.
+    deadline = time.time() + 20
+    while time.time() < deadline:
+        result = dispatcher.handle(taught)
+        assert result.get("error_code") is None, (
+            f"the receipt taught a call the registered schema rejects: {result}"
+        )
+        assert result["status"] in {"running", "done"}
+        if result["status"] == "done":
+            break
+        time.sleep(0.2)
+    assert result["status"] == "done"
+    assert "receipt-round-trip" in result["stdout"]
+
+
+def test_durable_reminder_teaches_a_call_the_registered_schema_accepts(tmp_path):
+    """The durable watchdog may wake an agent hours later (possibly post-molt),
+    so the call it hands over must also round-trip through the envelope."""
+    dispatcher, mgr = _make_dispatcher(tmp_path)
+
+    started = _run(dispatcher, command="sleep 30", **{"async": True})
+    job_id = started["job_id"]
+    published: list[str] = []
+    mgr._agent._enqueue_system_notification = (
+        lambda **kw: published.append(kw["body"]) or True
+    )
+    try:
+        mgr._publish_async_reminder(job_id)
+
+        assert published, "reminder published no notification body"
+        body = published[0]
+        assert f'shell(action="poll", input={{"job_id": "{job_id}"}})' in body
+        assert f'job_id="{job_id}"' not in body
+
+        taught = _parse_taught_call(body)
+        result = dispatcher.handle(taught)
+        assert result.get("error_code") is None, (
+            f"the reminder taught a call the registered schema rejects: {result}"
+        )
+        assert result["status"] in {"running", "done"}
+    finally:
+        dispatcher.handle(
+            {"action": "cancel", "input": {"job_id": job_id}, "reasoning": "cleanup"}
+        )
+
+
+def test_family_manual_worked_examples_use_the_registered_envelope():
+    """The manual is mandated reading served by ``action="manual"``. Every
+    worked ``shell(...)`` call in it must parse as the envelope shape, and
+    ``reminder`` must not appear on poll/cancel anywhere."""
+    manual = (
+        Path(__file__).resolve().parents[1]
+        / "src" / "lingtai" / "tools" / "bash" / "manual" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    # No flat run-only field is passed at the call root anywhere in the manual.
+    for flat in ('shell(async=', 'async=true,', 'job_id="job-', 'reminder=1800'):
+        assert flat not in manual, f"manual still teaches the flat shape: {flat}"
+
+    # Every worked call opens with an explicit action= and is one of the four.
+    calls = re.findall(r'shell\(action="(\w+)"', manual)
+    assert calls, "expected worked shell() examples in the manual"
+    assert set(calls) <= set(_ACTIONS)
+    # run/poll/cancel are all demonstrated.
+    assert {"run", "poll", "cancel"} <= set(calls)
+
+    # poll/cancel examples carry job_id and never reminder.
+    for action in ("poll", "cancel"):
+        block = re.search(
+            rf'shell\(action="{action}",\s*input=\{{(?P<input>[^}}]*)\}}', manual
+        )
+        assert block, f"no envelope-shaped {action} example in the manual"
+        assert "job_id" in block.group("input")
+        assert "reminder" not in block.group("input")
+
+
+# ---------------------------------------------------------------------------
+# Reserved manual child
+# ---------------------------------------------------------------------------
+
+def test_manual_returns_the_canonical_body_and_path_without_double_wrap(tmp_path):
+    manual_body = "# shell manual\n\nasync hygiene and advanced usage.\n"
+    manual_path = _install_shell_manual(tmp_path, manual_body)
+    agent = SimpleNamespace(
+        _notification_store=notification_store_for(tmp_path), _working_dir=tmp_path
+    )
+    mgr = ShellManager(policy=ShellPolicy.yolo(), working_dir=str(tmp_path), agent=agent)
+    dispatcher = ShellFamilyDispatcher(mgr, agent)
+
+    result = dispatcher.handle({"action": "manual", "input": {}, "reasoning": "read manual"})
+
+    assert result["status"] == "ok"
+    # Full body at content[0].text, host-local path in structuredContent — the
+    # shared ManualTool contract, returned verbatim (no second envelope).
+    assert result["content"][0]["text"] == manual_body
+    assert result["structuredContent"]["manual_path"] == str(manual_path)
+    assert "content" not in result["structuredContent"]
+    # Same body and same host-local path the installed manual actually holds —
+    # the destination `Agent._install_intrinsic_manuals` maps `bash/manual/` to.
+    assert result["content"][0]["text"] == manual_path.read_text(encoding="utf-8")
+    assert manual_path.parent.name == "shell"
+
+    # ``manual`` is a family child only. The engine's own manual branch is
+    # gone, so the engine no longer serves documentation: an internal call
+    # naming it falls through to `run`, which rejects the empty command
+    # instead of returning a manual.
+    engine_manual = mgr.handle({"action": "manual"})
+    assert "manual" not in engine_manual
+    assert engine_manual["status"] == "error"
+
+
+def test_manual_performs_no_shell_operation(tmp_path):
+    """Manual is no-I/O: it must not reach the execution engine at all."""
+    _install_shell_manual(tmp_path, "# shell manual\n")
+    agent = SimpleNamespace(
+        _notification_store=notification_store_for(tmp_path), _working_dir=tmp_path
+    )
+    mgr = ShellManager(policy=ShellPolicy.yolo(), working_dir=str(tmp_path), agent=agent)
+    mgr.handle = lambda args: pytest.fail("manual reached the shell execution engine")
+    dispatcher = ShellFamilyDispatcher(mgr, agent)
+
+    result = dispatcher.handle({"action": "manual", "input": {}, "reasoning": "read manual"})
+
+    assert result["status"] == "ok"
+    assert result["content"][0]["text"].startswith("# shell manual")
+
+
+def test_manual_name_is_reserved_once_by_the_family(tmp_path):
+    """The family owns exactly one ``manual`` child; a second registration is a
+    loud construction defect, not a silently-resolved naming choice."""
+    from lingtai.tools.tool_family import ChildTool, ToolFamily, ToolFamilyError
+
+    # Shell's real family registers ``manual`` exactly once.
+    assert get_schema()["properties"]["action"]["enum"].count("manual") == 1
+
+    with pytest.raises(ToolFamilyError, match="duplicate child name 'manual'"):
+        ToolFamily("shell", [
+            ChildTool("run", RUN_INPUT_SCHEMA, lambda _i: {}, title="run input"),
+            ChildTool("manual", MANUAL_INPUT_SCHEMA, lambda _i: {}, title="manual input"),
+            ChildTool("manual", MANUAL_INPUT_SCHEMA, lambda _i: {}, title="manual input"),
+        ])
+
+
+# ---------------------------------------------------------------------------
+# Provider wire parity
+# ---------------------------------------------------------------------------
+
+def test_shell_family_schema_survives_chat_and_responses_wires():
+    from lingtai.kernel.llm.base import FunctionSchema
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+    schema = FunctionSchema(name="shell", description="shell", parameters=get_schema())
+    chat = _build_tools([schema])[0]["function"]["parameters"]
+    responses = _build_responses_tools([schema])[0]["parameters"]
+
+    for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+        assert wire["type"] == "object"
+        assert wire["required"] == ["action", "input", "reasoning"]
+        assert wire["additionalProperties"] is False
+        assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert wire["properties"]["action"]["enum"] == _ACTIONS
+        branches = wire["properties"]["input"][combinator]
+        assert [b["title"] for b in branches] == [f"{a} input" for a in _ACTIONS]
+        for branch in branches:
+            assert branch["additionalProperties"] is False
+            for host_field in ("reasoning", "_reasoning", "summarize"):
+                assert host_field not in branch["properties"]
+
+
+def test_responses_wire_preserves_the_root_action_input_correlation():
+    """The root ``allOf``/``if``/``then`` correlation must survive the Responses
+    scrubber, so a mismatched action/input pairing is refusable at the schema
+    layer on both wires — dispatch remains authoritative regardless."""
+    from lingtai.kernel.llm.base import FunctionSchema
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+    schema = FunctionSchema(name="shell", description="shell", parameters=get_schema())
+    chat = _build_tools([schema])[0]["function"]["parameters"]
+    responses = _build_responses_tools([schema])[0]["parameters"]
+
+    for wire in (chat, responses):
+        actions = [c["if"]["properties"]["action"]["const"] for c in wire["allOf"]]
+        assert actions == _ACTIONS
+        run_condition = wire["allOf"][0]["then"]["properties"]["input"]
+        assert "job_id" not in run_condition["properties"]
+        poll_condition = wire["allOf"][1]["then"]["properties"]["input"]
+        assert set(poll_condition["properties"]) == {"job_id"}
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting Host surfaces
+# ---------------------------------------------------------------------------
+
+def test_shell_is_a_migrated_family_for_the_single_central_summarizer():
+    """``summarize`` is recognized for ``shell`` by the one existing central
+    summarizer — no second summarizer and no shell-specific mechanism."""
+    from lingtai.kernel.tool_result_summary import summary_requested
+
+    assert summary_requested({"summarize": True}, "shell") is True
+    assert summary_requested({"summarize": True}, "some_unmigrated_tool") is False
+    assert summary_requested({"summarize": False}, "shell") is False
+    # The legacy spelling stays honored unconditionally for historical callers.
+    assert summary_requested({"summary": True}, "shell") is True
+
+
+def test_recovery_notice_reads_shell_fields_from_the_new_envelope():
+    """The synthesized-recovery context helper must still name the command and
+    action after migration; those fields now live under ``input``."""
+    from lingtai.kernel.llm.interface import ToolCallBlock, _tool_call_context
+
+    context = _tool_call_context(ToolCallBlock(
+        id="tc-1", name="shell",
+        args={
+            "action": "run",
+            "input": {"command": "echo recovered", "working_dir": "/tmp", "async": True},
+            "reasoning": "r",
+        },
+    ))
+
+    assert "shell action: run" in context
+    assert "shell command preview: echo recovered" in context
+    assert "shell working_dir: /tmp" in context
+    assert "shell async: True" in context
+
+
+def test_recovery_notice_still_reads_a_historical_flat_call():
+    from lingtai.kernel.llm.interface import ToolCallBlock, _tool_call_context
+
+    context = _tool_call_context(ToolCallBlock(
+        id="tc-2", name="bash",
+        args={"action": "poll", "job_id": "job-1"},
+    ))
+
+    assert "shell action: poll" in context
+    assert "shell job_id: job-1" in context


### PR DESCRIPTION
> **Exact source head:** `ecc52faf20c8853c89fd89e95548fae28eb07c6b`  
> **Exact base:** `4ad8b1555a5b0368af81aa57292438719a105052`  
> **dev4 exact-head live-use gate:** pending immediately after PR opening; this body will be updated with the durable receipt.

# feat(tools): migrate Shell to the action-separated ToolFamily envelope

## Summary

Migrates the public `shell` tool to the LingTai Tool Protocol v2
action-separated shape, using the existing generic `tools/tool_family`
infrastructure — the same one `web` adopted in #1059. The execution engine is
untouched; this changes the model-facing surface and consolidates the package
onto a single schema/description pair.

**Public tool name is unchanged: `shell`.** `bash` remains only the
implementation package and durable-state namespace, never a public name and
never a second registered schema.

### Public actions and envelope

Four canonical children — `run | poll | cancel | manual` — where the child
name is simultaneously the public `action` value and the dispatch key, with no
mapping layer.

The model-facing root is exactly four fields, strict and closed
(`additionalProperties: false`, `required: ["action", "input", "reasoning"]`):

| Root field | Required | Purpose |
|---|---|---|
| `action` | yes | one of `run`, `poll`, `cancel`, `manual`; no default |
| `input` | yes | strict, action-specific input object |
| `reasoning` | yes | Host InvocationContext/audit metadata; never forwarded into `input` |
| `summarize` | no | root cross-cutting result post-processing; never forwarded into `input` |

Field separation is enforced at two layers — schema and dispatch:

- Run-only fields (`command`, `timeout`, `working_dir`, `async`, `reminder`)
  exist **only** in `run`'s `input`.
- `job_id` exists **only** in `poll`'s and `cancel`'s `input`.
- `manual` takes a strict-empty `input`.

The root carries `allOf`/`if`/`then` correlating each `action` const to that
child's own input schema, plus `input.oneOf` disclosure of every branch.
Dispatch remains the authoritative fail-closed layer regardless of whether a
given provider validates the combinators: a key belonging to another action's
branch is rejected **before any handler I/O** with
`INVALID_ARGUMENT`; an unknown action returns `ACTION_REQUIRED` with the message
`action must be one of run, poll, cancel, or manual`.

Optional run fields follow the strict-schema convention already used by `web`'s
`browse`: declared REQUIRED but nullable, where `null` means *absent* and the
engine applies its own unchanged defaults (timeout 30, working_dir = the agent
sandbox, async false, reminder 1800). Falsy-but-present values (`timeout: 0`,
`async: false`, `working_dir: ""`) pass through verbatim.

### No flat compatibility

Per `tools/CONTRACT.md` ("the final migrated root property set MUST be exactly
`action`, `input`, `reasoning`, `summarize`") and the `web` precedent, **no flat
compatibility shim is retained**. A flat call to the public tool fails closed
with a typed, recoverable error. Adding a shim would reintroduce exactly the
flat provider schema the contract forbids.

The package now defines **exactly one** `get_schema`/`get_description` pair —
the migrated family surface in `_tool_family.py`, re-exported from
`__init__.py` under those canonical names — so no second, pre-migration public
schema exists to drift against.

### Sole manual path

`manual` is the family's reserved child, built from the shared
`tool_family.manual.build_manual_child`. It returns the canonical ManualTool
result (full body at `content[0].text`, host-local path at
`structuredContent.manual_path`) verbatim, with no double wrapping.

It is the **only** manual path: `ShellManager.handle` no longer has an
`action="manual"` branch, so the engine never serves documentation, spawns no
process, and touches no job state for it. `MANUAL_INPUT_SCHEMA` is sourced from
that same builder rather than re-declared, so the advertised and
dispatch-validated shapes are one definition.

The served body and path are unchanged
(`.library/intrinsic/capabilities/shell/SKILL.md`, the destination
`Agent._install_intrinsic_manuals` maps the retained `bash/manual/` bundle to).

### Taught async receipt / reminder now round-trip (Fable blocker fixes)

Two agent-facing guidance surfaces were still teaching the flat shape the newly
registered schema rejects. Both are fixed:

1. **Async start receipt** and **durable reminder notification body**
   (`tools/bash/__init__.py`) now teach
   `shell(action="poll", input={"job_id": "..."})`.
   These strings are the *instructional content* of the receipt and reminder the
   Shell acceptance line protects — a reminder can wake an agent hours later,
   possibly post-molt, and handing it a call that fails before dispatch is
   precisely the failure the guidance exists to prevent.
2. **Family manual** (`tools/bash/manual/SKILL.md`) — all three worked examples
   migrated to the envelope, `reminder` removed from `poll`/`cancel` entirely,
   and prose shorthands updated to `input.async=true`. The registered
   description mandates reading this manual, so shipping examples that all fail
   closed would have been prompt-surface drift inside the family's own directory.

Regression coverage is behavioral, not textual: the taught text is parsed back
into an args dict and dispatched through the **registered** handler, asserting
`error_code is None` and a real `running`/`done` result
(`test_async_receipt_teaches_a_call_the_registered_schema_accepts`,
`test_durable_reminder_teaches_a_call_the_registered_schema_accepts`,
`test_family_manual_worked_examples_use_the_registered_envelope`). These were
confirmed non-vacuous by reverting the receipt string and observing failure.

### Deliberately preserved (not removed)

- **`bash` → `shell` capability input alias** (`tools/registry.py`,
  `_LEGACY_CAPABILITY_ALIASES`) — shared config-input surface co-owned with
  `web_search`, a documented PR1 contract with dedicated passing tests.
- **`bash` historical/pending-call read fallback**
  (`kernel/base_agent/tools.py`) — shared runtime; `name="bash"` tool calls
  appear across executor/daemon/chat/codex surfaces.
- **Durable `bash.reminder:` / `bash.completion:` ref_ids and the
  `system/jobs/` layout** — on-disk state correlating in-flight jobs across
  restarts. Renaming would orphan live reminders; that is a data migration, not
  cleanup.
- **Public `BashManager` / `BashPolicy` facades** — exported from
  `lingtai/__init__.py` as public API and imported by name across existing
  suites. Removing them is an API break beyond this PR's scope.

### Obsolete branches/symbols removed (owner-local, with replacement proof)

| Removed | Location | Replaced by |
|---|---|---|
| flat `get_description()` (12 lines) | `tools/bash/__init__.py` | `_tool_family.get_description`, re-exported canonically |
| flat `get_schema()` (48 lines) | `tools/bash/__init__.py` | `_tool_family.get_schema`, re-exported canonically |
| `action == "manual"` branch | `ShellManager.handle` | reserved `manual` child via `build_manual_child` |
| `from .._manual import load_installed_manual` | `tools/bash/__init__.py` | dead after the branch removal |
| duplicate `MANUAL_INPUT_SCHEMA` literal | `tools/bash/_tool_family.py` | sourced from `build_manual_child(...).input_schema` |
| `get_family_schema` / `get_family_description` aliases | `tools/bash/__init__.py` | plain `get_schema` / `get_description` |

### LOC accounting (against exact base `4ad8b155`)

| Bucket | Added | Removed | Net |
|---|---|---|---|
| **Production** (`.py` outside `tests/`) | 51 modified + 249 new file | 70 | **+230** |
| **Tests** | 38 modified + 737 new file | 6 | +769 |
| **Docs** (`.md`) | 192 | 67 | +125 |

`tools/bash/__init__.py` is genuinely **net −35** — that is the consolidation.
The +230 is entirely the new `_tool_family.py`: 144 of its 249 lines are
executable, and 86 of those are the four per-action JSON schemas. The old flat
schema was one undifferentiated 61-line property bag; action separation
necessarily yields four closed schemas with per-action descriptions. **The line
growth is the separation.** Reaching net-negative production LOC was only
possible by not separating the actions, or by deleting the shared-runtime alias
or durable `bash.*` ids — both out of scope, and the latter would orphan live
jobs.

## Validation

**Exact base:** `4ad8b1555a5b0368af81aa57292438719a105052`.

| Gate | Result |
|---|---|
| Parent focused suite | **206 passed, 6 skipped** |
| Author focused suite (20 files, `PYTHONPATH=src`, `-p no:cacheprovider`) | **464 passed, 6 skipped** |
| `tests/test_shell_tool_family_migration.py` | 36 tests |
| `py_compile` | clean |
| `git diff --check` | clean |
| Anatomy drift | `No anatomy drift found across 54 file(s)` |

**Independent review:** Fable 5 — **APPROVE_WITH_NONBLOCKING_NOTES**
(`scratch/shell-toolfamily-fable-review-20260727.md`). Fable independently
reproduced every green result, ran its own live smoke, and initially returned
BLOCK on the two guidance surfaces above; both were repaired and the final
re-review approved. The last note (a stale `_tool_family.py` docstring claiming
the deleted engine manual passthrough remained reachable) is also fixed.

**Live end-to-end** through the registered dispatcher, real subprocesses in a
disposable temp dir:

```
RECEIPT               : Job started. Use shell(action="poll", input={"job_id": "job-327eda…"}) to check.
TAUGHT-CALL ROUND-TRIP: done 'taught'
REMINDER              : … Poll it with shell(action="poll", input={"job_id": "job-3ebe83…"}).
REMINDER ROUND-TRIP   : running | error_code: None
PROC ALIVE AFTER CANCEL: False        <- no orphan
ENGINE MANUAL GONE    : error         <- family child owns manual
```

Sync success, nonzero-exit failure with fidelity fields, sandbox rejection,
timeout, async run → terminal poll, cancel → terminal with no orphan, manual,
unknown action, and cross-action rejection are all covered by tests and were
exercised live.

Tests touching removed surfaces were **repointed, not weakened** — e.g. the
sandbox/`cd` documentation assertion now reads the `run` child branch (same
invariant, new location), and the reminder-default assertion additionally
asserts `reminder` is absent from `poll`/`cancel`.

### Still pending

- **dev4 / live exact-head Agent exercise** (review contract step 5) — an
  isolated runtime exercise measuring the actual public action count and Manual
  usability is **not yet done** and remains required before merge consideration.
- One pre-existing failure at base,
  `test_skills.py::test_lingtai_owned_skill_frontmatter_has_last_changed_at`
  (a `last_changed_at` timestamp on an unrelated `system-manual` file), is
  untouched by this PR and is **not** a regression from it.

## Known limitations

1. Flat calls to the public tool fail closed, including historical/pending calls
   forwarded through the `bash` runtime alias. This is the contracted LTP v2
   posture rather than a defect; the receipt/reminder fix materially softens it
   by handing mid-flight agents the correct shape exactly when they hit the
   boundary.
2. Production LOC is net-positive (+230), explained above.
3. `tools/tool_family/CONTRACT.md` is stale — it still names `web_search` as the
   sole production consumer and omits Shell from `related_files`. Left untouched
   deliberately: the parallel File/Notification/Skills PRs conflict on the same
   lines, so the parent should reconcile it once at group-merge.
4. Cross-cutting flat-shape mentions remain outside Shell's scope in
   `intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md` and
   `tools/email/manual/SKILL.md` — repo-wide follow-up.
5. No shell-specific ToolGuard/annotation/risk surface exists at this base, so
   none was updated. An undifferentiated `shell` guard already assumes the
   strongest child (`run`); the family therefore hides nothing stronger. Flagged
   as unverified rather than claimed.

## Rollback

Self-contained and low-risk to revert: reverting this commit restores the flat
`get_schema`/`get_description`, the engine `manual` branch, and the previous
receipt/reminder/manual text in one step. No migration, no data change, and no
durable-state format change is involved — `system/jobs/` layout and the
`bash.reminder:` / `bash.completion:` ref_ids are untouched, so in-flight async
jobs and pending reminders survive a revert in either direction. The only
cross-cutting production edits are two small ones
(`kernel/tool_result_summary.py` adds `"shell"` to the existing
`_LTP_V2_MIGRATED_FAMILIES` allowlist; `kernel/llm/interface.py` makes the
recovery notice read `input` while still reading the flat shape), both additive
and independently revertible.

## Provenance note

The candidate was authored across sessions in the worktree
`shell-action-children-dev1-20260727` at exact base `4ad8b155`. It began from a
cancelled Sonnet run's partial edits, which were treated as untrusted
provenance — inspected and edited forward, never reset or deleted.

During the repair pass the author ran a `git stash` while checking whether two
pyflakes findings pre-existed at base. Because the stash stack is shared across
the concurrent worktree agents, that entry collided with another agent's
(`skills`) stash, so a `stash pop` would have been incorrect. The Shell changes
were instead recovered from the unreachable stash commit
`3f9075a287a4bc0573517741b174554ba655f1ef` ("WIP on
feat/shell-action-children-dev1-20260727") via
`git checkout <commit> -- <paths>`, restoring all 13 tracked files. No other
agent's stash entry was disturbed.

**The final Shell worktree and index were independently re-inspected and
accepted after that recovery**: file inventory verified (13 modified + 2
untracked), `HEAD` confirmed still at the exact base, both envelope-teaching
strings and the flat-pair deletion confirmed present, the full focused suite
re-run green, and Fable's final independent re-review performed against the
recovered tree. The provenance of the recovery does not rest on the author's
assertion alone.

---

Exact base: `4ad8b1555a5b0368af81aa57292438719a105052`
Head: *(fill in at push time)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
