### PR TITLE
feat(cloud-mail): adopt LingTai Tool Protocol envelope

### DIFF
--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -13,6 +13,7 @@ related_files:
   - src/lingtai/mcp_servers/_skill.py
   - src/lingtai/mcp_servers/daemon_common/server.py
   - src/lingtai/mcp_servers/cloud_mail/manager.py
+  - src/lingtai/mcp_servers/cloud_mail/_family.py
   - src/lingtai/mcp_servers/feishu/manager.py
   - src/lingtai/mcp_servers/imap/manager.py
   - src/lingtai/mcp_servers/telegram/account.py

--- a/src/lingtai/mcp_servers/cloud_mail/SKILL.md
+++ b/src/lingtai/mcp_servers/cloud_mail/SKILL.md
@@ -6,11 +6,13 @@ description: |
   check/search filters, the compound id (account:emailId) for read, send (needs
   user credentials), plain vs HTML bodies, accounts/add_user basics, and the
   external-email side-effect caveats. Pulled on demand via action='manual'; you
-  do not need to call it before every send.
-version: 1.0.0
-last_changed_at: "2026-07-19T00:00:00Z"
+  do not need to call it before every send. Calls use the strict LTP-v2
+  action/input/reasoning/summarize envelope.
+version: 1.1.0
+last_changed_at: "2026-07-29T00:00:00Z"
 related_files:
 - src/lingtai/mcp_servers/cloud_mail/manager.py
+- src/lingtai/mcp_servers/cloud_mail/_family.py
 - src/lingtai/mcp_servers/cloud_mail/server.py
 - src/lingtai/mcp_servers/cloud_mail/client.py
 maintenance: |
@@ -26,6 +28,33 @@ Setup, config file/schema, credential and auth model, and watermark state are
 owned by the `mcp-manual` skill (`reference/curated-addons.md`, §Cloud Mail
 setup). Read it before editing config; do not guess field names.
 
+## HOW TO CALL IT — the envelope
+
+`cloud_mail` is a single strict LTP-v2 tool family. Every call takes a closed
+root `{action, input, reasoning, summarize?}` — `action`, `input`, and
+`reasoning` are required; `summarize` is optional and never nested under
+`input`. `input` is the strict argument object **for the selected action
+only**; a key from another action's branch is rejected before anything is
+read or sent. Actions are exactly `check`, `search`, `read`, `send`,
+`accounts`, `add_user`, `manual`. Do not use a flat/legacy shape, `_reasoning`,
+aliases, or a generic dispatcher.
+
+```python
+cloud_mail(action="check", input={"limit": 10}, reasoning="check for new mail")
+cloud_mail(action="read", input={"id": "cloudmail:1234"}, reasoning="read the request")
+cloud_mail(action="send", input={"address": "user@example.com", "message": "done"},
+           reasoning="report completion")
+```
+
+**`summarize` guidance for this family.** `check`, `search`, and `read` are
+**bulky-result** actions — mailbox listings and full email bodies can be long,
+so `summarize=true` is reasonable when you only need the gist. Leave it false
+when you need exact email ids, addresses, or verbatim body text, because you
+will act on those literally. `send`, `accounts`, and `add_user` are
+**short-result**: their receipts are small and meant to be read exactly, so
+leave `summarize` false. Call `manual` itself with `summarize=false` so
+procedure and constraints are not summarized away.
+
 ## EMAIL IDS
 
 - `read` fetches the full content of one email by compound id
@@ -34,8 +63,8 @@ setup). Read it before editing config; do not guess field names.
 
 ## READING: check / search
 
-- `check`: list recent inbound emails (optional `limit`/`n`, plus the same
-  filters as search).
+- `check`: list recent inbound emails (optional `limit`, plus the same filters
+  as search).
 - `search`: filter the public email list by `to_email`, `send_email`,
   `send_name`, `subject`, `content`, `time_sort` (`asc`/`desc`), and paginate
   with `num`/`size`. Filters are LIKE matches.

