### PR TITLE
feat(task-card): add remove lifecycle action

### DIFF
--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -295,10 +295,12 @@ chat-history cardinality. Normative source:
   `<workdir>/taskcard/taskcard.md`, then writes exact `active` to
   `<workdir>/taskcard/status`. `stop` and agent shutdown write exact `inactive`;
   the last body remains on disk.
-- Actions are `start | inspect | retry | stop | manual`. `start` performs the
-  first render synchronously and starts no watch on failure. `retry` updates only
-  the body for the active watch. `stop` deactivates the intrinsic artifact. One
-  intrinsic-owned watch may be active per agent.
+- Actions are `start | inspect | retry | stop | remove | manual`. `start`
+  performs the first render synchronously and starts no watch on failure.
+  `retry` updates only the body for the active watch. `stop` deactivates the
+  intrinsic artifact while preserving its body; `remove` is terminal cleanup
+  that retires the watch and deletes the body. One intrinsic-owned watch may be
+  active per agent.
 - Telegram is only a read-only resident projector for that artifact. Its poller
   reads `taskcard/status` and `taskcard/taskcard.md`; exact `active` plus a
   nonempty body may project under `— WATCH —`. Missing, invalid, inactive, or

--- a/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
@@ -28,8 +28,8 @@ The authoritative public capability owner is
 model-facing instructions live at
 [`src/lingtai/tools/task_card/manual/SKILL.md`](../../../tools/task_card/manual/SKILL.md).
 Use that intrinsic manual for renderer authoring, the
-`start | inspect | retry | stop | manual` actions, refresh limits, failure
-handling, and terminal cleanup.
+`start | inspect | retry | stop | remove | manual` actions, refresh limits,
+failure handling, and terminal cleanup.
 
 Current contract summary:
 

--- a/src/lingtai/prompts/procedures/procedures.md
+++ b/src/lingtai/prompts/procedures/procedures.md
@@ -188,6 +188,17 @@ When there is nothing to do, go idle rather than using timed sleep. ASLEEP agent
 wake by mail; SUSPENDED agents need CPR. Use `system-manual` for lifecycle
 operations, preset swaps, notification handling, and karma actions.
 
+### Task Card Lifecycle
+
+Start a `task_card` watch only for meaningful ongoing work a human is
+following; skip it for quick single-step work or ritual updates. Keep the
+rendered body truthful and current while it runs, and optionally `retry` once
+more to publish a final state before winding down. Use `stop` to pause a watch
+while preserving its last body; use `remove` once the work is completed,
+cancelled, or abandoned so `/taskcard` and other consumers cannot keep
+exposing a stale card — never reach around it with a shell/file-tool delete.
+Read `task_card(action='manual')` for the full contract.
+
 ### Molt and Durable Stores
 
 **If you are about to molt, first read `context-manual`.** It owns the molt

--- a/src/lingtai/tools/task_card/ANATOMY.md
+++ b/src/lingtai/tools/task_card/ANATOMY.md
@@ -24,7 +24,10 @@ plus its persisted agent-wide configuration, both under `<workdir>/taskcard/`,
 and nothing else. It is producer-first and channel-neutral: it runs a
 renderer, writes `taskcard/taskcard.md`, and writes `taskcard/status` as exact
 `active` or `inactive`, reading `taskcard/taskcard.json` to resolve each new
-watch's cadence/ceiling defaults. It does not own Telegram, Feishu, portals,
+watch's cadence/ceiling defaults. `stop` pauses a watch and preserves the last
+body; `remove` is the terminal lifecycle action that also retires any active
+watch and deletes the body, so a caller never needs to reach around this
+capability with a filesystem delete. It does not own Telegram, Feishu, portals,
 chat IDs, retry policy against a transport, or any resident message state.
 Normative promises live in [`CONTRACT.md`](CONTRACT.md).
 
@@ -76,8 +79,10 @@ Normative promises live in [`CONTRACT.md`](CONTRACT.md).
 ## Notes
 
 - Atomic ordering is the structural point of this unit: write the body fully
-  before activation, update the body by atomic replace, and write `inactive`
-  before stopping.
+  before activation, update the body by atomic replace, write `inactive`
+  before stopping, and — for `remove` — confirm the watch has quiesced before
+  deleting the body, so the updater can never recreate a file `remove` just
+  removed.
 - Missing, invalid, or inactive producer state is a consumer concern. This
   intrinsic capability only writes the artifact truthfully.
 - The legacy-config migration is a one-time bootstrap, not an integration:

