### PR TITLE
feat(windows): enforce UTF-8 console output and OEM fallback decode

### DIFF
--- a/.github/workflows/shell-windows-pr.yml
+++ b/.github/workflows/shell-windows-pr.yml
@@ -12,6 +12,7 @@ on:
       - "tests/test_shell_windows_native.py"
       - "tests/test_windows_taskkill_fallback.py"
       - "tests/test_windows_regression.py"
+      - "tests/test_powershell_decode_windows_output.py"
   workflow_dispatch:
 
 permissions:
@@ -51,4 +52,4 @@ jobs:
         env:
           PYTHONUTF8: "1"
         run: |
-          python -m pytest -q tests/test_shell_pr1_contract.py tests/test_shell_windows_native.py tests/test_windows_taskkill_fallback.py tests/test_windows_regression.py
+          python -m pytest -q tests/test_shell_pr1_contract.py tests/test_shell_windows_native.py tests/test_windows_taskkill_fallback.py tests/test_windows_regression.py tests/test_powershell_decode_windows_output.py

--- a/src/lingtai/adapters/windows/ANATOMY.md
+++ b/src/lingtai/adapters/windows/ANATOMY.md
@@ -168,9 +168,12 @@ spawn. No adapter here persists state beyond those capability-owned files.
 `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); $OutputEncoding = [System.Text.UTF8Encoding]::new($false)`
 so native commands (ipconfig, chcp-sensitive tools) write UTF-8 to the pipe.
 Async `stdout.log`/`stderr.log` bytes are decoded at the bash read-back
-boundary with `decode_windows_output` (strict UTF-8 first, then OEM codepage
-guesses cp437/cp850/cp1252) instead of `errors="replace"`, which silently
-corrupts OEM-encoded output.
+boundary with `decode_windows_output` (strict UTF-8 first; the OEM codepage
+guesses cp437/cp850/cp1252 are applied *per line* so a mostly-UTF-8 log with
+one invalid byte run keeps its valid text) instead of `errors="replace"`,
+which silently corrupts OEM-encoded output.  The read-back boundary also
+restores the universal-newlines translation (CRLF/CR -> LF) the previous
+`read_text` provided, so async output never carries stray `\r` characters.
 
 The workdir-lease byte range (`.agent.lock`, byte 0, length 1) is a
 cross-repository interop invariant with the TUI duplicate-launch probe; the

--- a/src/lingtai/adapters/windows/ANATOMY.md
+++ b/src/lingtai/adapters/windows/ANATOMY.md
@@ -164,6 +164,14 @@ spawn. No adapter here persists state beyond those capability-owned files.
 
 ## Notes
 
+**Console encoding:** the PowerShell wrapper prepends
+`[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); $OutputEncoding = [System.Text.UTF8Encoding]::new($false)`
+so native commands (ipconfig, chcp-sensitive tools) write UTF-8 to the pipe.
+Async `stdout.log`/`stderr.log` bytes are decoded at the bash read-back
+boundary with `decode_windows_output` (strict UTF-8 first, then OEM codepage
+guesses cp437/cp850/cp1252) instead of `errors="replace"`, which silently
+corrupts OEM-encoded output.
+
 The workdir-lease byte range (`.agent.lock`, byte 0, length 1) is a
 cross-repository interop invariant with the TUI duplicate-launch probe; the
 normative statement lives in `src/lingtai/kernel/workdir_lease/CONTRACT.md`.

--- a/src/lingtai/adapters/windows/powershell.py
+++ b/src/lingtai/adapters/windows/powershell.py
@@ -325,6 +325,61 @@ def _find_pwsh() -> str | None:
     return shutil.which("pwsh")
 
 
