### PR TITLE
fix(wechat): retry failed LICC publication

### DIFF
--- a/src/lingtai/mcp_servers/_licc_compat.py
+++ b/src/lingtai/mcp_servers/_licc_compat.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from datetime import datetime, timezone
@@ -30,6 +31,7 @@ LICC_VERSION = 1
 INBOX_DIRNAME = ".mcp_inbox"
 TMP_SUFFIX = ".json.tmp"
 EVENT_SUFFIX = ".json"
+_EVENT_ID_RE = re.compile(r"^[A-Za-z0-9_.-]{1,128}$")
 
 
 def push_inbox_event(
@@ -39,12 +41,14 @@ def push_inbox_event(
     *,
     metadata: dict | None = None,
     wake: bool = True,
+    event_id: str | None = None,
 ) -> bool:
     """Write a LICC event into the host agent's inbox.
 
     In a current LingTai runtime, delegate to the canonical kernel helper.
     If the helper is unavailable, use the local compatibility fallback so
-    older hosts and standalone development remain functional.
+    older hosts and standalone development remain functional. ``event_id``
+    optionally selects a deterministic safe filename for idempotent delivery.
     """
     if _kernel_push_inbox_event is not None:
         return _kernel_push_inbox_event(
@@ -53,6 +57,7 @@ def push_inbox_event(
             body,
             metadata=metadata,
             wake=wake,
+            event_id=event_id,
         )
     return _fallback_push_inbox_event(
         sender,
@@ -60,6 +65,7 @@ def push_inbox_event(
         body,
         metadata=metadata,
         wake=wake,
+        event_id=event_id,
     )
 
 
@@ -70,6 +76,7 @@ def _fallback_push_inbox_event(
     *,
     metadata: dict | None = None,
     wake: bool = True,
+    event_id: str | None = None,
 ) -> bool:
     """Local LICC v1 writer used only when the kernel helper is unavailable."""
     agent_dir = os.environ.get("LINGTAI_AGENT_DIR")
@@ -93,11 +100,17 @@ def _fallback_push_inbox_event(
     }
 
     try:
+        if event_id is None:
+            stem = f"{int(time.time() * 1000)}-{uuid.uuid4().hex[:8]}"
+        elif not isinstance(event_id, str) or not _EVENT_ID_RE.fullmatch(event_id):
+            return False
+        else:
+            stem = event_id
+
         target_dir = Path(agent_dir) / INBOX_DIRNAME / mcp_name
         target_dir.mkdir(parents=True, exist_ok=True)
-        event_id = f"{int(time.time() * 1000)}-{uuid.uuid4().hex[:8]}"
-        tmp = target_dir / f"{event_id}{TMP_SUFFIX}"
-        final = target_dir / f"{event_id}{EVENT_SUFFIX}"
+        tmp = target_dir / f"{stem}{TMP_SUFFIX}"
+        final = target_dir / f"{stem}{EVENT_SUFFIX}"
         # Write + fsync + atomic replace so the host poller never sees a
         # half-written file.
         text = json.dumps(event, ensure_ascii=False)

--- a/src/lingtai/mcp_servers/wechat/manager.py
+++ b/src/lingtai/mcp_servers/wechat/manager.py
@@ -69,6 +69,7 @@ _STRUCTURED_MESSAGE_TEXT_CAP = 500
 # guard never forgets a message inside the replay window, while keeping the
 # state file bounded.
 SEEN_KEYS_MAX = 5000
+_PENDING_PUBLICATION_KEY = "pending_publication"
 
 # Public callers receive the strict LTP-v2 family schema. Manager dispatch
 # remains the internal flat action boundary after family validation.
@@ -105,7 +106,7 @@ class WechatManager:
         poll_interval: float = 1.0,
         allowed_users: list[str] | None = None,
         working_dir: Path,
-        on_inbound: Callable[[dict], None],
+        on_inbound: Callable[[dict], bool | None],
         config_source: str | None = None,
         credentials_source: str | None = None,
     ) -> None:
@@ -153,7 +154,8 @@ class WechatManager:
         # so two pollers for the same bot_token race over inbound messages.
         self._account_lock = AccountLock(token)
 
-        # Load persisted state
+        # Load persisted state. Pending producer callbacks are drained only by
+        # start(), after this manager owns the per-account poller lock.
         self._load_state()
 
     def start(self) -> None:
@@ -177,16 +179,38 @@ class WechatManager:
             )
             raise
 
-        self._last_verified_at = datetime.now(timezone.utc).isoformat()
-        self._running = True
-        self._loop = asyncio.new_event_loop()
-        self._poll_thread = threading.Thread(
-            target=self._loop.run_until_complete,
-            args=(self._poll_loop(),),
-            daemon=True,
-            name="wechat-poll",
-        )
-        self._poll_thread.start()
+        # Recovery is producer work, so it must run while this manager owns
+        # the account lock and before any new upstream poll starts. Keep all
+        # post-lock setup transactional: a loop/thread construction failure
+        # must not leave ownership or partial runtime state behind.
+        loop: asyncio.AbstractEventLoop | None = None
+        poll_coro = None
+        previous_verified_at = self._last_verified_at
+        try:
+            self._drain_pending_callbacks()
+            self._last_verified_at = datetime.now(timezone.utc).isoformat()
+            loop = asyncio.new_event_loop()
+            self._loop = loop
+            poll_coro = self._poll_loop()
+            self._poll_thread = threading.Thread(
+                target=loop.run_until_complete,
+                args=(poll_coro,),
+                daemon=True,
+                name="wechat-poll",
+            )
+            self._running = True
+            self._poll_thread.start()
+        except Exception:
+            self._running = False
+            self._poll_thread = None
+            self._loop = None
+            self._last_verified_at = previous_verified_at
+            if poll_coro is not None:
+                poll_coro.close()
+            if loop is not None and not loop.is_closed():
+                loop.close()
+            self._account_lock.release()
+            raise
         try:
             path = self.write_identity_file()
             log.info("Wrote WeChat MCP identity metadata to %s", path)
@@ -368,10 +392,12 @@ class WechatManager:
         if self._is_replay(stable_key):
             with self._lock:
                 first_id = self._seen_keys.get(stable_key)
+            self._retry_pending_for_key(stable_key)
             log.info(
-                "WeChat inbound replay suppressed: stable_key=%s "
-                "first_local_id=%s from=%s (skipped duplicate landing)",
-                stable_key, first_id, from_user,
+                "WeChat inbound replay suppressed: stable_key_hash=%s "
+                "first_local_id=%s event_id=%s",
+                self._stable_key_hash(stable_key), first_id,
+                self._event_id_for_local_id(first_id),
             )
             return
 
@@ -392,56 +418,66 @@ class WechatManager:
             "upstream_message_id": msg.message_id,
             "upstream_create_time_ms": msg.create_time_ms,
         }
