### PR TITLE
fix: MCP subprocess leak on Windows refresh/molt (duplicate Telegram listeners)

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -1138,6 +1138,8 @@ class Agent(BaseAgent):
         """
         from .services import mcp as mcp_service
         from .services.mcp import MCPClient
+        from lingtai.kernel.logging import get_logger as _get_logger
+        logger = _get_logger()
 
         # Expand per-agent placeholders (e.g. {agent_id}) so a shared registry
         # template gives each agent its own scope. See _expand_agent_placeholders.
@@ -1146,6 +1148,23 @@ class Agent(BaseAgent):
             args = [self._expand_agent_placeholders(a) for a in args]
         if env:
             env = {k: self._expand_agent_placeholders(v) for k, v in env.items()}
+
+        # Dedupe by identity: if an identical server is already connected,
+        # reuse it instead of spawning a duplicate subprocess. Without this,
+        # every boot/refresh/molt respawn adds another stdio pair that close()
+        # cannot reliably terminate on Windows (venv shim -> interpreter).
+        identity = None
+        default_name = getattr(MCPClient, "_default_name", None)
+        if default_name is not None:
+            identity = default_name(command, args or [])
+        if identity is not None:
+            for existing in getattr(self, "_mcp_clients", []) or []:
+                if (
+                    getattr(existing, "name", None) == identity
+                    and existing.is_connected()
+                ):
+                    logger.info("MCP %s already connected; reusing client", identity)
+                    return []
 
         client = MCPClient(command=command, args=args, env=env)
         client.start()
@@ -1334,6 +1353,16 @@ class Agent(BaseAgent):
                 name: self._expand_agent_placeholders(value)
                 for name, value in headers.items()
             }
+
+        # Dedupe by endpoint: an identical HTTP server already connected must
+        # not get a second connection (same accumulation class as stdio).
+        for existing in getattr(self, "_mcp_clients", []) or []:
+            if (
+                getattr(existing, "url", None) == url
+                and existing.is_connected()
+            ):
+                logger.info("HTTP MCP %s already connected; reusing client", url)
+                return []
 
         client = HTTPMCPClient(url=url, headers=headers)
         client.start()

--- a/src/lingtai/services/mcp.py
+++ b/src/lingtai/services/mcp.py
@@ -18,6 +18,7 @@ kernel-facing projection of typed results.
 from __future__ import annotations
 
 import json
+import os
 import threading
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -223,6 +224,132 @@ async def _list_all_tools(client: Any) -> list[dict[str, Any]]:
 _STALE_RETRY_POLICIES = frozenset({"never", "safe"})
 
 
+def _snapshot_process_table() -> list[dict]:
+    """Return [{pid, ppid, cmdline}] for every visible process.
+
+    stdlib-only, cross-platform. The MCP server may be a wrapper that spawns
+    a real interpreter child (Windows venv shim -> base python), so callers
+    that need to kill a server must walk the whole descendant tree, not just
+    direct children.
+    """
+    rows: list[dict] = []
+    try:
+        if os.name == "nt":
+            import json
+            import subprocess
+
+            script = (
+                "Get-CimInstance Win32_Process | "
+                "Select-Object ProcessId,ParentProcessId,CommandLine | "
+                "ConvertTo-Json -Compress"
+            )
+            out = subprocess.check_output(
+                ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+                text=True,
+                timeout=20,
+                errors="replace",
+            ).strip()
+            if not out:
+                return rows
+            data = json.loads(out)
+            if isinstance(data, dict):
+                data = [data]
+            for item in data:
+                rows.append(
+                    {
+                        "pid": int(item.get("ProcessId") or 0),
+                        "ppid": int(item.get("ParentProcessId") or 0),
+                        "cmdline": (item.get("CommandLine") or "").lower(),
+                    }
+                )
+        else:
+            import subprocess
+
+            out = subprocess.check_output(
+                ["ps", "-axo", "pid=,ppid=,command="],
+                text=True,
+                timeout=20,
+                errors="replace",
+            )
+            for line in out.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                parts = line.split(None, 2)
+                if len(parts) < 2:
+                    continue
+                try:
+                    pid = int(parts[0])
+                    ppid = int(parts[1])
+                except ValueError:
+                    continue
+                cmdline = (parts[2] if len(parts) > 2 else "").lower()
+                rows.append({"pid": pid, "ppid": ppid, "cmdline": cmdline})
+    except Exception:
+        # Best effort: if the snapshot fails we simply cannot clean up by pid.
+        return rows
+    return rows
+
+
+def _descendant_pids(root_pid: int, table: list[dict]) -> list[int]:
+    """Return every pid in the descendant closure of ``root_pid``."""
+    children: dict[int, list[int]] = {}
+    for row in table:
+        children.setdefault(row["ppid"], []).append(row["pid"])
+    found: list[int] = []
+    stack = list(children.get(root_pid, []))
+    while stack:
+        pid = stack.pop()
+        found.append(pid)
+        stack.extend(children.get(pid, []))
+    return found
+
+
+def _kill_process_tree(pid: int, timeout: float = 3.0) -> bool:
+    """Terminate a process and all its descendants; return True if gone."""
+    try:
+        if os.name == "nt":
+            import subprocess
+
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                capture_output=True,
+                text=True,
+                timeout=timeout + 2,
+            )
+        else:
+            import signal
+
+            try:
+                os.killpg(pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError, OSError):
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except (ProcessLookupError, PermissionError, OSError):
+                    pass
+            import time
+
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    return True
+                except PermissionError:
+                    return False
+                time.sleep(0.05)
+            try:
+                os.killpg(pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError, OSError):
+                    pass
+    except Exception:
+        return False
+    return True
+
+
 class MCPClient:
     """Async-to-sync bridge for any MCP stdio server.
 
