### PR TITLE
fix(imap): preserve requested account in responses

### DIFF
--- a/src/lingtai/mcp_servers/imap/SKILL.md
+++ b/src/lingtai/mcp_servers/imap/SKILL.md
@@ -50,7 +50,9 @@ a list of ids.
 
 - `email_id` is a compound key: `account:folder:uid` (e.g.
   `me@example.com:INBOX:1234`). Use the ids returned by `check`/`search`; do not
-  construct them by hand.
+  construct them by hand. Every action response includes `account` set to the
+  explicitly requested or default-resolved account, while returned compound ids
+  retain their own account prefix.
 - An empty or whitespace-only `folder` (check/search) or `account` (any action)
   is treated as omitted: `folder` defaults to `INBOX`, and `account` uses the
   default/sole account rather than failing with `Unknown account`. Most actions

--- a/src/lingtai/mcp_servers/imap/manager.py
+++ b/src/lingtai/mcp_servers/imap/manager.py
@@ -279,10 +279,18 @@ class IMAPMailManager:
     # Meta injection
     # ------------------------------------------------------------------
 
-    def _inject_meta(self, result: dict) -> dict:
-        """Add tcp_alias and account to every response."""
+    def _inject_meta(
+        self,
+        result: dict,
+        account: "IMAPAccount | None" = None,
+    ) -> dict:
+        """Add tcp_alias and the resolved account to every response."""
         result["tcp_alias"] = self._tcp_alias
-        result["account"] = self._service.default_account.address
+        result["account"] = (
+            account.address
+            if account is not None
+            else self._service.default_account.address
+        )
         return result
 
     # ------------------------------------------------------------------
@@ -328,7 +336,7 @@ class IMAPMailManager:
                 "status": "error",
                 "error": f"Unknown account: {requested_account}",
                 "requested_account": requested_account,
-            })
+            }, account)
 
         dispatch = {
             "send": self._send,
@@ -347,11 +355,14 @@ class IMAPMailManager:
         }
 
         if action == "accounts":
-            return self._inject_meta(self._accounts(args))
+            return self._inject_meta(self._accounts(args), account)
         elif action in dispatch:
-            return self._inject_meta(dispatch[action](args, account))
+            return self._inject_meta(dispatch[action](args, account), account)
         else:
-            return self._inject_meta({"error": f"Unknown imap action: {action}"})
+            return self._inject_meta(
+                {"error": f"Unknown imap action: {action}"},
+                account,
+            )
 
     def _manual(self) -> dict:
         # The manual lives in this package's bundled SKILL.md (standard skill

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -169,6 +169,7 @@ related_files:
   - tests/test_how_to_change_name.py
   - tests/test_how_to_change_name_e2e.py
   - tests/test_i18n.py
+  - tests/test_imap_account_metadata.py
   - tests/test_imap_empty_args.py
   - tests/test_imap_outlook_oauth.py
   - tests/test_imap_read_attachment_sanitization.py

