### PR TITLE
fix: enforce tool-call result batch integrity

### DIFF
--- a/src/lingtai/intrinsic_skills/context-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/context-manual/SKILL.md
@@ -200,7 +200,7 @@ Before you call `context(action="molt", ...)`, always verify at minimum:
 
 **`keep_tool_calls`** — optional list of tool-call IDs to preserve across molt. Each named pair (tool_use + tool_result) is replayed into the fresh session right after the summary, in the order you list them. If any ID is not found, the molt is refused. Keep this list short — the durable stores are the primary persistence.
 
-**`keep_last`** — optional integer (default: 20). Number of recent conversation entries to preserve. These entries are replayed so the post-molt self retains recent context. Pass 0 to explicitly disable (archive everything). Overlapping entries with `keep_tool_calls` are deduplicated.
+**`keep_last`** — optional integer (default: 20). Requested minimum number of recent conversation entries to preserve. The retained suffix may expand backward to include one adjacent assistant tool-call/result batch whole, so it can contain more entries when needed to avoid splitting that batch. These entries are replayed so the post-molt self retains recent context. Pass 0 to explicitly disable (archive everything). Overlapping entries with `keep_tool_calls` are deduplicated.
 
 ## 7. Context Pressure Reminder
 

--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -99,10 +99,10 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting. Ca
 
 `generate()` follows the same wire selection as `create_chat()` via `_should_use_responses()`: Chat Completions by default/legacy, or Responses API when `wire_api="responses"` (or legacy `use_responses=True` without a custom base URL / with `force_responses=True`). This keeps service-level one-shot calls consistent with multi-turn sessions. `CodexOpenAIAdapter.generate` is the native exception to the generic Responses helper: it creates a context-owned `CodexResponsesSession` and sends one real streamed request, preserving `service_tier`, `store=false`, Codex identity/cache/account headers, normal temperature/output/schema arguments, and safe pool selection metadata.
 
-### Chat Completions session flow (`OpenAIChatSession.send`, `adapter.py:1424`)
+### Chat Completions session flow (`OpenAIChatSession.send`, `adapter.py:1523`)
 
 1. Record user input into `ChatInterface` (str → `add_user_message`; list → `add_tool_results`)
-2. `_build_kwargs()`: enforce tool pairing → serialize via `_build_messages()` → `_pair_orphan_tool_calls()` wire guard
+2. `_build_kwargs()`: enforce tool pairing → serialize via `_build_messages()` → `_pair_orphan_tool_calls()` preserves only known-call placeholders → `_validate_openai_tool_pairing()` rejects standalone, non-contiguous, wrong-batch, duplicate, or id-less role=tool rows with sanitized structural reason/phase
 3. `_run_with_overflow_recovery(_do_call)` — retries with context trimming on 400 context-length errors
 4. On success: record assistant response into interface via `_record_assistant_response()`
 
