### PR TITLE
docs(task-card): guide proactive producer use

### DIFF
--- a/src/lingtai/tools/task_card/CONTRACT.md
+++ b/src/lingtai/tools/task_card/CONTRACT.md
@@ -91,6 +91,12 @@ declarative artifact and one active watch per agent.
     `max_refreshes` at its own never-customized default — migrating that
     incidental value would silently cap most ordinary agents below the new
     built-in default instead of leaving them on it.
+12. Agents SHOULD start a watch proactively — without being asked — when a
+    human is following meaningful long-running, multi-step, or parallel work
+    and a durable progress view would materially help; they SHOULD NOT start
+    one for quick single-step work, as ritual, or when they cannot keep the
+    rendered body truthful and current. This is agent usage guidance, not a
+    runtime-enforced precondition.
 
 ## Port
 
@@ -131,8 +137,9 @@ Public LTP-v2 family root `task_card` with actions `start`, `inspect`, `retry`,
 - `tests/test_task_card_controller.py` covers intrinsic registration,
   exact paths, atomic ordering, one-watch enforcement, failure/recovery, stop
   semantics, configured defaults/ceilings (including the omitted-value and
-  lower-not-bypass cases), per-field config validation, and the one-way
-  legacy-migration fallback.
+  lower-not-bypass cases), per-field config validation, the one-way
+  legacy-migration fallback, and the proactive-use guidance carried in the
+  description, manual, and this contract's Behavior rule 12.
 - `tests/test_telegram_toolfamily_ltpv2.py` covers the strict public family
   schema plus intrinsic refresh-limit behavior.
 - `tests/test_telegram_task_card_programmable.py` covers Telegram's read-only

--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -138,7 +138,10 @@ def get_description() -> str:
         "body to write into taskcard/taskcard.md. The capability writes taskcard/"
         "taskcard.md atomically, writes taskcard/status as exact active/inactive, "
         "keeps at most one active watch per agent, and leaves projection to "
-        "channel-specific readers. Actions: start, inspect, retry, stop, manual."
+        "channel-specific readers. Use it proactively for meaningful long-running, "
+        "multi-step, or parallel work so a human can follow progress; skip it for "
+        "quick single-step work, ritual updates, or a body you cannot keep truthful "
+        "and current. Actions: start, inspect, retry, stop, manual."
     )
 
 

--- a/src/lingtai/tools/task_card/manual/SKILL.md
+++ b/src/lingtai/tools/task_card/manual/SKILL.md
@@ -15,6 +15,16 @@ maintenance: |
 
 Use `task_card` to maintain one agent-local declarative Task Card artifact.
 
+## When to use it
+
+Start a watch proactively — without waiting to be asked — whenever a human is
+following meaningful long-running, multi-step, or parallel work and a durable
+progress view would materially help them track it. Skip it for quick
+single-step work: starting a watch you will stop moments later is ritual
+noise, not progress reporting. Only keep a watch running while you can make
+its renderer output truthful and current; a stale or inaccurate card misleads
+more than no card at all, so stop the watch rather than let it drift.
+
 The capability owns exactly two files under your working directory:
 
 - `taskcard/status`

--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -74,6 +74,29 @@ def test_description_routes_to_manual_and_file_contract():
     assert "manual" in desc.lower()
 
 
+def test_description_manual_and_contract_encourage_proactive_use():
+    """The schema, manual, and Contract Behavior all teach when to (not) use it."""
+    use_fragments = ["long-running", "multi-step", "parallel"]
+    skip_fragments = ["single-step", "ritual", "truthful"]
+
+    desc = get_description()
+    for fragment in use_fragments + skip_fragments:
+        assert fragment in desc, f"{fragment!r} missing from get_description()"
+
+    root = Path(__file__).resolve().parents[1]
+    manual_body = (root / "src/lingtai/tools/task_card/manual/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    for fragment in use_fragments + skip_fragments:
+        assert fragment in manual_body, f"{fragment!r} missing from manual/SKILL.md"
+
+    contract_body = (root / "src/lingtai/tools/task_card/CONTRACT.md").read_text(
+        encoding="utf-8"
+    )
+    for fragment in use_fragments + skip_fragments:
+        assert fragment in contract_body, f"{fragment!r} missing from CONTRACT.md"
+
+
 def test_start_writes_body_before_active_and_reports_exact_paths(agent, manager, monkeypatch):
     renderer = _write_renderer(agent._working_dir, _OK_BODY)
     order: list[str] = []


### PR DESCRIPTION
## Summary

- encourage agents to start intrinsic Task Card watches proactively for meaningful long-running, multi-step, or parallel work when a durable progress view helps the human
- explicitly discourage Task Cards for quick single-step work, ritual updates, or bodies the agent cannot keep truthful and current
- keep this as model-facing usage guidance only — no runtime precondition, watcher, config, transport policy, or automatic behavior
- pin description/manual/CONTRACT parity with a focused regression test

## Rebase note

This follow-up is rebased directly onto merged #1098 (`51b7e7b9`). The only stacked conflict was in `CONTRACT.md`; the resolution preserves #1098's persisted-config Behavior rules 9–11 byte-for-byte and adds proactive-use guidance as rule 12. Existing rule-11 references remain correct.

## Validation

- parent focused gate: `55 passed`
- exact independent Claude Opus 5 review: `ACCEPT`, no blockers
- Opus controller boundary: `48 passed`
- Opus three CONTRACT-listed suites: `66 passed`
- `py_compile`, `git diff --check`, and conflict-marker scan passed
- exact diff: 4 files, +46/-3
