### PR TITLE
feat(daemon): migrate daemon to the LTP v2 ToolFamily envelope

### DIFF
--- a/src/lingtai/kernel/tool_result_summary.py
+++ b/src/lingtai/kernel/tool_result_summary.py
@@ -155,7 +155,7 @@ def is_apriori_summary(content: Any) -> bool:
 _LTP_V2_MIGRATED_FAMILIES = frozenset(
     {
         "web", "mcp", "knowledge", "file", "vision", "avatar", "soul",
-        "shell", "skills", "notification", "system",
+        "shell", "skills", "notification", "system", "daemon",
     }
 )
 

--- a/src/lingtai/tools/CONTRACT.md
+++ b/src/lingtai/tools/CONTRACT.md
@@ -23,6 +23,7 @@ related_files:
   - src/lingtai/kernel/tool_result_summary.py
   - src/lingtai/tools/notification/CONTRACT.md
   - src/lingtai/tools/system/CONTRACT.md
+  - src/lingtai/tools/daemon/CONTRACT.md
   - tests/test_browser_capability.py
   - tests/test_wire_tool_description.py
 maintenance: |
@@ -331,13 +332,29 @@ child `input` must declare every key its handler accepts, so declaring it
 surfaces existing behavior rather than adding a capability. `system` owns no
 settings file at either level and its manual says so.
 
+`daemon` (`emanate | list | ask | check | reclaim | manual`) is the twelfth
+family migrated to this contract, and the one with the largest retained engine.
+Its final model-facing root is exactly `action`, `input`, `reasoning`, and
+`summarize`, and each action's arguments live only in that action's own strict
+`input`: `tasks`/`backend`/`max_turns`/`timeout` belong to `emanate`,
+`contains`/`status`/`include_done` to `list`, `message` to `ask`, `truncate` to
+`check`, while `reclaim` and `manual` take the canonical strict-empty `input`
+(`id` is shared by `ask`/`check` and `last` by `list`/`check`, each declared in
+both branches). It follows `shell`'s division: a dedicated
+`daemon/_tool_family.py` owns the public schema and a `DaemonFamilyDispatcher`
+that translates the envelope into `DaemonManager`'s unchanged legacy flat call
+shape, so the emanation engine, backend routing, detached supervisor,
+completion signaling, cancellation, timeouts, and terminal notifications are
+untouched by the migration. Its pre-migration flat `summary` boolean is
+replaced by the canonical root `summarize`, joining the allowlist below in the
+same change. See `src/lingtai/tools/daemon/CONTRACT.md`.
 The legacy a-priori result-summarization flag under the literal key `summary`
 (`src/lingtai/kernel/tool_result_summary.py:172`) remains honored for every
 still-unmigrated caller; `src/lingtai/kernel/tool_result_summary.py` recognizes
 the canonical `summarize` spelling only when the calling tool is a migrated LTP
 v2 family (`_LTP_V2_MIGRATED_FAMILIES`, currently `web`, `mcp`, `knowledge`,
-`file`, `vision`, `avatar`, `soul`, `shell`, `skills`, `notification`, and
-`system`), so
+`file`, `vision`, `avatar`, `soul`, `shell`, `skills`, `notification`, `system`,
+and `daemon`), so
 an unmigrated tool's own field literally named `summarize` is never
 reinterpreted as this control. A family adopting this envelope MUST join that
 allowlist in the same change, or the root `summarize` it advertises to the

--- a/src/lingtai/tools/daemon/ANATOMY.md
+++ b/src/lingtai/tools/daemon/ANATOMY.md
@@ -3,7 +3,10 @@ related_files:
   - src/lingtai/ANATOMY.md
   - src/lingtai/tools/daemon/CONTRACT.md
   - src/lingtai/tools/daemon/__init__.py
+  - src/lingtai/tools/daemon/_tool_family.py
   - src/lingtai/tools/daemon/system_prompt.py
+  - src/lingtai/tools/tool_family/ANATOMY.md
+  - src/lingtai/tools/tool_family/__init__.py
   - src/lingtai/prompts/ANATOMY.md
   - src/lingtai/kernel/meta_block.py
   - src/lingtai/kernel/llm/base.py
@@ -24,6 +27,7 @@ related_files:
   - src/lingtai/tools/daemon/run_dir.py
   - src/lingtai/mcp_servers/daemon_common/server.py
   - tests/test_daemon.py
+  - tests/test_tool_family_daemon_migration.py
   - tests/test_daemon_empty_parity.py
   - tests/test_apriori_summary_executor.py
   - tests/test_daemon_run_dir.py
