### PR TITLE
fix(openai): handle forced SSE Responses bodies

### DIFF
--- a/src/lingtai/llm/openai/ANATOMY.md
+++ b/src/lingtai/llm/openai/ANATOMY.md
@@ -22,6 +22,7 @@ related_files:
   - tests/test_codex_prompt_cache_key.py
   - tests/test_codex_native_multiaccount.py
   - tests/test_codex_standalone_compaction.py
+  - tests/test_custom_responses_stateless.py
   - tests/test_mimo_responses_compaction.py
   - ENVIRONMENT_VARIABLES.md
 maintenance: |
@@ -75,6 +76,8 @@ OpenAI adapter — wraps the `openai` SDK for Chat Completions and Responses API
 | `_parse_response()` | `adapter.py:1104` | ChatCompletion → `LLMResponse` (extracts reasoning from `reasoning_content` or `reasoning`) |
 | `_handle_responses_reasoning_event()` | `adapter.py:1171` | Responses stream reasoning-summary event handler; accumulates `summary_text` deltas/done fallback without raw reasoning text |
 | `_parse_responses_api_response()` | `adapter.py:1217` | Responses API output → `LLMResponse` (handles `message`, `function_call`, `reasoning` output items) |
+| `_decode_responses_sse_text()` | `adapter.py:1370` | Strictly decodes a completed SSE body when a compatible gateway ignores a non-streaming Responses request and the SDK exposes the body as `str`; malformed/non-SSE strings fail loud. |
+| `_consume_responses_stream()` | `adapter.py:1431` | Shared Responses event accumulator for normal SDK streams and locally decoded forced-SSE bodies; returns the finalized response plus response id without a second provider request. |
 
 ## Connections
 
@@ -111,6 +114,13 @@ Both paths return sessions wrapped via `_wrap_with_gate()` for rate limiting. Ca
 Two modes share one session class:
 1. **Official/stateful** — `_convert_input(message)` builds only the new Responses input items (`adapter.py:1829-1884`), `previous_response_id` is sent when available (`adapter.py:1974-1975`, `adapter.py:2027-2028`), and the returned id becomes the next resume id (`adapter.py:1988`, `adapter.py:2085`). `_convert_input` maps a canonical `ToolResultBlock` continuation to the `function_call_output` wire item (`adapter.py:1835-1845`) using the same shape as `to_responses_input`, so a plain (non-Codex) Responses session serializes tool-result turns correctly instead of forwarding the dataclass unconverted; prebuilt Responses-wire `function_call_output` dicts pass through unchanged, while legacy `role=tool` dicts are converted to the same Responses shape (`adapter.py:1856-1868`).
 2. **Custom/stateless** — `_snapshot_interface` captures the pre-stage snapshot before `_stage_input`, `_request_input` records string/tool-result input (or leaves `send(None)` pre-staged entries alone), enforces tool pairing, and serializes full canonical history through `to_responses_input`; no `previous_response_id` is sent (`adapter.py:1886-1889`, `adapter.py:1891-1900`, `adapter.py:1974-1975`, `adapter.py:1938-1943`). On success `_record_assistant_response` persists reasoning/text/tool calls plus usage, including cached tokens, into canonical history (`adapter.py:1915-1936`, `adapter.py:1985-1986`, `adapter.py:2082-2083`). On transport/stream/enforce/serialization/parse/finalize/callback/record failure, `_rollback_staged` restores the pre-send canonical snapshot in place while preserving the recovery lookup (`adapter.py:1902-1913`, `adapter.py:1990-1992`, `adapter.py:2087-2089`).
+
+If a compatible gateway ignores the non-streaming request shape and returns a
+complete SSE body, the OpenAI SDK may expose it as a plain string. `send()`
+validates and decodes that already-returned body, then feeds its events through
+the same accumulator as `send_stream()`; it never retries or issues a second
+potentially billable provider request. A plain non-SSE or malformed SSE string
+still fails loud and follows the ordinary stateless rollback path.
 
 ### Codex continuation flow (`CodexResponsesSession.send_stream`)
 
@@ -484,7 +494,7 @@ In-flight official/stateful Responses and Codex sessions keep no-op prompt/tool 
 ### Streaming
 
 - **CC streaming** (`adapter.py:1712`) — `stream=True, stream_options={include_usage: True}`. Uses `StreamingAccumulator` for text + tool deltas. Reasoning deltas captured from `delta.reasoning` or `delta.reasoning_content`. The post-build pairing validator runs before stream open, matching the non-streaming path. Overflow recovery wraps stream open + first chunk in the Chat Completions send-stream path.
