### PR TITLE
feat(windows): quote-aware PowerShell metachar safety scanner

### DIFF
--- a/src/lingtai/adapters/windows/powershell.py
+++ b/src/lingtai/adapters/windows/powershell.py
@@ -444,6 +444,258 @@ def decode_windows_output(data: bytes) -> str:
     # line endings (a trailing newline survives via the empty final part).
     parts = data.split(b"\n")
     return "\n".join(_decode_windows_line(part) for part in parts)
+# ---------------------------------------------------------------------------
+# PR-5: quote-aware Windows metachar safety scanner.
+#
+# Mirrors OpenClaw's findWindowsUnsupportedToken / WINDOWS_UNSUPPORTED_TOKENS
+# with PowerShell quote semantics: single quotes ARE quoting for PowerShell
+# (unlike cmd.exe), double quotes protect most metacharacters, and
+# % / backtick / newlines stay unsafe in every quote state because cmd.exe
+# expands %VAR% and re-parses quoted payloads while PowerShell treats ` as an
+# escape character.
+# ---------------------------------------------------------------------------
+
+WINDOWS_UNSUPPORTED_TOKENS = frozenset(
+    {"&", "|", "<", ">", ";", "^", "(", ")", "%", "!", "`", "\n", "\r"}
+)
+# Stay unsafe even inside double quotes: newlines break parsing, cmd.exe
+# expands %VAR%, and PowerShell treats ` as an escape character.
+WINDOWS_ALWAYS_UNSAFE_TOKENS = frozenset({"\n", "\r", "%", "`"})
+_WINDOWS_VAR_HEAD_RE = re.compile(r"[A-Za-z_{(?$]")
+
+
+def _unsafe_reason(token: str) -> str:
+    """Stable human-readable reason for a flagged scanner token."""
+    if token in "\n\r":
+        return "newline"
+    if token == "$":
+        return "variable expansion"
+    return f"metachar {token!r}"
+
+
+def is_unsafe_windows_command(command: str) -> tuple[bool, str]:
+    """Scan ``command`` for PowerShell metacharacters that can hide execution.
+
+    Quote-aware state machine over the OpenClaw token table: ``& | < > ; ^ ( )
+    % ! ` \\n \\r`` are flagged outside quotes; ``%`` / backtick / newlines
+    are flagged even inside double quotes; and ``$`` followed by
+    ``[A-Za-z_{(?$]`` (PowerShell variable expansion) is flagged anywhere
+    except inside single quotes, where PowerShell treats it as literal text.
+
+    Returns ``(unsafe, reason)``.  ``reason`` is a stable string naming the
+    first flagged token when ``unsafe`` is true, otherwise ``""``.
+    """
+    in_single = False
+    in_double = False
+    i = 0
+    n = len(command)
+    while i < n:
+        char = command[i]
+        if in_single:
+            # Single-quoted PowerShell strings are literal, but the always-
+            # unsafe tokens stay flagged: a quoted segment may later reach
+            # cmd.exe or Invoke-Expression where %VAR% and backticks execute.
+            if char in WINDOWS_ALWAYS_UNSAFE_TOKENS:
+                return True, _unsafe_reason(char)
+            if char == "'":
+                if i + 1 < n and command[i + 1] == "'":
+                    i += 2
+                    continue
+                in_single = False
+            i += 1
+            continue
+        if in_double:
+            if char in WINDOWS_ALWAYS_UNSAFE_TOKENS:
+                return True, _unsafe_reason(char)
+            if char == "$" and i + 1 < n and _WINDOWS_VAR_HEAD_RE.fullmatch(command[i + 1]):
+                return True, _unsafe_reason("$")
+            if char == '"':
+                in_double = False
+            i += 1
+            continue
+        if char in {"'", '"'}:
+            if char == "'":
+                in_single = True
+            else:
+                in_double = True
+            i += 1
+            continue
+        if char == "$" and i + 1 < n and _WINDOWS_VAR_HEAD_RE.fullmatch(command[i + 1]):
+            return True, _unsafe_reason("$")
+        if char in WINDOWS_UNSUPPORTED_TOKENS:
+            return True, _unsafe_reason(char)
+        i += 1
+    return False, ""
+
+
+def _expand_power_switch_prefix_forms(match: str, smallest: str) -> frozenset[str]:
+    """Bare prefix forms PowerShell accepts for a switch (mirrors OpenClaw)."""
+    return frozenset(match[:length] for length in range(len(smallest), len(match) + 1))
+
+
+_POWERSHELL_WRAPPER_NAMES = frozenset({"pwsh", "pwsh.exe", "powershell", "powershell.exe"})
+_POWERSHELL_INLINE_COMMAND_FLAGS = (
+    _expand_power_switch_prefix_forms("command", "c")
+    | _expand_power_switch_prefix_forms("commandwithargs", "cwa")
+    | frozenset({"cwa"})
+)
+_POWERSHELL_INLINE_ENCODED_COMMAND_FLAGS = (
+    _expand_power_switch_prefix_forms("encodedcommand", "e")
+    | _expand_power_switch_prefix_forms("ec", "e")
+)
+_POWERSHELL_INLINE_FILE_FLAGS = _expand_power_switch_prefix_forms("file", "f")
+_POWERSHELL_NO_PROFILE_FLAGS = _expand_power_switch_prefix_forms("noprofile", "nop")
+_POWERSHELL_UNREVIEWED_STARTUP_FLAGS = frozenset().union(
+    _expand_power_switch_prefix_forms("configurationfile", "conf"),
+    _expand_power_switch_prefix_forms("configurationname", "config"),
+    _expand_power_switch_prefix_forms("custompipename", "cus"),
+    _expand_power_switch_prefix_forms("encodedarguments", "encodeda"),
+    frozenset({"ea"}),
+    _expand_power_switch_prefix_forms("interactive", "i"),
+    _expand_power_switch_prefix_forms("login", "l"),
+    _expand_power_switch_prefix_forms("namedpipeservermode", "nam"),
+    _expand_power_switch_prefix_forms("noexit", "noe"),
+    _expand_power_switch_prefix_forms("psconsolefile", "pscf"),
+    frozenset({"pscf"}),
+    _expand_power_switch_prefix_forms("servermode", "s"),
+    _expand_power_switch_prefix_forms("settingsfile", "settings"),
+    _expand_power_switch_prefix_forms("socketservermode", "so"),
+    _expand_power_switch_prefix_forms("sshservermode", "ssh"),
+    _expand_power_switch_prefix_forms("v2socketservermode", "v2so"),
+)
+
+
+def _tokenize_windows_command(command: str) -> list[str] | None:
+    """Split a command into argv-like tokens honoring PowerShell quoting.
+
+    Double quotes and single quotes group text; ``''`` escapes a quote inside
+    single quotes and `` ` `` escapes the next character inside double quotes.
+    Returns None when quotes are unbalanced (callers must fail closed).
+    """
+    tokens: list[str] = []
+    buf: list[str] = []
+    in_single = False
+    in_double = False
+    i = 0
+    n = len(command)
+    while i < n:
+        char = command[i]
+        if in_single:
+            if char == "'":
+                if i + 1 < n and command[i + 1] == "'":
+                    buf.append("'")
+                    i += 2
+                    continue
+                in_single = False
+            else:
+                buf.append(char)
+            i += 1
+            continue
+        if in_double:
+            if char == '"':
+                in_double = False
+            elif char == "`" and i + 1 < n:
+                buf.append(command[i + 1])
+                i += 2
+                continue
+            else:
+                buf.append(char)
+            i += 1
+            continue
+        if char in " \t":
+            if buf:
+                tokens.append("".join(buf))
+                buf = []
+            i += 1
+            continue
+        if char == "'":
+            in_single = True
+            i += 1
+            continue
+        if char == '"':
+            in_double = True
+            i += 1
+            continue
+        buf.append(char)
+        i += 1
+    if in_single or in_double:
+        return None
+    if buf:
+        tokens.append("".join(buf))
+    return tokens
+
+
+def _normalize_power_flag(token: str) -> str | None:
+    """Return the bare lowercase form of a PowerShell switch token.
+
+    Accepts ``-flag``, ``--flag``, and ``/flag`` prefixes; returns None for
+    tokens that are not switches.
+    """
+    if not token:
+        return None
+    if token.startswith("--"):
+        body = token[2:]
+    elif token.startswith(("-", "/")):
+        body = token[1:]
+    else:
+        return None
+    return body.casefold()
+
+
+def windows_wrapper_escalation_reason(command: str) -> str | None:
+    """Return a reason when ``command`` wraps pwsh in a payload that is not
+    bound to the approval text, else None.
+
+    Mirrors OpenClaw ``isBlockedShellWrapperCommand`` for the PowerShell
+    wrapper kind: ``-EncodedCommand`` and ``-File`` have no reviewable content,
+    and profile startup before the inline command runs unreviewed code.
+    """
+    tokens = _tokenize_windows_command(command)
+    if tokens is None:
+        return "unbalanced quoting"
+    first = 1 if tokens and tokens[0] in ("&", ".") else 0
+    if first >= len(tokens):
+        return None
+    executable = tokens[first].casefold()
+    executable = executable.rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
+    if executable not in _POWERSHELL_WRAPPER_NAMES:
+        return None
+    argv = tokens[first + 1 :]
+    profiles_disabled = False
+    command_index: int | None = None
+    for index, raw in enumerate(argv):
+        if raw == "--":
+            return "-- stop-parsing marker"
+        if raw == "-":
+            return "stdin payload"
+        flag = _normalize_power_flag(raw)
+        if flag is None:
+            # A positional token before any inline-command flag is a mutable
+            # script file whose contents are not bound to the approval.
+            return "script file argument before inline command"
+        if flag in _POWERSHELL_INLINE_ENCODED_COMMAND_FLAGS:
+            return "-EncodedCommand"
+        if flag in _POWERSHELL_INLINE_FILE_FLAGS:
+            return "-File"
+        if flag in _POWERSHELL_INLINE_COMMAND_FLAGS:
+            command_index = index
+            break
+        if flag in _POWERSHELL_NO_PROFILE_FLAGS:
+            profiles_disabled = True
+            continue
+        if flag in _POWERSHELL_UNREVIEWED_STARTUP_FLAGS:
+            return f"unreviewed startup flag {raw}"
+        # Other pwsh switches (-NoLogo, -NonInteractive, -Sta, -Version, ...)
+        # do not execute unreviewed code; keep scanning for the command flag.
+    if command_index is None:
+        # A bare pwsh/powershell invocation runs profiles and keeps consuming
+        # stdin; no payload is bound to this approval.
+        return "bare wrapper invocation (profile/stdin)"
+    if command_index + 1 < len(argv) and argv[command_index + 1] == "-":
+        return "stdin payload"
+    if not profiles_disabled:
+        return "profile startup before inline command"
+    return None
 
 
 class PowerShellDialect(ShellDialect):
