### PR TITLE
fix(release): decouple Gitee from wheels workflow

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,17 +5,10 @@ on:
     inputs:
       publish:
         description: >-
-          Actually publish the manifest/wheels/sdist to the GitHub release and
-          (when GITEE_ACCESS_TOKEN is configured) Gitee. Default false keeps
-          manual dispatch a safe dry-run/shape-check; the automatic
-          release.published trigger always publishes.
-        type: boolean
-        default: false
-      gitee_only_recovery:
-        description: >-
-          Gitee-only recovery: download the exact existing GitHub release bytes
-          for an explicit release_tag and resume only Gitee publication; requires
-          publish=true and a simple vX.Y.Z tag. No builds or GitHub replacement.
+          Actually publish the manifest/wheels/sdist to the GitHub release.
+          Default false keeps manual dispatch a safe dry-run/shape-check; the
+          automatic release.published trigger always publishes. Gitee is not
+          part of this publish path.
         type: boolean
         default: false
       release_tag:
@@ -32,7 +25,6 @@ permissions:
 
 jobs:
   build-wheels:
-    if: inputs.gitee_only_recovery != true
     name: Wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     # Fail loud instead of hanging: cibuildwheel across three CPythons plus a
@@ -185,7 +177,6 @@ jobs:
           if-no-files-found: error
 
   build-sdist:
-    if: inputs.gitee_only_recovery != true
     name: Source distribution
     runs-on: ubuntu-latest
     # Independent of build-wheels so a wheel/auditwheel failure on any platform
@@ -240,7 +231,6 @@ jobs:
           if-no-files-found: error
 
   release-manifest:
-    if: inputs.gitee_only_recovery != true
     name: Generate release manifest
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
@@ -263,10 +253,6 @@ jobs:
         with:
           ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
           persist-credentials: false
-          # sync_gitee_mirror.py needs the full history reachable from
-          # the checked-out commit to `git cat-file -e`/push it; a shallow
-          # checkout (the actions/checkout@v4 default) would make that fail.
-          fetch-depth: 0
 
       - name: Validate manual recovery tag
         if: github.event_name == 'workflow_dispatch'
@@ -358,29 +344,9 @@ jobs:
             echo "execute=0" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Non-force synchronize the exact commit/tag to Gitee
-        if: steps.publish_mode.outputs.execute == '1'
-        env:
-          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
-          tag="${{ github.event.release.tag_name || inputs.release_tag || '' }}"
-          tag="${tag:-v${version}}"
-          # Skips cleanly (exit 0, prints why) when GITEE_ACCESS_TOKEN is
-          # unset — see sync_gitee_mirror.py. Every push is non-force; a
-          # divergence/existing-tag conflict fails this step loud rather than
-          # silently overwriting the mirror.
-          python scripts/sync_gitee_mirror.py \
-            --commit "$(git rev-parse HEAD)" \
-            --tag "$tag" \
-            --branch main \
-            --execute
-
       - name: Publish manifest/wheels/sdist
         env:
           GH_TOKEN: ${{ github.token }}
-          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
         run: |
           set -euo pipefail
           version="$(python -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
@@ -395,11 +361,13 @@ jobs:
           fi
           # publish_release_assets.py is idempotent (skips already-attached
           # same-name assets) and never force-syncs/deletes — safe to run
-          # repeatedly. Gitee leg is skipped internally when
-          # GITEE_ACCESS_TOKEN is unset, regardless of execute_flag.
+          # repeatedly. --skip-gitee keeps the primary release path
+          # GitHub-only: Gitee is not synchronized or published from this
+          # job, so a Gitee problem can never delay or fail a release.
           python scripts/publish_release_assets.py \
             --manifest release-assets/lingtai-kernel-release-manifest.json \
             --assets-dir release-assets \
+            --skip-gitee \
             $execute_flag
 
       - name: Upload release manifest artifact
@@ -410,149 +378,3 @@ jobs:
             release-assets/lingtai-kernel-release-manifest.json
             release-assets/SHA256SUMS
           if-no-files-found: error
