### PR TITLE
Add a preemptive steering lane for human guidance

### DIFF
--- a/src/lingtai/agent.py
+++ b/src/lingtai/agent.py
@@ -119,6 +119,36 @@ def build_agent_config(manifest: dict[str, Any], *, max_rpm: int) -> AgentConfig
         max_aed_attempts=manifest.get(
             "max_aed_attempts", defaults.max_aed_attempts
         ),
+        # Steering block: per-agent steering.enabled (default true for human
+        # channel) plus optional priority channel / budget overrides. The
+        # kernel default channel set applies when steering.priority_channels is
+        # omitted/empty (see lingtai.kernel.steering.DEFAULT_PRIORITY_CHANNELS).
+        steering_enabled=bool(
+            manifest.get("steering", {}).get(
+                "enabled", defaults.steering_enabled
+            )
+        ),
+        steering_priority_channels=tuple(
+            manifest.get("steering", {}).get(
+                "priority_channels", defaults.steering_priority_channels
+            )
+            or ()
+        ),
+        steering_max_turns=int(
+            manifest.get("steering", {}).get(
+                "max_turns", defaults.steering_max_turns
+            )
+        ),
+        steering_timeout_s=float(
+            manifest.get("steering", {}).get(
+                "timeout_s", defaults.steering_timeout_s
+            )
+        ),
+        steering_tail_messages=int(
+            manifest.get("steering", {}).get(
+                "tail_messages", defaults.steering_tail_messages
+            )
+        ),
         max_rpm=max_rpm,
     )
 

--- a/src/lingtai/kernel/base_agent/__init__.py
+++ b/src/lingtai/kernel/base_agent/__init__.py
@@ -1492,6 +1492,20 @@ class BaseAgent:
                     pass
 
         elif self._state == AgentState.ACTIVE:
+            # Preemptive parallel steering: when the active turn is a tool_call
+            # and a high-priority human-channel message is present, dispatch a
+            # bounded steering lane instead of only deferring. The lane replies
+            # on the channel and may write steering_interrupt.json; the main
+            # tool-call await loop honors it at its next safe boundary.
+            # ``getattr`` keeps minimal test stubs (which never set
+            # ``_active_turn_kind``) on the plain deferral path.
+            if getattr(self, "_active_turn_kind", None) == "tool_call":
+                from ..steering import dispatch_steering_lane
+
+                try:
+                    dispatch_steering_lane(self, notifications)
+                except Exception as exc:
+                    self._log("steering_lane_dispatch_error", error=str(exc)[:300])
             # Do not mutate unrelated tool results while a turn is active.
             # Leave the fingerprint uncommitted so the same on-disk
             # notification state is retried once the run loop transitions

--- a/src/lingtai/kernel/base_agent/turn.py
+++ b/src/lingtai/kernel/base_agent/turn.py
@@ -1789,6 +1789,33 @@ def _process_response(agent, response, *, ledger_source: str = "main") -> dict:
         # can carry the post-batch ACTIVE-turn progress meter.
         guard.record_calls(len(response.tool_calls))
 
+        # Steering interrupt boundary: the preemptive steering lane may have
+        # written steering_interrupt.json while the main loop was mid-turn.
+        # At this safe boundary (before dispatching the next tool batch),
+        # abort the current tool call, mark the turn interrupted, and surface
+        # the steering decision to the next turn.
+        from ..steering import check_steering_interrupt, abort_current_tool_call
+
+        steering_interrupt = check_steering_interrupt(agent)
+        if steering_interrupt is not None:
+            if agent._chat is not None and agent._chat.interface.has_pending_tool_calls():
+                agent._chat.interface.close_pending_tool_calls(
+                    reason="steering_interrupt"
+                )
+            abort_current_tool_call(agent, steering_interrupt)
+            agent._save_chat_history()
+            agent._log(
+                "turn_aborted_by_steering",
+                reason=steering_interrupt.get("reason"),
+                run_id=steering_interrupt.get("run_id"),
+            )
+            return {
+                "text": "\n".join(collected_text_parts),
+                "failed": False,
+                "errors": list(collected_errors),
+                "interrupted_by_steering": True,
+            }
+
         # Delegate to ToolExecutor.  The progress notice is batch-scoped: it is
         # visible on this batch's tool results, then cleared before the next LLM
         # response is processed.