@@ -172,7 +176,14 @@ remains deferred until ConPTY has its own accepted adapter. `ClaudeInteractiveBr
 
 ## Public API
 
-The `daemon` tool exposes five actions:
+`daemon` is one model-facing tool carrying the LTP v2 action-separated envelope
+(`action`, `input`, required `reasoning`, optional `summarize`) composed by
+`_tool_family.py` from six internal `ChildTool`s. The children consume no extra
+model tool slot. Each action's own strict `input` fields are listed in
+`CONTRACT.md` §Tool Surface; `list`/`check`/`manual` are read-only and
+`emanate`/`ask`/`reclaim` are the side-effectful three.
+
+The `daemon` tool exposes six actions:
 
 | Action     | Description |
 |------------|-------------|
@@ -182,6 +193,7 @@ The `daemon` tool exposes five actions:
 | `check`    | Read-only progress tail: `daemon.json` state + last N events from `events.jsonl` + a compact `artifacts` block (the run's artifact manifest — relative path/size/mtime/role per important file, plus run-level state/result_path/error_path). On in-memory registry miss (e.g. after refresh/molt) falls back to the durable `daemons/*/` run dirs, resolving by full `run_id` (exact) or short `handle` (most-recent, with ambiguity flagged) |
 | `list`     | Progressive-disclosure index: active registry + historical run dirs; lazily rebuilds missing/invalid/stale-version `daemon.json` and returns prompt/result previews with search filters |
 | `reclaim`  | Cancel all running emanations, shut down CLI process groups/thread pools through the same runtime-shutdown helper used by agent stop, reset ID counter |
+| `manual`   | Return the installed `daemon-manual` skill via the shared reserved `tool_family.manual.build_manual_child(agent, "daemon")` child: canonical `content[0].text` body + `structuredContent.manual_path`, returned verbatim with no double wrap. Reaches no `DaemonManager` method, so it performs no daemon operation |
 
 Every LingTai worker also receives the intrinsic `compact` tool. Its `action`
 is required: explicit `action="manual"` is read-only, explicit `action="run"`
@@ -196,7 +208,7 @@ axis is not inherited.
 ```
 daemon/__init__.py
   ├── DaemonManager.__init__        — stores agent ref, config ceilings, emanation registry
-  ├── handle()                      — top-level dispatcher (emanate/list/ask/check/reclaim)
+  ├── handle()                      — internal legacy flat dispatcher (emanate/list/ask/check/reclaim/manual); NOT the registered model-facing handler since the ToolFamily migration
   ├── _daemon_intrinsic_surface()   — exposes explicitly requested `email` plus the automatic LingTai `compact` schema
   ├── _build_tool_surface()         — auto-includes `compact`, filters other requested tools against blacklist, expands groups, and merges preset/MCP/email surfaces; preset emanations also keep the NARROW parent host floor (`_parent_host_tool_floor()`: shell + file primitives only) so saved presets that omit core caps don't make requested host tools unknown — optional/provider parent tools (vision/web_search) are NOT borrowed and stay unknown unless the preset supplies them
   ├── _instantiate_preset_capabilities() — sets up preset tool surface in a sandbox
@@ -327,4 +339,4 @@ intentional omission of the parent notification axis.
   exposes its run-local raw-result locator to the worker.
 - **Manual:** `daemon/manual/SKILL.md` — skill documentation for the LLM.
 - **Contract:** `daemon/CONTRACT.md` — unified daemon contract for tool-surface behavior, selected skills, one-run MCP registrations, completion, artifacts, backend support status, review triggers, and acceptance gates.
-- **Kernel hooks:** `setup()` is called during capability initialization; `DaemonManager.handle()` is registered as the `daemon` tool handler.
+- **Kernel hooks:** `setup()` is called during capability initialization; `DaemonFamilyDispatcher.handle()` (`daemon/_tool_family.py`) is registered as the `daemon` tool handler, and translates one envelope call into `DaemonManager.handle()`'s unchanged flat shape. `daemon` is on `kernel/tool_result_summary.py`'s `_LTP_V2_MIGRATED_FAMILIES` allowlist, so the canonical root `summarize` control it advertises is actually honored.

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -7,12 +7,16 @@ description: >
   daemon_common completion signaling, support-status honesty, run artifacts,
   terminal notifications, and compaction boundaries.
 status: active
-contract_version: 7
-last_changed_at: "2026-07-26"
+contract_version: 8
+last_changed_at: "2026-07-27"
 related_files:
   - src/lingtai/tools/daemon/ANATOMY.md
   - src/lingtai/tools/daemon/__init__.py
+  - src/lingtai/tools/daemon/_tool_family.py
   - src/lingtai/tools/daemon/system_prompt.py
+  - src/lingtai/tools/tool_family/CONTRACT.md
+  - src/lingtai/tools/tool_family/__init__.py
+  - src/lingtai/tools/tool_family/manual.py
   - src/lingtai/kernel/meta_block.py
   - src/lingtai/kernel/tool_executor.py
   - src/lingtai/kernel/tool_result_summary.py
@@ -34,6 +38,7 @@ related_files:
   - src/lingtai/llm/openai/ANATOMY.md
   - src/lingtai/llm/mimo/ANATOMY.md
   - tests/test_daemon_contract_doc.py
+  - tests/test_tool_family_daemon_migration.py
   - tests/test_daemon.py
   - tests/test_daemon_empty_parity.py
   - tests/test_apriori_summary_executor.py
@@ -50,6 +55,7 @@ related_files:
   - tests/test_daemon_windows_supervisor.py
 review_triggers:
   - src/lingtai/tools/daemon/__init__.py
+  - src/lingtai/tools/daemon/_tool_family.py
   - src/lingtai/tools/daemon/system_prompt.py
   - src/lingtai/kernel/meta_block.py
   - src/lingtai/llm/interface_converters.py
@@ -111,8 +117,9 @@ ownership -> §Process and Terminal Boundaries.
 ## Scope
 
 - Canonical tool name: `daemon`.
-- The parent `daemon` tool exposes five actions: `emanate`, `list`, `ask`, `check`,
-  `reclaim`; `action` is required. Every LingTai emanation additionally receives
+- The parent `daemon` tool exposes six actions: `emanate`, `list`, `ask`, `check`,
+  `reclaim`, `manual`; `action` is required, and so are `input` and `reasoning`
+  (see §Tool Surface). Every LingTai emanation additionally receives
   the intrinsic `compact` tool, whose required `action` is explicit `run`
   (non-terminal reset) or `manual` (read-only procedures); omission is refused.
 - Backends (`backend`, default `lingtai`): schema enum is `lingtai`, `claude-p`,
@@ -136,11 +143,66 @@ where those changes affect the invariants here.
 
 ## Tool Surface
 
-Schema `required: ["action"]`. Relevant properties: `tasks[]` (each requires
-`task` + `tools`; optional `skills`, `mcp`, `preset`, `backend_options`,
-`prompt`, `context_token_limit`), `id`, `message`, `last`, `truncate`,
-`contains`, `status`, `include_done`, `max_turns`, `timeout`, `backend`,
-`summary`.
+`daemon` is migrated to the LingTai Tool Protocol v2 action-separated envelope
+(`../CONTRACT.md`, `../tool_family/CONTRACT.md`) using the generic
+`tool_family` infrastructure. The public root is exactly `action`, `input`,
+required `reasoning`, and optional `summarize`, with
+`required: ["action", "input", "reasoning"]` and
+`additionalProperties: false`. Exactly one model-facing tool named `daemon`
+remains registered: the six actions are internal `ChildTool`s and MUST NOT
+consume additional model tool slots, and no compatibility alias or second
+public root exists.
+
+The six canonical children are `emanate | list | ask | check | reclaim |
+manual`, each owning one strict, closed `input` schema. Every field the
+pre-migration flat root advertised to all six actions at once now lives in
+exactly the branch that consumes it:
+
+| Action | `input` fields |
+|---|---|
+| `emanate` | `tasks[]` (each requires `task` + `tools`; optional per-task fields are unchanged and specified below), `backend`, `max_turns`, `timeout` |
+| `list` | `contains`, `status`, `include_done`, `last` |
+| `ask` | `id`, `message` |
+| `check` | `id`, `last`, `truncate` |
+| `reclaim` | — (canonical strict-empty `input`) |
+| `manual` | — (canonical strict-empty `input`) |
+
+Optional fields are spelled as required-nullable properties, as strict
+validators demand of a closed object; `null` means *absent* and the engine
+applies its own unchanged default, so a falsy-but-present value (`truncate: 0`,
+`include_done: false`, `contains: ""`) is preserved verbatim. The nested
+per-task object inside `emanate.tasks` is deliberately left open
+(`additionalProperties` unset), because `_handle_emanate`'s own strict per-task
+validation owns that boundary and returns domain-specific errors (notably the
+obsolete `system_prompt` migration message) a schema rejection would replace
+with a generic one.
+
+Dispatch is the second, always-authoritative enforcement layer: an unknown or
+unhashable `action`, an unknown root field, a non-object `input`, a non-boolean
+`summarize`, and any `input` key belonging to another action's branch are all
+refused before the daemon engine runs, fail-closed. The unknown-action envelope
+failure carries daemon's own six-action message.
+
+The former flat root `summary` boolean is replaced by the canonical root
+`summarize`; `daemon` is on `kernel/tool_result_summary.py`'s
+`_LTP_V2_MIGRATED_FAMILIES` allowlist so that spelling is actually honored
+rather than silently ignored, and the legacy `summary` spelling remains
+accepted there for historical/pending calls.
+
+`_tool_family.py` owns the child registry, the composed schema, and the
+`DaemonFamilyDispatcher` that translates one envelope call into
+`DaemonManager.handle`'s unchanged legacy flat shape. `DaemonManager` remains
+the untouched engine: batch emanation, backend routing, run directories, the
+detached supervisor, `daemon_common` completion signaling, cancellation,
+timeouts, terminal notifications, and result/error persistence are unchanged by
+the migration. `DaemonManager.handle`'s own `action="manual"` branch is retained
+as that internal flat shape only; the registered model-facing `manual` is the
+shared reserved `build_manual_child(agent, "daemon")` child, returning the
+canonical `content[0].text` / `structuredContent.manual_path` result verbatim
+with no double wrap, and reaching no engine method.
+
+`list`, `check`, and `manual` are read-only. `emanate`, `ask`, and `reclaim`
+are the three side-effectful actions.
 
 `tasks[].task` is required and is the complete parent-controlled daemon system
 instruction for `backend="lingtai"`: objective, role, constraints, tool policy,
@@ -449,7 +511,10 @@ kernel `ToolExecutor`. The closure:
 - accounts usage through `DaemonRunDir.append_tokens`, keeping daemon and parent
   ledgers consistent.
 
-`ToolExecutor` remains responsible for the `summary=true` gate, raw logging,
+`ToolExecutor` remains responsible for the summary gate (the parent-facing
+`daemon` tool now opts in via the canonical root `summarize`; the daemon
+worker's own visible result tools keep their unmigrated `summary=true`
+spelling), raw logging,
 fail-closed replacement, and the 500,000-character cap. Daemons expose the
 run-local `logs/events.jsonl` / `daemon_tool_result` recovery locator. The closure
 is inert unless a tool explicitly requests `summary=true`.

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -47,6 +47,12 @@ from lingtai.kernel.time_veil import now_iso
 from lingtai.kernel.token_counter import count_tokens
 from lingtai.kernel.trace_redaction import redact_text
 from .._manual import load_installed_manual
+from ._tool_family import (
+    CHECK_LAST_MAX as _FAMILY_CHECK_LAST_MAX,
+    DEFAULT_MAX_TURNS as _FAMILY_DEFAULT_MAX_TURNS,
+    DaemonFamilyDispatcher,
+    build_schema as _family_build_schema,
+)
 from lingtai.adapters.posix.process_identity import (
     process_identity,
     process_identity_matches,
@@ -1064,6 +1070,13 @@ assert set(_BACKEND_SCHEMA_ENUM) == (
     (set(_BACKEND_SPECS) - _HIDDEN_SCHEMA_BACKENDS)
     | set(_BACKEND_ALIASES)
 )
+# ``_tool_family`` restates ``DEFAULT_MAX_TURNS`` as its own literal because
+# importing it from this module would be circular (this module imports
+# ``_tool_family``). Prove at import time that ``emanate``'s child schema still
+# advertises exactly the ceiling the engine enforces. The matching
+# ``CHECK_LAST_MAX`` assertion lives just after ``DaemonManager``, which owns
+# ``_CHECK_LAST_MAX`` and is not defined yet here.
+assert _FAMILY_DEFAULT_MAX_TURNS == DEFAULT_MAX_TURNS
 
 
 def _normalize_backend(backend: str | None) -> str:
@@ -1140,159 +1153,18 @@ class _ToolCollector:
 
 
 def get_description(lang: str = "en") -> str:
-    return 'Daemon (神識) — delegate work to ephemeral subagents for context isolation. Each is a disposable LLM session sharing your working directory, retaining no memory after completion. Use for noisy work where you only need the conclusion. Results truncated to ~2000 chars — instruct the emanation to write detailed output to a file. Actions: emanate (dispatch), list (status), ask (follow-up), check (inspect recent events), reclaim (kill all), manual (return the installed daemon-manual skill). Every terminal outcome is push-notified exactly once — done, failed, cancelled, or timed out — so after you dispatch you can safely go idle and wait for the notification; do not poll for "is it done". The notification carries the daemon id, terminal status, task summary, and the result/error path; act on it with daemon(action="check", id=...). LingTai daemons also receive compact; compact(action="manual") is read-only procedures, while explicit compact(action="run", _reason="...") is the repeatable sole-call context reset; action is required. Before using this tool, read the `daemon-manual` skill — it covers inspection patterns, polling cadence, preset/capability inheritance, and compact procedures; no exceptions.'
-
-
-def _backend_option_value_schema() -> dict:
-    """Return a fresh JSON schema for one generic CLI option value.
-
-    ``backend_options`` remains an open-ended argv passthrough.  A factory keeps
-    its explicit provider-visible properties and ``additionalProperties`` on
-    the same validation contract without sharing mutable schema nodes.
-    """
-    return {
-        "anyOf": [
-            {"type": "boolean"},
-            {"type": "string"},
-            {"type": "integer"},
-            {"type": "number"},
-            {"type": "null"},
-            {
-                "type": "array",
-                "items": {
-                    "anyOf": [
-                        {"type": "string"},
-                        {"type": "integer"},
-                        {"type": "number"},
-                    ],
-                },
-            },
-        ],
-    }
+    return 'Daemon (神識) — delegate work to ephemeral subagents for context isolation. Each is a disposable LLM session sharing your working directory, retaining no memory after completion. Use for noisy work where you only need the conclusion. Results truncated to ~2000 chars — instruct the emanation to write detailed output to a file. Every call takes exactly action, input, and reasoning; each action owns its own strict input object. Actions: daemon(action=\'emanate\', input={"tasks": [...], "backend": null, "max_turns": null, "timeout": null}) dispatches; daemon(action=\'list\', input={"contains": null, "status": null, "include_done": null, "last": null}) shows status; daemon(action=\'ask\', input={"id": "em-1", "message": "..."}) sends a follow-up; daemon(action=\'check\', input={"id": "em-1", "last": null, "truncate": null}) inspects recent events; daemon(action=\'reclaim\', input={}) kills all; daemon(action=\'manual\', input={}) returns the installed daemon-manual skill. Every terminal outcome is push-notified exactly once — done, failed, cancelled, or timed out — so after you dispatch you can safely go idle and wait for the notification; do not poll for "is it done". The notification carries the daemon id, terminal status, task summary, and the result/error path; act on it with daemon(action="check", input={"id": ...}). LingTai daemons also receive compact; compact(action="manual") is read-only procedures, while explicit compact(action="run", _reason="...") is the repeatable sole-call context reset; action is required. Before using this tool, read the `daemon-manual` skill — it covers inspection patterns, polling cadence, preset/capability inheritance, and compact procedures; no exceptions.'
 
 
 def get_schema(lang: str = "en") -> dict:
-    return {
-        "type": "object",
-        "properties": {
-            "action": {
-                "type": "string",
-                "enum": ["emanate", "list", "ask", "check", "reclaim", "manual"],
-                "description": "Action to perform: 'emanate' (dispatch subagents), 'list' (show status), 'ask' (follow-up message), 'check' (read recent events of one emanation), 'reclaim' (kill all), 'manual' (return the installed daemon-manual skill). LingTai emanations additionally receive compact(action='manual') for read-only compaction procedures or explicit compact(action='run', _reason='...') for the non-terminal sole-call reset; action is required.",
-            },
-            "tasks": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "task": {"type": "string"},
-                        "tools": {"type": "array", "items": {"type": "string"}},
-                        "skills": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Optional skill context for this daemon task. Array of paths; each item may be a skill directory (containing SKILL.md) or a direct SKILL.md file path. Relative paths resolve against the parent agent working directory. The daemon runtime parses each skill frontmatter and injects a compact YAML skill list into this run's system prompt.",
-                        },
-                        "mcp": {
-                            "type": "array",
-                            "items": {"type": "object"},
-                            "description": 'Optional one-run MCP registrations for this daemon task. Array of full MCP registration objects: {name, transport/type: stdio|http, command+args+env for stdio or url+headers for http}. The registrations are serialized into the daemon prompt as YAML; LingTai backend also starts them as task-scoped MCP clients and exposes their tools for this run. CLI backends receive the same serialized registrations as context and may load them if their runtime supports MCP. Secret env/header values are redacted in prompts.',
-                        },
-                        "preset": {
-                            "type": "string",
-                            "description": "Optional preset file path. Must be a .json/.jsonc path as returned by system(action='presets'). Do NOT use shorthand names — use the full 'name' field from the presets listing. Example: '~/.lingtai-tui/presets/saved/cheap.json'. Omit to inherit the parent's regular (non-MCP) tool surface; provide task MCP registrations separately with `mcp`.",
-                        },
-                        "backend_options": {
-                            "type": "object",
-                            "properties": {
-                                "config": {
-                                    **_backend_option_value_schema(),
-                                    "description": (
-                                        "Explicitly declared so constrained tool-schema "
-                                        "providers can generate repeated --config overrides; "
-                                        "uses the same scalar/list contract as generic "
-                                        "backend_options."
-                                    ),
-                                },
-                            },
-                            "additionalProperties": _backend_option_value_schema(),
-                            "description": 'Optional free-form CLI options for \'claude-code\' / \'codex\' / \'opencode\' / \'mimocode\' / \'qwen-code\' / \'oh-my-pi\' / \'kimicode\' / \'cursor\' backends ONLY (ignored by lingtai). JSON object mapping flag names to values: true → flag only (e.g. {"search": true} → --search); string/int/float → \'--flag <value>\'; list of scalars → \'--flag <v1> --flag <v2>\'; false/null omits the flag. Underscores in keys become dashes; nested objects and unsafe keys are rejected. Applies only when starting the emanation (not to `ask`). Discover supported flags by running \'claude --help\', \'codex exec --help\', \'opencode run --help\', \'mimo run --help\', \'qwen --help\', \'omp --help\', \'kimi --help\', or \'agent --help\' in bash — the CLI\'s flag list changes between versions; this field is intentionally a passthrough rather than a fixed list. See daemon-manual.',
-                        },
-                        "prompt": {
-                            "type": "string",
-                            "description": 'Optional first ordinary user message for a LingTai daemon. Blank or omitted uses exactly "Begin the assigned daemon task.". Unsupported by external CLI backends.',
-                        },
-                        "context_token_limit": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "description": "Optional context-token compaction threshold for this daemon task (rendered/provider-context tokens, not cumulative spend). Currently effective only for backend='lingtai' tasks whose resolved provider is Codex ('codex'/'codex-pool') or the native 'mimo' provider; every other provider and every external CLI backend ignores this field. This threshold does not set daemon context. When the provider-visible input-token count for this session reaches the limit, the runtime compacts provider context via the provider's standalone compaction and continues the same tool loop. For Codex a standalone-compaction failure is non-fatal (that turn's compaction is skipped and the loop continues on full history); for 'mimo' it is a HARD failure that propagates to the caller instead of silently continuing on full history or falling back to a different wire. Omit to use the daemon session's own resolved context window as the separate provider-compaction threshold: for an explicit preset, valid canonical manifest.llm.context_limit or 272,000 fallback; for implicit/no-preset, a valid inherited parent effective window or 272,000 fallback. Must be a positive integer.",
-                        },
-                    },
-                    "required": ["task", "tools"],
-                },
-                "description": "List of task objects for 'emanate'. Each: {task: str (required — instructions including where to save work), tools: list[str] (required — capability names, e.g. ['file', 'shell']), skills: list[str] (optional — skill directory or SKILL.md paths to render into the daemon prompt), mcp: list[object] (optional — full one-run MCP registrations to serialize into daemon context; LingTai backend also loads them as task-scoped MCP tools), preset: str (optional — preset file path, use name from system(action='presets') output). Omit preset to inherit the parent's regular tool surface. Parent MCP tools are not auto-inherited; provide complete task mcp registrations when needed. See daemon-manual for preset inheritance and capability resolution details.",
-            },
-            "id": {
-                "type": "string",
-                "description": "Subagent ID for 'ask' action (e.g. 'em-1')",
-            },
-            "message": {
-                "type": "string",
-                "description": "Follow-up message for 'ask' action",
-            },
-            "last": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 1000,
-                "description": "For 'check': how many most-recent events to return from events.jsonl. For 'list': positive maximum number of list entries to show after filtering. Default 20 for check; no list limit unless provided.",
-            },
-            "truncate": {
-                "type": "integer",
-                "minimum": 0,
-                "description": "For 'check': maximum length of any string field in returned events; longer fields get an ellipsis suffix. Default 500. Set to 0 to disable.",
-            },
-            "contains": {
-                "type": "string",
-                "description": "For 'list': case-insensitive substring search across daemon task, prompt preview, result preview, backend, status, group_id, run_id, and visible call parameters.",
-            },
-            "status": {
-                "type": "string",
-                "description": "For 'list': optional status filter such as running, done, failed, cancelled, timeout, or all.",
-            },
-            "include_done": {
-                "type": "boolean",
-                "description": "For 'list': include completed historical daemon run directories as well as currently tracked runs. Defaults to true.",
-            },
-            "summary": {"type": "boolean", "description": 'Optional. Default false. When true, this tool runs normally and the raw result is preserved in the durable log (retrievable by tool_call_id), but before the result enters your context it is replaced by an LLM-generated summary driven by your `reasoning` field — so make `reasoning` specific about what to retain. Set true only when the output is expected to be large (>10k chars) and you do NOT need the exact raw text. Leave false when you need exact line/file/diff/stderr text. The summary is non-canonical; if the raw exceeds 500,000 chars no summary is generated and you get a refusal pointing at the preserved raw.', "default": False},
-            "max_turns": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": DEFAULT_MAX_TURNS,
-                "description": "For 'emanate': max LLM tool-loop turns per emanation. Default: parent ceiling (1000). Use a smaller value to keep simple emanations bounded.",
-            },
-            "timeout": {
-                "type": "number",
-                "minimum": 5,
-                "description": "For 'emanate': max wall-clock seconds for the whole batch. Default: parent max (3600s). Watchdog kills any emanation still running when the timer fires.",
-            },
-            "backend": {
-                "type": "string",
-                "enum": list(_BACKEND_SCHEMA_ENUM),
-                "description": (
-                    "Execution backend: 'lingtai' (default — parallel LLM reasoning, uses your current model), "
-                    "'claude-p' (Claude Code print-mode backend; 'claude-code' is a compatibility alias), "
-                    "'codex' (coding tasks via OpenAI Codex CLI), "
-                    "'opencode' (multi-provider open-source agent via the opencode-ai CLI), "
-                    "'mimocode' / 'mimo' (MiMo Code CLI), "
-                    "'qwen-code' / 'qwen' (Qwen Code CLI), "
-                    "'oh-my-pi' / 'omp' (Oh-My-Pi pi-coding-agent CLI), "
-                    "'kimicode' / 'kimi' (MoonshotAI Kimi Code CLI; ask/resume not supported yet), "
-                    "'cursor' (coding tasks via Cursor Agent CLI). "
-                    "CLI backends use external tools with no LLM overhead from the parent."
-                ),
-            },
-        },
-        "required": ["action"],
-    }
+    """Compose the LTP v2 model-facing schema for the single public ``daemon`` tool.
+
+    The composition itself lives in ``_tool_family.py`` (the package's one
+    canonical child registry); this stays the package's public entry point.
+    ``_BACKEND_SCHEMA_ENUM`` is passed in rather than imported there so the
+    child schema and the engine's own backend routing cannot drift apart.
+    """
+    return _family_build_schema(list(_BACKEND_SCHEMA_ENUM), lang)
 
 
 # Sentinel strings a cooperatively-exited run returns through the future.
@@ -8242,6 +8114,12 @@ class DaemonManager:
             self._agent._log(event_type, **fields)
 
 
+# Pair of the ``DEFAULT_MAX_TURNS`` assertion above: ``_tool_family``'s
+# ``check``/``list`` child schemas advertise the same ``last`` ceiling the
+# engine enforces. Stated here because ``DaemonManager`` owns ``_CHECK_LAST_MAX``.
+assert _FAMILY_CHECK_LAST_MAX == DaemonManager._CHECK_LAST_MAX
+
+
 def setup(agent: "Agent", max_emanations: int = 100,
           max_turns: int = DEFAULT_MAX_TURNS, timeout: float = 3600.0,
           notify_threshold: int = 20,
@@ -8272,6 +8150,10 @@ def setup(agent: "Agent", max_emanations: int = 100,
                         process_port=process_port,
                         interactive_terminal_port=interactive_terminal_port)
     schema = get_schema()
-    agent.add_tool("daemon", schema=schema, handler=mgr.handle,
+    # The model-facing handler is the LTP v2 envelope dispatcher, not the
+    # engine's legacy flat ``handle``. Still exactly one registered public
+    # tool named ``daemon`` — the six children consume no extra tool slot.
+    dispatcher = DaemonFamilyDispatcher(mgr, agent, list(_BACKEND_SCHEMA_ENUM))
+    agent.add_tool("daemon", schema=schema, handler=dispatcher.handle,
                    description=get_description(), glossary_package=__package__)
     return mgr

--- a/src/lingtai/tools/daemon/_tool_family.py
+++ b/src/lingtai/tools/daemon/_tool_family.py
@@ -1,0 +1,431 @@
+"""ToolFamily envelope for the canonical ``daemon`` tool.
+
+The public/model-facing ``daemon`` tool is migrated to the LingTai Tool
+Protocol v2 action-separated shape (``action``/``input``/``reasoning``/
+``summarize``, see ``../CONTRACT.md``) using the generic, optional
+``tool_family`` infrastructure (``../tool_family/__init__.py``). ``emanate``,
+``list``, ``ask``, ``check``, ``reclaim``, and the reserved ``manual`` become
+six ``ChildTool``s with their own strict per-action ``input`` schemas —
+``tasks``/``backend``/``max_turns``/``timeout`` live only in ``emanate``'s
+branch; ``contains``/``status``/``include_done`` only in ``list``'s;
+``id``/``message`` only in ``ask``'s; ``id``/``last``/``truncate`` only in
+``check``'s; ``reclaim`` and ``manual`` take the canonical strict-empty
+``input``. The pre-migration flat root advertised all thirteen fields to all
+six actions at once (``tasks`` sat next to ``truncate`` next to ``message``),
+so nothing at the schema level said which field belonged to which action.
+
+``DaemonManager`` (``__init__.py``) is the unchanged execution engine: its
+``handle()`` still accepts the historical flat legacy shape
+(``{"action": "check", "id": ..., "last": ...}``) and its full lifecycle —
+batch emanation, backend routing, run directories, the detached supervisor,
+``daemon_common`` completion signaling, cancellation, timeouts, terminal
+notifications, and result/error persistence — is untouched. This module only
+translates the new envelope into that flat shape before delegating, so every
+existing ``DaemonManager`` test keeps exercising the exact same code path.
+That flat shape is internal only — this module owns the package's single
+public ``get_schema``/``get_description`` pair, re-exported from
+``daemon/__init__.py``.
+
+This is the same division ``shell`` (``../bash/_tool_family.py``) uses between
+``ToolFamily.handle()`` (envelope validation/dispatch) and a legacy engine:
+the *inner* engine keeps the flat shape and the *outer* envelope is new.
+Children never consume a second model tool slot — ``daemon`` remains exactly
+one registered public tool.
+
+Two behaviors deliberately do NOT move here:
+
+* ``manual`` is served by the shared ``build_manual_child(agent, "daemon")``
+  reserved child, which reads the same installed
+  ``.library/intrinsic/capabilities/daemon/SKILL.md`` body/path the
+  pre-migration ``DaemonManager.handle({"action": "manual"})`` branch read via
+  ``load_installed_manual``. It returns the canonical
+  ``content``/``structuredContent`` shape and performs no daemon operation.
+* The legacy flat root ``summary`` boolean is replaced by the canonical root
+  ``summarize`` control, which ``ToolFamily.build_schema`` advertises and
+  ``ToolFamily.handle`` strips before any child handler runs. ``daemon`` joins
+  ``kernel/tool_result_summary.py``'s ``_LTP_V2_MIGRATED_FAMILIES`` in the
+  same change so that spelling is actually honored rather than silently
+  ignored; the legacy ``summary`` spelling stays accepted there for any
+  historical/pending call, exactly as ``shell``'s migration left it.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..tool_family import ChildTool, ToolFamily
+from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
+
+# Re-exported engine constants the child schemas pin. Imported lazily inside
+# ``_emanate_input_schema`` would hide them from readers; a module-level import
+# from the package ``__init__`` would be circular (``__init__`` imports this
+# module), so the two literals are restated here with an import-time assertion
+# in ``__init__.py`` proving they still match the engine's own values.
+DEFAULT_MAX_TURNS = 1000
+CHECK_LAST_MAX = 1000
+
+#: The canonical action order, model-facing enum order, and dispatch order.
+DAEMON_ACTIONS: tuple[str, ...] = (
+    "emanate",
+    "list",
+    "ask",
+    "check",
+    "reclaim",
+    "manual",
+)
+
+
+def _backend_option_value_schema() -> dict[str, Any]:
+    """Return a fresh JSON schema for one generic CLI option value.
+
+    ``backend_options`` remains an open-ended argv passthrough.  A factory keeps
+    its explicit provider-visible properties and ``additionalProperties`` on
+    the same validation contract without sharing mutable schema nodes.
+    """
+    return {
+        "anyOf": [
+            {"type": "boolean"},
+            {"type": "string"},
+            {"type": "integer"},
+            {"type": "number"},
+            {"type": "null"},
+            {
+                "type": "array",
+                "items": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "number"},
+                    ],
+                },
+            },
+        ],
+    }
+
+
+def _emanate_task_schema() -> dict[str, Any]:
+    """One task object inside ``emanate``'s ``tasks`` array.
+
+    Byte-for-byte the pre-migration nested task schema (``task``, ``tools``,
+    ``skills``, ``mcp``, ``preset``, ``backend_options``, ``prompt``,
+    ``context_token_limit``, ``required: ["task", "tools"]``). The nested
+    object is deliberately NOT closed with ``additionalProperties: false``:
+    the engine's own strict per-task validation in ``_handle_emanate`` owns
+    that boundary and returns domain-specific errors (e.g. the ``system_prompt``
+    obsolescence message) that a schema-level rejection would replace with a
+    generic one. A factory keeps every call's nested nodes unshared.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "task": {"type": "string"},
+            "tools": {"type": "array", "items": {"type": "string"}},
+            "skills": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional skill context for this daemon task. Array of paths; each item may be a skill directory (containing SKILL.md) or a direct SKILL.md file path. Relative paths resolve against the parent agent working directory. The daemon runtime parses each skill frontmatter and injects a compact YAML skill list into this run's system prompt.",
+            },
+            "mcp": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": 'Optional one-run MCP registrations for this daemon task. Array of full MCP registration objects: {name, transport/type: stdio|http, command+args+env for stdio or url+headers for http}. The registrations are serialized into the daemon prompt as YAML; LingTai backend also starts them as task-scoped MCP clients and exposes their tools for this run. CLI backends receive the same serialized registrations as context and may load them if their runtime supports MCP. Secret env/header values are redacted in prompts.',
+            },
+            "preset": {
+                "type": "string",
+                "description": "Optional preset file path. Must be a .json/.jsonc path as returned by system(action='presets'). Do NOT use shorthand names — use the full 'name' field from the presets listing. Example: '~/.lingtai-tui/presets/saved/cheap.json'. Omit to inherit the parent's regular (non-MCP) tool surface; provide task MCP registrations separately with `mcp`.",
+            },
+            "backend_options": {
+                "type": "object",
+                "properties": {
+                    "config": {
+                        **_backend_option_value_schema(),
+                        "description": (
+                            "Explicitly declared so constrained tool-schema "
+                            "providers can generate repeated --config overrides; "
+                            "uses the same scalar/list contract as generic "
+                            "backend_options."
+                        ),
+                    },
+                },
+                "additionalProperties": _backend_option_value_schema(),
+                "description": 'Optional free-form CLI options for \'claude-code\' / \'codex\' / \'opencode\' / \'mimocode\' / \'qwen-code\' / \'oh-my-pi\' / \'kimicode\' / \'cursor\' backends ONLY (ignored by lingtai). JSON object mapping flag names to values: true → flag only (e.g. {"search": true} → --search); string/int/float → \'--flag <value>\'; list of scalars → \'--flag <v1> --flag <v2>\'; false/null omits the flag. Underscores in keys become dashes; nested objects and unsafe keys are rejected. Applies only when starting the emanation (not to `ask`). Discover supported flags by running \'claude --help\', \'codex exec --help\', \'opencode run --help\', \'mimo run --help\', \'qwen --help\', \'omp --help\', \'kimi --help\', or \'agent --help\' in bash — the CLI\'s flag list changes between versions; this field is intentionally a passthrough rather than a fixed list. See daemon-manual.',
+            },
+            "prompt": {
+                "type": "string",
+                "description": 'Optional first ordinary user message for a LingTai daemon. Blank or omitted uses exactly "Begin the assigned daemon task.". Unsupported by external CLI backends.',
+            },
+            "context_token_limit": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional context-token compaction threshold for this daemon task (rendered/provider-context tokens, not cumulative spend). Currently effective only for backend='lingtai' tasks whose resolved provider is Codex ('codex'/'codex-pool') or the native 'mimo' provider; every other provider and every external CLI backend ignores this field. This threshold does not set daemon context. When the provider-visible input-token count for this session reaches the limit, the runtime compacts provider context via the provider's standalone compaction and continues the same tool loop. For Codex a standalone-compaction failure is non-fatal (that turn's compaction is skipped and the loop continues on full history); for 'mimo' it is a HARD failure that propagates to the caller instead of silently continuing on full history or falling back to a different wire. Omit to use the daemon session's own resolved context window as the separate provider-compaction threshold: for an explicit preset, valid canonical manifest.llm.context_limit or 272,000 fallback; for implicit/no-preset, a valid inherited parent effective window or 272,000 fallback. Must be a positive integer.",
+            },
+        },
+        "required": ["task", "tools"],
+    }
+
+
+def _emanate_input_schema(backend_enum: list[str]) -> dict[str, Any]:
+    """``emanate``'s own strict input.
+
+    ``backend_enum`` is the engine's ``_BACKEND_SCHEMA_ENUM``, passed in rather
+    than imported to keep this module free of a circular package import; the
+    one public schema builder below supplies it.
+
+    Optionals are required-nullable because that is what strict OpenAI-style
+    validators demand of a closed object; null means "absent" to the engine
+    (see ``_strip_nulls``), which then applies its own unchanged default —
+    ``max_turns=None``/``timeout=None`` and ``backend="lingtai"`` exactly as a
+    legacy flat caller that omitted the field got.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "tasks": {
+                "type": "array",
+                "items": _emanate_task_schema(),
+                "description": "List of task objects for 'emanate'. Each: {task: str (required — instructions including where to save work), tools: list[str] (required — capability names, e.g. ['file', 'shell']), skills: list[str] (optional — skill directory or SKILL.md paths to render into the daemon prompt), mcp: list[object] (optional — full one-run MCP registrations to serialize into daemon context; LingTai backend also loads them as task-scoped MCP tools), preset: str (optional — preset file path, use name from system(action='presets') output). Omit preset to inherit the parent's regular tool surface. Parent MCP tools are not auto-inherited; provide complete task mcp registrations when needed. See daemon-manual for preset inheritance and capability resolution details.",
+            },
+            "backend": {
+                "type": ["string", "null"],
+                "enum": [*backend_enum, None],
+                "description": (
+                    "Execution backend: 'lingtai' (default — parallel LLM reasoning, uses your current model), "
+                    "'claude-p' (Claude Code print-mode backend; 'claude-code' is a compatibility alias), "
+                    "'codex' (coding tasks via OpenAI Codex CLI), "
+                    "'opencode' (multi-provider open-source agent via the opencode-ai CLI), "
+                    "'mimocode' / 'mimo' (MiMo Code CLI), "
+                    "'qwen-code' / 'qwen' (Qwen Code CLI), "
+                    "'oh-my-pi' / 'omp' (Oh-My-Pi pi-coding-agent CLI), "
+                    "'kimicode' / 'kimi' (MoonshotAI Kimi Code CLI; ask/resume not supported yet), "
+                    "'cursor' (coding tasks via Cursor Agent CLI). "
+                    "CLI backends use external tools with no LLM overhead from the parent. "
+                    "Null for the default 'lingtai'."
+                ),
+            },
+            "max_turns": {
+                "type": ["integer", "null"],
+                "minimum": 1,
+                "maximum": DEFAULT_MAX_TURNS,
+                "description": "For 'emanate': max LLM tool-loop turns per emanation. Default: parent ceiling (1000). Use a smaller value to keep simple emanations bounded. Null for the default.",
+            },
+            "timeout": {
+                "type": ["number", "null"],
+                "minimum": 5,
+                "description": "For 'emanate': max wall-clock seconds for the whole batch. Default: parent max (3600s). Watchdog kills any emanation still running when the timer fires. Null for the default.",
+            },
+        },
+        "required": ["tasks", "backend", "max_turns", "timeout"],
+        "additionalProperties": False,
+    }
+
+
+LIST_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "contains": {
+            "type": ["string", "null"],
+            "description": "For 'list': case-insensitive substring search across daemon task, prompt preview, result preview, backend, status, group_id, run_id, and visible call parameters. Null or empty for no search filter.",
+        },
+        "status": {
+            "type": ["string", "null"],
+            "description": "For 'list': optional status filter such as running, done, failed, cancelled, timeout, or all. Null for the default 'all'.",
+        },
+        "include_done": {
+            "type": ["boolean", "null"],
+            "description": "For 'list': include completed historical daemon run directories as well as currently tracked runs. Defaults to true. Null for the default.",
+        },
+        "last": {
+            "type": ["integer", "null"],
+            "minimum": 1,
+            "maximum": CHECK_LAST_MAX,
+            "description": "For 'list': positive maximum number of list entries to show after filtering. Null for no list limit.",
+        },
+    },
+    "required": ["contains", "status", "include_done", "last"],
+    "additionalProperties": False,
+}
+
+ASK_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "description": "Subagent ID for 'ask' action (e.g. 'em-1')",
+        },
+        "message": {
+            "type": "string",
+            "description": "Follow-up message for 'ask' action",
+        },
+    },
+    "required": ["id", "message"],
+    "additionalProperties": False,
+}
+
+CHECK_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "description": "Subagent ID to inspect (e.g. 'em-1'). Accepts a currently tracked emanation or a historical run id.",
+        },
+        "last": {
+            "type": ["integer", "null"],
+            "minimum": 1,
+            "maximum": CHECK_LAST_MAX,
+            "description": "For 'check': how many most-recent events to return from events.jsonl. Default 20. Null for the default.",
+        },
+        "truncate": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "description": "For 'check': maximum length of any string field in returned events; longer fields get an ellipsis suffix. Default 500. Set to 0 to disable. Null for the default.",
+        },
+    },
+    "required": ["id", "last", "truncate"],
+    "additionalProperties": False,
+}
+
+#: ``reclaim`` takes no input — the canonical strict-empty object, the same
+#: spelling ``MANUAL_INPUT_SCHEMA`` uses, restated as its own literal because
+#: it is a distinct child (a shared mutable object would let one child's
+#: schema edit the other's).
+RECLAIM_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+    "additionalProperties": False,
+}
+
+
+def _child_specs(backend_enum: list[str]) -> tuple[tuple[str, dict[str, Any]], ...]:
+    """The one child registry source: canonical action name → strict input schema.
+
+    Both the module-level schema-only family and each dispatcher's
+    handler-bound family are built from this single source, so the composed
+    schema and the dispatch registry cannot drift apart.
+    """
+    return (
+        ("emanate", _emanate_input_schema(backend_enum)),
+        ("list", LIST_INPUT_SCHEMA),
+        ("ask", ASK_INPUT_SCHEMA),
+        ("check", CHECK_INPUT_SCHEMA),
+        ("reclaim", RECLAIM_INPUT_SCHEMA),
+        ("manual", MANUAL_INPUT_SCHEMA),
+    )
+
+
+def build_schema(backend_enum: list[str], lang: str = "en") -> dict[str, Any]:
+    """Compose the action-separated public ``daemon`` schema.
+
+    Generated purely from the child registry by the generic ``ToolFamily``
+    infra (root ``allOf`` correlation plus ``input.oneOf`` disclosure) — this
+    is the schema registered for the public ``daemon`` tool, and the only one
+    the package defines. Constructing the family here is also the registry's
+    duplicate/reserved-``manual``-collision check.
+    """
+    _ = lang  # The daemon tool surface is canonical English.
+
+    def _unused(_input: Mapping[str, Any]) -> dict[str, Any]:
+        raise AssertionError("the schema-only ToolFamily never dispatches")
+
+    family = ToolFamily(
+        "daemon",
+        [
+            ChildTool(name, schema, _unused, title=f"{name} input")
+            for name, schema in _child_specs(backend_enum)
+        ],
+    )
+    return family.build_schema()
+
+
+class DaemonFamilyDispatcher:
+    """Adapts the ``action``/``input`` envelope to ``DaemonManager``'s legacy flat call shape.
+
+    Built per-agent, bound to one live ``DaemonManager``. ``handle()`` is the
+    public ``daemon`` tool's registered handler: ``ToolFamily.handle()``
+    validates the envelope and dispatches to exactly one of the six
+    ``ChildTool`` handlers below, each of which flattens its own validated
+    ``input`` mapping (injecting the matching ``action`` key, mirroring the
+    legacy dispatch contract in ``DaemonManager.handle``) and calls
+    ``DaemonManager.handle()`` unchanged — so every side effect, receipt,
+    process interaction, notification, and error string stays exactly what the
+    engine already produces.
+
+    ``manual`` is registered directly, unwrapped, from ``build_manual_child``
+    — the shared reserved-name contract every LingTai family uses — so
+    ``ToolFamily.handle()`` returns its canonical
+    ``content``/``structuredContent`` result verbatim with no double wrap. It
+    is the family's sole manual surface and reaches no engine method, so
+    ``manual`` performs no daemon operation. ``DaemonManager.handle``'s own
+    ``action == "manual"`` branch is retained for historical/internal flat
+    callers but is never the registered model-facing path.
+    """
+
+    def __init__(self, manager: Any, agent: Any, backend_enum: list[str]) -> None:
+        self._manager = manager
+        specs = dict(_child_specs(backend_enum))
+        self._family = ToolFamily(
+            "daemon",
+            [
+                ChildTool("emanate", specs["emanate"], self._dispatch_emanate, title="emanate input"),
+                ChildTool("list", specs["list"], self._dispatch_list, title="list input"),
+                ChildTool("ask", specs["ask"], self._dispatch_ask, title="ask input"),
+                ChildTool("check", specs["check"], self._dispatch_check, title="check input"),
+                ChildTool("reclaim", specs["reclaim"], self._dispatch_reclaim, title="reclaim input"),
+                build_manual_child(agent, "daemon"),
+            ],
+        )
+
+    @staticmethod
+    def _strip_nulls(action_input: Mapping[str, Any]) -> dict[str, Any]:
+        # Strict schemas express optional fields as required nullable
+        # properties. Null means *absent* to ``DaemonManager``, which then
+        # applies its own unchanged runtime default — dropping the key is what
+        # makes ``args.get("last", 20)`` / ``args.get("include_done", True)``
+        # behave exactly as they did for a legacy flat caller that simply
+        # omitted the field. A falsy-but-present value (``truncate: 0``,
+        # ``include_done: False``, ``contains: ""``) is preserved verbatim,
+        # never dropped.
+        return {key: value for key, value in action_input.items() if value is not None}
+
+    def _dispatch_emanate(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        flat = self._strip_nulls(action_input)
+        flat["action"] = "emanate"
+        flat.setdefault("tasks", [])
+        return self._manager.handle(flat)
+
+    def _dispatch_list(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        flat = self._strip_nulls(action_input)
+        flat["action"] = "list"
+        return self._manager.handle(flat)
+
+    def _dispatch_ask(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        return self._manager.handle(
+            {
+                "action": "ask",
+                "id": action_input.get("id", ""),
+                "message": action_input.get("message", ""),
+            }
+        )
+
+    def _dispatch_check(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
+        flat = self._strip_nulls(action_input)
+        flat["action"] = "check"
+        flat.setdefault("id", "")
+        return self._manager.handle(flat)
+
+    def _dispatch_reclaim(self, _action_input: Mapping[str, Any]) -> dict[str, Any]:
+        return self._manager.handle({"action": "reclaim"})
+
+    def handle(self, args: Mapping[str, Any] | None) -> dict[str, Any]:
+        # ``ToolFamily.handle`` validates the envelope, strips/type-checks
+        # root ``summarize``, rejects unknown root fields and cross-action
+        # ``input`` keys, then returns the selected child's own raw canonical
+        # result verbatim — no double wrap, no Host envelope. The one Host
+        # normalization below narrows the generic dispatcher's action list to
+        # Daemon's exact six; the generic canonical error shape
+        # (``status``/``error_code``/``message``) is left untouched.
+        result = self._family.handle(args)
+        if result.get("error_code") == "ACTION_REQUIRED":
+            result["message"] = (
+                "action must be one of emanate, list, ask, check, reclaim, or manual"
+            )
+        return result

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -3,11 +3,11 @@ name: daemon-manual
 description: >
   Operational router for the `daemon` tool: inspect slow/stuck/failed emanations,
   read daemon artifact folders, choose polling cadence, avoid reclaiming on a
-  hunch, understand `daemon(action="list")`, use CLI backends and `backend_options`,
+  hunch, understand `daemon(action="list", input={})`, use CLI backends and `backend_options`,
   and clean up daemon footprint. Read this after dispatching daemon work that is
   slow, failed, timed out, exited 143 / SIGTERM, or needs backend-specific reasoning.
-version: 0.9.0
-last_changed_at: 2026-07-21T00:00:00Z
+version: 0.10.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/CONTRACT.md
 - src/lingtai/tools/daemon/ANATOMY.md
@@ -57,7 +57,7 @@ files, not standalone top-level skills.
 - name: daemon-cli-backends
   location: reference/cli-backends/SKILL.md
   description: |
-    Daemon API details and CLI backends: daemon(action=list), claude-p/codex/opencode behavior,
+    Daemon API details and CLI backends: daemon(action=list, input={}), claude-p/codex/opencode behavior,
     backend_options flag passing, preset/capability inheritance, and Codex
     modal capabilities.
 - name: daemon-cleanup
@@ -67,6 +67,26 @@ files, not standalone top-level skills.
     cover, reclaim persistence, and safe cleanup of old daemon artifacts.
 ```
 
+## Call shape
+
+Every `daemon` call is the same four-field envelope: a required `action`, a
+required `input` object holding **only** that action's own fields, and a
+required `reasoning` string. The optional root `summarize` boolean replaces the
+former flat `summary` field. Passing another action's field — or any field at
+the call root — is refused before the daemon engine runs.
+
+| Action | Call |
+|---|---|
+| `emanate` | `daemon(action="emanate", input={"tasks": [{"task": "...", "tools": ["file"]}], "backend": "codex"}, reasoning="...")` |
+| `list` | `daemon(action="list", input={"status": "running", "last": 20}, reasoning="...")` |
+| `ask` | `daemon(action="ask", input={"id": "em-1", "message": "..."}, reasoning="...")` |
+| `check` | `daemon(action="check", input={"id": "em-1", "last": 20, "truncate": 500}, reasoning="...")` |
+| `reclaim` | `daemon(action="reclaim", input={}, reasoning="...")` |
+| `manual` | `daemon(action="manual", input={}, reasoning="...")` |
+
+`list`, `check`, and `manual` are read-only. `emanate`, `ask`, and `reclaim`
+are the three that change state.
+
 ## Router table
 
 | Need / keywords | Read |
@@ -74,7 +94,7 @@ files, not standalone top-level skills.
 | Find an emanation's folder; inspect `daemon.json`, transcript, token ledger, event log; understand result paths or token attribution | `reference/forensics/SKILL.md` |
 | Interpret a CLI-backend **exit code 143 / SIGTERM** (terminated from outside — watchdog/timeout/reclaim — not a test or code failure); decide rerun vs hand-off; report it to a human | `reference/forensics/SKILL.md` |
 | Decide whether a daemon is stuck; choose when to list/check/tail; avoid polling too often; set a reminder before resting | `reference/inspection/SKILL.md` |
-| Use `daemon(action="list")`; choose `lingtai` vs `claude-p`/`codex`/`opencode`; pass `backend_options`; understand CLI backend limitations | `reference/cli-backends/SKILL.md` |
+| Use `daemon(action="list", input={})`; choose `lingtai` vs `claude-p`/`codex`/`opencode`; pass `backend_options`; understand CLI backend limitations | `reference/cli-backends/SKILL.md` |
 | Retire or audit old daemon artifacts; understand what `reclaim` does and does not delete; scope boundaries | `reference/cleanup/SKILL.md` |
 
 ## Quick decision tree
@@ -224,8 +244,8 @@ files, not standalone top-level skills.
 - Track daemon work in the parent agent's pad, not in daemon itself. When you
   fan out multiple tasks, immediately write a small pad table after `emanate`:
   label/purpose, returned `id`, `group_id`, brief/context file path, expected
-  artifact, and current status. Use `daemon(action="list")` and
-  `daemon(action="check", id=...)` as the mechanical truth, then update the pad
+  artifact, and current status. Use `daemon(action="list", input={})` and
+  `daemon(action="check", input={"id": ...})` as the mechanical truth, then update the pad
   as the parent-facing map. Daemon should stay thin; if you need durable memory
   or identity, use an avatar instead.
 - Do not copy large background into every task. Put reusable context in a
@@ -237,7 +257,7 @@ files, not standalone top-level skills.
   easy to point at over copying or reviving a daemon session.
 - Each emanation is disposable memory but durable evidence: its folder persists
   after completion or reclaim until cleanup.
-- `daemon(action="list")` is the first layer of progressive disclosure over
+- `daemon(action="list", input={})` is the first layer of progressive disclosure over
   active and historical runs — compact metadata, previews, and paths, not a full
   transcript. Use the returned paths for detail; see
   `reference/cli-backends/SKILL.md` for its filters and lazy-rebuild behavior.
@@ -246,7 +266,7 @@ files, not standalone top-level skills.
   for the notification; do not poll only to ask "is it done yet". The
   notification arrives on the system channel carrying the daemon id, terminal
   status, task summary, and the result/error path. React to it with
-  `daemon(action="check", id=...)` (and read `result.txt` for the full output).
+  `daemon(action="check", input={"id": ...})` (and read `result.txt` for the full output).
 - **Use a Task Card for progress when one is available for this turn.**
   The dispatch success `handoff` is conditional: if Telegram is connected and a
   Task Card is available for the current turn, use it to report progress — call
@@ -257,12 +277,12 @@ files, not standalone top-level skills.
   you a fresh daemon registry with no in-memory entries, but the run folders
   and their notifications survive on disk. New daemon ids are compact run ids
   such as `em-a1b2` (or `em-a1b2-1` after a collision), and
-  `daemon(action="check", id=...)` exact-matches that `daemons/<run_id>/` folder
+  `daemon(action="check", input={"id": ...})` exact-matches that `daemons/<run_id>/` folder
   on a registry miss. Legacy short handles such as `em-5` are accepted only when
   they resolve to one historical run; if several old runs share the handle,
   `check` returns an ambiguity error with `match_count`/`latest_run_id` instead
   of an unbounded path list. Use the exact `run_id` from the notification or
-  `daemon(action="list")` when a legacy handle is ambiguous.
+  `daemon(action="list", input={})` when a legacy handle is ambiguous.
 - **Defense-in-depth, not primary signal: a self-wake guards against a daemon
   that never reaches a terminal state at all.** The terminal notification covers
   every state a run can *finish* in, but a run that hangs without the watchdog

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
@@ -2,12 +2,12 @@
 name: daemon-cli-backends
 description: >
   Nested daemon-manual reference for daemon API details and CLI backends:
-  daemon(action=list), claude-p/codex/opencode behavior,
+  daemon(action=list, input={}), claude-p/codex/opencode behavior,
   backend_options flag passing, preset/capability inheritance, and nested
   per-backend references (Codex, OpenCode, claude-p, MiMo Code, Qwen Code,
   Kimi Code, Cursor, and Oh-My-Pi flag discovery, built-in LingTai knowledge entrypoint).
-version: 1.13.0
-last_changed_at: 2026-07-19T00:00:00Z
+version: 1.14.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/SKILL.md
 - src/lingtai/tools/daemon/CONTRACT.md
@@ -19,7 +19,7 @@ maintenance: |
 # Daemon CLI Backend Reference
 
 Nested daemon-manual reference. Open this when choosing a daemon backend,
-inspecting `daemon(action="list")`, or passing CLI flags through `backend_options`.
+inspecting `daemon(action="list", input={})`, or passing CLI flags through `backend_options`.
 
 ## Nested reference catalog
 
@@ -111,7 +111,7 @@ catalog. Only backends with proven demand get a page.
 | Oh-My-Pi (`omp`)-specific flags for a daemon task: model selection, tool/provider switches, the harness-reserved mode/approval/session flags; discover the installed `omp` CLI's flags and translate them into `backend_options` | `reference/backends/oh-my-pi/SKILL.md` |
 | Built-in `lingtai` backend knowledge for a daemon task: confirm it has no CLI/`backend_options` flag surface; find the live authorities for preset selection/inspection, lingtai/tools/skills/MCP inheritance, and the completion contract | `reference/backends/lingtai/SKILL.md` |
 
-## API note: `daemon(action="list")`
+## API note: `daemon(action="list", input={})`
 
 `list` is a compact index over both currently tracked runs and historical run
 folders. By default it scans `daemons/*/daemon.json` and returns completed,
@@ -318,7 +318,7 @@ The exact list lives on that backend's page under "Harness boundary"; consult it
 before adding options.
 
 **When it applies:** `backend_options` is honored only at `emanate` time (when
-the CLI session is first spawned). `daemon(action="ask", ...)` reuses the
+the CLI session is first spawned). `daemon(action="ask", input={"id": ..., "message": ...})` reuses the
 existing session via `claude --resume` / `codex exec resume` / backend-specific
 resume and does not re-pass `backend_options` — the runtime flags chosen at
 emanate time persist for the life of the session.
@@ -349,11 +349,11 @@ persisted to the run directory as `cli_output` events and
 notification.
 
 **`ask` on CLI backends is asynchronous.** For resumable CLI emanations,
-`daemon(action="ask", id="em-N", message="...")` spawns/resumes the backend and
+`daemon(action="ask", input={"id": "em-N", "message": "..."})` spawns/resumes the backend and
 returns immediately with `{"status":"sent","async":true}`. Progress streams
 into the same run directory (`cli_output` events, `last_output`); the final reply
 text arrives as a `follow-up completed` system notification and is also visible
-via `daemon(action="check", id="em-N")`. Poll `check` (or wait for the
+via `daemon(action="check", input={"id": "em-N"})`. Poll `check` (or wait for the
 notification) instead of expecting the reply in the `ask` return value.
 
 While one CLI `ask` is in flight against a given emanation, a second `ask` to the

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
@@ -7,8 +7,8 @@ description: >
   restrictions): it routes you to the installed CLI's live help via shell and
   shows how to translate that help into the generic `backend_options`
   mechanism. It is not a flag catalog.
-version: 0.1.0
-last_changed_at: 2026-07-19T00:00:00Z
+version: 0.2.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-claude-code/SKILL.md
@@ -75,7 +75,7 @@ Related run-scoped behavior you should not fight through flags:
   not use it because claude-p terminal success requires the injected
   `daemon_common.finish(status="done")`. For read-only runs, keep MCP enabled
   and combine a read-only brief with the live-help `--allowedTools` surface.
-- Resume: `daemon(action="ask")` runs `claude --resume <claude_session_id>
+- Resume: `daemon(action="ask", input={"id": ..., "message": ...})` runs `claude --resume <claude_session_id>
   --print ...` against the session id persisted to `daemon.json.claude_session_id`;
   `backend_options` are not re-passed on ask — emanate-time flags persist for
   the session's life.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
