### PR TITLE
fix(task_card): persist active watch across restart (refresh/molt)

### DIFF
--- a/src/lingtai/tools/task_card/ANATOMY.md
+++ b/src/lingtai/tools/task_card/ANATOMY.md
@@ -27,7 +27,9 @@ plus its persisted agent-wide configuration, both under `<workdir>/taskcard/`,
 and nothing else. It is producer-first and channel-neutral: it runs a
 renderer, writes `taskcard/taskcard.md`, and writes `taskcard/status` as exact
 `active` or `inactive`, reading `taskcard/taskcard.json` to resolve each new
-watch's cadence/ceiling defaults. `stop` pauses a watch and preserves the last
+watch's cadence/ceiling defaults. An active watch persists a resume descriptor
+at `taskcard/watch.json` so a `refresh`/molt/agent-stop can rehydrate the same
+watch on the next boot; `stop` pauses a watch and preserves the last
 body; `remove` is the terminal lifecycle action that also retires any active
 watch and deletes the body, so a caller never needs to reach around this
 capability with a filesystem delete. It does not own Telegram, Feishu, portals,
@@ -47,9 +49,12 @@ Normative promises live in [`CONTRACT.md`](CONTRACT.md).
 ## Connections
 
 - `setup(agent)` registers the public `task_card` tool through
-  `lingtai.tools.registry`.
+  `lingtai.tools.registry` and rehydrates a persisted active watch
+  (`TaskCardManager.resume_persisted_watch`) so the card survives
+  `refresh`/molt/agent-stop restarts.
 - `lifecycle._stop` calls `shutdown_for_agent_stop()` so a stopping agent
-  writes `inactive` and joins the watch thread best-effort.
+  writes `inactive`, joins the watch thread best-effort, and re-persists the
+  watch descriptor with its carried refresh budget for the next boot.
 - Telegram and Feishu are only consumers: each manager reads
   `<workdir>/taskcard/status` and `<workdir>/taskcard/taskcard.md` and projects
   them separately. The intrinsic capability never calls back into either
@@ -78,8 +83,14 @@ Normative promises live in [`CONTRACT.md`](CONTRACT.md).
   (`interval_s`/`timeout_s`/`max_refreshes`); read fresh on every `start`,
   written only by the one-way legacy migration (never by any model-facing
   action)
+- `<workdir>/taskcard/watch.json` — persisted active-watch descriptor
+  (`watch_id`/`renderer_path`/`interval_s`/`timeout_s`/`max_refreshes`/
+  `refreshes_used`/`started_at`); written on `start` and re-written on
+  agent-stop with the carried refresh budget, read by `setup` to resume the
+  watch, and cleared on `stop`/`remove`/refresh exhaustion
 - In-memory only: one active watch, its thread, last valid body/timestamp, and
-  deduped error/limit bookkeeping
+  deduped error/limit bookkeeping (the descriptor is the only cross-process
+  watch state)
 
 ## Notes
 

--- a/src/lingtai/tools/task_card/CONTRACT.md
+++ b/src/lingtai/tools/task_card/CONTRACT.md
@@ -36,17 +36,23 @@ declarative artifact and one active watch per agent.
 1. The capability owns exactly two artifact files under the agent working
    directory: `taskcard/status` and `taskcard/taskcard.md`. It additionally
    owns one persisted agent-wide configuration file, `taskcard/taskcard.json`
-   (see rule 9), which is policy input, not producer output.
+   (see rule 9), which is policy input, not producer output, and one
+   persisted active-watch descriptor, `taskcard/watch.json` (see rule 14),
+   which is producer state for restart recovery, not channel-facing output.
 2. `start` validates a Python renderer path contained within the agent working
    directory, runs it synchronously, requires non-empty stdout, writes the full
    body atomically to `taskcard/taskcard.md`, then atomically writes
-   `taskcard/status` as exact `active`, and only then starts the watch thread.
+   `taskcard/status` as exact `active`, and only then starts the watch thread
+   and persists `taskcard/watch.json` for restart resume.
 3. `retry` reruns the renderer for the active watch. On success it atomically
    replaces only `taskcard/taskcard.md`; `status` remains `active`.
 4. `stop` and agent shutdown write exact `inactive` before stopping the updater.
    The last body remains on disk. `stop` is non-terminal: it pauses/preserves
    the artifact for a possible later `retry`/inspection, it does not clean it
-   up.
+   up. Agent shutdown (refresh/molt/agent-stop) also re-persists the watch
+   descriptor with its carried refresh budget so the next boot can resume the
+   watch; `stop` is the explicit pause that clears the descriptor instead, so
+   a stopped watch does not auto-resume on the next boot.
 5. At most one watch may be active per agent. A second `start` fails closed.
 6. The capability is channel-neutral. It MUST NOT own transport-specific
    concepts such as Telegram chat/message IDs, API retries, or consumer
@@ -117,7 +123,23 @@ declarative artifact and one active watch per agent.
     SHOULD call `remove` once the underlying work is completed, cancelled, or
     abandoned, so a consumer such as `/taskcard` cannot keep exposing a stale
     card; agents MUST NOT reach around this capability with a shell/file-tool
