### PR TITLE
chore(release): prepare v0.19.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.19.1"
+version = "0.19.2"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump the kernel package version from `0.19.1` to `0.19.2`
- prepare a second urgent patch release containing DeepSeek PR #1112 (`5ce8a78c`), which opts DeepSeek V4 Flash into the OpenAI Responses API
- freeze authorization-time main `b8607105`, which also contains already-merged Windows MCP subprocess-leak fix #1113
- keep the release-candidate diff to the single expected `pyproject.toml` line

## Validation

- exact authorization-time base/public main: `b860710514265686cf69d5c0ab39c6ac064d8251`
- Python `tomllib` reads project version `0.19.2`
- changed path is exactly `pyproject.toml`
- `git diff --check` passes

## Release path

After merge, create the annotated `v0.19.2` tag and GitHub release. The existing release workflow will build and attach the 15 platform wheels, sdist, manifest, and SHA256SUMS; the exact package bytes will then be published to PyPI and verified.