### PR TITLE
fix(file_io): recursive glob includes top-level files

### DIFF
--- a/src/lingtai/services/file_io.py
+++ b/src/lingtai/services/file_io.py
@@ -327,6 +327,15 @@ class LocalFileIOBackend(FileIOBackend):
         self.last_traversal = TraversalStats()
         search_root = Path(root) if root else (self._root or Path("."))
         results: list[str] = []
+        # fnmatch's translation of a leading "**/" requires a literal "/"
+        # in the matched string, so it never matches a zero-depth relative
+        # path (a direct child of search_root). Standard recursive-glob
+        # semantics (stdlib glob.glob(recursive=True), pathlib.Path.glob)
+        # treat "**/" as zero-or-more directory levels, so also try the
+        # pattern with that prefix stripped.
+        zero_depth_pattern = (
+            pattern[3:] if pattern.startswith("**/") else None
+        )
         for path in self._walk_files(
             search_root,
             exclude_dirs=exclude_dirs,
@@ -340,7 +349,11 @@ class LocalFileIOBackend(FileIOBackend):
             except ValueError:
                 # cross-volume on Windows — fall back to absolute.
                 rel = str(path)
-            if fnmatch.fnmatch(rel, pattern):
+            if fnmatch.fnmatch(rel, pattern) or (
+                zero_depth_pattern is not None
+                and "/" not in rel
+                and fnmatch.fnmatch(rel, zero_depth_pattern)
+            ):
                 results.append(str(path))
                 if max_results is not None and len(results) >= max_results:
                     self.last_traversal.truncated_reason = (

--- a/tests/test_services_file_io.py
+++ b/tests/test_services_file_io.py
@@ -80,15 +80,17 @@ class TestLocalFileIOService:
         svc.write("sub/other.txt", "nested, wrong extension")
 
         results = svc.glob("**/*")
-        assert any(r.endswith("/STAGE_A_STATUS.md") for r in results)
-        assert any(r.endswith("/sub/nested.md") for r in results)
-        assert any(r.endswith("/sub/other.txt") for r in results)
+        relative_results = [Path(r).relative_to(tmp_dir).as_posix() for r in results]
+        assert set(relative_results) == {
+            "STAGE_A_STATUS.md",
+            "sub/nested.md",
+            "sub/other.txt",
+        }
         assert results == sorted(results)
 
         md_results = svc.glob("**/*.md")
-        assert any(r.endswith("/STAGE_A_STATUS.md") for r in md_results)
-        assert any(r.endswith("/sub/nested.md") for r in md_results)
-        assert not any(r.endswith("/sub/other.txt") for r in md_results)
+        relative_md_results = [Path(r).relative_to(tmp_dir).as_posix() for r in md_results]
+        assert set(relative_md_results) == {"STAGE_A_STATUS.md", "sub/nested.md"}
         assert md_results == sorted(md_results)
 
     def test_grep(self, svc, tmp_dir):

--- a/tests/test_services_file_io.py
+++ b/tests/test_services_file_io.py
@@ -71,6 +71,26 @@ class TestLocalFileIOService:
         results = svc.glob("src/*.py")
         assert len(results) == 2
 
+    def test_glob_recursive_includes_zero_depth_files(self, svc, tmp_dir):
+        # `**/` is documented as "recursive search" (zero or more directory
+        # levels), so a top-level file with no `/` in its relative path must
+        # be included alongside deeper descendants.
+        svc.write("STAGE_A_STATUS.md", "top-level")
+        svc.write("sub/nested.md", "nested")
+        svc.write("sub/other.txt", "nested, wrong extension")
+
+        results = svc.glob("**/*")
+        assert any(r.endswith("/STAGE_A_STATUS.md") for r in results)
+        assert any(r.endswith("/sub/nested.md") for r in results)
+        assert any(r.endswith("/sub/other.txt") for r in results)
+        assert results == sorted(results)
+
+        md_results = svc.glob("**/*.md")
+        assert any(r.endswith("/STAGE_A_STATUS.md") for r in md_results)
+        assert any(r.endswith("/sub/nested.md") for r in md_results)
+        assert not any(r.endswith("/sub/other.txt") for r in md_results)
+        assert md_results == sorted(md_results)
+
     def test_grep(self, svc, tmp_dir):
         svc.write("a.txt", "hello world\ngoodbye world\nhello again")
         results = svc.grep("hello")


### PR DESCRIPTION
## Summary

`file.glob(pattern="**/*")` returned zero matches for a directory whose only match was a top-level file, while `pattern="*"` found it correctly. Nested files matched; the zero-directory-depth case did not.

`LocalFileIOBackend.glob` uses `fnmatch` against a root-relative path. A leading `**/` in `fnmatch` requires a literal slash, so direct children cannot match. This conflicts with the documented recursive-search contract and standard recursive-glob semantics, where `**/` means zero or more directory levels.

This patch keeps the existing match first, then tests only slash-free direct-child paths against the pattern with one leading `**/` stripped. Traversal budgets, exclusions, sandbox resolution, sorting, and non-recursive matching are unchanged.

The regression covers both `**/*` and `**/*.md`, top-level and nested matches, extension filtering, and sorted output.

## Validation

- New regression fails on unmodified `origin/main` and passes with the patch.
- `python3 -m pytest tests/test_services_file_io.py -q` — 29 passed.
- Adjacent file capability suites — 135 passed.
- Parent rerun of the focused regression — 1 passed.
- `git diff --check` — clean.

`tests/test_architecture_documents.py` has one unrelated, pre-existing failure on the same base for an anatomy reference to the absent `daemon_supervisor/supervisor.py`; it is unchanged by this two-file patch.