-    delete of `taskcard/taskcard.md`.
+    delete of `taskcard/taskcard.md`. `remove` also clears the watch
+    descriptor, so the removed card never auto-resumes on a later boot.
+14. The active watch is persisted to `taskcard/watch.json` so the card
+    survives process restarts (`refresh`, molt, agent-stop). `start` writes
+    the descriptor after a successful spawn; agent shutdown re-writes it with
+    the carried refresh budget; `setup` reads it on boot and rehydrates the
+    watch (same `watch_id`, renderer path, cadence, ceilings, and remaining
+    refresh budget), reruns the renderer to refresh the body, marks `active`,
+    and respawns the updater thread. `stop`, `remove`, and refresh-limit
+    exhaustion clear the descriptor, because those are deliberate terminal
+    ends of the watch rather than process-transient stops. A stale descriptor
+    (missing/corrupt file, renderer path that no longer exists or escapes the
+    working directory, already-exhausted refresh budget) is cleared on boot
+    and leaves the card `inactive` — a restart never silently resurrects a
+    dead watch. A transient renderer failure during resume preserves the last
+    body and lets the updater thread retry, matching live-watch error
+    semantics.
 
 ## Port
 
@@ -132,6 +154,9 @@ Public LTP-v2 family root `task_card` with actions `start`, `inspect`, `retry`,
   for `start`/`retry`/`stop`; `remove` additionally unlinks `taskcard/
   taskcard.md` (tolerating an already-missing file) after the watch is
   retired.
+- Watch-descriptor writer: atomic JSON write of `taskcard/watch.json` on
+  `start` and agent shutdown (carried refresh budget); unlink on
+  `stop`/`remove`/refresh exhaustion (tolerating an already-missing file).
 - Filesystem config reader: plain read of `taskcard/taskcard.json` (no fsync;
   read-only in the steady state) plus the one-way legacy-migration writer
   described in Behavior rule 11.
@@ -159,6 +184,11 @@ Public LTP-v2 family root `task_card` with actions `start`, `inspect`, `retry`,
 9. Removal order is strict: retire the watch (write `inactive`, then confirm
    the updater has quiesced) before deleting `taskcard/taskcard.md`. `remove`
    MUST NOT delete the body while a watch might still be running.
+10. Restart resume is safe and honest: the watch descriptor is the only
+    cross-process watch state, `setup` rehydrates at most one watch from it,
+    stale descriptors are cleared without resurrecting a dead watch, and the
+    resumed watch keeps the same refresh budget rather than silently
+    resetting its ceiling.
 
 ## Tests
 

--- a/src/lingtai/tools/task_card/CONTRACT.md
+++ b/src/lingtai/tools/task_card/CONTRACT.md
@@ -201,6 +201,15 @@ Public LTP-v2 family root `task_card` with actions `start`, `inspect`, `retry`,
   terminal cleanup: removal after a stopped watch, removal of an active watch
   with no body-recreation race, blocking (without deleting) on a watch that
   will not quiesce, and idempotence when already removed or never started.
+  Watch persistence/resume (Behavior rule 14, Invariant 10): descriptor
+  written on start and re-written with the carried refresh budget on agent
+  shutdown; `setup()` rehydrating the watch on the next boot with the same
+  id/params/budget; a transient renderer failure at resume preserving the
+  last body, writing `active` unconditionally, and staying `active` after a
+  later successful tick; corrupt/empty/stale descriptors being cleared;
+  partial and exhausted budgets being carried; and stop/remove/exhaust
+  clearing the descriptor so a deliberately stopped watch is never
+  resurrected.
 - `tests/test_telegram_toolfamily_ltpv2.py` covers the strict public family
   schema plus intrinsic refresh-limit behavior.
 - `tests/test_telegram_task_card_programmable.py` covers Telegram's read-only

--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -5,9 +5,12 @@ under ``<workdir>/taskcard/``:
 
 - ``status``     — exact text ``active`` or ``inactive``
 - ``taskcard.md`` — the rendered card body
+- ``watch.json`` — persisted active-watch descriptor for restart resume
 
 The producer writes only those files. Channels consume/project them