@@ -465,7 +465,7 @@ When a Codex session has a stable LingTai session/thread identity, `CodexRespons
 
 ### Wire-layer orphan guard
 
-`_pair_orphan_tool_calls()` (`adapter.py:1362`) scans the serialized message list for `assistant.tool_calls` without matching `role=tool` messages. Synthesizes placeholder tool results with `[synthesized placeholder — real result was not in context at send time]`. Logs warnings for investigation. Does NOT mutate canonical interface.
+`_pair_orphan_tool_calls()` (`adapter.py:1464`) scans the serialized message list for `assistant.tool_calls` without matching `role=tool` messages. Synthesizes placeholder tool results with `[synthesized placeholder — real result was not in context at send time]`. Logs only sanitized structural warnings. The shared `_validate_openai_tool_pairing()` immediately follows it in both `send()` and `send_stream()`, rejecting malformed standalone, non-contiguous, wrong-batch, duplicate, or id-less rows before SDK dispatch. Neither guard mutates the canonical interface.
 
 The Codex / Responses path has the same invariant: `to_responses_input` ends with `_pair_responses_orphan_function_calls` (`../interface_converters.py:190-250`) which synthesizes a `function_call_output` for any `function_call` without a matching output anywhere in the items list. Same placeholder string, same non-mutating semantics. Without this guard the provider returns `400 No tool output found for function call …` when a continuation request is built from a half-committed tool loop (issue #170).
 
@@ -483,7 +483,7 @@ In-flight official/stateful Responses and Codex sessions keep no-op prompt/tool 
 
 ### Streaming
 
-- **CC streaming** (`adapter.py:1612`) — `stream=True, stream_options={include_usage: True}`. Uses `StreamingAccumulator` for text + tool deltas. Reasoning deltas captured from `delta.reasoning` or `delta.reasoning_content`. Overflow recovery wraps stream open + first chunk in the Chat Completions send-stream path.
+- **CC streaming** (`adapter.py:1712`) — `stream=True, stream_options={include_usage: True}`. Uses `StreamingAccumulator` for text + tool deltas. Reasoning deltas captured from `delta.reasoning` or `delta.reasoning_content`. The post-build pairing validator runs before stream open, matching the non-streaming path. Overflow recovery wraps stream open + first chunk in the Chat Completions send-stream path.
 - **Responses streaming** (`adapter.py:1995`) — event types: `response.reasoning_summary_text.delta/done` (summary thoughts only), `response.output_text.delta`, `response.function_call_arguments.delta`, `response.output_item.added/done`, `response.completed`. Custom/stateless mode snapshots before staging, replays full canonical history, records the finalized assistant turn, and restores the pre-send snapshot on enforce, serialization, stream-open, iteration, callback, finalize, or record failure (`adapter.py:2002-2089`).
 - **Codex streaming** — forces `stream=True` even on `send()`. Runs the `full`/`incremental` planner per request over the selected transport (REST default / WebSocket opt-in): REST carries the whole converted interface in both modes; WebSocket carries the whole interface for `full` and delta + `previous_response_id` for `incremental`. Captured summary thoughts and raw encrypted reasoning items are persisted as ThinkingBlocks so `to_responses_input` replays reasoning items before function calls; if Codex later rejects a raw encrypted item as unverifiable, the adapter strips only that opaque replay state and retries once with summary/plain transcript. Optional diagnostics (`LINGTAI_CODEX_RESPONSES_TRACE=1`) append safe per-event metadata to `logs/codex_responses_trace.jsonl` without changing accumulator/persistence behavior.
 

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -51,6 +51,81 @@ from lingtai.kernel.token_counter import count_tokens
 logger = get_logger()
 
 
+class _OpenAIToolPairingError(ValueError):
+    """Sanitized structural failure at the Chat Completions wire boundary."""
+
+    def __init__(self, reason: str, *, phase: str = "wire_validation"):
+        self.reason = reason
+        self.phase = phase
+        super().__init__(f"tool pairing rejected: reason={reason} phase={phase}")
+
+
+def _validate_openai_tool_pairing(messages: list[dict]) -> None:
+    """Fail closed unless every Chat Completions tool batch is positional.
+
+    A role=tool run is valid only immediately after one assistant tool-call
+    batch and only when its IDs cover that batch exactly once.  The final
+    assistant tool-call entry may remain as the intentional live tail; the
+    existing local placeholder guard normally closes it before this check.
+    """
+    if not isinstance(messages, list):
+        raise _OpenAIToolPairingError("invalid_message_list")
+
+    known_call_ids: set[str] = set()
+    index = 0
+    while index < len(messages):
+        message = messages[index]
+        if not isinstance(message, dict):
+            raise _OpenAIToolPairingError("invalid_message")
+        role = message.get("role")
+        if role == "tool":
+            result_id = message.get("tool_call_id")
+            if not isinstance(result_id, str) or not result_id:
+                raise _OpenAIToolPairingError("idless")
+            reason = "non_contiguous" if result_id in known_call_ids else "standalone"
+            raise _OpenAIToolPairingError(reason)
+        if role != "assistant" or not message.get("tool_calls"):
+            index += 1
+            continue
+
+        calls = message.get("tool_calls")
+        if not isinstance(calls, list) or not calls:
+            raise _OpenAIToolPairingError("invalid_call_batch")
+        expected: list[str] = []
+        for call in calls:
+            call_id = call.get("id") if isinstance(call, dict) else None
+            if not isinstance(call_id, str) or not call_id:
+                raise _OpenAIToolPairingError("idless_call")
+            if call_id in expected:
+                raise _OpenAIToolPairingError("duplicate_call")
+            expected.append(call_id)
+        known_call_ids.update(expected)
+
+        result_index = index + 1
+        if result_index == len(messages):
+            # This is the intentional final live tail before closure.
+            index = result_index
+            continue
+        if not isinstance(messages[result_index], dict) or messages[result_index].get("role") != "tool":
+            raise _OpenAIToolPairingError("non_contiguous")
+
+        actual: list[str] = []
+        while result_index < len(messages):
+            result = messages[result_index]
+            if not isinstance(result, dict) or result.get("role") != "tool":
+                break
+            result_id = result.get("tool_call_id")
+            if not isinstance(result_id, str) or not result_id:
+                raise _OpenAIToolPairingError("idless")
+            if result_id in actual:
+                raise _OpenAIToolPairingError("duplicate")
+            actual.append(result_id)
+            result_index += 1
+        if set(actual) != set(expected):
+            raise _OpenAIToolPairingError("wrong_batch")
+        index = result_index
+
+
 _CODEX_RESPONSES_TRACE_ENV = "LINGTAI_CODEX_RESPONSES_TRACE"
 _CODEX_RESPONSES_TRACE_PATH_ENV = "LINGTAI_CODEX_RESPONSES_TRACE_PATH"
 _CODEX_RESPONSES_TRACE_FILE = "codex_responses_trace.jsonl"
@@ -1405,16 +1480,22 @@ class OpenAIChatSession(ChatSession):
         serialization sees it naturally and no synthesis fires — implicit
         dedup without any stateful replace step.
 
-        Each synthesis logs a warning with the tool_call_id and tool name
-        so we can track how often this fires and fix the root cause if it
-        becomes common.
+        Each synthesis logs only the structural missing-result reason and
+        phase. The following shared validator rejects any remaining malformed
+        row before the SDK call.
         """
         patched: list[dict] = []
         for i, msg in enumerate(messages):
+            if not isinstance(msg, dict):
+                raise _OpenAIToolPairingError("invalid_message", phase="wire_pairing")
             patched.append(msg)
             if msg.get("role") != "assistant":
                 continue
-            tool_calls = msg.get("tool_calls") or []
+            if "tool_calls" not in msg:
+                continue
+            tool_calls = msg["tool_calls"]
+            if not isinstance(tool_calls, list):
+                raise _OpenAIToolPairingError("invalid_call_batch", phase="wire_pairing")
             if not tool_calls:
                 continue
             # Look ahead in the ORIGINAL input list for role=tool entries
@@ -1422,23 +1503,27 @@ class OpenAIChatSession(ChatSession):
             # placeholders for any tool_call_id not covered.
             seen_ids: set[str] = set()
             j = i + 1
-            while j < len(messages) and messages[j].get("role") == "tool":
-                tcid = messages[j].get("tool_call_id")
+            while j < len(messages):
+                result = messages[j]
+                if not isinstance(result, dict):
+                    raise _OpenAIToolPairingError("invalid_message", phase="wire_pairing")
+                if result.get("role") != "tool":
+                    break
+                tcid = result.get("tool_call_id")
                 if tcid:
                     seen_ids.add(tcid)
                 j += 1
             # For each tool_call without a matching tool message, emit a
             # synthesized placeholder immediately after the assistant turn.
             for tc in tool_calls:
+                if not isinstance(tc, dict):
+                    raise _OpenAIToolPairingError("invalid_call", phase="wire_pairing")
                 tcid = tc.get("id")
-                name = (tc.get("function") or {}).get("name", "?")
                 if not tcid or tcid in seen_ids:
                     continue
                 logger.warning(
-                    "[wire-guard] synthesizing placeholder tool_result for "
-                    "orphan tool_call id=%s name=%s — real result was not "
-                    "in context at send time. Investigate if this recurs.",
-                    tcid, name,
+                    "[wire-guard] synthesized missing tool result "
+                    "placeholder (reason=missing_result phase=wire_pairing)"
                 )
                 patched.append({
                     "role": "tool",
@@ -1492,6 +1577,7 @@ class OpenAIChatSession(ChatSession):
             # any orphan assistant[tool_calls] that aren't immediately followed
             # by matching role=tool entries. Canonical interface untouched.
             candidate = self._pair_orphan_tool_calls(candidate)
+            _validate_openai_tool_pairing(candidate)
             kw: dict[str, Any] = {
                 "model": self._model,
                 "messages": candidate,
@@ -1665,6 +1751,7 @@ class OpenAIChatSession(ChatSession):
             candidate = self._build_messages()
             # Final wire-layer guard — same as non-streaming send().
             candidate = self._pair_orphan_tool_calls(candidate)
+            _validate_openai_tool_pairing(candidate)
             kw: dict[str, Any] = {
                 "model": self._model,
                 "messages": candidate,

--- a/src/lingtai/tools/context/ANATOMY.md
+++ b/src/lingtai/tools/context/ANATOMY.md
@@ -43,7 +43,9 @@ passive lifecycle scenarios.
 - `../system/summarize.py` — private history-summary engine. It records pending
   marker replacements, marks the applied set done, persists history, and only
   then calls `chat.request_history_rebuild`. It is not a public `system` action.
-- `_molt.py` — agent and system molt implementations, replay selection,
+- `_molt.py` — agent and system molt implementations; shared
+  `_select_keep_last_entries` atomically selects suffixes around complete
+  single/parallel assistant tool-result batches; replay selection,
   archive/wipe, post-molt hook invocation before fresh-session creation, and
   post-molt notification publishing.
 - `_session_journal.py` — fail-closed journal-path/frontmatter gate.

--- a/src/lingtai/tools/context/__init__.py
+++ b/src/lingtai/tools/context/__init__.py
@@ -99,7 +99,7 @@ _MOLT_INPUT_SCHEMA: dict[str, Any] = {
         },
         "keep_last": {
             "type": ["integer", "null"],
-            "description": 'Optional number of recent conversation entries to replay into the fresh session (default: 20 when null). Pass 0 to archive everything. Overlapping entries with keep_tool_calls are deduplicated. See context-manual.',
+            "description": 'Optional requested minimum number of recent conversation entries to replay into the fresh session (default: 20 when null). The retained suffix may contain more entries when needed to preserve one adjacent assistant tool-call/result batch whole. Pass 0 to archive everything. Overlapping entries with keep_tool_calls are deduplicated. See context-manual.',
         },
     },
     "required": ["summary", "session_journal_path", "keep_tool_calls", "keep_last"],

--- a/src/lingtai/tools/context/_molt.py
+++ b/src/lingtai/tools/context/_molt.py
@@ -35,6 +35,55 @@ SYSTEM_FORCED_MOLT_REASONING = (
 )
 
 
+def _select_keep_last_entries(
+    entries: list,
+    keep_last: int | None,
+    *,
+    exclude_tool_call_id: str | None = None,
+) -> list:
+    """Select a suffix without splitting an assistant tool-result batch."""
+    if keep_last is None or keep_last <= 0:
+        return []
+    candidates = [entry for entry in entries if entry.role != "system"]
+    if exclude_tool_call_id is not None:
+        candidates = [
+            entry for entry in candidates
+            if not any(
+                isinstance(block, ToolCallBlock) and block.id == exclude_tool_call_id
+                for block in entry.content
+            )
+        ]
+    if not candidates:
+        return []
+    start = max(0, len(candidates) - keep_last)
+
+    index = 0
+    while index < len(candidates):
+        entry = candidates[index]
+        is_call_batch = (
+            entry.role == "assistant"
+            and any(isinstance(block, ToolCallBlock) for block in entry.content)
+        )
+        if not is_call_batch:
+            index += 1
+            continue
+        end = index + 1
+        while end < len(candidates):
+            result_entry = candidates[end]
+            if (
+                result_entry.role != "user"
+                or not result_entry.content
+                or not all(isinstance(block, ToolResultBlock) for block in result_entry.content)
+            ):
+                break
+            end += 1
+        if index < start < end:
+            start = index
+            break
+        index = end
+    return candidates[start:]
+
+
 def _first_nonempty_line(text: str | None) -> str:
     if not text:
         return ""
@@ -313,20 +362,13 @@ def _context_molt(agent, args: dict) -> dict:
 
     before_tokens = iface_pre.estimate_context_tokens()
 
-    # Capture keep_last entries from the pre-molt interface BEFORE the
-    # snapshot (which mutates iface_pre by closing orphan tool calls) and
-    # BEFORE the wipe. These are the last N non-system entries that will
-    # be replayed into the fresh session so the post-molt self retains
-    # recent conversational context.
-    # Exclude the molt call's own entry — it is replayed separately.
-    keep_last_entries: list = []
-    if keep_last is not None:
-        non_system = [
-            e for e in iface_pre.entries
-            if e.role != "system"
-            and not any(isinstance(b, ToolCallBlock) and b.id == tc_id for b in e.content)
-        ]
-        keep_last_entries = non_system[-keep_last:] if keep_last <= len(non_system) else non_system[:]
+    # Capture keep_last entries before the snapshot and wipe. The shared
+    # selector excludes the molt call, then keeps tool batches atomic.
+    keep_last_entries = _select_keep_last_entries(
+        iface_pre.entries,
+        keep_last,
+        exclude_tool_call_id=tc_id,
+    )
 
     # Deduplicate: when both keep_last and keep_tool_calls are used, remove
     # any keep_last entries whose ToolCallBlocks or ToolResultBlocks are
@@ -617,11 +659,9 @@ def context_forget(agent, *, source: str = "warning_ladder", attempts: int = 0,
     iface_pre = agent._chat.interface
     before_tokens = iface_pre.estimate_context_tokens()
 
-    # Capture keep_last entries from the pre-molt interface BEFORE wiping.
-    keep_last_entries: list = []
-    if keep_last is not None and keep_last > 0:
-        non_system = [e for e in iface_pre.entries if e.role != "system"]
-        keep_last_entries = non_system[-keep_last:] if keep_last <= len(non_system) else non_system[:]
+    # Capture keep_last entries before wiping; the shared selector preserves
+    # complete assistant tool-call/result batches atomically.
+    keep_last_entries = _select_keep_last_entries(iface_pre.entries, keep_last)
 
     from . import _write_molt_snapshot
     _write_molt_snapshot(

--- a/tests/test_deepseek_adapter.py
+++ b/tests/test_deepseek_adapter.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from lingtai.llm.deepseek.adapter import DeepSeekAdapter, DeepSeekChatSession
 from lingtai.kernel.llm.interface import (
     ChatInterface,
@@ -289,3 +291,42 @@ class TestDeepSeekAdapterWiring:
     def test_base_url_override(self):
         adapter = DeepSeekAdapter(api_key="stub", base_url="https://alt.example/v1")
         assert adapter.base_url == "https://alt.example/v1"
+
+
+
+def test_deepseek_inherits_shared_tool_pairing_rejection_after_reasoning_hook():
+    """DeepSeek's reasoning hook runs, then the shared validator blocks dispatch."""
+    class _MalformedDeepSeekSession(DeepSeekChatSession):
+        def _build_messages(self):
+            messages = super()._build_messages()
+            messages.append({
+                "role": "tool",
+                "tool_call_id": "unknown-after-hook",
+                "content": "provider-secret",
+            })
+            return messages
+
+    iface = ChatInterface()
+    iface.add_assistant_message([
+        ToolCallBlock(id="known-call", name="lookup", args={}),
+    ])
+    iface.add_tool_results([
+        ToolResultBlock(id="known-call", name="lookup", content="known-result"),
+    ])
+    client = MagicMock()
+    session = _MalformedDeepSeekSession(
+        client=client,
+        model="deepseek-v4-pro",
+        interface=iface,
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+        client_kwargs={},
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        session.send(None)
+
+    assert "tool pairing" in str(exc_info.value)
+    assert "provider-secret" not in str(exc_info.value)
+    assert client.chat.completions.create.call_count == 0

--- a/tests/test_molt_task_persistence.py
+++ b/tests/test_molt_task_persistence.py
@@ -13,7 +13,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from lingtai.kernel.llm.interface import ChatInterface, TextBlock, ToolCallBlock
+from lingtai.kernel.llm.interface import (
+    ChatInterface,
+    TextBlock,
+    ToolCallBlock,
+    ToolResultBlock,
+)
 
 
 from tests._molt_helpers import write_session_journal as _write_session_journal
@@ -515,3 +520,124 @@ class TestContextForgetKeepLast:
             assert "task_snapshot_saved" not in result
         finally:
             agent.stop()
+
+
+# ---------------------------------------------------------------------------
+# Atomic keep_last batch selection regressions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("keep_last", "expected_indices"),
+    [
+        (6, [1, 2, 3, 4, 5, 6]),  # cut before the single-call batch
+        (5, [1, 2, 3, 4, 5, 6]),  # cut between its call and result
+        (4, [3, 4, 5, 6]),        # cut after the single-call batch
+        (3, [4, 5, 6]),            # cut before the parallel batch
+        (2, [4, 5, 6]),            # cut between its calls and results
+        (1, [6]),                  # cut after the parallel batch
+    ],
+)
+def test_keep_last_suffix_retains_tool_batches_atomically(keep_last, expected_indices):
+    """A suffix cut never retains only part of a single or parallel tool batch."""
+    from lingtai.tools.context._molt import _select_keep_last_entries
+
+    iface = ChatInterface()
+    iface.add_system("system")
+    iface.add_user_message("old")                         # 0
+    iface.add_assistant_message([                         # 1
+        ToolCallBlock(id="single-call", name="lookup", args={}),
+    ])
+    iface.add_tool_results([                               # 2
+        ToolResultBlock(id="single-call", name="lookup", content="single-result"),
+    ])
+    iface.add_user_message("between")                     # 3
+    iface.add_assistant_message([                         # 4
+        ToolCallBlock(id="parallel-a", name="lookup", args={}),
+        ToolCallBlock(id="parallel-b", name="lookup", args={}),
+    ])
+    iface.add_tool_results([                               # 5
+        ToolResultBlock(id="parallel-b", name="lookup", content="parallel-b-result"),
+        ToolResultBlock(id="parallel-a", name="lookup", content="parallel-a-result"),
+    ])
+    iface.add_user_message("after")                       # 6
+
+    entries = [entry for entry in iface.entries if entry.role != "system"]
+    selected = _select_keep_last_entries(entries, keep_last)
+    assert [entry.id for entry in selected] == [entries[i].id for i in expected_indices]
+
+
+def test_ordinary_molt_replays_atomic_keep_last_batch(tmp_path):
+    """The ordinary molt call site uses the shared atomic suffix selector."""
+    from lingtai.tools.context._molt import _context_molt
+
+    agent = _make_agent(tmp_path)
+    agent.start()
+    try:
+        _ensure_session(agent)
+        iface = agent._chat.interface
+        iface.add_user_message("before")
+        iface.add_assistant_message([
+            ToolCallBlock(id="ordinary-call", name="lookup", args={}),
+        ])
+        iface.add_tool_results([
+            ToolResultBlock(id="ordinary-call", name="lookup", content="result"),
+        ])
+        iface.add_user_message("after")
+        tc_id = _add_molt_call(agent)
+
+        result = _context_molt(agent, {
+            "summary": "summary",
+            "_tc_id": tc_id,
+            "keep_last": 2,
+            "session_journal_path": _write_session_journal(agent),
+        })
+
+        assert result["status"] == "ok"
+        assert result["kept_last"] == 3
+        replayed = agent._chat.interface
+        assert sum(
+            isinstance(block, ToolCallBlock) and block.id == "ordinary-call"
+            for entry in replayed.entries for block in entry.content
+        ) == 1
+        assert sum(
+            isinstance(block, ToolResultBlock) and block.id == "ordinary-call"
+            for entry in replayed.entries for block in entry.content
+        ) == 1
+    finally:
+        agent.stop()
+
+
+def test_forced_context_forget_replays_atomic_keep_last_batch(tmp_path):
+    """Forced context_forget shares the same atomic suffix selector."""
+    from lingtai.tools.context._molt import context_forget
+
+    agent = _make_agent(tmp_path)
+    agent.start()
+    try:
+        _ensure_session(agent)
+        iface = agent._chat.interface
+        iface.add_user_message("before")
+        iface.add_assistant_message([
+            ToolCallBlock(id="forced-call", name="lookup", args={}),
+        ])
+        iface.add_tool_results([
+            ToolResultBlock(id="forced-call", name="lookup", content="result"),
+        ])
+        iface.add_user_message("after")
+
+        result = context_forget(agent, source="admin", keep_last=2)
+
+        assert result["status"] == "ok"
+        assert result["kept_last"] == 3
+        replayed = agent._chat.interface
+        assert sum(
+            isinstance(block, ToolCallBlock) and block.id == "forced-call"
+            for entry in replayed.entries for block in entry.content
+        ) == 1
+        assert sum(
+            isinstance(block, ToolResultBlock) and block.id == "forced-call"
+            for entry in replayed.entries for block in entry.content
+        ) == 1
+    finally:
+        agent.stop()

--- a/tests/test_wire_orphan_pairing.py
+++ b/tests/test_wire_orphan_pairing.py
@@ -13,20 +13,28 @@ naturally on the next send (implicit dedup).
 """
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock
 
+import pytest
+
 from lingtai.llm.openai.adapter import OpenAIChatSession
-from lingtai.kernel.llm.interface import ChatInterface
+from lingtai.kernel.llm.interface import (
+    ChatInterface,
+    ToolCallBlock,
+    ToolResultBlock,
+)
+from tests._chat_completion_helpers import make_raw_response
 
 
 _SYNTH_MARKER = "[synthesized placeholder"
 
 
-def _make_session() -> OpenAIChatSession:
+def _make_session(client=None) -> OpenAIChatSession:
     """Build an isolated session with no real state; we only call
     _pair_orphan_tool_calls directly with hand-crafted message lists."""
     return OpenAIChatSession(
-        client=MagicMock(),
+        client=client or MagicMock(),
         model="test",
         interface=ChatInterface(),
         tools=None,
@@ -227,3 +235,161 @@ def test_tool_call_with_missing_id_is_skipped():
     tool_msgs = [m for m in out if m.get("role") == "tool"]
     assert len(tool_msgs) == 1
     assert tool_msgs[0]["tool_call_id"] == "B"
+
+
+# ---------------------------------------------------------------------------
+# Shared post-build/pre-SDK validator regressions
+# ---------------------------------------------------------------------------
+
+
+_VALID_TOOL_CALL = {
+    "id": "call-known",
+    "type": "function",
+    "function": {"name": "lookup", "arguments": '{"secret":"do-not-leak"}'},
+}
+
+
+@pytest.mark.parametrize(
+    ("label", "messages"),
+    [
+        (
+            "standalone",
+            [{"role": "tool", "tool_call_id": "old-call", "content": "secret-result"}],
+        ),
+        (
+            "non_contiguous",
+            [
+                {"role": "assistant", "tool_calls": [_VALID_TOOL_CALL]},
+                {"role": "user", "content": "separator"},
+                {"role": "tool", "tool_call_id": "call-known", "content": "secret-result"},
+            ],
+        ),
+        (
+            "wrong_batch",
+            [
+                {"role": "assistant", "tool_calls": [_VALID_TOOL_CALL]},
+                {"role": "tool", "tool_call_id": "other-call", "content": "secret-result"},
+            ],
+        ),
+        (
+            "duplicate",
+            [
+                {"role": "assistant", "tool_calls": [_VALID_TOOL_CALL]},
+                {"role": "tool", "tool_call_id": "call-known", "content": "first-secret"},
+                {"role": "tool", "tool_call_id": "call-known", "content": "second-secret"},
+            ],
+        ),
+        (
+            "idless",
+            [
+                {"role": "assistant", "tool_calls": [_VALID_TOOL_CALL]},
+                {"role": "tool", "content": "secret-result"},
+            ],
+        ),
+    ],
+)
+@pytest.mark.parametrize("streaming", [False, True], ids=["send", "send_stream"])
+def test_malformed_tool_rows_fail_closed_before_client_call(label, messages, streaming):
+    """Every malformed row is rejected after post-build pairing and before SDK dispatch."""
+    client = MagicMock()
+    session = _make_session(client)
+    session._build_messages = lambda: messages
+
+    with pytest.raises(ValueError) as exc_info:
+        if streaming:
+            session.send_stream(None)
+        else:
+            session.send(None)
+
+    error = str(exc_info.value)
+    assert "tool pairing" in error
+    assert "phase=" in error
+    assert "secret" not in error
+    assert "call-known" not in error
+    assert label in error
+    assert client.chat.completions.create.call_count == 0
+
+
+_MIXED_OBJECT_SENTINEL = "mixed-tool-call-secret-do-not-leak"
+
+
+class _NonDictToolCall:
+    def __repr__(self):
+        return f"<non-dict-tool-call {_MIXED_OBJECT_SENTINEL}>"
+
+
+@pytest.mark.parametrize("streaming", [False, True], ids=["send", "send_stream"])
+def test_mixed_non_dict_tool_call_fails_closed_before_client_call(streaming, caplog):
+    """A mixed call batch gets a sanitized structural error before dispatch."""
+    client = MagicMock()
+    session = _make_session(client)
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [_VALID_TOOL_CALL, _NonDictToolCall()],
+        },
+    ]
+    session._build_messages = lambda: messages
+
+    caplog.set_level(logging.WARNING)
+    with pytest.raises(ValueError) as exc_info:
+        if streaming:
+            session.send_stream(None)
+        else:
+            session.send(None)
+
+    error = exc_info.value
+    assert str(error) == "tool pairing rejected: reason=invalid_call phase=wire_pairing"
+    assert error.reason == "invalid_call"
+    assert error.phase == "wire_pairing"
+    assert _MIXED_OBJECT_SENTINEL not in str(error)
+    assert _MIXED_OBJECT_SENTINEL not in caplog.text
+    assert client.chat.completions.create.call_count == 0
+
+
+def test_valid_single_and_parallel_batches_reach_sdk_unchanged():
+    """Single and parallel result batches remain ordered/content-preserving."""
+    client = MagicMock()
+    client.chat.completions.create.return_value = make_raw_response(content="done")
+    iface = ChatInterface()
+    iface.add_assistant_message(
+        [
+            ToolCallBlock(id="single", name="lookup", args={}),
+        ]
+    )
+    iface.add_tool_results([
+        ToolResultBlock(id="single", name="lookup", content="single-result"),
+    ])
+    iface.add_assistant_message(
+        [
+            ToolCallBlock(id="parallel-a", name="lookup", args={}),
+            ToolCallBlock(id="parallel-b", name="lookup", args={}),
+        ]
+    )
+    # Parallel result order is intentionally not call order.
+    iface.add_tool_results([
+        ToolResultBlock(id="parallel-b", name="lookup", content="parallel-b-result"),
+        ToolResultBlock(id="parallel-a", name="lookup", content="parallel-a-result"),
+    ])
+    session = OpenAIChatSession(
+        client=client,
+        model="test",
+        interface=iface,
+        tools=None,
+        tool_choice=None,
+        extra_kwargs={},
+        client_kwargs={},
+    )
+
+    session.send(None)
+
+    sent = client.chat.completions.create.call_args.kwargs["messages"]
+    assert [m["role"] for m in sent] == [
+        "assistant", "tool", "assistant", "tool", "tool",
+    ]
+    assert [m.get("tool_call_id") for m in sent if m["role"] == "tool"] == [
+        "single", "parallel-b", "parallel-a",
+    ]
+    assert [m["content"] for m in sent if m["role"] == "tool"] == [
+        "single-result", "parallel-b-result", "parallel-a-result",
+    ]


### PR DESCRIPTION
## Summary

- validate final OpenAI-compatible Chat-Completions tool-call/result batches after message construction and known-call missing-result pairing, but before normal or streaming SDK dispatch
- fail closed with structural-only diagnostics for standalone, non-contiguous, wrong-batch, duplicate, id-less, or structurally invalid tool results while preserving valid single and parallel batches
- make ordinary molt and forced context-forget `keep_last` selection retain an adjacent assistant tool-call batch and its contiguous result run atomically, expanding beyond the requested minimum when necessary
- prove DeepSeek inherits the shared boundary; update the owning Anatomy and public `keep_last` wording

## Evidence boundary

The retained incident evidence proves repeated provider-bound malformed tool-result relationships, but it does not contain live request/chat bodies and therefore does **not** identify the exact historical creator, tool ID, or position. This PR is shared fail-closed containment plus losslessness prevention. It does not reorder/drop unknown real history, fabricate unknown results, or claim destructive creator-specific repair.

## Frozen candidate

- base/current main: `834274df1304488d3e6b5b2cde4a3b481a81e38b`
- base tree: `ff4853047baad9b4c79d33311d0c4c038a85b2f3`
- accepted pre-commit patch SHA-256: `73cef6a7b2ebd214839343ef7b7849d081cf75a44aa065b71c0cc192593a1d81`
- accepted manifest SHA-256: `0bb4138311ce266a0c79fc8cf03dc9eaa0079556c374cab3fad3b02500f315d0`
- scope: 9 files, `+503/-41`

## Validation

- 61 focused + drift-checker tests passed
- 183 affected wire/context/molt tests passed
- 13 context tests passed; 1 separately proven base-identical legacy-psyche test deselected
- 12 architecture/drift tests passed
- touched OpenAI and context Anatomy drift checks passed
- in-memory compilation of all six touched Python files passed
- Ruff `--no-cache` passed on all touched Python files
- `git diff --check` passed
- fresh pre-publication live diff remained byte-identical to the accepted patch
- independent final exact-Terra review: **ACCEPT**, no P0/P1/P2; 12/12 rows exact `gpt-5.6-terra`

No live malformed provider traffic was sent.
