### PR TITLE
feat(vision): generic local OpenAI-compatible provider + settings/vision.json

### DIFF
--- a/src/lingtai/services/vision/__init__.py
+++ b/src/lingtai/services/vision/__init__.py
@@ -84,7 +84,8 @@ def _require_api_key(api_key: object, provider: str) -> str:
     if not isinstance(api_key, str) or not api_key.strip():
         raise ValueError(
             f"api_key is required for provider {provider!r}. "
-            f"Use provider='local' for on-device vision without an API key."
+            f"Use provider='mlx' for on-device MLX vision or provider='local' "
+            f"for a local OpenAI-compatible server without an API key."
         )
     return api_key
 
@@ -93,7 +94,7 @@ def create_vision_service(provider: str, *, api_key: str | None = None, **kwargs
     """Factory — create a VisionService for the given provider.
 
     Args:
-        provider: Provider name ("anthropic", "openai", "gemini", "mimo", "codex", "local").
+        provider: Provider name ("anthropic", "openai", "gemini", "mimo", "codex", "mlx").
         api_key: API key for the provider (not required for "codex" or "local").
         **kwargs: Additional provider-specific kwargs (e.g., model, base_url).
 
@@ -103,7 +104,7 @@ def create_vision_service(provider: str, *, api_key: str | None = None, **kwargs
     Raises:
         ValueError: If the provider is not supported or api_key missing for API providers.
     """
-    if provider == "local":
+    if provider == "mlx":
         from .local import LocalVisionService
         return LocalVisionService(**kwargs)
     elif provider == "codex":
@@ -130,5 +131,5 @@ def create_vision_service(provider: str, *, api_key: str | None = None, **kwargs
     else:
         raise ValueError(
             f"Unsupported vision provider: {provider!r}. "
-            f"Supported: anthropic, openai, gemini, mimo, codex, local."
+            f"Supported: anthropic, openai, gemini, mimo, codex, mlx."
         )

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -7,15 +7,21 @@ Usage:
     agent.add_capability("vision", vision_service=my_svc)
     agent.add_capability("vision", provider="anthropic", api_key="sk-...")
 
-The local mlx-vlm pseudo-provider remains available through explicit
-``add_capability(..., provider="local")`` opt-in, but it is intentionally not
-advertised in ``PROVIDERS`` or first-run/check-caps surfaces yet.
+The native mlx pseudo-provider (Apple MLX, on-device) remains available
+through explicit ``add_capability(..., provider="mlx")`` opt-in, but it is
+intentionally not advertised in ``PROVIDERS`` or first-run/check-caps
+surfaces: it is macOS-only and requires an on-device model.
 
-``ollama`` is a first-class local OpenAI-compatible provider: it defaults to
-``http://localhost:11434/v1``, a small vision model (``moondream``), and a
-placeholder key (Ollama ignores the value). Configure it with
-``add_capability("vision", provider="ollama", model="<pulled-model>")`` or via
-``manifest.capabilities.vision``; no API key is required.
+``local`` is a first-class generic local OpenAI-compatible provider: it
+points at any OpenAI-compatible vision server on your machine (Ollama, LM
+Studio, vLLM, llama.cpp, …) via ``base_url`` (default
+``http://localhost:11434/v1``) and requires an explicit ``model``. The
+operator-owned endpoint configuration lives in ``settings/vision.json``
+(``base_url``, ``model``, optional ``api_key``/``max_tokens``); capability
+kwargs override the file. No API key is required — local servers ignore the
+value, so a placeholder is synthesized. Configure it with
+``add_capability("vision", provider="local", model="<pulled-model>")``, via
+``manifest.capabilities.vision``, or via ``settings/vision.json``.
 
 ``vision`` is migrated to the LingTai Tool Protocol v2 action-separated shape
 (``src/lingtai/tools/CONTRACT.md``): one public ``vision`` tool whose canonical
@@ -128,7 +134,7 @@ PROVIDERS = {
         "gemini", "anthropic", "openai", "openrouter", "custom", "deepseek",
         "minimax", "mimo", "glm", "zhipu", "grok", "qwen", "kimi",
         "codex", "codex-pool", "codex_pool", "claude-code", "claude_code",
-        "ollama",
+        "local",
     ],
     "default": None,
     "fallback_on_inherit": None,  # no agnostic fallback for vision
@@ -349,11 +355,12 @@ def setup(
         active_model = getattr(active_service, "_model", None) if same_provider else None
         active_base_url = getattr(active_service, "_base_url", None) if same_provider else None
         active_api_key = getattr(active_service, "api_key", None) if same_provider else None
-        if provider_key == "local":
-            # Local vision is an explicit pseudo-provider: keep it out of
-            # PROVIDERS/check-caps, but preserve the documented opt-in route.
-            # Its constructor accepts only model/max_tokens and needs no key.
-            local_kwargs = {
+        if provider_key == "mlx":
+            # Native Apple-MLX on-device vision is an explicit pseudo-provider:
+            # keep it out of PROVIDERS/check-caps, but preserve the documented
+            # opt-in route. Its constructor accepts only model/max_tokens and
+            # needs no key.
+            mlx_kwargs = {
                 key: kwargs[key]
                 for key in ("model", "max_tokens")
                 if key in kwargs and kwargs[key] is not None
@@ -361,43 +368,75 @@ def setup(
             from lingtai.services.vision import create_vision_service
             try:
                 vision_service = create_vision_service(
-                    "local",
+                    "mlx",
                     api_key=None,
-                    **local_kwargs,
+                    **mlx_kwargs,
                 )
             except Exception as exc:
                 manual_reason = _setup_failure(provider, exc)
-        elif provider_key == "ollama":
-            # Ollama is a local OpenAI-compatible server (default
-            # http://localhost:11434/v1). It accepts any non-blank API key and
-            # serves the Chat Completions wire only. Unlike the generic custom
-            # relay below, a missing api_key is NOT a hard failure: Ollama
-            # ignores the value, so we synthesize a placeholder that satisfies
-            # the OpenAI SDK's non-blank requirement. base_url/model default to
-            # the standard local endpoint and a sensible small vision model.
+        elif provider_key == "local":
+            # Local is a generic OpenAI-compatible vision server on this
+            # machine (Ollama, LM Studio, vLLM, llama.cpp, ...). The endpoint
+            # is operator-owned and configured in settings/vision.json
+            # (base_url/model/api_key/max_tokens); capability kwargs override
+            # the file. base_url defaults to the standard local port. model is
+            # REQUIRED — no hardcoded default, because a silently assumed
+            # model masks misconfiguration; when it is missing we surface
+            # guided setup steps instead. api_key is optional: local servers
+            # ignore it, so a placeholder satisfies the OpenAI SDK.
             from lingtai.services.vision.openai import OpenAIVisionService
-            ollama_base_url = kwargs.get("base_url") or "http://localhost:11434/v1"
-            ollama_model = kwargs.get("model") or "moondream"
-            ollama_key = api_key or "ollama"  # placeholder; Ollama ignores value
-            ollama_wire = _effective_openai_wire(
-                kwargs.get("wire_api"),
-                use_responses_api=False,
-                base_url=ollama_base_url,
+            from .settings import (
+                DEFAULT_LOCAL_BASE_URL,
+                SettingsError,
+                read_local_settings,
             )
-            svc_kwargs: dict = {
-                "api_key": ollama_key,
-                "model": ollama_model,
-                "base_url": ollama_base_url,
-            }
-            if ollama_wire and ollama_wire != "auto":
-                svc_kwargs["wire_api"] = ollama_wire
-            cap_max_tokens = kwargs.get("max_tokens")
-            if cap_max_tokens is not None:
-                svc_kwargs["max_tokens"] = cap_max_tokens
             try:
-                vision_service = OpenAIVisionService(**svc_kwargs)
-            except Exception as exc:
-                manual_reason = _setup_failure(provider, exc)
+                local_settings = read_local_settings(agent)
+            except SettingsError as exc:
+                manual_reason = (
+                    f"Local vision settings are invalid: {exc}; fix "
+                    "settings/vision.json or pass provider='local' with "
+                    "base_url/model kwargs; see vision(action='manual')."
+                )
+            else:
+                local_base_url = (
+                    kwargs.get("base_url")
+                    or local_settings.base_url
+                    or DEFAULT_LOCAL_BASE_URL
+                )
+                local_model = kwargs.get("model") or local_settings.model
+                if not local_model:
+                    manual_reason = (
+                        "Local vision needs an explicit model: install a local "
+                        "OpenAI-compatible vision server, pull a vision model, "
+                        "then set base_url+model in settings/vision.json or "
+                        "pass provider='local' with model=...; see "
+                        "vision(action='manual', input={}, "
+                        "reasoning='local vision setup')."
+                    )
+                else:
+                    local_key = api_key or local_settings.api_key or "local"
+                    local_wire = _effective_openai_wire(
+                        kwargs.get("wire_api"),
+                        use_responses_api=False,
+                        base_url=local_base_url,
+                    )
+                    svc_kwargs: dict = {
+                        "api_key": local_key,
+                        "model": local_model,
+                        "base_url": local_base_url,
+                    }
+                    if local_wire and local_wire != "auto":
+                        svc_kwargs["wire_api"] = local_wire
+                    cap_max_tokens = kwargs.get("max_tokens")
+                    if cap_max_tokens is None:
+                        cap_max_tokens = local_settings.max_tokens
+                    if cap_max_tokens is not None:
+                        svc_kwargs["max_tokens"] = cap_max_tokens
+                    try:
+                        vision_service = OpenAIVisionService(**svc_kwargs)
+                    except Exception as exc:
+                        manual_reason = _setup_failure(provider, exc)
         elif provider_key not in PROVIDERS["providers"]:
             # No dedicated VisionService for this provider (custom relay,
             # OpenRouter, an anthropic-compat local proxy, ...). Route vision

--- a/src/lingtai/tools/vision/manual/SKILL.md
+++ b/src/lingtai/tools/vision/manual/SKILL.md
@@ -66,47 +66,75 @@ Never request or print API keys, OAuth tokens, environment values, headers, or
 full unsanitized URLs. Missing provider, model, or endpoint fields are simply
 unknown; do not fill them with guesses.
 
-## Local vision with Ollama (first-class provider)
+## Local vision (generic OpenAI-compatible provider)
 
-`provider="ollama"` is a built-in local route: it needs no API key, defaults to
-`http://localhost:11434/v1`, and uses a small vision model (`moondream`) unless
-one is configured. It is the fastest way to get private, offline image
-understanding on a machine that already runs Ollama.
+`provider="local"` points the `vision` capability at any local
+OpenAI-compatible vision server (Ollama, LM Studio, vLLM, llama.cpp server, ...)
+by URL. It needs no API key (a placeholder is synthesized; local servers ignore
+it), defaults `base_url` to `http://localhost:11434/v1`, and requires an
+explicit `model` - there is no hidden default model, because a silently assumed
+model masks misconfiguration.
 
-### 1. Install and pull a vision model
+The endpoint is operator-owned. Configure it in `settings/vision.json` (the
+family-owned file, like `settings/web.json`), in the capability manifest, or
+both (capability kwargs override the file).
 
-Install [Ollama](https://ollama.com) for your platform, then pull a vision-capable
-model. `moondream` is the recommended default: it is tiny (~1.7 GB), runs on
-CPU or a small GPU, and is sufficient for OCR and basic image description.
+### 1. Pick and install a server + pull a vision model
 
-    ollama pull moondream
+Any server that speaks the OpenAI Chat Completions API with image support
+works. Examples:
 
-Other vision-capable Ollama models exist (for example the `llava` family or
-`qwen2.5vl`); pull whichever fits your hardware. The model must be a vision
-model — a text-only model will fail at request time with a "does not support
-images" style error.
+- **Ollama** (easiest): install from <https://ollama.com>, then pull a
+  vision-capable model. `moondream` is a good small default (~1.7 GB, runs on
+  CPU or a small GPU, fine for OCR and basic description):
 
-### 2. Configure the capability
+      ollama pull moondream
 
-In `init.json` (or the active preset's `manifest.capabilities`), declare the
-vision capability with provider `ollama`. Both of these work:
+  Other vision-capable Ollama models exist (`llava`, `qwen2.5vl`, ...). The
+  model must be a vision model - a text-only model fails at request time with a
+  "does not support images" style error.
+
+- **LM Studio**: start a local server with an image-capable model, note the
+  port (default `http://localhost:1234/v1`).
+- **vLLM / llama.cpp server**: serve a multimodal model and point `base_url` at
+  its `/v1` endpoint.
+
+### 2. Configure the endpoint
+
+Two equivalent ways; capability kwargs win over the file.
+
+**`settings/vision.json`** (agent working dir, applies on next refresh):
+
+    {
+      "schema_version": 1,
+      "base_url": "http://localhost:11434/v1",
+      "model": "moondream",
+      "max_tokens": 1024
+    }
+
+`api_key` is optional and omitted here. Only `schema_version` plus the
+documented fields are allowed; an invalid file is a hard setup error surfaced
+as manual guidance.
+
+**Capability manifest** (`init.json` or the active preset's
+`manifest.capabilities`):
 
     "vision": {
-      "provider": "ollama",
+      "provider": "local",
       "model": "moondream"
     }
 
     "vision": {
-      "provider": "ollama",
+      "provider": "local",
       "model": "moondream",
       "base_url": "http://localhost:11434/v1",
       "max_tokens": 1024
     }
 
-`model` must name a model you actually pulled. `base_url` defaults to
-`http://localhost:11434/v1`; change it only when Ollama runs elsewhere or on a
+`model` is required and must name a model the server actually serves. `base_url`
+defaults to `http://localhost:11434/v1`; change it when the server runs on a
 non-default port (the `/v1` OpenAI-compatible suffix is required). `api_key` is
-optional — Ollama ignores its value, so the kernel synthesizes a placeholder.
+optional - local servers ignore it, so a placeholder is synthesized.
 
 > **Preset note.** If your agent uses an active preset (a `manifest.preset`
 > block), the preset's `manifest.capabilities` replace `init.json`'s for
@@ -123,33 +151,23 @@ After configuring and refreshing, the `vision` tool is available:
 A successful call returns `{"status": "ok", "analysis": "..."}`. If you get a
 sanitized setup failure instead, check the troubleshooting table below.
 
-### 4. Troubleshooting local Ollama vision
+### 4. Troubleshooting local vision
 
 | Symptom | Likely cause / fix |
 |---|---|
 | "No direct vision provider was configured" | The `vision` capability is not in the effective manifest. Add it to the preset (see the preset note above), then refresh. |
-| Connection refused on `localhost:11434` | Ollama is not running. Start it (`ollama serve` or the desktop app) and retry. |
-| "model 'moondream' not found" | The model was never pulled or has a different name. Run `ollama list` and `ollama pull <name>`, then set `model` to the exact pulled name. |
-| "does not support images" / vision request rejected | The configured model is text-only. Pull a vision model (e.g. `moondream`) and point `model` at it. |
-| "...missing the '/v1' suffix..." (from the service) | `base_url` is missing the OpenAI-compatible suffix. Use `http://localhost:11434/v1`. |
-| HTML/JSON parse failure on the response | Ollama returned a non-ChatCompletion body — usually the route is wrong (see previous row) or an old Ollama version. Upgrade Ollama and use `/v1`. |
-| GPU not used / slow | Ollama offloads to the GPU only when the model fits VRAM. `moondream` fits most GPUs; larger models fall back to CPU. Use `ollama ps` to confirm. |
+| "Local vision needs an explicit model" | No `model` is set in `settings/vision.json` or the capability manifest. Set `model` to a pulled/served vision model name, then refresh. |
+| "Local vision settings are invalid" | `settings/vision.json` has an unknown field, bad type, or a schema_version other than 1. Fix the file and refresh. |
+| Connection refused on the endpoint | The local server is not running. Start it (`ollama serve` or the desktop app) and retry. |
+| "model '<name>' not found" | The model was never pulled or has a different name. Run `ollama list` (or your server's model list) and set `model` to the exact name. |
+| "does not support images" / vision request rejected | The configured model is text-only. Pull/serve a vision model (e.g. `moondream`) and point `model` at it. |
+| "...missing the '/v1' suffix..." (from the service) | `base_url` is missing the OpenAI-compatible suffix. Use e.g. `http://localhost:11434/v1`. |
+| HTML/JSON parse failure on the response | The server returned a non-ChatCompletion body - usually the route is wrong (see previous row) or the server is too old. Upgrade and use `/v1`. |
+| GPU not used / slow | The server offloads to the GPU only when the model fits VRAM. `moondream` fits most GPUs; larger models fall back to CPU. |
 
-## Other local OpenAI-compatible servers
+### 5. Apple MLX (macOS only)
 
-Any local server that speaks the OpenAI Chat Completions API with image support
-(LM Studio, vLLM, llama.cpp server, etc.) can be wired through the generic
-custom relay with an explicit OpenAI-compatible shape:
-
-    "vision": {
-      "provider": "custom",
-      "api_compat": "openai",
-      "model": "<vision-model-name>",
-      "base_url": "http://localhost:1234/v1",
-      "api_key": "local-placeholder"
-    }
-
-Unlike `ollama`, the generic custom relay still requires a non-blank `api_key`
-string (many local servers accept any value); supply a placeholder. The manual
-above stays provider-neutral: the concrete server name and port are operator
-configuration, not something this manual auto-discovers.
+The native on-device MLX pseudo-provider (`provider="mlx"`) is available as an
+explicit opt-in for Apple Silicon. It is not advertised in check-caps; pass
+`model` (an `mlx-community/...` vision model) and `max_tokens`. It requires no
+API key.

--- a/src/lingtai/tools/vision/settings.py
+++ b/src/lingtai/tools/vision/settings.py
@@ -1,0 +1,185 @@
+"""Strict per-Agent settings for the ``vision`` capability's local endpoint.
+
+``settings/vision.json`` is a family-owned provider configuration file for the
+``provider: local`` route: it holds the operator-configured local
+OpenAI-compatible vision endpoint (``base_url``, ``model``, optional
+``api_key``/``max_tokens``). It mirrors the ``settings/web.json`` pattern from
+``lingtai.tools.web_search.settings``: a bounded, race-checked read with a
+stable digest so "default applied" is a truthful, verifiable fact.
+
+Resolution order at capability setup: capability kwargs override
+``settings/vision.json``; a missing file means defaults apply (base_url
+defaults to the standard local port; model stays unset and setup raises
+guided manual guidance). An invalid file is a hard setup error surfaced as
+manual guidance, never a silent fallback.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+MAX_SETTINGS_BYTES = 64 * 1024
+
+DEFAULT_LOCAL_BASE_URL = "http://localhost:11434/v1"
+
+
+class SettingsError(ValueError):
+    """A settings snapshot was absent, unstable, malformed, or disallowed."""
+
+
+@dataclass(frozen=True, slots=True)
+class LocalVisionSettings:
+    """Resolved local vision endpoint settings snapshot.
+
+    ``base_url`` is the OpenAI-compatible endpoint URL. ``model`` is the
+    vision model served at that endpoint; ``None`` means the operator has not
+    configured one yet (setup must raise guided guidance). ``api_key`` is
+    optional: local servers ignore it, so a placeholder satisfies the OpenAI
+    SDK when unset. ``max_tokens`` caps the response length when set.
+    """
+
+    base_url: str | None
+    model: str | None
+    api_key: str | None
+    max_tokens: int | None
+    source: str
+    revision: str
+    digest: str | None
+    error: str | None = None
+
+
+def settings_path(agent: Any) -> Path:
+    """Return the one fixed, family-owned local vision settings path."""
+    return Path(agent._working_dir) / "settings" / "vision.json"
+
+
+def _default_snapshot() -> LocalVisionSettings:
+    """Return the deterministic snapshot for a missing ``settings/vision.json``.
+
+    ``revision``/``digest`` are computed over the effective default document
+    (``{"schema_version": 1}``) so a caller can recompute and verify.
+    """
+    canonical = json.dumps(
+        {"schema_version": 1},
+        sort_keys=True, separators=(",", ":"),
+    ).encode("utf-8")
+    digest = hashlib.sha256(canonical).hexdigest()[:32]
+    return LocalVisionSettings(None, None, None, None, "default", "default", digest)
+
+
+def _bounded_error(exc: Exception) -> str:
+    # OS errors commonly include the absolute path passed to ``open``. The
+    # result contract exposes only the agent-relative settings path, never the
+    # host filesystem location.
+    if isinstance(exc, OSError):
+        return "settings/vision.json could not be read (OSError)"
+    text = str(exc).replace("\n", " ").strip()
+    return (text or "invalid settings")[:240]
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise SettingsError("duplicate settings field")
+        result[key] = value
+    return result
+
+
+def _read_stable(path: Path) -> tuple[bytes, str]:
+    """Bounded, race-checked read of ``settings/vision.json``."""
+    try:
+        first = path.lstat()
+    except FileNotFoundError:
+        return b"", "missing"
+    if stat.S_ISLNK(first.st_mode) or not stat.S_ISREG(first.st_mode):
+        raise SettingsError("settings/vision.json must be a regular file")
+    if first.st_size > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings/vision.json exceeds the 64 KiB size bound")
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise SettingsError(_bounded_error(exc)) from exc
+    if len(raw) > MAX_SETTINGS_BYTES:
+        raise SettingsError("settings/vision.json exceeds the 64 KiB size bound")
+    try:
+        second = path.lstat()
+    except OSError as exc:
+        raise SettingsError(_bounded_error(exc)) from exc
+    if (second.st_mtime_ns, second.st_size) != (first.st_mtime_ns, first.st_size):
+        raise SettingsError("settings/vision.json changed while being read")
+    return raw, "file"
+
+
+def _validate(doc: dict[str, Any]) -> LocalVisionSettings:
+    """Validate a parsed vision settings document into a frozen snapshot."""
+    allowed = {"schema_version", "base_url", "model", "api_key", "max_tokens"}
+    unknown = sorted(set(doc) - allowed)
+    if unknown:
+        raise SettingsError(
+            "settings/vision.json has unknown fields: " + ", ".join(unknown)
+        )
+    if doc.get("schema_version") != 1:
+        raise SettingsError("settings/vision.json schema_version must be integer 1")
+
+    base_url = doc.get("base_url")
+    if base_url is not None and (
+        not isinstance(base_url, str) or not base_url.strip()
+    ):
+        raise SettingsError("settings/vision.json base_url must be a non-empty string")
+    model = doc.get("model")
+    if model is not None and (not isinstance(model, str) or not model.strip()):
+        raise SettingsError("settings/vision.json model must be a non-empty string")
+    api_key = doc.get("api_key")
+    if api_key is not None and not isinstance(api_key, str):
+        raise SettingsError("settings/vision.json api_key must be a string")
+    max_tokens = doc.get("max_tokens")
+    if max_tokens is not None and (
+        not isinstance(max_tokens, int)
+        or isinstance(max_tokens, bool)
+        or max_tokens <= 0
+    ):
+        raise SettingsError(
+            "settings/vision.json max_tokens must be a positive integer"
+        )
+
+    canonical = json.dumps(doc, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    digest = hashlib.sha256(canonical).hexdigest()[:32]
+    return LocalVisionSettings(
+        base_url=base_url.strip() if isinstance(base_url, str) else None,
+        model=model.strip() if isinstance(model, str) else None,
+        api_key=api_key,
+        max_tokens=max_tokens,
+        source="file",
+        revision=digest,
+        digest=digest,
+    )
+
+
+def read_local_settings(agent: Any) -> LocalVisionSettings:
+    """Read and validate the shared ``settings/vision.json`` snapshot.
+
+    A missing file returns the deterministic default snapshot (no error). A
+    present-but-invalid file raises ``SettingsError`` so setup can surface
+    guided manual guidance instead of silently falling back.
+    """
+    path = settings_path(agent)
+    try:
+        raw, source = _read_stable(path)
+    except SettingsError:
+        raise
+    if source == "missing":
+        return _default_snapshot()
+    try:
+        doc = json.loads(raw, object_pairs_hook=_pairs)
+    except SettingsError:
+        raise
+    except Exception as exc:
+        raise SettingsError(_bounded_error(exc)) from exc
+    if not isinstance(doc, dict):
+        raise SettingsError("settings/vision.json must contain a JSON object")
+    return _validate(doc)

--- a/tests/test_check_caps.py
+++ b/tests/test_check_caps.py
@@ -38,10 +38,11 @@ def test_provider_dependent_capabilities():
     assert result["vision"]["default"] is None
     assert "minimax" in result["vision"]["providers"]
     assert "gemini" in result["vision"]["providers"]
-    # "local" is intentionally NOT advertised in PROVIDERS yet — it works
-    # via explicit opt-in (add_capability(..., provider="local")) but
-    # should not appear in check-caps output. See tools/vision.
-    assert "local" not in result["vision"]["providers"]
+    # "local" is the generic local OpenAI-compatible provider: advertised in
+    # check-caps so operators see it as a first-class route. The native
+    # on-device "mlx" pseudo-provider stays hidden (explicit opt-in only).
+    assert "local" in result["vision"]["providers"]
+    assert "mlx" not in result["vision"]["providers"]
 
 
 def test_check_caps_cli_output():

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -1,6 +1,7 @@
 """Tests for vision capability and VisionService."""
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -300,9 +301,9 @@ def test_vision_setup_with_provider_and_key(tmp_path):
         assert isinstance(mgr, VisionManager)
 
 
-def test_local_vision_is_hidden_but_explicitly_constructible(tmp_path):
-    """The local pseudo-provider stays out of discovery yet keeps its opt-in path."""
-    assert "local" not in PROVIDERS["providers"]
+def test_mlx_vision_is_hidden_but_explicitly_constructible(tmp_path):
+    """The mlx pseudo-provider stays out of discovery yet keeps its opt-in path."""
+    assert "mlx" not in PROVIDERS["providers"]
 
     with patch("lingtai.services.vision.create_vision_service") as mock_factory:
         mock_svc = MagicMock(spec=VisionService)
@@ -311,7 +312,7 @@ def test_local_vision_is_hidden_but_explicitly_constructible(tmp_path):
 
         mgr = setup(
             agent,
-            provider="local",
+            provider="mlx",
             model="mlx-community/local-test-model",
             max_tokens=128,
             api_compat="openai",
@@ -319,7 +320,7 @@ def test_local_vision_is_hidden_but_explicitly_constructible(tmp_path):
         )
 
     mock_factory.assert_called_once_with(
-        "local",
+        "mlx",
         api_key=None,
         model="mlx-community/local-test-model",
         max_tokens=128,
@@ -328,21 +329,36 @@ def test_local_vision_is_hidden_but_explicitly_constructible(tmp_path):
     agent.add_tool.assert_called_once()
 
 
-def test_ollama_vision_is_advertised_and_needs_no_key(tmp_path):
-    """Ollama is a first-class local provider with defaults and no key needed."""
-    assert "ollama" in PROVIDERS["providers"]
+def test_local_vision_is_advertised_and_requires_model(tmp_path):
+    """Local is advertised but refuses a silent model default with guidance."""
+    assert "local" in PROVIDERS["providers"]
+    assert "ollama" not in PROVIDERS["providers"]
 
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_svc_cls:
+        agent = make_mock_agent(tmp_path)
+
+        # Minimal config: provider only. No model anywhere -> guided failure.
+        mgr = setup(agent, provider="local")
+
+    mock_svc_cls.assert_not_called()
+    assert mgr._vision_service is None
+    assert "model" in mgr._manual_reason
+    assert "settings/vision.json" in mgr._manual_reason
+    agent.add_tool.assert_called_once()
+
+
+def test_local_vision_uses_default_base_url_with_explicit_model(tmp_path):
+    """Local with an explicit model synthesizes a placeholder key and default URL."""
     with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_svc_cls:
         mock_svc = MagicMock(spec=VisionService)
         mock_svc_cls.return_value = mock_svc
         agent = make_mock_agent(tmp_path)
 
-        # Minimal config: provider only. base_url/model default, key synthesized.
-        mgr = setup(agent, provider="ollama")
+        mgr = setup(agent, provider="local", model="llava")
 
     mock_svc_cls.assert_called_once_with(
-        api_key="ollama",
-        model="moondream",
+        api_key="local",
+        model="llava",
         base_url="http://localhost:11434/v1",
         wire_api="chat_completions",
     )
@@ -350,8 +366,8 @@ def test_ollama_vision_is_advertised_and_needs_no_key(tmp_path):
     agent.add_tool.assert_called_once()
 
 
-def test_ollama_vision_respects_explicit_override(tmp_path):
-    """Explicit ollama kwargs win over local defaults."""
+def test_local_vision_respects_explicit_override(tmp_path):
+    """Explicit local kwargs win over defaults."""
     with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_svc_cls:
         mock_svc = MagicMock(spec=VisionService)
         mock_svc_cls.return_value = mock_svc
@@ -359,7 +375,7 @@ def test_ollama_vision_respects_explicit_override(tmp_path):
 
         setup(
             agent,
-            provider="ollama",
+            provider="local",
             api_key="real-key",
             model="llava",
             base_url="http://127.0.0.1:9999/v1",
@@ -372,6 +388,70 @@ def test_ollama_vision_respects_explicit_override(tmp_path):
         base_url="http://127.0.0.1:9999/v1",
         wire_api="chat_completions",
         max_tokens=256,
+    )
+
+
+def test_local_vision_reads_settings_json(tmp_path):
+    """settings/vision.json supplies the local endpoint when kwargs are absent."""
+    settings_dir = tmp_path / "settings"
+    settings_dir.mkdir()
+    (settings_dir / "vision.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "base_url": "http://127.0.0.1:8080/v1",
+                "model": "moondream",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_svc_cls:
+        mock_svc = MagicMock(spec=VisionService)
+        mock_svc_cls.return_value = mock_svc
+        agent = make_mock_agent(tmp_path)
+
+        mgr = setup(agent, provider="local")
+
+    mock_svc_cls.assert_called_once_with(
+        api_key="local",
+        model="moondream",
+        base_url="http://127.0.0.1:8080/v1",
+        wire_api="chat_completions",
+    )
+    assert mgr._vision_service is mock_svc
+
+
+def test_local_vision_kwargs_override_settings_json(tmp_path):
+    """Capability kwargs override settings/vision.json file values."""
+    settings_dir = tmp_path / "settings"
+    settings_dir.mkdir()
+    (settings_dir / "vision.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "base_url": "http://127.0.0.1:8080/v1",
+                "model": "moondream",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_svc_cls:
+        mock_svc = MagicMock(spec=VisionService)
+        mock_svc_cls.return_value = mock_svc
+        agent = make_mock_agent(tmp_path)
+
+        setup(
+            agent,
+            provider="local",
+            model="llava",
+            base_url="http://127.0.0.1:9999/v1",
+        )
+
+    mock_svc_cls.assert_called_once_with(
+        api_key="local",
+        model="llava",
+        base_url="http://127.0.0.1:9999/v1",
+        wire_api="chat_completions",
     )
 
 


### PR DESCRIPTION
## What

Follow-up to #1115, addressing the design review: **drop the `provider=ollama` special-case and make local vision a generic, explicitly-configured route.**

Per feedback: no silent model default (a hardcoded `moondream` masks misconfiguration) and no provider-specific branch for one local server. Instead:

1. **`provider: local`** is now the advertised generic local OpenAI-compatible provider (Ollama, LM Studio, vLLM, llama.cpp — any local server that speaks Chat Completions with images). It defaults `base_url` to `http://localhost:11434/v1`, requires an explicit `model` (missing → guided setup error), and synthesizes a placeholder `api_key` (local servers ignore it).
2. **`settings/vision.json`** — a new family-owned config file mirroring the `settings/web.json` pattern (`src/lingtai/tools/vision/settings.py`): operator sets `{schema_version, base_url, model, api_key?, max_tokens?}`; capability kwargs override the file; invalid file is a hard setup error with guidance.
3. **`provider=ollama` removed** from PROVIDERS and the setup branch. The manual keeps Ollama as one *example* server through the single `local` provider.
4. **Native Apple-MLX pseudo-provider renamed `mlx`** (service factory key + setup opt-in) so `local` is unambiguous; still not advertised in check-caps.
5. **Manual rewritten**: install/pick a server, configure via `settings/vision.json` or manifest, troubleshooting table covers missing-model and invalid-settings errors, Apple MLX note.

## Why

A provider named after one tool (`ollama`) with a silently assumed model is too magical and doesn't scale to the many local OpenAI-compatible servers. The operator-owned `settings/vision.json` file is the canonical home for endpoint config, and the capability advertises *how to set it up* rather than pretending it is already configured.

## Tests

- `tests/test_vision_capability.py`: 106 pass (added: local advertised + model-required guidance, default base_url + explicit model, explicit kwargs override, settings/vision.json read, kwargs-over-file, mlx hidden-but-constructible; removed the two ollama tests).
- `tests/test_check_caps.py`: `test_provider_dependent_capabilities` updated for advertised `local` + hidden `mlx`.
- Pre-existing unrelated failure on main: `test_get_all_providers_returns_all_capabilities` expects 8 capabilities but the registry now has `task_card` (9) — not touched here.
