### PR TITLE
fix(nudge): separate dev version suppression

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -65,7 +65,9 @@ The end-to-end path is:
    version. `runtime_identity.py` separately stamps durable event identity with
    package/dev mode, source kind, and available git state. No package-index
    request is needed for the local comparison.
-2. **Check `kernel_version` — `kernel_version.py`.** If running and installed
+2. **Check `kernel_version` — `kernel_version.py`.** This is the
+   `release_version` nudge channel. In editable/source/dev runtimes it is
+   silent and clears only its own stale release-version entry. If running and installed
    versions differ, it emits a local refresh nudge and preserves the existing
    local-only path. For packaged, non-editable, non-dev runtimes whose versions
    match, it fetches the exact `lingtai-kernel-release-manifest.json` asset from
@@ -75,13 +77,13 @@ The end-to-end path is:
    version. If one mirror is unavailable, the other may establish the result.
    A newer manifest version produces a package-availability nudge; network or
    response errors are recorded diagnostically and do not become an update.
-3. **Check `source_drift` — `source_drift.py`.** For non-dev runtimes it
-   compares the startup runtime fingerprint (git revision and curated source
-   digest when available) with a fresh on-disk fingerprint. Drift means the
-   running process is stale relative to code already on disk. Editable,
-   source-checkout, and dev-version runtimes skip this check deliberately.
-   This is local read-only source diagnosis and refresh mechanics only; it does
-   not enter the release-migration route.
+3. **Check `source_drift` — `source_drift.py`.** This is the
+   `source_integrity` nudge channel. It compares the startup runtime fingerprint
+   (git revision and curated source digest when available) with a fresh on-disk
+   fingerprint. Drift means the running process differs from code currently on
+   disk. Editable/source/dev runtimes still emit this diagnostic; the finding is
+   local read-only source diagnosis and refresh mechanics only, and does not
+   enter the release-migration route.
 4. **Dispatch — `nudge/__init__.py` and `lifecycle.py`.** The heartbeat loop
    runs the nudge dispatcher once per one-second tick. `kernel_version` and
    `source_drift` each have their own roughly 60-second in-memory probe gate;
@@ -147,20 +149,25 @@ has been downloaded.
 The editable/source/dev modes are detected through `direct_url.json` with
 `dir_info.editable: true`; source checkouts are recognized from the module path
 and the checkout's `.git` plus `pyproject.toml`; dev-version markers also
-suppress the package-index check. Missing distribution metadata is treated as
-source/dev rather than as permission to install. In these modes, the checkout,
-branch, commit, dirty state, and import path are the useful truth. A source-drift
-refresh nudge is also intentionally suppressed: refreshing arbitrary in-flight
-checkout changes could amplify a broken development edit.
+suppress only the `kernel_version` release-version check. Missing distribution
+metadata is treated as source/dev rather than as permission to install. In these
+modes, the checkout, branch, commit, dirty state, and import path are the useful
+truth. A `source_drift` finding can still appear as a source-integrity
+diagnostic, and an `init_config_shape` finding can still appear as
+configuration-staleness guidance; neither is package-update authority.
 
 ## Nudge mechanics and dismissal
 
-`kernel_version` and `source_drift` are producers of the shared low-priority
-`.notification/nudge.json` envelope. The envelope carries `data.nudges`, a
-`published_at` timestamp, channel-level instructions, and a self-describing
-policy block. `kind: kernel_version` has `running`, `installed`, `latest` (or
-`null` for a local refresh), `source`, and a suggested action. `source_drift`
-carries startup and disk fingerprints instead.
+`kernel_version`, `source_drift`, and `init_config_shape` are producers of the
+shared low-priority `.notification/nudge.json` envelope. The envelope carries
+`data.nudges`, a `published_at` timestamp, channel-level instructions, and a
+self-describing policy block. Those built-in producer kinds carry fixed
+`nudge_channel` metadata: `release_version` for `kernel_version`,
+`source_integrity` for `source_drift`, and `configuration_staleness` for
+`init_config_shape`. Unrelated legacy/unknown entries remain channel-less.
+`kind: kernel_version` has `running`, `installed`, `latest` (or `null` for a
+local refresh), `source`, and a suggested action. `source_drift` carries startup
+and disk fingerprints instead.
 
 The shared Nudge policy records finding identity and dismissal mute expiry in
 `.notification/.nudge_state.json`. The two global controls
@@ -168,8 +175,9 @@ The shared Nudge policy records finding identity and dismissal mute expiry in
 and set the post-dismiss repeat window for an unresolved finding; their defaults,
 accepted values, reload behavior, and invalid-value fallback are owned by
 `reference/environment-variables/SKILL.md`. Producer probe gates are only bounded
