### PR TITLE
feat(vision): failed vision results guide agent to setup skill with human consent

### DIFF
--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -64,9 +64,11 @@ def _consent_guidance() -> str:
     full steps live in the vision manual skill.
     """
     return (
-        "To enable vision, ask the human for consent to set it up, then load "
-        "the vision manual skill: vision(action='manual', input={}, "
-        "reasoning='vision is not set up, load the setup steps')."
+        "To enable vision, load the vision manual skill for the setup steps: "
+        "vision(action='manual', input={}, reasoning='vision is not set up, "
+        "load the setup steps'); then ask the human for consent before "
+        "installing a local vision server, pulling a model, or editing "
+        "settings/vision.json / the capability manifest."
     )
 
 
@@ -295,11 +297,11 @@ class VisionManager:
                     "provider's Responses-API vision, which may not support "
                     "images. Alternative vision may be available: the current "
                     "provider's MCP, or a local OpenAI-compatible vision "
-                    "server via provider='local'. Ask the human for consent "
-                    "to set one up, then load the vision manual skill for the "
-                    "steps: vision(action='manual', input={}, "
-                    "reasoning='default vision failed, load the setup "
-                    "alternatives')."
+                    "server via provider='local'. Load the vision manual skill "
+                    "for the setup alternatives: vision(action='manual', "
+                    "input={}, reasoning='default vision failed, load the "
+                    "setup alternatives'); then ask the human for consent "
+                    "before setting one up."
                 ),
             }
 
@@ -429,10 +431,10 @@ def setup(
                 local_model = kwargs.get("model") or local_settings.model
                 if not local_model:
                     manual_reason = (
-                        "Local vision needs an explicit model. Ask the human "
-                        "for consent to set it up, then load the vision manual "
-                        "skill: vision(action='manual', input={}, "
-                        "reasoning='local vision setup')."
+                        "Local vision needs an explicit model. Load the vision "
+                        "manual skill: vision(action='manual', input={}, "
+                        "reasoning='local vision setup'); then ask the human "
+                        "for consent before setting it up."
                     )
                 else:
                     local_key = api_key or local_settings.api_key or "local"

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -55,6 +55,21 @@ def _setup_failure(provider: str, exc: BaseException) -> str:
     )
 
 
+def _consent_guidance() -> str:
+    """Build the setup-with-human-consent guidance for a vision failure.
+
+    Installing a local vision server, pulling a model, or editing
+    settings/vision.json / the capability manifest are external side effects:
+    the agent must obtain explicit human consent before performing them. The
+    full steps live in the vision manual skill.
+    """
+    return (
+        "To enable vision, ask the human for consent to set it up, then load "
+        "the vision manual skill: vision(action='manual', input={}, "
+        "reasoning='vision is not set up, load the setup steps')."
+    )
+
+
 _CODEX_POOL_ALIASES = {"codex-pool", "codex_pool"}
 _CODEX_FAMILY = {"codex"} | _CODEX_POOL_ALIASES
 
@@ -239,13 +254,14 @@ class VisionManager:
         default prompt, and success/failure result shapes.
         """
         if self._vision_service is None:
+            reason = self._manual_reason or (
+                "Direct vision is unavailable; call vision(action='manual', "
+                "input={}, reasoning='no direct vision route, load the "
+                "manual alternatives')."
+            )
             return {
                 "status": "error",
-                "message": self._manual_reason or (
-                    "Direct vision is unavailable; call vision(action='manual', "
-                    "input={}, reasoning='no direct vision route, load the "
-                    "manual alternatives')."
-                ),
+                "message": f"{reason} {_consent_guidance()}",
             }
         image_path = action_input.get("image_path") or ""
         question = action_input.get("question")
@@ -277,7 +293,8 @@ class VisionManager:
                     f"Vision analysis failed ({type(e).__name__}). Call "
                     "vision(action='manual', input={}, reasoning='the direct "
                     "vision request failed, load the explicit manual route') "
-                    "for the explicit manual route."
+                    "for the explicit manual route. "
+                    f"{_consent_guidance()}"
                 ),
             }
 