--- a/src/lingtai/mcp_servers/cloud_mail/_family.py
+++ b/src/lingtai/mcp_servers/cloud_mail/_family.py
@@ -1,0 +1,245 @@
+"""Cloud Mail's independent LTP-v2 tool family.
+
+This module owns only the public Cloud Mail envelope and action branches.
+``CloudMailManager`` remains the legacy result/business boundary behind the
+validated family, mirroring ``telegram/_family.py``.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .. import _skill
+
+# Kept local to avoid importing the manager (which consumes this schema).
+_SKILL_NAME = "cloud-mail-mcp-manual"
+_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _skill.load_skill(
+    "lingtai.mcp_servers.cloud_mail"
+)
+
+_ACTIONS = ("check", "search", "read", "send", "accounts", "add_user", "manual")
+
+
+def _nullable(schema: dict[str, Any]) -> dict[str, Any]:
+    return {"anyOf": [schema, {"type": "null"}]}
+
+
+def _object(
+    properties: dict[str, Any],
+    *,
+    required: list[str] | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        result["required"] = required
+    return result
+
+
+def _cloud_mail_input_schemas() -> dict[str, dict[str, Any]]:
+    empty = _object({})
+    account = {"type": "string", "description": "Account alias (or admin email). Defaults to the first configured account."}
+    time_sort = _nullable({"type": "string", "enum": ["asc", "desc"]})
+    check = _object(
+        {
+            "account": _nullable(account),
+            "limit": _nullable({"type": "integer"}),
+            "to_email": _nullable({"type": "string"}),
+            "send_email": _nullable({"type": "string"}),
+            "subject": _nullable({"type": "string"}),
+            "time_sort": time_sort,
+            "type": _nullable({"type": "integer"}),
+        },
+    )
+    search = _object(
+        {
+            "account": _nullable(account),
+            "to_email": _nullable({"type": "string"}),
+            "send_email": _nullable({"type": "string"}),
+            "send_name": _nullable({"type": "string"}),
+            "subject": _nullable({"type": "string"}),
+            "content": _nullable({"type": "string"}),
+            "time_sort": time_sort,
+            "num": _nullable({"type": "integer"}),
+            "size": _nullable({"type": "integer"}),
+            "type": _nullable({"type": "integer"}),
+            "is_del": _nullable({"type": "integer"}),
+        },
+    )
+    read = _object(
+        {
+            "account": _nullable(account),
+            "id": _nullable({"type": "string"}),
+            "email_id": _nullable({"anyOf": [{"type": "string"}, {"type": "integer"}]}),
+        },
+    )
+    send = _object(
+        {
+            "account": _nullable(account),
+            "address": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}},
+                ],
+                "description": "Recipient address or list of addresses.",
+            },
+            "subject": _nullable({"type": "string"}),
+            "message": _nullable({"type": "string"}),
+            "text": _nullable({"type": "string"}),
+            "html": _nullable({"type": "string"}),
+            "content_html": _nullable({"type": "string"}),
+            "name": _nullable({"type": "string"}),
+            "send_account_id": _nullable({"type": "integer"}),
+            "attachments": _nullable({"type": "array"}),
+        },
+        required=["address"],
+    )
+    accounts = empty
+    add_user = _object(
+        {
+            "account": _nullable(account),
+            "email": {"type": "string"},
+            "password": {"type": "string"},
+            "role_name": _nullable({"type": "string"}),
+        },
+        required=["email", "password"],
+    )
+    return {
+        "check": check,
+        "search": search,
+        "read": read,
+        "send": send,
+        "accounts": accounts,
+        "add_user": add_user,
+        "manual": empty,
+    }
+
+
+def cloud_mail_schema() -> dict[str, Any]:
+    schemas = _cloud_mail_input_schemas()
+    branches = []
+    for action in _ACTIONS:
+        branch = {"title": f"{action} input"}
+        branch.update(schemas[action])
+        branches.append(branch)
+    return {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": list(_ACTIONS),
+                "description": (
+                    "Cloud Mail action. Each action owns a strict input branch. "
+                    "check (recent inbound mail), search (filter by sender/"
+                    "recipient/subject/content), read (full content by compound "
+                    "id '<account>:<emailId>'), send (requires user credentials "
+                    "in config), accounts (redacted status), add_user (create a "
+                    "Cloud Mail user). Call manual "
+                    + _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME)
+                ),
+            },
+            "input": {
+                "description": (
+                    "Strict action-specific input; the selected action is "
+                    "validated again at dispatch."
+                ),
+                "anyOf": branches,
+            },
+            "reasoning": {
+                "type": "string",
+                "description": "Brief explanation of why you are calling this tool (recorded in your diary).",
+            },
+            "summarize": {
+                "type": "boolean",
+                "description": (
+                    "Root, cross-cutting result post-processing control; "
+                    "absent or false by default. Not action input."
+                ),
+            },
+        },
+        "required": ["action", "input", "reasoning"],
+        "additionalProperties": False,
+    }
+
+
+def _basic_validate(value: Any, schema: Mapping[str, Any]) -> bool:
+    """Small dependency-free validator for the dispatch safety boundary."""
+    if "anyOf" in schema and not any(
+        _basic_validate(value, branch) for branch in schema["anyOf"]
+    ):
+        return False
+    expected = schema.get("type")
+    if expected is None:
+        required = schema.get("required")
+        if required is None:
+            return True
+        return isinstance(value, Mapping) and all(key in value for key in required)
+    if expected == "object":
+        if not isinstance(value, Mapping):
+            return False
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False and set(value) - set(properties):
+            return False
+        if any(key not in value for key in schema.get("required", [])):
+            return False
+        if not all(
+            key not in value or _basic_validate(item, child_schema)
+            for key, child_schema in properties.items()
+            for item in [value.get(key)]
+        ):
+            return False
+        return True
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str) and value in schema.get("enum", [value])
+    if expected == "integer":
+        return type(value) is int and value in schema.get("enum", [value])
+    if expected == "null":
+        return value is None
+    return True
+
+
+def build_cloud_mail_family(manager: Any | None):
+    """Bind action handlers to ``manager`` (or produce no-op stubs)."""
+    schemas = _cloud_mail_input_schemas()
+
+    def _handler(action: str):
+        if action == "manual":
+            if manager is not None:
+                return lambda _input: manager.handle({"action": "manual"})
+            return lambda _input: _skill.manual_payload(
+                _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
+            )
+        if manager is not None:
+            return lambda input_, action=action: manager.handle({"action": action, **dict(input_)})
+        return lambda _input: {}
+
+    return {action: _handler(action) for action in _ACTIONS}, schemas
+
+
+def handle_cloud_mail(manager: Any | None, args: Mapping[str, Any] | None) -> dict[str, Any]:
+    raw = dict(args or {})
+    if set(raw) - {"action", "input", "reasoning", "summarize"}:
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "unsupported cloud_mail argument"}
+    action = raw.get("action")
+    if type(action) is not str or action not in _ACTIONS:
+        return {"status": "failed", "error_code": "ACTION_REQUIRED", "message": "invalid cloud_mail action"}
+    if "input" not in raw or not isinstance(raw.get("input"), Mapping):
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "input must be an object"}
+    if type(raw.get("reasoning")) is not str:
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "reasoning is required"}
+    if "summarize" in raw and type(raw["summarize"]) is not bool:
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "summarize must be a boolean"}
+    schema = _cloud_mail_input_schemas()[action]
+    if not _basic_validate(raw["input"], schema):
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "invalid cloud_mail input"}
+    handlers, _schemas = build_cloud_mail_family(manager)
+    return handlers[action](raw["input"])
+
+
+CLOUD_MAIL_SCHEMA = cloud_mail_schema()
+CLOUD_MAIL_ACTIONS = _ACTIONS

--- a/src/lingtai/mcp_servers/cloud_mail/manager.py
+++ b/src/lingtai/mcp_servers/cloud_mail/manager.py
@@ -21,6 +21,7 @@ from typing import Any, Callable
 
 from .client import CloudMailClient, CloudMailError
 from ._watermark import WatermarkStore
+from . import _family
 from .. import _skill
 
 log = logging.getLogger("lingtai_cloud_mail")
@@ -87,6 +88,10 @@ SCHEMA: dict[str, Any] = {
     },
     "required": ["action"],
 }
+
+# Public callers receive the strict LTP-v2 family schema. Manager dispatch
+# remains the internal flat action boundary after family validation.
+SCHEMA = _family.CLOUD_MAIL_SCHEMA
 
 
 class CloudMailAccount:

--- a/src/lingtai/mcp_servers/cloud_mail/server.py
+++ b/src/lingtai/mcp_servers/cloud_mail/server.py
@@ -1,8 +1,9 @@
 """LingTai Cloud Mail MCP server.
 
