### PR TITLE
fix(telegram): fail fast on Bot API rate limits

### DIFF
--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -8,8 +8,8 @@ description: |
   the programmable Task Card (task_card tool) — including task-specific watcher
   design for meaningful long-running work — and error surfacing. Pulled on demand
   via action='manual'; you do not need to call it before every send.
-version: 1.5.2
-last_changed_at: 2026-07-19T00:00:00Z
+version: 1.5.3
+last_changed_at: 2026-07-28T00:00:00Z
 related_files:
 - src/lingtai/mcp_servers/ANATOMY.md
 - src/lingtai/mcp_servers/telegram/manager.py
@@ -307,6 +307,12 @@ chat-history cardinality. Normative source:
   failure (e.g. missing `chat_id`, unreadable `media.path`, bad `parse_mode`).
   Check for the `'error'` key and surface or act on it rather than assuming the
   message was delivered.
+- Telegram HTTP 429 responses fail fast with `status: 'error'`,
+  `error_code: 429`, `retryable: false`, and the provider's numeric
+  `retry_after` when Telegram supplied one. Wait at least that many seconds and
+  do not retry the action automatically. The addon never sleeps inside the tool
+  call or schedules a hidden second side effect; missing or malformed cooldown
+  metadata is omitted rather than replaced with a guessed default.
 - The hosted Telegram Bot API limits `getFile` downloads to 20 MB. If an inbound
   document cannot be downloaded, `read` retains its available Telegram metadata
   without a local path, adds a safe bounded provider reason in `download_error`,

--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -12,7 +12,6 @@ import logging
 import os
 import tempfile
 import threading
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -27,6 +26,38 @@ httpx: Any = None
 
 _API_BASE = "https://api.telegram.org/bot{token}/{method}"
 _FILE_BASE = "https://api.telegram.org/file/bot{token}/{file_path}"
+
+
+class TelegramRateLimitError(RuntimeError):
+    """Telegram rejected one request with HTTP 429.
+
+    ``retry_after`` is copied only when Telegram supplied a valid integer number
+    of seconds.  Missing or malformed provider metadata stays ``None``; callers
+    must never invent a cooldown or schedule an automatic retry.
+    """
+
+    error_code = 429
+
+    def __init__(self, retry_after: int | None) -> None:
+        self.retry_after = retry_after
+        message = "Telegram API rate limited"
+        if retry_after is not None:
+            message += f"; retry after {retry_after} seconds"
+        super().__init__(message)
+
+
+def _retry_after_from_payload(payload: Any) -> int | None:
+    """Return Telegram's valid integer cooldown without coercion or defaults."""
+    if not isinstance(payload, dict):
+        return None
+    parameters = payload.get("parameters")
+    if not isinstance(parameters, dict):
+        return None
+    retry_after = parameters.get("retry_after")
+    if type(retry_after) is not int or retry_after < 0:
+        return None
+    return retry_after
+
 
 # Default slash commands registered with @BotFather via setMyCommands on
 # bot startup. Override per-account via the "commands" config field.
@@ -218,14 +249,23 @@ class TelegramAccount:
             self._client = httpx.Client(timeout=httpx.Timeout(60.0, connect=10.0))
 
     def _request(self, method: str, **kwargs: Any) -> dict:
-        """Make a Bot API request. Returns the 'result' field or raises."""
+        """Make one Bot API request. Returns the result or raises immediately."""
         self._ensure_client()
         resp = self._client.post(self._api_url(method), **kwargs)
         if resp.status_code == 429:
-            retry_after = resp.json().get("parameters", {}).get("retry_after", 5)
-            logger.warning("Rate limited, sleeping %ds", retry_after)
-            time.sleep(retry_after)
-            resp = self._client.post(self._api_url(method), **kwargs)
+            try:
+                data = resp.json()
+            except Exception:
+                data = None
+            retry_after = _retry_after_from_payload(data)
+            if retry_after is None:
+                logger.warning("Telegram rate limited the request without a valid retry_after")
+            else:
+                logger.warning(
+                    "Telegram rate limited the request; retry_after=%d seconds",
+                    retry_after,
+                )
+            raise TelegramRateLimitError(retry_after)
         data = resp.json()
         if not data.get("ok"):
             raise RuntimeError(f"Telegram API error: {data.get('description', data)}")

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -28,6 +28,7 @@ import threading
 
 from .. import _skill
 from . import updates as tg_updates
+from .account import TelegramRateLimitError
 from .task_card.resident import TaskCardResident
 
 if TYPE_CHECKING:
@@ -680,6 +681,21 @@ class TelegramManager:
                 return self._handle_task_card_update(args)
             else:
                 return {"error": f"Unknown telegram action: {action}"}
+        except TelegramRateLimitError as exc:
+            result: dict[str, Any] = {
+                "status": "error",
+                "error": str(exc),
+                "error_code": exc.error_code,
+                "retryable": False,
+                "guidance": "Do not retry this Telegram action automatically.",
+            }
+            if exc.retry_after is not None:
+                result["retry_after"] = exc.retry_after
+                result["guidance"] = (
+                    "Do not retry this Telegram action for at least "
+                    f"{exc.retry_after} seconds."
+                )
+            return result
         except Exception as e:
             return {"error": str(e)}
 

