### PR TITLE
feat(web): preserve complete search and browse output

### DIFF
--- a/src/lingtai/kernel/tool_result_artifacts.py
+++ b/src/lingtai/kernel/tool_result_artifacts.py
@@ -47,6 +47,19 @@ from ._fsutil import atomic_write_text
 # readable.
 ARTIFACT_MARKER = "lingtai_tool_result_spill"
 
+# Canonical marker for the ``web`` capability's own inline-vs-artifact
+# envelope (``tools/web_search/_spill.py``). This is a DIFFERENT manifest
+# shape from ``ARTIFACT_MARKER`` above — a web artifact envelope is a
+# successful action result (``status`` is the family's own "ok"/"failed",
+# never "spilled") with the large body already omitted, not a generic
+# too-big-result replacement. ``is_spill_manifest`` recognizes it via a
+# separate branch (see below) precisely so the generic preventive spill in
+# ``spill_oversized_result`` treats an already-built web artifact as "already
+# spilled, leave it alone" without requiring it to fake ``status: "spilled"``
+# and without the generic recognizer accidentally matching an unrelated
+# family's dict that merely happens to reuse a "status"/"spill_path" pair.
+WEB_ARTIFACT_MARKER = "lingtai_web_output_artifact/v1"
+
 # Top-level reserved fields that ``ToolExecutor`` attaches to dict-shaped
 # primary results before they reach the wire.  When the primary result
 # itself is oversized and gets spilled, replacing the whole dict with the
@@ -90,24 +103,43 @@ def _slug(value: str, *, limit: int = 40) -> str:
 
 
 def is_spill_manifest(value: Any) -> bool:
-    """Return True iff ``value`` is a manifest produced by ``spill_oversized_result``.
+    """Return True iff ``value`` is a manifest/artifact envelope this module
+    (or a recognized sibling owner) already spilled the full content for.
 
-    Detection is conservative.  The preferred shape carries the explicit
-    namespaced marker ``artifact == ARTIFACT_MARKER`` *and* the required
-    structural fields (``status="spilled"``, ``spill_path`` key,
-    ``cap_chars``, ``original_char_count``) — this matches everything
-    produced by the current implementation and refuses arbitrary business
-    dicts that happen to use ``status`` + ``spill_path`` independently.
+    Two independent recognized shapes:
 
-    Backward-compatible legacy branch: dicts without the marker are still
-    accepted as manifests when *all four* structural fields are present
-    with the right types.  This preserves recognition of any persisted
-    history from earlier turns of this same patch (which produced manifests
-    before the marker was added) but rejects unrelated dicts that happen to
-    share one or two keys.
+    1. The generic ``spill_oversized_result`` manifest: the preferred form
+       carries the explicit namespaced marker ``artifact == ARTIFACT_MARKER``
+       *and* the required structural fields (``status="spilled"``,
+       ``spill_path`` key, ``cap_chars``, ``original_char_count``) — this
+       matches everything produced by the current implementation and refuses
+       arbitrary business dicts that happen to use ``status`` + ``spill_path``
+       independently. A backward-compatible legacy branch accepts dicts
+       without the marker when *all four* structural fields are present with
+       the right types, preserving recognition of persisted history from
+       before the marker was added.
+
+    2. The ``web`` capability's own artifact envelope
+       (``tools/web_search/_spill.py``): carries ``artifact ==
+       WEB_ARTIFACT_MARKER`` plus its own required structural fields
+       (``file_path``, ``content_chars``, ``content_sha256``). This shape's
+       top-level ``status`` is the *family's own* "ok"/"failed" value, never
+       "spilled" — recognized on its own namespaced marker precisely so this
+       is never confused with shape 1 and never requires web to fake a
+       generic-shaped manifest.  Recognizing this shape lets the generic
+       preventive spill in ``spill_oversized_result`` treat an already-built
+       web artifact as already spilled (skip re-spilling it) even if its
+       serialized size happens to exceed ``PREVENTIVE_MAX_CHARS``.
     """
     if not isinstance(value, dict):
         return False
+    if (
+        value.get("artifact") == WEB_ARTIFACT_MARKER
+        and isinstance(value.get("file_path"), str)
+        and isinstance(value.get("content_chars"), int)
+        and isinstance(value.get("content_sha256"), str)
+    ):
+        return True
     if value.get("status") != "spilled":
         return False
     if "spill_path" not in value:
@@ -121,6 +153,69 @@ def is_spill_manifest(value: Any) -> bool:
         and isinstance(value.get("cap_chars"), int)
         and isinstance(value.get("original_char_count"), int)
     )
+
+
+def build_artifact_filename(*, stem_slug: str, ext: str) -> str:
+    """Return a fresh ``<timestamp>-<stem_slug>-<uuid6>.<ext>`` filename.
+
+    The one canonical filename-shaping rule shared by every caller of
+    :func:`write_artifact_file` that does not need its own bespoke shape:
+    UUID/call-identity-only components, never caller-controlled query/title/
+    URL text. ``spill_oversized_result`` builds its own richer
+    ``<timestamp>-<tool>-<id>-<uuid>`` filename directly (its identity
+    components are already validated/slugged there) and passes it to
+    :func:`write_artifact_file` as an explicit ``filename`` instead of using
+    this helper.
+    """
+    timestamp = _dt.datetime.now(_dt.timezone.utc).strftime("%Y%m%dT%H%M%S")
+    unique = _uuid.uuid4().hex[:6]
+    return f"{timestamp}-{stem_slug}-{unique}.{ext}"
+
+
+def write_artifact_file(
+    text: str,
+    *,
+    directory: Path,
+    working_dir: Path,
+    filename: str | None = None,
+    stem_slug: str | None = None,
+    ext: str | None = None,
+) -> tuple[str | None, str | None, str | None]:
+    """Atomically write *text* under ``directory`` and return its paths.
+
+    Shared low-level primitive underneath both ``spill_oversized_result``
+    (generic, any-tool, 200K-ceiling preventive spill) and callers that need
+    the exact same atomic-write-and-relative-path convention for their own,
+    differently-shaped manifest (for example the ``web`` capability's
+    configurable-threshold, no-preview artifact envelope) — there is exactly
+    one atomic-write code path for tool-result artifacts, shared by both.
+
+    Callers pass either an explicit, already-built ``filename`` (e.g.
+    ``spill_oversized_result``, which needs its own richer
+    ``<timestamp>-<tool>-<id>-<uuid>`` shape built from already-slugged
+    identity components) or ``stem_slug``/``ext`` to have
+    :func:`build_artifact_filename` build a fresh
+    ``<timestamp>-<stem_slug>-<uuid6>.<ext>`` name. Exactly one of
+    ``filename`` or (``stem_slug`` and ``ext``) must be supplied.
+
+    Returns ``(relative_path, absolute_path, error)``. On success ``error``
+    is ``None`` and both paths are set. On failure both paths are ``None``
+    and ``error`` carries a ``"<ExceptionType>: <message>"`` string that
+    includes the raw ``OSError`` text (which may embed the absolute host
+    path); callers that must not surface host paths substitute their own
+    fixed message instead of exposing this string.
+    """
+    if filename is None:
+        if stem_slug is None or ext is None:
+            raise TypeError("write_artifact_file requires either filename or (stem_slug and ext)")
+        filename = build_artifact_filename(stem_slug=stem_slug, ext=ext)
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        target = directory / filename
+        atomic_write_text(target, text)
+        return str(target.relative_to(working_dir)), str(target.resolve()), None
+    except OSError as exc:
+        return None, None, f"{type(exc).__name__}: {exc}"
 
 
 def spill_oversized_result(
@@ -195,14 +290,12 @@ def spill_oversized_result(
     if working_dir is not None:
         wd = Path(working_dir)
         spill_dir = workdir_layout(wd).tool_results_dir
-        try:
-            spill_dir.mkdir(parents=True, exist_ok=True)
-            spill_path = spill_dir / filename
-            atomic_write_text(spill_path, serialized_text)
-            spill_path_str = str(spill_path.relative_to(wd))
-            spill_path_abs = str(spill_path.resolve())
-        except OSError as exc:
-            spill_failed = f"{type(exc).__name__}: {exc}"
+        spill_path_str, spill_path_abs, spill_failed = write_artifact_file(
+            serialized_text,
+            directory=spill_dir,
+            working_dir=wd,
+            filename=filename,
+        )
 
     # Build the compact manifest.  Preview is a head of the canonical text,
     # bounded so the manifest itself stays comfortably under the cap even

--- a/src/lingtai/services/websearch/__init__.py
+++ b/src/lingtai/services/websearch/__init__.py
@@ -54,12 +54,15 @@ class SearchService(ABC):
     """
 
     @abstractmethod
-    def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+    def search(self, query: str, max_results: int | None = 5) -> list[SearchResult]:
         """Search the web and return results.
 
         Args:
             query: Search query string.
-            max_results: Maximum number of results to return.
+            max_results: Maximum number of results to request from the
+                provider, or ``None`` for no LingTai-imposed count cap (the
+                provider's own native finite result count still applies,
+                where the provider has one).
 
         Returns:
             List of search results.

--- a/src/lingtai/services/websearch/anthropic.py
+++ b/src/lingtai/services/websearch/anthropic.py
@@ -39,22 +39,22 @@ class AnthropicSearchService(SearchService):
         self._api_key = api_key
         self._model = model
 
-    def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+    def search(self, query: str, max_results: int | None = 5) -> list[SearchResult]:
         import anthropic
 
         client = anthropic.Anthropic(api_key=self._api_key)
+        web_search_tool: dict = {
+            "type": "web_search_20250305",
+            "name": "web_search",
+        }
+        if max_results is not None:
+            web_search_tool["max_uses"] = max_results
         try:
             raw = client.messages.create(
                 model=self._model,
                 max_tokens=4096,
                 messages=[{"role": "user", "content": query}],
-                tools=[
-                    {
-                        "type": "web_search_20250305",
-                        "name": "web_search",
-                        "max_uses": max_results,
-                    }
-                ],
+                tools=[web_search_tool],
             )
         except Exception as e:
             logger.warning("Anthropic web search failed: %s", type(e).__name__)

--- a/src/lingtai/services/websearch/duckduckgo.py
+++ b/src/lingtai/services/websearch/duckduckgo.py
@@ -12,9 +12,10 @@ class DuckDuckGoSearchService(SearchService):
     ``pip install ddgs``.
     """
 
-    def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+    def search(self, query: str, max_results: int | None = 5) -> list[SearchResult]:
         from ddgs import DDGS  # type: ignore[import-untyped]
