### PR TITLE
feat(wechat): adopt LingTai Tool Protocol envelope

### DIFF
--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -26,6 +26,7 @@ related_files:
   - src/lingtai/mcp_servers/telegram/task_card/resident.py
   - src/lingtai/adapters/posix/notification_store.py
   - src/lingtai/mcp_servers/wechat/manager.py
+  - src/lingtai/mcp_servers/wechat/_family.py
   - src/lingtai/mcp_servers/whatsapp/manager.py
   - tests/test_cloud_mail_addon.py
   - tests/test_mcp_skill_manuals.py

--- a/src/lingtai/mcp_servers/wechat/SKILL.md
+++ b/src/lingtai/mcp_servers/wechat/SKILL.md
@@ -6,17 +6,46 @@ description: |
   reply, check/read/search, media_path attachments (image/video/voice/file),
   contacts/accounts basics, and external-delivery side-effect caveats. Pulled on
   demand via action='manual'; you do not need to call it before every send.
-version: 1.0.1
-last_changed_at: "2026-07-19T00:00:00Z"
+version: 1.2.0
+last_changed_at: "2026-07-29T01:00:00Z"
 related_files:
 - src/lingtai/mcp_servers/wechat/manager.py
 - src/lingtai/mcp_servers/wechat/server.py
+- src/lingtai/mcp_servers/wechat/_family.py
 - src/lingtai/mcp_servers/wechat/api.py
 maintenance: |
   Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
 ---
 
 # WeChat MCP — usage manual (progressive disclosure)
+
+## PUBLIC TOOL FAMILY: strict LTP-v2
+
+Raw MCP discovery exposes exactly one public tool, `wechat`. It is an
+independent strict LTP-v2 family with the closed root
+`{action, input, reasoning, summarize?}` (`action`, `input`, and `reasoning`
+required). `action` selects one of the 10 actions below; `input` is a closed,
+action-owned object — only that action's own fields are accepted, and a field
+from another action (or any top-level/host-only key) is rejected before any
+WeChat I/O runs. `wechat` actions are exactly `send`, `check`, `read`,
+`reply`, `search`, `contacts`, `add_contact`, `remove_contact`, `accounts`,
+and `manual`. The `manual` action is the discovery path for this document. Do
+not use the retired flat/legacy shape (arguments at the top level alongside
+`action`), `_reasoning`, aliases, or a generic dispatcher.
+
+Example call:
+
+```json
+{
+  "action": "send",
+  "input": {"user_id": "wxid_abc123@im.wechat", "text": "hi"},
+  "reasoning": "acknowledging the user's question"
+}
+```
+
+`send`'s `text` and `media_path` are independent, combinable fields (at least
+one is required, and both may be given together in one call — see MEDIA /
+ATTACHMENTS below), not a mutually exclusive choice.
 
 ## RECIPIENTS: user_id
 
@@ -39,6 +68,11 @@ maintenance: |
   anything else → file.
 - For charts, reports, and other artifacts the user should open intact, send them
   as a file/document rather than pasting a local path into the message text.
+- `text` and `media_path` may be given together in one `send` call. They are
+  delivered as **two separate WeChat messages** — the text first, then the
+  media — not as a single captioned attachment. A missing `media_path` file
+  is rejected before any text is sent, but a later upload/transport failure
+  can still leave the text delivered without the media.
 
 ## INBOUND MEDIA / FILES
 

--- a/src/lingtai/mcp_servers/wechat/_family.py
+++ b/src/lingtai/mcp_servers/wechat/_family.py
@@ -159,6 +159,12 @@ _SCHEMA_FAMILY = _schema_only_family()
 
 def wechat_schema() -> dict[str, Any]:
     schema = _SCHEMA_FAMILY.build_schema()
