### PR TITLE
fix(telegram): honor programmable task card intent

### DIFF
--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -301,11 +301,14 @@ chat-history cardinality. Normative source:
   intrinsic artifact while preserving its body; `remove` is terminal cleanup
   that retires the watch and deletes the body. One intrinsic-owned watch may be
   active per agent.
-- Telegram is only a read-only resident projector for that artifact. Its poller
-  reads `taskcard/status` and `taskcard/taskcard.md`; exact `active` plus a
-  nonempty body may project under `— WATCH —`. Missing, invalid, inactive, or
-  unchanged producer state is a no-op at the Telegram boundary. The automatic
-  event-journal slot remains independent and is preserved.
+- Telegram owns the resident message, automatic/mechanical event-journal slot,
+  composition, persistence, and message updates. It reads
+  `taskcard/status` and `taskcard/taskcard.md` only for the agent-owned
+  programmable frame: exact `active` plus a nonempty body includes or updates
+  `— WATCH —`; exact `inactive` idempotently excludes only that programmable
+  frame while preserving the resident, automatic content, and local body.
+  Missing/unreadable/other status, active with a missing/blank body, or
+  unchanged bytes remain a no-op at the Telegram boundary.
 - Skipping unchanged bytes is not a rate-limit exemption. Every time your
   renderer's output actually changes, Telegram performs a real message
   edit/send, subject to the same Bot API flood-control limits as any other

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2813,14 +2813,14 @@ class TelegramManager:
     def _taskcard_body_path(self) -> Path:
         return self._working_dir / "taskcard" / "taskcard.md"
 
-    def _read_programmable_task_card_body(self) -> str | None:
-        """Read the intrinsic Task Card body when its status is exactly active."""
+    def _read_taskcard_status(self) -> str | None:
         try:
-            status = self._taskcard_status_path().read_text(encoding="utf-8")
+            return self._taskcard_status_path().read_text(encoding="utf-8")
         except OSError:
             return None
-        if status != "active":
-            return None
+
+    def _read_programmable_task_card_body(self) -> str | None:
+        """Read the intrinsic Task Card body (caller has already gated status)."""
         try:
             body = self._taskcard_body_path().read_text(encoding="utf-8")
         except OSError:
@@ -2832,13 +2832,25 @@ class TelegramManager:
         return body
 
     def _broadcast_programmable_task_card_file(self) -> None:
-        """Project the current intrinsic Task Card body onto every resident.
+        """Project the current intrinsic Task Card intent onto every resident.
 
