### PR TITLE
fix(claude-code): project ToolResultBlock.metadata into full-history render

### DIFF
--- a/src/lingtai/llm/claude_code/adapter.py
+++ b/src/lingtai/llm/claude_code/adapter.py
@@ -33,6 +33,7 @@ from lingtai.kernel.llm.interface import (
 from lingtai.kernel.logging import get_logger
 
 from lingtai.llm.base import LLMAdapter
+from lingtai.llm.interface_converters import _project_tool_result
 
 logger = get_logger()
 
@@ -397,11 +398,14 @@ class ClaudeCodeChatSession(ChatSession):
             logger.warning("[claude-code] could not write system-prompt file; prompt caching disabled")
 
     def _render_conversation(self) -> str:
-        # Model-facing full-history serialization: every historical tool
-        # result's content is rendered as-is, including any
-        # ``_meta.agent_meta`` / ``guidance`` / ``notifications`` /
-        # ``notification_guidance`` it carries — this render does not strip
-        # those keys from any holder, same as the shared wire converters.
+        # Model-facing full-history serialization. Every historical tool result
+        # is projected through the shared ``_project_tool_result`` used by the
+        # wire converters, so the runtime sidecar (``ToolResultBlock.metadata``:
+        # ``agent_meta`` / ``guidance`` / ``notifications`` /
+        # ``notification_guidance``) is merged into a ``_meta`` envelope
+        # alongside the handler content instead of being dropped. Content that
+        # already carries its own ``_meta`` holder is preserved verbatim; this
+        # render strips those keys from no holder.
         lines: list[str] = []
         for entry in self._interface._entries:
             role = entry.role
@@ -424,7 +428,7 @@ class ClaudeCodeChatSession(ChatSession):
                         f"ASSISTANT_ACTION: called tool `{block.name}` with input {args}"
                     )
                 elif isinstance(block, ToolResultBlock):
-                    content = block.content
+                    content = _project_tool_result(block)
                     if not isinstance(content, str):
                         try:
                             content = json.dumps(content, ensure_ascii=False)

--- a/tests/test_timely_transient_serialization.py
+++ b/tests/test_timely_transient_serialization.py
@@ -41,6 +41,7 @@ tool-result bodies.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -261,14 +262,18 @@ def test_content_is_read_directly_without_intermediate_helpers():
 # ---------------------------------------------------------------------------
 
 
-def test_claude_code_render_preserves_historical_and_newest_holders():
+def _claude_session(iface: ChatInterface) -> "ClaudeCodeChatSession":
+    """Build a ClaudeCodeChatSession without a live CLI.
+
+    The constructor persists the stable system context through the adapter's
+    prompt-cache file, so the adapter must be a real object exposing
+    ``_system_prompt_file`` (``None`` disables the cache write). A bare
+    ``None`` adapter fails before the render is ever reached.
+    """
     from lingtai.llm.claude_code.adapter import ClaudeCodeChatSession
 
