### PR TITLE
feat(provider): opencode preset provider (like codex sub)

### DIFF
--- a/docs/references/opencode-preset-guide.md
+++ b/docs/references/opencode-preset-guide.md
@@ -1,0 +1,151 @@
+---
+name: opencode-preset-guide
+description: >
+  Reference for powering LingTai with OpenCode (github.com/sst/opencode) as a
+  preset provider, the same way the codex sub preset works. OpenCode is a
+  Go-based open-source coding agent CLI that runs locally, supports 75+ LLM
+  providers through Models.dev, and serves an OpenAI-compatible API via
+  `opencode serve` on http://127.0.0.1:4050 by default.
+version: 1.0.0
+tags: [preset, provider, opencode, llm]
+last_changed_at: 2026-08-06T00:00:00Z
+related_files:
+- presets/templates/opencode.json
+- src/lingtai/llm/opencode/adapter.py
+- src/lingtai/llm/opencode/defaults.py
+- src/lingtai/llm/_register.py
+- src/lingtai/kernel/preset_connectivity.py
+- src/lingtai/tools/bash/manual/reference/bash-opencode/SKILL.md
+- src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
+maintenance: |
+  Tracks the OpenCode preset provider integration; update when the adapter,
+  preset template, or connectivity entry changes.
+---
+
+# OpenCode as a LingTai Preset Provider
+
+This page documents how to use OpenCode to power a LingTai agent as a **preset**
+— the same pattern as the `codex` sub preset: a JSON preset template whose
+`manifest.llm.provider` is `opencode`, wired to the local `opencode serve`
+OpenAI-compatible endpoint instead of a hosted API.
+
+## How it works
+
+- `opencode serve` starts a headless HTTP server on `http://127.0.0.1:4050` by
+  default, exposing OpenAI-compatible routes: `POST /v1/chat/completions`,
+  `POST /v1/responses`, and `GET /v1/models`.
+- Models are addressed as `provider/model` (for example
+  `anthropic/claude-sonnet-4-5` or `openai/gpt-5.5`). The server resolves the
+  provider prefix and authenticates through the CLI's own credential store
+  (`~/.local/share/opencode/auth.json`, environment variables, or a project
+  `.env`) — **no LingTai-side API key is needed**.
+- LingTai's `opencode` provider is `OpenCodeAdapter`
+  (`src/lingtai/llm/opencode/adapter.py`), a thin subclass of `OpenAIAdapter`
+  pinned to `http://127.0.0.1:4050/v1`. It registers under the provider name
+  `opencode` in `src/lingtai/llm/_register.py`.
+
+## Prerequisites (on the machine running the agent)
+
+```bash
+# 1. Install OpenCode
+curl -fsSL https://opencode.ai/install | bash
+opencode --version
+
+# 2. Authenticate at least one provider
+opencode auth login          # interactive provider selection
+opencode auth list
+
+# 3. Start the headless server (default port 4050)
+opencode serve
+```
+
+Run `opencode serve --port <port>` to change the port; then set the preset's
+`base_url` to `http://127.0.0.1:<port>/v1`.
+
+## Installing the preset
+
+Copy the bundled template into the LingTai TUI preset templates directory:
+
+```bash
+cp presets/templates/opencode.json ~/.lingtai-tui/presets/templates/opencode.json
+```
+
+The template mirrors `codex.json`'s shape:
+
+```json
+{
+  "name": "opencode",
+  "description": {
+    "summary": "OpenCode (local opencode serve) — any Models.dev provider, tool calls"
+  },
+  "manifest": {
+    "capabilities": {
+      "skills": {
+        "paths": ["../.library_shared", "~/.lingtai-tui/utilities"]
+      }
+    },
+    "llm": {
+      "api_key": null,
+      "api_key_env": "",
+      "base_url": "http://127.0.0.1:4050/v1",
+      "model": "anthropic/claude-sonnet-4-5",
+      "provider": "opencode"
+    }
+  }
+}
+```
+
+Key fields:
+
+| Field | Value | Notes |
+|---|---|---|
+| `provider` | `opencode` | Registered adapter name (dash/underscore spellings are **not** aliased for opencode). |
+| `base_url` | `http://127.0.0.1:4050/v1` | Must match the running `opencode serve` port. |
+| `model` | any `provider/model` | Replace with a model from a provider you authenticated (`opencode models` lists the cache; `GET /v1/models` lists what the server exposes). |
+| `api_key` / `api_key_env` | `null` / `""` | OpenCode owns its own auth; no LingTai credential. |
+
+Then activate the preset (via the TUI, or by pointing `manifest.preset.active`
+at the file). The agent's `manifest.llm` is substituted from the preset at
+boot, exactly like the `codex` preset.
+
+## Connectivity check
+
+`preset_connectivity` probes the preset's LLM endpoint when listing presets:
+
+- `_PROVIDER_DEFAULT_URLS["opencode"] = "http://127.0.0.1:4050"` — used when
+  the preset omits `base_url`.
+- With no `api_key_env`, the free credential check is skipped.
+- The TCP probe succeeds only while `opencode serve` is actually running, so a
+  stopped server shows `unreachable` — accurate, since the preset is unusable
+  without it.
+
+## What is (and is not) supported
+
+- **Tool calls**: yes — the OpenAI-compatible Chat Completions wire is the
+  default (`wire_api: "chat_completions"`); the Responses wire is available via
+  `manifest.llm.wire_api: "responses"`.
+- **Vision / web search capabilities**: not declared — opencode does not vend
+  LingTai `vision`/`web_search` capability providers (unlike the codex preset
+  whose capability providers are `codex`). The template declares `skills` only.
+- **`manifest.llm.thinking`**: not supported for `opencode`. Reasoning effort in
+  opencode is the per-provider `--variant` concept on the CLI, not a wire-level
+  `reasoning.effort` contract LingTai can validate, so `opencode` is not in
+  `THINKING_PROVIDERS` and the template omits `thinking`. An agent that needs
+  explicit reasoning tiers should use the `codex` (or custom Responses) preset
+  instead.
+- **Multiple providers**: any provider you authenticate in opencode becomes
+  selectable by changing `model` to `provider/model`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| Preset shows `unreachable` | Start `opencode serve` (and check the port matches `base_url`). |
+| `Connection refused` on first turn | The serve server is not running; opencode does not auto-spawn it from the adapter. |
+| `No provider/model available` | `opencode auth login`, then `opencode models --refresh`. |
+| Model not found | Pick a `provider/model` string the server exposes via `GET /v1/models`. |
+| Wrong port | `opencode serve --port <port>` and set `base_url` to `http://127.0.0.1:<port>/v1`. |
+
+See also the nested CLI references for OpenCode usage: the bash manual
+`reference/bash-opencode/SKILL.md` and the daemon backend
+`reference/cli-backends/reference/backends/opencode/SKILL.md`.