-
-  gitee-only-recovery:
-    name: Recover Gitee assets from the existing GitHub release
-    if: github.event_name == 'workflow_dispatch' && inputs.gitee_only_recovery == true
-    runs-on: ubuntu-latest
-    # Asset discovery plus a bounded retry loop must outlive the original
-    # publisher's 15-minute manifest-job ceiling, but never run indefinitely.
-    timeout-minutes: 120
-    permissions:
-      contents: read
-
-    steps:
-      - name: Check out reviewed publisher/tools at workflow SHA
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.sha }}
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Check out exact release tag as target source
-        uses: actions/checkout@v4
-        with:
-          ref: refs/tags/${{ inputs.release_tag }}
-          path: release-source
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Validate Gitee-only recovery inputs and checkout
-        shell: bash
-        env:
-          RECOVERY_REQUESTED: ${{ inputs.gitee_only_recovery }}
-          PUBLISH_REQUESTED: ${{ inputs.publish }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          WORKFLOW_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          if [[ "$RECOVERY_REQUESTED" != "true" || "$PUBLISH_REQUESTED" != "true" ]]; then
-            echo "::error::Gitee-only recovery requires gitee_only_recovery=true and publish=true."
-            exit 1
-          fi
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Gitee-only recovery requires an explicit simple vX.Y.Z release_tag."
-            exit 1
-          fi
-          main_head="$(git rev-parse HEAD)"
-          if [[ "$main_head" != "$WORKFLOW_SHA" ]]; then
-            echo "::error::Reviewed publisher checkout HEAD does not equal github.sha."
-            exit 1
-          fi
-          tag_commit="$(git -C release-source rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
-          target_head="$(git -C release-source rev-parse HEAD)"
-          if [[ "$tag_commit" != "$target_head" ]]; then
-            echo "::error::release-source HEAD does not match refs/tags/${RELEASE_TAG}."
-            exit 1
-          fi
-
-      - name: Set up Python for the Gitee publisher
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install publisher runtime dependency
-        run: python -m pip install "packaging>=24.0"
-
-      - name: Download exact GitHub release assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-        run: |
-          set -euo pipefail
-          if [[ -e release-assets ]]; then
-            echo "::error::release-assets must be fresh on the recovery runner."
-            exit 1
-          fi
-          mkdir release-assets
-          gh release download "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --dir release-assets
-
-      - name: Verify downloaded manifest and SHA256SUMS
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ inputs.release_tag }}
-        run: |
-          set -euo pipefail
-          export EXPECTED_COMMIT="$(git -C release-source rev-parse HEAD)"
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          path = Path("release-assets/lingtai-kernel-release-manifest.json")
-          data = json.loads(path.read_text(encoding="utf-8"))
-          expected_tag = os.environ["RELEASE_TAG"]
-          expected_commit = os.environ["EXPECTED_COMMIT"]
-          actual_tag = data.get("kernel_tag")
-          actual_commit = data.get("commit")
-          if actual_tag != expected_tag:
-              raise SystemExit(
-                  f"downloaded manifest kernel_tag {actual_tag!r} does not match requested release tag {expected_tag!r}"
-              )
-          if actual_commit != expected_commit:
-              raise SystemExit(
-                  f"downloaded manifest commit {actual_commit!r} does not match release-source commit {expected_commit!r}"
-              )
-          print(f"Downloaded manifest target verified: {expected_tag} at {expected_commit[:12]}.")
-          PY
-          (
-            cd release-assets
-            sha256sum --check --strict SHA256SUMS
-          )
-
-      - name: Resume Gitee publication (idempotent bounded retry)
-        shell: bash
-        env:
-          GITEE_ACCESS_TOKEN: ${{ secrets.GITEE_ACCESS_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${GITEE_ACCESS_TOKEN:-}" ]]; then
-            echo "::error::GITEE_ACCESS_TOKEN must be configured for Gitee-only recovery."
-            exit 1
-          fi
-          max_attempts=10
-          for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-            echo "Gitee-only publisher attempt ${attempt}/${max_attempts} (10-minute timeout)."
-            set +e
-            PYTHONUNBUFFERED=1 timeout --foreground --signal=TERM --kill-after=30s 10m \
-              python scripts/publish_release_assets.py \
-                --manifest release-assets/lingtai-kernel-release-manifest.json \
-                --assets-dir release-assets \
-                --skip-github \
-                --execute
-            status=$?
-            set -e
-            if (( status == 0 )); then
-              exit 0
-            fi
-            if (( status == 124 || status == 137 )); then
-              echo "::warning::Gitee-only publisher timed out (exit ${status}); retrying so remote completion can be rediscovered."
-              continue
-            fi
-            echo "::error::Gitee-only publisher failed with non-timeout exit ${status}."
-            exit "$status"
-          done
-          echo "::error::Gitee-only publisher timed out after ${max_attempts} bounded attempts."
-          exit 124

--- a/ANATOMY.md
+++ b/ANATOMY.md
@@ -173,9 +173,10 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
   docs-governance validator described below and the release-manifest
   generator/publisher/Gitee-mirror-sync scripts described in
   [`RELEASING.md`](RELEASING.md). `wheels.yml`'s `release-manifest` job
-  actually invokes these with `--execute` on a real `release.published`
-  event (or an explicit `workflow_dispatch` with `publish: true`) — every
-  other trigger shape stays dry-run.
+  invokes the generator and the publisher (always with `--skip-gitee`;
+  no path in that workflow touches Gitee) with `--execute` on a real
+  `release.published` event (or an explicit `workflow_dispatch` with
+  `publish: true`) — every other trigger shape stays dry-run.
 - [`.github/`](.github/) — GitHub Actions, issue templates, and pull request
   templates.
 - [`crates/lingtai-search-sidecar/`](crates/lingtai-search-sidecar/) — Rust file
@@ -204,7 +205,8 @@ disclosure, and fail-loud mismatch reports; do not duplicate that rule here.
   readmes live under `docs/readmes/`.
 - [`RELEASING.md`](RELEASING.md) — kernel release process: how
   `.github/workflows/wheels.yml` builds, verifies, and manifests wheel/sdist
-  assets, and how a future authorized run publishes them to GitHub and Gitee.
+  assets, and how an authorized run publishes them to the GitHub release
+  (no path in that workflow synchronizes or publishes to Gitee).
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — public contributor entry point.
 - [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), [`SECURITY.md`](SECURITY.md), and
   [`SUPPORT.md`](SUPPORT.md) — community and safety entry points.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -89,7 +89,7 @@ also attaches both files alongside the wheels/sdist.
 `wheels.yml`'s `release-manifest` job actually publishes on the real trigger:
 
 - **`release: {types: [published]}`** — a real kernel GitHub Release always
-  publishes (syncs Gitee, then uploads to GitHub + Gitee).
+  publishes (uploads the manifest + assets to that GitHub release).
 - **`workflow_dispatch`** — dry-run by default (the `publish` boolean input
   defaults `false`); pass `publish: true` to deliberately publish from a
   manual run too (for example to republish after a partial failure).
@@ -97,47 +97,33 @@ also attaches both files alongside the wheels/sdist.
   this workflow to sanity-check the manifest/wheel matrix has no side
   effects.
 
-### Step 1 — non-force Gitee mirror sync (only when publishing)
+### Gitee is not part of the workflow
 
-[`scripts/sync_gitee_mirror.py`](scripts/sync_gitee_mirror.py) pushes the
-exact release commit to `main` and creates the exact release tag on
-`huangzesen1997/lingtai-kernel`, using a **non-force** `git push` for both:
-the branch push only succeeds as a fast-forward, and the tag push only
-succeeds if that tag name doesn't already point somewhere else. Either
-condition failing is a **fail-loud stop** for the whole publish (the workflow
-does not proceed to upload against an unsynchronized mirror). The token
-travels via a short-lived, owner-only-permission `GIT_ASKPASS` helper file
-(deleted after use) — never in argv, a URL, or a log line. Skips cleanly
-(prints why, exits 0) when `GITEE_ACCESS_TOKEN` is unset.
+No path in `wheels.yml` invokes Gitee synchronization or Gitee asset
+publication. The workflow never runs
+[`scripts/sync_gitee_mirror.py`](scripts/sync_gitee_mirror.py), never
+receives `GITEE_ACCESS_TOKEN`, and always invokes the publisher with
+`--skip-gitee`: a kernel release neither synchronizes commits/tags to Gitee
+nor uploads assets there, so a Gitee problem can never delay, cancel, or
+fail a release. The Gitee scripts remain in the repository with their own
+tests, but nothing in CI invokes them.
 
-### Step 2 — publish manifest/wheels/sdist
+### Publish — manifest/wheels/sdist to the GitHub release
 
 [`scripts/publish_release_assets.py`](scripts/publish_release_assets.py)
-uploads the exact manifest + asset bytes to:
-
-- **GitHub Releases**, via the `gh` CLI (`gh release create` / `gh release
-  upload`), attaching the manifest and `SHA256SUMS` alongside the wheels/sdist.
-- **Gitee Releases** (`huangzesen1997/lingtai-kernel`), via the Gitee v5 REST
-  API, gated entirely on the `GITEE_ACCESS_TOKEN` secret. When that secret is
-  unset the Gitee leg is skipped with a printed reason — it is never a hard
-  failure, since Gitee credentials/configuration are a separate authorization
-  step from having the workflow code in place.
+uploads the exact manifest + asset bytes to **GitHub Releases**, via the `gh`
+CLI (`gh release create` / `gh release upload`), attaching the manifest and
+`SHA256SUMS` alongside the wheels/sdist.
 
 Every mutating action requires the explicit `--execute` flag; the workflow
 passes it only when the trigger is a real release (or an explicit
 `publish: true` dispatch) — see "Determine publish mode" in the job. Without
 it the script only prints its plan and exits 0.
 
-Before publishing to Gitee, the script re-verifies (independent of Step 1's
-push) that the Gitee tag ref already points at the exact release commit
-(`gitee_verify_tag_synchronized`) — belt-and-braces after Step 1's sync.
-**Neither script ever force-pushes or otherwise mutates history** on the
-Gitee git repository.
-
 Idempotency: an asset already attached under the same filename is skipped only
-after the actual GitHub or Gitee download bytes match the local SHA256. A
-same-name asset with different bytes, missing/ambiguous metadata, or a failed
-download always triggers a fail-loud error before upload planning completes.
+after the actual GitHub download bytes match the local SHA256. A same-name
+asset with different bytes, missing/ambiguous metadata, or a failed download
+always triggers a fail-loud error before upload planning completes.
 **There is no delete-and-replace path.**
 
 ### Manual dry run (safe, no token required)
@@ -155,26 +141,20 @@ python scripts/generate_release_manifest.py \
 
 python scripts/publish_release_assets.py \
   --manifest release-assets/lingtai-kernel-release-manifest.json \
-  --assets-dir release-assets
-# (no --execute: prints the GitHub/Gitee plan only)
+  --assets-dir release-assets \
+  --skip-gitee
+# (no --execute: prints the GitHub plan only)
 ```
 
 ### Manual authorized publish (maintainer-run, outside this task's authorization)
 
 ```bash
-export GITEE_ACCESS_TOKEN=...  # never echo or log this
-python scripts/sync_gitee_mirror.py \
-  --commit "$(git rev-parse HEAD)" --tag v0.16.4 --branch main --execute
 python scripts/publish_release_assets.py \
   --manifest release-assets/lingtai-kernel-release-manifest.json \
   --assets-dir release-assets \
+  --skip-gitee \
   --execute
 ```
-
-As of this writing the Gitee kernel mirror's `main` lags GitHub's `main` and
-has no releases — the first real publish run is also the first time the sync
-step has anything to fast-forward from empty, which is the expected/supported
-case (see `test_sync_fast_forwards_empty_remote`).
 
 ## Non-goals (v1)
 
@@ -184,4 +164,5 @@ case (see `test_sync_fast_forwards_empty_remote`).
   dependency resolution is unaffected and continues to use PyPI or a
   configured mirror.
 - No offline wheelhouse / vendored third-party dependency bundle.
-- No automatic Gitee mirror synchronization from this repository or workflow.
+- No Gitee synchronization or Gitee release publication from any path in
+  `wheels.yml`. The Gitee scripts stay in-repo but are not invoked by CI.

--- a/tests/test_wheels_workflow_publish_gating.py
+++ b/tests/test_wheels_workflow_publish_gating.py
@@ -2,18 +2,14 @@
 proves the publish step is actually reachable with --execute on the real
 release trigger (Blocker 3 repair), that manual dispatch defaults to dry-run,
 that exact-tag recovery checks out and validates the selected tag, that GitHub
-publication is authenticated without persisted checkout credentials, and that the
-Gitee sync step never force-pushes. This is a workflow-shape
-test, not a live GitHub Actions run — it parses the committed YAML/shell
-text.
+publication is authenticated without persisted checkout credentials, and that
+no path in the workflow synchronizes commits/tags to Gitee or publishes
+release assets to Gitee. This is a workflow-shape test, not a live GitHub
+Actions run — it parses the committed YAML/shell text.
 """
 from __future__ import annotations
 
-import json
-import os
 from pathlib import Path
-import subprocess
-import sys
 
 import yaml
 
@@ -88,46 +84,51 @@ def test_publish_step_conditionally_passes_execute_flag():
     assert 'execute_flag=""' in script
 
 
-def test_gitee_sync_step_is_gated_on_publish_mode_and_never_forces():
-    job = _release_manifest_job(_load_workflow())
-    step = _step(job, "synchronize the exact commit/tag to Gitee")
-    assert step.get("if") == "steps.publish_mode.outputs.execute == '1'", \
-        "Gitee sync must only run when actually publishing, not on every dry-run shape check"
-    script = step["run"]
-    assert "sync_gitee_mirror.py" in script
-    assert "--execute" in script
-    assert "--force" not in script
-    assert "force" not in script.lower() or "non-force" in script.lower()
-
-
-def test_gitee_token_never_echoed_via_echo_or_print():
-    # The env var name legitimately appears in comments/docs and in the
-    # `env:` mapping (sourced from the GitHub secret). What must never happen
-    # is a shell `echo`/`print`/`cat` of that variable, which would leak the
-    # value into the job log.
+def test_no_workflow_path_syncs_or_publishes_to_gitee():
+    # `gitee不用管了`: Gitee is fully decoupled from wheels.yml. No job may
+    # sync the mirror, receive the Gitee token, or run the publisher without
+    # explicitly skipping its Gitee leg — a Gitee problem must never delay,
+    # cancel, or fail this workflow.
     text = WORKFLOW_PATH.read_text()
-    for line in text.splitlines():
-        stripped = line.strip()
-        if "$GITEE_ACCESS_TOKEN" in stripped or "${GITEE_ACCESS_TOKEN" in stripped:
-            assert not any(stripped.startswith(cmd) for cmd in ("echo", "print", "cat")), (
-                f"found a shell command that appears to print the raw token: {line}"
-            )
+    assert "sync_gitee_mirror.py" not in text, (
+        "no path in wheels.yml may synchronize commits/tags to Gitee"
+    )
+    assert "GITEE_ACCESS_TOKEN" not in text, (
+        "no wheels.yml step may receive or reference the Gitee token"
+    )
+    data = _load_workflow()
+    publisher_invocations = 0
+    for job_name, job in data["jobs"].items():
+        for step in job["steps"]:
+            script = step.get("run", "")
+            if "publish_release_assets.py" in script:
+                publisher_invocations += 1
+                assert "--skip-gitee" in script, (
+                    f"{job_name}/{step.get('name')}: every publisher invocation "
+                    "must skip the Gitee leg explicitly, not depend on the "
+                    "token secret being absent"
+                )
+    assert publisher_invocations == 1, (
+        "exactly the release-manifest publish step invokes the publisher"
+    )
+
+
+def test_gitee_only_recovery_machinery_is_fully_removed():
+    data = _load_workflow()
+    on = data.get("on") or data.get(True)
+    assert "gitee_only_recovery" not in on["workflow_dispatch"]["inputs"]
+    assert "gitee-only-recovery" not in data["jobs"]
+    for job_name, job in data["jobs"].items():
+        assert "gitee_only_recovery" not in job.get("if", ""), (
+            f"{job_name} must not gate on the removed recovery input"
+        )
 
 
 def test_release_manifest_job_has_contents_write_for_publish():
     job = _release_manifest_job(_load_workflow())
     assert job["permissions"]["contents"] == "write", (
-        "publishing (gh release upload / git push to Gitee) requires contents:write; "
+        "publishing (gh release create/upload) requires contents:write; "
         "read-only permissions would make the publish step fail even when execute=1"
-    )
-
-
-def test_checkout_step_has_full_history_for_gitee_push():
-    job = _release_manifest_job(_load_workflow())
-    step = _step(job, "Check out repository")
-    assert step.get("with", {}).get("fetch-depth") == 0, (
-        "sync_gitee_mirror.py needs the release commit's full history reachable "
-        "to push it; a shallow checkout would break the non-force push"
     )
 
 
@@ -157,16 +158,13 @@ def test_all_release_jobs_checkout_the_optional_exact_recovery_tag():
         assert step.get("with", {}).get("persist-credentials") is False, job_name
 
 
-def test_manifest_and_gitee_sync_use_the_checked_out_commit_and_recovery_tag():
+def test_manifest_and_publish_use_the_checked_out_commit_and_recovery_tag():
     job = _release_manifest_job(_load_workflow())
     manifest = _step(job, "Generate release manifest")
-    sync = _step(job, "synchronize the exact commit/tag to Gitee")
     publish = _step(job, "Publish manifest")
     assert "inputs.release_tag" in manifest["env"]["KERNEL_TAG"]
-    for step in (manifest, sync):
-        assert "git rev-parse HEAD" in step["run"]
-        assert "github.sha" not in step["run"]
-    assert "inputs.release_tag" in sync["run"]
+    assert "git rev-parse HEAD" in manifest["run"]
+    assert "github.sha" not in manifest["run"]
     assert "inputs.release_tag" in publish["run"]
 
 
@@ -195,199 +193,3 @@ def test_manual_publish_requires_and_validates_an_exact_semver_tag():
     publish_mode = _step(_release_manifest_job(data), "Determine publish mode")["run"]
     assert "inputs.release_tag" in publish_mode
     assert "Manual publishing requires release_tag" in publish_mode
-
-
-def _recovery_job(data: dict) -> dict:
-    return data["jobs"]["gitee-only-recovery"]
-
-
-def test_gitee_only_recovery_input_has_boolean_default_and_safety_description():
-    data = _load_workflow()
-    on = data.get("on") or data.get(True)
-    recovery = on["workflow_dispatch"]["inputs"]["gitee_only_recovery"]
-    assert recovery["type"] == "boolean"
-    assert recovery["default"] is False
-    assert "Gitee-only recovery" in recovery["description"]
-    assert "publish=true" in recovery["description"]
-    assert "No builds" in recovery["description"]
-
-
-def test_gitee_only_gate_is_on_exactly_the_three_existing_jobs():
-    data = _load_workflow()
-    existing = ("build-wheels", "build-sdist", "release-manifest")
-    assert all(name in data["jobs"] for name in existing)
-    assert all(data["jobs"][name].get("if") == "inputs.gitee_only_recovery != true" for name in existing)
-    assert [name for name, job in data["jobs"].items() if job.get("if") == "inputs.gitee_only_recovery != true"] == list(existing)
-
-
-def test_gitee_only_recovery_job_is_ubuntu_bounded_and_read_only():
-    job = _recovery_job(_load_workflow())
-    assert job["if"] == "github.event_name == 'workflow_dispatch' && inputs.gitee_only_recovery == true"
-    assert job["runs-on"] == "ubuntu-latest"
-    assert job["timeout-minutes"] == 120
-    assert job["permissions"] == {"contents": "read"}
-
-
-def test_gitee_only_recovery_checks_out_exact_tag_with_no_persisted_credentials():
-    job = _recovery_job(_load_workflow())
-    main_checkout = _step(job, "Check out reviewed publisher/tools")
-    assert main_checkout["uses"] == "actions/checkout@v4"
-    assert main_checkout["with"] == {
-        "ref": "${{ github.sha }}",
-        "persist-credentials": False,
-        "fetch-depth": 0,
-    }
-    checkout = _step(job, "Check out exact release tag as target source")
-    assert checkout["uses"] == "actions/checkout@v4"
-    assert checkout["with"] == {
-        "ref": "refs/tags/${{ inputs.release_tag }}",
-        "path": "release-source",
-        "persist-credentials": False,
-        "fetch-depth": 0,
-    }
-    validation = _step(job, "Validate Gitee-only recovery inputs and checkout")
-    assert validation["shell"] == "bash"
-    assert validation["env"] == {
-        "RECOVERY_REQUESTED": "${{ inputs.gitee_only_recovery }}",
-        "PUBLISH_REQUESTED": "${{ inputs.publish }}",
-        "RELEASE_TAG": "${{ inputs.release_tag }}",
-        "WORKFLOW_SHA": "${{ github.sha }}",
-    }
-    script = validation["run"]
-    assert '"$RECOVERY_REQUESTED" != "true"' in script
-    assert '"$PUBLISH_REQUESTED" != "true"' in script
-    assert "^v[0-9]+\\.[0-9]+\\.[0-9]+$" in script
-    assert 'refs/tags/${RELEASE_TAG}^{commit}' in script
-    assert "git rev-parse HEAD" in script
-    assert "git -C release-source rev-parse HEAD" in script
-    assert '"$main_head" != "$WORKFLOW_SHA"' in script
-    assert '"$tag_commit" != "$target_head"' in script
-
-
-def test_gitee_only_download_scopes_gh_token_and_uses_exact_release_tag():
-    job = _recovery_job(_load_workflow())
-    download = _step(job, "Download exact GitHub release assets")
-    assert download["env"] == {
-        "GH_TOKEN": "${{ github.token }}",
-        "RELEASE_TAG": "${{ inputs.release_tag }}",
-    }
-    script = download["run"]
-    assert 'if [[ -e release-assets ]]' in script
-    assert "mkdir release-assets" in script
-    assert 'gh release download "$RELEASE_TAG"' in script
-    assert '--repo "$GITHUB_REPOSITORY"' in script
-    assert "--dir release-assets" in script
-    token_steps = [step for step in job["steps"] if "GH_TOKEN" in step.get("env", {})]
-    assert token_steps == [download]
-
-
-def test_gitee_only_publisher_requires_token_without_echoing_it():
-    job = _recovery_job(_load_workflow())
-    publisher = _step(job, "Resume Gitee publication")
-    assert publisher["env"] == {"GITEE_ACCESS_TOKEN": "${{ secrets.GITEE_ACCESS_TOKEN }}"}
-    script = publisher["run"]
-    assert '[[ -z "${GITEE_ACCESS_TOKEN:-}" ]]' in script
-    assert "must be configured" in script
-    token_steps = [step for step in job["steps"] if "GITEE_ACCESS_TOKEN" in step.get("env", {})]
-    assert token_steps == [publisher]
-    for line in script.splitlines():
-        stripped = line.strip()
-        if "$GITEE_ACCESS_TOKEN" in stripped or "${GITEE_ACCESS_TOKEN" in stripped:
-            assert not stripped.startswith(("echo", "print", "cat")), line
-
-
-def test_gitee_only_publisher_is_unbuffered_execute_and_github_skipping():
-    script = _step(_recovery_job(_load_workflow()), "Resume Gitee publication")["run"]
-    assert "PYTHONUNBUFFERED=1" in script
-    assert "scripts/publish_release_assets.py" in script
-    assert "--skip-github" in script
-    assert "--execute" in script
-
-
-def test_gitee_only_retry_budget_and_timeout_codes_are_bounded():
-    script = _step(_recovery_job(_load_workflow()), "Resume Gitee publication")["run"]
-    assert "max_attempts=10" in script
-    assert "10m" in script
-    assert "--kill-after=30s" in script
-    assert "status == 124 || status == 137" in script
-    assert 'exit "$status"' in script
-    assert "failed with non-timeout exit" in script
-    assert 'exit 124' in script
-
-
-def test_gitee_only_recovery_does_not_build_sync_or_publish_to_github():
-    job = _recovery_job(_load_workflow())
-    recovery_text = "\\n".join(
-        [step.get("uses", "") + "\\n" + step.get("run", "") for step in job["steps"]]
-    )
-    for forbidden in (
-        "cibuildwheel",
-        "uv build",
-        "actions/upload-artifact",
-        "actions/download-artifact",
-        "sync_gitee_mirror.py",
-        "gh release upload",
-        "gh release create",
-    ):
-        assert forbidden not in recovery_text
-    assert "gh release download" in recovery_text
-
-
-def test_gitee_only_downloaded_manifest_is_bound_to_requested_tag_and_checkout(tmp_path):
-    job = _recovery_job(_load_workflow())
-    steps = job["steps"]
-    names = [step.get("name", "") for step in steps]
-    download_index = names.index("Download exact GitHub release assets")
-    verify_index = names.index("Verify downloaded manifest and SHA256SUMS")
-    publish_index = names.index("Resume Gitee publication (idempotent bounded retry)")
-    assert download_index < verify_index < publish_index
-
-    verifier = steps[verify_index]
-    assert verifier["shell"] == "bash"
-    assert verifier["env"] == {"RELEASE_TAG": "${{ inputs.release_tag }}"}
-    shell_script = verifier["run"]
-    assert 'export EXPECTED_COMMIT="$(git -C release-source rev-parse HEAD)"' in shell_script
-    assert "data.get(\"kernel_tag\")" in shell_script
-    assert "data.get(\"commit\")" in shell_script
-    assert "sha256sum --check --strict SHA256SUMS" in shell_script
-    marker = "python - <<'PY'\n"
-    assert marker in shell_script and "\nPY" in shell_script
-    verifier_code = shell_script.split(marker, 1)[1].rsplit("\nPY", 1)[0]
-
-    assets = tmp_path / "release-assets"
-    assets.mkdir()
-    manifest_path = assets / "lingtai-kernel-release-manifest.json"
-    expected_tag = "v0.17.1"
-    expected_commit = "a" * 40
-    env = {
-        **os.environ,
-        "RELEASE_TAG": expected_tag,
-        "EXPECTED_COMMIT": expected_commit,
-    }
-
-    def run_verifier(manifest: dict) -> subprocess.CompletedProcess[str]:
-        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
-        return subprocess.run(
-            [sys.executable, "-c", verifier_code],
-            cwd=tmp_path,
-            env=env,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-    matching = run_verifier({"kernel_tag": expected_tag, "commit": expected_commit})
-    assert matching.returncode == 0, matching.stderr
-    assert "target verified" in matching.stdout
-
-    wrong_case_commit = run_verifier({"kernel_tag": expected_tag, "commit": expected_commit.upper()})
-    assert wrong_case_commit.returncode != 0
-    assert "manifest commit" in wrong_case_commit.stderr and "release-source commit" in wrong_case_commit.stderr
-
-    wrong_tag = run_verifier({"kernel_tag": "v0.17.0", "commit": expected_commit})
-    assert wrong_tag.returncode != 0
-    assert "kernel_tag" in wrong_tag.stderr and "requested release tag" in wrong_tag.stderr
-
-    wrong_commit = run_verifier({"kernel_tag": expected_tag, "commit": "b" * 40})
-    assert wrong_commit.returncode != 0
-    assert "manifest commit" in wrong_commit.stderr and "release-source commit" in wrong_commit.stderr


### PR DESCRIPTION
## Summary

- remove every Gitee synchronization/publication path from `wheels.yml`, including the manual Gitee recovery dispatch
- keep the primary workflow GitHub-only by passing the publisher's existing `--skip-gitee` flag
- replace recovery-specific workflow tests with whole-workflow Gitee-absence guards and align release/anatomy documentation

## Validation

```text
python -m pytest -q tests/test_wheels_workflow_publish_gating.py tests/test_publish_release_assets.py tests/test_sync_gitee_mirror.py
60 passed in 1.96s

git diff --check
# clean

workflow static contract
# no Gitee sync/token/recovery path; exactly one publisher invocation with --skip-gitee

independent Claude Code review
# ACCEPT; blockers: none
```

## Scope

This deliberately leaves `scripts/sync_gitee_mirror.py`, the publisher's existing Gitee capability, its direct tests, and the runtime's read-only Gitee update fallback unchanged. No release, tag, upload, deployment, or Gitee action is part of this PR.