@@ -6,8 +6,8 @@ description: >
   (model selection, output/tooling switches): it routes you to the installed
   CLI's live help via shell and shows how to translate that help into the
   generic `backend_options` mechanism. It is not a flag catalog.
-version: 0.1.0
-last_changed_at: 2026-07-19T00:00:00Z
+version: 0.2.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-cursor-agent/SKILL.md
@@ -69,7 +69,7 @@ rules. Still, do not re-set harness-owned surfaces: `-p` (non-interactive
 print mode), `--force` (allows file modifications in print mode),
 `--output-format stream-json` (one JSON event per stdout line — the daemon's
 progress/result parser and the session-id capture depend on it), and
-`--resume` (owned by `daemon(action='ask')` follow-ups, which replay the
+`--resume` (owned by `daemon(action='ask', input={'id': ..., 'message': ...})` follow-ups, which replay the
 captured session id).
 
 Session and completion behavior, source-verified: the first stream event

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
@@ -6,8 +6,8 @@ description: >
   (model selection, skills/workspace directories): it routes you to the
   installed CLI's live help via shell and shows how to translate that help into
   the generic `backend_options` mechanism. It is not a flag catalog.
-version: 0.1.0
-last_changed_at: 2026-07-19T00:00:00Z
+version: 0.2.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-kimicode/SKILL.md
@@ -69,7 +69,7 @@ drive the non-interactive text-capture harness), forbids `--yolo` (the CLI
 refuses `--prompt` combined with `--yolo`), and reserves the
 session/continue flags because resume is not wired for this backend: no
 stable machine-readable session-id output was verified, so
