### PR TITLE
chore(release): prepare v0.19.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.19.0"
+version = "0.19.1"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the kernel package version from `0.19.0` to `0.19.1`
- prepare an urgent patch release containing merged fix #1110 (`7f7ece2a`), which adds the shared OpenAI-compatible tool-call/result integrity guard and proves DeepSeek inherits it
- keep the release-candidate diff to the single expected `pyproject.toml` line

## Validation

- exact base/public main: `7f7ece2a4c42f02f3e96539d89698490e4be984d`
- Python `tomllib` reads project version `0.19.1`
- changed path is exactly `pyproject.toml`
- `git diff --check` passes

## Release path

After merge, create the annotated `v0.19.1` tag and GitHub release. The existing release workflow will build and attach the 15 platform wheels, sdist, manifest, and SHA256SUMS; the exact package bytes will then be published to PyPI and verified.