--- a/src/lingtai/tools/task_card/CONTRACT.md
+++ b/src/lingtai/tools/task_card/CONTRACT.md
@@ -41,7 +41,9 @@ declarative artifact and one active watch per agent.
 3. `retry` reruns the renderer for the active watch. On success it atomically
    replaces only `taskcard/taskcard.md`; `status` remains `active`.
 4. `stop` and agent shutdown write exact `inactive` before stopping the updater.
-   The last body remains on disk.
+   The last body remains on disk. `stop` is non-terminal: it pauses/preserves
+   the artifact for a possible later `retry`/inspection, it does not clean it
+   up.
 5. At most one watch may be active per agent. A second `start` fails closed.
 6. The capability is channel-neutral. It MUST NOT own transport-specific
    concepts such as Telegram chat/message IDs, API retries, or consumer
@@ -97,17 +99,36 @@ declarative artifact and one active watch per agent.
     one for quick single-step work, as ritual, or when they cannot keep the
     rendered body truthful and current. This is agent usage guidance, not a
     runtime-enforced precondition.
+13. `remove` is the terminal lifecycle cleanup, distinct from `stop`. It first
+    retires any active watch exactly as `stop` does — write `inactive`, then
+    join the updater thread — so the updater cannot race a deleted body back
+    into existence; only once that retirement is confirmed does it delete
+    `taskcard/taskcard.md`. If the watch will not quiesce (the same failure
+    `stop` can report), `remove` reports that failure and does not delete the
+    body, leaving the watch retryable exactly as an unsuccessful `stop` would.
+    `remove` takes no `watch_id`: it targets this agent's one artifact, not a
+    specific in-memory watch, so it stays useful after a restart lost the
+    watch handle. It is idempotent — calling it again after a successful
+    removal, or when no watch was ever started, still leaves `status` at
+    exact `inactive` and reports no body removed, never an error. Agents
+    SHOULD call `remove` once the underlying work is completed, cancelled, or
+    abandoned, so a consumer such as `/taskcard` cannot keep exposing a stale
+    card; agents MUST NOT reach around this capability with a shell/file-tool
+    delete of `taskcard/taskcard.md`.
 
 ## Port
 
 Public LTP-v2 family root `task_card` with actions `start`, `inspect`, `retry`,
-`stop`, and `manual`.
+`stop`, `remove`, and `manual`.
 
 ## Adapters
 
 - Renderer subprocess: `sys.executable <renderer>` with `cwd` set to the agent
   working directory.
-- Filesystem artifact writer: atomic temp-file write + `fsync` + `os.replace`.
+- Filesystem artifact writer: atomic temp-file write + `fsync` + `os.replace`
+  for `start`/`retry`/`stop`; `remove` additionally unlinks `taskcard/
+  taskcard.md` (tolerating an already-missing file) after the watch is
+  retired.
 - Filesystem config reader: plain read of `taskcard/taskcard.json` (no fsync;
   read-only in the steady state) plus the one-way legacy-migration writer
   described in Behavior rule 11.
@@ -121,16 +142,19 @@ Public LTP-v2 family root `task_card` with actions `start`, `inspect`, `retry`,
 2. `taskcard/taskcard.md` must never be partially visible to a consumer.
 3. Activation order is strict: body first, then `active`.
 4. Deactivation order is strict: write `inactive` before stopping the updater.
-5. The tool result for `start`/`inspect`/`retry`/`stop` must report the exact
-   artifact paths and current `status_value`.
+5. The tool result for `start`/`inspect`/`retry`/`stop`/`remove` must report the
+   exact artifact paths and current `status_value`.
 6. `manual` must remain discoverable from both this contract and the paired
    Anatomy.
 7. Configuration is resolved fresh from `taskcard/taskcard.json` on every
-   `start`; `inspect`/`retry`/`stop` act only on values already fixed onto the
-   existing watch and never re-resolve configuration.
+   `start`; `inspect`/`retry`/`stop`/`remove` act only on values already fixed
+   onto the existing watch and never re-resolve configuration.
 8. The legacy migration in Behavior rule 11 MUST NOT become an ongoing read
    path: it is gated strictly on `taskcard/taskcard.json` not yet existing, not
    on its content being valid.
