### PR TITLE
fix: make Path.write_text encoding explicit

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -372,7 +372,8 @@ class Agent(BaseAgent):
             llm_dir = self._working_dir / "system"
             llm_dir.mkdir(exist_ok=True)
             (llm_dir / "llm.json").write_text(
-                _json.dumps(llm_config, ensure_ascii=False)
+                _json.dumps(llm_config, ensure_ascii=False),
+                encoding="utf-8",
             )
         except (TypeError, AttributeError, OSError):
             pass  # LLM config not available (e.g., mock service in tests)
@@ -1909,7 +1910,7 @@ class Agent(BaseAgent):
         base_prompt = data.get("base_prompt", "")
         base_prompt_file = system_dir / "base_prompt.md"
         if base_prompt:
-            base_prompt_file.write_text(base_prompt)
+            base_prompt_file.write_text(base_prompt, encoding="utf-8")
         elif base_prompt_file.is_file():
             base_prompt = base_prompt_file.read_text(encoding="utf-8")
         self._base_prompt = base_prompt or ""
@@ -1918,7 +1919,7 @@ class Agent(BaseAgent):
         covenant = data.get("covenant", "")
         covenant_file = system_dir / "covenant.md"
         if covenant:
-            covenant_file.write_text(covenant)
+            covenant_file.write_text(covenant, encoding="utf-8")
         elif covenant_file.is_file():
             covenant = covenant_file.read_text(encoding="utf-8")
         if covenant:
@@ -1939,7 +1940,7 @@ class Agent(BaseAgent):
         # legacy alias.)
         lingtai_seed = data.get("lingtai", "")
         if lingtai_seed:
-            (system_dir / "lingtai.md").write_text(lingtai_seed)
+            (system_dir / "lingtai.md").write_text(lingtai_seed, encoding="utf-8")
         # Delegate to the single canonical composer so boot/refresh/molt all
         # produce byte-identical `character` content and no longer depend on
         # post-molt hook ordering.
@@ -1974,7 +1975,7 @@ class Agent(BaseAgent):
         try:
             from importlib.resources import files
             packaged = files("lingtai.prompts").joinpath("substrate/substrate.md").read_text(encoding="utf-8")
-            substrate_file.write_text(packaged)
+            substrate_file.write_text(packaged, encoding="utf-8")
             substrate = _strip_frontmatter(packaged)
         except (FileNotFoundError, ModuleNotFoundError, OSError):
             if substrate_file.is_file():
@@ -2059,7 +2060,7 @@ class Agent(BaseAgent):
         try:
             from importlib.resources import files
             packaged = files("lingtai.prompts").joinpath("principle/principle.md").read_text(encoding="utf-8")
-            principle_file.write_text(packaged)
+            principle_file.write_text(packaged, encoding="utf-8")
             principle = _strip_frontmatter(packaged)
         except (FileNotFoundError, ModuleNotFoundError, OSError):
             if principle_file.is_file():
@@ -2083,7 +2084,7 @@ class Agent(BaseAgent):
         try:
             from importlib.resources import files
             packaged = files("lingtai.prompts").joinpath("procedures/procedures.md").read_text(encoding="utf-8")
-            procedures_file.write_text(packaged)
+            procedures_file.write_text(packaged, encoding="utf-8")
             procedures = _strip_frontmatter(packaged)
         except (FileNotFoundError, ModuleNotFoundError, OSError):
             if procedures_file.is_file():

--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -462,13 +462,13 @@ class BaseAgent:
 
         # Covenant: constructor value wins, then fall back to file on disk
         if covenant:
-            covenant_file.write_text(covenant)
+            covenant_file.write_text(covenant, encoding="utf-8")
         elif covenant_file.is_file():
             covenant = _strip_frontmatter(covenant_file.read_text(encoding="utf-8"))
 
         # Principle: constructor value wins, then fall back to file on disk
         if principle:
-            principle_file.write_text(principle)
+            principle_file.write_text(principle, encoding="utf-8")
         elif principle_file.is_file():
             principle = _strip_frontmatter(principle_file.read_text(encoding="utf-8"))
 
@@ -476,26 +476,26 @@ class BaseAgent:
         # contract is enforced by lingtai.agent.Agent, where substrate is
         # kernel-owned and not an external override.
         if substrate:
-            substrate_file.write_text(substrate)
+            substrate_file.write_text(substrate, encoding="utf-8")
         elif substrate_file.is_file():
             substrate = _strip_frontmatter(substrate_file.read_text(encoding="utf-8"))
 
         # Procedures: same pattern as covenant/principle
         if procedures:
