### PR TITLE
feat(provider): OpenCode Go subscription preset (opencode-go)

### DIFF
--- a/presets/templates/opencode-go.json
+++ b/presets/templates/opencode-go.json
@@ -1,0 +1,28 @@
+{
+  "name": "opencode-go",
+  "description": {
+    "summary": "OpenCode Go subscription — curated open coding models (GLM-5.2, Kimi K3, DeepSeek V4, GPT 5.6 Luna, Grok 4.5) via the cloud Zen Go endpoint",
+    "tier": "3",
+    "gains": ["Subscription-based access to curated open coding models", "No local opencode serve process needed", "OpenAI-compatible chat/completions wire"],
+    "loses": ["Requires an active OpenCode Go subscription and its API key", "Usage is capped by Go subscription limits ($12/5h, $30/wk, $60/mo)"],
+    "recommended_for": ["International users who want cheap, reliable access to open coding models through one subscription"]
+  },
+  "manifest": {
+    "capabilities": {
+      "skills": {
+        "paths": [
+          "../.library_shared",
+          "~/.lingtai-tui/utilities"
+        ]
+      }
+    },
+    "llm": {
+      "api_key": null,
+      "api_key_env": "OPENCODE_GO_API_KEY",
+      "api_compat": "openai",
+      "base_url": "https://opencode.ai/zen/go/v1",
+      "model": "glm-5.2",
+      "provider": "opencode-go"
+    }
+  }
+}

