### PR TITLE
fix(release): make Gitee asset publishing timeout-safe

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -250,7 +250,17 @@ jobs:
     # `needs: [build-wheels, build-sdist]` makes it wait for every matrix leg,
     # so a partial/failed platform build fails this job loud via `needs`
     # rather than silently shipping an incomplete manifest.
-    timeout-minutes: 15
+    #
+    # 120 minutes (not 15): manifest generation + GitHub publish are fast,
+    # but the Gitee publish step below now runs its own bounded retry loop
+    # (up to 5 attempts, 10 minutes each — the same primitive as the
+    # gitee-only-recovery job's 120-minute ceiling). The job-level timeout
+    # must outlive that retry budget, or GitHub Actions cancels the whole
+    # job — including the already-succeeded "Publish ... to GitHub" step —
+    # partway through a slow-but-healthy Gitee retry, which is exactly the
+    # defect this change fixes (exact-tag run 30600070105 was cancelled
+    # here after GitHub publication had already completed).
+    timeout-minutes: 120
     permissions:
       # write is required only for the actual publish path (gh release
       # upload / create); the dry-run path never mutates anything regardless
@@ -377,10 +387,9 @@ jobs:
             --branch main \
             --execute
 
-      - name: Publish manifest/wheels/sdist
+      - name: Publish manifest/wheels/sdist to GitHub
         env:
           GH_TOKEN: ${{ github.token }}
-          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
         run: |
           set -euo pipefail
           version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
@@ -389,18 +398,65 @@ jobs:
           execute_flag=""
           if [[ "${{ steps.publish_mode.outputs.execute }}" == "1" ]]; then
             execute_flag="--execute"
-            echo "Publishing $tag for real (event=${{ github.event_name }})."
+            echo "Publishing $tag to GitHub for real (event=${{ github.event_name }})."
           else
             echo "Manifest ready for $tag. Dry run only (event=${{ github.event_name }}, publish input=${{ inputs.publish }})."
           fi
           # publish_release_assets.py is idempotent (skips already-attached
           # same-name assets) and never force-syncs/deletes — safe to run
-          # repeatedly. Gitee leg is skipped internally when
-          # GITEE_ACCESS_TOKEN is unset, regardless of execute_flag.
+          # repeatedly. --skip-gitee here: GitHub publication must be able to
+          # succeed and be reported on its own, independent of Gitee's
+          # separately bounded retry step below.
           python scripts/publish_release_assets.py \
             --manifest release-assets/lingtai-kernel-release-manifest.json \
             --assets-dir release-assets \
+            --skip-gitee \
             $execute_flag
+
+      - name: Publish manifest/wheels/sdist to Gitee (bounded retry, non-blocking)
+        if: steps.publish_mode.outputs.execute == '1'
+        # continue-on-error: a slow or flaky Gitee upload must never turn an
+        # already-successful GitHub publish (the step above) into a reported
+        # job/run failure. The retry loop below is the same idempotent
+        # bounded pattern proven in the gitee-only-recovery job; if every
+        # attempt times out, this step's own outcome is still "failure" (the
+        # step detail view shows it failed, and a warning annotation is
+        # printed) even though continue-on-error makes the job's overall
+        # conclusion "success" — recovery via the manual gitee-only-recovery
+        # dispatch stays available, and no state is silently marked complete.
+        continue-on-error: true
+        env:
+          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GITEE_ACCESS_TOKEN:-}" ]]; then
+            echo "Gitee publish skipped: GITEE_ACCESS_TOKEN is not configured."
+            exit 0
+          fi
+          max_attempts=5
+          for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+            echo "Gitee publish attempt ${attempt}/${max_attempts} (10-minute timeout)."
+            set +e
+            PYTHONUNBUFFERED=1 timeout --foreground --signal=TERM --kill-after=30s 10m \
+              python scripts/publish_release_assets.py \
+                --manifest release-assets/lingtai-kernel-release-manifest.json \
+                --assets-dir release-assets \
+                --skip-github \
+                --execute
+            status=$?
+            set -e
+            if (( status == 0 )); then
+              exit 0
+            fi
+            if (( status == 124 || status == 137 )); then
+              echo "::warning::Gitee publish attempt ${attempt} timed out (exit ${status}); retrying so remote completion can be rediscovered."
+              continue
+            fi
+            echo "::error::Gitee publish failed with non-timeout exit ${status}."
+            exit "$status"
+          done
+          echo "::warning::Gitee publish did not complete after ${max_attempts} bounded attempts. GitHub publication above already succeeded; start a new manual workflow_dispatch run of this workflow with gitee_only_recovery=true, publish=true, and this release's tag to resume Gitee only."
+          exit 124
 
       - name: Upload release manifest artifact
         uses: actions/upload-artifact@v4

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -89,7 +89,8 @@ also attaches both files alongside the wheels/sdist.
 `wheels.yml`'s `release-manifest` job actually publishes on the real trigger:
 
 - **`release: {types: [published]}`** — a real kernel GitHub Release always