--- a/presets/templates/opencode.json
+++ b/presets/templates/opencode.json
@@ -1,0 +1,23 @@
+{
+  "name": "opencode",
+  "description": {
+    "summary": "OpenCode (local opencode serve) — any Models.dev provider, tool calls"
+  },
+  "manifest": {
+    "capabilities": {
+      "skills": {
+        "paths": [
+          "../.library_shared",
+          "~/.lingtai-tui/utilities"
+        ]
+      }
+    },
+    "llm": {
+      "api_key": null,
+      "api_key_env": "",
+      "base_url": "http://127.0.0.1:4050/v1",
+      "model": "anthropic/claude-sonnet-4-5",
+      "provider": "opencode"
+    }
+  }
+}

--- a/src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
@@ -47,6 +47,7 @@ LingTai registers the following provider keys (each usable in presets / `init.js
 | `openrouter` | `OpenRouterAdapter` | REST | OpenRouter-compatible endpoint |
 | `claude-code`, `claude_code` | `ClaudeCodeAdapter` (in `claude_code/adapter.py`) | n/a (external CLI) | Local CLI-backed LLM provider (Claude Code harness); used as a main-agent/preset provider |
 | `kimi-code`, `kimi_code` | `KimiCodeAdapter` (in `kimi_code/adapter.py`) | n/a (external CLI) | Local CLI-backed LLM provider (Kimi Code harness); used as a main-agent/preset provider |
+| `opencode` | `OpenCodeAdapter` (in `opencode/adapter.py`) | REST (local OpenAI-compatible `opencode serve`, Chat Completions by default) | Local preset provider — talks to the local `opencode serve` endpoint (`http://127.0.0.1:4050/v1`); opencode owns provider auth (`opencode auth login`); models addressed as `provider/model` |
 
 Each adapter is lazy-imported on first use, so an unconfigured provider's SDK
 is never loaded. Prefer the provider's own section below when operating a

--- a/src/lingtai/kernel/preset_connectivity.py
+++ b/src/lingtai/kernel/preset_connectivity.py
@@ -47,6 +47,9 @@ _PROVIDER_DEFAULT_URLS = {
     "codex":      "https://chatgpt.com",
     "mimo":       "https://api.xiaomimimo.com",
     "kimi":       "https://api.kimi.com",
+    # Local ``opencode serve`` (default port). Probe succeeds only while the
+    # user's opencode headless server is actually running.
+    "opencode":   "http://127.0.0.1:4050",
 }
 
 

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -202,6 +202,39 @@ def register_all_adapters() -> None:
     for name in ("codex", "codex-pool", "codex_pool"):
         LLMService.register_adapter(name, _codex)
 
+    # -- opencode -------------------------------------------------------------
+    #
+    # OpenCode (github.com/sst/opencode) powers LingTai as a preset the same
+    # way Codex does: the user runs the local CLI's headless server
+    # (``opencode serve``, OpenAI-compatible on http://127.0.0.1:4050 by
+    # default) and the adapter talks to it. Provider/model strings
+    # (``provider/model``) and CLI-side auth replace a LingTai API key.
+
+    def _opencode(*, model=None, defaults=None, **kw):
+        """Build the adapter for a local ``opencode serve`` endpoint.
+
+        OpenCode authenticates providers inside its own CLI (auth.json / env /
+        project .env); the OpenAI-compatible serve endpoint needs no
+        LingTai-side key, so the adapter substitutes a localhost placeholder.
+        An explicit manifest ``base_url`` overrides the default
+        http://127.0.0.1:4050/v1 (e.g. a custom ``opencode serve --port``).
+        """
+        from .opencode.adapter import OpenCodeAdapter
+
+        kw.pop("model", None)
+        adapter_kw = {k: v for k, v in kw.items() if v is not None}
+        d = defaults or {}
+        if "wire_api" in d:
+            adapter_kw["wire_api"] = d["wire_api"]
+        if "use_responses_api" in d:
+            adapter_kw["use_responses"] = d["use_responses_api"]
+        if "compact_threshold" in d:
+            # Preserve explicit None after the general None-pruning pass above.
+            adapter_kw["compact_threshold"] = d["compact_threshold"]
+        return OpenCodeAdapter(**adapter_kw)
+
+    LLMService.register_adapter("opencode", _opencode)
+
     def _claude_code(*, model=None, defaults=None, **kw):
         from .claude_code.adapter import ClaudeCodeAdapter
         kw.pop("model", None)

--- a/src/lingtai/llm/opencode/ANATOMY.md
+++ b/src/lingtai/llm/opencode/ANATOMY.md
@@ -1,0 +1,50 @@
+---
+related_files:
+  - src/lingtai/llm/ANATOMY.md
+  - src/lingtai/llm/opencode/__init__.py
+  - src/lingtai/llm/opencode/adapter.py
+  - src/lingtai/llm/opencode/defaults.py
+  - src/lingtai/llm/openai/adapter.py
+maintenance: |
+  Keep related_files as repo-relative paths to real files. Include neighboring
+  ANATOMY.md files so the anatomy graph stays connected rather than isolated;
+  anatomy links must be bidirectional. If you create a new ANATOMY.md, copy this
+  maintenance field. If you notice drift between this anatomy and the code,
+  report it. See lingtai-dev-guide for details.
+---
+# src/lingtai/llm/opencode
+
+OpenCode adapter — thin OpenAI-compat wrapper over the local `opencode serve` endpoint (`http://127.0.0.1:4050/v1`).
+
+> **Maintenance:** see the `lingtai-kernel-anatomy` skill. **Coding agents** update this file in the same commit as code changes. **LingTai agents** report drift as issues.
+
+## Components
+
+| File | LOC | Role |
+|------|-----|------|
+| `__init__.py` | 4 | Re-exports `OpenCodeAdapter`, `DEFAULTS` |
+| `adapter.py` | 62 | `OpenCodeAdapter(OpenAIAdapter)` — pinned to local serve endpoint |
+| `defaults.py` | 6 | `DEFAULTS` dict: `api_compat=openai`, `base_url=http://127.0.0.1:4050/v1`, `api_key_env=""`, `model=""` |
+
+### Classes
+
+- **`OpenCodeAdapter(OpenAIAdapter)`** — default `base_url` is `http://127.0.0.1:4050/v1`; non-empty placeholder `api_key` satisfies the OpenAI SDK (opencode authenticates providers itself via `~/.local/share/opencode/auth.json`); Chat Completions wire by default (`wire_api="chat_completions"`), opt-in Responses via `wire_api`/`use_responses`; `prompt_cache_key` disabled by default (opencode has no shared prompt cache); overrides `_default_prompt_cache_key` → `lingtai-opencode:{model}:v1` for explicit opt-in.
+
+## Connections
+
+- **Inherits from**: `OpenAIAdapter` (`../openai/adapter.py`) — session management, tool calls, thinking-block replay, context-overflow auto-recovery.
+- **Registered by**: `lingtai/llm/_register.py` `_opencode` factory under the provider name `opencode`.
+- **Connectivity**: `lingtai/kernel/preset_connectivity.py` `_PROVIDER_DEFAULT_URLS["opencode"] = "http://127.0.0.1:4050"` — TCP probe of the local serve port.
+- **Preset template**: `presets/templates/opencode.json` — mirrors the `codex.json` template shape with `provider: "opencode"`.
+
+## State
+
+Stateless adapter — no module-level mutable state.
+
+## Notes
+
+- **No API key**: `opencode serve` needs no LingTai-side credential; auth lives in the CLI (`opencode auth login`). The placeholder key is only for the OpenAI SDK constructor.
+- **Model format**: `provider/model` (e.g. `anthropic/claude-sonnet-4-5`), resolved by the opencode server.
+- **Not a THINKING_PROVIDER**: reasoning effort is opencode's per-provider `--variant` concept and is not mapped to `manifest.llm.thinking`; keep `thinking` out of the opencode preset template.
+- **Capabilities**: tools only — opencode does not vend LingTai vision/web_search capability providers, so the template declares `skills` only (like `claude.json`).
+- Git history: initial preset-provider PR.

--- a/src/lingtai/llm/opencode/__init__.py
+++ b/src/lingtai/llm/opencode/__init__.py
@@ -1,0 +1,4 @@
+from .adapter import OpenCodeAdapter
+from .defaults import DEFAULTS
+
+__all__ = ["OpenCodeAdapter", "DEFAULTS"]

--- a/src/lingtai/llm/opencode/adapter.py
+++ b/src/lingtai/llm/opencode/adapter.py
@@ -1,0 +1,91 @@
+"""OpenCode adapter — OpenAI-compatible client for a local ``opencode serve`` endpoint.
+
+OpenCode (github.com/sst/opencode) is an open-source, Go-based coding agent CLI
+that runs locally and supports 75+ LLM providers through Models.dev. Its
+headless server (``opencode serve``) exposes an OpenAI-compatible API on
+``http://127.0.0.1:4050`` by default:
+
+    POST /v1/chat/completions   (OpenAI-compatible)
+    POST /v1/responses          (Responses API)
+    GET  /v1/models
+
+Models are addressed as ``provider/model`` (e.g. ``anthropic/claude-sonnet-4-5``
+or ``openai/gpt-5.5``); the server resolves the provider prefix and
+authenticates through the CLI's own credential store
+(``~/.local/share/opencode/auth.json``, environment variables, or a project
+``.env``) — LingTai never handles an OpenCode API key.
+
+This adapter is a thin subclass of OpenAIAdapter pinned to the local serve
+endpoint:
+
+* default ``base_url`` is ``http://127.0.0.1:4050/v1``;
+* a non-empty placeholder ``api_key`` satisfies the OpenAI SDK (the serve
+  endpoint is localhost and ignores it unless ``OPENCODE_SERVER_PASSWORD``
+  auth is configured);
+* the Chat Completions wire is the default (the broadest-compat surface of the
+  opencode server); ``wire_api`` / legacy ``use_responses`` still opt into the
+  Responses wire like the rest of the OpenAI-compatible family;
+* ``prompt_cache_key`` is disabled by default — opencode proxies to arbitrary
+  upstream providers and has no shared prompt cache of its own, so sending the
+  extra field is pointless; an explicit value re-enables it.
+
+Everything else (session management, tool calls, thinking-block replay,
+context-overflow auto-recovery) inherits from OpenAIAdapter unchanged.
+"""
+
+from __future__ import annotations
+
+from ..openai.adapter import OpenAIAdapter
+
+# Default ``opencode serve`` endpoint. The server listens on 127.0.0.1:4050 by
+# default; the OpenAI-compatible routes live under /v1.
+_OPENCODE_SERVE_DEFAULT_URL = "http://127.0.0.1:4050/v1"
+
+# OpenCode authenticates providers inside its own CLI. The OpenAI SDK still
+# requires a non-empty api_key value, so we send a localhost placeholder that
+# the serve endpoint ignores. Never forwarded off-machine.
+_OPENCODE_PLACEHOLDER_API_KEY = "opencode-local"
+
+
+class OpenCodeAdapter(OpenAIAdapter):
+    """OpenAI-compat adapter pinned to a local ``opencode serve`` endpoint."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        base_url: str | None = None,
+        timeout_ms: int = 300_000,
+        max_rpm: int = 0,
+        default_headers: dict | None = None,
+        wire_api: str | None = "chat_completions",
+        use_responses: bool | None = None,
+        force_responses: bool | None = None,
+        compact_threshold: int | None = None,
+        responses_stateless_replay: bool = True,
+        prompt_cache_key: str | bool = False,
+    ):
+        kwargs: dict = {}
+        if wire_api is not None:
+            kwargs["wire_api"] = wire_api
+        if use_responses is not None:
+            kwargs["use_responses"] = use_responses
+        if force_responses is not None:
+            kwargs["force_responses"] = force_responses
+        kwargs["compact_threshold"] = compact_threshold
+        kwargs["responses_stateless_replay"] = responses_stateless_replay
+        super().__init__(
+            api_key=api_key or _OPENCODE_PLACEHOLDER_API_KEY,
+            base_url=base_url or _OPENCODE_SERVE_DEFAULT_URL,
+            timeout_ms=timeout_ms,
+            max_rpm=max_rpm,
+            default_headers=default_headers,
+            prompt_cache_key=prompt_cache_key,
+            **kwargs,
+        )
+
+    def _default_prompt_cache_key(self, model: str) -> str:
+        # Fixed provider identity — clean ``lingtai-opencode`` namespace instead
+        # of the localhost base_url host. Only used when a caller explicitly
+        # enables prompt_cache_key (the constructor default disables it).
+        return f"lingtai-opencode:{model}:v1"

--- a/src/lingtai/llm/opencode/defaults.py
+++ b/src/lingtai/llm/opencode/defaults.py
@@ -1,0 +1,6 @@
+DEFAULTS = {
+    "api_compat": "openai",
+    "base_url": "http://127.0.0.1:4050/v1",
+    "api_key_env": "",
+    "model": "",
+}

--- a/tests/contracts/llm_conversation_input/regimes.py
+++ b/tests/contracts/llm_conversation_input/regimes.py
@@ -749,6 +749,9 @@ REGISTRY_EDGES: list[RegistryEdge] = [
     # --- OpenAI-compatible single-session providers ---------------------
     RegistryEdge("openrouter", "OpenRouterAdapter", "OpenAIChatSession"),
     RegistryEdge("deepseek", "DeepSeekAdapter", "DeepSeekChatSession"),
+    # OpenCode: local ``opencode serve`` OpenAI-compatible endpoint, Chat
+    # Completions wire by default (OpenCodeAdapter inherits OpenAIChatSession).
+    RegistryEdge("opencode", "OpenCodeAdapter", "OpenAIChatSession"),
     # MiMo defaults to the native Responses wire; Chat Completions remains an explicit escape hatch.
     RegistryEdge("mimo", "MimoAdapter", "MimoResponsesSession"),
     RegistryEdge("glm", "ZhipuAdapter", "ZhipuChatSession"),

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -62,7 +62,7 @@ def test_default_adapters_registered():
     saved = dict(LLMService._adapter_registry)
     LLMService._adapter_registry.clear()
     register_all_adapters()
-    expected = {"gemini", "anthropic", "openai", "minimax", "deepseek", "grok", "qwen", "glm", "kimi", "custom", "claude-code", "claude_code", "kimi-code", "kimi_code"}
+    expected = {"gemini", "anthropic", "openai", "minimax", "deepseek", "grok", "qwen", "glm", "kimi", "custom", "claude-code", "claude_code", "kimi-code", "kimi_code", "opencode"}
     assert expected.issubset(set(LLMService._adapter_registry.keys()))
     LLMService._adapter_registry.clear()
     LLMService._adapter_registry.update(saved)

--- a/tests/test_opencode_preset.py
+++ b/tests/test_opencode_preset.py
@@ -1,0 +1,206 @@
+"""Tests for the opencode preset provider.
+
+Covers: adapter registration, OpenCodeAdapter defaults (local serve endpoint,
+Chat Completions wire, placeholder api_key), LLMService construction,
+preset_connectivity entry, the preset template file shape, and preset
+activation end-to-end.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _reload_registry():
+    """Clear + re-register all adapters; restore on teardown."""
+    from lingtai.llm._register import register_all_adapters
+    from lingtai.llm.service import LLMService
+
+    saved = dict(LLMService._adapter_registry)
+    LLMService._adapter_registry.clear()
+    try:
+        register_all_adapters()
+        return LLMService, saved
+    except Exception:
+        LLMService._adapter_registry.clear()
+        LLMService._adapter_registry.update(saved)
+        raise
+
+
+def _restore_registry(saved: dict) -> None:
+    from lingtai.llm.service import LLMService
+
+    LLMService._adapter_registry.clear()
+    LLMService._adapter_registry.update(saved)
+
+
+class TestOpenCodeAdapter:
+    def test_defaults_to_local_serve_endpoint(self):
+        from lingtai.llm.opencode.adapter import (
+            OpenCodeAdapter,
+            _OPENCODE_SERVE_DEFAULT_URL,
+        )
+
+        adapter = OpenCodeAdapter()
+        assert _OPENCODE_SERVE_DEFAULT_URL == "http://127.0.0.1:4050/v1"
+        assert adapter.base_url == _OPENCODE_SERVE_DEFAULT_URL
+        # Chat Completions wire by default — broadest-compat surface.
+        assert adapter._should_use_responses() is False
+        # Placeholder key satisfies the OpenAI SDK; opencode authenticates itself.
+        assert adapter._client.api_key
+
+    def test_respects_explicit_base_url(self):
+        from lingtai.llm.opencode.adapter import OpenCodeAdapter
+
+        adapter = OpenCodeAdapter(base_url="http://127.0.0.1:4096/v1")
+        assert adapter.base_url == "http://127.0.0.1:4096/v1"
+
+    def test_prompt_cache_key_namespace(self):
+        from lingtai.llm.opencode.adapter import OpenCodeAdapter
+
+        adapter = OpenCodeAdapter()
+        assert adapter._default_prompt_cache_key("anthropic/claude-sonnet-4-5") == (
+            "lingtai-opencode:anthropic/claude-sonnet-4-5:v1"
+        )
+
+    def test_prompt_cache_key_disabled_by_default(self):
+        from lingtai.llm.opencode.adapter import OpenCodeAdapter
+
+        adapter = OpenCodeAdapter()
+        assert adapter._resolve_prompt_cache_key("anthropic/claude-sonnet-4-5") is None
+
+
+class TestRegistration:
+    def test_opencode_registered_after_register_all(self):
+        LLMService, saved = _reload_registry()
+        try:
+            assert "opencode" in LLMService._adapter_registry
+        finally:
+            _restore_registry(saved)
+
+    def test_llm_service_builds_opencode_adapter(self):
+        from lingtai.llm.opencode.adapter import OpenCodeAdapter
+
+        LLMService, saved = _reload_registry()
+        try:
+            svc = LLMService("opencode", "anthropic/claude-sonnet-4-5")
+            adapter = svc.get_adapter("opencode")
+            assert isinstance(adapter, OpenCodeAdapter)
+            assert adapter.base_url == "http://127.0.0.1:4050/v1"
+            assert adapter._client.api_key  # placeholder
+        finally:
+            _restore_registry(saved)
+
+    def test_llm_service_respects_manifest_base_url(self):
+        LLMService, saved = _reload_registry()
+        try:
+            svc = LLMService(
+                "opencode",
+                "anthropic/claude-sonnet-4-5",
+                base_url="http://127.0.0.1:4096/v1",
+            )
+            assert svc.get_adapter("opencode").base_url == "http://127.0.0.1:4096/v1"
+        finally:
+            _restore_registry(saved)
+
+
+class TestPresetTemplate:
+    def test_template_shape_mirrors_codex(self):
+        template_path = ROOT / "presets" / "templates" / "opencode.json"
+        data = json.loads(template_path.read_text(encoding="utf-8"))
+
+        assert data["name"] == "opencode"
+        llm = data["manifest"]["llm"]
+        assert llm["provider"] == "opencode"
+        assert llm["base_url"] == "http://127.0.0.1:4050/v1"
+        assert isinstance(llm["model"], str) and "/" in llm["model"]
+        assert llm["api_key"] is None
+        assert llm["api_key_env"] == ""
+        assert "thinking" not in llm
+        # opencode vends no LingTai vision/web_search capability providers.
+        caps = data["manifest"]["capabilities"]
+        assert "vision" not in caps
+        assert "web_search" not in caps
+        assert "skills" in caps
+
+
+def test_activate_opencode_preset(tmp_path):
+    """Substituting the opencode preset into init.json works end-to-end."""
+    from lingtai.agent import Agent
+
+    plib = tmp_path / "presets"
+    plib.mkdir()
+    template = json.loads(
+        (ROOT / "presets" / "templates" / "opencode.json").read_text("utf-8")
+    )
+    preset_path = str(plib / "opencode.json")
+    (plib / "opencode.json").write_text(json.dumps(template))
+
+    wd = tmp_path / "agent"
+    wd.mkdir()
+    init = {
+        "manifest": {
+            "agent_name": "alice",
+            "language": "en",
+            "preset": {
+                "active": preset_path,
+                "default": preset_path,
+                "allowed": [preset_path],
+            },
+            "llm": {"provider": "deepseek", "model": "deepseek-v4-flash",
+                    "api_key": None, "api_key_env": "DEEPSEEK_API_KEY"},
+            "capabilities": {"file": {}},
+            "soul": {"delay": 120},
+            "max_turns": 50,
+            "admin": {"karma": True},
+            "streaming": False,
+        },
+        "principle": "p", "covenant": "c", "pad": "", "lingtai": "",
+        "soul": "",
+    }
+    (wd / "init.json").write_text(json.dumps(init))
+
+    class _Probe(Agent):
+        def __init__(self, working_dir):
+            self._working_dir = Path(working_dir)
+            self._log_events = []
+        def _log(self, event, **kw):
+            self._log_events.append((event, kw))
+
+    a = _Probe(wd)
+    a._activate_preset(preset_path)
+
+    data = json.loads((wd / "init.json").read_text(encoding="utf-8"))
+    assert data["manifest"]["llm"]["provider"] == "opencode"
+    assert data["manifest"]["llm"]["base_url"] == "http://127.0.0.1:4050/v1"
+    assert data["manifest"]["llm"]["model"] == template["manifest"]["llm"]["model"]
+    assert data["manifest"]["preset"]["active"] == preset_path
+
+
+class TestPresetConnectivity:
+    def test_opencode_has_default_url(self):
+        from lingtai.kernel import preset_connectivity as pc
+
+        assert pc._PROVIDER_DEFAULT_URLS["opencode"] == "http://127.0.0.1:4050"
+
+    def test_check_connectivity_no_credential_check(self):
+        """api_key_env "" skips the credential gate; the probe is a TCP check
+        of the local serve port (ok only while a server is running)."""
+        from lingtai.kernel import preset_connectivity as pc
+
+        result = pc.check_connectivity("opencode", None, "")
+        assert result["status"] in {"ok", "unreachable"}
+        if result["status"] == "unreachable":
+            assert result["error"]
+
+    def test_check_connectivity_uses_manifest_base_url(self):
+        from lingtai.kernel import preset_connectivity as pc
+
+        result = pc.check_connectivity(
+            "opencode", "http://127.0.0.1:4050/v1", ""
+        )
+        assert result["status"] in {"ok", "unreachable"}


### PR DESCRIPTION
## Summary

Allows OpenCode (github.com/sst/opencode, the Go-based open-source coding agent CLI) to power LingTai as a preset provider, the same way the `codex` sub preset works. The user runs the local CLI's headless server (`opencode serve`, OpenAI-compatible on `http://127.0.0.1:4050` by default) and LingTai talks to it over the OpenAI-compatible Chat Completions wire.

### What's included

- **Provider adapter** — `src/lingtai/llm/opencode/` (`OpenCodeAdapter`, a thin subclass of `OpenAIAdapter`):
  - default `base_url` `http://127.0.0.1:4050/v1` (override via `manifest.llm.base_url` for a custom `opencode serve --port`);
  - no LingTai-side API key — opencode owns provider auth (`opencode auth login`); a localhost placeholder satisfies the OpenAI SDK;
  - Chat Completions wire by default, Responses wire opt-in via `wire_api`;
  - models addressed as `provider/model` (e.g. `anthropic/claude-sonnet-4-5`), resolved by the opencode server.
- **Registration** — `opencode` registered in `src/lingtai/llm/_register.py` (`LLMService.register_adapter("opencode", ...)`), mirroring the codex/claude-code registration pattern.
- **Preset template** — `presets/templates/opencode.json` mirroring the `codex.json` template shape (`provider: "opencode"`, `base_url: http://127.0.0.1:4050/v1`, `api_key: null`, `api_key_env: ""`). Capabilities are skills-only (opencode vends no LingTai vision/web_search capability providers).
- **Connectivity check** — `opencode` added to `_PROVIDER_DEFAULT_URLS` in `src/lingtai/kernel/preset_connectivity.py` (`http://127.0.0.1:4050`); with an empty `api_key_env` the free credential check is skipped and the TCP probe reports `ok`/`unreachable` depending on whether `opencode serve` is running.
- **Docs** — `docs/references/opencode-preset-guide.md` (install, template, model selection, connectivity, troubleshooting); `opencode` row added to the `llm-adapters` system-manual inventory table.
- **Registry matrix** — `RegistryEdge("opencode", "OpenCodeAdapter", "OpenAIChatSession")` in `tests/contracts/llm_conversation_input/regimes.py`; `opencode` added to the adapter-registry test expectation.

### Design decisions

- **Not added to `THINKING_PROVIDERS`**: opencode's reasoning effort is the CLI's per-provider `--variant` concept, not a wire-level `reasoning.effort` contract LingTai validates, so `manifest.llm.thinking` stays unsupported for `opencode` (documented in the guide).
- **No CLI auto-spawn**: the adapter requires the user's `opencode serve` to be running (documented); auto-spawning the server is left as follow-up work.

### Tests

```
pytest tests/test_opencode_preset.py tests/test_adapter_registry.py        # 18 passed (new tests)
pytest tests/contracts/llm_conversation_input/test_regime_inventory.py     # registry matrix incl. opencode edge
pytest tests/test_llm_adapters_manual.py                                   # manual <-> registry parity
pytest tests/ -k 'preset or provider or connectivity'                       # 571 passed
```

AST-parse validation run on all changed Python files.

**Pre-existing failures on this branch (verified against the pristine tree via `git stash` — unrelated to this PR):** `test_send_str_reaches_transport_as_provider_text[claude_code]`, `test_canonical_tool_result_converts_to_provider_wire[claude_code]`, `test_no_regime_forwards_unconverted_dataclass` (TypeError in `claude_code/adapter.py:332`), `test_check_caps.py::test_get_all_providers_returns_all_capabilities`, `test_daemon_preset_capabilities.py::test_parent_host_tool_floor_is_exactly_shell_and_file`, `test_preset_runtime_model_docs.py` (2), `test_architecture_documents.py::test_governed_child_contracts_have_reciprocal_anatomy_pairs` (missing `daemon_supervisor/supervisor.py` citation), docs-governance feishu frontmatter failures.
