### PR TITLE
fix(claude-code): stable system context via --append-system-prompt-file enables prompt caching

### DIFF
--- a/src/lingtai/llm/claude_code/adapter.py
+++ b/src/lingtai/llm/claude_code/adapter.py
@@ -73,6 +73,12 @@ _OVERFLOW_MARKERS = (
     "input is too long",
 )
 
+# Sentinel for ``_invoke_raw``'s optional ``system_prompt_file`` argument so a
+# caller can explicitly pass ``None`` (no system-prompt file — used by the
+# one-shot ``generate`` path) while the default still resolves to the adapter's
+# stable prompt-cache file.
+_UNSET = object()
+
 
 class ClaudeCodeError(RuntimeError):
     """A ``claude`` CLI invocation failed (non-zero exit, no output, etc.)."""
@@ -196,6 +202,9 @@ class ClaudeCodeChatSession(ChatSession):
         self._tools = tools
         self._interface = interface
         self._context_window = context_window
+        # Persist the stable system context to the adapter's prompt-cache file
+        # so the first ``send`` already has it in the cached system block.
+        self._write_system_file()
 
     # -- ChatSession contract -------------------------------------------------
 
@@ -267,6 +276,7 @@ class ClaudeCodeChatSession(ChatSession):
             self._system_prompt,
             tools=[t.to_dict() for t in self._tools] if self._tools else None,
         )
+        self._write_system_file()
 
     def update_system_prompt(self, system_prompt: str) -> None:
         self._system_prompt = system_prompt
@@ -274,6 +284,7 @@ class ClaudeCodeChatSession(ChatSession):
             system_prompt,
             tools=[t.to_dict() for t in self._tools] if self._tools else None,
         )
+        self._write_system_file()
 
     def commit_tool_results(self, tool_results: list) -> None:
         self._interface.add_tool_results(tool_results)
@@ -333,7 +344,25 @@ class ClaudeCodeChatSession(ChatSession):
         return LLMResponse(text=text, tool_calls=tool_calls, usage=usage, raw=raw)
 
     def _render_prompt(self) -> str:
-        """Serialise system prompt + tools + conversation into one CLI prompt."""
+        """Serialise only the conversation into the per-turn user message.
+
+        The stable context (protocol + system prompt + tools) is passed via
+        ``--append-system-prompt-file`` so it lives in the system block that
+        Claude Code caches across turns; only the growing conversation (which
+        changes every turn) is sent as the user message. This is what makes
+        prompt caching effective: previously the whole stable context was
+        embedded in the user message, which is rewritten every turn as the
+        conversation grows, forcing a full cache write each turn.
+        """
+        parts: list[str] = ["# CONVERSATION"]
+        parts.append(self._render_conversation())
+        parts.append("")
+        parts.append("# NOW")
+        parts.append("Decide your next action and output the single JSON object.")
+        return "\n".join(parts)
+
+    def _render_system_context(self) -> str:
+        """Serialise the stable part (protocol + system + tools) for the cached system block."""
         parts: list[str] = [_PROTOCOL, ""]
         parts.append("# AGENT SYSTEM INSTRUCTIONS")
         parts.append(self._system_prompt or "(none)")
@@ -355,12 +384,17 @@ class ClaudeCodeChatSession(ChatSession):
             parts.append("(no tools available — respond with a final answer)")
             parts.append("")
 
-        parts.append("# CONVERSATION")
-        parts.append(self._render_conversation())
-        parts.append("")
-        parts.append("# NOW")
-        parts.append("Decide your next action and output the single JSON object.")
         return "\n".join(parts)
+
+    def _write_system_file(self) -> None:
+        """Write the stable context to the adapter's system-prompt file."""
+        path = self._adapter._system_prompt_file
+        if path is None:
+            return
+        try:
+            path.write_text(self._render_system_context(), encoding="utf-8")
+        except OSError:
+            logger.warning("[claude-code] could not write system-prompt file; prompt caching disabled")
 
     def _render_conversation(self) -> str:
         # Model-facing full-history serialization: every historical tool