-        The projector is read-only: it consumes the agent-local declarative files
-        and proposes the exact body bytes (bounded only by Telegram's transport
-        ceiling) as the programmable channel frame. Missing/invalid/non-active
-        producer state is a no-op, preserving the last good projected card.
+        Telegram owns the resident message, its automatic/mechanical content,
+        and delivery; the agent owns only the programmable frame plus its
+        ``status`` intent. Exact ``active`` with a nonempty body composes/
+        updates the programmable frame. Exact ``inactive`` excludes only the
+        programmable frame from composition and updates the same resident with
+        its Telegram-owned automatic content intact -- it never deletes/hides
+        the resident message, never deletes the local body, and never pauses
+        automatic updates. Missing, unreadable, or any other status/body state
+        is unchanged: a no-op that preserves whatever programmable frame is
+        already committed.
         """
+        status = self._read_taskcard_status()
+        if status == "inactive":
+            self._clear_programmable_task_card_frame()
+            return
+        if status != "active":
+            return
         body = self._read_programmable_task_card_body()
         if body is None:
             return
@@ -2859,6 +2871,38 @@ class TelegramManager:
             except Exception as e:
                 log.debug(
                     "Programmable task card broadcast failed for %s:%s: %s",
+                    account,
+                    chat_id,
+                    e,
+                )
+
+    def _clear_programmable_task_card_frame(self) -> None:
+        """Exclude the programmable frame from every resident, idempotently.
+
+        Only the programmable slot is cleared; the automatic/mechanical
+        content Telegram owns is untouched and still gets recomposed into the
+        same resident message (never deleted/hidden). A resident with no
+        committed programmable frame is already the target state, so repeated
+        ``inactive`` handling delivers nothing further.
+        """
+        for account, chat_id in self._resident_task_card_targets():
+            try:
+                current = self._task_card_channels.get(f"{account}:{chat_id}", {}).get(
+                    "programmable"
+                )
+                if current is None:
+                    continue
+                self._deliver_channel_frame(
+                    account,
+                    chat_id,
+                    "programmable",
+                    None,
+                    error="Failed to clear programmable task card",
+                    empty_fallback=self._TASK_CARD_WATCH_STOPPED,
+                )
+            except Exception as e:
+                log.debug(
+                    "Programmable task card clear failed for %s:%s: %s",
                     account,
                     chat_id,
                     e,

--- a/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
@@ -43,11 +43,12 @@ onto its one tracked resident Task Card target per account+chat.
 
 - The intrinsic producer writes `<workdir>/taskcard/status` and
   `<workdir>/taskcard/taskcard.md`.
-- `TelegramManager._read_programmable_task_card_body()` reads those files only
-  when status is exactly `active`.
-- `TelegramManager._broadcast_programmable_task_card_file()` compares the new
-  body against the last committed programmable frame and only projects when the
-  bytes differ.
+- `TelegramManager._broadcast_programmable_task_card_file()` reads
+  `taskcard/status` first: exact `active` reads the body and projects it
+  (diff-only against the last committed programmable frame); exact `inactive`
+  calls `_clear_programmable_task_card_frame()` to exclude only the
+  programmable frame from the resident, idempotently; any other status is
+  unchanged.
 - `TaskCardResident` composes the programmable frame with the existing
   automatic frame under one tracked resident message.
 
@@ -66,7 +67,10 @@ onto its one tracked resident Task Card target per account+chat.
 
 ## Notes
 
-- Missing, blank, invalid, or inactive producer state is a Telegram no-op that
-  preserves the last good projected programmable frame.
+- Missing, unreadable, or `active`-with-blank/missing-body producer state is a
+  Telegram no-op that preserves the last good projected programmable frame.
+- Exact `inactive` producer state instead excludes only the programmable frame
+  from the resident (idempotently); it never touches the resident message, the
+  automatic frame, or the local producer body.
 - Telegram-specific transport, diff-only updates, and toggle behavior belong
   here, not in the intrinsic producer contract.

--- a/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/CONTRACT.md
@@ -36,12 +36,17 @@ live here; the public producer contract lives in
    composes two independent channels into it: `automatic` and `programmable`.
 2. The programmable channel is read-only with respect to the intrinsic
    producer. It reads `<workdir>/taskcard/status` and `<workdir>/taskcard/taskcard.md`.
-3. Telegram reads the programmable body only when `taskcard/status` is exactly
-   `active`. Missing status, any non-`active` content, missing body, or blank
-   body is a no-op.
-4. A no-op preserves the last valid programmable Telegram frame. Telegram must
-   not clear or replace the resident message just because the producer files are
-   temporarily missing or invalid.
+3. Telegram reads and composes the programmable body only when `taskcard/status`
+   is exactly `active` and the body is nonempty. Exact `inactive` instead
+   excludes only the programmable frame from composition and updates the same
+   resident using Telegram's own automatic content. Missing status, unreadable
+   status content that is neither exactly `active` nor exactly `inactive`, or
+   `active` with a missing/blank body remain a no-op.
+4. A no-op (rule 3's third case) preserves the last valid programmable Telegram
+   frame. Exact-`inactive` handling (rule 3's second case) is itself idempotent:
+   once the programmable frame is already excluded, repeated `inactive` delivers
+   nothing further. Neither case ever deletes/hides the resident message,
+   deletes the local producer body, or pauses Telegram's own automatic updates.
 5. Projection is diff-only. If the body bytes match the committed programmable
    frame, Telegram performs no transport update.
 6. When the Telegram `/taskcard` setting is off, presentation is suppressed.
@@ -68,7 +73,10 @@ Internal resident/projector boundary owned by `TaskCardResident` and consumed by
 1. Telegram must not expose a public MCP `task_card` tool from `server.py`.
 2. Programmable projection must remain read-only; no Telegram code may rewrite
    the intrinsic producer files.
-3. Missing/invalid/inactive producer state is a no-op, not an implicit clear.
+3. Missing/unreadable producer status, or `active` with a missing/blank body,
+   is a no-op, not an implicit clear. Exact `inactive` is instead a deliberate,
+   idempotent exclusion of only the programmable frame — never an implicit
+   clear of the resident message, the automatic frame, or the local body.
 4. Diff-only comparison is against the committed programmable frame, not the
    composed resident text.
 5. The automatic Task Card behavior remains independent of the programmable
@@ -79,7 +87,9 @@ Internal resident/projector boundary owned by `TaskCardResident` and consumed by
 ## Tests
 
 - `tests/test_telegram_task_card_programmable.py` covers active projection,
-  diff-only updates, inactive/no-op handling, and last-good preservation.
+  diff-only updates, exact-`inactive` frame exclusion (idempotent, resident/
+  automatic/body preserved), reactivation, and last-good preservation for
+  missing/blank producer state.
 - `tests/test_telegram_task_card_toggle.py` covers toggle suppression and the
   hidden-finalize clear semantics.
 - `tests/test_telegram_task_card_event_tail.py` continues to cover the automatic

--- a/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/task_card/SKILL.md
@@ -44,9 +44,11 @@ Current contract summary:
 - At most one intrinsic-owned watch may be active per agent.
 - Telegram is a read-only projector for the intrinsic artifact. It polls
   `taskcard/status` and `taskcard/taskcard.md`, projects exact active +
-  nonempty bodies into the resident programmable slot, preserves the automatic
-  event-journal slot, and treats missing/invalid/inactive/unchanged producer
-  state as a no-op.
+  nonempty bodies into the resident programmable slot, and preserves the
+  automatic event-journal slot. Exact `inactive` idempotently excludes only the
+  programmable slot from the resident (the message, automatic content, and
+  local body are never touched); missing/unreadable status, or active with a
+  missing/blank body, or an unchanged body, remain a no-op.
 
 Do not use this retained Telegram package as an active schema, endpoint,
 controller lifecycle, JSON-card renderer contract, private reverse-MCP route, or

--- a/tests/test_telegram_task_card_programmable.py
+++ b/tests/test_telegram_task_card_programmable.py
@@ -130,17 +130,15 @@ def test_projection_is_diff_only_against_last_programmable_frame(tmp_path):
     assert manager._task_card_channels["mybot:55"]["programmable"] == "same body\n"
 
 
-def test_inactive_or_invalid_state_is_noop_and_preserves_last_good_projection(tmp_path):
+def test_active_with_blank_body_is_noop_and_preserves_last_good_projection(tmp_path):
+    """Only exact ``inactive`` clears the programmable frame; any other
+    non-active-with-valid-body state (blank body while still ``active``, here)
+    stays the unchanged preserve-last-good no-op."""
     manager, acct, _service = _manager(tmp_path)
     _auto(manager)
     _write_intrinsic_taskcard(tmp_path, status="active", body="v1\n")
     manager._broadcast_programmable_task_card_file()
     calls_after_good = len(acct.calls)
-
-    _write_intrinsic_taskcard(tmp_path, status="inactive", body="v2\n")
-    manager._broadcast_programmable_task_card_file()
-    assert len(acct.calls) == calls_after_good
-    assert manager._task_card_channels["mybot:55"]["programmable"] == "v1\n"
 
     _write_intrinsic_taskcard(tmp_path, status="active", body="   ")
     manager._broadcast_programmable_task_card_file()
@@ -186,44 +184,71 @@ def test_existing_automatic_channel_behavior_is_preserved_by_programmable_file_u
     assert automatic_only != _current(acct)
 
 
-def test_inactive_stops_rendering_without_deleting_or_hiding_existing_resident(tmp_path):
-    """`stop`/`remove`-style inactive must gate the render loop only.
+def test_inactive_clears_programmable_frame_but_preserves_resident_and_automatic(tmp_path):
+    """`stop`/`remove`-style inactive excludes only the programmable frame.
 
-    The existing Telegram message and its tracked slot must survive untouched,
-    even once the local body file itself is later deleted (as `task_card.remove`
-    does) while status stays `inactive`.
+    Telegram owns the resident message and its automatic content: inactive
+    must update the same resident (never delete/send-new), drop the
+    programmable ``— WATCH —`` section while keeping the automatic content
+    intact, and never touch automatic updates going forward. Repeated
+    inactive handling must be idempotent, and it must never delete the local
+    body file either.
     """
     manager, acct, _service = _manager(tmp_path)