-observation costs, not product cadence. A producer removes an entry when its real
-fact resolves or the runtime is intentionally skipped.
+observation costs, not product cadence. A producer removes an entry when its
+real fact resolves; `kernel_version` also removes its own entry when the runtime
+is intentionally release-version-silent.
 
 After interpreting a nudge, use the narrowest safe action:
 

--- a/src/lingtai/kernel/nudge/ANATOMY.md
+++ b/src/lingtai/kernel/nudge/ANATOMY.md
@@ -34,6 +34,12 @@ the ordinary Notification Store channel; it does not create a second transport.
 - `__init__.py` — `run_checks`, `upsert`, `remove`, `effective_policy`, and
   `record_dismissal` provide the shared policy, finding identity, dismissal mute,
   and `.notification/nudge.json` mutation (`src/lingtai/kernel/nudge/__init__.py:1-360`).
+  New built-in producer entries carry fixed `nudge_channel` metadata:
+  `release_version` for `kernel_version`, `source_integrity` for
+  `source_drift`, and `configuration_staleness` for `init_config_shape`;
+  unrelated legacy/unknown entries remain channel-less, and legacy entries
+  persisted before this field existed remain visible as-is until their producer
+  rewrites or removes them.
   `upsert` also enforces the hard `INLINE_MAX_CHARS=10_000` inline-payload cap
   via `_cap_inline_payload`: at or below the cap the assembled entry (producer
   body plus shared policy fields and `kind`) is unchanged; above it, the full
@@ -54,8 +60,9 @@ the ordinary Notification Store channel; it does not create a second transport.
 - `kernel_version.py` — read-only installed/running observation plus bounded
   GitHub/Gitee release-manifest comparison; it does not own a product repeat
   cadence (`src/lingtai/kernel/nudge/kernel_version.py:91-229`).
-- `source_drift.py` — read-only runtime/source comparison, skipped for editable
-  or source runtimes (`src/lingtai/kernel/nudge/source_drift.py:21-111`).
+- `source_drift.py` — read-only runtime/source comparison in a separate
+  integrity/diagnostic channel; it remains active for editable/source/dev
+  runtimes (`src/lingtai/kernel/nudge/source_drift.py:21-111`).
 - `goal.py` — IDLE-only protected-goal reminder projected into the ordinary
   `system` notification channel, gated by an in-memory 10-second check
   cadence (`src/lingtai/kernel/nudge/goal.py:20-75`).
@@ -106,12 +113,18 @@ These sidecar files are local to one agent run and are not auto-cleaned.
 
 ## Notes
 
-Every emitted entry includes the effective `LINGTAI_NUDGE_ENABLED` and
-`LINGTAI_NUDGE_REPEAT_INTERVAL` values, both names, and the environment catalogue
-route. `FULLY_EFFECTIVE`, ignored-field, and failed init-reader outcomes are a
-separate axis from Nudge action; a dismissed finding is not resolved until the
-same real reader reports no finding. The old per-kind daily/fingerprint state is
-not consulted for repeat behavior.
+Every built-in producer entry includes an explicit fixed `nudge_channel`
+classification, the effective `LINGTAI_NUDGE_ENABLED` and
+`LINGTAI_NUDGE_REPEAT_INTERVAL` values, both names, and the environment
+catalogue route. Unrelated legacy/unknown entries are preserved honestly
+without a channel. `kernel_version` is the only producer whose release-version
+channel is silent for editable/source/dev runtimes; `source_drift` remains an
+integrity diagnostic and `init_config_shape` remains configuration-staleness
+guidance in those runtimes.
+`FULLY_EFFECTIVE`, ignored-field, and failed init-reader outcomes are a separate
+axis from Nudge action; a dismissed finding is not resolved until the same real
+reader reports no finding. The old per-kind daily/fingerprint state is not
+consulted for repeat behavior.
 
 The kernel-version producer reads only the exact
 `lingtai-kernel-release-manifest.json` release asset from the GitHub/Gitee latest

--- a/src/lingtai/kernel/nudge/__init__.py
+++ b/src/lingtai/kernel/nudge/__init__.py
@@ -16,14 +16,16 @@ Channel ``.notification/nudge.json`` carries a list of active nudges:
       "icon": "🔔",
       "priority": "low",
       "instructions": "Call notification(action='dismiss_channel', input={'channel': 'nudge', ...}, reasoning='...') ...",
-      "data": {"nudges": [{"kind": "kernel_version", ...}, ...]}
+      "data": {"nudges": [{"kind": "kernel_version", "nudge_channel": "release_version", ...}, ...]}
     }
 
