### PR TITLE
feat(telegram): show current model name on resident Task Card

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -347,6 +347,9 @@ class TaskCardEventProjection:
             return []
 
         session_parts: list[str] = []
+        model = metadata.get("model")
+        if isinstance(model, str) and model.strip():
+            session_parts.append(f"model {model.strip()}")
         cache_rate = metadata.get("session_cache_rate")
         if (
             type(cache_rate) in {int, float}

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2176,7 +2176,36 @@ class TelegramManager:
         lifecycle = self._task_card_agent_lifecycle_status()
         if lifecycle is not None:
             snapshot["agent_lifecycle"] = lifecycle
+        model = self._task_card_current_model()
+        if model:
+            snapshot["model"] = model
         return snapshot or None
+
+    def _task_card_current_model(self) -> str | None:
+        """Read the agent's current LLM model from ``.agent.json``.
+
+        ``llm.model`` is the canonical running model (the same value the
+        runtime reports in its identity); ``provider`` is kept out so the card
+        stays compact. Missing, malformed, or non-object data degrades to
+        ``None`` — no line is rendered rather than fabricating a model.
+        """
+        try:
+            raw = (self._working_dir / ".agent.json").read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        llm = data.get("llm")
+        if not isinstance(llm, dict):
+            return None
+        model = llm.get("model")
+        if not isinstance(model, str) or not model.strip():
+            return None
+        return model.strip()
 
     def _task_card_agent_lifecycle_status(self) -> str | None:
         """Read this agent's own canonical lifecycle for the footer.

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -608,3 +608,23 @@ def test_event_metadata_snapshot_merges_with_existing_session_metadata(tmp_path)
     assert snapshot == {"api_calls": 4, "agent_lifecycle": "suspended"}
     # The manager's own stored metadata must not be mutated by the merge.
     assert mgr._task_card_event_metadata == {"api_calls": 4}
+
+
+def test_metadata_renders_current_model_first():
+    lines = TelegramManager._format_task_card_metadata({
+        "model": "deepseek-v4-flash",
+        "session_cache_rate": 0.5,
+    })
+    assert lines == ["session · model deepseek-v4-flash · cache 50.0%"]
+
+
+def test_event_metadata_snapshot_adds_current_model(tmp_path):
+    import json as _json
+
+    (tmp_path / ".agent.json").write_text(
+        _json.dumps({"llm": {"model": "deepseek-v4-flash"}}), encoding="utf-8"
+    )
+    mgr, _ = _integration_manager(tmp_path)
+    _write_status(tmp_path, {"runtime": {"state": "active"}})
+    snapshot = mgr._task_card_event_metadata_snapshot()
+    assert snapshot == {"agent_lifecycle": "active", "model": "deepseek-v4-flash"}


### PR DESCRIPTION
## Summary

Minimal display-only change: the resident automatic Task Card now shows the agent's current model name in its session metadata line (e.g. `session · model deepseek-v4-flash · …`).

- `manager.py`: read `llm.model` from `.agent.json` in `_task_card_event_metadata_snapshot()` (safe degradation to no-line when missing/malformed).
- `event_projection.py`: render `model <name>` first in `format_metadata` session parts.

## Validation

- `py_compile` PASS.
- `tests/test_telegram_task_card_rows.py` + `tests/test_telegram_task_card_event_tail.py`: **80 passed** (2 new tests cover model rendering and snapshot model read).
- `git diff --check` PASS.
