### PR TITLE
refactor(skills): separate info and manual actions

### DIFF
--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -3,7 +3,7 @@ name: psyche-manual
 description: |
   Router and operational guide for the psyche tool — molt, pad management, session journaling, and post-wipe recovery. Read this when: you are about to molt; you need to tend the four durable stores; you want guidance on writing a good summary or session journal; you wake up after a system-performed wipe with a system-authored summary; or you need to understand keep_tool_calls, keep_last, and pad.append. Routes consequential molt handoffs to assets/molt-template.md while keeping routine guidance compact.
 version: 1.1.0
-last_changed_at: 2026-07-19T00:00:00Z
+last_changed_at: 2026-07-27T04:30:00-07:00
 related_files:
 - src/lingtai/tools/psyche/__init__.py
 - src/lingtai/tools/psyche/_molt.py
@@ -216,7 +216,7 @@ If you wake up after a *system-performed* molt (triggered by karma, `.clear`, or
 1. Read the `summary_path` from the post-molt notification
 2. `email(check)` — see what arrived while you were down
 3. Check `knowledge/session-journal/KNOWLEDGE.md` — your session history index
-4. `skills(action="info")` — confirm which skills you have
+4. `skills(action="info", input={}, reasoning="confirm my skills")` — confirm which skills you have
 5. `shell({"command": "tail -n 200 logs/events.jsonl | grep ..."})` — surgical reads if needed
 
 Reconstruct your situation from these sources.

--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -152,7 +152,7 @@ def is_apriori_summary(content: Any) -> bool:
 # unmigrated tool's own domain field literally named ``summarize`` is never
 # silently reinterpreted as this cross-cutting control (see
 # ``src/lingtai/tools/CONTRACT.md`` Contract rules > Envelope).
-_LTP_V2_MIGRATED_FAMILIES = frozenset({"web"})
+_LTP_V2_MIGRATED_FAMILIES = frozenset({"web", "skills"})
 
 
 def summary_requested(args: dict | None, tool_name: str | None = None) -> bool:

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -9,6 +9,8 @@ related_files:
   - src/lingtai/kernel/tool_executor.py
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/skills/CONTRACT.md
+  - src/lingtai/tools/skills/__init__.py
   - src/lingtai/tools/tool_family/CONTRACT.md
   - tests/test_browser_capability.py
   - tests/test_wire_tool_description.py
@@ -235,12 +237,19 @@ documents. `web` (`search | browse | manual`) is the first family migrated to
 this contract: its final model-facing root is exactly `action`, `input`,
 `reasoning`, and `summarize`; its `search` action reads the action-owned
 `settings/web.search.json` (see `src/lingtai/tools/web_search/CONTRACT.md`).
+`skills` (`info | manual`) is the second: it keeps its public tool name and both
+public action values, adopts the same closed root, declares the canonical
+strict-empty `input` object for both actions, and supports no settings file at
+all — its manual says so explicitly (see
+`src/lingtai/tools/skills/CONTRACT.md`). Family boundaries here follow the
+shared-domain rule above: `info` and `manual` are two actions of one skill-
+catalogue authority, not two related tools grouped for convenience.
 The legacy a-priori result-summarization flag under the literal key `summary`
 (`src/lingtai/kernel/tool_result_summary.py:172`) remains honored for every
 still-unmigrated caller; `src/lingtai/kernel/tool_result_summary.py` recognizes
 the canonical `summarize` spelling only when the calling tool is a migrated LTP
-v2 family (currently only `web`), so an unmigrated tool's own field literally
-named `summarize` is never reinterpreted as this control. Every other
+v2 family (`web` and `skills` as of this migration), so an unmigrated tool's own field
+literally named `summarize` is never reinterpreted as this control. Every other
 LingTai-owned family remains unmigrated and keeps its existing schema and
 settings surface unchanged by this file.
 
@@ -250,7 +259,9 @@ infrastructure implementing this envelope (schema composition from a
 ManualTool builder) that a family MAY adopt instead of hand-writing the
 equivalent code; `web` is its first consumer, using it for schema composition
 and dispatch while retaining its own outer `handle()` for family-specific
-diagnostics. Using it is never required — see its own
+diagnostics, and `skills` is its second, using it the same way but returning
+its canonical envelope failures verbatim, having no such diagnostics. The two
+consumers share nothing but that package. Using it is never required — see its own
 `src/lingtai/tools/tool_family/CONTRACT.md` "Implementation independence" is
 binding on it exactly as it is on every family.
 

--- a/src/lingtai/tools/skills/ANATOMY.md
+++ b/src/lingtai/tools/skills/ANATOMY.md
@@ -6,6 +6,9 @@ related_files:
   - src/lingtai/tools/skills/__init__.py
   - src/lingtai/tools/skills/manual/SKILL.md
   - src/lingtai/init_schema.py
+  - src/lingtai/tools/tool_family/ANATOMY.md
+  - src/lingtai/tools/tool_family/CONTRACT.md
+  - src/lingtai/tools/skills/CONTRACT.md
   - tests/test_skills.py
   - tests/test_validate_skill.py
   - src/lingtai/tools/skills/glossary-en.md
@@ -24,7 +27,7 @@ Skills capability — per-agent skill catalog and skill-manual surface. This is 
 
 ## Components
 
-- `skills/__init__.py` — the capability implementation. `get_description` (`__init__.py:166-167`), `get_schema` (`__init__.py:170-181`), `setup` (`__init__.py:184-219`), `_reconcile` (`__init__.py:75-159`), and path/scanner helpers (`__init__.py:50-68`).
+- `skills/__init__.py` — the capability implementation. The canonical strict-empty child input factory `_strict_empty_input` (`__init__.py:54-55`), `_reconcile` (`__init__.py:87-171`), `_skills_info` (`__init__.py:174-179`), the Host-owned `_adapt_manual_result` flattener (`__init__.py:182-204`), `get_description` (`__init__.py:207-208`), the single canonical child-registry builder `_build_family` and its import-time schema-only instance `_SCHEMA_FAMILY` (`__init__.py:211-246`), `get_schema` (`__init__.py:249-252`), `setup` with its `handle_skills` wrapper (`__init__.py:255-292`), and path/scanner helpers (`__init__.py:62-80`).
 - `skills/manual/` — `skills-manual` skill documentation, template assets, and validator script. The validator can optionally require `last_changed_at` for LingTai-maintained skill bundles.
 
 ## Connections
@@ -32,25 +35,37 @@ Skills capability — per-agent skill catalog and skill-manual surface. This is 
 - `lingtai.tools.registry` maps canonical `skills` here. Former skill-catalog `library.paths` compatibility is removed in the clean rename.
 - `Agent._install_intrinsic_manuals()` copies every capability `manual/` bundle into `.library/intrinsic/capabilities/<name>/`, then re-runs `skills._reconcile()` for first-turn catalog freshness when `skills` is loaded (`src/lingtai/agent.py:256`).
 - The daemon capability blacklists `skills` so emanations do not recursively receive the skill catalog tool (`../daemon/__init__.py:34`).
+- The generic [`../tool_family/ANATOMY.md`](../tool_family/ANATOMY.md) owns the reusable schema-composition/dispatch infrastructure this package builds its `ToolFamily` instances from, and the reserved `manual` child builder (`tool_family/manual.py`). It has no knowledge of the skill catalogue.
+- `lingtai.kernel.tool_result_summary` lists `skills` in `_LTP_V2_MIGRATED_FAMILIES`, so this family's root `summarize` boolean is recognized as the canonical a-priori summary control (`src/lingtai/kernel/tool_result_summary.py:155`).
 
 ## Public API
 
-The `skills` tool exposes two signpost actions:
+`skills` is a migrated LTP v2 family: one model-facing root, closed to exactly
+`action`, `input`, `reasoning`, and `summarize`, with `required: [action,
+input, reasoning]`. The public tool name and both public action values are
+unchanged by the migration; each action value equals its child/dispatch key.
+Both children take the canonical strict-empty `input` object.
 
-| Action | Description |
-|---|---|
-| `info` | Refresh/reconcile the skills catalog and return runtime health (catalog size, paths report, problems) without manual bodies |
-| `manual` | Return the skills manual body plus the library manual body on demand |
+| Action | Input | Description |
+|---|---|---|
+| `info` | `{}` (strict-empty) | Refresh/reconcile the skills catalog and return runtime health (catalog size, paths report, problems) without manual bodies |
+| `manual` | `{}` (strict-empty) | Return the skills manual body plus the library manual body on demand, without any catalogue mutation |
+
+`handle_skills` delegates envelope validation and dispatch to the agent-bound
+`ToolFamily`, then flattens only the reserved `manual` child's canonical
+`content`/`structuredContent` result back to this capability's public
+`skills_manual`/`library_manual`/`manual_path` shape — strictly after dispatch,
+never inside a registered child, and never wrapping either child's result.
 
 ## State
 
-- Skill storage remains `<agent>/.library/` for compatibility: `intrinsic/` is CLI-managed and `custom/` is agent-authored (`__init__.py:87-90`).
+- Skill storage remains `<agent>/.library/` for compatibility: `intrinsic/` is CLI-managed and `custom/` is agent-authored (`__init__.py:112-115`).
 - Config path source is canonical `manifest.capabilities.skills.paths` (`src/lingtai/init_schema.py:403-421`).
-- Prompt state is the `skills` section (`__init__.py:125-131`).
-- Health check expects `.library/intrinsic/capabilities/skills/SKILL.md` and reports `skills_manual`, with `library_manual` retained as a response compatibility key (`__init__.py:133-152`).
+- Prompt state is the `skills` section, written only by `_reconcile` — reached by `setup` and the `info` child, never by `manual` (`__init__.py:150-155`).
+- Health check expects `.library/intrinsic/capabilities/skills/SKILL.md` and reports `skills_manual`, with `library_manual` retained as a response compatibility key (`__init__.py:157-183`).
 
 ## Notes
 
 - The `.library/` directory name and `.library_shared/` convention are intentionally preserved in this rename-only change; they are storage compatibility names, not the user-facing capability name.
-- New callers should use `skills({"action":"info"})`; old `library({"action":"info"})` is not registered because private durable memory is now `knowledge` and `library` is not registered.
+- New callers should use `skills({"action":"info","input":{},"reasoning":"..."})`; old `library({"action":"info"})` is not registered because private durable memory is now `knowledge` and `library` is not registered.
 - LingTai-maintained `SKILL.md` files carry `last_changed_at` in frontmatter, initialized from git history for metadata-only backfills and updated on substantive skill edits.

--- a/src/lingtai/tools/skills/CONTRACT.md
+++ b/src/lingtai/tools/skills/CONTRACT.md
@@ -1,11 +1,16 @@
 ---
 name: skills-contract
 tool: skills
-contract_version: 1
+contract_version: 2
 related_files:
   - src/lingtai/tools/skills/__init__.py
   - src/lingtai/tools/skills/ANATOMY.md
   - src/lingtai/tools/_catalog.py
+  - src/lingtai/tools/CONTRACT.md
+  - src/lingtai/tools/tool_family/CONTRACT.md
+  - src/lingtai/tools/tool_family/__init__.py
+  - src/lingtai/kernel/tool_result_summary.py
+  - tests/test_skills.py
 maintenance: |
   Keep related_files as repo-relative paths to real files. If behavior and this
   contract disagree, the code is the source of truth — fix the contract in the
@@ -33,6 +38,9 @@ in `src/lingtai/tools/skills/__init__.py`; the code is the source of truth.
   structurally isomorphic, physically separate sibling).
 - Code navigation only: read `src/lingtai/tools/skills/ANATOMY.md`.
 - Shared Markdown catalog mechanics: read `src/lingtai/tools/_catalog.py`.
