### PR TITLE
fix(telegram): distinguish delayed retry from auto-retry

### DIFF
--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -26,6 +26,7 @@ related_files:
   - src/lingtai/mcp_servers/telegram/task_card/_family.py
   - src/lingtai/mcp_servers/telegram/service.py
   - src/lingtai/mcp_servers/telegram/SKILL.md
+  - src/lingtai/mcp_servers/telegram/reference/rate-limits/SKILL.md
   - src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
   - src/lingtai/mcp_servers/telegram/task_card/resident.py
   - src/lingtai/adapters/posix/notification_store.py

--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -8,8 +8,8 @@ description: |
   the programmable Task Card (task_card tool) — including task-specific watcher
   design for meaningful long-running work — and error surfacing. Pulled on demand
   via action='manual'; you do not need to call it before every send.
-version: 1.5.3
-last_changed_at: 2026-07-28T00:00:00Z
+version: 1.5.4
+last_changed_at: 2026-07-29T00:00:00Z
 related_files:
 - src/lingtai/mcp_servers/ANATOMY.md
 - src/lingtai/mcp_servers/telegram/manager.py
@@ -18,6 +18,7 @@ related_files:
 - src/lingtai/mcp_servers/telegram/task_card/_family.py
 - src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
 - src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+- src/lingtai/mcp_servers/telegram/reference/rate-limits/SKILL.md
 maintenance: |
   Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
 ---
@@ -44,12 +45,20 @@ setup readiness checklist are **not** here — they belong to `mcp-manual`
     custom-renderer example, the renderer contract, the
     start|inspect|retry|stop walkthrough, and terminal/fail-loud cleanup.
     Read this before authoring a renderer.
