### PR TITLE
fix(notification): keep synthetic call args schema-valid

### DIFF
--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -1607,14 +1607,17 @@ class BaseAgent:
         distinguish kernel-injected reads from voluntary calls when reading
         conversation history.
 
-        Both call.args and result.content carry safe notification freshness
-        fields from build_meta plus a monotonic injection_seq. Internal tool-meta
+        The result content carries a monotonic injection_seq; its metadata
+        carries the current build_meta-derived runtime sidecar. Internal tool-meta
         transit keys are stripped below before the synthesized pair reaches the wire.
-        This makes
-        every synthesized pair tokenize uniquely even when the underlying
-        notification payload repeats — a protection layer against the
-        DeepSeek cache fast-path empty-response failure without needing a
-        visible assistant text prefix.
+        call.args deliberately carries none of this: it must stay byte-identical
+        to what a voluntary ``notification(action="check")`` call could produce,
+        since a provider/model can copy assistant-turn call args into a new real
+        call, and the freshness fields would fail the family's root-field
+        allowlist. The freshness fields still make every synthesized pair's
+        result tokenize uniquely even when the underlying notification payload
+        repeats — a protection layer against the DeepSeek cache fast-path
+        empty-response failure without needing a visible assistant text prefix.
 
         Returns True if injection succeeded, False if it had to abort
         (e.g. pending tool_calls block append).  When False is returned,
@@ -1667,12 +1670,12 @@ class BaseAgent:
 
         call_id = f"notif_{int(time.time()*1000):x}_{secrets.token_hex(2)}"
 
-        # Meta freshness fields — same build_meta current-state hints real tool
-        # results use for runtime state snapshots, embedded in BOTH call.args
-        # and result.content so every synthesized pair tokenizes
-        # uniquely even when the notification payload repeats. The monotonic
-        # injection_seq is added on top to guarantee novelty within the same
-        # second (heal+retry tight loops, time-blind agents).
+        # Capture the same build_meta current-state hints real tool results use
+        # for runtime diagnostics. This copy is recorded in the injection event;
+        # the model-visible freshness marker is added to result.content below.
+        # Keep both result-side representations out of call.args: the monotonic
+        # injection_seq guarantees novelty within the same second (heal+retry
+        # tight loops, time-blind agents).
         # Defensive getattr covers test doubles that bypass __init__ and
         # don't carry the full agent attribute surface.
         self._notification_inject_seq = getattr(self, "_notification_inject_seq", 0) + 1
@@ -1802,21 +1805,26 @@ class BaseAgent:
         # wire: successful notification sync should be a structured
         # notification(action="check") call/result pair, not a visible
         # synthesized diary/text-input row.
-        # ``notification`` is an LTP v2 family (``tools/CONTRACT.md``): a real
-        # voluntary read is ``{action, input, reasoning}`` with ``check``'s own
-        # strict-empty ``input``. This synthesized call must carry that same
-        # envelope, because the pair is deliberately byte-shape-identical to a
+        # ``notification`` is an LTP v2 family (``tools/CONTRACT.md``): the
+        # default voluntary read is ``{action, input, reasoning}`` with
+        # ``check``'s own strict-empty ``input``; the optional public
+        # ``summarize`` control is valid but absent here. This synthesized call
+        # must carry that same minimal envelope, because the pair is deliberately
+        # byte-shape-identical to a
         # voluntary read (see this method's docstring) — emitting the old flat
         # ``{action}`` shape would make the kernel's own injection the one
         # notification call the model could never have produced itself.
         # ``reasoning`` is required by the family schema, so a truthful
         # synthetic rationale is supplied rather than omitted.
-        # ``injection_seq`` remains outside the envelope: real tool calls don't
-        # carry runtime freshness fields in their args (those live in results),
-        # and the seq is only there to defeat byte-equality on the assistant
-        # turn. It never reaches the tool — this pair is spliced onto the wire,
-        # not dispatched — and ``notification.handle`` would reject it as an
-        # unknown root field if it ever were.
+        # ``injection_seq`` stays out of ``call_block.args``: a provider/model
+        # can and does copy assistant-turn tool-call args verbatim into a new
+        # real call, and ``notification.handle`` rejects any root field
+        # outside the public ``{action, input, reasoning, summarize}`` allowlist with
+        # ``INVALID_ARGUMENT: unsupported notification argument`` — so this
+        # pair's args must be exactly what a voluntary call could produce.
+        # Freshness/novelty against byte-equality is carried on the result
+        # side instead (``result_block.content["injection_seq"]`` /
+        # ``result_block.metadata``), which is never fed back as call args.
         call_block = ToolCallBlock(
             id=call_id,
             name="notification",
@@ -1824,7 +1832,6 @@ class BaseAgent:
                 "action": "check",
                 "input": {},
                 "reasoning": "kernel notification sync",
-                "injection_seq": self._notification_inject_seq,
             },
         )
         result_block = ToolResultBlock(

--- a/src/lingtai/tools/notification/ANATOMY.md
+++ b/src/lingtai/tools/notification/ANATOMY.md
@@ -163,11 +163,16 @@ are unchanged.
 - The kernel may synthesize the same `notification(action="check")` call/result
   shape at an idle boundary; that delivery plumbing is not another agent-callable
   action (`src/lingtai/kernel/base_agent/__init__.py:1255-1461`;
-  `src/lingtai/kernel/base_agent/__init__.py:1562-1800`). Because that pair is
+  `src/lingtai/kernel/base_agent/__init__.py:1582-1844`). Because that pair is
   deliberately byte-shape-identical to a voluntary read, its synthesized call
