### PR TITLE
fix(cloud-mail): retry failed wake delivery

### DIFF
--- a/src/lingtai/mcp_servers/cloud_mail/manager.py
+++ b/src/lingtai/mcp_servers/cloud_mail/manager.py
@@ -156,7 +156,7 @@ class CloudMailManager:
         accounts: list[dict],
         *,
         working_dir: Path | str | None = None,
-        on_inbound: Callable[[dict], None] | None = None,
+        on_inbound: Callable[[dict], bool | None] | None = None,
         transport=None,
     ) -> None:
         self._working_dir = Path(working_dir) if working_dir else None
@@ -445,15 +445,25 @@ class CloudMailManager:
             key=_eid,
         )
         pushed = 0
+        safe_id = last_id
         for r in new_rows:
+            email_id = _eid(r)
             if not acct.sender_allowed(r.get("sendEmail")):
+                safe_id = email_id
                 continue
-            if self._push_licc(acct, r):
-                pushed += 1
-        # Advance watermark to the max we observed regardless of allow-list,
-        # so filtered-out senders don't replay forever.
-        if max_id > last_id:
-            acct.watermark.set_last_email_id(max_id, seeded=True)
+            if not self._push_licc(acct, r):
+                # Do not deliver or advance past a failed allowed row. The next
+                # poll retries it before any later rows in this page.
+                log.warning(
+                    "cloud_mail delivery paused at %s:%s; retrying next poll",
+                    acct.alias,
+                    email_id,
+                )
+                break
+            pushed += 1
+            safe_id = email_id
+        if safe_id > last_id:
+            acct.watermark.set_last_email_id(safe_id, seeded=True)
         return pushed
 
     def _push_licc(self, acct: CloudMailAccount, row: dict) -> bool:
@@ -462,7 +472,7 @@ class CloudMailManager:
         email_id = row.get("emailId")
         compound = f"{acct.alias}:{email_id}"
         sender = row.get("sendEmail") or row.get("sendName") or "unknown"
-        subject = row.get("subject") or "(no subject)"
+        subject = str(row.get("subject") or "(no subject)")[:200]
         body = row.get("text") or _strip_to_text(row.get("content")) or ""
         event = {
             "from": sender,
@@ -482,8 +492,7 @@ class CloudMailManager:
             },
         }
         try:
-            self._on_inbound(event)
-            return True
+            return self._on_inbound(event) is not False
         except Exception:
             log.exception("cloud_mail LICC push failed for %s", compound)
             return False

--- a/src/lingtai/mcp_servers/cloud_mail/server.py
+++ b/src/lingtai/mcp_servers/cloud_mail/server.py
@@ -115,8 +115,8 @@ def build_manager() -> tuple[CloudMailManager, Path]:
     working_dir = Path(agent_dir_raw) if agent_dir_raw else Path.cwd()
     working_dir.mkdir(parents=True, exist_ok=True)
 
