### PR TITLE
chore(release): prepare v0.19.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lingtai"
-version = "0.19.2"
+version = "0.19.4"
 description = "Generic research agent with intrinsic tools and MCP-compatible extension interface"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Urgent release candidate: v0.19.4

Prepares the currently frozen `main` baseline for the requested urgent kernel release.

- Base: `8e51c06a54d6290bacf47d3935c0881057a4c4f4`
- Only change: `pyproject.toml` version `0.19.2` → `0.19.4`
- Excluded: Gitee, PyPI, TUI, Homebrew, website/blog, cleanup, and unrelated source changes.

PRECHECK receipts and the final release evidence are retained under the agent task root; no release/tag/upload is performed by this PR itself.