+- The generic envelope/dispatch/manual-child infrastructure itself: read
+  `src/lingtai/tools/tool_family/CONTRACT.md`; the protocol it implements is
+  `src/lingtai/tools/CONTRACT.md`.
 
 **Fast paths:** tool schema -> §Tool surface; on-disk layout & path sources ->
 §State & storage; skills vs knowledge -> §Scope.
@@ -54,13 +62,38 @@ in `src/lingtai/tools/skills/__init__.py`; the code is the source of truth.
 
 ## Tool surface
 
-Schema requires `action`; the handler is `handle_skills` (dispatched via
-`dispatch_action`). Exactly two actions.
+`skills` is a family migrated to the LingTai Tool Protocol v2 shape defined in
+`src/lingtai/tools/CONTRACT.md`, built on the generic
+`src/lingtai/tools/tool_family/` infrastructure. The public tool name and both
+public action values are unchanged by that migration; only the envelope around
+them is canonical now.
+
+The final model-facing root is a closed object whose properties are exactly
+`action`, `input`, `reasoning`, and `summarize`, with
+`required: ["action", "input", "reasoning"]` and
+`additionalProperties: false`. `action` is one of `info` or `manual`; each
+action value equals its child name and its dispatch key, with no mapping layer.
+Both actions declare the canonical **strict-empty** `input` object
+(`{"type": "object", "properties": {}, "required": [], "additionalProperties":
+false}`) — there is no field to pass on either action. Root `summarize` is an
+optional boolean (absent or false by default) and `reasoning` is required Host
+InvocationContext/audit metadata; neither is ever action input, and no `input`
+branch admits `reasoning`, `_reasoning`, or `summarize`. The root also carries
+one `allOf` `if`/`then` condition per action correlating the `action` const
+with that exact action's `input` schema, on both the Chat Completions and
+Responses wires.
+
+The child registry is declared exactly once, in `_build_family`: both the
+advertised schema and runtime dispatch are built from it, so action names,
+input schemas, titles, and order cannot drift apart. The handler is
+`handle_skills`, which delegates envelope validation and dispatch to an
+agent-bound `ToolFamily` and owns only the post-dispatch presentation
+adaptation of the reserved `manual` child. Exactly two actions.
 
 | Action | Required inputs | Optional inputs | Success output | Error shapes |
 |---|---|---|---|---|
-| `info` | `action="info"` | — | reconciles catalog, re-injects prompt, returns `{status, skills_dir, library_dir, catalog_size, paths, problems}` (manual body omitted) | see below |
-| `manual` | `action="manual"` | — | `{status: "ok", skills_manual, library_manual, manual_path}` — manual body without refreshing catalog | degraded shape below |
+| `info` | `action="info"`, `input={}`, `reasoning` | root `summarize` | reconciles catalog, re-injects prompt, returns `{status, skills_dir, library_dir, catalog_size, paths, problems}` (manual body omitted) | see below |
+| `manual` | `action="manual"`, `input={}`, `reasoning` | root `summarize` | `{status: "ok", skills_manual, library_manual, manual_path}` — manual body without refreshing catalog | degraded shape below |
 
 Status is `"ok"` normally; `info` and `manual` return `status: "degraded"` (with
 an `error` string and empty manual body) when the skills manual
@@ -68,8 +101,49 @@ an `error` string and empty manual body) when the skills manual
 and `library_dir` are back-compat keys mirroring the `skills_*` keys; the on-disk
 directory remains `.library`.
 
-**Error shapes** (plain dicts):
-- Unknown action: `{"status": "error", "message": "unknown action: <action>, only 'info' or 'manual' is supported"}`.
+Each action's own success/degraded result stays canonical and is returned
+verbatim — there is no child-result envelope nested inside another action
+result. `manual`'s reserved child (`tool_family.manual.build_manual_child`)
+returns the canonical `content`/`structuredContent` MCP-compatible shape;
+`handle_skills` flattens exactly that, strictly after dispatch, to the public
+`skills_manual`/`library_manual`/`manual_path` keys above (no double wrap).
+
+**Action separation.** `info` only refreshes/reconciles the catalogue and
+reports health: it never authors, pins, publishes, installs, or executes a
+skill. `manual` only reads the installed manual: it performs no catalogue
+scan, no prompt injection, and no other `info`-side effect.
+
+**Error shapes** (plain dicts). Envelope failures are raised by the generic
+dispatcher before any handler I/O and are returned verbatim — `skills` has no
+family-specific diagnostic block to stamp onto them:
+- Unknown action (including a missing action key, and an unhashable `action`
+  from invalid JSON): `{"status": "failed", "error_code": "ACTION_REQUIRED", "message": "action must be one of info, manual"}`.
+- Any key inside `input` on either action:
+  `{"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "unsupported skills input field"}`.
+- Missing or non-object `input`:
+  `{"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "input must be an object"}`.
+- Unknown root field:
+  `{"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "unsupported skills argument"}`.
+- Non-boolean root `summarize`:
+  `{"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "summarize must be a boolean"}`.
+
+This replaces the pre-migration router envelope
+(`{"status": "error", "message": "unknown action: ..."}`), which no longer
+exists on this tool.
+
+## Summarize profile
+
+Per `src/lingtai/tools/CONTRACT.md` "Dispatch and actions", this family
+assigns profiles per action: `info` is **short-result** (its health snapshot is
+normally small — `summarize` is available but normally unnecessary, leave it
+false), and `manual` is **bulky-result** (`summarize=true` is reasonable for a
+gist, but calls meant to follow the exact procedure should keep the default
+`false`). `skills` is listed in
+`src/lingtai/kernel/tool_result_summary.py`'s `_LTP_V2_MIGRATED_FAMILIES`, so
+its root `summarize` spelling is recognized as the canonical a-priori summary
+control and its canonical `status: "failed"` envelope errors are never
+summarized. The existing raw-first cap and centralized summarizer remain the
+single source; this family adds no second summarizer.
 
 ## State & storage
 
@@ -106,9 +180,20 @@ Do not change any of the following; documented for reviewers only.
 
 | Claim | Source `src/lingtai/tools/skills/...` | Test |
 |---|---|---|
-| Unknown actions return a `{status: error}` dict | `__init__.py` (`handle_skills`) | `tests/test_skills.py::test_unknown_action_returns_error` |
+| Unknown actions return the typed `ACTION_REQUIRED` failure | `__init__.py` (`handle_skills`) | `tests/test_skills.py::test_unknown_action_returns_error` |
+| Unknown actions do no handler I/O | `__init__.py` (`handle_skills`) | `tests/test_skills.py::test_unknown_action_fails_before_any_handler_io` |
+| Root is the closed LTP v2 envelope with strict-empty inputs | `__init__.py` (`get_schema`) | `tests/test_skills.py::test_family_schema_is_the_canonical_ltp_v2_root` |
+| Schema and dispatch come from one child registry | `__init__.py` (`_build_family`) | `tests/test_skills.py::test_schema_children_are_the_same_registry_dispatch_uses` |
+| Both actions reject any `input` key / bad envelope fields | `__init__.py` (`handle_skills`) | `tests/test_skills.py::test_both_actions_reject_extra_input_before_dispatch` |
+| `reasoning`/`_reasoning`/`summarize` never reach a handler | `__init__.py` (`handle_skills`) | `tests/test_skills.py::test_envelope_metadata_never_reaches_either_handler` |
+| The composed schema survives both provider wires | `__init__.py` (`get_schema`) | `tests/test_skills.py::test_skills_family_reaches_both_provider_wires` |
+| Root `summarize` is this family's canonical control | `src/lingtai/kernel/tool_result_summary.py` | `tests/test_skills.py::test_skills_is_a_migrated_ltp_v2_family_for_summarize` |
 | `info` omits the manual body | `__init__.py` (`_skills_info`) | `tests/test_skills.py::test_info_omits_skills_manual_body` |
