### PR TITLE
feat(telegram): show tool actions in task cards

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2257,6 +2257,9 @@ class TelegramManager:
             # The ellipsis itself must stay inside the cap, not extend past it.
             reasoning = reasoning[:cap - 1] + "…"
         row = {"tool": tool_name, "reasoning": reasoning}
+        action = tool_args.get("action")
+        if isinstance(action, str) and action:
+            row["tool_action"] = action
         started_at = TelegramManager._format_task_card_row_timestamp(event.get("ts"))
         if started_at:
             row["started_at"] = started_at

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -103,9 +103,10 @@ data source. Normative promises live in the paired [`CONTRACT.md`](CONTRACT.md).
 ## Automatic event-tail projection paths
 
 - **Rows/timestamps:** after validating `type == "tool_call"`,
-  `_project_tool_call_row` reads only `tool_name`, redacted/bounded
-  `tool_args._reasoning`, and top-level Unix-epoch `ts`; raw action is excluded.
-  `_format_task_card_row_timestamp` projects a valid value as optional
+  `_project_tool_call_row` reads only `tool_name`, a non-empty string
+  `tool_args.action` projected as `tool_action`, redacted/bounded
+  `tool_args._reasoning`, and top-level Unix-epoch `ts`; all other raw arguments
+  are excluded. `_format_task_card_row_timestamp` projects a valid value as optional
   `started_at` in `HH:MM:SS UTC±HH`; missing, boolean, non-numeric, non-finite,
   or out-of-range values omit it. `_meta`, row arguments, notifications, and
   render time are never timestamp sources. Navigation:

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -168,8 +168,9 @@ the procedure lives in [`SKILL.md`](SKILL.md), not here:
     `ensure` once; the existing account `task_cards` id is rehydrated on restart
     and updated in place. Explicit `taskcard: false` suppresses presentation;
     explicit on notifies the resident and reprojects the same id exactly once.
-12. Automatic events accept only canonical public `diary` text and tool name plus
-    redacted/bounded `_reasoning`; raw action/arguments/results are excluded.
+12. Automatic events accept only canonical public `diary` text and tool name, a
+    non-empty string `tool_args.action` projected as `tool_action`, plus
+    redacted/bounded `_reasoning`; all other raw arguments/results are excluded.
     Hidden thinking, system prompts, raw tool args/results, auth/secrets, and
     private runtime logs never reach the card. Rows/text are redacted and bounded.
     Events sharing one provider `api_call_id` form one render group and produce
@@ -336,8 +337,9 @@ The automatic slot is a bounded projection of the agent's authoritative
 one source of truth for each projection axis:
 
 1. **Tool rows and timestamps.** A row is projected only from a validated
-   `type == "tool_call"` event. Its allowlisted fields are `tool_name` and
-   redacted/capped `tool_args._reasoning`; raw `action` is excluded. Its optional
+   `type == "tool_call"` event. Its allowlisted fields are `tool_name`, a
+   non-empty string `tool_args.action` projected as `tool_action`, and
+   redacted/capped `tool_args._reasoning`; all other raw arguments are excluded. Its optional
    `started_at` is derived only from that same event's top-level Unix-epoch `ts`
    and uses `HH:MM:SS UTC±HH`. Missing, boolean, non-numeric, non-finite, or
    out-of-range `ts` omits `started_at` without failing the tail. `_meta`, row

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -222,7 +222,7 @@ def test_restart_rehydrates_latest_n_from_tail_without_checkpoint_file(tmp_path)
 # ---------------------------------------------------------------------------
 
 
-def test_provider_groups_count_calls_and_exclude_private_fields(tmp_path):
+def test_provider_groups_count_calls_and_exclude_unprojected_fields(tmp_path):
     acct = FakeAccount()
     manager, service = _manager(tmp_path, acct)
     _pre_resident(acct, 555, manager)