@@ -407,11 +424,9 @@ def setup(
                 local_model = kwargs.get("model") or local_settings.model
                 if not local_model:
                     manual_reason = (
-                        "Local vision needs an explicit model: install a local "
-                        "OpenAI-compatible vision server, pull a vision model, "
-                        "then set base_url+model in settings/vision.json or "
-                        "pass provider='local' with model=...; see "
-                        "vision(action='manual', input={}, "
+                        "Local vision needs an explicit model. Ask the human "
+                        "for consent to set it up, then load the vision manual "
+                        "skill: vision(action='manual', input={}, "
                         "reasoning='local vision setup')."
                     )
                 else:

--- a/src/lingtai/tools/vision/__init__.py
+++ b/src/lingtai/tools/vision/__init__.py
@@ -290,11 +290,16 @@ class VisionManager:
             return {
                 "status": "error",
                 "message": (
-                    f"Vision analysis failed ({type(e).__name__}). Call "
-                    "vision(action='manual', input={}, reasoning='the direct "
-                    "vision request failed, load the explicit manual route') "
-                    "for the explicit manual route. "
-                    f"{_consent_guidance()}"
+                    f"Vision analysis failed on the default vision route "
+                    f"({type(e).__name__}). The default route is the current "
+                    "provider's Responses-API vision, which may not support "
+                    "images. Alternative vision may be available: the current "
+                    "provider's MCP, or a local OpenAI-compatible vision "
+                    "server via provider='local'. Ask the human for consent "
+                    "to set one up, then load the vision manual skill for the "
+                    "steps: vision(action='manual', input={}, "
+                    "reasoning='default vision failed, load the setup "
+                    "alternatives')."
                 ),
             }
 

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -358,6 +358,8 @@ def test_local_vision_missing_model_result_guides_with_consent(tmp_path):
     assert result["status"] == "error"
     assert "ask the human for consent" in result["message"]
     assert "vision(action='manual'" in result["message"]
+    # Skill load comes before the consent ask.
+    assert result["message"].index("vision(action='manual'") < result["message"].index("consent")
 
 
 def test_default_vision_failure_informs_agent_of_alternatives(tmp_path):

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -343,8 +343,21 @@ def test_local_vision_is_advertised_and_requires_model(tmp_path):
     mock_svc_cls.assert_not_called()
     assert mgr._vision_service is None
     assert "model" in mgr._manual_reason
-    assert "settings/vision.json" in mgr._manual_reason
+    assert "consent" in mgr._manual_reason
     agent.add_tool.assert_called_once()
+
+
+def test_local_vision_missing_model_result_guides_with_consent(tmp_path):
+    """The analyze result on a missing-service setup failure guides setup with consent."""
+    with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_svc_cls:
+        agent = make_mock_agent(tmp_path)
+        mgr = setup(agent, provider="local")
+
+    result = mgr._dispatch_analyze({"image_path": "x.png", "question": None})
+
+    assert result["status"] == "error"
+    assert "ask the human for consent" in result["message"]
+    assert "vision(action='manual'" in result["message"]
 
 
 def test_local_vision_uses_default_base_url_with_explicit_model(tmp_path):

--- a/tests/test_vision_capability.py
+++ b/tests/test_vision_capability.py
@@ -360,6 +360,26 @@ def test_local_vision_missing_model_result_guides_with_consent(tmp_path):
     assert "vision(action='manual'" in result["message"]
 
 
+def test_default_vision_failure_informs_agent_of_alternatives(tmp_path):
+    """A default-route analyze failure explains the cause and alternatives."""
+    agent = make_mock_agent(tmp_path)
+    svc = MagicMock(spec=VisionService)
+    svc.analyze_image.side_effect = RuntimeError("model does not support images")
+    mgr = setup(agent, vision_service=svc)
+
+    image = tmp_path / "test.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+    result = mgr._dispatch_analyze({"image_path": str(image), "question": None})
+
+    assert result["status"] == "error"
+    assert "default vision route" in result["message"]
+    assert "Responses-API" in result["message"]
+    assert "provider='local'" in result["message"]
+    assert "provider's MCP" in result["message"]
+    assert "consent" in result["message"]
+    assert "vision(action='manual'" in result["message"]
+
+
 def test_local_vision_uses_default_base_url_with_explicit_model(tmp_path):
     """Local with an explicit model synthesizes a placeholder key and default URL."""
     with patch("lingtai.services.vision.openai.OpenAIVisionService") as mock_svc_cls:


### PR DESCRIPTION
## What

Follow-up to #1116 (already merged). When vision fails — either because the default/inherited provider route can't analyze the image (e.g. the active model isn't image-capable) or because local setup is incomplete — the tool result now issues a comment that:

1. **Points the agent to the vision manual skill** (`vision(action='manual', ...)`) for the setup steps — per review feedback, keep it short, just point to the skill.
2. **Requires human consent before setup** — installing a local server, pulling a model, or editing `settings/vision.json`/the capability manifest are external side effects; the agent must ask the human first.

Covered paths:
- Missing-service guard in `_dispatch_analyze` (setup failures, incl. missing local model) → appends consent+skill guidance.
- Request-failure path in `_dispatch_analyze` (default vision fails at analyze time) → appends consent+skill guidance.
- Local missing-model `manual_reason` itself now names consent and points to the skill.

## Why

A failed default vision call currently just says "load the manual" — it doesn't tell the agent that enabling vision is an external side effect requiring explicit human consent. This closes that gap so agents never silently install/pull/config vision on their own.

## Tests

- `tests/test_vision_capability.py`: 107 pass (added: missing-model result carries consent + skill pointer; updated the requires-model test to assert the consent wording).