-independently.
+independently. The watch descriptor survives ``refresh``/molt/agent-stop so a
+restart rehydrates the active watch; ``stop``/``remove``/refresh exhaustion
+clear it because those are deliberate terminal ends.
 """
 
 from __future__ import annotations
@@ -48,6 +51,7 @@ _TASKCARD_DIR = "taskcard"
 _STATUS_FILENAME = "status"
 _BODY_FILENAME = "taskcard.md"
 _CONFIG_FILENAME = "taskcard.json"
+_WATCH_FILENAME = "watch.json"
 # One-way migration source only: the retired Telegram-owned reverse-channel
 # design persisted its own refresh ceiling here. Consulted only when this
 # capability's own config file has never been created; that first resolution
@@ -224,6 +228,7 @@ class TaskCardManager:
         self._status_path = self._taskcard_dir / _STATUS_FILENAME
         self._body_path = self._taskcard_dir / _BODY_FILENAME
         self._config_path = self._taskcard_dir / _CONFIG_FILENAME
+        self._watch_path = self._taskcard_dir / _WATCH_FILENAME
         self._legacy_config_path = self._taskcard_dir.parent / _LEGACY_CONFIG_DIR / _CONFIG_FILENAME
 
     def handle(self, args: dict[str, Any] | None) -> dict[str, Any]:
@@ -299,6 +304,7 @@ class TaskCardManager:
             watch.last_valid_body = body
             watch.last_valid_at = _utc_now_iso()
         self._spawn(watch)
+        self._persist_watch(watch)
         return {
             "status": "ok",
             "watch_id": watch.watch_id,
@@ -388,6 +394,7 @@ class TaskCardManager:
         with self._lock:
             if self._watch is watch:
                 self._watch = None
+        self._clear_watch_descriptor()
         return {
             "status": "ok",
             "watch_id": watch.watch_id,
@@ -446,6 +453,7 @@ class TaskCardManager:
                 **self._paths_payload(),
                 **self._status_payload("inactive"),
             }
+        self._clear_watch_descriptor()
         self._clear_reminder()
         return {
             "status": "ok",
@@ -544,6 +552,7 @@ class TaskCardManager:
         with self._lock:
             if self._watch is watch:
                 self._watch = None
+        self._clear_watch_descriptor()
 
     def _stop_requested(self, watch: _Watch) -> bool:
         if watch.stop_event.is_set():
@@ -775,6 +784,148 @@ class TaskCardManager:
         watch.stop_event.set()
         if watch.thread is not None and watch.thread.is_alive():
             watch.thread.join(timeout=watch.timeout_s + 1.0)
+        # Carry the live refresh budget into the persisted descriptor so a
+        # restart resume honors it instead of starting over at zero.
+        try:
+            self._persist_watch(watch)
+        except OSError:
+            pass
+
+    def _persist_watch(self, watch: _Watch) -> None:
+        """Persist the active watch descriptor so a restart can resume it.
+
+        Written atomically on a successful ``start``. Kept across
+        ``shutdown_for_agent_stop`` (refresh/molt/agent-stop) so the next
+        process can rehydrate the watch; cleared on ``stop``, ``remove``, or
+        refresh-limit exhaustion because those are deliberate terminal ends
+        of the watch, not process-transient stops.
+        """
+        with watch.lock:
+            payload = {
+                "watch_id": watch.watch_id,
+                "renderer_path": str(watch.renderer_path),
+                "interval_s": watch.interval_s,
+                "timeout_s": watch.timeout_s,
+                "max_refreshes": watch.max_refreshes,
+                "refreshes_used": watch.refreshes_used,
+                "started_at": _utc_now_iso(),
+            }
+        atomic_write_json(self._watch_path, payload)
+
+    def _clear_watch_descriptor(self) -> None:
+        try:
+            self._watch_path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            # A stale descriptor is harmless; a later start/resume overwrites it.
+            pass
+
+    def resume_persisted_watch(self) -> dict[str, Any] | None:
+        """Rehydrate the persisted watch after a process restart.
+
+        Called from ``setup`` on every boot. If ``taskcard/watch.json`` exists
+        and is valid, re-creates the watch (same id/params/refresh budget),
+        writes the current renderer output to the body, marks ``active``, and
+        spawns the updater thread. Returns the start-style payload on success
+        or ``None`` when there is nothing to resume.
+
+        A missing/corrupt descriptor, a renderer that no longer exists, an
+        invalid path, or an already-exhausted refresh budget are treated as
+        stale: the descriptor is cleared and the card left ``inactive`` so a
+        boot never silently resurrects a dead watch.
+        """
+        with self._lock:
+            if self._watch is not None:
+                return None
+        try:
+            payload = read_json(self._watch_path, expect=dict)
+        except (OSError, ValueError, TypeError):
+            return None
+        if not payload:
+            return None
+        watch_id = payload.get("watch_id")
+        renderer_raw = payload.get("renderer_path")
+        if not isinstance(watch_id, str) or not isinstance(renderer_raw, str):
+            self._clear_watch_descriptor()
+            return None
+        try:
+            renderer_path = self._validate_renderer_path(renderer_raw)
+        except TaskCardError:
+            self._clear_watch_descriptor()
+            return None
+        config = self._load_config()
+        interval_s = self._coerce_positive(
+            payload.get("interval_s", config.interval_s), "interval_s", _MIN_INTERVAL_S
+        )
+        requested_timeout = payload.get("timeout_s")
+        if requested_timeout is None:
+            timeout_s = config.timeout_s
+        else:
+            timeout_s = min(
+                self._coerce_positive(requested_timeout, "timeout_s", _MIN_TIMEOUT_S),
+                config.timeout_s,
+            )
+        requested_max = payload.get("max_refreshes")
+        if type(requested_max) is int and requested_max > 0:
+            effective_max = min(requested_max, config.max_refreshes)
+        else:
+            effective_max = config.max_refreshes
+        refreshes_used = payload.get("refreshes_used", 0)
+        if type(refreshes_used) is not int or refreshes_used < 0:
+            refreshes_used = 0
+        if refreshes_used >= effective_max:
+            # Budget already exhausted while away: retire the stale card.
+            self._clear_watch_descriptor()
+            return None
+        try:
+            counter = int(str(watch_id).split("_")[-1])
+            self._counter = max(self._counter, counter)
+        except (ValueError, IndexError):
+            pass
+        watch = _Watch(
+            watch_id,
+            renderer_path,
+            interval_s,
+            timeout_s,
+            effective_max,
+        )
+        watch.refreshes_used = refreshes_used
+        with self._lock:
+            self._watch = watch
+        try:
+            body = self._run_renderer(renderer_path, timeout_s)
+            self._publish_active(body)
+            self._clear_reminder()
+        except Exception:
+            # A transient renderer failure at boot must not kill the card:
+            # keep the last body, mark active, and let the thread retry.
+            try:
+                body = self._body_path.read_text(encoding="utf-8")
+            except OSError:
+                body = None
+            if body is None:
+                try:
+                    self._write_status("active")
+                except OSError:
+                    pass
+            with watch.lock:
+                watch.last_valid_body = body
+                watch.last_valid_at = _utc_now_iso() if body is not None else None
+        else:
+            with watch.lock:
+                watch.last_valid_body = body
+                watch.last_valid_at = _utc_now_iso()
+        self._spawn(watch)
+        return {
+            "status": "ok",
+            "watch_id": watch.watch_id,
+            "state": "watching",
+            "resumed": True,
+            **self._paths_payload(),
+            **self._status_payload("active"),
+            **self._refresh_fields(watch),
+        }
 
     def _load_config(self) -> _Config:
         """Load this agent's persisted Task Card defaults/ceilings.
