### PR TITLE
Use native Telegram Rich Messages for structured rendering

### DIFF
--- a/src/lingtai/mcp_servers/ANATOMY.md
+++ b/src/lingtai/mcp_servers/ANATOMY.md
@@ -28,6 +28,7 @@ related_files:
   - tests/test_imap_toolfamily_ltpv2.py
   - src/lingtai/mcp_servers/telegram/account.py
   - src/lingtai/mcp_servers/telegram/manager.py
+  - src/lingtai/mcp_servers/telegram/render.py
   - src/lingtai/mcp_servers/telegram/server.py
   - src/lingtai/mcp_servers/telegram/_family.py
   - src/lingtai/mcp_servers/telegram/service.py
@@ -45,6 +46,7 @@ related_files:
   - tests/test_mcp_skill_manuals.py
   - tests/test_telegram_account_last_message_id.py
   - tests/test_telegram_rich_formatting.py
+  - tests/test_telegram_structured_rendering.py
   - tests/test_telegram_task_card_in_place.py
   - tests/test_telegram_task_card_last_message.py
   - tests/test_feishu_control_cards.py
@@ -141,6 +143,7 @@ Curated and built-in MCP server package implementations shipped inside the `ling
 | `daemon_common/` | Built-in daemon lifecycle MCP. `daemon_common/server.py` exposes `finish(action='finish', input={status, summary?, reason?, artifacts?}, reasoning)` in the LTP v2 envelope every daemon MCP tool uses, validates the call, and atomically writes the internal per-run `daemon_completion.json` file named by `LINGTAI_DAEMON_COMPLETION_FILE`; daemon runners validate that file before allowing success. |
 | `daemon_email/` | Built-in daemon `email` MCP — the exact `lingtai.tools.email` LTP v2 tool family (unmodified schema/description/dispatch) hosted on a lightweight duck-typed `DaemonEmailAgentShim` (`agent_shim.py`) instead of a live `BaseAgent`, so a daemon subprocess never contends for the parent's workdir lease. Bound to `LINGTAI_AGENT_DIR` (the *parent* agent's own working directory — the daemon's own nested run-dir has no `.agent.json`/heartbeat and cannot pass the mail handshake), so a daemon speaks with the parent's own already-live mailbox address; a daemon, its parent, and any sibling daemon of that same parent are therefore all reachable at that one address. Auto-mounted per task only when `tools` explicitly includes `"email"` (`daemon/__init__.py` `_daemon_email_mcp_registration`/`_with_daemon_email_mcp`), mirroring exactly how `daemon_common` is auto-mounted for `finish` — a `tools=[]` result-only daemon never gets this registration. |
 | `telegram/`, `imap/`, `feishu/`, `wechat/`, `whatsapp/`, `cloud_mail/` | Curated messaging MCPs. TelegramManager requires an injected `NotificationStorePort`; `telegram/server.py` constructs one POSIX adapter, and handled-mirror policy runs against the current payload in one compare-update so newer mirrors survive (`src/lingtai/mcp_servers/telegram/manager.py:415-425`, `src/lingtai/mcp_servers/telegram/manager.py:1239-1281`, `src/lingtai/mcp_servers/telegram/server.py:655-663`). The external LICC path/envelope and persistent-message lanes remain unchanged. `whatsapp/_family.py` mirrors `telegram/_family.py`'s native LTP-v2 tool family: one strict root envelope (`action`/`input`/`reasoning`/`summarize`) with an action-correlated `input` branch per action, dispatched through `handle_whatsapp()`; `manager.py`'s `SCHEMA`/`ACTIONS` now alias `_family.py`'s, and the manager stays the internal flat action/business boundary behind it. |
+| `telegram/render.py` | Converts the model-facing `structured_message` semantic object into Telegram Bot API `InputRichMessage.blocks` and a searchable plain-text preview. It preserves agent-authored wording and emoji while assigning native heading, list, bold-label, code, divider, and footer semantics; `TelegramManager` owns conflict validation and send/reply/edit routing. |
 | `telegram/task_card/` | Telegram-owned **adapter + programmable projection** unit (governed component with paired `ANATOMY.md`/`CONTRACT.md` + packaged docs). Its `resident.py` is a compatibility re-export of the shared core; `TelegramManager` supplies compound-ID binding, last-message high-water policy, Telegram error classification, transport, and persistence callbacks. The public `task_card` tool lives in `src/lingtai/tools/task_card/`; Telegram reads the intrinsic artifact and projects it read-only. |
 | `feishu/task_card.py` | Feishu-owned resident bindings plus lifecycle workers for the shared automatic event projection and the read-only intrinsic programmable artifact projection. `FeishuManager` supplies account+chat+optional-thread routing, conservative process-local high-water policy, Feishu card transport, and exact resident persistence. |
 | `feishu/control_cards.py` | Feishu-owned schema-2.0 renderer and bounded hashed-event claim store for local `/help`, `/status`, `/kanban`, `/system`, `/brief`, `/refresh`, `/sleep`, `/clear`, and `/taskcard` cards. Shared command semantics stay in `local_commands/core.py`; actor admission, routing, callback dispatch, and transport stay in the account/manager adapter. |

--- a/src/lingtai/mcp_servers/telegram/SKILL.md
+++ b/src/lingtai/mcp_servers/telegram/SKILL.md
@@ -4,12 +4,13 @@ description: |
   Progressive-disclosure usage manual for the Telegram MCP tool. Read this when
   you need detail beyond the one-line action descriptions: media.type='document'
   vs 'photo' for charts/reports/generated artifacts, placeholder/live-status
-  messages, reply vs send, read/check/search, rendering_mode/entities, chat_action, dynamic slash commands,
+  messages, reply vs send, read/check/search, rendering_mode/entities/native rich
+  messages, chat_action, dynamic slash commands,
   the programmable Task Card (task_card tool) — including task-specific watcher
   design for meaningful long-running work — and error surfacing. Pulled on demand
   via action='manual'; you do not need to call it before every send.
-version: 1.5.8
-last_changed_at: 2026-08-03T00:00:00Z
+version: 1.6.0
+last_changed_at: 2026-08-08T00:00:00Z
 related_files:
 - src/lingtai/mcp_servers/ANATOMY.md
 - src/lingtai/mcp_servers/task_card/event_projection.py
@@ -17,12 +18,15 @@ related_files:
 - src/lingtai/mcp_servers/local_commands/ANATOMY.md
 - src/lingtai/mcp_servers/local_commands/core.py
 - src/lingtai/mcp_servers/telegram/manager.py
+- src/lingtai/mcp_servers/telegram/account.py
+- src/lingtai/mcp_servers/telegram/render.py
 - src/lingtai/mcp_servers/telegram/server.py
 - src/lingtai/mcp_servers/telegram/_family.py
 - src/lingtai/mcp_servers/telegram/task_card/_family.py
 - src/lingtai/mcp_servers/telegram/task_card/ANATOMY.md
 - src/lingtai/mcp_servers/telegram/task_card/SKILL.md
 - src/lingtai/mcp_servers/telegram/reference/rate-limits/SKILL.md
+- tests/test_telegram_structured_rendering.py
 maintenance: |
   Tracks the MCP server's manager/config behavior; update when the server's setup or API surface changes.
 ---
@@ -130,13 +134,28 @@ setup readiness checklist are **not** here — they belong to `mcp-manual`
 
 - Every content-bearing `send`, `reply`, and `edit` must include
   `rendering_mode`; there is no default. Choose exactly one of `plain_text`,
-  `HTML`, `Markdown`, `MarkdownV2`, or `entities`.
+  `HTML`, `Markdown`, `MarkdownV2`, `entities`, or `rich`.
 - `plain_text` maps to an omitted Bot API `parse_mode`; the other three named
   formats map to Telegram `parse_mode`. The agent must still provide the label
   even when no formatting is wanted.
 - `entities` selects explicit `MessageEntity[]` formatting. Pass `entities` for
   message text or `caption_entities` for media captions; do not combine entity
   fields with a parse-mode rendering choice.
+- `rich` sends a native Telegram Rich Message. Pass `structured_message`
+  instead of `text` or `media`; its semantic fields are `title`, optional
+  `summary`, `facts` (`label`/`value`), `bullets`, ordered `steps`, `code`
+  (`text` plus optional `language`), `next` (`label`/`text`), and `footer`.
+  The renderer maps those fields to native heading, paragraph, list,
+  preformatted, divider, and footer blocks. Rich messages can also be used by
+  `reply` and to edit a text/rich message, but not to edit a media caption.
+- Rich-message expression is agent-directed, not a fixed decoration template.
+  Use emoji as semantic signposts wherever they genuinely improve scanning —
+  for example in a title, field label, or an occasional bullet. There is no
+  hard count or title-only rule. Let message density and meaning decide; avoid
+  repeating decorative emoji that add no information. Use facts for compact
+  label/value emphasis, bullets for parallel ideas, and steps only for ordered
+  actions. Ordinary conversational prose should remain ordinary text rather
+  than being forced into a card.
 - For `send` with only `chat_action` and no text/media, use `plain_text` because
   no message body is rendered. `rendering_mode` is still required by the strict
   public branch.

--- a/src/lingtai/mcp_servers/telegram/_family.py
+++ b/src/lingtai/mcp_servers/telegram/_family.py
@@ -25,7 +25,7 @@ _ACTIONS = (
     "contacts", "add_contact", "remove_contact", "accounts", "manual",
 )
 
-_RENDERING_MODES = ("plain_text", "HTML", "MarkdownV2", "Markdown", "entities")
+_RENDERING_MODES = ("plain_text", "HTML", "MarkdownV2", "Markdown", "entities", "rich")
 
 
 def _nullable(schema: dict[str, Any]) -> dict[str, Any]:
@@ -71,6 +71,29 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
         },
         required=["type", "path"],
     )
+    fact = _object(
+        {"label": {"type": "string"}, "value": {"type": "string"}},
+        required=["label", "value"],
+    )
+    structured_message = _object(
+        {
+            "title": {"type": "string"},
+            "summary": {"type": "string"},
+            "facts": {"type": "array", "items": fact},
+            "bullets": {"type": "array", "items": {"type": "string"}},
+            "steps": {"type": "array", "items": {"type": "string"}},
+            "code": _object(
+                {"text": {"type": "string"}, "language": {"type": "string"}},
+                required=["text"],
+            ),
+            "next": _object(
+                {"label": {"type": "string"}, "text": {"type": "string"}},
+                required=["label", "text"],
+            ),
+            "footer": {"type": "string"},
+        },
+        required=["title"],
+    )
     send = _object(
         {
             "account": _nullable({"type": "string"}),
@@ -88,11 +111,12 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
             },
             "entities": _nullable({"type": "array"}),
             "caption_entities": _nullable({"type": "array"}),
-            "structured_blocks": _nullable({
-                "type": "array",
+            "structured_message": _nullable({
+                **structured_message,
                 "description": (
-                    "System-generated structured content rendered deterministically "
-                    "into escaped Telegram HTML."
+                    "System-generated semantic content sent as native Telegram Rich "
+                    "Message blocks. Agent-authored emoji are preserved wherever they "
+                    "improve scanning; use rendering_mode='rich' and omit text/media."
                 ),
             }),
             "link_preview_options": _nullable({"type": "object"}),
@@ -103,6 +127,7 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
             {"required": ["text"]},
             {"required": ["media"]},
             {"required": ["chat_action"]},
+            {"required": ["structured_message"]},
         ],
     )
     send["properties"]["media"]["description"] = (
@@ -115,9 +140,9 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
     )
     send["properties"]["rendering_mode"]["description"] = (
         "Required rendering choice for every send. Choose plain_text for unformatted "
-        "text or chat actions, HTML/Markdown/MarkdownV2 for Telegram parse_mode, or "
-        "entities when supplying MessageEntity data. There is no default; do not "
-        "combine entities with a parse-mode choice."
+        "text or chat actions, HTML/Markdown/MarkdownV2 for Telegram parse_mode, "
+        "entities when supplying MessageEntity data, or rich for a native structured "
+        "message. There is no default; do not combine the modes."
     )
     send["properties"]["entities"]["anyOf"][0]["description"] = (
         "Telegram MessageEntity[] for rendering_mode='entities' on message text."
@@ -150,16 +175,14 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
                     "type": "string", "enum": list(_RENDERING_MODES),
                     "description": (
                         "Required rendering choice: plain_text, HTML, Markdown, "
-                        "MarkdownV2, or entities. There is no default."
+                        "MarkdownV2, entities, or rich. There is no default."
                     ),
                 },
                 "entities": _nullable({"type": "array"}),
-                "structured_blocks": _nullable({
-                    "type": "array",
-                    "description": "System-generated blocks rendered as escaped Telegram HTML.",
-                }),
+                "structured_message": _nullable(structured_message),
             },
-            required=["message_id", "text", "rendering_mode"],
+            required=["message_id", "rendering_mode"],
+            any_of=[{"required": ["text"]}, {"required": ["structured_message"]}],
         ),
         "search": _object(
             {
@@ -179,16 +202,14 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
                     "type": "string", "enum": list(_RENDERING_MODES),
                     "description": (
                         "Required rendering choice: plain_text, HTML, Markdown, "
-                        "MarkdownV2, or entities. There is no default."
+                        "MarkdownV2, entities, or rich. There is no default."
                     ),
                 },
                 "entities": _nullable({"type": "array"}),
-                "structured_blocks": _nullable({
-                    "type": "array",
-                    "description": "System-generated blocks rendered as escaped Telegram HTML.",
-                }),
+                "structured_message": _nullable(structured_message),
             },
-            required=["message_id", "text", "rendering_mode"],
+            required=["message_id", "rendering_mode"],
+            any_of=[{"required": ["text"]}, {"required": ["structured_message"]}],
         ),
         "contacts": _object({"account": _nullable({"type": "string"})}),
         "add_contact": _object(
@@ -237,7 +258,7 @@ def telegram_schema() -> dict[str, Any]:
     schema["properties"]["action"]["description"] = (
         "Telegram action. Each action owns a strict input branch. Content-bearing "
         "send/reply/edit calls must provide rendering_mode explicitly: plain_text, "
-        "HTML, Markdown, MarkdownV2, or entities; there is no default. For charts, "
+        "HTML, Markdown, MarkdownV2, entities, or rich; there is no default. For charts, "
         "reports, generated artifacts, and other files the user should open intact, "
         "prefer media.type='document'; use media.type='photo' only for an inline "
         "preview because photo previews may crop or compress text-heavy graphics. "

--- a/src/lingtai/mcp_servers/telegram/_family.py
+++ b/src/lingtai/mcp_servers/telegram/_family.py
@@ -88,6 +88,13 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
             },
             "entities": _nullable({"type": "array"}),
             "caption_entities": _nullable({"type": "array"}),
+            "structured_blocks": _nullable({
+                "type": "array",
+                "description": (
+                    "System-generated structured content rendered deterministically "
+                    "into escaped Telegram HTML."
+                ),
+            }),
             "link_preview_options": _nullable({"type": "object"}),
             "disable_web_page_preview": _nullable({"type": "boolean"}),
         },
@@ -147,6 +154,10 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
                     ),
                 },
                 "entities": _nullable({"type": "array"}),
+                "structured_blocks": _nullable({
+                    "type": "array",
+                    "description": "System-generated blocks rendered as escaped Telegram HTML.",
+                }),
             },
             required=["message_id", "text", "rendering_mode"],
         ),
@@ -172,6 +183,10 @@ def _telegram_input_schemas() -> dict[str, dict[str, Any]]:
                     ),
                 },
                 "entities": _nullable({"type": "array"}),
+                "structured_blocks": _nullable({
+                    "type": "array",
+                    "description": "System-generated blocks rendered as escaped Telegram HTML.",
+                }),
             },
             required=["message_id", "text", "rendering_mode"],
         ),

--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -1029,6 +1029,26 @@ class TelegramAccount:
         self._note_chat_message_id(chat_id, result.get("message_id"))
         return result
 
+    def send_rich_message(
+        self,
+        chat_id: int,
+        rich_message: dict[str, Any],
+        reply_markup: dict | None = None,
+        reply_to_message_id: int | None = None,
+    ) -> dict:
+        """Send a native Telegram ``InputRichMessage``."""
+        payload: dict[str, Any] = {
+            "chat_id": chat_id,
+            "rich_message": rich_message,
+        }
+        if reply_markup:
+            payload["reply_markup"] = reply_markup
+        if reply_to_message_id:
+            payload["reply_parameters"] = {"message_id": reply_to_message_id}
+        result = self._request("sendRichMessage", json=payload)
+        self._note_chat_message_id(chat_id, result.get("message_id"))
+        return result
+
     def send_photo(
         self,
         chat_id: int,
@@ -1085,7 +1105,7 @@ class TelegramAccount:
         self,
         chat_id: int,
         message_id: int,
-        text: str,
+        text: str | None,
         reply_markup: dict | None = None,
         is_caption: bool = False,
         parse_mode: str | None = None,
@@ -1093,6 +1113,7 @@ class TelegramAccount:
         caption_entities: list[dict[str, Any]] | None = None,
         link_preview_options: dict[str, Any] | None = None,
         disable_web_page_preview: bool | None = None,
+        rich_message: dict[str, Any] | None = None,
     ) -> dict:
         """Edit a sent message's text or caption."""
         if is_caption:
@@ -1108,8 +1129,12 @@ class TelegramAccount:
             return self._request("editMessageCaption", json=payload)
         else:
             payload = {
-                "chat_id": chat_id, "message_id": message_id, "text": text,
+                "chat_id": chat_id, "message_id": message_id,
             }
+            if text is not None:
+                payload["text"] = text
+            if rich_message is not None:
+                payload["rich_message"] = rich_message
             if reply_markup:
                 payload["reply_markup"] = reply_markup
             if parse_mode:

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -3658,7 +3658,18 @@ class TelegramManager:
             opts["parse_mode"] = mode
         return opts, None
 
+    @staticmethod
+    def _apply_structured_blocks(args: dict) -> None:
+        blocks = args.get("structured_blocks")
+        if not isinstance(blocks, list) or not blocks:
+            return
+        from .render import render_structured_blocks
+
+        args["text"] = render_structured_blocks(blocks)
+        args["rendering_mode"] = "HTML"
+
     def _send(self, args: dict) -> dict:
+        self._apply_structured_blocks(args)
         account = self._resolve_account(args)
         chat_id = args.get("chat_id")
         text = args.get("text", "")
@@ -3935,6 +3946,7 @@ class TelegramManager:
         return {"status": "ok", "taskcard": taskcard, "messages": cleaned}
 
     def _reply(self, args: dict) -> dict:
+        self._apply_structured_blocks(args)
         compound_id = args.get("message_id", "")
         text = args.get("text", "")
         if not compound_id:
@@ -4020,6 +4032,7 @@ class TelegramManager:
         return {"status": "deleted", "message_id": compound_id}
 
     def _edit(self, args: dict) -> dict:
+        self._apply_structured_blocks(args)
         compound_id = args.get("message_id", "")
         text = args.get("text", "")
         if not compound_id:

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -388,16 +388,16 @@ SCHEMA = {
                 "accounts", "manual",
             ],
             "description": (
-                "send: send message to a chat (chat_id, text, rendering_mode; optional media, reply_markup, placeholder, chat_action, entities). "
+                "send: send message to a chat (chat_id, rendering_mode, and text or structured_message; optional media, reply_markup, placeholder, chat_action, entities). "
                 "For charts, reports, generated artifacts, and other files the user should open intact, prefer media.type='document'; use media.type='photo' only when an inline Telegram photo preview is desired, because photo previews may crop, compress, or display poorly for text-heavy graphics. "
                 "If chat_action is set and no text/media is provided, sends a typing "
                 "indicator (auto-expires after 5s) instead of a message. "
                 "check: list recent conversations with unread counts (optional account). "
                 "read: read messages from a chat (chat_id; optional limit). "
-                "reply: reply to a specific message (message_id from read results, text, rendering_mode; optional entities). "
+                "reply: reply to a specific message (message_id from read results, rendering_mode, and text or structured_message; optional entities). "
                 "search: search messages (query; optional account, chat_id). "
                 "delete: delete a bot message (message_id). "
-                "edit: edit a bot message (message_id, text, rendering_mode; optional reply_markup, entities). "
+                "edit: edit a bot message (message_id, rendering_mode, and text or structured_message; optional reply_markup, entities). "
                 "contacts: list saved contacts. "
                 "add_contact: save a chat alias (chat_id, alias); this does not grant inbound permission. "
                 "To receive messages from that user, their Telegram user ID must also be in allowed_users. "
@@ -3571,7 +3571,7 @@ class TelegramManager:
     # ------------------------------------------------------------------
 
     _PARSE_MODES = {"HTML", "MarkdownV2", "Markdown"}
-    _RENDERING_MODES = _PARSE_MODES | {"plain_text", "entities"}
+    _RENDERING_MODES = _PARSE_MODES | {"plain_text", "entities", "rich"}
 
     @staticmethod
     def _normalize_chat_action(value: Any) -> Any:
@@ -3607,7 +3607,7 @@ class TelegramManager:
         if mode not in cls._RENDERING_MODES:
             return (
                 "rendering_mode must be one of: plain_text, HTML, MarkdownV2, "
-                "Markdown, entities"
+                "Markdown, entities, rich"
             )
         if mode == "entities" and not has_entities:
             return "rendering_mode='entities' requires entities or caption_entities"
@@ -3658,18 +3658,50 @@ class TelegramManager:
             opts["parse_mode"] = mode
         return opts, None
 
-    @staticmethod
-    def _apply_structured_blocks(args: dict) -> None:
-        blocks = args.get("structured_blocks")
-        if not isinstance(blocks, list) or not blocks:
-            return
-        from .render import render_structured_blocks
+    @classmethod
+    def _native_rich_message(
+        cls,
+        args: dict,
+        *,
+        text: str,
+        media: Any,
+    ) -> tuple[dict[str, Any] | None, str | None, str | None]:
+        """Validate and build native rich content at the model/API boundary."""
+        structured = args.get("structured_message")
+        mode = cls._rendering_mode(args)
+        if mode != "rich":
+            if structured is not None:
+                return None, None, "structured_message requires rendering_mode='rich'"
+            return None, None, None
+        if structured is None:
+            return None, None, "rendering_mode='rich' requires structured_message"
 
-        args["text"] = render_structured_blocks(blocks)
-        args["rendering_mode"] = "HTML"
+        conflicts = []
+        if text:
+            conflicts.append("text")
+        if media:
+            conflicts.append("media")
+        for field in (
+            "entities", "caption_entities", "link_preview_options",
+            "disable_web_page_preview",
+        ):
+            if args.get(field) is not None:
+                conflicts.append(field)
+        if conflicts:
+            return None, None, (
+                "rendering_mode='rich' cannot be combined with "
+                + ", ".join(conflicts)
+            )
+
+        from .render import render_structured_message
+
+        try:
+            rich_message, preview = render_structured_message(structured)
+            return rich_message, preview, None
+        except ValueError as exc:
+            return None, None, str(exc)
 
     def _send(self, args: dict) -> dict:
-        self._apply_structured_blocks(args)
         account = self._resolve_account(args)
         chat_id = args.get("chat_id")
         text = args.get("text", "")
@@ -3680,6 +3712,13 @@ class TelegramManager:
         # media so text-only sends do not try to upload/open an empty path.
         if media and isinstance(media, dict) and not (media.get("path") or "").strip():
             media = None
+        rich_message, rich_preview, rich_error = self._native_rich_message(
+            args, text=text, media=media,
+        )
+        if rich_error:
+            return {"error": rich_error}
+        if rich_preview is not None:
+            text = rich_preview
         reply_markup = args.get("reply_markup")
         chat_action = self._normalize_chat_action(args.get("chat_action"))
         placeholder = bool(args.get("placeholder", False))
@@ -3777,6 +3816,11 @@ class TelegramManager:
                 )
             else:
                 return {"error": f"Unknown media type: {media_type}"}
+        elif rich_message is not None:
+            result = acct.send_rich_message(
+                chat_id, rich_message, reply_markup=reply_markup,
+                reply_to_message_id=reply_to,
+            )
         else:
             result = acct.send_message(
                 chat_id, text, reply_markup=reply_markup,
@@ -3807,6 +3851,8 @@ class TelegramManager:
             "caption_entities": args.get("caption_entities"),
             "link_preview_options": args.get("link_preview_options"),
             "disable_web_page_preview": args.get("disable_web_page_preview"),
+            "structured_message": args.get("structured_message"),
+            "rich_message": rich_message,
             "sent_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             "status": "placeholder" if placeholder else "sent",
         }
@@ -3946,13 +3992,13 @@ class TelegramManager:
         return {"status": "ok", "taskcard": taskcard, "messages": cleaned}
 
     def _reply(self, args: dict) -> dict:
-        self._apply_structured_blocks(args)
         compound_id = args.get("message_id", "")
         text = args.get("text", "")
+        structured_message = args.get("structured_message")
         if not compound_id:
             return {"error": "message_id is required"}
-        if not text:
-            return {"error": "text is required"}
+        if not text and structured_message is None:
+            return {"error": "text or structured_message is required"}
 
         account, chat_id, tg_msg_id = self._parse_compound_id(compound_id)
         result = self._send({
@@ -3966,6 +4012,7 @@ class TelegramManager:
             "caption_entities": args.get("caption_entities"),
             "link_preview_options": args.get("link_preview_options"),
             "disable_web_page_preview": args.get("disable_web_page_preview"),
+            "structured_message": structured_message,
             # We need to pass reply_to_message_id through
             "_reply_to_message_id": tg_msg_id,
         })
@@ -4032,13 +4079,13 @@ class TelegramManager:
         return {"status": "deleted", "message_id": compound_id}
 
     def _edit(self, args: dict) -> dict:
-        self._apply_structured_blocks(args)
         compound_id = args.get("message_id", "")
         text = args.get("text", "")
+        structured_message = args.get("structured_message")
         if not compound_id:
             return {"error": "message_id is required"}
-        if not text:
-            return {"error": "text is required"}
+        if not text and structured_message is None:
+            return {"error": "text or structured_message is required"}
         account, chat_id, tg_msg_id = self._parse_compound_id(compound_id)
         reply_markup = args.get("reply_markup")
         acct = self._service.get_account(account)
@@ -4058,6 +4105,15 @@ class TelegramManager:
                     except (json.JSONDecodeError, OSError):
                         continue
 
+        if is_caption and self._rendering_mode(args) == "rich":
+            return {"error": "rendering_mode='rich' cannot edit a media caption"}
+
+        rich_message, _rich_preview, rich_error = self._native_rich_message(
+            args, text=text, media=None,
+        )
+        if rich_error:
+            return {"error": rich_error}
+
         if is_caption:
             edit_options, rendering_error = self._caption_options(args)
         else:
@@ -4065,11 +4121,17 @@ class TelegramManager:
         if rendering_error:
             return {"error": rendering_error}
 
-        acct.edit_message(
-            chat_id=chat_id, message_id=tg_msg_id, text=text,
-            reply_markup=reply_markup, is_caption=is_caption,
+        edit_args: dict[str, Any] = {
+            "chat_id": chat_id,
+            "message_id": tg_msg_id,
+            "text": None if rich_message is not None else text,
+            "reply_markup": reply_markup,
+            "is_caption": is_caption,
             **edit_options,
-        )
+        }
+        if rich_message is not None:
+            edit_args["rich_message"] = rich_message
+        acct.edit_message(**edit_args)
         return {"status": "edited", "message_id": compound_id}
 
     def _contacts(self, args: dict) -> dict:

--- a/src/lingtai/mcp_servers/telegram/render.py
+++ b/src/lingtai/mcp_servers/telegram/render.py
@@ -1,40 +1,175 @@
-"""Deterministic Telegram HTML rendering for system-generated content."""
+"""Native Telegram Rich Message rendering for system-generated content."""
 from __future__ import annotations
 
 from typing import Any
 
-_ESCAPE_TABLE = str.maketrans({"&": "&amp;", "<": "&lt;", ">": "&gt;"})
-_DIVIDER = "──────────"
-_TAGS = {"heading": "b", "bold": "b", "italic": "i", "code": "code"}
+_FIELDS = {"title", "summary", "facts", "bullets", "steps", "code", "next", "footer"}
 
 
-def html_escape(value: object) -> str:
-    return value.translate(_ESCAPE_TABLE) if isinstance(value, str) else ""
+def _text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value.strip()
 
 
-def _render_block(block: Any) -> str:
-    if not isinstance(block, dict):
-        return ""
-    for kind, value in block.items():
-        escaped = html_escape(value)
-        if kind in _TAGS:
-            tag = _TAGS[kind]
-            return f"<{tag}>{escaped}</{tag}>" if escaped else ""
-        if kind == "code_block":
-            return f"<pre>{escaped}</pre>" if escaped else ""
-        if kind == "bullet":
-            return f"• {escaped}" if escaped else ""
-        if kind == "divider":
-            return _DIVIDER
-        if kind == "paragraph":
-            return escaped
-    return ""
+def _optional_text(message: dict[str, Any], field: str) -> str | None:
+    if field not in message:
+        return None
+    return _text(message[field], field)
 
 
-def render_structured_blocks(blocks: list[Any]) -> str:
-    """Render supported blocks, escaping every caller-provided string."""
-    if not isinstance(blocks, list):
-        return ""
-    return "\n".join(
-        rendered for block in blocks if (rendered := _render_block(block))
-    )
+def _string_list(message: dict[str, Any], field: str) -> list[str]:
+    value = message.get(field, [])
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a list of non-empty strings")
+    return [_text(item, field) for item in value]
+
+
+def _facts(message: dict[str, Any]) -> list[tuple[str, str]]:
+    value = message.get("facts", [])
+    if not isinstance(value, list):
+        raise ValueError("facts must be a list of label/value objects")
+    result: list[tuple[str, str]] = []
+    for item in value:
+        if not isinstance(item, dict) or set(item) != {"label", "value"}:
+            raise ValueError("facts must contain only label/value objects")
+        result.append((
+            _text(item["label"], "facts.label"),
+            _text(item["value"], "facts.value"),
+        ))
+    return result
+
+
+def _next(message: dict[str, Any]) -> tuple[str, str] | None:
+    value = message.get("next")
+    if value is None:
+        return None
+    if not isinstance(value, dict) or set(value) != {"label", "text"}:
+        raise ValueError("next must contain exactly label and text")
+    return _text(value["label"], "next.label"), _text(value["text"], "next.text")
+
+
+def _code(message: dict[str, Any]) -> tuple[str, str | None] | None:
+    value = message.get("code")
+    if value is None:
+        return None
+    if (
+        not isinstance(value, dict)
+        or not set(value).issubset({"text", "language"})
+        or "text" not in value
+    ):
+        raise ValueError("code must contain text and optional language")
+    language = _text(value["language"], "code.language") if "language" in value else None
+    return _text(value["text"], "code.text"), language
+
+
+def _validated(message: Any) -> dict[str, Any]:
+    if not isinstance(message, dict):
+        raise ValueError("structured_message must be an object")
+    unknown = set(message) - _FIELDS
+    if unknown:
+        raise ValueError(
+            f"structured_message has unknown fields: {', '.join(sorted(unknown))}"
+        )
+    return {
+        "title": _text(message.get("title"), "title"),
+        "summary": _optional_text(message, "summary"),
+        "facts": _facts(message),
+        "bullets": _string_list(message, "bullets"),
+        "steps": _string_list(message, "steps"),
+        "code": _code(message),
+        "next": _next(message),
+        "footer": _optional_text(message, "footer"),
+    }
+
+
+def _paragraph(text: Any) -> dict[str, Any]:
+    return {"type": "paragraph", "text": text}
+
+
+def _list_item(text: Any, *, position: int | None = None) -> dict[str, Any]:
+    item: dict[str, Any] = {"blocks": [_paragraph(text)]}
+    if position is not None:
+        item.update({"type": "1", "value": position})
+    return item
+
+
+def _label_value(label: str, value: str) -> list[Any]:
+    return [{"type": "bold", "text": f"{label}："}, value]
+
+
+def _build(data: dict[str, Any]) -> dict[str, Any]:
+    blocks: list[dict[str, Any]] = [
+        {"type": "heading", "text": data["title"], "size": 2},
+    ]
+    if data["summary"]:
+        blocks.append(_paragraph(data["summary"]))
+
+    if any(data[field] for field in ("facts", "bullets", "steps", "code", "next")):
+        blocks.append({"type": "divider"})
+    if data["facts"]:
+        blocks.append({
+            "type": "list",
+            "items": [
+                _list_item(_label_value(label, value))
+                for label, value in data["facts"]
+            ],
+        })
+    if data["bullets"]:
+        blocks.append({
+            "type": "list",
+            "items": [_list_item(item) for item in data["bullets"]],
+        })
+    if data["steps"]:
+        blocks.append({
+            "type": "list",
+            "items": [
+                _list_item(item, position=index)
+                for index, item in enumerate(data["steps"], 1)
+            ],
+        })
+    if data["code"]:
+        code, language = data["code"]
+        block = {"type": "pre", "text": code}
+        if language:
+            block["language"] = language
+        blocks.append(block)
+    if data["next"]:
+        blocks.append(_paragraph(_label_value(*data["next"])))
+    if data["footer"]:
+        blocks.append({"type": "footer", "text": data["footer"]})
+    return {"blocks": blocks}
+
+
+def _preview(data: dict[str, Any]) -> str:
+    lines = [data["title"]]
+    if data["summary"]:
+        lines.append(data["summary"])
+    lines.extend(f"{label}：{value}" for label, value in data["facts"])
+    lines.extend(f"• {item}" for item in data["bullets"])
+    lines.extend(f"{index}. {item}" for index, item in enumerate(data["steps"], 1))
+    if data["code"]:
+        lines.append(data["code"][0])
+    if data["next"]:
+        lines.append(f"{data['next'][0]}：{data['next'][1]}")
+    if data["footer"]:
+        lines.append(data["footer"])
+    return "\n".join(lines)
+
+
+def render_structured_message(
+    message: dict[str, Any],
+) -> tuple[dict[str, Any], str]:
+    """Validate once, then return native blocks and their searchable preview."""
+    data = _validated(message)
+    return _build(data), _preview(data)
+
+
+def build_rich_message(message: dict[str, Any]) -> dict[str, Any]:
+    """Build one ``InputRichMessage`` while preserving agent-authored wording."""
+    return _build(_validated(message))
+
+
+def plain_text_preview(message: dict[str, Any]) -> str:
+    """Return searchable text for duplicate detection and sent-message history."""
+    return _preview(_validated(message))

--- a/src/lingtai/mcp_servers/telegram/render.py
+++ b/src/lingtai/mcp_servers/telegram/render.py
@@ -1,0 +1,40 @@
+"""Deterministic Telegram HTML rendering for system-generated content."""
+from __future__ import annotations
+
+from typing import Any
+
+_ESCAPE_TABLE = str.maketrans({"&": "&amp;", "<": "&lt;", ">": "&gt;"})
+_DIVIDER = "──────────"
+_TAGS = {"heading": "b", "bold": "b", "italic": "i", "code": "code"}
+
+
+def html_escape(value: object) -> str:
+    return value.translate(_ESCAPE_TABLE) if isinstance(value, str) else ""
+
+
+def _render_block(block: Any) -> str:
+    if not isinstance(block, dict):
+        return ""
+    for kind, value in block.items():
+        escaped = html_escape(value)
+        if kind in _TAGS:
+            tag = _TAGS[kind]
+            return f"<{tag}>{escaped}</{tag}>" if escaped else ""
+        if kind == "code_block":
+            return f"<pre>{escaped}</pre>" if escaped else ""
+        if kind == "bullet":
+            return f"• {escaped}" if escaped else ""
+        if kind == "divider":
+            return _DIVIDER
+        if kind == "paragraph":
+            return escaped
+    return ""
+
+
+def render_structured_blocks(blocks: list[Any]) -> str:
+    """Render supported blocks, escaping every caller-provided string."""
+    if not isinstance(blocks, list):
+        return ""
+    return "\n".join(
+        rendered for block in blocks if (rendered := _render_block(block))
+    )

--- a/tests/test_telegram_rich_formatting.py
+++ b/tests/test_telegram_rich_formatting.py
@@ -123,7 +123,7 @@ def test_schema_exposes_explicit_rendering_fields():
     props = _send_schema()["properties"]
     for field in ("rendering_mode", "entities", "caption_entities", "link_preview_options", "disable_web_page_preview"):
         assert field in props
-    assert _schema_enum(props["rendering_mode"]) == ["plain_text", "HTML", "MarkdownV2", "Markdown", "entities"]
+    assert _schema_enum(props["rendering_mode"]) == ["plain_text", "HTML", "MarkdownV2", "Markdown", "entities", "rich"]
     assert "no default" in _schema_description(props["rendering_mode"])
     assert "parse_mode" not in props
 
@@ -401,7 +401,7 @@ def test_edit_text_passes_rendering_mode(tmp_path):
 def test_invalid_rendering_mode_is_rejected(tmp_path):
     manager, account = _manager(tmp_path)
     result = manager._send({"account": "mybot", "chat_id": 123, "text": "hello", "rendering_mode": "BBCode"})
-    assert result == {"error": "rendering_mode must be one of: plain_text, HTML, MarkdownV2, Markdown, entities"}
+    assert result == {"error": "rendering_mode must be one of: plain_text, HTML, MarkdownV2, Markdown, entities, rich"}
     assert account.calls == []
 
 @pytest.mark.parametrize("rendering_mode", ["plain_text", "HTML", "Markdown", "MarkdownV2"])

--- a/tests/test_telegram_structured_rendering.py
+++ b/tests/test_telegram_structured_rendering.py
@@ -1,35 +1,122 @@
+"""Contract tests for native Telegram Rich Message rendering."""
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
+import pytest
+
+from lingtai.mcp_servers.telegram.account import TelegramAccount
 from lingtai.mcp_servers.telegram.manager import TelegramManager
-from lingtai.mcp_servers.telegram.render import render_structured_blocks
+from lingtai.mcp_servers.telegram.render import (
+    build_rich_message,
+    plain_text_preview,
+)
 from tests._notification_store_helpers import FakeNotificationStore
+
+
+STRUCTURED_MESSAGE = {
+    "status": "success",
+    "title": "修复完成",
+    "summary": "三个 Telegram bot 已恢复。",
+    "facts": [
+        {"label": "版本", "value": "1.6.0"},
+        {"label": "范围", "value": "所有 bot"},
+    ],
+    "bullets": ["已读回执即时发送", "任务卡保持常驻"],
+    "steps": ["重启 host", "发送验收消息"],
+    "code": {"text": "pytest -q", "language": "bash"},
+    "next": {"label": "下一步", "text": "执行 GUI 验收"},
+    "footer": "普通自由文本不受影响",
+}
+
+
+EXPECTED_RICH_MESSAGE = {
+    "blocks": [
+        {"type": "heading", "text": "✅ 修复完成", "size": 2},
+        {"type": "paragraph", "text": "三个 Telegram bot 已恢复。"},
+        {"type": "divider"},
+        {
+            "type": "list",
+            "items": [
+                {
+                    "blocks": [{
+                        "type": "paragraph",
+                        "text": [
+                            {"type": "bold", "text": "版本："},
+                            "1.6.0",
+                        ],
+                    }],
+                },
+                {
+                    "blocks": [{
+                        "type": "paragraph",
+                        "text": [
+                            {"type": "bold", "text": "范围："},
+                            "所有 bot",
+                        ],
+                    }],
+                },
+            ],
+        },
+        {
+            "type": "list",
+            "items": [
+                {"blocks": [{"type": "paragraph", "text": "已读回执即时发送"}]},
+                {"blocks": [{"type": "paragraph", "text": "任务卡保持常驻"}]},
+            ],
+        },
+        {
+            "type": "list",
+            "items": [
+                {
+                    "blocks": [{"type": "paragraph", "text": "重启 host"}],
+                    "type": "1",
+                    "value": 1,
+                },
+                {
+                    "blocks": [{"type": "paragraph", "text": "发送验收消息"}],
+                    "type": "1",
+                    "value": 2,
+                },
+            ],
+        },
+        {"type": "pre", "text": "pytest -q", "language": "bash"},
+        {
+            "type": "paragraph",
+            "text": [
+                {"type": "bold", "text": "下一步："},
+                "执行 GUI 验收",
+            ],
+        },
+        {"type": "footer", "text": "普通自由文本不受影响"},
+    ],
+}
 
 
 class _Account:
     alias = "bot"
 
-    def __init__(self):
-        self.calls = []
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
 
-    def send_message(self, chat_id, text, **kwargs):
-        self.calls.append((chat_id, text, kwargs))
+    def send_rich_message(self, chat_id, rich_message, **kwargs):
+        self.calls.append(("send_rich_message", chat_id, rich_message, kwargs))
         return {"message_id": 1}
 
-    def get_task_card(self, chat_id):
-        return None
+    def edit_message(self, **kwargs):
+        self.calls.append(("edit_message", kwargs))
+        return {"message_id": kwargs["message_id"]}
 
-    def set_task_card(self, chat_id, message_id):
-        pass
-
-    def get_last_message_id(self, chat_id):
-        return None
+    def set_message_reaction(self, *_args, **_kwargs):
+        return True
 
 
 class _Service:
     def __init__(self, account):
         self.default_account = account
 
-    def get_account(self, alias):
+    def get_account(self, _alias):
         return self.default_account
 
     def list_accounts(self):
@@ -39,7 +126,7 @@ class _Service:
         return False
 
 
-def test_structured_blocks_are_escaped_and_sent_as_html(tmp_path: Path):
+def _manager(tmp_path: Path) -> tuple[TelegramManager, _Account]:
     account = _Account()
     manager = TelegramManager(
         _Service(account),
@@ -47,24 +134,167 @@ def test_structured_blocks_are_escaped_and_sent_as_html(tmp_path: Path):
         on_inbound=lambda _: None,
         notification_store=FakeNotificationStore(),
     )
-    result = manager.handle({
-        "action": "send",
+    return manager, account
+
+
+def test_builder_uses_native_blocks_and_semantic_emphasis():
+    assert build_rich_message(STRUCTURED_MESSAGE) == EXPECTED_RICH_MESSAGE
+    assert plain_text_preview(STRUCTURED_MESSAGE) == (
+        "✅ 修复完成\n"
+        "三个 Telegram bot 已恢复。\n"
+        "版本：1.6.0\n范围：所有 bot\n"
+        "• 已读回执即时发送\n• 任务卡保持常驻\n"
+        "1. 重启 host\n2. 发送验收消息\n"
+        "pytest -q\n下一步：执行 GUI 验收\n"
+        "普通自由文本不受影响"
+    )
+
+
+@pytest.mark.parametrize(
+    ("message", "error"),
+    [
+        ({"status": "celebration", "title": "x"}, "status"),
+        ({"status": "success", "title": ""}, "title"),
+        ({"status": "success", "title": "x", "bullets": "not-a-list"}, "bullets"),
+        ({"status": "success", "title": "x", "facts": [{"label": "x"}]}, "facts"),
+    ],
+)
+def test_builder_rejects_invalid_boundary_data(message, error):
+    with pytest.raises(ValueError, match=error):
+        build_rich_message(message)
+
+
+def test_manager_sends_native_rich_message_and_persists_searchable_preview(tmp_path: Path):
+    manager, account = _manager(tmp_path)
+
+    result = manager._send({
+        "account": "bot",
         "chat_id": 123,
-        "text": "ignored",
-        "rendering_mode": "plain_text",
-        "structured_blocks": [
-            {"heading": "中文标题"},
-            {"paragraph": "内容 & <b>raw</b>"},
-            {"code_block": "x < 2"},
-        ],
+        "rendering_mode": "rich",
+        "structured_message": STRUCTURED_MESSAGE,
     })
 
-    assert result["status"] == "sent"
-    _, text, options = account.calls[-1]
-    assert text == (
-        "<b>中文标题</b>\n"
-        "内容 &amp; &lt;b&gt;raw&lt;/b&gt;\n"
-        "<pre>x &lt; 2</pre>"
+    assert result == {"status": "sent", "message_id": "bot:123:1"}
+    assert account.calls == [
+        ("send_rich_message", 123, EXPECTED_RICH_MESSAGE, {
+            "reply_markup": None,
+            "reply_to_message_id": None,
+        }),
+    ]
+    sent_file = next((tmp_path / "telegram" / "bot" / "sent").glob("*/message.json"))
+    sent = json.loads(sent_file.read_text(encoding="utf-8"))
+    assert sent["text"].startswith("✅ 修复完成\n三个 Telegram bot 已恢复。")
+    assert sent["structured_message"] == STRUCTURED_MESSAGE
+    assert sent["rich_message"] == EXPECTED_RICH_MESSAGE
+
+
+def test_manager_replies_and_edits_with_native_rich_message(tmp_path: Path):
+    manager, account = _manager(tmp_path)
+
+    reply = manager._reply({
+        "message_id": "bot:123:456",
+        "rendering_mode": "rich",
+        "structured_message": STRUCTURED_MESSAGE,
+    })
+    edit = manager._edit({
+        "message_id": "bot:123:1",
+        "rendering_mode": "rich",
+        "structured_message": STRUCTURED_MESSAGE,
+    })
+
+    assert reply["status"] == "sent"
+    assert edit == {"status": "edited", "message_id": "bot:123:1"}
+    assert account.calls[0] == (
+        "send_rich_message",
+        123,
+        EXPECTED_RICH_MESSAGE,
+        {"reply_markup": None, "reply_to_message_id": 456},
     )
-    assert options["parse_mode"] == "HTML"
-    assert render_structured_blocks([{"bullet": "👀 & done"}]) == "• 👀 &amp; done"
+    assert account.calls[1] == (
+        "edit_message",
+        {
+            "chat_id": 123,
+            "message_id": 1,
+            "text": None,
+            "rich_message": EXPECTED_RICH_MESSAGE,
+            "reply_markup": None,
+            "is_caption": False,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        {"text": "plain", "structured_message": STRUCTURED_MESSAGE},
+        {"media": {"type": "photo", "path": "x"}, "structured_message": STRUCTURED_MESSAGE},
+        {"entities": [], "structured_message": STRUCTURED_MESSAGE},
+    ],
+)
+def test_rich_mode_rejects_conflicting_message_inputs(args, tmp_path: Path):
+    manager, account = _manager(tmp_path)
+    result = manager._send({
+        "account": "bot",
+        "chat_id": 123,
+        "rendering_mode": "rich",
+        **args,
+    })
+    assert "cannot be combined" in result["error"]
+    assert account.calls == []
+
+
+def test_non_rich_mode_rejects_structured_message(tmp_path: Path):
+    manager, account = _manager(tmp_path)
+    result = manager._send({
+        "account": "bot",
+        "chat_id": 123,
+        "rendering_mode": "plain_text",
+        "structured_message": STRUCTURED_MESSAGE,
+    })
+    assert result == {
+        "error": "structured_message requires rendering_mode='rich'",
+    }
+    assert account.calls == []
+
+
+class _CaptureAccount(TelegramAccount):
+    def __init__(self):
+        pass
+
+    def _request(self, method, **kwargs):
+        return {"method": method, "kwargs": kwargs, "message_id": 99}
+
+
+def test_account_uses_send_rich_message_and_reply_parameters():
+    account = _CaptureAccount()
+    result = account.send_rich_message(
+        123,
+        EXPECTED_RICH_MESSAGE,
+        reply_markup={"inline_keyboard": []},
+        reply_to_message_id=456,
+    )
+
+    assert result["method"] == "sendRichMessage"
+    assert result["kwargs"]["json"] == {
+        "chat_id": 123,
+        "rich_message": EXPECTED_RICH_MESSAGE,
+        "reply_markup": {"inline_keyboard": []},
+        "reply_parameters": {"message_id": 456},
+    }
+
+
+def test_account_edits_rich_message_without_text():
+    account = _CaptureAccount()
+    result = account.edit_message(
+        123,
+        456,
+        None,
+        rich_message=EXPECTED_RICH_MESSAGE,
+    )
+
+    assert result["method"] == "editMessageText"
+    assert result["kwargs"]["json"] == {
+        "chat_id": 123,
+        "message_id": 456,
+        "rich_message": EXPECTED_RICH_MESSAGE,
+    }

--- a/tests/test_telegram_structured_rendering.py
+++ b/tests/test_telegram_structured_rendering.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from lingtai.mcp_servers.telegram.account import TelegramAccount
-from lingtai.mcp_servers.telegram.manager import TelegramManager
+from lingtai.mcp_servers.telegram.manager import SCHEMA, TelegramManager
 from lingtai.mcp_servers.telegram.render import (
     build_rich_message,
     plain_text_preview,
@@ -134,6 +134,17 @@ def _manager(tmp_path: Path) -> tuple[TelegramManager, _Account]:
         notification_store=FakeNotificationStore(),
     )
     return manager, account
+
+
+def test_public_schema_exposes_rich_message_without_requiring_text():
+    send = next(
+        branch
+        for branch in SCHEMA["properties"]["input"]["anyOf"]
+        if branch.get("title") == "send input"
+    )
+    assert "structured_message" in send["properties"]
+    assert "rich" in send["properties"]["rendering_mode"]["enum"]
+    assert {"required": ["structured_message"]} in send["anyOf"]
 
 
 def test_builder_uses_native_blocks_and_semantic_emphasis():

--- a/tests/test_telegram_structured_rendering.py
+++ b/tests/test_telegram_structured_rendering.py
@@ -16,17 +16,16 @@ from tests._notification_store_helpers import FakeNotificationStore
 
 
 STRUCTURED_MESSAGE = {
-    "status": "success",
-    "title": "修复完成",
+    "title": "✅ 修复完成",
     "summary": "三个 Telegram bot 已恢复。",
     "facts": [
-        {"label": "版本", "value": "1.6.0"},
+        {"label": "🧩 版本", "value": "1.6.0"},
         {"label": "范围", "value": "所有 bot"},
     ],
-    "bullets": ["已读回执即时发送", "任务卡保持常驻"],
+    "bullets": ["👀 已读回执即时发送", "任务卡保持常驻"],
     "steps": ["重启 host", "发送验收消息"],
     "code": {"text": "pytest -q", "language": "bash"},
-    "next": {"label": "下一步", "text": "执行 GUI 验收"},
+    "next": {"label": "👉 下一步", "text": "执行 GUI 验收"},
     "footer": "普通自由文本不受影响",
 }
 
@@ -43,7 +42,7 @@ EXPECTED_RICH_MESSAGE = {
                     "blocks": [{
                         "type": "paragraph",
                         "text": [
-                            {"type": "bold", "text": "版本："},
+                            {"type": "bold", "text": "🧩 版本："},
                             "1.6.0",
                         ],
                     }],
@@ -62,7 +61,7 @@ EXPECTED_RICH_MESSAGE = {
         {
             "type": "list",
             "items": [
-                {"blocks": [{"type": "paragraph", "text": "已读回执即时发送"}]},
+                {"blocks": [{"type": "paragraph", "text": "👀 已读回执即时发送"}]},
                 {"blocks": [{"type": "paragraph", "text": "任务卡保持常驻"}]},
             ],
         },
@@ -85,7 +84,7 @@ EXPECTED_RICH_MESSAGE = {
         {
             "type": "paragraph",
             "text": [
-                {"type": "bold", "text": "下一步："},
+                {"type": "bold", "text": "👉 下一步："},
                 "执行 GUI 验收",
             ],
         },
@@ -142,10 +141,10 @@ def test_builder_uses_native_blocks_and_semantic_emphasis():
     assert plain_text_preview(STRUCTURED_MESSAGE) == (
         "✅ 修复完成\n"
         "三个 Telegram bot 已恢复。\n"
-        "版本：1.6.0\n范围：所有 bot\n"
-        "• 已读回执即时发送\n• 任务卡保持常驻\n"
+        "🧩 版本：1.6.0\n范围：所有 bot\n"
+        "• 👀 已读回执即时发送\n• 任务卡保持常驻\n"
         "1. 重启 host\n2. 发送验收消息\n"
-        "pytest -q\n下一步：执行 GUI 验收\n"
+        "pytest -q\n👉 下一步：执行 GUI 验收\n"
         "普通自由文本不受影响"
     )
 
@@ -153,10 +152,10 @@ def test_builder_uses_native_blocks_and_semantic_emphasis():
 @pytest.mark.parametrize(
     ("message", "error"),
     [
-        ({"status": "celebration", "title": "x"}, "status"),
-        ({"status": "success", "title": ""}, "title"),
-        ({"status": "success", "title": "x", "bullets": "not-a-list"}, "bullets"),
-        ({"status": "success", "title": "x", "facts": [{"label": "x"}]}, "facts"),
+        ({"title": ""}, "title"),
+        ({"title": "x", "bullets": "not-a-list"}, "bullets"),
+        ({"title": "x", "facts": [{"label": "x"}]}, "facts"),
+        ({"title": "x", "emoji_limit": 1}, "unknown fields"),
     ],
 )
 def test_builder_rejects_invalid_boundary_data(message, error):

--- a/tests/test_telegram_structured_rendering.py
+++ b/tests/test_telegram_structured_rendering.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+from lingtai.mcp_servers.telegram.render import render_structured_blocks
+from tests._notification_store_helpers import FakeNotificationStore
+
+
+class _Account:
+    alias = "bot"
+
+    def __init__(self):
+        self.calls = []
+
+    def send_message(self, chat_id, text, **kwargs):
+        self.calls.append((chat_id, text, kwargs))
+        return {"message_id": 1}
+
+    def get_task_card(self, chat_id):
+        return None
+
+    def set_task_card(self, chat_id, message_id):
+        pass
+
+    def get_last_message_id(self, chat_id):
+        return None
+
+
+class _Service:
+    def __init__(self, account):
+        self.default_account = account
+
+    def get_account(self, alias):
+        return self.default_account
+
+    def list_accounts(self):
+        return [self.default_account.alias]
+
+    def taskcard_enabled(self):
+        return False
+
+
+def test_structured_blocks_are_escaped_and_sent_as_html(tmp_path: Path):
+    account = _Account()
+    manager = TelegramManager(
+        _Service(account),
+        working_dir=tmp_path,
+        on_inbound=lambda _: None,
+        notification_store=FakeNotificationStore(),
+    )
+    result = manager.handle({
+        "action": "send",
+        "chat_id": 123,
+        "text": "ignored",
+        "rendering_mode": "plain_text",
+        "structured_blocks": [
+            {"heading": "中文标题"},
+            {"paragraph": "内容 & <b>raw</b>"},
+            {"code_block": "x < 2"},
+        ],
+    })
+
+    assert result["status"] == "sent"
+    _, text, options = account.calls[-1]
+    assert text == (
+        "<b>中文标题</b>\n"
+        "内容 &amp; &lt;b&gt;raw&lt;/b&gt;\n"
+        "<pre>x &lt; 2</pre>"
+    )
+    assert options["parse_mode"] == "HTML"
+    assert render_structured_blocks([{"bullet": "👀 & done"}]) == "• 👀 &amp; done"

--- a/tests/test_telegram_toolfamily_ltpv2.py
+++ b/tests/test_telegram_toolfamily_ltpv2.py
@@ -73,11 +73,12 @@ def test_telegram_send_requires_rendering_mode_before_manager_io():
 def test_telegram_send_schema_requires_rendering_mode_and_preserves_content_alternatives():
     send = _branches(TELEGRAM_SCHEMA)["send"]
     assert "rendering_mode" in send["required"]
-    assert send["properties"]["rendering_mode"]["enum"] == ["plain_text", "HTML", "MarkdownV2", "Markdown", "entities"]
-    assert send["anyOf"] == [{"required": ["text"]}, {"required": ["media"]}, {"required": ["chat_action"]}]
+    assert send["properties"]["rendering_mode"]["enum"] == ["plain_text", "HTML", "MarkdownV2", "Markdown", "entities", "rich"]
+    assert send["anyOf"] == [{"required": ["text"]}, {"required": ["media"]}, {"required": ["chat_action"]}, {"required": ["structured_message"]}]
     assert _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "text": "hello"}, send)
     assert _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "media": {"type": "photo", "path": "x"}}, send)
     assert _basic_validate({"chat_id": 3, "rendering_mode": "plain_text", "chat_action": "typing"}, send)
+    assert _basic_validate({"chat_id": 3, "rendering_mode": "rich", "structured_message": {"title": "✅ Done"}}, send)
     assert not _basic_validate({"chat_id": 3, "text": "hello"}, send)
     assert not _basic_validate({"chat_id": 3, "rendering_mode": "plain_text"}, send)
     assert not _basic_validate({"text": "missing chat", "rendering_mode": "plain_text"}, send)


### PR DESCRIPTION
## What changed

- Replaced escaped HTML assembly with Telegram Bot API native Rich Messages (`sendRichMessage` and `editMessageText.rich_message`).
- Added a model-facing `structured_message` contract for headings, summaries, facts, bullets, ordered steps, code, next actions, and footers.
- Preserved agent-authored wording and emoji without a hard count or title-only restriction; the manual now gives semantic, density-aware guidance instead.
- Persisted a searchable plain-text preview alongside the semantic input and native block payload.
- Added send, reply, edit, conflict-validation, schema, transport-payload, and history tests.

## Why

System and task updates need stronger visual hierarchy than provider-authored Markdown can reliably provide. Native Telegram blocks give consistent headings, lists, bold labels, dividers, code, and footers while keeping normal conversational messages unchanged.

## Compatibility

- Existing `plain_text`, `HTML`, `Markdown`, `MarkdownV2`, and `entities` modes are unchanged.
- Rich messages require `rendering_mode='rich'` plus `structured_message`; they deliberately do not combine with text, media captions, parse-mode entities, or link-preview options.
- No HTML fallback is used.

## Validation

- RED contract checkpoints committed before implementation.
- `59 passed, 1 deselected` across structured rendering, rich formatting, and Telegram ToolFamily tests.
- The one deselected test imports an unrelated OpenAI adapter dependency absent from the local focused test environment.
- `git diff --check` passed.
- Changed source/test files are reachable from the root ANATOMY graph.
