### PR TITLE
refactor(feishu): adopt lark channel sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     # here.
     "imapclient>=3.0.0",
     "msal>=1.37.0",
-    "lark-oapi>=1.4.0",
+    "lark-channel-sdk>=1.2,<2",
     "cryptography>=42.0.0",
     "qrcode>=7.4.0",
     "faster-whisper>=1.0.0",

--- a/src/lingtai/mcp_servers/feishu/account.py
+++ b/src/lingtai/mcp_servers/feishu/account.py
@@ -1,6 +1,6 @@
 """FeishuAccount — single app credential, WebSocket listener + REST sender.
 
-One daemon thread per account runs the lark-oapi WebSocket client.
+One daemon thread per account runs the lark-channel-sdk WebSocket client.
 Constructor stores config only — no connections, no threads.
 start() spawns the WebSocket thread and initialises the REST client.
 stop() signals the thread to stop and joins it.
@@ -20,12 +20,12 @@ from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
-# lark_oapi is lazy-imported so the module stays importable without
+# lark_channel is lazy-imported so the module stays importable without
 # the optional dependency installed.
 lark: Any = None
 
-# The lark_oapi.ws.client module, captured lazily. Stored as a module global so
-# tests can inject a fake SDK module (see tests/test_ws_event_loop.py). The real
+# The lark_channel.ws.client module, captured lazily. Stored globally so tests
+# can inject a fake SDK module (see test_feishu_channel_sdk_account.py). The real
 # SDK keeps its own module-level ``loop`` attribute that ``Client.start()`` uses
 # directly — see ``_ThreadLocalLoop`` and ``_ws_loop`` for why that matters.
 _sdk_ws_client_module: Any = None
@@ -47,27 +47,27 @@ def _route_lark_stdout_handlers_to_stderr() -> None:
 def _import_lark() -> Any:
     global lark
     if lark is None:
-        import lark_oapi as _lark
+        import lark_channel as _lark
         lark = _lark
     _route_lark_stdout_handlers_to_stderr()
     return lark
 
 
 def _get_sdk_ws_client_module() -> Any:
-    """Return the ``lark_oapi.ws.client`` module (or an injected fake).
+    """Return the ``lark_channel.ws.client`` module (or an injected fake).
 
     Tests set ``_sdk_ws_client_module`` directly to a stand-in that exposes the
     same ``loop`` attribute contract as the real SDK module.
     """
     global _sdk_ws_client_module
     if _sdk_ws_client_module is None:
-        import lark_oapi.ws.client as _ws_client
+        import lark_channel.ws.client as _ws_client
         _sdk_ws_client_module = _ws_client
     return _sdk_ws_client_module
 
 
 class _ThreadLocalLoop:
-    """Per-thread proxy that stands in for ``lark_oapi.ws.client.loop``.
+    """Per-thread proxy that stands in for ``lark_channel.ws.client.loop``.
 
     The SDK captures ``loop = asyncio.get_event_loop()`` at *import time* into a
     module global, and ``Client.start()`` calls ``loop.run_until_complete(...)``
@@ -150,6 +150,8 @@ class FeishuAccount:
 
         self._ws_thread: threading.Thread | None = None
         self._ws_client: Any = None
+        self._ws_event_loop: asyncio.AbstractEventLoop | None = None
+        self._ws_loop_lock = threading.Lock()
         self._rest_client: Any = None
         self._stop_event = threading.Event()
         self._bot_info: dict | None = None
@@ -190,8 +192,9 @@ class FeishuAccount:
                     "Feishu event processing error (%s): %s", self.alias, exc
                 )
 
+        security = _lark.SecurityConfig(mode="compat")
         event_handler = (
-            _lark.EventDispatcherHandler.builder("", "")
+            _lark.EventDispatcherHandler.builder("", "", security=security)
             .register_p2_im_message_receive_v1(_handle_message)
             .build()
         )
@@ -203,6 +206,7 @@ class FeishuAccount:
             self._app_secret,
             event_handler=event_handler,
             log_level=_lark.LogLevel.INFO,
