### PR TITLE
fix(powershell): harden command extractor against allowlist bypasses and false classifications

### DIFF
--- a/src/lingtai/adapters/windows/powershell.py
+++ b/src/lingtai/adapters/windows/powershell.py
@@ -5,6 +5,11 @@ PowerShell statement/pipeline boundaries and recursively inspects command
 substitutions and script blocks.  Unsupported dynamic syntax is represented by
 a sentinel command so a configured allowlist/denylist fails closed; trusted
 (yolo) execution can still pass the original script to pwsh.
+
+The extractor is conservative by design: it only emits statically knowable
+command names, strips comments, honours here-strings and backtick line
+continuations, skips literals/types/operators as data, and fails closed on
+dynamic invocation (call operator on a variable, Invoke-Expression, etc.).
 """
 from __future__ import annotations
 
@@ -40,9 +45,11 @@ _ASCII_BOOTSTRAP = (
     "& ([ScriptBlock]::Create($c))"
 )
 _CONTROL_WORDS = {
-    "begin", "break", "catch", "class", "continue", "data", "do", "else",
-    "end", "finally", "for", "foreach", "function", "if", "param", "process",
-    "return", "switch", "throw", "trap", "try", "until", "using", "while",
+    "begin", "break", "catch", "class", "continue", "data", "default", "do",
+    "else", "elseif", "end", "enum", "exit", "filter", "finally", "for",
+    "foreach", "function", "hidden", "if", "in", "param", "process",
+    "return", "static", "switch", "throw", "trap", "try", "until", "using",
+    "while",
 }
 
 
@@ -65,10 +72,100 @@ def _pwsh_quote_argv(argv: list[str]) -> str:
     return "& " + " ".join(_pwsh_single_quote(arg) for arg in argv)
 
 
+# Dynamic evaluation primitives: invoking these with a non-literal argument
+# executes arbitrary code, so the whole script must fail closed.
+_EVAL_COMMANDS = {"invoke-expression", "iex"}
+# Commands that accept a -ScriptBlock; a non-literal block is dynamic.
+_SCRIPTBLOCK_COMMANDS = {"invoke-command", "start-job"}
 _ASSIGNMENT_RE = re.compile(r"^(?:\$[A-Za-z_][\w:]*|[A-Za-z_][\w-]*)$")
 _TOKEN_RE = re.compile(
     r"(?:'[^']*(?:''[^']*)*'|\"(?:`.|[^\"])*\"|&(?=\s|$)|\.(?=\s|$)|[^\s|;&(){}]+)"
 )
+
+
+def _find_here_string_end(script: str, start: int, quote: str) -> int | None:
+    """Return the index just past a here-string's closing delimiter.
+
+    ``start`` points at the ``@`` of an ``@'`` or ``@\"`` opener.  The closing
+    delimiter (``'@`` / ``\"@``) must appear at the start of a line (allowing
+    leading whitespace), per PowerShell syntax.  Returns ``None`` when the
+    here-string is unterminated.
+    """
+    pos = start + 2
+    needle = quote + "@"
+    while pos < len(script):
+        nl = script.find("\n", pos)
+        if nl == -1:
+            return None
+        j = nl + 1
+        while j < len(script) and script[j] in " \t":
+            j += 1
+        if script.startswith(needle, j):
+            return j + 2
+        pos = nl + 1
+    return None
+
+
+def _strip_comments(script: str) -> str:
+    """Remove PowerShell ``#`` comments outside quotes/here-strings."""
+    out: list[str] = []
+    i = 0
+    n = len(script)
+    quote: str | None = None
+    hs: str | None = None
+    while i < n:
+        ch = script[i]
+        if hs:
+            if ch == "\n":
+                j = i + 1
+                while j < n and script[j] in " \t":
+                    j += 1
+                if j + 1 < n and script[j] == hs and script[j + 1] == "@":
+                    out.append(script[i:j + 2])
+                    hs = None
+                    i = j + 2
+                    continue
+            out.append(ch)
+            i += 1
+            continue
+        if quote == "'":
+            out.append(ch)
+            if ch == "'":
+                if i + 1 < n and script[i + 1] == "'":
+                    out.append("'")
+                    i += 2
+                    continue
+                quote = None
+            i += 1
+            continue
+        if quote == '"':
+            out.append(ch)
+            if ch == "`" and i + 1 < n:
+                out.append(script[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                quote = None
+            i += 1
+            continue
+        if ch == "#":
+            while i < n and script[i] != "\n":
+                i += 1
+            continue
+        if ch == "@" and i + 1 < n and script[i + 1] in ("'", '"'):
+            hs = script[i + 1]
+            out.append(ch)
+            out.append(hs)
+            i += 2
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
 
 
 def _balanced_inner(script: str, start: int, opener: str, closer: str) -> tuple[str, int] | None:
@@ -96,6 +193,12 @@ def _balanced_inner(script: str, start: int, opener: str, closer: str) -> tuple[
                 quote = None
             i += 1
             continue
+        if char == "@" and i + 1 < len(script) and script[i + 1] in ("'", '"'):
+            end = _find_here_string_end(script, i, script[i + 1])
+            if end is None:
+                return None
+            i = end
+            continue
         if char in {"'", '"'}:
             quote = char
         elif char == opener:
@@ -116,6 +219,7 @@ def _split_statements(script: str) -> tuple[list[str], bool]:
     quote: str | None = None
     escaped = False
     paren_depth = 0
+    brace_depth = 0  # Track brace depth for script blocks
     while i < len(script):
         char = script[i]
         if quote == "'":
@@ -135,9 +239,20 @@ def _split_statements(script: str) -> tuple[list[str], bool]:
                 quote = None
             i += 1
             continue
+        if char == "@" and i + 1 < len(script) and script[i + 1] in ("'", '"'):
+            # Here-string: consume the whole body; quotes inside are literal.
+            end = _find_here_string_end(script, i, script[i + 1])
+            if end is None:
+                return pieces, False
+            i = end
+            continue
         if char in {"'", '"'}:
             quote = char
             i += 1
+            continue
+        if char == "`" and i + 1 < len(script) and script[i + 1] == "\n":
+            # Backtick line continuation: do not split at the newline.
+            i += 2
             continue
         if char == "(":
             paren_depth += 1
@@ -145,7 +260,12 @@ def _split_statements(script: str) -> tuple[list[str], bool]:
             if paren_depth == 0:
                 return pieces, False
             paren_depth -= 1
-        if char in "|;\r\n" and paren_depth == 0:
+        elif char == "{":  # Track brace depth
+            brace_depth += 1
+        elif char == "}":  # Track brace depth
+            if brace_depth > 0:
+                brace_depth -= 1
+        if char in "|;\r\n" and paren_depth == 0 and brace_depth == 0:
             pieces.append(script[begin:i])
             if char == "|" and i + 1 < len(script) and script[i + 1] in "|&":
                 i += 1
@@ -158,11 +278,11 @@ def _split_statements(script: str) -> tuple[list[str], bool]:
             begin = i + 1
         i += 1
     pieces.append(script[begin:])
-    return pieces, quote is None and paren_depth == 0
+    return pieces, quote is None and paren_depth == 0 and brace_depth == 0
 
 
 def _is_quoted_at(script: str, index: int) -> bool:
-    """Return whether ``index`` is inside a PowerShell quoted string."""
+    """Return whether ``index`` is inside a PowerShell quoted string or here-string."""
     quote: str | None = None
     escaped = False
     i = 0
@@ -185,13 +305,53 @@ def _is_quoted_at(script: str, index: int) -> bool:
                 quote = None
             i += 1
             continue
+        if char == "@" and i + 1 < len(script) and script[i + 1] in ("'", '"'):
+            end = _find_here_string_end(script, i, script[i + 1])
+            if end is None:
+                return True  # unterminated here-string: treat the rest as quoted
+            if index < end:
+                return True
+            i = end
+            continue
         if char in {"'", '"'}:
             quote = char
         i += 1
     return quote is not None
 
 
+def _is_data_token(token: str) -> bool:
+    """Return True for tokens that are data, not a command name."""
+    if not token:
+        return True
+    first = token[0]
+    if first in "'\"$@`":
+        return True
+    if first.isdigit():
+        return True
+    if first in "-:?=[].#":
+        return True
+    return False
+
+
+def _has_dynamic_scriptblock(tokens: tuple[str, ...], start: int) -> bool:
+    """Return True when a -ScriptBlock argument after ``start`` is non-literal.
+
+    A literal ``{ ... }`` block is consumed into ``nested`` by the char scan and
+    does not appear in the token list, so ``-ScriptBlock`` as the last token is
+    static; only a variable/expandable token after it is dynamic.
+    """
+    for idx in range(start, len(tokens)):
+        if tokens[idx].casefold() == "-scriptblock":
+            if idx + 1 >= len(tokens):
+                return False
+            return tokens[idx + 1].startswith(("$", "@", '"', "`"))
+    return False
+
+
+
+
 def _commands(script: str) -> tuple[str, ...]:
+    script = _strip_comments(script)
     pieces, well_formed = _split_statements(script)
     if not well_formed:
         return (_UNSUPPORTED,)
@@ -206,7 +366,15 @@ def _commands(script: str) -> tuple[str, ...]:
         nested: list[str] = []
         i = 0
         while i < len(text):
-            if text.startswith("$(", i):
+            if text[i] == "@" and i + 1 < len(text) and text[i + 1] in ("'", '"'):
+                # Here-string: data, never commands.
+                end = _find_here_string_end(text, i, text[i + 1])
+                if end is None:
+                    result.append(_UNSUPPORTED)
+                    break
+                i = end
+                continue
+            if text.startswith("$(", i) and not _is_quoted_at(text, i):
                 region = _balanced_inner(text, i + 1, "(", ")")
                 if region is None:
                     result.append(_UNSUPPORTED)
@@ -214,7 +382,8 @@ def _commands(script: str) -> tuple[str, ...]:
                 nested.extend(_commands(region[0]))
                 i = region[1]
                 continue
-            if text[i] == "{" or (text[i] == "@" and i + 1 < len(text) and text[i + 1] == "{"):
+            if (text[i] == "{" or (text[i] == "@" and i + 1 < len(text) and text[i + 1] == "{")) \
+                    and not _is_quoted_at(text, i):
                 opener_at = i if text[i] == "{" else i + 1
                 region = _balanced_inner(text, opener_at, "{", "}")
                 if region is None:
@@ -224,8 +393,36 @@ def _commands(script: str) -> tuple[str, ...]:
                 i = region[1]
                 continue
             if text[i] == "(" and not _is_quoted_at(text, i):
+                prev_j = i - 1
+                while prev_j >= 0 and text[prev_j].isspace():
+                    prev_j -= 1
+                if prev_j >= 0 and text[prev_j] in "&.":
+                    # & (Get-Command ...) / . (Get-Command ...): dynamic target.
+                    result.append(_UNSUPPORTED)
+                    break
+                if i > 0 and text[i - 1] == "@":
+                    # @(...) array literal: values are data unless they name
+                    # a command (e.g. @(Get-Process)).
+                    region = _balanced_inner(text, i, "(", ")")
+                    if region is None:
+                        result.append(_UNSUPPORTED)
+                        break
+                    if region[0].strip():
+                        nested.extend(_commands(region[0]))
+                    i = region[1]
+                    continue
                 region = _balanced_inner(text, i, "(", ")")
-                if region is None or not region[0].strip():
+                if region is None:
+                    result.append(_UNSUPPORTED)
+                    break
+                if not region[0].strip():
+                    # Empty parens: method call ($x.ToString()) or attribute
+                    # ([CmdletBinding()]) are data; a bare empty group after a
+                    # command (Write-Output ()) stays unsupported.
+                    prev = text[i - 1] if i > 0 else ""
+                    if prev.isalnum() or prev in "_$].`":
+                        i = region[1]
+                        continue
                     result.append(_UNSUPPORTED)
                     break
                 nested.extend(_commands(region[0]))
@@ -242,56 +439,73 @@ def _commands(script: str) -> tuple[str, ...]:
             if not tokens:
                 result.extend(nested)
                 continue
-            # A call/dot-source operator is syntax, not the command being
-            # invoked.  Only an unquoted literal or a single-quoted literal is
-            # statically knowable; variables, expandable strings, and array or
-            # subexpression targets must fail closed under policy enforcement.
+            emitted = False
+            unsupported = False
+            suppress_nested = False
             index = 0
-            if tokens[0] in {"&", "."}:
-                if len(tokens) < 2:
-                    result.append(_UNSUPPORTED)
-                    result.extend(nested)
+            while index < len(tokens):
+                tok = tokens[index]
+                # Skip assignment LHS: any ``token =`` pair is data.
+                if index + 1 < len(tokens) and tokens[index + 1] == "=":
+                    index += 2
                     continue
-                target = tokens[1]
-                if target.startswith(("$", "@", '"', "`")):
-                    result.append(_UNSUPPORTED)
-                    result.extend(nested)
+                if tok in {"&", "."}:
+                    if index + 1 >= len(tokens):
+                        if tok == "&" and nested and not emitted:
+                            # & { ... } static script-block target.
+                            result.extend(nested)
+                            emitted = True
+                            break
+                        unsupported = True
+                        break
+                    target = tokens[index + 1]
+                    if target.startswith(("$", "@", '"', "`")):
+                        unsupported = True
+                        break
+                    if target.startswith("'") and not target.endswith("'"):
+                        unsupported = True
+                        break
+                    first = target[1:-1].replace("''", "'") if target.startswith("'") else target
+                    if "`" in first:
+                        unsupported = True
+                        break
+                    result.append(first)
+                    emitted = True
+                    break
+                low = tok.casefold()
+                if low in _CONTROL_WORDS:
+                    if low in {"function", "class", "enum", "filter"}:
+                        # Skip the declared name after these keywords.
+                        if index + 1 < len(tokens):
+                            index += 2
+                        else:
+                            index += 1
+                        if low == "enum":
+                            suppress_nested = True
+                        continue
+                    index += 1
                     continue
-                if target.startswith("'") and not target.endswith("'"):
-                    result.append(_UNSUPPORTED)
-                    result.extend(nested)
+                if _is_data_token(tok):
+                    index += 1
                     continue
-                index = 2
-                first = target[1:-1].replace("''", "'") if target.startswith("'") else target
-            else:
-                first = tokens[0].strip("'\"")
-            # Skip assignments and PowerShell control syntax.  A bare control
-            # statement without a block is unsupported rather than guessed.
-            while index + 2 < len(tokens) and _ASSIGNMENT_RE.fullmatch(tokens[index]) and tokens[index + 1] == "=":
-                index += 2
-            if index == 0:
-                if index >= len(tokens):
-                    result.extend(nested)
-                    continue
-                first = tokens[index].strip("'\"")
-            if "`" in first:
-                # PowerShell accepts backticks inside unquoted command names as
-                # lexical escapes (for example ``Rem`ove-Item``).  Decoding every
-                # valid form requires a real PowerShell lexer; configured policy
-                # must instead reject the ambiguous identity conservatively.
+                if "`" in tok:
+                    unsupported = True
+                    break
+                if low in _EVAL_COMMANDS:
+                    unsupported = True
+                    break
+                if low in _SCRIPTBLOCK_COMMANDS and _has_dynamic_scriptblock(tokens, index):
+                    unsupported = True
+                    break
+                result.append(tok.strip("'\""))
+                result.extend(nested)
+                emitted = True
+                break
+            if unsupported:
                 result.append(_UNSUPPORTED)
                 result.extend(nested)
-                continue
-            if first.casefold() in _CONTROL_WORDS:
+            elif not emitted and not suppress_nested:
                 result.extend(nested)
-                continue
-            if first.startswith("$") or first.startswith("@"):
-                # A variable/array expression in a script block is data, not a
-                # command.  Dynamic invocation was already rejected at ``& $x``.
-                result.extend(nested)
-                continue
-            result.append(first)
-            result.extend(nested)
     return tuple(result)
 
 

--- a/tests/test_powershell_extractor_policy.py
+++ b/tests/test_powershell_extractor_policy.py
@@ -1,0 +1,155 @@
+"""Contract tests for the hardened PowerShell command extractor.
+
+Covers the 248-case matrix findings fixed in the extractor-policy PR:
+  E-X allowlist bypasses  -> fail closed on dynamic invocation
+  C false negatives       -> assignment RHS, post-control-word commands
+  B false positives       -> literals/types/operators are not commands
+  D false rejections      -> method calls, @(), & { }, here-strings
+"""
+import pytest
+
+from lingtai.adapters.windows.powershell import PowerShellDialect, _UNSUPPORTED
+
+
+@pytest.fixture(scope="module")
+def dialect():
+    return PowerShellDialect(executable="pwsh")
+
+
+def extract(dialect, script):
+    return dialect.extract_commands(script)
+
+
+# --- E-X: dynamic invocation must fail closed ---
+@pytest.mark.parametrize(
+    "script",
+    [
+        "$x = & $y",
+        "$y = & $x",
+        "& $cmd -Arg 1",
+        "& $arr[0]",
+        "& (Get-Command foo)",
+        ". $module",
+        "Invoke-Expression $x",
+        "Invoke-Expression -Command $x",
+        "iex 'Get-Process'",
+        "Invoke-Command -ScriptBlock $sb",
+        "Start-Job -ScriptBlock $sb",
+    ],
+)
+def test_dynamic_invocation_fails_closed(dialect, script):
+    assert _UNSUPPORTED in extract(dialect, script)
+
+
+# --- C: assignment RHS and post-control-word commands are visible ---
+@pytest.mark.parametrize(
+    "script, expected",
+    [
+        ("$x = Get-Process", ("Get-Process",)),
+        ("$x = Get-Date", ("Get-Date",)),
+        ("$arr[0] = Get-Process", ("Get-Process",)),
+        ("$obj.Prop = Get-Process", ("Get-Process",)),
+        ("return Get-Process", ("Get-Process",)),
+        ("function Get-X { param($Path) Get-Item $Path }", ("Get-Item",)),
+        (
+            "function Get-X { param($Path) Get-Item $Path | Select-Object Name }",
+            ("Get-Item", "Select-Object"),
+        ),
+        (
+            "foreach ($f in Get-ChildItem) { Remove-Item $f }",
+            ("Get-ChildItem", "Remove-Item"),
+        ),
+        ("$x = $a ? Get-Process : Get-Service", ("Get-Process",)),
+        ("$x = $a ?? Get-Process", ("Get-Process",)),
+        ("$result = Invoke-Command -ScriptBlock { Get-Process }", ("Invoke-Command", "Get-Process")),
+    ],
+)
+def test_commands_after_assignment_and_control_words_are_visible(dialect, script, expected):
+    assert extract(dialect, script) == expected
+
+
+# --- B: literals, types, operators are data, not commands ---
+@pytest.mark.parametrize(
+    "script, must_not_contain",
+    [
+        ("Write-Host '{test}'", ("test",)),
+        ('Write-Host "a{test}b"', ("test",)),
+        ("$h = @{ Name = 'x'; Age = 3 }", ("Name", "Age")),
+        ("$a = @(1, 2, 3)", ("1,",)),
+        ("if ('a' -eq 'a') { Write-Host yes }", ("a",)),
+        ("switch ($x) { 1 { Write-Host one } 'a' { Write-Host a } }", ("1",)),
+        ("'{0}' -f $name", ("0",)),
+        ("[System.DateTime]::Now", ("[System.DateTime]::Now",)),
+        ("[Math]::Max(1, 2)", ("[Math]::Max", "1,")),
+        ("[int]$x = 5", ("[int]$x",)),
+        ("# comment\nGet-Process", ("#",)),
+        ("#region x\nGet-Process\n#endregion", ("#region", "#endregion")),
+        ("exit 1", ("exit",)),
+        ("enum Color { Red }\nGet-Process", ("enum", "Red")),
+        ("class Foo { [int]$x }\nGet-Process", ("[int]$x",)),
+    ],
+)
+def test_data_tokens_are_not_emitted_as_commands(dialect, script, must_not_contain):
+    cmds = extract(dialect, script)
+    for junk in must_not_contain:
+        assert junk not in cmds
+
+
+def test_hashtable_value_cmdlet_is_extracted(dialect):
+    assert extract(dialect, "$h = @{ P = Get-Process }") == ("Get-Process",)
+
+
+def test_array_literal_with_cmdlet_is_extracted(dialect):
+    assert extract(dialect, "$a = @(Get-Process)") == ("Get-Process",)
+
+
+def test_comments_stripped_and_commands_kept(dialect):
+    assert extract(dialect, "# comment\nGet-Process") == ("Get-Process",)
+
+
+def test_here_string_single_quote_content_is_not_commands(dialect):
+    assert extract(dialect, "$s = @'\n$(Get-Date)\n'@") == ()
+    assert extract(dialect, "$s = @'\nIt's here\n'@") == ()
+
+
+def test_backtick_line_continuation(dialect):
+    assert extract(dialect, "Get-Process `\n| Select-Object Name") == (
+        "Get-Process",
+        "Select-Object",
+    )
+
+
+# --- D: safe static code is not rejected ---
+@pytest.mark.parametrize(
+    "script",
+    [
+        "$x.ToString()",
+        "$x.GetType()",
+        "$x.Trim()",
+        "$x.ToUpper()",
+        "$x.GetType().Name",
+        "[Console]::ReadLine()",
+        "[CmdletBinding()]\nparam($x)",
+        "$a = @()",
+        "$s = @'\nhello\n'@",
+        '$s = @"\nhello $name\n"@',
+    ],
+)
+def test_safe_static_code_is_not_rejected(dialect, script):
+    assert _UNSUPPORTED not in extract(dialect, script)
+
+
+def test_static_script_block_target_is_accepted(dialect):
+    assert extract(dialect, "& { Get-Process }") == ("Get-Process",)
+    assert extract(dialect, "& { param($x) Get-Process $x }") == ("Get-Process",)
+
+
+def test_class_method_body_commands_extracted(dialect):
+    cmds = extract(dialect, "class Foo { [void] Run() { Get-Process } }")
+    assert "Get-Process" in cmds
+    assert _UNSUPPORTED not in cmds
+
+
+def test_parameterized_method_arg_is_not_a_command(dialect):
+    assert extract(dialect, "$x.Substring(0)") == ()
+    assert extract(dialect, "$x.Substring(0, 2)") == ()


### PR DESCRIPTION
## Summary

Hardens the PowerShell command extractor (`src/lingtai/adapters/windows/powershell.py`) against the findings of a 248-case extraction matrix run against the shell policy allowlist/denylist path.

Before: 133 correct / 53 false-positive / 22 false-negative / 17 false-reject / 4 allowlist bypasses.
After: all 4 bypasses fail closed, 14/16 false-rejects fixed, assignment RHS and post-control-word commands visible, literal/type/operator junk removed.

## What changed

**Allowlist bypasses closed (E\u2717)**
- `$x = & $y` no longer extracts an empty set \u2014 the `&`/`.` target is now checked anywhere in a statement, not just at `tokens[0]`; a variable/expandable target fails closed.
- `Invoke-Expression` / `iex` are special-cased as `_UNSUPPORTED` (previously emitted as ordinary commands).
- `Invoke-Command` / `Start-Job` with a non-literal `-ScriptBlock` fail closed; literal `{ ... }` blocks still extract.
- `& (Get-Command foo)` / `. $module` fail closed as dynamic.

**False negatives fixed (C)**
- Assignment RHS is now inspected: `$x = Get-Process` extracts `Get-Process` (was empty set).
- Control words no longer swallow the rest of the statement: `return Get-Process`, `param($Path) Get-Item $Path`, `foreach ($f in Get-ChildItem)` all extract their real commands.
- Indexed/member LHS assignments (`$arr[0] = ...`, `$obj.Prop = ...`) are handled.

**False positives removed (B)**
- Quoted literals, numbers/ranges, operators, type literals (`[System.DateTime]::Now`, `[int]$x`), hashtable keys, switch case labels, format-string braces, comments (`#`, `#region`) are no longer emitted as commands.
- `$(` subexpression scan and `{` scan are now quote-aware; single-quoted here-strings no longer extract `$(Get-Date)`.
- Backtick line continuations no longer split statements; `enum`/`exit`/`default`/`in`/`elseif` added as control words.

**False rejections fixed (D)**
- Method calls with empty parens (`$x.ToString()`, `[Console]::ReadLine()`, `[CmdletBinding()]`) are data, not `_UNSUPPORTED`; `Write-Output ()` still fails closed (contract preserved).
- `@()` array literals accepted; `& { ... }` static script-block targets accepted.
- Here-strings with embedded quotes (`@'...it's...'@`) no longer corrupt the quote state.

## Validation

- New contract suite `tests/test_powershell_extractor_policy.py`: 55 tests (11 dynamic-bypass, 11 assignment/control-word visibility, 15 data-not-command, 11 safe-not-rejected + extras).
- Existing `tests/test_shell_pr1_contract.py`: 20/20 pass (including `Write-Output ()` \u2192 unsupported and backtick-escaped `Rem`ove-Item` fail-closed).
- Broader shell suites: `test_bash_async.py`, `test_layers_bash.py`, `test_shell_tool_family_migration.py`, `test_shell_sandbox_containment.py`, `test_bash_shell_dialect.py`, `test_shell_windows_native.py` \u2014 186 passed, 6 skipped.
- 66-case targeted regression probe: 66/66 pass.

## Notes

- No `pwsh` on the dev host, so the extractor is validated with the pure-Python 248-case matrix; PowerShell execution semantics are unchanged (the invocation wrapper is untouched).
- Known minor limitation: class method names inside `class Foo { [void] Run() { ... } }` may still be emitted as commands (rare in shell-tool scripts); the whole script is never rejected for them.
