### PR TITLE
fix(logging): preserve agent identity in mail events

### DIFF
--- a/src/lingtai/kernel/base_agent/messaging.py
+++ b/src/lingtai/kernel/base_agent/messaging.py
@@ -51,7 +51,7 @@ def _on_normal_mail(agent, payload: dict) -> None:
     subject = payload.get("subject") or "(no subject)"
 
     agent._wake_nap("mail_arrived")
-    agent._log("mail_received", address=address, subject=subject,
+    agent._log("mail_received", sender_address=address, subject=subject,
                message=payload.get("message", ""))
 
     # The unread-digest producer is email-domain logic and lives with the email

--- a/src/lingtai/tools/email/primitives.py
+++ b/src/lingtai/tools/email/primitives.py
@@ -280,7 +280,7 @@ def _mailman(agent, msg_id: str, payload: dict, deliver_at: datetime,
         if outbox_entry.is_dir():
             shutil.rmtree(outbox_entry)
 
-    agent._log("mail_sent", address=address, subject=payload.get("subject", ""),
+    agent._log("mail_sent", recipient_address=address, subject=payload.get("subject", ""),
                status=status, message=payload.get("message", ""))
 
     # Bounce notification

--- a/tests/test_layers_email.py
+++ b/tests/test_layers_email.py
@@ -6,7 +6,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from lingtai.tools.email.primitives import EMAIL_BODY_CHAR_LIMIT
+from lingtai.kernel.services.logging import query_sqlite_event_index
+from lingtai.tools.email.primitives import EMAIL_BODY_CHAR_LIMIT, _mailman
 from uuid import uuid4
 
 from lingtai.agent import Agent
@@ -36,6 +37,30 @@ def _make_inbox_email(working_dir, *, sender="sender", to=None, subject="test",
         data["attachments"] = attachments
     (msg_dir / "message.json").write_text(json.dumps(data, indent=2))
     return email_id
+
+
+def _events_of_type(agent, event_type):
+    path = agent.working_dir / "logs" / "events.jsonl"
+    events = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    return [event for event in events if event.get("type") == event_type]
+
+
+def _sqlite_event(agent, event_type):
+    rows = query_sqlite_event_index(
+        agent.working_dir,
+        (
+            "SELECT agent_address, "
+            "json_extract(fields_json, '$.address') AS payload_address, "
+            "json_extract(fields_json, '$.sender_address') AS sender_address, "
+            "json_extract(fields_json, '$.recipient_address') AS recipient_address, "
+            "json_extract(fields_json, '$.subject') AS subject, "
+            "json_extract(fields_json, '$.message') AS message, "
+            "json_extract(fields_json, '$.status') AS status "
+            f"FROM events WHERE type='{event_type}' ORDER BY id"
+        ),
+    )
+    assert len(rows) == 1
+    return rows[0]
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +113,32 @@ def test_email_receive_notification(tmp_path):
     assert email["from"] == "sender"
     assert email["message"] == "body"
     assert email["message_truncated"] is False
+
+
+def test_mail_received_durable_event_preserves_agent_address(tmp_path):
+    agent = Agent(service=make_mock_service(), agent_name="receiver", working_dir=tmp_path / "receiver")
+    _make_inbox_email(agent.working_dir, sender="sender", subject="topic", message="body")
+
+    agent._on_mail_received({
+        "_mailbox_id": "abc123",
+        "from": "sender",
+        "to": ["receiver"],
+        "subject": "topic",
+        "message": "body",
+    })
+
+    [event] = _events_of_type(agent, "mail_received")
+    assert event["address"] == agent.working_dir.name
+    assert event["sender_address"] == "sender"
+    assert event["subject"] == "topic"
+    assert event["message"] == "body"
+
+    row = _sqlite_event(agent, "mail_received")
+    assert row["agent_address"] == agent.working_dir.name
+    assert row["payload_address"] is None
+    assert row["sender_address"] == "sender"
+    assert row["subject"] == "topic"
+    assert row["message"] == "body"
 
 
 def test_email_receive_fallback_id(tmp_path):
@@ -220,6 +271,40 @@ def test_email_send_through_mailman(tmp_path):
     msg = json.loads((sent_items[0] / "message.json").read_text())
     assert msg["message"] == "hello"
     assert msg["sent_at"]
+
+
+def test_mail_sent_durable_event_preserves_agent_address(tmp_path):
+    agent = Agent(service=make_mock_service(), agent_name="sender", working_dir=tmp_path / "sender-agent")
+    mail_svc = MagicMock()
+    mail_svc.address = "sender"
+    mail_svc.send.return_value = None
+    agent._mail_service = mail_svc
+
+    payload = {
+        "from": "sender",
+        "to": ["recipient"],
+        "_dispatch_to": "recipient",
+        "_mode": "peer",
+        "subject": "topic",
+        "message": "body",
+        "type": "normal",
+    }
+    _mailman(agent, "msg-1", payload, datetime.now(timezone.utc), skip_sent=True)
+
+    [event] = _events_of_type(agent, "mail_sent")
+    assert event["address"] == agent.working_dir.name
+    assert event["recipient_address"] == "recipient"
+    assert event["subject"] == "topic"
+    assert event["message"] == "body"
+    assert event["status"] == "delivered"
+
+    row = _sqlite_event(agent, "mail_sent")
+    assert row["agent_address"] == agent.working_dir.name
+    assert row["payload_address"] is None
+    assert row["recipient_address"] == "recipient"
+    assert row["subject"] == "topic"
+    assert row["message"] == "body"
+    assert row["status"] == "delivered"
 
 
 def test_email_send_with_delay(tmp_path):


### PR DESCRIPTION
## Summary

Two mail-event producers reused the canonical emitter `address` event-envelope key for their peer address:

- `mail_received` stored the sender under `address`.
- `mail_sent` stored the recipient under `address`.

Because the SQLite sidecar projects top-level `address` into `agent_address`, those new mail rows could be attributed to the sender or recipient instead of the agent that emitted the event.

This PR keeps the canonical JSONL `address` as the emitting agent working-directory name and stores mail peers as event-specific fields:

- `mail_received.sender_address`
- `mail_sent.recipient_address`

Subject, message, and send status fields are preserved.

## Validation

- `PYTHONPATH="$PWD/src" python3 -m pytest -q tests/test_layers_email.py::test_mail_received_durable_event_preserves_agent_address tests/test_layers_email.py::test_mail_sent_durable_event_preserves_agent_address`
  - Passed: 2 passed in 0.42s
- `PYTHONPATH="$PWD/src" python3 -m pytest -q tests/test_layers_email.py`
  - Passed: 67 passed, 1 warning in 30.90s
- `PYTHONPATH="$PWD/src" python3 -m pytest -q tests/test_services_logging.py tests/test_event_journal.py`
  - Passed: 47 passed in 0.54s
- `PYTHONPATH="$PWD/src" python3 -m pytest -q tests/test_email_identity.py tests/test_email_abs_reply_route.py tests/test_system_dismiss.py tests/test_tool_family_email_migration.py tests/test_tool_family_email_wire_parity.py`
  - Passed: 109 passed, 1 warning in 5.67s
- `git diff --check`
  - Passed

The regressions assert both JSONL and SQLite behavior for receive and actual `mail_sent` production through the mailman path.

## Non-goals and compatibility

- `email_sent` is unchanged.
- No global reserved-key guard or `_log` merge-order change is included.
- No SQLite/EventJournal/query schema change or migration is included.
- No historical log rewrite is included.
- Old JSONL rows and old SQLite sidecars stay as-is. Rebuilding SQLite from pre-fix JSONL reproduces their prior attribution because the old JSONL already contains the peer-valued `address`.
- No rebuild is required for new rows after this change; new mail events are written with correct emitter attribution immediately.

## Limitation

Full-suite attempt with `PYTHONPATH="$PWD/src" python3 -m pytest -q tests` did not collect in this local environment because the installed `mcp` package lacks APIs expected by multiple MCP-server tests (`mcp.server.ServerRequestContext` and `mcp.Client`). The focused and adjacent suites above completed successfully.