@@ -238,10 +365,17 @@ class MCPClient:
         command: str,
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
+        name: str | None = None,
     ):
         self._command = command
         self._args = args or []
         self._env = env
+        self._name = name or self._default_name(command, self._args)
+
+        # Child process tree owned by this client (captured after start so
+        # close() can terminate it even on platforms where EOF does not exit
+        # the child, e.g. Windows venv shim -> real interpreter).
+        self._child_pids: list[int] = []
 
         self._session: Any = None
         self._read_stream: Any = None
@@ -262,6 +396,48 @@ class MCPClient:
         # Activity log for debugging — last 50 calls
         self._activity_log: list[dict[str, Any]] = []
         self._activity_lock = threading.Lock()
+
+    @staticmethod
+    def _default_name(command: str, args: list[str]) -> str:
+        """Derive a stable identity from the spawn command for dedup."""
+        base = os.path.basename(command).lower()
+        tokens = [base]
+        for a in args:
+            tok = a.lower().strip()
+            if len(tok) >= 5 and not tok.startswith("-"):
+                tokens.append(tok)
+        return "|".join(tokens)
+
+    @property
+    def name(self) -> str:
+        """Stable identity for dedup (explicit name or derived from command)."""
+        return self._name
+
+    def _capture_child_pids(self) -> None:
+        """Record descendant PIDs matching this server's command signature."""
+        try:
+            signature_tokens = [t for t in self._name.split("|") if t]
+            table = _snapshot_process_table()
+            matches = []
+            for pid in _descendant_pids(os.getpid(), table):
+                row = next((r for r in table if r["pid"] == pid), None)
+                if row and row["cmdline"]:
+                    if any(tok in row["cmdline"] for tok in signature_tokens):
+                        matches.append(pid)
+            if matches:
+                self._child_pids = matches
+        except Exception:
+            pass
+
+    def _kill_children(self) -> None:
+        """Terminate the captured child process tree (best effort)."""
+        if not self._child_pids:
+            return
+        for pid in self._child_pids:
+            try:
+                _kill_process_tree(pid)
+            except Exception:
+                continue
 
     # ------------------------------------------------------------------
     # Exception helpers — never surface a blank error (issue #104)
@@ -340,9 +516,20 @@ class MCPClient:
         self._ready.wait(timeout=30)
         if self._error:
             raise RuntimeError(f"MCP server failed to start: {self._error}")
+        # The subprocess is now alive; record its tree so close() can
+        # terminate it on platforms where closing stdio does not exit it.
+        self._capture_child_pids()
 
     def close(self) -> None:
-        """Shut down the MCP session and background thread."""
+        """Shut down the MCP session, background thread, and subprocess tree.
+
+        Stopping the asyncio loop and joining the thread is enough on POSIX,
+        where closing the stdio pipes delivers EOF and the child exits. On
+        Windows that is not reliable (a venv launcher shim spawns a real
+        interpreter as a child that survives), so we additionally terminate
+        the captured subprocess tree. Harmless on POSIX, where the tree is
+        already gone.
+        """
         if self._closed:
             return
         self._closed = True