+9. Removal order is strict: retire the watch (write `inactive`, then confirm
+   the updater has quiesced) before deleting `taskcard/taskcard.md`. `remove`
+   MUST NOT delete the body while a watch might still be running.
 
 ## Tests
 
@@ -138,8 +162,11 @@ Public LTP-v2 family root `task_card` with actions `start`, `inspect`, `retry`,
   exact paths, atomic ordering, one-watch enforcement, failure/recovery, stop
   semantics, configured defaults/ceilings (including the omitted-value and
   lower-not-bypass cases), per-field config validation, the one-way
-  legacy-migration fallback, and the proactive-use guidance carried in the
-  description, manual, and this contract's Behavior rule 12.
+  legacy-migration fallback, the proactive-use guidance carried in the
+  description, manual, and this contract's Behavior rule 12, and `remove`'s
+  terminal cleanup: removal after a stopped watch, removal of an active watch
+  with no body-recreation race, blocking (without deleting) on a watch that
+  will not quiesce, and idempotence when already removed or never started.
 - `tests/test_telegram_toolfamily_ltpv2.py` covers the strict public family
   schema plus intrinsic refresh-limit behavior.
 - `tests/test_telegram_task_card_programmable.py` covers Telegram's read-only

--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -101,12 +101,14 @@ _START_INPUT_SCHEMA = _object(
     required=["renderer_path"],
 )
 _WATCH_INPUT_SCHEMA = _object({"watch_id": {"type": "string"}}, required=["watch_id"])
+_REMOVE_INPUT_SCHEMA = _object({}, required=[])
 
 _CHILDREN: tuple[tuple[str, dict[str, Any]], ...] = (
     ("start", _START_INPUT_SCHEMA),
     ("inspect", _WATCH_INPUT_SCHEMA),
     ("retry", _WATCH_INPUT_SCHEMA),
     ("stop", _WATCH_INPUT_SCHEMA),
+    ("remove", _REMOVE_INPUT_SCHEMA),
     ("manual", MANUAL_INPUT_SCHEMA),
 )
 
@@ -126,7 +128,8 @@ def get_schema() -> dict[str, Any]:
     schema["properties"]["action"]["description"] = (
         "Declarative Task Card action. start keeps one renderer watch writing the "
         "agent-local taskcard/status and taskcard/taskcard.md files; inspect, retry, "
-        "stop, and manual read or control that one artifact."
+        "and stop read or control that one artifact; remove is the terminal "
+        "lifecycle cleanup; manual explains the full contract."
     )
     return schema
 
@@ -141,7 +144,10 @@ def get_description() -> str:
         "channel-specific readers. Use it proactively for meaningful long-running, "
         "multi-step, or parallel work so a human can follow progress; skip it for "
         "quick single-step work, ritual updates, or a body you cannot keep truthful "
-        "and current. Actions: start, inspect, retry, stop, manual."
+        "and current. Use stop to pause a watch while preserving its last body, and "
+        "remove once the work is completed, cancelled, or abandoned so the artifact "
+        "cannot mislead a consumer as stale. Actions: start, inspect, retry, stop, "
+        "remove, manual."
     )
 
 
@@ -225,6 +231,7 @@ class TaskCardManager:
             ChildTool("inspect", _WATCH_INPUT_SCHEMA, self._inspect_child),
             ChildTool("retry", _WATCH_INPUT_SCHEMA, self._retry_child),
             ChildTool("stop", _WATCH_INPUT_SCHEMA, self._stop_child),
+            ChildTool("remove", _REMOVE_INPUT_SCHEMA, self._remove_child),
             build_manual_child(self._agent, _MANUAL_SKILL_NAME),
         ]
         return ToolFamily("task_card", children)
@@ -381,6 +388,72 @@ class TaskCardManager:
             **self._status_payload("inactive"),
             **self._refresh_fields(watch),
         }
