### PR TITLE
fix(feishu): keep MCP stdio stdout protocol-only

### DIFF
--- a/src/lingtai/mcp_servers/feishu/account.py
+++ b/src/lingtai/mcp_servers/feishu/account.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+import sys
 import tempfile
 import threading
 from datetime import datetime, timezone
@@ -29,12 +30,26 @@ lark: Any = None
 # directly — see ``_ThreadLocalLoop`` and ``_ws_loop`` for why that matters.
 _sdk_ws_client_module: Any = None
 
+_lark_logging_lock = threading.Lock()
+
+
+def _route_lark_stdout_handlers_to_stderr() -> None:
+    """Keep Lark's existing stdout handlers off the MCP protocol stream."""
+    lark_logger = logging.getLogger("Lark")
+    with _lark_logging_lock:
+        for handler in lark_logger.handlers:
+            if not isinstance(handler, logging.StreamHandler):
+                continue
+            if handler.stream is sys.stdout or handler.stream is sys.__stdout__:
+                handler.setStream(sys.stderr)
+
 
 def _import_lark() -> Any:
     global lark
     if lark is None:
         import lark_oapi as _lark
         lark = _lark
+    _route_lark_stdout_handlers_to_stderr()
     return lark
 
 

--- a/tests/test_feishu_stdio_logging.py
+++ b/tests/test_feishu_stdio_logging.py
@@ -1,0 +1,309 @@
+"""Feishu/Lark logging must not contaminate the MCP stdio protocol."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import selectors
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+from lingtai.mcp_servers.feishu import account
+
+
+_LARK_DIAGNOSTIC = "PR751_PRE_STDIO_LARK_DIAGNOSTIC"
+
+
+class _PreservedHandler(logging.Handler):
+    """A non-stream handler used to prove unrelated logger state is untouched."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        return None
+
+
+
+def test_lark_stdout_handlers_are_rerouted_without_changing_logger_state(capsys):
+    # Import the real SDK once before arranging the logger. The SDK's own
+    # one-time import side effect is then part of the state we restore, while
+    # the assertions below exercise both the fresh account cache path and the
+    # repeated cached path without allowing a second SDK handler to appear.
+    previous_lark = account.lark
+    account.lark = None
+    account._import_lark()
+    account.lark = previous_lark
+
+    logger = logging.getLogger("Lark")
+    original_handlers = logger.handlers[:]
+    original_level = logger.level
+    original_disabled = logger.disabled
+    original_propagate = logger.propagate
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(logging.INFO)
+    stdout_handler.setFormatter(logging.Formatter("stdout %(message)s"))
+    stdout_filter = logging.Filter("Lark")
+    stdout_handler.addFilter(stdout_filter)
+
+    original_stdout_handler = logging.StreamHandler(sys.__stdout__)
+    original_stdout_handler.setLevel(logging.ERROR)
+    original_stdout_handler.setFormatter(logging.Formatter("original %(message)s"))
+    original_stdout_filter = logging.Filter("Lark")
+    original_stdout_handler.addFilter(original_stdout_filter)
+
+    preserved_handler = _PreservedHandler()
+    preserved_handler.setLevel(logging.ERROR)
+    preserved_handler.setFormatter(logging.Formatter("preserved %(message)s"))
+    preserved_filter = logging.Filter("Lark")
+    preserved_handler.addFilter(preserved_filter)
+    arranged_handlers = [stdout_handler, preserved_handler, original_stdout_handler]
+
+    try:
+        logger.handlers[:] = arranged_handlers
+        logger.setLevel(logging.INFO)
+        logger.disabled = False
+        # Guard the exact #1036 regression: routing must not force propagation off.
+        logger.propagate = True
+        expected_logger_state = (logger.level, logger.disabled, logger.propagate)
+        expected_handler_state = [
+            (
+                handler,
+                handler.level,
+                handler.formatter,
+                tuple(handler.filters),
+            )
+            for handler in arranged_handlers
+        ]
+
+        previous_lark = account.lark
+        account.lark = None
+        try:
+            # Exercise both the real SDK import path and its cached return path.
+            assert account._import_lark() is account._import_lark()
+        finally:
+            account.lark = previous_lark
+
+        assert logger.handlers == arranged_handlers
+        assert len(logger.handlers) == len(arranged_handlers)
+        assert [
+            (handler, handler.level, handler.formatter, tuple(handler.filters))
+            for handler in logger.handlers
+        ] == expected_handler_state
+        assert (logger.level, logger.disabled, logger.propagate) == expected_logger_state
+        assert stdout_handler.stream is sys.stderr
+        assert original_stdout_handler.stream is sys.stderr
+
+        logger.info("PR751_HANDLER_ROUTING_DIAGNOSTIC")
+        captured = capsys.readouterr()
+        assert "PR751_HANDLER_ROUTING_DIAGNOSTIC" not in captured.out
+        assert "PR751_HANDLER_ROUTING_DIAGNOSTIC" in captured.err
+    finally:
+        logger.handlers[:] = original_handlers
+        logger.setLevel(original_level)
+        logger.disabled = original_disabled
+        logger.propagate = original_propagate
+
+
+_CHILD = textwrap.dedent(
+    f"""
+    import asyncio
+    import logging
+
+    import mcp.types as types
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+
+    from lingtai.mcp_servers.feishu.account import _import_lark
+
+
+    async def main():
+        # This is the vulnerable interval: the real installed Lark SDK is imported
+        # and emits before the real MCP stdio transport claims fd 1.
+        _import_lark()
+        lark_logger = logging.getLogger("Lark")
+        lark_logger.setLevel(logging.INFO)
+        lark_logger.info({ _LARK_DIAGNOSTIC!r })
+
+        async def list_tools(_ctx, _params):
+            return types.ListToolsResult(
+                tools=[
+                    types.Tool(
+                        name="stdio_probe",
+                        description="owned no-network probe",
+                        input_schema={{"type": "object"}},
+                    )
+                ]
+            )
+
+        async def call_tool(_ctx, _params):
+            return types.CallToolResult(
+                content=[types.TextContent(type="text", text="ok")]
+            )
+
+        server = Server(
+            "pr751-stdio-probe",
+            on_list_tools=list_tools,
+            on_call_tool=call_tool,
+        )
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(),
+            )
+
+
+    asyncio.run(main())
+    """
+)
+
+
+def _read_child_line(
+    selector: selectors.BaseSelector,
+    stdout_lines: list[str],
+    stderr_lines: list[str],
+    deadline: float,
+) -> None:
+    ready = selector.select(max(0.0, deadline - time.monotonic()))
+    if not ready:
+        return
+    for key, _events in ready:
+        line = key.fileobj.readline()
+        if not line:
+            selector.unregister(key.fileobj)
+            continue
+        decoded = line.decode("utf-8", errors="replace").rstrip("\n")
+        if key.data == "stdout":
+            stdout_lines.append(decoded)
+        else:
+            stderr_lines.append(decoded)
+
+
+def test_real_child_mcp_stdio_has_only_protocol_stdout_and_lark_stderr():
+    """The actual Lark import and MCP v2 stdio exchange stay fd-separated."""
+    source_root = Path(__file__).resolve().parents[1] / "src"
+    env = os.environ.copy()
+    # Explicitly select the candidate tree and avoid inherited config/credentials.
+    env["PYTHONPATH"] = str(source_root)
+    env.pop("LINGTAI_FEISHU_CONFIG", None)
+    env.pop("LINGTAI_AGENT_DIR", None)
+
+    child = subprocess.Popen(
+        [sys.executable, "-c", _CHILD],
+        cwd=str(source_root.parent),
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    selector = selectors.DefaultSelector()
+    assert child.stdout is not None
+    assert child.stderr is not None
+    assert child.stdin is not None
+    selector.register(child.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(child.stderr, selectors.EVENT_READ, "stderr")
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+
+    def send(message: dict) -> None:
+        child.stdin.write((json.dumps(message) + "\n").encode("utf-8"))
+        child.stdin.flush()
+
+    initialize_id = 1
+    tools_id = 2
+    responses: dict[int, dict] = {}
+    try:
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": initialize_id,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2026-07-28",
+                    "capabilities": {},
+                    "clientInfo": {"name": "pr751-test", "version": "1"},
+                },
+            }
+        )
+
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline and initialize_id not in responses:
+            before = len(stdout_lines)
+            _read_child_line(selector, stdout_lines, stderr_lines, deadline)
+            for line in stdout_lines[before:]:
+                try:
+                    message = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if message.get("id") == initialize_id:
+                    responses[initialize_id] = message
+                    break
+
+        assert initialize_id in responses, (
+            "owned child did not return initialize response within timeout; "
+            f"stdout={stdout_lines!r} stderr={stderr_lines!r}"
+        )
+        send({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+        send({"jsonrpc": "2.0", "id": tools_id, "method": "tools/list", "params": {}})
+
+        while time.monotonic() < deadline and tools_id not in responses:
+            before = len(stdout_lines)
+            _read_child_line(selector, stdout_lines, stderr_lines, deadline)
+            for line in stdout_lines[before:]:
+                try:
+                    message = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if message.get("id") == tools_id:
+                    responses[tools_id] = message
+                    break
+
+        assert tools_id in responses, (
+            "owned child did not return tools/list response within timeout; "
+            f"stdout={stdout_lines!r} stderr={stderr_lines!r}"
+        )
+        child.stdin.close()
+        child.stdin = None
+        child.wait(timeout=10.0)
+
+        # The process is owned by this test; drain any final diagnostics without
+        # scanning for or touching unrelated processes.
+        stdout_lines.extend(
+            line.decode("utf-8", errors="replace").rstrip("\n")
+            for line in child.stdout.read().splitlines()
+        )
+        stderr_lines.extend(
+            line.decode("utf-8", errors="replace").rstrip("\n")
+            for line in child.stderr.read().splitlines()
+        )
+    finally:
+        selector.close()
+        if child.stdin is not None and not child.stdin.closed:
+            child.stdin.close()
+        if child.poll() is None:
+            child.terminate()
+            child.wait(timeout=5.0)
+
+    assert child.returncode == 0
+    parsed_stdout: list[dict] = []
+    for line in stdout_lines:
+        if not line.strip():
+            continue
+        message = json.loads(line)
+        assert message.get("jsonrpc") == "2.0"
+        assert "id" in message and ("result" in message or "error" in message)
+        parsed_stdout.append(message)
+
+    by_id = {message["id"]: message for message in parsed_stdout}
+    assert by_id[initialize_id]["id"] == initialize_id
+    assert by_id[initialize_id].get("result", {}).get("serverInfo", {}).get("name") == (
+        "pr751-stdio-probe"
+    )
+    assert by_id[tools_id]["id"] == tools_id
+    assert by_id[tools_id].get("result", {}).get("tools", [])[0]["name"] == (
+        "stdio_probe"
+    )
+    assert _LARK_DIAGNOSTIC not in "\n".join(stdout_lines)
+    assert _LARK_DIAGNOSTIC in "\n".join(stderr_lines)


### PR DESCRIPTION
## Summary

- retarget only the Lark SDK's existing stdout/original-stdout `StreamHandler`s to stderr after fresh and cached imports
- preserve handler identity/order/count/state and the `Lark` logger's level, disabled state, and propagation policy
- add a real no-credential/no-network subprocess regression that proves MCP stdio remains JSON-RPC-only from initialization onward

Addresses Lingtai-AI/lingtai#751.

This is a fresh current-main replacement for the narrow owner-layer seam identified in #1036. It intentionally does **not** carry that PR's process-global `Lark.propagate = False` policy or its capsys-only transport evidence.

## Root cause

Feishu imports and initializes the Lark SDK before entering `mcp.server.stdio.stdio_server()`. The installed SDK creates a process-global `Lark` stdout handler and can emit an INFO diagnostic during that pre-stdio window. Those bytes can precede the first MCP response on stdout and break JSON-RPC framing.

The owner-layer helper runs after both fresh and cached SDK imports, under a module-local lock, and uses `StreamHandler.setStream(sys.stderr)` only for handlers whose stream identity is `sys.stdout` or `sys.__stdout__`. It does not add/remove/reorder handlers, globally redirect stdout, reorder startup, change credentials/config/network behavior, or suppress logger propagation.

## Failing-first and validation

- exact base failing-first: the real Lark diagnostic appeared as the first non-JSON stdout line before a real MCP response, producing `JSONDecodeError`
- current candidate: real Lark import before real MCP v2 stdio; correlated `initialize` id 1 and `tools/list` id 2 responses; every non-empty stdout line strict JSON-RPC; diagnostic only on stderr
- all `tests/test_feishu_*.py`: 16 passed
- MCP server scaffold + SDK v2 contract: 69 passed
- architecture-document tests: 3 passed
- candidate-source import, py_compile, Ruff, and diff check: passed
- no dependencies installed; an initial async-test command that disabled plugin autoload was rerun with the already-installed `anyio.pytest_plugin` explicitly loaded

## Review

- exact Luna implementation: 53/53 model-ledger rows
- parent replayed byte-identical production bytes from predecessor main onto current main `592fc39f`, then strengthened the state regression so `propagate=True` must remain true
- exact Terra final review: 27/27 model-ledger rows, no P0/P1/P2; real subprocess test judged proportionate to the framing boundary
- final scope: 2 files, 15 production insertions plus one self-contained real transport regression; no config, credential, runtime lifecycle, dependency, cleanup, deletion, or public API change
