### PR TITLE
Telegram: require an explicit rendering mode

### DIFF
--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Progressive-disclosure usage manual for the Telegram MCP tool. Read this when
   you need detail beyond the one-line action descriptions: media.type='document'
   vs 'photo' for charts/reports/generated artifacts, placeholder/live-status
-  messages, reply vs send, read/check/search, parse_mode/entities, chat_action, dynamic slash commands,
+  messages, reply vs send, read/check/search, rendering_mode/entities, chat_action, dynamic slash commands,
   the programmable Task Card (task_card tool) — including task-specific watcher
   design for meaningful long-running work — and error surfacing. Pulled on demand
   via action='manual'; you do not need to call it before every send.
@@ -122,13 +122,20 @@ setup readiness checklist are **not** here — they belong to `mcp-manual`
   non-numeric value the schema accepts) to `read`/`search` to recover them;
   `send`/`reply` still require a real numeric chat ID.
 
-## RICH TEXT: parse_mode / entities
+## RENDERING MODE: explicit per-message choice
 
-- `parse_mode` accepts `'HTML'`, `'MarkdownV2'`, or `'Markdown'` for
-  send/reply/edit and media captions; omit it or pass `''` for plain text.
-- `entities` sets `MessageEntity[]` for message text; `caption_entities` does the
-  same for media captions. If `caption_entities` is omitted on a media send,
-  `entities` is reused as the caption entities.
+- Every content-bearing `send`, `reply`, and `edit` must include
+  `rendering_mode`; there is no default. Choose exactly one of `plain_text`,
+  `HTML`, `Markdown`, `MarkdownV2`, or `entities`.
+- `plain_text` maps to an omitted Bot API `parse_mode`; the other three named
+  formats map to Telegram `parse_mode`. The agent must still provide the label
+  even when no formatting is wanted.
+- `entities` selects explicit `MessageEntity[]` formatting. Pass `entities` for
+  message text or `caption_entities` for media captions; do not combine entity
+  fields with a parse-mode rendering choice.
+- For `send` with only `chat_action` and no text/media, use `plain_text` because
+  no message body is rendered. `rendering_mode` is still required by the strict
+  public branch.
 
 ## CHAT ACTION
 
@@ -322,7 +329,7 @@ chat-history cardinality. Normative source:
 ## ERROR SURFACING
 
 - Actions return `{'status': ...}` on success or `{'error': <message>}` on
-  failure (e.g. missing `chat_id`, unreadable `media.path`, bad `parse_mode`).
+  failure (e.g. missing `chat_id`, unreadable `media.path`, bad `rendering_mode`).
   Check for the `'error'` key and surface or act on it rather than assuming the
   message was delivered.
 - Telegram HTTP 429 responses fail fast with `status: 'error'`,

--- a/src/lingtai/mcp_servers/telegram/_family.py
+++ b/src/lingtai/mcp_servers/telegram/_family.py
@@ -25,6 +25,8 @@ _ACTIONS = (
     "contacts", "add_contact", "remove_contact", "accounts", "manual",
 )
 
+_RENDERING_MODES = ("plain_text", "HTML", "MarkdownV2", "Markdown", "entities")
+
 
 def _nullable(schema: dict[str, Any]) -> dict[str, Any]:
     return {"anyOf": [schema, {"type": "null"}]}
@@ -81,15 +83,15 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
                 "type": "string",
                 "enum": ["typing", "upload_photo", "upload_document", "upload_voice", ""],
             }),
-            "parse_mode": _nullable({
-                "type": "string", "enum": ["HTML", "MarkdownV2", "Markdown", ""],
-            }),
+            "rendering_mode": {
+                "type": "string", "enum": list(_RENDERING_MODES),
+            },
             "entities": _nullable({"type": "array"}),
             "caption_entities": _nullable({"type": "array"}),
             "link_preview_options": _nullable({"type": "object"}),
             "disable_web_page_preview": _nullable({"type": "boolean"}),
         },
-        required=["chat_id"],
+        required=["chat_id", "rendering_mode"],
         any_of=[
             {"required": ["text"]},
             {"required": ["media"]},
@@ -104,9 +106,17 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
         "compress, thumbnail, or display text-heavy charts poorly. Do not paste local "
         "file paths in message text as a substitute for attaching the file."
     )