-Each check identifies its slot by a unique ``kind`` string. ``upsert``
-replaces (or appends) one entry; ``remove`` deletes one. When the last
-entry leaves, the channel file is cleared so the agent's wire surface
-drops the notification entirely. The agent dismisses everything at once
-with ``notification(action='dismiss_channel', input={'channel': 'nudge',
+Each check identifies its slot by a unique ``kind`` string. Built-in producers
+are classified by fixed Core-owned kind mapping; unrelated legacy/unknown
+entries remain channel-less. ``upsert`` replaces (or appends) one entry;
+``remove`` deletes one. When the last entry leaves, the channel file is cleared
+so the agent's wire surface drops the notification entirely. The agent
+dismisses everything at once with
+``notification(action='dismiss_channel', input={'channel': 'nudge',
 'force': null, 'reason': null}, reasoning='...')``.
 
 To add a new nudge: drop ``nudge/<name>.py`` exposing ``check(agent)``,
@@ -51,6 +53,14 @@ DEFAULT_REPEAT_INTERVAL_SECONDS = 24 * 60 * 60
 ENABLED_ENV = "LINGTAI_NUDGE_ENABLED"
 REPEAT_INTERVAL_ENV = "LINGTAI_NUDGE_REPEAT_INTERVAL"
 ENVIRONMENT_MANUAL = "system-manual/reference/environment-variables/SKILL.md"
+ENTRY_CHANNEL_RELEASE_VERSION = "release_version"
+ENTRY_CHANNEL_SOURCE_INTEGRITY = "source_integrity"
+ENTRY_CHANNEL_CONFIG_STALENESS = "configuration_staleness"
+_ENTRY_CHANNEL_BY_KIND = {
+    "kernel_version": ENTRY_CHANNEL_RELEASE_VERSION,
+    "source_drift": ENTRY_CHANNEL_SOURCE_INTEGRITY,
+    "init_config_shape": ENTRY_CHANNEL_CONFIG_STALENESS,
+}
 
 # Hard maximum for one nudge entry's inline, model-visible JSON serialization.
 # Entries at or below this size are unchanged; entries above it are
@@ -174,6 +184,9 @@ __all__ = [
     "DEFAULT_ENABLED",
     "DEFAULT_REPEAT_INTERVAL_SECONDS",
     "ENABLED_ENV",
+    "ENTRY_CHANNEL_CONFIG_STALENESS",
+    "ENTRY_CHANNEL_RELEASE_VERSION",
+    "ENTRY_CHANNEL_SOURCE_INTEGRITY",
     "ENVIRONMENT_MANUAL",
     "INLINE_MAX_CHARS",
     "NudgeExternalizationError",
@@ -233,8 +246,13 @@ def upsert(agent, kind: str, body: dict) -> None:
         _modify(agent, lambda entries: [e for e in entries if e.get("kind") != kind])
         return
 
+    resolved_channel = _entry_channel_for_kind(kind)
     entry = dict(body)
     entry["kind"] = kind
+    if resolved_channel is not None:
+        entry["nudge_channel"] = resolved_channel
+    else:
+        entry.pop("nudge_channel", None)
     entry["policy"] = policy.payload()
     entry["policy_message"] = policy.message()
     entry["detail"] = (
@@ -244,7 +262,12 @@ def upsert(agent, kind: str, body: dict) -> None:
     # muting is a property of the finding's facts, not of whether the wire
     # copy happened to be externalized this heartbeat.
     fingerprint = _finding_fingerprint(kind, entry)
-    if _dismissed_until(agent, fingerprint) > time.time():
+    legacy_fingerprint = _finding_fingerprint(kind, entry, include_channel=False)
+    now = time.time()
+    if (
+        _dismissed_until(agent, fingerprint) > now
+        or _dismissed_until(agent, legacy_fingerprint) > now
+    ):
         return
     # Externalization must complete (or return the entry unchanged) before
     # ANY state mutates. If it raises, neither `.notification/nudge.json`
@@ -252,6 +275,8 @@ def upsert(agent, kind: str, body: dict) -> None:
     # heartbeat retry sees byte-for-byte the same prior state.
     entry = _cap_inline_payload(agent, kind, entry, fingerprint=fingerprint)
     _clear_dismissal(agent, fingerprint)
+    if legacy_fingerprint != fingerprint:
+        _clear_dismissal(agent, legacy_fingerprint)
     _modify(agent, lambda entries: _replace_kind(entries, kind, entry))
 
 
@@ -284,6 +309,14 @@ def record_dismissal(agent) -> None:
             "dismissed_at": now,
             "until": now + policy.repeat_interval_seconds,
         }
+        if "nudge_channel" not in entry:
+            legacy_fingerprint = _finding_fingerprint(kind, entry, include_channel=False)
+            if legacy_fingerprint != fingerprint:
+                dismissed[legacy_fingerprint] = {
+                    "kind": kind,
+                    "dismissed_at": now,
+                    "until": now + policy.repeat_interval_seconds,
+                }
     _save_policy_state(agent, state)
     _safe_log(
         agent,
@@ -301,7 +334,7 @@ def record_dismissal(agent) -> None:
 _STATE_FILE = Path(".notification") / ".nudge_state.json"
 
 
-def _finding_fingerprint(kind: str, body: dict) -> str:
+def _finding_fingerprint(kind: str, body: dict, *, include_channel: bool = True) -> str:
     """Hash stable finding facts, excluding policy display bookkeeping.
 
     When an entry carries a stamped ``_dismiss_fingerprint`` (written by
@@ -326,6 +359,8 @@ def _finding_fingerprint(kind: str, body: dict) -> str:
         "latest": body.get("latest"),
         "drift_signals": body.get("drift_signals"),
     }
+    if include_channel:
+        stable["nudge_channel"] = body.get("nudge_channel")
     raw = json.dumps(stable, ensure_ascii=False, sort_keys=True, default=str)
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
@@ -487,6 +522,8 @@ def _cap_inline_payload(agent, kind: str, entry: dict, *, fingerprint: str) -> d
             f"(SHA-256 {digest}); read that file directly for full detail."
         ),
     }
+    if "nudge_channel" in entry:
+        compact["nudge_channel"] = entry["nudge_channel"]
 
     # Defensive: even the bounded fields above could combine to exceed the
     # cap in a degenerate case. Shrink detail/title first — this is
@@ -586,6 +623,10 @@ def _replace_kind(entries: list, kind: str, body: dict) -> list:
     entry["kind"] = kind
     out.append(entry)
     return out
+
+
+def _entry_channel_for_kind(kind: str) -> str | None:
+    return _ENTRY_CHANNEL_BY_KIND.get(kind)
 
 
 def _modify(agent, mutate) -> None:

--- a/src/lingtai/kernel/nudge/source_drift.py
+++ b/src/lingtai/kernel/nudge/source_drift.py
@@ -7,17 +7,15 @@ that was captured at startup (git rev + source digest) and compares with
 is stale: only a full process relaunch (``system(action='refresh')``) picks up
 new code.
 
-Editable/source/dev installs are intentionally skipped.  In a development
-checkout, source and git HEAD changes are normal, and automatically nudging a
-running agent to refresh into whatever is currently on disk is too aggressive:
-if the checkout is broken, the nudge amplifies that breakage.  Dev agents should
-use explicit runtime/import-path diagnosis instead.
+Editable/source/dev installs are intentionally included. This producer is an
+integrity/diagnostic channel: it reports that the running interpreter's startup
+fingerprint differs from current on-disk source, without classifying that fact
+as a package update or suppressing it under the release-version dev policy.
 
 Throttled to one check per 60 seconds so a long-running agent doesn't get a
-flood of nudge entries on every heartbeat tick.  If the on-disk state returns
-to match the startup fingerprint (revert, or stale state from a prior process),
-or the runtime is detected as dev/source/editable, the previously-emitted entry
-is cleared.
+flood of nudge entries on every heartbeat tick. If the on-disk state returns to
+match the startup fingerprint (revert, or stale state from a prior process), the
+previously-emitted entry is cleared.
 """
 from __future__ import annotations
 
@@ -38,18 +36,6 @@ def check(agent) -> None:
     state["last_probe_ts"] = now
 
     from . import upsert, remove
-
-    dev_reason = _dev_runtime_reason()
-    if dev_reason:
-        remove(agent, _KIND)
-        if state.get("emitted") or state.get("skipped_dev_reason") != dev_reason:
-            _safe_log(agent, "nudge_skipped", kind=_KIND, reason="dev-runtime", dev_reason=dev_reason)
-        state["emitted"] = False
-        state["emitted_for"] = None
-        state["skipped_dev_reason"] = dev_reason
-        return
-
-    state.pop("skipped_dev_reason", None)
 
     from ..base_agent.lifecycle import _capture_runtime_fingerprint
 
@@ -105,16 +91,6 @@ def check(agent) -> None:
         )
     except Exception as e:
         agent._log("nudge_emit_error", kind=_KIND, error=str(e)[:200])
-
-
-def _dev_runtime_reason() -> str | None:
-    """Return the dev/source/editable reason that should suppress this nudge."""
-    try:
-        from .kernel_version import _runtime_info
-
-        return _runtime_info().dev_reason
-    except Exception:
-        return None
 
 
 def _safe_log(agent, event: str, **fields) -> None:

--- a/tests/test_kernel_version_nudge.py
+++ b/tests/test_kernel_version_nudge.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from tests._notification_store_helpers import notification_store_for, snapshot_notifications
-from lingtai.kernel.nudge import upsert
+from lingtai.kernel.nudge import ENTRY_CHANNEL_RELEASE_VERSION, upsert
 from lingtai.kernel.nudge import kernel_version as kv
 
 
@@ -53,6 +53,7 @@ def test_installed_runtime_refresh_nudge_does_not_hit_remote(tmp_path, monkeypat
     assert len(entries) == 1
     entry = entries[0]
     assert entry["kind"] == "kernel_version"
+    assert entry["nudge_channel"] == ENTRY_CHANNEL_RELEASE_VERSION
     assert entry["source"] == "installed-distribution"
     assert entry["running"] == "0.14.1"
     assert entry["installed"] == "0.14.2"
@@ -307,6 +308,7 @@ def test_remote_update_check_uses_bounded_probe_not_daily_product_cadence(tmp_pa
     assert len(entries) == 1
     entry = entries[0]
     assert entry["source"] == "release-manifest"
+    assert entry["nudge_channel"] == ENTRY_CHANNEL_RELEASE_VERSION
     assert entry["latest"] == "0.14.2"
     assert entry["suggested_action"] == "execute-installer-help-then-ask-human"
     assert entry["install_url"] == "https://lingtai.ai/install.sh"

--- a/tests/test_nudge_inline_cap.py
+++ b/tests/test_nudge_inline_cap.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from lingtai.kernel.nudge import (
+    ENTRY_CHANNEL_RELEASE_VERSION,
     INLINE_MAX_CHARS,
     NudgeExternalizationError,
     effective_policy,
@@ -140,12 +141,38 @@ def test_externalization_preserves_full_content_and_metadata(
     full = json.loads(full_text)
     assert full["detail"].startswith(big_detail)
     assert full["title"] == "Oversized finding"
+    assert "nudge_channel" not in full
 
     raw_bytes = full_text.encode("utf-8")
     assert ext["original_char_count"] == len(full_text)
     assert ext["original_byte_count"] == len(raw_bytes)
     assert ext["sha256"] == hashlib.sha256(raw_bytes).hexdigest()
     assert (ext["original_byte_count"] > ext["original_char_count"]) == byte_count_exceeds_char_count
+
+
+def test_externalized_builtin_wire_entry_retains_fixed_channel(tmp_path):
+    agent = _Agent(tmp_path)
+    big_detail = "k" * 11_000
+
+    upsert(
+        agent,
+        "kernel_version",
+        {
+            "title": "Oversized kernel update",
+            "detail": big_detail,
+            "source": "release-manifest",
+        },
+    )
+
+    entry = _entry(tmp_path, "kernel_version")
+    assert _entry_chars(entry) <= INLINE_MAX_CHARS
+    assert entry["nudge_channel"] == ENTRY_CHANNEL_RELEASE_VERSION
+    assert "externalized" in entry
+    assert big_detail not in json.dumps(entry, ensure_ascii=False, default=str)
+
+    sidecar = json.loads(Path(entry["externalized"]["path"]).read_text(encoding="utf-8"))
+    assert sidecar["kind"] == "kernel_version"
+    assert sidecar["nudge_channel"] == ENTRY_CHANNEL_RELEASE_VERSION
 
 
 def test_content_addressed_reuse_and_distinct_files(tmp_path):
@@ -255,6 +282,7 @@ def test_ordinary_small_nudge_behavior_is_unchanged(tmp_path):
     assert "externalized" not in entry
     assert entry["kind"] == "small"
     assert not _findings_dir(tmp_path).exists()
+    assert "nudge_channel" not in entry
     # Internal bookkeeping field must never leak into the persisted payload.
     assert "_dismiss_fingerprint" not in entry
 
@@ -263,6 +291,11 @@ def test_ordinary_small_nudge_behavior_is_unchanged(tmp_path):
         upsert(agent, kind, {"title": "t", "detail": "short detail", "source": "s"})
     entries = snapshot_notifications(tmp_path)["nudge"]["data"]["nudges"]
     assert {e["kind"] for e in entries} >= {"small", "kernel_version", "source_drift", "init_config_shape"}
+    channel_by_kind = {e["kind"]: e.get("nudge_channel") for e in entries}
+    assert channel_by_kind["small"] is None
+    assert channel_by_kind["kernel_version"] == "release_version"
+    assert channel_by_kind["source_drift"] == "source_integrity"
+    assert channel_by_kind["init_config_shape"] == "configuration_staleness"
 
 
 def test_dismissal_round_trip_for_capped_finding(tmp_path, monkeypatch):

--- a/tests/test_nudge_policy.py
+++ b/tests/test_nudge_policy.py
@@ -4,7 +4,13 @@ import json
 import time
 
 from lingtai.init_reader import read_init
-from lingtai.kernel.nudge import effective_policy, run_checks, upsert
+from lingtai.kernel.nudge import (
+    ENTRY_CHANNEL_CONFIG_STALENESS,
+    effective_policy,
+    record_dismissal,
+    run_checks,
+    upsert,
+)
 from lingtai.kernel.nudge.init_config import check as check_init_config
 from lingtai.kernel.notifications import dismiss_channel
 from tests._notification_store_helpers import notification_store_for, snapshot_notifications
@@ -49,6 +55,7 @@ def test_emitted_finding_describes_effective_global_policy(monkeypatch, tmp_path
     upsert(agent, "example", {"title": "Needs attention", "detail": "read it"})
 
     entry = _entries(tmp_path)[0]
+    assert "nudge_channel" not in entry
     assert entry["policy"] == {
         "enabled": "on",
         "repeat_after_dismiss": "2h",
@@ -61,6 +68,123 @@ def test_emitted_finding_describes_effective_global_policy(monkeypatch, tmp_path
     assert "LINGTAI_NUDGE_ENABLED=on" in entry["detail"]
     assert "LINGTAI_NUDGE_REPEAT_INTERVAL=2h" in entry["detail"]
     assert "system-manual/reference/environment-variables/SKILL.md" in entry["detail"]
+
+
+def test_fixed_entry_channel_metadata_is_producer_kind_owned(tmp_path):
+    agent = _Agent(tmp_path)
+
+    upsert(
+        agent,
+        "init_config_shape",
+        {
+            "title": "Needs attention",
+            "detail": "read it",
+            "nudge_channel": "not-a-caller-override",
+        },
+    )
+    upsert(agent, "example", {"title": "Legacy", "nudge_channel": "not-a-channel"})
+
+    entries = _entries(tmp_path)
+    init = next(entry for entry in entries if entry["kind"] == "init_config_shape")
+    legacy = next(entry for entry in entries if entry["kind"] == "example")
+    assert init["nudge_channel"] == ENTRY_CHANNEL_CONFIG_STALENESS
+    assert "nudge_channel" not in legacy
+
+
+def test_legacy_entries_without_channel_metadata_remain_visible(tmp_path):
+    agent = _Agent(tmp_path)
+
+    def _seed_legacy(_current):
+        return {
+            "header": "1 nudge",
+            "icon": "\U0001f514",
+            "priority": "low",
+            "data": {"nudges": [{"kind": "legacy", "title": "old"}]},
+        }, True, None
+
+    from lingtai.kernel.notification_store import UNCONDITIONAL
+
+    agent._notification_store.compare_update_channel("nudge", UNCONDITIONAL, _seed_legacy)
+    upsert(agent, "example", {"title": "new"})
+
+    entries = _entries(tmp_path)
+    legacy = next(entry for entry in entries if entry["kind"] == "legacy")
+    new = next(entry for entry in entries if entry["kind"] == "example")
+    assert "nudge_channel" not in legacy
+    assert "nudge_channel" not in new
+
+
+def test_legacy_state_dismissal_fingerprint_mutes_rewritten_channel_entry(tmp_path):
+    agent = _Agent(tmp_path)
+    body = {"title": "Needs attention", "detail": "same finding"}
+    from lingtai.kernel import nudge as nudge_module
+
+    policy = effective_policy()
+    legacy_fingerprint = nudge_module._finding_fingerprint(
+        "example",
+        {
+            "kind": "example",
+            "title": body["title"],
+            "detail": f"{body['detail']}\n\n{policy.message()}",
+            "policy": policy.payload(),
+            "policy_message": policy.message(),
+        },
+        include_channel=False,
+    )
+    state_path = tmp_path / ".notification" / ".nudge_state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "dismissed": {
+                    legacy_fingerprint: {
+                        "kind": "example",
+                        "dismissed_at": time.time(),
+                        "until": time.time() + 3600,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    upsert(agent, "example", body)
+
+    assert _entries(tmp_path) == []
+
+
+def test_visible_legacy_entry_dismissed_after_upgrade_mutes_first_classified_rewrite(tmp_path):
+    agent = _Agent(tmp_path)
+    body = {"title": "Needs attention", "detail": "same finding", "source": "release-manifest"}
+
+    def _seed_legacy(_current):
+        return {
+            "header": "1 nudge",
+            "icon": "\U0001f514",
+            "priority": "low",
+            "data": {
+                "nudges": [
+                    {
+                        "kind": "kernel_version",
+                        "title": body["title"],
+                        "detail": f"{body['detail']}\n\n{effective_policy().message()}",
+                        "source": body["source"],
+                        "policy": effective_policy().payload(),
+                        "policy_message": effective_policy().message(),
+                    }
+                ]
+            },
+        }, True, None
+
+    from lingtai.kernel.notification_store import UNCONDITIONAL
+
+    agent._notification_store.compare_update_channel("nudge", UNCONDITIONAL, _seed_legacy)
+    record_dismissal(agent)
+    dismiss_channel(agent, "nudge", invoked_by="notification", force=True)
+
+    upsert(agent, "kernel_version", body)
+
+    assert _entries(tmp_path) == []
 
 
 def test_disabled_policy_suppresses_all_nudge_kinds(monkeypatch, tmp_path):
@@ -79,6 +203,66 @@ def test_run_checks_off_clears_visible_nudge_before_producer_gates(monkeypatch, 
     run_checks(agent)
 
     assert _entries(tmp_path) == []
+
+
+def test_run_checks_dev_kernel_version_silent_but_source_and_config_persist(monkeypatch, tmp_path):
+    agent = _Agent(tmp_path)
+    agent._source_revision_port = object()
+    agent._runtime_fingerprint = {
+        "git_rev": "startup111",
+        "source_digest": "startup222",
+        "captured_at": "t1",
+    }
+    upsert(agent, "kernel_version", {"title": "old", "source": "release-manifest"})
+
+    init_payload = {
+        "manifest": {
+            "llm": {"provider": "openai", "model": "gpt-4o"},
+            "capabilities": {"bash": {"yolo": True}},
+        },
+        "covenant": "operator contract",
+        "pad": "durable state",
+    }
+    init = tmp_path / "init.json"
+    init.write_text(json.dumps(init_payload), encoding="utf-8")
+    agent._last_init_read_outcome = read_init(tmp_path)
+
+    from lingtai.kernel.nudge import kernel_version as kv
+
+    monkeypatch.setattr(
+        kv,
+        "_runtime_info",
+        lambda: kv._RuntimeInfo(
+            running_version="0.14.1.dev0",
+            installed_version="0.14.1.dev0",
+            dev_reason="editable-install",
+        ),
+    )
+    monkeypatch.setattr(kv, "_today_utc", lambda: "2026-06-24")
+    monkeypatch.setattr(
+        kv,
+        "_fetch_latest_version",
+        lambda: (_ for _ in ()).throw(AssertionError("dev mode should skip remote")),
+    )
+    monkeypatch.setattr(
+        "lingtai.kernel.base_agent.lifecycle._capture_runtime_fingerprint",
+        lambda _port: {
+            "git_rev": "disk333",
+            "source_digest": "disk444",
+            "captured_at": "t2",
+        },
+    )
+
+    run_checks(agent)
+
+    entries = _entries(tmp_path)
+    by_kind = {entry["kind"]: entry for entry in entries}
+    assert "kernel_version" not in by_kind
+    assert by_kind["source_drift"]["nudge_channel"] == "source_integrity"
+    assert by_kind["init_config_shape"]["nudge_channel"] == ENTRY_CHANNEL_CONFIG_STALENESS
+    assert by_kind["source_drift"]["startup_fingerprint"]["git_rev"] == "startup111"
+    assert by_kind["source_drift"]["disk_fingerprint"]["git_rev"] == "disk333"
+    assert by_kind["init_config_shape"]["shape_decision"] == "NUDGE"
 
 
 def test_dismissal_mutes_unresolved_finding_then_global_interval_allows_repeat(monkeypatch, tmp_path):
@@ -117,6 +301,7 @@ def test_config_shape_nudge_consumes_outcome_and_clears_after_explicit_repair(tm
 
     entry = _entries(tmp_path)[0]
     assert entry["kind"] == "init_config_shape"
+    assert entry["nudge_channel"] == ENTRY_CHANNEL_CONFIG_STALENESS
     assert entry["shape_decision"] == "NUDGE"
     assert entry["compatibility_paths"][0]["raw_path"] == "manifest.capabilities.bash"
     assert entry["effective_outcome"]["effective_config"]["redacted"] is True

--- a/tests/test_source_drift.py
+++ b/tests/test_source_drift.py
@@ -7,8 +7,6 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from tests._notification_store_helpers import FakeNotificationStore
 from tests._snapshot_helpers import FakeSourceRevisionPort
 from tests._lifecycle_clock_helpers import make_test_lifecycle_clock
@@ -212,13 +210,6 @@ class TestSourceDriftNudge:
     # Patch target: _capture_runtime_fingerprint is imported locally inside
     # source_drift.check(), so we must patch it at its definition site.
     _PATCH_TARGET = "lingtai.kernel.base_agent.lifecycle._capture_runtime_fingerprint"
-    _DEV_RUNTIME_TARGET = "lingtai.kernel.nudge.source_drift._dev_runtime_reason"
-
-    @pytest.fixture(autouse=True)
-    def _packaged_runtime(self):
-        """Existing drift tests model a packaged/runtime install unless stated."""
-        with patch(self._DEV_RUNTIME_TARGET, return_value=None):
-            yield
 
     def test_no_drift_removes_prior_nudge(self):
         """When startup and disk fingerprints match, no nudge emitted."""
@@ -310,34 +301,8 @@ class TestSourceDriftNudge:
         # Should not raise
         check(agent)
 
-    def test_dev_runtime_skips_and_clears_prior_nudge(self):
-        """Editable/source/dev installs should not prompt source drift refresh."""
-        from lingtai.kernel.nudge.source_drift import check, _state
-
-        startup_fp = {"git_rev": "aaa1111", "source_digest": "bbb2222", "captured_at": "t1"}
-        disk_fp = {"git_rev": "ccc3333", "source_digest": "ddd4444", "captured_at": "t2"}
-        agent = self._make_agent(startup_fp=startup_fp)
-        state = _state(agent)
-        state["emitted"] = True
-        state["emitted_for"] = "git_rev: old → stale"
-
-        with (
-            patch(self._DEV_RUNTIME_TARGET, return_value="source-checkout"),
-            patch(self._PATCH_TARGET, return_value=disk_fp) as mock_capture,
-            patch("lingtai.kernel.nudge.remove") as mock_remove,
-            patch("lingtai.kernel.nudge.upsert") as mock_upsert,
-        ):
-            check(agent)
-
-        mock_remove.assert_called_once_with(agent, "source_drift")
-        mock_upsert.assert_not_called()
-        mock_capture.assert_not_called()
-        assert state.get("emitted") is False
-        assert state.get("emitted_for") is None
-        assert state.get("skipped_dev_reason") == "source-checkout"
-
-    def test_dev_runtime_clears_stale_channel_even_without_local_state(self):
-        """A fresh dev process should clear a source_drift nudge from an older run."""
+    def test_dev_runtime_still_emits_source_integrity_diagnostic(self):
+        """Editable/source/dev installs still surface source drift diagnostics."""
         from lingtai.kernel.nudge.source_drift import check, _state
 
         startup_fp = {"git_rev": "aaa1111", "source_digest": "bbb2222", "captured_at": "t1"}
@@ -345,20 +310,39 @@ class TestSourceDriftNudge:
         agent = self._make_agent(startup_fp=startup_fp)
 
         with (
-            patch(self._DEV_RUNTIME_TARGET, return_value="editable-install"),
             patch(self._PATCH_TARGET, return_value=disk_fp) as mock_capture,
-            patch("lingtai.kernel.nudge.remove") as mock_remove,
             patch("lingtai.kernel.nudge.upsert") as mock_upsert,
         ):
             check(agent)
 
+        mock_capture.assert_called_once()
+        mock_upsert.assert_called_once()
+        assert mock_upsert.call_args.args[1] == "source_drift"
+        assert mock_upsert.call_args.kwargs == {}
         state = _state(agent)
-        mock_remove.assert_called_once_with(agent, "source_drift")
-        mock_upsert.assert_not_called()
-        mock_capture.assert_not_called()
-        assert state.get("emitted") is False
-        assert state.get("emitted_for") is None
-        assert state.get("skipped_dev_reason") == "editable-install"
+        assert state.get("emitted") is True
+        assert "aaa1111" in state.get("emitted_for", "")
+        assert "ccc3333" in state.get("emitted_for", "")
+
+    def test_source_drift_entry_persists_source_integrity_channel(self, tmp_path):
+        """The real persisted source_drift entry carries channel metadata."""
+        from lingtai.kernel.nudge.source_drift import check, _state
+        from tests._notification_store_helpers import notification_store_for, snapshot_notifications
+
+        startup_fp = {"git_rev": "aaa1111", "source_digest": "bbb2222", "captured_at": "t1"}
+        disk_fp = {"git_rev": "ccc3333", "source_digest": "ddd4444", "captured_at": "t2"}
+        agent = self._make_agent(startup_fp=startup_fp)
+        agent._working_dir = tmp_path
+        agent._notification_store = notification_store_for(tmp_path)
+
+        with patch(self._PATCH_TARGET, return_value=disk_fp):
+            check(agent)
+
+        state = _state(agent)
+        assert state.get("emitted") is True
+        entry = snapshot_notifications(tmp_path)["nudge"]["data"]["nudges"][0]
+        assert entry["kind"] == "source_drift"
+        assert entry["nudge_channel"] == "source_integrity"
 
     def test_partial_drift_git_only(self):
         """Only git_rev differs → still detected as drift."""


### PR DESCRIPTION
## Summary

- Give the three built-in Nudge producers fixed, producer-owned channel metadata.
- In source/editable/dev runtimes, silence only stale-release `kernel_version`; keep `source_drift` and `init_config_shape` actionable.
- Preserve legacy dismissal compatibility and retain fixed metadata on externalized compact wire entries without adding a registry, override, config, migration, or new public API.

## Validation

```text
PYTHONDONTWRITEBYTECODE=1 <repo-venv>/bin/python -m pytest -q -p no:cacheprovider \
  tests/test_kernel_version_nudge.py tests/test_source_drift.py \
  tests/test_nudge_policy.py tests/test_nudge_inline_cap.py \
  tests/test_goal_notification.py
# 84 passed

git diff --check
# passed
```

A final independent read-only review accepted the exact eight-file candidate, including the persisted compact-payload channel regression.

## Known baseline/environmental checks

The reviewer also recorded two unrelated supplemental documentation-suite failures: a pre-existing stale daemon-supervisor Anatomy citation and a shared-venv MCP dependency mismatch. They are outside this diff and are not presented as passing validation.