+_OEM_CODEPAGE_GUESSES = ("cp437", "cp850", "cp1252")
+
+
+def _oem_text_score(text: str) -> int:
+    """Lower is better: penalize C0 controls and non-Latin characters.
+
+    Every single-byte codepage decodes every byte, so a first-successful-decode
+    fallback would always pick ``cp437`` and never reach ``cp850``/``cp1252``.
+    Scoring instead prefers the candidate whose bytes look most like text: C0
+    controls signal binary data, and characters beyond Latin Extended-B (box
+    drawing, Greek, ...) are rarely produced by OEM text tools.
+    """
+    score = 0
+    for char in text:
+        value = ord(char)
+        if value < 32 and char not in "\t\n\r":
+            score += 5
+        elif value > 0x24F:
+            score += 2
+        elif value > 0xFF:
+            score += 1
+    return score
+
+
+def decode_windows_output(data: bytes) -> str:
+    """Decode captured child output: strict UTF-8 first, then OEM codepages.
+
+    The PowerShell wrapper forces ``[Console]::OutputEncoding`` and
+    ``$OutputEncoding`` to UTF-8, so native commands normally emit valid UTF-8
+    bytes.  If a child still writes OEM console bytes (for example a tool that
+    re-enables the OEM codepage or is invoked outside the wrapper), strict
+    UTF-8 decoding fails and the bytes are re-decoded with the common Windows
+    OEM codepages (cp437/cp850/cp1252 heuristics, lowest text score wins)
+    instead of being silently corrupted by ``errors="replace"``.
+    ``errors="replace"`` is used only as a last resort for binary data, so
+    this function never raises.
+    """
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        best: tuple[int, str] | None = None
+        for codepage in _OEM_CODEPAGE_GUESSES:
+            try:
+                text = data.decode(codepage)
+            except UnicodeDecodeError:
+                continue
+            score = _oem_text_score(text)
+            if best is None or score < best[0]:
+                best = (score, text)
+        if best is not None:
+            return best[1]
+        return data.decode(_OEM_CODEPAGE_GUESSES[0], errors="replace")
+>>>>>>> e98ae4e9 (feat(windows): enforce UTF-8 console output and OEM fallback decode (ps/pr-2))
+
+
 class PowerShellDialect(ShellDialect):
     """PowerShell 7 (``pwsh``) invocation and policy extraction."""
 
@@ -384,6 +439,7 @@ class PowerShellDialect(ShellDialect):
         # between user statements, so ordinary PowerShell status checks retain
         # their native semantics.
         #
+<<<<<<< HEAD
         # Transport: the wrapped payload below is byte-for-byte what used to be
         # passed as the ``-Command`` argument, so the existing escape/quote and
         # exit-code handling is preserved as the stdin payload.  The command
@@ -392,7 +448,17 @@ class PowerShellDialect(ShellDialect):
         # which avoids code-page mangling of the ``-Command`` argument, the
         # 32,768-character process command-line limit, and UTF-8 in/out
         # problems (the bootstrap forces Input/OutputEncoding to UTF-8).