-- **Responses streaming** (`adapter.py:1995`) — event types: `response.reasoning_summary_text.delta/done` (summary thoughts only), `response.output_text.delta`, `response.function_call_arguments.delta`, `response.output_item.added/done`, `response.completed`. Custom/stateless mode snapshots before staging, replays full canonical history, records the finalized assistant turn, and restores the pre-send snapshot on enforce, serialization, stream-open, iteration, callback, finalize, or record failure (`adapter.py:2002-2089`).
+- **Responses streaming** (`adapter.py:1995`) — event types: `response.reasoning_summary_text.delta/done` (summary thoughts only), `response.output_text.delta`, `response.function_call_arguments.delta`, `response.output_item.added/done`, `response.completed`. The event consumer is shared with the non-streaming forced-SSE compatibility path. Custom/stateless mode snapshots before staging, replays full canonical history, records the finalized assistant turn, and restores the pre-send snapshot on enforce, serialization, stream-open, iteration, callback, finalize, or record failure (`adapter.py:2002-2089`).
 - **Codex streaming** — forces `stream=True` even on `send()`. Runs the `full`/`incremental` planner per request over the selected transport (REST default / WebSocket opt-in): REST carries the whole converted interface in both modes; WebSocket carries the whole interface for `full` and delta + `previous_response_id` for `incremental`. Captured summary thoughts and raw encrypted reasoning items are persisted as ThinkingBlocks so `to_responses_input` replays reasoning items before function calls; if Codex later rejects a raw encrypted item as unverifiable, the adapter strips only that opaque replay state and retries once with summary/plain transcript. Optional diagnostics (`LINGTAI_CODEX_RESPONSES_TRACE=1`) append safe per-event metadata to `logs/codex_responses_trace.jsonl` without changing accumulator/persistence behavior.
 
 ### Authentication paths

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -19,6 +19,7 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Callable
 from urllib.parse import urlsplit
 
@@ -1356,6 +1357,134 @@ def _parse_responses_api_response(raw) -> LLMResponse:
     )
 
 
