### PR TITLE
fix(tools): declare ToolFamily input as an object

### DIFF
--- a/src/lingtai/tools/tool_family/CONTRACT.md
+++ b/src/lingtai/tools/tool_family/CONTRACT.md
@@ -83,9 +83,12 @@ both built from the same deep-copied canonical child schemas:
    `allOf`/`if`/`then` schema without error on the current route (see
    `_scrub_responses_schema` in `../../llm/openai/adapter.py` for the
    corresponding wire-level change and its own scope note).
-2. **`input.oneOf` disclosure:** the same per-child `input_schema`s, embedded
-   verbatim under a `title`, retained under `input` for model discoverability
-   of every action's exact shape in one place.
+2. **Typed `input.oneOf` disclosure:** `input` explicitly declares the common
+   `type: object` constraint required of every action, then embeds the same
+   per-child `input_schema`s verbatim under a `title` for model discoverability
+   of every action's exact shape in one place. The direct type is redundant for
+   a complete JSON Schema validator, but keeps the object contract unambiguous
+   for model/provider schema consumers that inspect only the immediate node.
 
 Both layers expose the envelope root `action`, `input`, required
 `reasoning`, and optional `summarize` — exactly the four public fields;
@@ -344,8 +347,9 @@ its own scoped migration.
 - A `ToolFamily`'s child registry MUST be validated at construction: duplicate
   child names and more than one child named the reserved `manual` MUST raise
   `ToolFamilyError`, not register silently or resolve by precedence.
-- `build_schema()` MUST embed each child's own `input_schema` verbatim (no
-  copy-and-reshape) under a `oneOf` branch pairing it with that child's
+- `build_schema()` MUST declare the aggregate `input` property as direct
+  `type: object`, then embed each child's own object `input_schema` verbatim
+  (no copy-and-reshape) under a `oneOf` branch pairing it with that child's
   `title`. It MUST declare a root `reasoning` string property and include
   `reasoning` in the root `required` list — `reasoning` is Host
   InvocationContext/audit metadata, not left to Agent schema composition's