+=======
+        # Windows console utilities (ipconfig, chcp-sensitive tools) write
+        # through WriteConsole; PowerShell redirects that output, but only if
+        # the console encoding matches what the pipe consumer expects.  Force
+        # the child's console and pipeline encodings to UTF-8 up front so
+        # captured bytes decode cleanly at the boundary instead of arriving in
+        # the OEM codepage (which ``errors="replace"`` would corrupt).
+>>>>>>> e98ae4e9 (feat(windows): enforce UTF-8 console output and OEM fallback decode (ps/pr-2))
         wrapped = (
+            "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)\n"
+            "$OutputEncoding = [System.Text.UTF8Encoding]::new($false)\n"
             "$global:__lingtai_success = $false\n"
             "$global:__lingtai_native_exit = 0\n"
             "$global:__lingtai_final_native_failure = $false\n"
@@ -454,4 +520,4 @@ class PowerShellDialect(ShellDialect):
         return ShellKind.POWERSHELL.value
 
 
-__all__ = ["PowerShellDialect"]
+__all__ = ["PowerShellDialect", "decode_windows_output"]

--- a/src/lingtai/adapters/windows/powershell.py
+++ b/src/lingtai/adapters/windows/powershell.py
@@ -8,6 +8,7 @@ a sentinel command so a configured allowlist/denylist fails closed; trusted
 """
 from __future__ import annotations
 
+import codecs
 import os
 import re
 import shutil
@@ -326,6 +327,7 @@ def _find_pwsh() -> str | None:
 
 
 _OEM_CODEPAGE_GUESSES = ("cp437", "cp850", "cp1252")
+_UTF8_BOM = b"\xef\xbb\xbf"
 
 
 def _oem_text_score(text: str) -> int:
@@ -335,7 +337,9 @@ def _oem_text_score(text: str) -> int:
     fallback would always pick ``cp437`` and never reach ``cp850``/``cp1252``.
     Scoring instead prefers the candidate whose bytes look most like text: C0
     controls signal binary data, and characters beyond Latin Extended-B (box
-    drawing, Greek, ...) are rarely produced by OEM text tools.
+    drawing, Greek, ...) are rarely produced by OEM text tools.  U+FFFD
+    replacement characters score too, so the same metric can compare an OEM
+    interpretation against a mostly-intact UTF-8 interpretation of a line.
     """
     score = 0
     for char in text:
@@ -349,35 +353,97 @@ def _oem_text_score(text: str) -> int:
     return score
 
 
+def _is_tail_truncation(line: bytes) -> bool:
+    """True when ``line`` ends with an incomplete multibyte UTF-8 sequence.
+
+    A log read that catches the child mid-write can tear a multibyte character
+    at the end of the file.  The incremental decoder only reports that at
+    finalization, after successfully consuming every byte as a valid prefix;
+    mid-line invalid bytes (the genuine OEM case) fail during consumption and
+    return False.
+    """
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    try:
+        decoder.decode(line)
+    except UnicodeDecodeError:
+        return False
+    try:
+        decoder.decode(b"", final=True)
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+def _decode_windows_line(line: bytes) -> str:
+    """Decode one captured line: strict UTF-8, then per-line OEM fallback.
+
+    A whole-file OEM fallback is deliberately avoided: as soon as *any* byte
+    run in a mostly-UTF-8 log is invalid (one native tool that re-enabled the
+    OEM codepage, or a torn multibyte character from a read that caught the
+    child mid-write), re-decoding the entire file as cp437/cp850/cp1252 turns
+    the previously valid Chinese/emoji text into box-drawing mojibake.
+    Deciding per line confines the fallback to the lines that actually contain
+    non-UTF-8 bytes, and the remaining heuristics keep sparse damage sparse:
+
+    - a torn multibyte character at the end of the line is replaced (one
+      U+FFFD), never re-interpreted as OEM bytes;
+    - a line that still decodes to genuine non-ASCII UTF-8 text keeps that
+      text even when it also contains invalid bytes (only those bytes are
+      replaced);
+    - only otherwise-Latin lines with invalid bytes are re-decoded with the
+      OEM codepage guesses, and only when the OEM text scores better than the
+      ``errors="replace"`` version of the same bytes.
+    """
+    try:
+        return line.decode("utf-8")
+    except UnicodeDecodeError:
+        pass
+    utf8_replaced = line.decode("utf-8", errors="replace")
+    if _is_tail_truncation(line):
+        return utf8_replaced
+    if any(ch != "\ufffd" and ord(ch) > 127 for ch in utf8_replaced):
+        return utf8_replaced
+    best: tuple[int, str] | None = None
+    for codepage in _OEM_CODEPAGE_GUESSES:
+        try:
+            text = line.decode(codepage)
+        except UnicodeDecodeError:
+            continue
+        score = _oem_text_score(text)
+        if best is None or score < best[0]:
+            best = (score, text)
+    if best is not None and best[0] < _oem_text_score(utf8_replaced):
+        return best[1]
+    return utf8_replaced
+
+
 def decode_windows_output(data: bytes) -> str:
-    """Decode captured child output: strict UTF-8 first, then OEM codepages.
+    """Decode captured child output: strict UTF-8 first, then OEM per line.
 
     The PowerShell wrapper forces ``[Console]::OutputEncoding`` and
     ``$OutputEncoding`` to UTF-8, so native commands normally emit valid UTF-8
-    bytes.  If a child still writes OEM console bytes (for example a tool that
-    re-enables the OEM codepage or is invoked outside the wrapper), strict
-    UTF-8 decoding fails and the bytes are re-decoded with the common Windows
-    OEM codepages (cp437/cp850/cp1252 heuristics, lowest text score wins)
-    instead of being silently corrupted by ``errors="replace"``.
-    ``errors="replace"`` is used only as a last resort for binary data, so
-    this function never raises.
+    bytes.  A leading UTF-8 BOM is stripped, and a buffer that is entirely
+    valid UTF-8 is returned as-is.  If any byte run is invalid, the fallback
+    is decided *per line* (see ``_decode_windows_line``) with the common
+    Windows OEM codepages (cp437/cp850/cp1252 heuristics) instead of
+    re-decoding the whole file or corrupting the invalid bytes with
+    ``errors="replace"``.  Line endings are preserved byte-for-byte; callers
+    normalize CRLF (the bash read-back boundary translates ``\r\n``/``\r`` to
+    ``\n`` exactly like the historical ``read_text``).  This function never
+    raises.
     """
+    if data.startswith(_UTF8_BOM):
+        data = data[len(_UTF8_BOM):]
     try:
         return data.decode("utf-8")
     except UnicodeDecodeError:
-        best: tuple[int, str] | None = None
-        for codepage in _OEM_CODEPAGE_GUESSES:
-            try:
-                text = data.decode(codepage)
-            except UnicodeDecodeError:
-                continue
-            score = _oem_text_score(text)
-            if best is None or score < best[0]:
-                best = (score, text)
-        if best is not None:
-            return best[1]
-        return data.decode(_OEM_CODEPAGE_GUESSES[0], errors="replace")
->>>>>>> e98ae4e9 (feat(windows): enforce UTF-8 console output and OEM fallback decode (ps/pr-2))
+        pass
+    # 0x0A is a line break in UTF-8 and in every OEM codepage and never
+    # occurs inside a multibyte sequence, so the split never tears a
+    # character.  Re-join with the same separators, preserving the original
+    # line endings (a trailing newline survives via the empty final part).
+    parts = data.split(b"\n")
+    return "\n".join(_decode_windows_line(part) for part in parts)
 
 
 class PowerShellDialect(ShellDialect):
@@ -439,7 +505,6 @@ class PowerShellDialect(ShellDialect):
         # between user statements, so ordinary PowerShell status checks retain
         # their native semantics.
         #
-<<<<<<< HEAD
         # Transport: the wrapped payload below is byte-for-byte what used to be
         # passed as the ``-Command`` argument, so the existing escape/quote and
         # exit-code handling is preserved as the stdin payload.  The command
@@ -448,14 +513,12 @@ class PowerShellDialect(ShellDialect):
         # which avoids code-page mangling of the ``-Command`` argument, the
         # 32,768-character process command-line limit, and UTF-8 in/out
         # problems (the bootstrap forces Input/OutputEncoding to UTF-8).
-=======
         # Windows console utilities (ipconfig, chcp-sensitive tools) write
         # through WriteConsole; PowerShell redirects that output, but only if
         # the console encoding matches what the pipe consumer expects.  Force
         # the child's console and pipeline encodings to UTF-8 up front so
         # captured bytes decode cleanly at the boundary instead of arriving in
         # the OEM codepage (which ``errors="replace"`` would corrupt).
->>>>>>> e98ae4e9 (feat(windows): enforce UTF-8 console output and OEM fallback decode (ps/pr-2))
         wrapped = (
             "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)\n"
             "$OutputEncoding = [System.Text.UTF8Encoding]::new($false)\n"

--- a/src/lingtai/tools/bash/CONTRACT.md
+++ b/src/lingtai/tools/bash/CONTRACT.md
@@ -279,6 +279,13 @@ POSIX script-form job. If either field is present, both must be valid; malformed
 or incomplete new state becomes an explicit unrecoverable launch failure and
 never falls back to the raw display command.
 
+Decoding policy: sync execution decodes inside `subprocess` text mode with the
+dialect's `encoding`/`errors` (the PowerShell wrapper forces UTF-8 console
+output, so `errors="replace"` rarely corrupts). Async output files are bytes;
+on Windows the read-back boundary decodes them with
+`lingtai.adapters.windows.powershell.decode_windows_output` (strict UTF-8,
+then OEM codepage fallback) so OEM-codepage output is not replaced.
+
 `ShellInvocation` serializes five keys by default (`script`, `executable`,
 `argv`, `encoding`, `errors`) plus an optional sixth `stdin_script` when the
 dialect transports the command through stdin. Script form uses `argv: null`
@@ -295,6 +302,12 @@ selected and validated by outer composition; the detached supervisor executes
 this self-contained invocation and does not use the key for adapter dispatch.
 This is fail-loud schema/semantic validation, not cryptographic integrity for
 user-rewritable durable state.
+unrecoverable. `shell_dialect` is non-empty provenance selected and validated
+by outer composition; the detached supervisor executes this self-contained
+invocation and does not use the key for adapter dispatch. This is fail-loud
+schema/semantic validation, not cryptographic integrity for user-rewritable
+durable state.
+>>>>>>> e98ae4e9 (feat(windows): enforce UTF-8 console output and OEM fallback decode (ps/pr-2))
 
 The registered description is setup-time metadata and always includes
 `Active shell dialect: posix` or `Active shell dialect: powershell`, plus a

--- a/src/lingtai/tools/bash/CONTRACT.md
+++ b/src/lingtai/tools/bash/CONTRACT.md
@@ -284,7 +284,11 @@ dialect's `encoding`/`errors` (the PowerShell wrapper forces UTF-8 console
 output, so `errors="replace"` rarely corrupts). Async output files are bytes;
 on Windows the read-back boundary decodes them with
 `lingtai.adapters.windows.powershell.decode_windows_output` (strict UTF-8,
-then OEM codepage fallback) so OEM-codepage output is not replaced.
+then OEM codepage fallback decided per line) so OEM-codepage output is not
+replaced and a mostly-UTF-8 log with one invalid byte run keeps its valid
+text.  The read-back boundary then translates `\r\n`/`\r` to `\n`,
+preserving the universal-newlines semantics of the previous `read_text`
+decode (async output never carries stray CR characters).
 
 `ShellInvocation` serializes five keys by default (`script`, `executable`,
 `argv`, `encoding`, `errors`) plus an optional sixth `stdin_script` when the

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -1322,13 +1322,23 @@ class ShellManager:
             if os.name != "nt":
                 # POSIX async logs keep the historical replacement-character
                 # decode; the Windows OEM fallback below is console-specific.
-                return raw.decode("utf-8", errors="replace")
-            # The PowerShell wrapper forces the child's console encoding to
-            # UTF-8, but a native tool can still emit OEM-codepage bytes;
-            # re-decode those instead of corrupting them with errors="replace".
-            from lingtai.adapters.windows.powershell import decode_windows_output
+                text = raw.decode("utf-8", errors="replace")
+            else:
+                # The PowerShell wrapper forces the child's console encoding
+                # to UTF-8, but a native tool can still emit OEM-codepage
+                # bytes; re-decode those instead of corrupting them with
+                # errors="replace".  The fallback is decided per line, so a
+                # mostly-UTF-8 log with one invalid byte run is not re-decoded
+                # wholesale as OEM (which would garble the whole log).
+                from lingtai.adapters.windows.powershell import decode_windows_output
 
-            return decode_windows_output(raw)
+                text = decode_windows_output(raw)
+            # Restore the universal-newlines translation the previous
+            # read_text() provided: pwsh emits CRLF-terminated lines, and
+            # without this every async stdout/stderr line would carry a
+            # stray "\r" into results, truncation accounting, and
+            # newline-based splitting.
+            return text.replace("\r\n", "\n").replace("\r", "\n")
 
         try:
             stdout = read_log("stdout.log")

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -1317,12 +1317,25 @@ class ShellManager:
             return False
 
     def _read_logs(self, job_dir: Path) -> tuple[str, str]:
+        def read_log(name: str) -> str:
+            raw = (job_dir / name).read_bytes()
+            if os.name != "nt":
+                # POSIX async logs keep the historical replacement-character
+                # decode; the Windows OEM fallback below is console-specific.
+                return raw.decode("utf-8", errors="replace")
+            # The PowerShell wrapper forces the child's console encoding to
+            # UTF-8, but a native tool can still emit OEM-codepage bytes;
+            # re-decode those instead of corrupting them with errors="replace".
+            from lingtai.adapters.windows.powershell import decode_windows_output
+
+            return decode_windows_output(raw)
+
         try:
-            stdout = (job_dir / "stdout.log").read_text(encoding="utf-8", errors="replace")
+            stdout = read_log("stdout.log")
         except OSError:
             stdout = ""
         try:
-            stderr = (job_dir / "stderr.log").read_text(encoding="utf-8", errors="replace")
+            stderr = read_log("stderr.log")
         except OSError:
             stderr = ""
         # Same hygiene as the sync path: async logs are surfaced to the model

--- a/tests/test_powershell_decode_windows_output.py
+++ b/tests/test_powershell_decode_windows_output.py
@@ -1,0 +1,107 @@
+"""Regression tests for Windows console-output decoding (PR #1184 follow-up).
+
+Covers the two review findings fixed here:
+
+1. The OEM fallback must not blanket-decode a whole file: a mostly-valid
+   UTF-8 log with one invalid byte run (a native tool that re-enabled the OEM
+   codepage, or a torn multibyte character from a read that caught the child
+   mid-write) must keep its valid text, with only the invalid bytes replaced.
+2. Async read-back restores the universal-newlines translation, so pwsh's
+   CRLF-terminated output never leaks stray CR characters.
+
+``decode_windows_output`` is pure Python and platform-independent; the module
+imports cleanly without a console or pwsh, so these run on POSIX CI too.
+"""
+from pathlib import Path
+from types import SimpleNamespace
+
+from lingtai.adapters.windows.powershell import decode_windows_output
+from lingtai.tools.bash import BashManager, BashPolicy
+
+_UTF8_BOM = b"\xef\xbb\xbf"
+_ZH = "\u4e2d\u6587"  # CJK text that whole-file OEM decoding would garble
+
+
+class TestDecodeWindowsOutput:
+    def test_pure_utf8_passthrough(self):
+        text = "\u6b22\u8fce\u8f93\u51fa\nsecond line\n"
+        assert decode_windows_output(text.encode("utf-8")) == text
+
+    def test_utf8_bom_stripped(self):
+        assert decode_windows_output(_UTF8_BOM + b"hello") == "hello"
+
+    def test_sparse_invalid_byte_keeps_utf8_text(self):
+        # Review finding 1: one invalid byte run in an otherwise-valid UTF-8
+        # log must not re-decode the whole log as OEM.
+        data = _ZH.encode("utf-8") + b"\x82tail"
+        result = decode_windows_output(data)
+        assert _ZH in result
+        assert result.endswith("tail")
+        assert "\ufffd" in result
+        assert "\ufffd" not in result.replace("\ufffd", "", 1)
+
+    def test_oem_line_decoded_among_utf8_lines(self):
+        data = _ZH.encode("utf-8") + b"\nMontr\x82al\n"
+        result = decode_windows_output(data)
+        assert _ZH in result
+        assert "Montr\u00e9al" in result
+
+    def test_pure_oem_file_still_decodes(self):
+        result = decode_windows_output(b"Montr\x82al \xe9\r\n")
+        assert "Montr\u00e9al" in result
+
+    def test_sparse_latin_oem_byte_still_uses_oem(self):
+        # A Latin line with one OEM byte is still OEM-decoded (the fallback
+        # is per line, not per file).
+        assert "\u00e9" in decode_windows_output(b"abc\x82def")
+
+    def test_torn_multibyte_tail_replaced_not_oem(self):
+        # Read caught the child mid-write: incomplete 3-byte char at EOF.
+        torn = b"abc" + "\u4e2d".encode("utf-8")[:-1]
+        assert decode_windows_output(torn) == "abc\ufffd"
+
+    def test_torn_tail_after_utf8_text(self):
+        data = _ZH.encode("utf-8") + "\u4e2d".encode("utf-8")[:-1]
+        result = decode_windows_output(data)
+        assert result.startswith(_ZH)
+        assert result.endswith("\ufffd")
+
+    def test_crlf_preserved_at_decode_level(self):
+        # The decoder is byte-faithful; newline normalization happens at the
+        # read-back boundary (see TestReadLogsNewlineNormalization).
+        assert decode_windows_output(b"a\r\nb\r\n") == "a\r\nb\r\n"
+
+    def test_empty_and_newline_only(self):
+        assert decode_windows_output(b"") == ""
+        assert decode_windows_output(b"\n\n") == "\n\n"
+
+
+class TestReadLogsNewlineNormalization:
+    """Review finding 2: async read-back must not leak CRLF/CR characters."""
+
+    def _manager(self, tmp_path: Path) -> BashManager:
+        agent = SimpleNamespace(_notification_store=None)
+        return BashManager(
+            policy=BashPolicy.yolo(), working_dir=str(tmp_path), agent=agent
+        )
+
+    def _write_logs(self, tmp_path: Path, stdout: bytes, stderr: bytes) -> Path:
+        job_id = "job-10000000000000000000000000000101"
+        job_dir = tmp_path / "system" / "jobs" / job_id
+        job_dir.mkdir(parents=True)
+        (job_dir / "stdout.log").write_bytes(stdout)
+        (job_dir / "stderr.log").write_bytes(stderr)
+        return job_dir
+
+    def test_crlf_normalized_in_async_logs(self, tmp_path):
+        job_dir = self._write_logs(tmp_path, b"line1\r\nline2\r\n", b"err1\r\n")
+        stdout, stderr = self._manager(tmp_path)._read_logs(job_dir)
+        assert stdout == "line1\nline2\n"
+        assert stderr == "err1\n"
+        assert "\r" not in stdout and "\r" not in stderr
+
+    def test_lone_cr_normalized(self, tmp_path):
+        # Universal-newlines parity with the historical read_text() decode.
+        job_dir = self._write_logs(tmp_path, b"progress\r10%\r100%\n", b"")
+        stdout, _ = self._manager(tmp_path)._read_logs(job_dir)
+        assert stdout == "progress\n10%\n100%\n"


### PR DESCRIPTION
## What
Prepend [Console]::OutputEncoding UTF-8 to the pwsh wrapper so native commands (ipconfig etc.) write UTF-8 to pipes; add OEM-codepage fallback decode when bytes fail UTF-8.

## Why
OpenClaw insight: Windows console utilities bypass stdout pipes; PowerShell redirects them, but only if the console encoding matches. Our errors=replace silently corrupts OEM-encoded output.

## Tests
Existing powershell/windows tests pass: 81 passed, 25 skipped (native-Windows-only tests skip on this Linux runner), 0 failures.