### PR TITLE
chore(release): prepare v0.19.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.19.2"
+version = "0.19.3"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Closed as superseded: main is already at 0.19.5; the urgent Claude prompt-caching fix (3c0881dc, PR #1118) is already merged into main. Verified 2026-08-02 by deepseek-1 per Jason.