--- a/src/lingtai/kernel/config.py
+++ b/src/lingtai/kernel/config.py
@@ -185,6 +185,15 @@ class AgentConfig:
     soul_voice: str = "inner"  # consultation prompt profile — "inner" (terse, "you are the soul, speak as inner voice"), "observer" (structured stepped-back hook framing), or "custom" (use soul_voice_prompt). One unified prompt per profile; the per-fire cue text differentiates insights (current diary) vs past (future-self diary).
     soul_voice_prompt: str = ""  # custom voice prompt — only used when soul_voice == "custom". Set/cleared by the agent via soul(action="voice", set="custom", prompt="..."). Length-capped at SOUL_VOICE_PROMPT_MAX in soul.py.
     snapshot_interval: float | None = None  # seconds between git snapshots; None = off
+    # Preemptive parallel steering (see lingtai.kernel.steering).
+    # steering_enabled defaults True for the human channel: while a turn is
+    # running a tool call, high-priority human-channel messages dispatch a
+    # bounded steering lane instead of only being deferred.
+    steering_enabled: bool = True
+    steering_priority_channels: tuple[str, ...] = ()  # () = kernel default set
+    steering_max_turns: int = 10
+    steering_timeout_s: float = 300.0
+    steering_tail_messages: int = 8
 
     def __post_init__(self):
         # Clamp max_aed_attempts to at least 1.  A value of 0 or negative