+def _responses_json_namespace(value: Any) -> Any:
+    """Convert decoded Responses SSE JSON into attribute-style event objects."""
+    if isinstance(value, dict):
+        return SimpleNamespace(
+            **{key: _responses_json_namespace(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return [_responses_json_namespace(item) for item in value]
+    return value
+
+
+def _decode_responses_sse_text(raw: str) -> list[Any]:
+    """Decode an SSE body returned unexpectedly to a non-streaming request.
+
+    Some OpenAI-compatible gateways ignore ``stream=false`` and return a
+    complete ``text/event-stream`` body.  The OpenAI SDK exposes that body as a
+    plain string, so recover the already-completed response locally instead of
+    issuing a second (potentially billable) request.
+    """
+    events: list[Any] = []
+    data_lines: list[str] = []
+    event_name: str | None = None
+    saw_sse_field = False
+
+    def flush() -> None:
+        nonlocal data_lines, event_name
+        if not data_lines:
+            event_name = None
+            return
+        payload = "\n".join(data_lines).strip()
+        data_lines = []
+        if not payload or payload == "[DONE]":
+            event_name = None
+            return
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise TypeError(
+                "Responses API returned malformed SSE data to a non-streaming request"
+            ) from exc
+        if not isinstance(decoded, dict):
+            raise TypeError(
+                "Responses API returned non-object SSE data to a non-streaming request"
+            )
+        if not decoded.get("type") and event_name:
+            decoded["type"] = event_name
+        if not decoded.get("type"):
+            raise TypeError(
+                "Responses API returned an SSE event without a type"
+            )
+        events.append(_responses_json_namespace(decoded))
+        event_name = None
+
+    for line in raw.splitlines():
+        if not line:
+            flush()
+        elif line.startswith("event:"):
+            saw_sse_field = True
+            event_name = line[6:].strip() or None
+        elif line.startswith("data:"):
+            saw_sse_field = True
+            data_lines.append(line[5:].lstrip())
+        elif line.startswith(":"):
+            saw_sse_field = True
+    flush()
+
+    if not saw_sse_field or not events:
+        raise TypeError(
+            "Responses API returned a string instead of a Response object or SSE events"
+        )
+    return events
+
+
+def _consume_responses_stream(
+    stream: Any,
+    on_chunk: Callable[[str], None] | None = None,
+) -> tuple[LLMResponse, str | None]:
+    """Consume typed SDK events or locally decoded Responses SSE events."""
+    acc = StreamingAccumulator()
+    response_id = None
+    usage = UsageMetadata()
+    seen_reasoning_summary_items: set[str] = set()
+
+    for event in stream:
+        if _handle_responses_reasoning_event(event, acc, seen_reasoning_summary_items):
+            continue
+        if event.type == "response.output_text.delta":
+            acc.add_text(event.delta)
+            if on_chunk:
+                on_chunk(event.delta)
+        elif event.type == "response.function_call_arguments.delta":
+            acc.add_tool_args(event.delta)
+        elif event.type == "response.function_call_arguments.done":
+            # Spark may emit complete args without any deltas.
+            acc.set_tool_args_if_empty(getattr(event, "arguments", None))
+        elif event.type == "response.output_item.added":
+            if getattr(event.item, "type", None) == "function_call":
+                acc.start_tool(id=event.item.call_id, name=event.item.name)
+        elif event.type == "response.output_item.done":
+            if getattr(event.item, "type", None) == "function_call":
+                # Use the final item as a second complete-args fallback.
+                acc.set_tool_args_if_empty(getattr(event.item, "arguments", None))
+                acc.finish_tool()
+        elif event.type == "response.completed":
+            response_id = event.response.id
+            if event.response.usage:
+                cached = getattr(event.response.usage, "input_tokens_details", None)
+                cached_tokens = (
+                    (getattr(cached, "cached_tokens", 0) or 0) if cached else 0
+                )
+                usage = UsageMetadata(
+                    input_tokens=getattr(event.response.usage, "input_tokens", 0) or 0,
+                    output_tokens=getattr(event.response.usage, "output_tokens", 0) or 0,
+                    thinking_tokens=getattr(
+                        event.response.usage, "output_tokens_details", None
+                    )
+                    and getattr(
+                        event.response.usage.output_tokens_details,
+                        "reasoning_tokens",
+                        0,
+                    )
+                    or 0,
+                    cached_tokens=cached_tokens,
+                )
+
+    return acc.finalize(usage=usage), response_id
+
+
 # ---------------------------------------------------------------------------
 # OpenAIChatSession
 # ---------------------------------------------------------------------------
@@ -2107,11 +2236,21 @@ class OpenAIResponsesSession(ChatSession):
                 kwargs["prompt_cache_key"] = self._prompt_cache_key
 
             raw = self._client.responses.create(**kwargs)
-            response = _parse_responses_api_response(raw)
+            if isinstance(raw, str):
+                logger.warning(
+                    "Responses endpoint returned SSE text to a non-streaming request; "
+                    "parsing the completed stream locally"
+                )
+                response, response_id = _consume_responses_stream(
+                    _decode_responses_sse_text(raw)
+                )
+            else:
+                response = _parse_responses_api_response(raw)
+                response_id = raw.id
             if self._stateless_replay:
                 self._record_assistant_response(response)
             else:
-                self._response_id = raw.id
+                self._response_id = response_id
             return response
         except Exception:
             if self._stateless_replay:
@@ -2120,11 +2259,6 @@ class OpenAIResponsesSession(ChatSession):
 
     def send_stream(self, message, on_chunk=None) -> LLMResponse:
         """Send a streaming request."""
-        acc = StreamingAccumulator()
-        response_id = None
-        usage = UsageMetadata()
-        seen_reasoning_summary_items: set[str] = set()
-
         rollback_snapshot: list[dict] | None = None
         try:
             if self._stateless_replay:
@@ -2160,51 +2294,7 @@ class OpenAIResponsesSession(ChatSession):
                 kwargs["prompt_cache_key"] = self._prompt_cache_key
 
             stream = self._client.responses.create(**kwargs)
-            for event in stream:
-                if _handle_responses_reasoning_event(event, acc, seen_reasoning_summary_items):
-                    continue
-                if event.type == "response.output_text.delta":
-                    acc.add_text(event.delta)
-                    if on_chunk:
-                        on_chunk(event.delta)
-                elif event.type == "response.function_call_arguments.delta":
-                    acc.add_tool_args(event.delta)
-                elif event.type == "response.function_call_arguments.done":
-                    # Spark may emit complete args without any deltas.
-                    acc.set_tool_args_if_empty(getattr(event, "arguments", None))
-                elif event.type == "response.output_item.added":
-                    if getattr(event.item, "type", None) == "function_call":
-                        acc.start_tool(id=event.item.call_id, name=event.item.name)
-                elif event.type == "response.output_item.done":
-                    if getattr(event.item, "type", None) == "function_call":
-                        # Use the final item as a second complete-args fallback.
-                        acc.set_tool_args_if_empty(
-                            getattr(event.item, "arguments", None)
-                        )
-                        acc.finish_tool()
-                elif event.type == "response.completed":
-                    response_id = event.response.id
-                    if event.response.usage:
-                        cached = getattr(event.response.usage, "input_tokens_details", None)
-                        cached_tokens = (getattr(cached, "cached_tokens", 0) or 0) if cached else 0
-                        usage = UsageMetadata(
-                            input_tokens=getattr(event.response.usage, "input_tokens", 0)
-                            or 0,
-                            output_tokens=getattr(event.response.usage, "output_tokens", 0)
-                            or 0,
-                            thinking_tokens=getattr(
-                                event.response.usage, "output_tokens_details", None
-                            )
-                            and getattr(
-                                event.response.usage.output_tokens_details,
-                                "reasoning_tokens",
-                                0,
-                            )
-                            or 0,
-                            cached_tokens=cached_tokens,
-                        )
-
-            response = acc.finalize(usage=usage)
+            response, response_id = _consume_responses_stream(stream, on_chunk)
             if self._stateless_replay:
                 self._record_assistant_response(response)
             else:

--- a/tests/test_custom_responses_stateless.py
+++ b/tests/test_custom_responses_stateless.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -157,6 +158,60 @@ def _stream_tool_events(response_id: str):
     ]
 
 
+def _forced_sse_tool_response(response_id: str) -> str:
+    """SSE body from a provider that ignored a non-streaming request."""
+    events = [
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "delta": "Need forced stream.",
+            "item_id": "rs_forced",
+        },
+        {
+            "type": "response.reasoning_summary_text.done",
+            "text": "Need forced stream.",
+            "item_id": "rs_forced",
+        },
+        {"type": "response.output_text.delta", "delta": "Checking forced stream."},
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "call_id": "call_forced",
+                "name": "lookup",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.done",
+            "arguments": '{"query":"forced"}',
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "function_call",
+                "call_id": "call_forced",
+                "name": "lookup",
+                "arguments": '{"query":"forced"}',
+            },
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": response_id,
+                "usage": {
+                    "input_tokens": 21,
+                    "output_tokens": 9,
+                    "input_tokens_details": {"cached_tokens": 4},
+                    "output_tokens_details": {"reasoning_tokens": 3},
+                },
+            },
+        },
+    ]
+    return "".join(
+        f"event: {event['type']}\ndata: {json.dumps(event)}\n\n"
+        for event in events
+    )
+
+
 def _broken_stream():
     yield SimpleNamespace(type="response.output_text.delta", delta="partial")
     raise RuntimeError("stream")