-| `manual` returns the skills manual body | `__init__.py` (`_skills_manual`) | `tests/test_skills.py::test_manual_returns_skills_manual_body` |
+| `info` returns the exact health/problem report | `__init__.py` (`_reconcile`) | `tests/test_skills.py::test_info_result_keys_and_health_are_exactly_preserved` |
+| `manual` returns the skills manual body | `__init__.py` (`_adapt_manual_result`) | `tests/test_skills.py::test_manual_returns_skills_manual_body` |
+| `manual` returns exact body/path with no double wrap | `__init__.py` (`_adapt_manual_result`) | `tests/test_skills.py::test_manual_result_is_exact_body_and_path_without_double_wrap` |
+| `manual` performs no `info`-side catalogue mutation | `__init__.py` (`handle_skills`) | `tests/test_skills.py::test_manual_has_no_info_side_effect` |
+| `manual` degrades with the exact loader message | `__init__.py` (`_adapt_manual_result`) | `tests/test_skills.py::test_manual_degrades_with_exact_loader_message` |
 | Missing intrinsic manual reports `degraded` | `__init__.py` (`_reconcile`) | `tests/test_skills.py::test_info_reports_degraded_when_intrinsic_missing` |
 | Declared paths resolve (absolute / relative / `~`) | `__init__.py` (`_resolve_path`) | `tests/test_skills.py::test_skills_scans_absolute_path`, `::test_skills_resolves_relative_path_from_working_dir`, `::test_skills_expands_tilde` |
 | Catalog is injected into the `skills` prompt section | `__init__.py` (`_reconcile`) | `tests/test_skills.py::test_catalog_injected_into_skills_section` |
@@ -120,7 +205,9 @@ Do not change any of the following; documented for reviewers only.
 
 | Invariant | Automated test | Manual check | Risk if broken |
 |---|---|---|---|
-| Only `info` / `manual` are accepted | `tests/test_skills.py::test_unknown_action_returns_error` | Call `skills(action="foo")` | Silent mis-dispatch |
+| Only `info` / `manual` are accepted | `tests/test_skills.py::test_unknown_action_returns_error` | Call `skills(action="foo", input={}, reasoning="x")` | Silent mis-dispatch |
+| Both actions take strict-empty `input` | `tests/test_skills.py::test_both_actions_reject_extra_input_before_dispatch` | Call `skills(action="info", input={"paths": []}, reasoning="x")` | Smuggled/ignored arguments |
+| `manual` never mutates the catalogue | `tests/test_skills.py::test_manual_has_no_info_side_effect` | Add a skill on disk, call `manual`, inspect the `skills` prompt section | Signpost silently reconciles; hidden side effect |
 | Catalog reaches the prompt | `tests/test_skills.py::test_catalog_injected_into_skills_section` | Boot with a custom skill, inspect `skills` prompt section | Skills invisible to the model |
 | Body stays out of prompt | `tests/test_catalog_helpers.py::test_build_catalog_yaml_golden` | Author a long-body skill, inspect prompt | Prompt bloat |
 | Missing manual is degraded not fatal | `tests/test_skills.py::test_info_reports_degraded_when_intrinsic_missing` | Remove the intrinsic manual, call `info` | Boot failure vs. graceful degrade |

--- a/src/lingtai/tools/skills/__init__.py
+++ b/src/lingtai/tools/skills/__init__.py
@@ -21,6 +21,11 @@ initializer's job.
 
 Tool surface: ``info`` refreshes/reconciles the catalog and returns runtime
 health without manual bodies; ``manual`` returns the skills manual body on demand.
