### PR TITLE
test(feishu): fix stdio child fixture syntax

### DIFF
--- a/tests/test_feishu_stdio_logging.py
+++ b/tests/test_feishu_stdio_logging.py
@@ -124,7 +124,7 @@ _CHILD = textwrap.dedent(
         _import_lark()
         lark_logger = logging.getLogger("Lark")
         lark_logger.setLevel(logging.INFO)
-        lark_logger.info({ _LARK_DIAGNOSTIC!r })
+        lark_logger.info({_LARK_DIAGNOSTIC!r})
 
         async def list_tools(_ctx, _params):
             return types.ListToolsResult(


### PR DESCRIPTION
## Minimal test-fixture syntax hotfix

Fixes an existing test-collection blocker on the frozen release baseline `8e51c06a54d6290bacf47d3935c0881057a4c4f4`.

- Only change: remove invalid whitespace from the f-string conversion expression in `tests/test_feishu_stdio_logging.py`.
- The broken expression causes `SyntaxError: f-string: expecting '}'` during test collection.
- This is deliberately separate from version-only release PR #1134.

Validation: direct Python compilation and the affected test module are run against this candidate before it is considered for merge.
