### PR TITLE
docs(update): route nudges through stable installer entrypoint

### DIFF
--- a/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
@@ -39,8 +39,9 @@ model-visible notification lane.
 `nudge` is the formal channel for mechanical, throttled checks. Runtime update
 checks publish `data.nudges[]` entries with `kind: kernel_version`; the sole
 normal install/update route is `https://lingtai.ai/install.sh`. Let Shell execute
-its concise `--help`, then `update --help`, without reading or pasting the script
-source. The installer owns exact-tag migration navigation; real update, mutation,
+its concise `--help`, without reading or pasting the script source, and follow
+whatever it currently instructs rather than assuming a specific child command.
+The installer owns exact-tag migration navigation; real update, mutation,
 configuration writes, and refresh require explicit human/config-owner authority.
 The bundled `runtime-update-checks` reference is limited to local read-only
 diagnosis and refresh mechanics. Source-freshness checks may publish

--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -46,10 +46,13 @@ Kernel-local read-only diagnosis and refresh mechanics
 
 For a `kernel_version` nudge, use the release-manifest facts for diagnosis.
 When a newer release exists, let Shell execute the official installer at
-`https://lingtai.ai/install.sh` with `--help` and then `update --help`; do not
-read or paste the large script source into agent context. A `source_drift` nudge
-stays local to these mechanics and never enters release-migration routing. This
-is operational guidance, not permission to download, install, change
+`https://lingtai.ai/install.sh` with `--help`; do not read or paste the large
+script source into agent context. Follow whatever the installer's own concise
+help output currently instructs rather than assuming or hardcoding a specific
+child command or subcommand name — the installer's own help is the current
+source of truth, not this reference. A `source_drift` nudge stays local to
+these mechanics and never enters release-migration routing. This is
+operational guidance, not permission to download, install, change
 configuration, or relaunch a runtime.
 
 ## The lifecycle and its owners
@@ -103,9 +106,9 @@ The end-to-end path is:
    Treat the payload as kernel-synchronized facts, not a human command. Compare
    `running`, `installed`, `latest`, and `source`; inspect the runtime when
    ambiguous. For a real update, let Shell execute the installer's concise
-   `--help` and then `update --help`; the installer owns release-interval
-   migration navigation while this reference owns local diagnosis and refresh
-   mechanics.
+   `--help` and follow whatever it currently instructs; the installer owns
+   release-interval migration navigation and the exact child command shape
+   while this reference owns local diagnosis and refresh mechanics.
 8. **Confirm — the human/config-owner.** After the installer has displayed the
    applicable release-interval migrations, obtain explicit human/config-owner
    authorization for every migration/config write and for refresh. Apply only

--- a/src/lingtai/kernel/nudge/prompts.py
+++ b/src/lingtai/kernel/nudge/prompts.py
@@ -113,10 +113,12 @@ def _render_package_update(facts: NudgeFacts) -> dict[str, Any]:
             "The official LingTai release manifest reports a newer kernel. "
             f"Use Shell to execute the official installer at {INSTALL_ROUTE} "
             "with --help; do not read or paste the script source into context. "
-            "Then execute its update --help mode to inspect the exact runtime, "
-            "migration, mirror, hash, and refresh contract. Before the real "
-            "update, the agent must obtain explicit human/config-owner "
-            "authorization; this nudge and help output are not authorization."
+            "Follow whatever the installer's own concise help output currently "
+            "instructs for inspecting the exact runtime, migration, mirror, "
+            "hash, and refresh contract; do not assume or hardcode a specific "
+            "child command or subcommand name. Before the real update, the "
+            "agent must obtain explicit human/config-owner authorization; this "
+            "nudge and help output are not authorization."
         ),
         "running": facts.running,
         "installed": facts.installed,

--- a/src/lingtai/prompts/substrate/substrate.md
+++ b/src/lingtai/prompts/substrate/substrate.md
@@ -57,8 +57,9 @@ when available and confirm the module files it imports (`lingtai.__file__`,
 `python`, conda env, or checkout; `refresh` reloads the current on-disk/runtime
 surface but does not fetch or switch code by itself. For a `kernel_version` nudge,
 the sole normal install/update route is `https://lingtai.ai/install.sh`: let
-Shell execute its concise `--help`, then `update --help`, without reading or
-pasting the script source. The installer owns exact-tag migration navigation.
+Shell execute its concise `--help`, without reading or pasting the script
+source, and follow whatever it currently instructs rather than assuming a
+specific child command. The installer owns exact-tag migration navigation.
 Obtain explicit human/config-owner authority before any real update, migration,
 configuration write, or refresh, and refresh only after authorized validation.
 The bundled `runtime-update-checks` manual is only for local read-only diagnosis

--- a/tests/test_kernel_update_contract.py
+++ b/tests/test_kernel_update_contract.py
@@ -37,7 +37,7 @@ def test_kernel_update_guidance_uses_only_the_installer_route():
         text = path.read_text(encoding="utf-8")
         assert "https://lingtai.ai/install.sh" in text
         assert "--help" in text
-        assert "update --help" in text
+        assert "update --help" not in text
         assert "explicit human/config-owner" in text
         assert "https://lingtai.ai/skill.md" not in text
 
@@ -52,6 +52,7 @@ def test_repository_kernel_version_guidance_cannot_restore_obsolete_routes():
         "https://lingtai.ai/skill.md",
         "normal install/update commands remain TUI-managed",
         "normal installation/update commands remain TUI-managed",
+        "update --help",
     )
     for path in ROOT.rglob("*.md"):
         if ".git" in path.parts or "scratch" in path.parts:

--- a/tests/test_nudge_prompts.py
+++ b/tests/test_nudge_prompts.py
@@ -63,7 +63,9 @@ def test_package_update_points_to_installer_and_requires_authorization():
     assert "Use Shell to execute" in detail
     assert "with --help" in detail
     assert "do not read or paste the script source into context" in detail
-    assert "update --help" in detail
+    assert "Follow whatever the installer's own concise help output currently" in detail
+    assert "do not assume or hardcode a specific" in detail
+    assert "update --help" not in detail
     assert "must obtain explicit human/config-owner authorization" in detail
     assert "this nudge and help output are not authorization" in detail
     assert "skill.md" not in detail


### PR DESCRIPTION
## Summary

- replaces all five live agent-facing hard-coded `update --help` routes with the stable `install.sh` entrypoint
- tells agents to run the stable entrypoint's current `--help` and follow the instructions it returns, instead of baking mutable child routes into prompt/manual copies
- preserves the existing explicit-authorization boundary for any real update, migration, configuration write, or refresh
- adds guards which inventory every live copy and prevent the old route from reappearing

This is PR 4 of the four-PR canonical-installer batch. It changes guidance/tests only; no installer or update logic is changed, and the batch will not be partially merged.

## Validation

- base-object inventory: exactly 5 live `update --help` copies across 4 files; candidate: 0
- mutation check: combining the old base prose with the new guards produces 3 failures, proving the guards are non-tautological
- isolated focused candidate/base control: both `1 failed, 10 passed`; the one failure is the same pre-existing `migration.md` version mismatch
- isolated broader candidate/base control: identical `7 failed, 257 passed, 4 errors`; collection count 7,284
- rendered runtime nudge remains actionable: stable `install.sh` URL, current `--help`, follow-current-instructions wording, and explicit authorization gate
- independent Opus review: **ACCEPT**, zero blockers; all six candidate file hashes remained unchanged through review

## Batch gate

Before any grouped merge or release continuation, the exact four-PR heads still require real install→update→remove acceptance on macOS POSIX, WSL/Linux, and native Windows PowerShell.