@@ -231,11 +231,11 @@ def test_provider_groups_count_calls_and_exclude_private_fields(tmp_path):
     events = [
         {"type": "diary", "api_call_id": "api-1", "text": "text one"},
         {"type": "tool_call", "api_call_id": "api-1", "tool_name": "bash",
-         "tool_args": {"action": "ACTION_SECRET_ONE", "_reasoning": "safe one"}},
+         "tool_args": {"action": "run", "_reasoning": "safe one"}},
         {"type": "assistant_text", "api_call_id": "api-1", "text": "ALIAS_SECRET"},
         {"type": "diary", "api_call_id": "api-2", "text": visible},
         {"type": "tool_call", "api_call_id": "api-2", "tool_name": "read",
-         "tool_args": {"action": "ACTION_SECRET_TWO", "command": "ARG_SECRET",
+         "tool_args": {"action": "read", "command": "ARG_SECRET",
                        "_reasoning": "safe two"}},
         {"type": "thinking", "api_call_id": "api-2", "text": "THINKING_SECRET"},
         {"type": "tool_result", "api_call_id": "api-2", "result": "RESULT_SECRET"},
@@ -245,18 +245,17 @@ def test_provider_groups_count_calls_and_exclude_private_fields(tmp_path):
     rendered = [call for call in acct.calls if call[0] == "edit_message"][-1][3]
     divider = manager._TASK_CARD_API_CALL_DIVIDER
     assert rendered.count(divider) == 2
-    assert all(value in rendered for value in ("text one", "• bash:", "text two", "• read:"))
+    assert all(value in rendered for value in ("text one", "• bash.run:", "text two", "• read.read:"))
     assert len(rendered) <= manager._TASK_CARD_TEXT_LIMIT
     assert all(secret not in rendered for secret in (
-        "ACTION_SECRET_ONE", "ACTION_SECRET_TWO", "ARG_SECRET", "ALIAS_SECRET",
-        "THINKING_SECRET", "RESULT_SECRET",
+        "ARG_SECRET", "ALIAS_SECRET", "THINKING_SECRET", "RESULT_SECRET",
     ))
 
     service.normal_rows = 1
     manager._broadcast_task_card_event_window()
     latest = acct.calls[-1][3]
-    assert latest.count(divider) == 1 and "text two" in latest and "• read:" in latest
-    assert "text one" not in latest and "• bash:" not in latest
+    assert latest.count(divider) == 1 and "text two" in latest and "• read.read:" in latest
+    assert "text one" not in latest and "• bash.run:" not in latest
 
 
 def test_non_whitelisted_event_types_are_skipped(tmp_path):
@@ -439,9 +438,9 @@ def test_only_safe_bounded_fields_are_projected(tmp_path):
     window = manager._task_card_event_window()
     assert len(window) == 1
     row = window[0]
-    assert set(row.keys()) <= {"tool", "reasoning", "started_at"}
+    assert set(row.keys()) <= {"tool", "tool_action", "reasoning", "started_at"}
     assert row["tool"] == "bash"
-    assert "tool_action" not in row
+    assert row["tool_action"] == "run"
     assert row["reasoning"] == "safe text"
 
     manager._poll_event_tail()
@@ -450,6 +449,36 @@ def test_only_safe_bounded_fields_are_projected(tmp_path):
     assert "sk-should-never-appear" not in rendered
     assert "/very/secret/path" not in rendered
     assert "--token=abc123" not in rendered
+
+
+def test_tool_call_action_is_rendered_as_tool_action():
+    event = json.loads(_tool_call_line(tool_name="knowledge", action="info"))
+    row = TelegramManager._project_tool_call_row(event)
+
+    assert row["tool_action"] == "info"
+    rendered = TelegramManager._format_task_card_text("", "", "", rows=[row])
+    assert "• knowledge.info: doing a thing" in rendered
+
+
+def test_tool_call_without_action_preserves_tool_label():
+    event = json.loads(_tool_call_line(tool_name="edit"))
+    del event["tool_args"]["action"]
+    row = TelegramManager._project_tool_call_row(event)
+
+    assert "tool_action" not in row
+    rendered = TelegramManager._format_task_card_text("", "", "", rows=[row])
+    assert "• edit: doing a thing" in rendered
+
+
+def test_empty_none_and_non_string_actions_do_not_add_suffix():
+    for action in ("", None, 0, False, []):
+        event = json.loads(_tool_call_line(tool_name="system"))
+        event["tool_args"]["action"] = action
+        row = TelegramManager._project_tool_call_row(event)
+
+        assert "tool_action" not in row
+        rendered = TelegramManager._format_task_card_text("", "", "", rows=[row])
+        assert "• system: doing a thing" in rendered
 
 
 # ---------------------------------------------------------------------------
@@ -544,7 +573,7 @@ def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tm
     edits = [call for call in acct.calls if call[0] == "edit_message"]
     assert edits
     rendered = edits[-1][3]
-    assert "• bash: event-log row" in rendered
+    assert "• bash.run: event-log row" in rendered
     assert f" · {expected_stamp}" in rendered
     assert "session · cache 87.8% · miss 170.6k/1.0M · calls 13" in rendered
     assert "ctx · 171.2k/272.0k · 63%" in rendered


### PR DESCRIPTION
## Summary

- project a non-empty string `tool_args.action` into the automatic Task Card row's existing safe `tool_action` field
- render those rows as `tool.action`, while missing, empty, `None`, and non-string actions keep the existing `tool` label
- synchronize the governed Task Card Contract/Anatomy and keep every other raw tool argument excluded

This is presentation-only: it does not change tool invocation, arguments, lifecycle, transport, state, timing, row grouping, redaction, or the programmable Task Card channel.

## Validation

- `python -m pytest -q tests/test_task_card_controller.py tests/test_telegram_task_card.py tests/test_telegram_task_card_api_error.py tests/test_telegram_task_card_batch.py tests/test_telegram_task_card_blockers.py tests/test_telegram_task_card_event_tail.py tests/test_telegram_task_card_in_place.py tests/test_telegram_task_card_last_message.py tests/test_telegram_task_card_programmable.py tests/test_telegram_task_card_result_hook.py tests/test_telegram_task_card_rows.py tests/test_telegram_task_card_singleton.py tests/test_telegram_task_card_state.py tests/test_telegram_task_card_timestamp.py tests/test_telegram_task_card_toggle.py tests/test_telegram_task_card_transport.py tests/test_telegram_account_last_message_id.py` — **291 passed**
- `python -m pytest -q tests/test_architecture_documents.py tests/test_mcp_skill_manuals.py` — **26 passed**
- `python -m py_compile src/lingtai/mcp_servers/telegram/manager.py tests/test_telegram_task_card_event_tail.py` — PASS
- `ruff check --select E9,F src/lingtai/mcp_servers/telegram/manager.py tests/test_telegram_task_card_event_tail.py` — PASS
- `git diff --check` — PASS
