### PR TITLE
feat(shell): background/no-output timeout guidance + interactive-child stdin docs (PR-7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ MagicMock/
 # Local resolver lockfiles may appear during experiments; pyproject.toml is the
 # packaging source of truth for this repo.
 uv.lock
+DELIVERABLE.md
+PR_BODY.md
+PR_URL.txt

--- a/src/lingtai/tools/bash/__init__.py
+++ b/src/lingtai/tools/bash/__init__.py
@@ -214,6 +214,20 @@ _BROAD_SCAN_HINT = (
     "for a genuinely large tree."
 )
 
+# Steering guidance appended to a timeout error when the command produced no
+# output before it was killed (OpenClaw exec-runner.ts ``no-output-timeout`` /
+# overall-timeout copy, adapted to our ``async`` parameter name; Hermes
+# foreground-hint guidance).  The point is to steer the model away from both
+# failure modes that this class of timeout represents: a foreground command that
+# should have been launched with ``async=true``, and shell backgrounding with a
+# trailing ``&``, which detaches the child from any supervision/collectable
+# output stream.
+_BACKGROUND_GUIDANCE = (
+    "Long-running or no-output work should be launched with async=true "
+    "(or as a daemon) rather than as a foreground command; do not rely on "
+    "shell backgrounding with a trailing &."
+)
+
 
 def _broad_scan_hint(command: str) -> str | None:
     """Return a broad-scan recipe hint if the command resembles a recursive walk.
@@ -224,11 +238,26 @@ def _broad_scan_hint(command: str) -> str | None:
     return _BROAD_SCAN_HINT if _BROAD_SCAN_RE.search(command) else None
 
 
-def _timeout_error(command: str, timeout: float) -> dict:
-    """Build the historical timeout result shape; shared by every sync path."""
+def _timeout_error(command: str, timeout: float, no_output: bool = False) -> dict:
+    """Build the historical timeout result shape; shared by every sync path.
+
+    ``no_output`` is the OpenClaw ``no-output-timeout`` signal: the command was
+    killed by the timeout before it produced any output.  In that case the
+    message appends the background-discipline steering guidance so the model
+    learns to launch long/no-output work with ``async=true`` instead of a
+    foreground command (or a bare trailing ``&``).  Backward compatible: callers
+    that do not pass ``no_output`` (and timeouts that did capture output) keep
+    the exact historical message.
+    """
     msg = f"Command timed out after {timeout}s"
     hint = _broad_scan_hint(command)
-    return {"status": "error", "message": f"{msg}. {hint}" if hint else msg}
+    if hint:
+        msg = f"{msg}. {hint}"
+    if no_output:
+        # ``hint`` (when present) already ends with a period, so a plain space
+        # keeps a clean sentence boundary in both shapes.
+        msg = f"{msg}{' ' if hint else '. '}{_BACKGROUND_GUIDANCE}"
+    return {"status": "error", "message": msg}
 
 
 # =============================================================================
@@ -759,8 +788,14 @@ class ShellManager:
                 "status": "ok", "exit_code": result.returncode,
                 "stdout": stdout, "stderr": stderr,
             }, command=command)
-        except subprocess.TimeoutExpired:
-            return _timeout_error(command, timeout)
+        except subprocess.TimeoutExpired as exc:
+            # ``no-output`` timeout (OpenClaw exec-runner.ts semantics): the
+            # command was killed before it produced any output, so steer the
+            # model toward async=true / a daemon instead of a silent foreground
+            # run (or a trailing-& shell background).
+            return _timeout_error(
+                command, timeout, no_output=not (exc.stdout or exc.stderr)
+            )
         except Exception as e:
             return {"status": "error", "message": f"Command failed: {e}"}
 
@@ -839,14 +874,16 @@ class ShellManager:
                     process_args, capture_output=True, text=True,
                     timeout=timeout, cwd=cwd, **process_kwargs,
                 )
-            except subprocess.TimeoutExpired:
-                return _timeout_error(command, timeout)
+            except subprocess.TimeoutExpired as exc:
+                return _timeout_error(
+                    command, timeout, no_output=not (exc.stdout or exc.stderr)
+                )
             return self._sync_result_from(result.stdout, result.stderr, result.returncode, command)
         try:
             try:
                 stdout, stderr = process.communicate(input=input_data, timeout=timeout)
                 returncode = process.returncode
-            except subprocess.TimeoutExpired:
+            except subprocess.TimeoutExpired as exc:
                 win32_job.terminate_owned_tree(job, process.pid)
                 # Bounded drain: a grandchild that survived the kill and still
                 # holds the pipe write ends must not block this supervisor on
@@ -854,7 +891,9 @@ class ShellManager:
                 # process is never ``wait()``-ed on this double-timeout path;
                 # the bounded drain plus handle close is the documented bound.
                 win32_job.drain_pipes(process, win32_job.IO_DRAIN_TIMEOUT_SECONDS)
-                return _timeout_error(command, timeout)
+                return _timeout_error(
+                    command, timeout, no_output=not (exc.stdout or exc.stderr)
+                )
         finally:
             # Closing the last job handle fires KILL_ON_JOB_CLOSE, terminating
             # any surviving descendant — this is the containment contract of

--- a/tests/test_bash_shell_dialect.py
+++ b/tests/test_bash_shell_dialect.py
@@ -1,5 +1,6 @@
 """Contract coverage for the Bash-local shell-language boundary."""
 import json
+import sys
 import time
 from types import SimpleNamespace
 
@@ -7,6 +8,7 @@ import pytest
 
 from lingtai.adapters.bash import select_bash_shell_dialect
 from lingtai.tools.bash import BashManager, BashPolicy
+from lingtai.tools.bash import _BACKGROUND_GUIDANCE, _timeout_error
 from lingtai.tools.bash._shell_dialect import ShellDialect, ShellInvocation
 from tests._notification_store_helpers import notification_store_for
 
@@ -144,3 +146,53 @@ def test_selector_fails_loudly_on_unsupported_platform(monkeypatch):
     monkeypatch.setattr(composition.os, "name", "java")
     with pytest.raises(NotImplementedError, match="unsupported"):
         composition.select_bash_shell_dialect()
+
+
+# ---------------------------------------------------------------------------
+# PR-7: no-output timeout backgrounding guidance (OpenClaw exec-runner.ts
+# overall/no-output timeout copy + Hermes foreground hint, adapted to our
+# ``async`` parameter name)
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_error_no_output_appends_background_guidance():
+    result = _timeout_error("sleep 5", 5.0, no_output=True)
+    assert result == {
+        "status": "error",
+        "message": (
+            "Command timed out after 5.0s. Long-running or no-output work should "
+            "be launched with async=true (or as a daemon) rather than as a "
+            "foreground command; do not rely on shell backgrounding with a "
+            "trailing &."
+        ),
+    }
+
+
+def test_timeout_error_with_output_keeps_historical_message():
+    assert _timeout_error("echo x", 5.0) == {
+        "status": "error",
+        "message": "Command timed out after 5.0s",
+    }
+    assert _timeout_error("echo x", 5.0, no_output=False) == {
+        "status": "error",
+        "message": "Command timed out after 5.0s",
+    }
+
+
+def test_sync_timeout_with_no_output_returns_background_guidance(tmp_path):
+    mgr = manager(tmp_path)
+    result = mgr.handle({"command": "sleep 5", "timeout": 1.0})
+    assert result["status"] == "error"
+    assert result["message"].startswith("Command timed out after 1.0s")
+    assert _BACKGROUND_GUIDANCE in result["message"]
+
+
+def test_sync_timeout_with_captured_output_omits_guidance(tmp_path):
+    mgr = manager(tmp_path)
+    command = (
+        f"{sys.executable} -u -c \"print('started'); import time; time.sleep(5)\""
+    )
+    result = mgr.handle({"command": command, "timeout": 1.0})
+    assert result["status"] == "error"
+    assert result["message"].startswith("Command timed out after 1.0s")
+    assert "trailing &" not in result["message"]


### PR DESCRIPTION
## Summary

PR-7: background discipline & timeout guidance text (research: OpenClaw `exec-runner.ts` overall/no-output timeout copy + Hermes foreground hints / `close_stdin`; OpenClaw `eof`).

**Runtime guidance (`src/lingtai/tools/bash/__init__.py`)**

- Added `_BACKGROUND_GUIDANCE` steering copy (adapted to our `async=true` parameter name): *"Long-running or no-output work should be launched with async=true (or as a daemon) rather than as a foreground command; do not rely on shell backgrounding with a trailing &."*
- Extended `_timeout_error(command, timeout, no_output=False)` (backward compatible: existing two-arg callers keep the exact historical message). When `no_output=True` (OpenClaw `no-output-timeout` semantics), the timeout message appends the guidance; the broad-scan hint is preserved in both shapes.
- Wired `no_output` at all three sync timeout sites by inspecting the captured partial output on `subprocess.TimeoutExpired` (`exc.stdout`/`exc.stderr`): plain `subprocess.run` path, the Job-Object fallback path, and the contained `communicate()` path.
- Async jobs have no overall/output timeout today, so the async side is documented rather than given a new kill-watchdog (kept minimal to preserve the supervisor/reminder state contract).

**Documentation (`src/lingtai/tools/bash/manual/SKILL.md`)**

- New section "Timeouts, backgrounding, and interactive children": the no-output-timeout guidance text, `async=true` as the only supported background mechanism (trailing `&` detaches from supervision), daemon for out-of-band work, and close-after-write / EOF semantics for interactive children (Hermes `close_stdin`, OpenClaw `eof`: a child that waits on stdin needs its stdin closed to finish; sync runs never inherit the parent console stdin; data must not be passed via stdin reads).
- Version bumped 1.8.0 -> 1.9.0.

## Tests

Added to `tests/test_bash_shell_dialect.py` (mirroring existing style):

- `_timeout_error` unit tests: no-output appends guidance (exact message), with-output/legacy keeps historical message, no-output keeps the broad-scan hint.
- Real-run integration: sync `sleep 5` timeout with no output returns the guidance; a command that prints before hanging omits the guidance.
- Contained (Windows Job Object) path with mocked no-output `TimeoutExpired` returns the guidance and still performs terminate/drain/close.

Mandated run -- `PYTHONPATH=src python -m pytest -q tests/test_bash_shell_dialect.py tests/test_shell_pr1_contract.py tests/test_exit_code_interpretation.py -p no:cacheprovider` -- **84 passed**. Broader bash/shell set: 243 passed; the only failures (`test_win32_job.py::test_sync_contained_delivers_stdin_bootstrap_script`, `test_layers_bash.py::test_missing_module_is_detected`, `test_shell_stdin_bootstrap.py::test_stdin_script_serializes_as_optional_sixth_key`, and `test_tools_package_data.py` packaging tests) are pre-existing on the base branch (verified via `git stash` on the clean tree).

Not merged -- review requested.
