### PR TITLE
Make Telegram read receipts Agent-open durable

### DIFF
--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -355,9 +355,6 @@ class TelegramAccount:
     def _process_update(self, update: dict) -> None:
         """Process a single update — filter, dispatch, track offset."""
         update_id = update.get("update_id", 0)
-        if update_id > self._last_update_id:
-            self._last_update_id = update_id
-            self._save_state()
 
         if "message" in update:
             # A plain message is a new bottom message in the chat; record it so a
@@ -385,14 +382,23 @@ class TelegramAccount:
         # boundary with their uncertainty recorded on the envelope.
         actor = tg_updates.resolve_update_actor(update)
         if not tg_updates.is_admitted(actor, self._allowed_users):
+            self._commit_update(update_id)
             return
 
         # Intercept slash commands before they reach the agent
         if self._handle_slash_command(update):
+            self._commit_update(update_id)
             return
 
         if self._on_message:
             self._on_message(self.alias, update)
+        self._commit_update(update_id)
+
+    def _commit_update(self, update_id: object) -> None:
+        """Advance the durable offset only after handling succeeds."""
+        if type(update_id) is int and update_id > self._last_update_id:
+            self._last_update_id = update_id
+            self._save_state()
 
     def _handle_slash_command(self, update: dict) -> bool:
         """Handle slash commands locally (no LLM call). Returns True if handled."""

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -44,6 +44,8 @@ from .. import _skill
 from . import _family
 from . import updates as tg_updates
 from .account import TelegramRateLimitError
+from .receipts import ReceiptStore, ReceiptWorker, extract_opened_message_ids
+from .task_card_revisions import TaskCardRevisionStore
 
 if TYPE_CHECKING:
     from lingtai.kernel.notification_store import NotificationStorePort
@@ -642,6 +644,11 @@ class TelegramManager:
         self._task_card_tail_stop = threading.Event()
         self._programmable_task_card_thread: threading.Thread | None = None
         self._programmable_task_card_stop = threading.Event()
+        self._receipt_store: ReceiptStore | None = None
+        self._receipt_worker: ReceiptWorker | None = None
+        self._receipt_tail_thread: threading.Thread | None = None
+        self._receipt_tail_stop = threading.Event()
+        self._revision_store: TaskCardRevisionStore | None = None
 
     @property
     def _task_card_channels(self) -> dict[str, dict[str, str]]:
@@ -717,8 +724,10 @@ class TelegramManager:
         self._service.start()
         self._start_task_card_tail()
         self._start_programmable_task_card_poller()
+        self._start_receipt_path()
 
     def stop(self) -> None:
+        self._stop_receipt_path()
         self._stop_programmable_task_card_poller()
         self._stop_task_card_tail()
         self._service.stop()
@@ -889,13 +898,6 @@ class TelegramManager:
             # Issue #8: Start typing indicator immediately
             if account:
                 _typing_manager.start_typing(account, chat_id)
-
-            # Issue #8: Add "seen" reaction (👀)
-            if account:
-                try:
-                    account.set_message_reaction(chat_id, tg_message_id, REACTION_SEEN)
-                except Exception as e:
-                    log.debug("Failed to add 'seen' reaction: %s", e)
 
             # Issue #6: Transcribe voice messages
             if payload.get("media") and payload["media"].get("type") in ("voice", "audio"):
@@ -1225,6 +1227,7 @@ class TelegramManager:
         except Exception as e:
             log.error("on_inbound callback failed for telegram msg %s: %s",
                       payload.get("id"), e)
+            raise
         # Note: typing indicator continues until _send() is called by the agent.
         # _send() stops typing when it sends the response.
 
@@ -2092,11 +2095,20 @@ class TelegramManager:
         *, error: str, resident_id: str | None = None,
         empty_fallback: str | None = None,
     ) -> dict:
