### PR TITLE
feat: opt DeepSeek V4 Flash into the OpenAI Responses API

### DIFF
--- a/src/lingtai/init_schema.py
+++ b/src/lingtai/init_schema.py
@@ -388,15 +388,16 @@ def validate_init(data: dict) -> list[str]:
                 f"{', '.join(sorted(allowed_wire_api))}, got {wire_api!r}"
             )
         # The wire_api field is scoped to OpenAI-compatible wire semantics.
-        # Non-auto values are allowed only for the official OpenAI provider, or
-        # for a custom OpenAI-compatible endpoint (api_compat omitted/openai).
+        # Non-auto values are allowed only for the official OpenAI provider,
+        # DeepSeek (whose adapter now supports both wires), or a custom
+        # OpenAI-compatible endpoint (api_compat omitted/openai).
         # Every other provider/compat is rejected — including Codex, which is
         # forcibly on Responses and out of scope here — so misuse fails loudly.
         # ``auto`` is harmless everywhere and is left through unchanged.
         if wire_api != "auto":
             provider = str(llm.get("provider", "")).lower()
             api_compat = str(llm.get("api_compat", "openai")).lower() or "openai"
-            allowed_scope = provider == "openai" or (
+            allowed_scope = provider in {"openai", "deepseek"} or (
                 provider == "custom" and api_compat == "openai"
             )
             if not allowed_scope:

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -216,7 +216,19 @@ def register_all_adapters() -> None:
     def _deepseek(*, model=None, defaults=None, **kw):
         from .deepseek.adapter import DeepSeekAdapter
         kw.pop("model", None)
-        return DeepSeekAdapter(**{k: v for k, v in kw.items() if v is not None})
+        adapter_kw = {k: v for k, v in kw.items() if v is not None}
+        d = defaults or {}
+        # Honor Responses-API wiring from provider defaults, mirroring the
+        # _openai/_custom factories: wire_api selects the wire, and the
+        # legacy use_responses_api preference may coexist with it.
+        if "wire_api" in d:
+            adapter_kw["wire_api"] = d["wire_api"]
+        if "use_responses_api" in d:
+            adapter_kw["use_responses"] = d["use_responses_api"]
+        if "compact_threshold" in d:
+            # Preserve explicit None after the general None-pruning pass above.
+            adapter_kw["compact_threshold"] = d["compact_threshold"]
+        return DeepSeekAdapter(**adapter_kw)
 
     LLMService.register_adapter("deepseek", _deepseek)
 

--- a/src/lingtai/llm/deepseek/adapter.py
+++ b/src/lingtai/llm/deepseek/adapter.py
@@ -1,5 +1,9 @@
-"""DeepSeek adapter — thin OpenAI-compat wrapper that satisfies the
-reasoning_content round-trip contract for thinking mode.
+"""DeepSeek adapter — OpenAI-compat wrapper that satisfies the
+reasoning_content round-trip contract for thinking mode, on both the
+Chat Completions and Responses wires.
+
+Chat Completions
+----------------
 
 DeepSeek V4 thinking mode rejects requests missing ``reasoning_content``
 on assistant turns once thinking has been triggered. Omitting it returns
@@ -34,14 +38,35 @@ entries where the provider returned no reasoning text at all), inject a
 per-turn-unique stub so DeepSeek's field-presence validator is satisfied
 without re-introducing the cache-collapse pattern.
 
