### PR TITLE
Localize Telegram Task Cards in Chinese

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -16,15 +16,15 @@ class TaskCardEventProjection:
 
     REASONING_CAP = 500
     TEXT_LIMIT = 3500
-    HEADER = "📋 ACTIVITIES"
+    HEADER = "📋 活动"
     FOOTER = (
-        "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
-        "/taskcard N sets normal rows (1-10"
+        "请勿回复此任务卡片。使用 /taskcard on|off 切换；"
+        "/taskcard N 设置显示组数 (1-10"
     )
     DEFAULT_NORMAL_ROWS = 1
     METADATA_MAX_CHARS = 150
     METADATA_MAX_LINES = 2
-    TIME_PREFIX = "Last Updated: "
+    TIME_PREFIX = "最后更新: "
     AGENT_STATES = frozenset(state.value for state in AgentState)
 
     EVENT_WINDOW = 10
@@ -35,7 +35,7 @@ class TaskCardEventProjection:
 
     @classmethod
     def footer(cls, normal_rows: int) -> str:
-        return f"{cls.FOOTER}, current: {normal_rows})."
+        return f"{cls.FOOTER}，当前: {normal_rows})。"
 
     @staticmethod
     def format_current_time(now: datetime) -> str:
@@ -385,7 +385,7 @@ class TaskCardEventProjection:
         agent_line: str | None = None
         lifecycle = metadata.get("agent_lifecycle")
         if lifecycle in (AgentState.STUCK.value, "offline"):
-            agent_line = f"agent · {lifecycle} · try /refresh"
+            agent_line = f"agent · {lifecycle} · 尝试 /refresh"
         elif lifecycle in cls.AGENT_STATES:
             agent_line = f"agent · {lifecycle}"
 
@@ -551,7 +551,7 @@ class TaskCardEventProjection:
     @classmethod
     def format_api_error_line(cls, row: dict[str, Any]) -> str:
         state = row.get("state")
-        parts = ["API error"]
+        parts = ["API 错误"]
         error_type = cls.machine_identifier(row.get("error_type"), limit=48)
         if error_type is not None:
             parts.append(error_type)
@@ -570,9 +570,9 @@ class TaskCardEventProjection:
         summary = " · ".join(parts)
 
         if state == "recovered":
-            return f"✓ {summary} · recovered"
+            return f"✓ {summary} · 已恢复"
         if state == "error":
-            return f"⚠️ {summary} · failed"
+            return f"⚠️ {summary} · 失败"
         attempt = row.get("attempt")
         max_attempts = row.get("max_attempts")
         if (
@@ -581,10 +581,10 @@ class TaskCardEventProjection:
             and attempt > 0
             and max_attempts > 0
         ):
-            return f"⚠️ {summary} · retrying {attempt}/{max_attempts}"
+            return f"⚠️ {summary} · 重试中 {attempt}/{max_attempts}"
         if type(attempt) is int and attempt > 0:
-            return f"⚠️ {summary} · retrying (attempt {attempt})"
-        return f"⚠️ {summary} · retrying"
+            return f"⚠️ {summary} · 重试中 (第 {attempt} 次)"
+        return f"⚠️ {summary} · 重试中"
 
     @staticmethod
     def format_elapsed(value: object) -> str:

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -125,13 +125,13 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
 
     assert shared == telegram
     assert shared == (
-        "📋 ACTIVITIES\n"
+        "📋 活动\n"
         "──────────\n"
         "• public response\n"
         "• bash.run: build (0s, ???) · 12:00:00 UTC+00\n"
         "\n"
-        "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
-        "/taskcard N sets normal rows (1-10, current: 1).\n"
+        "请勿回复此任务卡片。使用 /taskcard on|off 切换；"
+        "/taskcard N 设置显示组数 (1-10，当前: 1)。\n"
         "agent · active · session · calls 2\n"
-        "Last Updated: 02:30:00 UTC+08"
+        "最后更新: 02:30:00 UTC+08"
     )

--- a/tests/test_telegram_task_card.py
+++ b/tests/test_telegram_task_card.py
@@ -1,7 +1,7 @@
 """Tests for route B — single transient current-step Task Card.
 
 Product contract: cap 500 Unicode code points after redaction, current-step
-only (no cumulative history), no continuation/overflow, loud 📋 ACTIVITIES.
+only (no cumulative history), no continuation/overflow, loud 📋 活动.
 """
 
 from __future__ import annotations