@@ -435,6 +469,23 @@ class ClaudeCodeAdapter(LLMAdapter):
         except OSError:
             self._cwd = Path(tempfile.gettempdir())
 
+        # Stable context file for prompt caching. Claude Code puts a cache
+        # breakpoint on the *system* block, so the stable protocol/system/tools
+        # context must be passed via ``--append-system-prompt-file`` (it then
+        # lives in the cached system block) instead of being embedded in the
+        # per-turn user message, which is rewritten every turn as the
+        # conversation grows (forcing a full cache write each turn). The file
+        # path is stable per adapter instance; the session rewrites its content
+        # only when the system prompt or tools change.
+        self._system_prompt_file = Path(tempfile.gettempdir()) / (
+            f"lingtai-claude-sp-{uuid.uuid4().hex[:12]}.txt"
+        )
+        try:
+            self._system_prompt_file.write_text("", encoding="utf-8")
+        except OSError:
+            logger.warning("[claude-code] could not create system-prompt file; prompt caching disabled")
+            self._system_prompt_file = None
+
     # -- LLMAdapter contract --------------------------------------------------
 
     def create_chat(
@@ -502,7 +553,12 @@ class ClaudeCodeAdapter(LLMAdapter):
             )
         prompt = "\n".join(prompt_parts)
 
