### PR TITLE
test: slim Telegram ToolFamily coverage

### DIFF
--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -36,6 +36,7 @@ class _FakeClient:
         assert name == _TASK_CARD_TOOL
         assert "action" not in args  # server forces the private action
         assert args.get("channel") == "programmable"
+        assert "automatic" not in args
         if self.fail:
             return {"status": "error", "error": "backend down"}
         if self.result is not None:
@@ -103,12 +104,6 @@ def test_setup_binds_handler_only(agent):
     assert description == ""
     assert glossary == "__unset__"
     assert callable(handler)
-
-
-def test_schema_requires_strict_root_fields():
-    schema = get_schema()
-    assert schema["required"] == ["action", "input", "reasoning"]
-    assert schema["additionalProperties"] is False
 
 
 def test_description_routes_to_the_telegram_manual():

--- a/tests/test_telegram_task_card_transport.py
+++ b/tests/test_telegram_task_card_transport.py
@@ -208,14 +208,21 @@ def test_each_public_family_has_strict_root_and_action_owned_branches(tmp_path):
     assert [tool.name for tool in tools] == ["telegram", "task_card"]
     for tool in tools:
         schema = tool.inputSchema
-        assert schema["required"] == ["action", "input", "reasoning"]
-        assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
-        assert schema["additionalProperties"] is False
-        assert len(schema["allOf"]) == len(schema["properties"]["action"]["enum"])
+        actions = schema["properties"]["action"]["enum"]
         branches = schema["properties"]["input"].get(
             "oneOf", schema["properties"]["input"].get("anyOf")
         )
-        assert len(branches) == len(schema["properties"]["action"]["enum"])
+        assert schema["required"] == ["action", "input", "reasoning"]
+        assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
+        assert schema["additionalProperties"] is False
+        assert len(schema["allOf"]) == len(actions) == len(branches)
+        for action, branch, condition in zip(actions, branches, schema["allOf"]):
+            assert branch["title"] == f"{action} input"
+            assert branch["additionalProperties"] is False
+            assert condition["if"]["properties"]["action"]["const"] == action
+            expected = dict(branch)
+            expected.pop("title")
+            assert condition["then"]["properties"]["input"] == expected
 
 
 def test_raw_task_card_manual_is_family_owned_and_flat_root_is_rejected(tmp_path):
