### PR TITLE
feat(feishu): normalize inbound conversations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     # here.
     "imapclient>=3.0.0",
     "msal>=1.37.0",
-    "lark-oapi>=1.4.0",
+    "lark-channel-sdk>=1.2,<2",
     "cryptography>=42.0.0",
     "qrcode>=7.4.0",
     "faster-whisper>=1.0.0",

--- a/src/lingtai/mcp_servers/feishu/SKILL.md
+++ b/src/lingtai/mcp_servers/feishu/SKILL.md
@@ -5,12 +5,14 @@ description: |
   when you need detail beyond the one-line action descriptions: receive_id vs
   receive_id_type (open_id/chat_id), send vs reply, check/read/search, placeholder
   + edit for long responses, contacts/accounts basics, the notification
-  transient-hook vs persistent-context split, and side-effect caveats.
+  transient-hook vs persistent-context split, normalized inbound conversations,
+  group @Bot routing, and side-effect caveats.
   Pulled on demand via action='manual'; you do not need to call it before every
   send.
-version: 1.3.0
-last_changed_at: 2026-07-29T00:00:00Z
+version: 1.4.0
+last_changed_at: 2026-08-02T00:00:00Z
 related_files:
+- src/lingtai/mcp_servers/feishu/account.py
 - src/lingtai/mcp_servers/feishu/manager.py
 - src/lingtai/mcp_servers/feishu/server.py
 - src/lingtai/mcp_servers/feishu/service.py
@@ -64,6 +66,24 @@ maintenance: |
 - `message_id` is the compound id returned by read/check
   (`{alias}:{chat_id}:{feishu_message_id}`); pass it back verbatim to
   `reply`/`edit`/`delete`.
+
+## INBOUND CONVERSATIONS
+
+- Direct messages are admitted without an `@Bot` mention. Group and topic
+  messages are admitted only when they explicitly mention this bot; `@all`
+  alone does not wake it.
+- `allowed_users`, when configured for an account, still filters the sender's
+  `open_id` in both direct and group chats. Saving a contact does not change
+  this admission rule.
+- `read` preserves the legacy fields and adds `thread_id`, `root_id`,
+  `reply_to`, resolved `mentions`, the SDK-normalized `content` union, normalized
+  sender identity fields, and the complete raw event under `feishu`.
+- For group commands, the normalized `text` removes this bot's own mention;
+  other resolved mentions remain visible. `content.kind` identifies the
+  original Feishu content family.
+- Topic/thread routing metadata is observational in this slice. Thread-aware
+  outbound reply behavior is introduced with rich outbound content; until then,
+  pass the compound message ID to `reply` as before.
 
 ## NOTIFICATIONS: TRANSIENT HOOK vs PERSISTENT CONTEXT
 

--- a/src/lingtai/mcp_servers/feishu/account.py
+++ b/src/lingtai/mcp_servers/feishu/account.py
@@ -1,6 +1,6 @@
 """FeishuAccount — single app credential, WebSocket listener + REST sender.
 
-One daemon thread per account runs the lark-oapi WebSocket client.
+One daemon thread per account runs the lark-channel-sdk WebSocket client.
 Constructor stores config only — no connections, no threads.
 start() spawns the WebSocket thread and initialises the REST client.
 stop() signals the thread to stop and joins it.
@@ -20,12 +20,12 @@ from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
-# lark_oapi is lazy-imported so the module stays importable without
+# lark_channel is lazy-imported so the module stays importable without
 # the optional dependency installed.
 lark: Any = None
 
-# The lark_oapi.ws.client module, captured lazily. Stored as a module global so
-# tests can inject a fake SDK module (see tests/test_ws_event_loop.py). The real
+# The lark_channel.ws.client module, captured lazily. Stored globally so tests
+# can inject a fake SDK module (see test_feishu_channel_sdk_account.py). The real
 # SDK keeps its own module-level ``loop`` attribute that ``Client.start()`` uses
 # directly — see ``_ThreadLocalLoop`` and ``_ws_loop`` for why that matters.
 _sdk_ws_client_module: Any = None
@@ -47,27 +47,27 @@ def _route_lark_stdout_handlers_to_stderr() -> None:
 def _import_lark() -> Any:
     global lark
     if lark is None:
-        import lark_oapi as _lark
+        import lark_channel as _lark
         lark = _lark
     _route_lark_stdout_handlers_to_stderr()
     return lark
 
 
 def _get_sdk_ws_client_module() -> Any:
-    """Return the ``lark_oapi.ws.client`` module (or an injected fake).
+    """Return the ``lark_channel.ws.client`` module (or an injected fake).
 
     Tests set ``_sdk_ws_client_module`` directly to a stand-in that exposes the
     same ``loop`` attribute contract as the real SDK module.
     """
     global _sdk_ws_client_module
     if _sdk_ws_client_module is None:
-        import lark_oapi.ws.client as _ws_client
+        import lark_channel.ws.client as _ws_client
         _sdk_ws_client_module = _ws_client
     return _sdk_ws_client_module
 
 
 class _ThreadLocalLoop:
-    """Per-thread proxy that stands in for ``lark_oapi.ws.client.loop``.
+    """Per-thread proxy that stands in for ``lark_channel.ws.client.loop``.
 
     The SDK captures ``loop = asyncio.get_event_loop()`` at *import time* into a
     module global, and ``Client.start()`` calls ``loop.run_until_complete(...)``
@@ -150,6 +150,8 @@ class FeishuAccount:
 
         self._ws_thread: threading.Thread | None = None
         self._ws_client: Any = None
+        self._ws_event_loop: asyncio.AbstractEventLoop | None = None
+        self._ws_loop_lock = threading.Lock()
         self._rest_client: Any = None
         self._stop_event = threading.Event()
         self._bot_info: dict | None = None
@@ -190,8 +192,9 @@ class FeishuAccount:
                     "Feishu event processing error (%s): %s", self.alias, exc
                 )
 
+        security = _lark.SecurityConfig(mode="compat")
         event_handler = (
-            _lark.EventDispatcherHandler.builder("", "")
+            _lark.EventDispatcherHandler.builder("", "", security=security)
             .register_p2_im_message_receive_v1(_handle_message)
             .build()
         )
@@ -203,6 +206,7 @@ class FeishuAccount:
             self._app_secret,
             event_handler=event_handler,
             log_level=_lark.LogLevel.INFO,