-            procedures_file.write_text(procedures)
+            procedures_file.write_text(procedures, encoding="utf-8")
         elif procedures_file.is_file():
             procedures = _strip_frontmatter(procedures_file.read_text(encoding="utf-8"))
 
         # Brief: disk-owned context (normally written by secretary/briefing
         # flows). Init.json brief overrides are retired at the Agent wrapper.
         if brief and not brief_file.is_file():
-            brief_file.write_text(brief)
+            brief_file.write_text(brief, encoding="utf-8")
         elif brief_file.is_file():
             brief = brief_file.read_text(encoding="utf-8")
 
         # Pad: constructor value seeds the file if it doesn't exist
         if pad and not pad_file.is_file():
-            pad_file.write_text(pad)
+            pad_file.write_text(pad, encoding="utf-8")
 
         # Auto-load pad from file into prompt manager
         loaded_pad = ""

--- a/src/lingtai/kernel/base_agent/lifecycle.py
+++ b/src/lingtai/kernel/base_agent/lifecycle.py
@@ -899,7 +899,7 @@ def _check_rules_file(agent) -> None:
     # Content changed — persist and refresh
     try:
         canonical.parent.mkdir(parents=True, exist_ok=True)
-        canonical.write_text(content)
+        canonical.write_text(content, encoding="utf-8")
     except OSError:
         agent._log("rules_write_error", source="signal")
         return

--- a/src/lingtai/kernel/base_agent/prompt.py
+++ b/src/lingtai/kernel/base_agent/prompt.py
@@ -64,7 +64,7 @@ def _flush_system_prompt(agent) -> None:
     prompt = agent._build_system_prompt()
     system_md = agent._working_dir / "system" / "system.md"
     system_md.parent.mkdir(exist_ok=True)
-    system_md.write_text(prompt)
+    system_md.write_text(prompt, encoding="utf-8")
     if agent._chat is not None:
         agent._chat.update_system_prompt(prompt)
 

--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -616,7 +616,8 @@ class IMAPMailManager:
                 "attachments": saved_attachments or data.get("attachments", []),
             }
             (persist_dir / "message.json").write_text(
-                json.dumps(record, indent=2, default=str)
+                json.dumps(record, indent=2, default=str),
+                encoding="utf-8",
             )
 
             results.append(record)

--- a/src/lingtai/tools/avatar/__init__.py
+++ b/src/lingtai/tools/avatar/__init__.py
@@ -871,7 +871,7 @@ class AvatarManager:
 
         # Write .rules signal to self — heartbeat will consume and persist
         try:
-            (parent._working_dir / ".rules").write_text(content)
+            (parent._working_dir / ".rules").write_text(content, encoding="utf-8")
         except OSError as e:
             return {"error": f"failed to write .rules signal: {e}"}
 
@@ -945,7 +945,7 @@ class AvatarManager:
         distributed: list[str] = []
         for child_dir in self._walk_avatar_tree(root):
             try:
-                (child_dir / ".rules").write_text(content)
+                (child_dir / ".rules").write_text(content, encoding="utf-8")
                 distributed.append(child_dir.name)
             except OSError:
                 pass

--- a/src/lingtai/tools/email/manager.py
+++ b/src/lingtai/tools/email/manager.py
@@ -344,7 +344,8 @@ class EmailManager:
         if bcc:
             sent_record["bcc"] = bcc
         (sent_dir / "message.json").write_text(
-            json.dumps(sent_record, indent=2, default=str)
+            json.dumps(sent_record, indent=2, default=str),
+            encoding="utf-8",
         )
 
         for addr in all_recipients:

--- a/src/lingtai/tools/email/primitives.py
+++ b/src/lingtai/tools/email/primitives.py
@@ -113,7 +113,7 @@ def _save_read_ids(agent, ids: set[str]) -> None:
     path = _read_ids_path(agent)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(sorted(ids)))
+    tmp.write_text(json.dumps(sorted(ids)), encoding="utf-8")
     os.replace(str(tmp), str(path))
 
 
@@ -200,7 +200,8 @@ def _persist_to_inbox(agent, payload: dict) -> str:
     payload["_mailbox_id"] = msg_id
     payload["received_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     (msg_dir / "message.json").write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False, default=str)
+        json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+        encoding="utf-8",
     )
     return msg_id
 