-Everything else inherits from ``OpenAIAdapter`` / ``OpenAIChatSession``
-unchanged via the ``_build_messages`` and ``_session_class`` hook points
-on the parent.
+Responses API
+-------------
+
+``DeepSeekAdapter`` now forwards the same wire-selection flags as the
+OpenAI-compatible family (``wire_api`` / ``use_responses`` /
+``force_responses`` / ``compact_threshold`` /
+``responses_stateless_replay``), so a DeepSeek endpoint that serves
+``/responses`` (native or via an OpenAI-compatible gateway) can be
+opted in. The Responses wire has no ``reasoning_content`` field; its
+equivalent is the ``reasoning`` input item:
+
+    {"type": "reasoning", "summary": [{"type": "summary_text", "text": ...}]}
+
+``to_responses_input`` already emits those from captured ThinkingBlocks.
+``DeepSeekResponsesSession`` adds the fallback: after the first
+``function_call`` item, any later assistant turn that has no reasoning
+item gets a per-turn-unique ``reasoning`` item injected — the Responses
+analogue of ``DeepSeekChatSession._build_messages``. Sessions are
+stateless (no ``previous_response_id``) and never send generic
+``context_management`` (``compact_threshold=None`` default), matching
+the MiMo pattern for endpoints without server-side response storage.
+
+Everything else inherits from ``OpenAIAdapter`` unchanged via the
+``_build_messages`` and ``_session_class`` hook points on the parent.
 """
 
 from __future__ import annotations
 
-from ..openai.adapter import OpenAIAdapter, OpenAIChatSession
+from ..openai.adapter import OpenAIAdapter, OpenAIChatSession, OpenAIResponsesSession
 
 
 _DEEPSEEK_BASE_URL = "https://api.deepseek.com"
@@ -74,6 +99,58 @@ def _fallback_reasoning_for(msg: dict, turn_idx: int) -> str:
     return f"reply [{snippet}] (turn {turn_idx})"
 
 
+def _fallback_responses_reasoning_item(role_text: str, turn_idx: int) -> dict:
+    """Build a per-turn-unique Responses ``reasoning`` input item.
+
+    ``role_text`` is the assistant plain-text content for the turn being
+    repaired (empty for a tool-call turn). The stub is inline-suffixed
+    with the turn index so consecutive missing turns stay byte-different.
+    """
+    snippet = (role_text or "")[:64].replace("\n", " ")
+    label = f"reply [{snippet}]" if snippet else "call"
+    return {
+        "type": "reasoning",
+        "summary": [{"type": "summary_text", "text": f"{label} (turn {turn_idx})"}],
+    }
+
+
+def _inject_responses_reasoning_fallback(items: list[dict]) -> list[dict]:
+    """Inject DeepSeek reasoning-item fallbacks into a Responses input list.
+
+    Responses items are a flat list; a single assistant turn can span
+    multiple items (reasoning, text, function_call). After the first
+    ``function_call`` item we must ensure every later assistant turn
+    carries a ``reasoning`` item — the Responses analogue of
+    ``DeepSeekChatSession._build_messages``. We walk the list, track
+    whether a ``function_call`` has been seen, and for each ``assistant``
+    text item that follows a call without an immediately-preceding
+    reasoning item, insert one before it.
+    """
+    seen_function_call = False
+    turn_idx = 0
+    out: list[dict] = []
+    for item in items:
+        if item.get("type") == "function_call":
+            seen_function_call = True
+            out.append(item)
+            continue
+        if seen_function_call and item.get("role") == "assistant":
+            turn_idx += 1
+            # Insert a fallback reasoning item before this assistant text
+            # item unless the immediately preceding item already carries
+            # reasoning (real thinking was preserved).
+            if not (out and out[-1].get("type") == "reasoning"):
+                out.append(
+                    _fallback_responses_reasoning_item(
+                        item.get("content") or "", turn_idx
+                    )
+                )
+            out.append(item)
+            continue
+        out.append(item)
+    return out
+
+
 class DeepSeekChatSession(OpenAIChatSession):
     """Chat session that satisfies DeepSeek's reasoning_content round-trip contract.
 
@@ -103,8 +180,29 @@ class DeepSeekChatSession(OpenAIChatSession):
         return messages
 
 
+class DeepSeekResponsesSession(OpenAIResponsesSession):
+    """Stateless Responses session that satisfies DeepSeek's reasoning round-trip.
+
+    Replays the full canonical interface as Responses input items every
+    turn (no ``previous_response_id``, no server-side store) and injects a
+    per-turn-unique ``reasoning`` item fallback on assistant turns after
+    the first ``function_call`` that lack preserved thinking — the
+    Responses analogue of ``DeepSeekChatSession._build_messages``.
+    """
+
+    def _replay_input_items(self) -> list[dict]:
+        items = super()._replay_input_items()
+        return _inject_responses_reasoning_fallback(items)
+
+
 class DeepSeekAdapter(OpenAIAdapter):
-    """OpenAI-compat adapter pinned to DeepSeek with reasoning_content round-trip."""
+    """OpenAI-compat adapter pinned to DeepSeek with reasoning_content round-trip.
+
+    Wire selection is configurable: by default Chat Completions
+    (``DeepSeekChatSession``); set ``wire_api="responses"`` (or the legacy
+    ``use_responses``/``force_responses`` flags) to use the Responses wire
+    via ``DeepSeekResponsesSession`` for endpoints that serve ``/responses``.
+    """
 
     _session_class = DeepSeekChatSession
 
@@ -123,11 +221,84 @@ class DeepSeekAdapter(OpenAIAdapter):
         timeout_ms: int = 300_000,
         max_rpm: int = 0,
         default_headers: dict | None = None,
+        wire_api: str | None = None,
+        use_responses: bool | None = None,
+        force_responses: bool | None = None,
+        compact_threshold: int | None = None,
+        responses_stateless_replay: bool = True,
     ):