+    # check/contacts/accounts/manual all publish an empty-object branch, so a
+    # oneOf discovery list makes {} match more than one branch and native
+    # JSON-Schema validators reject a valid zero-input call. The root allOf
+    # discriminator still correlates each action to its exact closed branch;
+    # use anyOf for the discovery list, mirroring telegram_schema().
+    schema["properties"]["input"]["anyOf"] = schema["properties"]["input"].pop("oneOf")
     schema["properties"]["action"]["description"] = (
         "send: send a message to a WeChat user "
         "(user_id, text; optional media_path for file/image/voice/video). "

--- a/src/lingtai/mcp_servers/wechat/_family.py
+++ b/src/lingtai/mcp_servers/wechat/_family.py
@@ -1,0 +1,282 @@
+"""WeChat's independent LTP-v2 tool family.
+
+This module owns only the public WeChat envelope and action branches. The
+manager remains the legacy result/business boundary behind the validated
+family, mirroring ``lingtai.mcp_servers.telegram._family``.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from lingtai.tools.tool_family import ChildTool, ToolFamily
+
+from .. import _skill
+
+# Kept local to avoid importing the manager (which consumes this schema).
+_SKILL_NAME = "wechat-mcp-manual"
+_SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH = _skill.load_skill(
+    "lingtai.mcp_servers.wechat"
+)
+
+_ACTIONS = (
+    "send", "check", "read", "reply", "search",
+    "contacts", "add_contact", "remove_contact", "accounts", "manual",
+)
+
+
+def _object(
+    properties: dict[str, Any],
+    *,
+    required: list[str] | None = None,
+    one_of: list[dict[str, Any]] | None = None,
+    any_of: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        result["required"] = required
+    if one_of:
+        result["oneOf"] = one_of
+    if any_of:
+        result["anyOf"] = any_of
+    return result
+
+
+def _wechat_input_schemas() -> dict[str, dict[str, Any]]:
+    send = _object(
+        {
+            "user_id": {
+                "type": "string",
+                "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
+            },
+            "text": {
+                "type": "string",
+                "description": "Message text content",
+            },
+            "media_path": {
+                "type": "string",
+                "description": (
+                    "Absolute path to a file to send as media. "
+                    "Type detected from extension: "
+                    ".jpg/.png=image, .mp4=video, .wav/.mp3=voice, other=file."
+                ),
+            },
+        },
+        required=["user_id"],
+        any_of=[{"required": ["text"]}, {"required": ["media_path"]}],
+    )
+    return {
+        "send": send,
+        "check": _object({}),
+        "read": _object(
+            {
+                "user_id": {
+                    "type": "string",
+                    "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max messages to return (default 10)",
+                },
+            },
+            required=["user_id"],
+        ),
+        "reply": _object(
+            {
+                "message_id": {
+                    "type": "string",
+                    "description": "Message ID from read results (for reply action)",
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Message text content",
+                },
+            },
+            required=["message_id", "text"],
+        ),
+        "search": _object(
+            {
+                "query": {
+                    "type": "string",
+                    "description": "Search query (regex pattern)",
+                },
+                "user_id": {
+                    "type": "string",
+                    "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
+                },
+            },
+            required=["query"],
+        ),
+        "contacts": _object({}),
+        "add_contact": _object(
+            {
+                "user_id": {
+                    "type": "string",
+                    "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
+                },
+                "alias": {
+                    "type": "string",
+                    "description": "Human-friendly contact alias",
+                },
+            },
+            required=["user_id", "alias"],
+        ),
+        "remove_contact": _object(
+            {
+                "user_id": {
+                    "type": "string",
+                    "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
+                },
+                "alias": {
+                    "type": "string",
+                    "description": "Human-friendly contact alias",
+                },
+            },
+            one_of=[{"required": ["alias"]}, {"required": ["user_id"]}],
+        ),
+        "accounts": _object({}),
+        "manual": _object({}),
+    }
+
+
+def _schema_only_family() -> ToolFamily:
+    schemas = _wechat_input_schemas()
+    return ToolFamily(
+        "wechat",
+        [
+            ChildTool(action, schemas[action], lambda _input: {})
+            for action in _ACTIONS
+        ],
+    )
+
+
+_SCHEMA_FAMILY = _schema_only_family()
+
+
+def wechat_schema() -> dict[str, Any]:
+    schema = _SCHEMA_FAMILY.build_schema()
+    schema["properties"]["action"]["description"] = (
+        "send: send a message to a WeChat user "
+        "(user_id, text; optional media_path for file/image/voice/video). "
+        "check: list recent conversations with unread counts. "
+        "read: read messages from a user (user_id; optional limit). "
+        "reply: reply to a specific message "
+        "(message_id from read results, text). "
+        "search: search inbox messages by regex "
+        "(query; optional user_id). "
+        "contacts: list saved contacts. "
+        "add_contact: save a contact (user_id, alias). "
+        "remove_contact: remove a contact (alias or user_id). "
+        "accounts: list configured WeChat accounts. "
+        + _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME)
+    )
+    return schema
+
+
+def _basic_validate(value: Any, schema: Mapping[str, Any]) -> bool:
+    """Small dependency-free validator for the dispatch safety boundary.
+
+    JSON-Schema combinators compose with sibling constraints. Validate them
+    first without returning early, then validate the schema's own type,
+    required fields, properties, and bounds.
+    """
+    if "anyOf" in schema and not any(
+        _basic_validate(value, branch) for branch in schema["anyOf"]
+    ):
+        return False
+    if "oneOf" in schema and sum(
+        _basic_validate(value, branch) for branch in schema["oneOf"]
+    ) != 1:
+        return False
+    expected = schema.get("type")
+    if expected is None:
+        required = schema.get("required")
+        if required is None:
+            return True
+        return isinstance(value, Mapping) and all(key in value for key in required)
+    if expected == "object":
+        if not isinstance(value, Mapping):
+            return False
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False and set(value) - set(properties):
+            return False
+        if any(key not in value for key in schema.get("required", [])):
+            return False
+        if not all(
+            key not in value or _basic_validate(item, child_schema)
+            for key, child_schema in properties.items()
+            for item in [value.get(key)]
+        ):
+            return False
+        return True
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str) and value in schema.get("enum", [value])
+    if expected == "integer":
+        return (
+            type(value) is int
+            and value in schema.get("enum", [value])
+            and value >= schema.get("minimum", value)
+            and value <= schema.get("maximum", value)
+        )
+    if expected == "number":
+        return (
+            type(value) in (int, float)
+            and not isinstance(value, bool)
+            and value >= schema.get("minimum", value)
+            and value <= schema.get("maximum", value)
+        )
+    if expected == "boolean":
+        return type(value) is bool
+    if expected == "null":
+        return value is None
+    return True
+
+
+def build_wechat_family(manager: Any | None) -> ToolFamily:
+    schemas = _wechat_input_schemas()
+    children: list[ChildTool] = []
+    for action in _ACTIONS:
+        if action == "manual":
+            handler = (
+                (lambda _input: manager.handle({"action": "manual"}))
+                if manager is not None
+                else lambda _input: _skill.manual_payload(
+                    _SKILL_FRONTMATTER, _SKILL_BODY, _SKILL_PATH, _SKILL_NAME
+                )
+            )
+        else:
+            handler = (
+                (lambda input_, action=action: manager.handle({"action": action, **dict(input_)}))
+                if manager is not None else (lambda _input: {})
+            )
+        children.append(ChildTool(action, schemas[action], handler))
+    return ToolFamily("wechat", children)
+
+
+def handle_wechat(manager: Any | None, args: Mapping[str, Any] | None) -> dict[str, Any]:
+    raw = dict(args or {})
+    if set(raw) - {"action", "input", "reasoning", "summarize"}:
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "unsupported wechat argument"}
+    action = raw.get("action")
+    if type(action) is not str or action not in _ACTIONS:
+        return {"status": "failed", "error_code": "ACTION_REQUIRED", "message": "invalid wechat action"}
+    if "input" not in raw or not isinstance(raw.get("input"), Mapping):
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "input must be an object"}
+    if type(raw.get("reasoning")) is not str:
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "reasoning is required"}
+    if "summarize" in raw and type(raw["summarize"]) is not bool:
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "summarize must be a boolean"}
+    schema = _wechat_input_schemas()[action]
+    if not _basic_validate(raw["input"], schema):
+        return {"status": "failed", "error_code": "INVALID_ARGUMENT", "message": "invalid wechat input"}
+    return build_wechat_family(manager).handle(raw)
+
+
+WECHAT_SCHEMA = wechat_schema()
+WECHAT_ACTIONS = _ACTIONS

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -23,6 +23,7 @@ from .types import (
     msg_from_dict, msg_to_dict,
 )
 from . import api
+from . import _family
 from . import media as media_mod
 from .lockfile import AccountLock, PollerLockBusy
 from .. import _identity, _skill
@@ -69,68 +70,9 @@ _STRUCTURED_MESSAGE_TEXT_CAP = 500
 # state file bounded.
 SEEN_KEYS_MAX = 5000
 
-SCHEMA = {
-    "type": "object",
-    "properties": {
-        "action": {
-            "type": "string",
-            "enum": [
-                "send", "check", "read", "reply", "search",
-                "contacts", "add_contact", "remove_contact", "accounts",
-                "manual",
-            ],
-            "description": (
-                "send: send a message to a WeChat user "
-                "(user_id, text; optional media_path for file/image/voice/video). "
-                "check: list recent conversations with unread counts. "
-                "read: read messages from a user (user_id; optional limit). "
-                "reply: reply to a specific message "
-                "(message_id from read results, text). "
-                "search: search inbox messages by regex "
-                "(query; optional user_id). "
-                "contacts: list saved contacts. "
-                "add_contact: save a contact (user_id, alias). "
-                "remove_contact: remove a contact (alias or user_id). "
-                "accounts: list configured WeChat accounts. "
-                + _skill.manual_action_description(_SKILL_FRONTMATTER, _SKILL_NAME)
-            ),
-        },
-        "user_id": {
-            "type": "string",
-            "description": "WeChat user ID (e.g. wxid_abc123@im.wechat)",
-        },
-        "text": {
-            "type": "string",
-            "description": "Message text content",
-        },
-        "media_path": {
-            "type": "string",
-            "description": (
-                "Absolute path to a file to send as media. "
-                "Type detected from extension: "
-                ".jpg/.png=image, .mp4=video, .wav/.mp3=voice, other=file."
-            ),
-        },
-        "message_id": {
-            "type": "string",
-            "description": "Message ID from read results (for reply action)",
-        },
-        "limit": {
-            "type": "integer",
-            "description": "Max messages to return (for read, default 10)",
-            "default": 10,
-        },
-        "query": {
-            "type": "string",
-            "description": "Search query (regex pattern)",
-        },
-        "alias": {
-            "type": "string",
-            "description": "Human-friendly contact alias",
-        },
-    },
-    "required": ["action"],
-}
+# Public callers receive the strict LTP-v2 family schema. Manager dispatch
+# remains the internal flat action boundary after family validation.
+SCHEMA = _family.WECHAT_SCHEMA
 
 DESCRIPTION = (
     "WeChat client — interact with WeChat users via iLink Bot API. "
@@ -504,6 +446,12 @@ class WechatManager:
     # ── Tool handler dispatch ──────────────────────────────────
 
     def handle(self, args: dict) -> dict:
+        # Keep the standalone manager surface in parity with the public family
+        # while retaining the flat internal boundary used by existing manager
+        # tests. Family validation occurs before any manager action I/O; child
+        # dispatch re-enters here with a flat action mapping exactly once.
+        if isinstance(args, dict) and {"input", "reasoning"}.issubset(args):
+            return _family.handle_wechat(self, args)
         action = args.get("action")
         try:
             if action == "send":

--- a/src/lingtai/mcp_servers/wechat/server.py
+++ b/src/lingtai/mcp_servers/wechat/server.py
@@ -1,9 +1,9 @@
 """LingTai WeChat MCP server.
 
-Exposes a single omnibus ``wechat`` MCP tool that dispatches to
-WechatManager for all 8 actions (send, check, read, reply, search,
-contacts, add_contact, remove_contact). Inbound WeChat events flow into
-the host agent's inbox via LICC.
+Exposes one independent public LTP-v2 family, ``wechat``. Actions dispatch to
+WechatManager for all 10 actions (send, check, read, reply, search, contacts,
+add_contact, remove_contact, accounts, manual). Inbound WeChat events flow
+into the host agent's inbox via LICC.
 
 Configuration:
     LINGTAI_WECHAT_CONFIG  — path to ``config.json``. ``credentials.json``
@@ -341,10 +341,11 @@ def _profile_manifest(
         "tools": [
             {
                 "name": "wechat",
-                "description": "Omnibus WeChat tool for send/check/read/reply/search/contacts/accounts.",
+                "description": "Strict WeChat LTP-v2 family.",
                 "actions": [
                     "send", "check", "read", "reply", "search",
                     "contacts", "add_contact", "remove_contact", "accounts",
+                    "manual",
                 ],
             }
         ],

--- a/src/lingtai/mcp_servers/wechat/server.py
+++ b/src/lingtai/mcp_servers/wechat/server.py
@@ -52,6 +52,7 @@ from .._results import unknown_resource_error as _unknown_resource
 from .._results import unknown_tool_error as _unknown_tool
 
 from . import api
+from ._family import handle_wechat
 from .licc import push_inbox_event
 from .manager import WechatManager, SCHEMA, DESCRIPTION
 
@@ -885,12 +886,13 @@ def build_server(
         if params.name != "wechat":
             raise _unknown_tool(params.name)
         arguments = params.arguments or {}
-        if manager is None:
+
+        def _startup_error_result() -> dict[str, Any]:
             # Surface the actual startup exception type + message so the
             # agent/operator sees concrete remediation (e.g. PollerLockBusy
             # with ps/kill hints) instead of just "check stderr". stderr is
             # not always visible at the moment a tool call returns.
-            result = {
+            return {
                 "status": "error",
                 "error": (
                     "WeChat manager not initialized — server boot failed. "
@@ -901,15 +903,28 @@ def build_server(
                 "startup_error_type": startup_error_type,
                 "startup_error": startup_error,
             }
-        else:
-            try:
-                result = await asyncio.to_thread(manager.handle, arguments)
-            except Exception as e:
-                result = {
-                    "status": "error",
-                    "error": str(e),
-                    "error_type": type(e).__name__,
-                }
+
+        try:
+            if manager is None and arguments.get("action") == "status":
+                # Legacy pre-LTP-v2 startup-diagnostic probe: "status" was
+                # never a real wechat action, so it can only ever reach here
+                # (no manager means no I/O risk either way). Answer directly,
+                # before family validation, so this diagnostic contract
+                # survives independently of it — handle_wechat would reject
+                # "status" as an unknown action and mask the startup detail.
+                result = _startup_error_result()
+            elif manager is None:
+                result = handle_wechat(None, arguments)
+                if not result:
+                    result = _startup_error_result()
+            else:
+                result = await asyncio.to_thread(handle_wechat, manager, arguments)
+        except Exception as e:
+            result = {
+                "status": "error",
+                "error": str(e),
+                "error_type": type(e).__name__,
+            }
         return _tool_result(result)
 
     server: Server = Server(

--- a/tests/test_wechat_toolfamily_ltpv2.py
+++ b/tests/test_wechat_toolfamily_ltpv2.py
@@ -429,3 +429,198 @@ def test_openai_responses_scrub_preserves_family_root_and_action_branches():
     assert wire["properties"]["input"]["anyOf"] or wire["properties"]["input"]["oneOf"]
     assert len(wire["allOf"]) == len(WECHAT_ACTIONS)
     assert wire["additionalProperties"] is False
+
+
+# ---------------------------------------------------------------------------
+# B3 regression: check/contacts/accounts/manual all publish an empty-object
+# input branch, so a oneOf discovery list makes {} match more than one
+# branch — the same "instance is valid under each of ..." collision the
+# telegram schema documents. The published discovery list must be anyOf, not
+# oneOf, even though the root allOf/if/then still discriminates by action.
+# ---------------------------------------------------------------------------
+
+def test_input_discovery_branch_is_anyof_not_oneof():
+    assert "oneOf" not in WECHAT_SCHEMA["properties"]["input"]
+    assert "anyOf" in WECHAT_SCHEMA["properties"]["input"]
+
+
+def test_zero_input_action_schema_is_decisive_not_ambiguous():
+    """{} legitimately satisfies all four empty-object branches at once
+    (check/contacts/accounts/manual). Under oneOf that is an ambiguous
+    "matches more than one schema" rejection; under anyOf it is a clean,
+    decisive accept — exactly what a real MCP client validating against the
+    published discovery schema needs for a zero-input action to be usable."""
+    branches = WECHAT_SCHEMA["properties"]["input"]["anyOf"]
+    empty_branches = [b for b in branches if b.get("properties") == {}]
+    assert {b["title"] for b in empty_branches} == {
+        "check input", "contacts input", "accounts input", "manual input",
+    }
+    matches = sum(1 for b in empty_branches if _basic_validate({}, b))
+    assert matches == len(empty_branches) == 4
+
+
+# ---------------------------------------------------------------------------
+# B1 regression: the public server must route every call through
+# handle_wechat (family validation), never call manager.handle directly.
+# A retired flat send (pre-LTPv2 shape) and a partial envelope (input
+# present, reasoning missing) must both be rejected before any manager I/O;
+# a proper strict envelope must still route through to the manager exactly
+# once. Driven through the real in-memory MCP transport (mcp.Client +
+# build_server), mirroring test_telegram_terra_repairs.py's _call_tool —
+# no network I/O.
+# ---------------------------------------------------------------------------
+
+def test_server_routes_through_family_validation_not_manager_handle_directly(tmp_path):
+    import anyio
+    import mcp.types as types
+    from mcp import Client
+
+    from lingtai.mcp_servers.wechat.server import build_server
+
+    class _FakeManager:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        def handle(self, args: dict) -> dict:
+            self.calls.append(dict(args))
+            return {"status": "ok", "action": args.get("action")}
+
+    manager = _FakeManager()
+    server = build_server(manager)
+
+    def _payload(result):
+        block = result.content[0]
+        assert isinstance(block, types.TextContent)
+        import json as _json
+        return _json.loads(block.text)
+
+    async def _call(arguments: dict):
+        async with Client(server) as client:
+            return await client.call_tool("wechat", arguments)
+
+    # Retired flat send envelope (no "input"/"reasoning") — must never reach
+    # manager.handle, which would otherwise perform a real send.
+    retired_flat = {"action": "send", "user_id": "wxid_x", "text": "hi"}
+    result = anyio.run(_call, retired_flat)
+    payload = _payload(result)
+    assert payload["status"] == "failed"
+    assert manager.calls == []
+
+    # Partial envelope: "input" present but "reasoning" missing — must be
+    # rejected by family validation, not silently accepted by manager.handle.
+    partial = {"action": "send", "input": {"user_id": "wxid_x", "text": "hi"}}
+    result = anyio.run(_call, partial)
+    payload = _payload(result)
+    assert payload["status"] == "failed"
+    assert manager.calls == []
+
+    # Proper strict envelope: must still route through to the manager once.
+    strict = {
+        "action": "send",
+        "input": {"user_id": "wxid_x", "text": "hi"},
+        "reasoning": "transport regression test",
+    }
+    result = anyio.run(_call, strict)
+    payload = _payload(result)
+    assert payload == {"status": "ok", "action": "send"}
+    assert manager.calls == [{"action": "send", "user_id": "wxid_x", "text": "hi"}]
+
+
+def test_server_manager_none_branch_routes_through_handle_wechat_first(tmp_path):
+    """The manager-None branch must call handle_wechat(None, arguments) first
+    (mirroring the telegram server) and only fall back to the static
+    startup-error dict when that returns falsy — never skip family
+    validation just because the manager failed to start."""
+    import anyio
+    import mcp.types as types
+    from mcp import Client
+
+    from lingtai.mcp_servers.wechat.server import build_server
+
+    server = build_server(
+        None, startup_error="boom", startup_error_type="RuntimeError",
+    )
+
+    def _payload(result):
+        block = result.content[0]
+        assert isinstance(block, types.TextContent)
+        import json as _json
+        return _json.loads(block.text)
+
+    async def _call(arguments: dict):
+        async with Client(server) as client:
+            return await client.call_tool("wechat", arguments)
+
+    # Malformed envelope (missing reasoning) must be rejected as a schema
+    # failure, not swallowed into the generic "manager not initialized"
+    # startup-error fallback.
+    result = anyio.run(_call, {"action": "send", "input": {"user_id": "x", "text": "hi"}})
+    payload = _payload(result)
+    assert payload["status"] == "failed"
+    assert payload.get("error_code") == "INVALID_ARGUMENT"
+    assert "startup_error_type" not in payload
+
+    # A well-formed envelope with no manager falls back to the startup-error
+    # payload (handle_wechat(None, ...) routes to child handlers that return
+    # {} when manager is None, which is falsy).
+    result = anyio.run(_call, {
+        "action": "accounts", "input": {}, "reasoning": "probe",
+    })
+    payload = _payload(result)
+    assert payload["status"] == "error"
+    assert payload["startup_error_type"] == "RuntimeError"
+    assert payload["startup_error"] == "boom"
+
+
+def test_server_legacy_status_probe_survives_family_validation_when_manager_none(tmp_path):
+    """Regression: {"action": "status"} is a legacy pre-LTP-v2 startup
+    diagnostic probe, not a real wechat action ("status" is not in
+    WECHAT_ACTIONS). Routing manager-None calls through handle_wechat first
+    made this probe collide with action validation (ACTION_REQUIRED), which
+    is truthy and so silently ate the startup_error_type/startup_error
+    contract callers rely on for concrete remediation (e.g. PollerLockBusy).
+    The probe must reach the startup-error payload directly, before family
+    validation — while a genuinely malformed or retired-shape call for a
+    real action must still be rejected by family validation first."""
+    import anyio
+    import mcp.types as types
+    from mcp import Client
+
+    from lingtai.mcp_servers.wechat.server import build_server
+
+    server = build_server(
+        None, startup_error="poller lock busy", startup_error_type="PollerLockBusy",
+    )
+
+    def _payload(result):
+        block = result.content[0]
+        assert isinstance(block, types.TextContent)
+        import json as _json
+        return _json.loads(block.text)
+
+    async def _call(arguments: dict):
+        async with Client(server) as client:
+            return await client.call_tool("wechat", arguments)
+
+    # The legacy startup probe: concrete startup detail must survive.
+    result = anyio.run(_call, {"action": "status"})
+    payload = _payload(result)
+    assert payload["status"] == "error"
+    assert payload["startup_error_type"] == "PollerLockBusy"
+    assert payload["startup_error"] == "poller lock busy"
+
+    # A retired flat send for a real action must still be family-validated
+    # and rejected — the status-probe carve-out must not widen into a
+    # general bypass for manager-None calls.
+    result = anyio.run(_call, {"action": "send", "user_id": "wxid_x", "text": "hi"})
+    payload = _payload(result)
+    assert payload["status"] == "failed"
+    assert "startup_error_type" not in payload
+
+    # An unknown action that merely resembles the probe is still rejected by
+    # family validation, not silently answered with startup detail.
+    result = anyio.run(_call, {"action": "not_a_real_action", "input": {}, "reasoning": "x"})
+    payload = _payload(result)
+    assert payload["status"] == "failed"
+    assert payload.get("error_code") == "ACTION_REQUIRED"
+    assert "startup_error_type" not in payload

--- a/tests/test_wechat_toolfamily_ltpv2.py
+++ b/tests/test_wechat_toolfamily_ltpv2.py
@@ -1,0 +1,431 @@
+"""Focused WeChat LTP-v2 family strict-schema and dispatch-routing tests.
+
+Mirrors ``tests/test_telegram_toolfamily_ltpv2.py``: proves the composed root
+schema shape (``action``/``input``/``reasoning``/``summarize``), the
+``allOf``/``if``/``then`` action<->input correlation, and that
+``handle_wechat``/``WechatManager.handle`` reject malformed envelopes,
+cross-action field leakage, missing required root fields, and unknown
+actions/params (``ACTION_REQUIRED`` / ``INVALID_ARGUMENT``) before any
+manager I/O — then that every one of the 10 real actions routes to the
+correct flat manager call. ``send``'s ``text``/``media_path`` is a
+non-exclusive ``anyOf`` (the manager sends both in one call when both are
+given), not a ``oneOf`` choice — covered explicitly below.
+"""
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from lingtai.mcp_servers.wechat._family import (
+    WECHAT_ACTIONS,
+    WECHAT_SCHEMA,
+    _basic_validate,
+    handle_wechat,
+)
+from lingtai.mcp_servers.wechat.manager import WechatManager
+
+
+class _CountingManager:
+    """A minimal manager double that records every flat call it receives."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def handle(self, args: dict) -> dict:
+        self.calls.append(dict(args))
+        return {"status": "ok", "action": args.get("action")}
+
+
+def _branches(schema: dict) -> dict[str, dict]:
+    inputs = schema["properties"]["input"]
+    branches = inputs.get("oneOf") or inputs.get("anyOf")
+    return {branch["title"].removesuffix(" input"): branch for branch in branches}
+
+
+# ---------------------------------------------------------------------------
+# Root envelope shape
+# ---------------------------------------------------------------------------
+
+def test_root_schema_has_exactly_the_ltp_v2_envelope_fields():
+    props = WECHAT_SCHEMA["properties"]
+    assert set(props) == {"action", "input", "reasoning", "summarize"}
+    assert WECHAT_SCHEMA["required"] == ["action", "input", "reasoning"]
+    assert WECHAT_SCHEMA["additionalProperties"] is False
+    assert props["action"]["enum"] == list(WECHAT_ACTIONS)
+    assert props["reasoning"]["type"] == "string"
+    assert props["summarize"]["type"] == "boolean"
+
+
+def test_action_enum_is_exactly_the_ten_wechat_actions():
+    assert WECHAT_ACTIONS == (
+        "send", "check", "read", "reply", "search",
+        "contacts", "add_contact", "remove_contact", "accounts", "manual",
+    )
+
+
+def test_root_allof_correlates_every_action_with_its_own_input_branch():
+    all_of = WECHAT_SCHEMA["allOf"]
+    assert len(all_of) == len(WECHAT_ACTIONS)
+    branches = _branches(WECHAT_SCHEMA)
+    seen_actions = set()
+    for condition in all_of:
+        action = condition["if"]["properties"]["action"]["const"]
+        assert condition["if"]["required"] == ["action"]
+        assert action in WECHAT_ACTIONS
+        seen_actions.add(action)
+        # then.input must be exactly that action's own canonical branch,
+        # modulo the branch-only "title" key the oneOf disclosure adds.
+        then_input = dict(condition["then"]["properties"]["input"])
+        own_branch = dict(branches[action])
+        own_branch.pop("title", None)
+        assert then_input == own_branch
+    assert seen_actions == set(WECHAT_ACTIONS)
+
+
+def test_no_audit_or_presentation_field_leaks_into_any_action_branch():
+    for action in WECHAT_ACTIONS:
+        branch = _branches(WECHAT_SCHEMA)[action]
+        props = branch.get("properties", {})
+        assert "reasoning" not in props
+        assert "_reasoning" not in props
+        assert "summarize" not in props
+        assert "action" not in props
+
+
+# ---------------------------------------------------------------------------
+# Strict-schema accept/reject per action (via the dependency-free validator
+# the dispatch boundary itself uses)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("action", "valid_input"),
+    [
+        ("send", {"user_id": "wxid_a@im.wechat", "text": "hi"}),
+        ("send", {"user_id": "wxid_a@im.wechat", "media_path": "/tmp/x.png"}),
+        ("send", {"user_id": "wxid_a@im.wechat", "text": "hi", "media_path": "/tmp/x.png"}),
+        ("check", {}),
+        ("read", {"user_id": "wxid_a@im.wechat"}),
+        ("read", {"user_id": "wxid_a@im.wechat", "limit": 5}),
+        ("reply", {"message_id": "abc", "text": "hi"}),
+        ("search", {"query": "hello"}),
+        ("search", {"query": "hello", "user_id": "wxid_a@im.wechat"}),
+        ("contacts", {}),
+        ("add_contact", {"user_id": "wxid_a@im.wechat", "alias": "friend"}),
+        ("remove_contact", {"alias": "friend"}),
+        ("remove_contact", {"user_id": "wxid_a@im.wechat"}),
+        ("accounts", {}),
+        ("manual", {}),
+    ],
+)
+def test_valid_payload_accepted_per_action(action, valid_input):
+    schema = _branches(WECHAT_SCHEMA)[action]
+    assert _basic_validate(valid_input, schema)
+
+
+@pytest.mark.parametrize(
+    ("action", "bad_input"),
+    [
+        # missing required fields
+        ("send", {"text": "no user_id"}),
+        ("send", {"user_id": "wxid_a@im.wechat"}),  # neither text nor media_path
+        ("read", {}),  # user_id required
+        ("reply", {"message_id": "abc"}),  # text required
+        ("reply", {"text": "hi"}),  # message_id required
+        ("search", {}),  # query required
+        ("add_contact", {"user_id": "wxid_a@im.wechat"}),  # alias required
+        ("remove_contact", {}),  # neither alias nor user_id
+        # cross-action field leakage
+        ("send", {"user_id": "a", "text": "hi", "message_id": "reply-only"}),
+        ("reply", {"message_id": "abc", "text": "hi", "user_id": "leak"}),
+        ("search", {"query": "x", "media_path": "leak"}),
+        ("check", {"user_id": "leak"}),
+        ("contacts", {"query": "leak"}),
+        ("accounts", {"alias": "leak"}),
+        ("manual", {"reasoning": "leak"}),
+        # wrong types
+        ("send", {"user_id": "a", "text": 5}),
+        ("read", {"user_id": "a", "limit": "not-an-int"}),
+        ("add_contact", {"user_id": 5, "alias": "friend"}),
+    ],
+)
+def test_invalid_payload_rejected_per_action(action, bad_input):
+    schema = _branches(WECHAT_SCHEMA)[action]
+    assert not _basic_validate(bad_input, schema)
+
+
+# ---------------------------------------------------------------------------
+# handle_wechat: envelope-level rejection before any manager I/O
+# ---------------------------------------------------------------------------
+
+def test_family_dispatch_rejects_root_and_cross_branch_before_manager_io():
+    manager = _CountingManager()
+    valid = {"action": "accounts", "input": {}, "reasoning": "schema probe"}
+    invalid = [
+        # legacy out-of-band reasoning key must not be tolerated
+        {"action": "accounts", "input": {}, "reasoning": "x", "_reasoning": "legacy"},
+        # unknown root field
+        {"action": "accounts", "input": {}, "reasoning": "x", "unknown": 1},
+        # reasoning wrong type / missing
+        {"action": "accounts", "input": {}, "reasoning": 7},
+        {"action": "accounts", "input": {}},
+        # summarize wrong type
+        {"action": "accounts", "input": {}, "reasoning": "x", "summarize": "yes"},
+        # missing root fields entirely
+        {"input": {}, "reasoning": "x"},
+        {"action": "send", "reasoning": "x"},
+        {"action": "send", "input": {"user_id": "a", "text": "hi"}},
+        # cross-action field leakage caught at dispatch too, not just schema
+        ("accounts", {"user_id": "leak"}),
+        # unknown action
+        {"action": "not_a_real_action", "input": {}, "reasoning": "x"},
+        {"action": "delete", "input": {}, "reasoning": "x"},  # telegram-only action
+        # unhashable action (issue #513 class) must not raise
+        {"action": [], "input": {}, "reasoning": "x"},
+        {"action": {}, "input": {}, "reasoning": "x"},
+    ]
+    for case in invalid:
+        if isinstance(case, tuple):
+            action, bad_input = case
+            args = {"action": action, "input": bad_input, "reasoning": "x"}
+        else:
+            args = case
+        result = handle_wechat(manager, args)
+        assert result["status"] == "failed", args
+        assert result["error_code"] in {"ACTION_REQUIRED", "INVALID_ARGUMENT"}, args
+        assert manager.calls == [], args
+
+    assert handle_wechat(manager, valid)["status"] == "ok"
+    assert len(manager.calls) == 1
+
+
+def test_unhashable_action_returns_action_required_not_typeerror():
+    manager = _CountingManager()
+    for bad_action in ([], {}, {"nested": 1}):
+        result = handle_wechat(manager, {"action": bad_action, "input": {}, "reasoning": "x"})
+        assert result == {
+            "status": "failed",
+            "error_code": "ACTION_REQUIRED",
+            "message": "invalid wechat action",
+        }
+    assert manager.calls == []
+
+
+def test_unsupported_root_argument_is_rejected_before_action_lookup():
+    manager = _CountingManager()
+    result = handle_wechat(
+        manager,
+        {"action": "accounts", "input": {}, "reasoning": "x", "extra_root_key": 1},
+    )
+    assert result == {
+        "status": "failed",
+        "error_code": "INVALID_ARGUMENT",
+        "message": "unsupported wechat argument",
+    }
+    assert manager.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Dispatch routing: every one of the 10 actions reaches the correct flat
+# manager call with only its own validated input.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("action", "action_input"),
+    [
+        ("send", {"user_id": "wxid_a@im.wechat", "text": "hi"}),
+        ("check", {}),
+        ("read", {"user_id": "wxid_a@im.wechat", "limit": 3}),
+        ("reply", {"message_id": "abc", "text": "hi"}),
+        ("search", {"query": "hello"}),
+        ("contacts", {}),
+        ("add_contact", {"user_id": "wxid_a@im.wechat", "alias": "friend"}),
+        ("remove_contact", {"alias": "friend"}),
+        ("accounts", {}),
+        ("manual", {}),
+    ],
+)
+def test_dispatch_routes_each_action_to_flat_manager_call(action, action_input):
+    manager = _CountingManager()
+    args = {"action": action, "input": action_input, "reasoning": "probe"}
+    result = handle_wechat(manager, args)
+
+    assert result == {"status": "ok", "action": action}
+    assert len(manager.calls) == 1
+    # The child handler must receive exactly {"action": action, **input} —
+    # never "reasoning", "_reasoning", or "summarize".
+    assert manager.calls[0] == {"action": action, **action_input}
+
+
+# ---------------------------------------------------------------------------
+# B1 regression: send's text/media_path is a non-exclusive combination
+# (the manager sends both in one call — text chunks then the media message),
+# not a oneOf choice. anyOf must accept text-only, media-only, and both
+# together; it must still reject neither, and cross-branch/host keys must
+# still be rejected before any manager I/O.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "send_input",
+    [
+        {"user_id": "wxid_a@im.wechat", "text": "hi"},
+        {"user_id": "wxid_a@im.wechat", "media_path": "/tmp/x.png"},
+        {"user_id": "wxid_a@im.wechat", "text": "hi", "media_path": "/tmp/x.png"},
+    ],
+)
+def test_send_accepts_text_only_media_only_and_text_plus_media(send_input):
+    schema = _branches(WECHAT_SCHEMA)["send"]
+    assert _basic_validate(send_input, schema)
+
+    manager = _CountingManager()
+    result = handle_wechat(
+        manager, {"action": "send", "input": send_input, "reasoning": "probe"},
+    )
+    assert result == {"status": "ok", "action": "send"}
+    assert manager.calls == [{"action": "send", **send_input}]
+
+
+@pytest.mark.parametrize(
+    "bad_send_input",
+    [
+        {"user_id": "wxid_a@im.wechat"},  # neither text nor media_path
+        {"user_id": "wxid_a@im.wechat", "text": "hi", "message_id": "reply-only"},  # cross-branch
+        {"user_id": "wxid_a@im.wechat", "text": "hi", "host_agent_id": "x"},  # host-only key
+        {"text": "hi", "media_path": "/tmp/x.png"},  # missing required user_id
+    ],
+)
+def test_send_still_rejects_neither_field_and_cross_branch_host_keys(bad_send_input):
+    schema = _branches(WECHAT_SCHEMA)["send"]
+    assert not _basic_validate(bad_send_input, schema)
+
+    manager = _CountingManager()
+    result = handle_wechat(
+        manager, {"action": "send", "input": bad_send_input, "reasoning": "probe"},
+    )
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+    assert manager.calls == []
+
+
+def test_dispatch_covers_all_ten_actions_exactly_once():
+    manager = _CountingManager()
+    inputs = {
+        "send": {"user_id": "a", "text": "hi"},
+        "check": {},
+        "read": {"user_id": "a"},
+        "reply": {"message_id": "m", "text": "hi"},
+        "search": {"query": "q"},
+        "contacts": {},
+        "add_contact": {"user_id": "a", "alias": "x"},
+        "remove_contact": {"alias": "x"},
+        "accounts": {},
+        "manual": {},
+    }
+    assert set(inputs) == set(WECHAT_ACTIONS)
+    for action in WECHAT_ACTIONS:
+        handle_wechat(manager, {"action": action, "input": inputs[action], "reasoning": "r"})
+    assert [c["action"] for c in manager.calls] == list(WECHAT_ACTIONS)
+
+
+# ---------------------------------------------------------------------------
+# Real WechatManager: envelope routing + manual/no-double-wrap + error parity
+# ---------------------------------------------------------------------------
+
+def _manager(tmp_path):
+    return WechatManager(
+        token="test-token",
+        user_id="test-bot",
+        working_dir=tmp_path,
+        on_inbound=lambda event: None,
+    )
+
+
+def test_real_manager_handle_detects_envelope_shape_and_routes_through_family(tmp_path):
+    mgr = _manager(tmp_path)
+    result = mgr.handle({"action": "accounts", "input": {}, "reasoning": "probe"})
+    assert result["status"] == "ok"
+    assert result["accounts"] == ["default"]
+
+
+def test_real_manager_rejects_cross_branch_field_before_send_io(tmp_path, monkeypatch):
+    mgr = _manager(tmp_path)
+    called = {"n": 0}
+    monkeypatch.setattr(mgr, "_handle_send", lambda args: called.__setitem__("n", 1) or {})
+
+    result = mgr.handle({
+        "action": "send",
+        "input": {"user_id": "a", "text": "hi", "message_id": "reply-only-field"},
+        "reasoning": "x",
+    })
+
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+    assert called["n"] == 0
+
+
+def test_real_manager_manual_action_matches_flat_manual_contract(tmp_path):
+    mgr = _manager(tmp_path)
+    enveloped = mgr.handle({"action": "manual", "input": {}, "reasoning": "probe"})
+    flat = mgr.handle({"action": "manual"})
+
+    # No double-wrap: the family-routed result is byte-identical to the
+    # manager's own pre-migration flat manual result.
+    assert enveloped == flat
+    assert enveloped["status"] == "ok"
+    assert enveloped["skill"] == "wechat-mcp-manual"
+    assert set(enveloped) == {"status", "action", "skill", "metadata", "path", "manual"}
+
+
+def test_real_manager_unknown_action_via_envelope_is_action_required(tmp_path):
+    mgr = _manager(tmp_path)
+    result = mgr.handle({"action": "delete", "input": {}, "reasoning": "x"})
+    assert result == {
+        "status": "failed",
+        "error_code": "ACTION_REQUIRED",
+        "message": "invalid wechat action",
+    }
+
+
+def test_real_manager_flat_internal_shape_still_used_for_re_entry(tmp_path):
+    """The manager's own re-entry path (child handler -> manager.handle with a
+    flat {"action": ..., **input} mapping) must still work — it is not the
+    public envelope, and must not require input/reasoning."""
+    mgr = _manager(tmp_path)
+    result = mgr.handle({"action": "accounts"})
+    assert result["status"] == "ok"
+    assert result["accounts"] == ["default"]
+
+
+# ---------------------------------------------------------------------------
+# Wire-parity: composed schema survives a JSON round trip and remains a valid
+# plain-dict JSON Schema shape (no non-serializable objects).
+# ---------------------------------------------------------------------------
+
+def test_schema_round_trips_through_json_unchanged():
+    import json
+
+    dumped = json.dumps(WECHAT_SCHEMA)
+    reloaded = json.loads(dumped)
+    assert reloaded == WECHAT_SCHEMA
+
+
+def test_schema_is_deep_copy_safe_between_calls():
+    from lingtai.mcp_servers.wechat._family import wechat_schema
+
+    first = wechat_schema()
+    second = wechat_schema()
+    assert first == second
+    assert first is not second
+    first["properties"]["action"]["enum"].append("mutated")
+    assert "mutated" not in second["properties"]["action"]["enum"]
+
+
+def test_openai_responses_scrub_preserves_family_root_and_action_branches():
+    from lingtai.llm.openai.adapter import _scrub_responses_schema
+
+    wire = _scrub_responses_schema(copy.deepcopy(WECHAT_SCHEMA), is_root=True)
+    assert wire["required"] == WECHAT_SCHEMA["required"]
+    assert wire["properties"]["action"]["enum"] == list(WECHAT_ACTIONS)
+    assert wire["properties"]["input"]["anyOf"] or wire["properties"]["input"]["oneOf"]
+    assert len(wire["allOf"]) == len(WECHAT_ACTIONS)
+    assert wire["additionalProperties"] is False


### PR DESCRIPTION
## Summary

- migrate WeChat's 10 maintained actions to the strict LingTai Tool Protocol family envelope: `action + input + reasoning + summarize`
- expose closed action-specific inputs and reject flat legacy, host-only, unknown, cross-action, and malformed arguments before manager I/O
- preserve the established `send` contract: text-only, media-only, and text+media in one call are all valid; `remove_contact` retains its exclusive alias-or-user lookup
- route the server through the family schema/dispatcher, update the packaged manual, and preserve manager, media, replay, LICC/notification, identity, contact, startup-diagnostic, and result/error behavior

This is an independent curated-addon migration modeled on the already-merged Telegram reference. Generic third-party MCP insertion and every other addon family are unchanged.

## Public contract

The public action set remains exactly:

`send`, `check`, `read`, `reply`, `search`, `contacts`, `add_contact`, `remove_contact`, `accounts`, `manual`.

For combined `text` + `media_path`, one tool call produces **two separate WeChat messages** (text first, then media), not a captioned or atomic attachment. A missing file is rejected before text is sent; a later upload/transport failure can still leave text delivered without media.

## Validation

- original Parent authoritative gate: **303 passed**
- post-schema/manual-repair Parent gate: **338 passed**
- original final manual governance gate: **93 passed**
- current-head 12-file WeChat/shared-MCP regression gate under runtime Python 3.13 + MCP SDK 2.0.0: **299 passed**
- whole-suite `-k "wechat or mcp"` repair-owner sweep: **503 passed**, 0 failed
- compileall / docs governance / Anatomy / `git diff --check`: PASS
- original independent per-PR Claude Opus 5 review after the text+media repair: **ACCEPT**; the later five-PR combined Opus review correctly superseded that verdict by reproducing the raw-schema and server-boundary regressions below
- current exact head: `931b865e16104df9ac3c758fafc1fd285f36722f`
- current exact tree: `0611dfeb693a5136d71bfe4cb8fc400bcf0551d5`
- original pre-repair candidate freeze, retained for audit:
  - patch SHA-256: `1c64ec29abb2c082fb06bbfffaa306236a996df0a902a72932d77b3f48796546`
  - manifest SHA-256: `e46fbcc7b015a583392a9259db2b07e9988da6c2585dca4314c70143722a2b3b`

Validation was offline/mocked; no live WeChat side effect was used as acceptance evidence.

## Review and regression repairs

The first per-PR review found one real capability regression: exclusive `oneOf` made the already-supported text+media combination unreachable. The repaired action schema uses non-exclusive `anyOf`, with focused tests proving only that exclusivity changed. Opus also corrected an overclaim in the manual about captioned/atomic delivery; the final wording matches actual two-message sequencing and partial-failure behavior.

The later five-PR combined Opus review found two further real regressions:

1. the published raw `input.oneOf` made `{}` ambiguous across `check`, `contacts`, `accounts`, and `manual`; current head uses Telegram-reference `anyOf` while preserving strict root `allOf` and dispatch validation;
2. the public server called `manager.handle` directly, letting retired flat or partial envelopes bypass family validation and potentially reach real I/O; current head routes manager-present calls through `handle_wechat`, proves malformed/retired shapes make zero manager calls, and preserves strict-envelope dispatch.

A Parent gate then caught a startup-diagnostic regression in the first repair: manager-none legacy `{"action":"status"}` probes lost concrete `startup_error_type/startup_error`. Current head has a narrow no-manager/no-I/O status-probe carve-out and regressions proving it does not widen into a general validation bypass. Final group merge still requires a fresh combined-tree zero-regression gate and exact Opus ACCEPT.

The manager's dual-mode LTP re-entry remains current-main Telegram reference parity, non-recursive, and appropriate for this single-tool server; it is not a candidate-specific compatibility shim.

## Scope

Six original migration paths only: WeChat family/manual/manager/server, the MCP-server Anatomy pointer, and focused tests. The repair changes only the existing family/server/test paths. No external MCP registry, generic ToolFamily runtime, configuration, credentials, hooks, package state, or unrelated addon code is changed.