-  publishes (syncs Gitee, then uploads to GitHub + Gitee).
+  publishes: syncs Gitee, uploads to GitHub, then (separately, see Step 3)
+  uploads to Gitee.
 - **`workflow_dispatch`** — dry-run by default (the `publish` boolean input
   defaults `false`); pass `publish: true` to deliberately publish from a
   manual run too (for example to republish after a partial failure).
@@ -110,18 +111,34 @@ travels via a short-lived, owner-only-permission `GIT_ASKPASS` helper file
 (deleted after use) — never in argv, a URL, or a log line. Skips cleanly
 (prints why, exits 0) when `GITEE_ACCESS_TOKEN` is unset.
 
-### Step 2 — publish manifest/wheels/sdist
+### Step 2 — publish manifest/wheels/sdist to GitHub
 
-[`scripts/publish_release_assets.py`](scripts/publish_release_assets.py)
-uploads the exact manifest + asset bytes to:
+[`scripts/publish_release_assets.py --skip-gitee`](scripts/publish_release_assets.py)
+uploads the exact manifest + asset bytes to GitHub Releases via the `gh` CLI
+(`gh release create` / `gh release upload`), attaching the manifest and
+`SHA256SUMS` alongside the wheels/sdist. This step is fast (no retry loop)
+and is reported as its own step status: GitHub publication succeeding must
+never depend on how long Gitee's leg takes.
 