-    send["properties"]["parse_mode"]["anyOf"][0]["description"] = (
-        "Telegram Bot API parse_mode for rich text (send/reply/edit and media captions). "
-        "Omit or pass an empty string for plain text."
+    send["properties"]["rendering_mode"]["description"] = (
+        "Required rendering choice for every send. Choose plain_text for unformatted "
+        "text or chat actions, HTML/Markdown/MarkdownV2 for Telegram parse_mode, or "
+        "entities when supplying MessageEntity data. There is no default; do not "
+        "combine entities with a parse-mode choice."
+    )
+    send["properties"]["entities"]["anyOf"][0]["description"] = (
+        "Telegram MessageEntity[] for rendering_mode='entities' on message text."
+    )
+    send["properties"]["caption_entities"]["anyOf"][0]["description"] = (
+        "Telegram MessageEntity[] for rendering_mode='entities' on media captions."
     )
     send["properties"]["chat_action"]["anyOf"][0]["description"] = (
         "For send only. When set and no text/media is provided, sends a chat action "
@@ -129,12 +139,16 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
             {
                 "message_id": {"type": "string"},
                 "text": {"type": "string"},
-                "parse_mode": _nullable({
-                    "type": "string", "enum": ["HTML", "MarkdownV2", "Markdown", ""],
-                }),
+                "rendering_mode": {
+                    "type": "string", "enum": list(_RENDERING_MODES),
+                    "description": (
+                        "Required rendering choice: plain_text, HTML, Markdown, "
+                        "MarkdownV2, or entities. There is no default."
+                    ),
+                },
                 "entities": _nullable({"type": "array"}),
             },
-            required=["message_id", "text"],
+            required=["message_id", "text", "rendering_mode"],
         ),
         "search": _object(
             {
@@ -150,12 +164,16 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
                 "message_id": {"type": "string"},
                 "text": {"type": "string"},
                 "reply_markup": {"type": "object"},
-                "parse_mode": _nullable({
-                    "type": "string", "enum": ["HTML", "MarkdownV2", "Markdown", ""],
-                }),
+                "rendering_mode": {
+                    "type": "string", "enum": list(_RENDERING_MODES),
+                    "description": (
+                        "Required rendering choice: plain_text, HTML, Markdown, "
+                        "MarkdownV2, or entities. There is no default."
+                    ),
+                },
                 "entities": _nullable({"type": "array"}),
             },
-            required=["message_id", "text"],
+            required=["message_id", "text", "rendering_mode"],
         ),
         "contacts": _object({"account": _nullable({"type": "string"})}),
         "add_contact": _object(
@@ -202,7 +220,9 @@ def telegram_schema() -> dict[str, Any]:
     # not reject a valid input merely because another action's branch also fits.
     schema["properties"]["input"]["anyOf"] = schema["properties"]["input"].pop("oneOf")
     schema["properties"]["action"]["description"] = (
-        "Telegram action. Each action owns a strict input branch. For charts, "
+        "Telegram action. Each action owns a strict input branch. Content-bearing "
+        "send/reply/edit calls must provide rendering_mode explicitly: plain_text, "
+        "HTML, Markdown, MarkdownV2, or entities; there is no default. For charts, "
         "reports, generated artifacts, and other files the user should open intact, "
         "prefer media.type='document'; use media.type='photo' only for an inline "
         "preview because photo previews may crop or compress text-heavy graphics. "

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -373,16 +373,16 @@ SCHEMA = {
                 "accounts", "manual",
             ],
             "description": (
-                "send: send message to a chat (chat_id, text; optional media, reply_markup, placeholder, chat_action, parse_mode/entities). "
+                "send: send message to a chat (chat_id, text, rendering_mode; optional media, reply_markup, placeholder, chat_action, entities). "
                 "For charts, reports, generated artifacts, and other files the user should open intact, prefer media.type='document'; use media.type='photo' only when an inline Telegram photo preview is desired, because photo previews may crop, compress, or display poorly for text-heavy graphics. "
                 "If chat_action is set and no text/media is provided, sends a typing "
                 "indicator (auto-expires after 5s) instead of a message. "
                 "check: list recent conversations with unread counts (optional account). "
                 "read: read messages from a chat (chat_id; optional limit). "
-                "reply: reply to a specific message (message_id from read results, text; optional parse_mode/entities). "
+                "reply: reply to a specific message (message_id from read results, text, rendering_mode; optional entities). "
                 "search: search messages (query; optional account, chat_id). "
                 "delete: delete a bot message (message_id). "
-                "edit: edit a bot message (message_id, text; optional reply_markup, parse_mode/entities). "
+                "edit: edit a bot message (message_id, text, rendering_mode; optional reply_markup, entities). "
                 "contacts: list saved contacts. "
                 "add_contact: save a chat alias (chat_id, alias); this does not grant inbound permission. "
                 "To receive messages from that user, their Telegram user ID must also be in allowed_users. "
@@ -436,12 +436,14 @@ SCHEMA = {
             "type": "object",
             "description": "Inline keyboard markup",
         },
-        "parse_mode": {
+        "rendering_mode": {
             "type": "string",
-            "enum": ["HTML", "MarkdownV2", "Markdown", ""],
+            "enum": ["plain_text", "HTML", "MarkdownV2", "Markdown", "entities"],
             "description": (
-                "Telegram Bot API parse_mode for rich text (send/reply/edit, "
-                "and media captions). Omit or pass an empty string for plain text."
+                "Required for every content-bearing send/reply/edit. Choose "
+                "plain_text, HTML, Markdown, MarkdownV2, or entities; there is no "
+                "default. The runtime maps the choice to Telegram parse_mode or "
+                "MessageEntity data."
             ),
         },
         "entities": {
@@ -3838,18 +3840,7 @@ class TelegramManager:
     # ------------------------------------------------------------------
 
     _PARSE_MODES = {"HTML", "MarkdownV2", "Markdown"}
-
-    @staticmethod
-    def _normalize_parse_mode(value: Any) -> Any:
-        """Treat an empty parse_mode as omitted/plain text.
-
-        Some tool callers serialize absent optional string fields as ``""``.
-        Telegram Bot API itself omits parse_mode for plain text, so normalize
-        the empty string before validation and payload persistence.
-        """
-        if value == "":
-            return None
-        return value
+    _RENDERING_MODES = _PARSE_MODES | {"plain_text", "entities"}
 
     @staticmethod
     def _normalize_chat_action(value: Any) -> Any:
@@ -3863,21 +3854,57 @@ class TelegramManager:
             return None
         return value
 
-    def _rich_text_options(self, args: dict) -> tuple[dict[str, Any], str | None]:
-        """Extract Bot API rich text options for text messages from tool args.
+    @classmethod
+    def _rendering_mode(cls, args: dict) -> str:
+        """Return the explicit rendering choice, with an internal plain fallback.
 
-        Returns (options, error). When nothing relevant is supplied the
-        options dict is empty, so existing plain-text callers behave exactly
-        as before.
+        The public ToolFamily requires ``rendering_mode``.  Manager internals
+        also send text (for example automatic progress) without passing through
+        that model-facing schema, so those internal calls retain plain-text
+        behavior without creating a public default.
+        """
+        value = args.get("rendering_mode")
+        return "plain_text" if value is None else value
+
+    @classmethod
+    def _bot_parse_mode(cls, args: dict) -> str | None:
+        mode = cls._rendering_mode(args)
+        return mode if mode in cls._PARSE_MODES else None
+
+    @classmethod
+    def _rendering_error(cls, mode: str, *, has_entities: bool) -> str | None:
+        if mode not in cls._RENDERING_MODES:
+            return (
+                "rendering_mode must be one of: plain_text, HTML, MarkdownV2, "
+                "Markdown, entities"
+            )
+        if mode == "entities" and not has_entities:
+            return "rendering_mode='entities' requires entities or caption_entities"
+        if mode != "entities" and has_entities:
+            return (
+                f"rendering_mode='{mode}' cannot be combined with entities; "
+                "choose rendering_mode='entities'"
+            )
+        return None
+
+    def _rich_text_options(self, args: dict) -> tuple[dict[str, Any], str | None]:
+        """Extract Bot API options for a text message from rendering_mode.
+
+        ``rendering_mode`` is required at the public family boundary.  Missing
+        values here are only for manager-owned internal sends and mean plain
+        text; the model-facing schema never relies on that fallback.
         """
         opts: dict[str, Any] = {}
-        parse_mode = self._normalize_parse_mode(args.get("parse_mode"))
-        if parse_mode is not None:
-            if parse_mode not in self._PARSE_MODES:
-                return {}, "parse_mode must be one of: HTML, MarkdownV2, Markdown"
-            opts["parse_mode"] = parse_mode
-        if args.get("entities") is not None:
-            opts["entities"] = args.get("entities")
+        entities = args.get("entities")
+        has_entities = entities is not None or args.get("caption_entities") is not None
+        mode = self._rendering_mode(args)
+        error = self._rendering_error(mode, has_entities=has_entities)
+        if error:
+            return {}, error
+        if mode == "entities":
+            opts["entities"] = entities
+        elif mode in self._PARSE_MODES:
+            opts["parse_mode"] = mode
         if args.get("link_preview_options") is not None:
             opts["link_preview_options"] = args.get("link_preview_options")
         if args.get("disable_web_page_preview") is not None:
@@ -3885,22 +3912,19 @@ class TelegramManager:
         return opts, None
 
     def _caption_options(self, args: dict) -> tuple[dict[str, Any], str | None]:
-        """Extract Bot API rich caption options for media sends from tool args.
-
-        If ``caption_entities`` is omitted but ``entities`` is supplied, the
-        latter is treated as caption entities for convenience.
-        """
+        """Extract Bot API options for a media caption from rendering_mode."""
         opts: dict[str, Any] = {}
-        parse_mode = self._normalize_parse_mode(args.get("parse_mode"))
-        if parse_mode is not None:
-            if parse_mode not in self._PARSE_MODES:
-                return {}, "parse_mode must be one of: HTML, MarkdownV2, Markdown"
-            opts["parse_mode"] = parse_mode
         caption_entities = args.get("caption_entities")
         if caption_entities is None:
             caption_entities = args.get("entities")
-        if caption_entities is not None:
+        mode = self._rendering_mode(args)
+        error = self._rendering_error(mode, has_entities=caption_entities is not None)
+        if error:
+            return {}, error
+        if mode == "entities":
             opts["caption_entities"] = caption_entities
+        elif mode in self._PARSE_MODES:
+            opts["parse_mode"] = mode
         return opts, None
 
     def _send(self, args: dict) -> dict:
@@ -4035,7 +4059,8 @@ class TelegramManager:
             "media": media,
             "reply_markup": reply_markup,
             "reply_to_message_id": reply_to,
-            "parse_mode": self._normalize_parse_mode(args.get("parse_mode")),
+            "rendering_mode": self._rendering_mode(args),
+            "parse_mode": self._bot_parse_mode(args),
             "entities": args.get("entities"),
             "caption_entities": args.get("caption_entities"),
             "link_preview_options": args.get("link_preview_options"),
@@ -4193,7 +4218,7 @@ class TelegramManager:
             "text": text,
             "media": args.get("media"),
             "reply_markup": args.get("reply_markup"),
-            "parse_mode": self._normalize_parse_mode(args.get("parse_mode")),
+            "rendering_mode": self._rendering_mode(args),
             "entities": args.get("entities"),
             "caption_entities": args.get("caption_entities"),
             "link_preview_options": args.get("link_preview_options"),
@@ -4272,10 +4297,6 @@ class TelegramManager:
             return {"error": "text is required"}
         account, chat_id, tg_msg_id = self._parse_compound_id(compound_id)
         reply_markup = args.get("reply_markup")
-        rich_text_options, rich_text_error = self._rich_text_options(args)
-        caption_options, caption_error = self._caption_options(args)
-        if rich_text_error or caption_error:
-            return {"error": rich_text_error or caption_error}
         acct = self._service.get_account(account)
 
         # Detect if original message had media (caption edit vs text edit)
@@ -4293,7 +4314,13 @@ class TelegramManager:
                     except (json.JSONDecodeError, OSError):
                         continue
 
-        edit_options = caption_options if is_caption else rich_text_options
+        if is_caption:
+            edit_options, rendering_error = self._caption_options(args)
+        else:
+            edit_options, rendering_error = self._rich_text_options(args)
+        if rendering_error:
+            return {"error": rendering_error}
+
         acct.edit_message(
             chat_id=chat_id, message_id=tg_msg_id, text=text,
             reply_markup=reply_markup, is_caption=is_caption,

--- a/tests/test_telegram_rich_formatting.py
+++ b/tests/test_telegram_rich_formatting.py
@@ -1,7 +1,7 @@
 """Tests for Telegram MCP rich-formatting pass-through (issue #301).
 
 Proves that the in-kernel Telegram MCP manager forwards Bot API
-formatting options (parse_mode / entities / caption_entities /
+formatting options (rendering_mode / entities / caption_entities /
 link_preview_options / disable_web_page_preview) through to the account
 wrapper for send / reply / edit / media-caption paths, and that callers
 who supply none of these options get exactly the previous behaviour.
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+
+import pytest
 
 from lingtai.mcp_servers.telegram.account import TelegramAccount
 from lingtai.mcp_servers.telegram.manager import SCHEMA, TelegramManager
@@ -117,19 +119,13 @@ def _schema_description(schema):
     return " ".join(branch.get("description", "") for branch in schema.get("anyOf", []))
 
 
-def test_schema_exposes_rich_formatting_fields():
+def test_schema_exposes_explicit_rendering_fields():
     props = _send_schema()["properties"]
-    for field in (
-        "parse_mode",
-        "entities",
-        "caption_entities",
-        "link_preview_options",
-        "disable_web_page_preview",
-    ):
+    for field in ("rendering_mode", "entities", "caption_entities", "link_preview_options", "disable_web_page_preview"):
         assert field in props
-
-    assert "" in _schema_enum(props["parse_mode"])
-    assert "plain text" in _schema_description(props["parse_mode"])
+    assert _schema_enum(props["rendering_mode"]) == ["plain_text", "HTML", "MarkdownV2", "Markdown", "entities"]
+    assert "no default" in _schema_description(props["rendering_mode"])
+    assert "parse_mode" not in props
 
 
 def test_schema_allows_empty_chat_action():
@@ -227,46 +223,31 @@ def test_manual_action_returns_usage_guidance(tmp_path):
     # the other facets the manual should cover
     assert "placeholder" in lowered
     assert "reply" in lowered
-    assert "parse_mode" in manual
+    assert "rendering_mode" in manual
+    assert "parse_mode" in manual  # Bot API mapping remains documented.
     assert "chat_action" in manual
     assert "error" in lowered
 
 
 # ---------------------------------------------------------------------------
-# Manager pass-through (the acceptance-critical parse_mode path lives here)
+# Manager pass-through (the acceptance-critical rendering path lives here)
 # ---------------------------------------------------------------------------
 
 
-def test_send_passes_parse_mode_entities_and_link_preview(tmp_path):
+@pytest.mark.parametrize(
+    ("rendering_mode", "expected_options"),
+    [("plain_text", {}), ("HTML", {"parse_mode": "HTML"}), ("Markdown", {"parse_mode": "Markdown"}), ("MarkdownV2", {"parse_mode": "MarkdownV2"})],
+)
+def test_send_maps_explicit_rendering_mode(rendering_mode, expected_options, tmp_path):
     manager, account = _manager(tmp_path)
-    entities = [{"type": "bold", "offset": 0, "length": 4}]
     link_preview_options = {"is_disabled": True}
-
     result = manager._send({
-        "account": "mybot",
-        "chat_id": 123,
-        "text": "bold link",
-        "parse_mode": "HTML",
-        "entities": entities,
-        "link_preview_options": link_preview_options,
+        "account": "mybot", "chat_id": 123, "text": "formatted link",
+        "rendering_mode": rendering_mode, "link_preview_options": link_preview_options,
         "disable_web_page_preview": True,
     })
-
     assert result == {"status": "sent", "message_id": "mybot:123:111"}
-    assert account.calls == [(
-        "send_message",
-        123,
-        "bold link",
-        None,
-        None,
-        {
-            "parse_mode": "HTML",
-            "entities": entities,
-            "link_preview_options": link_preview_options,
-            "disable_web_page_preview": True,
-        },
-    )]
-
+    assert account.calls[0][-1] == {**expected_options, "link_preview_options": link_preview_options, "disable_web_page_preview": True}
 
 def test_reply_persists_reply_to_message_id_in_sent_record(tmp_path):
     manager, account = _manager(tmp_path)
@@ -274,6 +255,7 @@ def test_reply_persists_reply_to_message_id_in_sent_record(tmp_path):
     result = manager._reply({
         "message_id": "mybot:123:456",
         "text": "reply text",
+        "rendering_mode": "plain_text",
     })
 
     assert result == {"status": "sent", "message_id": "mybot:123:111"}
@@ -295,6 +277,7 @@ def test_send_accepts_public_reply_target_fields(tmp_path):
         "account": "mybot",
         "chat_id": 123,
         "text": "reply text",
+        "rendering_mode": "plain_text",
         "message_id": "mybot:123:456",
     })
 
@@ -312,6 +295,7 @@ def test_send_accepts_raw_reply_to_message_id(tmp_path):
         "account": "mybot",
         "chat_id": 123,
         "text": "reply text",
+        "rendering_mode": "plain_text",
         "reply_to_message_id": 456,
     })
 
@@ -329,6 +313,7 @@ def test_send_reply_target_precedence_prefers_private_field(tmp_path):
         "account": "mybot",
         "chat_id": 123,
         "text": "reply text",
+        "rendering_mode": "plain_text",
         "_reply_to_message_id": 111,
         "reply_to_message_id": 222,
         "message_id": "mybot:123:333",
@@ -341,8 +326,8 @@ def test_send_reply_target_precedence_prefers_private_field(tmp_path):
     assert read_result["messages"][0]["reply_to_message_id"] == 111
 
 
-def test_send_without_formatting_is_unchanged(tmp_path):
-    """Backward compatibility: a plain send forwards no formatting kwargs."""
+def test_internal_send_without_rendering_mode_keeps_plain_fallback(tmp_path):
+    """Manager-owned internal sends retain plain-text compatibility."""
     manager, account = _manager(tmp_path)
 
     result = manager._send({
@@ -362,93 +347,40 @@ def test_send_without_formatting_is_unchanged(tmp_path):
     )]
 
 
-def test_empty_parse_mode_is_treated_as_plain_text(tmp_path):
-    """Optional parse_mode serialized as "" should mean omitted/plain text."""
+def test_explicit_plain_text_omits_bot_parse_mode(tmp_path):
     manager, account = _manager(tmp_path)
-
-    result = manager._send({
-        "account": "mybot",
-        "chat_id": 123,
-        "text": "plain",
-        "parse_mode": "",
-    })
-
+    result = manager._send({"account": "mybot", "chat_id": 123, "text": "plain", "rendering_mode": "plain_text"})
     assert result == {"status": "sent", "message_id": "mybot:123:111"}
-    assert account.calls == [(
-        "send_message",
-        123,
-        "plain",
-        None,
-        None,
-        {},
-    )]
+    assert account.calls == [("send_message", 123, "plain", None, None, {})]
     sent_files = list((Path(tmp_path) / "telegram" / "mybot" / "sent").glob("*/message.json"))
-    assert len(sent_files) == 1
-    assert json.loads(sent_files[0].read_text())["parse_mode"] is None
+    record = json.loads(sent_files[0].read_text())
+    assert record["rendering_mode"] == "plain_text"
+    assert record["parse_mode"] is None
 
-
-def test_empty_chat_action_with_text_is_treated_as_omitted(tmp_path):
-    """Optional chat_action serialized as "" should not block text sends."""
+def test_explicit_plain_text_with_empty_chat_action_sends_text(tmp_path):
     manager, account = _manager(tmp_path)
-
-    result = manager._send({
-        "account": "mybot",
-        "chat_id": 123,
-        "text": "plain",
-        "chat_action": "",
-    })
-
+    result = manager._send({"account": "mybot", "chat_id": 123, "text": "plain", "rendering_mode": "plain_text", "chat_action": ""})
     assert result == {"status": "sent", "message_id": "mybot:123:111"}
-    assert account.calls == [(
-        "send_message",
-        123,
-        "plain",
-        None,
-        None,
-        {},
-    )]
+    assert account.calls == [("send_message", 123, "plain", None, None, {})]
 
-
-def test_empty_parse_mode_reply_is_treated_as_plain_text(tmp_path):
+def test_plain_text_reply_is_forwarded_without_bot_parse_mode(tmp_path):
     manager, account = _manager(tmp_path)
-
-    result = manager._reply({
-        "message_id": "mybot:123:456",
-        "text": "plain reply",
-        "parse_mode": "",
-    })
-
+    result = manager._reply({"message_id": "mybot:123:456", "text": "plain reply", "rendering_mode": "plain_text"})
     assert result == {"status": "sent", "message_id": "mybot:123:111"}
-    assert account.calls == [(
-        "send_message",
-        123,
-        "plain reply",
-        None,
-        456,
-        {},
-    )]
-
+    assert account.calls == [("send_message", 123, "plain reply", None, 456, {})]
 
 def test_reply_passes_rich_formatting_options(tmp_path):
     manager, account = _manager(tmp_path)
-    entities = [{"type": "code", "offset": 0, "length": 1}]
-
-    result = manager._reply({
-        "message_id": "mybot:123:456",
-        "text": "x",
-        "parse_mode": "MarkdownV2",
-        "entities": entities,
-    })
-
+    result = manager._reply({"message_id": "mybot:123:456", "text": "x", "rendering_mode": "MarkdownV2"})
     assert result == {"status": "sent", "message_id": "mybot:123:111"}
-    assert account.calls == [(
-        "send_message",
-        123,
-        "x",
-        None,
-        456,
-        {"parse_mode": "MarkdownV2", "entities": entities},
-    )]
+    assert account.calls == [("send_message", 123, "x", None, 456, {"parse_mode": "MarkdownV2"})]
+
+def test_reply_entities_mode_passes_entities(tmp_path):
+    manager, account = _manager(tmp_path)
+    entities = [{"type": "code", "offset": 0, "length": 1}]
+    result = manager._reply({"message_id": "mybot:123:456", "text": "x", "rendering_mode": "entities", "entities": entities})
+    assert result == {"status": "sent", "message_id": "mybot:123:111"}
+    assert account.calls[0][-1] == {"entities": entities}
 
 
 def test_send_media_passes_caption_entities(tmp_path):
@@ -456,68 +388,35 @@ def test_send_media_passes_caption_entities(tmp_path):
     media_path.write_text("demo", encoding="utf-8")
     manager, account = _manager(tmp_path)
     caption_entities = [{"type": "italic", "offset": 0, "length": 4}]
-
-    result = manager._send({
-        "account": "mybot",
-        "chat_id": 123,
-        "text": "demo",
-        "media": {"type": "document", "path": str(media_path)},
-        "parse_mode": "HTML",
-        "caption_entities": caption_entities,
-    })
-
+    result = manager._send({"account": "mybot", "chat_id": 123, "text": "demo", "media": {"type": "document", "path": str(media_path)}, "rendering_mode": "entities", "caption_entities": caption_entities})
     assert result == {"status": "sent", "message_id": "mybot:123:222"}
-    assert account.calls == [(
-        "send_document",
-        123,
-        str(media_path),
-        "demo",
-        None,
-        {"parse_mode": "HTML", "caption_entities": caption_entities},
-    )]
+    assert account.calls == [("send_document", 123, str(media_path), "demo", None, {"caption_entities": caption_entities})]
 
-
-def test_edit_text_passes_parse_mode(tmp_path):
+def test_edit_text_passes_rendering_mode(tmp_path):
     manager, account = _manager(tmp_path)
-
-    result = manager._edit({
-        "message_id": "mybot:123:456",
-        "text": "<b>x</b>",
-        "parse_mode": "HTML",
-    })
-
+    result = manager._edit({"message_id": "mybot:123:456", "text": "<b>x</b>", "rendering_mode": "HTML"})
     assert result == {"status": "edited", "message_id": "mybot:123:456"}
-    assert account.calls == [(
-        "edit_message",
-        {
-            "chat_id": 123,
-            "message_id": 456,
-            "text": "<b>x</b>",
-            "reply_markup": None,
-            "is_caption": False,
-            "parse_mode": "HTML",
-        },
-    )]
+    assert account.calls == [("edit_message", {"chat_id": 123, "message_id": 456, "text": "<b>x</b>", "reply_markup": None, "is_caption": False, "parse_mode": "HTML"})]
 
-
-def test_invalid_parse_mode_is_rejected(tmp_path):
+def test_invalid_rendering_mode_is_rejected(tmp_path):
     manager, account = _manager(tmp_path)
+    result = manager._send({"account": "mybot", "chat_id": 123, "text": "hello", "rendering_mode": "BBCode"})
+    assert result == {"error": "rendering_mode must be one of: plain_text, HTML, MarkdownV2, Markdown, entities"}
+    assert account.calls == []
 
-    result = manager._send({
-        "account": "mybot",
-        "chat_id": 123,
-        "text": "hello",
-        "parse_mode": "BBCode",
-    })
-
-    assert result == {"error": "parse_mode must be one of: HTML, MarkdownV2, Markdown"}
+@pytest.mark.parametrize("rendering_mode", ["plain_text", "HTML", "Markdown", "MarkdownV2"])
+def test_entity_data_is_rejected_for_parse_mode_rendering(rendering_mode, tmp_path):
+    manager, account = _manager(tmp_path)
+    result = manager._send({"account": "mybot", "chat_id": 123, "text": "hello", "rendering_mode": rendering_mode, "entities": [{"type": "bold", "offset": 0, "length": 5}]})
+    assert result == {"error": f"rendering_mode='{rendering_mode}' cannot be combined with entities; choose rendering_mode='entities'"}
     assert account.calls == []
 
 
-# ---------------------------------------------------------------------------
-# Account wrapper payload shaping
-# ---------------------------------------------------------------------------
-
+def test_entities_rendering_requires_entity_data(tmp_path):
+    manager, account = _manager(tmp_path)
+    result = manager._send({"account": "mybot", "chat_id": 123, "text": "hello", "rendering_mode": "entities"})
+    assert result == {"error": "rendering_mode='entities' requires entities or caption_entities"}
+    assert account.calls == []
 
 class CaptureAccount(TelegramAccount):
     def __init__(self):

--- a/tests/test_telegram_toolfamily_ltpv2.py
+++ b/tests/test_telegram_toolfamily_ltpv2.py
@@ -58,20 +58,30 @@ def test_family_dispatch_rejects_root_and_cross_branch_before_manager_io():
     assert len(manager.calls) == 1
 
 
-def test_telegram_send_schema_preserves_text_media_chat_action_alternatives():
-    send = _branches(TELEGRAM_SCHEMA)["send"]
-    assert send["anyOf"] == [
-        {"required": ["text"]},
-        {"required": ["media"]},
-        {"required": ["chat_action"]},
-    ]
-    assert _basic_validate({"chat_id": 3, "text": "hello"}, send)
-    assert _basic_validate({"chat_id": 3, "media": {"type": "photo", "path": "x"}}, send)
-    assert _basic_validate({"chat_id": 3, "chat_action": "typing"}, send)
-    assert not _basic_validate({"chat_id": 3}, send)
-    assert not _basic_validate({"text": "missing chat"}, send)
-    assert not _basic_validate({"chat_id": 3, "text": 17}, send)
+def test_telegram_send_requires_rendering_mode_before_manager_io():
+    manager = _CountingManager()
+    for input_ in (
+        {"chat_id": 2, "text": "x"},
+        {"chat_id": 2, "text": "x", "parse_mode": "HTML"},
+        {"chat_id": 2, "chat_action": "typing"},
+    ):
+        result = handle_telegram(manager, {"action": "send", "input": input_, "reasoning": "schema probe"})
+        assert result["status"] == "failed", input_
+        assert result["error_code"] == "INVALID_ARGUMENT"
+        assert manager.calls == []
 
+def test_telegram_send_schema_requires_rendering_mode_and_preserves_content_alternatives():
+    send = _branches(TELEGRAM_SCHEMA)["send"]
+    assert "rendering_mode" in send["required"]
+    assert send["properties"]["rendering_mode"]["enum"] == ["plain_text", "HTML", "MarkdownV2", "Markdown", "entities"]
+    assert send["anyOf"] == [{"required": ["text"]}, {"required": ["media"]}, {"required": ["chat_action"]}]
+    assert _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "text": "hello"}, send)
+    assert _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "media": {"type": "photo", "path": "x"}}, send)
+    assert _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "chat_action": "typing"}, send)
+    assert not _basic_validate({"chat_id": 3, "text": "hello"}, send)
+    assert not _basic_validate({"chat_id": 3, "rendering_mode": "plain_text"}, send)
+    assert not _basic_validate({"text": "missing chat", "rendering_mode": "plain_text"}, send)
+    assert not _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "text": 17}, send)
 
 def test_taskcard_refresh_setting_defaults_invalid_values_preserves_valid_siblings(
     tmp_path, caplog


### PR DESCRIPTION
## Summary

- Require `rendering_mode` on public Telegram `send`, `reply`, and `edit` branches with no implicit default.
- Use explicit `plain_text`, `HTML`, `Markdown`, `MarkdownV2`, or `entities` labels and map them deterministically to Bot API options.
- Reject mixed entity/parse-mode choices and missing entity data; preserve a private plain-text fallback only for manager-owned internal sends.
- Synchronize the Telegram manual and focused contract/forwarding tests.

## Validation

- Focused Telegram suite: **46 passed**.
- Ruff check: **passed**; `git diff --check`: **passed**.
- Docs governance: **305 documents passed**.
- Architecture/Anatomy contract tests: **12 passed**.
- Full Anatomy drift check reports one pre-existing unrelated citation issue in `src/lingtai/kernel/notification_store/ANATOMY.md` (`src/lingtai/tools/daemon/supervisor_runtime.py:600-620 > 601 lines`).
- Broader `tests/test_mcp_skill_manuals.py` collection is blocked by the machine-installed MCP SDK missing `ServerRequestContext` for Feishu; the focused Telegram manual test passes.

## Scope / boundaries

- Base: `3c0881dcbc2aa1c59f889d6c37c7f8a379f8b147`
- Candidate: `cbabd7847c0e56ee9cecebe3ec62f03eb99e505e`
- Five files, source/manual/tests only.
- No runtime refresh, config/auth change, merge, release, or deployment performed.

Draft for review; merge remains separately unauthorized.