-    _auto(manager)
+    _auto(manager, reasoning="stay put")
     _write_intrinsic_taskcard(tmp_path, status="active", body="v1\n")
     manager._broadcast_programmable_task_card_file()
 
     resident_before = acct.get_task_card(55)
-    calls_before = list(acct.calls)
     assert resident_before is not None
     assert "v1" in _current(acct)
+    assert "— WATCH —" in _current(acct)
+    assert (tmp_path / "taskcard" / "taskcard.md").exists()
 
     # `stop` writes inactive but leaves the last body on disk (possibly stale).
+    calls_before_inactive = list(acct.calls)
     _write_intrinsic_taskcard(tmp_path, status="inactive", body="v2 (must not render)\n")
     manager._broadcast_programmable_task_card_file()
-    manager._broadcast_programmable_task_card_file()
 
-    assert acct.calls == calls_before
-    assert not any(call[0] == "delete" for call in acct.calls)
-    assert acct.get_task_card(55) == resident_before
+    new_calls = acct.calls[len(calls_before_inactive):]
+    assert not any(call[0] in ("send", "delete") for call in new_calls)
+    assert any(call[0] == "edit" for call in new_calls)  # resident updated in place
+    assert acct.get_task_card(55) == resident_before  # same resident, not a new/deleted one
     assert 55 in acct.list_task_card_chats()