+- name: telegram-rate-limits
+  location: reference/rate-limits/SKILL.md
+  description: |
+    Current Telegram Bot API flood-control guidance and official source links:
+    published per-chat, group, and bulk quotas; the exact `retry_after` meaning;
+    what Telegram leaves unspecified; and safe client behavior. Read this before
+    changing send cadence, programmable Task Card cadence, or 429 recovery.
 ```
 
 | Need | Read |
 |---|---|
 | Send/reply/edit, media, reading, rich text, slash commands, `/taskcard`, errors | this file |
 | Authoring or operating a programmable Task Card watcher | [`task_card/SKILL.md`](task_card/SKILL.md) |
+| Current Telegram quotas, `retry_after`, and safe 429 policy | [`reference/rate-limits/SKILL.md`](reference/rate-limits/SKILL.md) |
 | Normative resident/slot promises and code structure | [`task_card/CONTRACT.md`](task_card/CONTRACT.md), [`task_card/ANATOMY.md`](task_card/ANATOMY.md) |
 
 ## MEDIA: document vs photo
@@ -310,11 +319,15 @@ chat-history cardinality. Normative source:
   Check for the `'error'` key and surface or act on it rather than assuming the
   message was delivered.
 - Telegram HTTP 429 responses fail fast with `status: 'error'`,
-  `error_code: 429`, `retryable: false`, and the provider's numeric
-  `retry_after` when Telegram supplied one. Wait at least that many seconds and
-  do not retry the action automatically. The addon never sleeps inside the tool
-  call or schedules a hidden second side effect; missing or malformed cooldown
-  metadata is omitted rather than replaced with a guessed default.
+  `error_code: 429`, and `auto_retry: false`. A valid provider `retry_after`
+  makes `retryable: true`: wait at least that many seconds before starting a new
+  action. Without valid cooldown metadata, both `retryable` and `retry_after`
+  are omitted rather than guessed. The addon never sleeps inside a
+  tool call or schedules a hidden second side effect.
+- Read [`reference/rate-limits/SKILL.md`](reference/rate-limits/SKILL.md) for
+  Telegram's currently documented quotas, official source links, and the
+  distinction between provider facts and product policy before changing message
+  or programmable Task Card cadence.
 - The hosted Telegram Bot API limits `getFile` downloads to 20 MB. If an inbound
   document cannot be downloaded, `read` retains its available Telegram metadata
   without a local path, adds a safe bounded provider reason in `download_error`,

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -728,14 +728,18 @@ class TelegramManager:
                 "status": "error",
                 "error": str(exc),
                 "error_code": exc.error_code,
-                "retryable": False,
-                "guidance": "Do not retry this Telegram action automatically.",
+                "auto_retry": False,
+                "guidance": (
+                    "Do not retry this Telegram action automatically; Telegram "
+                    "did not supply a valid retry_after."
+                ),
             }
             if exc.retry_after is not None:
+                result["retryable"] = True
                 result["retry_after"] = exc.retry_after
                 result["guidance"] = (
-                    "Do not retry this Telegram action for at least "
-                    f"{exc.retry_after} seconds."
+                    f"Wait at least {exc.retry_after} seconds before starting a new "
+                    "Telegram action; do not retry it automatically."
                 )
             return result
         except Exception as e:

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -3600,6 +3600,8 @@ class TelegramManager:
                 acct._request("sendChatAction", json={
                     "chat_id": chat_id, "action": "typing",
                 })
+            except TelegramRateLimitError:
+                raise
             except Exception as e:
                 log.warning(
                     "sendChatAction (placeholder typing) failed for %s:%s: %s",

--- a/src/lingtai/mcp_servers/telegram/reference/rate-limits/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/reference/rate-limits/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: telegram-rate-limits
+description: |
+  Current official Telegram Bot API flood-control guidance: published quotas,
+  `retry_after` semantics, documented unknowns, and safe client policy. Read
+  before changing Telegram send cadence, programmable Task Card cadence, or 429
+  recovery behavior.
+version: 1.0.0
+last_changed_at: 2026-07-29T00:00:00Z
+related_files:
+  - src/lingtai/mcp_servers/telegram/SKILL.md
+  - src/lingtai/mcp_servers/telegram/account.py
+  - src/lingtai/mcp_servers/telegram/manager.py
+  - tests/test_telegram_rate_limit.py
+maintenance: |
+  Re-check the two official Telegram sources before changing any quoted quota or
+  retry semantics. Keep provider facts distinct from LingTai product policy and
+  keep the parent manual as the concise progressive-disclosure entry point.
+---
+
+# Telegram Bot API rate limits
+
+This reference records Telegram's current published guidance. It is not a
+second tool contract and it does not make undocumented provider behavior into a
+LingTai guarantee. Re-check the official links before changing cadence or
+recovery policy.
+
+## Official sources
+
+- [`ResponseParameters`](https://core.telegram.org/bots/api#responseparameters)
+- [`Bots FAQ — Broadcasting to Users`](https://core.telegram.org/bots/faq#broadcasting-to-users)
+
+Last verified against both pages: **2026-07-29 UTC**.
+
+## Currently documented quotas
+
+Telegram's FAQ says:
+
+- In one chat, avoid sending more than **one message per second**. Short bursts
+  may pass, but continued excess eventually produces HTTP 429 errors.
+- In a group, bots cannot send more than **20 messages per minute**.
+- For bulk notifications, bots cannot broadcast more than **about 30 messages
+  per second** unless paid broadcasts are enabled.
+- Paid broadcasts can raise the published bulk ceiling to 1000 messages per
+  second for eligible bots at the documented Stars cost. This is opt-in billing,
+  never an automatic LingTai fallback.
+- Without paid broadcasts, Telegram recommends spreading large notification
+  batches over longer intervals such as 8–12 hours.
+
+These are provider guidelines, not permission to run every source of traffic at
+its individual maximum. Normal messages, automatic card updates, and
+programmable card updates can share a chat and bot account, so presentation
+traffic should coalesce and leave headroom for human communication.
+
+## What `retry_after` means
+
+Telegram defines `ResponseParameters.retry_after` as an optional Integer: in
+case of flood control, it is the number of seconds left to wait before the
+request can be repeated.
+
+LingTai therefore distinguishes two facts:
+
+- `retryable: true` means Telegram supplied a valid nonnegative integer
+  `retry_after`, so a caller may start a **new** action after waiting at least
+  that long.
+- `auto_retry: false` means the addon never sleeps inside the current tool call,
+  never holds the MCP worker for the cooldown, and never schedules a hidden
+  second side effect.
+
+If Telegram omits or malforms `retry_after`, LingTai omits both `retry_after`
+and `retryable` rather than turning an unknown wait into a false promise or an
+invented default.
+
+## What Telegram does not document
+
+`ResponseParameters` does not identify whether a particular cooldown is scoped
+to a chat, group, method, bot account, or another provider bucket. It also does
+not publish the penalty formula or promise whether requests during a cooldown
+reset or extend it. A result must therefore not invent `retry_scope`, infer a
+global ban from one method, or claim a long penalty's cause from its duration.
+
+## Safe client policy
+
+- A definite 429 is a definite failed request: do not persist it as delivered.
+- Return the provider's valid cooldown immediately and release the worker.
+- Do not send a second Telegram message saying that Telegram is rate limited;
+  that notice itself consumes the rate-limited route. Surface the countdown in
+  the tool result, local UI, or another healthy channel.
+- Any durable wait, cancellation, coalescing, Task Card pause, or later retry is
+  an orchestrator/controller policy outside the one-request adapter. It needs
+  explicit authorization and must remain distinguishable from automatic retry.
+- Because the provider does not disclose `retry_scope`, throttle presentation
+  traffic conservatively and prefer normal human communication over automatic
+  or programmable updates.

--- a/tests/test_telegram_rate_limit.py
+++ b/tests/test_telegram_rate_limit.py
@@ -147,6 +147,79 @@ def test_manager_serializes_rate_limit_without_persisting_a_send(
     assert not (tmp_path / "telegram" / "bot" / "sent").exists()
 
 
+class _PlaceholderRateLimitedAccount:
+    alias = "bot"
+
+    def __init__(self, retry_after: int | None) -> None:
+        self.retry_after = retry_after
+        self.calls: list[str] = []
+
+    def _request(self, method: str, **_kwargs: object) -> dict:
+        self.calls.append(method)
+        raise TelegramRateLimitError(self.retry_after)
+
+    def send_message(self, *_args: object, **_kwargs: object) -> dict:
+        self.calls.append("sendMessage")
+        return {"message_id": 777}
+
+
+class _PlaceholderService:
+    def __init__(self, retry_after: int | None) -> None:
+        self.default_account = _PlaceholderRateLimitedAccount(retry_after)
+
+    def get_account(self, alias: str) -> _PlaceholderRateLimitedAccount:
+        assert alias == "bot"
+        return self.default_account
+
+
+@pytest.mark.parametrize("retry_after", [17, None])
+def test_placeholder_preflight_429_stops_before_send_and_persistence(
+    tmp_path: Path,
+    retry_after: int | None,
+) -> None:
+    service = _PlaceholderService(retry_after)
+    manager = TelegramManager(
+        service,
+        working_dir=tmp_path,
+        on_inbound=lambda _: None,
+        notification_store=notification_store_for(tmp_path),
+    )
+
+    result = manager.handle({
+        "action": "send",
+        "account": "bot",
+        "chat_id": 123,
+        "text": "hello",
+        "placeholder": True,
+    })
+
+    expected = {
+        "status": "error",
+        "error": "Telegram API rate limited",
+        "error_code": 429,
+        "auto_retry": False,
+        "guidance": (
+            "Do not retry this Telegram action automatically; Telegram "
+            "did not supply a valid retry_after."
+        ),
+    }
+    if retry_after is not None:
+        expected.update({
+            "error": f"Telegram API rate limited; retry after {retry_after} seconds",
+            "retryable": True,
+            "retry_after": retry_after,
+            "guidance": (
+                f"Wait at least {retry_after} seconds before starting a new "
+                "Telegram action; do not retry it automatically."
+            ),
+        })
+
+    assert result == expected
+    assert service.default_account.calls == ["sendChatAction"]
+    assert not (tmp_path / "telegram" / "bot" / "sent").exists()
+
+
+
 def test_manual_progressively_routes_current_rate_limit_reference() -> None:
     package = resources.files("lingtai.mcp_servers.telegram")
     manual = package.joinpath("SKILL.md").read_text(encoding="utf-8")

--- a/tests/test_telegram_rate_limit.py
+++ b/tests/test_telegram_rate_limit.py
@@ -1,5 +1,6 @@
 """Focused contract tests for Telegram Bot API 429 handling."""
 
+from importlib import resources
 from pathlib import Path
 import time
 from unittest.mock import Mock
@@ -124,19 +125,43 @@ def test_manager_serializes_rate_limit_without_persisting_a_send(
         "status": "error",
         "error": "Telegram API rate limited",
         "error_code": 429,
-        "retryable": False,
-        "guidance": "Do not retry this Telegram action automatically.",
+        "auto_retry": False,
+        "guidance": (
+            "Do not retry this Telegram action automatically; Telegram "
+            "did not supply a valid retry_after."
+        ),
     }
     if retry_after is not None:
         expected.update({
             "error": f"Telegram API rate limited; retry after {retry_after} seconds",
+            "retryable": True,
             "retry_after": retry_after,
             "guidance": (
-                "Do not retry this Telegram action for at least "
-                f"{retry_after} seconds."
+                f"Wait at least {retry_after} seconds before starting a new "
+                "Telegram action; do not retry it automatically."
             ),
         })
 
     assert result == expected
     assert service.default_account.calls == 1
     assert not (tmp_path / "telegram" / "bot" / "sent").exists()
+
+
+def test_manual_progressively_routes_current_rate_limit_reference() -> None:
+    package = resources.files("lingtai.mcp_servers.telegram")
+    manual = package.joinpath("SKILL.md").read_text(encoding="utf-8")
+    reference = (
+        package.joinpath("reference")
+        .joinpath("rate-limits")
+        .joinpath("SKILL.md")
+        .read_text(encoding="utf-8")
+    )
+
+    assert "reference/rate-limits/SKILL.md" in manual
+    assert "https://core.telegram.org/bots/api#responseparameters" in reference
+    assert "https://core.telegram.org/bots/faq#broadcasting-to-users" in reference
+    assert "one message per second" in reference
+    assert "20 messages per minute" in reference
+    assert "about 30 messages" in reference
+    assert "per second" in reference
+    assert "retry_scope" in reference


### PR DESCRIPTION
## Summary

- keep the Telegram adapter fail-fast: one provider request, no handler sleep, no hidden retry, and no false sent-record persistence
- distinguish eventual provider retry from automatic retry: a valid `retry_after` yields `retryable: true`, every 429 yields `auto_retry: false`, and missing cooldown metadata leaves retryability unknown/omitted
- add a progressively disclosed Telegram rate-limit reference with current official per-chat, group, and bulk quotas, official source links, documented unknowns, and safe client policy

## Official sources

- https://core.telegram.org/bots/api#responseparameters
- https://core.telegram.org/bots/faq#broadcasting-to-users

## #1081 serial integration

- rebased cleanly onto exact #1081 squash/main `d9f527249f8b1ce4b878356b7326e622d5250da6`, tree `0f33ff689b341476384ca47823e647ef8e80b72a`
- preserves the package-owned strict closed-root `telegram` + `task_card` ToolFamilies, native family handler → `TelegramManager` boundary, action names, manual ownership, and Task Card controller/lifecycle behavior
- the three overlapping files are incremental only: manager 429 result semantics, parent-manual progressive routing, and the Anatomy leaf; no flat schema or Agent-owned Telegram dispatcher returns
- exact candidate head `2619a60c45e383b75170c40f129bfcf97ea157cf`, tree `f1fb16e2de07acaf13650c7e10780bd220211900`

## Validation

- exact import proof from this checkout through `PYTHONPATH=<candidate>/src`
- `python -m pytest -q tests/test_telegram_rate_limit.py tests/test_telegram_toolfamily_ltpv2.py tests/test_telegram_task_card_transport.py tests/test_telegram_rich_formatting.py tests/test_telegram_send_media_contract.py` — 66 passed
- `python -m pytest -q tests/test_architecture_documents.py` — 3 passed
- `python -m py_compile src/lingtai/mcp_servers/telegram/manager.py tests/test_telegram_rate_limit.py`
- `ruff check src/lingtai/mcp_servers/telegram/manager.py tests/test_telegram_rate_limit.py`
- `git diff --check origin/main...HEAD`

The broader `tests/test_mcp_skill_manuals.py` collector remains unavailable in the existing shared repository venv because the unrelated IMAP module imports missing optional dependency `msal`; the focused resource test directly validates the packaged Telegram manual route and official-source content. #1081 already passed its separate 23-test optional-`msal` manual gate on the exact tree now in this PR's base.

## Scope and coordination

- no Telegram account transport change beyond the already-merged #1079 fail-fast boundary
- no programmable Task Card controller/lifecycle/Contract change
- no durable scheduler, automatic resend, live Telegram test, refresh, config change, merge, or cleanup
- dev-3 owns a separate tests-only slimming follow-up; it does not change MCP/production behavior and is not a prerequisite for this serial rebase

Base lock: `d9f527249f8b1ce4b878356b7326e622d5250da6`.