-Exposes a single omnibus ``cloud_mail`` MCP tool that dispatches to
-``CloudMailManager`` (check/read/search/send/accounts/add_user). Inbound mail
-flows into the host agent's inbox via LICC.
+Exposes a single ``cloud_mail`` MCP tool with the strict LTP-v2 envelope
+(``action``/``input``/``reasoning``/``summarize``, see ``_family.py``) that
+dispatches through ``CloudMailManager`` (check/read/search/send/accounts/
+add_user). Inbound mail flows into the host agent's inbox via LICC.
 
 Configuration:
     LINGTAI_CLOUD_MAIL_CONFIG  — path to a JSON config file (required).
@@ -50,6 +51,7 @@ from .._results import unknown_tool_error as _unknown_tool
 from .. import _config
 from .licc import push_inbox_event
 from .manager import CloudMailManager, DESCRIPTION, SCHEMA
+from ._family import handle_cloud_mail
 
 log = logging.getLogger("lingtai_cloud_mail")
 
@@ -169,7 +171,7 @@ def build_server(manager: CloudMailManager | None) -> Server:
             }
         else:
             try:
-                result = await asyncio.to_thread(manager.handle, arguments)
+                result = await asyncio.to_thread(handle_cloud_mail, manager, arguments)
             except Exception as e:
                 result = {
                     "status": "error",

--- a/tests/test_cloud_mail_toolfamily_ltpv2.py
+++ b/tests/test_cloud_mail_toolfamily_ltpv2.py
@@ -1,0 +1,151 @@
+"""Focused Cloud Mail LTP-v2 family tests: strict envelope, dispatch boundary."""
+from __future__ import annotations
+
+import copy
+import re
+
+from lingtai.mcp_servers.cloud_mail import manager as cloud_mail_mgr
+from lingtai.mcp_servers.cloud_mail._family import (
+    CLOUD_MAIL_ACTIONS,
+    CLOUD_MAIL_SCHEMA,
+    _basic_validate,
+    _cloud_mail_input_schemas,
+    handle_cloud_mail,
+)
+
+
+class _CountingManager:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def handle(self, args: dict) -> dict:
+        self.calls.append(dict(args))
+        return {"status": "ok", "action": args.get("action")}
+
+
+def _branches(schema: dict) -> dict[str, dict]:
+    inputs = schema["properties"]["input"]
+    branches = inputs.get("oneOf") or inputs.get("anyOf")
+    return {branch["title"].removesuffix(" input"): branch for branch in branches}
+
+
+def test_schema_declares_strict_root_envelope():
+    assert set(CLOUD_MAIL_SCHEMA["properties"]) == {"action", "input", "reasoning", "summarize"}
+    assert CLOUD_MAIL_SCHEMA["required"] == ["action", "input", "reasoning"]
+    assert CLOUD_MAIL_SCHEMA["additionalProperties"] is False
+    assert CLOUD_MAIL_SCHEMA["properties"]["action"]["enum"] == list(CLOUD_MAIL_ACTIONS)
+    assert set(_branches(CLOUD_MAIL_SCHEMA)) == set(CLOUD_MAIL_ACTIONS)
+
+
+def test_family_dispatch_rejects_root_and_cross_branch_before_manager_io():
+    manager = _CountingManager()
+    valid = {"action": "accounts", "input": {}, "reasoning": "schema probe"}
+    invalid = [
+        # legacy compatibility field must not be forwarded/accepted
+        {"action": "accounts", "input": {}, "reasoning": "x", "_reasoning": "legacy"},
+        {"action": "accounts", "input": {}, "reasoning": "x", "unknown": 1},
+        {"action": "accounts", "input": {}, "reasoning": 7},
+        # cross-branch: 'address' belongs to send, not accounts
+        {"action": "accounts", "input": {"address": "x@y.com"}, "reasoning": "x"},
+        # send requires 'address'
+        {"action": "send", "input": {"message": "missing address"}, "reasoning": "x"},
+        # unknown action
+        {"action": "bogus", "input": {}, "reasoning": "x"},
+        # missing input
+        {"action": "check", "reasoning": "x"},
+        # missing reasoning
+        {"action": "check", "input": {}},
+        # summarize wrong type
+        {"action": "check", "input": {}, "reasoning": "x", "summarize": "yes"},
+    ]
+    for args in invalid:
+        result = handle_cloud_mail(manager, args)
+        assert result["status"] == "failed", args
+        assert manager.calls == []
+    ok = handle_cloud_mail(manager, valid)
+    assert ok["status"] == "ok"
+    assert len(manager.calls) == 1
+    assert manager.calls[0] == {"action": "accounts"}
+
+
+def test_send_requires_address_and_accepts_valid_input():
+    manager = _CountingManager()
+    result = handle_cloud_mail(
+        manager,
+        {
+            "action": "send",
+            "input": {"address": ["a@x.com", "b@x.com"], "message": "hi"},
+            "reasoning": "send test",
+        },
+    )
+    assert result["status"] == "ok"
+    assert manager.calls[-1] == {
+        "action": "send", "address": ["a@x.com", "b@x.com"], "message": "hi",
+    }
+    assert not _basic_validate({}, _branches(CLOUD_MAIL_SCHEMA)["send"])
+    assert _basic_validate({"address": "x@y.com"}, _branches(CLOUD_MAIL_SCHEMA)["send"])
+
+
+def test_reasoning_and_summarize_never_reach_manager_input():
+    manager = _CountingManager()
+    handle_cloud_mail(
+        manager,
+        {
+            "action": "check",
+            "input": {"limit": 5},
+            "reasoning": "why",
+            "summarize": True,
+        },
+    )
+    assert manager.calls == [{"action": "check", "limit": 5}]
+
+
+def test_manual_action_dispatches_to_manager_manual():
+    manager = _CountingManager()
+    result = handle_cloud_mail(manager, {"action": "manual", "input": {}, "reasoning": "x"})
+    assert result["status"] == "ok"
+    assert manager.calls == [{"action": "manual"}]
+
+
+def test_manual_action_without_manager_returns_bundled_skill():
+    result = handle_cloud_mail(None, {"action": "manual", "input": {}, "reasoning": "x"})
+    assert result["status"] == "ok"
+    assert result["action"] == "manual"
+    assert result["skill"] == "cloud-mail-mcp-manual"
+    assert isinstance(result["manual"], str) and result["manual"].strip()
+
+
+def test_openai_responses_scrub_preserves_family_root_and_action_branches():
+    from lingtai.llm.openai.adapter import _scrub_responses_schema
+
+    wire = _scrub_responses_schema(copy.deepcopy(CLOUD_MAIL_SCHEMA), is_root=True)
+    assert wire["required"] == CLOUD_MAIL_SCHEMA["required"]
+    assert wire["properties"]["action"]["enum"] == list(CLOUD_MAIL_ACTIONS)
+    assert wire["properties"]["input"]["anyOf"]
+    assert wire["additionalProperties"] is False
+
+
+# ---------------------------------------------------------------------------
+# Manual (SKILL.md) truthfulness — guards against re-drifting to a flat/legacy
+# example or an undocumented root ``summarize`` control (CONTRACT.md
+# "Dispatch and actions" MUST).
+# ---------------------------------------------------------------------------
+
+def test_manual_documents_the_ltp_v2_envelope_and_summarize_profile():
+    body = cloud_mail_mgr._SKILL_BODY
+    lowered = body.lower()
+    assert "action, input, reasoning" in lowered or "action`, `input`, and\n`reasoning`" in body
+    assert "summarize" in lowered
+    assert "bulky-result" in lowered
+    assert "short-result" in lowered
+
+
+def test_manual_never_teaches_the_retired_check_n_alias():
+    # 'n' was a flat-shape alias for 'limit' on the pre-migration manager
+    # dispatch; the LTP-v2 'check' input branch does not accept it
+    # (additionalProperties: false), so the manual must not teach it.
+    assert "check" in _cloud_mail_input_schemas()
+    assert "n" not in _cloud_mail_input_schemas()["check"]["properties"]
+    body = cloud_mail_mgr._SKILL_BODY
+    assert not re.search(r"`limit`/`n`", body)
+    assert not re.search(r"optional[^.\n]*\bn\b[^.\n]*filters", body, re.IGNORECASE)


### PR DESCRIPTION
## Summary

- migrate Cloud Mail's 7 maintained actions to the strict LingTai Tool Protocol family envelope: `action + input + reasoning + summarize`
- expose closed action-specific schemas and reject flat legacy, host-only, unknown, cross-action, and malformed arguments before manager I/O
- route the server through the family schema/dispatcher while preserving the existing Cloud Mail manager, provider, watermark, LICC, identity, account/user, and typed result/error behavior
- update the packaged manual with valid envelope examples, truthful per-action summarize profiles, and removal of the rejected legacy `n` alias

This is an independent curated-addon migration modeled on the already-merged Telegram reference. Generic third-party MCP insertion and every other addon family are unchanged.

## Public contract

The public action set remains exactly:

`check`, `search`, `read`, `send`, `accounts`, `add_user`, `manual`.

`reasoning` and `summarize` remain host-envelope fields and never reach the Cloud Mail manager. The manual now classifies `check`/`search`/`read` as bulky-result actions and `send`/`accounts`/`add_user` as short-result actions; exact IDs, addresses, and body text should still be read unsummarized when needed.

## Validation

- original Parent authoritative gate: **303 passed**
- post-review-repair Parent gate: **252 passed**
- targeted compileall: PASS
- docs governance / Anatomy: PASS
- `git diff --check`: PASS
- independent exact Claude Opus 5 review after repair: **ACCEPT**, zero blockers
- manual examples executed through the live family handler; all forwarded valid manager payloads
- candidate freeze before commit:
  - patch SHA-256: `594c07e58846ac3733d17eeaa6562c628054b3589b7b2eebb88059c20ae7ef39`
  - manifest SHA-256: `9fb7d340ede4fb6523dd220993f0a64b138f8d5759baa54d424d5f4d0f692a64`

Validation was offline/mocked; no live Cloud Mail provider side effect was used as acceptance evidence. The author's unfinished background whole-suite was excluded from the evidence above.

## Review notes

Opus identified and then closed one blocker: the original unchanged manual taught a now-rejected flat call and omitted the required summarize profile. The repaired manual and mutation-checked guards now prevent that drift.

Remaining nonblockers are shared/reference follow-ups: Cloud Mail's hand-built schema does not yet advertise Telegram's root `allOf/if/then` correlation, although the authoritative dispatcher is fail-closed and verified pre-I/O; the validator would need strengthening if future branches add numeric bounds or exclusive combinators. Neither changes current behavior in this PR.

## Scope

Six paths only: Cloud Mail family/manual/manager/server, the MCP-server Anatomy pointer, and focused tests. No external MCP registry, generic ToolFamily runtime, configuration, credentials, hooks, package state, or unrelated addon code is changed.
