### PR TITLE
feat(shell): ANSI/control sanitization and startup-noise stripping

### DIFF
--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -46,6 +46,11 @@ from ._async_process import (
 # second, flat, pre-migration pair to drift against.
 from ._tool_family import ShellFamilyDispatcher, get_description, get_schema
 
+# Output hygiene (ANSI/CSI stripping, C0/C1 control escaping, startup-noise
+# stripping, explicit truncation) applied at the tool boundary before results
+# are returned to the model.
+from ._output_hygiene import sanitize_output
+
 
 if TYPE_CHECKING:
     from lingtai.kernel.base_agent import BaseAgent
@@ -583,7 +588,16 @@ class ShellManager:
                 process_args, capture_output=True, text=True,
                 timeout=timeout, cwd=cwd, **process_kwargs,
             )
-            return self._sync_result_from(result.stdout, result.stderr, result.returncode)
+            stdout, stderr = result.stdout, result.stderr
+            # Output hygiene at the tool boundary: strip ANSI/CSI, escape
+            # C0/C1 controls, drop startup noise, then cap with the explicit
+            # truncation marker (all in one pass per stream).
+            stdout = sanitize_output(stdout, self._max_output)
+            stderr = sanitize_output(stderr, self._max_output)
+            return _augment_command_result({
+                "status": "ok", "exit_code": result.returncode,
+                "stdout": stdout, "stderr": stderr,
+            })
         except subprocess.TimeoutExpired:
             return _timeout_error(command, timeout)
         except Exception as e:
@@ -1305,10 +1319,11 @@ class ShellManager:
             stderr = (job_dir / "stderr.log").read_text(encoding="utf-8", errors="replace")
         except OSError:
             stderr = ""
-        if len(stdout) > self._max_output:
-            stdout = stdout[: self._max_output] + f"\n... (truncated, {len(stdout)} chars total)"
-        if len(stderr) > self._max_output:
-            stderr = stderr[: self._max_output] + f"\n... (truncated, {len(stderr)} chars total)"
+        # Same hygiene as the sync path: async logs are surfaced to the model
+        # through poll results and completion previews, so they get the same
+        # ANSI/control/noise stripping and capped truncation.
+        stdout = sanitize_output(stdout, self._max_output)
+        stderr = sanitize_output(stderr, self._max_output)
         return stdout, stderr
 
     def _already_finished(self, state: dict) -> dict:

--- a/src/lingtai/tools/bash/_output_hygiene.py
+++ b/src/lingtai/tools/bash/_output_hygiene.py
@@ -1,0 +1,148 @@
+"""Output hygiene at the shell-tool boundary.
+
+Raw terminal output frequently carries ANSI/CSI color and cursor sequences,
+C0/C1 control bytes (bell, backspace, OSC title sequences, DEL), and
+shell-startup noise lines (``bash: no job control in this shell``,
+``warning: ...`` banners). Left verbatim, these pollute tool results, waste
+context window, and can confuse downstream parsers that expect plain text.
+
+This module provides the small, dependency-free helpers the shell tool
+applies before returning output:
+
+- :func:`strip_ansi` -- remove ANSI/CSI escape sequences (colors, cursor
+  moves, OSC titles, single-char ESC sequences).
+- :func:`escape_controls` -- escape C0/C1 control characters as ``\\xNN``
+  while keeping ``\\t``, ``\\n`` and ``\\r`` readable.
+- :func:`strip_shell_startup_noise` -- drop known startup-warning lines from
+  the head of a line list (Hermes ``_clean_shell_noise`` semantics: substring
+  noise list plus a ``^warning: `` banner pattern).
+- :func:`truncate_output` -- cap output with an explicit truncation marker.
+
+The shell tool composes these in :func:`sanitize_output`, applied to both
+stdout and stderr before a result is returned.
+"""
+from __future__ import annotations
+
+import re
+
+__all__ = [
+    "escape_controls",
+    "sanitize_output",
+    "strip_ansi",
+    "strip_shell_startup_noise",
+    "truncate_output",
+]
+
+# ANSI/CSI escape sequences.  Three shapes:
+#   CSI        ESC [ params... intermediates... final-byte  (colors, cursor moves)
+#   OSC        ESC ] ... BEL (0x07) or ESC \\               (window title, hyperlinks)
+#   single-ESC ESC + one byte (e.g. ESC c reset, ESC 7 save cursor)
+# Character-set designations (ESC ( B / ESC ) 0) are folded in via the [()]
+# alternative.  Dangling or malformed ESC bytes are left in place;
+# escape_controls then renders them (and any C1 control bytes) as \\xNN.
+_ANSI_ESCAPE_RE = re.compile(
+    r"""
+    \x1b\[[0-9;:?]*[ -/]*[@-~]            # CSI
+    | \x1b\][^\x07\x1b]*(?:\x07|\x1b\\)  # OSC, terminated by BEL or ESC \\
+    | \x1b[()][0-9A-Za-z]                 # character-set designation
+    | \x1b[@-Z\\-_]                       # other single-char ESC sequences
+    """,
+    re.VERBOSE,
+)
+
+# C0 (0x00-0x1F minus tab/LF/CR, plus DEL 0x7F) and C1 (0x80-0x9F) controls.
+_C0_C1_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+# Shell-startup noise substrings, mirroring Hermes ProcessRegistry.
+_SHELL_NOISE_SUBSTRINGS = (
+    "bash: cannot set terminal process group",
+    "bash: no job control in this shell",
+    "no job control in this shell",
+    "cannot set terminal process group",
+    "tcsetattr: Inappropriate ioctl for device",
+)
+
+# Leading banner pattern (bash warning lines, toolchain startup warnings).
+_STARTUP_NOISE_RE = re.compile(r"^warning: ")
+
+
+_TRUNCATION_MARKER = "... [output truncated at {max_chars} chars]"
+
+
+# ---------------------------------------------------------------------------
+# Individual helpers
+# ---------------------------------------------------------------------------
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI/CSI escape sequences from *text*.
+
+    Strips CSI color/cursor sequences, OSC title sequences, character-set
+    designations, and single-char ESC sequences.  Plain text passes through
+    unchanged; dangling ESC bytes are left for :func:`escape_controls`.
+    """
+    return _ANSI_ESCAPE_RE.sub("", text)
+
+
+def escape_controls(text: str) -> str:
+    """Escape C0/C1 control characters in *text* as ``\\xNN``.
+
+    Tab (``\\t``), newline (``\\n``) and carriage return (``\\r``) are kept
+    as-is; every other C0 control (including DEL) and every C1 control
+    (``0x80``-``0x9F``) is rendered as an explicit ``\\xNN`` escape so no
+    invisible or terminal-interpreting byte survives into a tool result.
+    """
+    return _C0_C1_CONTROL_RE.sub(lambda m: f"\\x{ord(m.group(0)):02x}", text)
+
+
+def strip_shell_startup_noise(lines: list[str]) -> list[str]:
+    """Drop known shell-startup noise lines from the head of *lines*.
+
+    Only the *head* is examined (Hermes ``_clean_shell_noise`` semantics): a
+    line is dropped while it is the first remaining line and either matches
+    ``^warning: `` or contains a known startup-noise substring (bash job
+    control / tcsetattr messages).  Genuine output lines that merely contain
+    such text later in the stream are preserved.
+    """
+    result = list(lines)
+    while result and _is_startup_noise_line(result[0]):
+        result.pop(0)
+    return result
+
+
+def truncate_output(text: str, max_chars: int = 100_000) -> str:
+    """Cap *text* at *max_chars* characters with an explicit marker.
+
+    Outputs at or under the cap are returned unchanged.  Longer outputs are
+    cut to ``max_chars`` characters and suffixed with a newline and
+    ``... [output truncated at N chars]`` so the truncation is explicit and
+    unambiguous to the model.
+    """
+    if len(text) <= max_chars:
+        return text
+    marker = _TRUNCATION_MARKER.format(max_chars=max_chars)
+    return text[:max_chars] + "\n" + marker
+
+
+# ---------------------------------------------------------------------------
+# Composed pipeline
+# ---------------------------------------------------------------------------
+
+def sanitize_output(text: str, max_chars: int = 100_000) -> str:
+    """Apply the full output-hygiene pipeline to one output stream.
+
+    Order: strip ANSI/CSI, escape remaining C0/C1 controls, drop shell
+    startup noise from the head, then cap with the truncation marker.
+    Stripping ANSI first lets the ``^warning: `` head pattern match banner
+    lines that arrived wrapped in color codes.
+    """
+    text = strip_ansi(text)
+    text = escape_controls(text)
+    text = "\n".join(strip_shell_startup_noise(text.split("\n")))
+    return truncate_output(text, max_chars=max_chars)
+
+
+def _is_startup_noise_line(line: str) -> bool:
+    """Return whether a single head line is startup noise."""
+    if _STARTUP_NOISE_RE.match(line):
+        return True
+    return any(noise in line for noise in _SHELL_NOISE_SUBSTRINGS)

--- a/src/lingtai/tools/bash/_output_hygiene.py
+++ b/src/lingtai/tools/bash/_output_hygiene.py
@@ -3,7 +3,7 @@
 Raw terminal output frequently carries ANSI/CSI color and cursor sequences,
 C0/C1 control bytes (bell, backspace, OSC title sequences, DEL), and
 shell-startup noise lines (``bash: no job control in this shell``,
-``warning: ...`` banners). Left verbatim, these pollute tool results, waste
+``tcsetattr: ...``). Left verbatim, these pollute tool results, waste
 context window, and can confuse downstream parsers that expect plain text.
 
 This module provides the small, dependency-free helpers the shell tool
@@ -13,10 +13,13 @@ applies before returning output:
   moves, OSC titles, single-char ESC sequences).
 - :func:`escape_controls` -- escape C0/C1 control characters as ``\\xNN``
   while keeping ``\\t``, ``\\n`` and ``\\r`` readable.
-- :func:`strip_shell_startup_noise` -- drop known startup-warning lines from
-  the head of a line list (Hermes ``_clean_shell_noise`` semantics: substring
-  noise list plus a ``^warning: `` banner pattern).
-- :func:`truncate_output` -- cap output with an explicit truncation marker.
+- :func:`strip_shell_startup_noise` -- drop known shell-init noise lines
+  (``bash: no job control in this shell``, ``tcsetattr: ...``) from the head
+  of a line list, using only specific line-anchored patterns so genuine
+  ``warning:`` command output (git checkout/add on Windows) is never
+  silently deleted.
+- :func:`truncate_output` -- cap output with an explicit truncation marker
+  that reports the original length.
 
 The shell tool composes these in :func:`sanitize_output`, applied to both
 stdout and stderr before a result is returned.
@@ -45,7 +48,7 @@ _ANSI_ESCAPE_RE = re.compile(
     \x1b\[[0-9;:?]*[ -/]*[@-~]            # CSI
     | \x1b\][^\x07\x1b]*(?:\x07|\x1b\\)  # OSC, terminated by BEL or ESC \\
     | \x1b[()][0-9A-Za-z]                 # character-set designation
-    | \x1b[@-Z\\-_]                       # other single-char ESC sequences
+    | \x1b[0-9@-Z\\^_a-z{|}~]              # single-char ESC (incl. ESC 7/8, ESC c reset)
     """,
     re.VERBOSE,
 )