@@ -77,7 +77,7 @@ def test_task_card_create_shows_header_and_current_tool(tmp_path):
     send_calls = [c for c in account.calls if c[0] == "send_message"]
     assert len(send_calls) == 1
     text = send_calls[0][2]
-    assert "📋 ACTIVITIES" in text
+    assert "📋 活动" in text
     assert "bash.run" in text
     assert "Check project structure" in text
 
@@ -112,7 +112,7 @@ def test_task_card_update_same_message_id(tmp_path):
     # Only current step visible; previous step replaced
     assert "Step 2" in edited
     assert "Step 1" not in edited  # replaced, not cumulative
-    assert "📋 ACTIVITIES" in edited
+    assert "📋 活动" in edited
 
 
 def test_task_card_finalize_shows_done_header(tmp_path):
@@ -160,7 +160,7 @@ def test_reasoning_499_fits_no_ellipsis(tmp_path):
     send_calls = [c for c in account.calls if c[0] == "send_message"]
     text = send_calls[0][2]
     assert "A" * 499 in text
-    assert "…" not in text.replace("📋 ACTIVITIES", "").replace("bash:", "").replace("…", "CHECK")  # no ellipsis
+    assert "…" not in text.replace("📋 活动", "").replace("bash:", "").replace("…", "CHECK")  # no ellipsis
 
 
 def test_reasoning_500_fits_exact_no_ellipsis(tmp_path):
@@ -417,7 +417,7 @@ def test_full_routing_chain_create_update_finalize(tmp_path):
     send_calls = [c for c in account.calls if c[0] == "send_message"]
     assert len(send_calls) == 1
     text = send_calls[0][2]
-    assert "📋 ACTIVITIES" in text
+    assert "📋 活动" in text
     assert "bash.run" in text
     assert "Check project structure" in text
 

--- a/tests/test_telegram_task_card_blockers.py
+++ b/tests/test_telegram_task_card_blockers.py
@@ -181,7 +181,7 @@ def test_timestamped_moderate_rows_stay_under_text_limit():
         if ln.startswith(("•", "✓")):
             assert "04:08:08 UTC-07" in ln
     # The bottom line is the single render-time stamp, distinct from row stamps.
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert text.splitlines()[-1] == "最后更新: 17:18:36 UTC-07"
 
 
 def test_extreme_row_count_exceeds_budget_but_keeps_every_row():
@@ -212,7 +212,7 @@ def test_extreme_row_count_exceeds_budget_but_keeps_every_row():
     assert not text.endswith("…")
     # The fixed footer and the single render-time line still render.
     assert _TASK_CARD_FOOTER in text
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert text.splitlines()[-1] == "最后更新: 17:18:36 UTC-07"
 
 
 def test_timestamped_rows_redaction_before_truncation():

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -668,7 +668,7 @@ def test_automatic_footer_label_is_last_updated(tmp_path):
 
     edits = [call for call in acct.calls if call[0] == "edit_message"]
     rendered = edits[-1][3]
-    assert "Last Updated: " in rendered
+    assert "最后更新: " in rendered
     assert "Current Time: " not in rendered
 
 
@@ -685,7 +685,7 @@ def test_programmable_frame_includes_its_own_last_updated_line(tmp_path):
     edits = [call for call in acct.calls if call[0] == "edit_message"]
     rendered = edits[-1][3]
     assert "watch line" in rendered
-    assert "Last Updated: " in rendered
+    assert "最后更新: " in rendered
 
 
 def test_programmable_update_leaves_automatic_frame_unchanged(tmp_path):
