### PR TITLE
feat(vision): first-class local Ollama provider + thick manual guidance

### DIFF
--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -11,6 +11,12 @@ The local mlx-vlm pseudo-provider remains available through explicit
 ``add_capability(..., provider="local")`` opt-in, but it is intentionally not
 advertised in ``PROVIDERS`` or first-run/check-caps surfaces yet.
 
+``ollama`` is a first-class local OpenAI-compatible provider: it defaults to
+``http://localhost:11434/v1``, a small vision model (``moondream``), and a
+placeholder key (Ollama ignores the value). Configure it with
+``add_capability("vision", provider="ollama", model="<pulled-model>")`` or via
+``manifest.capabilities.vision``; no API key is required.
+
 ``vision`` is migrated to the LingTai Tool Protocol v2 action-separated shape
 (``src/lingtai/tools/CONTRACT.md``): one public ``vision`` tool whose canonical
 children are ``analyze`` and the family-owned reserved ``manual``, composed and
@@ -122,6 +128,7 @@ PROVIDERS = {
         "gemini", "anthropic", "openai", "openrouter", "custom", "deepseek",
         "minimax", "mimo", "glm", "zhipu", "grok", "qwen", "kimi",
         "codex", "codex-pool", "codex_pool", "claude-code", "claude_code",
+        "ollama",
     ],
     "default": None,
     "fallback_on_inherit": None,  # no agnostic fallback for vision
@@ -358,6 +365,37 @@ def setup(
                     api_key=None,
                     **local_kwargs,
                 )
+            except Exception as exc:
+                manual_reason = _setup_failure(provider, exc)
+        elif provider_key == "ollama":
+            # Ollama is a local OpenAI-compatible server (default
+            # http://localhost:11434/v1). It accepts any non-blank API key and
+            # serves the Chat Completions wire only. Unlike the generic custom
+            # relay below, a missing api_key is NOT a hard failure: Ollama
+            # ignores the value, so we synthesize a placeholder that satisfies
+            # the OpenAI SDK's non-blank requirement. base_url/model default to
+            # the standard local endpoint and a sensible small vision model.
+            from lingtai.services.vision.openai import OpenAIVisionService
+            ollama_base_url = kwargs.get("base_url") or "http://localhost:11434/v1"
+            ollama_model = kwargs.get("model") or "moondream"
+            ollama_key = api_key or "ollama"  # placeholder; Ollama ignores value
+            ollama_wire = _effective_openai_wire(
+                kwargs.get("wire_api"),
+                use_responses_api=False,
+                base_url=ollama_base_url,
+            )
+            svc_kwargs: dict = {
+                "api_key": ollama_key,
+                "model": ollama_model,
+                "base_url": ollama_base_url,
+            }
+            if ollama_wire and ollama_wire != "auto":
+                svc_kwargs["wire_api"] = ollama_wire
+            cap_max_tokens = kwargs.get("max_tokens")
+            if cap_max_tokens is not None:
+                svc_kwargs["max_tokens"] = cap_max_tokens
+            try:
+                vision_service = OpenAIVisionService(**svc_kwargs)
             except Exception as exc:
                 manual_reason = _setup_failure(provider, exc)
         elif provider_key not in PROVIDERS["providers"]:

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -65,3 +65,91 @@ auto-invokes MCP.
 Never request or print API keys, OAuth tokens, environment values, headers, or
 full unsanitized URLs. Missing provider, model, or endpoint fields are simply
 unknown; do not fill them with guesses.