-        (msg_dir / "message.json").write_text(
-            json.dumps(msg_data, ensure_ascii=False, indent=2), encoding="utf-8",
-        )
-        # Record the signature only after the inbox write has succeeded, so a
-        # crash mid-write cannot mark a message as seen without landing it.
-        self._record_seen(stable_key, msg_id)
+        msg_file = msg_dir / "message.json"
 
-        # Forward to host via LICC. Body is a conversation preview with
+        # Build the complete callback event before the first durable message
+        # record so a crash cannot leave a valid orphan that lacks publication
+        # state. Forward to host via LICC. Body is a conversation preview with
         # guidance directing the agent to react only to the latest
         # unresponded incoming message — older lines are background only.
         # Metadata carries generic routing keys (platform/conversation_ref/
         # message_ref) plus structured recent_messages/latest_incoming so the
         # kernel can build _meta.agent_meta.notifications.persistent.mcp.wechat and keep
         # the transient _meta.agent_meta.notifications.attention lane a compact identity hook.
+        contact = self._find_contact_by_user_id(from_user)
+        display = contact.get("alias", from_user) if contact else from_user
+        preview_metadata: dict[str, Any] = {}
         try:
-            contact = self._find_contact_by_user_id(from_user)
-            display = contact.get("alias", from_user) if contact else from_user
-            preview_metadata: dict[str, Any] = {}
-            try:
-                preview, preview_metadata = (
-                    self._build_conversation_preview_and_metadata(from_user, msg_id)
+            # Include the current in-memory record in the preview window before
+            # it is durable; this preserves the existing preview/metadata shape
+            # without requiring an incomplete first write.
+            preview, preview_metadata = (
+                self._build_conversation_preview_and_metadata(
+                    from_user, msg_id, current_record=msg_data,
                 )
-            except Exception as exc:
-                log.warning(
-                    "_build_conversation_preview_and_metadata failed: %s", exc
-                )
-                preview = body[:300].replace("\n", " ")
-                if len(body) > 300:
-                    preview += "..."
-            self._on_inbound({
-                "from": display,
-                "subject": f"wechat message from {display}",
-                "body": preview,
-                "metadata": {
-                    "message_id": msg_id,
-                    "from_user_id": from_user,
-                    "preview_truncated": len(body) > 300,
-                    "full_length": len(body),
-                    "item_types": msg_data["raw_item_types"],
-                    # Generic LICC chat routing keys, copied by the kernel
-                    # inbox into .notification/mcp.wechat.json previews.
-                    "platform": "wechat",
-                    "conversation_ref": from_user,
-                    "message_ref": msg_id,
-                    **preview_metadata,
-                },
-                "wake": True,
-            })
-        except Exception as e:
-            log.error("Failed to forward inbound to LICC: %s", e)
+            )
+        except Exception as exc:
+            log.warning(
+                "_build_conversation_preview_and_metadata failed: %s",
+                type(exc).__name__,
+            )
+            preview = body[:300].replace("\n", " ")
+            if len(body) > 300:
+                preview += "..."
+        event = {
+            "from": display,
+            "subject": f"wechat message from {display}",
+            "body": preview,
+            "metadata": {
+                "message_id": msg_id,
+                "from_user_id": from_user,
+                "preview_truncated": len(body) > 300,
+                "full_length": len(body),
+                "item_types": msg_data["raw_item_types"],
+                # Generic LICC chat routing keys, copied by the kernel
+                # inbox into .notification/mcp.wechat.json previews.
+                "platform": "wechat",
+                "conversation_ref": from_user,
+                "message_ref": msg_id,
+                **preview_metadata,
+            },
+            "wake": True,
+        }
+        msg_data[_PENDING_PUBLICATION_KEY] = event
+        # This is the first durable message-record write for callback-enabled
+        # messages and already contains the exact callback event.
+        self._atomic_write(
+            msg_file, json.dumps(msg_data, ensure_ascii=False, indent=2)
+        )
+        # Record only after the complete inbox landing and exact pending
+        # callback payload are durable. A False/exception leaves that marker.
+        self._record_seen(stable_key, msg_id)
+        self._deliver_pending_callback(msg_file, msg_data)
 
     # ── Tool handler dispatch ──────────────────────────────────
 
@@ -832,11 +868,14 @@ class WechatManager:
         user_id: str,
         current_message_id: str,
         max_messages: int = _CONVERSATION_PREVIEW_MESSAGES,
+        *,
+        current_record: dict | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """Build the markdown preview plus structured WeChat context metadata.
 
-        The preview merges inbox + sent records filtered to *user_id*, takes
-        the last *max_messages* by date ascending, and formats each line as
+        The preview merges inbox + sent records filtered to *user_id*, plus an
+        optional in-memory current inbound record, takes the last
+        *max_messages* by date ascending, and formats each line as
         ``[relative_time] #id sender: text`` under a guidance header telling
         the agent to react only to the latest unresponded incoming message.
 
@@ -858,6 +897,11 @@ class WechatManager:
             if m.get("to_user_id") == user_id
         ]
         messages = inbox + sent
+        if (
+            isinstance(current_record, dict)
+            and current_record.get("from_user_id") == user_id
+        ):
+            messages.append({**current_record, "_direction": "incoming"})
         messages.sort(key=lambda m: m.get("date") or "")
         messages = messages[-max_messages:]
 
@@ -921,16 +965,199 @@ class WechatManager:
         if not folder.is_dir():
             return messages
         for msg_dir in folder.iterdir():
+            if msg_dir.is_symlink() or not msg_dir.is_dir():
+                continue
             msg_file = msg_dir / "message.json"
-            if not msg_file.is_file():
+            if msg_file.is_symlink() or not msg_file.is_file():
                 continue
             try:
                 data = json.loads(msg_file.read_text(encoding="utf-8"))
-                messages.append(data)
+                if isinstance(data, dict):
+                    data.pop(_PENDING_PUBLICATION_KEY, None)
+                    messages.append(data)
             except (json.JSONDecodeError, OSError):
                 continue
         messages.sort(key=lambda m: m.get("date", ""), reverse=True)
         return messages
+
+    @staticmethod
+    def _stable_key_hash(stable_key: str) -> str:
+        return hashlib.sha256(stable_key.encode("utf-8")).hexdigest()[:16]
+
+    @staticmethod
+    def _event_id_for_local_id(local_id: str | None) -> str:
+        if isinstance(local_id, str) and local_id:
+            return f"wechat-{local_id}"
+        return "wechat-unknown"
+
+    @staticmethod
+    def _safe_local_id(local_id: object, *, containing_dir: str | None = None) -> bool:
+        """Return whether a local ID is safe and names its containing inbox dir."""
+        if not isinstance(local_id, str) or not local_id:
+            return False
+        if local_id in {".", ".."} or "\x00" in local_id:
+            return False
+        if "/" in local_id or "\\" in local_id or Path(local_id).name != local_id:
+            return False
+        return containing_dir is None or local_id == containing_dir
+
+    @classmethod
+    def _pending_event_from_record(
+        cls, data: dict, *, containing_dir: str | None = None,
+    ) -> dict | None:
+        """Return a valid self-generated pending callback, else ignore it.
+
+        Pending state is trusted only when it is internally bound to the
+        containing local inbox directory and record. This keeps malformed or
+        hand-edited markers from widening into callback publication or path
+        traversal.
+        """
+        if not isinstance(data, dict):
+            return None
+        local_id = data.get("id")
+        if not cls._safe_local_id(local_id, containing_dir=containing_dir):
+            return None
+        stable_key = data.get("stable_key")
+        if not isinstance(stable_key, str) or not stable_key.strip():
+            return None
+        event = data.get(_PENDING_PUBLICATION_KEY)
+        if not isinstance(event, dict):
+            return None
+        if not all(
+            isinstance(event.get(key), str)
+            for key in ("from", "subject", "body")
+        ):
+            return None
+        metadata = event.get("metadata")
+        if not isinstance(metadata, dict):
+            return None
+        if metadata.get("message_id") != local_id:
+            return None
+        if metadata.get("message_ref") != local_id:
+            return None
+        if metadata.get("platform") != "wechat":
+            return None
+        record_from = data.get("from_user_id")
+        if not isinstance(record_from, str):
+            return None
+        for key in ("from_user_id", "conversation_ref"):
+            value = metadata.get(key)
+            if value is not None and value != record_from:
+                return None
+        if not isinstance(event.get("wake"), bool):
+            return None
+        return event
+
+    def _deliver_pending_callback(self, msg_file: Path, data: dict) -> bool:
+        """Retry one pending callback and clear only an accepted publication."""
+        if (
+            msg_file.name != "message.json"
+            or msg_file.is_symlink()
+            or msg_file.parent.is_symlink()
+        ):
+            return False
+        local_id = data.get("id")
+        event = self._pending_event_from_record(
+            data, containing_dir=msg_file.parent.name,
+        )
+        stable_key = data.get("stable_key")
+        if event is None or not isinstance(stable_key, str):
+            return False
+        stable_hash = self._stable_key_hash(stable_key)
+        event_id = self._event_id_for_local_id(local_id)
+        try:
+            result = self._on_inbound(event)
+        except Exception as exc:
+            log.warning(
+                "WeChat callback pending: stable_key_hash=%s local_id=%s "
+                "event_id=%s status=exception error=%s",
+                stable_hash, local_id, event_id, type(exc).__name__,
+            )
+            return False
+        if result is False:
+            log.info(
+                "WeChat callback pending: stable_key_hash=%s local_id=%s "
+                "event_id=%s status=false",
+                stable_hash, local_id, event_id,
+            )
+            return False
+
+        cleared = dict(data)
+        cleared.pop(_PENDING_PUBLICATION_KEY, None)
+        try:
+            self._atomic_write(
+                msg_file, json.dumps(cleared, ensure_ascii=False, indent=2)
+            )
+        except Exception as exc:
+            log.warning(
+                "WeChat callback accepted but pending marker remains: "
+                "stable_key_hash=%s local_id=%s event_id=%s error=%s",
+                stable_hash, local_id, event_id, type(exc).__name__,
+            )
+            return True
+        data.pop(_PENDING_PUBLICATION_KEY, None)
+        log.info(
+            "WeChat callback pending: stable_key_hash=%s local_id=%s "
+            "event_id=%s status=accepted",
+            stable_hash, local_id, event_id,
+        )
+        return True
+
+    def _retry_pending_for_key(self, stable_key: str) -> bool:
+        """Recover an existing local landing when a replay hits its stable key."""
+        with self._lock:
+            local_id = self._seen_keys.get(stable_key)
+        if not self._safe_local_id(local_id):
+            return False
+        msg_dir = self._inbox_dir / local_id
+        if not msg_dir.is_dir() or msg_dir.is_symlink():
+            return False
+        msg_file = msg_dir / "message.json"
+        if not msg_file.is_file() or msg_file.is_symlink():
+            return False
+        try:
+            data = json.loads(msg_file.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return False
+        if not isinstance(data, dict) or data.get("stable_key") != stable_key:
+            return False
+        return self._deliver_pending_callback(msg_file, data)
+
+    def _drain_pending_callbacks(self) -> None:
+        """Retry self-generated pending WeChat publications at manager startup."""
+        if not self._inbox_dir.is_dir():
+            return
+        for msg_dir in sorted(self._inbox_dir.iterdir(), key=lambda path: path.name):
+            if not msg_dir.is_dir() or msg_dir.is_symlink():
+                continue
+            msg_file = msg_dir / "message.json"
+            if not msg_file.is_file() or msg_file.is_symlink():
+                continue
+            try:
+                data = json.loads(msg_file.read_text(encoding="utf-8"))
+            except (OSError, ValueError, TypeError):
+                continue
+            if self._pending_event_from_record(
+                data, containing_dir=msg_dir.name,
+            ) is None:
+                continue
+            local_id = data["id"]
+            stable_key = data["stable_key"]
+            with self._lock:
+                existing_id = self._seen_keys.get(stable_key)
+            if existing_id is not None and existing_id != local_id:
+                continue
+            if existing_id is None:
+                try:
+                    self._record_seen(stable_key, local_id)
+                except Exception as exc:
+                    log.warning(
+                        "WeChat pending recovery could not record seen: "
+                        "stable_key_hash=%s local_id=%s error=%s",
+                        self._stable_key_hash(stable_key), local_id, type(exc).__name__,
+                    )
+                    continue
+            self._deliver_pending_callback(msg_file, data)
 
     # ── State persistence ──────────────────────────────────────
 
@@ -1066,6 +1293,8 @@ class WechatManager:
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
             os.replace(tmp, path)
         except BaseException:
             try:

--- a/src/lingtai/mcp_servers/wechat/server.py
+++ b/src/lingtai/mcp_servers/wechat/server.py
@@ -800,13 +800,21 @@ def build_manager() -> tuple[WechatManager, Path]:
     working_dir = Path(agent_dir_raw) if agent_dir_raw else Path.cwd()
     working_dir.mkdir(parents=True, exist_ok=True)
 
-    def _on_inbound(event: dict) -> None:
-        push_inbox_event(
+    def _on_inbound(event: dict) -> bool | None:
+        metadata = event.get("metadata") or {}
+        local_id = metadata.get("message_id")
+        event_id = (
+            f"wechat-{local_id}"
+            if isinstance(local_id, str) and local_id
+            else None
+        )
+        return push_inbox_event(
             sender=event["from"],
             subject=event["subject"],
             body=event["body"],
-            metadata=event.get("metadata"),
+            metadata=metadata,
             wake=event.get("wake", True),
+            event_id=event_id,
         )
 
     mgr = WechatManager(

--- a/tests/test_mcp_server_scaffold.py
+++ b/tests/test_mcp_server_scaffold.py
@@ -98,3 +98,39 @@ def test_fallback_push_noop_without_env(tmp_path: Path, monkeypatch):
     monkeypatch.delenv("LINGTAI_AGENT_DIR", raising=False)
     monkeypatch.delenv("LINGTAI_MCP_NAME", raising=False)
     assert _licc_compat.push_inbox_event("s", "subj", "body") is False
+
+
+@pytest.mark.parametrize(
+    ("event_id", "valid"),
+    [
+        ("wechat-local-id", True), ("a" * 128, True), (".", True), ("..", True),
+        ("", False), (" ", False), ("../escape", False), (r"..\escape", False),
+        ("has space", False), ("colon:name", False), ("unicode-λ", False),
+        ("a" * 129, False),
+    ],
+)
+def test_fallback_explicit_event_id_is_safe_and_deterministic(
+    tmp_path: Path, monkeypatch, event_id: str, valid: bool,
+):
+    monkeypatch.setattr(_licc_compat, "_kernel_push_inbox_event", None)
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path))
+    monkeypatch.setenv("LINGTAI_MCP_NAME", "wechat")
+
+    if not valid:
+        assert _licc_compat.push_inbox_event(
+            "s", "subj", "body", event_id=event_id,
+        ) is False
+        assert not any(tmp_path.rglob("*.json"))
+        return
+
+    assert _licc_compat.push_inbox_event(
+        "s", "subj", "first", event_id=event_id,
+    ) is True
+    assert _licc_compat.push_inbox_event(
+        "s", "subj", "replacement", event_id=event_id,
+    ) is True
+    inbox_dir = tmp_path / _licc_compat.INBOX_DIRNAME / "wechat"
+    events = [p for p in inbox_dir.iterdir() if p.suffix == ".json"]
+    assert [p.name for p in events] == [f"{event_id}.json"]
+    event = json.loads(events[0].read_text(encoding="utf-8"))
+    assert event["body"] == "replacement"

--- a/tests/test_wechat_inbound_replay.py
+++ b/tests/test_wechat_inbound_replay.py
@@ -14,18 +14,26 @@ import asyncio
 import json
 from pathlib import Path
 
+import pytest
+
+from lingtai.mcp_servers.wechat import manager as wechat_manager_module
+from lingtai.mcp_servers.wechat.lockfile import PollerLockBusy
 from lingtai.mcp_servers.wechat.manager import WechatManager
 from lingtai.mcp_servers.wechat.types import (
     MessageItem, MessageItemType, TextItem, WeixinMessage,
 )
 
 
-def _manager(tmp_path: Path, events: list[dict]) -> WechatManager:
+def _manager(
+    tmp_path: Path, events: list[dict] | None = None, *, on_inbound=None,
+) -> WechatManager:
     return WechatManager(
         token="test-token",
         user_id="test-bot",
         working_dir=tmp_path,
-        on_inbound=events.append,
+        on_inbound=on_inbound if on_inbound is not None else (
+            events.append if events is not None else None
+        ),
     )
 
 
@@ -62,6 +70,123 @@ def _inbox_count(tmp_path: Path) -> int:
 
 def _deliver(mgr: WechatManager, msg: WeixinMessage) -> None:
     asyncio.run(mgr._on_incoming(msg))
+
+
+class _FakeAccountLock:
+    def __init__(self, *, busy: bool = False) -> None:
+        self.busy = busy
+        self.acquire_calls = 0
+        self.release_calls = 0
+        self.owned = False
+        self.path = Path("fake-wechat-lock")
+
+    def acquire(self) -> None:
+        self.acquire_calls += 1
+        if self.busy:
+            raise PollerLockBusy("fake lock busy")
+        self.owned = True
+
+    def release(self) -> None:
+        self.release_calls += 1
+        self.owned = False
+
+
+class _InlineThread:
+    """Run the patched no-network poll target without creating a real thread."""
+
+    def __init__(self, *, target, args, daemon, name) -> None:
+        self._target = target
+        self._args = args
+
+    def start(self) -> None:
+        self._target(*self._args)
+
+    def join(self, timeout=None) -> None:
+        return None
+
+
+def _start_without_network(
+    mgr: WechatManager, monkeypatch, lock: _FakeAccountLock | None = None,
+) -> _FakeAccountLock:
+    fake_lock = lock or _FakeAccountLock()
+    monkeypatch.setattr(mgr, "_account_lock", fake_lock)
+
+    async def no_poll() -> None:
+        return None
+
+    monkeypatch.setattr(mgr, "_poll_loop", no_poll)
+    monkeypatch.setattr(
+        mgr, "write_identity_file", lambda: mgr._working_dir / "wechat.identity.json",
+    )
+    monkeypatch.setattr(wechat_manager_module.threading, "Thread", _InlineThread)
+    mgr.start()
+    return fake_lock
+
+
+@pytest.mark.parametrize(
+    "failure", ["drain", "new_event_loop", "thread_constructor", "thread_start"],
+)
+def test_start_setup_failure_rolls_back_lock_and_runtime_state(
+    tmp_path, monkeypatch, failure,
+):
+    """Every post-lock setup failure releases ownership and closes its loop."""
+    mgr = _manager(tmp_path, [])
+    lock = _FakeAccountLock()
+    monkeypatch.setattr(mgr, "_account_lock", lock)
+
+    loops = []
+    real_new_event_loop = wechat_manager_module.asyncio.new_event_loop
+
+    def tracked_new_event_loop():
+        loop = real_new_event_loop()
+        loops.append(loop)
+        return loop
+
+    if failure == "drain":
+        def fail_drain():
+            raise RuntimeError("drain failed")
+
+        monkeypatch.setattr(mgr, "_drain_pending_callbacks", fail_drain)
+    elif failure == "new_event_loop":
+        def fail_new_event_loop():
+            raise RuntimeError("new loop failed")
+
+        monkeypatch.setattr(
+            wechat_manager_module.asyncio, "new_event_loop", fail_new_event_loop,
+        )
+    else:
+        monkeypatch.setattr(
+            wechat_manager_module.asyncio, "new_event_loop", tracked_new_event_loop,
+        )
+        if failure == "thread_constructor":
+            def fail_thread(*args, **kwargs):
+                raise RuntimeError("thread construction failed")
+
+            monkeypatch.setattr(
+                wechat_manager_module.threading, "Thread", fail_thread,
+            )
+        else:
+            class FailingThread:
+                def __init__(self, **kwargs):
+                    self.kwargs = kwargs
+
+                def start(self):
+                    raise RuntimeError("thread start failed")
+
+            monkeypatch.setattr(
+                wechat_manager_module.threading, "Thread", FailingThread,
+            )
+
+    with pytest.raises(RuntimeError, match="failed"):
+        mgr.start()
+
+    assert lock.acquire_calls == 1
+    assert lock.release_calls == 1
+    assert lock.owned is False
+    assert mgr._running is False
+    assert mgr._loop is None
+    assert mgr._poll_thread is None
+    assert all(loop.is_closed() for loop in loops)
 
 
 # ── Replay suppression (the bug) ──────────────────────────────────────────
@@ -121,45 +246,360 @@ def test_replay_survives_relaunch_via_persisted_index(tmp_path):
     assert events2 == [], "replay after relaunch must not re-wake the host"
 
 
+def test_constructor_does_not_publish_until_owned_start_recovers_pending(
+    tmp_path, monkeypatch,
+):
+    """Constructor is inert; start drains only after fake lock ownership."""
+    user = "wxid_start@im.wechat"
+    first = _manager(tmp_path, on_inbound=lambda _event: False)
+    _deliver(first, _text_msg(from_user=user, text="startup", message_id=75310))
+
+    lock = _FakeAccountLock()
+    observed: list[tuple[bool, str]] = []
+
+    def accepted(event: dict) -> None:
+        observed.append((lock.owned, event["metadata"]["message_id"]))
+
+    second = _manager(tmp_path, on_inbound=accepted)
+    assert observed == []
+
+    _start_without_network(second, monkeypatch, lock)
+    assert observed == [(True, next(iter((tmp_path / "wechat" / "inbox").iterdir())).name)]
+    assert lock.acquire_calls == 1
+    assert lock.owned is True
+    second.stop()
+    assert lock.release_calls == 1
+    assert lock.owned is False
+
+
+def test_lock_busy_start_never_publishes_pending_callback(tmp_path, monkeypatch):
+    user = "wxid_busy@im.wechat"
+    first = _manager(tmp_path, on_inbound=lambda _event: False)
+    _deliver(first, _text_msg(from_user=user, text="busy", message_id=75311))
+
+    events: list[dict] = []
+    second = _manager(tmp_path, events)
+    lock = _FakeAccountLock(busy=True)
+    monkeypatch.setattr(second, "_account_lock", lock)
+
+    with pytest.raises(PollerLockBusy):
+        second.start()
+    assert events == []
+    assert lock.acquire_calls == 1
+    assert lock.release_calls == 0
+
+
+def test_crash_after_first_record_write_recovers_same_uuid_on_start(
+    tmp_path, monkeypatch,
+):
+    """The first durable callback record already carries pending state."""
+    user = "wxid_crash@im.wechat"
+    first_events: list[dict] = []
+    first = _manager(
+        tmp_path, on_inbound=lambda event: first_events.append(event),
+    )
+
+    def fail_before_seen(_key: str, _local_id: str) -> None:
+        raise RuntimeError("simulated crash before seen barrier")
+
+    monkeypatch.setattr(first, "_record_seen", fail_before_seen)
+    with pytest.raises(RuntimeError, match="before seen"):
+        _deliver(first, _text_msg(from_user=user, text="crash", message_id=75312))
+
+    inbox = tmp_path / "wechat" / "inbox"
+    dirs = [path for path in inbox.iterdir() if path.is_dir()]
+    assert len(dirs) == 1
+    local_id = dirs[0].name
+    record = json.loads((dirs[0] / "message.json").read_text(encoding="utf-8"))
+    assert record["id"] == local_id
+    assert record["pending_publication"]["metadata"]["message_id"] == local_id
+    assert first_events == []
+    assert not (tmp_path / "wechat" / "inbox_seen.json").exists()
+
+    recovered: list[dict] = []
+    second = _manager(tmp_path, recovered)
+    lock = _start_without_network(second, monkeypatch)
+    assert len(recovered) == 1
+    assert recovered[0]["metadata"]["message_id"] == local_id
+    seen = json.loads((tmp_path / "wechat" / "inbox_seen.json").read_text())
+    assert seen["keys"][record["stable_key"]] == local_id
+    final = json.loads((dirs[0] / "message.json").read_text(encoding="utf-8"))
+    assert "pending_publication" not in final
+    assert len([path for path in inbox.iterdir() if (path / "message.json").is_file()]) == 1
+    second.stop()
+    assert lock.release_calls == 1
+
+
+def test_same_manager_replay_retries_pending_without_second_uuid(tmp_path):
+    user = "wxid_same_manager@im.wechat"
+    attempts: list[tuple[str, bool | None]] = []
+    outcomes = iter((False, None))
+
+    def mutable(event: dict) -> bool | None:
+        attempts.append((event["metadata"]["message_id"], next(outcomes)))
+        return attempts[-1][1]
+
+    mgr = _manager(tmp_path, on_inbound=mutable)
+    msg = _text_msg(from_user=user, text="mutable", message_id=75313)
+    _deliver(mgr, msg)
+    inbox = tmp_path / "wechat" / "inbox"
+    local_id = next(path.name for path in inbox.iterdir() if path.is_dir())
+    _deliver(mgr, _text_msg(from_user=user, text="mutable", message_id=75313))
+
+    assert attempts == [(local_id, False), (local_id, None)]
+    assert _inbox_count(tmp_path) == 1
+    final = json.loads((inbox / local_id / "message.json").read_text(encoding="utf-8"))
+    assert "pending_publication" not in final
+
+
+def test_mismatched_pending_and_seen_mapping_are_ignored(tmp_path, monkeypatch):
+    user = "wxid_mismatch@im.wechat"
+    first = _manager(tmp_path, on_inbound=lambda _event: False)
+    _deliver(first, _text_msg(from_user=user, text="mismatch", message_id=75314))
+    inbox = tmp_path / "wechat" / "inbox"
+    msg_dir = next(path for path in inbox.iterdir() if path.is_dir())
+    msg_file = msg_dir / "message.json"
+    record = json.loads(msg_file.read_text(encoding="utf-8"))
+    local_id = msg_dir.name
+    stable_key = record["stable_key"]
+
+    record["pending_publication"]["metadata"]["message_ref"] = "other-local-id"
+    msg_file.write_text(json.dumps(record), encoding="utf-8")
+    malformed_events: list[dict] = []
+    malformed = _manager(tmp_path, malformed_events)
+    malformed_lock = _start_without_network(malformed, monkeypatch)
+    assert malformed_events == []
+    malformed.stop()
+    assert malformed_lock.release_calls == 1
+
+    record["pending_publication"]["metadata"]["message_ref"] = local_id
+    msg_file.write_text(json.dumps(record), encoding="utf-8")
+    seen_file = tmp_path / "wechat" / "inbox_seen.json"
+    seen = {"version": 1, "order": [stable_key], "keys": {stable_key: "different-id"}}
+    seen_file.write_text(json.dumps(seen), encoding="utf-8")
+    bounded_events: list[dict] = []
+    bounded = _manager(tmp_path, bounded_events)
+    lock = _start_without_network(bounded, monkeypatch)
+    assert bounded_events == []
+    bounded.stop()
+    assert lock.release_calls == 1
+
+
 # ── Genuine messages must NOT be dropped ──────────────────────────────────
 
-def test_distinct_upstream_ids_both_land(tmp_path):
-    """Two different upstream messages (different ids) both land, even with
-    identical text."""
+@pytest.mark.parametrize(
+    ("failure", "user", "upstream_id", "text"),
+    [
+        ("false", "wxid_false@im.wechat", 75301, "retry-false"),
+        ("exception", "wxid_raise@im.wechat", 75302, "retry-raise"),
+    ],
+)
+def test_callback_failure_is_retryable_after_fresh_manager_start(
+    tmp_path, monkeypatch, failure, user, upstream_id, text,
+):
+    """False and exception results both retain and later retry one landing."""
+    attempts: list[str] = []
+
+    def rejected(event: dict) -> bool:
+        attempts.append(event["metadata"]["message_id"])
+        if failure == "exception":
+            raise RuntimeError("test callback failure")
+        return False
+
+    mgr1 = _manager(
+        tmp_path,
+        on_inbound=rejected,
+    )
+    _deliver(mgr1, _text_msg(from_user=user, text=text, message_id=upstream_id))
+
+    inbox_dir = tmp_path / "wechat" / "inbox"
+    landed = json.loads(next(inbox_dir.iterdir()).joinpath("message.json").read_text())
+    local_id = landed["id"]
+    stable_key = landed["stable_key"]
+    seen = json.loads((tmp_path / "wechat" / "inbox_seen.json").read_text())
+    assert seen["keys"][stable_key] == local_id
+    assert stable_key == f"{user}|mid:{upstream_id}"
+    assert attempts == [local_id]
+    assert landed["pending_publication"]["metadata"]["message_id"] == local_id
+
+    retry_attempts: list[str] = []
+    mgr2 = _manager(
+        tmp_path,
+        on_inbound=lambda event: retry_attempts.append(
+            event["metadata"]["message_id"]
+        ),
+    )
+    lock = _start_without_network(mgr2, monkeypatch)
+
+    assert _inbox_count(tmp_path) == 1
+    assert retry_attempts == [local_id]
+    final_record = json.loads((inbox_dir / local_id / "message.json").read_text())
+    assert "pending_publication" not in final_record
+    mgr2.stop()
+    assert lock.release_calls == 1
+
+
+
+def test_public_surfaces_hide_pending_state(tmp_path):
+    user = "wxid_private@im.wechat"
+    mgr = _manager(tmp_path, on_inbound=lambda _event: False)
+    _deliver(mgr, _text_msg(from_user=user, text="private", message_id=75315))
+    local_id = next(
+        path.name for path in (tmp_path / "wechat" / "inbox").iterdir()
+        if path.is_dir()
+    )
+
+    public = [
+        mgr.handle({"action": "check"}),
+        mgr.handle({"action": "read", "user_id": user}),
+        mgr.handle({"action": "search", "query": "private"}),
+    ]
+    serialized = json.dumps(public, ensure_ascii=False)
+    assert "pending_publication" not in serialized
+    assert local_id in serialized
+
+
+@pytest.mark.parametrize("kind", ["malformed_json", "path_id", "mismatched_id"])
+def test_pending_recovery_ignores_invalid_record_without_publication(
+    tmp_path, monkeypatch, kind,
+):
+    """Startup recovery never publishes malformed or path-shaped local state."""
+    first = _manager(tmp_path, on_inbound=lambda _event: False)
+    _deliver(first, _text_msg(from_user="wxid_invalid@im.wechat", text="pending", message_id=75320))
+    inbox_dir = tmp_path / "wechat" / "inbox"
+    msg_dir = next(path for path in inbox_dir.iterdir() if path.is_dir())
+    msg_file = msg_dir / "message.json"
+
+    if kind == "malformed_json":
+        msg_file.write_text("{not-json", encoding="utf-8")
+    else:
+        record = json.loads(msg_file.read_text(encoding="utf-8"))
+        candidate = "../escape" if kind == "path_id" else "not-the-containing-dir"
+        record["id"] = candidate
+        record["pending_publication"]["metadata"]["message_id"] = candidate
+        record["pending_publication"]["metadata"]["message_ref"] = candidate
+        msg_file.write_text(json.dumps(record), encoding="utf-8")
+
+    recovered: list[dict] = []
+    second = _manager(tmp_path, recovered)
+    lock = _start_without_network(second, monkeypatch)
+    assert recovered == []
+    assert not (tmp_path / "wechat" / "escape").exists()
+    second.stop()
+    assert lock.release_calls == 1
+
+
+@pytest.mark.parametrize("kind", ["directory", "file"])
+def test_pending_recovery_ignores_symlinked_message_path(
+    tmp_path, monkeypatch, kind,
+):
+    """Recovery and public views skip symlinked message paths."""
+    first = _manager(tmp_path, on_inbound=lambda _event: False)
+    _deliver(first, _text_msg(from_user="wxid_symlink@im.wechat", text="pending", message_id=75321))
+    inbox_dir = tmp_path / "wechat" / "inbox"
+    msg_dir = next(path for path in inbox_dir.iterdir() if path.is_dir())
+    msg_file = msg_dir / "message.json"
+
+    try:
+        if kind == "directory":
+            target = tmp_path / "outside-pending"
+            msg_dir.rename(target)
+            msg_dir.symlink_to(target, target_is_directory=True)
+            outside_file = target / "message.json"
+        else:
+            target = tmp_path / "outside-message.json"
+            msg_file.rename(target)
+            msg_file.symlink_to(target)
+            outside_file = target
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlinks unavailable on this platform: {exc}")
+
+    sentinel = {
+        "id": "outside-sentinel",
+        "from_user_id": "wxid_outside_sentinel@im.wechat",
+        "body": "OUTSIDE_SENTINEL",
+        "date": "2099-01-01T00:00:00+00:00",
+    }
+    outside_file.write_text(json.dumps(sentinel), encoding="utf-8")
+    outside_content = outside_file.read_bytes()
+
+    recovered: list[dict] = []
+    second = _manager(tmp_path, recovered)
+    lock = _start_without_network(second, monkeypatch)
+    assert recovered == []
+
+    assert second.handle({"action": "check"}) == {"conversations": []}
+    assert second.handle({
+        "action": "read", "user_id": sentinel["from_user_id"],
+    }) == {"messages": []}
+    assert second.handle({
+        "action": "search", "query": "OUTSIDE_SENTINEL",
+    }) == {"matches": []}
+
+    second.stop()
+    assert lock.release_calls == 1
+    assert outside_file.exists()
+    assert outside_file.read_bytes() == outside_content
+    if kind == "directory":
+        assert msg_dir.is_symlink()
+    else:
+        assert msg_file.is_symlink()
+
+
+def test_corrupt_pending_marker_is_ignored_without_new_local_landing(tmp_path):
+    """Malformed self-generated state never widens into a duplicate landing."""
+    user = "wxid_corrupt@im.wechat"
+    mgr1 = _manager(tmp_path, [])
+    _deliver(mgr1, _text_msg(from_user=user, text="corrupt pending", message_id=75304))
+
+    inbox_dir = tmp_path / "wechat" / "inbox"
+    msg_dir = next(inbox_dir.iterdir())
+    record = json.loads((msg_dir / "message.json").read_text())
+    local_id = record["id"]
+    record["pending_publication"] = {"unexpected": "shape"}
+    (msg_dir / "message.json").write_text(json.dumps(record), encoding="utf-8")
+
+    retried: list[dict] = []
+    mgr2 = _manager(tmp_path, retried)
+    _deliver(mgr2, _text_msg(from_user=user, text="corrupt pending", message_id=75304))
+
+    assert retried == []
+    assert _inbox_count(tmp_path) == 1
+    assert next(inbox_dir.iterdir()).name == local_id
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        pytest.param(
+            _text_msg(from_user="wxid_dave@im.wechat", text="ok", message_id=1),
+            _text_msg(from_user="wxid_dave@im.wechat", text="ok", message_id=2),
+            id="different-upstream-ids",
+        ),
+        pytest.param(
+            _text_msg(
+                from_user="wxid_erin@im.wechat", text="here",
+                create_time_ms=1_700_000_000_000,
+            ),
+            _text_msg(
+                from_user="wxid_erin@im.wechat", text="here",
+                create_time_ms=1_700_000_060_000,
+            ),
+            id="different-create-times",
+        ),
+        pytest.param(
+            _text_msg(from_user="wxid_a@im.wechat", text="yo", create_time_ms=42),
+            _text_msg(from_user="wxid_b@im.wechat", text="yo", create_time_ms=42),
+            id="different-senders",
+        ),
+    ],
+)
+def test_distinct_messages_both_land(tmp_path, first, second):
+    """Distinct upstream identity dimensions never suppress a real message."""
     events: list[dict] = []
     mgr = _manager(tmp_path, events)
-    user = "wxid_dave@im.wechat"
-
-    _deliver(mgr, _text_msg(from_user=user, text="ok", message_id=1))
-    _deliver(mgr, _text_msg(from_user=user, text="ok", message_id=2))
-
-    assert _inbox_count(tmp_path) == 2
-    assert len(events) == 2
-
-
-def test_same_text_different_time_both_land(tmp_path):
-    """Content-signature fallback keys on create_time_ms, so the same text
-    sent at two different upstream times is two real messages, not a replay."""
-    events: list[dict] = []
-    mgr = _manager(tmp_path, events)
-    user = "wxid_erin@im.wechat"
-
-    _deliver(mgr, _text_msg(from_user=user, text="here", create_time_ms=1_700_000_000_000))
-    _deliver(mgr, _text_msg(from_user=user, text="here", create_time_ms=1_700_000_060_000))
-
-    assert _inbox_count(tmp_path) == 2
-    assert len(events) == 2
-
-
-def test_same_text_different_users_both_land(tmp_path):
-    """Stable key is namespaced by sender — same text from two users is not
-    a replay."""
-    events: list[dict] = []
-    mgr = _manager(tmp_path, events)
-
-    _deliver(mgr, _text_msg(from_user="wxid_a@im.wechat", text="yo", create_time_ms=42))
-    _deliver(mgr, _text_msg(from_user="wxid_b@im.wechat", text="yo", create_time_ms=42))
-
+    _deliver(mgr, first)
+    _deliver(mgr, second)
     assert _inbox_count(tmp_path) == 2
     assert len(events) == 2
 

--- a/tests/test_wechat_notification_metadata.py
+++ b/tests/test_wechat_notification_metadata.py
@@ -19,6 +19,8 @@ import json
 import uuid
 from pathlib import Path
 
+from lingtai.mcp_servers import _licc_compat
+from lingtai.mcp_servers.wechat import server as wechat_server
 from lingtai.mcp_servers.wechat.manager import (
     WechatManager,
     _CONVERSATION_PREVIEW_MESSAGES,
@@ -202,3 +204,50 @@ def test_latest_incoming_falls_back_to_newest_incoming(tmp_path):
 
     assert metadata["latest_incoming"]["id"] == in1
     assert all("is_current" not in m for m in metadata["recent_messages"])
+
+
+def test_server_closure_uses_real_licc_binding_and_propagates_result(
+    tmp_path, monkeypatch,
+):
+    """The production closure reaches the shared wrapper with stable IDs."""
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        wechat_server,
+        "load_config_and_credentials",
+        lambda: ({}, {"bot_token": "test-token", "user_id": "test-bot"}, tmp_path),
+    )
+    calls: list[dict] = []
+    outcomes = iter((False, True))
+
+    def fake_kernel_push(sender, subject, body, *, metadata=None, wake=True, event_id=None):
+        calls.append({
+            "sender": sender,
+            "subject": subject,
+            "body": body,
+            "metadata": metadata,
+            "wake": wake,
+            "event_id": event_id,
+        })
+        return next(outcomes)
+
+    # Keep the real server binding and shared wrapper; capture only the
+    # wrapper's canonical branch.
+    monkeypatch.setattr(
+        _licc_compat, "_kernel_push_inbox_event", fake_kernel_push,
+    )
+    assert wechat_server.push_inbox_event is _licc_compat.push_inbox_event
+    mgr, _working_dir = wechat_server.build_manager()
+
+    event = {
+        "from": "wxid_server@im.wechat",
+        "subject": "wechat message",
+        "body": "fixture body",
+        "metadata": {"message_id": "local-message-1", "platform": "wechat"},
+        "wake": True,
+    }
+    assert mgr._on_inbound(event) is False
+    assert mgr._on_inbound(event) is True
+    assert [call["event_id"] for call in calls] == [
+        "wechat-local-message-1", "wechat-local-message-1",
+    ]
+    assert [call["wake"] for call in calls] == [True, True]


### PR DESCRIPTION
## Summary

- durably record a private pending-publication event before the WeChat seen barrier, then retry failed callback delivery with the same local message UUID
- drain pending callbacks only after account-lock ownership, with transactional rollback for recovery/event-loop/thread startup failures
- pass a deterministic `wechat-<local UUID>` through the actual shared LICC compatibility wrapper, while keeping malformed/symlink/path-mismatched state fail-closed and stripping the private marker from public reads

Related to Lingtai-AI/lingtai#753.

This PR fixes a deterministic producer-side delivery/acknowledgement defect reproduced on current main. It does **not** establish that this defect caused the historical #753 worker-hang/refresh incident; that historical causation remains unproven.

## Root cause

The WeChat producer wrote the local inbox record and durable seen mapping before learning whether the LICC callback accepted the event. If the callback returned `False` or raised, a fresh manager treated the stable remote key as already seen and never retried publication. The local record survived, but the wake/publication transition could be lost.

The repair stores the complete callback event privately in the first atomic local record before the seen barrier. Explicit `False` and exceptions retain it; accepted delivery clears it. Startup recovery and same-manager replay reuse the existing local UUID, and the shared wrapper forwards the deterministic event ID to the canonical LICC writer.

## Slimming result

After review of the original `+977/-65` candidate, the final behavior-preserving pass reduced the patch to `+871/-96`:

- production: `+335/-65` → `+317/-67`
- tests: `+642/-0` → `+554/-29`
- total changed lines: `1042` → `967` (`75` fewer, about `7.2%`)

The pass removed duplicated scenarios/scaffolding and an unearned callback-less manager mode. It retained the failing-first and real unmocked WeChat→shared-LICC proof, crash/replay state-machine coverage, lock ownership, startup rollback, malformed-state and public-privacy boundaries. A final independent exact-Terra whole-diff/minimality review judged this the smallest honest surface for those earned invariants.

## Validation

Exact integration base: `7d82f7e183041d35021f5a4ce42a063ff512ea81`.
Final head/tree: `02b9a0b95e1a2ceef86e1477ce5c545a82ca186f` / `c2a89e7e2837cfe49c57cc88ab2f58e3585f6416`.

- deterministic untouched-base failing-first: callback `False` and exception each left one local UUID, but fresh-manager replay never reached the succeeding callback
- final parent gates: 207 owning/shared/adjacent + 82 docs/architecture + 300 docs-governance tests passed
- final broad MCP gate: 315 passed with explicit `anyio.pytest_plugin`
- compile, `git diff --check`, clean-file Ruff, and exact latest-main Ruff-output parity for the manager passed
- final exact-Terra whole-diff/minimality review: 11/11 `gpt-5.6-terra` ledger rows, PASS, no P0/P1/P2
- final frozen patch: 6 files, `+871/-96`, SHA-256 `0e727d9d86bea4fa787f8bfba7c549b5e6bf3b37276f0665f85fd44966c14a8f`
- final Terra report SHA-256: `b666724c81f40ce9bea25def8cab986f675c887ab49c05f83a83536aece42a30`

## Earned invariants

- durable `pending` before `seen`
- explicit `False` / exception retains pending; `None` / truthy acceptance clears it
- same UUID is retried in the same manager and after a fresh manager start
- account lock is acquired before pending drain
- event-loop/thread/start failures roll back and release ownership
- real shared LICC `event_id` forwarding and compatibility fallback
- malformed JSON, symlinks, path-shaped/mismatched IDs, and seen conflicts fail closed
- public `check`, `read`, and `search` hide private pending state and outside targets

## Scope and non-goals

This is a WeChat producer repair plus the shared compatibility signature it requires. It does not change generic `MCPInbox`, fan-in publication, ASLEEP/wake policy, cross-channel deduplication, configuration, credentials, or runtime lifecycle. Delivery is intentionally idempotent/at-least-once through deterministic file replacement; it does not claim end-to-end exactly-once host consumption.

**Merge remains on hold pending a separate maintainer decision after review of this slimmed update.**