@@ -855,7 +855,7 @@ def test_normal_rows_limits_rendered_event_tail_without_shrinking_buffer(tmp_pat
     rendered = edits[0][3]
     assert "newest" in rendered
     assert "older" not in rendered
-    assert "current: 1" in rendered
+    assert "当前: 1" in rendered
 
 
 def test_no_resident_targets_means_no_transport_calls(tmp_path):

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -26,8 +26,8 @@ def _fmt(rows):
 
 def test_footer_constant_exact_text():
     assert _TASK_CARD_FOOTER == (
-        "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
-        "/taskcard N sets normal rows (1-10"
+        "请勿回复此任务卡片。使用 /taskcard on|off 切换；"
+        "/taskcard N 设置显示组数 (1-10"
     )
 
 
@@ -37,8 +37,8 @@ def test_footer_renders_with_current_row_count_suffix():
          "elapsed_s": 3, "done": False},
     ])
     assert (
-        "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
-        "/taskcard N sets normal rows (1-10, current: 1)."
+        "请勿回复此任务卡片。使用 /taskcard on|off 切换；"
+        "/taskcard N 设置显示组数 (1-10，当前: 1)。"
     ) in text
 
 
@@ -48,7 +48,7 @@ def test_running_render_has_footer():
          "elapsed_s": 3, "done": False},
     ])
     assert _TASK_CARD_FOOTER in text
-    assert "📋 ACTIVITIES" in text
+    assert "📋 活动" in text
 
 
 def test_frozen_render_has_footer():
@@ -337,7 +337,7 @@ def test_metadata_is_two_lines_bounded_and_between_footer_and_timestamp():
     )
     lines = text.splitlines()
     footer_idx = next(i for i, line in enumerate(lines) if _TASK_CARD_FOOTER in line)
-    time_idx = next(i for i, line in enumerate(lines) if line.startswith("Last Updated: "))
+    time_idx = next(i for i, line in enumerate(lines) if line.startswith("最后更新: "))
     metadata_lines = lines[footer_idx + 1:time_idx]
     assert metadata_lines == [
         "session · cache 87.8% · miss 170.6k/1.0M · calls 13",
@@ -388,12 +388,12 @@ def test_metadata_renders_compact_normal_lifecycle_states():
 
 def test_metadata_renders_stuck_with_refresh_hint():
     lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": "stuck"})
-    assert lines == ["agent · stuck · try /refresh"]
+    assert lines == ["agent · stuck · 尝试 /refresh"]
 
 
 def test_metadata_renders_offline_with_refresh_hint():
     lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": "offline"})
-    assert lines == ["agent · offline · try /refresh"]
+    assert lines == ["agent · offline · 尝试 /refresh"]
 
 
 def test_metadata_suspended_never_gets_refresh_hint():
@@ -444,10 +444,10 @@ def test_metadata_stuck_hint_and_ctx_both_survive_full_metadata():
     # The 2-line cap holds; the hint leads line 1 (safe from end-truncation)
     # and ctx survives as line 2 instead of being dropped by the cap.
     assert lines == [
-        "agent · stuck · try /refresh · session · cache 87.8% · miss 170.6k/1.0M · calls 13",
+        "agent · stuck · 尝试 /refresh · session · cache 87.8% · miss 170.6k/1.0M · calls 13",
         "ctx · 171.2k/272.0k · 63%",
     ]
-    assert lines[0].startswith("agent · stuck · try /refresh")
+    assert lines[0].startswith("agent · stuck · 尝试 /refresh")
     assert len(lines) <= 2
     assert len("\n".join(lines)) <= 150
 

--- a/tests/test_telegram_task_card_timestamp.py
+++ b/tests/test_telegram_task_card_timestamp.py
@@ -38,7 +38,7 @@ _NOW = datetime(2026, 7, 12, 17, 18, 36, tzinfo=timezone(timedelta(hours=-7)))
 
 
 def _current_time_line(text):
-    return next(ln for ln in text.splitlines() if ln.startswith("Last Updated: "))
+    return next(ln for ln in text.splitlines() if ln.startswith("最后更新: "))
 
 
 def test_manager_renders_each_row_with_its_own_started_at():
@@ -57,7 +57,7 @@ def test_manager_renders_current_time_line_from_render_instant_not_row_start():
     ], now=_NOW)
     lines = text.splitlines()
     # The bottom line is the labelled render-time stamp, not the row's own start.
-    assert lines[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert lines[-1] == "最后更新: 17:18:36 UTC-07"
     assert "04:08:08 UTC-07" != "17:18:36 UTC-07"
 
 
@@ -68,9 +68,9 @@ def test_current_time_line_follows_the_footer():
     ], now=_NOW)
     lines = text.splitlines()
     footer_idx = next(i for i, ln in enumerate(lines) if _TASK_CARD_FOOTER in ln)
