### PR TITLE
fix(powershell): brace-depth statement splitting and actionable unsupported-syntax message

### DIFF
--- a/src/lingtai/adapters/windows/powershell.py
+++ b/src/lingtai/adapters/windows/powershell.py
@@ -116,6 +116,7 @@ def _split_statements(script: str) -> tuple[list[str], bool]:
     quote: str | None = None
     escaped = False
     paren_depth = 0
+    brace_depth = 0  # Track brace depth for script blocks
     while i < len(script):
         char = script[i]
         if quote == "'":
@@ -145,7 +146,12 @@ def _split_statements(script: str) -> tuple[list[str], bool]:
             if paren_depth == 0:
                 return pieces, False
             paren_depth -= 1
-        if char in "|;\r\n" and paren_depth == 0:
+        elif char == "{":  # Track brace depth
+            brace_depth += 1
+        elif char == "}":  # Track brace depth
+            if brace_depth > 0:
+                brace_depth -= 1
+        if char in "|;\r\n" and paren_depth == 0 and brace_depth == 0:
             pieces.append(script[begin:i])
             if char == "|" and i + 1 < len(script) and script[i + 1] in "|&":
                 i += 1
@@ -158,7 +164,7 @@ def _split_statements(script: str) -> tuple[list[str], bool]:
             begin = i + 1
         i += 1
     pieces.append(script[begin:])
-    return pieces, quote is None and paren_depth == 0
+    return pieces, quote is None and paren_depth == 0 and brace_depth == 0
 
 
 def _is_quoted_at(script: str, index: int) -> bool:

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -622,11 +622,11 @@ class ShellManager:
                     "refusing to run it"
                     if cmd
                     else (
-                        "PowerShell policy validation cannot statically extract all commands "
-                        "from this script (unsupported dynamic syntax detected: likely "
-                        "variable-based invocation, here-strings, or complex expressions). "
-                        "Options: (1) simplify the script to use only literal command names, "
-                        "(2) run with yolo=true to bypass policy, or "
+                        "PowerShell policy validation does not support this syntax; refusing "
+                        "to run it. The parser could not statically extract all commands "
+                        "(likely variable-based invocation, here-strings, or complex "
+                        "expressions). Options: (1) simplify the script to use only literal "
+                        "command names, (2) run with yolo=true to bypass policy, or "
                         "(3) split into multiple simpler commands."
                     )
                 ),

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -621,7 +621,14 @@ class ShellManager:
                     "cmd.exe policy validation does not support this syntax; "
                     "refusing to run it"
                     if cmd
-                    else "PowerShell policy validation does not support this syntax; refusing to run it"
+                    else (
+                        "PowerShell policy validation cannot statically extract all commands "
+                        "from this script (unsupported dynamic syntax detected: likely "
+                        "variable-based invocation, here-strings, or complex expressions). "
+                        "Options: (1) simplify the script to use only literal command names, "
+                        "(2) run with yolo=true to bypass policy, or "
+                        "(3) split into multiple simpler commands."
+                    )
                 ),
             }
         if not all(self._policy._check_single(cmd, case_insensitive=case_insensitive) for cmd in commands):

--- a/tests/test_shell_pr1_contract.py
+++ b/tests/test_shell_pr1_contract.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock
 import pytest
 
 import lingtai.adapters.shell as shell_adapter
-from lingtai.adapters.windows.powershell import PowerShellDialect, _ASCII_BOOTSTRAP
+from lingtai.adapters.windows.powershell import (
+    PowerShellDialect,
+    _ASCII_BOOTSTRAP,
+    _commands,
+)
 from lingtai.adapters.windows.powershell_process import _Owned, WindowsShellAsyncProcessAdapter
 from lingtai.tools.bash import ShellManager, ShellPolicy, setup
 from lingtai.tools.bash._async_process import ProcessRef
@@ -353,3 +357,40 @@ def test_non_posix_legacy_state_is_not_reinterpreted(monkeypatch):
     monkeypatch.setattr(supervisor.os, "name", "nt")
     with pytest.raises(ValueError, match="refusing to reinterpret"):
         _invocation_from_state({"command": "echo old"}, "echo old")
+
+
+# These two assert on ``_commands`` rather than ``PowerShellDialect.extract_commands``
+# because PR-5's quote-aware scanner now fails the whole script closed on ``|``
+# before extraction ever runs, which would mask the brace-depth behaviour under
+# test.  ``_commands`` is the recursive extractor these cases are about.
+def test_powershell_script_block_semicolons_do_not_split_statements():
+    """Semicolons inside a { ... } script block must not split statements."""
+    commands = _commands(
+        "Get-Process | Where-Object { $_.Name -eq 'pwsh'; $_.CPU -gt 10 }"
+    )
+    assert "Get-Process" in commands
+    assert "Where-Object" in commands
+    # The variable references inside the script block are not commands.
+    assert "$_" not in commands
+
+
+def test_powershell_unbalanced_brace_fails_closed():
+    """An unterminated script block is malformed and must fail closed."""
+    commands = _commands("Get-Process | Where-Object { $_.Name -eq 'pwsh'")
+    assert commands == ("__powershell_unsupported__",)
+
+
+def test_powershell_dynamic_unsupported_message_is_actionable(tmp_path):
+    """The unsupported-syntax error keeps the original wording and adds options."""
+    policy = ShellPolicy(deny=["Remove-Item"])
+    manager = ShellManager(
+        policy=policy,
+        working_dir=str(tmp_path),
+        agent=SimpleNamespace(),
+        dialect=PowerShellDialect(executable="pwsh"),
+    )
+    denied = manager.handle({"command": "& $command victim"})
+    assert denied["status"] == "error"
+    assert "does not support this syntax" in denied["message"]
+    assert "refusing to run" in denied["message"]
+    assert "yolo=true" in denied["message"]


### PR DESCRIPTION
Fixes PowerShell statement splitting so semicolons inside { ... } script blocks do not split top-level statements, and improves the unsupported-syntax error with actionable guidance while preserving existing message wording used by contract tests.

## Changes
- src/lingtai/adapters/windows/powershell.py: track brace depth in _split_statements so semicolons inside script blocks are not treated as statement separators, and an unterminated script block fails closed.
- src/lingtai/tools/bash/__init__.py: keep the original "does not support this syntax; refusing to run" message (contract tests depend on it) and append actionable options (simplify, yolo=true, split).
- tests/test_shell_pr1_contract.py: add contract tests for script-block semicolons, unterminated script blocks, and the actionable message.

## Validation
Verified with PYTHONPATH=src python3: script-block semicolons no longer split; unbalanced brace fails closed; message keeps required phrases; backtick-escaped commands still fail closed.