--- a/tests/test_telegram_rate_limit.py
+++ b/tests/test_telegram_rate_limit.py
@@ -1,0 +1,142 @@
+"""Focused contract tests for Telegram Bot API 429 handling."""
+
+from pathlib import Path
+import time
+from unittest.mock import Mock
+
+import pytest
+
+from lingtai.mcp_servers.telegram.account import (
+    TelegramAccount,
+    TelegramRateLimitError,
+)
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+from tests._notification_store_helpers import notification_store_for
+
+
+class _Response:
+    status_code = 429
+
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.json_calls = 0
+
+    def json(self) -> object:
+        self.json_calls += 1
+        return self.payload
+
+
+class _Client:
+    def __init__(self, response: _Response) -> None:
+        self.response = response
+        self.calls: list[tuple[str, dict]] = []
+
+    def post(self, url: str, **kwargs: object) -> _Response:
+        self.calls.append((url, kwargs))
+        return self.response
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_retry_after"),
+    [
+        ({"parameters": {"retry_after": 37}}, 37),
+        ({}, None),
+        ({"parameters": {"retry_after": "37"}}, None),
+        ({"parameters": {"retry_after": True}}, None),
+        ({"parameters": {"retry_after": -1}}, None),
+    ],
+)
+def test_429_fails_fast_without_sleep_or_second_request(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: object,
+    expected_retry_after: int | None,
+) -> None:
+    response = _Response(payload)
+    client = _Client(response)
+    account = TelegramAccount(
+        alias="bot",
+        bot_token="123:test",
+        allowed_users=None,
+        state_dir=tmp_path,
+    )
+    account._client = client
+    sleep = Mock()
+    monkeypatch.setattr(time, "sleep", sleep)
+
+    with pytest.raises(TelegramRateLimitError) as caught:
+        account._request("sendMessage", json={"chat_id": 123, "text": "hello"})
+
+    assert caught.value.error_code == 429
+    assert caught.value.retry_after == expected_retry_after
+    assert client.calls == [
+        (
+            "https://api.telegram.org/bot123:test/sendMessage",
+            {"json": {"chat_id": 123, "text": "hello"}},
+        )
+    ]
+    assert response.json_calls == 1
+    sleep.assert_not_called()
+
+
+class _RateLimitedAccount:
+    alias = "bot"
+
+    def __init__(self, retry_after: int | None) -> None:
+        self.retry_after = retry_after
+        self.calls = 0
+
+    def send_message(self, *_args: object, **_kwargs: object) -> dict:
+        self.calls += 1
+        raise TelegramRateLimitError(self.retry_after)
+
+
+class _Service:
+    def __init__(self, retry_after: int | None) -> None:
+        self.default_account = _RateLimitedAccount(retry_after)
+
+    def get_account(self, alias: str) -> _RateLimitedAccount:
+        assert alias == "bot"
+        return self.default_account
+
+
+@pytest.mark.parametrize("retry_after", [41, None])
+def test_manager_serializes_rate_limit_without_persisting_a_send(
+    tmp_path: Path,
+    retry_after: int | None,
+) -> None:
+    service = _Service(retry_after)
+    manager = TelegramManager(
+        service,
+        working_dir=tmp_path,
+        on_inbound=lambda _: None,
+        notification_store=notification_store_for(tmp_path),
+    )
+
+    result = manager.handle({
+        "action": "send",
+        "account": "bot",
+        "chat_id": 123,
+        "text": "hello",
+    })
+
+    expected = {
+        "status": "error",
+        "error": "Telegram API rate limited",
+        "error_code": 429,
+        "retryable": False,
+        "guidance": "Do not retry this Telegram action automatically.",
+    }
+    if retry_after is not None:
+        expected.update({
+            "error": f"Telegram API rate limited; retry after {retry_after} seconds",
+            "retry_after": retry_after,
+            "guidance": (
+                "Do not retry this Telegram action for at least "
+                f"{retry_after} seconds."
+            ),
+        })
+
+    assert result == expected
+    assert service.default_account.calls == 1
+    assert not (tmp_path / "telegram" / "bot" / "sent").exists()


### PR DESCRIPTION
## Summary

Fail fast when Telegram returns Bot API HTTP 429 instead of sleeping inside the MCP side-effect handler and issuing a hidden second request.

## Root cause

`TelegramAccount._request()` previously read `parameters.retry_after` with a fabricated 5-second default, called `time.sleep(retry_after)`, and retried the same outbound request once. The outer MCP call times out after 120 seconds, so a longer Telegram cooldown was hidden from the agent while the abandoned handler could later perform a second side effect.

## Change

- add one Telegram-owned `TelegramRateLimitError` carrying only a valid provider-supplied integer `retry_after`;
- remove the internal sleep and automatic retry: one tool action now makes exactly one Bot API request;
- serialize 429 through `TelegramManager.handle()` as `status: error`, `error_code: 429`, `retryable: false`, and numeric `retry_after` when present, with explicit wait/no-auto-retry guidance;
- update the Telegram MCP manual with the observable error contract;
- add focused regressions for one request, zero `time.sleep`, missing/malformed cooldown truthfulness, manager serialization, and no false sent persistence.

## Validation before Draft

- `py_compile` for both changed modules and the new test;
- `35 passed` across `test_telegram_rate_limit.py`, `test_telegram_send_media_contract.py`, and `test_telegram_rich_formatting.py`;
- Ruff lint passes for changed account/test files and manager with its pre-existing module-level E402 excluded;
- `git diff --check` passes.

Authorized dev4 in-situ refresh/live validation will follow on this exact Draft head.

## Architecture / scope

The retry/cooldown behavior stays entirely in the owning Telegram addon; no kernel/MCP-generic retry policy, config flag, or backoff abstraction is added. The nearest general `mcp_servers` Anatomy is not a root-governed component with a general Telegram Contract, while the existing Task Card Contract is unrelated; this PR does not manufacture a new Contract during an urgent adapter fix and instead updates the existing Telegram capability manual and focused tests.

**Out of scope:** Task Card coalescing/throttling, timeout changes, rate-limit policy redesign, merge, release, or cleanup. Task Card transport pressure remains a separate follow-up.
