### PR TITLE
feat(imap): adopt LingTai Tool Protocol envelope

### DIFF
--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -15,6 +15,8 @@ related_files:
   - src/lingtai/mcp_servers/cloud_mail/manager.py
   - src/lingtai/mcp_servers/feishu/manager.py
   - src/lingtai/mcp_servers/imap/manager.py
+  - src/lingtai/mcp_servers/imap/_family.py
+  - tests/test_imap_toolfamily_ltpv2.py
   - src/lingtai/mcp_servers/telegram/account.py
   - src/lingtai/mcp_servers/telegram/manager.py
   - src/lingtai/mcp_servers/telegram/server.py
@@ -63,6 +65,7 @@ Curated and built-in MCP server package implementations shipped inside the `ling
 - Catalog/script launchers (`pyproject.toml:43-49`) start these servers as subprocess MCPs; agents activate them through the generic MCP capability (`src/lingtai/tools/mcp/ANATOMY.md`).
 - Manager schemas include `manual` in each action enum and use `_skill.manual_action_description()` to advertise the bundled skill without loading the full body into the resident schema.
 - Tests pin the manual contract, package-data sidecar support, and Telegram parity in `tests/test_mcp_skill_manuals.py` and `tests/test_telegram_rich_formatting.py`.
+- `telegram/_family.py` and `imap/_family.py` each own an independent strict LTP-v2 envelope (`{action, input, reasoning, summarize?}`) built on `lingtai.tools.tool_family.ToolFamily`, with a dependency-free `_basic_validate` dispatch-safety gate that rejects an unknown action, non-string `reasoning`, unknown root field, or cross-branch `input` key before any manager I/O runs. Each manager module keeps its original flat `SCHEMA`/`DESCRIPTION` for the pre-migration per-action description text and `manager.handle()`'s legacy flat-args dispatch, then reassigns the module-level `SCHEMA` name to the family's composed schema (`SCHEMA = _family.TELEGRAM_SCHEMA` / `SCHEMA = _family.IMAP_SCHEMA`) so callers see the strict envelope while the manager's own internal dispatch boundary is unchanged. `tests/test_imap_toolfamily_ltpv2.py` is IMAP's family-specific evidence, mirroring `tests/test_telegram_toolfamily_ltpv2.py`.
 
 ## Composition
 

--- a/src/lingtai/mcp_servers/imap/SKILL.md
+++ b/src/lingtai/mcp_servers/imap/SKILL.md
@@ -8,12 +8,13 @@ description: |
   important external-email side-effect caveats (real outbound mail — confirm
   before sending). Pulled on demand via action='manual'; you do not need to call
   it before every send.
-version: 1.0.0
-last_changed_at: 2026-07-19T00:00:00Z
+version: 1.1.0
+last_changed_at: 2026-07-29T00:00:00Z
 related_files:
 - src/lingtai/mcp_servers/imap/manager.py
 - src/lingtai/mcp_servers/imap/server.py
 - src/lingtai/mcp_servers/imap/service.py
+- src/lingtai/mcp_servers/imap/_family.py
 maintenance: |
   Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
 ---
@@ -86,6 +87,20 @@ a list of ids.
 - Actions return a result dict on success or one carrying an `'error'` key on
   failure (e.g. unknown account, bad `email_id`, unreadable attachment). Check
   for the error and surface or act on it rather than assuming delivery.
+
+## PUBLIC TOOL FAMILY: strict LTP-v2
+
+Raw MCP discovery exposes exactly one public tool, `imap`, as a strict LTP-v2
+family with the closed root `{action, input, reasoning, summarize?}` (`action`,
+`input`, and `reasoning` required) and a closed action-owned input branch.
+`imap` actions are exactly `send`, `check`, `read`, `reply`, `search`, `delete`,
+`move`, `flag`, `folders`, `contacts`, `add_contact`, `remove_contact`,
+`edit_contact`, `accounts`, and `manual`. For example, checking the default
+account's inbox is `imap(action="check", input={}, reasoning="...")`, and
+sending mail is `imap(action="send", input={"address": "a@b.com", "message":
+"hi"}, reasoning="...")`. Do not use the retired flat/legacy shape (top-level
+`address`/`message`/`email_id`/... alongside `action`), `_reasoning`, aliases,
+or a generic dispatcher.
 
 ### Outlook IMAP OAuth
 ```json