-    assert "v1" in _current(acct)
-    assert manager._task_card_channels["mybot:55"]["programmable"] == "v1\n"
+    assert (tmp_path / "taskcard" / "taskcard.md").exists()  # local body never deleted
+    text = _current(acct)
+    assert "stay put" in text  # Telegram-owned automatic content preserved
+    assert "v1" not in text and "v2" not in text  # programmable frame excluded
+    assert "— WATCH —" not in text
+    assert manager._task_card_channels["mybot:55"].get("programmable") is None
+
+    # Repeated inactive handling (e.g. every 1s poll tick) is idempotent: no
+    # further transport calls once the programmable frame is already cleared.
+    calls_after_clear = list(acct.calls)
+    manager._broadcast_programmable_task_card_file()
+    manager._broadcast_programmable_task_card_file()
+    assert acct.calls == calls_after_clear
+
+    # Automatic updates keep flowing normally while inactive.
+    manager._handle_task_card_update(
+        {
+            "sub_action": "update",
+            "card_message_id": resident_before,
+            "tool": "read",
+            "tool_action": "open",
+            "reasoning": "still going",
+        }
+    )
+    assert "still going" in _current(acct)
+    assert acct.get_task_card(55) == resident_before
 
     # `remove` additionally deletes the local body once inactive is durable;
-    # Telegram must remain a pure no-op rather than deleting/hiding anything.
+    # Telegram must remain idempotent rather than deleting/hiding anything.
     (tmp_path / "taskcard" / "taskcard.md").unlink()
+    calls_before_remove = list(acct.calls)
     manager._broadcast_programmable_task_card_file()
-
-    assert acct.calls == calls_before
-    assert not any(call[0] == "delete" for call in acct.calls)
+    assert acct.calls == calls_before_remove
     assert acct.get_task_card(55) == resident_before
-    assert "v1" in _current(acct)
 
 
 def test_new_active_watch_after_inactive_renders_without_stale_state_corruption(tmp_path):