+        # Forward wire-selection flags so ``_should_use_responses()`` can
+        # opt DeepSeek into the Responses API. Defaults preserve today's
+        # Chat Completions behavior (no flags). ``compact_threshold``
+        # defaults to None on the Responses wire (no generic
+        # ``context_management`` — MiMo/Codex precedent) and is only
+        # non-None when explicitly configured; Chat Completions ignores
+        # it entirely.
+        kwargs: dict = {}
+        if wire_api is not None:
+            kwargs["wire_api"] = wire_api
+        if use_responses is not None:
+            kwargs["use_responses"] = use_responses
+        if force_responses is not None:
+            kwargs["force_responses"] = force_responses
+        kwargs["compact_threshold"] = compact_threshold
+        kwargs["responses_stateless_replay"] = responses_stateless_replay
         super().__init__(
             api_key=api_key,
             base_url=base_url or _DEEPSEEK_BASE_URL,
             timeout_ms=timeout_ms,
             max_rpm=max_rpm,
             default_headers=default_headers,
+            **kwargs,
+        )
+
+    def _create_responses_session(
+        self,
+        model: str,
+        system_prompt: str,
+        tools=None,
+        json_schema: dict | None = None,
+        force_tool_call: bool = False,
+        interface=None,
+        thinking: str = "default",
+        context_window: int = 0,
+    ) -> DeepSeekResponsesSession:
+        from ..openai.adapter import _build_responses_tools, _responses_reasoning_kwargs
+
+        if interface is None:
+            from lingtai.kernel.llm.interface import ChatInterface
+            interface = ChatInterface()
+            from lingtai.kernel.llm.base import FunctionSchema
+            interface.add_system(system_prompt, tools=FunctionSchema.list_to_dicts(tools))
+
+        ds_tools = _build_responses_tools(tools)
+        tool_choice: str | None = None
+        if force_tool_call and ds_tools:
+            tool_choice = "required"
+
+        extra_kwargs: dict = {}
+        if json_schema is not None:
+            extra_kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": json_schema.get("title", "response"),
+                    "strict": True,
+                    "schema": json_schema,
+                },
+            }
+        extra_kwargs.update(_responses_reasoning_kwargs(thinking))
+
+        return DeepSeekResponsesSession(
+            client=self._client,
+            model=model,
+            instructions=system_prompt,
+            tools=ds_tools,
+            tool_choice=tool_choice,
+            extra_kwargs=extra_kwargs,
+            previous_response_id=None,
+            compact_threshold=self._compact_threshold,
+            interface=interface,
+            prompt_cache_key=self._resolve_prompt_cache_key(model),
+            context_window=context_window,
+            stateless_replay=self._responses_stateless_replay,
         )