--- a/src/lingtai/mcp_servers/imap/_family.py
+++ b/src/lingtai/mcp_servers/imap/_family.py
@@ -1,0 +1,415 @@
+"""IMAP's independent LTP-v2 tool family.
+
+This module owns only the public IMAP envelope and action branches. The
+manager remains the legacy result/business boundary behind the validated
+family — mirrors ``telegram/_family.py``.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from lingtai.tools.tool_family import ChildTool, ToolFamily
+
+from .. import _skill
+
+# Kept local to avoid importing the manager (which consumes this schema).
+_SKILL_NAME = "imap-mcp-manual"
+_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _skill.load_skill(
+    "lingtai.mcp_servers.imap"
+)
+
+_ACTIONS = (
+    "send", "check", "read", "reply", "search",
+    "delete", "move", "flag", "folders",
+    "contacts", "add_contact", "remove_contact", "edit_contact",
+    "accounts", "manual",
+)
+
+
+def _nullable(schema: dict[str, Any]) -> dict[str, Any]:
+    return {"anyOf": [schema, {"type": "null"}]}
+
+
+def _object(
+    properties: dict[str, Any],
+    *,
+    required: list[str] | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        result["required"] = required
+    return result
+
+
+def _address_list() -> dict[str, Any]:
+    return {
+        "anyOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}},
+        ],
+    }
+
+
+def _email_id_list() -> dict[str, Any]:
+    return {
+        "anyOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}},
+        ],
+        "description": "Email ID(s) — compound key: account:folder:uid",
+    }
+
+
+def _account_field() -> dict[str, Any]:
+    return _nullable({
+        "type": "string",
+        "description": (
+            "Which account to use (email address). Optional — an empty or "
+            "whitespace-only string is treated as omitted and defaults to "
+            "the primary account."
+        ),
+    })
+
+
+def _imap_input_schemas() -> dict[str, dict[str, Any]]:
+    send = _object(
+        {
+            "account": _account_field(),
+            "address": _address_list(),
+            "subject": {"type": "string", "description": "Email subject line"},
+            "message": {"type": "string", "description": "Email body"},
+            "cc": _address_list(),
+            "bcc": _address_list(),
+            "attachments": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "List of file paths to attach (absolute or relative to "
+                    "working dir)."
+                ),
+            },
+        },
+        required=["address"],
+    )
+    send["properties"]["address"]["description"] = "Target email address(es) for send"
+    send["properties"]["cc"]["description"] = "CC address(es)"
+    send["properties"]["bcc"]["description"] = "BCC address(es)"
+
+    check = _object({
+        "account": _account_field(),
+        "folder": _nullable({
+            "type": "string",
+            "description": (
+                "IMAP folder name (e.g. INBOX, [Gmail]/Sent Mail). An empty "
+                "or whitespace-only string is treated as omitted and "
+                "defaults to INBOX."
+            ),
+        }),
+        "n": _nullable({
+            "type": "integer",
+            "description": "Max recent emails to show (default 10)",
+        }),
+    })
+
+    read = _object(
+        {
+            "account": _account_field(),
+            "email_id": _email_id_list(),
+        },
+        required=["email_id"],
+    )
+
+    reply = _object(
+        {
+            "account": _account_field(),
+            "email_id": _email_id_list(),
+            "subject": {"type": "string", "description": "Email subject line"},
+            "message": {"type": "string", "description": "Email body"},
+            "cc": _address_list(),
+            "attachments": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "List of file paths to attach (absolute or relative to "
+                    "working dir)."
+                ),
+            },
+        },
+        required=["email_id", "message"],
+    )
+    reply["properties"]["cc"]["description"] = "CC address(es)"
+
+    search = _object(
+        {
+            "account": _account_field(),
+            "query": {
+                "type": "string",
+                "description": (
+                    "IMAP search query (e.g. from:addr subject:text unseen "
+                    "since:YYYY-MM-DD)"
+                ),
+            },
+            "folder": _nullable({
+                "type": "string",
+                "description": (
+                    "IMAP folder name. An empty or whitespace-only string is "
+                    "treated as omitted and defaults to INBOX."
+                ),
+            }),
+        },
+        required=["query"],
+    )
+
+    delete = _object(
+        {
+            "account": _account_field(),
+            "email_id": _email_id_list(),
+        },
+        required=["email_id"],
+    )
+
+    move = _object(
+        {
+            "account": _account_field(),
+            "email_id": _email_id_list(),
+            "folder": {
+                "type": "string",
+                "description": (
+                    "Destination folder for move. Must be a non-empty name — "
+                    "never defaulted to INBOX."
+                ),
+            },
+        },
+        required=["email_id", "folder"],
+    )
+
+    flag = _object(
+        {
+            "account": _account_field(),
+            "email_id": _email_id_list(),
+            "flags": {
+                "type": "object",
+                "description": (
+                    "Required — dict of flag name to bool, e.g. "
+                    "{\"seen\": true, \"flagged\": false}"
+                ),
+            },
+        },
+        required=["email_id", "flags"],
+    )
+
+    folders = _object({"account": _account_field()})
+    contacts = _object({"account": _account_field()})
+
+    add_contact = _object(
+        {
+            "account": _account_field(),
+            "address": {"type": "string", "description": "Contact's email address"},
+            "name": {
+                "type": "string",
+                "description": "Contact's human-readable name",
+            },
+            "note": {"type": "string", "description": "Free-text note about the contact"},
+        },
+        required=["address", "name"],
+    )
+
+    remove_contact = _object(
+        {
+            "account": _account_field(),
+            "address": {"type": "string", "description": "Contact's email address"},
+        },
+        required=["address"],
+    )
+
+    edit_contact = _object(
+        {
+            "account": _account_field(),
+            "address": {"type": "string", "description": "Contact's email address"},
+            "name": {
+                "type": "string",
+                "description": "Contact's human-readable name",
+            },
+            "note": {"type": "string", "description": "Free-text note about the contact"},
+        },
+        required=["address"],
+    )
+
+    accounts = _object({})
+    empty = _object({})
+    return {
+        "send": send,
+        "check": check,
+        "read": read,
+        "reply": reply,
+        "search": search,
+        "delete": delete,
+        "move": move,
+        "flag": flag,
+        "folders": folders,
+        "contacts": contacts,
+        "add_contact": add_contact,
+        "remove_contact": remove_contact,
+        "edit_contact": edit_contact,
+        "accounts": accounts,
+        "manual": empty,
+    }
+
+
+def _schema_only_family() -> ToolFamily:
+    schemas = _imap_input_schemas()
+    return ToolFamily(
+        "imap",
+        [
+            ChildTool(action, schemas[action], lambda _input: {})
+            for action in _ACTIONS
+        ],
+    )
+
+
+_SCHEMA_FAMILY = _schema_only_family()
+
+
+def imap_schema() -> dict[str, Any]:
+    schema = _SCHEMA_FAMILY.build_schema()
+    # IMAP has intentionally overlapping optional fields (for example every
+    # action accepts optional account). The root allOf discriminator still
+    # correlates each action to its exact closed branch; use anyOf for the
+    # model-discovery list so native JSON-Schema validators do not reject a
+    # valid input merely because another action's branch also fits.
+    schema["properties"]["input"]["anyOf"] = schema["properties"]["input"].pop("oneOf")
+    schema["properties"]["action"]["description"] = (
+        "send: send email via IMAP/SMTP (requires address, message; optional "
+        "subject, cc, bcc, attachments). "
+        "check: list recent envelopes from a folder (optional folder, n). "
+        "read: fetch full email by ID list (email_id=[id1, ...]). "
+        "You are encouraged to read multiple relevant or even all unread "
+        "emails and think before acting. "
+        "reply: reply to an email (requires email_id, message; optional cc, "
+        "attachments). "
+        "search: server-side IMAP search (requires query, optional folder). "
+        "delete: delete email(s) by ID (email_id). "
+        "move: move email(s) to another folder (email_id, folder=destination). "
+        "flag: set/clear flags on email(s) (email_id, flags={flag: bool}, e.g. "
+        "flags={'seen': true}). "
+        "folders: list available IMAP folders. "
+        "contacts: list all contacts. "
+        "add_contact: add/update contact (requires address, name; optional "
+        "note). "
+        "remove_contact: remove contact (requires address). "
+        "edit_contact: update contact fields (requires address; optional "
+        "name, note). "
+        "accounts: list configured IMAP accounts and connection status. "
+        + _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME)
+    )
+    return schema
+
+
+def _basic_validate(value: Any, schema: Mapping[str, Any]) -> bool:
+    """Small dependency-free validator for the dispatch safety boundary.
+
+    JSON-Schema combinators compose with sibling constraints. Validate them
+    first without returning early, then validate the schema's own type,
+    required fields, properties, and bounds.
+    """
+    if "anyOf" in schema and not any(
+        _basic_validate(value, branch) for branch in schema["anyOf"]
+    ):
+        return False
+    if "oneOf" in schema and sum(
+        _basic_validate(value, branch) for branch in schema["oneOf"]
+    ) != 1:
+        return False
+    expected = schema.get("type")
+    if expected is None:
+        required = schema.get("required")
+        if required is None:
+            return True
+        return isinstance(value, Mapping) and all(key in value for key in required)
+    if expected == "object":
+        if not isinstance(value, Mapping):
+            return False
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False and set(value) - set(properties):
+            return False
+        if any(key not in value for key in schema.get("required", [])):
+            return False
+        if not all(
+            key not in value or _basic_validate(item, child_schema)
+            for key, child_schema in properties.items()
+            for item in [value.get(key)]
+        ):
+            return False
+        return True
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str) and value in schema.get("enum", [value])
+    if expected == "integer":
+        return (
+            type(value) is int
+            and value in schema.get("enum", [value])
+            and value >= schema.get("minimum", value)
+            and value <= schema.get("maximum", value)
+        )
+    if expected == "number":
+        return (
+            type(value) in (int, float)
+            and not isinstance(value, bool)
+            and value >= schema.get("minimum", value)
+            and value <= schema.get("maximum", value)
+        )
+    if expected == "boolean":
+        return type(value) is bool
+    if expected == "null":
+        return value is None
+    return True
+
+
+def build_imap_family(manager: Any | None) -> ToolFamily:
+    schemas = _imap_input_schemas()
+    children: list[ChildTool] = []
+    for action in _ACTIONS:
+        if action == "manual":
+            handler = (
+                (lambda _input: manager.handle({"action": "manual"}))
+                if manager is not None
+                else lambda _input: _skill.manual_payload(
+                    _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
+                )
+            )
+        else:
+            handler = (
+                (lambda input_, action=action: manager.handle({"action": action, **dict(input_)}))
+                if manager is not None else (lambda _input: {})
+            )
+        children.append(ChildTool(action, schemas[action], handler))
+    return ToolFamily("imap", children)
+
+
+def handle_imap(manager: Any | None, args: Mapping[str, Any] | None) -> dict[str, Any]:
+    raw = dict(args or {})
+    if set(raw) - {"action", "input", "reasoning", "summarize"}:
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "unsupported imap argument"}
+    action = raw.get("action")
+    if type(action) is not str or action not in _ACTIONS:
+        return {"status": "failed", "error_code": "ACTION_REQUIRED", "message": "invalid imap action"}
+    if "input" not in raw or not isinstance(raw.get("input"), Mapping):
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "input must be an object"}
+    if type(raw.get("reasoning")) is not str:
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "reasoning is required"}
+    if "summarize" in raw and type(raw["summarize"]) is not bool:
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "summarize must be a boolean"}
+    schema = _imap_input_schemas()[action]
+    if not _basic_validate(raw["input"], schema):
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "invalid imap input"}
+    return build_imap_family(manager).handle(raw)
+
+
+IMAP_SCHEMA = imap_schema()
+IMAP_ACTIONS = _ACTIONS

--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
 from .. import _skill
+from . import _family
 
 if TYPE_CHECKING:
     from .account import IMAPAccount
@@ -226,6 +227,10 @@ DESCRIPTION = (
     "(2) you can confirm the sender is the same human who contacts you via internal email. "
     "Unknown external senders require confirmation from your human before replying."
 )
+
+# Public callers receive the strict LTP-v2 family schema. Manager dispatch
+# remains the internal flat action boundary after family validation.
+SCHEMA = _family.IMAP_SCHEMA
 
 
 # ---------------------------------------------------------------------------

--- a/src/lingtai/mcp_servers/imap/server.py
+++ b/src/lingtai/mcp_servers/imap/server.py
@@ -49,6 +49,7 @@ from .._results import unknown_resource_error as _unknown_resource
 from .._results import unknown_tool_error as _unknown_tool
 
 from .. import _config
+from ._family import handle_imap
 from ._migrate import migrate_legacy_state
 from .bridge import FilesystemMailBridge
 from .licc import push_inbox_event
@@ -618,24 +619,27 @@ def build_server(manager: IMAPMailManager | None) -> Server:
         if params.name != "imap":
             raise _unknown_tool(params.name)
         arguments = params.arguments or {}
-        if manager is None:
+        try:
+            if manager is None:
+                result = handle_imap(None, arguments)
+                if not result:
+                    result = {
+                        "status": "error",
+                        "error": (
+                            "IMAP manager not initialized — server boot failed. "
+                            "Check stderr for the underlying exception (most "
+                            "often missing LINGTAI_IMAP_CONFIG or invalid "
+                            "credentials)."
+                        ),
+                    }
+            else:
+                result = await asyncio.to_thread(handle_imap, manager, arguments)
+        except Exception as e:
             result = {
                 "status": "error",
-                "error": (
-                    "IMAP manager not initialized — server boot failed. "
-                    "Check stderr for the underlying exception (most often "
-                    "missing LINGTAI_IMAP_CONFIG or invalid credentials)."
-                ),
+                "error": str(e),
+                "error_type": type(e).__name__,
             }
-        else:
-            try:
-                result = await asyncio.to_thread(manager.handle, arguments)
-            except Exception as e:
-                result = {
-                    "status": "error",
-                    "error": str(e),
-                    "error_type": type(e).__name__,
-                }
         return _tool_result(result)
 
     server: Server = Server(

--- a/tests/test_imap_toolfamily_ltpv2.py
+++ b/tests/test_imap_toolfamily_ltpv2.py
@@ -1,0 +1,135 @@
+"""Focused IMAP LTP-v2 family invariants (mirrors telegram's toolfamily test)."""
+from __future__ import annotations
+
+import copy
+
+from lingtai.mcp_servers.imap._family import (
+    IMAP_ACTIONS,
+    IMAP_SCHEMA,
+    _basic_validate,
+    handle_imap,
+)
+
+
+class _CountingManager:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def handle(self, args: dict) -> dict:
+        self.calls.append(dict(args))
+        return {"status": "ok", "action": args.get("action")}
+
+
+def _branches(schema: dict) -> dict[str, dict]:
+    inputs = schema["properties"]["input"]
+    branches = inputs.get("oneOf") or inputs.get("anyOf")
+    return {branch["title"].removesuffix(" input"): branch for branch in branches}
+
+
+def test_family_dispatch_rejects_root_and_cross_branch_before_manager_io():
+    manager = _CountingManager()
+    valid = {
+        "action": "accounts",
+        "input": {},
+        "reasoning": "schema probe",
+    }
+    invalid = [
+        {"action": "accounts", "input": {}, "reasoning": "x", "_reasoning": "legacy"},
+        {"action": "accounts", "input": {}, "reasoning": "x", "unknown": 1},
+        {"action": "accounts", "input": {}, "reasoning": 7},
+        {"action": "accounts", "input": {"email_id": "a:b:1"}, "reasoning": "x"},
+        {"action": "send", "input": {"note": "wrong branch key"}, "reasoning": "x"},
+        {"action": "send", "input": {}, "reasoning": "x"},
+        {"action": "move", "input": {"email_id": "a:b:1"}, "reasoning": "x"},
+        {"action": "flag", "input": {"email_id": "a:b:1"}, "reasoning": "x"},
+        {"action": "add_contact", "input": {"address": "a@b.com"}, "reasoning": "x"},
+    ]
+    for args in invalid:
+        result = handle_imap(manager, args)
+        assert result["status"] == "failed", args
+        assert manager.calls == []
+    assert handle_imap(manager, valid)["status"] == "ok"
+    assert len(manager.calls) == 1
+    assert manager.calls[0] == {"action": "accounts"}
+
+
+def test_family_dispatch_forwards_flat_input_to_manager_handle():
+    manager = _CountingManager()
+    handle_imap(manager, {
+        "action": "send",
+        "input": {"address": "a@b.com", "message": "hi"},
+        "reasoning": "x",
+    })
+    handle_imap(manager, {
+        "action": "move",
+        "input": {"email_id": "a:b:1", "folder": "Archive"},
+        "reasoning": "x",
+    })
+    handle_imap(manager, {
+        "action": "flag",
+        "input": {"email_id": "a:b:1", "flags": {"seen": True}},
+        "reasoning": "x",
+    })
+    assert manager.calls == [
+        {"action": "send", "address": "a@b.com", "message": "hi"},
+        {"action": "move", "email_id": "a:b:1", "folder": "Archive"},
+        {"action": "flag", "email_id": "a:b:1", "flags": {"seen": True}},
+    ]
+
+
+def test_manual_action_bypasses_manager_when_manager_is_none():
+    result = handle_imap(None, {"action": "manual", "input": {}, "reasoning": "x"})
+    assert result["status"] == "ok"
+    assert result["skill"] == "imap-mcp-manual"
+    assert isinstance(result["manual"], str) and result["manual"].strip()
+
+
+def test_imap_actions_match_exact_public_inventory():
+    assert IMAP_ACTIONS == (
+        "send", "check", "read", "reply", "search",
+        "delete", "move", "flag", "folders",
+        "contacts", "add_contact", "remove_contact", "edit_contact",
+        "accounts", "manual",
+    )
+    assert list(IMAP_SCHEMA["properties"]["action"]["enum"]) == list(IMAP_ACTIONS)
+
+
+def test_imap_send_schema_requires_address_and_rejects_unknown_fields():
+    send = _branches(IMAP_SCHEMA)["send"]
+    assert send["required"] == ["address"]
+    assert _basic_validate({"address": "a@b.com", "message": "hi"}, send)
+    assert not _basic_validate({"message": "missing address"}, send)
+    assert not _basic_validate({"address": "a@b.com", "bogus": 1}, send)
+
+
+def test_imap_move_schema_requires_email_id_and_destination_folder():
+    move = _branches(IMAP_SCHEMA)["move"]
+    assert set(move["required"]) == {"email_id", "folder"}
+    assert _basic_validate({"email_id": "a:b:1", "folder": "Archive"}, move)
+    assert not _basic_validate({"email_id": "a:b:1"}, move)
+
+
+def test_imap_flag_schema_requires_email_id_and_flags():
+    flag = _branches(IMAP_SCHEMA)["flag"]
+    assert set(flag["required"]) == {"email_id", "flags"}
+    assert _basic_validate({"email_id": "a:b:1", "flags": {"seen": True}}, flag)
+    assert not _basic_validate({"email_id": "a:b:1"}, flag)
+
+
+def test_imap_root_envelope_is_strict_ltp_v2():
+    assert IMAP_SCHEMA["required"] == ["action", "input", "reasoning"]
+    assert IMAP_SCHEMA["additionalProperties"] is False
+    assert "reasoning" in IMAP_SCHEMA["properties"]
+    assert "summarize" in IMAP_SCHEMA["properties"]
+    assert len(IMAP_SCHEMA["allOf"]) == len(IMAP_ACTIONS)
+
+
+def test_openai_responses_scrub_preserves_family_root_and_action_branches():
+    from lingtai.llm.openai.adapter import _scrub_responses_schema
+
+    wire = _scrub_responses_schema(copy.deepcopy(IMAP_SCHEMA), is_root=True)
+    assert wire["required"] == IMAP_SCHEMA["required"]
+    assert wire["properties"]["action"]["enum"] == list(IMAP_ACTIONS)
+    assert wire["properties"]["input"]["anyOf"]
+    assert len(wire["allOf"]) == len(IMAP_ACTIONS)
+    assert wire["additionalProperties"] is False


### PR DESCRIPTION
## Summary

- migrate IMAP's 15 maintained actions to the strict LingTai Tool Protocol family envelope: `action + input + reasoning + summarize`
- expose closed, action-specific input schemas for addresses, message bodies, folders, flags, contacts, accounts, and attachments
- reject flat legacy, host-only, unknown, and cross-action arguments before manager I/O while forwarding only the established flat manager payload internally
- route the server through the family schema/dispatcher and update the packaged IMAP manual and MCP-server Anatomy pointer
- preserve SMTP/IMAP business logic, accounts, folders, flags, attachments, contacts, LICC/listener ownership, and result/error behavior

This is an independent curated-addon migration modeled on the already-merged Telegram reference. Generic third-party MCP insertion and every other addon family are unchanged.

## Public contract

The public action set remains exactly:

`send`, `check`, `read`, `reply`, `search`, `delete`, `move`, `flag`, `folders`, `contacts`, `add_contact`, `remove_contact`, `edit_contact`, `accounts`, `manual`.

`reasoning` and `summarize` stay at the host envelope and never reach the IMAP manager. `manual` returns the existing family payload verbatim without a second wrapper.

## Validation

- Parent authoritative offline gate: **239 passed**
- targeted compileall: PASS
- docs governance / Anatomy: PASS
- `git diff --check`: PASS
- independent exact Claude Opus 5 review: **ACCEPT**, zero blockers
- accepted review fold-in: IMAP manual version/date refreshed and `_family.py` registered in `related_files`; docs governance revalidated across **298 documents**
- candidate freeze before commit:
  - patch SHA-256: `006da9171d0c27c71978b79c7b7a24e54f7385a19b9a03cf2bde9d8492cfa024`
  - manifest SHA-256: `b9f39786bc0ccd1a4822fe6e5e7d0d89f4f9157ac0c014f643e87fbbe60b9c2d`

Validation used the MCP SDK v2 runtime and offline/mocked probes; no live IMAP/SMTP side effect was used as acceptance evidence.

## Review notes

Opus confirmed the retained shadowed legacy manager `SCHEMA` literal is exact current-main Telegram reference parity rather than candidate-specific dead code. It also noted pre-existing family/shared follow-ups around the `send` description's optional empty message, generic array-item validation, and Anatomy prose density; none is introduced by or required for this migration.

## Scope

Six paths only: IMAP family/manual/manager/server, the MCP-server Anatomy pointer, and focused tests. No external MCP registry, generic ToolFamily runtime, configuration, credentials, hooks, package state, or unrelated addon code is changed.