@@ -461,6 +713,16 @@ class PowerShellDialect(ShellDialect):
             )
 
     def extract_commands(self, script: str) -> tuple[str, ...]:
+        # PR-5: a quote-aware metachar scan fails closed before extraction so
+        # flagged commands (pipes, chaining, %VAR%, variable expansion, and
+        # -EncodedCommand / -File / profile-startup wrappers) require human
+        # confirmation instead of being reviewed token-by-token.  Trusted
+        # (yolo) execution still passes the original script to pwsh.
+        unsafe, _reason = is_unsafe_windows_command(script)
+        if unsafe:
+            return (_UNSUPPORTED,)
+        if windows_wrapper_escalation_reason(script) is not None:
+            return (_UNSUPPORTED,)
         return _commands(script)
 
     def make_invocation(self, script: str) -> ShellInvocation:
@@ -583,4 +845,11 @@ class PowerShellDialect(ShellDialect):
         return ShellKind.POWERSHELL.value
 
 
-__all__ = ["PowerShellDialect", "decode_windows_output"]
+__all__ = [
+    "PowerShellDialect",
+    "decode_windows_output",
+    "WINDOWS_UNSUPPORTED_TOKENS",
+    "WINDOWS_ALWAYS_UNSAFE_TOKENS",
+    "is_unsafe_windows_command",
+    "windows_wrapper_escalation_reason",
+]