--- a/src/lingtai/tools/tool_family/__init__.py
+++ b/src/lingtai/tools/tool_family/__init__.py
@@ -212,6 +212,7 @@ class ToolFamily:
                     "description": f"Required operation within the {self.name} family.",
                 },
                 "input": {
+                    "type": "object",
                     "description": (
                         "Strict action-specific input; the selected action is "
                         "validated again at dispatch."

--- a/tests/test_tool_family_generic.py
+++ b/tests/test_tool_family_generic.py
@@ -95,6 +95,7 @@ def test_schema_composes_action_input_reasoning_summarize_root():
     assert schema["additionalProperties"] is False
     assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
     assert schema["properties"]["action"]["enum"] == ["spin", "manual"]
+    assert schema["properties"]["input"]["type"] == "object"
     assert schema["properties"]["reasoning"]["type"] == "string"
     assert schema["properties"]["summarize"]["type"] == "boolean"
     branches = schema["properties"]["input"]["oneOf"]

--- a/tests/test_tool_family_web_migration_parity.py
+++ b/tests/test_tool_family_web_migration_parity.py
@@ -1,5 +1,5 @@
 """``web``'s migration onto the generic ToolFamily infra changes nothing the
-model or a caller can observe, except three documented, authorized
+model or a caller can observe, except four documented, authorized
 differences:
 
 1. the ``anyOf`` -> ``oneOf`` combinator swap for the ``input`` discriminated
@@ -21,7 +21,12 @@ differences:
    ``then`` schema without error on the current route). The public root's
    four fields (``action``, ``input``, ``reasoning``, ``summarize``) and their
    requiredness are unchanged; ``allOf`` constrains them without adding a
-   fifth field or duplicating ``action`` inside ``input``.
+   fifth field or duplicating ``action`` inside ``input``;
+4. the aggregate ``input`` node now explicitly declares the common
+   ``type: object`` constraint already required by all three action branches.
+   This is redundant for a complete JSON Schema validator and changes no valid
+   instance, but keeps the object contract visible to model/provider consumers
+   that inspect only the immediate node.
 
 This module snapshots the true pre-migration schema shape (as it existed at
 this worktree's exact clean base, commit
@@ -156,6 +161,14 @@ def test_generated_schema_is_field_equivalent_to_pre_migration_schema_except_aut
     # against the true pre-migration fixture (which never had ``allOf``).
     assert "allOf" in normalized
     del normalized["allOf"]
+
+    # The direct ``input.type`` is the fourth authorized difference. Every
+    # historical branch already required an object, so assert the redundant
+    # common constraint, then strip it only for the exact historical snapshot
+    # comparison.
+    normalized["properties"]["input"] = dict(normalized["properties"]["input"])
+    assert normalized["properties"]["input"]["type"] == "object"
+    del normalized["properties"]["input"]["type"]
 
     assert normalized == pre
 

--- a/tests/test_tool_family_wire_parity.py
+++ b/tests/test_tool_family_wire_parity.py
@@ -59,7 +59,9 @@ def test_generic_family_schema_survives_chat_and_responses_wires():
         assert wire["additionalProperties"] is False
         assert set(wire["properties"]) == {"action", "input", "reasoning", "summarize"}
         assert wire["properties"]["reasoning"]["type"] == "string"
-        branches = wire["properties"]["input"][combinator]
+        input_schema = wire["properties"]["input"]
+        assert input_schema["type"] == "object"
+        branches = input_schema[combinator]
         assert [b["title"] for b in branches] == ["spin input", "manual input"]
         for branch in branches:
             assert branch["additionalProperties"] is False
@@ -105,6 +107,8 @@ def test_real_agent_startup_builds_web_family_schema_on_both_wires(tmp_path):
         assert set(responses["properties"]) == {"action", "input", "reasoning", "summarize"}
         assert chat["required"] == ["action", "input", "reasoning"]
         assert responses["required"] == ["action", "input", "reasoning"]
+        assert chat["properties"]["input"]["type"] == "object"
+        assert responses["properties"]["input"]["type"] == "object"
         assert len(chat["properties"]["input"]["oneOf"]) == 3
         assert len(responses["properties"]["input"]["anyOf"]) == 3
     finally:


### PR DESCRIPTION
## Summary

- declare the aggregate ToolFamily `input` node as direct `type: object`
- keep every strict child schema verbatim under `oneOf`; the Responses scrub still yields `type: object + anyOf`
- lock generic, Chat, Responses, real-Agent, and historical Web parity coverage; update the ToolFamily Contract

## Why

MiMo V2.5 Pro stringifies nested ToolFamily input when the immediate schema node is typeless `anyOf`, even though every branch is an object. Controlled provider runs showed:

- direct `type: object` → object
- typeless `anyOf: [object]` → JSON string
- `type: object + anyOf: [object]` → object

Every ToolFamily child input is already Contract-required to be an object, so this patch makes the common constraint explicit without changing the valid instance set.

Fixes Lingtai-AI/lingtai#755.

## Validation

- focused generic + wire + historical-parity gate: **29 passed**
- broader ToolFamily/File/Shell/wire/architecture gate: **567 passed** in 12.32s
- exact candidate File wire: Chat `type: object + oneOf`; Responses `type: object + anyOf`; six branches
- exact MiMo V2.5 Pro native-Responses re-smoke (`em-0154`): exactly one candidate File-schema call, no retry, nested `input` arrived as `dict`; `action=read`, `schema_input_type=object`, six branches, all six success criteria passed
- candidate-source `py_compile`: PASS
- touched-file Ruff with the two unchanged current-main diagnostics (`UP035`, `SIM103`) excluded: PASS
- `git diff --check` and clean exact-head worktree: PASS

## Non-goals

- no dispatcher relaxation
- no nested JSON/double decoding
- no provider-specific adapter branch
- no runtime refresh or merge