--- a/tests/test_deepseek_adapter.py
+++ b/tests/test_deepseek_adapter.py
@@ -22,7 +22,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from lingtai.llm.deepseek.adapter import DeepSeekAdapter, DeepSeekChatSession
+from lingtai.llm.deepseek.adapter import (
+    DeepSeekAdapter,
+    DeepSeekChatSession,
+    _inject_responses_reasoning_fallback,
+)
 from lingtai.kernel.llm.interface import (
     ChatInterface,
     TextBlock,
@@ -330,3 +334,72 @@ def test_deepseek_inherits_shared_tool_pairing_rejection_after_reasoning_hook():
     assert "tool pairing" in str(exc_info.value)
     assert "provider-secret" not in str(exc_info.value)
     assert client.chat.completions.create.call_count == 0
+
+
+def test_deepseek_responses_wire_selection():
+    """DeepSeekAdapter can opt into the Responses wire via wire_api/use_responses."""
+    chat = DeepSeekAdapter(api_key="x")
+    assert chat._should_use_responses() is False
+
+    responses = DeepSeekAdapter(api_key="x", wire_api="responses")
+    assert responses._should_use_responses() is True
+
+    explicit_chat = DeepSeekAdapter(api_key="x", wire_api="chat_completions", use_responses=True)
+    assert explicit_chat._should_use_responses() is False
+
+    legacy = DeepSeekAdapter(api_key="x", use_responses=True, force_responses=True)
+    assert legacy._should_use_responses() is True
+
+
+def test_deepseek_responses_defaults_are_stateless_no_compaction():
+    """Responses opt-in defaults to stateless replay and no context_management."""
+    adapter = DeepSeekAdapter(api_key="x", wire_api="responses")
+    assert adapter._responses_stateless_replay is True
+    assert adapter._compact_threshold is None
+
+
+def test_deepseek_responses_reasoning_fallback_injection():
+    """Fallback reasoning item is injected after first function_call in Responses items."""
+    items = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "pre-tool reply"},
+        {"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "c1", "output": "ok"},
+        {"role": "assistant", "content": "post-tool reply"},
+    ]
+    out = _inject_responses_reasoning_fallback(items)
+    assert out[1]["role"] == "assistant" and out[1].get("content") == "pre-tool reply"
+    assert out[-2]["type"] == "reasoning"
+    assert out[-2]["summary"][0]["type"] == "summary_text"
+    assert "post-tool reply" in out[-2]["summary"][0]["text"]
+    assert out[-1]["role"] == "assistant" and out[-1]["content"] == "post-tool reply"
+
+
+def test_deepseek_responses_keeps_existing_reasoning():
+    """Real preserved reasoning items are not duplicated by the fallback."""
+    items = [
+        {"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "c1", "output": "ok"},
+        {"type": "reasoning", "summary": [{"type": "summary_text", "text": "real thinking"}]},
+        {"role": "assistant", "content": "answer"},
+    ]
+    out = _inject_responses_reasoning_fallback(items)
+    reasoning_items = [i for i in out if i.get("type") == "reasoning"]
+    assert len(reasoning_items) == 1
+    assert reasoning_items[0]["summary"][0]["text"] == "real thinking"
+
+
+def test_deepseek_responses_create_responses_session_uses_deepseek_session():
+    """_create_responses_session builds a DeepSeekResponsesSession (stateless)."""
+    from lingtai.llm.deepseek.adapter import DeepSeekResponsesSession
+    from lingtai.kernel.llm.interface import ChatInterface
+
+    adapter = DeepSeekAdapter(api_key="x", wire_api="responses")
+    iface = ChatInterface()
+    iface.add_system("sys")
+    session = adapter._create_responses_session(
+        model="deepseek-v4-flash", system_prompt="sys", interface=iface
+    )
+    assert isinstance(session, DeepSeekResponsesSession)
+    assert session._stateless_replay is True
+

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -797,3 +797,14 @@ def test_legacy_prompt_is_not_reintroduced_as_lingtai_alias() -> None:
     warnings = validate_init(data)
 
     assert "unknown top-level field: prompt" in warnings
+
+
+def test_deepseek_wire_api_responses_allowed():
+    """wire_api=responses is accepted for the deepseek provider (Responses opt-in)."""
+    data = _valid_init()
+    data["manifest"]["llm"]["provider"] = "deepseek"
+    data["manifest"]["llm"]["model"] = "deepseek-v4-flash"
+    data["manifest"]["llm"]["base_url"] = "https://api.deepseek.com"
+    data["manifest"]["llm"]["wire_api"] = "responses"
+    validate_init(data)  # should not raise
+


### PR DESCRIPTION
## Summary

Enables DeepSeek (in particular `deepseek-v4-flash`) to run on the OpenAI **Responses API** wire when the endpoint serves `/responses` (native or via an OpenAI-compatible gateway). Today `provider='deepseek'` is hard-wired to Chat Completions: `DeepSeekAdapter.__init__` never forwards wire flags and always sets `base_url`, so `_should_use_responses()` is always False.

## Changes

- **`src/lingtai/llm/deepseek/adapter.py`**
  - `DeepSeekAdapter.__init__` now accepts `wire_api`, `use_responses`, `force_responses`, `compact_threshold`, `responses_stateless_replay` and forwards them to `OpenAIAdapter`. Default (no flags) preserves Chat Completions behavior.
  - New `DeepSeekResponsesSession(OpenAIResponsesSession)`: stateless full-history replay (no `previous_response_id`, no generic `context_management`) that injects a per-turn-unique `reasoning` item fallback after the first `function_call` — the Responses analogue of `DeepSeekChatSession._build_messages`.
  - Override `_create_responses_session()` (MiMo pattern) to build the DeepSeek session with stateless replay and no compaction.
- **`src/lingtai/llm/_register.py`** `_deepseek` factory now forwards `wire_api` / `use_responses_api` / `compact_threshold` from provider defaults (mirrors `_openai`/`_custom`).
- **`tests/test_deepseek_adapter.py`**: new tests for wire selection, stateless defaults, reasoning fallback injection, preserved-reasoning non-duplication, and session construction.

## Verification

- `pytest tests/test_deepseek_adapter.py` — 17 passed
- `pytest tests/test_responses_converter.py tests/test_custom_responses_stateless.py` — 18 passed (no regressions on the generic Responses path)

## Usage

Opt a DeepSeek model in via provider defaults or preset:

```jsonc
{
  "llm": {
    "provider": "deepseek",
    "model": "deepseek-v4-flash",
    "wire_api": "responses"
  }
}
```

## Risk notes

- DeepSeek's native API documents `/chat/completions`; this patch is meaningful when a `/responses` endpoint (native or gateway) exists. If it does not, the config-only gateway path via `provider=custom` + `wire_api=responses` remains available without this patch.
- `context_management`/`store` acceptance on a DeepSeek Responses endpoint is unverified; defaults keep them off (`compact_threshold=None`, stateless replay).
- Thinking-mode field-presence on the Responses wire is unverified; the fallback injection mirrors the Chat-Completions contract defensively.
