### PR TITLE
chore(release): prepare v0.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.18.2"
+version = "0.19.0"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the kernel package version from `0.18.2` to `0.19.0`
- keep the release candidate diff to the single expected `pyproject.toml` line
- prepare the already-scoped kernel `v0.19.0` release candidate

## Validation

- `PYTHONPATH=src $LINGTAI_RUNTIME_PYTHON scripts/check_docs_governance.py --check` — PASS (`305 documents` validated)
- `git diff --check` — PASS
- task-local CPython 3.12 full suite reached a terminal summary in 371.45s: `14 failed, 7239 passed, 27 skipped, 4 errors`
- normalized by test-node name, all 18 v7 failure/error nodes are a strict subset of the 32 nodes in the prior terminal exact-main PRECHECK baseline; there are no new node names and 14 old nodes are absent. All remaining nodes are the inherited source-checkout package-data/wheel-resource debt and are recorded as nonzero, not PASS.

## Next PRECHECK gate

After this PR exists, the release PRECHECK will run `wheels.yml` once with `publish=false`, freeze every artifact/hash, and run clean install/import/version smokes. That workflow is not a release publication.

## Limits

- Per Jason Telegram `11734`, no Windows/WSL execution was run or claimed.
- No merge, tag, upload, PyPI/Gitee publication, Homebrew mutation, website deploy, or release occurs in this PR.