@@ -350,6 +537,7 @@ class MCPClient:
             self._loop.call_soon_threadsafe(self._loop.stop)
         if self._thread:
             self._thread.join(timeout=5)
+        self._kill_children()
 
     def restart(self) -> None:
         """Tear down a (possibly stale) session and reconnect from scratch.

--- a/tests/test_mcp_client_close_kills_subprocess.py
+++ b/tests/test_mcp_client_close_kills_subprocess.py
@@ -1,0 +1,76 @@
+"""Regression: MCPClient.close() must terminate the subprocess tree.
+
+On POSIX, stopping the asyncio loop closes the stdio pipes and the child
+receives EOF on stdin, which exits it. On Windows that is not reliable: a
+venv launcher shim spawns a real interpreter as a child that survives,
+so every boot/refresh/molt respawn leaked another stdio pair (duplicate
+telegram listeners etc). close() now captures the child tree after start
+and explicitly terminates it.
+"""
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from lingtai.services.mcp import (
+    MCPClient,
+    _snapshot_process_table,
+)
+
+
+FAKE_SERVER = r"""
+import sys, time
+# Simulates a server that does NOT exit on stdin EOF (the Windows leak case).
+while True:
+    try:
+        data = sys.stdin.buffer.read(1)
+    except Exception:
+        break
+    if not data:
+        time.sleep(3600)
+"""
+
+
+@pytest.fixture
+def fake_server_script(tmp_path):
+    path = tmp_path / "fake_server_keepalive.py"
+    path.write_text(FAKE_SERVER, encoding="utf-8")
+    return str(path)
+
+
+def _pids_still_alive(pids):
+    table = _snapshot_process_table()
+    present = {r["pid"] for r in table}
+    return [pid for pid in pids if pid in present]
+
+
+def test_close_terminates_subprocess_tree(fake_server_script):
+    marker = "keepalive_marker_%d" % os.getpid()
+    client = MCPClient(command=sys.executable, args=[fake_server_script, marker])
+    client.start()
+    client._capture_child_pids()
+
+    assert client._child_pids, "expected at least one captured child process"
+    assert _pids_still_alive(client._child_pids), "child should be alive after start"
+
+    client.close()
+    time.sleep(0.5)
+
+    still = _pids_still_alive(client._child_pids)
+    assert not still, f"close() leaked subprocesses: {still}"
+
+
+def test_name_identity_derived_from_command(fake_server_script):
+    client = MCPClient(command=sys.executable, args=[fake_server_script])
+    assert client.name
+    assert "fake_server_keepalive" in client.name
+
+
+def test_dedup_identity_detects_same_server(fake_server_script):
+    c1 = MCPClient(command=sys.executable, args=[fake_server_script, "dedup_a"])
+    c2 = MCPClient(command=sys.executable, args=[fake_server_script, "dedup_a"])
+    assert c1.name == c2.name
+    c1.close()
+    c2.close()


### PR DESCRIPTION
## Problem

On native Windows, every refresh/molt/boot respawn of an MCP server leaked another stdio subprocess pair (venv launcher shim + real interpreter child). Users saw duplicate Telegram listeners/task cards after refresh, accumulating over time. mac and WSL were unaffected.

## Root cause

MCPClient.close() (services/mcp.py) only stopped the asyncio loop and joined the background thread:

`python
def close(self):
    self._closed = True
    if self._loop and self._loop.is_running():
        self._loop.call_soon_threadsafe(self._loop.stop)
    if self._thread:
        self._thread.join(timeout=5)
`

On POSIX, stopping the loop closes the stdio pipes; the child sees EOF on stdin and exits. On Windows, closing the pipe does NOT deliver EOF the same way - and the venv launcher shim spawns a real interpreter child that survives, so the pair keeps running and keeps polling Telegram.

## Fix

1. MCPClient now captures its descendant subprocess tree after start (stdlib-only snapshot: PowerShell CIM on Windows, ps on POSIX) and terminates the tree in close() (taskkill /T /F on Windows; SIGTERM/SIGKILL on POSIX). Harmless where EOF already works.
2. connect_mcp / connect_mcp_http dedupe by identity - an already-connected identical server is reused instead of spawning a duplicate.
3. Regression test tests/test_mcp_client_close_kills_subprocess.py validates close() terminates the tree and identity dedup works.

## Test results

- 3 new regression tests pass
- 73 capability + metadata tests pass
- 190 other MCP tests pass (1 unrelated pre-existing config-helper failure on Windows home expansion)

Closes the Windows-only accumulation of MCP subprocesses on refresh/molt.