+
+    def _remove_child(self, input_: dict[str, Any]) -> dict[str, Any]:
+        """Terminal lifecycle cleanup: retire any active watch, then delete the body.
+
+        Unlike ``stop``, ``remove`` takes no ``watch_id`` — it targets this
+        agent's one artifact, not a specific watch, so it stays useful even
+        after a restart lost the in-memory watch handle. If a watch is
+        active it is retired exactly like ``stop`` (write ``inactive`` before
+        the updater joins), so the updater cannot race a deleted body back
+        into existence; only once that retirement is confirmed is the body
+        actually removed. A stop failure (thread still running) blocks
+        removal and is returned verbatim under ``state: "remove_blocked"`` so
+        the caller can retry once the watch is quiescent.
+        """
+        with self._lock:
+            watch = self._watch
+        if watch is not None:
+            stopped = self._stop_watch(watch)
+            if stopped["status"] != "ok":
+                return {**stopped, "state": "remove_blocked"}
+        return self._finalize_remove()
+
+    def _finalize_remove(self) -> dict[str, Any]:
+        try:
+            self._write_status("inactive")
+        except OSError as exc:
+            return {
+                "status": "error",
+                "state": "remove_failed",
+                "error": {
+                    "code": "remove_finalize_failed",
+                    "retryable": True,
+                    "message": f"failed to write inactive status: {type(exc).__name__}",
+                },
+                **self._paths_payload(),
+                **self._status_payload("inactive"),
+            }
+        body_removed, delete_error = self._delete_body()
+        if delete_error is not None:
+            return {
+                "status": "error",
+                "state": "remove_failed",
+                "error": {
+                    "code": "remove_body_failed",
+                    "retryable": True,
+                    "message": f"failed to remove task card body: {type(delete_error).__name__}",
+                },
+                **self._paths_payload(),
+                **self._status_payload("inactive"),
+            }
+        return {
+            "status": "ok",
+            "state": "removed",
+            "body_removed": body_removed,
+            **self._paths_payload(),
+            **self._status_payload("inactive"),
+        }
+
+    def _delete_body(self) -> tuple[bool, OSError | None]:
+        try:
+            self._body_path.unlink()
+        except FileNotFoundError:
+            return False, None
+        except OSError as exc:
+            return False, exc
+        return True, None
 
     def _spawn(self, watch: _Watch) -> None:
         watch.thread = threading.Thread(

--- a/src/lingtai/tools/task_card/manual/SKILL.md
+++ b/src/lingtai/tools/task_card/manual/SKILL.md
@@ -23,14 +23,18 @@ progress view would materially help them track it. Skip it for quick
 single-step work: starting a watch you will stop moments later is ritual
 noise, not progress reporting. Only keep a watch running while you can make
 its renderer output truthful and current; a stale or inaccurate card misleads
-more than no card at all, so stop the watch rather than let it drift.
+more than no card at all. Optionally `retry` once more to publish a final
+state before winding down. Use `stop` to pause a watch while preserving its
+last body for a possible later `retry`/inspection; use `remove` once the
+underlying work is completed, cancelled, or abandoned, so `/taskcard` and
+other consumers cannot keep exposing a stale card.
 
 The capability owns exactly two files under your working directory:
 
 - `taskcard/status`
 - `taskcard/taskcard.md`
 
-Actions are `start`, `inspect`, `retry`, `stop`, and `manual`.
+Actions are `start`, `inspect`, `retry`, `stop`, `remove`, and `manual`.
 
 `start` runs a Python renderer under your working directory. The renderer must
 exit `0` and print a nonempty full body to stdout; that body is written to
@@ -41,7 +45,23 @@ writes `taskcard/status` as the exact text `active`.
 only `taskcard/taskcard.md` atomically; the status stays `active`.
 
 `stop` writes `taskcard/status` as `inactive` before stopping the updater. The
-last body stays on disk. Consumers treat non-`active` status as no-op.
+last body stays on disk. Consumers treat non-`active` status as no-op. `stop`
+is for pausing/preserving a card you may still `retry` or reinspect — it is
+not lifecycle cleanup.
+
+`remove` is the terminal lifecycle action: it retires any active watch exactly
+like `stop` (write `inactive`, then wait for the updater to quiesce) and then
+deletes `taskcard/taskcard.md`, so it never races the updater into recreating
+a body it just removed. It takes no `watch_id` — it targets your one artifact,
+not a specific in-memory watch — so it still works after a restart lost the
+watch handle. Call `remove`, not a shell/file-tool delete, once the underlying
+work is completed, cancelled, or abandoned, so `/taskcard` and other consumers
+cannot keep exposing a stale card. `remove` is idempotent: calling it again
+after a successful removal, or when no watch was ever started, still leaves
+`status` at exact `inactive` and reports no body to delete, never an error. If
+the watch will not quiesce (the same failure `stop` can report), `remove`
+reports that failure and leaves the body untouched so you can retry once the
+updater is actually stopped.
 
 ## Cadence and safety defaults
 

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -232,7 +232,7 @@ def test_shipped_task_card_manuals_only_document_intrinsic_file_contract() -> No
         assert "taskcard/status" in body, name
         assert "taskcard/taskcard.md" in body, name
         assert "nonempty" in lowered, name
-        for action in ("start", "inspect", "retry", "stop", "manual"):
+        for action in ("start", "inspect", "retry", "stop", "remove", "manual"):
             assert action in lowered, (name, action)
         for forbidden in forbidden_active_contracts:
             assert forbidden not in lowered, (name, forbidden)

--- a/tests/test_intrinsic_manual_actions.py
+++ b/tests/test_intrinsic_manual_actions.py
@@ -182,7 +182,7 @@ def test_manual_schemas_preserve_runtime_checks_for_ordinary_file_calls(
     assert len(vision_schema["properties"]["input"]["oneOf"]) == 2
     task_card_schema = task_card_tool.get_schema()
     assert task_card_schema["required"] == ["action", "input", "reasoning"]
-    assert len(task_card_schema["properties"]["input"]["oneOf"]) == 5
+    assert len(task_card_schema["properties"]["input"]["oneOf"]) == 6
     # ``shell`` is migrated to the same LTP v2 envelope, with four children.
     shell_schema = shell_tool.get_schema()
     assert shell_schema["required"] == ["action", "input", "reasoning"]

--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -203,6 +203,143 @@ def test_stop_writes_inactive_before_removing_the_watch(agent, manager, monkeypa
     assert writes == ["inactive"]
 
 
+def test_remove_after_stop_deletes_the_preserved_body(agent, manager):
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": _write_renderer(agent._working_dir, _OK_BODY), "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    manager.handle({"action": "stop", "input": {"watch_id": started["watch_id"]}, "reasoning": "pause"})
+    assert Path(started["body_path"]).exists()
+
+    result = manager.handle({"action": "remove", "input": {}, "reasoning": "work is done"})
+
+    assert result["status"] == "ok"
+    assert result["state"] == "removed"
+    assert result["body_removed"] is True
+    assert result["status_value"] == "inactive"
+    assert not Path(result["body_path"]).exists()
+    assert Path(result["status_path"]).read_text(encoding="utf-8") == "inactive"
+    assert manager._watch is None
+
+
+def test_remove_while_active_retires_the_watch_before_deleting_the_body(agent, manager, monkeypatch):
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": _write_renderer(agent._working_dir, _OK_BODY), "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    watch = manager._watch
+    assert watch.thread is not None and watch.thread.is_alive()
+
+    order: list[str] = []
+    real_stop_watch = manager._stop_watch
+    real_delete_body = manager._delete_body
+
+    def record_stop(w):
+        order.append("stop")
+        return real_stop_watch(w)
+
+    def record_delete():
+        order.append("delete")
+        return real_delete_body()
+
+    monkeypatch.setattr(manager, "_stop_watch", record_stop)
+    monkeypatch.setattr(manager, "_delete_body", record_delete)
+
+    result = manager.handle({"action": "remove", "input": {}, "reasoning": "abandon this work"})
+
+    assert order == ["stop", "delete"]
+    assert result["status"] == "ok"
+    assert result["state"] == "removed"
+    assert result["body_removed"] is True
+    assert not Path(started["body_path"]).exists()
+    assert Path(started["status_path"]).read_text(encoding="utf-8") == "inactive"
+    assert manager._watch is None
+    # The updater thread is fully joined before the body is unlinked, so it
+    # cannot race a deleted body back into existence.
+    assert not watch.thread.is_alive()
+
+
+def test_remove_blocks_when_the_watch_will_not_stop_and_does_not_delete_the_body(
+    agent, manager, monkeypatch
+):
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": _write_renderer(agent._working_dir, _OK_BODY), "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    watch = manager._watch
+    stop_failure = {
+        "status": "error",
+        "watch_id": watch.watch_id,
+        "state": "stop_failed",
+        "error": {"code": "stop_thread_alive", "retryable": True, "message": "still running"},
+        **manager._paths_payload(),
+        **manager._status_payload("inactive"),
+        **manager._refresh_fields(watch),
+    }
+    delete_calls: list[str] = []
+    monkeypatch.setattr(manager, "_stop_watch", lambda w: stop_failure)
+    monkeypatch.setattr(manager, "_delete_body", lambda: delete_calls.append("delete"))
+
+    result = manager.handle({"action": "remove", "input": {}, "reasoning": "abandon this work"})
+
+    assert result["status"] == "error"
+    assert result["state"] == "remove_blocked"
+    assert result["error"]["code"] == "stop_thread_alive"
+    assert delete_calls == []
+    assert Path(started["body_path"]).exists()
+    # ``stop``'s own retryable contract still applies: the watch is retained
+    # so a later remove can retry once the updater actually quiesces.
+    assert manager._watch is watch
+
+    monkeypatch.undo()
+    manager.handle({"action": "stop", "input": {"watch_id": started["watch_id"]}, "reasoning": "cleanup"})
+
+
+def test_remove_is_idempotent_when_never_started_or_already_removed(agent, manager):
+    never_started = manager.handle({"action": "remove", "input": {}, "reasoning": "cleanup just in case"})
+
+    assert never_started["status"] == "ok"
+    assert never_started["state"] == "removed"
+    assert never_started["body_removed"] is False
+    assert never_started["status_value"] == "inactive"
+    assert Path(never_started["status_path"]).read_text(encoding="utf-8") == "inactive"
+    assert not Path(never_started["body_path"]).exists()
+
+    renderer = _write_renderer(agent._working_dir, _OK_BODY)
+    manager.handle(
+        {"action": "start", "input": {"renderer_path": renderer, "interval_s": 3600}, "reasoning": "start"}
+    )
+    first = manager.handle({"action": "remove", "input": {}, "reasoning": "cleanup"})
+    assert first["body_removed"] is True
+
+    second = manager.handle({"action": "remove", "input": {}, "reasoning": "cleanup again"})
+    assert second["status"] == "ok"
+    assert second["state"] == "removed"
+    assert second["body_removed"] is False
+    assert manager._watch is None
+
+
+def test_remove_rejects_unknown_input_fields(agent, manager):
+    result = manager.handle(
+        {
+            "action": "remove",
+            "input": {"watch_id": "tc_1"},
+            "reasoning": "probe schema",
+        }
+    )
+    assert result["status"] == "failed"
+    assert result["error_code"] == "INVALID_ARGUMENT"
+
+
 def test_only_one_watch_may_be_active_per_agent(agent, manager):
     renderer = _write_renderer(agent._working_dir, _OK_BODY)
     started = manager.handle(

--- a/tests/test_telegram_toolfamily_ltpv2.py
+++ b/tests/test_telegram_toolfamily_ltpv2.py
@@ -121,7 +121,7 @@ def test_intrinsic_task_card_schema_is_a_strict_ltp_v2_family():
     assert schema["required"] == ["action", "input", "reasoning"]
     assert set(schema["properties"]) == {"action", "input", "reasoning", "summarize"}
     assert schema["additionalProperties"] is False
-    assert names == ["start", "inspect", "retry", "stop", "manual"]
+    assert names == ["start", "inspect", "retry", "stop", "remove", "manual"]
     assert len(schema["allOf"]) == len(names) == len(branches)
     for action, branch, condition in zip(names, branches, schema["allOf"]):
         assert branch["title"] == f"{action} input"


### PR DESCRIPTION
## Summary

- add a public, idempotent `task_card.remove` action for terminal Task Card cleanup
- retire any active watch before removing `taskcard/taskcard.md`, while keeping `taskcard/status` exact `inactive`
- document the full start -> maintain -> stop/preserve -> remove lifecycle in resident procedures, manual, contract, and anatomy
- keep `stop` non-terminal: it preserves the last body; `remove` prevents `/taskcard` and other consumers from showing stale completed/cancelled/abandoned work

## Validation

- `git diff --check`
- `PYTHONPATH=src /Users/huangzesen/work/GitHub/lingtai-kernel/.venv/bin/python -m pytest -q tests/test_task_card_controller.py tests/test_intrinsic_manual_actions.py tests/test_telegram_toolfamily_ltpv2.py`
  - `72 passed in 1.41s`
