### PR TITLE
Add a single-owner Telegram Gateway

### DIFF
--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -198,7 +198,8 @@ class TelegramAccount:
         self._last_update_id: int = 0
         self._bot_info: dict | None = None
         self._last_verified_at: str | None = None
-        self._client: httpx.Client | None = None
+        self._outbound_client: httpx.Client | None = None
+        self._poll_client: httpx.Client | None = None
 
         # Resident Task Card message id per chat: {chat_id_str: compound_id}.
         # Exactly one card stays resident per (account, chat) and ordinary frames
@@ -225,6 +226,15 @@ class TelegramAccount:
 
         self._load_state()
 
+    @property
+    def _client(self) -> httpx.Client | None:
+        """Compatibility alias for existing test doubles and callers."""
+        return self._outbound_client
+
+    @_client.setter
+    def _client(self, value: httpx.Client | None) -> None:
+        self._outbound_client = value
+
     # -- API helpers ---------------------------------------------------------
 
     def _api_url(self, method: str) -> str:
@@ -233,19 +243,22 @@ class TelegramAccount:
     def _file_url(self, file_path: str) -> str:
         return _FILE_BASE.format(token=self._bot_token, file_path=file_path)
 
-    def _ensure_client(self) -> None:
-        """Lazy-import httpx and create client on first use."""
+    def _ensure_client(self, *, polling: bool = False) -> None:
+        """Create only the client needed by this request."""
         global httpx
+        target = "_poll_client" if polling else "_outbound_client"
+        if getattr(self, target) is not None:
+            return
         if httpx is None or isinstance(httpx, type(None)):
             import httpx as _httpx
             httpx = _httpx
-        if self._client is None:
-            self._client = httpx.Client(timeout=httpx.Timeout(60.0, connect=10.0))
+        setattr(self, target, httpx.Client(timeout=httpx.Timeout(60.0, connect=10.0)))
 
     def _request(self, method: str, **kwargs: Any) -> dict:
         """Make one Bot API request. Returns the result or raises immediately."""
-        self._ensure_client()
-        resp = self._client.post(self._api_url(method), **kwargs)
+        self._ensure_client(polling=method == "getUpdates")
+        client = self._poll_client if method == "getUpdates" else self._outbound_client
+        resp = client.post(self._api_url(method), **kwargs)
         if resp.status_code == 429:
             try:
                 data = resp.json()
@@ -312,9 +325,11 @@ class TelegramAccount:
         if self._poll_thread is not None:
             self._poll_thread.join(timeout=5.0)
             self._poll_thread = None
-        if self._client is not None:
-            self._client.close()
-            self._client = None
+        for name in ("_outbound_client", "_poll_client"):
+            client = getattr(self, name)
+            if client is not None:
+                client.close()
+                setattr(self, name, None)
 
     # -- Polling -------------------------------------------------------------
 
@@ -1175,9 +1190,8 @@ class TelegramAccount:
         file_path = file_info["file_path"]
         filename = Path(file_path).name
         url = self._file_url(file_path)
-        if self._client is None:
-            self._client = httpx.Client(timeout=httpx.Timeout(60.0, connect=10.0))
-        resp = self._client.get(url)
+        self._ensure_client()
+        resp = self._outbound_client.get(url)
         resp.raise_for_status()
         return filename, resp.content
 