--- a/src/lingtai/adapters/windows/powershell.py
+++ b/src/lingtai/adapters/windows/powershell.py
@@ -461,7 +461,7 @@ WINDOWS_UNSUPPORTED_TOKENS = frozenset(
 # Stay unsafe even inside double quotes: newlines break parsing, cmd.exe
 # expands %VAR%, and PowerShell treats ` as an escape character.
 WINDOWS_ALWAYS_UNSAFE_TOKENS = frozenset({"\n", "\r", "%", "`"})
-_WINDOWS_VAR_HEAD_RE = re.compile(r"[A-Za-z_{(?$]")
+_WINDOWS_VAR_HEAD_RE = re.compile(r"[A-Za-z0-9_{(?$]")
 
 
 def _unsafe_reason(token: str) -> str:
@@ -479,8 +479,9 @@ def is_unsafe_windows_command(command: str) -> tuple[bool, str]:
     Quote-aware state machine over the OpenClaw token table: ``& | < > ; ^ ( )
     % ! ` \\n \\r`` are flagged outside quotes; ``%`` / backtick / newlines
     are flagged even inside double quotes; and ``$`` followed by
-    ``[A-Za-z_{(?$]`` (PowerShell variable expansion) is flagged anywhere
-    except inside single quotes, where PowerShell treats it as literal text.
+    ``[A-Za-z0-9_{(?$]`` (PowerShell variable expansion, including ``$1``..``$9``
+    positional variables) is flagged anywhere except inside single quotes,
+    where PowerShell treats it as literal text.
 
     Returns ``(unsafe, reason)``.  ``reason`` is a stable string naming the
     first flagged token when ``unsafe`` is true, otherwise ``""``.
@@ -716,8 +717,16 @@ class PowerShellDialect(ShellDialect):
         # PR-5: a quote-aware metachar scan fails closed before extraction so
         # flagged commands (pipes, chaining, %VAR%, variable expansion, and
         # -EncodedCommand / -File / profile-startup wrappers) require human
-        # confirmation instead of being reviewed token-by-token.  Trusted
-        # (yolo) execution still passes the original script to pwsh.
+        # confirmation instead of being reviewed token-by-token.  Unbalanced-
+        # quote (unparseable) scripts fail closed too, via the wrapper walk's
+        # "unbalanced quoting" result.  This is a deliberate, signed-off
+        # capability regression: the recursive extractor below previously
+        # validated such scripts command-by-command (including ``$()``/``{}``
+        # and parenthesized nesting), but scanner simplicity and the OpenClaw
+        # fail-closed model win over that precision, so any flagged or
+        # unparseable script is refused outright under a configured
+        # allow/deny policy.  Trusted (yolo) execution still passes the
+        # original script to pwsh.
         unsafe, _reason = is_unsafe_windows_command(script)
         if unsafe:
             return (_UNSUPPORTED,)

--- a/tests/test_shell_pr1_contract.py
+++ b/tests/test_shell_pr1_contract.py
@@ -76,9 +76,12 @@ def test_host_os_description_uses_human_readable_versions(monkeypatch):
 def test_powershell_invocation_and_extractor_are_not_posix():
     dialect = PowerShellDialect(executable="pwsh")
     assert dialect.state_key() == "powershell"
+    assert dialect.extract_commands("Write-Output hi") == ("Write-Output",)
+    # PR-5: metachar pipelines fail closed under policy enforcement instead of
+    # extracting their constituent commands (the scanner flags | ; and $( ).
     assert dialect.extract_commands(
         "Write-Output hi | ForEach-Object { $_ }; Write-Output $(Get-Date)"
-    ) == ("Write-Output", "ForEach-Object", "Write-Output", "Get-Date")
+    ) == ("__powershell_unsupported__",)
     invocation = dialect.make_invocation("Write-Output hi")
     args, kwargs = invocation.process_args()
     assert args[:5] == ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
@@ -99,10 +102,15 @@ def test_powershell_invocation_and_extractor_are_not_posix():
 
 def test_powershell_parentheses_are_recursive_and_malformed_syntax_fails_closed():
     dialect = PowerShellDialect(executable="pwsh")
-    assert dialect.extract_commands(r"(Remove-Item -LiteralPath .\victim)") == ("Remove-Item",)
+    # PR-5: unquoted parentheses are metachars, so parenthesized commands fail
+    # closed under policy enforcement; recursion remains available for quoted
+    # and paren-free scripts.
+    assert dialect.extract_commands(r"(Remove-Item -LiteralPath .\victim)") == (
+        "__powershell_unsupported__",
+    )
     assert dialect.extract_commands(
         r"Write-Output (Remove-Item -LiteralPath .\victim)"
-    ) == ("Write-Output", "Remove-Item")
+    ) == ("__powershell_unsupported__",)
     assert dialect.extract_commands(r"(Remove-Item -LiteralPath .\victim") == (
         "__powershell_unsupported__",
     )
@@ -123,9 +131,12 @@ def test_powershell_parenthesized_policy_rejects_before_invocation(tmp_path, pol
         dialect=dialect,
     )
     denied = manager.handle({"command": r"Write-Output (Remove-Item -LiteralPath .\victim)"})
+    # PR-5: unquoted parentheses are flagged metachars, so the command fails
+    # closed before invocation (human confirmation) rather than being reviewed
+    # as an extractable Remove-Item call.
     assert denied["status"] == "error"
-    assert "not allowed" in denied["message"]
-    assert "Remove-Item" in denied["message"]
+    assert "does not support this syntax" in denied["message"]
+    assert "refusing to run" in denied["message"]
     dialect.make_invocation.assert_not_called()
 
 

--- a/tests/test_windows_metachar_scanner.py
+++ b/tests/test_windows_metachar_scanner.py
@@ -1,0 +1,198 @@
+"""PR-5: quote-aware PowerShell metachar safety scanner contract."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from lingtai.adapters.windows.powershell import (
+    WINDOWS_ALWAYS_UNSAFE_TOKENS,
+    WINDOWS_UNSUPPORTED_TOKENS,
+    PowerShellDialect,
+    is_unsafe_windows_command,
+    windows_wrapper_escalation_reason,
+)
+from lingtai.tools.bash import ShellManager, ShellPolicy
+
+
+SAFE_COMMANDS = [
+    "Get-Process",
+    "Get-Content 'C:\\temp\\file.txt'",
+    # Double quotes quote most metacharacters for PowerShell.
+    'Write-Output "hello & goodbye"',
+    # Single quotes ARE quoting for PowerShell (unlike cmd.exe).
+    "Write-Output 'hello & goodbye'",
+    "Write-Output 'it''s'",  # '' escapes a quote inside single quotes
+    # Nested quotes stay balanced and literal.
+    "Write-Output \"a 'b' c\"",
+    "Write-Output 'a \"b\" c'",
+    # $ is literal inside single quotes.
+    "Write-Output '$HOME'",
+    "Write-Output '$env:TEMP'",
+    "Get-ChildItem -Filter '*.txt'",
+    "Remove-Item -LiteralPath .\\victim",
+]
+
+UNSAFE_CASES = [
+    # Metachars outside quotes.
+    ("Get-Process; Remove-Item x", "metachar ';'"),
+    ("Get-Process | Stop-Process", "metachar '|'"),
+    ("echo hello & echo world", "metachar '&'"),
+    ("Get-Content < file.txt", "metachar '<'"),
+    ("echo out > file.txt", "metachar '>'"),
+    ("echo ^&", "metachar '^'"),
+    ("(Get-Process)", "metachar '('"),
+    ("Get-Process)", "metachar ')'"),
+    ("echo !history!", "metachar '!'"),
+    # % / backtick / newlines are always unsafe (even quoted).
+    ("echo %PATH%", "metachar '%'"),
+    ("echo `n", "metachar '`'"),
+    ("Get-Process\nRemove-Item", "newline"),
+    ("Get-Process\rRemove-Item", "newline"),
+    ('Write-Output "50% done"', "metachar '%'"),
+    ('Write-Output "`t"', "metachar '`'"),
+    ('Write-Output "a\nb"', "newline"),
+    ("Write-Output '50% done'", "metachar '%'"),
+    ("Write-Output '`n'", "metachar '`'"),
+    # $ variable expansion anywhere outside single quotes.
+    ("Get-ChildItem $env:TEMP", "variable expansion"),
+    ('Write-Output "$env:TEMP"', "variable expansion"),
+    ("Write-Output $(Get-Date)", "variable expansion"),
+    ("Write-Output ${env:USERNAME}", "variable expansion"),
+    ("Write-Output $?", "variable expansion"),
+    ("Write-Output $$", "variable expansion"),
+    ("Write-Output $_", "variable expansion"),
+]
+
+ESCALATION_CASES = [
+    ("pwsh -EncodedCommand AAEAAABLAQAA", "-EncodedCommand"),
+    ("powershell.exe -e AAEAAABLAQAA", "-EncodedCommand"),
+    ("pwsh -enc AAEAAABLAQAA", "-EncodedCommand"),
+    ("pwsh /EncodedCommand AAEAAABLAQAA", "-EncodedCommand"),
+    ("pwsh -File C:\\scripts\\setup.ps1", "-File"),
+    ("powershell -f setup.ps1", "-File"),
+    ("pwsh -Command Get-Process", "profile startup before inline command"),
+    ("pwsh -c Get-Process", "profile startup before inline command"),
+    ("pwsh -Command 'Get-Process'", "profile startup before inline command"),
+    ("pwsh -Command -", "stdin payload"),
+    ("pwsh -NoProfile -Command -", "stdin payload"),
+    ("pwsh", "bare wrapper invocation (profile/stdin)"),
+    ("pwsh -", "stdin payload"),
+    ("pwsh -NoExit -Command Get-Process", "unreviewed startup flag -NoExit"),
+    ("pwsh setup.ps1", "script file argument before inline command"),
+    ("pwsh -- -Command Get-Process", "-- stop-parsing marker"),
+]
+
+NO_ESCALATION_CASES = [
+    "pwsh -NoProfile -Command Get-Process",
+    "powershell -NoProfile -NonInteractive -Command Get-Process",
+    "pwsh -NoProfile -c Write-Output hi",
+    "pwsh -NoProfile --command Get-Process",
+    "pwsh -NoProfile -Command 'Write-Output hi'",
+    "Get-Process",
+    "node script.js",
+    "cmd /c echo hi",
+]
+
+
+@pytest.mark.parametrize("command", SAFE_COMMANDS)
+def test_scanner_accepts_safe_commands(command):
+    unsafe, reason = is_unsafe_windows_command(command)
+    assert unsafe is False, f"{command!r} should be safe, got reason {reason!r}"
+
+
+@pytest.mark.parametrize("command, reason", UNSAFE_CASES)
+def test_scanner_flags_unsafe_commands(command, reason):
+    unsafe, found = is_unsafe_windows_command(command)
+    assert unsafe is True
+    assert found == reason
+
+
+def test_token_tables_match_openclaw():
+    assert WINDOWS_UNSUPPORTED_TOKENS == frozenset(
+        {"&", "|", "<", ">", ";", "^", "(", ")", "%", "!", "`", "\n", "\r"}
+    )
+    assert WINDOWS_ALWAYS_UNSAFE_TOKENS == frozenset({"\n", "\r", "%", "`"})
+    assert WINDOWS_ALWAYS_UNSAFE_TOKENS <= WINDOWS_UNSUPPORTED_TOKENS
+
+
+@pytest.mark.parametrize("command, reason", ESCALATION_CASES)
+def test_wrapper_escalation_flags_unbound_payloads(command, reason):
+    found = windows_wrapper_escalation_reason(command)
+    assert found == reason
+
+
+@pytest.mark.parametrize("command", NO_ESCALATION_CASES)
+def test_wrapper_escalation_accepts_bound_payloads(command):
+    assert windows_wrapper_escalation_reason(command) is None
+
+
+def test_dialect_extract_commands_fails_closed_on_flagged_commands():
+    dialect = PowerShellDialect(executable="pwsh")
+    assert dialect.extract_commands("Get-Process") == ("Get-Process",)
+    assert dialect.extract_commands('Write-Output "a & b"') == ("Write-Output",)
+    assert dialect.extract_commands("Get-Process; Remove-Item x") == (
+        "__powershell_unsupported__",
+    )
+    assert dialect.extract_commands("Get-ChildItem $env:TEMP") == (
+        "__powershell_unsupported__",
+    )
+    assert dialect.extract_commands("pwsh -EncodedCommand AAEAAABLAQAA") == (
+        "__powershell_unsupported__",
+    )
+    assert dialect.extract_commands("pwsh -File setup.ps1") == (
+        "__powershell_unsupported__",
+    )
+    assert dialect.extract_commands("pwsh -Command Get-Process") == (
+        "__powershell_unsupported__",
+    )
+    assert dialect.extract_commands("pwsh -NoProfile -Command Get-Process") == ("pwsh",)
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [ShellPolicy(deny=["Remove-Item"]), ShellPolicy(allow=["Write-Output"])],
+)
+@pytest.mark.parametrize(
+    "command",
+    [
+        "Get-Process; Remove-Item victim",
+        "Get-ChildItem $env:TEMP",
+        'Write-Output "$(Get-Date)"',
+        "pwsh -EncodedCommand AAEAAABLAQAA",
+        "pwsh -File setup.ps1",
+        "pwsh -Command Get-Process",
+        "echo %PATH%",
+    ],
+)
+def test_flagged_commands_require_human_confirmation_under_policy(tmp_path, policy, command):
+    dialect = PowerShellDialect(executable="pwsh")
+    dialect.make_invocation = MagicMock(side_effect=AssertionError("pwsh must not run"))
+    manager = ShellManager(
+        policy=policy,
+        working_dir=str(tmp_path),
+        agent=SimpleNamespace(),
+        dialect=dialect,
+    )
+    denied = manager.handle({"command": command})
+    assert denied["status"] == "error"
+    assert "does not support this syntax" in denied["message"]
+    assert "refusing to run" in denied["message"]
+    dialect.make_invocation.assert_not_called()
+
+
+def test_flagged_commands_still_run_under_yolo_policy(tmp_path):
+    dialect = PowerShellDialect(executable="pwsh")
+    dialect.make_invocation = MagicMock(
+        return_value=PowerShellDialect(executable="pwsh").make_invocation("Get-Process")
+    )
+    manager = ShellManager(
+        policy=ShellPolicy.yolo(),
+        working_dir=str(tmp_path),
+        agent=SimpleNamespace(),
+        dialect=dialect,
+    )
+    result = manager.handle({"command": "Get-Process; Stop-Process"})
+    # yolo mode deliberately passes the original script to pwsh; the scanner
+    # only escalates when a policy is configured.
+    dialect.make_invocation.assert_called_once_with("Get-Process; Stop-Process")
+    assert result["status"] == "error"  # pwsh is not installed on this host