@@ -923,6 +1074,7 @@ class TaskCardManager:
             "taskcard_dir": str(self._taskcard_dir),
             "status_path": str(self._status_path),
             "body_path": str(self._body_path),
+            "watch_path": str(self._watch_path),
         }
 
     @staticmethod
@@ -944,4 +1096,11 @@ def setup(agent: BaseAgent, **_ignored: Any) -> TaskCardManager:
         description=get_description(),
         glossary_package=None,
     )
+    # A watch persisted by a previous process (refresh/molt/agent-stop) is
+    # rehydrated on boot so the card survives process restarts. Deliberate
+    # terminal ends (stop/remove/exhaust) already cleared the descriptor.
+    try:
+        manager.resume_persisted_watch()
+    except Exception:
+        pass
     return manager

--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -185,6 +185,7 @@ class _Watch:
         "attempt_lock",
         "limit_notified",
         "stop_reason",
+        "terminated",
     )
 
     def __init__(
@@ -213,6 +214,7 @@ class _Watch:
         self.attempt_lock = threading.Lock()
         self.limit_notified = False
         self.stop_reason: str | None = None
+        self.terminated = False
 
 
 class TaskCardManager:
@@ -303,8 +305,15 @@ class TaskCardManager:
         with watch.lock:
             watch.last_valid_body = body
             watch.last_valid_at = _utc_now_iso()
+        # Persist the descriptor before spawning the thread: the updater could
+        # otherwise exhaust and clear it in the gap, resurrecting a dead watch.
+        # Persistence is best-effort here — a start that already succeeded must
+        # not fail because the descriptor write hit ENOSPC/EROFS/EACCES.
+        try:
+            self._persist_watch(watch)
+        except OSError:
+            pass
         self._spawn(watch)
-        self._persist_watch(watch)
         return {
             "status": "ok",
             "watch_id": watch.watch_id,
@@ -394,6 +403,8 @@ class TaskCardManager:
         with self._lock:
             if self._watch is watch:
                 self._watch = None
+        with watch.lock:
+            watch.terminated = True
         self._clear_watch_descriptor()
         return {
             "status": "ok",
@@ -454,6 +465,14 @@ class TaskCardManager:
                 **self._status_payload("inactive"),
             }
         self._clear_watch_descriptor()
+        # A concurrent agent-shutdown may still hold this watch: mark it
+        # terminated so shutdown does not re-persist the descriptor after
+        # ``remove`` deliberately retired it.
+        with self._lock:
+            watch = self._watch
+        if watch is not None:
+            with watch.lock:
+                watch.terminated = True
         self._clear_reminder()
         return {
             "status": "ok",
@@ -547,6 +566,8 @@ class TaskCardManager:
                 }
             self._emit_limit_event(watch)
             return
+        with watch.lock:
+            watch.terminated = True
         watch.stop_event.set()
         self._emit_limit_event(watch)
         with self._lock:
@@ -785,11 +806,17 @@ class TaskCardManager:
         if watch.thread is not None and watch.thread.is_alive():
             watch.thread.join(timeout=watch.timeout_s + 1.0)
         # Carry the live refresh budget into the persisted descriptor so a
-        # restart resume honors it instead of starting over at zero.
-        try:
-            self._persist_watch(watch)
-        except OSError:
-            pass
+        # restart resume honors it instead of starting over at zero. A watch
+        # already deliberately terminated (stop/remove/exhaust racing this
+        # shutdown) must not be resurrected: re-check the flag under
+        # ``watch.lock``, which also serializes against the descriptor write.
+        with watch.lock:
+            if watch.terminated:
+                return
+            try:
+                self._persist_watch(watch)
+            except OSError:
+                pass
 
     def _persist_watch(self, watch: _Watch) -> None:
         """Persist the active watch descriptor so a restart can resume it.
@@ -801,16 +828,23 @@ class TaskCardManager:
         of the watch, not process-transient stops.
         """
         with watch.lock:
+            workdir = Path(self._agent._working_dir).resolve()
+            try:
+                renderer_rel = str(watch.renderer_path.relative_to(workdir))
+            except ValueError:
+                # Path not under the workdir (should not happen given
+                # validation); fall back to the absolute path.
+                renderer_rel = str(watch.renderer_path)
             payload = {
                 "watch_id": watch.watch_id,
-                "renderer_path": str(watch.renderer_path),
+                "renderer_path": renderer_rel,
                 "interval_s": watch.interval_s,
                 "timeout_s": watch.timeout_s,
                 "max_refreshes": watch.max_refreshes,
                 "refreshes_used": watch.refreshes_used,
                 "started_at": _utc_now_iso(),
             }
-        atomic_write_json(self._watch_path, payload)
+        atomic_write_json(self._watch_path, payload, fsync=True)
 
     def _clear_watch_descriptor(self) -> None:
         try:
@@ -841,12 +875,29 @@ class TaskCardManager:
         try:
             payload = read_json(self._watch_path, expect=dict)
         except (OSError, ValueError, TypeError):
+            # Corrupt descriptor: the contract promises stale descriptors are
+            # cleared on boot, not left to wedge every future boot.
+            self._clear_watch_descriptor()
             return None
         if not payload:
+            # Valid-JSON but empty (e.g. ``{}``): can never resume; clear it.
+            self._clear_watch_descriptor()
             return None
         watch_id = payload.get("watch_id")
+        if not isinstance(watch_id, str):
+            self._clear_watch_descriptor()
+            return None
+        # Carry the watch-id counter before any stale-clear path: a discard
+        # must not reset the counter and let a later start reuse ``tc_1``
+        # (notification idempotency keys embed the watch id).
+        with self._lock:
+            try:
+                counter = int(str(watch_id).split("_")[-1])
+                self._counter = max(self._counter, counter)
+            except (ValueError, IndexError):
+                pass
         renderer_raw = payload.get("renderer_path")
-        if not isinstance(watch_id, str) or not isinstance(renderer_raw, str):
+        if not isinstance(renderer_raw, str):
             self._clear_watch_descriptor()
             return None
         try:
@@ -855,17 +906,22 @@ class TaskCardManager:
             self._clear_watch_descriptor()
             return None
         config = self._load_config()
-        interval_s = self._coerce_positive(
-            payload.get("interval_s", config.interval_s), "interval_s", _MIN_INTERVAL_S
-        )
-        requested_timeout = payload.get("timeout_s")
-        if requested_timeout is None:
-            timeout_s = config.timeout_s
-        else:
-            timeout_s = min(
-                self._coerce_positive(requested_timeout, "timeout_s", _MIN_TIMEOUT_S),
-                config.timeout_s,
+        try:
+            interval_s = self._coerce_positive(
+                payload.get("interval_s", config.interval_s), "interval_s", _MIN_INTERVAL_S
             )
+            requested_timeout = payload.get("timeout_s")
+            if requested_timeout is None:
+                timeout_s = config.timeout_s
+            else:
+                timeout_s = min(
+                    self._coerce_positive(requested_timeout, "timeout_s", _MIN_TIMEOUT_S),
+                    config.timeout_s,
+                )
+        except TaskCardError:
+            # Non-numeric cadence/ceiling in the descriptor: treat as stale.
+            self._clear_watch_descriptor()
+            return None
         requested_max = payload.get("max_refreshes")
         if type(requested_max) is int and requested_max > 0:
             effective_max = min(requested_max, config.max_refreshes)
@@ -878,11 +934,6 @@ class TaskCardManager:
             # Budget already exhausted while away: retire the stale card.
             self._clear_watch_descriptor()
             return None
-        try:
-            counter = int(str(watch_id).split("_")[-1])
-            self._counter = max(self._counter, counter)
-        except (ValueError, IndexError):
-            pass
         watch = _Watch(
             watch_id,
             renderer_path,
@@ -899,16 +950,16 @@ class TaskCardManager:
             self._clear_reminder()
         except Exception:
             # A transient renderer failure at boot must not kill the card:
-            # keep the last body, mark active, and let the thread retry.
+            # keep the last body, mark active unconditionally (the watch IS
+            # live and the returned payload says so), and let the thread retry.
             try:
                 body = self._body_path.read_text(encoding="utf-8")
             except OSError:
                 body = None
-            if body is None:
-                try:
-                    self._write_status("active")
-                except OSError:
-                    pass
+            try:
+                self._write_status("active")
+            except OSError:
+                pass
             with watch.lock:
                 watch.last_valid_body = body
                 watch.last_valid_at = _utc_now_iso() if body is not None else None
@@ -1101,6 +1152,11 @@ def setup(agent: BaseAgent, **_ignored: Any) -> TaskCardManager:
     # terminal ends (stop/remove/exhaust) already cleared the descriptor.
     try:
         manager.resume_persisted_watch()
-    except Exception:
-        pass
+    except Exception as exc:
+        log = getattr(agent, "_log", None)
+        if callable(log):
+            try:
+                log("task_card_resume_failed", error=str(exc))
+            except Exception:
+                pass
     return manager

--- a/src/lingtai/tools/task_card/manual/SKILL.md
+++ b/src/lingtai/tools/task_card/manual/SKILL.md
@@ -34,6 +34,16 @@ The capability owns exactly two files under your working directory:
 - `taskcard/status`
 - `taskcard/taskcard.md`
 
+While a watch is active it also keeps one restart descriptor at
+`taskcard/watch.json`, so the card survives `refresh`/molt/agent-stop: the next
+boot rehydrates the same watch (same `watch_id`, renderer, cadence, ceilings,
+and remaining refresh budget), reruns the renderer to refresh the body, marks
+`active`, and resumes the updater. `stop`, `remove`, and refresh-limit
+exhaustion clear the descriptor because those are deliberate ends of the watch;
+a stale descriptor (renderer gone, budget exhausted, corrupt file) is cleared
+on boot and leaves the card `inactive` rather than silently resurrecting a
+dead watch.
+
 Actions are `start`, `inspect`, `retry`, `stop`, `remove`, and `manual`.
 
 `start` runs a Python renderer under your working directory. The renderer must

--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -131,6 +131,155 @@ def test_start_writes_body_before_active_and_reports_exact_paths(agent, manager,
     manager.handle({"action": "stop", "input": {"watch_id": result["watch_id"]}, "reasoning": "cleanup"})
 
 
+def test_start_persists_watch_descriptor_for_restart_resume(agent, manager):
+    renderer = _write_renderer(agent._working_dir, _OK_BODY)
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": renderer, "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    watch_path = Path(started["watch_path"])
+    assert watch_path.is_file()
+    payload = json.loads(watch_path.read_text(encoding="utf-8"))
+    assert payload["watch_id"] == started["watch_id"]
+    assert payload["renderer_path"] == renderer
+    assert payload["interval_s"] == 3600
+    assert payload["max_refreshes"] == 2000
+    assert payload["refreshes_used"] == 0
+    manager.handle({"action": "stop", "input": {"watch_id": started["watch_id"]}, "reasoning": "cleanup"})
+    assert not watch_path.exists()
+
+
+def test_resume_persisted_watch_after_shutdown_rehydrates_watch(agent, manager):
+    renderer = _write_renderer(agent._working_dir, _OK_BODY)
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": renderer, "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    watch_id = started["watch_id"]
+    watch_path = Path(started["watch_path"])
+    assert watch_path.is_file()
+
+    # Simulate a process restart: shutdown stops the thread but keeps the
+    # descriptor; a fresh manager rehydrates the watch on setup.
+    manager.shutdown_for_agent_stop(reason="agent_stop")
+    assert manager._watch is None
+    assert watch_path.is_file()
+    assert Path(started["status_path"]).read_text(encoding="utf-8") == "inactive"
+
+    fresh = TaskCardManager(agent)
+    resumed = fresh.resume_persisted_watch()
+    assert resumed is not None
+    assert resumed["status"] == "ok"
+    assert resumed["resumed"] is True
+    assert resumed["watch_id"] == watch_id
+    assert resumed["state"] == "watching"
+    assert resumed["status_value"] == "active"
+    assert fresh._watch is not None
+    assert fresh._watch.watch_id == watch_id
+    assert fresh._watch.thread is not None and fresh._watch.thread.is_alive()
+    assert Path(started["status_path"]).read_text(encoding="utf-8") == "active"
+    assert Path(started["body_path"]).read_text(encoding="utf-8") == "# Task Card\n\n- first\n- second\n"
+    fresh.shutdown_for_agent_stop()
+
+
+def test_resume_persisted_watch_is_idempotent_with_active_watch(agent, manager):
+    renderer = _write_renderer(agent._working_dir, _OK_BODY)
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": renderer, "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    # A second resume while the watch is live is a no-op, not a duplicate.
+    assert manager.resume_persisted_watch() is None
+    manager.handle({"action": "stop", "input": {"watch_id": started["watch_id"]}, "reasoning": "cleanup"})
+
+
+def test_resume_missing_or_corrupt_descriptor_is_noop(agent, manager):
+    assert manager.resume_persisted_watch() is None
+    watch_path = manager._taskcard_dir / "watch.json"
+    watch_path.parent.mkdir(parents=True, exist_ok=True)
+    watch_path.write_text("{not json", encoding="utf-8")
+    assert manager.resume_persisted_watch() is None
+
+
+def test_resume_clears_descriptor_when_renderer_no_longer_exists(agent, manager):
+    renderer = _write_renderer(agent._working_dir, _OK_BODY)
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": renderer, "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    watch_path = Path(started["watch_path"])
+    Path(renderer).unlink()
+    manager.shutdown_for_agent_stop(reason="agent_stop")
+
+    fresh = TaskCardManager(agent)
+    assert fresh.resume_persisted_watch() is None
+    assert not watch_path.exists()
+    assert fresh._watch is None
+    assert Path(started["status_path"]).read_text(encoding="utf-8") == "inactive"
+
+
+def test_resume_respects_carried_refresh_budget(agent, manager):
+    renderer = _write_renderer(agent._working_dir, _OK_BODY)
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": renderer, "interval_s": 3600, "max_refreshes": 3},
+            "reasoning": "publish a task card",
+        }
+    )
+    watch = manager._watch
+    assert watch is not None
+    watch.refreshes_used = 3  # budget exhausted
+    manager.shutdown_for_agent_stop(reason="agent_stop")
+
+    fresh = TaskCardManager(agent)
+    assert fresh.resume_persisted_watch() is None
+    assert not Path(started["watch_path"]).exists()
+    assert fresh._watch is None
+
+
+def test_stop_clears_persisted_descriptor(agent, manager):
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": _write_renderer(agent._working_dir, _OK_BODY), "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    watch_path = Path(started["watch_path"])
+    assert watch_path.exists()
+    manager.handle({"action": "stop", "input": {"watch_id": started["watch_id"]}, "reasoning": "deactivate"})
+    assert not watch_path.exists()
+    assert manager.resume_persisted_watch() is None
+
+
+def test_remove_clears_persisted_descriptor(agent, manager):
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": _write_renderer(agent._working_dir, _OK_BODY), "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    watch_path = Path(started["watch_path"])
+    assert watch_path.exists()
+    manager.handle({"action": "remove", "input": {}, "reasoning": "work is done"})
+    assert not watch_path.exists()
+    assert manager.resume_persisted_watch() is None
+
+
 def test_retry_replaces_only_the_body_and_preserves_active_status(agent, manager, monkeypatch):
     renderer = _write_renderer(agent._working_dir, _OK_BODY)
     started = manager.handle(

--- a/tests/test_task_card_controller.py
+++ b/tests/test_task_card_controller.py
@@ -144,7 +144,9 @@ def test_start_persists_watch_descriptor_for_restart_resume(agent, manager):
     assert watch_path.is_file()
     payload = json.loads(watch_path.read_text(encoding="utf-8"))
     assert payload["watch_id"] == started["watch_id"]
-    assert payload["renderer_path"] == renderer
+    # The renderer path is persisted relative to the working directory so a
+    # relocated workdir can still resume the watch.
+    assert payload["renderer_path"] == "renderer.py"
     assert payload["interval_s"] == 3600
     assert payload["max_refreshes"] == 2000
     assert payload["refreshes_used"] == 0
@@ -208,6 +210,13 @@ def test_resume_missing_or_corrupt_descriptor_is_noop(agent, manager):
     watch_path.parent.mkdir(parents=True, exist_ok=True)
     watch_path.write_text("{not json", encoding="utf-8")
     assert manager.resume_persisted_watch() is None
+    # The contract promises stale descriptors are cleared, not left to wedge
+    # every future boot (CONTRACT Behavior rule 14).
+    assert not watch_path.exists(), "corrupt descriptor must be cleared on boot"
+    # A valid-JSON but empty descriptor is equally stale.
+    watch_path.write_text("{}", encoding="utf-8")
+    assert manager.resume_persisted_watch() is None
+    assert not watch_path.exists(), "empty descriptor must be cleared on boot"
 
 
 def test_resume_clears_descriptor_when_renderer_no_longer_exists(agent, manager):
@@ -248,6 +257,109 @@ def test_resume_respects_carried_refresh_budget(agent, manager):
     assert fresh.resume_persisted_watch() is None
     assert not Path(started["watch_path"]).exists()
     assert fresh._watch is None
+
+
+def test_resume_renderer_failure_writes_active_and_preserves_body(agent, manager):
+    """A transient renderer failure at resume keeps the card visible.
+
+    CONTRACT Behavior rule 14: resume marks ``active`` unconditionally, keeps
+    the last body on disk, and lets the updater thread retry; a later
+    successful tick must not leave the card stuck ``inactive``.
+    """
+    renderer = _write_renderer(agent._working_dir, _OK_BODY)
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": renderer, "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    status_path = Path(started["status_path"])
+    body_path = Path(started["body_path"])
+    manager.shutdown_for_agent_stop(reason="agent_stop")
+    assert status_path.read_text(encoding="utf-8") == "inactive"
+    assert body_path.read_text(encoding="utf-8") == "# Task Card\n\n- first\n- second\n"
+
+    # The renderer now fails transiently (nonzero exit); the last body stays
+    # on disk, exactly the case that used to leave status stuck inactive.
+    Path(renderer).write_text("import sys; sys.exit(3)", encoding="utf-8")
+    fresh = TaskCardManager(agent)
+    resumed = fresh.resume_persisted_watch()
+    try:
+        assert resumed is not None
+        assert resumed["status_value"] == "active"
+        assert fresh._watch is not None
+        assert fresh._watch.last_valid_body == "# Task Card\n\n- first\n- second\n"
+        assert fresh._watch.last_valid_at is not None
+        assert status_path.read_text(encoding="utf-8") == "active"
+        assert body_path.read_text(encoding="utf-8") == "# Task Card\n\n- first\n- second\n"
+
+        # Renderer recovers: a later successful tick keeps the card active.
+        Path(renderer).write_text(_OK_BODY, encoding="utf-8")
+        fresh._tick(fresh._watch)
+        assert fresh._watch.error is None
+        assert status_path.read_text(encoding="utf-8") == "active"
+        assert fresh._watch.last_valid_body == "# Task Card\n\n- first\n- second\n"
+    finally:
+        fresh.shutdown_for_agent_stop()
+
+
+def test_resume_carries_partial_refresh_budget_into_live_watch(agent, manager):
+    """A partial refresh budget survives shutdown and a live resume."""
+    renderer = _write_renderer(agent._working_dir, _OK_BODY)
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": renderer, "interval_s": 3600, "max_refreshes": 5},
+            "reasoning": "publish a task card",
+        }
+    )
+    watch = manager._watch
+    assert watch is not None
+    watch.refreshes_used = 3  # partial budget: 2 refreshes remain
+    manager.shutdown_for_agent_stop(reason="agent_stop")
+    payload = json.loads(Path(started["watch_path"]).read_text(encoding="utf-8"))
+    assert payload["refreshes_used"] == 3
+
+    fresh = TaskCardManager(agent)
+    resumed = fresh.resume_persisted_watch()
+    try:
+        assert resumed is not None
+        assert resumed["refreshes_used"] == 3
+        assert resumed["max_refreshes"] == 5
+        assert resumed["refreshes_remaining"] == 2
+        assert fresh._watch is not None
+        assert fresh._watch.refreshes_used == 3
+        assert fresh._watch.max_refreshes == 5
+    finally:
+        fresh.shutdown_for_agent_stop()
+
+
+def test_setup_resumes_a_persisted_watch_on_boot(agent, manager):
+    """setup() on a fresh agent rehydrates a persisted watch."""
+    renderer = _write_renderer(agent._working_dir, _OK_BODY)
+    started = manager.handle(
+        {
+            "action": "start",
+            "input": {"renderer_path": renderer, "interval_s": 3600},
+            "reasoning": "publish a task card",
+        }
+    )
+    watch_path = Path(started["watch_path"])
+    assert watch_path.is_file()
+    manager.shutdown_for_agent_stop(reason="agent_stop")
+
+    fresh_agent = _FakeAgent(agent._working_dir)
+    mgr = setup(fresh_agent)
+    try:
+        assert isinstance(mgr, TaskCardManager)
+        assert mgr._watch is not None
+        assert mgr._watch.watch_id == started["watch_id"]
+        assert mgr._watch.thread is not None and mgr._watch.thread.is_alive()
+        assert Path(started["status_path"]).read_text(encoding="utf-8") == "active"
+        assert fresh_agent.added_tools[0][0] == "task_card"
+    finally:
+        mgr.shutdown_for_agent_stop()
 
 
 def test_stop_clears_persisted_descriptor(agent, manager):


### PR DESCRIPTION
## Problem

Task Card watches were in-memory only. When the agent refreshed, molted, or stopped, the process relaunched, the updater thread died, and `taskcard/status` was left stuck at `inactive` — the card did not survive across restarts.

## Fix

Persist the active watch to `taskcard/watch.json`:

- `start` writes the descriptor after a successful spawn
- agent shutdown (`refresh`/molt/agent-stop) re-writes it with the carried refresh budget
- `setup()` rehydrates it on boot: same `watch_id`, renderer path, cadence, ceilings, and remaining refresh budget; reruns the renderer to refresh the body; marks `active`; respawns the updater
- `stop` / `remove` / refresh exhaustion clear the descriptor (deliberate terminal ends, not process-transient stops)
- stale descriptors (renderer gone, budget exhausted, corrupt) are cleared on boot without resurrecting a dead watch; a transient renderer failure during resume preserves the last body and lets the updater retry

## Tests

Adds 9 tests: descriptor persistence, shutdown→resume round-trip, idempotent resume, stale/corrupt descriptor handling, carried refresh budget, and stop/remove clearing. Full task_card suite: 102 passed.