+Both are action children of one LTP v2 ``ToolFamily`` (``src/lingtai/tools/
+CONTRACT.md``): the public tool name stays ``skills`` and the public action
+values stay exactly ``info`` and ``manual``; only the envelope shape around
+them changes to the canonical ``action`` + ``input`` + ``reasoning`` +
+``summarize`` root.
 
 Usage: ``Agent(capabilities={"skills": {"paths": [...]}})`` or via init.json.
 """
@@ -28,11 +33,11 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-from lingtai.kernel.tool_dispatch import dispatch_action
+from typing import TYPE_CHECKING, Any, Mapping
 
 from .._catalog import build_catalog_yaml, scan_markdown_catalog
+from ..tool_family import ChildTool, ToolFamily
+from ..tool_family.manual import build_manual_child
 from lingtai.kernel.i18n import t
 
 if TYPE_CHECKING:
@@ -41,6 +46,13 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 PROVIDERS = {"providers": [], "default": "builtin"}
+
+# Both skills actions are signposts that take no arguments at all, so both
+# child input schemas are the canonical strict-empty object. Built per call so
+# each child owns a distinct schema object: a future per-action field must not
+# silently widen its sibling.
+def _strict_empty_input() -> dict[str, Any]:
+    return {"type": "object", "properties": {}, "required": [], "additionalProperties": False}
 
 
 # ---------------------------------------------------------------------------
@@ -167,24 +179,25 @@ def _skills_info(agent: "BaseAgent", paths: list[str]) -> dict:
     return result
 
 
-def _skills_manual(agent: "BaseAgent") -> dict:
-    """Return the skills manual body without refreshing catalog health."""
-    manual_path = agent._working_dir / ".library" / "intrinsic" / "capabilities" / "skills" / "SKILL.md"
-    if not manual_path.is_file():
-        return {
-            "status": "degraded",
-            "skills_manual": "",
-            "library_manual": "",
-            "manual_path": str(manual_path),
-            "error": "skills manual missing — initializer may have failed or capability not installed correctly",
-        }
-    manual_body = manual_path.read_text(encoding="utf-8")
-    return {
-        "status": "ok",
+def _adapt_manual_result(mcp_result: dict) -> dict:
+    """Flatten the dispatched ``manual`` child's canonical result to skills' shape.
+
+    Skills' public manual shape predates the generic canonical
+    ``content``/``structuredContent`` contract and must stay byte-identical, so
+    this Host-owned adapter runs strictly *after* dispatch — never inside a
+    registered child, and never touching ``info``. ``library_manual`` remains
+    the back-compat mirror of ``skills_manual``.
+    """
+    manual_body = mcp_result["content"][0]["text"]
+    flat: dict = {
+        "status": mcp_result.get("status", "ok"),
         "skills_manual": manual_body,
         "library_manual": manual_body,
-        "manual_path": str(manual_path),
+        "manual_path": mcp_result["structuredContent"]["manual_path"],
     }
+    if "error" in mcp_result:
+        flat["error"] = mcp_result["error"]
+    return flat
 
 
 # ---------------------------------------------------------------------------
@@ -192,21 +205,51 @@ def _skills_manual(agent: "BaseAgent") -> dict:
 # ---------------------------------------------------------------------------
 
 def get_description(lang: str = "en") -> str:
-    return 'SIGNPOST ONLY: this tool does not author, pin, publish, install, or execute skills; `info` only refreshes/reconciles the skills catalog and returns health without the manual body; `manual` returns the skills-manual body. Your per-agent skill catalog. The skills section of your system prompt is a YAML list — one `- name:` block per skill with `location:` and `description:` — covering every skill reachable right now. Before using this tool (authoring, pinning, publishing, or managing skills), read the `skills-manual` skill — call `manual` for its body and `info` for a runtime health snapshot; no exceptions.'
+    return 'SIGNPOST ONLY: this tool does not author, pin, publish, install, or execute skills; `info` only refreshes/reconciles the skills catalog and returns health without the manual body; `manual` returns the skills-manual body. Your per-agent skill catalog. The skills section of your system prompt is a YAML list — one `- name:` block per skill with `location:` and `description:` — covering every skill reachable right now. Both actions take an empty input object: skills(action=\'info\', input={}, reasoning=\'refresh the skill catalogue\') and skills(action=\'manual\', input={}, reasoning=\'load skills guidance\'). Before using this tool (authoring, pinning, publishing, or managing skills), read the `skills-manual` skill — call `manual` for its body and `info` for a runtime health snapshot; no exceptions.'
+
+
+def _build_family(agent: "BaseAgent | None", paths: list[str]) -> ToolFamily:
+    """Build the skills family — the one canonical child registry.
+
+    Both the model-facing schema and runtime dispatch come from this single
+    declaration, so action names, input schemas, titles, and order cannot drift
+    apart. ``agent=None`` yields a schema-only family whose handlers are never
+    reachable: ``get_schema()`` calls only ``build_schema()``, which reads each
+    child's ``input_schema`` and never a handler. Constructing it at import time
+    also proves the registry has no duplicate or reserved-name collision
+    (``ToolFamilyError`` would raise here rather than shipping silently).
+
+    The ``manual`` child is ``build_manual_child``'s, registered directly and
+    unwrapped, so ``ToolFamily.handle()`` returns its canonical result verbatim
+    (no double wrap); the flat public shape is rebuilt strictly after dispatch
+    in ``handle_skills``. It reads the installed manual only — no catalog scan,
+    no prompt injection, no other ``info``-side effect.
+    """
+    if agent is None:
+        def _info(_input: Mapping[str, Any]) -> dict:
+            raise AssertionError("the schema-only skills family never dispatches")
+    else:
+        def _info(_input: Mapping[str, Any]) -> dict:
+            return _skills_info(agent, paths)
+
+    # Always the shared builder's own child, so the advertised ``manual`` input
+    # schema is exactly the one dispatch registers — schema and dispatch cannot
+    # disagree even about a detail like a redundant empty ``required``.
+    manual_child = build_manual_child(agent, "skills")
+
+    return ToolFamily(
+        "skills",
+        [ChildTool("info", _strict_empty_input(), _info, title="info input"), manual_child],
+    )
+
+
+_SCHEMA_FAMILY = _build_family(None, [])
 
 
 def get_schema(lang: str = "en") -> dict:
-    return {
-        "type": "object",
-        "properties": {
-            "action": {
-                "type": "string",
-                "enum": ["info", "manual"],
-                "description": 'info: refresh/reconcile the skills catalog and return runtime health (catalog size, resolved paths, problems) without the manual body. manual: return only the skills-manual skill body.',
-            },
-        },
-        "required": ["action"],
-    }
+    # Composed from the same child registry runtime dispatch uses, so the
+    # public action enum cannot drift from the dispatch keys.
+    return _SCHEMA_FAMILY.build_schema()
 
 
 def setup(agent: "BaseAgent", paths: list[str] | None = None, **_ignored) -> None:
@@ -227,19 +270,18 @@ def setup(agent: "BaseAgent", paths: list[str] | None = None, **_ignored) -> Non
     # This only READS from .library/ — the initializer has already written it.
     _reconcile(agent, path_list)
 
-    # Register signpost actions. `info` refreshes health; `manual` returns the large manual body.
+    family = _build_family(agent, path_list)
+
     def handle_skills(args: dict) -> dict:
-        return dispatch_action(
-            args,
-            {
-                "info": lambda _args: _skills_info(agent, path_list),
-                "manual": lambda _args: _skills_manual(agent),
-            },
-            unknown=lambda action: {
-                "status": "error",
-                "message": f"unknown action: {action!r}, only 'info' or 'manual' is supported",
-            },
-        )
+        # ``ToolFamily.handle`` is the fail-closed authorization boundary:
+        # schema conformance alone is not (``tools/CONTRACT.md`` "Dispatch and
+        # actions"). Flattening the dispatched ``manual`` result is this Host
+        # layer's own job, done strictly after dispatch.
+        action = args.get("action") if isinstance(args, Mapping) else None
+        result = family.handle(args)
+        if action == "manual" and "content" in result:
+            return _adapt_manual_result(result)
+        return result
 
     agent.add_tool(
         "skills",

--- a/src/lingtai/tools/skills/glossary-wen.md
+++ b/src/lingtai/tools/skills/glossary-wen.md
@@ -16,4 +16,7 @@ maintenance: |
 **名相对照**
 
 - `skills`：【路标之器】此器不代汝书技、固技、发布、安装或施技；`info` 唯重校/重扫技典并还康状，不载 manual 全文；`manual` 方还 skills-manual 之文。尔之器灵技能目录。系统之中技能典为 YAML 之列——每技一 `- name:` 块，附 `location:` 与 `description:` 之目——所列皆此时可取之技。用此器前（凡藏用、固定、出新、料理技能之事），必先读 `skills-manual` 一技——呼 `info` 即得其文与当时之康状，无所例外。
-- `action`：info：重校/重扫技能目录，并还当时之康状（技数、解径、患记），不载 manual 全文。manual：唯还 skills-manual 之文。
+- `action`：info：重校/重扫技能目录，并还当时之康状（技数、解径、患记），不载 manual 全文。manual：唯还 skills-manual 之文，不动技典。
+- `input`：所选 `action` 之严入之匣。此器二 action 皆空匣（`{}`），凡有所纳，未及施行而先败。
+- `reasoning`：必具，述此番呼器之由；乃封函之属，绝非 action 之入。
+- `summarize`：可有可无之然否，居根位，司果之后治，本为否；绝不入 `input`，亦绝非 action 之入。

--- a/src/lingtai/tools/skills/glossary-zh.md
+++ b/src/lingtai/tools/skills/glossary-zh.md
@@ -16,4 +16,7 @@ maintenance: |
 **术语对照**
 
 - `skills`：【路标工具】此工具不会编写、固定、发布、安装或执行技能；`info` 只重新协调/扫描技能目录并返回健康状态，不带 manual 正文；`manual` 才返回 skills-manual 正文。你的器灵专属技能目录。系统提示词中的技能目录为 YAML 列表——每项技能为一 `- name:` 块，附 `location:` 与 `description:` 字段——涵盖当前所有可用的技能。用此工具前（编写、固定、发布或管理技能），必先读 `skills-manual` 技能——调用 `info` 即可获取其正文与运行时健康快照，无例外。
-- `action`：info：刷新/协调技能目录并返回运行时健康快照（目录规模、解析后的路径、问题列表），不带 manual 正文。manual：只返回 skills-manual 技能正文。
+- `action`：info：刷新/协调技能目录并返回运行时健康快照（目录规模、解析后的路径、问题列表），不带 manual 正文。manual：只返回 skills-manual 技能正文，不触动技能目录。
+- `input`：所选 `action` 的严格入参对象。此工具两个 action 均为空入参（`{}`），传入任何字段都会在调用处理器之前失败。
+- `reasoning`：必填，本次调用的理由，属信封元数据，绝不作为 action 的入参。
+- `summarize`：可选布尔量，位于根层的结果后处理开关，默认为假；绝不嵌入 `input`，也绝不作为 action 的入参。

--- a/src/lingtai/tools/skills/manual/SKILL.md
+++ b/src/lingtai/tools/skills/manual/SKILL.md
@@ -8,8 +8,8 @@ description: >
   missing from the catalog, adding a skills path, or turning a manual into a
   progressive-disclosure router. Does NOT document the bundled skills themselves
   — their own SKILL.md files do.
-version: 1.1.0
-last_changed_at: "2026-07-26T20:55:00-07:00"
+version: 1.2.0
+last_changed_at: "2026-07-27T04:30:00-07:00"
 related_files:
 - src/lingtai/tools/skills/__init__.py
 - src/lingtai/tools/skills/ANATOMY.md
@@ -71,14 +71,56 @@ The `skills` section of your system prompt is a YAML list. Each skill is one
 `SKILL.md`) and a `description:` block scalar. To read a skill's body, `read` the
 file at its `location`.
 
-`skills({"action": "info"})` refreshes/reconciles the catalog and returns a
-runtime snapshot — `skills_dir`/`library_dir`, `catalog_size`, resolved paths
-with exist/skill-count info, and any `problems` (invalid frontmatter, unreadable
+`skills` is one LingTai Tool Protocol v2 family. Its model-facing root is closed
+and exactly `action`, `input`, `reasoning`, `summarize`. `action`, its nested
+`input` object, and top-level `reasoning` are required; root `summarize` is an
+optional boolean, absent or false by default. Both actions take the **empty**
+input object — there is no field to pass on either — and neither branch admits
+`reasoning`, `_reasoning`, or `summarize`.
+
+```text
+skills(action="info", input={}, reasoning="check catalogue health")
+```
+
+refreshes/reconciles the catalog and returns a runtime snapshot —
+`skills_dir`/`library_dir`, `catalog_size`, resolved paths with
+exist/skill-count info, and any `problems` (invalid frontmatter, unreadable
 folders) — without the manual body. Use it first when a skill you expect is
-missing. `skills({"action": "manual"})` returns this SKILL.md body instead. A
-`status` of `"degraded"` carries an error message naming the fix — typically a
-missing manual under `intrinsic/capabilities/skills/`, meaning the initializer
-did not install manuals correctly.
+missing.
+
+```text
+skills(action="manual", input={}, reasoning="load skills guidance")
+```
+
+returns this SKILL.md body instead, and performs no catalogue scan, prompt
+injection, or other `info`-side effect. A `status` of `"degraded"` carries an
+error message naming the fix — typically a missing manual under
+`intrinsic/capabilities/skills/`, meaning the initializer did not install
+manuals correctly.
+
+An unknown action, or any key at all inside `input`, fails before either
+handler runs with a typed envelope failure
+(`{"status": "failed", "error_code": ...}`).
+
+### `summarize` for this family
+
+`info` follows the **short-result** profile: its health snapshot is normally
+small, so `summarize` is available but normally unnecessary — leave it false.
+`manual` follows the **bulky-result** profile: this body is long, so
+`summarize=true` is reasonable when you only need the gist, but calls meant to
+follow an exact procedure should keep the default `summarize=false` so precise
+steps, paths, and constraints are not summarized away. `summarize` is a root,
+cross-cutting field — never nested inside `input`, and never an implementation
+argument to either action. A call that fails always returns its exact,
+unsummarized error regardless of `summarize`.
+
+### Settings
+
+`skills` supports **no settings file at all** — neither a family-level
+`settings/skills.json` nor any action-level `settings/skills.<action>.json`.
+Nothing is read from either address, and creating one has no effect. The
+catalogue's only configuration input is `manifest.capabilities.skills.paths`
+in `init.json`, described above.
 
 To pin a skill's body into your pad so it survives a molt and rides in the cached
 system-prompt prefix:

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -6,6 +6,7 @@ related_files:
   - src/lingtai/tools/tool_family/__init__.py
   - src/lingtai/tools/tool_family/manual.py
   - src/lingtai/tools/web_search/ANATOMY.md
+  - src/lingtai/tools/skills/ANATOMY.md
 maintenance: |
   Keep related_files repo-relative, duplicate-free, and linked to real files.
   Keep this component's ANATOMY.md and CONTRACT.md reciprocal and keep
@@ -82,6 +83,21 @@ diagnostic onto any envelope-level failure result, since a generic
 `ToolFamily` has no knowledge of a specific family's settings diagnostics.
 This division follows `../CONTRACT.md` "Implementation independence": using
 `ToolFamily.handle()` is `web`'s choice, not an inherited requirement.
+
+`skills/__init__.py` ([`../skills/ANATOMY.md`](../skills/ANATOMY.md)) is the
+second consumer and uses the same division with no shared code beyond this
+package, and differs from `web` in declaring its child registry exactly once:
+a single `_build_family(agent, paths)` builder registers the `info` child and
+`manual.build_manual_child(agent, "skills")` directly, and both `get_schema()`
+(via an import-time `agent=None` instance whose handlers are unreachable) and
+`setup()` obtain their `ToolFamily` from it — so the advertised input schemas
+are by construction the ones dispatch registers. Both of its children declare
+the canonical strict-empty `input` schema, so `handle()`'s allowed-key check
+rejects every `input` key for either action. Its
+`handle_skills` wrapper adapts only the dispatched `manual` child result to
+the capability's public `skills_manual`/`library_manual`/`manual_path` shape
+and, unlike `web`, keeps this package's canonical envelope-failure result
+verbatim — it has no family-specific diagnostic block to stamp on.
 
 ## Composition
 

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -10,6 +10,8 @@ related_files:
   - src/lingtai/tools/_manual.py
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
+  - src/lingtai/tools/skills/CONTRACT.md
+  - src/lingtai/tools/skills/__init__.py
   - tests/test_tool_family_generic.py
   - tests/test_tool_family_wire_parity.py
   - tests/test_tool_family_manual_contract.py
@@ -137,9 +139,26 @@ flattens the canonical result to Web's pre-migration public shape (`status`,
 `handle()`, not to the generic child or any wrapper registered in place of
 it. `WebManager.handle()` also stamps `current_setting` onto any
 envelope-level failure result (search/browse/unknown-action) before
-returning, unchanged from before. No other built-in family is migrated in
-this candidate; each remains fully independent of this package until its own
-scoped migration.
+returning, unchanged from before.
+
+`skills/__init__.py` (`../skills/CONTRACT.md`) is the second production
+Adapter/consumer. One `_build_family(agent, paths)` builder is its single
+canonical child registry, registering an `info` child and
+`manual.build_manual_child(agent, "skills")` directly — unwrapped; both
+`get_schema()` (through an import-time `agent=None` instance whose handlers are
+unreachable) and `setup()` obtain their `ToolFamily` from that one builder, so
+the composed schema advertises exactly the child `input_schema`s dispatch
+registers. Its `handle_skills` wrapper adapts only a successfully
+dispatched manual result (`"content" in result`) to that capability's public
+`skills_manual`/`library_manual`/`manual_path` shape, post-dispatch. Unlike
+`web`, it returns this package's canonical envelope-failure result verbatim,
+having no family-specific diagnostic block to stamp on; both of its children
+declare the canonical strict-empty `input_schema`, so `handle()`'s
+allowed-key check rejects every `input` key on either action. The two
+consumers share nothing but this package, as
+`../CONTRACT.md` "Implementation independence" requires. No other built-in
+family is migrated in this candidate; each remains fully independent of this
+package until its own scoped migration.
 
 ## Contract rules
 
@@ -168,6 +187,12 @@ scoped migration.
   sole enforcement boundary; dispatch remains always-authoritative and
   fail-closed regardless of whether a given provider validates the root
   `allOf`/`if`/`then` schema-side (`../CONTRACT.md` "Dispatch and actions").
+- An `action` value that is unhashable (invalid JSON can make it `[]` or
+  `{}`) MUST return the same typed `ACTION_REQUIRED` envelope failure as any
+  other unknown action, never raise. Membership-testing an unhashable key
+  against the child registry raises `TypeError`; `handle()` MUST treat that
+  as matching no child, mirroring the hand-written routers this dispatcher
+  replaces (`kernel/tool_dispatch.py`, issue #513).
 - A child handler MUST receive only its own validated `input` mapping — never
   `action`, `reasoning`, `_reasoning`, or `summarize`.
 - `handle()`'s dispatch result IS the child's own raw/canonical result;

--- a/src/lingtai/tools/tool_family/__init__.py
+++ b/src/lingtai/tools/tool_family/__init__.py
@@ -262,7 +262,18 @@ class ToolFamily:
         """
         raw = dict(args or {})
         action = raw.get("action")