@@ -53,20 +56,25 @@ _ANSI_ESCAPE_RE = re.compile(
 # C0 (0x00-0x1F minus tab/LF/CR, plus DEL 0x7F) and C1 (0x80-0x9F) controls.
 _C0_C1_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 
-# Shell-startup noise substrings, mirroring Hermes ProcessRegistry.
-_SHELL_NOISE_SUBSTRINGS = (
-    "bash: cannot set terminal process group",
-    "bash: no job control in this shell",
-    "no job control in this shell",
-    "cannot set terminal process group",
-    "tcsetattr: Inappropriate ioctl for device",
+# Shell-startup noise lines, mirrored from Hermes ProcessRegistry, anchored to
+# the *start* of a head line.  Anchoring (and dropping the generic
+# "^warning: " banner pattern) ensures genuine command output survives:
+# git checkout/add stderr on Windows routinely begins with "warning: LF will
+# be replaced by CRLF...", and `grep -r "no job control in this shell" .`
+# output lines start with a filename, not the search string.
+_STARTUP_NOISE_LINE_RE = re.compile(
+    r"^(?:"
+    r"bash: cannot set terminal process group"
+    r"|bash: no job control in this shell"
+    r"|no job control in this shell"
+    r"|cannot set terminal process group"
+    r"|tcsetattr: Inappropriate ioctl for device"
+    r")"
 )
 
-# Leading banner pattern (bash warning lines, toolchain startup warnings).
-_STARTUP_NOISE_RE = re.compile(r"^warning: ")
 
-
-_TRUNCATION_MARKER = "... [output truncated at {max_chars} chars]"
+# The truncation marker (``... (truncated, N chars total)``) is built inline
+# in truncate_output so it can report the original length.
 
 
 # ---------------------------------------------------------------------------
@@ -95,13 +103,15 @@ def escape_controls(text: str) -> str:
 
 
 def strip_shell_startup_noise(lines: list[str]) -> list[str]:
-    """Drop known shell-startup noise lines from the head of *lines*.
+    """Drop known shell-init noise lines from the head of *lines*.
 
     Only the *head* is examined (Hermes ``_clean_shell_noise`` semantics): a
-    line is dropped while it is the first remaining line and either matches
-    ``^warning: `` or contains a known startup-noise substring (bash job
-    control / tcsetattr messages).  Genuine output lines that merely contain
-    such text later in the stream are preserved.
+    line is dropped while it is the first remaining line and matches a
+    specific, line-anchored noise pattern (``bash: no job control in this
+    shell``, ``tcsetattr: Inappropriate ioctl for device``, ...).  Generic
+    ``warning:`` head lines are *not* dropped -- they are usually genuine
+    command output (git checkout/add on Windows) -- and lines merely
+    *containing* a noise substring later in the stream are preserved.
     """
     result = list(lines)
     while result and _is_startup_noise_line(result[0]):
@@ -109,40 +119,56 @@ def strip_shell_startup_noise(lines: list[str]) -> list[str]:
     return result
 
 
-def truncate_output(text: str, max_chars: int = 100_000) -> str:
+def truncate_output(
+    text: str, max_chars: int = 100_000, *, total_chars: int | None = None
+) -> str:
     """Cap *text* at *max_chars* characters with an explicit marker.
 
     Outputs at or under the cap are returned unchanged.  Longer outputs are
     cut to ``max_chars`` characters and suffixed with a newline and
-    ``... [output truncated at N chars]`` so the truncation is explicit and
-    unambiguous to the model.
+    ``... (truncated, N chars total)`` where *N* is the *original* length
+    (``total_chars`` when the caller passes a pre-capped slice, otherwise
+    ``len(text)``) so the model can tell whether it lost 1 KB or 500 MB.
     """
-    if len(text) <= max_chars:
+    if total_chars is None:
+        total_chars = len(text)
+    if len(text) <= max_chars and total_chars <= max_chars:
         return text
-    marker = _TRUNCATION_MARKER.format(max_chars=max_chars)
-    return text[:max_chars] + "\n" + marker
+    return text[:max_chars] + f"\n... (truncated, {total_chars} chars total)"
 
 
 # ---------------------------------------------------------------------------
 # Composed pipeline
 # ---------------------------------------------------------------------------
 
+# Pre-cap bound for sanitize_output: escape_controls can expand each control
+# byte to four chars, so before running the regex passes the input is sliced
+# to max_chars * 4 plus slack for head noise lines and the marker.  This
+# restores the old work bound (pre-PR code sliced to _max_output immediately)
+# for async log files that can be hundreds of MB or binary.
+_PRE_CAP_FACTOR = 4
+_PRE_CAP_SLACK = 4096
+
+
 def sanitize_output(text: str, max_chars: int = 100_000) -> str:
     """Apply the full output-hygiene pipeline to one output stream.
 
     Order: strip ANSI/CSI, escape remaining C0/C1 controls, drop shell
-    startup noise from the head, then cap with the truncation marker.
-    Stripping ANSI first lets the ``^warning: `` head pattern match banner
-    lines that arrived wrapped in color codes.
+    startup noise from the head, then cap with the truncation marker.  The
+    input is pre-capped to ``max_chars * 4 + slack`` before the regex passes
+    so pathological streams never cost multiple full-size passes, and the
+    marker reports the *original* length (captured before the pre-cap).
     """
+    original_len = len(text)
+    pre_cap = max_chars * _PRE_CAP_FACTOR + _PRE_CAP_SLACK
+    if original_len > pre_cap:
+        text = text[:pre_cap]
     text = strip_ansi(text)
     text = escape_controls(text)
     text = "\n".join(strip_shell_startup_noise(text.split("\n")))
-    return truncate_output(text, max_chars=max_chars)
+    return truncate_output(text, max_chars=max_chars, total_chars=original_len)
 
 
 def _is_startup_noise_line(line: str) -> bool:
-    """Return whether a single head line is startup noise."""
-    if _STARTUP_NOISE_RE.match(line):
-        return True
-    return any(noise in line for noise in _SHELL_NOISE_SUBSTRINGS)
+    """Return whether a single head line is startup noise (line-anchored)."""
+    return _STARTUP_NOISE_LINE_RE.match(line) is not None

--- a/tests/test_output_hygiene.py
+++ b/tests/test_output_hygiene.py
@@ -1,0 +1,224 @@
+"""Tests for the shell-tool output-hygiene module and its wiring.
+
+Covers the four public helpers in ``lingtai.tools.bash._output_hygiene``
+(strip_ansi, escape_controls, strip_shell_startup_noise, truncate_output)
+plus the composed ``sanitize_output`` pipeline, and end-to-end assertions
+that the hygiene is applied on the ``BashManager`` sync result path.
+"""
+
+import pytest
+
+from lingtai.tools.bash import BashManager, BashPolicy
+from lingtai.tools.bash._output_hygiene import (
+    escape_controls,
+    sanitize_output,
+    strip_ansi,
+    strip_shell_startup_noise,
+    truncate_output,
+)
+
+
+class _SyncOnlyAgent:
+    """Strict stand-in for manager tests that exercise only synchronous runs."""
+
+
+# ---------------------------------------------------------------------------
+# strip_ansi
+# ---------------------------------------------------------------------------
+
+class TestStripAnsi:
+    def test_strips_csi_color_codes(self):
+        assert strip_ansi("\x1b[31mred\x1b[0m") == "red"
+        assert strip_ansi("\x1b[1;32mbold green\x1b[0m") == "bold green"
+
+    def test_strips_csi_with_intermediates_and_private_params(self):
+        assert strip_ansi("a\x1b[2Jb") == "ab"          # clear screen
+        assert strip_ansi("a\x1b[?25lb") == "ab"        # hide cursor
+        assert strip_ansi("a\x1b[38;5;196mb") == "ab"   # 256-color fg
+
+    def test_strips_osc_title_sequences(self):
+        assert strip_ansi("\x1b]0;my title\x07content") == "content"
+        assert strip_ansi("\x1b]2;path\x1b\\content") == "content"
+
+    def test_strips_single_char_and_charset_escapes(self):
+        assert strip_ansi("a\x1b7b\x1b8c") == "abc"    # save/restore cursor
+        assert strip_ansi("a\x1bcb") == "ab"           # hard reset
+        assert strip_ansi("\x1b(0\x1b)0data") == "data"  # charset designations
+
+    def test_plain_text_passes_through(self):
+        assert strip_ansi("hello world\n") == "hello world\n"
+        assert strip_ansi("\tindented\r\n") == "\tindented\r\n"
+
+    def test_multiple_sequences_in_one_stream(self):
+        text = "\x1b[32mok\x1b[0m \x1b[1mstrong\x1b[0m\n"
+        assert strip_ansi(text) == "ok strong\n"
+
+
+# ---------------------------------------------------------------------------
+# escape_controls
+# ---------------------------------------------------------------------------
+
+class TestEscapeControls:
+    def test_keeps_tab_newline_carriage_return(self):
+        text = "a\tb\nc\rd"
+        assert escape_controls(text) == text
+
+    def test_escapes_c0_controls(self):
+        assert escape_controls("a\x07b") == "a\\x07b"      # bell
+        assert escape_controls("a\x00b") == "a\\x00b"      # NUL
+        assert escape_controls("a\x08b") == "a\\x08b"      # backspace
+        assert escape_controls("a\x0bb") == "a\\x0bb"      # vertical tab
+        assert escape_controls("a\x0cb") == "a\\x0cb"      # form feed
+
+    def test_escapes_del(self):
+        assert escape_controls("a\x7fb") == "a\\x7fb"
+
+    def test_escapes_c1_controls(self):
+        assert escape_controls("a\x85b") == "a\\x85b"      # NEL
+        assert escape_controls("a\x9bb") == "a\\x9bb"      # 8-bit CSI
+        assert escape_controls("a\x9fb") == "a\\x9fb"
+
+    def test_plain_text_passes_through(self):
+        assert escape_controls("plain ascii text") == "plain ascii text"
+
+
+# ---------------------------------------------------------------------------
+# strip_shell_startup_noise
+# ---------------------------------------------------------------------------
+
+class TestStripShellStartupNoise:
+    def test_drops_bash_job_control_head_lines(self):
+        lines = [
+            "bash: cannot set terminal process group",
+            "bash: no job control in this shell",
+            "real output",
+        ]
+        assert strip_shell_startup_noise(lines) == ["real output"]
+
+    def test_drops_tcsetattr_head_lines(self):
+        lines = ["tcsetattr: Inappropriate ioctl for device", "ok"]
+        assert strip_shell_startup_noise(lines) == ["ok"]
+
+    def test_drops_warning_banner_head_lines(self):
+        lines = ["warning: command substitution: ignored null byte in input", "data"]
+        assert strip_shell_startup_noise(lines) == ["data"]
+
+    def test_stops_at_first_non_noise_line(self):
+        lines = [
+            "bash: no job control in this shell",
+            "real first",
+            "tcsetattr: Inappropriate ioctl for device",
+            "tail",
+        ]
+        assert strip_shell_startup_noise(lines) == [
+            "real first",
+            "tcsetattr: Inappropriate ioctl for device",
+            "tail",
+        ]
+
+    def test_clean_head_is_unchanged(self):
+        lines = ["hello", "world"]
+        assert strip_shell_startup_noise(lines) == ["hello", "world"]
+
+    def test_returns_a_new_list(self):
+        lines = ["bash: no job control in this shell"]
+        result = strip_shell_startup_noise(lines)
+        assert result == []
+        assert lines == ["bash: no job control in this shell"]  # input untouched
+
+
+# ---------------------------------------------------------------------------
+# truncate_output
+# ---------------------------------------------------------------------------
+
+class TestTruncateOutput:
+    def test_under_cap_unchanged(self):
+        assert truncate_output("short", max_chars=100) == "short"
+        assert truncate_output("exactly twenty!", max_chars=14) == "exactly twenty!"
+
+    def test_over_cap_gets_explicit_marker(self):
+        text = "x" * 30
+        result = truncate_output(text, max_chars=10)
+        assert result == "x" * 10 + "\n... [output truncated at 10 chars]"
+
+    def test_marker_reports_the_cap(self):
+        result = truncate_output("y" * 5_001, max_chars=5_000)
+        assert "... [output truncated at 5000 chars]" in result
+
+    def test_default_max_chars_is_applied(self):
+        result = truncate_output("z" * (100_001), max_chars=100_000)
+        assert "output truncated at 100000 chars" in result
+
+
+# ---------------------------------------------------------------------------
+# sanitize_output (composed pipeline)
+# ---------------------------------------------------------------------------
+
+class TestSanitizeOutput:
+    def test_strips_ansi_escapes_controls_and_noise(self):
+        text = (
+            "\x1b[31m"
+            "bash: no job control in this shell\n"
+            "payload \x07 bell\n"
+        )
+        result = sanitize_output(text, max_chars=100_000)
+        assert result == "payload \\x07 bell\n"
+
+    def test_ansi_stripped_before_warning_banner_match(self):
+        # Banner wrapped in color codes must still be dropped from the head.
+        text = "\x1b[33mwarning: thing\x1b[0m\npayload\n"
+        assert sanitize_output(text) == "payload\n"
+
+    def test_truncation_marker_survives_pipeline(self):
+        result = sanitize_output("a" * 200, max_chars=50)
+        assert result.startswith("a" * 50)
+        assert "... [output truncated at 50 chars]" in result
+
+
+# ---------------------------------------------------------------------------
+# Wiring: BashManager sync result path applies hygiene
+# ---------------------------------------------------------------------------
+
+class TestBashManagerHygiene:
+    def _manager(self, **kwargs):
+        return BashManager(
+            agent=_SyncOnlyAgent(),
+            policy=BashPolicy.yolo(),
+            working_dir="/tmp",
+            **kwargs,
+        )
+
+    def test_ansi_codes_are_stripped_from_stdout(self):
+        mgr = self._manager()
+        result = mgr.handle({"command": "printf '\\033[31mred\\033[0m hello'"})
+        assert result["status"] == "ok"
+        assert "red hello" in result["stdout"]
+        assert "\x1b" not in result["stdout"]
+
+    def test_control_bytes_are_escaped(self):
+        mgr = self._manager()
+        result = mgr.handle({"command": "printf 'a\\ab'"})
+        assert "\\x07" in result["stdout"]
+        assert "\x07" not in result["stdout"]
+
+    def test_startup_noise_is_stripped_from_head(self):
+        mgr = self._manager()
+        result = mgr.handle(
+            {"command": "printf 'bash: no job control in this shell\\nreal output\\n'"}
+        )
+        assert "real output" in result["stdout"]
+        assert "no job control" not in result["stdout"]
+
+    def test_output_is_capped_with_explicit_marker(self):
+        mgr = self._manager(max_output=20)
+        result = mgr.handle(
+            {"command": "printf '0123456789abcdefghijklmnopqrstuvwxyz'"}
+        )
+        first_line = result["stdout"].split("\n", 1)[0]
+        assert len(first_line) == 20
+        assert "... [output truncated at 20 chars]" in result["stdout"]
+
+    def test_plain_output_passes_through_unchanged(self):
+        mgr = self._manager()
+        result = mgr.handle({"command": "echo hello"})
+        assert result["stdout"].strip() == "hello"

--- a/tests/test_output_hygiene.py
+++ b/tests/test_output_hygiene.py
@@ -99,9 +99,18 @@ class TestStripShellStartupNoise:
         lines = ["tcsetattr: Inappropriate ioctl for device", "ok"]
         assert strip_shell_startup_noise(lines) == ["ok"]
 
-    def test_drops_warning_banner_head_lines(self):
-        lines = ["warning: command substitution: ignored null byte in input", "data"]
-        assert strip_shell_startup_noise(lines) == ["data"]
+    def test_preserves_generic_warning_head_lines(self):
+        # Regression: git checkout/add stderr on Windows routinely starts with
+        # "warning: LF will be replaced by CRLF"; a generic ^warning: pattern
+        # would silently delete genuine command output.
+        lines = ["warning: LF will be replaced by CRLF", "data"]
+        assert strip_shell_startup_noise(lines) == lines
+
+    def test_preserves_head_lines_merely_containing_noise_text(self):
+        # Regression: grep output lines start with a filename, not the search
+        # string, so they must survive the (line-anchored) noise stripping.
+        lines = ["./src:no job control in this shell", "data"]
+        assert strip_shell_startup_noise(lines) == lines
 
     def test_stops_at_first_non_noise_line(self):
         lines = [
@@ -134,20 +143,21 @@ class TestStripShellStartupNoise:
 class TestTruncateOutput:
     def test_under_cap_unchanged(self):
         assert truncate_output("short", max_chars=100) == "short"
-        assert truncate_output("exactly twenty!", max_chars=14) == "exactly twenty!"
+        # "exactly twenty!" is 15 chars; a cap at 15 must leave it untouched.
+        assert truncate_output("exactly twenty!", max_chars=15) == "exactly twenty!"
 
     def test_over_cap_gets_explicit_marker(self):
         text = "x" * 30
         result = truncate_output(text, max_chars=10)
-        assert result == "x" * 10 + "\n... [output truncated at 10 chars]"
+        assert result == "x" * 10 + "\n... (truncated, 30 chars total)"
 
-    def test_marker_reports_the_cap(self):
+    def test_marker_reports_original_length(self):
         result = truncate_output("y" * 5_001, max_chars=5_000)
-        assert "... [output truncated at 5000 chars]" in result
+        assert "... (truncated, 5001 chars total)" in result
 
     def test_default_max_chars_is_applied(self):
         result = truncate_output("z" * (100_001), max_chars=100_000)
-        assert "output truncated at 100000 chars" in result
+        assert "... (truncated, 100001 chars total)" in result
 
 
 # ---------------------------------------------------------------------------
@@ -164,15 +174,31 @@ class TestSanitizeOutput:
         result = sanitize_output(text, max_chars=100_000)
         assert result == "payload \\x07 bell\n"
 
-    def test_ansi_stripped_before_warning_banner_match(self):
-        # Banner wrapped in color codes must still be dropped from the head.
+    def test_ansi_stripped_but_warning_head_lines_preserved(self):
+        # ANSI is stripped first; the warning line itself is genuine output
+        # and must be preserved, not dropped as startup noise.
         text = "\x1b[33mwarning: thing\x1b[0m\npayload\n"
-        assert sanitize_output(text) == "payload\n"
+        assert sanitize_output(text) == "warning: thing\npayload\n"
 
     def test_truncation_marker_survives_pipeline(self):
         result = sanitize_output("a" * 200, max_chars=50)
         assert result.startswith("a" * 50)
-        assert "... [output truncated at 50 chars]" in result
+        assert "... (truncated, 200 chars total)" in result
+
+    def test_huge_input_is_pre_capped_before_sanitizing(self):
+        # Regression: sanitization must not run full regex passes over the
+        # entire untruncated stream; the pre-cap bounds the work and the
+        # marker still reports the original size.
+        big = "\x07" * 2_000_000
+        result = sanitize_output(big, max_chars=100)
+        assert "... (truncated, 2000000 chars total)" in result
+        assert len(result) < 500
+
+    def test_huge_plain_text_keeps_head_and_reports_size(self):
+        big = "a" * 5_000_000
+        result = sanitize_output(big, max_chars=100)
+        assert result.startswith("a" * 100)
+        assert "... (truncated, 5000000 chars total)" in result
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +235,14 @@ class TestBashManagerHygiene:
         assert "real output" in result["stdout"]
         assert "no job control" not in result["stdout"]
 
+    def test_warning_head_lines_are_not_stripped(self):
+        mgr = self._manager()
+        result = mgr.handle(
+            {"command": "printf 'warning: LF will be replaced by CRLF\\nreal output\\n'"}
+        )
+        assert "warning: LF will be replaced by CRLF" in result["stdout"]
+        assert "real output" in result["stdout"]
+
     def test_output_is_capped_with_explicit_marker(self):
         mgr = self._manager(max_output=20)
         result = mgr.handle(
@@ -216,7 +250,8 @@ class TestBashManagerHygiene:
         )
         first_line = result["stdout"].split("\n", 1)[0]
         assert len(first_line) == 20
-        assert "... [output truncated at 20 chars]" in result["stdout"]
+        # printf output is 36 chars; the marker reports the original size.
+        assert "... (truncated, 36 chars total)" in result["stdout"]
 
     def test_plain_output_passes_through_unchanged(self):
         mgr = self._manager()


### PR DESCRIPTION
## What
Add output-hygiene helpers (strip ANSI/CSI, escape C0/C1 controls, strip shell startup noise, truncation marker) and apply at the shell tool boundary.

## Why
Raw ANSI/control bytes and startup banners pollute tool results; truncation keeps huge outputs bounded and explicit.

## Tests
New hygiene unit tests + existing bash/shell tests (list failures).