-`daemon(action="ask")` returns an explicit unsupported-backend error — start
+`daemon(action="ask", input={"id": ..., "message": ...})` returns an explicit unsupported-backend error — start
 a new kimicode emanation instead.
 
 Free-form options are inserted between `kimi` and the owned flags (the

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
@@ -6,8 +6,8 @@ description: >
   MiMo-specific CLI flags (model selection, provider switches): it routes you
   to the installed CLI's live help via shell and shows how to translate that
   help into the generic `backend_options` mechanism. It is not a flag catalog.
-version: 0.2.0
-last_changed_at: 2026-07-19T00:00:00Z
+version: 0.3.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-mimocode/SKILL.md
@@ -64,7 +64,7 @@ validate, enumerate, or simulate it.
 `--format json` JSONL events) plus its own session selectors — `--session`
 (`-s`), `--continue` (`-c`), and `--fork` — MiMo-specifically. Passing any of
 them in `backend_options` refuses the whole batch before any process is
-spawned, because session/resume is harness-owned: `daemon(action="ask")`
+spawned, because session/resume is harness-owned: `daemon(action="ask", input={"id": ..., "message": ...})`
 asynchronously runs
 `mimo run --session <mimocode_session_id> --format json <message>`, with the
 session id captured from the first session-shaped JSON event into

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
@@ -7,8 +7,8 @@ description: >
   routes you to the installed CLI's live help via shell and shows how to
   translate that help into the generic `backend_options` mechanism. It is not
   a flag catalog.
-version: 0.1.0
-last_changed_at: 2026-07-19T00:00:00Z
+version: 0.2.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-opencode/SKILL.md
@@ -63,7 +63,7 @@ OpenCode reserves `--format` at the validation layer: the daemon owns
 `opencode run --format json` so its per-line JSON event parsing keeps working,
 and passing `--format` in `backend_options` refuses the whole batch before
 spawn. Beyond that, do not re-set harness-owned surfaces: session flags
-(`--session` / `--continue`) belong to `daemon(action="ask")` resume
+(`--session` / `--continue`) belong to `daemon(action="ask", input={"id": ..., "message": ...})` resume
 (`opencode run --session <opencode_session_id> --format json ...`), and the
 completion MCP is injected through the `OPENCODE_CONFIG_CONTENT` environment
 variable — not argv — so breaking either silently breaks progress/result

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
@@ -7,8 +7,8 @@ description: >
   routes you to the installed CLI's live help via shell and shows how to
   translate that help into the generic `backend_options` mechanism. It is
   not a flag catalog.
-version: 0.1.0
-last_changed_at: 2026-07-19T00:00:00Z
+version: 0.2.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
 - src/lingtai/tools/bash/manual/reference/bash-qwen-code/SKILL.md
@@ -70,7 +70,7 @@ parent stdio MCP registrations) and injects it via the
 `QWEN_CODE_SYSTEM_SETTINGS_PATH` environment variable — overriding settings
 paths silently breaks completion enforcement.
 
-Plan flags at emanate time: `daemon(action='ask')` is intentionally
+Plan flags at emanate time: `daemon(action='ask', input={'id': ..., 'message': ...})` is intentionally
 unsupported for this backend (no stable headless resume contract), so there
 is no later chance to adjust a running session. Output parsing is verbatim
 text — Qwen Code headless mode has no machine-readable event stream here, so

--- a/src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
@@ -5,8 +5,8 @@ description: >
   daemons/em-* folders, daemon.json status fields, artifacts.json manifest,
   chat_history.jsonl, token_ledger.jsonl, events.jsonl, exit code 143 / SIGTERM,
   and how to inspect progress without guessing.
-version: 1.2.1
-last_changed_at: 2026-07-19T00:00:00Z
+version: 1.3.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/SKILL.md
 - src/lingtai/tools/daemon/run_dir.py
@@ -22,7 +22,7 @@ on-disk state, transcript, or token/event artifacts.
 
 ## Each emanation is a forensic mini-avatar
 
-Every time you call `daemon(action="emanate", tasks=[...])`, each task gets a working folder under `daemons/` in your own directory. New manager-created runs use one compact id everywhere — the returned daemon id, `daemon.json.run_id`, and the folder name:
+Every time you call `daemon(action="emanate", input={"tasks": [...]})`, each task gets a working folder under `daemons/` in your own directory. New manager-created runs use one compact id everywhere — the returned daemon id, `daemon.json.run_id`, and the folder name:
 
     daemons/em-<4 hex of time hash>[-<collision suffix>]/
 
@@ -63,14 +63,14 @@ a run drops more files than the cap). Because names and relative paths are still
 visible metadata, avoid creating daemon work products whose filenames themselves
 contain secrets.
 
-`daemon(action="check")` surfaces this as an `artifacts` block so you don't have
+`daemon(action="check", input={"id": ...})` surfaces this as an `artifacts` block so you don't have
 to scan the folder yourself: it prefers the persisted `artifacts.json`
 (`source: "manifest"`) and, for a still-running run or an old run that predates
 the manifest, computes an equivalent listing on the fly (`source: "fallback"`).
 Read the `artifacts` block first to learn which files exist and how big they are,
 then open `result_path` / `error_path` for the full content.
 
-Read these artifacts in disclosure order: start with `daemon(action="list")` (the
+Read these artifacts in disclosure order: start with `daemon(action="list", input={})` (the
 compact searchable index over these per-run files — see
 `../cli-backends/SKILL.md` for its filters and lazy-rebuild behavior), then the
 returned `.prompt` / `result.txt`, and only then drop to full forensic grep over
@@ -100,7 +100,7 @@ Tail `history/chat_history.jsonl`. Each line is one role/turn entry:
 - `{role: "user", kind: "task"}` — the original task
 - `{role: "assistant", text: "..."}` — what the emanation said
 - `{role: "user", kind: "tool_results"}` — what the tools returned
-- `{role: "user", kind: "followup"}` — your `daemon(action="ask", ...)` messages
+- `{role: "user", kind: "followup"}` — your `daemon(action="ask", input={"id": ..., "message": ...})` messages
 
 Read the most recent assistant text to see the latest progress narrative.
 
@@ -138,7 +138,7 @@ typically nothing wrong with either.
   low for the task's explore-then-act shape: the daemon watchdog SIGTERMs the
   child mid-exploration. This is the most common cause for `claude-p` / `codex`.
   See the `max_turns` guidance in `reference/cli-backends/SKILL.md`.
-- **`reclaim` / cancel.** A parent (or a human) ran `daemon(action="reclaim")`,
+- **`reclaim` / cancel.** A parent (or a human) ran `daemon(action="reclaim", input={})`,
   or otherwise cancelled the run. `reclaim` stops the process — that stop is a
   SIGTERM, surfacing as 143.
 - **Parent reclaim on shutdown.** When the parent agent molts, restarts, or is

--- a/src/lingtai/tools/daemon/manual/reference/inspection/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/inspection/SKILL.md
@@ -4,8 +4,8 @@ description: >
   Nested daemon-manual reference for polling cadence, stall heuristics, anti-
   patterns, backend-specific polling notes, and setting reminders before resting
   while daemon work remains pending.
-version: 1.1.0
-last_changed_at: 2026-07-19T00:00:00Z
+version: 1.2.0
+last_changed_at: 2026-07-27T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/manual/SKILL.md
 - src/lingtai/tools/daemon/manual/reference/forensics/SKILL.md
@@ -20,7 +20,7 @@ before reclaiming it, or before going to rest with daemon work pending.
 
 ## Polling cadence — when, how often, and which call
 
-**First principle: completion is push-notified, not polled.** When an emanation reaches a terminal state (`done`, `failed`, `cancelled`, `timeout`), the kernel publishes a compact entry to `.notification/system.json` naming the em-id and pointing at `daemon(action="check", id="em-N")`. You do **not** need to poll to discover completion. If you find yourself running `check` repeatedly waiting for a `state` transition, stop — you're duplicating work the kernel is already doing.
+**First principle: completion is push-notified, not polled.** When an emanation reaches a terminal state (`done`, `failed`, `cancelled`, `timeout`), the kernel publishes a compact entry to `.notification/system.json` naming the em-id and pointing at `daemon(action="check", input={"id": "em-N"})`. You do **not** need to poll to discover completion. If you find yourself running `check` repeatedly waiting for a `state` transition, stop — you're duplicating work the kernel is already doing.
 
 You *do* need to poll when:
 
@@ -43,8 +43,8 @@ Use `elapsed_s` (from `daemon.json` or `list`) to pick an interval. These are st
 
 ### Which call to use, in order
 
-1. **`daemon(action="list")` first** when multiple emanations are in flight and you want a status sweep. Cheap; one line per emanation with `elapsed_s` and `state`. Use it to decide *which* (if any) to investigate.
-2. **`daemon(action="check", id="em-N", last=20, truncate=500)`** when one emanation looks suspicious. `last=20` covers ~10 tool dispatches; bump to `last=50` for wider history. Keep `truncate=500` unless you specifically need full tool I/O. Read the response's `artifacts` block to learn which files exist and how big they are before opening any of them, instead of `ls`-ing the run folder by hand (see `../forensics/SKILL.md`).
+1. **`daemon(action="list", input={})` first** when multiple emanations are in flight and you want a status sweep. Cheap; one line per emanation with `elapsed_s` and `state`. Use it to decide *which* (if any) to investigate.
+2. **`daemon(action="check", input={"id": "em-N", "last": 20, "truncate": 500})`** when one emanation looks suspicious. `last=20` covers ~10 tool dispatches; bump to `last=50` for wider history. Keep `truncate=500` unless you specifically need full tool I/O. Read the response's `artifacts` block to learn which files exist and how big they are before opening any of them, instead of `ls`-ing the run folder by hand (see `../forensics/SKILL.md`).
 3. **Direct `Read` of `daemon.json`** — only when you need a field `check` doesn't surface (rare). Prefer `check`.
 4. **`tail` of `history/chat_history.jsonl`** — when `check` events don't tell you what the LLM is *thinking*. The last assistant text shows the current line of reasoning. (lingtai backend only — CLI backends don't write the LLM transcript here.)
 