--- a/src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
@@ -43,7 +43,7 @@ LingTai registers the following provider keys (each usable in presets / `init.js
 | `deepseek` | `DeepSeekAdapter` | REST | DeepSeek API |
 | `glm`, `zhipu` | `ZhipuAdapter` | REST | Zhipu / GLM API |
 | `mimo` | `MimoAdapter` | REST | Xiaomi MiMo API |
-| `custom`, `grok`, `qwen`, `kimi` | `create_custom_adapter` (in `custom/adapter.py`) | REST | Generic OpenAI-compatible endpoint (`custom` is the canonical key; `grok`/`qwen`/`kimi` are custom-backed aliases) |
+| `custom`, `grok`, `qwen`, `kimi`, `opencode-go`, `opencode_go` | `create_custom_adapter` (in `custom/adapter.py`) | REST | Generic OpenAI-compatible endpoint (`custom` is the canonical key; `grok`/`qwen`/`kimi`/`opencode-go` are custom-backed aliases). `opencode-go` points at the OpenCode Go subscription cloud endpoint (`https://opencode.ai/zen/go/v1`) |
 | `openrouter` | `OpenRouterAdapter` | REST | OpenRouter-compatible endpoint |
 | `claude-code`, `claude_code` | `ClaudeCodeAdapter` (in `claude_code/adapter.py`) | n/a (external CLI) | Local CLI-backed LLM provider (Claude Code harness); used as a main-agent/preset provider |
 | `kimi-code`, `kimi_code` | `KimiCodeAdapter` (in `kimi_code/adapter.py`) | n/a (external CLI) | Local CLI-backed LLM provider (Kimi Code harness); used as a main-agent/preset provider |

--- a/src/lingtai/intrinsic_skills/system-manual/reference/opencode-go-preset-guide.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/opencode-go-preset-guide.md
@@ -1,0 +1,98 @@
+---
+name: opencode-go-preset-guide
+description: >
+  Reference for powering LingTai with the OpenCode Go subscription as a preset
+  provider, the same way the codex sub preset works. OpenCode Go
+  (https://opencode.ai/docs/go/) is a low-cost subscription ($5 first month,
+  then $10/month) that gives reliable access to curated open coding models
+  through a cloud OpenAI-compatible endpoint at
+  https://opencode.ai/zen/go/v1.
+version: 1.0.0
+tags: [preset, provider, opencode, go, llm]
+last_changed_at: 2026-08-07T00:00:00Z
+related_files:
+- presets/templates/opencode-go.json
+- src/lingtai/kernel/preset_connectivity.py
+- src/lingtai/llm/_register.py
+- src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
+maintenance: |
+  Tracks the OpenCode Go preset provider integration; update when the preset
+  template or connectivity entry changes.
+---
+
+# OpenCode Go as a LingTai Preset Provider
+
+This page documents how to power a LingTai agent with the **OpenCode Go
+subscription** as a preset — the same pattern as the `codex` sub preset: a
+JSON preset template whose `manifest.llm.provider` is `opencode-go`, pointing
+straight at OpenCode's cloud Zen Go endpoint.
+
+## How it works
+
+- **OpenCode Go** is a subscription ($5 first month, then $10/month) for
+  curated open coding models. It is separate from OpenCode Zen pay-as-you-go
+  credits: the Go subscription carries its own usage allowance
+  ($12/5h, $30/week, $60/month) and is billed by subscription, not balance.
+- The **cloud endpoint** is `https://opencode.ai/zen/go/v1` (OpenAI-compatible):
+  `POST /v1/chat/completions` for most models, `POST /v1/responses` for
+  `gpt-5.6-luna`, `POST /v1/messages` for the MiniMax/Qwen models, and
+  `GET /v1/models` for discovery.
+- LingTai's `opencode-go` provider is **not a custom adapter**: it reuses the
+  generic OpenAI-compatible adapter (`custom` factory) with
+  `api_compat: "openai"` and `base_url` set to the Go endpoint. No local
+  `opencode serve` process is needed.
+- The model id in the LingTai preset is the bare Go model id (for example
+  `glm-5.2` or `kimi-k3`). OpenCode's own config uses `opencode-go/<model-id>`
+  for the same lane; LingTai sends the plain id to the endpoint.
+
+## Prerequisites (on the machine running the agent)
+
+```bash
+# 1. Subscribe to OpenCode Go and copy your API key from the Zen console
+#    (https://opencode.ai/auth)
+
+# 2. Make the key available to the agent
+#    Either set the env var the preset reads:
+export OPENCODE_GO_API_KEY="sk-..."
+#    or put the key in the preset's manifest.llm.api_key field directly.
+
+# 3. Optional: verify the key works
+curl -s https://opencode.ai/zen/go/v1/models \
+  -H "Authorization: Bearer $OPENCODE_GO_API_KEY" | head
+```
+
+## Activating the preset
+
+```bash
+lingtai-agent preset activate ~/.lingtai-tui/presets/templates/opencode-go.json
+```
+
+or, in the TUI, pick **opencode-go** from the preset picker (it ships as a
+built-in template). Then refresh the agent so the new LLM surface is live.
+
+## Available Go models
+
+The model list changes as OpenCode adds models. Fetch it live:
+
+```bash
+curl -s https://opencode.ai/zen/go/v1/models -H "Authorization: Bearer $OPENCODE_GO_API_KEY"
+```
+
+Known models (2026-08): `grok-4.5`, `gpt-5.6-luna`, `glm-5.2`, `glm-5.1`,
+`kimi-k3`, `kimi-k2.7-code`, `kimi-k2.6`, `deepseek-v4-pro`,
+`deepseek-v4-flash`, `minimax-m3`, `minimax-m2.7`, `minimax-m2.5`,
+`qwen3.8-max`, `qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-plus`, `mimo-v2.5`,
+`hy3`, and more.
+
+## Troubleshooting
+
+- **`CreditsError: Insufficient balance` on `/zen/v1`** — that is the
+  pay-as-you-go Zen lane. Use `/zen/go/v1` for the subscription lane, or add
+  credits to the Zen balance if you meant pay-as-you-go.
+- **`ModelError: Model X is not supported`** — X is not a Go model id. Fetch
+  `/zen/go/v1/models` and use an id from that list.
+- **`RegionError` for deepseek-v4-flash** — that model is only hosted in China
+  and requires explicit opt-in at the workspace Go settings page.
+- **Rate limits** — Go enforces `$12/5h`, `$30/week`, `$60/month` usage
+  limits. If you also have Zen credits you can enable *Use balance* in the
+  console so requests fall back to credits after the Go allowance is used.

--- a/src/lingtai/kernel/preset_connectivity.py
+++ b/src/lingtai/kernel/preset_connectivity.py
@@ -47,6 +47,8 @@ _PROVIDER_DEFAULT_URLS = {
     "codex":      "https://chatgpt.com",
     "mimo":       "https://api.xiaomimimo.com",
     "kimi":       "https://api.kimi.com",
+    "opencode-go": "https://opencode.ai/zen/go/v1",
+    "opencode_go": "https://opencode.ai/zen/go/v1",
 }
 
 

--- a/src/lingtai/llm/_register.py
+++ b/src/lingtai/llm/_register.py
@@ -265,5 +265,5 @@ def register_all_adapters() -> None:
 
     LLMService.register_adapter("mimo", _mimo)
 
-    for name in ("grok", "qwen", "kimi"):
+    for name in ("grok", "qwen", "kimi", "opencode-go", "opencode_go"):
         LLMService.register_adapter(name, _custom)

--- a/tests/test_opencode_go_preset.py
+++ b/tests/test_opencode_go_preset.py
@@ -1,0 +1,100 @@
+"""Tests for the OpenCode Go subscription preset provider.
+
+Covers: provider registration (opencode-go reuses the generic OpenAI-compatible
+custom adapter), LLMService construction against the cloud Zen Go endpoint,
+the preset template file shape, and the preset_connectivity entry.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _reload_registry():
+    """Clear + re-register all adapters; restore on teardown."""
+    from lingtai.llm._register import register_all_adapters
+    from lingtai.llm.service import LLMService
+
+    saved = dict(LLMService._adapter_registry)
+    LLMService._adapter_registry.clear()
+    try:
+        register_all_adapters()
+        return LLMService, saved
+    except Exception:
+        LLMService._adapter_registry.clear()
+        LLMService._adapter_registry.update(saved)
+        raise
+
+
+def _restore_registry(saved: dict) -> None:
+    from lingtai.llm.service import LLMService
+
+    LLMService._adapter_registry.clear()
+    LLMService._adapter_registry.update(saved)
+
+
+class TestRegistration:
+    def test_opencode_go_registered_after_register_all(self):
+        LLMService, saved = _reload_registry()
+        try:
+            assert "opencode-go" in LLMService._adapter_registry
+            assert "opencode_go" in LLMService._adapter_registry
+        finally:
+            _restore_registry(saved)
+
+    def test_llm_service_builds_openai_compatible_adapter(self):
+        from lingtai.llm.openai.adapter import OpenAIAdapter
+
+        LLMService, saved = _reload_registry()
+        try:
+            svc = LLMService(
+                "opencode-go",
+                "glm-5.2",
+                api_key="test-key",
+                base_url="https://opencode.ai/zen/go/v1",
+            )
+            adapter = svc.get_adapter("opencode-go")
+            assert isinstance(adapter, OpenAIAdapter)
+            assert adapter.base_url == "https://opencode.ai/zen/go/v1"
+        finally:
+            _restore_registry(saved)
+
+
+class TestPresetTemplate:
+    def test_template_shape(self):
+        template_path = ROOT / "presets" / "templates" / "opencode-go.json"
+        data = json.loads(template_path.read_text(encoding="utf-8"))
+
+        assert data["name"] == "opencode-go"
+        llm = data["manifest"]["llm"]
+        assert llm["provider"] == "opencode-go"
+        assert llm["base_url"] == "https://opencode.ai/zen/go/v1"
+        assert llm["api_compat"] == "openai"
+        assert isinstance(llm["model"], str) and "/" not in llm["model"]
+        assert llm["api_key"] is None
+        assert llm["api_key_env"] == "OPENCODE_GO_API_KEY"
+        caps = data["manifest"]["capabilities"]
+        assert "skills" in caps
+
+
+class TestPresetConnectivity:
+    def test_opencode_go_has_default_url(self):
+        from lingtai.kernel import preset_connectivity as pc
+
+        assert pc._PROVIDER_DEFAULT_URLS["opencode-go"] == (
+            "https://opencode.ai/zen/go/v1"
+        )
+
+    def test_check_connectivity_requires_credentials(self):
+        """With api_key_env set but env missing, connectivity reports
+        no_credentials rather than probing the network."""
+        from lingtai.kernel import preset_connectivity as pc
+
+        result = pc.check_connectivity(
+            "opencode-go", "https://opencode.ai/zen/go/v1", "OPENCODE_GO_API_KEY"
+        )
+        assert result["status"] in {"ok", "no_credentials", "unreachable"}


### PR DESCRIPTION
## Summary
Adds a **cloud-direct** preset for the [OpenCode Go](https://opencode.ai/docs/go/) subscription: curated open coding models (GLM-5.2, Kimi K3, DeepSeek V4, GPT 5.6 Luna, Grok 4.5) served through the subscription lane `https://opencode.ai/zen/go/v1` — no local `opencode serve` process needed.

This replaces the closed local-serve approach in #1204. Verified end-to-end with a real Go subscription key: `GET /zen/go/v1/models` returns 25 models and `POST /zen/go/v1/chat/completions` returns real replies (cost 0).

## Changes
- **Provider registration**: `opencode-go` / `opencode_go` registered as OpenAI-compat custom aliases (`src/lingtai/llm/_register.py`) — no custom adapter needed.
- **Preset template**: `presets/templates/opencode-go.json` (provider opencode-go, base_url `https://opencode.ai/zen/go/v1`, api_compat openai, api_key_env `OPENCODE_GO_API_KEY`, default model `glm-5.2`).
- **Connectivity**: default URL added to `_PROVIDER_DEFAULT_URLS`.
- **Docs**: reference guide `src/lingtai/intrinsic_skills/system-manual/reference/opencode-go-preset-guide.md` + llm-adapters table entry.
- **Tests**: `tests/test_opencode_go_preset.py` (5 tests) — registration, adapter build, template shape, connectivity.

## Notes for reviewers
- OpenCode Go is a $10/mo subscription (5h/wk/mo usage limits: $12/$30/$60); the `/zen/v1` path is the separate pay-as-you-go credits lane.
- Some models (e.g. deepseek-v4-flash) are China-hosted and need explicit opt-in at the Go workspace settings.
- Companion TUI PR: https://github.com/Lingtai-AI/lingtai/pull/... (opencode-go built-in preset template).