+
+## Local vision with Ollama (first-class provider)
+
+`provider="ollama"` is a built-in local route: it needs no API key, defaults to
+`http://localhost:11434/v1`, and uses a small vision model (`moondream`) unless
+one is configured. It is the fastest way to get private, offline image
+understanding on a machine that already runs Ollama.
+
+### 1. Install and pull a vision model
+
+Install [Ollama](https://ollama.com) for your platform, then pull a vision-capable
+model. `moondream` is the recommended default: it is tiny (~1.7 GB), runs on
+CPU or a small GPU, and is sufficient for OCR and basic image description.
+
+    ollama pull moondream
+
+Other vision-capable Ollama models exist (for example the `llava` family or
+`qwen2.5vl`); pull whichever fits your hardware. The model must be a vision
+model — a text-only model will fail at request time with a "does not support
+images" style error.
+
+### 2. Configure the capability
+
+In `init.json` (or the active preset's `manifest.capabilities`), declare the
+vision capability with provider `ollama`. Both of these work:
+
+    "vision": {
+      "provider": "ollama",
+      "model": "moondream"
+    }
+
+    "vision": {
+      "provider": "ollama",
+      "model": "moondream",
+      "base_url": "http://localhost:11434/v1",
+      "max_tokens": 1024
+    }
+
+`model` must name a model you actually pulled. `base_url` defaults to
+`http://localhost:11434/v1`; change it only when Ollama runs elsewhere or on a
+non-default port (the `/v1` OpenAI-compatible suffix is required). `api_key` is
+optional — Ollama ignores its value, so the kernel synthesizes a placeholder.
+
+> **Preset note.** If your agent uses an active preset (a `manifest.preset`
+> block), the preset's `manifest.capabilities` replace `init.json`'s for
+> non-core opt-in capabilities like `vision`. Add the `vision` entry to the
+> preset file (or the `default` preset) rather than only to `init.json`, then
+> refresh.
+
+### 3. Use it
+
+After configuring and refreshing, the `vision` tool is available:
+
+    vision(action="analyze", input={"image_path": "/path/to/image.png", "question": null}, reasoning="...")
+
+A successful call returns `{"status": "ok", "analysis": "..."}`. If you get a
+sanitized setup failure instead, check the troubleshooting table below.
+
+### 4. Troubleshooting local Ollama vision
+
+| Symptom | Likely cause / fix |
+|---|---|
+| "No direct vision provider was configured" | The `vision` capability is not in the effective manifest. Add it to the preset (see the preset note above), then refresh. |
+| Connection refused on `localhost:11434` | Ollama is not running. Start it (`ollama serve` or the desktop app) and retry. |
+| "model 'moondream' not found" | The model was never pulled or has a different name. Run `ollama list` and `ollama pull <name>`, then set `model` to the exact pulled name. |
+| "does not support images" / vision request rejected | The configured model is text-only. Pull a vision model (e.g. `moondream`) and point `model` at it. |
+| "...missing the '/v1' suffix..." (from the service) | `base_url` is missing the OpenAI-compatible suffix. Use `http://localhost:11434/v1`. |
+| HTML/JSON parse failure on the response | Ollama returned a non-ChatCompletion body — usually the route is wrong (see previous row) or an old Ollama version. Upgrade Ollama and use `/v1`. |
+| GPU not used / slow | Ollama offloads to the GPU only when the model fits VRAM. `moondream` fits most GPUs; larger models fall back to CPU. Use `ollama ps` to confirm. |
+
+## Other local OpenAI-compatible servers
+
+Any local server that speaks the OpenAI Chat Completions API with image support
+(LM Studio, vLLM, llama.cpp server, etc.) can be wired through the generic
+custom relay with an explicit OpenAI-compatible shape:
+
+    "vision": {
+      "provider": "custom",
+      "api_compat": "openai",
+      "model": "<vision-model-name>",
+      "base_url": "http://localhost:1234/v1",
+      "api_key": "local-placeholder"
+    }
+
+Unlike `ollama`, the generic custom relay still requires a non-blank `api_key`
+string (many local servers accept any value); supply a placeholder. The manual
+above stays provider-neutral: the concrete server name and port are operator
+configuration, not something this manual auto-discovers.

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -328,6 +328,53 @@ def test_local_vision_is_hidden_but_explicitly_constructible(tmp_path):
     agent.add_tool.assert_called_once()
 
 
+def test_ollama_vision_is_advertised_and_needs_no_key(tmp_path):
+    """Ollama is a first-class local provider with defaults and no key needed."""
+    assert "ollama" in PROVIDERS["providers"]
+
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_svc_cls:
+        mock_svc = MagicMock(spec=VisionService)
+        mock_svc_cls.return_value = mock_svc
+        agent = make_mock_agent(tmp_path)
+
+        # Minimal config: provider only. base_url/model default, key synthesized.
+        mgr = setup(agent, provider="ollama")
+
+    mock_svc_cls.assert_called_once_with(
+        api_key="ollama",
+        model="moondream",
+        base_url="http://localhost:11434/v1",
+        wire_api="chat_completions",
+    )
+    assert mgr._vision_service is mock_svc
+    agent.add_tool.assert_called_once()
+
+
+def test_ollama_vision_respects_explicit_override(tmp_path):
+    """Explicit ollama kwargs win over local defaults."""
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_svc_cls:
+        mock_svc = MagicMock(spec=VisionService)
+        mock_svc_cls.return_value = mock_svc
+        agent = make_mock_agent(tmp_path)
+
+        setup(
+            agent,
+            provider="ollama",
+            api_key="real-key",
+            model="llava",
+            base_url="http://127.0.0.1:9999/v1",
+            max_tokens=256,
+        )
+
+    mock_svc_cls.assert_called_once_with(
+        api_key="real-key",
+        model="llava",
+        base_url="http://127.0.0.1:9999/v1",
+        wire_api="chat_completions",
+        max_tokens=256,
+    )
+
+
 def test_minimax_vision_preserves_active_default_headers(tmp_path):
     headers = {"X-Preset": "active"}
     with patch("lingtai.services.vision.create_vision_service") as mock_factory:


### PR DESCRIPTION
## Summary

Make **local vision first-class**: add `ollama` as a built-in local OpenAI-compatible provider for the `vision` capability, plus thick manual guidance covering Ollama and other local OpenAI-compatible servers (LM Studio, vLLM, llama.cpp).

## Motivation

A user with a text-only main model (e.g. DeepSeek V4 Flash) cannot use `vision` at all — the capability is provider-routed and fails closed without a vision model. The fastest offline fix is a small local model (Ollama + moondream, ~1.7 GB). The generic custom relay already handled Ollama via the not-in-PROVIDERS branch, but it required an explicit non-blank `api_key` and surfaced no defaults or documentation, so the path was undiscoverable and error-prone.

## Changes

### `src/lingtai/tools/vision/__init__.py`
- Add `ollama` to `PROVIDERS["providers"]` so `check-caps` / first-run surfaces it.
- Add a dedicated `provider == "ollama"` setup branch:
  - Defaults `base_url` to `http://localhost:11434/v1` and `model` to `moondream`.
  - Synthesizes a placeholder `api_key` (Ollama ignores the value) so **no key is required** — unlike the generic custom relay which fails closed.
  - Routes through `OpenAIVisionService` with the Chat Completions wire.
- Update the module docstring to document the provider.

### `src/lingtai/tools/vision/manual/SKILL.md`
- New **"Local vision with Ollama (first-class provider)"** section: install/pull steps, init.json/preset config samples, usage, and a troubleshooting table (server down, model not pulled, text-only model, missing `/v1` suffix, non-JSON response, GPU offload).
- New **"Other local OpenAI-compatible servers"** section for the generic custom relay (LM Studio / vLLM / llama.cpp) with a config sample and the key-required caveat.
- Preset note: active presets replace `init.json` capabilities for non-core opt-in capabilities like vision.

### `tests/test_vision_capability.py`
- `test_ollama_vision_is_advertised_and_needs_no_key` — provider advertised, defaults applied, no key required.
- `test_ollama_vision_respects_explicit_override` — explicit model/base_url/api_key/max_tokens win.

## Test results

- `tests/test_vision_capability.py`: **103 passed** (incl. 2 new)
- `tests/test_vision_services.py` + `tests/test_tool_family_vision_migration.py`: **pass**
- `tests/test_check_caps.py::test_get_all_providers_returns_all_capabilities`: **pre-existing failure on main** (task_card set mismatch, unrelated — verified by stash).

## Live validation

- `ollama pull moondream` on Windows (RTX 4070): success.
- Wired `vision` into the active preset: after refresh, `vision(action=analyze)` correctly read the text "Lingtai Vision Test" from a test PNG via `http://localhost:11434/v1`.