@@ -102,7 +102,7 @@ This complements the polling rule above: completion is push-notified, stalls are
 
 ## Worked example: a daemon that's been running 5 minutes
 
-You called `daemon(action="emanate", ...)` for `em-3`, asked it to "scan src/ for security issues", and it's been running 5 minutes. You're nervous.
+You called `daemon(action="emanate", input={"tasks": [...]})` for `em-3`, asked it to "scan src/ for security issues", and it's been running 5 minutes. You're nervous.
 
 ```bash
 # What's the live state?

--- a/src/lingtai/tools/tool_family/ANATOMY.md
+++ b/src/lingtai/tools/tool_family/ANATOMY.md
@@ -13,6 +13,8 @@ related_files:
   - src/lingtai/tools/skills/ANATOMY.md
   - src/lingtai/tools/notification/ANATOMY.md
   - src/lingtai/tools/system/ANATOMY.md
+  - src/lingtai/tools/daemon/ANATOMY.md
+  - src/lingtai/tools/daemon/_tool_family.py
 maintenance: |
   Keep related_files repo-relative, duplicate-free, and linked to real files.
   Keep this component's ANATOMY.md and CONTRACT.md reciprocal and keep
@@ -193,6 +195,24 @@ package's largest consumer, and the one where the allowed-key rejection does
 the most safety work — `system`'s privilege classes are per action, so an
 `input` key outside the selected child's schema is refused before any
 lifecycle handler runs.
+
+`daemon/_tool_family.py` ([`../daemon/ANATOMY.md`](../daemon/ANATOMY.md)) is the
+twelfth consumer and repeats `shell`'s structural division rather than `web`'s:
+the family module is a separate file from the engine, owning the package's one
+public `get_schema`/`get_description` pair and a `DaemonFamilyDispatcher` whose
+six child handlers each flatten their own validated `input` (injecting the
+matching `action` key) and call the unchanged `DaemonManager.handle`. A single
+`_child_specs(backend_enum)` builder is the one registry source for both the
+schema-only family behind `get_schema()` and the dispatcher's handler-bound
+family, so composition and dispatch cannot drift; the engine's
+`_BACKEND_SCHEMA_ENUM` is passed *into* that builder rather than imported,
+because `daemon/__init__.py` imports this module and the reverse import would
+be circular. Two engine ceilings (`DEFAULT_MAX_TURNS`, `_CHECK_LAST_MAX`) are
+restated as module literals for the same reason and pinned by import-time
+assertions in `daemon/__init__.py`. It registers
+`build_manual_child(agent, "daemon")` directly and returns its canonical result
+verbatim; its only Host normalization is narrowing this package's generic
+`ACTION_REQUIRED` message to daemon's exact six actions.
 
 ## Composition
 

--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -20,10 +20,13 @@ related_files:
   - src/lingtai/tools/skills/__init__.py
   - src/lingtai/tools/notification/CONTRACT.md
   - src/lingtai/tools/system/CONTRACT.md
+  - src/lingtai/tools/daemon/CONTRACT.md
+  - src/lingtai/tools/daemon/_tool_family.py
   - tests/test_tool_family_generic.py
   - tests/test_tool_family_wire_parity.py
   - tests/test_tool_family_manual_contract.py
   - tests/test_tool_family_system_migration.py
+  - tests/test_tool_family_daemon_migration.py
 maintenance: |
   This component contract is governed by the root CONTRACT.md. Keep
   related_files complete and repo-relative, including the paired ANATOMY.md,
@@ -94,7 +97,8 @@ advertises `summarize` to the model regardless of family; whether the kernel
 actually honors it is a separate, per-family allowlist decision
 (`kernel/tool_result_summary.py` `_LTP_V2_MIGRATED_FAMILIES`) that this
 package does not own or enforce. Today `web`, `mcp`, `knowledge`, `file`,
-`vision`, `avatar`, and `soul` are on that allowlist, so `summarize` is
+`vision`, `avatar`, `soul`, `shell`, `skills`, `notification`, `system`, and
+`daemon` are on that allowlist, so `summarize` is
 meaningful for the families that use this infrastructure; a family adopting
 `ToolFamily` without also joining the kernel allowlist would advertise a
 model-visible `summarize` control that the kernel silently ignores —
@@ -261,6 +265,33 @@ per action, so rejecting an `input` key outside the selected child's own schema
 is what stops a smuggled `address` on a non-karma action from reaching a
 lifecycle handler at all.
 
+`daemon/_tool_family.py` (`../daemon/CONTRACT.md`) is the eighth production
+Adapter/consumer named here, and the largest-engine one: it repeats the
+`shell` division — a dedicated `_tool_family.py` module owning the package's
+single public `get_schema`/`get_description` pair and a
+`DaemonFamilyDispatcher` that translates one envelope call into
+`DaemonManager.handle()`'s unchanged legacy flat shape — so the ~13k-line
+engine (batch emanation, backend routing, run directories, the detached
+supervisor, completion signaling, cancellation, timeouts, terminal
+notifications) and every pre-migration suite exercising it stay untouched. It
+is the first consumer whose child `input_schema` carries a deep nested
+structure: `emanate`'s `tasks[]` items keep their full eight-property task
+object (including the open-ended `backend_options` argv passthrough)
+byte-for-byte, and that object is deliberately left *open* — the engine's own
+strict per-task validation owns that boundary and returns domain-specific
+errors a schema rejection would replace with a generic one, which this package
+neither requires nor prevents. It registers `build_manual_child(agent,
+"daemon")` directly and unwrapped and returns that canonical result verbatim,
+with no post-dispatch adaptation; the engine's own retained flat
+`action="manual"` branch is internal-only and never the model-facing path. Its
+one Host normalization is narrowing the generic `ACTION_REQUIRED` message to
+daemon's exact six actions, the same boundary `shell` uses. Because it also
+replaces a pre-migration flat `summary` boolean with the canonical root
+`summarize`, its migration joins `kernel/tool_result_summary.py`'s
+`_LTP_V2_MIGRATED_FAMILIES` in the same change — the allowlist step this
+contract notes is part of a migration, not something this package does on a
+family's behalf.
+
 Every other built-in family remains fully independent of this package until
 its own scoped migration.
 
@@ -373,6 +404,14 @@ using the fake `widget` family. `web`'s own existing suite
 — the last of which now also proves root `allOf` correlation survives
 identically on both Chat Completions and Responses wires)
 remains this migration's Web-specific evidence per `../web_search/CONTRACT.md`.
+`tests/test_tool_family_daemon_migration.py` is the family-specific evidence
+for `daemon` (`../daemon/CONTRACT.md`): one model tool slot proven against a
+real Agent's composed tool list, all six child schemas and their exact field
+ownership, the complete nested `emanate` task schema, cross-action and
+unknown-root rejection before any engine I/O, read-only vs side-effectful
+receipt truth, the reserved `manual` child's no-double-wrap result and its
+separation from the engine's retained internal flat branch, and the composed
+schema (including the nested task object) surviving both wires.
 `tests/test_tool_family_soul_migration.py` is the equivalent family-specific
 evidence for `soul` (`../soul/CONTRACT.md`), and independently exercises this
 package against an intrinsic consumer: all six child schemas and handlers, the

--- a/tests/_daemon_helpers.py
+++ b/tests/_daemon_helpers.py
@@ -186,3 +186,29 @@ def register_daemon_entry(
         entry["ask_future"] = ask_future
     mgr._emanations[em_id] = entry
     return entry
+
+
+def daemon_action_input_schema(action: str, lang: str = "en") -> dict[str, Any]:
+    """Return one action's own strict ``input`` schema from the public daemon schema.
+
+    Post-ToolFamily-migration the public ``daemon`` schema is the LTP v2
+    envelope (``action``/``input``/``reasoning``/``summarize``), so a field
+    that used to sit on the flat root now lives in exactly one action's
+    branch. This resolves the ``input.oneOf`` branch by its ``title``, which
+    ``ToolFamily.build_schema`` derives from the child's own registry name —
+    so a test navigating here is asserting against the same canonical child
+    schema dispatch validates.
+    """
+    from lingtai.tools.daemon import get_schema
+
+    schema = get_schema(lang)
+    return next(
+        branch
+        for branch in schema["properties"]["input"]["oneOf"]
+        if branch["title"] == f"{action} input"
+    )
+
+
+def daemon_emanate_task_schema(lang: str = "en") -> dict[str, Any]:
+    """Return the nested per-task object schema inside ``emanate``'s input."""
+    return daemon_action_input_schema("emanate", lang)["properties"]["tasks"]["items"]

--- a/tests/test_apriori_summary_schema.py
+++ b/tests/test_apriori_summary_schema.py
@@ -3,19 +3,42 @@
 ``glob`` used to be covered here too. It is now an action of the migrated
 ``file`` family, whose canonical control is the root ``summarize`` boolean —
 covered by ``tests/test_file_tool_family.py``, not by this legacy-flag test.
-``daemon`` remains unmigrated and still carries the literal ``summary`` field.
+
+``daemon`` used to be covered here as the last unmigrated holder of the literal
+``summary`` field. It is now a migrated LTP v2 family whose canonical control is
+the root ``summarize`` boolean, so its schema coverage moved to
+``tests/test_tool_family_daemon_migration.py`` for the same reason ``glob``'s
+did. This file keeps the assertion that still belongs to it: the legacy spelling
+remains honored by the central summarizer for any still-unmigrated or
+historical/pending caller, so migrating a family never silently drops a
+``summary=true`` call already in flight.
 """
 from __future__ import annotations
 
+from lingtai.kernel.tool_result_summary import summary_requested
 from lingtai.tools.daemon import get_schema as daemon_schema
 
 
-def _assert_summary_option(schema: dict) -> None:
-    prop = schema["properties"]["summary"]
-    assert prop["type"] == "boolean"
-    assert prop["default"] is False
-    assert "raw result is preserved" in prop["description"]
+def test_daemon_no_longer_advertises_the_legacy_flat_summary_option() -> None:
+    """The migrated public ``daemon`` schema exposes the canonical root
+    ``summarize``; the pre-migration flat ``summary`` field is gone from it."""
+    schema = daemon_schema()
+
+    assert "summary" not in schema["properties"]
+    assert schema["properties"]["summarize"]["type"] == "boolean"
 
 
-def test_daemon_exposes_apriori_summary_option() -> None:
-    _assert_summary_option(daemon_schema())
+def test_legacy_summary_spelling_is_still_honored_for_any_caller() -> None:
+    """The legacy flag is not removed from the summarizer — an unmigrated tool,
+    or a historical/pending call carrying the old spelling, still opts in."""
+    assert summary_requested({"summary": True}) is True
+    assert summary_requested({"summary": True}, "daemon") is True
+    assert summary_requested({"summary": False}) is False
+    assert summary_requested({}) is False
+
+
+def test_canonical_summarize_spelling_is_scoped_to_migrated_families() -> None:
+    """``summarize`` is recognized only for a migrated family, so an unmigrated
+    tool's own domain field named ``summarize`` is never reinterpreted."""
+    assert summary_requested({"summarize": True}, "daemon") is True
+    assert summary_requested({"summarize": True}, "some-unmigrated-tool") is False

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -461,9 +461,9 @@ def test_connect_task_mcp_registrations_builds_surface_and_closes(tmp_path, monk
 
 def test_daemon_schema_exposes_prompt_and_removes_system_prompt():
     """Task items expose LingTai first-user prompt and reject the old field."""
-    from lingtai.tools.daemon import get_schema
+    from tests._daemon_helpers import daemon_emanate_task_schema
 
-    task_props = get_schema("en")["properties"]["tasks"]["items"]["properties"]
+    task_props = daemon_emanate_task_schema("en")["properties"]
     assert "prompt" in task_props
     assert task_props["prompt"]["type"] == "string"
     assert "system_prompt" not in task_props
@@ -477,9 +477,9 @@ def test_daemon_schema_exposes_prompt_and_removes_system_prompt():
 
 
 def test_daemon_schema_context_token_limit_description_matches_contract():
-    from lingtai.tools.daemon import get_schema
+    from tests._daemon_helpers import daemon_emanate_task_schema
 
-    desc = get_schema("en")["properties"]["tasks"]["items"]["properties"][
+    desc = daemon_emanate_task_schema("en")["properties"][
         "context_token_limit"
     ]["description"].lower()
 

--- a/tests/test_daemon_backend_options.py
+++ b/tests/test_daemon_backend_options.py
@@ -441,9 +441,8 @@ def test_codex_cmd_appends_backend_argv_before_task(tmp_path):
 
 
 def test_schema_includes_backend_options():
-    from lingtai.tools.daemon import get_schema
-    schema = get_schema("en")
-    task_props = schema["properties"]["tasks"]["items"]["properties"]
+    from tests._daemon_helpers import daemon_emanate_task_schema
+    task_props = daemon_emanate_task_schema("en")["properties"]
     assert "backend_options" in task_props
     backend_options = task_props["backend_options"]
     assert backend_options["type"] == "object"
@@ -492,7 +491,13 @@ def test_backend_schema_enum_matches_ordered_contract():
         "cursor",
     ]
     assert list(_BACKEND_SCHEMA_ENUM) == expected
-    assert get_schema("en")["properties"]["backend"]["enum"] == expected
+    from tests._daemon_helpers import daemon_action_input_schema
+    assert (
+        daemon_action_input_schema("emanate", "en")["properties"]["backend"]["enum"]
+        # ``backend`` is required-nullable in the strict child schema; ``None``
+        # means "absent" and the engine then applies its own ``lingtai`` default.
+        == [*expected, None]
+    )
 
 
 def test_backend_metadata_consistency_keeps_hidden_legacy_claude():
@@ -524,9 +529,9 @@ def test_normalize_backend_aliases_only_true_aliases():
 
 
 def test_schema_includes_mimocode_and_qwen_code_backends():
-    from lingtai.tools.daemon import get_schema
+    from tests._daemon_helpers import daemon_action_input_schema
 
-    backend = get_schema("en")["properties"]["backend"]
+    backend = daemon_action_input_schema("emanate", "en")["properties"]["backend"]
     for name in ("mimocode", "mimo", "qwen-code", "qwen"):
         assert name in backend["enum"]
     assert "MiMo Code" in backend["description"]
@@ -820,9 +825,9 @@ def test_qwen_code_ask_is_explicitly_unsupported(tmp_path, monkeypatch):
 
 
 def test_schema_includes_kimicode_backend():
-    from lingtai.tools.daemon import get_schema
+    from tests._daemon_helpers import daemon_action_input_schema
 
-    backend = get_schema("en")["properties"]["backend"]
+    backend = daemon_action_input_schema("emanate", "en")["properties"]["backend"]
     for name in ("kimicode", "kimi"):
         assert name in backend["enum"]
     assert "Kimi Code" in backend["description"]
@@ -1214,9 +1219,9 @@ def test_kimicode_ask_is_explicitly_unsupported(tmp_path, monkeypatch):
 
 
 def test_schema_includes_oh_my_pi_backend():
-    from lingtai.tools.daemon import get_schema
+    from tests._daemon_helpers import daemon_action_input_schema
 
-    backend = get_schema("en")["properties"]["backend"]
+    backend = daemon_action_input_schema("emanate", "en")["properties"]["backend"]
     for name in ("oh-my-pi", "omp"):
         assert name in backend["enum"]
     assert "Oh-My-Pi" in backend["description"]

--- a/tests/test_daemon_claude_interactive_backend.py
+++ b/tests/test_daemon_claude_interactive_backend.py
@@ -187,7 +187,9 @@ def test_schema_hides_interactive_claude_backends_keeps_print_mode():
     # The legacy interactive Claude Code backend (claude / claude-interactive)
     # is no longer a user-selectable daemon backend: hidden from the enum and
     # the human-facing description. Print mode (claude-p / claude-code) stays.
-    backend = get_schema()["properties"]["backend"]
+    from tests._daemon_helpers import daemon_action_input_schema
+
+    backend = daemon_action_input_schema("emanate")["properties"]["backend"]
     assert "claude" not in backend["enum"]
     assert "claude-interactive" not in backend["enum"]
     assert "claude-p" in backend["enum"]

--- a/tests/test_daemon_contract_doc.py
+++ b/tests/test_daemon_contract_doc.py
@@ -45,7 +45,8 @@ def test_daemon_contract_frontmatter_lists_related_files_and_triggers():
     meta = _frontmatter(DOC)
     assert meta["name"] == "daemon-contract"
     assert meta["status"] == "active"
-    assert meta["contract_version"] == 7
+    # Bumped to 8 by the ToolFamily migration (LTP v2 envelope tool surface).
+    assert meta["contract_version"] == 8
     related = set(meta["related_files"])
     triggers = set(meta["review_triggers"])
     for rel in REQUIRED_RELATED:

--- a/tests/test_daemon_cursor_backend.py
+++ b/tests/test_daemon_cursor_backend.py
@@ -85,19 +85,17 @@ def _source_cursor_stream(*events):
 
 
 def test_schema_enum_includes_cursor():
-    from lingtai.tools.daemon import get_schema
+    from tests._daemon_helpers import daemon_action_input_schema
 
-    schema = get_schema("en")
-    backend = schema["properties"]["backend"]
+    backend = daemon_action_input_schema("emanate", "en")["properties"]["backend"]
     assert "cursor" in backend["enum"]
     assert "cursor" in backend["description"]
 
 
 def test_schema_backend_options_description_mentions_cursor():
-    from lingtai.tools.daemon import get_schema
+    from tests._daemon_helpers import daemon_emanate_task_schema
 
-    schema = get_schema("en")
-    bo = schema["properties"]["tasks"]["items"]["properties"]["backend_options"]
+    bo = daemon_emanate_task_schema("en")["properties"]["backend_options"]
     assert "cursor" in bo["description"]
     assert "agent --help" in bo["description"]
 

--- a/tests/test_daemon_kimicode_submanual.py
+++ b/tests/test_daemon_kimicode_submanual.py
@@ -104,7 +104,7 @@ def test_kimicode_child_names_canonical_alias_and_limitations():
     for flag in _KIMICODE_RESERVED_BACKEND_FLAGS:
         assert f"`{flag}`" in body, flag
     # Current limitations and MCP wiring stated as they are implemented.
-    assert 'daemon(action="ask")' in body
+    assert 'daemon(action="ask", input={"id": ..., "message": ...})' in body
     assert "unsupported" in body
     assert "kimi-code-home/mcp.json" in body
     assert "backend_harness_files.kimicode_mcp_config" in body

--- a/tests/test_daemon_opencode_backend.py
+++ b/tests/test_daemon_opencode_backend.py
@@ -125,17 +125,15 @@ class _RecordingPort:
 
 
 def test_schema_enum_includes_opencode():
-    from lingtai.tools.daemon import get_schema
-    schema = get_schema("en")
-    backend = schema["properties"]["backend"]
+    from tests._daemon_helpers import daemon_action_input_schema
+    backend = daemon_action_input_schema("emanate", "en")["properties"]["backend"]
     assert "opencode" in backend["enum"]
     assert "opencode" in backend["description"]
 
 
 def test_schema_backend_options_description_mentions_opencode():
-    from lingtai.tools.daemon import get_schema
-    schema = get_schema("en")
-    bo = schema["properties"]["tasks"]["items"]["properties"]["backend_options"]
+    from tests._daemon_helpers import daemon_emanate_task_schema
+    bo = daemon_emanate_task_schema("en")["properties"]["backend_options"]
     assert "opencode" in bo["description"]
     # The discovery hint should now point at opencode's own --help too.
     assert "opencode run --help" in bo["description"]

--- a/tests/test_daemon_per_batch_limits.py
+++ b/tests/test_daemon_per_batch_limits.py
@@ -25,7 +25,9 @@ def test_emanate_default_uses_ceiling(tmp_path, monkeypatch):
 def test_daemon_schema_advertises_1000_turn_ceiling():
     from lingtai.tools.daemon import get_schema
 
-    max_turns_schema = get_schema("en")["properties"]["max_turns"]
+    from tests._daemon_helpers import daemon_action_input_schema
+
+    max_turns_schema = daemon_action_input_schema("emanate", "en")["properties"]["max_turns"]
     assert max_turns_schema["minimum"] == 1
     assert max_turns_schema["maximum"] == 1000
     assert "1000" in max_turns_schema["description"]

--- a/tests/test_daemon_qwen_code_submanual.py
+++ b/tests/test_daemon_qwen_code_submanual.py
@@ -99,7 +99,7 @@ def test_qwen_code_child_states_harness_boundaries():
     # Per-run MCP settings injection and the no-resume planning consequence.
     assert "QWEN_CODE_SYSTEM_SETTINGS_PATH" in body
     assert "qwen-daemon-settings.json" in body
-    assert "daemon(action='ask')" in body
+    assert "daemon(action='ask', input={'id': ..., 'message': ...})" in body
 
 
 def test_qwen_code_child_stays_tiny_not_a_flag_catalog():

--- a/tests/test_tool_family_daemon_migration.py
+++ b/tests/test_tool_family_daemon_migration.py
@@ -1,0 +1,870 @@
+"""Daemon's LTP v2 action-separated migration: schema, dispatch, and parity.
+
+Proves the public/model-facing ``daemon`` tool is the ToolFamily-composed
+``action``/``input``/``reasoning``/``summarize`` envelope over the canonical
+children ``emanate | list | ask | check | reclaim | manual``, while
+``DaemonManager`` — batch emanation, backend routing, run directories, the
+detached supervisor, ``daemon_common`` completion signaling, cancellation,
+timeouts, terminal notifications, and result/error persistence — stays the
+exact, untouched engine the pre-migration suites (``test_daemon.py``,
+``test_daemon_check.py``, ``test_daemon_backend_options.py``,
+``test_daemon_detached_supervisor.py``, …) already exercise through its legacy
+flat call shape.
+
+The invariants under test come from ``src/lingtai/tools/CONTRACT.md``
+(Envelope, Dispatch and actions), ``src/lingtai/tools/tool_family/CONTRACT.md``,
+and the Daemon migration acceptance line: exactly one model tool slot, strict
+action/input correlation, read-only (``list``/``check``/``manual``) vs
+side-effectful (``emanate``/``ask``/``reclaim``) receipt truth, the reserved
+``manual`` performing no daemon operation with no double wrap, and the complete
+nested ``emanate`` task schema preserved field-for-field.
+
+Every test here uses an isolated temp working directory and a mock-service
+Agent. Nothing dispatches a real emanation, touches a live peer, or reaches an
+LLM: the side-effect actions are proven through their pre-run validation
+receipts and through a recording stub manager, never by starting a run.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests._daemon_helpers import (
+    daemon_action_input_schema,
+    daemon_emanate_task_schema,
+    make_daemon_agent,
+)
+from lingtai.tools import daemon as daemon_pkg
+from lingtai.tools.daemon import get_description, get_schema, setup
+from lingtai.tools.daemon._tool_family import (
+    ASK_INPUT_SCHEMA,
+    CHECK_INPUT_SCHEMA,
+    DAEMON_ACTIONS,
+    LIST_INPUT_SCHEMA,
+    RECLAIM_INPUT_SCHEMA,
+    DaemonFamilyDispatcher,
+)
+from lingtai.tools.tool_family import ToolFamilyError
+from lingtai.tools.tool_family.manual import MANUAL_INPUT_SCHEMA
+
+_ACTIONS = list(DAEMON_ACTIONS)
+_READ_ONLY = ("list", "check", "manual")
+_SIDE_EFFECTFUL = ("emanate", "ask", "reclaim")
+
+# One minimal, schema-valid ``input`` per action — every optional explicitly
+# null, which is how a strict provider fills a required-nullable property.
+_MINIMAL_INPUT: dict[str, dict[str, Any]] = {
+    "emanate": {"tasks": [], "backend": None, "max_turns": None, "timeout": None},
+    "list": {"contains": None, "status": None, "include_done": None, "last": None},
+    "ask": {"id": "em-1", "message": "hello"},
+    "check": {"id": "em-1", "last": None, "truncate": None},
+    "reclaim": {},
+    "manual": {},
+}
+
+
+class _RecordingManager:
+    """Stands in for ``DaemonManager``, recording the flat call it receives.
+
+    The migration's whole claim is that the dispatcher translates the envelope
+    into the engine's unchanged legacy flat shape. Recording that exact flat
+    dict is the direct proof, and it starts no process, writes no run
+    directory, and sends no notification.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def handle(self, args: dict) -> dict:
+        self.calls.append(dict(args))
+        return {"status": "ok", "echo": dict(args)}
+
+
+def _dispatcher(tmp_path: Path) -> tuple[DaemonFamilyDispatcher, _RecordingManager]:
+    agent = MagicMock()
+    agent._working_dir = tmp_path
+    mgr = _RecordingManager()
+    return (
+        DaemonFamilyDispatcher(mgr, agent, list(daemon_pkg._BACKEND_SCHEMA_ENUM)),
+        mgr,
+    )
+
+
+def _call(dispatcher: DaemonFamilyDispatcher, action: str, **overrides) -> dict:
+    action_input = dict(_MINIMAL_INPUT[action])
+    action_input.update(overrides)
+    return dispatcher.handle(
+        {"action": action, "input": action_input, "reasoning": "migration test"}
+    )
+
+
+def _install_daemon_manual(working_dir: Path, body: str) -> Path:
+    """Install a daemon manual exactly where the real initializer puts it.
+
+    ``Agent._install_intrinsic_manuals`` maps the package to the model-facing
+    destination name ``daemon`` under ``.library/intrinsic/capabilities/`` — so
+    ``build_manual_child(agent, "daemon")`` reads the same body/path the
+    pre-migration ``DaemonManager.handle({"action": "manual"})`` branch did via
+    ``load_installed_manual``.
+    """
+    manual_dir = working_dir / ".library" / "intrinsic" / "capabilities" / "daemon"
+    manual_dir.mkdir(parents=True, exist_ok=True)
+    manual_path = manual_dir / "SKILL.md"
+    manual_path.write_text(body, encoding="utf-8")
+    return manual_path
+
+
+# ---------------------------------------------------------------------------
+# Public identity: one tool slot, one name, the family schema
+# ---------------------------------------------------------------------------
+
+def test_public_model_facing_name_is_daemon_with_the_family_schema(tmp_path):
+    """The registered public name stays exactly ``daemon`` and the registered
+    schema is the action-separated family envelope, not the legacy flat shape."""
+    agent = MagicMock()
+    agent._working_dir = tmp_path
+
+    setup(agent)
+
+    assert agent.add_tool.call_args.args[0] == "daemon"
+    schema = agent.add_tool.call_args.kwargs["schema"]
+    assert schema == get_schema()
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    # Every legacy flat field is gone from the public root.
+    for legacy_flat_field in (
+        "tasks", "id", "message", "last", "truncate", "contains", "status",
+        "include_done", "summary", "max_turns", "timeout", "backend",
+    ):
+        assert legacy_flat_field not in schema["properties"]
+
+
+def test_setup_registers_exactly_one_model_facing_daemon_tool(tmp_path):
+    """The six children consume no extra model tool slot: a real Agent with the
+    daemon capability exposes exactly one ``daemon`` tool and no per-action tool."""
+    agent = make_daemon_agent(tmp_path)
+
+    from lingtai.kernel.base_agent.tools import _build_tool_schemas
+
+    model_tools = [schema.name for schema in _build_tool_schemas(agent)]
+
+    assert model_tools.count("daemon") == 1
+    for action in _ACTIONS:
+        assert f"daemon_{action}" not in model_tools
+        assert f"daemon.{action}" not in model_tools
+    # No second model-facing root and no compatibility alias was registered.
+    assert [name for name in model_tools if "daemon" in name] == ["daemon"]
+
+
+def test_registered_handler_is_the_envelope_dispatcher_not_the_flat_engine(tmp_path):
+    """The registered handler must be the family dispatcher. The engine's own
+    ``handle`` is retained as the internal flat shape, not the model surface."""
+    agent = MagicMock()
+    agent._working_dir = tmp_path
+
+    mgr = setup(agent)
+    handler = agent.add_tool.call_args.kwargs["handler"]
+
+    assert handler != mgr.handle
+    assert isinstance(handler.__self__, DaemonFamilyDispatcher)
+
+
+def test_registered_description_documents_the_action_separated_call_shape():
+    """The model-facing description must teach the shape actually registered —
+    ``input={...}``, not the legacy flat fields."""
+    description = get_description()
+
+    for action in _ACTIONS:
+        assert f"daemon(action='{action}'" in description
+    assert 'input={"id": "em-1", "message": "..."}' in description
+    # The pre-migration operational guidance is retained verbatim.
+    assert "push-notified exactly once" in description
+    assert 'do not poll for "is it done"' in description
+    assert "daemon-manual" in description
+
+
+# ---------------------------------------------------------------------------
+# Root envelope and child schemas
+# ---------------------------------------------------------------------------
+
+def test_root_is_strict_action_input_reasoning_summarize():
+    schema = get_schema()
+
+    assert schema["type"] == "object"
+    assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+    # ``reasoning`` is REQUIRED Host audit metadata declared by the family
+    # itself: Agent composition only merges ``properties``, never ``required``.
+    assert schema["required"] == ["action", "input", "reasoning"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["reasoning"]["type"] == "string"
+    assert schema["properties"]["summarize"]["type"] == "boolean"
+
+
+def test_canonical_children_are_the_six_daemon_actions():
+    schema = get_schema()
+
+    assert schema["properties"]["action"]["enum"] == _ACTIONS
+    assert [b["title"] for b in schema["properties"]["input"]["oneOf"]] == [
+        f"{a} input" for a in _ACTIONS
+    ]
+
+
+@pytest.mark.parametrize(
+    "action,expected_fields",
+    [
+        ("emanate", {"tasks", "backend", "max_turns", "timeout"}),
+        ("list", {"contains", "status", "include_done", "last"}),
+        ("ask", {"id", "message"}),
+        ("check", {"id", "last", "truncate"}),
+        ("reclaim", set()),
+        ("manual", set()),
+    ],
+)
+def test_each_action_owns_exactly_its_own_fields(action, expected_fields):
+    """The pre-migration flat root advertised all thirteen fields to all six
+    actions; each field now lives in exactly the branch that consumes it."""
+    branch = daemon_action_input_schema(action)
+
+    assert set(branch["properties"]) == expected_fields
+
+
+def test_no_field_leaks_across_action_branches():
+    """Cross-action isolation stated positively: a field belonging to one
+    action must not appear in any other action's branch."""
+    owners = {
+        "tasks": "emanate", "backend": "emanate", "max_turns": "emanate",
+        "timeout": "emanate", "contains": "list", "status": "list",
+        "include_done": "list", "message": "ask", "truncate": "check",
+    }
+    for field, owner in owners.items():
+        for action in _ACTIONS:
+            present = field in daemon_action_input_schema(action)["properties"]
+            assert present == (action == owner), (field, action)
+    # ``id`` and ``last`` are the two deliberately shared spellings.
+    assert {a for a in _ACTIONS if "id" in daemon_action_input_schema(a)["properties"]} == {"ask", "check"}
+    assert {a for a in _ACTIONS if "last" in daemon_action_input_schema(a)["properties"]} == {"list", "check"}
+
+
+def test_every_child_input_schema_is_closed_and_free_of_host_fields():
+    for action in _ACTIONS:
+        branch = daemon_action_input_schema(action)
+        assert branch["additionalProperties"] is False
+        for host_field in ("reasoning", "_reasoning", "summarize", "summary", "action"):
+            assert host_field not in branch["properties"], (action, host_field)
+
+
+def test_reclaim_and_manual_take_the_canonical_strict_empty_input():
+    for action in ("reclaim", "manual"):
+        branch = daemon_action_input_schema(action)
+        assert branch["properties"] == {}
+        assert branch["required"] == []
+        assert branch["additionalProperties"] is False
+    assert RECLAIM_INPUT_SCHEMA == MANUAL_INPUT_SCHEMA
+
+
+def test_root_allof_correlates_each_action_const_to_its_own_input_schema():
+    schema = get_schema()
+
+    assert [c["if"]["properties"]["action"]["const"] for c in schema["allOf"]] == _ACTIONS
+    for condition in schema["allOf"]:
+        action = condition["if"]["properties"]["action"]["const"]
+        assert condition["if"]["required"] == ["action"]
+        branch = daemon_action_input_schema(action)
+        correlated = condition["then"]["properties"]["input"]
+        # Same canonical child schema the ``oneOf`` branch embeds, minus the
+        # presentational ``title`` the branch adds.
+        assert correlated == {k: v for k, v in branch.items() if k != "title"}
+
+
+def test_composed_schema_branches_are_mutation_isolated():
+    """A caller mutating one composed schema must not corrupt the next call's."""
+    first = get_schema()
+    first["properties"]["input"]["oneOf"][0]["properties"].clear()
+    first["allOf"][0]["then"]["properties"]["input"]["properties"].clear()
+
+    second = get_schema()
+
+    assert set(second["properties"]["input"]["oneOf"][0]["properties"]) == {
+        "tasks", "backend", "max_turns", "timeout"
+    }
+
+
+# ---------------------------------------------------------------------------
+# The complete nested emanate task schema is preserved
+# ---------------------------------------------------------------------------
+
+def test_emanate_nested_task_schema_preserves_every_field():
+    task = daemon_emanate_task_schema()
+
+    assert set(task["properties"]) == {
+        "task", "tools", "skills", "mcp", "preset", "backend_options",
+        "prompt", "context_token_limit",
+    }
+    assert task["required"] == ["task", "tools"]
+    # The nested task object stays OPEN: the engine's own strict per-task
+    # validation owns that boundary and returns domain-specific errors (e.g.
+    # the ``system_prompt`` obsolescence message) a schema rejection would
+    # replace with a generic one.
+    assert "additionalProperties" not in task
+    assert task["properties"]["tools"]["items"]["type"] == "string"
+    assert task["properties"]["mcp"]["items"]["type"] == "object"
+    assert task["properties"]["context_token_limit"]["minimum"] == 1
+
+
+def test_emanate_backend_options_passthrough_contract_is_unchanged():
+    backend_options = daemon_emanate_task_schema()["properties"]["backend_options"]
+
+    assert backend_options["type"] == "object"
+    for schema in (
+        backend_options["additionalProperties"],
+        backend_options["properties"]["config"],
+    ):
+        types = {branch.get("type") for branch in schema["anyOf"]}
+        assert types == {"boolean", "string", "integer", "number", "null", "array"}
+
+
+def test_emanate_backend_enum_and_engine_ceilings_agree():
+    emanate = daemon_action_input_schema("emanate")["properties"]
+
+    # Every routable backend, plus the null that means "use the default".
+    assert emanate["backend"]["enum"] == [*daemon_pkg._BACKEND_SCHEMA_ENUM, None]
+    for hidden in ("claude", "claude-interactive"):
+        assert hidden not in emanate["backend"]["enum"]
+    assert emanate["max_turns"]["maximum"] == daemon_pkg.DEFAULT_MAX_TURNS
+    assert emanate["timeout"]["minimum"] == 5
+
+
+def test_check_and_list_last_ceiling_matches_the_engine():
+    for action in ("check", "list"):
+        last = daemon_action_input_schema(action)["properties"]["last"]
+        assert last["maximum"] == daemon_pkg.DaemonManager._CHECK_LAST_MAX
+        assert last["minimum"] == 1
+    assert daemon_action_input_schema("check")["properties"]["truncate"]["minimum"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Dispatch: action/input correlation reaches the engine unchanged
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("action", ["emanate", "list", "ask", "check", "reclaim"])
+def test_each_action_reaches_the_engine_with_its_own_flat_action(tmp_path, action):
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    _call(dispatcher, action)
+
+    assert len(mgr.calls) == 1
+    assert mgr.calls[0]["action"] == action
+
+
+def test_ask_forwards_exactly_id_and_message(tmp_path):
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    _call(dispatcher, "ask", id="em-7", message="status?")
+
+    assert mgr.calls[0] == {"action": "ask", "id": "em-7", "message": "status?"}
+
+
+def test_check_forwards_id_last_and_truncate(tmp_path):
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    _call(dispatcher, "check", id="em-3", last=5, truncate=0)
+
+    assert mgr.calls[0] == {"action": "check", "id": "em-3", "last": 5, "truncate": 0}
+
+
+def test_emanate_forwards_the_full_nested_task_batch_verbatim(tmp_path):
+    """The complex nested ``emanate`` input must reach the engine unaltered —
+    every task key, in full, with the batch-level controls alongside it."""
+    dispatcher, mgr = _dispatcher(tmp_path)
+    tasks = [
+        {
+            "task": "audit the parser",
+            "tools": ["file", "shell"],
+            "skills": ["./skills/audit"],
+            "mcp": [{"name": "svc", "transport": "stdio", "command": "x"}],
+            "preset": "~/.lingtai-tui/presets/saved/cheap.json",
+            "backend_options": {"config": ["a=1", "b=2"], "search": True},
+            "prompt": "Begin now.",
+            "context_token_limit": 120000,
+        }
+    ]
+
+    _call(dispatcher, "emanate", tasks=tasks, backend="codex", max_turns=25, timeout=90)
+
+    assert mgr.calls[0] == {
+        "action": "emanate",
+        "tasks": tasks,
+        "backend": "codex",
+        "max_turns": 25,
+        "timeout": 90,
+    }
+
+
+def test_null_optionals_are_dropped_so_engine_defaults_apply(tmp_path):
+    """Strict schemas spell optionals as required-nullable. Null must mean
+    *absent* to the engine, so its own unchanged defaults still apply."""
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    _call(dispatcher, "list")
+    _call(dispatcher, "check", id="em-1")
+
+    assert mgr.calls[0] == {"action": "list"}
+    assert mgr.calls[1] == {"action": "check", "id": "em-1"}
+
+
+def test_falsy_but_present_values_are_preserved_not_dropped(tmp_path):
+    """``truncate: 0`` and ``include_done: False`` are meaningful values, not
+    absences — dropping them would silently change daemon behavior."""
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    _call(dispatcher, "check", id="em-1", truncate=0)
+    _call(dispatcher, "list", include_done=False, contains="")
+
+    assert mgr.calls[0]["truncate"] == 0
+    assert mgr.calls[1]["include_done"] is False
+    assert mgr.calls[1]["contains"] == ""
+
+
+def test_reasoning_and_summarize_never_reach_the_engine(tmp_path):
+    """Envelope metadata is Host-owned: a child receives only its own input."""
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    dispatcher.handle(
+        {
+            "action": "list",
+            "input": dict(_MINIMAL_INPUT["list"]),
+            "reasoning": "why",
+            "_reasoning": "why",
+            "summarize": True,
+        }
+    )
+
+    for forbidden in ("reasoning", "_reasoning", "summarize", "summary"):
+        assert forbidden not in mgr.calls[0]
+
+
+# ---------------------------------------------------------------------------
+# Envelope validation is fail-closed before any engine I/O
+# ---------------------------------------------------------------------------
+
+def test_unknown_action_fails_with_daemons_own_six_action_message(tmp_path):
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    result = dispatcher.handle({"action": "kill", "input": {}, "reasoning": "r"})
+
+    assert result["status"] == "failed"
+    assert result["error_code"] == "ACTION_REQUIRED"
+    assert result["message"] == (
+        "action must be one of emanate, list, ask, check, reclaim, or manual"
+    )
+    assert mgr.calls == []
+
+
+@pytest.mark.parametrize("action", [[], {}, None, 7])
+def test_unhashable_or_wrong_typed_action_is_rejected_not_raised(tmp_path, action):
+    """Invalid JSON can make ``action`` unhashable (issue #513): it must render
+    the typed envelope failure, never raise ``TypeError`` out of dispatch."""
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    result = dispatcher.handle({"action": action, "input": {}, "reasoning": "r"})
+
+    assert result["error_code"] == "ACTION_REQUIRED"
+    assert mgr.calls == []
+
+
+@pytest.mark.parametrize(
+    "action,foreign_input",
+    [
+        ("list", {"id": "em-1"}),
+        ("check", {"tasks": []}),
+        ("ask", {"truncate": 10}),
+        ("emanate", {"message": "hi"}),
+        ("reclaim", {"id": "em-1"}),
+        ("manual", {"last": 5}),
+    ],
+)
+def test_cross_action_input_fields_are_rejected_before_engine_io(
+    tmp_path, action, foreign_input
+):
+    """Schema conformance is not the sole boundary: dispatch rejects any
+    ``input`` key outside the selected child's own declared schema."""
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    result = dispatcher.handle(
+        {"action": action, "input": foreign_input, "reasoning": "r"}
+    )
+
+    assert result["error_code"] == "INVALID_ARGUMENT"
+    assert result["message"] == "unsupported daemon input field"
+    assert mgr.calls == []
+
+
+def test_unknown_root_field_and_non_object_input_are_rejected(tmp_path):
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    unknown_root = dispatcher.handle(
+        {"action": "list", "input": {}, "reasoning": "r", "tasks": []}
+    )
+    bad_input = dispatcher.handle(
+        {"action": "list", "input": "everything", "reasoning": "r"}
+    )
+
+    assert unknown_root["message"] == "unsupported daemon argument"
+    assert bad_input["message"] == "input must be an object"
+    assert mgr.calls == []
+
+
+def test_non_boolean_summarize_is_rejected_before_dispatch(tmp_path):
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    result = dispatcher.handle(
+        {"action": "list", "input": {}, "reasoning": "r", "summarize": "yes"}
+    )
+
+    assert result["error_code"] == "INVALID_ARGUMENT"
+    assert result["message"] == "summarize must be a boolean"
+    assert mgr.calls == []
+
+
+def test_legacy_flat_call_no_longer_reaches_the_engine(tmp_path):
+    """A pre-migration flat call is refused at the envelope, not silently
+    honored — there is no compatibility alias on the model-facing surface."""
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    result = dispatcher.handle({"action": "check", "id": "em-1", "last": 5})
+
+    assert result["status"] == "failed"
+    assert mgr.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Read-only vs side-effectful receipt truth
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("action", _READ_ONLY)
+def test_read_only_actions_start_no_run_and_cancel_nothing(tmp_path, action):
+    """``list``/``check``/``manual`` must be pure reads against a real manager:
+    no emanation is created, nothing is cancelled, no run dir appears."""
+    agent = make_daemon_agent(tmp_path, working_dir_name=f"ro-{action}")
+    handler = agent._tool_handlers["daemon"]
+    mgr = agent._capability_managers["daemon"]
+    daemons_root = agent._working_dir / "daemons"
+    before = sorted(p.name for p in daemons_root.glob("*")) if daemons_root.is_dir() else []
+
+    result = handler(
+        {"action": action, "input": dict(_MINIMAL_INPUT[action]), "reasoning": "r"}
+    )
+
+    assert result is not None
+    assert mgr._emanations == {}
+    # No run directory was created and nothing was cancelled.
+    after = sorted(p.name for p in daemons_root.glob("*")) if daemons_root.is_dir() else []
+    assert after == before
+    assert getattr(mgr, "_last_reclaim_natural_terminal", 0) == 0
+
+
+@pytest.mark.parametrize("action", _SIDE_EFFECTFUL)
+def test_side_effect_actions_are_the_only_ones_that_can_mutate(tmp_path, action):
+    """``emanate``/``ask``/``reclaim`` are the mutating three. Each is proven
+    here at its own pre-run refusal/receipt boundary — no real run is started,
+    no live peer is touched, and no shared runtime is polluted."""
+    agent = make_daemon_agent(tmp_path, working_dir_name=f"se-{action}")
+    handler = agent._tool_handlers["daemon"]
+    mgr = agent._capability_managers["daemon"]
+
+    result = handler(
+        {"action": action, "input": dict(_MINIMAL_INPUT[action]), "reasoning": "r"}
+    )
+
+    if action == "emanate":
+        # Empty batch: the engine's own validation refuses before any run dir.
+        assert result == {"status": "error", "message": "No tasks provided"}
+    elif action == "ask":
+        assert result == {"status": "error", "message": "Unknown emanation: em-1"}
+    else:
+        # ``reclaim`` is always a real receipt, and truthfully reports zero.
+        assert result["status"] == "reclaimed"
+        assert result["cancelled"] == 0
+    assert mgr._emanations == {}
+
+
+def test_reclaim_receipt_reaches_the_engine_with_no_input(tmp_path):
+    dispatcher, mgr = _dispatcher(tmp_path)
+
+    result = _call(dispatcher, "reclaim")
+
+    assert mgr.calls[0] == {"action": "reclaim"}
+    # The engine's own raw result is returned verbatim — no second envelope.
+    assert result["echo"] == {"action": "reclaim"}
+
+
+def test_emanate_validation_refusal_is_returned_verbatim(tmp_path):
+    """The engine's exact pre-run validation errors survive the new envelope,
+    including the ``system_prompt`` obsolescence message the open nested task
+    schema deliberately leaves to the engine."""
+    agent = make_daemon_agent(tmp_path, working_dir_name="emanate-validation")
+    handler = agent._tool_handlers["daemon"]
+
+    result = handler(
+        {
+            "action": "emanate",
+            "input": {
+                "tasks": [{"task": "t", "tools": ["file"], "system_prompt": "old"}],
+                "backend": None, "max_turns": None, "timeout": None,
+            },
+            "reasoning": "r",
+        }
+    )
+
+    assert result["status"] == "error"
+    assert "tasks[0].system_prompt is obsolete" in result["message"]
+    assert agent._capability_managers["daemon"]._emanations == {}
+
+
+# ---------------------------------------------------------------------------
+# The reserved manual child
+# ---------------------------------------------------------------------------
+
+def test_manual_returns_the_canonical_body_and_path_without_double_wrap(tmp_path):
+    agent = make_daemon_agent(tmp_path, working_dir_name="manual-agent")
+    body = "# daemon manual\n\nInspection patterns and polling cadence.\n"
+    manual_path = _install_daemon_manual(agent._working_dir, body)
+
+    result = agent._tool_handlers["daemon"](
+        {"action": "manual", "input": {}, "reasoning": "r"}
+    )
+
+    assert result["status"] == "ok"
+    assert result["content"] == [{"type": "text", "text": body}]
+    assert result["structuredContent"] == {"manual_path": str(manual_path)}
+    # No second wrapper: the child's canonical result IS the dispatch result.
+    assert "result" not in result and "manual" not in result
+
+
+def test_manual_missing_is_reported_degraded_not_silently_empty(tmp_path):
+    """A real Agent installs the manual at startup, so the degraded branch is
+    exercised against a working dir where it was never installed — the loader
+    must say so truthfully rather than return an empty body as ``ok``."""
+    dispatcher, _ = _dispatcher(tmp_path)
+
+    result = _call(dispatcher, "manual")
+
+    assert result["status"] == "degraded"
+    assert "daemon manual missing" in result["error"]
+    assert result["content"][0]["text"] == ""
+    assert result["structuredContent"]["manual_path"].endswith(
+        "/.library/intrinsic/capabilities/daemon/SKILL.md"
+    )
+
+
+def test_manual_performs_no_daemon_operation(tmp_path):
+    """The reserved ``manual`` reaches ``build_manual_child``'s loader only —
+    never the engine — so reading documentation cannot dispatch or cancel."""
+    dispatcher, mgr = _dispatcher(tmp_path)
+    _install_daemon_manual(tmp_path, "# daemon manual\n")
+
+    _call(dispatcher, "manual")
+
+    assert mgr.calls == []
+
+
+def test_family_manual_worked_examples_use_the_registered_envelope():
+    """The manual is mandated reading served by ``action="manual"``. Every
+    worked ``daemon(...)`` call across the manual tree must teach the envelope
+    the registered schema actually accepts, not the pre-migration flat shape."""
+    import re
+
+    manual_root = (
+        Path(__file__).resolve().parents[1]
+        / "src" / "lingtai" / "tools" / "daemon" / "manual"
+    )
+    files = sorted(manual_root.rglob("SKILL.md"))
+    assert files, "expected the installed daemon manual tree"
+
+    actions_seen: set[str] = set()
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        for call in re.findall(r"daemon\(action=[^)]*\)", text):
+            assert "input=" in call, f"{path.name} still teaches the flat shape: {call}"
+            match = re.search(r"""daemon\(action=['"]?(\w+)""", call)
+            if match:
+                actions_seen.add(match.group(1))
+
+    # The manual demonstrates the actions an operator actually calls.
+    assert {"emanate", "list", "ask", "check", "reclaim"} <= actions_seen
+    assert actions_seen <= set(_ACTIONS) | {"list"}
+
+
+def test_manual_documents_the_read_only_versus_side_effect_split():
+    manual = (
+        Path(__file__).resolve().parents[1]
+        / "src" / "lingtai" / "tools" / "daemon" / "manual" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "`list`, `check`, and `manual` are read-only" in manual
+    assert "`emanate`, `ask`, and `reclaim`" in manual
+    # The envelope itself is taught, including the summarize rename.
+    assert 'daemon(action="reclaim", input={}' in manual
+    assert "The optional root `summarize` boolean replaces the" in manual
+    assert "former flat `summary` field." in manual
+
+
+def test_manual_name_is_reserved_once_by_the_family(tmp_path):
+    """Registering a second ``manual`` child must fail at construction."""
+    from lingtai.tools.tool_family import ChildTool, ToolFamily
+
+    with pytest.raises(ToolFamilyError):
+        ToolFamily(
+            "daemon",
+            [
+                ChildTool("manual", MANUAL_INPUT_SCHEMA, lambda _i: {}, title="a"),
+                ChildTool("manual", MANUAL_INPUT_SCHEMA, lambda _i: {}, title="b"),
+            ],
+        )
+
+
+def test_the_engines_flat_manual_branch_is_not_the_model_facing_path(tmp_path):
+    """``DaemonManager.handle``'s own ``action='manual'`` branch is retained for
+    historical/internal flat callers, but the registered surface serves the
+    canonical ManualTool shape instead — the two must not both be model-facing."""
+    agent = make_daemon_agent(tmp_path, working_dir_name="manual-split")
+    body = "# daemon manual\n"
+    _install_daemon_manual(agent._working_dir, body)
+    mgr = agent._capability_managers["daemon"]
+
+    engine_result = mgr.handle({"action": "manual"})
+    model_result = agent._tool_handlers["daemon"](
+        {"action": "manual", "input": {}, "reasoning": "r"}
+    )
+
+    assert engine_result["manual"] == body           # legacy flat shape
+    assert "content" not in engine_result
+    assert model_result["content"][0]["text"] == body  # canonical shape
+    assert "manual" not in model_result
+
+
+# ---------------------------------------------------------------------------
+# Chat/Responses wire parity
+# ---------------------------------------------------------------------------
+
+def test_daemon_family_schema_survives_chat_and_responses_wires():
+    from lingtai.kernel.llm.base import FunctionSchema
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+    schema = FunctionSchema(name="daemon", description="daemon", parameters=get_schema())
+    chat = _build_tools([schema])[0]["function"]["parameters"]
+    responses = _build_responses_tools([schema])[0]["parameters"]
+
+    for wire, combinator in ((chat, "oneOf"), (responses, "anyOf")):
+        assert wire["type"] == "object"
+        assert wire["required"] == ["action", "input", "reasoning"]
+        assert wire["additionalProperties"] is False
+        assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert wire["properties"]["action"]["enum"] == _ACTIONS
+        branches = wire["properties"]["input"][combinator]
+        assert [b["title"] for b in branches] == [f"{a} input" for a in _ACTIONS]
+        for branch in branches:
+            assert branch["additionalProperties"] is False
+            for host_field in ("reasoning", "_reasoning", "summarize"):
+                assert host_field not in branch["properties"]
+
+
+def test_responses_wire_preserves_the_root_action_input_correlation():
+    """The root ``allOf``/``if``/``then`` correlation must survive the Responses
+    scrubber, so a mismatched action/input pairing is refusable schema-side on
+    both wires — dispatch remains authoritative regardless."""
+    from lingtai.kernel.llm.base import FunctionSchema
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+    schema = FunctionSchema(name="daemon", description="daemon", parameters=get_schema())
+    chat = _build_tools([schema])[0]["function"]["parameters"]
+    responses = _build_responses_tools([schema])[0]["parameters"]
+
+    for wire in (chat, responses):
+        assert [c["if"]["properties"]["action"]["const"] for c in wire["allOf"]] == _ACTIONS
+        emanate_condition = wire["allOf"][0]["then"]["properties"]["input"]
+        assert set(emanate_condition["properties"]) == {
+            "tasks", "backend", "max_turns", "timeout"
+        }
+        ask_condition = wire["allOf"][2]["then"]["properties"]["input"]
+        assert set(ask_condition["properties"]) == {"id", "message"}
+        # The complex nested emanate task object survives both wires intact.
+        task_items = emanate_condition["properties"]["tasks"]["items"]
+        assert set(task_items["properties"]) == {
+            "task", "tools", "skills", "mcp", "preset", "backend_options",
+            "prompt", "context_token_limit",
+        }
+
+
+def test_nested_emanate_task_schema_is_identical_on_both_wires():
+    from lingtai.kernel.llm.base import FunctionSchema
+    from lingtai.llm.openai.adapter import _build_responses_tools, _build_tools
+
+    schema = FunctionSchema(name="daemon", description="daemon", parameters=get_schema())
+    chat = _build_tools([schema])[0]["function"]["parameters"]
+    responses = _build_responses_tools([schema])[0]["parameters"]
+
+    chat_task = chat["properties"]["input"]["oneOf"][0]["properties"]["tasks"]["items"]
+    responses_task = (
+        responses["properties"]["input"]["anyOf"][0]["properties"]["tasks"]["items"]
+    )
+
+    assert chat_task["properties"]["backend_options"]["description"] == (
+        responses_task["properties"]["backend_options"]["description"]
+    )
+    assert chat_task["required"] == responses_task["required"] == ["task", "tools"]
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting Host surfaces
+# ---------------------------------------------------------------------------
+
+def test_daemon_is_a_migrated_family_for_the_single_central_summarizer():
+    """``summarize`` is recognized for ``daemon`` by the one existing central
+    summarizer — no second summarizer and no daemon-specific mechanism. A
+    family advertising ``summarize`` without joining that allowlist would ship
+    a model-visible control the kernel silently ignores."""
+    from lingtai.kernel.tool_result_summary import summary_requested
+
+    assert summary_requested({"summarize": True}, "daemon") is True
+    assert summary_requested({"summarize": False}, "daemon") is False
+    assert summary_requested({}, "daemon") is False
+    # The legacy flat spelling stays honored for any historical/pending call.
+    assert summary_requested({"summary": True}, "daemon") is True
+
+
+def test_schema_no_longer_advertises_the_legacy_flat_summary_boolean():
+    """The result-summarization control is the canonical root ``summarize``;
+    the pre-migration flat ``summary`` field is off the public schema."""
+    schema = get_schema()
+
+    assert "summary" not in schema["properties"]
+    for action in _ACTIONS:
+        assert "summary" not in daemon_action_input_schema(action)["properties"]
+
+
+def test_child_schema_ceilings_match_the_engine_constants():
+    """The two engine ceilings ``_tool_family`` restates are import-time
+    asserted; prove the assertion's subjects are actually equal."""
+    from lingtai.tools.daemon import _tool_family
+
+    assert _tool_family.DEFAULT_MAX_TURNS == daemon_pkg.DEFAULT_MAX_TURNS
+    assert _tool_family.CHECK_LAST_MAX == daemon_pkg.DaemonManager._CHECK_LAST_MAX
+
+
+def test_module_level_child_specs_are_the_single_registry_source():
+    """The schema-only family and the dispatcher's handler-bound family must be
+    built from one spec source, so composition and dispatch cannot drift."""
+    dispatcher, _ = _dispatcher(Path("/tmp"))
+
+    assert dispatcher._family.child_names == DAEMON_ACTIONS
+    assert dispatcher._family.has_manual()
+    for action, schema in (
+        ("list", LIST_INPUT_SCHEMA), ("ask", ASK_INPUT_SCHEMA),
+        ("check", CHECK_INPUT_SCHEMA), ("reclaim", RECLAIM_INPUT_SCHEMA),
+    ):
+        assert daemon_action_input_schema(action) == {
+            "title": f"{action} input", **schema
+        }

--- a/tests/test_wire_tool_description.py
+++ b/tests/test_wire_tool_description.py
@@ -257,7 +257,14 @@ def test_openai_responses_preserves_daemon_backend_options_passthrough_schema():
     tools = _build_responses_tools([
         FunctionSchema(name="daemon", description="daemon", parameters=get_schema())
     ])
-    backend_options = tools[0]["parameters"]["properties"]["tasks"]["items"][
+    # Post-ToolFamily migration ``tasks`` lives inside ``emanate``'s own
+    # ``input`` branch; the nested passthrough schema below is unchanged.
+    emanate_branch = next(
+        branch
+        for branch in tools[0]["parameters"]["properties"]["input"]["anyOf"]
+        if branch["title"] == "emanate input"
+    )
+    backend_options = emanate_branch["properties"]["tasks"]["items"][
         "properties"
     ]["backend_options"]
 


### PR DESCRIPTION
## Summary

Migrate the single model-facing `daemon` tool to the LTP v2 ToolFamily envelope while keeping the Daemon engine and public tool slot unchanged.

- Keep exactly one registered public tool named `daemon` (`12 → 12` real-Agent tool count).
- Compose six canonical strict children: `emanate`, `list`, `ask`, `check`, `reclaim`, and `manual`.
- Register the root envelope as `action + input + reasoning + summarize`; host fields never enter child input or the engine.
- Translate each validated child input back to the existing flat `DaemonManager.handle()` shape. No engine method body changes.
- Route `manual` through the shared canonical Manual child, with the same installed body/path and no double wrap.
- Add `daemon` to the migrated summarization allowlist so `summarize` is honored while legacy `summary` remains supported for every caller.
- Preserve the merged #1055 all-empty recovery and #1056 context/overflow behavior.

**Explicit non-goal:** #1021 remains open and untouched. This PR does not copy or change its text-only completion/replay policy.

## Post-System #1075 rebase and combined acceptance

Jason explicitly authorized the serial sequence in Telegram `10995`: merge System #1075 first, then rebase, validate, refresh-smoke, update, and merge Daemon #1074. System #1075 merged first as main `454534c3cf8c06fa185e533b5c66b2b8fba7e8a9` (tree `49b7d85b1211c08dec5cb16af1a2c8cecaa18639`).

- Rebased the prior exact source `4c996ef8b054c41cdadb948321b607bed249a913` onto that main. New exact head: `0462356b8f34954a2fd0b5f9620dd3233be09377`; tree: `c4bf893cdc9135a7869338f08881688ea5f6c37e`; parent: exact System merge `454534c3...`. The one canonical Huang commit and source branch are preserved.
- Four real shared-file conflicts occurred in `kernel/tool_result_summary.py`, `tools/CONTRACT.md`, and the ToolFamily `ANATOMY.md` / `CONTRACT.md`. A first daemon (`em-b0aa`) failed before editing because the dev1-scoped source hook fresh-imported a conflict-marker Python file; its failed run remains preserved. A direct, mechanically verified Claude Sonnet 5 run then made the semantic union. Parent review caught and fixed its missed textual `system` summarize-allowlist entry and related-files ordering.
- Combined changed-test union for System + Daemon: **659 passed in 56.33s** across 20 test files. Docs governance: **279 documents passed**. `compileall`, `git diff --check`, and final clean-worktree checks passed.
- Authorized `system.refresh` loaded the exact rebased head/tree and six-action public Daemon schema from the scoped worktree. A fresh actual public run `em-ab08` / group `dg-20260728-003520-f22968` performed one 15.043-second shell call (exit 0, exact stdout `PR1074_REBASED_LIVE_DONE`), one `finish(done)`, and one terminal push.
- One public `ask` produced exactly one request file, one done receipt, one user follow-up marker, and one assistant acknowledgement `PR1074_REBASED_FOLLOWUP`; both execution/supervisor stderr logs were empty and both child PIDs were dead while the parent Agent stayed alive. Public `reclaim` then cancelled zero.
- The dedicated branch was updated from the exact old head to the exact rebased head with an exact-old-head `--force-with-lease`; GitHub and the remote branch both verified the new tested head. No branch, worktree, hook, run, stash, memory, or evidence cleanup occurred.

## Surface and ownership

The model still sees one `daemon` slot. The six actions are internal children of that family and do not become separate tools or aliases.

| Layer | Ownership after this PR |
|---|---|
| Public root | `action`, `input`, required `reasoning`, optional `summarize` |
| Child schemas | Closed, action-specific inputs derived from one registry |
| Runtime behavior | Existing `DaemonManager` engine, unchanged |
| Manual | Reserved family-owned `manual`, strict empty input |
| Presentation | Existing Host raw-first summarization pipeline |

The nested `emanate.tasks.items` schema is byte-identical to the exact base, including all eight task fields, bounds, and `backend_options` passthrough. Nullable public fields continue to mean “use the existing engine default”; falsy values such as `truncate: 0` and `include_done: false` are preserved.

## Change size

| Category | Added | Deleted | Net | Paths |
|---|---:|---:|---:|---:|
| Production Python | 464 | 151 | +313 | 3 |
| Tests | 972 | 40 | +932 | 13 |
| Docs/manual/contracts | 239 | 66 | +173 | 15 |
| **Total** | **1,675** | **257** | **+1,418** | **31** |

The +313 executable LOC is the six strict schemas plus the translation dispatcher replacing one open 13-field root. There is no public compatibility alias or second root, and the ~13k-line engine remains unchanged.

## Validation

### Parent gates

- Exact base/main before commit: `7023588cb586b8f7170f2f74dce76be91561f0ef`, tree `b080be8bc49eecba3900f6e757939b909fa61a86`.
- `git diff --check`: pass.
- `py_compile` over changed Python: pass.
- Docs governance: **279 documents validated**.
- Exact Daemon + ToolFamily + wire + a-priori union: **1,030 passed, 7 skipped**.
- Frozen patch SHA-256: `0711f41040e4c00f7eefb360e393a685f40ebb8915c82be8380660bfedff83c6`.
- Frozen manifest SHA-256: `b2a92ac1652e2ebeab3505d6104520ba4994ac2f33a71caea489a247ec9c24cb`; all 31 candidate files match it.

### Author run — exact Claude Opus 5

- New migration file: **68 passed**.
- Daemon + ToolFamily + wire + a-priori + docs union: **1,190 passed, 7 skipped**.
- Full suite: **6,582 passed, 28 skipped, 5 failed**.
  - Four failures reproduce at the untouched base: migration-version metadata, resolved-manifest redaction, a non-Daemon skill timestamp, and the Rust-sidecar wheel smoke.
  - The fifth rotated between two load-timing tests across consecutive runs; each passed repeatedly in isolation.
  - The optional `msal` collection gap also exists at base; the run used a `/tmp` test-only stub, outside the worktree.

### Independent review — exact Claude Fable 5

**APPROVE_WITH_NONBLOCKING_NOTES; zero P0/P1 blockers.** The reviewer independently:

- re-hashed patch/manifest and all **31/31** files;
- applied the frozen patch to a pristine `git archive` of the base and reproduced the worktree byte-for-byte;
- measured a real Agent before/after as `12 → 12`, with one `daemon`;
- ran **710 Daemon tests (7 skipped)**, **320 ToolFamily/wire/a-priori tests**, **76 focused tests**, **84 #1055/#1056 preservation tests**, and docs governance;
- ran 15 adversarial dispatcher probes with zero engine leakage;
- verified Chat/Responses schema parity, manual no-double-wrap, risk/receipt truth, and #1021 absence.

### Isolated real-process acceptance

A Parent-owned pytest harness routed the new **public envelope** through a real detached supervisor process in disposable `tmp_path` state:

`emanate → fresh-manager ask → agent-stop survival → check(done) → list → reclaim`

Result: **1 passed in 5.18s**. The supervisor became the durable owner, `ask` returned one sent receipt, parent stop cancelled zero children, terminal state reached `done`, a fresh manager found the run, reclaim cancelled zero completed children, and the inline sentinel was absent from durable state. The shared runtime was not touched.

The first harness invocation used the wrong absolute test-only `PYTHONPATH`, so the detached child could not register the fake adapter and truthfully ended `failed` in 0.389s. Inspection proved the candidate unchanged; correcting the scratch harness path only produced the passing run above.

### Actual running-Agent checkout + refresh acceptance — correction

**Acceptance clarification:** when Jason asked whether this Agent itself had checkout+refresh-tested the PR, the answer was initially **no**. The section above was a real detached-process pytest harness, not mimo-1 loading the candidate as its own runtime. The earlier delivery language implied too much; that gap was disclosed immediately and then corrected with the following separate acceptance.

- Activated exact head `4c996ef8b054c41cdadb948321b607bed249a913`, tree `7ba36837f9dbe89ed17770698292d8f7e6071a6f`, in dev1/mimo-1 only through a new reversible conditional `.pth` hook. The pre-existing #1035 hook was preserved.
- After `system.refresh`, the managed runtime mechanically imported `lingtai`, `lingtai.kernel`, and `lingtai.tools.daemon` from this exact worktree. The live root schema was exactly `action / input / reasoning / summarize`, required `action / input / reasoning`, with exactly six actions.
- From the refreshed Agent's actual model-facing public `daemon` tool, exercised all six actions: `manual`, `list`, `emanate`, `ask`, `check`, and `reclaim`. Manual returned canonical `content[0].text` plus `structuredContent.manual_path` with no double wrap.
- Deliberately sent one wrong-branch `list` input and received `INVALID_ARGUMENT: unsupported daemon input field`; a valid `list` immediately recovered and proved no run was created.
- Disposable live run `em-daee` / group `dg-20260728-000151-136503` executed exactly one synchronous 20-second shell call, exit 0, exact stdout `PR1074_LIVE_DONE`, then one `daemon_common.finish(done)`.
- One public `ask` produced one queued receipt, one user follow-up entry, and one assistant acknowledgement `PR1074_LIVE_FOLLOWUP`; no duplicate marker or pending follow-up remained. The final result correctly reflects the follow-up acknowledgement, while `daemon_completion.json` and events preserve the prior successful finish summary.
- Public `check` observed `running/current_tool=shell` and later `done`; filtered `list` observed the same lifecycle; the terminal push fired once; terminal `reclaim` cancelled zero. Supervisor/execution stderr were empty, their PIDs were dead, the parent Agent remained alive, and all evidence stayed preserved.
- Final candidate worktree remained clean at the exact head/tree. No code, peer, shared config, branch, worktree, or runtime evidence was changed or cleaned.

Durable local receipt: `scratch/daemon-pr1074-live-agent-receipt-20260727.json` (SHA-256 `16831794927ec360b4c68e9b0f8114ae8d7cc796bf8ba68a97f4fdcc78c0215e`) and `.md` (SHA-256 `f788b3d69c4b0546b1a757736f798efcdb12abc7339452d5c7baab49e8013e66`).

## Process incidents and candidate integrity

These are disclosed rather than cleaned up:

1. The Opus author used `git stash push -u --keep-index` / `stash pop` despite the no-Git-mutation worker boundary. It immediately restored the candidate. The pre-existing unrelated Skills stash remains present and untouched.
2. The Opus author wrote/edited Claude memory outside its sole permitted report path.
3. The Fable reviewer also wrote/edited Claude memory outside its read-only report boundary after completing the review.

None of those paths enter this repository candidate. Integrity is independently byte-closed: exact base + frozen patch reproduces the 31-path worktree, all file hashes match, HEAD/tree were unchanged until the canonical commit, and every relevant gate is green. The incident artifacts remain preserved; no stash, memory, branch, worktree, or evidence cleanup is part of this PR.

## Intentional decisions

- Keep the nested `emanate` task object open so the unchanged engine preserves its richer domain errors.
- Keep nullable `backend` spelling in the strict schema to express the existing default.
- Keep the two-line internal engine `manual` branch; it is not model-reachable, mirrors the Shell precedent, and deleting it was outside the approved migration contract.
- Correct stale in-place Daemon/ToolFamily docs while rewriting the same sections.
- Do not modify external MCP, other families, completion policy, replay policy, process ownership, cancellation, or terminal notification behavior.

## Risk and rollback

Risk is concentrated in schema composition and envelope-to-engine translation, not in process behavior: the engine is unchanged and the old flat model-facing root is intentionally rejected. The focused, full, adversarial, wire, and real-process gates above cover that boundary. Rollback is a single PR revert; no data migration or configuration change is required.

## Authorization boundary

Jason explicitly authorized the serial rebase+merge sequence in Telegram `10995`; merge remains conditional on the exact rebased head, successful combined/runtime gates, green required GitHub checks, and unchanged main. This does **not** authorize release, branch/worktree/hook/run/stash/memory/evidence cleanup, or #1021 changes.