-        result_str, usage, raw = self._invoke_raw(prompt, model or self._model)
+        # One-shot path: no cross-turn cache to protect; explicitly omit the
+        # system-prompt file so generate() never reuses (or poisons) the chat
+        # adapter's stable cache file.
+        result_str, usage, raw = self._invoke_raw(
+            prompt, model or self._model, system_prompt_file=None
+        )
         return LLMResponse(text=result_str, usage=usage, raw=raw)
 
     def make_tool_result_message(
@@ -526,13 +582,28 @@ class ClaudeCodeAdapter(LLMAdapter):
             env.pop(key, None)
         return env
 
-    def _invoke_raw(self, prompt: str, model: str) -> tuple[str, UsageMetadata, dict]:
-        """Run ``claude -p`` once. Returns (result_text, usage, envelope)."""
+    def _invoke_raw(
+        self,
+        prompt: str,
+        model: str,
+        system_prompt_file: Any = _UNSET,
+    ) -> tuple[str, UsageMetadata, dict]:
+        """Run ``claude -p`` once. Returns (result_text, usage, envelope).
+
+        ``system_prompt_file`` defaults to the adapter's stable prompt-cache
+        file (the chat path). Pass ``None`` to omit the flag entirely — used
+        by the one-shot ``generate`` path, which has no cross-turn cache to
+        protect and must not reuse (or poison) the chat system-prompt file.
+        """
         cmd = [self._cli_path, "-p", "--output-format", "json"]
         if model:
             cmd += ["--model", model]
         if self._disallowed:
             cmd += ["--disallowedTools", *self._disallowed]
+        if system_prompt_file is _UNSET:
+            system_prompt_file = self._system_prompt_file
+        if system_prompt_file:
+            cmd += ["--append-system-prompt-file", str(system_prompt_file)]
         cmd += self._extra_argv
 
         try:

--- a/tests/integration_test_claude_code.py
+++ b/tests/integration_test_claude_code.py
@@ -55,3 +55,41 @@ def test_live_service_path_keyless():
     sess.update_tools([_weather_tool()])
     r = sess.send("Reply with exactly: READY")
     assert "READY" in r.text
+
+
+def test_live_system_block_is_cache_read_across_growing_turns():
+    """The prompt-cache contract: the stable system block must be cache-read
+    on later turns even as the conversation grows.
+
+    Before the ``--append-system-prompt-file`` split, the whole stable context
+    was embedded in the per-turn user message, so a growing conversation forced
+    a full cache write every turn (``cached_tokens`` stayed flat at Claude
+    Code's own system-prompt size). With the split, the stable block lives in
+    the cached system block, so ``cached_tokens`` must grow on turn 2 and stay
+    stable on turn 3.
+    """
+    big_context = "\n".join(
+        "Context line %d: the quick brown fox jumps over the lazy dog. "
+        "This line makes the system prompt large enough to exceed Anthropic "
+        "cache minimums. Lorem ipsum dolor sit amet consectetur adipiscing elit "
+        "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua." % i
+        for i in range(120)
+    )
+    system_prompt = "You are a reasoning core under test.\n# SYSTEM CONTEXT\n" + big_context
+
+    ad = ClaudeCodeAdapter(model="sonnet", timeout_s=120)
+    sess = ad.create_chat("sonnet", system_prompt, None)
+
+    r1 = sess.send("First question: say hello.")
+    u1 = r1.usage
+    r2 = sess.send("Second question: now say goodbye.")
+    u2 = r2.usage
+    r3 = sess.send("Third question: and now a number.")
+    u3 = r3.usage
+
+    assert u2.cached_tokens > u1.cached_tokens, (
+        f"system block not cache-read on turn 2: t1={u1.cached_tokens} t2={u2.cached_tokens}"
+    )
+    assert u3.cached_tokens >= u2.cached_tokens, (
+        f"cache regressed on turn 3: t2={u2.cached_tokens} t3={u3.cached_tokens}"
+    )

--- a/tests/test_claude_code_adapter.py
+++ b/tests/test_claude_code_adapter.py
@@ -228,7 +228,100 @@ def test_command_includes_print_json_model_and_disallowed_tools():
     assert "--disallowedTools" in cmd and "Bash" in cmd
     # prompt is piped via stdin, not argv
     assert captured["kw"]["input"]
-    assert "AVAILABLE TOOLS" in captured["kw"]["input"]
+    # Stable context (protocol/system/tools) lives in the system-prompt file
+    # passed via --append-system-prompt-file (for prompt caching); the stdin
+    # user message carries only the conversation.
+    assert "# CONVERSATION" in captured["kw"]["input"]
+    assert "# NOW" in captured["kw"]["input"]
+    assert "# AVAILABLE TOOLS" not in captured["kw"]["input"]
+    assert "--append-system-prompt-file" in cmd
+    sp_idx = cmd.index("--append-system-prompt-file")
+    sp_path = cmd[sp_idx + 1]
+    with open(sp_path, encoding="utf-8") as f:
+        sp_content = f.read()
+    # The system block carries protocol + system prompt + tools.
+    assert "# AVAILABLE TOOLS" in sp_content
+    assert "(no tools available" in sp_content  # create_chat called with None
+    assert "sys" in sp_content  # the system prompt text
+    assert "You are the REASONING CORE" in sp_content  # the action protocol
+
+
+def test_system_prompt_file_stable_across_turns():
+    """The stable system block must not change as the conversation grows.
+
+    This is the prompt-cache contract: the system-prompt file passed via
+    ``--append-system-prompt-file`` must be byte-identical across turns (so
+    Claude Code's cache breakpoint on the system block hits), while only the
+    stdin user message grows.
+    """
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys", [_weather_tool()])
+    captured = []
+
+    def fake_run(cmd, **kw):
+        captured.append((cmd, kw))
+        return _FakeProc(stdout=_envelope('{"action":"final","text":"ok"}'))
+
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run):
+        sess.send("first message")
+        sess.send("second message")
+        sess.send("third message")
+
+    assert len(captured) == 3
+    sp_paths = set()
+    for cmd, _kw in captured:
+        sp_idx = cmd.index("--append-system-prompt-file")
+        sp_paths.add(cmd[sp_idx + 1])
+    assert len(sp_paths) == 1  # same stable file every turn
+
+    contents = []
+    for cmd, _kw in captured:
+        sp_idx = cmd.index("--append-system-prompt-file")
+        with open(cmd[sp_idx + 1], encoding="utf-8") as f:
+            contents.append(f.read())
+    assert contents[0] == contents[1] == contents[2]  # byte-identical system block
+
+    # Only the stdin user message grows.
+    stdins = [kw["input"] for _cmd, kw in captured]
+    assert len(stdins[0]) < len(stdins[1]) < len(stdins[2])
+    assert "# CONVERSATION" in stdins[0]
+
+
+def test_generate_omits_system_prompt_file():
+    """One-shot generate() must not reuse (or poison) the chat cache file."""
+    ad = ClaudeCodeAdapter(model="sonnet")
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return _FakeProc(stdout=_envelope("plain answer"))
+
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run):
+        resp = ad.generate("sonnet", "hello", system_prompt="sys")
+    assert resp.text == "plain answer"
+    assert "--append-system-prompt-file" not in captured["cmd"]
+
+
+def test_update_system_prompt_rewrites_system_file():
+    """Changing the system prompt must refresh the cached system block."""
+    ad = ClaudeCodeAdapter(model="sonnet")
+    sess = ad.create_chat("sonnet", "sys-v1", [_weather_tool()])
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return _FakeProc(stdout=_envelope('{"action":"final","text":"ok"}'))
+
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run):
+        sess.send("hi")
+    sp_idx = captured["cmd"].index("--append-system-prompt-file")
+    sp_path = captured["cmd"][sp_idx + 1]
+    with open(sp_path, encoding="utf-8") as f:
+        assert "sys-v1" in f.read()
+
+    sess.update_system_prompt("sys-v2")
+    with open(sp_path, encoding="utf-8") as f:
+        assert "sys-v2" in f.read()
 
 
 def test_env_strips_api_keys_but_keeps_oauth_token(monkeypatch):