-    call_1_content = {"ok": True, "_meta": dict(_ALL_TRANSIENT_META)}
-    call_2_content = {"done": True, "_meta": dict(_NEWER_TRANSIENT_META)}
-    iface = _iface_with_two_results(call_1_content, call_2_content)
-    session = ClaudeCodeChatSession(
-        adapter=None,
+    return ClaudeCodeChatSession(
+        adapter=SimpleNamespace(_system_prompt_file=None),
         model="sonnet",
         system_prompt="",
         tools=[],
@@ -276,7 +281,13 @@ def test_claude_code_render_preserves_historical_and_newest_holders():
         context_window=100_000,
     )
 
-    rendered = session._render_conversation()
+
+def test_claude_code_render_preserves_historical_and_newest_holders():
+    call_1_content = {"ok": True, "_meta": dict(_ALL_TRANSIENT_META)}
+    call_2_content = {"done": True, "_meta": dict(_NEWER_TRANSIENT_META)}
+    iface = _iface_with_two_results(call_1_content, call_2_content)
+
+    rendered = _claude_session(iface)._render_conversation()
 
     assert "email-1" in rendered  # historical notification copy preserved
     assert "email-2" in rendered  # newest payload also present
@@ -284,6 +295,45 @@ def test_claude_code_render_preserves_historical_and_newest_holders():
     assert call_1_content["_meta"]["notifications"] == {
         "email": {"data": {"email_ids": ["email-1"]}}
     }
+
+
+def test_claude_code_render_projects_runtime_metadata_sidecar():
+    """Regression: ToolResultBlock.metadata must reach the model-facing render.
+
+    The kernel stores runtime state (``agent_meta`` / ``guidance`` /
+    ``notifications`` / ``notification_guidance``) in the block's ``metadata``
+    sidecar, not in handler content. The claude-code full-history render used
+    to serialize ``block.content`` only, silently dropping every email/telegram
+    notification payload — the agent woke, saw "nothing pending", and never
+    replied. The render must project the sidecar through the same
+    ``_project_tool_result`` used by the wire converters.
+    """
+    iface = ChatInterface()
+    iface.add_user_message("start")
+    iface.add_assistant_message([ToolCallBlock(id="call_1", name="do_x", args={})])
+    iface.add_tool_results(
+        [
+            ToolResultBlock(
+                id="call_1",
+                name="do_x",
+                content="handler result body",
+                metadata=dict(_ALL_TRANSIENT_META),
+            )
+        ]
+    )
+
+    rendered = _claude_session(iface)._render_conversation()
+
+    # The metadata sidecar is merged into a ``_meta`` envelope next to the
+    # handler content instead of being dropped.
+    assert "email-1" in rendered
+    assert "handler result body" in rendered
+    assert '"_meta"' in rendered
+
+    # Non-mutating: the canonical block keeps its sidecar and its content.
+    block = iface._entries[-1].content[0]
+    assert block.metadata == _ALL_TRANSIENT_META
+    assert block.content == "handler result body"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# fix(claude-code): project ToolResultBlock.metadata into full-history render

## Problem

Agents running on the `claude-code` backend could receive email/Telegram notifications, wake up, and still say "nothing pending" — never replying.

Root cause: the claude-code adapter's `_render_conversation()` serialized only `block.content` for every historical `ToolResultBlock`. The kernel stores runtime state — `agent_meta`, `guidance`, `notifications`, `notification_guidance` — in the block's **`metadata` sidecar**, not in handler content. The full-history render silently dropped that sidecar, so the model never saw the notification payload that should have triggered a reply.

## Fix

`src/lingtai/llm/claude_code/adapter.py` — route the render through the shared `_project_tool_result` used by all wire converters (`to_anthropic` / `to_openai` / `to_responses_input` / `to_gemini`):

- `ToolResultBlock.metadata` is merged into a `_meta` envelope **alongside** the handler content instead of being dropped.
- Content that already carries its own `_meta` holder is preserved verbatim — the render strips these keys from no holder.

This keeps the claude-code CLI path parity with every other provider: the model sees the same runtime envelope the wire converters emit.

## Tests

`tests/test_timely_transient_serialization.py`

- **New** `test_claude_code_render_projects_runtime_metadata_sidecar` — regression: a `ToolResultBlock` carrying `metadata` (notifications/agent_meta/guidance) renders the sidecar into the conversation, content preserved, canonical block untouched (non-mutating).
- **Fixed** `test_claude_code_render_preserves_historical_and_newest_holders` — was broken on main since the session constructor began requiring a non-None adapter (`adapter=None` → `AttributeError` on `_system_prompt_file`). Added a `_claude_session` helper with a stub adapter.

## Verification

- `pytest tests/test_timely_transient_serialization.py` → 29 passed
- `pytest tests/test_claude_code_adapter.py tests/test_daemon_claude_usage.py tests/test_daemon_claude_p_submanual.py` → 45 passed
- 3 pre-existing failures in `test_daemon.py` e2e tests are environment-only (installed `mcp` package version lacks `ServerRequestContext`), present on main without this change.

## Reproduction

Observed live: test agent at `/Users/huangzesen/temp/.lingtai/claude` received 4 'hi' emails; notification fired; the agent woke, model saw no pending content, never replied. The fix makes the model-facing render carry the same `_meta` envelope the kernel attaches to every tool result.