-        raw = DDGS().text(query, max_results=max_results)
+        kwargs = {} if max_results is None else {"max_results": max_results}
+        raw = DDGS().text(query, **kwargs)
         return [
             SearchResult(
                 title=r.get("title", ""),

--- a/src/lingtai/services/websearch/gemini.py
+++ b/src/lingtai/services/websearch/gemini.py
@@ -35,7 +35,7 @@ class GeminiSearchService(SearchService):
         self._api_key = api_key
         self._model = model
 
-    def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+    def search(self, query: str, max_results: int | None = 5) -> list[SearchResult]:
         from google import genai
         from google.genai import types
 

--- a/src/lingtai/services/websearch/openai.py
+++ b/src/lingtai/services/websearch/openai.py
@@ -50,7 +50,7 @@ class OpenAISearchService(SearchService):
         self._api_key = api_key
         self._model = model
 
-    def search(self, query: str, max_results: int = 5) -> list[SearchResult]:
+    def search(self, query: str, max_results: int | None = 5) -> list[SearchResult]:
         import openai as openai_sdk
 
         client = openai_sdk.OpenAI(api_key=self._api_key)

--- a/src/lingtai/tools/browser/ANATOMY.md
+++ b/src/lingtai/tools/browser/ANATOMY.md
@@ -44,7 +44,12 @@ public `web` manager. It is deliberately not registered independently.
 
 `web_search.WebManager` constructs one engine and dispatches browse calls to it.
 The engine calls only `BrowserPort`; the adapter is selected by the composition
-root. SearchService and settings selection remain sibling concerns.
+root. SearchService and settings selection remain sibling concerns. After a
+successful `handle()` call, `WebManager._deliver_browse` also reads the
+resulting snapshot back out of `self.snapshots` (by `snapshot_id`) to obtain
+the complete joined block text for the inline-vs-artifact delivery decision;
+this is a read-only lookup on the engine's own snapshot store, not a new
+Core/Port boundary.
 
 ## Composition
 

--- a/src/lingtai/tools/browser/CONTRACT.md
+++ b/src/lingtai/tools/browser/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: browser-internal
-contract_version: 3
+contract_version: 4
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/browser/ANATOMY.md
@@ -35,8 +35,16 @@ model-facing browser tool.
 `BrowserEngine.handle` accepts browse arguments and returns the existing
 structured success or typed failure payload, including provenance, source hash,
 SSRF-safe redirects, snapshots, cursors, refs, bounded extraction, and
-`untrusted_content`. The unified parent adds public `action` and setting
-metadata. Manual loading belongs to the parent web manager.
+`untrusted_content`. Internally it still paginates a fetched/continued page
+via `paginate_blocks` and its own `max_chars`, but the unified parent
+(`WebManager._deliver_browse`) always overrides that internal page with the
+complete joined `snapshot.blocks` text before returning: the public contract
+never exposes only a first page or partial document for a fresh success. The
+unified parent adds public `action`, output-delivery setting metadata, and the
+inline-vs-artifact decision over that complete text (see
+`web_search/CONTRACT.md`); this Core has no knowledge of `settings/web.json`
+or artifact files — it only ever returns its own paginated shape, which the
+parent replaces or spills. Manual loading belongs to the parent web manager.
 
 ## Port
 

--- a/src/lingtai/tools/web_search/ANATOMY.md
+++ b/src/lingtai/tools/web_search/ANATOMY.md
@@ -6,12 +6,15 @@ related_files:
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
   - src/lingtai/tools/web_search/settings.py
+  - src/lingtai/tools/web_search/_spill.py
   - src/lingtai/tools/web_search/manual/SKILL.md
   - src/lingtai/tools/browser/ANATOMY.md
   - src/lingtai/tools/browser/core.py
   - src/lingtai/tools/browser/port.py
   - src/lingtai/tools/tool_family/ANATOMY.md
   - src/lingtai/services/websearch/ANATOMY.md
+  - src/lingtai/kernel/tool_result_artifacts.py
+  - src/lingtai/kernel/workdir.py
 maintenance: |
   Keep this public web Anatomy and its Contract reciprocal, keep the parent
   link bidirectional, and keep the sole web-manual edge on both owner twins.
@@ -83,7 +86,18 @@ action implementations, settings, and diagnostics.
   onto the `SEARCH_FAILED` result (`src/lingtai/tools/web_search/__init__.py`).
 - `read_settings()` — bounded regular-file snapshot and strict v1 selector
   validation over the action-owned `settings/web.search.json`
-  (`src/lingtai/tools/web_search/settings.py:49-182`).
+  (`src/lingtai/tools/web_search/settings.py`).
+- `read_output_settings()` — bounded regular-file snapshot and strict v1
+  `max_chars` validation over the family-owned `settings/web.json`, shared
+  identically by `search` and `browse` (`src/lingtai/tools/web_search/settings.py`).
+- `spill_if_over_threshold()` — the shared Web-owned inline-vs-artifact
+  decision and envelope builder, called by both `_deliver_search` and
+  `_deliver_browse`; atomically writes complete content via the kernel's
+  `write_artifact_file` under the canonical `WorkdirLayout.tool_results_dir`
+  (the same directory the generic preventive spill owns), and stamps the
+  envelope with the kernel's `WEB_ARTIFACT_MARKER` so `is_spill_manifest`
+  recognizes it explicitly
+  (`src/lingtai/tools/web_search/_spill.py`).
 - `BrowserEngine` — internal static browse use case, provenance, refs, cursors,
   SSRF policy, and typed failures (`src/lingtai/tools/browser/core.py:126-327`).
 - `SearchService` adapters — provider implementations behind the internal
@@ -117,9 +131,14 @@ that promise for web's actions, behavior, and evidence.
 
 Each manager owns immutable engine specs, a lazy per-engine service cache, one
 browser engine, and its bounded ref/snapshot/cursor stores. Settings are read
-from the Agent workdir on every call and never written by the capability.
-Credentials stay in operator wiring or process configuration; no call mutates
-environment state.
+from the Agent workdir on every call and never written by the capability,
+except for the artifact files `spill_if_over_threshold()` writes under the
+canonical `<agent-workdir>/tmp/tool-results/` directory when a call's
+complete content exceeds the shared threshold — the same directory the
+kernel's generic preventive spill already owns, not a second web-owned
+directory. Those are ephemeral output artifacts, not settings state, and
+unrelated to `<agent-workdir>/settings/*.json` above. Credentials stay in
+operator wiring or process configuration; no call mutates environment state.
 
 ## Notes
 

--- a/src/lingtai/tools/web_search/CONTRACT.md
+++ b/src/lingtai/tools/web_search/CONTRACT.md
@@ -1,12 +1,13 @@
 ---
 name: web
-contract_version: 4
+contract_version: 6
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/CONTRACT.md
   - src/lingtai/tools/web_search/__init__.py
   - src/lingtai/tools/web_search/settings.py
+  - src/lingtai/tools/web_search/_spill.py
   - src/lingtai/tools/web_search/manual/SKILL.md
   - src/lingtai/tools/browser/core.py
   - src/lingtai/tools/browser/port.py
@@ -16,6 +17,8 @@ related_files:
   - src/lingtai/services/websearch/anthropic.py
   - src/lingtai/services/websearch/gemini.py
   - src/lingtai/kernel/tool_result_summary.py
+  - src/lingtai/kernel/tool_result_artifacts.py
+  - src/lingtai/kernel/workdir.py
   - src/lingtai/tools/tool_family/CONTRACT.md
 maintenance: |
   Keep this unified web Contract and its Anatomy reciprocal. Keep the manual
@@ -41,13 +44,28 @@ using it changed no observable promise in this file.
 ## Behavior
 
 Search rereads the action-owned `settings/web.search.json` selector on every
-call; browse and manual read no settings file. Search returns bounded
-structured results and same-Agent `link_ref` handles. Browse consumes a URL or
-a search/browse reference through the same BrowserEngine state. Manual returns
-the installed web-manual without provider construction or network I/O. All
-success and failure envelopes include `action` and a bounded secret-free
-`current_setting` block. Explicit `engine` and irrelevant action fields fail
-loudly. `web`'s own schema (via `ToolFamily.build_schema()`) declares a
+call; browse and manual read no settings file at that path. Search and browse
+both also reread the shared family-owned `settings/web.json` output-delivery
+threshold on every call (`max_chars`, default 50000); manual reads neither
+settings file. Search returns the complete result set the selected provider
+returned for this call — no LingTai-imposed result-count cap and no
+per-field truncation of provider-returned text — with same-Agent `link_ref`
+handles on every URL-bearing result; a synthesized or otherwise URL-less
+result stays in the result set without a `link_ref`. Browse consumes a URL
+or a search/browse reference through the same BrowserEngine state and
+always delivers the complete extracted document for that fetch, never only
+a first page. At or below the effective `max_chars` threshold, both actions
+return the complete content inline. Above it, both atomically spill the
+complete content to a workdir-relative artifact file under the canonical
+`<agent-workdir>/tmp/tool-results/` directory (the same directory the
+generic preventive spill already owns) and return a compact envelope with
+no content preview — see "Output delivery" below. Manual returns the installed
+web-manual without provider construction or network I/O. All success and
+failure envelopes include `action` and a bounded secret-free
+`current_setting` block, which now also carries `output_max_chars` (the
+resolved shared-setting value, source, and — on error — a bounded diagnostic).
+Explicit `engine` and irrelevant action fields fail loudly. `web`'s own schema
+(via `ToolFamily.build_schema()`) declares a
 top-level, REQUIRED `reasoning` string property — Host InvocationContext/
 audit metadata — with the same description Agent schema composition also
 re-injects into every tool's `properties` uniformly (that central injection
@@ -221,18 +239,33 @@ above.
 - Settings v1 is the direct, action-owned strict schema
   `{"schema_version":1,"engine":"<admitted-name>"}`, read from
   `settings/web.search.json` (a direct child of `<agent-dir>/settings/`; no
-  nested `search` object). There is no family-owned `settings/web.json`, no
-  `settings/web.browse.json` or `settings/web.manual.json`, no cross-read of
-  any old or sibling settings path, and no compatibility fallback, overlay, or
-  merge. Only an operator-admitted engine name is permitted. Missing files use
-  the operator/built-in default; malformed, unknown, disallowed, unavailable,
-  or credential-missing selections fail search without substitution. Invalid
+  nested `search` object). There is no `settings/web.browse.json` or
+  `settings/web.manual.json`, no cross-read of any old or sibling settings
+  path, and no compatibility fallback, overlay, or merge between
+  `settings/web.search.json` and `settings/web.json` (below). Only an
+  operator-admitted engine name is permitted. Missing files use the
+  operator/built-in default; malformed, unknown, disallowed, unavailable, or
+  credential-missing selections fail search without substitution. Invalid
   settings use error code `WEB_SETTINGS_INVALID`; a selected or
   initialization-unavailable engine uses `SEARCH_ENGINE_UNAVAILABLE`; a
   selected Anthropic/Gemini engine on a non-canonical backend uses
   `PROVIDER_BACKEND_INELIGIBLE`. Browse and manual remain fully usable —
   including when `settings/web.search.json` is invalid — and never construct
   a search provider.
+- `settings/web.json` is a separate, family-owned strict schema
+  `{"schema_version":1,"max_chars":<integer 1..100000>}`, default
+  `max_chars` 50000, consumed identically by `search` and `browse` for the
+  same call's inline-vs-artifact delivery decision. Manual never reads it.
+  Missing file uses the default; a present malformed/unknown-field/
+  wrong-schema-version/non-integer/boolean/out-of-range value fails loud with
+  error code `WEB_OUTPUT_SETTINGS_INVALID` before any provider call or page
+  fetch — never clamped, coerced, or silently defaulted. Browse's existing
+  nullable per-call `input.max_chars` (unchanged 1..100000 range) may still
+  override the shared setting for that call only; it no longer selects a
+  pagination page size but the delivery threshold. Every search/browse
+  success and failure envelope's `current_setting.output_max_chars` echoes
+  the effective value, its source (`default` / `settings/web.json` /
+  `call_override`), and a bounded diagnostic on error.
 - Settings reads reject symlinks, non-regular files, unstable snapshots,
   oversize/wrong-UTF-8 data, unknown fields, duplicate fields, and wrong
   schema. A changed file is observed on the next call (hot-read, no caching).
@@ -241,11 +274,26 @@ above.
   changes apply on the next web call; use web(action='manual', input={},
   reasoning='load web guidance') for schema.`; secrets and absolute paths never
   appear.
-- Search results are bounded `{title,url,snippet,link_ref}` objects with count
-  and actual engine. References are same-Agent handles accepted by browse.
-  `link_ref` is `null` only for the one bounded citation-free narrative
-  result a canonical provider may legally return; every result with a real
-  `url` gets a real `link_ref`, never a fabricated one for an empty `url`.
+- Search results are `{title,url,snippet}` objects, plus `link_ref` on any
+  result carrying a usable HTTP(S) `url`; a synthesized or URL-less result is
+  preserved in the result set without `link_ref`. `link_ref` is `null` only
+  for the one bounded citation-free narrative result a canonical provider
+  may legally return; every result with a real `url` gets a real `link_ref`,
+  never a fabricated one for an empty `url`. `title`/`url`/`snippet` are the
+  exact finite strings the selected provider returned — no LingTai-imposed
+  per-field character slice and no LingTai-imposed result-count cap: `count`
+  reflects the true, uncapped number of results the selected provider
+  returned for that call. Provider adapters receive no LingTai count request
+  in this mode (`max_results=None`, or the provider's own request parameter
+  omitted where supported); a provider's own native finite result limit is
+  unchanged and reported as provider-native metadata, never as a global
+  completeness or total claim. `SearchService.search` is contracted to
+  return a finite list (the `SearchService` ABC docstring in
+  `services/websearch/__init__.py`, recorded in `services/websearch/ANATOMY.md`); there is no
+  LingTai-side iteration ceiling or partial-success shape defending against
+  an out-of-contract non-terminating iterable — provider/service call
+  deadlines and fail-loud cancellation are the only operational bound,
+  exactly as the provider boundary already requires.
 - Composing `web` with a retired provider (`minimax`, `zhipu`) via
   `provider=`, `default_engine=`, or `engines={}` raises
   `RetiredProviderError` at `setup()` time. Composing with a settings-only
@@ -258,7 +306,81 @@ above.
   injection) without that composition selecting either as the default.
 - Browse remains static public HTTP(S) only with its existing SSRF/DNS,
   extraction, provenance, cursor, snapshot, deadline, and typed-failure rules,
-  and stays provider/network independent of the search settings file.
+  and stays provider/network independent of the search settings file (though
+  it shares `settings/web.json` with search). A fresh Browse success always
+  delivers the complete extracted document for that fetch — never only a
+  first page — and never mints a `next_cursor`. An existing `cursor` input is
+  still accepted only as a compatibility locator for the cached snapshot; it
+  resolves without a refetch but returns the same complete-document delivery
+  policy, never another partial page. If the fetched/continued snapshot is no
+  longer resolvable when the delivery decision runs (only possible under
+  extreme concurrent pressure evicting the tiny process-local snapshot LRU
+  between the engine's success and this decision), Browse fails loud with
+  `error_code: "BROWSE_SNAPSHOT_UNAVAILABLE"` rather than falling back to the
+  engine's own internally-paginated page — a partial/first-page body with
+  `partial`/`next_cursor` would silently violate the complete-output policy
+  above, so no degraded "best effort" success is ever returned here.
+- Above the effective `output_max_chars` threshold, both `search` and
+  `browse` atomically write the exact complete canonical content (never a
+  truncated prefix) to a workdir-relative file under the canonical
+  `<agent-workdir>/tmp/tool-results/` directory and return a compact
+  artifact envelope in place of the inline body: `delivery: "artifact"`,
+  `artifact` (the namespaced marker `lingtai_web_output_artifact/v1`),
+  `content_scope` (`provider_response` for search, `fetched_static_document`
+  for browse), `content_kind`, `format`/`encoding`, `file_path`
+  (workdir-relative only, readable via the existing public `file.read`
+  tool), exact `content_chars` and `content_sha256` of the artifact file,
+  `output_setting_source`/`output_setting_revision`/`output_setting_hash`
+  (the shared setting state that produced this threshold), and an explicit
+  instruction that the artifact is the complete result with nothing
+  omitted. Search's `results` array and Browse's
+  `blocks`/`partial`/`next_cursor`/`returned_chars` are omitted entirely
+  when spilled — never a lossy subset alongside the artifact. Inline
+  (at-or-below-threshold) responses add `delivery: "inline"` and
+  `content_chars` but otherwise keep every existing successful field. An
+  artifact write failure returns `status: "failed"`, `error_code:
+  "ARTIFACT_WRITE_FAILED"` — never a silent fallback to a lossy inline
+  truncation.
+
+  The inline-vs-artifact threshold is measured against the exact canonical
+  serialization of the content that would actually be returned inline, not
+  merely against a compact file-representation proxy for it. For search
+  these are the same value (the rendered JSON result list is both the
+  decision content and the file content). For browse they can differ
+  substantially: the threshold is measured against the JSON serialization of
+  the complete structured `blocks` array (what is actually returned inline),
+  while the artifact file itself — if spilled — still holds the smaller
+  plain joined-text document. A page with many small blocks can have joined
+  text well under the default 50000-char threshold while its structured
+  `blocks` form is several times larger, large enough to cross the threshold
+  (and, left undetected, even the unrelated generic 200000-char preventive
+  ceiling) — this is measured explicitly rather than left to be silently
+  caught later by the generic mechanism's own lossy preview. When the
+  decision length differs from the file's own `content_chars`, the artifact
+  envelope adds `delivery_decision_chars` (the structured-serialization
+  length that triggered the spill) and `delivery_decision_basis`
+  (`"structured_blocks"` for browse) — `content_chars`/`content_sha256`
+  always describe the file actually written, never implying that the file
+  itself exceeded the threshold when the real trigger was the larger
+  structured form. An inline Browse response's own `content_chars` likewise
+  reflects the structured `blocks` serialization actually returned, not the
+  joined-text length.
+
+  The artifact writer shares the kernel's one atomic-write primitive
+  (`kernel/tool_result_artifacts.write_artifact_file`) and the kernel's one
+  canonical artifact directory (`WorkdirLayout.tool_results_dir`) with the
+  generic preventive spill (`spill_oversized_result`, still the unrelated,
+  unchanged 200000-char outer safety net) — there is exactly one atomic-write
+  code path and one artifact directory, not two parallel conventions. The web
+  artifact envelope is explicitly recognized by the kernel's
+  `is_spill_manifest` via its own namespaced `artifact` marker and required
+  structural fields (`file_path`, `content_chars`, `content_sha256`) — a
+  dedicated recognition branch independent of the generic manifest's
+  `status: "spilled"` shape, since a web artifact's own `status` is the
+  family's "ok"/"failed" value, never "spilled". This explicit recognition,
+  not envelope smallness, is what stops the generic preventive spill from
+  re-spilling an already-built web artifact, and holds even if the envelope
+  is padded past the generic 200000-char ceiling.
 
 ## Contract tests
 
@@ -312,6 +434,48 @@ level evidence proves the raw result is durably logged before any visible
 `summarize=true` replacement on both the sequential and a controlled-parallel
 path, and that search/browse `status: "failed"` results stay byte/content
 exact and unsummarized under `summarize=true`.
+
+Additional focused checks cover: `settings/web.json` missing/default (with a
+deterministic revision/hash for the default case)/valid-override/boundary/
+out-of-range/wrong-type/unknown-field states and its
+`WEB_OUTPUT_SETTINGS_INVALID` failure before any provider call or fetch;
+manual and the settings-isolation spy tests extended to assert
+`read_output_settings` is never called from manual; search with a large
+(hundreds-of-item) finite provider result set preserved completely with no
+count cap, no per-field truncation, and no adapter receiving a LingTai count
+parameter; a synthesized/URL-less result preserved in the result set without
+`link_ref`; inline and artifact delivery for both search and browse,
+including exact `content_chars`/`content_sha256` verified against the written
+file, the artifact's `output_setting_source`/`revision`/`hash` fields,
+Unicode character accounting, threshold boundary on both sides, atomic
+unique artifact filenames under the canonical `tmp/tool-results/` directory
+across rapid calls, no content preview when spilled, `ARTIFACT_WRITE_FAILED`
+on a simulated write failure, an end-to-end spill-then-`file.read` round
+trip, Browse's per-call `max_chars` override of the shared threshold, a
+legacy `cursor` locator returning the complete document under the same
+policy, and — directly, not by inference from envelope size — that the
+kernel's `is_spill_manifest` recognizes a web artifact envelope via its own
+explicit marker and that neither `spill_oversized_result` nor a full
+`ToolExecutor.execute()` pass re-spills an already-built web artifact result,
+even when the envelope is deliberately padded past the generic 200000-char
+preventive ceiling.
+
+A dedicated production-shaped regression (a page with thousands of small
+extracted blocks whose joined plain text stays under the default threshold
+while the structured `blocks` JSON that would actually be returned inline
+does not) proves the threshold decision is made against the structured
+serialization: the case spills to Web's own complete, no-preview artifact
+with truthful `delivery_decision_chars`/`delivery_decision_basis` fields and
+a `content_chars` describing only the written file, and a companion test
+proves the generic preventive spill never substitutes a lossy preview for
+it even though the structured decision length also exceeds the generic
+200000-char ceiling. A matching small-page control proves ordinary pages
+stay inline under both measurements, and an exact-boundary test pins the
+decision to the structured length precisely. A separate deterministic test
+evicts the fetched snapshot between the engine's success and the delivery
+decision and proves the result is `error_code: "BROWSE_SNAPSHOT_UNAVAILABLE"`
+with no `blocks`/`partial`/`next_cursor`/`delivery` field ever present —
+never a degraded first-page success.
 
 ## Maintenance
 

--- a/src/lingtai/tools/web_search/__init__.py
+++ b/src/lingtai/tools/web_search/__init__.py
@@ -6,16 +6,25 @@ internal adapters, while the tested browser Core/Port stays in
 """
 from __future__ import annotations
 
+import json
 import os
-from dataclasses import dataclass
-from itertools import islice
+from dataclasses import dataclass, replace
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
 from .._manual import load_installed_manual
 from ..browser.core import BrowserEngine
 from ..tool_family import ChildTool, ToolFamily
 from ..tool_family.manual import MANUAL_INPUT_SCHEMA, build_manual_child
-from .settings import SettingsSnapshot, current_setting, read_settings, valid_engine_name
+from ._spill import spill_if_over_threshold
+from .settings import (
+    OutputSettingsSnapshot,
+    SettingsSnapshot,
+    current_setting,
+    read_output_settings,
+    read_settings,
+    valid_engine_name,
+)
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
@@ -143,7 +152,7 @@ _BROWSE_INPUT_SCHEMA: dict[str, Any] = {
             "type": ["integer", "null"],
             "minimum": 1,
             "maximum": 100000,
-            "description": "Maximum returned characters, or null for the default 12000.",
+            "description": "Per-call override of the inline-vs-artifact delivery threshold; null uses the shared settings/web.json setting (default 50000). The complete document is always delivered, inline or as an artifact.",
         },
     },
     "required": ["url", "link_ref", "cursor", "extract", "max_chars"],
@@ -276,7 +285,19 @@ class WebManager:
             return "credential_missing"
         return "unavailable"
 
-    def _diagnostics(self, snapshot: SettingsSnapshot) -> dict[str, Any]:
+    @staticmethod
+    def _output_setting_block(snapshot: OutputSettingsSnapshot) -> dict[str, Any]:
+        block: dict[str, Any] = {
+            "value": snapshot.max_chars,
+            "source": snapshot.source,
+            "settings_revision": snapshot.revision,
+            "settings_hash": snapshot.digest,
+        }
+        if snapshot.error:
+            block["settings_error"] = snapshot.error
+        return block
+
+    def _diagnostics(self, snapshot: SettingsSnapshot, output_snapshot: OutputSettingsSnapshot) -> dict[str, Any]:
         statuses = {
             name: (
                 "initialization_failed"
@@ -289,6 +310,7 @@ class WebManager:
         if self._legacy_fallback_from:
             block["legacy_fallback_from"] = self._legacy_fallback_from[:64]
             block["legacy_fallback"] = "operator-config-only"
+        block["output_max_chars"] = self._output_setting_block(output_snapshot)
         return block
 
     def _default_engine_now(self) -> str | None:
@@ -312,18 +334,34 @@ class WebManager:
             return None
         return self._default_engine
 
-    def _resolve(self) -> tuple[str | None, SettingsSnapshot, dict[str, Any]]:
+    def _resolve_output_settings(self) -> OutputSettingsSnapshot:
+        # Shared by search and browse: both actions consume the same
+        # family-owned settings/web.json snapshot for the same call. Manual
+        # must never call this — it stays zero-settings-I/O.
+        return read_output_settings(self._agent)
+
+    def _resolve(self) -> tuple[str | None, SettingsSnapshot, OutputSettingsSnapshot, dict[str, Any]]:
         snapshot = read_settings(
             self._agent, self._specs, self._default_engine_now(), self._default_source
         )
-        return snapshot.engine, snapshot, self._diagnostics(snapshot)
+        output_snapshot = self._resolve_output_settings()
+        return snapshot.engine, snapshot, output_snapshot, self._diagnostics(snapshot, output_snapshot)
 
     def _no_settings_diagnostic(self) -> dict[str, Any]:
-        # Only ``search`` owns and reads settings/web.search.json. Every other
-        # action (and any pre-dispatch validation failure) reports a truthful
-        # synthetic snapshot without ever touching that file.
+        # Zero-settings-I/O diagnostic: used by manual (which never reads
+        # either settings file) and by every envelope-level/pre-dispatch
+        # failure path (invalid argument, unknown action) that never reaches
+        # a real action handler. Neither settings/web.search.json nor
+        # settings/web.json is read to build this block.
         snapshot = SettingsSnapshot(None, "not_applicable", "not_read", None)
-        return self._diagnostics(snapshot)
+        output_snapshot = OutputSettingsSnapshot(None, "not_applicable", "not_read", None)
+        return self._diagnostics(snapshot, output_snapshot)
+
+    def _browse_diagnostic(self, output_snapshot: OutputSettingsSnapshot) -> dict[str, Any]:
+        # Browse never reads settings/web.search.json (engine selection is a
+        # search-only concern) but does read the shared settings/web.json.
+        snapshot = SettingsSnapshot(None, "not_applicable", "not_read", None)
+        return self._diagnostics(snapshot, output_snapshot)
 
     def _failure(self, action: str, snapshot: SettingsSnapshot | None, diagnostic: dict[str, Any], code: str, message: str, **extra: Any) -> dict[str, Any]:
         result = {"status": "failed", "action": action, "error_code": code, "message": message, "current_setting": diagnostic}
@@ -363,13 +401,19 @@ class WebManager:
         return (str(getattr(item, "title", "")), str(getattr(item, "url", "")), str(getattr(item, "snippet", "")))
 
     def _run_service(self, service: Any, query: str) -> list[dict[str, str]]:
-        raw_results = service.search(query)
+        # ``max_results=None`` and no local slicing/per-field truncation: the
+        # locked complete-output contract forbids any LingTai-imposed
+        # result-count cap or character slice on provider-returned text.
+        # ``SearchService.search`` is contracted to return a finite list
+        # (services/websearch/__init__.py), so no local iteration ceiling is
+        # needed here either — provider/service deadlines and fail-loud
+        # cancellation are the only operational bound.
+        raw_results = service.search(query, max_results=None)
         if raw_results is None:
             raw_results = []
         results: list[dict[str, str]] = []
-        for item in islice(iter(raw_results), 20):
+        for item in raw_results:
             title, url, snippet = self._result_fields(item)
-            title, url, snippet = title[:512], url[:2048], snippet[:2000]
             if not url:
                 # No official source URL for this item (e.g. a provider's
                 # bounded synthesized-narrative fallback result with no
@@ -398,7 +442,9 @@ class WebManager:
         except Exception as exc:
             return [], type(exc).__name__[:64]
 
-    def _openai_duckduckgo_fallback(self, query: str, openai_failure_class: str, diagnostic: dict[str, Any]) -> dict[str, Any]:
+    def _openai_duckduckgo_fallback(
+        self, query: str, openai_failure_class: str, output_snapshot: OutputSettingsSnapshot, diagnostic: dict[str, Any]
+    ) -> dict[str, Any]:
         ddg_results, ddg_failure_class = self._duckduckgo_fallback(query)
         if ddg_failure_class is not None:
             return {
@@ -408,18 +454,30 @@ class WebManager:
                 "openai_failure_class": openai_failure_class, "duckduckgo_failure_class": ddg_failure_class,
             }
         comment = f"# OpenAI web search failed ({openai_failure_class}); DuckDuckGo was used as the fallback."
-        return {
+        payload = {
             "status": "ok", "action": "search", "query": query[:2000],
             "comment": comment,
             "engine": "openai", "actual_engine": "duckduckgo",
             "openai_failure_class": openai_failure_class,
             "results": ddg_results, "count": len(ddg_results), "current_setting": diagnostic,
         }
+        return self._deliver_search(payload, output_snapshot)
 
-    def _search(self, args: dict[str, Any], snapshot: SettingsSnapshot, diagnostic: dict[str, Any]) -> dict[str, Any]:
+    def _search(
+        self,
+        args: dict[str, Any],
+        snapshot: SettingsSnapshot,
+        output_snapshot: OutputSettingsSnapshot,
+        diagnostic: dict[str, Any],
+    ) -> dict[str, Any]:
         query = args.get("query")
         if not isinstance(query, str) or not query.strip():
             return self._failure("search", snapshot, diagnostic, "INVALID_QUERY", "query must be a non-empty string")
+        if output_snapshot.error:
+            return self._failure(
+                "search", snapshot, diagnostic, "WEB_OUTPUT_SETTINGS_INVALID",
+                "settings/web.json is invalid; no search was performed",
+            )
         name = snapshot.engine
         if snapshot.error:
             return self._failure("search", snapshot, diagnostic, "WEB_SETTINGS_INVALID", "settings/web.search.json is invalid; no search engine was selected")
@@ -456,15 +514,16 @@ class WebManager:
             # `_service_for` records a bounded internal failure marker. Rebuild
             # diagnostics so this same result does not contradict its error by
             # still advertising the engine as available.
-            diagnostic = self._diagnostics(snapshot)
+            diagnostic = self._diagnostics(snapshot, output_snapshot)
             return self._failure("search", snapshot, diagnostic, "SEARCH_ENGINE_UNAVAILABLE", "the selected search engine could not be initialized")
         try:
             results = self._run_service(service, query)
-            return {
+            payload = {
                 "status": "ok", "action": "search", "query": query[:2000],
                 "engine": name, "actual_engine": name, "results": results,
                 "count": len(results), "current_setting": diagnostic,
             }
+            return self._deliver_search(payload, output_snapshot)
         except Exception as exc:
             from lingtai.services.websearch import SearchProviderError
             from lingtai.services.websearch.openai import OpenAISearchError
@@ -478,7 +537,7 @@ class WebManager:
                 # defect, not a provider failure, and falls through to the
                 # generic SEARCH_FAILED return below — never silently
                 # retried against DuckDuckGo.
-                return self._openai_duckduckgo_fallback(query, exc.failure_class, diagnostic)
+                return self._openai_duckduckgo_fallback(query, exc.failure_class, output_snapshot, diagnostic)
             if isinstance(exc, SearchProviderError):
                 # A typed Anthropic/Gemini (or any other) provider failure —
                 # including Anthropic's official in-body HTTP-200
@@ -494,6 +553,51 @@ class WebManager:
             # A non-provider exception (a manager/programming defect) fails
             # the same way but carries no provider-specific failure class.
             return self._failure("search", snapshot, diagnostic, "SEARCH_FAILED", "the selected search engine failed")
+
+    def _deliver_search(self, payload: dict[str, Any], output_snapshot: OutputSettingsSnapshot) -> dict[str, Any]:
+        assert output_snapshot.max_chars is not None  # guarded by the caller's output_snapshot.error check
+        results = payload["results"]
+        serialized = json.dumps(results, ensure_ascii=False, indent=2)
+        working_dir = Path(self._agent._working_dir)
+        artifact = spill_if_over_threshold(
+            content=serialized,
+            output_setting=output_snapshot,
+            working_dir=working_dir,
+            action="search",
+            content_scope="provider_response",
+            content_kind="search_results",
+            format="json",
+            extra={
+                "query": payload["query"],
+                "engine": payload["engine"],
+                "actual_engine": payload["actual_engine"],
+            },
+        )
+        if artifact is None:
+            payload["delivery"] = "inline"
+            payload["content_chars"] = len(serialized)
+            return payload
+        if artifact.get("status") == "failed":
+            failure = {
+                "status": "failed", "action": "search", "error_code": "ARTIFACT_WRITE_FAILED",
+                "message": artifact["message"], "current_setting": payload["current_setting"],
+                "query": payload["query"], "engine": payload["engine"],
+            }
+            return failure
+        spilled: dict[str, Any] = {
+            "status": "ok", "action": "search", "query": payload["query"],
+            "engine": payload["engine"], "actual_engine": payload["actual_engine"],
+            "count": payload["count"], "current_setting": payload["current_setting"],
+        }
+        for key in ("comment", "openai_failure_class"):
+            # The OpenAI->DuckDuckGo fallback promises a top-level comment
+            # and bounded openai_failure_class with no spill carve-out
+            # (CONTRACT.md, runtime-fallback section): informed substitution
+            # must survive the artifact envelope, not just the inline one.
+            if key in payload:
+                spilled[key] = payload[key]
+        spilled.update(artifact)
+        return spilled
 
     def manual(self, diagnostic: dict[str, Any]) -> dict[str, Any]:
         # This path never reads settings/web.search.json and performs no
@@ -535,18 +639,127 @@ class WebManager:
 
     def _dispatch_search(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
         dispatch_args = self._strip_nulls(action_input)
-        _, snapshot, diagnostic = self._resolve()
-        return self._search(dispatch_args, snapshot, diagnostic)
+        _, snapshot, output_snapshot, diagnostic = self._resolve()
+        return self._search(dispatch_args, snapshot, output_snapshot, diagnostic)
 
     def _dispatch_browse(self, action_input: Mapping[str, Any]) -> dict[str, Any]:
         browse_args = self._strip_nulls(action_input)
+        output_snapshot = self._resolve_output_settings()
+        if output_snapshot.error:
+            diagnostic = self._browse_diagnostic(output_snapshot)
+            return self._failure(
+                "browse", None, diagnostic, "WEB_OUTPUT_SETTINGS_INVALID",
+                "settings/web.json is invalid; no browse was performed",
+            )
+        # A present ``max_chars`` is validated by ``BrowserEngine`` itself
+        # (its own 1..100000 range, via ``validate_max_chars``) before any
+        # call can succeed; if invalid, the call fails with
+        # ``INVALID_MAX_CHARS`` below and this override is never applied.
+        # Absent/None keeps the shared setting; present overrides the
+        # delivery threshold for this call only, per the locked contract.
+        call_override = browse_args.get("max_chars")
+        delivery_snapshot = (
+            output_snapshot if call_override is None
+            # The override value comes from this call's own validated input,
+            # not from settings/web.json, so it must not carry that file's
+            # revision/hash forward — those describe the *shared* setting
+            # state, which this call is deliberately not using.
+            else replace(
+                output_snapshot, max_chars=call_override, source="call_override",
+                revision="call_override", digest=None,
+            )
+        )
+        diagnostic = self._browse_diagnostic(delivery_snapshot)
         try:
             result = self._engine.handle(browse_args)
         except Exception:
             result = {"status": "failed", "error_code": "BROWSE_FAILED", "message": "browse failed safely"}
         result["action"] = "browse"
-        result["current_setting"] = self._no_settings_diagnostic()
+        result["current_setting"] = diagnostic
+        if result.get("status") == "ok":
+            result = self._deliver_browse(result, delivery_snapshot)
         return result
+
+    def _deliver_browse(self, result: dict[str, Any], output_snapshot: OutputSettingsSnapshot) -> dict[str, Any]:
+        assert output_snapshot.max_chars is not None  # guarded by the caller's output_snapshot.error check
+        snapshot = self._engine.snapshots.get(result["snapshot_id"])
+        if snapshot is None:
+            # The snapshot was evicted between the engine's fetch/continue
+            # success and this delivery decision (only possible under
+            # extreme concurrent pressure on the tiny max_snapshots LRU).
+            # The locked complete-output policy forbids ever returning a
+            # partial/first-page body, so falling back to the engine's own
+            # paginated result (which may carry partial=true/next_cursor)
+            # would silently violate it. Fail loud instead: this is a typed,
+            # explicit failure, not a degraded success.
+            return {
+                "status": "failed", "action": "browse",
+                "error_code": "BROWSE_SNAPSHOT_UNAVAILABLE",
+                "message": (
+                    "The fetched page snapshot was no longer available when "
+                    "building the complete delivery response; no partial or "
+                    "cached content was returned."
+                ),
+                "current_setting": result["current_setting"],
+                "request_id": result.get("request_id"), "snapshot_id": result.get("snapshot_id"),
+            }
+        complete_text = "".join(block.text for block in snapshot.blocks)
+        structured_blocks = [{"id": b.id, "kind": b.kind, "text": b.text} for b in snapshot.blocks]
+        # The threshold decision must be measured against the exact canonical
+        # serialization of what would actually be returned inline — the
+        # structured `blocks` array — not the compact joined-text artifact
+        # file representation. Many small blocks accumulate substantial JSON
+        # field/structure overhead per block, so the structured serialization
+        # can be many times larger than the plain joined text even though the
+        # file (written below, if spilled) stays the smaller plain-text form.
+        structured_chars = len(json.dumps(structured_blocks, ensure_ascii=False))
+        working_dir = Path(self._agent._working_dir)
+        artifact = spill_if_over_threshold(
+            content=complete_text,
+            decision_chars=structured_chars,
+            decision_basis="structured_blocks",
+            output_setting=output_snapshot,
+            working_dir=working_dir,
+            action="browse",
+            content_scope="fetched_static_document",
+            content_kind="page_text",
+            format="text",
+            extra={
+                "requested_url": result.get("requested_url"),
+                "final_url": result.get("final_url"),
+            },
+        )
+        if artifact is None:
+            # A fresh Browse success must never deliver only a prefix/first
+            # page: replace the engine's internally-paginated window with the
+            # complete block set and clear pagination fields, so "inline"
+            # always means the whole document, not whichever slice the
+            # per-call max_chars pagination window happened to produce.
+            result = dict(result)
+            result["blocks"] = structured_blocks
+            result["partial"] = False
+            result["next_cursor"] = None
+            result["returned_chars"] = len(complete_text)
+            result["delivery"] = "inline"
+            result["content_chars"] = structured_chars
+            return result
+        if artifact.get("status") == "failed":
+            return {
+                "status": "failed", "action": "browse", "error_code": "ARTIFACT_WRITE_FAILED",
+                "message": artifact["message"], "current_setting": result["current_setting"],
+                "request_id": result.get("request_id"), "snapshot_id": result.get("snapshot_id"),
+            }
+        # Cursor/pagination concepts stop applying once the complete document
+        # is available in one artifact: omit blocks/partial/next_cursor/
+        # returned_chars rather than mixing a spilled envelope with a
+        # continuable-but-partial inline shape.
+        spilled: dict[str, Any] = {
+            key: value
+            for key, value in result.items()
+            if key not in {"blocks", "partial", "next_cursor", "returned_chars"}
+        }
+        spilled.update(artifact)
+        return spilled
 
     def handle(self, args: dict[str, Any] | None) -> dict[str, Any]:
         # The generic ``ToolFamily`` dispatcher validates ``action``,

--- a/src/lingtai/tools/web_search/_spill.py
+++ b/src/lingtai/tools/web_search/_spill.py
@@ -1,0 +1,163 @@
+"""Shared Web inline-vs-artifact delivery decision for ``search`` and ``browse``.
+
+Both actions build their complete canonical content first (the full rendered
+result set for search; the full extracted document for browse), then call
+:func:`spill_if_over_threshold` once with that content. Below the shared
+``max_chars`` threshold, callers keep the content inline unchanged. Above it,
+this module atomically writes the *exact complete* content to a workdir-
+relative file under the canonical ``<agent-workdir>/tmp/tool-results/``
+directory — the same directory the generic preventive spill
+(``kernel/tool_result_artifacts.spill_oversized_result``) already owns and
+writes to — and returns a compact artifact envelope with no content preview —
+never a lossy prefix.
+
+This module owns the spill *decision* and envelope *shape* for the ``web``
+capability specifically (its own product-facing metadata, instruction
+wording, and threshold policy). It reuses the kernel's shared atomic-write
+primitive (``kernel/tool_result_artifacts.write_artifact_file``) and the
+kernel's canonical ``WorkdirLayout.tool_results_dir`` rather than
+re-implementing atomic file writes or inventing a second output directory —
+there is exactly one artifact directory and one atomic-write primitive,
+shared by both the generic preventive spill and this web-owned spill. The
+envelope is stamped with ``artifact == WEB_ARTIFACT_MARKER`` so the kernel's
+own ``is_spill_manifest`` recognizes it explicitly (see
+``tool_result_artifacts.py``), which is what stops the generic preventive
+spill from re-spilling an already-built web artifact — not an incidental
+"the envelope happens to be small" assumption. This module does not import
+from ``services/websearch`` or vice versa, keeping the browser/search
+boundary documented in ``browser/CONTRACT.md`` intact.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+from lingtai.kernel._fsutil import utc_now_iso
+from lingtai.kernel.tool_result_artifacts import WEB_ARTIFACT_MARKER, write_artifact_file
+from lingtai.kernel.workdir import workdir_layout
+
+from .settings import OutputSettingsSnapshot
+
+
+def spill_if_over_threshold(
+    *,
+    content: str,
+    output_setting: OutputSettingsSnapshot,
+    working_dir: Path,
+    action: str,
+    content_scope: str,
+    content_kind: str,
+    format: str,
+    decision_chars: int | None = None,
+    decision_basis: str = "content",
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Return ``None`` if the content fits inline, else a complete-artifact envelope.
+
+    ``content`` is the exact canonical serialization that gets written to the
+    artifact file when spilled (UTF-8 JSON for search's rendered result list,
+    model-readable text for browse's joined block text). Its Unicode
+    character count (``len(content)``) is measured directly for
+    ``content_chars``/``content_sha256`` — this is exactly what gets written
+    to disk, so those fields are trivially verifiable against the artifact
+    file, regardless of what triggered the spill decision.
+
+    ``decision_chars`` is the character count the inline-vs-artifact
+    *threshold comparison* is actually made against. It defaults to
+    ``len(content)`` (search's own case: the rendered JSON result list is
+    both the decision content and the file content). Browse passes a
+    different, larger value here — the exact canonical serialization of the
+    **complete structured content that would actually be returned inline**
+    (the JSON-serialized `blocks` array), which can be substantially larger
+    than the joined plain-text file this module writes, because JSON
+    structure/field overhead accumulates per block. Deciding on
+    ``len(content)`` alone would let a canonically-large inline response
+    (many small blocks) slip past the threshold undetected, exactly the bug
+    this parameter exists to close. When ``decision_chars`` differs from
+    ``len(content)``, the returned artifact envelope truthfully reports both:
+    ``content_chars``/``content_sha256`` still describe the file that was
+    written, while ``delivery_decision_chars``/``delivery_decision_basis``
+    record what the threshold was actually measured against, so a spilled
+    45,000-character *file* is never misreported as itself having exceeded a
+    50,000-character threshold when the real trigger was a ~397,570-character
+    structured inline serialization.
+
+    ``output_setting`` is the resolved shared-setting snapshot (or its
+    per-call override) already used to pick the threshold; its
+    ``source``/``revision``/``digest`` are echoed onto the artifact envelope
+    so a spilled result stays fully self-describing about *which* setting
+    state produced this threshold, not only the numeric ``max_chars`` value.
+
+    On a successful write the envelope never includes the content itself (no
+    preview, no truncated prefix) — only the workdir-relative ``file_path``,
+    exact character count, SHA-256, format/encoding, and a model-facing
+    instruction to read the file in full. On write failure, returns an
+    envelope with ``status: "failed"`` and ``error_code:
+    "ARTIFACT_WRITE_FAILED"`` — content is never dropped silently and never
+    falls back to a lossy inline truncation.
+    """
+    max_chars = output_setting.max_chars
+    assert max_chars is not None
+    content_chars = len(content)
+    effective_decision_chars = content_chars if decision_chars is None else decision_chars
+    if effective_decision_chars <= max_chars:
+        return None
+
+    wd = Path(working_dir)
+    layout = workdir_layout(wd)
+    ext = "json" if format == "json" else "txt"
+    relative_path, _absolute_path, error = write_artifact_file(
+        content,
+        directory=layout.tool_results_dir,
+        working_dir=wd,
+        stem_slug=f"web-{action}",
+        ext=ext,
+    )
+    if error is not None or relative_path is None:
+        return {
+            "status": "failed",
+            "error_code": "ARTIFACT_WRITE_FAILED",
+            "message": (
+                "The complete result exceeded the inline delivery threshold "
+                "and could not be written to a readable artifact file. No "
+                "content was returned inline to avoid a lossy truncation."
+            ),
+            "content_chars": content_chars,
+            "max_chars": max_chars,
+            **(extra or {}),
+        }
+
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    envelope: dict[str, Any] = {
+        "delivery": "artifact",
+        "artifact": WEB_ARTIFACT_MARKER,
+        "content_scope": content_scope,
+        "content_kind": content_kind,
+        "format": format,
+        "encoding": "utf-8",
+        "file_path": relative_path,
+        "content_chars": content_chars,
+        "content_sha256": digest,
+        "max_chars": max_chars,
+        "output_setting_source": output_setting.source,
+        "output_setting_revision": output_setting.revision,
+        "output_setting_hash": output_setting.digest,
+        "created_at": utc_now_iso(),
+        "artifact_lifetime": "ephemeral",
+        "artifact_state": "available",
+        "instruction": (
+            f"The complete {content_kind} ({content_chars} characters) exceeded "
+            f"the {max_chars}-character inline delivery threshold and was saved "
+            "in full, with no truncation, to the file at file_path. Use the "
+            "file.read tool to read it (in chunks if needed). This artifact "
+            "contains the complete canonical result; no content was omitted "
+            "or shortened."
+        ),
+    }
+    if effective_decision_chars != content_chars:
+        envelope["delivery_decision_chars"] = effective_decision_chars
+        envelope["delivery_decision_basis"] = decision_basis
+    if extra:
+        envelope.update(extra)
+    return envelope

--- a/src/lingtai/tools/web_search/manual/SKILL.md
+++ b/src/lingtai/tools/web_search/manual/SKILL.md
@@ -3,11 +3,12 @@ name: web-manual
 description: >
   One web workflow: search first, browse a known result next, and use one
   explicit legacy fallback only when static browsing cannot serve the need.
-version: 7.1.2
-last_changed_at: "2026-07-28T22:05:00Z"
+version: 8.1.0
+last_changed_at: "2026-07-29T00:00:00Z"
 related_files:
   - src/lingtai/tools/web_search/__init__.py
   - src/lingtai/tools/web_search/settings.py
+  - src/lingtai/tools/web_search/_spill.py
   - src/lingtai/tools/web_search/ANATOMY.md
   - src/lingtai/tools/web_search/CONTRACT.md
   - src/lingtai/tools/web_search/manual/scripts/extract_page.py
@@ -38,14 +39,19 @@ field and no nested branch admits `reasoning`, `_reasoning`, or `summarize`.
 web(action="search", input={"query": "precise question"}, reasoning="discover current sources")
 ```
 
-The search branch accepts only `query`. Search returns bounded structured
-results with `title`, `url`, `snippet`, and a same-Agent `link_ref`. The
-selected engine is reported as `engine`; every success or failure includes a
-bounded `current_setting`. Search never fetches page bodies and never accepts a
-per-call `engine` field. Search results can be bulky (many results, one per
-line) — use root `summarize=true` when you only need a distilled read, and
-leave it `false` (the default) when you need the exact `url`/`link_ref` values
-to browse a specific result next.
+The search branch accepts only `query`. Search returns the complete result set
+the selected provider returned for that call — there is no LingTai-imposed
+top-N/result-count cap — as `{title, url, snippet}` objects, plus a same-Agent
+`link_ref` on any result carrying a usable URL (a synthesized or URL-less
+result stays in the set without a `link_ref`). `count` is the true, uncapped
+result count. The selected engine is reported as `engine`; every success or
+failure includes a bounded `current_setting`. Search never fetches page bodies
+and never accepts a per-call `engine` field. A large result set is delivered
+as a complete artifact file rather than a lossy inline truncation — see
+"Output size and the shared `settings/web.json` threshold" below. Use root
+`summarize=true` when you only need a distilled read, and leave it `false`
+(the default) when you need the exact `url`/`link_ref` values to browse a
+specific result next.
 
 ## 2. Browse a known result
 
@@ -75,13 +81,21 @@ web(action="browse", input={
 
 Browse is static, read-only, SSRF-vetted HTTP(S) GET. Its strict input
 branch uses JSON `null` for absent optional fields; null is normalized to
-omission before dispatch. Browse returns bounded blocks, links, provenance,
-source hash, an untrusted-content marker, and typed failures.
-Use `cursor` with the same URL or link reference for continuation. Do not expect
-JavaScript, PDF, login, cookies, forms, or hidden search fallback. Keep the
-`final_url` and `source_sha256` with quotations — set root `summarize=true`
-only when you do not need to quote the page precisely; whether a browse result
-is bulky depends on what you asked it to extract, so choose per call.
+omission before dispatch. A fresh browse call delivers the complete extracted
+document for that fetch in one call — never only a first page — plus links,
+provenance, source hash, an untrusted-content marker, and typed failures. It
+never mints a continuation `next_cursor` on success; an existing `cursor`
+value is accepted only as a compatibility locator for an already-fetched page
+(no refetch), and still returns the same complete document under the same
+policy, not another partial page. A large document is delivered as a complete
+artifact file rather than a truncated inline page — see the next section. If
+the fetched page's cached snapshot is no longer available when the delivery
+decision runs (only under extreme concurrent pressure on the small
+process-local snapshot cache), browse fails loud with `error_code:
+"BROWSE_SNAPSHOT_UNAVAILABLE"` rather than returning a partial/first-page
+result. Do not expect JavaScript, PDF, login, cookies, forms, or hidden search
+fallback. Keep the `final_url` and `source_sha256` with quotations — set root
+`summarize=true` only when you do not need to quote the page precisely.
 
 ## 3. Manual, settings, and `summarize`
 
@@ -99,6 +113,71 @@ never an implementation argument to search, browse, or manual. A call that
 succeeds with `summarize=true` returns a generated-summary replacement instead
 of the raw result; a call that fails (`status: "failed"`) always returns its
 exact, unsummarized error, on every action, regardless of `summarize`.
+
+### Output size and the shared `settings/web.json` threshold
+
+Search and browse both build their complete canonical content first, then
+apply one shared, family-owned delivery threshold before returning:
+`<agent-workdir>/settings/web.json`, hot-read on every search/browse call
+(missing → default 50000; a present, invalid file fails loud — see below).
+Its complete v1 document is:
+
+```json
+{
+  "schema_version": 1,
+  "max_chars": 50000
+}
+```
+
+| Field | Required value |
+|---|---|
+| `schema_version` | JSON integer `1` exactly. |
+| `max_chars` | JSON integer, `1..100000` inclusive. Not a boolean, float, or string. |
+
+The threshold decision is measured against the exact canonical serialization
+of the content that would actually be returned inline — for search, the
+rendered JSON result list; for browse, the JSON serialization of the complete
+structured `blocks` array (not the smaller plain joined-text form). A page
+with many small blocks can have joined text well under 50000 characters while
+its structured `blocks` form is several times larger — the threshold decision
+catches that case explicitly rather than leaving it to be caught later by an
+unrelated, lossy safety net.
+
+If the decision content is at or below `max_chars`, it is returned inline
+unchanged, with `delivery: "inline"` and an exact `content_chars` (the length
+of what was actually returned — for browse, the structured `blocks`
+serialization) added. If it is larger, **no partial/prefix content is ever
+returned**: the complete content is atomically written to a file under the
+canonical `<agent-workdir>/tmp/tool-results/` directory (the same directory
+the kernel's generic oversized-tool-result spill already uses), and the
+response instead carries `delivery: "artifact"`, a workdir-relative
+`file_path`, exact `content_chars` and `content_sha256` of that file (for
+browse, the smaller plain-text document, not the structured decision length),
+`content_kind`/`format`/`encoding`, `output_setting_source`/
+`output_setting_revision`/`output_setting_hash` (which setting state produced
+this threshold), and an explicit instruction to read it in full with the
+`file.read` tool. When the decision length differs from the file's own
+`content_chars` (browse's case), the envelope also carries
+`delivery_decision_chars`/`delivery_decision_basis` so the file is never
+misread as itself having exceeded the threshold. Nothing is omitted or
+shortened in the artifact — it is the same complete content that would
+otherwise have been inline. Search's `results` array or Browse's
+`blocks`/`partial`/`next_cursor` are absent from a spilled envelope; do not
+expect a lossy subset alongside the artifact. A write failure returns
+`status: "failed"`, `error_code: "ARTIFACT_WRITE_FAILED"` rather than a
+silent fallback.
+
+Browse's existing per-call `input.max_chars` (`1..100000`, or `null`) still
+works, but now overrides this shared threshold for that one call instead of
+choosing a pagination page size; `null` uses the shared setting.
+
+`settings/web.json` is a separate file from `settings/web.search.json` below
+— different filename, different owner concern (shared output threshold vs.
+search-only engine selection), never merged or cross-read. Manual reads
+neither file. A present-but-invalid `settings/web.json` (wrong schema,
+unknown field, wrong type, out-of-range `max_chars`) fails the in-flight
+search or browse call with `error_code: "WEB_OUTPUT_SETTINGS_INVALID"` before
+any provider call or page fetch — never silently defaulted or clamped.
 
 ### Search settings — exact contract
 
@@ -157,13 +236,14 @@ MiniMax and Zhipu are retired from built-in admission entirely: naming
 either via `provider=`, `default_engine=`, or `engines={}` fails explicitly
 and actionably — never a silent DuckDuckGo substitution.
 
-There is no family-owned `settings/web.json`, no
-`settings/web.browse.json`, and no `settings/web.manual.json`. The old family
-path is not a compatibility source. Lingtai does not cross-read, merge, overlay,
-or apply precedence between settings files, and it never silently substitutes
-another engine when a present selection is invalid or unavailable. Operator
-composition owns admitted engines, provider credentials, models, and provider
-kwargs outside this file.
+There is no `settings/web.browse.json` and no `settings/web.manual.json`.
+`settings/web.json` exists but is a separate, family-owned file for the
+shared output-delivery threshold (previous section) — engine selection lives
+only in `settings/web.search.json`, and Lingtai never cross-reads, merges,
+overlays, or applies precedence between the two files, and never silently
+substitutes another engine when a present selection is invalid or
+unavailable. Operator composition owns admitted engines, provider
+credentials, models, and provider kwargs outside this file.
 
 Browse and manual stay usable and provider/network independent even when the
 search settings file is invalid. Their `current_setting` block is explicitly

--- a/src/lingtai/tools/web_search/settings.py
+++ b/src/lingtai/tools/web_search/settings.py
@@ -1,10 +1,14 @@
-"""Strict per-Agent settings for the ``web`` capability's ``search`` action.
+"""Strict per-Agent settings for the ``web`` capability.
 
-The settings file is intentionally a tiny selector, not a provider
+``settings/web.search.json`` is intentionally a tiny selector, not a provider
 configuration file.  Operators configure engines and credentials at setup;
 an Agent-owned, action-owned ``settings/web.search.json`` may select only one
-admitted engine.  There is no family-owned ``settings/web.json``; browse and
-manual read no settings file at all.
+admitted engine.
+
+``settings/web.json`` is a separate, family-owned file that holds the shared
+``max_chars`` inline-vs-artifact delivery threshold consumed identically by
+both ``search`` and ``browse``.  It is read by neither ``manual`` nor by the
+engine-selector reader above; the two files are never merged or cross-read.
 """
 from __future__ import annotations
 
@@ -56,6 +60,44 @@ def settings_path(agent: Any) -> Path:
     return Path(agent._working_dir) / "settings" / "web.search.json"
 
 
+DEFAULT_OUTPUT_MAX_CHARS = 50_000
+MIN_OUTPUT_MAX_CHARS = 1
+MAX_OUTPUT_MAX_CHARS = 100_000
+
+
+def output_settings_path(agent: Any) -> Path:
+    """Return the one fixed, family-owned output-delivery settings path."""
+    return Path(agent._working_dir) / "settings" / "web.json"
+
+
+@dataclass(frozen=True, slots=True)
+class OutputSettingsSnapshot:
+    max_chars: int | None
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def _default_output_snapshot() -> "OutputSettingsSnapshot":
+    """Return the deterministic snapshot for a missing ``settings/web.json``.
+
+    ``revision``/``digest`` are not ``None``/a bare sentinel string: they are
+    computed the same way a present, valid file's own canonical serialization
+    would be hashed, over the *effective default document*
+    (``{"schema_version": 1, "max_chars": DEFAULT_OUTPUT_MAX_CHARS}``). This
+    makes "default applied" a truthful, stable, independently-verifiable
+    diagnostic fact rather than an opaque absence — a caller can recompute
+    the same digest from the documented default and confirm it matches.
+    """
+    canonical = json.dumps(
+        {"schema_version": 1, "max_chars": DEFAULT_OUTPUT_MAX_CHARS},
+        sort_keys=True, separators=(",", ":"),
+    ).encode("utf-8")
+    digest = hashlib.sha256(canonical).hexdigest()[:32]
+    return OutputSettingsSnapshot(DEFAULT_OUTPUT_MAX_CHARS, "default", "default", digest)
+
+
 def _bounded_error(exc: Exception) -> str:
     # OS errors commonly include the absolute path passed to ``open``. The
     # result contract exposes only the agent-relative settings path, never the
@@ -75,15 +117,21 @@ def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     return result
 
 
-def _read_stable(path: Path) -> tuple[bytes, str]:
+def _read_stable_named(path: Path, *, filename: str) -> tuple[bytes, str]:
+    """Bounded, race-checked read of one settings file, named for error text.
+
+    Shared by both settings readers so ``settings/web.json`` gets the exact
+    same symlink/non-regular/size/stability guarantees as
+    ``settings/web.search.json`` without duplicating the check logic.
+    """
     try:
         first = path.lstat()
     except FileNotFoundError:
         return b"", "missing"
     if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
-        raise SettingsError("settings/web.search.json must be a regular file")
+        raise SettingsError(f"{filename} must be a regular file")
     if first.st_size > MAX_SETTINGS_BYTES:
-        raise SettingsError("settings/web.search.json exceeds the bounded size")
+        raise SettingsError(f"{filename} exceeds the bounded size")
     # Open by path only after lstat: a changed link/non-regular file is rejected
     # rather than followed.  A second stat closes ordinary replacement races.
     with path.open("rb") as handle:
@@ -103,6 +151,10 @@ def _read_stable(path: Path) -> tuple[bytes, str]:
         raise SettingsError("settings snapshot changed during read")
     digest = hashlib.sha256(raw).hexdigest()[:32]
     return raw, digest
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    return _read_stable_named(path, filename="settings/web.search.json")
 
 
 def read_settings(
@@ -148,6 +200,60 @@ def read_settings(
             digest or "error",
             digest,
             _bounded_error(exc if isinstance(exc, Exception) else SettingsError("invalid settings")),
+        )
+
+
+def read_output_settings(agent: Any) -> OutputSettingsSnapshot:
+    """Read and validate the shared ``settings/web.json`` output-delivery snapshot.
+
+    Consumed identically by ``search`` and ``browse`` for the inline-vs-artifact
+    ``max_chars`` threshold. Missing file uses the built-in default
+    (``DEFAULT_OUTPUT_MAX_CHARS``); a present-but-invalid file (malformed JSON,
+    unknown/duplicate fields, wrong schema_version, non-int/bool/out-of-range
+    ``max_chars``, symlink, non-regular, oversize, bad UTF-8, unstable snapshot)
+    fails loud via ``OutputSettingsSnapshot.error`` — never silently clamped or
+    coerced, and never treated as missing. Neither ``manual`` nor
+    ``read_settings`` calls this reader.
+    """
+    path = output_settings_path(agent)
+    try:
+        raw, revision = _read_stable_named(path, filename="settings/web.json")
+        if revision == "missing":
+            return _default_output_snapshot()
+        text = raw.decode("utf-8")
+        value = json.loads(text, object_pairs_hook=_pairs)
+        if not isinstance(value, dict) or set(value) != {"schema_version", "max_chars"}:
+            raise SettingsError("settings/web.json must contain only schema_version and max_chars")
+        if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+            raise SettingsError("settings/web.json schema_version must be integer 1")
+        max_chars = value["max_chars"]
+        if (
+            isinstance(max_chars, bool)
+            or not isinstance(max_chars, int)
+            or not (MIN_OUTPUT_MAX_CHARS <= max_chars <= MAX_OUTPUT_MAX_CHARS)
+        ):
+            raise SettingsError(
+                f"settings/web.json max_chars must be an integer between "
+                f"{MIN_OUTPUT_MAX_CHARS} and {MAX_OUTPUT_MAX_CHARS}"
+            )
+        return OutputSettingsSnapshot(max_chars, "settings/web.json", revision, revision)
+    except (OSError, UnicodeError, json.JSONDecodeError, SettingsError) as exc:
+        digest: str | None = None
+        try:
+            if path.is_file() and not path.is_symlink():
+                with path.open("rb") as handle:
+                    digest = hashlib.sha256(handle.read(MAX_SETTINGS_BYTES)).hexdigest()[:32]
+        except OSError:
+            pass
+        message = str(exc).replace("\n", " ").strip()
+        if isinstance(exc, OSError):
+            message = f"settings/web.json could not be read ({type(exc).__name__})"
+        return OutputSettingsSnapshot(
+            None,
+            "settings_error",
+            digest or "error",
+            digest,
+            (message or "invalid settings")[:240],
         )
 
 

--- a/tests/test_browser_capability.py
+++ b/tests/test_browser_capability.py
@@ -39,7 +39,7 @@ class FakeSearch:
     def __init__(self):
         self.queries: list[str] = []
 
-    def search(self, query: str):
+    def search(self, query: str, max_results: int | None = None):
         self.queries.append(query)
         return [{
             "title": "Provider-shaped result",
@@ -89,7 +89,7 @@ def test_web_browse_vertical_slice(tmp_path):
                 "link_ref": None,
                 "cursor": None,
                 "extract": None,
-                "max_chars": 18,
+                "max_chars": None,
             },
         })
         assert first["status"] == "ok"
@@ -98,25 +98,38 @@ def test_web_browse_vertical_slice(tmp_path):
         assert first["requested_url"] == "https://public.example/page"
         assert first["final_url"] == "https://public.example/page"
         assert first["untrusted_content"] is True
-        assert first["next_cursor"]
+        # A fresh Browse success delivers the complete extracted document in
+        # one call and never mints a continuation cursor.
+        assert first["next_cursor"] is None
+        assert first["partial"] is False
+        assert first["delivery"] == "inline"
         calls_after_first = len(port.calls)
 
+        # A legacy cursor (obtained directly from the underlying engine, as a
+        # pre-migration caller would have) remains accepted only as a
+        # compatibility locator: it resolves the same cached snapshot without
+        # a refetch, but still returns the complete document under the new
+        # full-output policy rather than another partial page.
+        from lingtai.tools.browser.cursor import CursorPayload
+        web_manager = agent._tool_handlers["web"].__self__
+        engine = web_manager.browser_engine
+        snapshot_id = first["snapshot_id"]
+        legacy_cursor = engine.cursor.encode(CursorPayload(snapshot_id, "article", 0, 5))
         second = agent._tool_handlers["web"]({
             "action": "browse",
             "input": {
                 "url": "https://public.example/page",
                 "link_ref": None,
-                "cursor": first["next_cursor"],
+                "cursor": legacy_cursor,
                 "extract": None,
-                "max_chars": 18,
+                "max_chars": None,
             },
         })
         assert second["status"] == "ok"
-        assert second["timings_ms"] == {}
         assert len(port.calls) == calls_after_first
-        first_ids = {block["id"] for block in first["blocks"]}
-        second_ids = {block["id"] for block in second["blocks"]}
-        assert first_ids.isdisjoint(second_ids)
+        assert second["next_cursor"] is None
+        assert second["partial"] is False
+        assert second["blocks"] == first["blocks"]
 
         link_ref = first["links"][0]["ref"]
         followed = agent._tool_handlers["web"]({

--- a/tests/test_tool_family_web_migration_parity.py
+++ b/tests/test_tool_family_web_migration_parity.py
@@ -100,7 +100,7 @@ def _pre_migration_schema() -> dict:
                                 "type": ["integer", "null"],
                                 "minimum": 1,
                                 "maximum": 100000,
-                                "description": "Maximum returned characters, or null for the default 12000.",
+                                "description": "Per-call override of the inline-vs-artifact delivery threshold; null uses the shared settings/web.json setting (default 50000). The complete document is always delivered, inline or as an artifact.",
                             },
                         },
                         "required": ["url", "link_ref", "cursor", "extract", "max_chars"],

--- a/tests/test_unified_web_capability.py
+++ b/tests/test_unified_web_capability.py
@@ -28,7 +28,7 @@ class _Search:
     def __init__(self) -> None:
         self.calls: list[str] = []
 
-    def search(self, query: str):
+    def search(self, query: str, max_results: int | None = None):
         self.calls.append(query)
         return [type("Result", (), {"title": "title", "url": "https://example.test/r", "snippet": "snippet"})()]
 
@@ -222,21 +222,32 @@ def test_settings_changed_file_is_observed_on_next_call(tmp_path):
     assert third["current_setting"]["settings_revision"] == first_revision
 
 
-def test_no_old_family_owned_web_json_cross_read(tmp_path):
-    """A stale/legacy family-owned settings/web.json must never be consulted;
-    only the action-owned settings/web.search.json is read."""
+def test_web_search_json_is_a_separate_family_owned_file_from_engine_selector(tmp_path):
+    """settings/web.json (shared output threshold) and settings/web.search.json
+    (engine selector) are two distinct, non-overlapping settings files: an
+    engine-shaped payload under the wrong filename is genuinely invalid for
+    settings/web.json's own schema, and a valid settings/web.json does not
+    affect engine selection, which still reads only web.search.json."""
     agent = _Agent(tmp_path)
     manager = setup(agent, search_service=_Search(), browser_port=_Port())
     settings_dir = tmp_path / "settings"
     settings_dir.mkdir()
+    # An old-shape (engine-selector) payload under the new family-owned
+    # filename is malformed for settings/web.json's own {schema_version,
+    # max_chars} schema and must fail loud, not be silently reinterpreted.
     (settings_dir / "web.json").write_text(
         json.dumps({"schema_version": 1, "search": {"engine": "not-admitted"}})
     )
-    # The old-path file is present but must be ignored: no web.search.json
-    # exists, so this call takes the built-in/operator default, not the
-    # invalid selector recorded in the legacy family-owned file.
+    result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "WEB_OUTPUT_SETTINGS_INVALID"
+
+    # A genuinely valid settings/web.json coexists with, and never overrides,
+    # the separate engine-selector file.
+    (settings_dir / "web.json").write_text(json.dumps({"schema_version": 1, "max_chars": 1234}))
     result = manager.handle({"action": "search", "input": {"query": "q"}})
     assert result["status"] == "ok"
+    assert result["current_setting"]["output_max_chars"]["value"] == 1234
     assert result["current_setting"]["source"] != "settings/web.json"
 
 
@@ -382,9 +393,9 @@ def test_summarize_is_stripped_before_dispatch_and_not_leaked_to_search(tmp_path
     captured_args = {}
     original_search = manager._search
 
-    def spy(args, snapshot, diagnostic):
+    def spy(args, snapshot, output_snapshot, diagnostic):
         captured_args.update(args)
-        return original_search(args, snapshot, diagnostic)
+        return original_search(args, snapshot, output_snapshot, diagnostic)
 
     manager._search = spy
     manager.handle({"action": "search", "input": {"query": "q2"}, "summarize": True})
@@ -425,21 +436,34 @@ def test_summarize_absent_is_default_false_and_unaffected(tmp_path):
     assert result["status"] == "ok"
 
 
-def test_search_caps_an_unbounded_provider_iterable(tmp_path):
-    class GeneratorSearch:
-        def search(self, query):
-            def results():
-                index = 0
-                while True:
-                    yield {"title": str(index), "url": f"https://example.test/{index}", "snippet": "s"}
-                    index += 1
-            return results()
+def test_search_has_no_result_count_cap_for_a_large_finite_provider_response(tmp_path):
+    """No LingTai-imposed top-N or content-size cap: a large finite result set
+    — well beyond both the historical 20-item cap and the 50_000-char inline
+    threshold — is preserved completely (delivered as an artifact, never
+    trimmed or marked partial). ``SearchService`` is contracted to return a
+    finite list; there is no operational iteration ceiling to test here
+    because none exists — an out-of-contract non-terminating iterable is
+    explicitly not defended against (see ``_search``'s own comment)."""
+    class LargeFiniteSearch:
+        def search(self, query, max_results=None):
+            assert max_results is None  # no-count-cap mode: the call site omits it
+            return [
+                {"title": f"Result {i}", "url": f"https://example.test/{i}", "snippet": "Lorem ipsum dolor sit amet."}
+                for i in range(500)
+            ]
 
-    manager = setup(_Agent(tmp_path), search_service=GeneratorSearch(), browser_port=_Port())
+    manager = setup(_Agent(tmp_path), search_service=LargeFiniteSearch(), browser_port=_Port())
     result = manager.handle({"action": "search", "input": {"query": "question"}})
     assert result["status"] == "ok"
-    assert result["count"] == 20
-    assert len(result["results"]) == 20
+    assert result["count"] == 500
+    assert "iteration_bounded" not in result
+    assert "partial" not in result
+    # 500 results at this size comfortably exceed the 50_000-char default
+    # threshold, so this is delivered as a complete artifact, not inline.
+    assert result["delivery"] == "artifact"
+    artifact_path = tmp_path / result["file_path"]
+    parsed = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert len(parsed) == 500
 
 
 class _CompressedPort:

--- a/tests/test_web_canonical_provider_routing.py
+++ b/tests/test_web_canonical_provider_routing.py
@@ -111,7 +111,7 @@ def test_real_no_config_default_falls_back_to_duckduckgo_without_openai_key(tmp_
     assert result["current_setting"]["source"] == "built_in_default"
     assert result["engine"] == "duckduckgo"
     assert result["status"] == "ok"
-    mock_ddg_cls.return_value.search.assert_called_once_with("q")
+    mock_ddg_cls.return_value.search.assert_called_once_with("q", max_results=None)
 
 
 def test_real_no_config_default_reports_anthropic_and_gemini_as_selectable_but_unselected(tmp_path, monkeypatch):
@@ -201,7 +201,7 @@ def test_settings_file_selection_succeeds_on_canonical_backend(tmp_path, engine)
     result = mgr.handle({"action": "search", "input": {"query": "q"}})
     assert result["status"] == "ok"
     assert result["engine"] == engine
-    service.search.assert_called_once_with("q")
+    service.search.assert_called_once_with("q", max_results=None)
 
 
 @pytest.mark.parametrize("engine", ["anthropic", "gemini"])
@@ -238,7 +238,7 @@ def test_settings_file_selection_is_hot_read_live_change_no_refresh(tmp_path):
     second = mgr.handle({"action": "search", "input": {"query": "q"}})
     assert second["engine"] == "duckduckgo"
     assert second["current_setting"]["source"] == "settings/web.search.json"
-    ddg_service.search.assert_called_once_with("q")
+    ddg_service.search.assert_called_once_with("q", max_results=None)
 
 
 @pytest.mark.parametrize("engine", ["anthropic", "gemini"])
@@ -413,7 +413,7 @@ def test_openai_runtime_failure_falls_back_to_duckduckgo_once(tmp_path):
     assert "comment" in result and "OpenAI" in result["comment"] and "DuckDuckGo" in result["comment"]
     assert result["openai_failure_class"] == "Timeout"
     assert result["count"] == 1
-    mock_ddg_cls.return_value.search.assert_called_once_with("q")
+    mock_ddg_cls.return_value.search.assert_called_once_with("q", max_results=None)
 
 
 def test_openai_runtime_failure_no_secrets_in_comment_or_diagnostics(tmp_path):
@@ -443,7 +443,7 @@ def test_openai_and_duckduckgo_both_fail_reports_typed_failure_no_second_retry(t
     assert result["error_code"] == "SEARCH_FAILED"
     assert result["openai_failure_class"] == "ServerError"
     assert result["duckduckgo_failure_class"] == "RuntimeError"
-    mock_ddg_cls.return_value.search.assert_called_once_with("q")
+    mock_ddg_cls.return_value.search.assert_called_once_with("q", max_results=None)
 
 
 def test_openai_programming_bug_does_not_trigger_duckduckgo_fallback(tmp_path):

--- a/tests/test_web_output_spill.py
+++ b/tests/test_web_output_spill.py
@@ -1,0 +1,829 @@
+"""Web full-result inline-vs-artifact delivery: settings/web.json, spill
+envelopes for search and browse, Unicode/threshold boundaries, atomic
+uniqueness, artifact readability via file.read, write failure, and no outer
+double-spill.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from lingtai.tools.browser.port import TransportResponse
+from lingtai.tools.web_search import setup
+from lingtai.tools.web_search._spill import spill_if_over_threshold
+from lingtai.tools.web_search.settings import (
+    DEFAULT_OUTPUT_MAX_CHARS,
+    OutputSettingsSnapshot,
+    read_output_settings,
+)
+from lingtai.kernel.tool_executor import ToolExecutor
+from lingtai.kernel.tool_result_artifacts import PREVENTIVE_MAX_CHARS, is_spill_manifest
+
+
+def _snapshot(max_chars: int) -> OutputSettingsSnapshot:
+    return OutputSettingsSnapshot(max_chars, "default", "default", "test-digest")
+
+
+class _Agent:
+    def __init__(self, root: Path) -> None:
+        self._working_dir = root
+
+    def add_tool(self, *args, **kwargs) -> None:
+        self.tool_name = args[0]
+        self.schema = kwargs["schema"]
+        self.handler = kwargs["handler"]
+
+
+class _LargeSearch:
+    """Returns a large finite result set, including synthesized (non-URL) hits."""
+
+    def __init__(self, count: int, *, include_synthesized: bool = False) -> None:
+        self._count = count
+        self._include_synthesized = include_synthesized
+
+    def search(self, query: str, max_results=None):
+        assert max_results is None
+        results = [
+            {
+                "title": f"Result {i}",
+                "url": f"https://example.test/article-{i}",
+                "snippet": "Lorem ipsum dolor sit amet.",
+            }
+            for i in range(self._count)
+        ]
+        if self._include_synthesized:
+            results.append({"title": "Synthesized answer", "url": "", "snippet": "no url here"})
+        return results
+
+
+class _Port:
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.requests: list[str] = []
+
+    def resolve(self, hostname: str, *, timeout_s: float):
+        return ["93.184.216.34"]
+
+    def request(self, url: str, *, resolved, max_bytes: int, timeout_s: float):
+        self.requests.append(url)
+        return TransportResponse(200, {"content-type": "text/html"}, self.body, False, url)
+
+
+def _read_web_json(agent) -> dict:
+    path = agent._working_dir / "settings" / "web.json"
+    return json.loads(path.read_text())
+
+
+# --- settings/web.json shared-setting contract ---
+
+
+def test_output_settings_missing_file_uses_default(tmp_path):
+    agent = _Agent(tmp_path)
+    snapshot = read_output_settings(agent)
+    assert snapshot.max_chars == DEFAULT_OUTPUT_MAX_CHARS == 50_000
+    assert snapshot.source == "default"
+    assert snapshot.error is None
+
+
+def test_output_settings_valid_override_is_respected(tmp_path):
+    agent = _Agent(tmp_path)
+    (tmp_path / "settings").mkdir()
+    (tmp_path / "settings" / "web.json").write_text(json.dumps({"schema_version": 1, "max_chars": 100}))
+    snapshot = read_output_settings(agent)
+    assert snapshot.max_chars == 100
+    assert snapshot.source == "settings/web.json"
+    assert snapshot.error is None
+
+
+def test_output_settings_boundary_values_are_valid(tmp_path):
+    agent = _Agent(tmp_path)
+    (tmp_path / "settings").mkdir()
+    settings_path = tmp_path / "settings" / "web.json"
+    for boundary in (1, 100_000):
+        settings_path.write_text(json.dumps({"schema_version": 1, "max_chars": boundary}))
+        snapshot = read_output_settings(agent)
+        assert snapshot.max_chars == boundary
+        assert snapshot.error is None
+
+
+def test_output_settings_out_of_range_fails_loud_not_clamped(tmp_path):
+    agent = _Agent(tmp_path)
+    (tmp_path / "settings").mkdir()
+    settings_path = tmp_path / "settings" / "web.json"
+    for bad in (0, -1, 100_001, 10**9):
+        settings_path.write_text(json.dumps({"schema_version": 1, "max_chars": bad}))
+        snapshot = read_output_settings(agent)
+        assert snapshot.max_chars is None
+        assert snapshot.error is not None
+
+
+def test_output_settings_wrong_type_and_bool_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    (tmp_path / "settings").mkdir()
+    settings_path = tmp_path / "settings" / "web.json"
+    for bad in (True, False, "50000", 50000.0, None, [50000]):
+        settings_path.write_text(json.dumps({"schema_version": 1, "max_chars": bad}))
+        snapshot = read_output_settings(agent)
+        assert snapshot.error is not None, bad
+
+
+def test_output_settings_unknown_and_missing_fields_are_rejected(tmp_path):
+    agent = _Agent(tmp_path)
+    (tmp_path / "settings").mkdir()
+    settings_path = tmp_path / "settings" / "web.json"
+    for payload in (
+        {"schema_version": 1, "max_chars": 5000, "extra": "x"},
+        {"schema_version": 1},
+        {"max_chars": 5000},
+    ):
+        settings_path.write_text(json.dumps(payload))
+        snapshot = read_output_settings(agent)
+        assert snapshot.error is not None, payload
+
+
+def test_output_settings_search_and_browse_share_one_setting(tmp_path):
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=_Port(b"<p>x</p>"))
+    (tmp_path / "settings").mkdir()
+    (tmp_path / "settings" / "web.json").write_text(json.dumps({"schema_version": 1, "max_chars": 7}))
+    search_result = manager.handle({"action": "search", "input": {"query": "q"}})
+    browse_result = manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/page", "link_ref": None, "cursor": None, "extract": None, "max_chars": None},
+    })
+    assert search_result["current_setting"]["output_max_chars"]["value"] == 7
+    assert browse_result["current_setting"]["output_max_chars"]["value"] == 7
+
+
+def test_invalid_output_settings_fails_search_and_browse_before_side_effects(tmp_path):
+    port = _Port(b"<p>x</p>")
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=port)
+    (tmp_path / "settings").mkdir()
+    (tmp_path / "settings" / "web.json").write_text("{not-json")
+
+    search_result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert search_result["status"] == "failed"
+    assert search_result["error_code"] == "WEB_OUTPUT_SETTINGS_INVALID"
+
+    browse_result = manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/page", "link_ref": None, "cursor": None, "extract": None, "max_chars": None},
+    })
+    assert browse_result["status"] == "failed"
+    assert browse_result["error_code"] == "WEB_OUTPUT_SETTINGS_INVALID"
+    # No side effect: browse never fetched the page.
+    assert port.requests == []
+
+
+def test_manual_performs_zero_settings_io_including_web_json(tmp_path, monkeypatch):
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=_Port(b"<p>x</p>"))
+    (tmp_path / "settings").mkdir()
+    (tmp_path / "settings" / "web.json").write_text("{not-json")
+
+    def fail_read_output_settings(*args, **kwargs):
+        raise AssertionError("manual must never read settings/web.json")
+
+    monkeypatch.setattr("lingtai.tools.web_search.read_output_settings", fail_read_output_settings)
+    result = manager.handle({"action": "manual", "input": {}})
+    # No AssertionError from fail_read_output_settings means manual never
+    # called it; the diagnostic block confirms the same truthfully.
+    assert result["action"] == "manual"
+    assert result["current_setting"]["output_max_chars"]["source"] == "not_applicable"
+
+
+# --- Search: inline vs artifact delivery ---
+
+
+def test_search_small_result_set_delivered_inline(tmp_path):
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_LargeSearch(3), browser_port=_Port(b"<p>x</p>"))
+    result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert result["status"] == "ok"
+    assert result["delivery"] == "inline"
+    assert len(result["results"]) == 3
+    assert "file_path" not in result
+
+
+def test_search_large_result_set_spills_to_json_artifact_with_no_preview(tmp_path):
+    agent = _Agent(tmp_path)
+    # Each result is ~350+ chars; 400 results guarantees > 50_000 total chars.
+    manager = setup(agent, search_service=_LargeSearch(400), browser_port=_Port(b"<p>x</p>"))
+    result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert result["status"] == "ok"
+    assert result["delivery"] == "artifact"
+    assert "results" not in result
+    assert result["count"] == 400
+    assert result["content_kind"] == "search_results"
+    assert result["format"] == "json"
+    assert result["content_scope"] == "provider_response"
+
+    artifact_path = tmp_path / result["file_path"]
+    assert artifact_path.is_file()
+    content = artifact_path.read_text(encoding="utf-8")
+    assert len(content) == result["content_chars"]
+    assert hashlib.sha256(content.encode("utf-8")).hexdigest() == result["content_sha256"]
+    parsed = json.loads(content)
+    assert len(parsed) == 400
+    assert "file.read" in result["instruction"]
+    assert "preview" not in result
+
+
+def test_search_preserves_synthesized_non_url_results_and_long_fields(tmp_path):
+    agent = _Agent(tmp_path)
+    manager = setup(
+        agent,
+        search_service=_LargeSearch(2, include_synthesized=True),
+        browser_port=_Port(b"<p>x</p>"),
+    )
+    result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert result["status"] == "ok"
+    assert result["count"] == 3
+    synthesized = [r for r in result["results"] if r["url"] == ""]
+    assert len(synthesized) == 1
+    # A bounded citation-free narrative result is preserved with an explicit
+    # link_ref: null — never a fabricated ref, but never an omitted key
+    # either (CONTRACT.md "Provider ownership and routing").
+    assert synthesized[0]["link_ref"] is None
+    url_bearing = [r for r in result["results"] if r["url"]]
+    assert all(r["link_ref"] is not None for r in url_bearing)
+
+
+def test_search_unicode_character_count_is_code_points_not_utf8_bytes(tmp_path):
+    class UnicodeSearch:
+        def search(self, query, max_results=None):
+            return [{"title": "中文标题" * 5000, "url": "https://example.test/z", "snippet": "s"}]
+
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=UnicodeSearch(), browser_port=_Port(b"<p>x</p>"))
+    (tmp_path / "settings").mkdir()
+    (tmp_path / "settings" / "web.json").write_text(json.dumps({"schema_version": 1, "max_chars": 100}))
+    result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert result["delivery"] == "artifact"
+    artifact_path = tmp_path / result["file_path"]
+    content = artifact_path.read_text(encoding="utf-8")
+    assert len(content) == result["content_chars"]
+    # Sanity: multi-byte UTF-8 means byte length exceeds character length.
+    assert len(content.encode("utf-8")) > len(content)
+
+
+def test_search_threshold_boundary_off_by_one(tmp_path):
+    class FixedSearch:
+        def search(self, query, max_results=None):
+            return [{"title": "x" * 10, "url": "https://example.test/a", "snippet": ""}]
+
+    # Compute the exact serialized length for a 1-result payload, then probe
+    # max_chars at that exact boundary from both sides.
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=FixedSearch(), browser_port=_Port(b"<p>x</p>"))
+    probe_result = manager.handle({"action": "search", "input": {"query": "q"}})
+    exact_chars = probe_result["content_chars"]
+
+    (tmp_path / "settings").mkdir()
+    (tmp_path / "settings" / "web.json").write_text(json.dumps({"schema_version": 1, "max_chars": exact_chars}))
+    at_boundary = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert at_boundary["delivery"] == "inline"
+
+    (tmp_path / "settings" / "web.json").write_text(json.dumps({"schema_version": 1, "max_chars": exact_chars - 1}))
+    over_boundary = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert over_boundary["delivery"] == "artifact"
+
+
+def test_search_per_engine_adapters_receive_no_count_cap(tmp_path):
+    calls = []
+
+    class RecordingSearch:
+        def search(self, query, max_results=None):
+            calls.append(max_results)
+            return [{"title": "t", "url": "https://example.test/a", "snippet": "s"}]
+
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=RecordingSearch(), browser_port=_Port(b"<p>x</p>"))
+    manager.handle({"action": "search", "input": {"query": "q"}})
+    assert calls == [None]
+
+
+def test_search_spilled_openai_fallback_preserves_comment_and_failure_class(tmp_path):
+    """The one OpenAI->DuckDuckGo runtime fallback must stay *informed* when
+    its success result spills: CONTRACT.md's fallback section promises a
+    top-level ``comment`` and bounded ``openai_failure_class`` with no spill
+    carve-out, so both must survive in the spilled envelope exactly as they
+    do inline, alongside ``engine``/``actual_engine`` and the complete
+    artifact metadata."""
+    from unittest.mock import MagicMock, patch
+
+    from lingtai.services.websearch import SearchResult, SearchService
+    from lingtai.services.websearch.openai import OpenAISearchError
+
+    agent = _Agent(tmp_path)
+    failing_service = MagicMock(spec=SearchService)
+    failing_service.search.side_effect = OpenAISearchError("Timeout")
+    manager = setup(agent, engines={"openai": {"search_service": failing_service}}, browser_port=_Port(b"<p>x</p>"))
+    ddg_results = [
+        SearchResult(title=f"Fallback {i}", url=f"https://example.test/f-{i}", snippet="s")
+        for i in range(3)
+    ]
+
+    with patch("lingtai.services.websearch.duckduckgo.DuckDuckGoSearchService") as mock_ddg_cls:
+        mock_ddg_cls.return_value.search.return_value = ddg_results
+        inline = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert inline["status"] == "ok"
+    assert inline["delivery"] == "inline"
+    assert "OpenAI" in inline["comment"] and "DuckDuckGo" in inline["comment"]
+    assert inline["openai_failure_class"] == "Timeout"
+
+    # Force the same fallback success to spill through a contractually valid
+    # operator setting (settings/web.json max_chars may be as low as 1).
+    (tmp_path / "settings").mkdir()
+    (tmp_path / "settings" / "web.json").write_text(json.dumps({"schema_version": 1, "max_chars": 1}))
+    with patch("lingtai.services.websearch.duckduckgo.DuckDuckGoSearchService") as mock_ddg_cls:
+        mock_ddg_cls.return_value.search.return_value = ddg_results
+        spilled = manager.handle({"action": "search", "input": {"query": "q"}})
+
+    assert spilled["status"] == "ok"
+    assert spilled["delivery"] == "artifact"
+    # Informed-substitution provenance survives the spill, identical to inline.
+    assert spilled["comment"] == inline["comment"]
+    assert spilled["openai_failure_class"] == "Timeout"
+    assert spilled["engine"] == "openai"
+    assert spilled["actual_engine"] == "duckduckgo"
+    # Complete artifact metadata; no inline results, no preview.
+    assert spilled["count"] == 3
+    assert "results" not in spilled and "preview" not in spilled
+    artifact_path = tmp_path / spilled["file_path"]
+    content = artifact_path.read_text(encoding="utf-8")
+    assert len(content) == spilled["content_chars"]
+    assert hashlib.sha256(content.encode("utf-8")).hexdigest() == spilled["content_sha256"]
+    assert spilled["content_kind"] == "search_results"
+    assert spilled["format"] == "json"
+    # The failure-only DDG class never appears on a success envelope.
+    assert "duckduckgo_failure_class" not in inline
+    assert "duckduckgo_failure_class" not in spilled
+
+
+def test_search_non_fallback_spill_carries_no_fallback_fields(tmp_path):
+    """A plain (non-fallback) spilled search must not grow the fallback-only
+    ``comment``/``openai_failure_class`` fields."""
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_LargeSearch(400), browser_port=_Port(b"<p>x</p>"))
+    result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert result["delivery"] == "artifact"
+    assert "comment" not in result
+    assert "openai_failure_class" not in result
+
+
+# --- Browse: inline vs artifact delivery ---
+
+
+def test_browse_small_page_delivered_inline_complete(tmp_path):
+    agent = _Agent(tmp_path)
+    port = _Port(b"<html><body><p>short page text</p></body></html>")
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=port)
+    result = manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/page", "link_ref": None, "cursor": None, "extract": None, "max_chars": None},
+    })
+    assert result["status"] == "ok"
+    assert result["delivery"] == "inline"
+    assert result["partial"] is False
+    assert result["next_cursor"] is None
+    assert "file_path" not in result
+
+
+def test_browse_large_page_spills_to_text_artifact_with_no_preview(tmp_path):
+    paragraphs = "".join(f"<p>{'word ' * 50} paragraph {i}</p>" for i in range(400))
+    body = f"<html><body>{paragraphs}</body></html>".encode()
+    agent = _Agent(tmp_path)
+    port = _Port(body)
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=port)
+    result = manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/big", "link_ref": None, "cursor": None, "extract": None, "max_chars": None},
+    })
+    assert result["status"] == "ok"
+    assert result["delivery"] == "artifact"
+    assert "blocks" not in result
+    assert "partial" not in result
+    assert "next_cursor" not in result
+    assert result["content_kind"] == "page_text"
+    assert result["format"] == "text"
+    assert result["content_scope"] == "fetched_static_document"
+
+    artifact_path = tmp_path / result["file_path"]
+    assert artifact_path.is_file()
+    content = artifact_path.read_text(encoding="utf-8")
+    assert len(content) == result["content_chars"]
+    assert hashlib.sha256(content.encode("utf-8")).hexdigest() == result["content_sha256"]
+    assert "preview" not in result
+    assert "file.read" in result["instruction"]
+
+
+def test_browse_per_call_max_chars_overrides_delivery_threshold(tmp_path):
+    agent = _Agent(tmp_path)
+    port = _Port(b"<html><body><p>twenty-five characters!!</p></body></html>")
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=port)
+    result = manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/page", "link_ref": None, "cursor": None, "extract": None, "max_chars": 3},
+    })
+    assert result["status"] == "ok"
+    assert result["delivery"] == "artifact"
+    assert result["current_setting"]["output_max_chars"]["value"] == 3
+    assert result["current_setting"]["output_max_chars"]["source"] == "call_override"
+
+
+def test_browse_null_max_chars_uses_shared_setting(tmp_path):
+    agent = _Agent(tmp_path)
+    port = _Port(b"<html><body><p>content</p></body></html>")
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=port)
+    (tmp_path / "settings").mkdir()
+    (tmp_path / "settings" / "web.json").write_text(json.dumps({"schema_version": 1, "max_chars": 12345}))
+    result = manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/page", "link_ref": None, "cursor": None, "extract": None, "max_chars": None},
+    })
+    assert result["current_setting"]["output_max_chars"]["value"] == 12345
+    assert result["current_setting"]["output_max_chars"]["source"] == "settings/web.json"
+
+
+# --- Browse: threshold decision must measure the structured inline
+# serialization, not the compact joined-text file representation
+# (Blocker A). A production page with many small blocks can have joined
+# plain text well under the 50_000-char default threshold while its
+# structured `blocks` JSON — the content actually returned inline — is
+# several times larger, large enough to also cross the unrelated generic
+# 200_000-char preventive-spill ceiling if left undetected. ---
+
+
+def _many_small_blocks_page(count: int) -> bytes:
+    paragraphs = "".join(f"<p>{i:010d}</p>" for i in range(count))
+    return f"<html><body>{paragraphs}</body></html>".encode()
+
+
+def test_browse_production_4500_small_blocks_spills_webs_own_complete_artifact(tmp_path):
+    """Reproduces the exact production bug: 4500 ten-character blocks join to
+    45_000 chars (under the 50_000 default threshold) but the structured
+    `blocks` array that would actually be returned inline serializes to
+    270_000 chars — over both the 50_000 web threshold and the unrelated
+    200_000 generic preventive-spill ceiling. Web's own no-preview artifact
+    must win: no generic lossy preview may ever be substituted."""
+    agent = _Agent(tmp_path)
+    port = _Port(_many_small_blocks_page(4500))
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=port)
+    result = manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/many-blocks", "link_ref": None, "cursor": None, "extract": None, "max_chars": None},
+    })
+    assert result["status"] == "ok"
+    # The bug this reproduces: joined-text-only measurement would have
+    # returned "inline" here (45_000 <= 50_000). The fix must spill.
+    assert result["delivery"] == "artifact"
+    assert result["delivery_decision_chars"] == 270_000
+    assert result["delivery_decision_basis"] == "structured_blocks"
+    # content_chars/content_sha256 describe the file actually written — the
+    # smaller joined-text form (45_000 chars) — never the structured
+    # decision length, and never implying the file itself exceeded 50_000.
+    assert result["content_chars"] == 45_000
+    assert result["content_chars"] != result["delivery_decision_chars"]
+
+    # No generic lossy preview anywhere: this is web's own complete,
+    # no-preview artifact, recognized by the kernel's own marker.
+    assert "preview" not in result
+    assert "blocks" not in result
+    assert is_spill_manifest(result) is True
+
+    artifact_path = tmp_path / result["file_path"]
+    assert artifact_path.is_file()
+    file_content = artifact_path.read_text(encoding="utf-8")
+    assert len(file_content) == result["content_chars"] == 45_000
+    assert hashlib.sha256(file_content.encode("utf-8")).hexdigest() == result["content_sha256"]
+    # The file holds the complete extracted document: every block's text is
+    # present and in order, nothing trimmed.
+    assert file_content == "".join(f"{i:010d}" for i in range(4500))
+
+
+def test_browse_production_4500_small_blocks_never_substitutes_generic_preview(tmp_path):
+    """Directly proves the generic preventive spill never re-triggers on this
+    result even though its structured decision length (270_000) exceeds the
+    generic 200_000-char ceiling — the web artifact is already spilled and
+    explicitly marked before the generic mechanism ever sees it."""
+    from lingtai.kernel.tool_result_artifacts import spill_oversized_result
+
+    agent = _Agent(tmp_path)
+    port = _Port(_many_small_blocks_page(4500))
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=port)
+    result = manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/many-blocks", "link_ref": None, "cursor": None, "extract": None, "max_chars": None},
+    })
+    assert result["delivery"] == "artifact"
+
+    capped = spill_oversized_result(
+        result, max_chars=PREVENTIVE_MAX_CHARS, tool_name="web",
+        tool_call_id="call-1", working_dir=tmp_path,
+    )
+    assert capped is result  # unchanged: recognized as already spilled
+    assert "preview" not in capped
+
+
+def test_browse_small_page_control_stays_inline_when_structured_form_also_fits(tmp_path):
+    """Control: a genuinely small page (few blocks) stays inline under both
+    the joined-text and structured-blocks measurements — proves the fix
+    does not over-trigger spilling for ordinary small pages."""
+    agent = _Agent(tmp_path)
+    port = _Port(_many_small_blocks_page(5))
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=port)
+    result = manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/tiny", "link_ref": None, "cursor": None, "extract": None, "max_chars": None},
+    })
+    assert result["status"] == "ok"
+    assert result["delivery"] == "inline"
+    assert len(result["blocks"]) == 5
+    assert result["partial"] is False
+    assert result["next_cursor"] is None
+    # content_chars reflects the structured serialization actually returned.
+    assert result["content_chars"] == len(json.dumps(result["blocks"], ensure_ascii=False))
+
+
+def test_browse_structured_decision_chars_exact_boundary(tmp_path):
+    """Exact boundary on the structured-blocks decision length: at the
+    threshold stays inline; one character over spills — proving the decision
+    is made against the structured serialization, not the joined text."""
+    agent = _Agent(tmp_path)
+
+    # 60 blocks: structured JSON is comfortably below 50_000 (joined text is
+    # tiny too) — establish a working count near the boundary by binary
+    # search on the structured length computed directly.
+    import json as _json
+    from lingtai.tools.browser.extractor import extract_html
+
+    def _structured_len(count: int) -> int:
+        html = _many_small_blocks_page(count)
+        doc = extract_html(html, base_url="https://public.example/probe")
+        structured = [{"id": b.id, "kind": b.kind, "text": b.text} for b in doc.blocks]
+        return len(_json.dumps(structured, ensure_ascii=False))
+
+    # Find the smallest block count whose structured length exceeds 50_000.
+    count = 1
+    while _structured_len(count) <= 50_000:
+        count += 50
+    over_count = count
+
+    (tmp_path / "settings").mkdir()
+    exact_over_chars = _structured_len(over_count)
+    (tmp_path / "settings" / "web.json").write_text(json.dumps({"schema_version": 1, "max_chars": exact_over_chars}))
+
+    at_boundary_port = _Port(_many_small_blocks_page(over_count))
+    at_boundary_manager = setup(_Agent(tmp_path), search_service=_LargeSearch(1), browser_port=at_boundary_port)
+    at_boundary = at_boundary_manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/at-boundary", "link_ref": None, "cursor": None, "extract": None, "max_chars": None},
+    })
+    assert at_boundary["delivery"] == "inline"
+    assert at_boundary["content_chars"] == exact_over_chars
+
+    (tmp_path / "settings" / "web.json").write_text(json.dumps({"schema_version": 1, "max_chars": exact_over_chars - 1}))
+    over_boundary = at_boundary_manager.handle({
+        "action": "browse",
+        "input": {"url": "https://public.example/over-boundary", "link_ref": None, "cursor": None, "extract": None, "max_chars": None},
+    })
+    assert over_boundary["delivery"] == "artifact"
+    assert over_boundary["delivery_decision_chars"] == exact_over_chars
+
+
+# --- Browse: snapshot eviction between engine success and delivery must
+# fail loud, never fall back to a partial/first-page success (Blocker B). ---
+
+
+def test_browse_snapshot_eviction_before_delivery_fails_loud_not_partial(tmp_path):
+    """Deterministically evicts the snapshot the engine just built, between
+    its fetch success and WebManager's delivery decision, and proves the
+    result is a typed, loud failure — never a partial body, never a
+    next_cursor, never a degraded "best effort" success."""
+    agent = _Agent(tmp_path)
+    port = _Port(b"<html><body><p>content that would otherwise deliver fine</p></body></html>")
+    manager = setup(agent, search_service=_LargeSearch(1), browser_port=port)
+
+    # Drive the engine directly to get a real fetch success, exactly what
+    # _dispatch_browse would have received before calling _deliver_browse.
+    engine_result = manager.browser_engine.handle({
+        "url": "https://public.example/page", "extract": "article", "max_chars": 12000,
+    })
+    assert engine_result["status"] == "ok"
+    snapshot_id = engine_result["snapshot_id"]
+    assert manager.browser_engine.snapshots.get(snapshot_id) is not None
+
+    # Deterministically evict: remove the snapshot from the store's backing
+    # dict directly, simulating the LRU having evicted it under concurrent
+    # pressure between the engine's success and this delivery decision.
+    del manager.browser_engine.snapshots._items[snapshot_id]
+    assert manager.browser_engine.snapshots.get(snapshot_id) is None
+
+    engine_result["action"] = "browse"
+    engine_result["current_setting"] = manager._browse_diagnostic(_snapshot(DEFAULT_OUTPUT_MAX_CHARS))
+    result = manager._deliver_browse(engine_result, _snapshot(DEFAULT_OUTPUT_MAX_CHARS))
+
+    assert result["status"] == "failed"
+    assert result["error_code"] == "BROWSE_SNAPSHOT_UNAVAILABLE"
+    # No partial-success body may escape: no blocks, no partial flag implying
+    # success, no continuation cursor.
+    assert "blocks" not in result
+    assert "partial" not in result
+    assert "next_cursor" not in result
+    assert "delivery" not in result
+    assert result["current_setting"] is not None
+    assert result["snapshot_id"] == snapshot_id
+
+
+# --- Atomicity, write failure, direct spill helper unit coverage ---
+
+
+def test_spill_helper_writes_under_canonical_tool_results_dir(tmp_path):
+    result = spill_if_over_threshold(
+        content="x" * 100, output_setting=_snapshot(1), working_dir=tmp_path, action="search",
+        content_scope="provider_response", content_kind="search_results", format="json",
+    )
+    assert result["file_path"].startswith("tmp/tool-results/")
+    assert (tmp_path / result["file_path"]).is_file()
+
+
+def test_spill_helper_atomic_unique_filenames_across_rapid_calls(tmp_path):
+    first = spill_if_over_threshold(
+        content="x" * 100, output_setting=_snapshot(1), working_dir=tmp_path, action="search",
+        content_scope="provider_response", content_kind="search_results", format="json",
+    )
+    second = spill_if_over_threshold(
+        content="x" * 100, output_setting=_snapshot(1), working_dir=tmp_path, action="search",
+        content_scope="provider_response", content_kind="search_results", format="json",
+    )
+    assert first["file_path"] != second["file_path"]
+    assert (tmp_path / first["file_path"]).is_file()
+    assert (tmp_path / second["file_path"]).is_file()
+
+
+def test_spill_helper_inline_when_at_or_under_threshold():
+    assert spill_if_over_threshold(
+        content="x" * 10, output_setting=_snapshot(10), working_dir=Path("/tmp"), action="search",
+        content_scope="provider_response", content_kind="search_results", format="json",
+    ) is None
+
+
+def test_spill_helper_write_failure_is_explicit_not_lossy_fallback(tmp_path, monkeypatch):
+    import lingtai.tools.web_search._spill as spill_mod
+
+    def fail_write(*args, **kwargs):
+        return None, None, "OSError: disk full"
+
+    monkeypatch.setattr(spill_mod, "write_artifact_file", fail_write)
+    result = spill_if_over_threshold(
+        content="x" * 100, output_setting=_snapshot(1), working_dir=tmp_path, action="search",
+        content_scope="provider_response", content_kind="search_results", format="json",
+    )
+    assert result["status"] == "failed"
+    assert result["error_code"] == "ARTIFACT_WRITE_FAILED"
+    assert "content" not in result
+
+
+def test_spill_helper_envelope_carries_output_setting_source_revision_hash(tmp_path):
+    snapshot = OutputSettingsSnapshot(5, "settings/web.json", "abc123", "deadbeef" * 4)
+    result = spill_if_over_threshold(
+        content="x" * 100, output_setting=snapshot, working_dir=tmp_path, action="search",
+        content_scope="provider_response", content_kind="search_results", format="json",
+    )
+    assert result["output_setting_source"] == "settings/web.json"
+    assert result["output_setting_revision"] == "abc123"
+    assert result["output_setting_hash"] == "deadbeef" * 4
+
+
+def test_output_settings_default_case_has_deterministic_revision_and_hash(tmp_path):
+    agent = _Agent(tmp_path)
+    first = read_output_settings(agent)
+    second = read_output_settings(agent)
+    assert first.source == "default"
+    assert first.revision == second.revision
+    assert first.digest is not None
+    assert first.digest == second.digest
+
+
+def test_search_artifact_write_failure_surfaces_as_typed_failure(tmp_path, monkeypatch):
+    import lingtai.tools.web_search as ws_mod
+
+    def fail_spill(**kwargs):
+        return {"status": "failed", "message": "boom"}
+
+    monkeypatch.setattr(ws_mod, "spill_if_over_threshold", fail_spill)
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_LargeSearch(400), browser_port=_Port(b"<p>x</p>"))
+    result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert result["status"] == "failed"
+    assert result["error_code"] == "ARTIFACT_WRITE_FAILED"
+
+
+# --- No outer double-spill: the web artifact envelope carries an explicit,
+# namespaced marker (WEB_ARTIFACT_MARKER) that the kernel's is_spill_manifest
+# recognizes on its own terms, so the generic preventive spill treats an
+# already-built web artifact as "already spilled" and never re-spills it —
+# this is a recognized-manifest guarantee, not an incidental "the envelope
+# happens to be small" property. Both are proven below: the explicit marker
+# recognition directly, and the same guarantee holding even when the
+# envelope is deliberately padded past the 200_000-char preventive ceiling.
+
+
+def test_web_artifact_envelope_is_recognized_by_is_spill_manifest(tmp_path):
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_LargeSearch(400), browser_port=_Port(b"<p>x</p>"))
+    result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert result["delivery"] == "artifact"
+    assert is_spill_manifest(result) is True
+
+
+def test_generic_preventive_spill_never_rewrites_an_already_marked_web_artifact(tmp_path):
+    """Directly exercise kernel spill_oversized_result on a web artifact result
+    padded well past the 200_000-char preventive ceiling, proving recognition
+    — not smallness — is what prevents double-spill."""
+    from lingtai.kernel.tool_result_artifacts import spill_oversized_result
+
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_LargeSearch(400), browser_port=_Port(b"<p>x</p>"))
+    result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert result["delivery"] == "artifact"
+    # Pad the envelope itself well past the generic preventive ceiling with a
+    # large advisory-shaped field, so a size-based recognition would have
+    # re-spilled it; only the explicit marker can prevent that.
+    result["_padding_for_test"] = "z" * (PREVENTIVE_MAX_CHARS + 50_000)
+    assert len(json.dumps(result)) > PREVENTIVE_MAX_CHARS
+
+    capped = spill_oversized_result(
+        result, max_chars=PREVENTIVE_MAX_CHARS, tool_name="web",
+        tool_call_id="call-1", working_dir=tmp_path,
+    )
+    assert capped is result  # unchanged: recognized as already spilled
+
+
+def test_tool_executor_does_not_double_spill_a_large_web_artifact_result(tmp_path):
+    """End-to-end through the real ToolExecutor: a web search artifact result,
+    padded past the preventive ceiling, must reach the wire unchanged — not
+    replaced by a second, generic spill manifest."""
+    from lingtai.kernel.llm.base import ToolCall
+    from lingtai.kernel.loop_guard import LoopGuard
+
+    agent = _Agent(tmp_path)
+    manager = setup(agent, search_service=_LargeSearch(400), browser_port=_Port(b"<p>x</p>"))
+    web_result = manager.handle({"action": "search", "input": {"query": "q"}})
+    assert web_result["delivery"] == "artifact"
+    web_result["_padding_for_test"] = "z" * (PREVENTIVE_MAX_CHARS + 50_000)
+
+    def make_tool_result_fn(name, result, **kw):
+        return {"role": "tool", "name": name, "content": result, **kw}
+
+    executor = ToolExecutor(
+        dispatch_fn=lambda tc: web_result,
+        make_tool_result_fn=make_tool_result_fn,
+        guard=LoopGuard(),
+        known_tools={"web"},
+        working_dir=tmp_path,
+    )
+    results, _, _ = executor.execute(
+        [ToolCall(name="web", args={"action": "search", "input": {"query": "q"}}, id="w1")]
+    )
+    wire_content = results[0]["content"]
+    assert is_spill_manifest(wire_content)
+    assert wire_content.get("delivery") == "artifact"
+    assert wire_content.get("file_path") == web_result["file_path"]
+    # The generic manifest's own distinguishing fields must be absent — this
+    # is still web's own envelope, not a second, generic replacement.
+    assert "cap_chars" not in wire_content
+    assert "spill_path" not in wire_content
+
+
+def test_artifact_readable_end_to_end_via_file_read_tool(tmp_path):
+    from lingtai.agent import Agent
+    from tests._service_helpers import make_gemini_mock_service
+
+    agent = Agent(
+        service=make_gemini_mock_service(),
+        agent_name="web-artifact-file-read",
+        working_dir=tmp_path,
+        capabilities={
+            "web": {"search_service": _LargeSearch(400), "browser_port": _Port(b"<p>x</p>")},
+            "file": {},
+        },
+        disable=["knowledge", "skills", "shell", "avatar", "daemon", "mcp", "vision"],
+    )
+    try:
+        result = agent._tool_handlers["web"]({"action": "search", "input": {"query": "q"}})
+        assert result["delivery"] == "artifact"
+        read_result = agent._tool_handlers["file"]({
+            "action": "read",
+            "input": {"file_path": result["file_path"], "offset": None, "limit": None, "max_chars": None},
+            "reasoning": "read the spilled web artifact",
+        })
+        assert read_result.get("status") != "error"
+        assert "content" in read_result
+        parsed = json.loads((tmp_path / result["file_path"]).read_text())
+        assert len(parsed) == 400
+    finally:
+        agent.stop(timeout=1.0)

--- a/tests/test_web_search_capability.py
+++ b/tests/test_web_search_capability.py
@@ -56,7 +56,7 @@ def test_web_manager_uses_search_service():
     result = mgr.handle({"action": "search", "input": {"query": "test"}})
     assert result["status"] == "ok"
     assert result["results"][0]["title"] == "Result"
-    mock_svc.search.assert_called_once_with("test")
+    mock_svc.search.assert_called_once_with("test", max_results=None)
 
 
 def test_web_service_exception():


### PR DESCRIPTION
## Summary

- remove LingTai-imposed Search top-N and per-field truncation so `count` and the result set reflect the complete response returned by the selected provider
- add one strict, hot-read `settings/web.json` output threshold shared by Search and Browse (`max_chars`, default `50000`)
- return complete content inline at or below the threshold; above it, atomically save the complete canonical content under `tmp/tool-results/` and return an exact Agent-readable artifact locator instead of a prefix
- make Browse decide against the full structured `blocks` serialization and fail loud with `BROWSE_SNAPSHOT_UNAVAILABLE` if its complete cached snapshot disappears before delivery
- document the public contract in the Web manual plus paired `ANATOMY.md` / `CONTRACT.md`, with focused regressions for settings, provider completeness, artifact provenance, no-preview behavior, Browser failure semantics, and `file.read` recovery
- preserve merged #1087 provider routing and its exactly-one informed OpenAI→DuckDuckGo fallback, including `comment` / `openai_failure_class` when the successful fallback result spills

## Design notes

- `settings/web.json` owns only the shared output threshold. Existing `settings/web.search.json` remains Search-engine selection only; neither file merges or cross-reads the other.
- The implementation reuses the kernel's canonical artifact directory and atomic writer rather than creating a Web-private storage surface.
- "Complete Search" means the complete selected-provider response for that call, not exhaustive Internet coverage.
- Browse artifacts contain the complete plain extracted text. The envelope separately reports `delivery_decision_chars` / `delivery_decision_basis` when the full structured-block decision size differs from the written file size.
- Artifact responses omit inline `results` / `blocks` instead of returning a misleading subset beside the file locator.

## Validation

Final semantic rebase gate on merged #1087 base `82e6ae139fa27beba7254941dc03f6991fd102e8`:

```text
final head  = 97d4c6d5218319bf93b969e5b99ed4841a8627b2
final tree  = 4b57dc3cafb5708cf61c3302f948ca7ac4e4ee11
parent/base = 82e6ae139fa27beba7254941dc03f6991fd102e8
20 files, +1878/-157; one canonical Huang commit; tracked state clean

Parent semantic-union gate: 461 passed, 2 skipped, 1 exact-base-only deselected
Documentation governance: 298 passed
Six-path seam repair gates: 162 passed + 74 passed
compileall / git diff --check: pass
```

Correctly pinned Claude Sonnet 5 owner verification: **PASS**; 247 reviewer-selected tests passed, with one unrelated failure reproduced at the exact base.

Correctly pinned independent Claude Opus 5 final review: **ACCEPT**, zero blockers. It independently matched the frozen patch/manifest hashes and clean apply, ran 162 focused Web tests (all passed), then a broader 643-test blast radius. The same three broader failures reproduced identically at exact base (`KeyError: web_search`); 35 MCP collection errors were also proven to be pre-existing local SDK skew on paths untouched by this PR. Introduced regressions: **zero**.

The semantic union keeps #1087's canonical OpenAI / Anthropic / Gemini routing and typed failures, exactly one informed eligible OpenAI→DuckDuckGo fallback, same-backend/no-silent-fallback behavior for explicit Anthropic/Gemini, and retired MiniMax/Zhipu rejection. It layers complete Search/Browse delivery on top without a second fallback, prefix, or truncation path.

## Live Agent acceptance (feature behavior before semantic rebase)

Before #1087 landed, a scoped Agent refresh loaded the then-reviewed #1083 feature bytes and exercised the public `web` and `file` tools. The final #1087 semantic union was intentionally not refreshed during this merge operation; its compatibility is covered by the final Parent/Sonnet/Opus gates above:

- default 50k: Search returned all 10 provider results inline (`content_chars=4195`); Browse returned the complete IANA Example Domains document inline (`11` blocks, `8` links, `partial=false`, `next_cursor=null`, structured `content_chars=1363`)
- temporary 500-char setting: Search returned a complete 4,069-character JSON artifact; Browse returned a complete 817-character text artifact with a 1,363-character structured-block delivery decision
- public `file.read` read both artifacts; independent character counts and SHA-256 values matched their envelopes exactly
- removing only the task-created setting restored default 50k inline Search on the next call without refresh

## Risks and non-goals

- artifacts are intentionally ephemeral and remain under the existing Agent-owned `tmp/tool-results/` lifecycle
- static Browse behavior remains unchanged: no JavaScript execution, PDF parsing, login, cookie, form, or hidden search fallback
- present-but-invalid output settings fail loud before provider/fetch I/O; they are never silently defaulted or clamped
- the retained but unregistered `tools/browser/` module still contains dead 12000/pagination teaching; it is not model-facing and is left for a separate cleanup rather than expanding this PR
- this PR does not release, deploy, refresh runtime, or clean retained worktrees/branches/evidence