### PR DESCRIPTION
## Problem

The Claude preset (`claude-code` provider) never effectively benefits from Anthropic prompt caching. Usage telemetry showed `cached_tokens` stuck at ~Claude Code's own system-prompt size (~20k) with the entire LingTai system prompt + tools rewritten to cache on **every** turn.

## Root cause

`ClaudeCodeChatSession._render_prompt()` serialized the **entire** context — protocol + system prompt + tools + full conversation — into **one** stdin user message. Claude Code places its cache breakpoint at the end of that user message. In a multi-turn agent loop the conversation **grows every turn**, so the whole user message differs from the previous one → full cache write every turn:

- TURN1: `cache_read=20345 cache_write=24125`
- TURN2 (grew): `cache_read=20345 cache_write=24160` ← same, whole thing rewritten

Only Claude Code's own default system prompt (~20k) was cache-read; LingTai's system prompt + tools (the bulk, often 50–150k) was rewritten **every single turn**.

## Fix

Split the prompt into the **stable system block** and the **growing user message**:

- Stable context (`_PROTOCOL` + `# AGENT SYSTEM INSTRUCTIONS` + `# AVAILABLE TOOLS`) → written to a per-adapter temp file, passed via **`--append-system-prompt-file`** so it lives in the *system* block that Claude Code caches independently.
- Per-turn user message (`# CONVERSATION` + `# NOW`) → stdin only.
- The file is rewritten only when `update_system_prompt` / `update_tools` change the system/tools, so its bytes stay identical across turns and the cache breakpoint hits.
- One-shot `generate()` explicitly omits the flag (`system_prompt_file=None`) so it never reuses or poisons the chat cache file.

Live measurement through the real adapter (120-line system prompt, 3 turns):

| Turn | cached_tokens |
|---|---|
| TURN1 | 14,995 |
| TURN2 (grew) | 33,971 (+18,976 — system block now cache-read) |
| TURN3 (grew more) | 33,971 (stable) |

## Tests

- `tests/test_claude_code_adapter.py` — 29 unit tests, including 3 new: system-prompt file stays byte-identical across growing turns, `generate()` omits the flag, `update_system_prompt` rewrites the file.
- `tests/integration_test_claude_code.py` — 3 live tests (new: `test_live_system_block_is_cache_read_across_growing_turns` asserts cache grows on turn 2 and stays stable on turn 3).
- All 32 pass (`32 passed in 19.56s`), including live runs against the real `claude` CLI.

The 33 failures in `test_daemon_claude_*` are **pre-existing on main** (verified by stashing this change) and concern the daemon interactive runner, unrelated to this adapter path.