@@ -238,7 +263,8 @@ def test_new_active_watch_after_inactive_renders_without_stale_state_corruption(
     # Old watch retires and its body is removed, exactly as `task_card.remove` does.
     _write_intrinsic_taskcard(tmp_path, status="inactive", body=None)
     manager._broadcast_programmable_task_card_file()
-    assert manager._task_card_channels["mybot:55"]["programmable"] == "v1\n"
+    assert manager._task_card_channels["mybot:55"].get("programmable") is None
+    assert "v1" not in _current(acct)
 
     # A brand-new watch starts: body written first, then status flips to active.
     _write_intrinsic_taskcard(tmp_path, status="active", body="v2 fresh\n")

--- a/tests/test_telegram_task_card_programmable.py
+++ b/tests/test_telegram_task_card_programmable.py
@@ -27,6 +27,10 @@ class FakeAccount:
         self.calls.append(("edit", chat_id, message_id, text))
         return {"ok": True}
 
+    def delete_message(self, chat_id, message_id, **kwargs):
+        self.calls.append(("delete", chat_id, message_id))
+        return {"ok": True}
+
     def get_task_card(self, chat_id):
         return self._resident.get(chat_id)
 
@@ -180,3 +184,69 @@ def test_existing_automatic_channel_behavior_is_preserved_by_programmable_file_u
     assert "next step" in _current(acct)
     assert "watch body" in _current(acct)
     assert automatic_only != _current(acct)
+
+
+def test_inactive_stops_rendering_without_deleting_or_hiding_existing_resident(tmp_path):
+    """`stop`/`remove`-style inactive must gate the render loop only.
+
+    The existing Telegram message and its tracked slot must survive untouched,
+    even once the local body file itself is later deleted (as `task_card.remove`
+    does) while status stays `inactive`.
+    """
+    manager, acct, _service = _manager(tmp_path)
+    _auto(manager)
+    _write_intrinsic_taskcard(tmp_path, status="active", body="v1\n")
+    manager._broadcast_programmable_task_card_file()
+
+    resident_before = acct.get_task_card(55)
+    calls_before = list(acct.calls)
+    assert resident_before is not None
+    assert "v1" in _current(acct)
+
+    # `stop` writes inactive but leaves the last body on disk (possibly stale).
+    _write_intrinsic_taskcard(tmp_path, status="inactive", body="v2 (must not render)\n")
+    manager._broadcast_programmable_task_card_file()
+    manager._broadcast_programmable_task_card_file()
+
+    assert acct.calls == calls_before
+    assert not any(call[0] == "delete" for call in acct.calls)
+    assert acct.get_task_card(55) == resident_before
+    assert 55 in acct.list_task_card_chats()
+    assert "v1" in _current(acct)
+    assert manager._task_card_channels["mybot:55"]["programmable"] == "v1\n"
+
+    # `remove` additionally deletes the local body once inactive is durable;
+    # Telegram must remain a pure no-op rather than deleting/hiding anything.
+    (tmp_path / "taskcard" / "taskcard.md").unlink()
+    manager._broadcast_programmable_task_card_file()
+
+    assert acct.calls == calls_before
+    assert not any(call[0] == "delete" for call in acct.calls)
+    assert acct.get_task_card(55) == resident_before
+    assert "v1" in _current(acct)
+
+
+def test_new_active_watch_after_inactive_renders_without_stale_state_corruption(tmp_path):
+    """A fresh watch after `stop`/`remove` must render cleanly, not resurface old content."""
+    manager, acct, _service = _manager(tmp_path)
+    _auto(manager)
+    _write_intrinsic_taskcard(tmp_path, status="active", body="v1\n")
+    manager._broadcast_programmable_task_card_file()
+    resident_id = acct.get_task_card(55)
+    assert "v1" in _current(acct)
+
+    # Old watch retires and its body is removed, exactly as `task_card.remove` does.
+    _write_intrinsic_taskcard(tmp_path, status="inactive", body=None)
+    manager._broadcast_programmable_task_card_file()
+    assert manager._task_card_channels["mybot:55"]["programmable"] == "v1\n"
+
+    # A brand-new watch starts: body written first, then status flips to active.
+    _write_intrinsic_taskcard(tmp_path, status="active", body="v2 fresh\n")
+    manager._broadcast_programmable_task_card_file()
+
+    text = _current(acct)
+    assert "v2 fresh" in text
+    assert "v1" not in text
+    assert manager._task_card_channels["mybot:55"]["programmable"] == "v2 fresh\n"
+    assert acct.get_task_card(55) == resident_id
+    assert acct.calls[-1][0] == "edit"


### PR DESCRIPTION
## Summary

- make Telegram own the resident Task Card message, automatic/mechanical frame, composition, persistence, and updates
- treat the agent-local `taskcard/status` as intent for only the programmable frame
- exact `active` + nonempty body includes/updates the programmable `— WATCH —` frame
- exact `inactive` idempotently excludes only the programmable frame from the same resident while preserving automatic content and the local body
- lock same-resident/no-delete, automatic-preservation, repeated-inactive, and reactivation behavior with focused tests and aligned manuals/contracts

## Why

The original regression-only premise was disproved by a live test: after `taskcard/status` became `inactive`, Telegram still showed the old programmable WATCH body and kept advancing `Last Updated`. The automatic stream was recomposing a stale cached programmable frame.

This correction clears that cached programmable slot through the existing commit-on-success resident delivery path. It does **not** delete/hide the Telegram-owned resident message, delete the local body, or pause automatic updates.

## Validation

- directly affected clean Python 3.12 gate: **235 passed**
- broader Task Card/transport/manual/architecture gate: **268 passed, 1 inherited base-control failure**
  - unchanged exact-base failure: `test_public_telegram_action_reaches_manager` uses a fake service without `list_accounts`
- `git diff --check`: clean
- exact head commit author/committer: `Huang Zesen <hzsbazinga@outlook.com>`

## Live verification

Before the fix, screenshot evidence showed stale WATCH content after inactive. After updating this PR, the live agent will refresh from the exact head while status remains inactive and repeat the same Telegram-side observation before any merge.

## Boundary

No merge or release publishing is performed by this PR update. PR #1105 and the frozen release candidates remain separate.