-  args carry the same LTP v2 envelope (`input: {}` plus a `reasoning` string);
-  the `injection_seq` freshness field stays outside the envelope and never
-  reaches the tool, since the pair is spliced onto the wire, not dispatched.
+  args carry the same minimal LTP v2 envelope (`action`, `input: {}`, and a
+  `reasoning` string); the optional public `summarize` control is valid but
+  absent here. No `injection_seq` or other internal freshness field is admitted,
+  since a provider/model can copy assistant-turn call args verbatim into a new
+  real call, and `_ROOT_FIELDS` rejects keys outside the public root allowlist
+  with `INVALID_ARGUMENT: unsupported notification argument`. Freshness/novelty
+  against byte-equality is carried on the result side (`content`/`metadata`)
+  instead, which is never fed back as call args.
 - Large tool results are ranked and compacted through
   `context(action="summarize")`. Notification dismissal retains only the legacy
   reminder escape hatch described by the manual.

--- a/tests/test_notification_sync.py
+++ b/tests/test_notification_sync.py
@@ -943,7 +943,18 @@ def test_sync_idle_injects_pair_with_synthesized_marker(tmp_path: Path) -> None:
     # The kernel-synthesized delivery pair impersonates a voluntary
     # notification(action="check") read — not system(action="notification").
     assert call_block.name == "notification"
-    assert call_block.args["action"] == "check"
+    # Pin the full synthesized call envelope: it must be byte-identical to
+    # what a voluntary notification(action="check") call could produce, with
+    # no internal freshness field such as injection_seq. A provider/model can
+    # copy assistant-turn call args verbatim into a new real call, and
+    # notification's ToolFamily dispatcher rejects any root field outside the
+    # public {action, input, reasoning, summarize} allowlist with
+    # INVALID_ARGUMENT: unsupported notification argument.
+    assert call_block.args == {
+        "action": "check",
+        "input": {},
+        "reasoning": "kernel notification sync",
+    }
     assert isinstance(result_block, ToolResultBlock)
     assert result_block.name == "notification"
     assert result_block.synthesized is True
@@ -964,9 +975,47 @@ def test_sync_idle_injects_pair_with_synthesized_marker(tmp_path: Path) -> None:
     assert agent._notification_block_id == call_block.id
 
 
+def test_synthesized_notification_call_args_survive_real_dispatch(
+    tmp_path: Path,
+) -> None:
+    """A model that copies the synthesized call's args into a new real
+    notification call must not get INVALID_ARGUMENT.
+
+    This reproduces the live failure: the kernel-injected historical
+    notification(action="check") ToolCallBlock.args were fed straight into
+    the real dispatcher (as a provider/model copying an assistant-turn tool
+    call would do), and strict envelope validation rejected an
+    injection_seq root field with "unsupported notification argument".
+    """
+    from lingtai.kernel.llm.interface import ToolCallBlock
+    from lingtai.tools.notification import handle
+
+    publish_test_payload(tmp_path, "email", {"count": 1, "data": {"count": 1}})
+    agent = _make_stub_agent_for_block_log(tmp_path)
+    agent._sync_notifications()
+
+    entries = agent._chat_stub.interface.entries
+    call_block = entries[0].content[0]
+    assert isinstance(call_block, ToolCallBlock)
+    assert call_block.name == "notification"
+
+    @dataclass
+    class _DispatchStub:
+        _working_dir: Path = tmp_path
+        _logs: list[tuple[str, dict]] = field(default_factory=list)
+
+        def _log(self, evt: str, **fields: Any) -> None:
+            self._logs.append((evt, fields))
+
+    res = handle(_DispatchStub(), dict(call_block.args))
+
+    assert res.get("error_code") != "INVALID_ARGUMENT"
+    assert res.get("_notification_placeholder") is True
+
+
 def test_sync_idle_releases_then_reinjects(tmp_path: Path) -> None:
-    """Two consecutive sync calls — old payload is released (append-only,
-    never mutated), new pair appended."""
+    """Payload A — payload B — payload A again keeps append-only history
+    and gives each synthetic result a fresh injection sequence."""
     from lingtai.kernel.base_agent import BaseAgent
     from lingtai.kernel.state import AgentState
 
@@ -1005,29 +1054,38 @@ def test_sync_idle_releases_then_reinjects(tmp_path: Path) -> None:
             pass
 
     agent = _Agent(tmp_path)