-        """Project via the single resident owner."""
-        return self._resident.project(
+        """Project via the resident owner and persist desired/applied revision."""
+        text = self._resident.compose(account, chat_id, channel=channel, frame=frame)
+        if not text and empty_fallback is not None:
+            text = empty_fallback
+        route_key = self._resident.key(account, chat_id)
+        if text:
+            self._ensure_revision_store().propose(route_key, text, time.time())
+        outcome = self._resident.project(
             account, chat_id, channel, frame, error=error,
             resident_id=resident_id, empty_fallback=empty_fallback,
         )
+        if text and outcome.get("status") == "ok":
+            self._ensure_revision_store().applied(route_key, time.time())
+        return outcome
 
     def _deliver_channel_frame_locked(
         self, account: str, chat_id: int, channel: str, frame: str | None,
@@ -2769,6 +2781,129 @@ class TelegramManager:
                 per_call_usages,
             )
         return bool(projected_events) or metadata_changed or result_changed or usage_changed
+
+    def _ensure_receipt_store(self) -> ReceiptStore:
+        if self._receipt_store is None:
+            self._receipt_store = ReceiptStore(
+                self._working_dir / "telegram" / "receipts.sqlite3"
+            )
+            self._receipt_worker = ReceiptWorker(
+                self._receipt_store, apply=self._apply_opened_receipt
+            )
+        return self._receipt_store
+
+    def _apply_opened_receipt(self, message_id: str) -> None:
+        account_alias, chat_id, telegram_message_id = self._parse_compound_id(
+            message_id.removeprefix("telegram:")
+        )
+        self._service.get_account(account_alias).set_message_reaction(
+            chat_id, telegram_message_id, REACTION_SEEN
+        )
+
+    def _poll_receipt_events(self) -> None:
+        store = self._ensure_receipt_store()
+        path = self._task_card_events_path()
+        try:
+            stat = path.stat()
+        except OSError:
+            return
+        offset, _, stored_identity = store.cursor()
+        identity = self._event_file_identity(stat)
+        identity_token = ":".join(map(str, identity)) if identity is not None else None
+        if stat.st_size < offset or (
+            stored_identity is not None
+            and identity_token is not None
+            and stored_identity != identity_token
+        ):
+            store.reset_cursor()
+            offset = 0
+        if stat.st_size <= offset:
+            return
+        try:
+            with open(path, "rb") as stream:
+                stream.seek(offset)
+                data = stream.read(min(
+                    stat.st_size - offset, self._TASK_CARD_EVENT_TAIL_CHUNK
+                ))
+        except OSError:
+            return
+        last_newline = data.rfind(b"\n")
+        if last_newline < 0:
+            return
+        complete = data[:last_newline + 1]
+        opened_ids: list[str] = []
+        for raw in complete.split(b"\n"):
+            event = TaskCardEventProjection.decode_event_line(raw)
+            if event is not None:
+                opened_ids.extend(extract_opened_message_ids(event))
+        store.enqueue_many_and_advance(
+            opened_ids,
+            offset + len(complete),
+            stat.st_size,
+            time.time(),
+            identity_token,
+        )
+
+    def _start_receipt_path(self) -> None:
+        self._ensure_receipt_store()
+        if self._receipt_tail_thread is not None and self._receipt_tail_thread.is_alive():
+            return
+        self._resume_pending_task_card_revisions()
+        self._receipt_tail_stop.clear()
+
+        def run() -> None:
+            while not self._receipt_tail_stop.is_set():
+                try:
+                    self._poll_receipt_events()
+                except Exception as exc:
+                    log.debug("Receipt event tail poll failed: %s", exc)
+                if self._receipt_tail_stop.wait(self._TASK_CARD_EVENT_POLL_INTERVAL):
+                    return
+
+        self._receipt_tail_thread = threading.Thread(
+            target=run, name="telegram-receipt-tail", daemon=True
+        )
+        self._receipt_tail_thread.start()
+        if self._receipt_worker is not None:
+            self._receipt_worker.start()
+
+    def _stop_receipt_path(self) -> None:
+        self._receipt_tail_stop.set()
+        if self._receipt_tail_thread is not None:
+            self._receipt_tail_thread.join(timeout=5)
+        self._receipt_tail_thread = None
+        if self._receipt_worker is not None:
+            self._receipt_worker.stop()
+        if self._receipt_store is not None:
+            self._receipt_store.close()
+        if self._revision_store is not None:
+            self._revision_store.close()
+        self._receipt_store = self._receipt_worker = self._revision_store = None
+
+    def _ensure_revision_store(self) -> TaskCardRevisionStore:
+        if self._revision_store is None:
+            self._revision_store = TaskCardRevisionStore(
+                self._working_dir / "telegram" / "taskcard_revisions.sqlite3"
+            )
+        return self._revision_store
+
+    def _resume_pending_task_card_revisions(self) -> None:
+        store = self._ensure_revision_store()
+        for route_key, _, text in store.pending_routes():
+            account, separator, chat_raw = route_key.partition(":")
+            if not separator:
+                continue
+            try:
+                chat_id = int(chat_raw)
+                outcome = self._resident.ensure(
+                    account, chat_id, text,
+                    error="Failed to resume pending task card revision",
+                )
+            except Exception as exc:
+                log.debug("Pending task card resume failed for %s: %s", route_key, exc)
+                continue
+            if outcome.get("status") == "ok":
+                store.applied(route_key, time.time())
 
     def _resident_task_card_targets(self) -> list[tuple[str, int]]:
         """Enumerate every ``(account, chat_id)`` with a resident Task Card.

--- a/src/lingtai/mcp_servers/telegram/receipts.py
+++ b/src/lingtai/mcp_servers/telegram/receipts.py
@@ -1,0 +1,203 @@
+"""Durable Agent-open receipts for Telegram."""
+from __future__ import annotations
+
+import re
+import logging
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+from .account import TelegramRateLimitError
+
+_RETRYABLE = {"rate_limit", "network", "server"}
+log = logging.getLogger(__name__)
+
+
+def extract_opened_message_ids(event: dict[str, Any]) -> list[str]:
+    if event.get("type") == "steering_messages_opened":
+        messages = event.get("message_ids")
+    elif event.get("type") == "notification_block_injected":
+        try:
+            messages = event["_meta"]["agent_meta"]["notifications"]["persistent"]["mcp"]["telegram"]["messages"]
+        except (KeyError, TypeError):
+            return []
+    else:
+        return []
+    return [
+        message_id
+        for item in (messages if isinstance(messages, list) else [])
+        if isinstance((message_id := item.get("id") if isinstance(item, dict) else item), str)
+        and message_id
+    ]
+
+
+def classify_receipt_error(exc: Exception) -> tuple[str, int | None]:
+    if isinstance(exc, TelegramRateLimitError):
+        retry_after = exc.retry_after
+        return "rate_limit", retry_after if type(retry_after) is int and retry_after >= 0 else None
+    if isinstance(exc, OSError) or type(exc).__module__.startswith("httpx"):
+        return "network", None
+    if str(exc).startswith("Telegram API error:"):
+        match = re.search(r"\bHTTP (\d{3})\b", str(exc))
+        return ("server" if not match or int(match.group(1)) >= 500 else "invalid"), None
+    return "other", None
+
+
+class ReceiptStore:
+    """SQLite receipt intent and event cursor committed in one transaction."""
+
+    def __init__(self, db_path: Path | str) -> None:
+        path = Path(db_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        with self._conn:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS telegram_receipts (
+                    message_id TEXT PRIMARY KEY,
+                    state TEXT NOT NULL CHECK (state IN ('pending','applied','failed')),
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    next_attempt_at REAL NOT NULL DEFAULT 0,
+                    applied_at REAL,
+                    last_error TEXT,
+                    updated_at REAL NOT NULL
+                )
+            """)
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS telegram_receipt_cursor (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    offset INTEGER NOT NULL CHECK (offset >= 0),
+                    size INTEGER NOT NULL CHECK (size >= 0),
+                    identity TEXT
+                )
+            """)
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def enqueue_many_and_advance(
+        self, message_ids: list[str], offset: int, size: int, now: float,
+        identity: str | None = None,
+    ) -> None:
+        with self._lock, self._conn:
+            self._conn.executemany(
+                "INSERT OR IGNORE INTO telegram_receipts "
+                "(message_id,state,attempts,next_attempt_at,updated_at) "
+                "VALUES (?,'pending',0,0,?)",
+                [(message_id, now) for message_id in message_ids],
+            )
+            self._conn.execute("""
+                INSERT INTO telegram_receipt_cursor (id,offset,size,identity)
+                VALUES (1,?,?,?) ON CONFLICT(id) DO UPDATE SET
+                offset=excluded.offset,size=excluded.size,identity=excluded.identity
+            """, (offset, size, identity))
+
+    def reset_cursor(self) -> None:
+        with self._lock, self._conn:
+            self._conn.execute("""
+                INSERT INTO telegram_receipt_cursor (id,offset,size,identity)
+                VALUES (1,0,0,NULL) ON CONFLICT(id) DO UPDATE SET
+                offset=0,size=0,identity=NULL
+            """)
+
+    def cursor(self) -> tuple[int, int, str | None]:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT offset,size,identity FROM telegram_receipt_cursor WHERE id=1"
+            ).fetchone()
+        return (int(row["offset"]), int(row["size"]), row["identity"]) if row else (0, 0, None)
+
+    def pending_due(self, now: float) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute("""
+                SELECT message_id,attempts FROM telegram_receipts
+                WHERE state='pending' AND next_attempt_at<=?
+                ORDER BY next_attempt_at LIMIT 100
+            """, (now,)).fetchall()
+        return [dict(row) for row in rows]
+
+    def get(self, message_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM telegram_receipts WHERE message_id=?", (message_id,)
+            ).fetchone()
+        return dict(row) if row else None
+
+    def mark_applied(self, message_id: str, now: float) -> None:
+        with self._lock, self._conn:
+            self._conn.execute("""
+                UPDATE telegram_receipts SET state='applied',applied_at=?,updated_at=?
+                WHERE message_id=?
+            """, (now, now, message_id))
+
+    def mark_failed(
+        self, message_id: str, now: float, attempts: int,
+        next_attempt_at: float | None, error_class: str,
+    ) -> None:
+        state = "pending" if next_attempt_at is not None else "failed"
+        with self._lock, self._conn:
+            self._conn.execute("""
+                UPDATE telegram_receipts SET state=?,attempts=?,next_attempt_at=?,
+                last_error=?,updated_at=? WHERE message_id=?
+            """, (state, attempts, next_attempt_at, error_class[:40], now, message_id))
+
+
+class ReceiptWorker:
+    BACKOFF_CAP = 60.0
+
+    def __init__(
+        self, store: ReceiptStore, apply: Callable[[str], None], *, poll_interval: float = 1.0,
+    ) -> None:
+        self._store = store
+        self._apply = apply
+        self._poll_interval = poll_interval
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def poll_once(self, now: float | None = None) -> int:
+        now = time.time() if now is None else now
+        applied = 0
+        for row in self._store.pending_due(now):
+            message_id = row["message_id"]
+            try:
+                self._apply(message_id)
+            except Exception as exc:
+                error_class, retry_after = classify_receipt_error(exc)
+                attempts = int(row["attempts"]) + 1
+                next_at = None
+                if error_class in _RETRYABLE:
+                    delay = retry_after if retry_after is not None else min(self.BACKOFF_CAP, 2 ** attempts)
+                    next_at = now + delay
+                self._store.mark_failed(message_id, now, attempts, next_at, error_class)
+            else:
+                self._store.mark_applied(message_id, now)
+                applied += 1
+        return applied
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop.clear()
+
+        def run() -> None:
+            while not self._stop.is_set():
+                try:
+                    self.poll_once()
+                except Exception as exc:
+                    log.warning("Telegram receipt worker poll failed: %s", exc)
+                if self._stop.wait(self._poll_interval):
+                    return
+
+        self._thread = threading.Thread(target=run, name="telegram-receipt-worker", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+        self._thread = None

--- a/src/lingtai/mcp_servers/telegram/task_card_revisions.py
+++ b/src/lingtai/mcp_servers/telegram/task_card_revisions.py
@@ -1,0 +1,76 @@
+"""Durable desired/applied revisions for resident Telegram Task Cards."""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+
+
+class TaskCardRevisionStore:
+    def __init__(self, db_path: Path | str) -> None:
+        path = Path(db_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        with self._conn:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS telegram_task_card_revisions (
+                    route_key TEXT PRIMARY KEY,
+                    desired_rev INTEGER NOT NULL DEFAULT 0,
+                    desired_text TEXT NOT NULL DEFAULT '',
+                    applied_rev INTEGER NOT NULL DEFAULT 0,
+                    applied_text TEXT NOT NULL DEFAULT '',
+                    updated_at REAL NOT NULL
+                )
+            """)
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def _row(self, route_key: str):
+        return self._conn.execute(
+            "SELECT * FROM telegram_task_card_revisions WHERE route_key=?", (route_key,)
+        ).fetchone()
+
+    def propose(self, route_key: str, text: str, now: float) -> bool:
+        with self._lock, self._conn:
+            row = self._row(route_key)
+            if row is not None and row["desired_text"] == text:
+                return False
+            revision = (int(row["desired_rev"]) if row else 0) + 1
+            self._conn.execute("""
+                INSERT INTO telegram_task_card_revisions
+                (route_key,desired_rev,desired_text,applied_rev,applied_text,updated_at)
+                VALUES (?,?,?,0,'',?) ON CONFLICT(route_key) DO UPDATE SET
+                desired_rev=excluded.desired_rev,desired_text=excluded.desired_text,
+                updated_at=excluded.updated_at
+            """, (route_key, revision, text, now))
+            return True
+
+    def applied(self, route_key: str, now: float) -> None:
+        with self._lock, self._conn:
+            self._conn.execute("""
+                UPDATE telegram_task_card_revisions SET applied_rev=desired_rev,
+                applied_text=desired_text,updated_at=? WHERE route_key=?
+            """, (now, route_key))
+
+    def pending_routes(self) -> list[tuple[str, int, str]]:
+        with self._lock:
+            rows = self._conn.execute("""
+                SELECT route_key,desired_rev,desired_text
+                FROM telegram_task_card_revisions WHERE applied_rev<desired_rev
+            """).fetchall()
+        return [(row["route_key"], int(row["desired_rev"]), row["desired_text"]) for row in rows]
+
+    def desired_rev(self, route_key: str) -> int:
+        with self._lock:
+            row = self._row(route_key)
+        return int(row["desired_rev"]) if row else 0
+
+    def applied_rev(self, route_key: str) -> int:
+        with self._lock:
+            row = self._row(route_key)
+        return int(row["applied_rev"]) if row else 0