@@ -216,7 +217,8 @@ def _persist_to_outbox(agent, payload: dict, deliver_at: datetime) -> str:
     payload["_mailbox_id"] = msg_id
     payload["deliver_at"] = deliver_at.strftime("%Y-%m-%dT%H:%M:%SZ")
     (msg_dir / "message.json").write_text(
-        json.dumps(payload, indent=2, ensure_ascii=False, default=str)
+        json.dumps(payload, indent=2, ensure_ascii=False, default=str),
+        encoding="utf-8",
     )
     return msg_id
 
@@ -236,7 +238,7 @@ def _move_to_sent(agent, msg_id: str, sent_at: str, status: str) -> None:
             data = {}
         data["sent_at"] = sent_at
         data["status"] = status
-        msg_file.write_text(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+        msg_file.write_text(json.dumps(data, indent=2, ensure_ascii=False, default=str), encoding="utf-8")
     shutil.move(str(src), str(dst))
 
 

--- a/src/lingtai/tools/pad/_pad.py
+++ b/src/lingtai/tools/pad/_pad.py
@@ -71,7 +71,7 @@ def _pad_load(agent, args: dict, *, publish: bool = True) -> dict:
     system_dir.mkdir(exist_ok=True)
     pad_path = system_dir / "pad.md"
     if not pad_path.is_file():
-        pad_path.write_text("")
+        pad_path.write_text("", encoding="utf-8")
 
     content = pad_path.read_text(encoding="utf-8")
     size_bytes = len(content.encode("utf-8"))

--- a/src/lingtai/tools/system/karma.py
+++ b/src/lingtai/tools/system/karma.py
@@ -127,7 +127,7 @@ def _lull(agent, args: dict) -> dict:
     resolved = args["_resolved_address"]
     if not _is_alive(resolved):
         return {"error": True, "message": f"Agent at {address} is not running — already asleep?"}
-    (resolved / ".sleep").write_text("")
+    (resolved / ".sleep").write_text("", encoding="utf-8")
     agent._log("karma_lull", target=address)
     return {"status": "asleep", "address": address}
 
@@ -141,7 +141,7 @@ def _suspend(agent, args: dict) -> dict:
     resolved = args["_resolved_address"]
     if not _is_alive(resolved):
         return {"error": True, "message": f"Agent at {address} is not running — already suspended?"}
-    (resolved / ".suspend").write_text("")
+    (resolved / ".suspend").write_text("", encoding="utf-8")
     agent._log("karma_suspend", target=address)
     return {"status": "suspended", "address": address}
 
@@ -175,7 +175,7 @@ def _interrupt(agent, args: dict) -> dict:
     resolved = args["_resolved_address"]
     if not _is_alive(resolved):
         return {"error": True, "message": f"Agent at {address} is not running"}
-    (resolved / ".interrupt").write_text("")
+    (resolved / ".interrupt").write_text("", encoding="utf-8")
     agent._log("karma_interrupt", target=address)
     return {"status": "interrupted", "address": address}
 
@@ -197,7 +197,7 @@ def _clear(agent, args: dict) -> dict:
     # Content of .clear becomes the `source` tag in the recovery summary.
     # Default to the calling agent's name so targets can see who forced it.
     source = (args.get("reason") or "").strip() or agent.agent_name or "admin"
-    (resolved / ".clear").write_text(source)
+    (resolved / ".clear").write_text(source, encoding="utf-8")
     agent._log("karma_clear", target=address, source=source)
     return {"status": "cleared", "address": address, "source": source}
 
@@ -214,7 +214,7 @@ def _nirvana(agent, args: dict) -> dict:
         # .sleep sets _asleep — heartbeat continues, is_alive() stays True,
         # and the wait loop below would always time out.
         # .suspend sets _shutdown — process terminates, heartbeat stops.
-        (resolved / ".suspend").write_text("")
+        (resolved / ".suspend").write_text("", encoding="utf-8")
         import time as _time
         deadline = _time.time() + 10.0
         while _time.time() < deadline:

--- a/tests/test_utf8_write_text.py
+++ b/tests/test_utf8_write_text.py
@@ -1,0 +1,200 @@
+"""Regression tests for the Chinese-Windows cp936/GBK Path.write_text() defect.
+
+The runtime reads almost all text files as UTF-8.  When ``Path.write_text()``
+is called without an explicit ``encoding=`` keyword, Python falls back to the
+process locale (cp936 on Chinese Windows).  Ordinary Chinese can be encoded as
+GBK and written successfully, but the subsequent UTF-8 read raises
+``UnicodeDecodeError``.  Emoji and rare CJK can fail at write time with
+``UnicodeEncodeError`` and leave the target file truncated.
+
+These tests enforce the project-wide invariant that every production
+``Path.write_text()`` call under ``src/lingtai/`` must pass ``encoding="utf-8"``
+explicitly, and they exercise the concrete chains identified in the 2026-08-01
+audit.
+"""
+from __future__ import annotations
+
+import ast
+from contextlib import contextmanager
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Static invariant and locale test double
+# ---------------------------------------------------------------------------
+
+def _service_mock():
+    """Return a minimal service stub that lets ``Agent`` construct in tests."""
+    svc = MagicMock()
+    svc.get_adapter.return_value = MagicMock()
+    svc.provider = "gemini"
+    svc.model = "gemini-test"
+    return svc
+
+
+@contextmanager
+def _cp936_default_for(target: Path):
+    """Make an omitted encoding use cp936 for one audited target path.
+
+    Explicit encodings remain untouched.  This deterministically reproduces a
+    Chinese-Windows default without changing the host locale or pretending that
+    the test ran on Windows.
+    """
+    original = Path.write_text
+
+    def write_text(self, data, encoding=None, errors=None, newline=None):
+        if self == target and encoding is None:
+            encoding = "cp936"
+        return original(self, data, encoding=encoding, errors=errors, newline=newline)
+
+    with patch.object(Path, "write_text", new=write_text):
+        yield
+
+
+def test_source_write_text_calls_pin_utf8_encoding() -> None:
+    """Production code must not depend on the host locale when writing text."""
+    root = Path(__file__).resolve().parents[1]
+    offenders: list[str] = []
+    for path in sorted((root / "src" / "lingtai").rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        lines = source.splitlines()
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "write_text"
+            ):
+                continue
+            encoding_values = [kw.value for kw in node.keywords if kw.arg == "encoding"]
+            if (
+                len(encoding_values) == 1
+                and isinstance(encoding_values[0], ast.Constant)
+                and encoding_values[0].value == "utf-8"
+            ):
+                continue
+            rel = path.relative_to(root)
+            offenders.append(f"{rel}:{node.lineno}: {lines[node.lineno - 1].strip()}")
+
+    assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# Behavioral regression tests for the audited crash chains
+# ---------------------------------------------------------------------------
+
+def test_flush_system_prompt_persists_emoji_with_cp936_default(tmp_path):
+    """An omitted encoding would fail immediately for emoji under cp936.
+
+    The target-only test double makes only a missing encoding on ``system.md``
+    inherit cp936.  The patched explicit UTF-8 write must bypass that default;
+    the frozen base raises ``UnicodeEncodeError`` and can truncate the file.
+    """
+    from lingtai.agent import Agent
+    from lingtai.kernel.base_agent.prompt import _flush_system_prompt
+
+    agent = Agent(
+        service=_service_mock(),
+        agent_name="test",
+        working_dir=tmp_path / "agent",
+    )
+    prompt = "系统提示包含 emoji 👀"
+    agent._build_system_prompt = lambda: prompt
+    system_md = agent._working_dir / "system" / "system.md"
+
+    with _cp936_default_for(system_md):
+        _flush_system_prompt(agent)
+
+    assert system_md.read_text(encoding="utf-8") == prompt
+
+
+def test_lingtai_seed_chinese_roundtrip_with_cp936_default(tmp_path):
+    """The Agent seed write survives the cp936 write -> UTF-8-read chain.
+
+    Ordinary Chinese is intentionally used without emoji: an omitted encoding
+    writes GBK successfully, then ``_lingtai_load`` raises ``UnicodeDecodeError``.
+    Passing a nonempty value through ``_reload_prompt_sections`` proves the
+    changed Agent write itself is reached instead of pre-seeding the file.
+    """
+    from lingtai.agent import Agent
+
+    agent = Agent(
+        service=_service_mock(),
+        agent_name="test",
+        working_dir=tmp_path / "agent",
+    )
+    content = "灵台内容为中文"
+    lingtai_path = agent._working_dir / "system" / "lingtai.md"
+
+    with _cp936_default_for(lingtai_path):
+        agent._reload_prompt_sections({"lingtai": content})
+
+    assert lingtai_path.read_text(encoding="utf-8") == content
+    assert agent._prompt_manager.read_section("character") == content
+
+
+def test_pad_chinese_roundtrip(tmp_path):
+    """A Chinese pad seed is written as UTF-8 and then read back as UTF-8."""
+    from lingtai.agent import Agent
+
+    content = "中文 pad 内容"
+    agent = Agent(
+        service=_service_mock(),
+        agent_name="test",
+        working_dir=tmp_path / "agent",
+        pad=content,
+    )
+
+    pad_file = agent._working_dir / "system" / "pad.md"
+    assert pad_file.read_text(encoding="utf-8") == content
+
+
+def test_rules_chinese_roundtrip(tmp_path):
+    """A Chinese ``.rules`` signal is persisted to ``system/rules.md`` as UTF-8."""
+    from lingtai.agent import Agent
+
+    agent = Agent(
+        service=_service_mock(),
+        agent_name="test",
+        working_dir=tmp_path / "agent",
+    )
+    content = "规则内容：禁止删除文件。👀"
+    (agent._working_dir / ".rules").write_text(content, encoding="utf-8")
+
+    agent._check_rules_file()
+
+    assert (agent._working_dir / "system" / "rules.md").read_text(encoding="utf-8") == content
+    assert agent._prompt_manager.read_section("rules") == content
+
+
+def test_email_inbox_persists_chinese_ensure_ascii_false(tmp_path):
+    """``ensure_ascii=False`` Chinese email JSON is written and re-read as UTF-8.
+
+    The original code in ``tools/email/primitives.py`` wrote the JSON without
+    encoding, so ``ensure_ascii=False`` Chinese bodies would be persisted as
+    GBK on Chinese Windows and later fail the UTF-8 read in ``_load_message``
+    and ``_list_inbox``.
+    """
+    from lingtai.tools.email.primitives import _persist_to_inbox
+
+    agent = SimpleNamespace(_working_dir=tmp_path / "agent")
+    payload = {
+        "from": "sender",
+        "to": "recipient",
+        "subject": "中文主题",
+        "message": "中文邮件正文",
+    }
+
+    msg_id = _persist_to_inbox(agent, payload)
+
+    msg_file = agent._working_dir / "mailbox" / "inbox" / msg_id / "message.json"
+    assert msg_file.is_file()
+    # The persisted file must decode as UTF-8 and round-trip the Chinese body.
+    raw = msg_file.read_text(encoding="utf-8")
+    assert "中文邮件正文" in raw
+    data = json.loads(raw)
+    assert data["message"] == "中文邮件正文"
+    assert data["subject"] == "中文主题"


### PR DESCRIPTION
## Summary

- make all 29 remaining production `Path.write_text()` call sites explicitly use `encoding="utf-8"`
- add a repository-wide AST invariant that requires the literal UTF-8 value for every direct production `.write_text()` call
- add deterministic cp936 regressions for both observed failure forms: an immediate emoji write failure and a successful GBK write followed by a UTF-8 read failure
- preserve paths, payloads, JSON formatting, newlines, control flow, exception behavior, and file schemas; the production diff only makes the intended text encoding deterministic

## Validation

- [x] `git diff --check`
- [x] Relevant tests or documentation checks:
  - `pytest tests/test_utf8_write_text.py tests/test_utf8_read_text.py tests/test_avatar_rules.py tests/test_base_agent.py tests/test_agent.py -q` — **114 passed**
  - every staged Python file compiles with the runtime Python interpreter
  - strict AST inventory — **377 production Python files / 83 direct calls / 83 literal UTF-8 / 0 bad or omitted**
  - frozen-base negative control — the AST guard plus both cp936 regressions fail on `cb8cb590a5ae9869050aa1c8fe562847a6119da0` and pass on this branch

## Notes

- On macOS and most Linux development environments, the locale default is already UTF-8, so an omitted encoding behaves like an explicit UTF-8 encoding and can stay hidden in ordinary CI. The regressions therefore apply a target-only cp936 default while leaving explicit encodings untouched.
- The cp936 tests are deterministic simulations; no physical Windows machine run is claimed. The repository's native Windows workflow remains the best independent platform check.
- Local collection of three optional IMAP-focused suites was blocked by a Python 3.14 pytest process loading Python 3.13 `pydantic_core`; this is an environment mismatch, not an observed failure of the IMAP encoding hunk.
- Anatomy and Contract were checked. This change moves no symbols or state ownership and changes no Port/interface promise, so no architecture-document update is needed.
- Related context: #756 noted locale-dependent `write_text()` behavior in an earlier mail writer. This PR addresses the broader explicit-UTF-8 invariant and does not implement the `_fsutil` migration proposed there.
- The diff, logs, and examples contain no secrets or private absolute paths.