+            security=security,
         )
 
         self._ws_thread = threading.Thread(
@@ -220,8 +224,8 @@ class FeishuAccount:
     def _ws_loop(self) -> None:
         """Run the blocking WebSocket client in a background thread.
 
-        lark-oapi captures ``loop = asyncio.get_event_loop()`` into a *module
-        global* (``lark_oapi.ws.client.loop``) at import time, and
+        lark-channel-sdk captures ``loop = asyncio.get_event_loop()`` into a
+        *module global* (``lark_channel.ws.client.loop``) at import time, and
         ``Client.start()`` calls ``loop.run_until_complete(...)`` on that global
         — it never re-reads the thread-current loop. Imported on the main MCP
         thread under ``asyncio.run(serve())``, that global is the already-running
@@ -242,7 +246,14 @@ class FeishuAccount:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         proxy.bind(loop)
+        with self._ws_loop_lock:
+            self._ws_event_loop = loop
+        set_loop = getattr(self._ws_client, "_set_loop", None)
+        if callable(set_loop):
+            set_loop(loop)
         try:
+            if self._stop_event.is_set():
+                return
             self._ws_client.start()
         except Exception as e:
             if not self._stop_event.is_set():
@@ -251,7 +262,17 @@ class FeishuAccount:
                     self.alias, e,
                 )
         finally:
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending and not loop.is_closed():
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
             proxy.unbind()
+            with self._ws_loop_lock:
+                if self._ws_event_loop is loop:
+                    self._ws_event_loop = None
             try:
                 loop.close()
             finally:
@@ -260,14 +281,21 @@ class FeishuAccount:
     def stop(self) -> None:
         """Signal the WebSocket thread to stop."""
         self._stop_event.set()
-        if self._ws_client is not None:
-            try:
-                self._ws_client.stop()
-            except Exception:
-                pass
+        with self._ws_loop_lock:
+            loop = self._ws_event_loop
+        if loop is not None and not loop.is_closed():
+            disconnect = getattr(self._ws_client, "_disconnect", None)
+            if callable(disconnect) and loop.is_running():
+                try:
+                    future = asyncio.run_coroutine_threadsafe(disconnect(), loop)
+                    future.result(timeout=2.0)
+                except Exception:
+                    pass
+            loop.call_soon_threadsafe(loop.stop)
         if self._ws_thread is not None:
             self._ws_thread.join(timeout=5.0)
-            self._ws_thread = None
+            if not self._ws_thread.is_alive():
+                self._ws_thread = None
 
     # ------------------------------------------------------------------
     # Event processing
@@ -300,8 +328,10 @@ class FeishuAccount:
         text: str,
     ) -> dict:
         """Send a plain-text message. Returns created Message fields as dict."""
-        from lark_oapi.api.im.v1 import (
+        from lark_channel.api.im.v1.model.create_message_request import (
             CreateMessageRequest,
+        )
+        from lark_channel.api.im.v1.model.create_message_request_body import (
             CreateMessageRequestBody,
         )
 
@@ -331,8 +361,10 @@ class FeishuAccount:
 
     def reply_text(self, message_id: str, text: str) -> dict:
         """Reply to a specific message by Feishu message_id."""
-        from lark_oapi.api.im.v1 import (
+        from lark_channel.api.im.v1.model.reply_message_request import (
             ReplyMessageRequest,
+        )
+        from lark_channel.api.im.v1.model.reply_message_request_body import (
             ReplyMessageRequestBody,
         )
 
@@ -378,7 +410,9 @@ class FeishuAccount:
         Returns:
             (filename, content_bytes) tuple.
         """
-        from lark_oapi.api.im.v1 import GetMessageResourceRequest
+        from lark_channel.api.im.v1.model.get_message_resource_request import (
+            GetMessageResourceRequest,
+        )
 
         request = (
             GetMessageResourceRequest.builder()
@@ -411,9 +445,13 @@ class FeishuAccount:
         Returns:
             True on success.
         """
-        from lark_oapi.api.im.v1 import (
+        from lark_channel.api.im.v1.model.create_message_reaction_request import (
             CreateMessageReactionRequest,
+        )
+        from lark_channel.api.im.v1.model.create_message_reaction_request_body import (
             CreateMessageReactionRequestBody,
+        )
+        from lark_channel.api.im.v1.model.emoji import (
             Emoji,
         )
 
@@ -454,8 +492,10 @@ class FeishuAccount:
         Returns:
             Response dict (empty on success since PATCH returns no body).
         """
-        from lark_oapi.api.im.v1 import (
+        from lark_channel.api.im.v1.model.patch_message_request import (
             PatchMessageRequest,
+        )
+        from lark_channel.api.im.v1.model.patch_message_request_body import (
             PatchMessageRequestBody,
         )
 
@@ -486,7 +526,9 @@ class FeishuAccount:
         Returns:
             True on success.
         """
-        from lark_oapi.api.im.v1 import DeleteMessageRequest
+        from lark_channel.api.im.v1.model.delete_message_request import (
+            DeleteMessageRequest,
+        )
 
         request = (
             DeleteMessageRequest.builder()

--- a/src/lingtai/mcp_servers/feishu/account.py
+++ b/src/lingtai/mcp_servers/feishu/account.py
@@ -14,6 +14,8 @@ import os
 import sys
 import tempfile
 import threading
+from collections import OrderedDict
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -127,6 +129,14 @@ def _install_thread_local_sdk_loop(sdk: Any) -> _ThreadLocalLoop:
         return proxy
 
 
+@dataclass(frozen=True)
+class FeishuInboundEvent:
+    """SDK-normalized message paired with its complete Feishu event envelope."""
+
+    message: Any
+    feishu: dict[str, Any]
+
+
 class FeishuAccount:
     """Manages a single Feishu (Lark) app credential — WS polling + REST sending."""
 
@@ -152,10 +162,15 @@ class FeishuAccount:
         self._ws_client: Any = None
         self._ws_event_loop: asyncio.AbstractEventLoop | None = None
         self._ws_loop_lock = threading.Lock()
+        self._channel: Any = None
         self._rest_client: Any = None
         self._stop_event = threading.Event()
         self._bot_info: dict | None = None
+        self._bot_open_id: str | None = None
         self._last_verified_at: str | None = None
+        self._raw_envelopes: OrderedDict[str, dict[str, Any]] = OrderedDict()
+        self._raw_envelopes_lock = threading.Lock()
+        self._raw_envelopes_limit = 1000
 
         self._load_state()
 
@@ -170,34 +185,61 @@ class FeishuAccount:
 
         _lark = _import_lark()
 
-        # REST client (for sending)
-        self._rest_client = (
-            _lark.Client.builder()
-            .app_id(self._app_id)
-            .app_secret(self._app_secret)
-            .build()
+        # Use the SDK channel facade for inbound normalization while retaining
+        # the established low-level WS thread and generated REST actions. The
+        # facade owns the dispatcher/normalizer; its transport is deliberately
+        # not started here.
+        security = _lark.SecurityConfig(mode="compat")
+        self._channel = _lark.FeishuChannel(
+            app_id=self._app_id,
+            app_secret=self._app_secret,
+            inbound=_lark.InboundConfig(
+                expand_merge_forward=False,
+                fetch_interactive_card=False,
+                include_raw=True,
+                emit_raw_events=True,
+            ),
+            # The account-level gate below owns LingTai's legacy allowlist and
+            # exact DM/group routing semantics. Let ordinary group events reach
+            # it after normalization so a cached bot identity still works when
+            # the live identity lookup is temporarily unavailable. The SDK
+            # continues to reject @all-only messages before this boundary.
+            policy=_lark.PolicyConfig(
+                require_mention=False,
+                respond_to_mention_all=False,
+            ),
+            outbound=_lark.OutboundConfig(
+                retry=_lark.RetryConfig(max_attempts=1),
+            ),
+            # LingTai persists one durable record per Feishu event. Disable the
+            # SDK's default 600 ms text merge while retaining its per-chat
+            # serialization queue; otherwise rapid messages lose their own
+            # compound IDs and raw envelopes before manager persistence.
+            safety=_lark.SafetyConfig(
+                text_batch=_lark.TextBatchConfig(max_messages=1),
+            ),
+            security=security,
         )
+        self._rest_client = self._channel.client
 
-        # Store minimal bot info — full bot info API path varies by SDK version
-        self._bot_info = {"app_id": self._app_id}
+        # Preserve a previously resolved open_id for conservative group
+        # mention gating if the identity endpoint is temporarily unavailable.
+        self._bot_info = dict(self._bot_info or {})
+        self._bot_info["app_id"] = self._app_id
         self._last_verified_at = datetime.now(timezone.utc).isoformat()
         self._save_state()
 
-        # Event handler
-        def _handle_message(data: Any) -> None:
+        def _handle_message(message: Any) -> None:
             try:
-                self._process_event(data)
+                self._process_event(message)
             except Exception as exc:
                 logger.warning(
                     "Feishu event processing error (%s): %s", self.alias, exc
                 )
 
-        security = _lark.SecurityConfig(mode="compat")
-        event_handler = (
-            _lark.EventDispatcherHandler.builder("", "", security=security)
-            .register_p2_im_message_receive_v1(_handle_message)
-            .build()
-        )
+        self._channel.on(_lark.Events.RAW, self._capture_raw_envelope)
+        self._channel.on(_lark.Events.MESSAGE, _handle_message)
+        event_handler = self._channel.dispatcher
 
         # WebSocket client — start() blocks, run in daemon thread
         self._stop_event.clear()
@@ -254,6 +296,7 @@ class FeishuAccount:
         try:
             if self._stop_event.is_set():
                 return
+            self._resolve_bot_identity(loop)
             self._ws_client.start()
         except Exception as e:
             if not self._stop_event.is_set():
@@ -296,26 +339,103 @@ class FeishuAccount:
             self._ws_thread.join(timeout=5.0)
             if not self._ws_thread.is_alive():
                 self._ws_thread = None
+        if self._channel is not None:
+            try:
+                # The facade owns a normalization background loop but not this
+                # account's WS client, so stopping it cannot duplicate the
+                # transport shutdown above.
+                self._channel.stop()
+            except Exception as exc:
+                logger.debug("Feishu channel cleanup failed (%s): %s", self.alias, exc)
 
     # ------------------------------------------------------------------
     # Event processing
     # ------------------------------------------------------------------
 
-    def _process_event(self, data: Any) -> None:
-        """Filter by allowed_users and dispatch to on_message callback."""
-        event = getattr(data, "event", None)
-        if event is None:
+    def _resolve_bot_identity(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Resolve the bot open_id before WS delivery enables group @ gating."""
+        if self._channel is None:
             return
+        try:
+            identity = loop.run_until_complete(self._channel.resolve_bot_identity())
+        except Exception as exc:
+            logger.warning(
+                "Feishu bot identity resolution failed (%s); group messages "
+                "remain mention-gated using cached identity when available: %s",
+                self.alias,
+                exc,
+            )
+            identity = None
+        if identity is None:
+            return
+        self._bot_open_id = identity.open_id
+        self._bot_info = {
+            "app_id": identity.app_id or self._app_id,
+            "open_id": identity.open_id,
+            "user_id": identity.user_id,
+            "name": identity.name,
+        }
+        self._last_verified_at = datetime.now(timezone.utc).isoformat()
+        self._save_state()
 
-        sender = getattr(event, "sender", None)
-        sender_id = getattr(sender, "sender_id", None) if sender else None
-        open_id: str = getattr(sender_id, "open_id", "") if sender_id else ""
+    @staticmethod
+    def _raw_message_id(envelope: dict[str, Any]) -> str:
+        event = envelope.get("event")
+        if not isinstance(event, dict):
+            return ""
+        message = event.get("message")
+        if not isinstance(message, dict):
+            return ""
+        value = message.get("message_id")
+        return value if isinstance(value, str) else ""
+
+    def _capture_raw_envelope(self, envelope: dict[str, Any]) -> None:
+        """Retain the SDK raw envelope until its normalized message is emitted."""
+        if not isinstance(envelope, dict):
+            return
+        message_id = self._raw_message_id(envelope)
+        if not message_id:
+            return
+        with self._raw_envelopes_lock:
+            self._raw_envelopes[message_id] = envelope
+            self._raw_envelopes.move_to_end(message_id)
+            while len(self._raw_envelopes) > self._raw_envelopes_limit:
+                self._raw_envelopes.popitem(last=False)
+
+    def _take_raw_envelope(self, message_id: str) -> dict[str, Any]:
+        with self._raw_envelopes_lock:
+            return self._raw_envelopes.pop(message_id, {})
+
+    def _process_event(self, message: Any) -> None:
+        """Apply legacy allowlist + DM/group routing to one normalized message."""
+        message_id = getattr(message, "id", "") or ""
+        raw_envelope = self._take_raw_envelope(message_id)
+        sender = getattr(message, "sender", None)
+        open_id = getattr(sender, "open_id", "") if sender else ""
 
         if self._allowed_users is not None and open_id not in self._allowed_users:
             return
 
+        conversation = getattr(message, "conversation", None)
+        chat_type = getattr(conversation, "chat_type", "unknown")
+        if chat_type != "p2p":
+            mentioned_bot = bool(getattr(message, "mentioned_bot", False))
+            if not mentioned_bot and self._bot_open_id:
+                mentioned_bot = any(
+                    getattr(mention, "open_id", None) == self._bot_open_id
+                    for mention in (getattr(message, "mentions", None) or [])
+                )
+            if not mentioned_bot:
+                return
+
         if self._on_message:
-            self._on_message(self.alias, data)
+            self._on_message(
+                self.alias,
+                FeishuInboundEvent(
+                    message=message,
+                    feishu=raw_envelope,
+                ),
+            )
 
     # ------------------------------------------------------------------
     # Sending
@@ -581,6 +701,9 @@ class FeishuAccount:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             self._bot_info = data.get("bot_info")
+            if isinstance(self._bot_info, dict):
+                open_id = self._bot_info.get("open_id")
+                self._bot_open_id = open_id if isinstance(open_id, str) else None
             self._last_verified_at = data.get("last_verified_at")
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Failed to load Feishu state: %s", e)

--- a/src/lingtai/mcp_servers/feishu/manager.py
+++ b/src/lingtai/mcp_servers/feishu/manager.py
@@ -18,6 +18,7 @@ import re
 import tempfile
 import threading
 from collections import OrderedDict
+from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 from importlib import resources
 from pathlib import Path
@@ -26,6 +27,7 @@ from uuid import uuid4
 
 from .. import _skill
 from . import _family
+from .account import FeishuInboundEvent
 from lingtai.kernel._frontmatter import strip_frontmatter
 
 if TYPE_CHECKING:
@@ -66,6 +68,61 @@ _CONVERSATION_PREVIEW_MESSAGES = 10
 # messages carry text_truncated=true so the agent knows to feishu.read for the
 # exact producer state.
 _STRUCTURED_MESSAGE_TEXT_CAP = 500
+_STRUCTURED_MESSAGE_MENTION_CAP = 20
+
+
+def _normalized_content_payload(content: object, message_type: str) -> dict:
+    """Project one SDK content union without duplicating its raw wire body."""
+    if is_dataclass(content):
+        value = asdict(content)
+    elif isinstance(content, dict):
+        value = dict(content)
+    else:
+        value = {}
+    value.pop("raw", None)
+    value.setdefault("kind", message_type or "unknown")
+    return value
+
+
+def _normalized_mentions_payload(mentions: object) -> list[dict]:
+    result: list[dict] = []
+    if not isinstance(mentions, (list, tuple)):
+        return result
+    for mention in mentions:
+        if is_dataclass(mention):
+            item = asdict(mention)
+        elif isinstance(mention, dict):
+            item = dict(mention)
+        else:
+            item = {
+                key: getattr(mention, key, None)
+                for key in (
+                    "key", "open_id", "union_id", "user_id", "name",
+                    "is_bot", "tenant_key",
+                )
+            }
+        result.append({key: value for key, value in item.items() if value is not None})
+    return result
+
+
+def _legacy_envelope_payload(value: object) -> object:
+    """JSON-safe fallback for pre-normalized callback fixtures/callers."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _legacy_envelope_payload(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_legacy_envelope_payload(item) for item in value]
+    if is_dataclass(value):
+        return _legacy_envelope_payload(asdict(value))
+    fields = getattr(value, "__dict__", None)
+    if isinstance(fields, dict):
+        return {
+            key: _legacy_envelope_payload(item)
+            for key, item in fields.items()
+            if not key.startswith("_")
+        }
+    return str(value)
 
 
 class TypingIndicatorManager:
@@ -405,15 +462,121 @@ class FeishuManager:
     def on_incoming(self, account_alias: str, data: object) -> None:
         """Persist an incoming Feishu message event to disk and notify agent."""
         try:
-            event = getattr(data, "event", None)
-            if event is None:
-                return
-            message = getattr(event, "message", None)
-            sender = getattr(event, "sender", None)
-            if message is None or sender is None:
-                return
+            if isinstance(data, FeishuInboundEvent):
+                inbound = data.message
+                conversation = getattr(inbound, "conversation", None)
+                sender = getattr(inbound, "sender", None)
+                if conversation is None or sender is None:
+                    return
+                feishu_msg_id = getattr(inbound, "id", "") or ""
+                chat_id = getattr(conversation, "chat_id", "") or ""
+                chat_type = getattr(conversation, "chat_type", "unknown") or "unknown"
+                thread_id = getattr(conversation, "thread_id", None) or ""
+                msg_type = (
+                    getattr(inbound, "raw_content_type", "")
+                    or getattr(getattr(inbound, "content", None), "kind", "")
+                    or "unknown"
+                )
+                create_time = str(getattr(inbound, "create_time", 0) or "")
+                raw_message = getattr(inbound, "raw", None)
+                raw_message = raw_message if isinstance(raw_message, dict) else {}
+                parent_id = raw_message.get("parent_id") or ""
+                root_id = raw_message.get("root_id") or ""
+                if not parent_id:
+                    reply = getattr(inbound, "reply", None)
+                    parent_id = getattr(reply, "message_id", "") if reply else ""
+                open_id = getattr(sender, "open_id", "") or ""
+                user_id = getattr(sender, "user_id", None)
+                union_id = getattr(sender, "union_id", None)
+                sender_name = getattr(sender, "display_name", None)
+                sender_type = getattr(sender, "sender_type", None)
+                sender_is_bot = bool(getattr(sender, "is_bot", False))
+                content_obj = getattr(inbound, "content", None)
+                content_data = getattr(content_obj, "raw", None)
+                content_data = content_data if isinstance(content_data, dict) else {}
+                normalized_content = _normalized_content_payload(content_obj, msg_type)
+                mentions = _normalized_mentions_payload(
+                    getattr(inbound, "mentions", None)
+                )
+                body_text = getattr(inbound, "body_text", None)
+                text = (
+                    body_text
+                    if isinstance(body_text, str)
+                    else (getattr(inbound, "content_text", "") or "")
+                )
+                raw_envelope = data.feishu
+            else:
+                # Backward-compatible callback shape used by older callers and
+                # fixtures. Live SDK delivery uses FeishuInboundEvent above.
+                event = getattr(data, "event", None)
+                if event is None:
+                    return
+                message = getattr(event, "message", None)
+                sender = getattr(event, "sender", None)
+                if message is None or sender is None:
+                    return
+                feishu_msg_id = getattr(message, "message_id", "") or ""
+                chat_id = getattr(message, "chat_id", "") or ""
+                chat_type = getattr(message, "chat_type", "p2p") or "p2p"
+                thread_id = getattr(message, "thread_id", "") or ""
+                msg_type = getattr(message, "message_type", "text") or "text"
+                content_str = getattr(message, "content", "{}") or "{}"
+                create_time = getattr(message, "create_time", "") or ""
+                parent_id = getattr(message, "parent_id", "") or ""
+                root_id = getattr(message, "root_id", "") or ""
+                sender_id = getattr(sender, "sender_id", None)
+                open_id = (
+                    (getattr(sender_id, "open_id", "") or "") if sender_id else ""
+                )
+                user_id = getattr(sender_id, "user_id", None) if sender_id else None
+                union_id = getattr(sender_id, "union_id", None) if sender_id else None
+                sender_name = None
+                sender_type = getattr(sender, "sender_type", None)
+                sender_is_bot = sender_type in {"bot", "app"}
+                try:
+                    content_data = json.loads(content_str)
+                except (json.JSONDecodeError, AttributeError):
+                    content_data = {}
+                normalized_content = {
+                    "kind": msg_type,
+                    **content_data,
+                }
+                mentions = _normalized_mentions_payload(
+                    getattr(message, "mentions", None)
+                )
+                raw_envelope = _legacy_envelope_payload(data)
 
-            feishu_msg_id: str = getattr(message, "message_id", "") or ""
+                if msg_type == "text":
+                    text = content_data.get("text", "")
+                elif msg_type == "audio":
+                    text = ""
+                elif msg_type == "image":
+                    text = content_data.get("text", "") or "[Image]"
+                elif msg_type == "file":
+                    text = content_data.get("text", "") or "[File]"
+                elif msg_type == "sticker":
+                    text = "[Sticker]"
+                elif msg_type == "interactive":
+                    text = content_data.get("text", "") or "[Interactive card]"
+                elif msg_type == "post":
+                    post_content = content_data.get("content", {})
+                    title = content_data.get("title", "")
+                    text_parts = [title] if title else []
+                    if isinstance(post_content, dict):
+                        for paragraphs in post_content.values():
+                            if isinstance(paragraphs, list):
+                                for para in paragraphs:
+                                    if isinstance(para, list):
+                                        for elem in para:
+                                            if (
+                                                isinstance(elem, dict)
+                                                and elem.get("tag") == "text"
+                                            ):
+                                                text_parts.append(elem.get("text", ""))
+                    text = " ".join(text_parts).strip() or "[Rich text message]"
+                else:
+                    text = content_data.get("text", "") or f"[{msg_type} message]"
+
             if feishu_msg_id and self._is_duplicate_event(
                 account_alias, feishu_msg_id,
             ):
@@ -422,59 +585,7 @@ class FeishuManager:
                     feishu_msg_id, account_alias,
                 )
                 return
-            chat_id: str = getattr(message, "chat_id", "") or ""
-            chat_type: str = getattr(message, "chat_type", "p2p") or "p2p"
-            msg_type: str = getattr(message, "message_type", "text") or "text"
-            content_str: str = getattr(message, "content", "{}") or "{}"
-            create_time: str = getattr(message, "create_time", "") or ""
-            parent_id: str = getattr(message, "parent_id", "") or ""
-
-            sender_id = getattr(sender, "sender_id", None)
-            open_id: str = (
-                (getattr(sender_id, "open_id", "") or "") if sender_id else ""
-            )
-
-            # Parse content based on message type
-            text = ""
             media_info: dict | None = None
-            content_data: dict = {}
-            try:
-                content_data = json.loads(content_str)
-            except (json.JSONDecodeError, AttributeError):
-                content_data = {}
-
-            if msg_type == "text":
-                text = content_data.get("text", "")
-            elif msg_type == "audio":
-                # Audio/voice message — will be transcribed below
-                text = ""
-            elif msg_type == "image":
-                text = content_data.get("text", "") or "[Image]"
-            elif msg_type == "file":
-                text = content_data.get("text", "") or "[File]"
-            elif msg_type == "sticker":
-                text = "[Sticker]"
-            elif msg_type == "interactive":
-                text = content_data.get("text", "") or "[Interactive card]"
-            elif msg_type == "post":
-                # Rich text — extract plain text from the post content
-                post_content = content_data.get("content", {})
-                title = content_data.get("title", "")
-                # Flatten the post content to extract text
-                text_parts = []
-                if title:
-                    text_parts.append(title)
-                if isinstance(post_content, dict):
-                    for _lang, paragraphs in post_content.items():
-                        if isinstance(paragraphs, list):
-                            for para in paragraphs:
-                                if isinstance(para, list):
-                                    for elem in para:
-                                        if isinstance(elem, dict) and elem.get("tag") == "text":
-                                            text_parts.append(elem.get("text", ""))
-                text = " ".join(text_parts).strip() or "[Rich text message]"
-            else:
-                text = content_data.get("text", "") or f"[{msg_type} message]"
 
             if create_time:
                 try:
@@ -496,13 +607,26 @@ class FeishuManager:
                 "feishu_message_id": feishu_msg_id,
                 "chat_id": chat_id,
                 "chat_type": chat_type,
+                "thread_id": thread_id or None,
                 "message_type": msg_type,
                 "from_open_id": open_id,
+                "from_user_id": user_id,
+                "from_union_id": union_id,
+                "from_name": sender_name,
+                "sender_type": sender_type,
+                "sender_is_bot": sender_is_bot,
                 "text": text,
                 "date": date_str,
                 "parent_id": parent_id,
+                "root_id": root_id,
+                "reply_to": (
+                    f"{account_alias}:{chat_id}:{parent_id}" if parent_id else None
+                ),
+                "mentions": mentions,
+                "content": normalized_content,
                 "media": None,
                 "voice_transcript": None,
+                "feishu": raw_envelope,
             }
 
             msg_uuid = str(uuid4())
@@ -615,7 +739,11 @@ class FeishuManager:
         # carries routing keys plus the structured recent_messages /
         # latest_incoming context the kernel moves into the persistent
         # notification lane.
-        display_name = self._get_contact_name(account_alias, open_id) or open_id
+        display_name = (
+            payload.get("from_name")
+            or self._get_contact_name(account_alias, open_id)
+            or open_id
+        )
         try:
             preview, preview_metadata = self._build_conversation_preview_and_metadata(
                 account_alias, chat_id, compound_id,
@@ -647,6 +775,7 @@ class FeishuManager:
                     "account": account_alias,
                     "chat_id": chat_id,
                     "chat_type": chat_type,
+                    "thread_id": thread_id or None,
                     "from_open_id": open_id,
                     # Generic LICC preview metadata copied into
                     # .notification/mcp.feishu.json.  Keep both the legacy
@@ -754,7 +883,12 @@ class FeishuManager:
         if message.get("_folder") == "sent":
             return "me"
         open_id = message.get("from_open_id", "") or ""
-        return self._get_contact_name(account_alias, open_id) or open_id or "unknown"
+        return (
+            message.get("from_name")
+            or self._get_contact_name(account_alias, open_id)
+            or open_id
+            or "unknown"
+        )
 
     @staticmethod
     def _message_display_text(message: dict) -> str:
@@ -796,6 +930,17 @@ class FeishuManager:
             "text": text,
             "text_truncated": text_truncated,
         }
+        message_type = message.get("message_type")
+        if message_type:
+            item["type"] = message_type
+        thread_id = message.get("thread_id")
+        if thread_id:
+            item["thread_id"] = thread_id
+        mentions = message.get("mentions")
+        if isinstance(mentions, list) and mentions:
+            item["mentions"] = mentions[:_STRUCTURED_MESSAGE_MENTION_CAP]
+            if len(mentions) > _STRUCTURED_MESSAGE_MENTION_CAP:
+                item["mentions_truncated"] = True
         if current_compound_id and cid == current_compound_id:
             item["is_current"] = True
         if message.get("media"):
@@ -1109,6 +1254,7 @@ class FeishuManager:
                 conversations[cid] = {
                     "chat_id": cid,
                     "chat_type": msg.get("chat_type", "p2p"),
+                    "last_thread_id": msg.get("thread_id"),
                     "last_from_open_id": last_from_open_id,
                     "last_from_name": name,
                     "last_text": (msg.get("text") or "")[:100],
@@ -1160,22 +1306,35 @@ class FeishuManager:
             outgoing = self._is_outgoing_record(m)
             name = (
                 "me" if outgoing
-                else self._get_contact_name(account, m.get("from_open_id", ""))
+                else (
+                    m.get("from_name")
+                    or self._get_contact_name(account, m.get("from_open_id", ""))
+                )
             )
             cleaned.append({
                 "id": m.get("id"),
                 "feishu_message_id": m.get("feishu_message_id"),
                 "chat_id": m.get("chat_id"),
                 "chat_type": m.get("chat_type"),
+                "thread_id": m.get("thread_id"),
                 "from_open_id": m.get("from_open_id"),
+                "from_user_id": m.get("from_user_id"),
+                "from_union_id": m.get("from_union_id"),
                 "from_name": name,
+                "sender_type": m.get("sender_type"),
+                "sender_is_bot": m.get("sender_is_bot"),
                 "to": m.get("to"),
                 "message_type": m.get("message_type"),
                 "text": m.get("text"),
                 "date": m.get("date"),
                 "parent_id": m.get("parent_id"),
+                "root_id": m.get("root_id"),
+                "reply_to": m.get("reply_to"),
+                "mentions": m.get("mentions", []),
+                "content": m.get("content"),
                 "media": m.get("media"),
                 "voice_transcript": m.get("voice_transcript"),
+                "feishu": m.get("feishu"),
                 "_direction": "outgoing" if outgoing else "incoming",
             })
 
@@ -1257,7 +1416,10 @@ class FeishuManager:
         for msg in messages:
             if target_chat and msg.get("chat_id") != target_chat:
                 continue
-            name = self._get_contact_name(account, msg.get("from_open_id", ""))
+            name = (
+                msg.get("from_name")
+                or self._get_contact_name(account, msg.get("from_open_id", ""))
+            )
             searchable = " ".join([
                 msg.get("from_open_id", ""),
                 name,
@@ -1269,8 +1431,14 @@ class FeishuManager:
                     "from_open_id": msg.get("from_open_id"),
                     "from_name": name,
                     "chat_id": msg.get("chat_id"),
+                    "thread_id": msg.get("thread_id"),
                     "date": msg.get("date"),
                     "text": msg.get("text"),
+                    "parent_id": msg.get("parent_id"),
+                    "root_id": msg.get("root_id"),
+                    "reply_to": msg.get("reply_to"),
+                    "mentions": msg.get("mentions", []),
+                    "content": msg.get("content"),
                 })
 
         return {"status": "ok", "total": len(matches), "messages": matches}

--- a/src/lingtai/mcp_servers/feishu/manager.py
+++ b/src/lingtai/mcp_servers/feishu/manager.py
@@ -289,7 +289,7 @@ class FeishuManager:
         self._last_sent: dict[tuple[str, str, str], int] = {}
         self._dup_free_passes = 2
         # Incoming event dedupe: per-account FIFO of recently-seen
-        # feishu_message_id values. Protects against lark-oapi WS
+        # feishu_message_id values. Protects against Feishu SDK WS
         # reconnect redelivery (issue #5). Bounded; oldest evicted first.
         self._seen_msg_ids: dict[str, OrderedDict[str, None]] = {}
         self._dedupe_lock = threading.Lock()

--- a/src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
+++ b/src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md
@@ -5,7 +5,7 @@ description: >
   into _meta.agent_meta.notifications.attention and _meta.agent_meta.notifications.persistent.
 status: active
 contract_version: 2
-last_changed_at: "2026-07-15"
+last_changed_at: "2026-08-02"
 related_files:
   - docs/references/licc-notification-wake-runbook.md
   - src/lingtai/tools/mcp/ANATOMY.md
@@ -13,6 +13,7 @@ related_files:
   - src/lingtai/services/mcp_licc.py
   - src/lingtai/mcp_servers/ANATOMY.md
   - src/lingtai/mcp_servers/telegram/manager.py
+  - src/lingtai/mcp_servers/feishu/account.py
   - src/lingtai/mcp_servers/feishu/manager.py
   - src/lingtai/mcp_servers/wechat/manager.py
   - src/lingtai/mcp_servers/whatsapp/manager.py
@@ -38,6 +39,7 @@ review_triggers:
   - src/lingtai/services/mcp_licc.py
   - src/lingtai/mcp_servers/telegram/manager.py
   - src/lingtai/mcp_servers/imap/manager.py
+  - src/lingtai/mcp_servers/feishu/account.py
   - src/lingtai/mcp_servers/feishu/manager.py
   - src/lingtai/mcp_servers/wechat/manager.py
   - src/lingtai/mcp_servers/whatsapp/manager.py
@@ -138,7 +140,9 @@ where they share the `.notification/` filesystem protocol.
    MCP supplies `recent_messages` and `latest_incoming` built from its merged
    inbox+sent preview window with per-message text bounded at 500 chars
    (`src/lingtai/mcp_servers/wechat/manager.py:835-956`); Feishu supplies the
-   same bounded structured fields from its merged inbox+sent preview window; and
+   same bounded structured fields from its merged inbox+sent preview window,
+   adding normalized message type, topic `thread_id`, and a capped resolved
+   mention list when present; and
    WhatsApp supplies a bounded current snapshot from its local inbox/sent store
    without raw Cloud API payloads. Each delta lane's seed/delta boundary matches
    its producer preview window (Telegram 20, WeChat 10, Feishu 10).
@@ -311,6 +315,12 @@ includes the non-secret boolean `taskcard` on every item in `recent_messages`,
 persistent lane preserve that field without moving it into the transient identity
 hook.
 
+Feishu's structured items may additionally carry `type`, `thread_id`, resolved
+`mentions` (at most 20 per message), and `mentions_truncated=true` when that cap
+is exceeded. The complete raw Feishu event and normalized content union remain
+in the producer's durable message record/read surface; they MUST NOT be copied
+into bounded LICC preview metadata or the transient attention hook.
+
 ## State
 
 Persistent/on-disk state involved in this contract:
@@ -371,7 +381,9 @@ Re-check this contract whenever a change touches any of these areas:
   `_meta.agent_meta.notifications.persistent.mcp.wechat`. WeChat inbox/sent records and
   `wechat.read` remain source of truth.
 - **Feishu:** compliant with the content split. The producer attaches bounded
-  `recent_messages`/`latest_incoming` plus generic routing keys; transient
+  `recent_messages`/`latest_incoming` plus generic routing keys. Its structured
+  items preserve additive topic/reply/mention context without copying the full
+  raw Feishu envelope; transient
   `_meta.agent_meta.notifications.attention.mcp.feishu` is identity-only; content/context lives in
   the Feishu delta lane at `_meta.agent_meta.notifications.persistent.mcp.feishu`.
 - **WhatsApp:** compliant with the content split. The producer attaches bounded

--- a/tests/test_feishu_channel_sdk_account.py
+++ b/tests/test_feishu_channel_sdk_account.py
@@ -1,0 +1,158 @@
+"""Focused compatibility coverage for the low-level lark-channel-sdk adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import threading
+from types import SimpleNamespace
+
+from lingtai.mcp_servers.feishu import account as account_module
+from lingtai.mcp_servers.feishu.account import FeishuAccount
+
+
+class _Success:
+    def __init__(self, **values: object) -> None:
+        self.code = 0
+        self.msg = "ok"
+        for key, value in values.items():
+            setattr(self, key, value)
+
+    def success(self) -> bool:
+        return True
+
+
+def test_outbound_methods_use_channel_sdk_generated_models() -> None:
+    requests: dict[str, object] = {}
+
+    class _Message:
+        def create(self, request: object) -> _Success:
+            requests["create"] = request
+            return _Success(
+                data=SimpleNamespace(
+                    message_id="om_created",
+                    chat_id="oc_chat",
+                    create_time="123",
+                )
+            )
+
+        def reply(self, request: object) -> _Success:
+            requests["reply"] = request
+            return _Success(
+                data=SimpleNamespace(message_id="om_reply", chat_id="oc_chat")
+            )
+
+        def patch(self, request: object) -> _Success:
+            requests["patch"] = request
+            return _Success()
+
+        def delete(self, request: object) -> _Success:
+            requests["delete"] = request
+            return _Success()
+
+    class _MessageResource:
+        def get(self, request: object) -> _Success:
+            requests["resource"] = request
+            return _Success(file_name="voice.ogg", file=io.BytesIO(b"audio"))
+
+    class _MessageReaction:
+        def create(self, request: object) -> _Success:
+            requests["reaction"] = request
+            return _Success()
+
+    rest_client = SimpleNamespace(
+        im=SimpleNamespace(
+            v1=SimpleNamespace(
+                message=_Message(),
+                message_resource=_MessageResource(),
+                message_reaction=_MessageReaction(),
+            )
+        )
+    )
+    account = FeishuAccount("main", "app", "secret", ["ou_allowed"])
+    account._rest_client = rest_client
+
+    assert account.send_text("ou_allowed", "open_id", "hello") == {
+        "message_id": "om_created",
+        "chat_id": "oc_chat",
+        "create_time": "123",
+    }
+    assert account.reply_text("om_original", "reply") == {
+        "message_id": "om_reply",
+        "chat_id": "oc_chat",
+    }
+    assert account.get_message_resource("om_original", "file-key") == (
+        "voice.ogg",
+        b"audio",
+    )
+    assert account.add_reaction("om_original", "OK") is True
+    assert account.update_message("om_reply", "edited") == {}
+    assert account.delete_message("om_reply") is True
+
+    create = requests["create"]
+    assert create.receive_id_type == "open_id"
+    assert create.request_body.receive_id == "ou_allowed"
+    assert create.request_body.msg_type == "text"
+    assert json.loads(create.request_body.content) == {"text": "hello"}
+
+    reply = requests["reply"]
+    assert reply.message_id == "om_original"
+    assert json.loads(reply.request_body.content) == {"text": "reply"}
+
+    resource = requests["resource"]
+    assert resource.message_id == "om_original"
+    assert resource.file_key == "file-key"
+    assert resource.type == "file"
+
+    reaction = requests["reaction"]
+    assert reaction.message_id == "om_original"
+    assert reaction.request_body.reaction_type.emoji_type == "OK"
+
+    patch = requests["patch"]
+    assert patch.message_id == "om_reply"
+    assert json.loads(patch.request_body.content) == {"text": "edited"}
+    assert requests["delete"].message_id == "om_reply"
+
+
+def test_ws_loop_stops_channel_sdk_client_without_public_stop(monkeypatch) -> None:
+    fallback_loop = asyncio.new_event_loop()
+    sdk_module = SimpleNamespace(loop=fallback_loop)
+    monkeypatch.setattr(account_module, "_sdk_ws_client_module", sdk_module)
+
+    class _BlockingWsClient:
+        def __init__(self) -> None:
+            self.started = threading.Event()
+            self.disconnected = threading.Event()
+            self.loop: asyncio.AbstractEventLoop | None = None
+
+        def _set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+            self.loop = loop
+
+        def start(self) -> None:
+            assert self.loop is not None
+            self.started.set()
+            self.loop.run_forever()
+
+        async def _disconnect(self) -> None:
+            self.disconnected.set()
+
+    ws_client = _BlockingWsClient()
+    account = FeishuAccount("main", "app", "secret", ["ou_allowed"])
+    account._ws_client = ws_client
+    account._stop_event.clear()
+    account._ws_thread = threading.Thread(target=account._ws_loop, daemon=True)
+
+    try:
+        account._ws_thread.start()
+        assert ws_client.started.wait(timeout=2.0)
+
+        account.stop()
+
+        assert ws_client.disconnected.is_set()
+        assert account._ws_thread is None
+        assert account._ws_event_loop is None
+        assert ws_client.loop is not None and ws_client.loop.is_closed()
+    finally:
+        account.stop()
+        fallback_loop.close()

--- a/tests/test_feishu_channel_sdk_account.py
+++ b/tests/test_feishu_channel_sdk_account.py
@@ -8,8 +8,10 @@ import json
 import threading
 from types import SimpleNamespace
 
+import lark_channel as lark_channel_sdk
+
 from lingtai.mcp_servers.feishu import account as account_module
-from lingtai.mcp_servers.feishu.account import FeishuAccount
+from lingtai.mcp_servers.feishu.account import FeishuAccount, FeishuInboundEvent
 
 
 class _Success:
@@ -156,3 +158,117 @@ def test_ws_loop_stops_channel_sdk_client_without_public_stop(monkeypatch) -> No
     finally:
         account.stop()
         fallback_loop.close()
+
+
+def _normalized_message(
+    message_id: str,
+    *,
+    open_id: str = "ou_allowed",
+    chat_type: str = "p2p",
+    mentioned_bot: bool = False,
+    mentions: list[SimpleNamespace] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=message_id,
+        sender=SimpleNamespace(open_id=open_id),
+        conversation=SimpleNamespace(chat_id="oc_chat", chat_type=chat_type),
+        mentioned_bot=mentioned_bot,
+        mentions=mentions or [],
+    )
+
+
+def test_start_keeps_routing_in_account_and_disables_sdk_text_merging(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _Channel:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+            self.client = object()
+            self.dispatcher = object()
+
+        def on(self, _event: str, _handler: object) -> None:
+            pass
+
+        def stop(self) -> None:
+            pass
+
+    fake_lark = SimpleNamespace(
+        FeishuChannel=_Channel,
+        InboundConfig=lark_channel_sdk.InboundConfig,
+        LogLevel=lark_channel_sdk.LogLevel,
+        OutboundConfig=lark_channel_sdk.OutboundConfig,
+        PolicyConfig=lark_channel_sdk.PolicyConfig,
+        RetryConfig=lark_channel_sdk.RetryConfig,
+        SafetyConfig=lark_channel_sdk.SafetyConfig,
+        SecurityConfig=lark_channel_sdk.SecurityConfig,
+        TextBatchConfig=lark_channel_sdk.TextBatchConfig,
+        Events=lark_channel_sdk.Events,
+        ws=SimpleNamespace(Client=lambda *_args, **_kwargs: object()),
+    )
+    monkeypatch.setattr(account_module, "_import_lark", lambda: fake_lark)
+
+    account = FeishuAccount("main", "app", "secret", ["ou_allowed"])
+    monkeypatch.setattr(account, "_ws_loop", lambda: None)
+    account.start()
+    account.stop()
+
+    policy = captured["policy"]
+    assert policy.require_mention is False
+    assert policy.respond_to_mention_all is False
+    safety = captured["safety"]
+    assert safety.text_batch.max_messages == 1
+    outbound = captured["outbound"]
+    assert outbound.retry.max_attempts == 1
+    assert captured["security"].mode == "compat"
+
+
+def test_normalized_routing_preserves_allowlist_and_requires_group_mention() -> None:
+    seen: list[tuple[str, FeishuInboundEvent]] = []
+    account = FeishuAccount(
+        "main",
+        "app",
+        "secret",
+        ["ou_allowed"],
+        on_message=lambda alias, event: seen.append((alias, event)),
+    )
+    account._bot_open_id = "ou_bot"
+
+    envelopes = {
+        message_id: {
+            "schema": "2.0",
+            "header": {"event_id": f"event-{message_id}"},
+            "event": {"message": {"message_id": message_id}},
+        }
+        for message_id in ("om_dm", "om_plain_group", "om_group", "om_cached")
+    }
+    for envelope in envelopes.values():
+        account._capture_raw_envelope(envelope)
+
+    # Legacy allowlist semantics still apply to direct messages.
+    account._process_event(_normalized_message("om_denied", open_id="ou_denied"))
+    account._process_event(_normalized_message("om_dm"))
+    # Groups do not wake without an explicit @Bot.
+    account._process_event(_normalized_message("om_plain_group", chat_type="group"))
+    account._process_event(
+        _normalized_message("om_group", chat_type="group", mentioned_bot=True)
+    )
+    # A resolved mention also supports conservative cached-identity gating.
+    account._process_event(
+        _normalized_message(
+            "om_cached",
+            chat_type="topic",
+            mentions=[SimpleNamespace(open_id="ou_bot")],
+        )
+    )
+
+    assert [event.message.id for _alias, event in seen] == [
+        "om_dm",
+        "om_group",
+        "om_cached",
+    ]
+    assert all(alias == "main" for alias, _event in seen)
+    assert seen[0][1].feishu == envelopes["om_dm"]
+    assert seen[1][1].feishu == envelopes["om_group"]
+    assert seen[2][1].feishu == envelopes["om_cached"]

--- a/tests/test_feishu_notification_metadata.py
+++ b/tests/test_feishu_notification_metadata.py
@@ -14,8 +14,12 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+from lark_channel import Conversation, Identity, InboundMessage, Mention, TextContent
+
+from lingtai.mcp_servers.feishu.account import FeishuInboundEvent
 from lingtai.mcp_servers.feishu.manager import (
     _CONVERSATION_PREVIEW_MESSAGES,
+    _STRUCTURED_MESSAGE_MENTION_CAP,
     _STRUCTURED_MESSAGE_TEXT_CAP,
     FeishuManager,
 )
@@ -47,6 +51,9 @@ def _write_message(
     text: str,
     date: str,
     parent_id: str = "",
+    thread_id: str | None = None,
+    message_type: str = "text",
+    mentions: list[dict] | None = None,
     media: dict | None = None,
 ) -> str:
     compound_id = f"{account}:{chat_id}:{msg_id}"
@@ -57,10 +64,12 @@ def _write_message(
         "feishu_message_id": msg_id,
         "chat_id": chat_id,
         "chat_type": "p2p",
-        "message_type": "text",
+        "thread_id": thread_id,
+        "message_type": message_type,
         "from_open_id": "ou_jason",
         "text": text,
         "parent_id": parent_id,
+        "mentions": mentions or [],
         "media": media,
         "voice_transcript": None,
     }
@@ -229,3 +238,121 @@ def test_on_incoming_licc_event_carries_routing_and_structured_context(tmp_path)
     assert metadata["message_id"] == "main:oc_chat:om_new"
     assert metadata["chat_id"] == "oc_chat"
     assert metadata["account"] == "main"
+
+
+def _sdk_incoming_event(*, body_text: str) -> FeishuInboundEvent:
+    inbound = InboundMessage(
+        id="om_normalized",
+        create_time=0,
+        conversation=Conversation(
+            chat_id="oc_topic",
+            chat_type="topic",
+            thread_id="omt_thread",
+        ),
+        sender=Identity(
+            open_id="ou_sender",
+            union_id="on_sender",
+            user_id="user_sender",
+            display_name="Sender",
+            sender_type="user",
+        ),
+        mentions=[
+            Mention(key="@_user_1", open_id="ou_bot", name="Mac PA", is_bot=True),
+            Mention(key="@_user_2", open_id="ou_other", name="Other"),
+        ],
+        content=TextContent(raw={"text": "@_user_1 hello"}, text="@Mac PA hello"),
+        raw={"parent_id": "om_parent", "root_id": "om_root"},
+        content_text="@Mac PA hello",
+        body_text=body_text,
+        mentioned_bot=True,
+        raw_content_type="text",
+    )
+    envelope = {
+        "schema": "2.0",
+        "header": {"event_id": "event-normalized"},
+        "event": {"message": {"message_id": "om_normalized"}},
+    }
+    return FeishuInboundEvent(message=inbound, feishu=envelope)
+
+
+def test_sdk_incoming_persists_normalized_context_without_licc_raw_copy(tmp_path):
+    events: list[dict] = []
+    mgr = _manager(tmp_path, events)
+
+    incoming = _sdk_incoming_event(body_text="hello")
+    mgr.on_incoming("main", incoming)
+
+    message_path = next((tmp_path / "feishu" / "main" / "inbox").glob("*/message.json"))
+    payload = json.loads(message_path.read_text(encoding="utf-8"))
+    assert payload["id"] == "main:oc_topic:om_normalized"
+    assert payload["thread_id"] == "omt_thread"
+    assert payload["root_id"] == "om_root"
+    assert payload["reply_to"] == "main:oc_topic:om_parent"
+    assert payload["text"] == "hello"
+    assert payload["content"] == {"kind": "text", "text": "@Mac PA hello"}
+    assert payload["mentions"][0]["is_bot"] is True
+    assert payload["from_name"] == "Sender"
+    assert payload["sender_type"] == "user"
+    assert payload["feishu"] == incoming.feishu
+
+    read_result = mgr.handle({"action": "read", "account": "main", "chat_id": "oc_topic"})
+    read_message = read_result["messages"][0]
+    assert read_message["from_name"] == "Sender"
+    assert read_message["thread_id"] == "omt_thread"
+    assert read_message["content"] == payload["content"]
+    assert read_message["feishu"] == incoming.feishu
+
+    search_result = mgr.handle({
+        "action": "search",
+        "account": "main",
+        "chat_id": "oc_topic",
+        "query": "Sender",
+    })
+    assert search_result["total"] == 1
+    assert search_result["messages"][0]["from_name"] == "Sender"
+
+    metadata = events[0]["metadata"]
+    assert metadata["thread_id"] == "omt_thread"
+    structured = metadata["latest_incoming"]
+    assert structured["type"] == "text"
+    assert structured["thread_id"] == "omt_thread"
+    assert len(structured["mentions"]) == 2
+    assert "feishu" not in structured
+    assert "content" not in structured
+
+
+def test_sdk_bare_bot_mention_keeps_empty_normalized_body(tmp_path):
+    mgr = _manager(tmp_path)
+
+    mgr.on_incoming("main", _sdk_incoming_event(body_text=""))
+
+    message_path = next((tmp_path / "feishu" / "main" / "inbox").glob("*/message.json"))
+    payload = json.loads(message_path.read_text(encoding="utf-8"))
+    assert payload["text"] == ""
+
+
+def test_structured_metadata_caps_mentions(tmp_path):
+    mgr = _manager(tmp_path)
+    mentions = [
+        {"key": f"@_user_{index}", "open_id": f"ou_{index}"}
+        for index in range(_STRUCTURED_MESSAGE_MENTION_CAP + 1)
+    ]
+    current = _write_message(
+        tmp_path,
+        msg_id="om_mentions",
+        text="mentions",
+        date="2026-07-06T09:00:01Z",
+        thread_id="omt_thread",
+        message_type="post",
+        mentions=mentions,
+    )
+
+    _preview, metadata = mgr._build_conversation_preview_and_metadata(
+        "main", "oc_chat", current
+    )
+
+    item = metadata["latest_incoming"]
+    assert item["type"] == "post"
+    assert item["thread_id"] == "omt_thread"
+    assert item["mentions"] == mentions[:_STRUCTURED_MESSAGE_MENTION_CAP]
+    assert item["mentions_truncated"] is True


### PR DESCRIPTION
## Summary

- Series: Feishu Bot v1 (2/15). Tracking: #1139. Depends on and follows #1138.
- Normalize inbound Feishu SDK messages while preserving legacy fields and the complete raw envelope; persist thread/reply metadata, resolved mentions, normalized content, and sender.
- Keep legacy `allowed_users`; admit DMs directly and require explicit `@Bot` for groups/topics (`@all` alone does not wake).
- Keep LICC notification metadata bounded and document the new behavior in the Feishu skill and notification contract.

## Validation

- [x] `git diff --check`
- [x] Targeted Feishu account and notification tests — 12 passed
- [x] Feishu 12-action family and stdio tests — 11 passed
- [x] Docs governance — 70 tests passed; 305 documents validated
- [x] `ruff check` and import smoke

## Notes

- Stacked temporarily on #1138; the SDK migration is the first commit. Review-specific commit: `c30f818f25b5a44e762f56542365667ef4b6c12d`. This PR's diff will shrink automatically when #1138 lands.
- Gray-deployed to the existing allowlisted bot. A real DM was normalized, persisted, woke the agent, and received a reply before and after refresh; WebSocket, identity, and heartbeat remained healthy. Evidence is intentionally content- and ID-free.
- Group `@Bot` and topic live smoke is pending: the designated one-member test group does not expose an Add Bot action, and member search excludes bots. No other group was touched.
- `tests/test_architecture_documents.py`: 72 passed, 1 pre-existing failure, reproduced at base `fc014a4e`; existing Anatomy drift is a missing `daemon_supervisor/supervisor.py` plus three stale line references.
- `security.mode="compat"` and outbound `max_attempts=1` remain intentional for v1.
- Logs, screenshots, examples, and this PR contain no credentials, raw chat content, raw identifiers, or raw envelopes.

## Final gray update

Subsequent series acceptance supersedes the earlier pending group note. A real allowlisted group `@Bot` message and a native topic message were admitted with mention/thread/parent/root metadata; Bot text and its Task Card reply both remained in the exact topic.