--- a/tests/test_telegram_account_last_message_id.py
+++ b/tests/test_telegram_account_last_message_id.py
@@ -47,6 +47,20 @@ def test_inbound_message_bumps_last_message_id(tmp_path):
     assert seen
 
 
+def test_failed_delivery_does_not_commit_update_offset(tmp_path):
+    def fail(_alias, _update):
+        raise RuntimeError("inbox unavailable")
+
+    acct = _account(tmp_path, on_message=fail)
+    with pytest.raises(RuntimeError, match="inbox unavailable"):
+        acct._process_update({
+            "update_id": 7,
+            "message": {"message_id": 42, "chat": {"id": 555},
+                        "from": {"id": 9}, "text": "retry me"},
+        })
+    assert acct._last_update_id == 0
+
+
 def test_last_message_id_is_monotonic_per_chat(tmp_path):
     acct = _account(tmp_path)
     acct._note_chat_message_id(555, 10)

--- a/tests/test_telegram_agent_open_receipts.py
+++ b/tests/test_telegram_agent_open_receipts.py
@@ -1,0 +1,104 @@
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.telegram.manager import TelegramManager
+from lingtai.mcp_servers.telegram.receipts import ReceiptStore
+from lingtai.mcp_servers.telegram.task_card_revisions import TaskCardRevisionStore
+from tests._notification_store_helpers import FakeNotificationStore
+
+
+class _Account:
+    alias = "bot"
+
+    def __init__(self, failures=0):
+        self.failures = failures
+        self.reactions = []
+        self.task_cards = {}
+
+    def set_message_reaction(self, chat_id, message_id, reaction):
+        if self.failures:
+            self.failures -= 1
+            raise ConnectionError("offline")
+        self.reactions.append((chat_id, message_id, reaction))
+
+    def get_task_card(self, chat_id):
+        return self.task_cards.get(str(chat_id))
+
+    def set_task_card(self, chat_id, message_id):
+        self.task_cards[str(chat_id)] = message_id
+
+    def get_last_message_id(self, chat_id):
+        return None
+
+    def edit_message(self, chat_id, message_id, text, **kwargs):
+        return {"ok": True}
+
+
+class _Service:
+    def __init__(self, account):
+        self.default_account = account
+
+    def get_account(self, alias):
+        return self.default_account
+
+    def list_accounts(self):
+        return [self.default_account.alias]
+
+    def taskcard_enabled(self):
+        return True
+
+    def taskcard_normal_rows(self):
+        return 1
+
+
+def _manager(path: Path, account: _Account) -> TelegramManager:
+    return TelegramManager(
+        _Service(account), working_dir=path, on_inbound=lambda _: None,
+        notification_store=FakeNotificationStore(),
+    )
+
+
+def test_receipt_survives_failure_and_restart(tmp_path: Path):
+    events = tmp_path / "logs" / "events.jsonl"
+    events.parent.mkdir(parents=True)
+    events.write_text(json.dumps({
+        "type": "notification_block_injected",
+        "_meta": {"agent_meta": {"notifications": {"persistent": {"mcp": {
+            "telegram": {"messages": [{"id": "telegram:bot:123:55"}]},
+        }}}}},
+    }) + "\n", encoding="utf-8")
+
+    first = _manager(tmp_path, _Account(failures=1))
+    first._poll_receipt_events()
+    first._receipt_worker.poll_once(now=time.time())
+    assert first._ensure_receipt_store().get("telegram:bot:123:55")["state"] == "pending"
+
+    healthy = _Account()
+    restarted = _manager(tmp_path, healthy)
+    restarted._receipt_worker = None
+    restarted._ensure_receipt_store()
+    restarted._receipt_worker.poll_once(now=time.time() + 3600)
+    assert [(chat, message) for chat, message, _ in healthy.reactions] == [(123, 55)]
+    assert restarted._ensure_receipt_store().get("telegram:bot:123:55")["state"] == "applied"
+
+
+def test_receipt_and_cursor_are_atomic(tmp_path: Path):
+    store = ReceiptStore(tmp_path / "receipts.sqlite3")
+    with pytest.raises(sqlite3.IntegrityError):
+        store.enqueue_many_and_advance(["telegram:bot:1:2"], -1, 0, time.time())
+    assert store.pending_due(time.time() + 1) == []
+    assert store.cursor()[:2] == (0, 0)
+
+
+def test_task_card_revisions_keep_only_the_latest_pending_text(tmp_path: Path):
+    store = TaskCardRevisionStore(tmp_path / "taskcards.sqlite3")
+    assert store.propose("bot:123", "第一版", 1.0)
+    assert not store.propose("bot:123", "第一版", 2.0)
+    assert store.propose("bot:123", "第二版", 3.0)
+    assert store.pending_routes() == [("bot:123", 2, "第二版")]
+    store.applied("bot:123", 4.0)
+    assert store.pending_routes() == []

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -1216,8 +1216,7 @@ def test_start_stop_run_exactly_one_tail_worker(tmp_path):
         assert service.start_calls == 1
         new_threads = set(threading.enumerate()) - before_threads
         tail_threads = [
-            t for t in new_threads if "task_card" in t.name.lower()
-            or "event_tail" in t.name.lower() or "tail" in t.name.lower()
+            t for t in new_threads if t.name.lower() == "telegram-task-card-event-tail"
         ]
         assert len(tail_threads) == 1, f"expected exactly one tail worker, got {new_threads}"
     finally:
@@ -1246,8 +1245,12 @@ def test_start_called_twice_does_not_start_a_second_worker(tmp_path):
     manager.start()
     try:
         new_threads = set(threading.enumerate()) - before_threads
-        tail_threads = [t for t in new_threads if "tail" in t.name.lower()]
+        tail_threads = [
+            t for t in new_threads if t.name.lower() == "telegram-task-card-event-tail"
+        ]
         assert len(tail_threads) == 1
+        assert len([t for t in new_threads if t.name == "telegram-receipt-tail"]) == 1
+        assert len([t for t in new_threads if t.name == "telegram-receipt-worker"]) == 1
     finally:
         manager.stop()
 


### PR DESCRIPTION
## What changed

- Moved the Telegram 👀 reaction from ingress time to an Agent-open event.
- Persisted receipt intent and event cursor atomically in SQLite WAL, with retry/backoff for transient Telegram failures.
- Advanced the Telegram update offset only after inbox delivery succeeds.
- Added desired/applied Task Card revisions so the newest failed update resumes after restart.

## Why

The previous receipt meant only “transport received it,” could disappear on transient API failure, and could commit an update before the agent inbox accepted it.

## Impact

👀 now represents an actual Agent-open boundary, survives restarts, and does not depend on Task Card rendering.

## Validation

- `78 passed` across durable receipts, update-offset handling, Task Card revisions, and event-tail lifecycle tests.