-        if action not in self._children:
+        # Invalid JSON can make ``action`` an unhashable value (e.g. ``[]`` or
+        # ``{}``) — the issue #513 class of blocker the hand-written routers
+        # this dispatcher replaces guarded against explicitly
+        # (``kernel/tool_dispatch.py``). Membership testing an unhashable key
+        # against a dict raises ``TypeError``; treat it as simply matching no
+        # child so an unknown action always fails with the stable typed
+        # envelope failure rather than crashing out of dispatch.
+        try:
+            known_action = action in self._children
+        except TypeError:
+            known_action = False
+        if not known_action:
             return self._envelope_error(
                 "ACTION_REQUIRED",
                 f"action must be one of {', '.join(self._order)}",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -64,34 +64,175 @@ def _write_skill(folder: Path, name: str, desc: str = "test skill"):
     )
 
 
-def test_unknown_action_returns_error(tmp_path):
-    """Only `info` is supported; the exact error envelope is model-visible.
+_UNKNOWN_ACTION = {
+    "status": "failed",
+    "error_code": "ACTION_REQUIRED",
+    "message": "action must be one of info, manual",
+}
 
-    Locks the unknown-action envelope through the issue #513 dispatch-helper
-    migration: wording, quoting, and key names must stay verbatim.
+
+def test_unknown_action_returns_error(tmp_path):
+    """Only `info` and `manual` are supported; the failure is model-visible.
+
+    After the LTP v2 ToolFamily migration the unknown-action envelope is the
+    generic family failure (`status: "failed"` + typed `error_code`), not the
+    pre-migration `{status: "error", message: "unknown action: ..."}` router
+    envelope. Skills has no per-result diagnostic block of its own to preserve
+    (unlike `web`'s `action`/`current_setting`), so it keeps the canonical
+    family shape verbatim rather than renormalizing it.
     """
     agent, _ = _mk_agent(tmp_path)
     try:
         handler = agent._tool_handlers["skills"]
-        assert handler({"action": "list"}) == {
-            "status": "error",
-            "message": "unknown action: 'list', only 'info' or 'manual' is supported",
-        }
-        # Missing action key renders the empty-string default, not None.
-        assert handler({}) == {
-            "status": "error",
-            "message": "unknown action: '', only 'info' or 'manual' is supported",
-        }
+        assert handler({"action": "list", "input": {}, "reasoning": "r"}) == _UNKNOWN_ACTION
+        # Missing action key fails the same way, before any handler I/O.
+        assert handler({}) == _UNKNOWN_ACTION
         # Invalid JSON can make `action` unhashable (issue #513 blocker): the
-        # router must render the unknown-action envelope, not raise TypeError.
-        assert handler({"action": []}) == {
-            "status": "error",
-            "message": "unknown action: [], only 'info' or 'manual' is supported",
+        # dispatcher must render the typed failure, not raise TypeError.
+        assert handler({"action": []}) == _UNKNOWN_ACTION
+        assert handler({"action": {}}) == _UNKNOWN_ACTION
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_unknown_action_fails_before_any_handler_io(tmp_path, monkeypatch):
+    """An unknown action must not scan the catalogue or read the manual."""
+    agent, workdir = _mk_agent(tmp_path)
+    try:
+        from lingtai.tools import skills as skills_tool
+
+        def _boom(*_args, **_kwargs):
+            raise AssertionError("handler I/O ran for an unknown action")
+
+        monkeypatch.setattr(skills_tool, "_reconcile", _boom)
+        monkeypatch.setattr(skills_tool, "_skills_info", _boom)
+        before = agent._prompt_manager.read_section("skills")
+        assert agent._tool_handlers["skills"](
+            {"action": "publish", "input": {}, "reasoning": "r"}
+        ) == _UNKNOWN_ACTION
+        assert agent._prompt_manager.read_section("skills") == before
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_family_schema_is_the_canonical_ltp_v2_root(tmp_path):
+    """Public name/actions are unchanged; only the envelope is canonical now."""
+    from lingtai.tools import skills as skills_tool
+
+    schema = skills_tool.get_schema()
+    assert schema["type"] == "object"
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    assert schema["required"] == ["action", "input", "reasoning"]
+    assert schema["additionalProperties"] is False
+    # Public action values are unchanged and equal the dispatch keys.
+    assert schema["properties"]["action"]["enum"] == ["info", "manual"]
+    assert schema["properties"]["reasoning"]["type"] == "string"
+    assert schema["properties"]["summarize"]["type"] == "boolean"
+
+    branches = schema["properties"]["input"]["oneOf"]
+    assert [b["title"] for b in branches] == ["info input", "manual input"]
+    for branch in branches:
+        # Canonical strict-empty input for both actions.
+        assert branch["type"] == "object"
+        assert branch["properties"] == {}
+        assert branch["additionalProperties"] is False
+        assert "reasoning" not in branch["properties"]
+        assert "_reasoning" not in branch["properties"]
+        assert "summarize" not in branch["properties"]
+
+    # Root correlates each action const with that exact child's input schema.
+    conditions = schema["allOf"]
+    assert len(conditions) == 2
+    for condition, name, branch in zip(conditions, ["info", "manual"], branches):
+        assert condition["if"]["properties"]["action"]["const"] == name
+        assert condition["if"]["required"] == ["action"]
+        assert condition["then"]["properties"]["input"]["additionalProperties"] is False
+        # Both surfaces derive from the one child registry, so the correlated
+        # schema is exactly the disclosed branch (minus its display title).
+        assert condition["then"]["properties"]["input"] == {
+            k: v for k, v in branch.items() if k != "title"
         }
-        assert handler({"action": {}}) == {
-            "status": "error",
-            "message": "unknown action: {}, only 'info' or 'manual' is supported",
+
+
+def test_schema_children_are_the_same_registry_dispatch_uses():
+    """One canonical child-spec source backs both schema and dispatch.
+
+    The advertised input schema for each action must be the exact object the
+    dispatched child declares — not a parallel literal that can drift from it.
+    """
+    from lingtai.tools import skills as skills_tool
+
+    schema_family = skills_tool._build_family(None, [])
+    runtime_family = skills_tool._build_family(object(), ["/some/path"])
+    assert schema_family.child_names == runtime_family.child_names == ("info", "manual")
+    for name in ("info", "manual"):
+        assert (
+            schema_family._children[name].input_schema
+            == runtime_family._children[name].input_schema
+        )
+        assert schema_family._children[name].title == runtime_family._children[name].title
+    # And the composed schema is identical regardless of which one built it.
+    assert schema_family.build_schema() == runtime_family.build_schema()
+
+
+def test_both_actions_reject_extra_input_before_dispatch(tmp_path):
+    """Strict-empty means any input key fails, on either action."""
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        handler = agent._tool_handlers["skills"]
+        for action in ("info", "manual"):
+            assert handler(
+                {"action": action, "input": {"paths": ["/tmp"]}, "reasoning": "r"}
+            ) == {
+                "status": "failed",
+                "error_code": "INVALID_ARGUMENT",
+                "message": "unsupported skills input field",
+            }
+        # A missing/non-object input is rejected too.
+        assert handler({"action": "info", "reasoning": "r"}) == {
+            "status": "failed",
+            "error_code": "INVALID_ARGUMENT",
+            "message": "input must be an object",
         }
+        # Unknown root fields and non-boolean summarize fail at the envelope.
+        assert handler(
+            {"action": "info", "input": {}, "reasoning": "r", "engine": "x"}
+        ) == {
+            "status": "failed",
+            "error_code": "INVALID_ARGUMENT",
+            "message": "unsupported skills argument",
+        }
+        assert handler(
+            {"action": "info", "input": {}, "reasoning": "r", "summarize": "yes"}
+        ) == {
+            "status": "failed",
+            "error_code": "INVALID_ARGUMENT",
+            "message": "summarize must be a boolean",
+        }
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_envelope_metadata_never_reaches_either_handler(tmp_path):
+    """`reasoning`/`_reasoning`/`summarize` are root-only, never action input."""
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        handler = agent._tool_handlers["skills"]
+        for action in ("info", "manual"):
+            result = handler(
+                {
+                    "action": action,
+                    "input": {},
+                    "reasoning": "why",
+                    "_reasoning": "internal",
+                    "summarize": True,
+                }
+            )
+            # Dispatch succeeded (the envelope fields were stripped, not
+            # forwarded into the strict-empty child input).
+            assert result["status"] == "ok"
+            for leaked in ("reasoning", "_reasoning", "summarize"):
+                assert leaked not in result
     finally:
         agent.stop(timeout=1.0)
 
@@ -594,7 +735,7 @@ def test_skills_scans_absolute_path(tmp_path):
 
     agent, _ = _mk_agent(tmp_path, {"paths": [str(extra)]})
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}, "reasoning": "test"})
         assert result["status"] == "ok"
         assert result["paths"][str(extra)]["skills"] == 1
         assert result["catalog_size"] >= 2  # skills-manual + shared-skill
@@ -610,7 +751,7 @@ def test_skills_resolves_relative_path_from_working_dir(tmp_path):
 
     agent, _ = _mk_agent(tmp_path, {"paths": ["../.library_shared"]})
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}, "reasoning": "test"})
         assert result["status"] == "ok"
         assert result["paths"]["../.library_shared"]["exists"] is True
         assert result["paths"]["../.library_shared"]["skills"] == 1
@@ -627,7 +768,7 @@ def test_skills_expands_tilde(tmp_path, monkeypatch):
 
     agent, _ = _mk_agent(tmp_path, {"paths": ["~/my-utils"]})
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}, "reasoning": "test"})
         assert result["paths"]["~/my-utils"]["exists"] is True
     finally:
         agent.stop(timeout=1.0)
@@ -636,7 +777,7 @@ def test_skills_expands_tilde(tmp_path, monkeypatch):
 def test_skills_reports_missing_path_as_not_existing(tmp_path):
     agent, _ = _mk_agent(tmp_path, {"paths": ["/does/not/exist"]})
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}, "reasoning": "test"})
         assert result["paths"]["/does/not/exist"]["exists"] is False
         assert result["paths"]["/does/not/exist"]["skills"] == 0
     finally:
@@ -651,7 +792,7 @@ def test_skills_reports_missing_path_as_not_existing(tmp_path):
 def test_info_omits_skills_manual_body(tmp_path):
     agent, _ = _mk_agent(tmp_path)
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}, "reasoning": "test"})
         assert "skills_manual" not in result
         assert "library_manual" not in result
     finally:
@@ -661,7 +802,7 @@ def test_info_omits_skills_manual_body(tmp_path):
 def test_manual_returns_skills_manual_body(tmp_path):
     agent, _ = _mk_agent(tmp_path)
     try:
-        result = agent._tool_handlers["skills"]({"action": "manual"})
+        result = agent._tool_handlers["skills"]({"action": "manual", "input": {}, "reasoning": "test"})
         assert "skills_manual" in result
         assert "library_manual" in result
         assert "name: skills-manual" in result["skills_manual"]
@@ -672,7 +813,7 @@ def test_manual_returns_skills_manual_body(tmp_path):
 def test_info_reports_ok_when_healthy(tmp_path):
     agent, _ = _mk_agent(tmp_path)
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}, "reasoning": "test"})
         assert result["status"] == "ok"
         assert "error" not in result
     finally:
@@ -691,7 +832,7 @@ def test_info_reports_degraded_when_intrinsic_missing(tmp_path):
         assert manual_path.is_file(), "precondition: initializer installed manual"
         manual_path.unlink()
 
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}, "reasoning": "test"})
         assert result["status"] == "degraded"
         assert "error" in result
     finally:
@@ -712,11 +853,194 @@ def test_info_surfaces_problems(tmp_path):
         capabilities={"skills": {}},
     )
     try:
-        result = agent._tool_handlers["skills"]({"action": "info"})
+        result = agent._tool_handlers["skills"]({"action": "info", "input": {}, "reasoning": "test"})
         problem_folders = [p["folder"] for p in result["problems"]]
         assert any("broken" in f for f in problem_folders)
     finally:
         agent.stop(timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# LTP v2 migration: exact semantic preservation of both children
+# ---------------------------------------------------------------------------
+
+
+def test_info_result_keys_and_health_are_exactly_preserved(tmp_path):
+    """`info` still returns the exact pre-migration health/problem report.
+
+    The envelope changed; the child's own canonical result did not. Keys, the
+    resolved-path report, the problem list entries, and `catalog_size` are
+    returned verbatim, with the manual body still omitted and no wrapper
+    around the child result.
+    """
+    extra = tmp_path / "extra"
+    _write_skill(extra / "good-skill", "good-skill")
+    workdir = tmp_path / "agent"
+    bad = workdir / ".library" / "custom" / "broken" / "SKILL.md"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("---\nname: broken\n---\nno description!\n")
+
+    agent = Agent(
+        service=make_mock_service(),
+        agent_name="test",
+        working_dir=workdir,
+        capabilities={"skills": {"paths": [str(extra)]}},
+    )
+    try:
+        result = agent._tool_handlers["skills"](
+            {"action": "info", "input": {}, "reasoning": "health check"}
+        )
+        assert set(result) == {
+            "status",
+            "skills_dir",
+            "library_dir",
+            "catalog_size",
+            "paths",
+            "problems",
+        }
+        assert result["status"] == "ok"
+        assert result["skills_dir"] == str(workdir / ".library")
+        assert result["library_dir"] == result["skills_dir"]
+        assert result["paths"] == {
+            str(extra): {"resolved": str(extra), "exists": True, "skills": 1}
+        }
+        assert result["problems"] == [
+            {
+                "folder": "broken",
+                "reason": "SKILL.md missing required frontmatter field: description",
+            }
+        ]
+        assert result["catalog_size"] >= 2
+        # No child-result envelope nested inside the action result.
+        assert "content" not in result
+        assert "structuredContent" not in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_manual_result_is_exact_body_and_path_without_double_wrap(tmp_path):
+    """`manual` returns the exact installed bytes and host-local path."""
+    agent, workdir = _mk_agent(tmp_path)
+    try:
+        manual_path = (
+            workdir / ".library" / "intrinsic" / "capabilities" / "skills" / "SKILL.md"
+        )
+        expected = manual_path.read_text(encoding="utf-8")
+        result = agent._tool_handlers["skills"](
+            {"action": "manual", "input": {}, "reasoning": "load guidance"}
+        )
+        assert result == {
+            "status": "ok",
+            "skills_manual": expected,
+            "library_manual": expected,
+            "manual_path": str(manual_path),
+        }
+        # The canonical child result is adapted by the Host, never nested.
+        assert "content" not in result
+        assert "structuredContent" not in result
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_manual_has_no_info_side_effect(tmp_path):
+    """`manual` must not scan, reconcile, or re-inject the catalogue.
+
+    A skill added on disk after setup stays invisible until `info` runs: this
+    proves `manual` performed no catalogue mutation, only a manual read.
+    """
+    extra = tmp_path / "extra"
+    _write_skill(extra / "before-skill", "before-skill")
+    agent, _ = _mk_agent(tmp_path, {"paths": [str(extra)]})
+    try:
+        handler = agent._tool_handlers["skills"]
+        before = agent._prompt_manager.read_section("skills") or ""
+        assert "- name: before-skill" in before
+
+        # Add a new skill on disk, then call `manual` only.
+        _write_skill(extra / "after-skill", "after-skill")
+        manual_result = handler(
+            {"action": "manual", "input": {}, "reasoning": "read manual"}
+        )
+        assert manual_result["status"] == "ok"
+        unchanged = agent._prompt_manager.read_section("skills") or ""
+        assert unchanged == before
+        assert "- name: after-skill" not in unchanged
+        # `manual` reports no health fields at all.
+        for info_only in ("catalog_size", "paths", "problems", "skills_dir"):
+            assert info_only not in manual_result
+
+        # `info` is what reconciles — the new skill appears only now.
+        info_result = handler({"action": "info", "input": {}, "reasoning": "refresh"})
+        refreshed = agent._prompt_manager.read_section("skills") or ""
+        assert "- name: after-skill" in refreshed
+        assert info_result["paths"][str(extra)]["skills"] == 2
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_manual_degrades_with_exact_loader_message(tmp_path):
+    """A missing manual degrades on `manual` exactly as before the migration."""
+    agent, workdir = _mk_agent(tmp_path)
+    try:
+        manual_path = (
+            workdir / ".library" / "intrinsic" / "capabilities" / "skills" / "SKILL.md"
+        )
+        assert manual_path.is_file(), "precondition: initializer installed manual"
+        manual_path.unlink()
+
+        assert agent._tool_handlers["skills"](
+            {"action": "manual", "input": {}, "reasoning": "read manual"}
+        ) == {
+            "status": "degraded",
+            "skills_manual": "",
+            "library_manual": "",
+            "manual_path": str(manual_path),
+            "error": (
+                "skills manual missing — initializer may have failed or "
+                "capability not installed correctly"
+            ),
+        }
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_skills_family_reaches_both_provider_wires(tmp_path):
+    """The composed schema survives Chat Completions and Responses unchanged."""
+    from lingtai.kernel.base_agent.tools import _build_tool_schemas
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+    agent, _ = _mk_agent(tmp_path)
+    try:
+        schemas = _build_tool_schemas(agent)
+        # Exactly one public model root for the family; no duplicate old roots.
+        assert [s.name for s in schemas].count("skills") == 1
+        skills_schema = next(s for s in schemas if s.name == "skills")
+        chat = _build_tools([skills_schema])[0]["function"]["parameters"]
+        responses = _build_responses_tools([skills_schema])[0]["parameters"]
+        for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+            assert set(wire["properties"]) == {
+                "action",
+                "input",
+                "reasoning",
+                "summarize",
+            }
+            assert wire["required"] == ["action", "input", "reasoning"]
+            assert wire["additionalProperties"] is False
+            assert wire["properties"]["action"]["enum"] == ["info", "manual"]
+            branches = wire["properties"]["input"][combinator]
+            assert [b["title"] for b in branches] == ["info input", "manual input"]
+    finally:
+        agent.stop(timeout=1.0)
+
+
+def test_skills_is_a_migrated_ltp_v2_family_for_summarize(tmp_path):
+    """Root `summarize` is the canonical control for this migrated family."""
+    from lingtai.kernel.tool_result_summary import summary_requested
+
+    assert summary_requested({"summarize": True}, tool_name="skills") is True
+    assert summary_requested({"summarize": False}, tool_name="skills") is False
+    # Still scoped by name: an unmigrated tool's own field is not this control.
+    assert summary_requested({"summarize": True}, tool_name="knowledge") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_family_generic.py
+++ b/tests/test_tool_family_generic.py
@@ -137,6 +137,28 @@ def test_dispatch_missing_action_fails_with_action_required():
     assert result["error_code"] == "ACTION_REQUIRED"
 
 
+def test_dispatch_unhashable_action_fails_without_raising():
+    """Invalid JSON can make ``action`` unhashable (issue #513).
+
+    Membership-testing an unhashable key against the child registry raises
+    ``TypeError``; dispatch must render the stable typed failure instead, the
+    way the hand-written routers this dispatcher replaces did.
+    """
+    fam = _widget_family()
+    for bad_action in ([], {}, [1, 2], {"a": 1}):
+        result = fam.handle({"action": bad_action, "input": {}})
+        assert result["status"] == "failed"
+        assert result["error_code"] == "ACTION_REQUIRED"
+
+
+def test_dispatch_unhashable_action_runs_no_handler():
+    """The unhashable-action guard must fail before any child handler I/O."""
+    calls = []
+    fam = _widget_family(calls)
+    assert fam.handle({"action": [], "input": {"speed": 1}})["error_code"] == "ACTION_REQUIRED"
+    assert calls == []
+
+
 def test_dispatch_non_object_input_fails_with_invalid_argument():
     fam = _widget_family()
     result = fam.handle({"action": "spin", "input": "not-an-object"})


### PR DESCRIPTION
> **Exact source head:** `f1170c8f385428132fe3e7dadb3ecb99b78069a7`  
> **Exact base:** `4ad8b1555a5b0368af81aa57292438719a105052`  
> **Canonical materialization:** 14 verified paths from `PARENT_ISOLATION_MANIFEST.txt`; contaminated original preserved untouched.  
> **dev4 exact-head live-use gate:** pending immediately after PR opening; this body will be updated with the durable receipt.

## Decision

Migrate the public signpost-only `skills` tool to one action-separated
ToolFamily while preserving the public root and both action values:

```text
skills
├── info
└── manual
```

Calls now use the strict family envelope `action + input + reasoning`, with
optional Host `summarize`. This is the third family to migrate after `web`
(#1059) and reuses that merged `ToolFamily`/`ManualTool` infrastructure. **It
adds no authoring, pinning, publishing, installing, or executing behavior** —
the signpost-only boundary is unchanged and restated in the description,
manual, ANATOMY, and CONTRACT.

## Product schema (exact, as composed)

Root is closed to exactly four properties, `additionalProperties: false`,
required `["action", "input", "reasoning"]`:

| Root property | Type | Notes |
|---|---|---|
| `action` | string enum | `info \| manual` |
| `input` | object | the one strict input object for the selected action |
| `reasoning` | string | **required**; Host InvocationContext/audit metadata |
| `summarize` | boolean | optional, root-only cross-cutting post-processing control |

Both actions are argument-free signposts, so both `input` branches are the
canonical **strict-empty** object:

| Action | `input` properties | Required |
|---|---|---|
| `info` | *(none)* | — |
| `manual` | *(none)* | — |

Each action value equals its child name equals its dispatch key — no mapping
layer. The root also carries one `allOf` `if`/`then` per action correlating the
`action` const with that exact child's `input` schema, verified present on both
the Chat Completions (`oneOf`) and Responses (`anyOf`) wires.

## Behavior — exact public `skills` semantics

- **`info`** still re-scans/reconciles the skill catalogue, re-injects the
  protected `skills` prompt section, and returns the exact health shape
  `{status, skills_dir, library_dir, catalog_size, paths, problems}` with the
  manual body omitted. Key set, `paths` report (`resolved`/`exists`/`skills`),
  and `problems` entries (`folder`/`reason`) are byte-identical to
  pre-migration; `_reconcile`/`_skills_info` are untouched hunks against base.
- **`manual`** still reads only the installed skills manual and returns the
  exact `{status, skills_manual, library_manual, manual_path}` result (plus
  `error` when degraded), **without double wrapping**. It performs **no**
  catalogue scan, **no** prompt injection, and no other `info`-side effect —
  proven by a test that adds a skill on disk, calls `manual`, and asserts the
  prompt section is unchanged, then calls `info` and sees it appear.
- The `degraded` message is character-identical: `load_installed_manual(agent,
  "skills")` interpolates `skills` into the same sentence the deleted inline
  code carried.
- `library_manual` / `library_dir` remain the pre-existing back-compat mirrors
  (untouched base behavior; the on-disk root stays `.library`).
- Both children have canonical strict-empty inputs; **any** `input` key on
  either action fails before handler I/O.
- Invalid/cross-action input, unknown root fields, and non-boolean `summarize`
  fail at the envelope with typed failures, before any handler runs.
- `reasoning`, `_reasoning` and `summarize` remain Host controls and never
  enter child arguments.
- Chat and Responses preserve root action↔input correlation.
- The family uses the existing raw-first summarizer allowlist
  (`_LTP_V2_MIGRATED_FAMILIES`); no second summarizer or cap is introduced.
  Per-action profiles are documented: `info` = **short-result**, `manual` =
  **bulky-result**.

The manual and CONTRACT now state explicitly that Skills has **no settings
surface and no settings file** at either the family or action address.

### Deliberate public change — unknown-action error

The unknown-action result moves from the pre-migration router envelope
`{"status": "error", "message": "unknown action: 'x', only 'info' or 'manual'
is supported"}` to the canonical typed family failure
`{"status": "failed", "error_code": "ACTION_REQUIRED", "message": "action must
be one of info, manual"}`.

`web` retained its flat error shape only because every web result carries an
`action`/`current_setting` diagnostic block; Skills has no such block, so
renormalizing would mean inventing a bespoke shape to hide the canonical one.
Contract invariant 8 requires a *stable typed failure*, which this is. Under the
no-compat directive this is the cleanup-aligned choice. **No compatibility
alias or opt-out exists**; `skills/CONTRACT.md` records that the old shape "no
longer exists on this tool". Fable reviewed this and concurred (nonblocker 2 —
sign-off, not repair).

## One-time cleanup / no compatibility shim

Owner-bounded, with exact replacement proof against base
`4ad8b155:src/lingtai/tools/skills/__init__.py`:

| Old path (base) | Fate |
|---|---|
| Hand-written flat root schema, `get_schema` body (base :170-181, 12 lines) | **Deleted**; replaced by `build_schema()` composition |
| `from lingtai.kernel.tool_dispatch import dispatch_action` + router invocation (base :33, :210-222, ~14 lines) | **Deleted**; replaced by `ToolFamily.handle()` |
| `_skills_manual` handler (base :170-189 region, 20 lines) | **Deleted**; replaced by shared `build_manual_child(agent, "skills")`, registered unwrapped |
| Old flat unknown-action error literal (3 lines) | **Deleted**; canonical `ACTION_REQUIRED` envelope |
| Duplicate schema-only child registry (`_schema_only_family`, `_FAMILY`, `_INFO_INPUT_SCHEMA`, `_MANUAL_INPUT_SCHEMA`, second `ToolFamily([...])` literal) | **Deleted**; collapsed to one `_build_family(agent \| None, paths)` source |

Verified residuals — none:

- `add_tool("skills", ...)` appears exactly once; the registry maps one name;
  no second registration, no old model-facing root, no alias.
- Old flat calls fail closed; there is no legacy-call alias or opt-out.
- Repo-wide grep finds no old-shape producer: every teaching surface
  (description, manual, glossaries, psyche-manual, tests) speaks the new
  envelope.
- `kernel/tool_dispatch.py` is **deliberately not deleted** — three unmigrated
  families still import it (`mcp`, `knowledge`, `avatar`). The last migrating
  family owes that deletion.
- `_adapt_manual_result` is **not a compat shim**: `tool_family/manual.py`
  explicitly requires the manual child's canonical `content`/`structuredContent`
  result to be dispatched verbatim and assigns any flat public shape to the
  family's own Host layer, "as `web` does".
- Internal kernel caller `agent.py` invokes `skillsmod._reconcile()` directly
  (not through the envelope) — unaffected by design.

### Single canonical child-registry source

The child registry — names, input schemas, titles, order — is declared **once**,
in `_build_family(agent, paths)`. `get_schema()` uses an import-time
`agent=None` instance (handlers unreachable; `build_schema()` only ever reads
`input_schema`); `setup()` calls the same builder with the real agent. This also
fixed a latent drift the reviewer flagged: the schema side previously declared
`manual` with `"required": []` while dispatch registered `build_manual_child`'s
schema without it. The schema-only branch now takes the shared builder's actual
child, so advertised and dispatched schemas are identical by construction. The
only observable effect is that the `manual` branch no longer carries a redundant
empty `required` list (semantically identical — an object with no properties can
require nothing).

### Shared-infrastructure fix riding in this PR

`ToolFamily.handle()` raised `TypeError: unhashable type` when `action` was `[]`
or `{}` — reachable from malformed model JSON, the exact issue #513 class the
hand-written routers guarded against. Proven pre-existing at the exact base
(`web` is affected too). Fixed at the owning layer with a `TypeError` guard
falling through to the same `ACTION_REQUIRED` failure, plus a contract rule and
two generic tests. Skills cannot satisfy invariant 8 without it; the parent may
lift it into its own commit for strict PR isolation.

## LOC accounting

Exact diff against `4ad8b1555a5b0368af81aa57292438719a105052` after the
simplification pass. Code-only = comments, docstrings and blank lines stripped
via Python's `tokenize`.

| Bucket | Added | Removed | Net |
|---|---:|---:|---:|
| Production Python | 97 | 44 | **+53 raw** |
| Production executable lines | — | — | **+22** |
| Tests | 375 | 29 | +346 |
| Docs / contracts / manuals / i18n | 241 | 39 | +202 |

Per-file (isolated tree vs base): `tools/skills/__init__.py` +84/−42,
`tools/tool_family/__init__.py` +12/−1, `kernel/tool_result_summary.py` +1/−1
(the skills-pure one-token form), `tests/test_skills.py` +353/−29,
`tests/test_tool_family_generic.py` +22/−0.

Per production file (raw → code-only): `tools/skills/__init__.py` 250→292 raw
(+42), 167→185 code (+18); `tools/tool_family/__init__.py` 289→300 raw (+11),
213→217 code (+4); `kernel/tool_result_summary.py` ±0 code (one token).

The remaining executable delta is the strict registry/envelope, root wire
correlation, pre-I/O cross-branch validation, summarize wiring and the shared
unhashable-action hardening — capability the base flat tool did not have, so
this is not pure consolidation and the net-negative bar does not apply. The
simplification pass moved production raw from +130/−44 (the reviewer's
pre-simplification measurement) to +97/−44 via comment tightening, while
code-only moved +18 → +22 — the collapse's own cost for single-source-of-truth.

## Exact paths (14)

```
src/lingtai/tools/skills/__init__.py
src/lingtai/tools/skills/CONTRACT.md
src/lingtai/tools/skills/ANATOMY.md
src/lingtai/tools/skills/manual/SKILL.md
src/lingtai/tools/skills/glossary-zh.md
src/lingtai/tools/skills/glossary-wen.md
src/lingtai/tools/tool_family/__init__.py
src/lingtai/tools/tool_family/CONTRACT.md
src/lingtai/tools/tool_family/ANATOMY.md
src/lingtai/tools/CONTRACT.md
src/lingtai/kernel/tool_result_summary.py     # skills-pure form, see warning
src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
tests/test_skills.py
tests/test_tool_family_generic.py
```

No files created, renamed, or deleted. SHA-256 for each is in
`PARENT_ISOLATION_MANIFEST.txt` and the Opus report.

## Validation

- **Parent exact-base isolated gate: 487 passed, 1 exact-base deselect.**
- Opus 5 author gate (contaminated worktree, `PYTHONPATH=src`): **371 passed**,
  plus the same single exact-base failure.
- Fable 5 independent review: **FINAL ACCEPT**, no blockers.
- The 1 deselect/failure is exact-base and untouched by this PR:
  `test_lingtai_owned_skill_frontmatter_has_last_changed_at`, caused by
  `src/lingtai/intrinsic_skills/system-manual/reference/environment-variables/SKILL.md`
  carrying a date-only `2026-07-24` stamp (introduced by #1026). Reproduced on
  clean base.
- `py_compile`: pass.
- glossary validator: **60 resources across 20 packages**, pass.
- docs governance: **294 documents + docs.yaml**, pass.
- anatomy drift / architecture documents: clean.
- `git diff --check`: clean.
- Direct `get_schema()` inspection: root closed to the four properties,
  `required:[action,input,reasoning]`, enum `["info","manual"]`, both branches
  strict-empty, both `allOf` correlations exact.
- Fable's independent 12-case dispatch smoke (unknown/missing/unhashable
  action, extra input key, smuggled `reasoning`/`summarize`, non-bool
  `summarize`, unknown root field, missing input): all exact typed failures with
  **zero handler executions**; good calls hand the handler exactly `{}`.

## ⚠ Contamination warning — canonical source

The original authoring worktree
`lingtai-kernel-worktrees/skills-action-children-dev1-20260727` was **shared
concurrently by the Notification candidate**. A `git stash`/`pop` cycle during
the base-differential gate briefly displaced this candidate's files; they were
recovered from `stash@{0}` file-by-file (the stash was preserved, not dropped).
That worktree therefore contains **both PRs**, and `git diff HEAD` in it is
**not** a clean inventory of this PR.

**Materialize a new clean exact-base worktree from the verified 14 paths only.**
Do not branch from, commit from, or diff against the contaminated worktree.

**The one shared file.** `src/lingtai/kernel/tool_result_summary.py` is touched
by both PRs, which each add their family to `_LTP_V2_MIGRATED_FAMILIES`. Three
forms exist — pick deliberately:

| Form | Line 155 | SHA-256 |
|---|---|---|
| Exact base | `frozenset({"web"})` | `f36ed53dce0603bb6fcce7124c3c8b2022b585895d6c6efa0483cb13675bc0ff` |
| **Skills-pure — use if Skills lands first** | `frozenset({"web", "skills"})` | `ef0275c16af8472c591084e84b9dd02edcfc06f3adb1c2c04f6247311cf27eba` |
| Sibling-combined (contaminated worktree) | `frozenset({"web", "notification", "skills"})` | `3d30347e0ea5f0eef2fae938755db3eb7c42324db2a641b659fb311eb5bd39a6` |

Skills' own contribution to that file is exactly the `"skills"` token. The
isolated gate tree carries the **skills-pure** form, and its manifest hash
(`ef0275c1…`) is the one to reproduce. If Notification lands first, re-add
`"skills"` to whatever the then-current frozenset contains.

Committing the index of the contaminated worktree as-is would omit the
`"skills"` token entirely and fail this PR's own
`test_skills_is_a_migrated_ltp_v2_family_for_summarize`.

## Materializing the canonical source (for whoever opens this)

```
# From a NEW clean checkout at exact base — NOT the contaminated worktree,
# NOT the materialization directory.
git worktree add -b feat/skills-ltp-v2 <new-path> 4ad8b1555a5b0368af81aa57292438719a105052

# Copy exactly the 14 paths from the verified isolated tree:
#   scratch/skills-isolated-parent-gate-20260727-0355/
# then verify every hash before committing:
shasum -a 256 -c scratch/skills-isolated-parent-gate-20260727-0355/PARENT_ISOLATION_MANIFEST.txt

# Confirm the diff is exactly 14 files, +713/-112 before committing:
git diff --stat
```

## Scope boundaries

- No skill authoring, pinning, publishing, installing, or executing capability
  is introduced — the signpost-only boundary is unchanged.
- No settings surface is added; the manual states Skills has none.
- No shared config, merge, release or cleanup is part of this PR.
- `kernel/tool_dispatch.py` is intentionally retained for the three still-
  unmigrated families.
- Parallel family PRs touch shared ToolFamily documentation
  (`tool_family/CONTRACT.md` "second production Adapter/consumer",
  `tools/CONTRACT.md` migrated-family list) and the migrated-family allowlist;
  **group integration must reconcile those lists deliberately** — textual
  conflicts there are expected and are not candidate defects.

## Rollback

Revert this commit to restore the previous flat schema/router/manual call shape
atomically with its tests and documentation. The migration is self-contained in
the 14 paths; the only cross-cutting line is the one-token
`_LTP_V2_MIGRATED_FAMILIES` entry, which reverts with it. Reverting also removes
the shared unhashable-action guard — if that is to be retained independently,
lift it into its own commit before reverting.

---

## PLACEHOLDERS — fill before opening

> These are intentionally unresolved. Do not invent values.

- [ ] **Exact head SHA** — `<EXACT-HEAD-SHA — TO BE FILLED AFTER COMMIT>`, once
      the 14 paths are applied and committed onto clean base `4ad8b155`.
- [ ] **PR number / URL** — add once opened.
- [ ] **dev4 exact-head live-use exercise** — **not yet performed.** Per the
      review contract (gate 5) this runs against the *separated, committed
      head*. Record here:
      - dev4 agent / run id: `<TBD>`
      - actual public action count observed: `<TBD>` (expected: **2** —
        `info`, `manual`)
      - `info` model-visible experience — catalogue refresh + health snapshot
        usability: `<TBD>`
      - `manual` usability, and confirmation it caused **no** catalogue
        mutation in live use: `<TBD>`
      - unknown-action typed failure as experienced by the model: `<TBD>`
- [ ] **Full-suite differential re-run on the committed head** — the numbers
      above are from the clean isolated materialization. Re-confirm on the
      actual head and update if they move.
- [ ] **Shared-file form chosen** — record which
      `_LTP_V2_MIGRATED_FAMILIES` form was committed and why: `<TBD>`.
- [ ] **Group-merge approval** — the review contract requires fresh Jason
      approval in the morning before any merge. **Open only.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