--- a/src/lingtai/kernel/steering.py
+++ b/src/lingtai/kernel/steering.py
@@ -1,0 +1,476 @@
+"""Preemptive parallel steering lane.
+
+When a high-priority (human channel) message arrives while the agent is
+mid-tool-call, the kernel dispatches a lightweight STEERING LANE instead of
+only deferring the notification: a bounded, isolated LLM sub-turn seeded with
+the recent conversation tail + the new message + a steering prompt. The lane
+replies on the original channel and may request an interrupt by writing
+``<lane run_dir>/steering_interrupt.json`` ``{reason, by}``; the main
+tool-call await loop checks for that file at a safe boundary and aborts the
+current tool call when present.
+
+Design doc: stations/control-total/work/steering_design.md (control-total).
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from ._fsutil import atomic_write_json
+
+# Steering lane budget (design: max_turns ~10, timeout ~300s).
+STEERING_MAX_TURNS_DEFAULT = 10
+STEERING_TIMEOUT_S_DEFAULT = 300.0
+STEERING_TAIL_MESSAGES_DEFAULT = 8
+
+# Channels treated as "human" by default: any MCP-hosted chat channel plus the
+# legacy email surface. Configurable per-agent via ``steering.priority_channels``.
+DEFAULT_PRIORITY_CHANNELS = (
+    "mcp.telegram",
+    "mcp.whatsapp",
+    "mcp.wechat",
+    "mcp.feishu",
+    "email",
+)
+
+# Interrupt contract file name inside a steering lane run dir.
+STEERING_INTERRUPT_FILENAME = "steering_interrupt.json"
+
+STEERING_PROMPT = (
+    "You are the agent's steering voice. A human sent a high-priority message "
+    "while the agent is busy running a tool call. Answer the human now, in the "
+    "first person as the agent, concisely and helpfully, using only the recent "
+    "conversation tail and the new message below. Do not start new long-running "
+    "work. If the new message requires stopping or redirecting the agent's "
+    "current work (e.g. an explicit stop/cancel, a security or safety concern, "
+    "or a hard direction change), end your reply with a line containing exactly "
+    "`[INTERRUPT] <reason>`; otherwise end with `[CONTINUE]`. The kernel will "
+    "deliver your text to the original channel."
+)
+
+
+# ---------------------------------------------------------------------------
+# Channel / payload helpers
+# ---------------------------------------------------------------------------
+
+
+def is_priority_human_channel(channel: str, config: Any = None) -> bool:
+    """Return True when *channel* is a steering-eligible human channel."""
+    if not channel:
+        return False
+    priority = tuple(getattr(config, "steering_priority_channels", None) or ())
+    if not priority:
+        priority = DEFAULT_PRIORITY_CHANNELS
+    return channel in priority
+
+
+def extract_message_text(payload: Any) -> str:
+    """Best-effort extraction of human-readable text from a notification payload."""
+    if isinstance(payload, str):
+        return payload
+    if not isinstance(payload, dict):
+        return ""
+    for key in ("text", "message", "body", "content", "caption"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    data = payload.get("data")
+    if isinstance(data, dict):
+        for key in ("text", "message", "body", "content", "caption"):
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        nested = data.get("message")
+        if isinstance(nested, dict):
+            for key in ("text", "message", "body", "content"):
+                value = nested.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+    # Fall back to a compact serialization of the payload.
+    try:
+        dump = json.dumps(payload, ensure_ascii=False, default=str)
+    except Exception:
+        dump = str(payload)
+    return dump[:2000]
+
+
+def _recent_conversation_tail(agent: Any, limit: int) -> str:
+    """Read the last ``limit`` messages of the agent's chat history as text.
+
+    Uses the persisted ``history/chat_history.jsonl`` (defensive; never
+    touches the live session wire). Returns "" when unavailable.
+    """
+    try:
+        history_path = Path(agent.working_dir) / "history" / "chat_history.jsonl"
+    except Exception:
+        return ""
+    if not history_path.is_file():
+        return ""
+    try:
+        lines = history_path.read_text(encoding="utf-8").splitlines()[-limit:]
+    except OSError:
+        return ""
+    out: list[str] = []
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
+            continue
+        role = entry.get("role") or entry.get("type") or ""
+        content = entry.get("content") or entry.get("text") or ""
+        if isinstance(content, list):
+            parts: list[str] = []
+            for block in content:
+                if isinstance(block, dict):
+                    parts.append(
+                        str(block.get("text") or block.get("content") or "")
+                    )
+            content = "\n".join(p for p in parts if p)
+        if isinstance(content, str) and content.strip():
+            out.append(f"{role}: {content[:500]}")
+    return "\n".join(out[-limit:])
+
+
+# ---------------------------------------------------------------------------
+# Steering lane dispatch
+# ---------------------------------------------------------------------------
+
+
+def _lane_run_dir(agent: Any) -> Path:
+    """Directory that owns steering lane run dirs (mirrors daemons/ layout)."""
+    root = getattr(agent, "working_dir", None) or getattr(agent, "_working_dir", ".")
+    return Path(root) / "daemons"
+
+
+def dispatch_steering_lane(
+    agent: Any,
+    notifications: dict[str, Any],
+    *,
+    runner: Callable | None = None,
+) -> dict | None:
+    """Dispatch one steering lane for the first priority human notification.
+
+    Returns a result dict (``{"status": "dispatched", "run_id": ...,
+    "channel": ...}``) when a lane was spawned, or ``None`` when there is
+    nothing to steer (no eligible channel / steering disabled / lane spawn
+    failed). ``runner`` is an injectable lane body for tests; the default
+    executes the bounded LLM sub-turn (see ``_default_lane_runner``).
+    """
+    if not getattr(agent, "_config", None):
+        return None
+    if not getattr(agent._config, "steering_enabled", True):
+        return None
+    priority = tuple(getattr(agent._config, "steering_priority_channels", None) or ())
+    if not priority:
+        priority = DEFAULT_PRIORITY_CHANNELS
+    # Only steering-eligible (priority human) channels are considered, in the
+    # configured priority order so e.g. mcp.telegram wins over email.
+    ordered = [ch for ch in priority if ch in notifications]
+    ordered += [
+        ch for ch in sorted(notifications.keys())
+        if ch not in priority and is_priority_human_channel(ch, agent._config)
+    ]
+    for channel in ordered:
+        payload = notifications[channel]
+        run_id = f"steer-{secrets.token_hex(4)}"
+        run_dir = _lane_run_dir(agent) / run_id
+        try:
+            run_dir.mkdir(parents=True, exist_ok=False)
+        except OSError:
+            return None
+        seed = {
+            "channel": channel,
+            "message": extract_message_text(payload),
+            "tail": _recent_conversation_tail(
+                agent, getattr(agent._config, "steering_tail_messages", STEERING_TAIL_MESSAGES_DEFAULT)
+            ),
+            "dispatched_at": time.time(),
+            "max_turns": getattr(
+                agent._config, "steering_max_turns", STEERING_MAX_TURNS_DEFAULT
+            ),
+            "timeout_s": getattr(
+                agent._config, "steering_timeout_s", STEERING_TIMEOUT_S_DEFAULT
+            ),
+        }
+        try:
+            atomic_write_json(run_dir / "steering_seed.json", seed)
+            (run_dir / "steering_prompt.txt").write_text(
+                _build_lane_prompt(seed), encoding="utf-8"
+            )
+        except OSError:
+            return None
+        lane_runner = runner or _default_lane_runner
+        thread = threading.Thread(
+            target=_run_lane_safely,
+            args=(agent, run_dir, seed, lane_runner),
+            name=f"steering-{run_id}",
+            daemon=True,
+        )
+        thread.start()
+        try:
+            agent._log("steering_lane_dispatched", run_id=run_id, channel=channel)
+        except Exception:
+            pass
+        return {"status": "dispatched", "run_id": run_id, "channel": channel}
+    return None
+
+
+def _build_lane_prompt(seed: dict) -> str:
+    tail = seed.get("tail") or "(no recent conversation available)"
+    message = seed.get("message") or "(no message text available)"
+    return (
+        f"{STEERING_PROMPT}\n\n"
+        f"Recent conversation tail:\n{tail}\n\n"
+        f"New high-priority message (channel {seed.get('channel')}):\n{message}\n"
+    )
+
+
+def _run_lane_safely(agent: Any, run_dir: Path, seed: dict, runner: Callable) -> None:
+    """Run the lane body with a bounded timeout; never raise into the agent."""
+    try:
+        runner(agent, run_dir, seed)
+    except Exception as exc:
+        try:
+            agent._log("steering_lane_error", run_id=run_dir.name, error=str(exc)[:300])
+        except Exception:
+            pass
+        try:
+            atomic_write_json(
+                run_dir / "steering_result.json",
+                {"status": "error", "error": str(exc)[:500]},
+            )
+        except OSError:
+            pass
+
+
+def _resolve_llm_service_class():
+    """Lazily resolve the LLMService class (kept out of import time to avoid
+    kernel/tools import cycles; overridable seam for tests)."""
+    from lingtai.llm.service import LLMService
+
+    return LLMService
+
+
+def _default_lane_runner(agent: Any, run_dir: Path, seed: dict) -> None:
+    """Bounded LLM sub-turn: answer + optional interrupt decision.
+
+    Builds an isolated session off the agent's LLM service (same provider
+    config, no shared wire), sends the seeded steering prompt, writes the
+    reply into the run dir, delivers it on the original channel, and requests
+    an interrupt when the model's reply carries the ``[INTERRUPT]`` marker.
+    """
+    LLMService = _resolve_llm_service_class()
+
+    service = getattr(agent, "service", None)
+    if service is None:
+        raise RuntimeError("agent has no LLM service; steering lane cannot run")
+    provider = getattr(service, "provider", None)
+    model = getattr(service, "model", None)
+    api_key = getattr(service, "api_key", None)
+    base_url = getattr(service, "base_url", None)
+    llm = LLMService(
+        provider=provider,
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+        context_window=getattr(service, "context_window", None),
+    )
+    session = llm.create_session(
+        system_prompt=STEERING_PROMPT,
+        tools=None,
+        model=model,
+        thinking="default",
+        tracked=False,
+    )
+    prompt = (run_dir / "steering_prompt.txt").read_text(encoding="utf-8")
+    deadline = time.monotonic() + float(seed.get("timeout_s") or STEERING_TIMEOUT_S_DEFAULT)
+    response = session.send(prompt, timeout=max(1.0, deadline - time.monotonic()))
+    reply = getattr(response, "text", None) or ""
+    atomic_write_json(
+        run_dir / "steering_result.json",
+        {"status": "done", "reply": reply, "finished_at": time.time()},
+    )
+    interrupt_reason = _interrupt_reason_from_reply(reply)
+    if interrupt_reason:
+        atomic_write_json(
+            run_dir / STEERING_INTERRUPT_FILENAME,
+            {"reason": interrupt_reason, "by": "steering_lane"},
+        )
+    deliver_steering_reply(agent, seed.get("channel"), seed.get("message"), reply)
+
+
+def _interrupt_reason_from_reply(reply: str) -> str | None:
+    """Extract the ``[INTERRUPT] <reason>`` decision from the lane reply."""
+    if not reply:
+        return None
+    for line in reply.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[INTERRUPT]"):
+            reason = stripped[len("[INTERRUPT]"):].strip()
+            return reason or "steering requested interruption"
+    return None
+
+
+def deliver_steering_reply(agent: Any, channel: str, message: str, reply: str) -> None:
+    """Deliver the lane's reply on the original channel (best effort).
+
+    Order of attempts:
+    1. ``agent._steering_reply_hook`` if set (test seam / station bridge).
+    2. The agent's telegram MCP client ``send`` action when channel is
+       ``mcp.telegram`` and a client is registered.
+    3. Durable ``steering_reply.txt`` in the lane run dir + event log.
+    """
+    if not reply:
+        return
+    hook = getattr(agent, "_steering_reply_hook", None)
+    if callable(hook):
+        try:
+            hook(channel, message, reply)
+            return
+        except Exception:
+            pass
+    if channel == "mcp.telegram":
+        client = None
+        try:
+            client = getattr(agent, "_mcp_clients_by_tool", {}).get("telegram")
+        except Exception:
+            client = None
+        if client is not None and hasattr(client, "call_tool"):
+            try:
+                client.call_tool(
+                    "telegram",
+                    {"action": "send", "chat_id": None, "text": reply},
+                )
+                return
+            except Exception:
+                pass
+    try:
+        atomic_write_json(
+            Path(agent.working_dir) / "daemons" / "steering_reply.txt",
+            {"channel": channel, "reply": reply, "ts": time.time()},
+        )
+        agent._log("steering_reply_stored", channel=channel, chars=len(reply))
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Interrupt contract (checked by the main tool-call await loop)
+# ---------------------------------------------------------------------------
+
+
+def iter_steering_interrupts(agent: Any):
+    """Yield ``(run_dir, interrupt_dict)`` for every unconsumed interrupt file."""
+    root = _lane_run_dir(agent)
+    if not root.is_dir():
+        return
+    for run_dir in sorted(root.glob("steer-*")):
+        target = run_dir / STEERING_INTERRUPT_FILENAME
+        if not target.is_file():
+            continue
+        try:
+            interrupt = json.loads(target.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(interrupt, dict):
+            yield run_dir, interrupt
+
+
+def check_steering_interrupt(agent: Any) -> dict | None:
+    """Return the first pending steering interrupt and consume it.
+
+    Called by the main tool-call await loop at a safe boundary. Consuming
+    renames the file to ``<name>.consumed`` so a single interrupt fires once.
+    """
+    for run_dir, interrupt in iter_steering_interrupts(agent):
+        target = run_dir / STEERING_INTERRUPT_FILENAME
+        try:
+            target.rename(target.with_name(target.name + ".consumed"))
+        except OSError:
+            pass
+        interrupt.setdefault("run_id", run_dir.name)
+        return interrupt
+    return None
+
+
+def abort_current_tool_call(agent: Any, interrupt: dict) -> None:
+    """Abort the current tool call at the safe boundary.
+
+    Marks the turn interrupted, cancels the executor, kills any tracked tool
+    child process tree (Windows: ``taskkill /T /F``), and enqueues the
+    steering message for the next turn.
+    """
+    try:
+        agent._cancel_event.set()
+    except Exception:
+        pass
+    _kill_tracked_tool_process_tree(agent)
+    try:
+        agent._log(
+            "turn_interrupted_by_steering",
+            run_id=interrupt.get("run_id"),
+            reason=interrupt.get("reason"),
+        )
+        agent._active_turn_kind = "interrupted"
+    except Exception:
+        pass
+    _enqueue_steering_message(agent, interrupt)
+
+
+def _kill_tracked_tool_process_tree(agent: Any) -> None:
+    """Kill the current tool's child process tree if the executor tracks one."""
+    pid = None
+    try:
+        pid = getattr(agent, "_steering_current_tool_pid", None)
+    except Exception:
+        pid = None
+    if not pid:
+        return
+    if os.name == "nt":
+        _taskkill_tree_windows(pid)
+    else:
+        try:
+            os.killpg(pid, 9)  # type: ignore[attr-defined]
+        except (AttributeError, OSError):
+            try:
+                os.kill(pid, 9)
+            except OSError:
+                pass
+
+
+def _taskkill_tree_windows(pid: int) -> None:
+    import subprocess
+
+    try:
+        subprocess.run(
+            ["taskkill", "/T", "/F", "/PID", str(pid)],
+            capture_output=True,
+            timeout=15,
+        )
+    except Exception:
+        pass
+
+
+def _enqueue_steering_message(agent: Any, interrupt: dict) -> None:
+    """Surface the steering decision to the next agent turn."""
+    from .message import MSG_REQUEST, _make_message
+
+    reason = interrupt.get("reason") or "steering requested interruption"
+    text = (
+        "[steering] A high-priority message required interrupting your previous "
+        f"turn. Steering reason: {reason}. Re-read the steering lane run dir "
+        f"({interrupt.get('run_id')}) and the pending channel message before "
+        "continuing."
+    )
+    try:
+        agent.inbox.put(_make_message(MSG_REQUEST, "system", text))
+        agent._wake_nap("steering_interrupt")
+    except Exception:
+        pass