--- a/tests/test_imap_account_metadata.py
+++ b/tests/test_imap_account_metadata.py
@@ -1,0 +1,121 @@
+"""Regression tests for account-scoped IMAP response metadata."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from lingtai.mcp_servers.imap.manager import IMAPMailManager
+
+
+PRIMARY = "primary@example.com"
+SECONDARY = "secondary@example.com"
+
+
+class FakeAccount:
+    def __init__(self, address: str) -> None:
+        self.address = address
+        self.check_calls: list[tuple[str, int]] = []
+        self.read_calls: list[tuple[str, str]] = []
+        self.flag_calls: list[tuple[str, str, list[str], str]] = []
+
+    def fetch_envelopes(self, folder: str, n: int) -> list[dict]:
+        self.check_calls.append((folder, n))
+        return [{
+            "email_id": f"{self.address}:{folder}:7",
+            "subject": self.address,
+        }]
+
+    def fetch_full(self, folder: str, uid: str) -> dict:
+        self.read_calls.append((folder, uid))
+        return {
+            "from": "sender@example.com",
+            "subject": "Synthetic message",
+            "body": "synthetic body",
+            "attachments_raw": [],
+        }
+
+    def store_flags(
+        self,
+        folder: str,
+        uid: str,
+        flags: list[str],
+        action: str = "+FLAGS",
+    ) -> bool:
+        self.flag_calls.append((folder, uid, flags, action))
+        return True
+
+
+class FakeService:
+    def __init__(self) -> None:
+        self.accounts = [FakeAccount(PRIMARY), FakeAccount(SECONDARY)]
+        self.default_account = self.accounts[0]
+        self._account_map = {account.address: account for account in self.accounts}
+
+    def get_account(self, address: str | None):
+        if address is None:
+            return self.default_account
+        return self._account_map.get(address)
+
+
+def _manager(tmp_path: Path) -> tuple[IMAPMailManager, FakeService]:
+    service = FakeService()
+    manager = IMAPMailManager(
+        service,
+        working_dir=tmp_path,
+        tcp_alias="synthetic-bridge",
+        on_inbound=lambda payload: None,
+    )
+    return manager, service
+
+
+def test_check_reports_requested_account_and_account_scoped_id(tmp_path: Path):
+    manager, service = _manager(tmp_path)
+
+    result = manager.handle({
+        "action": "check",
+        "account": SECONDARY,
+        "folder": "INBOX",
+    })
+
+    assert result["status"] == "ok"
+    assert result["account"] == SECONDARY
+    assert result["emails"][0]["email_id"] == f"{SECONDARY}:INBOX:7"
+    assert service.accounts[0].check_calls == []
+    assert service.accounts[1].check_calls == [("INBOX", 10)]
+
+
+def test_read_reports_requested_account_and_preserves_compound_id(tmp_path: Path):
+    manager, service = _manager(tmp_path)
+    email_id = f"{SECONDARY}:INBOX:42"
+
+    result = manager.handle({
+        "action": "read",
+        "account": SECONDARY,
+        "email_id": email_id,
+    })
+
+    assert result["status"] == "ok"
+    assert result["account"] == SECONDARY
+    assert result["emails"][0]["email_id"] == email_id
+    assert service.accounts[0].read_calls == []
+    assert service.accounts[1].read_calls == [("INBOX", "42")]
+    assert (tmp_path / "imap" / SECONDARY / "INBOX" / "42" / "message.json").is_file()
+
+
+def test_flag_reports_requested_account_and_preserves_compound_id(tmp_path: Path):
+    manager, service = _manager(tmp_path)
+    email_id = f"{SECONDARY}:INBOX:42"
+
+    result = manager.handle({
+        "action": "flag",
+        "account": SECONDARY,
+        "email_id": email_id,
+        "flags": {"seen": True},
+    })
+
+    assert result["status"] == "ok"
+    assert result["account"] == SECONDARY
+    assert result["results"] == [{"email_id": email_id, "flagged": True}]
+    assert service.accounts[0].flag_calls == []
+    assert service.accounts[1].flag_calls == [
+        ("INBOX", "42", ["\\Seen"], "+FLAGS"),
+    ]


### PR DESCRIPTION
## Summary

- Preserve the account resolved by `IMAPMailManager.handle()` in the outer response envelope instead of always reporting the service default account.
- Add synthetic two-account regressions covering `check`, `read`, and `flag`, including account-scoped compound `email_id` routing and returned IDs.
- Document the response-account invariant in the IMAP manual.

## Validation

- `git diff --check` — PASS.
- `python -m compileall -q src/lingtai/mcp_servers/imap tests/test_imap_account_metadata.py` — PASS under the pinned project runtime.
- Direct focused harness under the pinned project runtime and `PYTHONPATH="$PWD/src:$PWD/tests"` — PASS, 24 tests across `test_imap_account_metadata.py`, `test_imap_empty_args.py`, and `test_imap_toolfamily_ltpv2.py`.
- Exact-base regression proof — PASS: the new check assertion fails against base `878220f…` because the old implementation reports the default account.
- Standard pytest collection was not available in the pinned project runtime (`No module named pytest`); no dependency or environment mutation was made. The available system pytest has incompatible installed MCP/MSAL dependencies and was not used as a product pass.