-    publish_test_payload(tmp_path, "email", {"count": 1})
+    payload_a = {"count": 1}
+    payload_b = {"count": 2, "extra": "more bytes"}
+
+    publish_test_payload(tmp_path, "email", payload_a)
     agent._sync_notifications()
     first_id = agent._notification_block_id
     assert first_id is not None
     assert len(agent._chat_stub.interface.entries) == 2
 
-    # Producer publishes new state — fingerprint must change for sync
-    # to fire.  Sleep a moment to bump mtime_ns.
-    import time as _time
-    _time.sleep(0.001)
-    publish_test_payload(tmp_path, "email", {"count": 2, "extra": "more bytes"})
+    publish_test_payload(tmp_path, "email", payload_b)
     agent._sync_notifications()
     second_id = agent._notification_block_id
 
     assert second_id is not None
     assert second_id != first_id
-    # Old pair is kept in history verbatim (append-only — released from live
-    # tracking, never mutated); new pair appended as the current holder.
-    assert len(agent._chat_stub.interface.entries) == 4
-    first_body = agent._chat_stub.interface.entries[1].content[0].content
+
+    # The original payload bytes reappear after an intervening payload.
+    publish_test_payload(tmp_path, "email", payload_a)
+    agent._sync_notifications()
+
+    # Every pair remains in history verbatim; only the newest is the current
+    # holder.
+    entries = agent._chat_stub.interface.entries
+    assert len(entries) == 6
+    first_body = entries[1].content[0].content
     assert first_body["_synthesized"] is True
-    first_block = agent._chat_stub.interface.entries[1].content[0]
-    assert first_block.metadata["agent_meta"]["notifications"]["attention"]["email"]["count"] == 1
+    result_blocks = [entries[index].content[0] for index in (1, 3, 5)]
+    assert [block.content["injection_seq"] for block in result_blocks] == [1, 2, 3]
+    assert [
+        block.metadata["agent_meta"]["notifications"]["attention"]["email"]["count"]
+        for block in result_blocks
+    ] == [1, 2, 1]
 
 
 def test_sync_idle_empty_releases_holder(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to merged aggregate PR #1072 and its still-open Notification slice PR #1071.

The merged synthetic IDLE/ASLEEP notification pair put the internal `injection_seq` freshness field in historical assistant-turn call args. A provider/model later copied those args into a new real `notification(action="check")` call; the strict LTP v2 family correctly rejected that unknown root field before dispatch with `INVALID_ARGUMENT: unsupported notification argument`.

This PR:

- keeps synthesized call args identical to the default voluntary `notification(action="check", input={}, reasoning=...)` envelope;
- keeps the optional public `summarize` control valid while excluding internal freshness fields;
- preserves freshness/dedup novelty on the result side through `content["injection_seq"]` and result metadata;
- pins the exact call envelope, copied-call real dispatch, and repeated payload A → B → A result-side injection sequence;
- updates the Notification Anatomy to document the actual provider/model-copy boundary.

## Relationship to #1071 / #1072

- #1072 merged the aggregate ToolFamily work, including the Notification slice from #1071.
- #1071 explicitly listed synthesized call args as a non-blocking test gap and described `injection_seq` as part of those args.
- This PR closes that concrete post-merge gap without changing Notification actions, public schema, result shapes, producer state, dismissal semantics, or notification persistence.
- It does not close, merge, or otherwise mutate #1071.

## Freshness and dedup invariant

The synthesized pair still tokenizes uniquely when the same producer payload returns: every result receives a monotonic `injection_seq`, and notification/runtime sidecars remain in result metadata. Only assistant-turn call args lose the internal field so they remain safe when a provider/model copies them into a real call.

## Validation

Exact base/parent: `b5ba2a2008e5e824b9a3ae490da00c2a4303c81d`

Exact head: `024bcf0df1f94ef7bbbe0bebacefeb3adc9fc477`

Exact tree: `4765bb799bbf5642fa8ee790502d2d0ebc0e6683`

Diff: 3 files, `+113/-43`; SHA-256 `3adc0a795ee54d1a2a27ab367eb853da77fac4df273e9e12a73e9ea76873b2b9`.

Using Python 3.13.14 with `PYTHONPATH` forced to this exact worktree:

- `python -m pytest -q tests/test_notification_sync.py` → **68 passed**
- `python -m pytest -q tests/test_notification_tool.py tests/test_architecture_documents.py` → **56 passed**
- after parent review wording repair: `python -m pytest -q tests/test_notification_sync.py tests/test_architecture_documents.py` → **71 passed**
- `git diff --check` → **PASS**

## Review

Parent exact-diff/contract review: **PASS** after one pre-push repair. The review caught that candidate comments named only the three required root fields and omitted the optional public `summarize` field; source, Anatomy, and test wording now name the full public allowlist while preserving the exact minimal-call assertion. No additional behavior or surface was introduced.

## Checks intentionally omitted

- No runtime refresh or live-agent rollout: not authorized for this task.
- No merge: not authorized.
- No broad full-suite run: this is a one-line production behavior fix with focused owner, dispatcher-contract, and architecture validation; unrelated suites were not used to delay the reviewable PR.

## Scope / authority

This task is authorized through commit, branch push, and PR opening only. Merge and refresh remain explicitly out of scope.
