### PR TITLE
fix(task-card): add missing tool glossaries

### DIFF
--- a/src/lingtai/tools/task_card/glossary-en.md
+++ b/src/lingtai/tools/task_card/glossary-en.md
@@ -1,0 +1,15 @@
+---
+kind: tool-glossary
+schema_version: 1
+tool_package: lingtai.tools.task_card
+language: en
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/task_card/glossary-zh.md
+- src/lingtai/tools/task_card/glossary-wen.md
+maintenance: |
+  English glossary for the `task_card` tool package (lingtai.tools.task_card); the English body must stay empty per tool_glossary.py's language contract — update only the identity/schema fields here, and update the zh/wen bodies in lockstep when task_card's public tool schema changes.
+  Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
+---

--- a/src/lingtai/tools/task_card/glossary-wen.md
+++ b/src/lingtai/tools/task_card/glossary-wen.md
@@ -1,0 +1,24 @@
+---
+kind: tool-glossary
+schema_version: 1
+tool_package: lingtai.tools.task_card
+language: wen
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/task_card/glossary-en.md
+- src/lingtai/tools/task_card/glossary-zh.md
+maintenance: |
+  Classical-Chinese (wen) glossary for the `task_card` tool package (lingtai.tools.task_card); body must stay non-empty and distinct from glossary-zh.md. Update in lockstep with glossary-en.md/glossary-zh.md whenever task_card's public tool schema changes.
+  Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
+---
+**名相对照**
+
+- `task_card`：任务牌。唯一公开之器，以 `action` 分遣；每 agent 至多存一声明之产、一路之监。
+- `action`：必填。`start`（启，始一路监）｜`inspect`（查，视其现状）｜`retry`（续，复运渲染之脚）｜`stop`（止，暂监而存其文）｜`remove`（撤，终清而删其文）｜`manual`（手册，还此器手册全文）。
+- `renderer_path`：`start` 必填，渲染之脚在工作之境内者，其径。
+- `watch_id`：`inspect`/`retry`/`stop` 用以指既存之监，其识。
+- `interval_s`：刷新之隔，以秒计。
+- `timeout_s`：一渲之限时，以秒计，为安全之限。
+- `max_refreshes`：刷新之至多次数，亦为安全之限。

--- a/src/lingtai/tools/task_card/glossary-zh.md
+++ b/src/lingtai/tools/task_card/glossary-zh.md
@@ -1,0 +1,24 @@
+---
+kind: tool-glossary
+schema_version: 1
+tool_package: lingtai.tools.task_card
+language: zh
+related_files:
+- docs.yaml
+- src/lingtai/kernel/tool_glossary.py
+- src/lingtai/tools/glossary_validator.py
+- src/lingtai/tools/task_card/glossary-en.md
+- src/lingtai/tools/task_card/glossary-wen.md
+maintenance: |
+  Simplified-Chinese (zh) glossary for the `task_card` tool package (lingtai.tools.task_card); body must stay non-empty. Update in lockstep with glossary-en.md/glossary-wen.md whenever task_card's public tool schema changes.
+  Body policy: maintain only a minimal term mapping plus at most one or two sentences of naming rationale; do not translate or duplicate the tool schema, parameters, action behavior, manual, contract, or anatomy.
+---
+**术语对照**
+
+- `task_card`：任务卡。唯一公开工具，以 `action` 分派；每个 agent 至多维护一份声明式产物、一路监视。
+- `action`：必填。`start`（启，开始一路监视）｜`inspect`（查，查看现状）｜`retry`（续，重跑渲染脚本）｜`stop`（止，暂停监视并保留正文）｜`remove`（撤，终止清理并删正文）｜`manual`（手册，返回本工具手册全文）。
+- `renderer_path`：`start` 必填，渲染脚本在工作目录内之路径。
+- `watch_id`：`inspect`/`retry`/`stop` 用以定位既有监视之标识。
+- `interval_s`：刷新间隔（秒）。
+- `timeout_s`：单次渲染超时（秒），为安全上限。
+- `max_refreshes`：最大刷新次数，亦为安全上限。

--- a/tests/test_tool_glossary.py
+++ b/tests/test_tool_glossary.py
@@ -457,9 +457,11 @@ _ALL_PACKAGES = sorted(
 # Glossary ownership follows the package resource, not the public tool surface,
 # so ``pad``/``lingtai``/``knowledge``/``skills`` still own glossaries as
 # private domain packages while ``psyche`` — the public root named for
-# ``pad + lingtai + knowledge + skills = psyche`` — adds the nineteenth.
-assert len(_ALL_PACKAGES) == 19, _ALL_PACKAGES
+# ``pad + lingtai + knowledge + skills = psyche`` — adds the nineteenth, and
+# the intrinsic ``task_card`` producer adds the twentieth.
+assert len(_ALL_PACKAGES) == 20, _ALL_PACKAGES
 assert "psyche" in _ALL_PACKAGES
+assert "task_card" in _ALL_PACKAGES
 assert "substrate" not in _ALL_PACKAGES
 # The five pre-migration file packages were deleted into ``file``; their
 # glossaries must not come back.


### PR DESCRIPTION
## Summary

- add the missing package-owned `task_card` glossaries for English, Simplified Chinese, and Literary Chinese
- update the glossary-owner invariant from 19 to 20 and explicitly assert `task_card`
- keep the change limited to glossary resources and their invariant test

## Why

Current `main` contains the intrinsic `task_card` package but not its three required glossary resources. The clean Python 3.12 release PRECHECK first stopped during collection because `_ALL_PACKAGES` contained 20 owners while the test still asserted 19. After correcting that stale count, the validator exposed the underlying missing `task_card` resources.

This PR fixes that frozen-main validation gap without changing Task Card behavior, release machinery, versions, or provider configuration.

## Validation

- `tests/test_tool_glossary.py`: **173 passed**
- `git diff --check`: clean
- exact commit author/committer: `Huang Zesen <hzsbazinga@outlook.com>`

## Release boundary

This is a narrow PRECHECK blocker fix for the planned kernel `v0.19.0` release. It is not merge or release authorization; the release baseline will only move after an explicit gate decision.