--- a/src/lingtai/mcp_servers/telegram/bus.py
+++ b/src/lingtai/mcp_servers/telegram/bus.py
@@ -1,0 +1,235 @@
+"""SQLite WAL command bus between agent-side proxies and the Gateway owner.
+
+Proxy-mode ``TelegramManager`` instances (one per station) never touch the
+Telegram network: every outbound call is serialized into a gateway command and
+submitted through this bus. The single-process Gateway is the sole consumer:
+it claims pending commands one at a time, dispatches them through
+``GatewayCommandRouter``, and writes the result back.
+
+Why SQLite (WAL) and not an in-memory list:
+
+- Agent host and Gateway host are separate processes that share one bus file
+  per station (``<agent_dir>/telegram/gateway.sqlite3`` by default).
+- A submission is durable the moment it is inserted; pending commands survive
+  a Gateway restart (``reset_stale`` re-opens any row a dead owner left in
+  ``running`` state — the single-owner invariant makes every ``running`` row
+  stale on startup).
+- ``claim`` is a single atomic ``UPDATE ... RETURNING`` so exactly one
+  consumer ever executes one command, and the agent's bounded wait reads back
+  exactly the result that consumer wrote.
+
+Test doubles may keep using a plain ``list`` sink; production code paths use
+this module only.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_STATE_PENDING = "pending"
+_STATE_RUNNING = "running"
+_STATE_DONE = "done"
+
+# Agent-side bounded wait for a gateway result; the command stays queued when
+# it expires so a restart can still execute it (never silently dropped).
+_DEFAULT_SUBMIT_TIMEOUT = 30.0
+# Both sides poll at a small interval; SQLite WAL keeps readers lock-free.
+_POLL_INTERVAL = 0.02
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS gateway_commands (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    method TEXT NOT NULL,
+    params TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'running', 'done')),
+    result TEXT,
+    created_at REAL NOT NULL,
+    claimed_at REAL,
+    completed_at REAL
+)
+"""
+_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_gateway_commands_pending "
+    "ON gateway_commands (status, id)"
+)
+
+
+class SqliteCommandBus:
+    """Durable, single-owner command queue backed by one SQLite WAL database.
+
+    Agent side: :meth:`submit` inserts one command and blocks until the owner
+    completes it (bounded by ``timeout``).
+    Gateway side (single owner): :meth:`claim` atomically moves the oldest
+    pending command to ``running``; :meth:`complete` writes back the JSON
+    result; :meth:`reset_stale` re-opens rows left behind by a dead owner.
+    """
+
+    def __init__(self, db_path: Path | str) -> None:
+        self._path = Path(db_path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        self._closed = False
+        with self._lock:
+            with self._conn:
+                self._conn.execute("PRAGMA journal_mode=WAL")
+                self._conn.execute("PRAGMA busy_timeout=10000")
+                self._conn.execute(_SCHEMA)
+                self._conn.execute(_INDEX_SQL)
+
+    # -- Agent side ------------------------------------------------------------
+
+    def submit(
+        self,
+        command: dict[str, Any],
+        *,
+        timeout: float = _DEFAULT_SUBMIT_TIMEOUT,
+    ) -> Any:
+        """Insert one command and wait (bounded) for the gateway result.
+
+        Returns the JSON-decoded result the gateway owner wrote back, or an
+        error dict when the wait expires (the command remains queued and a
+        Gateway restart will still execute it).
+        """
+        if not isinstance(command, dict):
+            return {"status": "error", "error": "command must be an object"}
+        method = command.get("method")
+        params = command.get("params")
+        if not isinstance(method, str) or not isinstance(params, dict):
+            return {"status": "error", "error": "command needs 'method' and 'params'"}
+        with self._lock:
+            if self._closed:
+                return {"status": "error", "error": "command bus is closed"}
+            with self._conn:
+                cur = self._conn.execute(
+                    "INSERT INTO gateway_commands "
+                    "(method, params, status, created_at) VALUES (?, ?, ?, ?)",
+                    (method, json.dumps(params, default=str), _STATE_PENDING, time.time()),
+                )
+                command_id = int(cur.lastrowid)
+        deadline = time.monotonic() + timeout
+        while True:
+            result = self._result(command_id)
+            if result is not None:
+                return result
+            if time.monotonic() >= deadline:
+                log.warning(
+                    "gateway command %s (%s) timed out after %.1fs; still queued",
+                    command_id, method, timeout,
+                )
+                return {
+                    "status": "error",
+                    "error": "gateway command timed out; it remains queued",
+                    "command_id": command_id,
+                    "method": method,
+                }
+            time.sleep(_POLL_INTERVAL)
+
+    def _result(self, command_id: int) -> Any | None:
+        """Return the completed result for one command, or ``None`` if pending."""
+        with self._lock:
+            if self._closed:
+                return None
+            row = self._conn.execute(
+                "SELECT status, result FROM gateway_commands WHERE id = ?",
+                (command_id,),
+            ).fetchone()
+        if row is None or row["status"] != _STATE_DONE:
+            return None
+        try:
+            return json.loads(row["result"]) if row["result"] is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    # -- Gateway side (single owner) -------------------------------------------
+
+    def claim(self) -> tuple[int, dict[str, Any]] | None:
+        """Atomically claim the oldest pending command.
+
+        Returns ``(command_id, command)`` or ``None`` when nothing is pending.
+        The atomic ``UPDATE ... RETURNING`` guarantees exactly one consumer
+        ever executes one command, even with multiple gateway threads or
+        processes attached to the same file.
+        """
+        with self._lock:
+            if self._closed:
+                return None
+            with self._conn:
+                row = self._conn.execute(
+                    """
+                    UPDATE gateway_commands
+                    SET status = 'running', claimed_at = ?
+                    WHERE id = (
+                        SELECT id FROM gateway_commands
+                        WHERE status = 'pending' ORDER BY id LIMIT 1
+                    )
+                    RETURNING id, method, params
+                    """,
+                    (time.time(),),
+                ).fetchone()
+        if row is None:
+            return None
+        command_id = int(row["id"])
+        try:
+            params = json.loads(row["params"])
+        except (TypeError, ValueError):
+            params = {}
+        return command_id, {"method": row["method"], "params": params}
+
+    def complete(self, command_id: int, result: Any) -> None:
+        """Write back the gateway result for one claimed command."""
+        with self._lock:
+            with self._conn:
+                self._conn.execute(
+                    """
+                    UPDATE gateway_commands
+                    SET status = 'done', result = ?, completed_at = ?
+                    WHERE id = ? AND status = 'running'
+                    """,
+                    (json.dumps(result, default=str), time.time(), command_id),
+                )
+
+    def reset_stale(self) -> int:
+        """Re-open every ``running`` row left by a dead Gateway owner.
+
+        The single-owner invariant makes this safe: only the one Gateway
+        consumes a bus, so at startup any ``running`` row is stale by
+        definition. Returns the number of rows re-opened.
+        """
+        with self._lock:
+            with self._conn:
+                cur = self._conn.execute(
+                    "UPDATE gateway_commands SET status = 'pending', claimed_at = NULL "
+                    "WHERE status = 'running'"
+                )
+                return int(cur.rowcount)
+
+    def pending_count(self) -> int:
+        """Number of commands waiting to be claimed (never raises when open)."""
+        with self._lock:
+            if self._closed:
+                return 0
+            row = self._conn.execute(
+                "SELECT COUNT(*) AS n FROM gateway_commands WHERE status = 'pending'",
+            ).fetchone()
+        return int(row["n"]) if row is not None else 0
+
+    def close(self) -> None:
+        """Close the underlying connection; idempotent."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            try:
+                self._conn.close()
+            except sqlite3.Error:
+                pass

--- a/src/lingtai/mcp_servers/telegram/gateway.py
+++ b/src/lingtai/mcp_servers/telegram/gateway.py
@@ -1,0 +1,471 @@
+"""Gateway/proxy mode: one gateway-owned Telegram transport for stations.
+
+The gateway process owns polling and outbound Bot API calls for every
+configured station by reusing the standalone ``TelegramService``/account
+machinery. Agent-side stations run in proxy mode
+(``lingtai.mcp_servers.telegram.proxy.TelegramGatewayProxy``): they queue
+commands into a sink and never call ``getUpdates`` or construct a network
+client.
+
+The gateway manifest is free of secrets: it only names each station and
+references that station's existing configuration path (which holds the bot
+tokens). ``load_gateway_manifest`` rejects any manifest that tries to carry
+inline secret material.
+
+``run_gateway`` builds a complete ``TelegramManager`` + ``TelegramService``
+per manifest station (not a bare service) and returns a ``GatewayHost`` whose
+``stop()`` closes every manager and command bus. Each manager delivers inbound
+updates to the correct Agent via
+``lingtai.services.mcp_licc.push_inbox_event(..., agent_dir=<station>,
+mcp_name='telegram')`` and uses that station's ``agent_dir`` with a
+``PosixNotificationStoreAdapter``, so resident Task Card state, receipts, and
+the event tail stay per-station.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+from lingtai.services.mcp_licc import push_inbox_event
+
+from .bus import SqliteCommandBus
+
+log = logging.getLogger(__name__)
+
+# Keys that are never allowed inside the gateway manifest (secrets-free).
+_FORBIDDEN_MANIFEST_KEYS = frozenset({
+    "bot_token", "token", "api_key", "api_token", "access_token",
+    "secret", "password", "oauth",
+})
+
+# Default per-station command bus file (relative to the station agent_dir).
+_DEFAULT_BUS_FILENAME = "gateway.sqlite3"
+
+
+class GatewayManifestError(ValueError):
+    """Raised when a gateway manifest is malformed or carries secrets."""
+
+
+def load_gateway_manifest(manifest_path: Path | str) -> list[dict[str, Any]]:
+    """Load and validate a secrets-free gateway manifest.
+
+    Schema:
+
+    .. code-block:: json
+
+        {
+          "stations": [
+            {"name": "control-total", "config": "<absolute-or-relative config path>"}
+          ]
+        }
+
+    Returns the normalized station list with absolute config paths. Raises
+    ``GatewayManifestError`` for malformed manifests, unknown top-level keys,
+    or any attempt to embed secret material.
+    """
+    path = Path(manifest_path)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise GatewayManifestError(f"cannot read gateway manifest {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise GatewayManifestError(f"invalid gateway manifest JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise GatewayManifestError("gateway manifest must be a JSON object")
+    unknown = set(data) - {"stations"}
+    if unknown:
+        raise GatewayManifestError(f"unknown gateway manifest keys: {sorted(unknown)}")
+    forbidden = set(data) & _FORBIDDEN_MANIFEST_KEYS
+    if forbidden:
+        raise GatewayManifestError(
+            f"gateway manifest must stay secrets-free; remove {sorted(forbidden)}"
+        )
+    stations = data.get("stations")
+    if not isinstance(stations, list) or not stations:
+        raise GatewayManifestError("gateway manifest needs a non-empty 'stations' list")
+
+    base = path.parent
+    normalized: list[dict[str, Any]] = []
+    for index, station in enumerate(stations):
+        if not isinstance(station, dict):
+            raise GatewayManifestError(f"stations[{index}] must be an object")
+        forbidden = set(station) & _FORBIDDEN_MANIFEST_KEYS
+        if forbidden:
+            raise GatewayManifestError(
+                f"stations[{index}] must stay secrets-free; remove {sorted(forbidden)}"
+            )
+        name = station.get("name")
+        config = station.get("config")
+        if not isinstance(name, str) or not name.strip():
+            raise GatewayManifestError(f"stations[{index}] needs a 'name'")
+        if not isinstance(config, str) or not config.strip():
+            raise GatewayManifestError(f"stations[{index}] needs a 'config' path")
+        config_path = Path(config)
+        if not config_path.is_absolute():
+            config_path = base / config_path
+        agent_dir = station.get("agent_dir")
+        if agent_dir is not None and not isinstance(agent_dir, str):
+            raise GatewayManifestError(f"stations[{index}].agent_dir must be a path string")
+        normalized.append(
+            {
+                "name": name.strip(),
+                "config": str(config_path),
+                "agent_dir": str(agent_dir) if agent_dir else str(config_path.parent),
+            }
+        )
+    return normalized
+
+
+def _load_station_config(config_path: Path) -> list[dict[str, Any]]:
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GatewayManifestError(f"cannot read station config {config_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise GatewayManifestError(f"station config {config_path} must be an object")
+    accounts = data.get("accounts")
+    if not isinstance(accounts, list) or not accounts:
+        raise GatewayManifestError(f"station config {config_path} needs 'accounts'")
+    return accounts
+
+
+def _read_gateway_marker(agent_dir: Path) -> dict | None:
+    """Read the optional ``<agent_dir>/telegram/gateway.json`` marker (proxy mode).
+
+    The marker may carry a ``"bus"`` path (absolute or relative to the
+    agent_dir) pointing at the station's shared command bus; anything else is
+    ignored. Malformed markers degrade to ``None`` so a station still runs.
+    """
+    marker = agent_dir / "telegram" / "gateway.json"
+    if not marker.is_file():
+        return None
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        log.warning("unreadable gateway marker %s; ignoring it", marker)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _station_bus_path(agent_dir: Path, marker: dict | None) -> Path:
+    """Resolve the per-station command bus file path."""
+    default = agent_dir / "telegram" / _DEFAULT_BUS_FILENAME
+    if not marker:
+        return default
+    value = marker.get("bus")
+    if not isinstance(value, str) or not value.strip():
+        return default
+    path = Path(value)
+    return path if path.is_absolute() else agent_dir / path
+
+
+def _default_on_inbound(agent_dir: Path) -> Callable[[dict], None]:
+    """Build the manager inbound callback: LICC push into this station's Agent.
+
+    ``agent_dir`` and ``mcp_name='telegram'`` are explicit so the event lands
+    in the right station's inbox regardless of the process environment.
+    """
+
+    def _on_inbound(event: dict) -> None:
+        push_inbox_event(
+            sender=event.get("from") or "telegram",
+            subject=event.get("subject") or "telegram update",
+            body=event.get("body") or "",
+            metadata=event.get("metadata"),
+            wake=event.get("wake", True),
+            agent_dir=str(agent_dir),
+            mcp_name="telegram",
+        )
+
+    return _on_inbound
+
+
+class GatewayCommandRouter:
+    """Consume proxy-queued commands and dispatch to the owning service account."""
+
+    def __init__(self, services: Iterable[Any]) -> None:
+        self._by_alias: dict[str, Any] = {}
+        for service in services:
+            for alias in service.list_accounts():
+                self._by_alias[alias] = service.get_account(alias)
+
+    def route(self, command: dict[str, Any], alias: str | None = None) -> dict[str, Any]:
+        """Dispatch one queued gateway command; returns the account result.
+
+        Unknown methods fail fast with an explicit error result — they are
+        never silently ignored or routed elsewhere.
+        """
+        if not isinstance(command, dict):
+            return {"status": "error", "error": "command must be an object"}
+        method = command.get("method")
+        params = command.get("params")
+        if not isinstance(method, str) or not isinstance(params, dict):
+            return {"status": "error", "error": "command needs 'method' and 'params'"}
+        params = dict(params)
+        target = alias or params.pop("alias", None) or params.pop("account", None)
+        account = self._by_alias.get(target) if isinstance(target, str) else None
+        if account is None:
+            return {"status": "error", "error": f"unknown account alias: {target}"}
+        handler = _COMMAND_HANDLERS.get(method)
+        if handler is None:
+            return {"status": "error", "error": f"unsupported gateway command: {method}"}
+        return handler(account, params)
+
+
+def _handle_send_message(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.send_message(
+        params["chat_id"],
+        params["text"],
+        reply_markup=params.get("reply_markup"),
+        reply_to_message_id=params.get("reply_to_message_id"),
+        **{k: v for k, v in params.items() if k not in {
+            "chat_id", "text", "reply_markup", "reply_to_message_id"}},
+    )
+
+
+def _handle_edit_message(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.edit_message(
+        params["chat_id"], params["message_id"], params["text"],
+        **{k: v for k, v in params.items() if k not in {"chat_id", "message_id", "text"}},
+    )
+
+
+def _handle_edit_caption(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.edit_message(
+        params["chat_id"], params["message_id"], params.get("caption", ""),
+        is_caption=True,
+        **{k: v for k, v in params.items() if k not in {"chat_id", "message_id", "caption"}},
+    )
+
+
+def _handle_delete_message(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.delete_message(params["chat_id"], params["message_id"])
+
+
+def _handle_reaction(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.set_message_reaction(
+        params["chat_id"], params["message_id"],
+        reaction=params.get("reaction"),
+        is_big=bool(params.get("is_big", False)),
+    )
+
+
+def _handle_chat_action(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.send_chat_action(params["chat_id"], params["action"])
+
+
+def _handle_callback(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    # The real TelegramAccount auto-answers callbacks during polling and has no
+    # public answer_callback_query surface; the manager never routes this
+    # command. Guard instead of crashing the consumer loop with AttributeError.
+    handler = getattr(account, "answer_callback_query", None)
+    if not callable(handler):
+        return {
+            "status": "error",
+            "error": "account does not support answerCallbackQuery",
+        }
+    return handler(
+        params["callback_query_id"],
+        **{k: v for k, v in params.items() if k != "callback_query_id"},
+    )
+
+
+def _handle_get_me(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.public_identity()
+
+
+def _handle_send_photo(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.send_photo(
+        params["chat_id"],
+        params["path"],
+        caption=params.get("caption"),
+        reply_to_message_id=params.get("reply_to_message_id"),
+        **{k: v for k, v in params.items() if k not in {
+            "chat_id", "path", "caption", "reply_to_message_id"}},
+    )
+
+
+def _handle_send_document(account: Any, params: dict[str, Any]) -> dict[str, Any]:
+    return account.send_document(
+        params["chat_id"],
+        params["path"],
+        caption=params.get("caption"),
+        reply_to_message_id=params.get("reply_to_message_id"),
+        **{k: v for k, v in params.items() if k not in {
+            "chat_id", "path", "caption", "reply_to_message_id"}},
+    )
+
+
+_COMMAND_HANDLERS: dict[str, Callable[[Any, dict[str, Any]], dict[str, Any]]] = {
+    "sendMessage": _handle_send_message,
+    "sendPhoto": _handle_send_photo,
+    "sendDocument": _handle_send_document,
+    "editMessageText": _handle_edit_message,
+    "editMessageCaption": _handle_edit_caption,
+    "deleteMessage": _handle_delete_message,
+    "setMessageReaction": _handle_reaction,
+    "sendChatAction": _handle_chat_action,
+    "answerCallbackQuery": _handle_callback,
+    "getMe": _handle_get_me,
+}
+
+
+class GatewayHost:
+    """A running single-process Gateway: managers + command buses + router.
+
+    ``start()`` recovers stale claims and spawns one consumer thread per
+    station bus (the gateway is the single owner). ``stop()`` joins the
+    consumer threads, stops every manager, and closes every command bus so no
+    poll thread or consumer is orphaned.
+    """
+
+    def __init__(
+        self,
+        *,
+        stations: list[dict[str, Any]],
+        managers: list[Any],
+        services: list[Any],
+        router: GatewayCommandRouter,
+        buses: dict[str, SqliteCommandBus],
+    ) -> None:
+        self.stations = stations
+        self.managers = managers
+        self.services = services
+        self.router = router
+        self.buses = buses
+        self._stop = threading.Event()
+        self._threads: list[threading.Thread] = []
+
+    def start(self) -> None:
+        """Recover stale claims and start one consumer thread per station bus."""
+        for bus in self.buses.values():
+            try:
+                bus.reset_stale()
+            except Exception as exc:
+                log.warning("gateway stale-claim recovery failed: %s", exc)
+        for name, bus in self.buses.items():
+            thread = threading.Thread(
+                target=self._consume_loop,
+                args=(name, bus),
+                name=f"gateway-consumer-{name}",
+                daemon=True,
+            )
+            thread.start()
+            self._threads.append(thread)
+
+    def _consume_loop(self, name: str, bus: SqliteCommandBus) -> None:
+        """Single-owner loop: claim one command, route it, write back the result."""
+        while not self._stop.is_set():
+            try:
+                claimed = bus.claim()
+            except Exception as exc:
+                log.warning("gateway claim failed (%s): %s", name, exc)
+                claimed = None
+            if claimed is None:
+                self._stop.wait(0.05)
+                continue
+            command_id, command = claimed
+            try:
+                result = self.router.route(command)
+            except Exception as exc:
+                result = {
+                    "status": "error",
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            try:
+                bus.complete(command_id, result)
+            except Exception as exc:
+                log.warning("gateway complete failed (%s): %s", name, exc)
+
+    def stop(self) -> None:
+        """Close consumer threads, managers, and command buses (idempotent)."""
+        self._stop.set()
+        for thread in self._threads:
+            thread.join(timeout=5.0)
+        self._threads = []
+        for manager in self.managers:
+            try:
+                manager.stop()
+            except Exception as exc:
+                log.warning("gateway manager stop failed: %s", exc)
+        for bus in self.buses.values():
+            bus.close()
+
+
+def run_gateway(
+    manifest_path: Path | str,
+    *,
+    on_inbound: Callable[[dict], None] | None = None,
+    command_source: Iterable[dict[str, Any]] | None = None,
+    service_factory: Callable[..., Any] | None = None,
+    start: bool = True,
+) -> GatewayHost:
+    """Start one complete ``TelegramManager`` + ``TelegramService`` per station.
+
+    Each manager uses the station's ``agent_dir``, a
+    ``PosixNotificationStoreAdapter``, and delivers inbound to that station's
+    Agent via ``push_inbox_event(..., agent_dir=<station>, mcp_name='telegram')``.
+    Returns a ``GatewayHost`` whose ``stop()`` closes every manager and command
+    bus. ``service_factory`` is an injectable seam for tests; production uses
+    the real ``TelegramService``.
+    """
+    from .manager import TelegramManager
+    from .service import TelegramService
+
+    stations = load_gateway_manifest(manifest_path)
+    managers: list[TelegramManager] = []
+    services: list[Any] = []
+    buses: dict[str, SqliteCommandBus] = {}
+    factory = service_factory or TelegramService
+
+    for station in stations:
+        accounts_config = _load_station_config(Path(station["config"]))
+        agent_dir = Path(station["agent_dir"])
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        marker = _read_gateway_marker(agent_dir)
+        bus = SqliteCommandBus(_station_bus_path(agent_dir, marker))
+        buses[station["name"]] = bus
+
+        inbound = on_inbound or _default_on_inbound(agent_dir)
+        # Forward declare the manager so the service's on_message callback can
+        # reach it (same pattern as server.build_manager).
+        mgr_ref: list[TelegramManager | None] = [None]
+        svc = factory(
+            working_dir=agent_dir,
+            accounts_config=accounts_config,
+            on_message=lambda alias, update, ref=mgr_ref: ref[0].on_incoming(
+                alias, update,
+            ),
+            config_source=station["config"],
+        )
+        notification_store = PosixNotificationStoreAdapter(agent_dir)
+        mgr = TelegramManager(
+            service=svc,
+            working_dir=agent_dir,
+            notification_store=notification_store,
+            on_inbound=inbound,
+        )
+        mgr_ref[0] = mgr
+        managers.append(mgr)
+        services.append(svc)
+
+    router = GatewayCommandRouter(services)
+    host = GatewayHost(
+        stations=stations,
+        managers=managers,
+        services=services,
+        router=router,
+        buses=buses,
+    )
+    if start:
+        for mgr in managers:
+            mgr.start()
+        host.start()
+    if command_source is not None:
+        for command in command_source:
+            host.router.route(command)
+    return host

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -560,11 +560,13 @@ class TelegramManager:
         working_dir: Path,
         notification_store: "NotificationStorePort",
         on_inbound: "Callable[[dict], None]",
+        proxy_mode: bool = False,
     ) -> None:
         self._service = service
         self._working_dir = Path(working_dir)
         self._notification_store = notification_store
         self._on_inbound = on_inbound
+        self._proxy_mode = proxy_mode
         # Duplicate send protection: (account, chat_id, text) → count
         self._last_sent: dict[tuple[str, int, str], int] = {}
         self._dup_free_passes = 2
@@ -715,12 +717,15 @@ class TelegramManager:
 
     def start(self) -> None:
         self._service.start()
+        if self._proxy_mode:
+            return
         self._start_task_card_tail()
         self._start_programmable_task_card_poller()
 
     def stop(self) -> None:
-        self._stop_programmable_task_card_poller()
-        self._stop_task_card_tail()
+        if not self._proxy_mode:
+            self._stop_programmable_task_card_poller()
+            self._stop_task_card_tail()
         self._service.stop()
 
     # ------------------------------------------------------------------

--- a/src/lingtai/mcp_servers/telegram/proxy.py
+++ b/src/lingtai/mcp_servers/telegram/proxy.py
@@ -1,0 +1,230 @@
+"""Agent-side Telegram gateway proxy (proxy mode).
+
+A ``TelegramGatewayProxy`` exposes the same account surface the manager uses
+but serializes each outbound call into a gateway command delivered to the
+injected ``command_sink`` — it never calls ``getUpdates``, never constructs a
+Telegram network client, and never imports httpx. The real transport stays in
+the gateway process (see ``gateway.py``), which owns polling and outbound
+Bot API calls for all configured stations.
+
+The production ``command_sink`` is the SQLite WAL command bus
+(``SqliteCommandBus.submit``): the proxy waits (bounded) for the gateway
+result and returns it to the manager, so compound message ids built from
+``message_id`` keep working in proxy mode. A plain ``list`` sink keeps the
+older queue-only behavior for tests.
+
+``TelegramGatewayProxyService`` is the minimal proxy-mode service surface: it
+reuses ``TelegramService``'s durable taskcard-settings implementation and
+adds only the account/service surface the manager really needs — it never
+copies the whole service and never builds a network client.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from .service import TelegramService
+
+
+class TelegramGatewayProxy:
+    """Queue-only Telegram account surface for gateway/proxy deployments."""
+
+    def __init__(
+        self,
+        alias: str,
+        command_sink: Callable[[dict], None] | list[dict],
+    ) -> None:
+        self.alias = alias
+        self._sink = command_sink
+        # Proxy mode never constructs a Telegram network client.
+        self._network_client: Any = None
+        self._poll_thread: Any = None
+
+    def _queue(self, method: str, **params: Any) -> dict:
+        # The gateway resolves the target account from the alias; a station may
+        # own several accounts, so every command carries its own.
+        params.setdefault("alias", self.alias)
+        command = {"method": method, "params": params}
+        if isinstance(self._sink, list):
+            self._sink.append(command)
+            return {"status": "queued", "method": method}
+        result = self._sink(command)
+        # Production sink (SqliteCommandBus.submit) returns the gateway result;
+        # test doubles may return None, in which case keep the queue-only shape.
+        if isinstance(result, dict):
+            return result
+        return {"status": "queued", "method": method}
+
+    # -- Outbound surface (queued to the gateway) ----------------------------
+
+    def send_message(self, chat_id, text, reply_markup=None, reply_to_message_id=None, **kwargs):
+        params: dict[str, Any] = {"chat_id": chat_id, "text": text}
+        if reply_markup is not None:
+            params["reply_markup"] = reply_markup
+        if reply_to_message_id is not None:
+            params["reply_to_message_id"] = reply_to_message_id
+        params.update(kwargs)
+        return self._queue("sendMessage", **params)
+
+    def send_photo(self, chat_id, path, caption=None, reply_to_message_id=None, **kwargs):
+        params: dict[str, Any] = {"chat_id": chat_id, "path": path}
+        if caption is not None:
+            params["caption"] = caption
+        if reply_to_message_id is not None:
+            params["reply_to_message_id"] = reply_to_message_id
+        params.update(kwargs)
+        return self._queue("sendPhoto", **params)
+
+    def send_document(self, chat_id, path, caption=None, reply_to_message_id=None, **kwargs):
+        params: dict[str, Any] = {"chat_id": chat_id, "path": path}
+        if caption is not None:
+            params["caption"] = caption
+        if reply_to_message_id is not None:
+            params["reply_to_message_id"] = reply_to_message_id
+        params.update(kwargs)
+        return self._queue("sendDocument", **params)
+
+    def edit_message(self, chat_id, message_id, text, **kwargs):
+        params: dict[str, Any] = {"chat_id": chat_id, "message_id": message_id, "text": text}
+        params.update(kwargs)
+        return self._queue("editMessageText", **params)
+
+    def edit_message_caption(self, chat_id, message_id, caption=None, **kwargs):
+        params: dict[str, Any] = {"chat_id": chat_id, "message_id": message_id}
+        if caption is not None:
+            params["caption"] = caption
+        params.update(kwargs)
+        return self._queue("editMessageCaption", **params)
+
+    def delete_message(self, chat_id, message_id):
+        return self._queue(
+            "deleteMessage", chat_id=chat_id, message_id=message_id,
+        )
+
+    def set_message_reaction(self, chat_id, message_id, reaction=None, is_big=False):
+        params: dict[str, Any] = {"chat_id": chat_id, "message_id": message_id}
+        if reaction is not None:
+            params["reaction"] = reaction
+        params["is_big"] = is_big
+        return self._queue("setMessageReaction", **params)
+
+    def send_chat_action(self, chat_id, action):
+        return self._queue("sendChatAction", chat_id=chat_id, action=action)
+
+    def answer_callback_query(self, callback_query_id, **kwargs):
+        params: dict[str, Any] = {"callback_query_id": callback_query_id}
+        params.update(kwargs)
+        return self._queue("answerCallbackQuery", **params)
+
+    def get_me(self):
+        return self._queue("getMe")
+
+    def public_identity(self):
+        """Non-secret identity via the gateway's getMe (or alias-only fallback)."""
+        result = self._queue("getMe")
+        if isinstance(result, dict) and result.get("status") != "error":
+            if result.get("alias") is not None:
+                return result
+        return {"alias": self.alias}
+
+    def _request(self, method: str, **kwargs: Any) -> dict:
+        """Minimal Bot-API-shaped passthrough for manager best-effort paths.
+
+        The manager's placeholder-typing shortcut calls
+        ``acct._request('sendChatAction', json={...})``; proxy mode routes it
+        through the gateway like every other outbound call.
+        """
+        params: dict[str, Any] = {}
+        payload = kwargs.get("json")
+        if isinstance(payload, dict):
+            params.update(payload)
+        return self._queue(method, **params)
+
+    # -- Polling is forbidden in proxy mode ----------------------------------
+
+    def get_updates(self):
+        raise NotImplementedError(
+            "proxy mode never calls getUpdates; the gateway owns polling"
+        )
+
+    def start(self) -> None:
+        """Proxy mode has no poll thread; the gateway owns the transport."""
+        return None
+
+    def stop(self) -> None:
+        return None
+
+
+class TelegramGatewayProxyService(TelegramService):
+    """Proxy-mode service: reuses the taskcard settings implementation only.
+
+    Deliberately builds no network account and starts no poll thread: every
+    ``get_account`` returns a ``TelegramGatewayProxy`` bound to the station's
+    command bus. ``start()``/``stop()`` are no-ops — the gateway owns polling
+    and the Task Card/receipt background owners. The manager keeps working
+    because the inherited taskcard settings surface
+    (``taskcard_enabled``, ``taskcard_normal_rows``, ``set_taskcard_listener``,
+    ``set_taskcard_enabled``) is unchanged, and only the account surface the
+    manager really needs is added.
+    """
+
+    def __init__(
+        self,
+        working_dir: Path | str,
+        aliases: Iterable[str],
+        command_sink: Callable[[dict], Any],
+        *,
+        config_source: str | None = None,
+    ) -> None:
+        # Reuse TelegramService's durable taskcard state + LocalCommandCore;
+        # an empty accounts_config means no network account is ever built.
+        super().__init__(
+            working_dir=working_dir,
+            accounts_config=[],
+            on_message=lambda _alias, _update: None,
+            config_source=config_source,
+        )
+        self._proxy_accounts = [
+            TelegramGatewayProxy(alias, command_sink) for alias in aliases
+        ]
+        self._proxy_by_alias = {p.alias: p for p in self._proxy_accounts}
+        # Optional bus reference so stop() can close the process-owned bus.
+        self._command_bus: Any = None
+
+    def get_account(self, alias: str) -> TelegramGatewayProxy:
+        try:
+            return self._proxy_by_alias[alias]
+        except KeyError:
+            raise KeyError(f"unknown account alias: {alias}") from None
+
+    @property
+    def default_account(self) -> TelegramGatewayProxy:
+        return self._proxy_accounts[0]
+
+    def list_accounts(self) -> list[str]:
+        return [proxy.alias for proxy in self._proxy_accounts]
+
+    def account_details(self) -> list[dict[str, Any]]:
+        details: list[dict[str, Any]] = []
+        for proxy in self._proxy_accounts:
+            try:
+                item = proxy.public_identity()
+            except Exception:
+                item = {}
+            item.setdefault("alias", proxy.alias)
+            details.append(item)
+        return details
+
+    def start(self) -> None:
+        """Proxy mode never polls; the gateway owns the transport."""
+        return None
+
+    def stop(self) -> None:
+        """Close the process-owned command bus if one was attached."""
+        bus = self._command_bus
+        if bus is not None:
+            try:
+                bus.close()
+            except Exception:
+                pass
+            self._command_bus = None

--- a/src/lingtai/mcp_servers/telegram/server.py
+++ b/src/lingtai/mcp_servers/telegram/server.py
@@ -48,9 +48,10 @@ from .._results import unknown_resource_error as _unknown_resource
 from .._results import unknown_tool_error as _unknown_tool
 
 from lingtai.adapters.posix.notification_store import PosixNotificationStoreAdapter
+from lingtai.services.mcp_licc import push_inbox_event
 
 from .. import _config
-from .licc import push_inbox_event
+from .bus import SqliteCommandBus
 from .manager import TelegramManager, SCHEMA, DESCRIPTION
 from ._family import handle_telegram
 from .service import TelegramService
@@ -629,6 +630,26 @@ def _accounts_from_config(cfg: dict) -> list[dict]:
 # Manager construction
 # ---------------------------------------------------------------------------
 
+def _gateway_marker(agent_dir: Path) -> dict | None:
+    marker = agent_dir / "telegram" / "gateway.json"
+    if not marker.is_file():
+        return None
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        log.warning("unreadable gateway marker %s; ignoring it", marker)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _proxy_bus_path(agent_dir: Path, marker: dict | None) -> Path:
+    value = marker.get("bus") if marker else None
+    if not isinstance(value, str) or not value.strip():
+        return agent_dir / "telegram" / "gateway.sqlite3"
+    path = Path(value)
+    return path if path.is_absolute() else agent_dir / path
+
+
 def build_manager() -> tuple[TelegramManager, Path]:
     """Construct manager + service from env + config. Returns (manager, working_dir)."""
     cfg = load_config()
@@ -637,6 +658,8 @@ def build_manager() -> tuple[TelegramManager, Path]:
     agent_dir_raw = os.environ.get("LINGTAI_AGENT_DIR")
     working_dir = Path(agent_dir_raw) if agent_dir_raw else Path.cwd()
     working_dir.mkdir(parents=True, exist_ok=True)
+    marker = _gateway_marker(working_dir)
+    proxy_mode = marker is not None
 
     def _on_inbound(event: dict) -> None:
         push_inbox_event(
@@ -645,18 +668,32 @@ def build_manager() -> tuple[TelegramManager, Path]:
             body=event["body"],
             metadata=event.get("metadata"),
             wake=event.get("wake", True),
+            agent_dir=str(working_dir),
+            mcp_name="telegram",
         )
 
     # Forward declare the manager so the service's on_message callback can
     # reach it. Same pattern as the legacy addon's lambda + mgr_ref dance.
     mgr_ref: list[TelegramManager | None] = [None]
 
-    svc = TelegramService(
-        working_dir=working_dir,
-        accounts_config=accounts,
-        on_message=lambda alias, update: mgr_ref[0].on_incoming(alias, update),
-        config_source=os.environ.get("LINGTAI_TELEGRAM_CONFIG"),
-    )
+    if proxy_mode:
+        from .proxy import TelegramGatewayProxyService
+
+        bus = SqliteCommandBus(_proxy_bus_path(working_dir, marker))
+        svc = TelegramGatewayProxyService(
+            working_dir=working_dir,
+            aliases=[str(item["alias"]) for item in accounts if item.get("alias")],
+            command_sink=bus.submit,
+            config_source=os.environ.get("LINGTAI_TELEGRAM_CONFIG"),
+        )
+        svc._command_bus = bus
+    else:
+        svc = TelegramService(
+            working_dir=working_dir,
+            accounts_config=accounts,
+            on_message=lambda alias, update: mgr_ref[0].on_incoming(alias, update),
+            config_source=os.environ.get("LINGTAI_TELEGRAM_CONFIG"),
+        )
 
     notification_store = PosixNotificationStoreAdapter(working_dir)
     mgr = TelegramManager(
@@ -664,6 +701,7 @@ def build_manager() -> tuple[TelegramManager, Path]:
         working_dir=working_dir,
         notification_store=notification_store,
         on_inbound=_on_inbound,
+        proxy_mode=proxy_mode,
     )
     mgr_ref[0] = mgr
     return mgr, working_dir

--- a/tests/test_telegram_single_owner_gateway.py
+++ b/tests/test_telegram_single_owner_gateway.py
@@ -1,0 +1,175 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from lingtai.mcp_servers.telegram.account import TelegramAccount
+from lingtai.mcp_servers.telegram.bus import SqliteCommandBus
+from lingtai.mcp_servers.telegram.gateway import GatewayManifestError, load_gateway_manifest, run_gateway
+from lingtai.mcp_servers.telegram.proxy import TelegramGatewayProxy
+
+
+class _Account:
+    def __init__(self, alias):
+        self.alias = alias
+        self.calls = []
+        self._next_id = 100
+        self._task_cards = {}
+
+    def send_message(self, chat_id, text, **kwargs):
+        message_id = self._next_id
+        self._next_id += 1
+        self.calls.append(("send_message", chat_id, message_id, text))
+        return {"message_id": message_id}
+
+    def edit_message(self, chat_id, message_id, text, **kwargs):
+        return {"ok": True}
+
+    def delete_message(self, chat_id, message_id):
+        return {"ok": True}
+
+    def send_chat_action(self, chat_id, action="typing"):
+        return {"ok": True}
+
+    def public_identity(self):
+        return {"alias": self.alias}
+
+    def set_message_reaction(self, chat_id, message_id, reaction):
+        return {"ok": True}
+
+    def get_task_card(self, chat_id):
+        return self._task_cards.get(str(chat_id))
+
+    def set_task_card(self, chat_id, message_id):
+        self._task_cards[str(chat_id)] = message_id
+
+    def clear_task_card(self, chat_id):
+        self._task_cards.pop(str(chat_id), None)
+
+    def list_task_card_chats(self):
+        return [int(chat_id) for chat_id in self._task_cards]
+
+    def get_last_message_id(self, chat_id):
+        return None
+
+
+class _Service:
+    def __init__(self, account):
+        self.default_account = account
+        self._account = account
+
+    def get_account(self, alias):
+        return self._account
+
+    def list_accounts(self):
+        return [self._account.alias]
+
+    def taskcard_enabled(self):
+        return False
+
+    def taskcard_normal_rows(self):
+        return 1
+
+    def set_taskcard_listener(self, listener):
+        self._listener = listener
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+def test_proxy_queues_commands_without_a_network_client():
+    commands = []
+    proxy = TelegramGatewayProxy(alias="bot", command_sink=commands)
+    assert proxy.send_message(123, "你好")["status"] == "queued"
+    assert commands[-1]["method"] == "sendMessage"
+    assert proxy._network_client is None
+    with pytest.raises(NotImplementedError):
+        proxy.get_updates()
+
+
+def test_manifest_references_configs_and_rejects_embedded_secrets(tmp_path: Path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({
+        "stations": [{"name": "control", "config": "telegram.json"}],
+    }), encoding="utf-8")
+    assert load_gateway_manifest(manifest)[0]["config"] == str(tmp_path / "telegram.json")
+
+    manifest.write_text(json.dumps({
+        "stations": [{"name": "control", "config": "x", "bot_token": "secret"}],
+    }), encoding="utf-8")
+    with pytest.raises(GatewayManifestError):
+        load_gateway_manifest(manifest)
+
+
+def test_polling_and_outbound_clients_are_independent(monkeypatch):
+    import lingtai.mcp_servers.telegram.account as account_module
+
+    class _Httpx:
+        Timeout = staticmethod(lambda *args, **kwargs: None)
+        Client = staticmethod(lambda *args, **kwargs: _Client())
+
+    class _Client:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(account_module, "httpx", _Httpx)
+    account = TelegramAccount("bot", "123:not-real", None)
+    account._ensure_client()
+    account._ensure_client(polling=True)
+    assert account._poll_client is not account._outbound_client
+    account.stop()
+    assert account._poll_client is account._outbound_client is None
+
+
+def test_two_station_gateway_routes_inbound_and_bus_commands(tmp_path: Path):
+    agents = [tmp_path / "a", tmp_path / "b"]
+    configs = [tmp_path / "a.json", tmp_path / "b.json"]
+    aliases = ["botA", "botB"]
+    for agent, config, alias in zip(agents, configs, aliases):
+        (agent / "telegram").mkdir(parents=True)
+        config.write_text(json.dumps({
+            "accounts": [{"alias": alias, "bot_token": "123:not-real"}],
+        }), encoding="utf-8")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"stations": [
+        {"name": "a", "config": str(configs[0]), "agent_dir": str(agents[0])},
+        {"name": "b", "config": str(configs[1]), "agent_dir": str(agents[1])},
+    ]}), encoding="utf-8")
+
+    accounts = {alias: _Account(alias) for alias in aliases}
+
+    def service_factory(working_dir, accounts_config, on_message, config_source=None):
+        service = _Service(accounts[accounts_config[0]["alias"]])
+        service.on_message = on_message
+        return service
+
+    host = run_gateway(manifest, service_factory=service_factory)
+    update = lambda message_id, chat_id, text: {
+        "update_id": message_id,
+        "message": {
+            "message_id": message_id, "date": 1700000000, "text": text,
+            "chat": {"id": chat_id, "type": "private"},
+            "from": {"id": 7, "first_name": "Human"},
+        },
+    }
+    host.managers[0].on_incoming("botA", update(1, 111, "hello A"))
+    host.managers[1].on_incoming("botB", update(2, 222, "hello B"))
+    assert len(list((agents[0] / ".mcp_inbox" / "telegram").glob("*.json"))) == 1
+    assert len(list((agents[1] / ".mcp_inbox" / "telegram").glob("*.json"))) == 1
+
+    client = SqliteCommandBus(agents[0] / "telegram" / "gateway.sqlite3")
+    result = client.submit({
+        "method": "sendMessage",
+        "params": {"alias": "botA", "chat_id": 111, "text": "ping"},
+    }, timeout=10)
+    assert result["message_id"] == 100
+    assert len([call for call in accounts["botA"].calls if call[0] == "send_message"]) == 1
+    assert accounts["botB"].calls == []
+    client.close()
+
+    host.stop()
+    assert not any(thread.is_alive() for thread in host._threads)
+    assert all(bus._closed for bus in host.buses.values())


### PR DESCRIPTION
## What changed

- Added one Telegram Gateway process that owns polling for all configured stations.
- Added a SQLite command bus and agent-side proxy so per-agent MCP processes never call `getUpdates`.
- Split long-poll and outbound HTTP clients per account.
- Added explicit per-station LICC routing and a secrets-free manifest format.

## Why

Multiple agent processes polling the same bot token caused ownership conflicts, while a shared synchronous HTTP client let long polling delay outbound replies and reactions.

## Impact

Each bot has one poll owner, outbound calls remain responsive, and station routing remains isolated across restarts.

## Validation

- `45 passed` across two-station Gateway routing, cross-connection command bus execution, proxy no-poll behavior, rate limits, and existing Task Card behavior.