-    time_idx = next(i for i, ln in enumerate(lines) if ln.startswith("Last Updated: "))
+    time_idx = next(i for i, ln in enumerate(lines) if ln.startswith("最后更新: "))
     assert time_idx > footer_idx
-    assert lines[time_idx] == "Last Updated: 17:18:36 UTC-07"
+    assert lines[time_idx] == "最后更新: 17:18:36 UTC-07"
 
 
 def test_parallel_rows_each_keep_their_own_started_at_not_the_first_rows():
@@ -90,7 +90,7 @@ def test_parallel_rows_each_keep_their_own_started_at_not_the_first_rows():
     assert "04:08:09 UTC-07" in read_line
     assert "04:08:11 UTC-07" in grep_line
     # The bottom line is still the single render-time stamp, distinct from any row.
-    assert _current_time_line(text) == "Last Updated: 17:18:36 UTC-07"
+    assert _current_time_line(text) == "最后更新: 17:18:36 UTC-07"
 
 
 def test_current_time_line_present_even_when_no_row_has_a_stamp():
@@ -102,7 +102,7 @@ def test_current_time_line_present_even_when_no_row_has_a_stamp():
     ], now=_NOW)
     # Last Updated never depends on any row carrying a stamp — it always
     # reflects the render instant.
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert text.splitlines()[-1] == "最后更新: 17:18:36 UTC-07"
     # Rows without a stamp render with no inline suffix (malformed/missing
     # timestamp tolerance), never crashing and never fabricating one.
     for ln in text.splitlines():
@@ -122,9 +122,9 @@ def test_api_error_row_never_carries_a_stamp_alongside_a_stamped_tool_row():
     ], now=_NOW)
     bash_line = next(ln for ln in text.splitlines() if "bash.run" in ln)
     assert "04:08:08 UTC-07" in bash_line
-    api_line = next(ln for ln in text.splitlines() if "API error" in ln)
+    api_line = next(ln for ln in text.splitlines() if "API 错误" in ln)
     assert "UTC" not in api_line
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert text.splitlines()[-1] == "最后更新: 17:18:36 UTC-07"
 
 
 def test_render_tool_row_without_started_at_is_safe():
@@ -140,7 +140,7 @@ def test_render_tool_row_without_started_at_is_safe():
     assert "(1s)" in text
     row_line = next(ln for ln in text.splitlines() if ln.startswith(("•", "✓")))
     assert "UTC" not in row_line
-    assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"
+    assert text.splitlines()[-1] == "最后更新: 17:18:36 UTC-07"
 
 
 def test_footer_shows_actual_current_normal_row_setting():
@@ -148,7 +148,7 @@ def test_footer_shows_actual_current_normal_row_setting():
         {"tool": "bash", "tool_action": "run", "reasoning": "x",
          "elapsed_s": 1, "done": False, "started_at": "04:08:08 UTC-07"},
     ], normal_rows=7, now=_NOW)
-    assert "/taskcard N sets normal rows (1-10, current: 7)." in text
+    assert "/taskcard N 设置显示组数 (1-10，当前: 7)。" in text
 
 
 def test_footer_current_row_count_stays_within_1_10_semantics():
@@ -157,4 +157,4 @@ def test_footer_current_row_count_stays_within_1_10_semantics():
             {"tool": "bash", "tool_action": "run", "reasoning": "x",
              "elapsed_s": 1, "done": False, "started_at": "04:08:08 UTC-07"},
         ], normal_rows=n, now=_NOW)
-        assert f"current: {n}" in text
+        assert f"当前: {n}" in text


### PR DESCRIPTION
## What changed

- Localized Telegram Task Card header, footer, refresh hint, API status, retry state, and update timestamp into Simplified Chinese.
- Kept command names, identifiers, and Task Card behavior unchanged.

## Why

The Telegram Task Card surface was hard-coded in English even for Chinese-first agents, making operational updates harder to scan.

## Impact

Telegram users see consistent Chinese Task Cards without any routing, state, or API contract change.

## Validation

- `126 passed` across the Task Card projection, rows, timestamp, blocker, and event-tail suites.
