### PR TITLE
feat(windows): trusted cmd.exe shim handling for .cmd/.bat tools

### DIFF
--- a/src/lingtai/adapters/windows/powershell.py
+++ b/src/lingtai/adapters/windows/powershell.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import subprocess
 import sys
 
 from lingtai.tools.bash._shell_dialect import (
@@ -19,6 +20,8 @@ from lingtai.tools.bash._shell_dialect import (
     ShellKind,
     make_invocation_for_kind,
 )
+
+from .windows_cmd_shim import try_cmd_shim_plan
 
 _UNSUPPORTED = "__powershell_unsupported__"
 
@@ -320,6 +323,35 @@ class PowerShellDialect(ShellDialect):
         return _commands(script)
 
     def make_invocation(self, script: str) -> ShellInvocation:
+        # Trusted cmd.exe shim handling: when the script is one simple command
+        # whose first token resolves to a .cmd/.bat shim (or npm/npx), do not
+        # let pwsh call the shim through the ambient cmd.exe.  npm/npx are
+        # rewritten to a direct ``node .../npm-cli.js`` invocation that still
+        # runs inside the normal pwsh exit-code envelope below; other shims are
+        # wrapped in a trusted ``cmd.exe /d /s /c`` invocation with
+        # metacharacter rejection (see ``windows_cmd_shim``).  A ``ValueError``
+        # here rejects metacharacters that are unsafe under cmd.exe instead of
+        # silently reinterpreting them; anything not a simple shim command
+        # falls through to the pwsh wrapper unchanged.
+        plan = try_cmd_shim_plan(script)
+        if plan is not None:
+            kind, argv = plan
+            if kind == "cmd":
+                return ShellInvocation(
+                    script=argv[-1],
+                    executable=argv[0],
+                    argv=tuple(argv[1:-1]),
+                    encoding="utf-8",
+                    errors="replace",
+                )
+            # npm/npx: direct node invocation of the CLI script, still wrapped
+            # in the pwsh exit-code envelope (no cmd.exe involved).  Args are
+            # quote-free by construction, so ``list2cmdline`` output is also
+            # valid PowerShell syntax.
+            script = subprocess.list2cmdline(argv)
+        return self._pwsh_invocation(script)
+
+    def _pwsh_invocation(self, script: str) -> ShellInvocation:
         # ``pwsh -Command`` otherwise collapses an external program's native
         # exit status to PowerShell's generic 0/1 process status.  PowerShell
         # 7.3+ can expose non-zero native results as a typed ErrorRecord without

--- a/src/lingtai/adapters/windows/powershell.py
+++ b/src/lingtai/adapters/windows/powershell.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import os
 import re
 import shutil
-import subprocess
 import sys
 
 from lingtai.tools.bash._shell_dialect import (
@@ -44,6 +43,27 @@ _CONTROL_WORDS = {
     "end", "finally", "for", "foreach", "function", "if", "param", "process",
     "return", "switch", "throw", "trap", "try", "until", "using", "while",
 }
+
+
+def _pwsh_single_quote(arg: str) -> str:
+    """Emit ``arg`` as a PowerShell single-quoted literal (embedded ``'`` doubled)."""
+    return "'" + arg.replace("'", "''") + "'"
+
+
+def _pwsh_quote_argv(argv: list[str]) -> str:
+    """Render ``argv`` as PowerShell source for ``pwsh -Command``.
+
+    Uses the call operator with every element single-quoted, so the result is
+    valid PowerShell for *any* argument: paths with spaces
+    (``C:\\Program Files\\nodejs\\node.exe``), apostrophes (``it's`` via
+    ``'it''s'``), and ``$``/backtick/``--%`` tokens all stay literal.
+    ``subprocess.list2cmdline`` must never be used to generate PS source: its
+    C-runtime quoting emits a quoted string in command position, which
+    PowerShell rejects with an "Unexpected token" parse error.
+    """
+    return "& " + " ".join(_pwsh_single_quote(arg) for arg in argv)
+
+
 _ASSIGNMENT_RE = re.compile(r"^(?:\$[A-Za-z_][\w:]*|[A-Za-z_][\w-]*)$")
 _TOKEN_RE = re.compile(
     r"(?:'[^']*(?:''[^']*)*'|\"(?:`.|[^\"])*\"|&(?=\s|$)|\.(?=\s|$)|[^\s|;&(){}]+)"
@@ -345,10 +365,13 @@ class PowerShellDialect(ShellDialect):
                     errors="replace",
                 )
             # npm/npx: direct node invocation of the CLI script, still wrapped
-            # in the pwsh exit-code envelope (no cmd.exe involved).  Args are
-            # quote-free by construction, so ``list2cmdline`` output is also
-            # valid PowerShell syntax.
-            script = subprocess.list2cmdline(argv)
+            # in the pwsh exit-code envelope (no cmd.exe involved).  The
+            # payload is PowerShell *source*, so it is built with the call
+            # operator plus PS-native single-quoting (see ``_pwsh_quote_argv``)
+            # -- never ``subprocess.list2cmdline``, whose C-runtime quoting
+            # produces a quoted string in command position and breaks on the
+            # default Windows layout ``C:\Program Files\nodejs\``.
+            script = _pwsh_quote_argv(argv)
         return self._pwsh_invocation(script)
 
     def _pwsh_invocation(self, script: str) -> ShellInvocation:

--- a/src/lingtai/adapters/windows/windows_cmd_shim.py
+++ b/src/lingtai/adapters/windows/windows_cmd_shim.py
@@ -32,10 +32,13 @@ capturing piped output (node-based tools write UTF-8).
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shutil
 import subprocess
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "build_cmd_exe_invocation",
@@ -93,6 +96,12 @@ def escape_for_windows_cmd_exe(arg: str) -> str:
         )
     escaped = arg.replace("^", "^^")
     if '"' in escaped:
+        # NOTE: on the trusted-shim calling path this branch (and the ``^``
+        # branch above) is dead: ``reject_unsafe_metachars`` rejects ``^``
+        # first, and ``split_simple_command`` refuses tokens containing ``"``.
+        # They are kept so this remains a correct general-purpose cmd.exe
+        # escaper; a future caller that reorders the checks would silently
+        # change semantics.
         escaped = '"' + escaped.replace('"', '""') + '"'
     return escaped
 
@@ -186,7 +195,18 @@ def _which(name: str, path: str | None) -> str | None:
 
 
 def _default_cmd_exe() -> str:
-    """Return the trusted cmd.exe path (``COMSPEC``) or a bare fallback name."""
+    """Return the trusted cmd.exe path or a bare fallback name.
+
+    Prefers ``%SystemRoot%\\System32\\cmd.exe`` when that file exists (the
+    hardened path, independent of the ambient ``COMSPEC``); falls back to
+    ``COMSPEC`` and finally a bare ``cmd.exe`` name so minimal environments
+    and tests keep working.
+    """
+    system_root = os.environ.get("SystemRoot")
+    if system_root:
+        candidate = os.path.join(system_root, "System32", "cmd.exe")
+        if os.path.isfile(candidate):
+            return candidate
     return os.environ.get("COMSPEC") or "cmd.exe"
 
 
@@ -296,6 +316,21 @@ def try_cmd_shim_plan(
     """
     argv = split_simple_command(script)
     if not argv:
+        # Falls back to pwsh: complex scripts and scripts containing
+        # PowerShell variables (``$var``/``$(...)``) keep PowerShell
+        # semantics.  A .cmd/.bat shim in that position then runs through the
+        # *ambient* cmd.exe, so log it for diagnosis -- unlike unsafe
+        # metachars on the shim path, which raise :class:`ValueError`.
+        first = script.split(None, 1)[0] if script.strip() else ""
+        if first and (
+            is_cmd_bat_shim(first) or resolve_cmd_bat_shim(first, path=path)
+        ):
+            logger.debug(
+                "cmd shim command %r not shimmed (falls back to pwsh -> "
+                "ambient cmd.exe): %s",
+                first,
+                script,
+            )
         return None
     npm_argv = resolve_npm_argv(argv, path=path)
     if npm_argv is not None:

--- a/src/lingtai/adapters/windows/windows_cmd_shim.py
+++ b/src/lingtai/adapters/windows/windows_cmd_shim.py
@@ -1,0 +1,306 @@
+"""Trusted cmd.exe shim handling for .cmd/.bat tools on Windows.
+
+Our shell dialect is PowerShell (pwsh), but tools such as ``npm.cmd``,
+``npx.cmd`` and ``yarn.cmd`` invoked by the model still resolve through
+``cmd.exe`` when pwsh calls them implicitly.  That exposes the command to
+cmd.exe semantics (``%VAR%`` expansion, ``^`` escaping, no single-quote
+quoting, AutoRun) that PowerShell users do not expect.
+
+This module mirrors OpenClaw's ``src/process/windows-command.ts`` approach:
+
+1. ``npm``/``npx`` (with or without a ``.cmd``/``.bat`` suffix) resolve to a
+   direct ``node <npm-dir>/bin/npm-cli.js`` (or ``npx-cli.js``) invocation so
+   the .cmd shim is bypassed entirely; otherwise
+2. a first token that resolves to a ``.cmd``/``.bat`` on PATH is wrapped in a
+   trusted ``cmd.exe /d /s /c <command line>`` invocation with the same
+   ``windowsVerbatimArguments``-style single-command-string transport, and
+   metacharacters that are unsafe under cmd.exe (``%``, backtick, ``^``,
+   ``$var``) are rejected rather than silently reinterpreted.
+
+The single command string is produced with ``subprocess.list2cmdline`` over
+args that were first passed through :func:`escape_for_windows_cmd_exe`; the
+result is passed to ``cmd.exe`` as one final argument, so Python's own
+CreateProcess command-line quoting (``shell=False`` -> ``list2cmdline``) only
+adds the outer quoting pair that ``cmd.exe /s`` strips.  Args containing an
+embedded double quote are deliberately not shimmed (the caller falls back to
+pwsh) because ``list2cmdline`` escapes quotes with backslashes, which cmd.exe
+does not understand.
+
+Output is read as UTF-8 with replacement errors; cmd.exe builtins writing in
+the OEM codepage may be mojibake'd, which is the accepted trade-off for
+capturing piped output (node-based tools write UTF-8).
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+
+__all__ = [
+    "build_cmd_exe_invocation",
+    "escape_for_windows_cmd_exe",
+    "is_cmd_bat_shim",
+    "reject_unsafe_metachars",
+    "resolve_cmd_bat_shim",
+    "resolve_npm_argv",
+    "split_simple_command",
+    "try_cmd_shim_plan",
+]
+
+_CMD_BAT_SUFFIXES = (".cmd", ".bat")
+
+# Characters that change meaning inside a cmd.exe command line even when the
+# command is wrapped in a trusted ``/d /s /c`` invocation (OpenClaw's
+# ``escapeForWindowsCmdExe`` rejection set).  ``%`` expands variables, ``&
+# | < >`` are operators, and ``\r``/``\n`` break line parsing.
+_UNSAFE_ESCAPE_RE = re.compile(r"[&|<>%\r\n]")
+
+# Metacharacters rejected for the trusted cmd.exe shim path (stricter than
+# :func:`escape_for_windows_cmd_exe`): ``%VAR%`` expands under cmd.exe, the
+# backtick is PowerShell's escape character, ``^`` is cmd.exe's escape
+# character, and ``$var``/``$(...)``/``${...}`` are PowerShell expansions that
+# a .cmd shim would pass through verbatim instead.
+_UNSAFE_SHIM_METACHAR_RE = re.compile(r"[%`^]|\$[A-Za-z_0-9][A-Za-z0-9_:]*|\$\(|\$\{")
+
+# Characters that make a script require PowerShell semantics (pipelines,
+# chains, redirection, script blocks, subexpressions, escape sequences) and
+# therefore disqualify it from the conservative single-command shim path.
+_SIMPLE_COMMAND_FORBIDDEN = set(";|&(){}<>`")
+
+# PowerShell variable/subexpression forms that must not be re-interpreted by a
+# .cmd shim: ``$name``, ``$name:qual``, ``$(...)``, ``${...}``.
+_PS_VAR_RE = re.compile(r"\$[A-Za-z_0-9][A-Za-z0-9_:]*|\$\(|\$\{")
+
+
+def is_cmd_bat_shim(token: str) -> bool:
+    """Return whether ``token`` names a ``.cmd``/``.bat`` shim (case-insensitive)."""
+    return token.casefold().endswith(_CMD_BAT_SUFFIXES)
+
+
+def escape_for_windows_cmd_exe(arg: str) -> str:
+    """Escape one argument for a cmd.exe command line (OpenClaw-compatible).
+
+    Rejects ``& | < > %`` and ``\r``/``\n`` with :class:`ValueError` (they
+    cannot be safely escaped), escapes ``^`` as ``^^``, and doubles embedded
+    double quotes with surrounding quotes (cmd.exe has no backslash
+    escaping).  Args with spaces are left for ``subprocess.list2cmdline`` to
+    quote.
+    """
+    if _UNSAFE_ESCAPE_RE.search(arg):
+        raise ValueError(
+            f"cannot escape argument for cmd.exe: unsafe metacharacter in {arg!r}"
+        )
+    escaped = arg.replace("^", "^^")
+    if '"' in escaped:
+        escaped = '"' + escaped.replace('"', '""') + '"'
+    return escaped
+
+
+def reject_unsafe_metachars(args: list[str]) -> None:
+    """Reject metacharacters that are unsafe under the cmd.exe shim.
+
+    Rejects ``%``, backtick, ``^``, and PowerShell ``$var``/``$(...)``/
+    ``${...}`` forms in any argument with :class:`ValueError`.  These stay
+    unsafe even inside double quotes: cmd.exe expands ``%VAR%`` and treats
+    ``^`` as an escape, and a ``$var`` would silently lose its PowerShell
+    meaning when handed to a .cmd shim.
+    """
+    for arg in args:
+        match = _UNSAFE_SHIM_METACHAR_RE.search(arg)
+        if match:
+            raise ValueError(
+                "refusing cmd.exe shim: unsafe metacharacter "
+                f"{match.group(0)!r} in argument {arg!r}"
+            )
+
+
+def split_simple_command(script: str) -> list[str] | None:
+    """Tokenize a single simple command, or return ``None``.
+
+    A *simple command* is one bare command word plus whitespace-separated
+    arguments with balanced single/double quotes.  PowerShell quoting rules
+    are honored for the conservative subset: doubled quotes inside a quoted
+    region (``"a""b"`` -> ``a"b``, ``'it''s'`` -> ``it's``) decode to a
+    literal quote, and backtick escapes are rejected outright.
+
+    Returns ``None`` (caller falls back to pwsh) for pipelines, chains,
+    redirection, script blocks, subexpressions, backtick escapes, PowerShell
+    variables, unbalanced quotes, or any argument that still contains an
+    embedded double quote (``list2cmdline`` cannot round-trip those through
+    cmd.exe).
+    """
+    script = script.strip()
+    if not script:
+        return None
+    if any(char in _SIMPLE_COMMAND_FORBIDDEN for char in script):
+        return None
+    if _PS_VAR_RE.search(script):
+        return None
+    tokens: list[str] = []
+    index = 0
+    length = len(script)
+    while index < length:
+        while index < length and script[index].isspace():
+            index += 1
+        if index >= length:
+            break
+        token: list[str] = []
+        quote: str | None = None
+        while index < length:
+            char = script[index]
+            if quote is not None:
+                if char == quote:
+                    if index + 1 < length and script[index + 1] == quote:
+                        token.append(quote)
+                        index += 2
+                        continue
+                    quote = None
+                    index += 1
+                    continue
+                token.append(char)
+                index += 1
+                continue
+            if char in "\"'":
+                quote = char
+                index += 1
+                continue
+            if char.isspace():
+                break
+            token.append(char)
+            index += 1
+        if quote is not None:
+            return None
+        tokens.append("".join(token))
+    if not tokens:
+        return None
+    if any('"' in token for token in tokens):
+        return None
+    return tokens
+
+
+def _which(name: str, path: str | None) -> str | None:
+    if path is not None:
+        return shutil.which(name, path=path)
+    return shutil.which(name)
+
+
+def _default_cmd_exe() -> str:
+    """Return the trusted cmd.exe path (``COMSPEC``) or a bare fallback name."""
+    return os.environ.get("COMSPEC") or "cmd.exe"
+
+
+def resolve_cmd_bat_shim(token: str, *, path: str | None = None) -> str | None:
+    """Resolve ``token`` to a ``.cmd``/``.bat`` path on PATH, or ``None``.
+
+    Handles explicit ``.cmd``/``.bat`` suffixes and PATHEXT-style bare names
+    (on Windows ``npm`` resolves through ``npm.cmd``).  Returns ``None`` when
+    the token does not resolve to a cmd shim, so callers keep the pwsh path.
+    """
+    if is_cmd_bat_shim(token):
+        return _which(token, path)
+    resolved = _which(token, path)
+    if resolved is not None and is_cmd_bat_shim(resolved):
+        return resolved
+    return None
+
+
+def _find_npm_cli_js(base: str, path: str | None) -> str | None:
+    """Locate ``<base>-cli.js`` (npm-cli.js / npx-cli.js) next to the shim.
+
+    Standard npm layout is ``<prefix>/node_modules/npm/bin/npm-cli.js`` next
+    to ``<prefix>/npm.cmd``; a flat ``<prefix>/npm-cli.js`` layout is also
+    accepted.  Lookups try both the token's original case and its casefolded
+    form so an uppercase ``NPM.CMD`` still resolves on case-sensitive
+    filesystems.  Returns the first existing script path or ``None``.
+    """
+    bases = [base]
+    folded = base.casefold()
+    if folded != base:
+        bases.append(folded)
+    dirs: list[str] = []
+    for candidate_base in bases:
+        for candidate in (f"{candidate_base}.cmd", f"{candidate_base}.bat", candidate_base):
+            hit = _which(candidate, path)
+            if hit:
+                directory = os.path.dirname(hit)
+                if directory not in dirs:
+                    dirs.append(directory)
+    for directory in dirs:
+        for candidate_base in bases:
+            cli_name = f"{candidate_base}-cli.js"
+            for candidate in (
+                os.path.join(directory, "node_modules", "npm", "bin", cli_name),
+                os.path.join(directory, cli_name),
+            ):
+                if os.path.isfile(candidate):
+                    return candidate
+    return None
+
+
+def resolve_npm_argv(cmd: list[str], *, path: str | None = None) -> list[str] | None:
+    """Resolve npm/npx (or ``npm.cmd``/``npx.cmd``) to a direct node invocation.
+
+    Returns ``[node, <npm-dir>/bin/npm-cli.js|npx-cli.js, *rest]``, bypassing
+    the .cmd shim and its cmd.exe semantics, or ``None`` when the first token
+    is not npm/npx or the CLI script/node executable cannot be located.
+    """
+    if not cmd:
+        return None
+    first = cmd[0]
+    base = first[:-4] if is_cmd_bat_shim(first) else first
+    if base.casefold() not in {"npm", "npx"}:
+        return None
+    node = _which("node", path)
+    if node is None:
+        return None
+    cli = _find_npm_cli_js(base, path)
+    if cli is None:
+        return None
+    return [node, cli, *cmd[1:]]
+
+
+def build_cmd_exe_invocation(
+    args: list[str], *, cmd_exe: str | None = None,
+) -> list[str]:
+    """Build the trusted ``cmd.exe`` wrapper argv for ``args``.
+
+    Returns ``[<cmd.exe>, /d, /s, /c, <list2cmdline>]``: the payload is a
+    single command string (the ``windowsVerbatimArguments`` equivalent).
+    With ``shell=False`` Python builds the CreateProcess command line with
+    ``subprocess.list2cmdline``, so the only extra quoting around the payload
+    is the outer pair that ``cmd.exe /s`` strips.  Each argument is first
+    passed through :func:`escape_for_windows_cmd_exe` (``^`` escaping and
+    ``""`` doubling); reject unsafe metachars with
+    :func:`reject_unsafe_metachars` before calling this when the shim path is
+    taken.
+    """
+    if not args:
+        raise ValueError("cannot build a cmd.exe shim invocation for an empty command")
+    escaped = [escape_for_windows_cmd_exe(arg) for arg in args]
+    payload = subprocess.list2cmdline(escaped)
+    return [cmd_exe or _default_cmd_exe(), "/d", "/s", "/c", payload]
+
+
+def try_cmd_shim_plan(
+    script: str, *, path: str | None = None,
+) -> tuple[str, list[str]] | None:
+    """Plan a trusted non-pwsh execution for a .cmd/.bat shim command.
+
+    Returns ``("node", argv)`` for npm/npx (direct node invocation of the CLI
+    JS, no cmd.exe involved), ``("cmd", argv)`` for other ``.cmd``/``.bat``
+    shims wrapped in trusted ``cmd.exe /d /s /c``, or ``None`` when the script
+    is not a single simple command whose first token resolves to a shim (the
+    caller then keeps the normal pwsh path).  Raises :class:`ValueError` when
+    the command is a shim but contains metacharacters unsafe under cmd.exe.
+    """
+    argv = split_simple_command(script)
+    if not argv:
+        return None
+    npm_argv = resolve_npm_argv(argv, path=path)
+    if npm_argv is not None:
+        return ("node", npm_argv)
+    if resolve_cmd_bat_shim(argv[0], path=path) is None:
+        return None
+    reject_unsafe_metachars(argv)
+    return ("cmd", build_cmd_exe_invocation(argv))

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -533,7 +533,13 @@ class ShellManager:
         err = self._validate_working_dir(cwd)
         if err:
             return err
-        invocation = self._dialect.make_invocation(command)
+        # The powershell dialect may reject cmd.exe-shim commands whose
+        # metacharacters would be unsafe under cmd.exe; surface that as a
+        # regular error instead of an unhandled exception.
+        try:
+            invocation = self._dialect.make_invocation(command)
+        except ValueError as exc:
+            return {"status": "error", "message": str(exc)}
         if args.get("async", False):
             reminder, err = self._validate_reminder(args.get("reminder"))
             if err:

--- a/tests/test_windows_cmd_shim.py
+++ b/tests/test_windows_cmd_shim.py
@@ -1,0 +1,243 @@
+"""Unit tests for the trusted cmd.exe shim handling (PR-3).
+
+Covers npm/npx resolution to a direct node invocation, .cmd/.bat shim
+identification, cmd.exe escaping, unsafe metachar rejection, the simple
+command tokenizer, and the PowerShellDialect wiring.
+"""
+import os
+import stat
+
+import pytest
+
+from lingtai.adapters.windows.powershell import PowerShellDialect
+from lingtai.adapters.windows import windows_cmd_shim as shim
+from lingtai.adapters.windows.windows_cmd_shim import (
+    build_cmd_exe_invocation,
+    escape_for_windows_cmd_exe,
+    is_cmd_bat_shim,
+    reject_unsafe_metachars,
+    resolve_cmd_bat_shim,
+    resolve_npm_argv,
+    split_simple_command,
+    try_cmd_shim_plan,
+)
+
+_FAKE_CMD_EXE = r"C:\Windows\System32\cmd.exe"
+
+
+def _make_executable(path) -> None:
+    path.write_bytes(b"@echo off\r\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@pytest.fixture
+def npm_prefix(tmp_path):
+    """A fake npm prefix: node + npm.cmd/npx.cmd shims + npm-cli.js layout."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "node").write_bytes(b"#!/bin/sh\nexit 0\n")
+    (bin_dir / "node").chmod(0o755)
+    _make_executable(bin_dir / "npm.cmd")
+    _make_executable(bin_dir / "npx.cmd")
+    npm_bin = bin_dir / "node_modules" / "npm" / "bin"
+    npm_bin.mkdir(parents=True)
+    (npm_bin / "npm-cli.js").write_text("// npm-cli\n", encoding="utf-8")
+    (npm_bin / "npx-cli.js").write_text("// npx-cli\n", encoding="utf-8")
+    return bin_dir
+
+
+# --- shim detection ----------------------------------------------------------
+
+
+def test_is_cmd_bat_shim():
+    assert is_cmd_bat_shim("npm.cmd")
+    assert is_cmd_bat_shim("yarn.bat")
+    assert is_cmd_bat_shim("NPM.CMD")
+    assert is_cmd_bat_shim(r"C:\tools\foo.cmd")
+    assert not is_cmd_bat_shim("npm")
+    assert not is_cmd_bat_shim("npm.exe")
+    assert not is_cmd_bat_shim("foo.txt")
+    assert not is_cmd_bat_shim("a.cmd.exe")
+
+
+# --- escaping ----------------------------------------------------------------
+
+
+def test_escape_for_windows_cmd_exe():
+    assert escape_for_windows_cmd_exe("npm.cmd") == "npm.cmd"
+    assert escape_for_windows_cmd_exe("run") == "run"
+    assert escape_for_windows_cmd_exe("a^b") == "a^^b"
+    assert escape_for_windows_cmd_exe('a"b') == '"a""b"'
+    for bad in ("a&b", "a|b", "a<b", "a>b", "a%b", "a\rb", "a\nb"):
+        with pytest.raises(ValueError, match="unsafe metacharacter"):
+            escape_for_windows_cmd_exe(bad)
+
+
+def test_reject_unsafe_metachars():
+    reject_unsafe_metachars(["npm.cmd", "run", "build"])  # clean args pass
+    for bad in ("%FOO%", "a`b", "a^b", "$var", "$(cmd)", "${x}", "$env:PATH", "$5"):
+        with pytest.raises(ValueError, match="unsafe metacharacter"):
+            reject_unsafe_metachars(["foo.cmd", bad])
+
+
+# --- invocation construction ------------------------------------------------
+
+
+def test_build_cmd_exe_invocation():
+    argv = build_cmd_exe_invocation(
+        ["npm.cmd", "run", "build"], cmd_exe=_FAKE_CMD_EXE
+    )
+    assert argv == [_FAKE_CMD_EXE, "/d", "/s", "/c", "npm.cmd run build"]
+    # args with spaces are quoted by list2cmdline inside the /c payload
+    argv = build_cmd_exe_invocation(["foo.cmd", "a b"], cmd_exe="cmd.exe")
+    assert argv[-1] == 'foo.cmd "a b"'
+    # caret escaping survives into the payload
+    argv = build_cmd_exe_invocation(["foo.cmd", "a^b"], cmd_exe="cmd.exe")
+    assert argv[-1] == "foo.cmd a^^b"
+    with pytest.raises(ValueError, match="empty command"):
+        build_cmd_exe_invocation([])
+
+
+# --- simple command tokenizer -----------------------------------------------
+
+
+def test_split_simple_command():
+    assert split_simple_command("npm.cmd run build") == ["npm.cmd", "run", "build"]
+    assert split_simple_command("  npm.cmd   run  build  ") == ["npm.cmd", "run", "build"]
+    assert split_simple_command('foo.cmd run "a b"') == ["foo.cmd", "run", "a b"]
+    assert split_simple_command("foo.cmd run 'a b'") == ["foo.cmd", "run", "a b"]
+    # doubled quotes inside a quoted region decode to one literal quote
+    assert split_simple_command("foo.cmd 'it''s'") == ["foo.cmd", "it's"]
+    # ...while a bare ``it''s`` is token concatenation (``it`` + ``''`` + ``s``)
+    assert split_simple_command("foo.cmd it''s") == ["foo.cmd", "its"]
+    assert split_simple_command("") is None
+    assert split_simple_command("   ") is None
+    assert split_simple_command("foo.cmd a; b") is None
+    assert split_simple_command("foo.cmd a | b") is None
+    assert split_simple_command("foo.cmd a && b") is None
+    assert split_simple_command("foo.cmd $(x)") is None
+    assert split_simple_command("foo.cmd $env:X") is None
+    assert split_simple_command("foo.cmd a`tb") is None
+    assert split_simple_command("foo.cmd 'unbalanced") is None
+    # embedded double quotes cannot round-trip through cmd.exe/list2cmdline
+    assert split_simple_command('foo.cmd run "a""b"') is None
+
+
+# --- npm/npx resolution ------------------------------------------------------
+
+
+def test_resolve_npm_argv(npm_prefix):
+    path = str(npm_prefix)
+    node = str(npm_prefix / "node")
+    cli = str(npm_prefix / "node_modules" / "npm" / "bin" / "npm-cli.js")
+    npx_cli = str(npm_prefix / "node_modules" / "npm" / "bin" / "npx-cli.js")
+    assert resolve_npm_argv(["npm", "run", "build"], path=path) == [
+        node, cli, "run", "build",
+    ]
+    assert resolve_npm_argv(["npm.cmd", "run", "build"], path=path) == [
+        node, cli, "run", "build",
+    ]
+    assert resolve_npm_argv(["NPM.CMD", "run", "build"], path=path) == [
+        node, cli, "run", "build",
+    ]
+    assert resolve_npm_argv(["npx", "tsc"], path=path) == [node, npx_cli, "tsc"]
+    assert resolve_npm_argv(["npx.cmd", "tsc"], path=path) == [node, npx_cli, "tsc"]
+    assert resolve_npm_argv(["yarn", "build"], path=path) is None
+    assert resolve_npm_argv(["npm", "run"], path=str(npm_prefix / "missing")) is None
+    assert resolve_npm_argv([], path=path) is None
+
+
+# --- PATH resolution ---------------------------------------------------------
+
+
+def test_resolve_cmd_bat_shim(npm_prefix):
+    path = str(npm_prefix)
+    assert resolve_cmd_bat_shim("npm.cmd", path=path) == str(npm_prefix / "npm.cmd")
+    assert resolve_cmd_bat_shim("node", path=path) is None
+    assert resolve_cmd_bat_shim("missing.cmd", path=path) is None
+
+
+def test_resolve_cmd_bat_shim_pathext_bare_name(monkeypatch, tmp_path):
+    # On Windows a bare name can resolve through PATHEXT to a .cmd shim;
+    # stub _which so that branch is exercised on POSIX too.
+    fake = str(tmp_path / "npm.cmd")
+    monkeypatch.setattr(shim, "_which", lambda name, path: fake if name == "npm" else None)
+    assert resolve_cmd_bat_shim("npm") == fake
+
+
+# --- public plan entry -------------------------------------------------------
+
+
+def test_try_cmd_shim_plan(npm_prefix, tmp_path, monkeypatch):
+    path = str(npm_prefix)
+    node = str(npm_prefix / "node")
+    cli = str(npm_prefix / "node_modules" / "npm" / "bin" / "npm-cli.js")
+
+    # npm/npx -> direct node invocation (no cmd.exe involved)
+    kind, argv = try_cmd_shim_plan("npm run build", path=path)
+    assert (kind, argv) == ("node", [node, cli, "run", "build"])
+    kind, argv = try_cmd_shim_plan("npm.cmd --version", path=path)
+    assert (kind, argv) == ("node", [node, cli, "--version"])
+
+    # non-shim and complex scripts -> None (pwsh fallback)
+    assert try_cmd_shim_plan("echo hi", path=path) is None
+    assert try_cmd_shim_plan("npm.cmd run build; echo hi", path=path) is None
+
+    # other .cmd/.bat shims -> trusted cmd.exe /d /s /c wrapper
+    _make_executable(tmp_path / "tool.cmd")
+    monkeypatch.setenv("COMSPEC", _FAKE_CMD_EXE)
+    kind, argv = try_cmd_shim_plan("tool.cmd run --flag", path=str(tmp_path))
+    assert kind == "cmd"
+    assert argv[0] == _FAKE_CMD_EXE
+    assert argv[1:4] == ["/d", "/s", "/c"]
+    assert argv[-1] == "tool.cmd run --flag"
+
+    # unsafe metachars on a shim command are rejected, not reinterpreted
+    with pytest.raises(ValueError, match="unsafe metacharacter"):
+        try_cmd_shim_plan("tool.cmd run %FOO%", path=str(tmp_path))
+    with pytest.raises(ValueError, match="unsafe metacharacter"):
+        try_cmd_shim_plan("tool.cmd run a^b", path=str(tmp_path))
+    # ``$var`` needs PowerShell expansion, so it keeps pwsh semantics instead
+    # of being handed to cmd.exe verbatim (no rejection, no shim)
+    assert try_cmd_shim_plan("tool.cmd run $env:VAR", path=str(tmp_path)) is None
+    # ...but a complex script that needs PowerShell semantics is not an error
+    assert try_cmd_shim_plan("tool.cmd run %FOO%; echo done", path=str(tmp_path)) is None
+
+
+# --- PowerShellDialect wiring ------------------------------------------------
+
+
+def test_powershell_dialect_uses_trusted_cmd_shim(npm_prefix, tmp_path, monkeypatch):
+    _make_executable(tmp_path / "tool.cmd")
+    monkeypatch.setenv(
+        "PATH",
+        str(tmp_path) + os.pathsep + str(npm_prefix) + os.pathsep
+        + os.environ.get("PATH", ""),
+    )
+    monkeypatch.setenv("COMSPEC", _FAKE_CMD_EXE)
+    dialect = PowerShellDialect(executable="pwsh")
+
+    # .cmd first token -> trusted cmd.exe invocation, pwsh never runs
+    invocation = dialect.make_invocation("tool.cmd run build")
+    args, kwargs = invocation.process_args()
+    assert kwargs == {"shell": False}
+    assert args == [_FAKE_CMD_EXE, "/d", "/s", "/c", "tool.cmd run build"]
+
+    # npm -> direct node invocation inside the normal pwsh envelope
+    invocation = dialect.make_invocation("npm run build")
+    args, kwargs = invocation.process_args()
+    assert args[:5] == ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
+    assert "npm-cli.js" in args[-1]
+    assert "node" in args[-1]
+    assert "$global:__lingtai_success" in args[-1]
+
+    # unsafe metachars on a shim command -> clean ValueError
+    with pytest.raises(ValueError, match="unsafe metacharacter"):
+        dialect.make_invocation("tool.cmd run %FOO%")
+
+    # non-shim commands keep the plain pwsh wrapper
+    invocation = dialect.make_invocation("Write-Output hi")
+    args, kwargs = invocation.process_args()
+    assert args[:5] == ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
+    assert "Write-Output hi" in args[-1]
+    assert kwargs == {"shell": False}

--- a/tests/test_windows_cmd_shim.py
+++ b/tests/test_windows_cmd_shim.py
@@ -239,9 +239,9 @@ def test_powershell_dialect_uses_trusted_cmd_shim(npm_prefix, tmp_path, monkeypa
     assert args[:5] == ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
     node = shutil.which("node", path=str(npm_prefix))
     cli = str(npm_prefix / "node_modules" / "npm" / "bin" / "npm-cli.js")
-    assert f"& '{node}' '{cli}' 'run' 'build'" in args[-1]
-    assert '"' not in args[-1]  # PS source: never list2cmdline C-runtime quoting
-    assert "$global:__lingtai_success" in args[-1]
+    assert f"& '{node}' '{cli}' 'run' 'build'" in invocation.stdin_script
+    assert '"' not in invocation.stdin_script  # PS source: never list2cmdline C-runtime quoting
+    assert "$global:__lingtai_success" in invocation.stdin_script
 
     # unsafe metachars on a shim command -> clean ValueError
     with pytest.raises(ValueError, match="unsafe metacharacter"):
@@ -251,7 +251,7 @@ def test_powershell_dialect_uses_trusted_cmd_shim(npm_prefix, tmp_path, monkeypa
     invocation = dialect.make_invocation("Write-Output hi")
     args, kwargs = invocation.process_args()
     assert args[:5] == ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
-    assert "Write-Output hi" in args[-1]
+    assert "Write-Output hi" in invocation.stdin_script
     assert kwargs == {"shell": False}
 
 
@@ -293,9 +293,9 @@ def test_npm_script_with_spaces_in_path(tmp_path, monkeypatch):
     node = shutil.which("node", path=str(prefix))
     cli = str(prefix / "node_modules" / "npm" / "bin" / "npm-cli.js")
     assert " " in node  # the spacey path is genuinely exercised
-    assert f"& '{node}' '{cli}' 'run' 'build'" in args[-1]
-    assert '"' not in args[-1]  # no list2cmdline C-runtime quoting
-    assert args[-1].count("'") % 2 == 0  # balanced quotes -> no parse error
+    assert f"& '{node}' '{cli}' 'run' 'build'" in invocation.stdin_script
+    assert '"' not in invocation.stdin_script  # no list2cmdline C-runtime quoting
+    assert invocation.stdin_script.count("'") % 2 == 0  # balanced quotes -> no parse error
 
 
 def test_npm_script_with_single_quote_arg(npm_prefix, monkeypatch):
@@ -312,5 +312,5 @@ def test_npm_script_with_single_quote_arg(npm_prefix, monkeypatch):
     args, kwargs = invocation.process_args()
     node = shutil.which("node", path=str(npm_prefix))
     cli = str(npm_prefix / "node_modules" / "npm" / "bin" / "npm-cli.js")
-    assert f"& '{node}' '{cli}' 'view' 'it''s'" in args[-1]
-    assert args[-1].count("'") % 2 == 0  # balanced quotes -> no parse error
+    assert f"& '{node}' '{cli}' 'view' 'it''s'" in invocation.stdin_script
+    assert invocation.stdin_script.count("'") % 2 == 0  # balanced quotes -> no parse error

--- a/tests/test_windows_cmd_shim.py
+++ b/tests/test_windows_cmd_shim.py
@@ -5,6 +5,7 @@ identification, cmd.exe escaping, unsafe metachar rejection, the simple
 command tokenizer, and the PowerShellDialect wiring.
 """
 import os
+import shutil
 import stat
 
 import pytest
@@ -37,6 +38,10 @@ def npm_prefix(tmp_path):
     bin_dir.mkdir()
     (bin_dir / "node").write_bytes(b"#!/bin/sh\nexit 0\n")
     (bin_dir / "node").chmod(0o755)
+    # Windows resolves bare ``node`` through PATHEXT to ``node.exe``; provide
+    # both so the fixtures behave on POSIX CI and on Windows hosts.
+    (bin_dir / "node.exe").write_bytes(b"#!/bin/sh\nexit 0\n")
+    (bin_dir / "node.exe").chmod(0o755)
     _make_executable(bin_dir / "npm.cmd")
     _make_executable(bin_dir / "npx.cmd")
     npm_bin = bin_dir / "node_modules" / "npm" / "bin"
@@ -128,7 +133,7 @@ def test_split_simple_command():
 
 def test_resolve_npm_argv(npm_prefix):
     path = str(npm_prefix)
-    node = str(npm_prefix / "node")
+    node = shutil.which("node", path=path)
     cli = str(npm_prefix / "node_modules" / "npm" / "bin" / "npm-cli.js")
     npx_cli = str(npm_prefix / "node_modules" / "npm" / "bin" / "npx-cli.js")
     assert resolve_npm_argv(["npm", "run", "build"], path=path) == [
@@ -170,7 +175,7 @@ def test_resolve_cmd_bat_shim_pathext_bare_name(monkeypatch, tmp_path):
 
 def test_try_cmd_shim_plan(npm_prefix, tmp_path, monkeypatch):
     path = str(npm_prefix)
-    node = str(npm_prefix / "node")
+    node = shutil.which("node", path=path)
     cli = str(npm_prefix / "node_modules" / "npm" / "bin" / "npm-cli.js")
 
     # npm/npx -> direct node invocation (no cmd.exe involved)
@@ -186,6 +191,8 @@ def test_try_cmd_shim_plan(npm_prefix, tmp_path, monkeypatch):
     # other .cmd/.bat shims -> trusted cmd.exe /d /s /c wrapper
     _make_executable(tmp_path / "tool.cmd")
     monkeypatch.setenv("COMSPEC", _FAKE_CMD_EXE)
+    # neutralise the SystemRoot preference on hosts that set it (e.g. Windows)
+    monkeypatch.setenv("SystemRoot", str(tmp_path / "no-such-root"))
     kind, argv = try_cmd_shim_plan("tool.cmd run --flag", path=str(tmp_path))
     assert kind == "cmd"
     assert argv[0] == _FAKE_CMD_EXE
@@ -215,6 +222,8 @@ def test_powershell_dialect_uses_trusted_cmd_shim(npm_prefix, tmp_path, monkeypa
         + os.environ.get("PATH", ""),
     )
     monkeypatch.setenv("COMSPEC", _FAKE_CMD_EXE)
+    # neutralise the SystemRoot preference on hosts that set it (e.g. Windows)
+    monkeypatch.setenv("SystemRoot", str(tmp_path / "no-such-root"))
     dialect = PowerShellDialect(executable="pwsh")
 
     # .cmd first token -> trusted cmd.exe invocation, pwsh never runs
@@ -223,12 +232,15 @@ def test_powershell_dialect_uses_trusted_cmd_shim(npm_prefix, tmp_path, monkeypa
     assert kwargs == {"shell": False}
     assert args == [_FAKE_CMD_EXE, "/d", "/s", "/c", "tool.cmd run build"]
 
-    # npm -> direct node invocation inside the normal pwsh envelope
+    # npm -> direct node invocation inside the normal pwsh envelope, emitted
+    # as PS source via the call operator + single-quoted literals
     invocation = dialect.make_invocation("npm run build")
     args, kwargs = invocation.process_args()
     assert args[:5] == ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
-    assert "npm-cli.js" in args[-1]
-    assert "node" in args[-1]
+    node = shutil.which("node", path=str(npm_prefix))
+    cli = str(npm_prefix / "node_modules" / "npm" / "bin" / "npm-cli.js")
+    assert f"& '{node}' '{cli}' 'run' 'build'" in args[-1]
+    assert '"' not in args[-1]  # PS source: never list2cmdline C-runtime quoting
     assert "$global:__lingtai_success" in args[-1]
 
     # unsafe metachars on a shim command -> clean ValueError
@@ -241,3 +253,64 @@ def test_powershell_dialect_uses_trusted_cmd_shim(npm_prefix, tmp_path, monkeypa
     assert args[:5] == ["pwsh", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command"]
     assert "Write-Output hi" in args[-1]
     assert kwargs == {"shell": False}
+
+
+# --- PS quoting of the npm/npx rewrite (PR #1189 blocker fixes) -------------
+
+
+def _fake_nodejs_prefix(tmp_path):
+    r"""A node prefix whose path contains spaces, like ``C:\Program Files\nodejs``."""
+    prefix = tmp_path / "Program Files" / "nodejs"
+    prefix.mkdir(parents=True)
+    for name in ("node", "node.exe"):
+        script = prefix / name
+        script.write_bytes(b"#!/bin/sh\nexit 0\n")
+        script.chmod(0o755)
+    _make_executable(prefix / "npm.cmd")
+    _make_executable(prefix / "npx.cmd")
+    npm_bin = prefix / "node_modules" / "npm" / "bin"
+    npm_bin.mkdir(parents=True)
+    (npm_bin / "npm-cli.js").write_text("// npm-cli\n", encoding="utf-8")
+    (npm_bin / "npx-cli.js").write_text("// npx-cli\n", encoding="utf-8")
+    return prefix
+
+
+def test_npm_script_with_spaces_in_path(tmp_path, monkeypatch):
+    r"""Default Windows layout (path with spaces) yields valid PS source.
+
+    Regression for the PR #1189 blocker: ``subprocess.list2cmdline`` quoting
+    (``"C:\Program Files\nodejs\node.exe" ...``) is rejected by PowerShell
+    as a quoted string in command position; the rewrite must use the call
+    operator with PS single-quoted elements instead.
+    """
+    prefix = _fake_nodejs_prefix(tmp_path)
+    monkeypatch.setenv(
+        "PATH", str(prefix) + os.pathsep + os.environ.get("PATH", ""),
+    )
+    dialect = PowerShellDialect(executable="pwsh")
+    invocation = dialect.make_invocation("npm run build")
+    args, kwargs = invocation.process_args()
+    node = shutil.which("node", path=str(prefix))
+    cli = str(prefix / "node_modules" / "npm" / "bin" / "npm-cli.js")
+    assert " " in node  # the spacey path is genuinely exercised
+    assert f"& '{node}' '{cli}' 'run' 'build'" in args[-1]
+    assert '"' not in args[-1]  # no list2cmdline C-runtime quoting
+    assert args[-1].count("'") % 2 == 0  # balanced quotes -> no parse error
+
+
+def test_npm_script_with_single_quote_arg(npm_prefix, monkeypatch):
+    """An argument containing an apostrophe stays balanced in the PS source.
+
+    Regression for the PR #1189 must-fix: ``npm view "it's"`` must become
+    ``... view 'it''s'`` (PS ``''`` doubling), not leak an unbalanced quote.
+    """
+    monkeypatch.setenv(
+        "PATH", str(npm_prefix) + os.pathsep + os.environ.get("PATH", ""),
+    )
+    dialect = PowerShellDialect(executable="pwsh")
+    invocation = dialect.make_invocation('npm view "it\'s"')
+    args, kwargs = invocation.process_args()
+    node = shutil.which("node", path=str(npm_prefix))
+    cli = str(npm_prefix / "node_modules" / "npm" / "bin" / "npm-cli.js")
+    assert f"& '{node}' '{cli}' 'view' 'it''s'" in args[-1]
+    assert args[-1].count("'") % 2 == 0  # balanced quotes -> no parse error


### PR DESCRIPTION
## What
Add windows_cmd_shim.py: resolve npm/npx to direct node invocation, otherwise wrap .cmd/.bat shims in trusted cmd.exe /d /s /c with metachar rejection.

## Why
Tools like npm.cmd still hit cmd semantics even with pwsh shell; ambient ComSpec fallback is unsafe.

## Tests
New shim unit tests (10 passed) + existing powershell/windows selection: 91 passed, 25 skipped; shell/bash suites: 198 passed.