### PR TITLE
fix: replace Claude Code native prompt for chat

### DIFF
--- a/src/lingtai/llm/claude_code/adapter.py
+++ b/src/lingtai/llm/claude_code/adapter.py
@@ -75,6 +75,14 @@ _OVERFLOW_MARKERS = (
     "input is too long",
 )
 
+# The replacement mode removes Claude Code's native coding-agent prompt while
+# retaining the LingTai protocol/tools in the stable system block. Append stays
+# available as an explicit compatibility mode.
+_SYSTEM_PROMPT_FILE_FLAGS = {
+    "append": "--append-system-prompt-file",
+    "replace": "--system-prompt-file",
+}
+
 # Sentinel for ``_invoke_raw``'s optional ``system_prompt_file`` argument so a
 # caller can explicitly pass ``None`` (no system-prompt file — used by the
 # one-shot ``generate`` path) while the default still resolves to the adapter's
@@ -423,9 +431,9 @@ class ClaudeCodeChatSession(ChatSession):
     def _render_prompt(self, entry_start: int = 0) -> str:
         """Serialise only the conversation into the per-turn user message.
 
-        The stable context (protocol + system prompt + tools) is passed via
-        ``--append-system-prompt-file`` so it lives in the system block that
-        Claude Code caches across turns; only the growing conversation (which
+        The stable context (protocol + system prompt + tools) is passed via the
+        mode-selected system-prompt-file flag so it lives in the system block
+        that Claude Code caches across turns; only the growing conversation (which
         changes every turn) is sent as the user message. This is what makes
         prompt caching effective: previously the whole stable context was
         embedded in the user message, which is rewritten every turn as the
@@ -528,7 +536,12 @@ class ClaudeCodeAdapter(LLMAdapter):
         strip_env: tuple[str, ...] | list[str] | None = None,
         extra_argv: list[str] | None = None,
         context_window: int = _DEFAULT_CONTEXT_WINDOW,
+        system_prompt_mode: str = "replace",
     ) -> None:
+        if system_prompt_mode not in _SYSTEM_PROMPT_FILE_FLAGS:
+            allowed = ", ".join(sorted(_SYSTEM_PROMPT_FILE_FLAGS))
+            raise ValueError(f"system_prompt_mode must be one of: {allowed}")
+        self._system_prompt_mode = system_prompt_mode
         self._model = model or "sonnet"
         self._cli_path = cli_path
         self._disallowed = (
@@ -551,12 +564,12 @@ class ClaudeCodeAdapter(LLMAdapter):
 
         # Stable context file for prompt caching. Claude Code puts a cache
         # breakpoint on the *system* block, so the stable protocol/system/tools
-        # context must be passed via ``--append-system-prompt-file`` (it then
-        # lives in the cached system block) instead of being embedded in the
-        # per-turn user message, which is rewritten every turn as the
-        # conversation grows (forcing a full cache write each turn). The file
-        # path is stable per adapter instance; the session rewrites its content
-        # only when the system prompt or tools change.
+        # context must be passed via the mode-selected system-prompt-file flag
+        # instead of being embedded in the per-turn user message, which is
+        # rewritten every turn as the conversation grows (forcing a full cache
+        # write each turn). The file path is stable per adapter instance; the
+        # session rewrites its content only when the system prompt or tools
+        # change.
         self._system_prompt_file = Path(tempfile.gettempdir()) / (
             f"lingtai-claude-sp-{uuid.uuid4().hex[:12]}.txt"
         )
@@ -672,9 +685,11 @@ class ClaudeCodeAdapter(LLMAdapter):
         """Run ``claude -p`` once. Returns (result_text, usage, envelope).
 
         ``system_prompt_file`` defaults to the adapter's stable prompt-cache