+            security=security,
         )
 
         self._ws_thread = threading.Thread(
@@ -220,8 +224,8 @@ class FeishuAccount:
     def _ws_loop(self) -> None:
         """Run the blocking WebSocket client in a background thread.
 
-        lark-oapi captures ``loop = asyncio.get_event_loop()`` into a *module
-        global* (``lark_oapi.ws.client.loop``) at import time, and
+        lark-channel-sdk captures ``loop = asyncio.get_event_loop()`` into a
+        *module global* (``lark_channel.ws.client.loop``) at import time, and
         ``Client.start()`` calls ``loop.run_until_complete(...)`` on that global
         — it never re-reads the thread-current loop. Imported on the main MCP
         thread under ``asyncio.run(serve())``, that global is the already-running
@@ -242,7 +246,14 @@ class FeishuAccount:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         proxy.bind(loop)
+        with self._ws_loop_lock:
+            self._ws_event_loop = loop
+        set_loop = getattr(self._ws_client, "_set_loop", None)
+        if callable(set_loop):
+            set_loop(loop)
         try:
+            if self._stop_event.is_set():
+                return
             self._ws_client.start()
         except Exception as e:
             if not self._stop_event.is_set():
@@ -251,7 +262,17 @@ class FeishuAccount:
                     self.alias, e,
                 )
         finally:
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending and not loop.is_closed():
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
             proxy.unbind()
+            with self._ws_loop_lock:
+                if self._ws_event_loop is loop:
+                    self._ws_event_loop = None
             try:
                 loop.close()
             finally:
@@ -260,14 +281,21 @@ class FeishuAccount:
     def stop(self) -> None:
         """Signal the WebSocket thread to stop."""
         self._stop_event.set()
-        if self._ws_client is not None:
-            try:
-                self._ws_client.stop()
-            except Exception:
-                pass
+        with self._ws_loop_lock:
+            loop = self._ws_event_loop
+        if loop is not None and not loop.is_closed():
+            disconnect = getattr(self._ws_client, "_disconnect", None)
+            if callable(disconnect) and loop.is_running():
+                try:
+                    future = asyncio.run_coroutine_threadsafe(disconnect(), loop)
+                    future.result(timeout=2.0)
+                except Exception:
+                    pass
+            loop.call_soon_threadsafe(loop.stop)
         if self._ws_thread is not None:
             self._ws_thread.join(timeout=5.0)
-            self._ws_thread = None
+            if not self._ws_thread.is_alive():
+                self._ws_thread = None
 
     # ------------------------------------------------------------------
     # Event processing
@@ -300,8 +328,10 @@ class FeishuAccount:
         text: str,
     ) -> dict:
         """Send a plain-text message. Returns created Message fields as dict."""
-        from lark_oapi.api.im.v1 import (
+        from lark_channel.api.im.v1.model.create_message_request import (
             CreateMessageRequest,
+        )
+        from lark_channel.api.im.v1.model.create_message_request_body import (
             CreateMessageRequestBody,
         )
 
@@ -331,8 +361,10 @@ class FeishuAccount:
 
     def reply_text(self, message_id: str, text: str) -> dict:
         """Reply to a specific message by Feishu message_id."""
-        from lark_oapi.api.im.v1 import (
+        from lark_channel.api.im.v1.model.reply_message_request import (
             ReplyMessageRequest,
+        )
+        from lark_channel.api.im.v1.model.reply_message_request_body import (
             ReplyMessageRequestBody,
         )
 
@@ -378,7 +410,9 @@ class FeishuAccount:
         Returns:
             (filename, content_bytes) tuple.
         """
-        from lark_oapi.api.im.v1 import GetMessageResourceRequest
+        from lark_channel.api.im.v1.model.get_message_resource_request import (
+            GetMessageResourceRequest,
+        )
 
         request = (
             GetMessageResourceRequest.builder()
@@ -411,9 +445,13 @@ class FeishuAccount:
         Returns:
             True on success.
         """
-        from lark_oapi.api.im.v1 import (
+        from lark_channel.api.im.v1.model.create_message_reaction_request import (
             CreateMessageReactionRequest,
+        )
+        from lark_channel.api.im.v1.model.create_message_reaction_request_body import (
             CreateMessageReactionRequestBody,
+        )
+        from lark_channel.api.im.v1.model.emoji import (
             Emoji,
         )
 
@@ -454,8 +492,10 @@ class FeishuAccount:
         Returns:
             Response dict (empty on success since PATCH returns no body).
         """
-        from lark_oapi.api.im.v1 import (
+        from lark_channel.api.im.v1.model.patch_message_request import (
             PatchMessageRequest,
+        )
+        from lark_channel.api.im.v1.model.patch_message_request_body import (
             PatchMessageRequestBody,
         )
 
@@ -486,7 +526,9 @@ class FeishuAccount:
         Returns:
             True on success.
         """
-        from lark_oapi.api.im.v1 import DeleteMessageRequest
+        from lark_channel.api.im.v1.model.delete_message_request import (
+            DeleteMessageRequest,
+        )
 
         request = (
             DeleteMessageRequest.builder()

--- a/src/lingtai/mcp_servers/feishu/manager.py
+++ b/src/lingtai/mcp_servers/feishu/manager.py
@@ -289,7 +289,7 @@ class FeishuManager:
         self._last_sent: dict[tuple[str, str, str], int] = {}
         self._dup_free_passes = 2
         # Incoming event dedupe: per-account FIFO of recently-seen
-        # feishu_message_id values. Protects against lark-oapi WS
+        # feishu_message_id values. Protects against Feishu SDK WS
         # reconnect redelivery (issue #5). Bounded; oldest evicted first.
         self._seen_msg_ids: dict[str, OrderedDict[str, None]] = {}
         self._dedupe_lock = threading.Lock()

--- a/tests/test_feishu_channel_sdk_account.py
+++ b/tests/test_feishu_channel_sdk_account.py
@@ -1,0 +1,158 @@
+"""Focused compatibility coverage for the low-level lark-channel-sdk adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import threading
+from types import SimpleNamespace
+
+from lingtai.mcp_servers.feishu import account as account_module
+from lingtai.mcp_servers.feishu.account import FeishuAccount
+
+
+class _Success:
+    def __init__(self, **values: object) -> None:
+        self.code = 0
+        self.msg = "ok"
+        for key, value in values.items():
+            setattr(self, key, value)
+
+    def success(self) -> bool:
+        return True
+
+
+def test_outbound_methods_use_channel_sdk_generated_models() -> None:
+    requests: dict[str, object] = {}
+
+    class _Message:
+        def create(self, request: object) -> _Success:
+            requests["create"] = request
+            return _Success(
+                data=SimpleNamespace(
+                    message_id="om_created",
+                    chat_id="oc_chat",
+                    create_time="123",
+                )
+            )
+
+        def reply(self, request: object) -> _Success:
+            requests["reply"] = request
+            return _Success(
+                data=SimpleNamespace(message_id="om_reply", chat_id="oc_chat")
+            )
+
+        def patch(self, request: object) -> _Success:
+            requests["patch"] = request
+            return _Success()
+
+        def delete(self, request: object) -> _Success:
+            requests["delete"] = request
+            return _Success()
+
+    class _MessageResource:
+        def get(self, request: object) -> _Success:
+            requests["resource"] = request
+            return _Success(file_name="voice.ogg", file=io.BytesIO(b"audio"))
+
+    class _MessageReaction:
+        def create(self, request: object) -> _Success:
+            requests["reaction"] = request
+            return _Success()
+
+    rest_client = SimpleNamespace(
+        im=SimpleNamespace(
+            v1=SimpleNamespace(
+                message=_Message(),
+                message_resource=_MessageResource(),
+                message_reaction=_MessageReaction(),
+            )
+        )
+    )
+    account = FeishuAccount("main", "app", "secret", ["ou_allowed"])
+    account._rest_client = rest_client
+
+    assert account.send_text("ou_allowed", "open_id", "hello") == {
+        "message_id": "om_created",
+        "chat_id": "oc_chat",
+        "create_time": "123",
+    }
+    assert account.reply_text("om_original", "reply") == {
+        "message_id": "om_reply",
+        "chat_id": "oc_chat",
+    }
+    assert account.get_message_resource("om_original", "file-key") == (
+        "voice.ogg",
+        b"audio",
+    )
+    assert account.add_reaction("om_original", "OK") is True
+    assert account.update_message("om_reply", "edited") == {}
+    assert account.delete_message("om_reply") is True
+
+    create = requests["create"]
+    assert create.receive_id_type == "open_id"
+    assert create.request_body.receive_id == "ou_allowed"
+    assert create.request_body.msg_type == "text"
+    assert json.loads(create.request_body.content) == {"text": "hello"}
+
+    reply = requests["reply"]
+    assert reply.message_id == "om_original"
+    assert json.loads(reply.request_body.content) == {"text": "reply"}
+
+    resource = requests["resource"]
+    assert resource.message_id == "om_original"
+    assert resource.file_key == "file-key"
+    assert resource.type == "file"
+
+    reaction = requests["reaction"]
+    assert reaction.message_id == "om_original"
+    assert reaction.request_body.reaction_type.emoji_type == "OK"
+
+    patch = requests["patch"]
+    assert patch.message_id == "om_reply"
+    assert json.loads(patch.request_body.content) == {"text": "edited"}
+    assert requests["delete"].message_id == "om_reply"
+
+
+def test_ws_loop_stops_channel_sdk_client_without_public_stop(monkeypatch) -> None:
+    fallback_loop = asyncio.new_event_loop()
+    sdk_module = SimpleNamespace(loop=fallback_loop)
+    monkeypatch.setattr(account_module, "_sdk_ws_client_module", sdk_module)
+
+    class _BlockingWsClient:
+        def __init__(self) -> None:
+            self.started = threading.Event()
+            self.disconnected = threading.Event()
+            self.loop: asyncio.AbstractEventLoop | None = None
+
+        def _set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+            self.loop = loop
+
+        def start(self) -> None:
+            assert self.loop is not None
+            self.started.set()
+            self.loop.run_forever()
+
+        async def _disconnect(self) -> None:
+            self.disconnected.set()
+
+    ws_client = _BlockingWsClient()
+    account = FeishuAccount("main", "app", "secret", ["ou_allowed"])
+    account._ws_client = ws_client
+    account._stop_event.clear()
+    account._ws_thread = threading.Thread(target=account._ws_loop, daemon=True)
+
+    try:
+        account._ws_thread.start()
+        assert ws_client.started.wait(timeout=2.0)
+
+        account.stop()
+
+        assert ws_client.disconnected.is_set()
+        assert account._ws_thread is None
+        assert account._ws_event_loop is None
+        assert ws_client.loop is not None and ws_client.loop.is_closed()
+    finally:
+        account.stop()
+        fallback_loop.close()


### PR DESCRIPTION
## Series

- Feishu Bot v1: **1/15**
- Tracking issue: #1139
- Follows: none (series root)
- Next planned after this PR merges: `feat(feishu): normalize inbound conversations`
- This description will be back-linked to the next PR once that PR is opened.

## Summary

- replace the Feishu transport dependency with `lark-channel-sdk>=1.2,<2`
- adapt the existing raw event dispatcher, generated REST requests, and per-account WebSocket lifecycle without changing the public 12-action tool surface
- keep MCP stdio stdout protocol-only and explicitly run the SDK in `security.mode="compat"`
- add focused coverage for the generated request shapes and the low-level SDK's private disconnect path

## Validation

- [x] `git diff --check`
- [x] `python -m pytest -q tests/test_feishu_toolfamily_ltpv2.py tests/test_feishu_channel_sdk_account.py tests/test_feishu_stdio_logging.py` — 13 passed
- [x] Existing allowlisted Bot gray rollout: startup, DM send/receive, reply, delete, reaction, seen/done feedback, stop, refresh, and post-refresh inbound delivery
- [x] Installed SDK version and committed `account.py` bytes verified before restoring the supervised Bot process

## Notes

- Public actions, account config, on-disk state, compound message IDs, and raw inbound callback shape are unchanged, so this PR does not update the Feishu usage skill or Anatomy/Contract documents.
- Outbound calls continue to use the generated low-level REST client, which performs one request and does not hide retries.
- The existing text-edit PATCH returns Feishu error `230001` for non-card messages. The same result was reproduced with both old and new SDKs; this refactor deliberately preserves that baseline and leaves the endpoint change to the rich-outbound slice.
- Gray evidence contains only scenario/result summaries. No credentials, IDs, original chat content, or raw logs are included.