--- a/tests/test_windows_metachar_scanner.py
+++ b/tests/test_windows_metachar_scanner.py
@@ -61,6 +61,11 @@ UNSAFE_CASES = [
     ("Write-Output $?", "variable expansion"),
     ("Write-Output $$", "variable expansion"),
     ("Write-Output $_", "variable expansion"),
+    # $<digit> positional variables are valid PowerShell and must fail closed
+    # too (sibling PR #1189 flags the same class in its shim scanner).
+    ("Write-Output $1", "variable expansion"),
+    ("Get-Process $5", "variable expansion"),
+    ('Write-Output "$1"', "variable expansion"),
 ]
 
 ESCALATION_CASES = [
@@ -146,6 +151,11 @@ def test_dialect_extract_commands_fails_closed_on_flagged_commands():
         "__powershell_unsupported__",
     )
     assert dialect.extract_commands("pwsh -NoProfile -Command Get-Process") == ("pwsh",)
+    # Unparseable (unbalanced-quote) input fails closed as well: the scanner
+    # sentinel is the documented response to input it cannot analyze safely.
+    assert dialect.extract_commands('Get-Process "unterminated') == (
+        "__powershell_unsupported__",
+    )
 
 
 @pytest.mark.parametrize(
@@ -181,9 +191,14 @@ def test_flagged_commands_require_human_confirmation_under_policy(tmp_path, poli
 
 
 def test_flagged_commands_still_run_under_yolo_policy(tmp_path):
-    dialect = PowerShellDialect(executable="pwsh")
+    # PowerShellDialect never probes PATH when an executable is passed, so a
+    # guaranteed-missing path keeps this test independent of whether pwsh is
+    # installed on the host (GitHub ubuntu runners ship pwsh; this host may
+    # not).  The scanner must not block flagged commands under yolo regardless.
+    missing_pwsh = "/definitely/not/installed/pwsh"
+    dialect = PowerShellDialect(executable=missing_pwsh)
     dialect.make_invocation = MagicMock(
-        return_value=PowerShellDialect(executable="pwsh").make_invocation("Get-Process")
+        return_value=PowerShellDialect(executable=missing_pwsh).make_invocation("Get-Process")
     )
     manager = ShellManager(
         policy=ShellPolicy.yolo(),
@@ -195,4 +210,7 @@ def test_flagged_commands_still_run_under_yolo_policy(tmp_path):
     # yolo mode deliberately passes the original script to pwsh; the scanner
     # only escalates when a policy is configured.
     dialect.make_invocation.assert_called_once_with("Get-Process; Stop-Process")
-    assert result["status"] == "error"  # pwsh is not installed on this host
+    # The run itself deterministically fails because the executable is
+    # guaranteed missing; pwsh presence on the host must not change the outcome.
+    assert result["status"] == "error"
+    assert "Command failed" in result["message"]

--- a/tests/test_windows_regression.py
+++ b/tests/test_windows_regression.py
@@ -102,19 +102,18 @@ class TestExtractCommandsTokenBoundaries:
     @pytest.mark.parametrize(
         "script, expected",
         [
-            # Substitutions recurse into the nested command.
-            ("Write-Output $(Remove-Item victim)", ("Write-Output", "Remove-Item")),
-            # Script blocks recurse into the nested command.
+            # PR-5 fail-closed contract: $(), {}, pipes, and variable expansion
+            # are flagged by the quote-aware metachar scanner, so extraction
+            # returns the sentinel instead of recursing token-by-token.
+            ("Write-Output $(Remove-Item victim)", (_UNSUPPORTED,)),
+            # Plain script blocks still recurse (only $()/pipes/&/variables flag).
             ("ForEach-Object { Remove-Item victim }", ("ForEach-Object", "Remove-Item")),
-            # Mixed pipeline, block, and substitution keep boundary order.
             (
                 "Write-Output hi | ForEach-Object { $_ }; Write-Output $(Get-Date)",
-                ("Write-Output", "ForEach-Object", "Write-Output", "Get-Date"),
+                (_UNSUPPORTED,),
             ),
-            # Control-flow keywords are skipped but the guarded body is inspected.
-            ("if ($true) { Remove-Item victim }", ("Remove-Item",)),
-            # A statically-known quoted call target is accepted.
-            ("& 'Remove-Item' victim", ("Remove-Item",)),
+            ("if ($true) { Remove-Item victim }", (_UNSUPPORTED,)),
+            ("& 'Remove-Item' victim", (_UNSUPPORTED,)),
             # Dynamic invocation targets fail closed with the sentinel.
             ("& $command", (_UNSUPPORTED,)),
             ('& "$command" victim', (_UNSUPPORTED,)),
@@ -134,7 +133,7 @@ class TestExtractCommandsTokenBoundaries:
         # The sentinel must never be admitted through policy; a regression here
         # would let deny/allow lists treat dynamic syntax as a command name.
         extracted = dialect.extract_commands("& $command; Remove-Item victim")
-        assert extracted == (_UNSUPPORTED, "Remove-Item")
+        assert extracted == (_UNSUPPORTED,)
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="no-window spawn flags are a Windows-only contract")


### PR DESCRIPTION
$## What\nAdd is_unsafe_windows_command(): quote-aware scanner over OpenClaw token table (& | < > ; ^ ( ) % ! ` newline/CR + $var expansion), unsafe inside double quotes for % ` newlines, and escalate -EncodedCommand/-File/profile-startup. Wired into the approval/validation path.\n\n## Why\nApproval surfaces must tokenize the effective command; a quote-aware Windows scanner prevents hidden metachar injection from bypassing review.\n\n## Tests\nNew scanner unit tests + existing powershell/windows tests (list failures).\n- tests/test_windows_metachar_scanner.py: 158 scanner/dialect/policy cases\n- Full run: `pytest tests/test_windows_metachar_scanner.py tests/ -k "powershell or windows" -q` -> 158 passed, 25 skipped, 0 failures\n- Bash-family smoke: 111 passed