@@ -241,6 +296,39 @@ def test_custom_responses_nonstreaming_replays_full_history_and_records_assistan
         "output_tokens": 5,
         "thinking_tokens": 0,
         "cached_tokens": 1,
+    }
+
+
+def test_custom_responses_nonstreaming_parses_provider_forced_sse_without_retry():
+    adapter = create_custom_adapter(
+        api_key="fake",
+        api_compat="openai",
+        base_url="https://sub2api.example/v1",
+        wire_api="responses",
+    )
+    adapter._client = _Client(_Responses([_forced_sse_tool_response("resp_forced")]))
+    session = adapter.create_chat("gpt-test", "system", tools=[_tool()])
+
+    result = session.send("start")
+
+    assert result.text == "Checking forced stream."
+    assert result.thoughts == ["Need forced stream."]
+    assert [(call.id, call.name, call.args) for call in result.tool_calls] == [
+        ("call_forced", "lookup", {"query": "forced"}),
+    ]
+    assert result.usage.input_tokens == 21
+    assert result.usage.output_tokens == 9
+    assert result.usage.thinking_tokens == 3
+    assert result.usage.cached_tokens == 4
+    assert len(adapter._client.responses.kwargs) == 1
+    assert "stream" not in adapter._client.responses.kwargs[0]
+
+    assistant = session.interface.entries[-1]
+    assert assistant.usage == {
+        "input_tokens": 21,
+        "output_tokens": 9,
+        "thinking_tokens": 3,
+        "cached_tokens": 4,
     }
 
 


### PR DESCRIPTION
## Summary

- handle OpenAI-compatible Responses gateways that ignore a non-streaming request and return a completed SSE body as `str`
- parse the already-returned SSE body through the existing Responses streaming accumulator, without retrying or issuing a second billable request
- share event consumption between normal streaming and the compatibility path
- cover reasoning summaries, text, function calls, usage, canonical history, and the single-request invariant

## Root cause

Some compatible gateways(e.g. sub2api) return `Content-Type: text/event-stream` even when the request is non-streaming. The OpenAI Python SDK exposes this unexpected response as a plain string. `OpenAIResponsesSession.send()` then passed it to the ordinary response parser, which attempted `raw.output` and raised:

```text
'str' object has no attribute 'output'
```

The fallback is deliberately narrow: only valid SSE framing is decoded. Plain strings and malformed SSE fail loudly and retain the existing stateless rollback behavior.

## Tests

- `171 passed` across the OpenAI/Responses/wire-api targeted suites
- `git diff --check`
- OpenAI Anatomy drift check passes

The repository-wide architecture checks still report four pre-existing `origin/main` documentation drift items outside this change: missing `kernel/daemon_supervisor/supervisor.py` and stale citations in the i18n, notification-store, and nudge Anatomy files.