-    def _on_inbound(event: dict) -> None:
-        push_inbox_event(
+    def _on_inbound(event: dict) -> bool:
+        return push_inbox_event(
             sender=event["from"],
             subject=event["subject"],
             body=event["body"],

--- a/tests/test_cloud_mail_addon.py
+++ b/tests/test_cloud_mail_addon.py
@@ -424,6 +424,114 @@ def test_allowed_senders_filter_case_insensitive(tmp_path):
     mgr.stop()
 
 
+def test_explicit_false_callback_is_delivery_failure(tmp_path):
+    transport, _ = make_router(rows=[])
+    mgr = CloudMailManager(
+        accounts=[{
+            "alias": "cloudmail",
+            "base_url": "https://mail.example.com",
+            "admin_email": "admin@example.com",
+            "admin_password": "adminpw",
+        }],
+        working_dir=tmp_path,
+        on_inbound=lambda _event: False,
+        transport=transport,
+    )
+
+    assert mgr._push_licc(mgr.default_account, _row(1)) is False
+    mgr.stop()
+
+
+def test_push_licc_truncates_subject_to_licc_limit(tmp_path):
+    events = []
+    transport, _ = make_router(rows=[])
+    mgr = CloudMailManager(
+        accounts=[{
+            "alias": "cloudmail",
+            "base_url": "https://mail.example.com",
+            "admin_email": "admin@example.com",
+            "admin_password": "adminpw",
+        }],
+        working_dir=tmp_path,
+        on_inbound=events.append,
+        transport=transport,
+    )
+    row = _row(1)
+    row["subject"] = "x" * 250
+
+    assert mgr._push_licc(mgr.default_account, row) is True
+    assert events[0]["subject"] == "x" * 200
+    mgr.stop()
+
+
+def test_failed_allowed_row_stops_batch_and_retries_next_poll(tmp_path, caplog):
+    rows = [_row(1, sender="allowed@x.com")]
+    delivered = []
+    outcomes = {2: True, 4: False, 5: True}
+
+    def sink(event):
+        email_id = event["metadata"]["email_id"]
+        delivered.append(email_id)
+        return outcomes[email_id]
+
+    transport, _ = make_router(rows=rows)
+    mgr = CloudMailManager(
+        accounts=[{
+            "alias": "cloudmail",
+            "base_url": "https://mail.example.com",
+            "admin_email": "admin@example.com",
+            "admin_password": "adminpw",
+            "allowed_senders": ["allowed@x.com"],
+        }],
+        working_dir=tmp_path,
+        on_inbound=sink,
+        transport=transport,
+    )
+    acct = mgr.default_account
+    mgr.poll_once(acct)  # seed at 1
+    rows[:0] = [
+        _row(5, sender="allowed@x.com"),
+        _row(4, sender="allowed@x.com"),
+        _row(3, sender="disallowed@x.com"),
+        _row(2, sender="allowed@x.com"),
+    ]
+
+    assert mgr.poll_once(acct) == 1
+    assert delivered == [2, 4]
+    assert acct.watermark.last_email_id == 3
+    assert "delivery paused at cloudmail:4" in caplog.text
+
+    outcomes[4] = True
+    assert mgr.poll_once(acct) == 2
+    assert delivered == [2, 4, 4, 5]
+    assert acct.watermark.last_email_id == 5
+    mgr.stop()
+
+
+def test_build_manager_propagates_false_inbox_result(tmp_path, monkeypatch):
+    monkeypatch.setenv("LINGTAI_AGENT_DIR", str(tmp_path))
+    monkeypatch.setattr(cm_server, "load_config", lambda: {
+        "accounts": [{
+            "alias": "cloudmail",
+            "base_url": "https://mail.example.com",
+            "admin_email": "admin@example.com",
+            "admin_password": "adminpw",
+        }],
+    })
+    monkeypatch.setattr(cm_server, "push_inbox_event", lambda **_kwargs: False)
+
+    mgr, _ = cm_server.build_manager()
+    event = {
+        "from": "sender@example.com",
+        "subject": "subject",
+        "body": "body",
+        "metadata": {"email_id": 1},
+        "wake": True,
+    }
+    assert mgr._on_inbound(event) is False
+    mgr.stop()
+
+
 def test_add_user_uses_cloud_mail_batch_contract(tmp_path):
     mgr, captured = make_manager(tmp_path)
     out = mgr.handle({


### PR DESCRIPTION
## Summary

- keep the Cloud Mail watermark behind the first allowed message whose LICC wake delivery returns `False`
- advance through disallowed messages and successfully delivered messages, then retry the failed row first on the next poll
- preserve legacy callbacks that return `None`, propagate the current MCP2 server callback's Boolean result, and bound subjects to the LICC 200-character contract

## Provenance and credit

This is a fresh current-main recut of #879 for #644. The original investigation and patch were authored by @TZZheng; the replacement commit preserves TZZheng as the Git author while applying the exact stable patch to current main.

Stable patch-id: `8bd63564b0ab4225402bb4886433d3789ed69b8b`

## LICC contract check

The existing LICC contract was rechecked. Event identity, schema, preview/persistent-lane behavior, dismissal ownership, and authority semantics are unchanged. This patch only makes the Cloud Mail producer honor the existing Boolean delivery result when deciding how far it may advance its watermark, so no Anatomy/manual contract change is needed.

## Validation

Exact base: `7d82f7e183041d35021f5a4ce42a063ff512ea81`  
Candidate tree: `d82f83b419fe1ca7101d53138f537fa8627fa68a`

- Cloud Mail + LICC + MCP2 + architecture/docs: **265 passed** on Python 3.13.14 / MCP 2.0.0
- `git diff --check`: PASS
- `py_compile` for the two production files: PASS
- canonical pool Terra exact-slice review: no correctness blocker; recommend fresh recut rather than reviving the stale branch
- current main moved only through #862 after the review; it did not touch these three paths, and the fresh candidate preserves the exact stable patch-id above

## Explicit non-goals

No IMAP behavior change, durable spool/dead-letter queue, pagination/backlog guarantee, or lifecycle refactor.

Closes #644.
Supersedes #879 while preserving its author credit.