--- a/tests/test_steering_lane.py
+++ b/tests/test_steering_lane.py
@@ -1,0 +1,277 @@
+"""Focused unit tests for the preemptive parallel steering lane.
+
+Covers: lane spawned during tool_call; reply delivered on channel; interrupt
+request aborts at the boundary; no-interrupt leaves the main turn running.
+"""
+from __future__ import annotations
+
+import json
+import queue
+import threading
+from pathlib import Path
+
+import pytest
+
+from lingtai.kernel import steering
+from lingtai.kernel.config import AgentConfig
+
+
+class _FakeAgent:
+    """Minimal agent surface the steering module touches."""
+
+    def __init__(self, tmp_path: Path, *, steering_enabled: bool = True):
+        self.working_dir = tmp_path
+        self._config = AgentConfig(steering_enabled=steering_enabled)
+        self._active_turn_kind = "tool_call"
+        self._cancel_event = threading.Event()
+        self._events: list[dict] = []
+        self.inbox: queue.Queue = queue.Queue()
+        self._woke: list[str] = []
+        self._steering_reply_hook = None
+        self._steering_current_tool_pid = None
+        self._mcp_clients_by_tool = {}
+
+    def _log(self, event_type: str, **fields) -> None:
+        self._events.append({"type": event_type, **fields})
+
+    def _wake_nap(self, reason: str) -> None:
+        self._woke.append(reason)
+
+    @property
+    def _chat(self):
+        return None
+
+
+@pytest.fixture()
+def fake_agent(tmp_path):
+    return _FakeAgent(tmp_path)
+
+
+def _wait_for(predicate, timeout=5.0):
+    deadline = __import__("time").monotonic() + timeout
+    while __import__("time").monotonic() < deadline:
+        if predicate():
+            return True
+        __import__("time").sleep(0.02)
+    return False
+
+
+class TestLaneSpawnedDuringToolCall:
+    def test_dispatch_creates_lane_run_dir_and_seed(self, fake_agent):
+        notifications = {
+            "mcp.telegram": {"data": {"text": "Stop the current run now"}},
+            "email": {"body": "low priority"},
+        }
+        captured: dict = {}
+
+        def runner(agent, run_dir, seed):
+            captured["seed"] = seed
+            captured["run_dir"] = run_dir
+
+        result = steering.dispatch_steering_lane(
+            fake_agent, notifications, runner=runner
+        )
+        assert result is not None
+        assert result["status"] == "dispatched"
+        assert result["channel"] == "mcp.telegram"
+        # Lane run dir created under daemons/ with seed + prompt.
+        run_dir = Path(fake_agent.working_dir) / "daemons" / result["run_id"]
+        assert run_dir.is_dir()
+        assert (run_dir / "steering_seed.json").is_file()
+        prompt = (run_dir / "steering_prompt.txt").read_text(encoding="utf-8")
+        assert "Stop the current run now" in prompt
+        # Thread ran the runner.
+        assert _wait_for(lambda: "seed" in captured)
+        assert captured["seed"]["channel"] == "mcp.telegram"
+        assert "Stop the current run now" in captured["seed"]["message"]
+
+    def test_no_dispatch_when_steering_disabled(self, tmp_path):
+        agent = _FakeAgent(tmp_path, steering_enabled=False)
+        notifications = {"mcp.telegram": {"text": "hi"}}
+        assert (
+            steering.dispatch_steering_lane(agent, notifications, runner=lambda *a: None)
+            is None
+        )
+
+    def test_no_dispatch_for_non_priority_channel(self, fake_agent):
+        notifications = {"cron": {"text": "tick"}}
+        assert (
+            steering.dispatch_steering_lane(fake_agent, notifications, runner=lambda *a: None)
+            is None
+        )
+
+
+class TestReplyDelivered:
+    def test_reply_hook_called(self, fake_agent):
+        delivered: list[tuple] = []
+        fake_agent._steering_reply_hook = (
+            lambda channel, message, reply: delivered.append((channel, message, reply))
+        )
+        steering.deliver_steering_reply(
+            fake_agent, "mcp.telegram", "the message", "I'm on it."
+        )
+        assert delivered == [("mcp.telegram", "the message", "I'm on it.")]
+
+    def test_reply_stored_when_no_hook(self, fake_agent):
+        steering.deliver_steering_reply(
+            fake_agent, "mcp.telegram", "the message", "I'm on it."
+        )
+        stored = (
+            Path(fake_agent.working_dir) / "daemons" / "steering_reply.txt"
+        )
+        assert stored.is_file()
+        data = json.loads(stored.read_text(encoding="utf-8"))
+        assert data["reply"] == "I'm on it."
+        assert data["channel"] == "mcp.telegram"
+
+    def test_empty_reply_not_delivered(self, fake_agent):
+        fake_agent._steering_reply_hook = (
+            lambda channel, message, reply: delivered.append((channel, reply))
+        )
+        delivered: list = []
+        steering.deliver_steering_reply(fake_agent, "mcp.telegram", "m", "")
+        assert delivered == []
+
+
+class TestInterruptContract:
+    def test_interrupt_request_aborts_at_boundary(self, fake_agent):
+        run_dir = Path(fake_agent.working_dir) / "daemons" / "steer-test1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "steering_interrupt.json").write_text(
+            json.dumps({"reason": "human said stop", "by": "steering_lane"}),
+            encoding="utf-8",
+        )
+
+        interrupt = steering.check_steering_interrupt(fake_agent)
+        assert interrupt is not None
+        assert interrupt["reason"] == "human said stop"
+        assert interrupt["run_id"] == "steer-test1"
+
+        steering.abort_current_tool_call(fake_agent, interrupt)
+        # Turn marked interrupted, cancel event set, steering message queued.
+        assert fake_agent._active_turn_kind == "interrupted"
+        assert fake_agent._cancel_event.is_set()
+        assert fake_agent._woke == ["steering_interrupt"]
+        msg = fake_agent.inbox.get_nowait()
+        assert msg.type == "request"
+        assert "steering" in msg.content.lower()
+        # Interrupt file consumed (renamed) so it fires exactly once.
+        assert not (run_dir / "steering_interrupt.json").exists()
+        assert (
+            run_dir / "steering_interrupt.json.consumed"
+        ).exists()
+        assert steering.check_steering_interrupt(fake_agent) is None
+
+    def test_no_interrupt_leaves_turn_running(self, fake_agent):
+        # No lane / no interrupt file anywhere.
+        assert steering.check_steering_interrupt(fake_agent) is None
+        assert not fake_agent._cancel_event.is_set()
+        assert fake_agent._active_turn_kind == "tool_call"
+
+    def test_interrupt_not_consumed_for_non_lane_dir(self, fake_agent):
+        # A daemon run dir without steering_interrupt.json is ignored.
+        run_dir = Path(fake_agent.working_dir) / "daemons" / "em-other"
+        run_dir.mkdir(parents=True)
+        (run_dir / "daemon.json").write_text("{}", encoding="utf-8")
+        assert steering.check_steering_interrupt(fake_agent) is None
+
+    def test_taskkill_windows_tree(self, monkeypatch):
+        calls: list[list] = []
+
+        class _Popen:
+            def __init__(self, argv, **kw):
+                calls.append(argv)
+                self.returncode = 0
+
+        monkeypatch.setattr("subprocess.run", _Popen)
+        steering._taskkill_tree_windows(4242)
+        assert calls and calls[0] == ["taskkill", "/T", "/F", "/PID", "4242"]
+
+
+class TestLaneRunnerDecision:
+    def test_interrupt_marker_detected(self):
+        reply = "Okay, stopping now.\n[INTERRUPT] user explicitly asked to cancel"
+        assert (
+            steering._interrupt_reason_from_reply(reply)
+            == "user explicitly asked to cancel"
+        )
+
+    def test_continue_marker_no_interrupt(self):
+        reply = "Will do, one moment.\n[CONTINUE]"
+        assert steering._interrupt_reason_from_reply(reply) is None
+
+    def test_default_lane_runner_writes_result_and_interrupt(
+        self, fake_agent, monkeypatch
+    ):
+        class _FakeSession:
+            def send(self, prompt, timeout=None):
+                class _Resp:
+                    text = "Hold on, I will stop.\n[INTERRUPT] stop now"
+
+                return _Resp()
+
+        class _FakeLLM:
+            def __init__(self, **kw):
+                self.kw = kw
+
+            def create_session(self, **kw):
+                return _FakeSession()
+
+        monkeypatch.setattr(steering, "_resolve_llm_service_class", lambda: _FakeLLM)
+        fake_agent.service = object()  # type: ignore[attr-defined]
+        run_dir = Path(fake_agent.working_dir) / "daemons" / "steer-test2"
+        run_dir.mkdir(parents=True)
+        (run_dir / "steering_prompt.txt").write_text(
+            steering._build_lane_prompt(
+                {"channel": "mcp.telegram", "message": "stop", "tail": ""}
+            ),
+            encoding="utf-8",
+        )
+        seed = {
+            "channel": "mcp.telegram",
+            "message": "stop",
+            "tail": "",
+            "timeout_s": 60.0,
+        }
+        steering._default_lane_runner(fake_agent, run_dir, seed)
+        result = json.loads(
+            (run_dir / "steering_result.json").read_text(encoding="utf-8")
+        )
+        assert result["status"] == "done"
+        assert "Hold on" in result["reply"]
+        interrupt = json.loads(
+            (run_dir / "steering_interrupt.json").read_text(encoding="utf-8")
+        )
+        assert interrupt["reason"] == "stop now"
+        assert interrupt["by"] == "steering_lane"
+
+    def test_default_lane_runner_continue_no_interrupt(
+        self, fake_agent, monkeypatch
+    ):
+        class _FakeSession:
+            def send(self, prompt, timeout=None):
+                class _Resp:
+                    text = "Noted, continuing.\n[CONTINUE]"
+
+                return _Resp()
+
+        class _FakeLLM:
+            def __init__(self, **kw):
+                pass
+
+            def create_session(self, **kw):
+                return _FakeSession()
+
+        monkeypatch.setattr(steering, "_resolve_llm_service_class", lambda: _FakeLLM)
+        fake_agent.service = object()  # type: ignore[attr-defined]
+        run_dir = Path(fake_agent.working_dir) / "daemons" / "steer-test3"
+        run_dir.mkdir(parents=True)
+        (run_dir / "steering_prompt.txt").write_text("prompt", encoding="utf-8")
+        seed = {
+            "channel": "mcp.telegram",
+            "message": "ok",
+            "tail": "",
+            "timeout_s": 60.0,
+        }
+        steering._default_lane_runner(fake_agent, run_dir, seed)
+        assert not (run_dir / "steering_interrupt.json").exists()


### PR DESCRIPTION
## What changed

- Added a bounded parallel steering lane for high-priority human messages received during an active tool call.
- Injected recent conversation context, returned the reply on the source channel, and honored explicit interrupt decisions at the next safe tool boundary.
- Added per-agent steering configuration and lifecycle coverage.

## Why

Human messages arriving during a long tool call were only deferred, so follow-up guidance could not influence the active task until the turn ended.

## Impact

Agents can read and respond to live guidance without corrupting the main tool result, while interruption remains explicit and bounded.

## Validation

- `42 passed` across steering-lane and production call-site regression tests.