@@ -236,16 +243,21 @@ def test_raw_task_card_manual_is_family_owned_and_flat_root_is_rejected(tmp_path
     assert not account.calls
 
 
-def test_raw_task_card_cross_branch_input_is_rejected_before_controller_io(tmp_path):
+def test_raw_task_card_invalid_inputs_are_rejected_before_controller_io(tmp_path):
     manager, account = _make_manager(tmp_path)
-    result = _call_tool_via_transport(
-        manager,
-        "task_card",
+    invalid = (
         {
             "action": "inspect",
             "input": {"renderer_path": "watch.py"},
             "reasoning": "cross branch probe",
         },
+        {
+            "action": "start",
+            "input": {"renderer_path": "watch.py", "max_refreshes": 1001},
+            "reasoning": "hard ceiling probe",
+        },
     )
-    assert result.isError is True
-    assert not account.calls
+    for payload in invalid:
+        result = _call_tool_via_transport(manager, "task_card", payload)
+        assert result.isError is True
+        assert not account.calls

--- a/tests/test_telegram_toolfamily_ltpv2.py
+++ b/tests/test_telegram_toolfamily_ltpv2.py
@@ -14,11 +14,6 @@ from lingtai.mcp_servers.telegram._family import (
     handle_telegram,
 )
 from lingtai.mcp_servers.telegram.service import TelegramService
-from lingtai.mcp_servers.telegram.task_card._family import (
-    TASK_CARD_ACTIONS,
-    TASK_CARD_SCHEMA,
-    handle_task_card,
-)
 from lingtai.mcp_servers.telegram.task_card.controller import TaskCardController
 
 from .test_task_card_controller import _FakeAgent, _OK_BODY, _write_renderer
@@ -37,28 +32,6 @@ def _branches(schema: dict) -> dict[str, dict]:
     inputs = schema["properties"]["input"]
     branches = inputs.get("oneOf") or inputs.get("anyOf")
     return {branch["title"].removesuffix(" input"): branch for branch in branches}
-
-
-@pytest.mark.parametrize("family_schema, actions", [
-    (TELEGRAM_SCHEMA, TELEGRAM_ACTIONS),
-    (TASK_CARD_SCHEMA, TASK_CARD_ACTIONS),
-])
-def test_ltpv2_family_schema_has_closed_root_and_correlated_closed_branches(
-    family_schema, actions
-):
-    assert family_schema["required"] == ["action", "input", "reasoning"]
-    assert set(family_schema["properties"]) == {"action", "input", "reasoning", "summarize"}
-    assert family_schema["additionalProperties"] is False
-    assert family_schema["properties"]["action"]["enum"] == list(actions)
-    branches = _branches(family_schema)
-    assert list(branches) == list(actions)
-    assert len(family_schema["allOf"]) == len(actions)
-    for action, condition in zip(actions, family_schema["allOf"]):
-        assert condition["if"]["properties"]["action"]["const"] == action
-        branch = dict(branches[action])
-        branch.pop("title", None)
-        assert condition["then"]["properties"]["input"] == branch
-        assert branches[action]["additionalProperties"] is False
 
 
 def test_family_dispatch_rejects_root_and_cross_branch_before_manager_io():
@@ -85,53 +58,6 @@ def test_family_dispatch_rejects_root_and_cross_branch_before_manager_io():
     assert len(manager.calls) == 1
 
 
-def test_task_card_start_rejects_above_global_ceiling_before_controller_io():
-    class Controller:
-        def __init__(self):
-            self.calls = []
-
-        def handle(self, args):
-            self.calls.append(args)
-            return {"status": "ok"}
-
-    controller = Controller()
-    result = handle_task_card(
-        controller,
-        {
-            "action": "start",
-            "input": {"renderer_path": "r.py", "max_refreshes": 1001},
-            "reasoning": "hard-ceiling probe",
-        },
-    )
-    assert result["status"] == "failed"
-    assert controller.calls == []
-
-
-def test_task_card_dispatch_rejects_cross_branch_before_controller_io():
-    class Controller:
-        def __init__(self):
-            self.calls = []
-
-        def handle(self, args):
-            self.calls.append(args)
-            return {"status": "ok"}
-
-    controller = Controller()
-    bad = {
-        "action": "inspect",
-        "input": {"renderer_path": "r.py"},
-        "reasoning": "probe",
-    }
-    result = handle_task_card(controller, bad)
-    assert result["status"] == "failed"
-    assert controller.calls == []
-    assert handle_task_card(
-        controller,
-        {"action": "manual", "input": {}, "reasoning": "discover"},
-    )["status"] == "ok"
-    assert controller.calls == []
-
-
 def test_telegram_send_schema_preserves_text_media_chat_action_alternatives():
     send = _branches(TELEGRAM_SCHEMA)["send"]
     assert send["anyOf"] == [
@@ -145,13 +71,6 @@ def test_telegram_send_schema_preserves_text_media_chat_action_alternatives():
     assert not _basic_validate({"chat_id": 3}, send)
     assert not _basic_validate({"text": "missing chat"}, send)
     assert not _basic_validate({"chat_id": 3, "text": 17}, send)
-
-
-def test_task_card_manual_is_package_owned_and_not_controller_io():
-    result = handle_task_card(None, {"action": "manual", "input": {}, "reasoning": "help"})
-    assert result["status"] == "ok"
-    assert result["action"] == "manual"
-    assert result["manual"]
 
 
 def test_taskcard_refresh_setting_defaults_invalid_values_preserves_valid_siblings(
@@ -320,14 +239,6 @@ def test_limit_finalize_failure_retains_retryable_stop_state_without_restart(tmp
     assert start["watch_id"] not in controller._watches
     assert len(agent._client.calls) == calls + 1
     assert agent._client.calls[-1][1]["sub_action"] == "finalize"
-
-
-def test_initial_create_is_programmable_only_and_automatic_state_is_untouched(tmp_path):
-    agent = _FakeAgent(tmp_path)
-    controller, start = _start_with_ceiling(agent, 1)
-    assert all(call[1]["channel"] == "programmable" for call in agent._client.calls)
-    assert all("automatic" not in call[1] for call in agent._client.calls)
-    controller.handle({"action": "stop", "watch_id": start["watch_id"]})
 
 
 def test_openai_responses_scrub_preserves_family_root_and_action_branches():


### PR DESCRIPTION
## Summary

This follow-up keeps PR #1081's Telegram architecture unchanged—Telegram remains an independent MCP server exposing mounted strict `telegram` and `task_card` ToolFamilies—while removing duplicated test coverage.

The diff is test-only: 3 files, `+24/-106` (net -82).

## What changed

- Strengthen the raw MCP transport matrix so it verifies both model-facing families, exact action/schema correlation, strict closed LTP-v2 roots, family-owned Task Card manual behavior, flat-envelope rejection, cross-action rejection, and `max_refreshes=1001` rejection before controller/account I/O.
- Make the shared Task Card reverse-projection fake enforce on every call that the private projection has `channel="programmable"`, no public `action`, and no `automatic` field.
- Remove lower-layer schema/validation/projection tests that are now subsumed by those stronger ingress and all-call invariants.

## Unchanged

- No production, schema, lifecycle, settings, Contract, Anatomy, or manual files change.
- Telegram remains MCP; Agent still only mounts and dispatches the two MCP-provided families.
- Unique coverage remains for same-client family composition, reasoning propagation, Telegram `send` `anyOf`, settings/fuse behavior, exactly-one limit behavior, retryable finalize, and in-flight lifecycle cases.

## Validation

- Focused changed-file suite: **79 passed**.
- #1081 ten-file surface: **274 passed** plus one environment-only missing-`msal` import failure; the exact curated-MCP import/resource contract passed against candidate source with the existing global runtime (`msal 1.37.0`).
- Ruff: **PASS**.
- `git diff --check`: **PASS**.
- Frozen patch SHA-256: `eb7ff6c4f6815f7916899bfac76eb61692c2cf4bd3e6b111ce001d9b924ba3ff`.
- Independent exact-Terra review (`em-a534`): **PASS**, no P0/P1; 11/11 ledger rows are `gpt-5.6-terra`.

No merge, runtime refresh, configuration change, or cleanup is part of this PR.