-- **GitHub Releases**, via the `gh` CLI (`gh release create` / `gh release
-  upload`), attaching the manifest and `SHA256SUMS` alongside the wheels/sdist.
-- **Gitee Releases** (`huangzesen1997/lingtai-kernel`), via the Gitee v5 REST
-  API, gated entirely on the `GITEE_ACCESS_TOKEN` secret. When that secret is
-  unset the Gitee leg is skipped with a printed reason — it is never a hard
-  failure, since Gitee credentials/configuration are a separate authorization
-  step from having the workflow code in place.
+### Step 3 — publish manifest/wheels/sdist to Gitee (separately bounded, non-blocking)
+
+The same script, invoked again with `--skip-github --execute`, uploads the
+identical bytes to Gitee Releases (`huangzesen1997/lingtai-kernel`) via the
+Gitee v5 REST API. This step is gated on `GITEE_ACCESS_TOKEN` being
+configured (prints why and exits 0 when it is unset — never a hard failure,
+since Gitee credentials are a separate authorization step from having the
+workflow code in place) and wraps the call in the same idempotent
+bounded-retry loop (`timeout --foreground ... 10m`, up to 5 attempts) already
+used by the manual `gitee-only-recovery` job below, so a slow Gitee API can be
+retried without ever hanging the job past its own ceiling.
+
+The workflow step itself carries `continue-on-error: true`: a Gitee stall or
+exhausted retry budget still sets *this step's own outcome* to failure (with
+a `::warning::`/`::error::` annotation pointing at `gitee-only-recovery` for
+manual resume, visible in the step's detail view), but `continue-on-error`
+makes the job's and run's overall *conclusion* stay success — the top-level
+badge stays green because GitHub publication from Step 2 already succeeded,
+and that must be reported truthfully regardless of how slow Gitee is.
 
 Every mutating action requires the explicit `--execute` flag; the workflow
 passes it only when the trigger is a real release (or an explicit
@@ -184,4 +201,7 @@ case (see `test_sync_fast_forwards_empty_remote`).
   dependency resolution is unaffected and continues to use PyPI or a
   configured mirror.
 - No offline wheelhouse / vendored third-party dependency bundle.
-- No automatic Gitee mirror synchronization from this repository or workflow.
+- No force-push or history mutation of the Gitee mirror from this workflow —
+  sync is fast-forward-only and release assets are uploaded, never replaced.
+  (Automatic non-force Gitee mirror sync + asset publish on every real
+  release IS in scope — see "Publish" above.)

--- a/tests/test_wheels_workflow_publish_gating.py
+++ b/tests/test_wheels_workflow_publish_gating.py
@@ -76,16 +76,90 @@ def test_publish_mode_step_executes_on_explicit_manual_publish_true():
 
 def test_publish_step_conditionally_passes_execute_flag():
     job = _release_manifest_job(_load_workflow())
-    step = _step(job, "Publish manifest")
+    step = _step(job, "Publish manifest/wheels/sdist to GitHub")
     script = step["run"]
     assert "publish_mode.outputs.execute" in script
     assert "--execute" in script
     assert "publish_release_assets.py" in script
+    assert "--skip-gitee" in script, (
+        "the GitHub publish step must not also attempt Gitee inline — Gitee "
+        "publication is a separately bounded step so a slow Gitee API can "
+        "never block or fail an already-successful GitHub publish"
+    )
     # The flag must be conditional, not unconditionally omitted (the prior
     # defect) or unconditionally present (which would always try to publish,
     # even on ordinary workflow_dispatch shape-checks).
     assert 'execute_flag="--execute"' in script
     assert 'execute_flag=""' in script
+
+
+def test_github_publish_step_has_no_gitee_token_and_is_not_continue_on_error():
+    job = _release_manifest_job(_load_workflow())
+    step = _step(job, "Publish manifest/wheels/sdist to GitHub")
+    assert "GITEE_ACCESS_TOKEN" not in step.get("env", {}), (
+        "the GitHub-only publish step has no business holding the Gitee "
+        "token; it must be able to succeed or fail purely on GitHub state"
+    )
+    assert step.get("continue-on-error") is not True, (
+        "GitHub publication is the primary, authoritative publish signal "
+        "and must surface its own real failures"
+    )
+
+
+def test_release_manifest_job_timeout_outlives_the_gitee_retry_budget():
+    job = _release_manifest_job(_load_workflow())
+    assert job["timeout-minutes"] > 15, (
+        "the original 15-minute release-manifest ceiling coupled manifest "
+        "generation, Gitee mirror sync, GitHub publish, and Gitee publish "
+        "into one budget; exact-tag run 30600070105 was cancelled here "
+        "while GitHub had already published successfully and only Gitee's "
+        "asset upload was still slow — the job must be widened to give the "
+        "now-separately-bounded Gitee retry loop real room"
+    )
+
+
+def test_gitee_publish_step_is_split_from_github_bounded_and_non_blocking():
+    job = _release_manifest_job(_load_workflow())
+    step = _step(job, "Publish manifest/wheels/sdist to Gitee")
+    assert step.get("if") == "steps.publish_mode.outputs.execute == '1'", (
+        "Gitee publish must only run when actually publishing, not on every "
+        "dry-run shape check"
+    )
+    assert step.get("continue-on-error") is True, (
+        "a stalled/slow Gitee upload must never flip the job's reported "
+        "conclusion to failure now that GitHub has already published "
+        "successfully in the step above"
+    )
+    script = step["run"]
+    assert "publish_release_assets.py" in script
+    assert "--skip-github" in script
+    assert "--execute" in script
+    assert "GITEE_ACCESS_TOKEN" in step.get("env", {})
+    # Separately bounded: the job's own timeout-minutes must be able to fit
+    # the *entire* retry budget (max_attempts * per-attempt minutes), not
+    # just one attempt. This is the actual fix for the
+    # 15-minute-job-kills-slow-Gitee-upload defect (exact-tag run
+    # 30600070105): the prior single coupled `timeout-minutes: 15` for
+    # manifest+sync+GitHub+Gitee could cancel the whole job — including the
+    # already-succeeded GitHub publish step above — mid-retry, misreporting
+    # a successful release as incomplete just because Gitee was slow.
+    job_timeout = job["timeout-minutes"]
+    assert "timeout --foreground" in script
+    assert "10m" in script
+    per_attempt_minutes = 10
+    assert "max_attempts=" in script
+    max_attempts = int(script.split("max_attempts=")[1].splitlines()[0])
+    assert max_attempts > 1, "must actually retry, not just bound a single attempt"
+    assert max_attempts * per_attempt_minutes < job_timeout, (
+        "the job's timeout-minutes must be large enough to let the Gitee "
+        "retry loop actually exhaust its own attempt budget rather than "
+        "being killed by the job-level ceiling first (the original defect)"
+    )
+    assert "status == 124 || status == 137" in script
+    assert "::warning::" in script and "gitee_only_recovery" in script, (
+        "an exhausted retry budget must fail loud with a pointer to the "
+        "manual recovery path, not silently disappear"
+    )
 
 
 def test_gitee_sync_step_is_gated_on_publish_mode_and_never_forces():


### PR DESCRIPTION
## Summary

- publish the exact manifest, wheels, and sdist to GitHub in a hard-fail GitHub-only step
- retry the Gitee asset upload separately with 5 bounded 10-minute attempts under a 120-minute job ceiling, while keeping the existing manual Gitee-only recovery path
- document the outcome-vs-conclusion behavior and lock the split, timeout budget, token boundary, and recovery warning with focused workflow tests

## Why

Exact-tag release run `30600070105` finished GitHub publication but hit the old 15-minute `release-manifest` ceiling while Gitee was still uploading. That coupled a successful GitHub release to a slower secondary provider and reported the whole job as cancelled.

This reuses the publisher's existing `--skip-gitee` / `--skip-github` flags and the already-shipped bounded recovery primitive. It adds no workflow input, script mode, or new abstraction. The released `v0.19.0` bytes and provider state are not touched; this applies only to future releases after merge.

## Validation

```text
git diff --check
# clean

env -u PYTHONPATH PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider -q tests/test_wheels_workflow_publish_gating.py
# 28 passed

env -u PYTHONPATH PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider -q tests/test_publish_release_assets.py tests/test_sync_gitee_mirror.py tests/test_release_manifest.py tests/test_wheel_platlib_layout.py
# 86 passed

env -u PYTHONPATH PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider -q tests/test_architecture_documents.py
# 3 passed

env -u PYTHONPATH PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider -q tests/test_docs_governance.py
# 69 passed, 1 failed
```

The docs-governance failure is the pre-existing environment mismatch importing `ServerRequestContext` from the installed `mcp.server` through the unchanged Feishu MCP module; this diff does not touch that surface.

## Review and risk

- independent explicit Claude Opus (`claude-opus-5`) review: **ACCEPT**, zero blockers
- no live GitHub Actions run was dispatched and no GitHub Release, Gitee, PyPI, tag, or other provider state was changed
- `continue-on-error: true` keeps the overall run conclusion green after GitHub succeeds, while the Gitee step retains a failure outcome and emits visible warning/error annotations plus the exact manual `gitee_only_recovery` dispatch instructions