-        file (the chat path). Pass ``None`` to omit the flag entirely — used
-        by the one-shot ``generate`` path, which has no cross-turn cache to
-        protect and must not reuse (or poison) the chat system-prompt file.
+        file (the chat path), and ``system_prompt_mode`` selects whether Claude
+        appends or replaces its native system prompt. Pass ``None`` to omit the
+        flag entirely — used by the one-shot ``generate`` path, which has no
+        cross-turn cache to protect and must not reuse (or poison) the chat
+        system-prompt file.
         """
         cmd = [self._cli_path, "-p", "--output-format", "json"]
         if model:
@@ -686,7 +701,10 @@ class ClaudeCodeAdapter(LLMAdapter):
         if system_prompt_file is _UNSET:
             system_prompt_file = self._system_prompt_file
         if system_prompt_file:
-            cmd += ["--append-system-prompt-file", str(system_prompt_file)]
+            cmd += [
+                _SYSTEM_PROMPT_FILE_FLAGS[self._system_prompt_mode],
+                str(system_prompt_file),
+            ]
         cmd += self._extra_argv
 
         try:

--- a/tests/test_claude_code_adapter.py
+++ b/tests/test_claude_code_adapter.py
@@ -267,13 +267,14 @@ def test_command_includes_print_json_model_and_disallowed_tools():
     # prompt is piped via stdin, not argv
     assert captured["kw"]["input"]
     # Stable context (protocol/system/tools) lives in the system-prompt file
-    # passed via --append-system-prompt-file (for prompt caching); the stdin
+    # passed via --system-prompt-file (for prompt caching); the stdin
     # user message carries only the conversation.
     assert "# CONVERSATION" in captured["kw"]["input"]
     assert "# NOW" in captured["kw"]["input"]
     assert "# AVAILABLE TOOLS" not in captured["kw"]["input"]
-    assert "--append-system-prompt-file" in cmd
-    sp_idx = cmd.index("--append-system-prompt-file")
+    assert "--system-prompt-file" in cmd
+    assert "--append-system-prompt-file" not in cmd
+    sp_idx = cmd.index("--system-prompt-file")
     sp_path = cmd[sp_idx + 1]
     with open(sp_path, encoding="utf-8") as f:
         sp_content = f.read()
@@ -282,6 +283,27 @@ def test_command_includes_print_json_model_and_disallowed_tools():
     assert "(no tools available" in sp_content  # create_chat called with None
     assert "sys" in sp_content  # the system prompt text
     assert "You are the REASONING CORE" in sp_content  # the action protocol
+
+
+def test_append_system_prompt_mode_keeps_legacy_flag():
+    ad = ClaudeCodeAdapter(model="sonnet", system_prompt_mode="append")
+    sess = ad.create_chat("sonnet", "sys", None)
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return _FakeProc(stdout=_envelope('{"action":"final","text":"ok"}'))
+
+    with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run):
+        sess.send("hi")
+
+    assert "--append-system-prompt-file" in captured["cmd"]
+    assert "--system-prompt-file" not in captured["cmd"]
+
+
+def test_invalid_system_prompt_mode_fails_closed():
+    with pytest.raises(ValueError, match="system_prompt_mode"):
+        ClaudeCodeAdapter(system_prompt_mode="discard")
 
 
 def test_session_resume_keeps_system_block_stable_and_sends_only_new_history():
@@ -313,13 +335,13 @@ def test_session_resume_keeps_system_block_stable_and_sends_only_new_history():
 
     sp_paths = set()
     for cmd, _kw in captured:
-        sp_idx = cmd.index("--append-system-prompt-file")
+        sp_idx = cmd.index("--system-prompt-file")
         sp_paths.add(cmd[sp_idx + 1])
     assert len(sp_paths) == 1  # same stable file every turn
 
     contents = []
     for cmd, _kw in captured:
-        sp_idx = cmd.index("--append-system-prompt-file")
+        sp_idx = cmd.index("--system-prompt-file")
         with open(cmd[sp_idx + 1], encoding="utf-8") as f:
             contents.append(f.read())
     assert contents[0] == contents[1] == contents[2]  # byte-identical system block
@@ -362,7 +384,7 @@ def test_per_turn_resync_with_identical_content_keeps_resuming():
     # The cached system block stays byte-identical across the resyncs.
     contents = []
     for cmd, _kw in captured:
-        with open(cmd[cmd.index("--append-system-prompt-file") + 1], encoding="utf-8") as f:
+        with open(cmd[cmd.index("--system-prompt-file") + 1], encoding="utf-8") as f:
             contents.append(f.read())
     assert len(set(contents)) == 1
 
@@ -538,7 +560,7 @@ def test_generate_omits_system_prompt_file():
     with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run):
         resp = ad.generate("sonnet", "hello", system_prompt="sys")
     assert resp.text == "plain answer"
-    assert "--append-system-prompt-file" not in captured["cmd"]
+    assert "--system-prompt-file" not in captured["cmd"]
 
 
 def test_update_system_prompt_rewrites_system_file():
@@ -553,7 +575,7 @@ def test_update_system_prompt_rewrites_system_file():
 
     with patch("lingtai.llm.claude_code.adapter.subprocess.run", side_effect=fake_run):
         sess.send("hi")
-    sp_idx = captured["cmd"].index("--append-system-prompt-file")
+    sp_idx = captured["cmd"].index("--system-prompt-file")
     sp_path = captured["cmd"][sp_idx + 1]
     with open(sp_path, encoding="utf-8") as f:
         assert "sys-v1" in f.read()


### PR DESCRIPTION
## Summary

- Make the main Claude Code chat adapter use `--system-prompt-file` by default, replacing Claude Code's native coding-agent system prompt while retaining LingTai's protocol, system instructions, and tool schemas in the supplied stable file.
- Add an explicit `system_prompt_mode="append"` compatibility mode for callers that need the previous `--append-system-prompt-file` behavior; invalid modes fail closed.
- Keep the one-shot `generate()` path, daemon `claude-p` backend, auth/environment handling, sessions/resume, and other prompt composers unchanged.

## Why

Claude Code documents these distinct semantics:

- [`--system-prompt-file`](https://code.claude.com/docs/en/cli-reference) replaces the default system prompt.
- [`--append-system-prompt-file`](https://code.claude.com/docs/en/headless) retains the default prompt and appends additional instructions.

The current LingTai chat adapter used the append form, so Claude Code's native coding-agent prompt remained in every main chat session. This change selects the documented replacement form while preserving the existing stable-file/stdin split used for cache-friendly multi-turn sessions.

OpenClaw's Claude CLI backend was also checked as requested. Its current documented default is still append mode and its implementation uses a prompt file; OpenClaw issue [#71600](https://github.com/openclaw/openclaw/issues/71600) supports file-based prompt transport after Windows `ENAMETOOLONG`, but is not evidence that OpenClaw removes Claude's defaults by default.

## Validation

- `tests/test_claude_code_adapter.py`: **34 passed**
- Related registry/service/timeout/session tests: **73 passed**
- `py_compile`: PASS for the changed Python files
- Ruff check: PASS
- `git diff --check`: PASS
- `ruff format --check`: the immutable `main` baseline already requests formatting changes for both touched files; this PR does not introduce a whole-file formatter sweep or unrelated formatting churn.
- No live authenticated Claude call was made; that requires separate authorization.

Base was locked at `00a80ad094dbfd710698d3432ac45c567814c9c6` (tree `41e9007f32bcdbd8659ef0effed29740ced09129`).

Merge and release are intentionally out of scope for this PR.
