### PR TITLE
docs(daemon): per-backend subscription/auth sections + llm-adapters cross-link

### DIFF
--- a/src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
@@ -132,3 +132,29 @@ speaking a wire protocol directly. They are valid main-agent/preset providers
 and are lazy-imported like every other adapter. They are **not** the daemon CLI
 backend axis: the daemon system can dispatch external coding CLIs as task
 subprocesses (`daemon-manual`), independent of these registered providers.
+
+### External CLI harnesses (daemon backends)
+
+The daemon tool runs external coding CLIs as task subprocesses through the
+`backend` axis (`daemon-manual`). Each CLI backend has its own small
+progressive-disclosure page under
+`daemon-manual` → `reference/cli-backends` — what it is, what LingTai uses it
+for, its subscription/auth model, its official docs, and the reserved
+harness-owned flags it refuses in `backend_options`. These pages are
+entrypoints, not flag catalogs; the installed CLI's live help remains the
+authority.
+
+| Daemon backend | Page | Subscription/auth model | Official docs |
+|---|---|---|---|
+| `claude-p` / `claude-code` | `reference/backends/claude-p/SKILL.md` | Claude subscription (Pro/Max), CLI OAuth login | https://docs.anthropic.com/en/docs/claude-code |
+| `codex` | `reference/backends/codex/SKILL.md` | ChatGPT subscription (Plus/Pro), `codex login` or codex-pool | https://developers.openai.com/codex/ |
+| `opencode` | `reference/backends/opencode/SKILL.md` | provider-agnostic auth; OpenCode Go subscription via `OPENCODE_GO_API_KEY` | https://opencode.ai/docs/ |
+| `mimocode` / `mimo` | `reference/backends/mimocode/SKILL.md` | MiMo Code provider keys | https://github.com/XiaomiMiMo/MiMo-Code |
+| `qwen-code` / `qwen` | `reference/backends/qwen-code/SKILL.md` | Qwen provider config | https://github.com/QwenLM/qwen-code |
+| `oh-my-pi` / `omp` | `reference/backends/oh-my-pi/SKILL.md` | Oh-My-Pi provider keys | https://github.com/pi-coding-agent/pi-coding-agent |
+| `kimicode` / `kimi` | `reference/backends/kimicode/SKILL.md` | Moonshot AI keys | https://github.com/MoonshotAI/kimi-code |
+| `cursor` | `reference/backends/cursor/SKILL.md` | Cursor account/subscription login | https://docs.cursor.com/agent |
+
+Each backend page carries the same small `## Subscription & auth` section so
+the question "what do I need to pay for / how does LingTai connect" is
+answered per backend without reading the vendor's full billing docs.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/SKILL.md
@@ -111,6 +111,12 @@ catalog. Only backends with proven demand get a page.
 | Oh-My-Pi (`omp`)-specific flags for a daemon task: model selection, tool/provider switches, the harness-reserved mode/approval/session flags; discover the installed `omp` CLI's flags and translate them into `backend_options` | `reference/backends/oh-my-pi/SKILL.md` |
 | Built-in `lingtai` backend knowledge for a daemon task: confirm it has no CLI/`backend_options` flag surface; find the live authorities for preset selection/inspection, lingtai/tools/skills/MCP inheritance, and the completion contract | `reference/backends/lingtai/SKILL.md` |
 
+Each backend page also carries a small `## Subscription & auth` section:
+what the vendor subscription/account model is, how LingTai connects (login,
+API-key env, or config file), and the official docs link — enough to answer
+"what do I need to pay for / how does LingTai authenticate" per backend
+without reading the vendor's full billing docs.
+
 ## API note: `daemon(action="list", input={})`
 
 `list` is a compact index over both currently tracked runs and historical run

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
@@ -59,7 +59,7 @@ Uses the human's **Claude subscription** (Pro/Max) via `claude login` OAuth
 (`~/.claude/.credentials.json`); spawn strips `ANTHROPIC_API_KEY` /
 `ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN`.
 
-Official docs: https://docs.anthropic.com/en/docs/claude-code
+Official docs: https://platform.claude.com/docs/en/docs/claude-code
 
 ## Harness boundary
 

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/claude-p/SKILL.md
@@ -19,19 +19,16 @@ maintenance: |
 # claude-p Daemon Backend — Flag Discovery Entrypoint
 
 The installed CLI's own help is the authority for Claude Code flags; this page is
-only the entrypoint. Conversion rules, key safety, and persistence live in the
-parent [`reference/cli-backends/SKILL.md`](../../../SKILL.md). `claude-p` is the
-canonical print-mode backend id; `claude-code` is a compatibility alias with the
-same runner and reserved-flag set.
+only the entrypoint. Conversion rules and persistence live in the parent
+[`reference/cli-backends/SKILL.md`](../../../SKILL.md). `claude-p` is the
+canonical print-mode backend id; `claude-code` is a compatibility alias.
 
 ## Discover flags from the installed CLI
 
 1. Load `shell-manual` (its nested `reference/bash-claude-code/SKILL.md` has
    broader Claude Code CLI context).
-2. Run, in bash: `claude --version` and `claude --help`. The daemon backend
-   wraps `claude --print`, so the print-mode flags in `claude --help` are the
-   relevant surface. These are local read-only commands; no session is
-   started.
+2. Run `claude --version` and `claude --help` in bash. The daemon wraps
+   `claude --print`; the print-mode flags are the relevant surface.
 3. Translate what you found into `backend_options` with the parent's generic
    conversion rules. Nothing Claude-specific is added to that contract here.
 
@@ -56,6 +53,14 @@ Through `backend_options`, an underscore key becomes a dashed long flag:
 The model-name vocabulary belongs to the installed CLI and the provider account —
 LingTai does not validate, enumerate, or simulate model names.
 
+## Subscription & auth
+
+Uses the human's **Claude subscription** (Pro/Max) via `claude login` OAuth
+(`~/.claude/.credentials.json`); spawn strips `ANTHROPIC_API_KEY` /
+`ANTHROPIC_AUTH_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN`.
+
+Official docs: https://docs.anthropic.com/en/docs/claude-code
+
 ## Harness boundary
 
 The harness spawns `claude --print --dangerously-skip-permissions
@@ -79,12 +84,7 @@ Related run-scoped behavior you should not fight through flags:
   --print ...` against the session id persisted to `daemon.json.claude_session_id`;
   `backend_options` are not re-passed on ask — emanate-time flags persist for
   the session's life.
-- Auth-env hygiene: the spawn environment strips `ANTHROPIC_API_KEY` and
-  `ANTHROPIC_AUTH_TOKEN` (force API billing; GH #107) plus
-  `CLAUDE_CODE_OAUTH_TOKEN` (a stale inherited token can override a refreshed
-  `~/.claude/.credentials.json`, surfacing as a false "weekly limit"; see
-  Lingtai-AI/lingtai#189) so the CLI's own OAuth credentials win — do not
-  re-inject auth overrides via flags. A *manual* `claude` shell invocation has
-  no such protection; for the weekly-limit smoke test and the stale token's
-  source, read `shell-manual` → `reference/bash-claude-code/SKILL.md`. Never
-  print token values while diagnosing.
+- Auth-env hygiene: the daemon spawn strips `ANTHROPIC_API_KEY`,
+  `ANTHROPIC_AUTH_TOKEN`, and `CLAUDE_CODE_OAUTH_TOKEN` so refreshed OAuth wins
+  over stale inherited tokens (see Subscription & auth above; a stale token
+  surfaces as a false "weekly limit"). Never print token values.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/codex/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/codex/SKILL.md
@@ -56,6 +56,14 @@ The effort vocabulary belongs to the installed CLI and the selected model —
 LingTai does not validate, enumerate, or simulate effort levels. A value like
 `ultra` passes through and the CLI/model decides its semantics (or rejects it).
 
+## Subscription & auth
+
+Billed through the **ChatGPT subscription** (Plus/Pro) via `codex login`, or a
+shared codex-pool (`~/.lingtai-tui/codex-auth-pool.json`). LingTai inherits the
+CLI's own credentials; see `bash-openai-codex` for login/API-key variants.
+
+Official docs: https://developers.openai.com/codex/
+
 ## Harness boundary
 
 Codex currently declares no reserved-flag list at the validation layer, so

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/cursor/SKILL.md
@@ -18,8 +18,8 @@ maintenance: |
 # Cursor Daemon Backend — Flag Discovery Entrypoint
 
 The installed CLI's own help is the authority for Cursor Agent flags; this page
-is only the entrypoint. Conversion rules, key safety, and persistence live in the
-parent [`reference/cli-backends/SKILL.md`](../../../SKILL.md).
+is only the entrypoint. Conversion rules live in the parent
+[`reference/cli-backends/SKILL.md`](../../../SKILL.md).
 
 ## Discover flags from the installed CLI
 
@@ -27,10 +27,9 @@ parent [`reference/cli-backends/SKILL.md`](../../../SKILL.md).
    broader Cursor Agent CLI context).
 2. Run `agent --version` and `agent --help` in bash. The daemon spawns root
    `agent` directly — `agent -p --force --output-format stream-json <prompt>` —
-   so root help is authoritative (open a subcommand only if root routes there).
-   These are read-only checks; keychain errors happen before help on some builds.
+   so root help is authoritative (keychain errors happen before help on some builds).
 3. Translate what you found into `backend_options` with the parent's generic
-   conversion rules. Nothing Cursor-specific is added to that contract here.
+   conversion rules (nothing Cursor-specific is added).
 
 ## Example: model selection via the generic route
 
@@ -61,26 +60,29 @@ For installed `agent-cli@2026.05.28-a70ca7c`, accept usage only from `type=resul
 `inputTokens` is already net; UI-only `cli_tokens` adds read + write as cached, preserves raw usage, ignores invalid/all-zero blocks, and counts duplicate terminal results once.
 Join model only from a preceding matching `system/init` by `session_id`; provider stays unknown because this source emits no provider identity (do not infer it from `apiKeySource`, model, backend, credentials, or environment). This is version-pinned, not a cross-release claim.
 
+## Subscription & auth
+
+Cursor account/subscription (keychain login); LingTai does not inject
+credentials — the CLI must be signed in.
+
+Official docs: https://docs.cursor.com/agent
+
 ## Harness boundary
 
-Cursor currently declares no reserved-flag list at the validation layer, so
-nothing is refused for this backend beyond the generic key/value safety
-rules. Still, do not re-set harness-owned surfaces: `-p` (non-interactive
+Cursor declares no reserved-flag list at validation, so nothing is refused
+beyond generic key/value safety rules. Still, do not re-set harness-owned
+surfaces: `-p` (non-interactive
 print mode), `--force` (allows file modifications in print mode),
 `--output-format stream-json` (one JSON event per stdout line — the daemon's
 progress/result parser and the session-id capture depend on it), and
-`--resume` (owned by `daemon(action='ask', input={'id': ..., 'message': ...})` follow-ups, which replay the
-captured session id).
+`--resume` (owned by `ask` follow-ups, which replay the captured session id).
 
-Session and completion behavior, source-verified: the first stream event
-carrying a session-id-shaped field is stored in `daemon.json` as
-`cursor_session_id`; `ask` resumes with
+Session and completion: the first session-id-shaped stream event is stored
+as `cursor_session_id`; `ask` resumes with
 `agent -p --force --resume <cursor_session_id> --output-format stream-json
-<message>` (async, one follow-up in flight per session). Per-run MCP
-injection — including the `daemon_common` completion MCP — is not wired for
-this backend yet, so there are no MCP loader flags to collide with and no
-`finish` contract: success comes from the stream's final result event and
-the process exit code.
+<message>` (one follow-up in flight per session). Per-run MCP injection is
+not wired for this backend yet, so no `finish` contract: success comes from
+the stream's final result event and the process exit code.
 
 `backend_options` is honored only at `emanate` time; `ask` follow-ups reuse the
 session without re-passing it.

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/kimicode/SKILL.md
@@ -59,6 +59,13 @@ Through `backend_options`, a string value becomes `--flag <value>`:
 The model vocabulary belongs to the installed CLI and its provider
 configuration — LingTai does not validate, enumerate, or simulate model names.
 
+## Subscription & auth
+
+Moonshot AI keys: `KIMICODE_API_KEY` / `KIMI_API_KEY` / `MOONSHOT_API_KEY` map
+to `KIMI_MODEL_API_KEY` only when unset. Never print key values.
+
+Official docs: https://github.com/MoonshotAI/kimi-code
+
 ## Harness boundary
 
 Kimi Code declares a reserved-flag list at the validation layer; passing any

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/mimocode/SKILL.md
@@ -58,6 +58,13 @@ between the harness flags and the trailing prompt positional.
 The flag/value vocabulary belongs to the installed CLI — LingTai does not
 validate, enumerate, or simulate it.
 
+## Subscription & auth
+
+Per-provider keys (see `swiss-knife`'s `xiaomi-mimo` reference); the CLI reads
+its configured credentials at spawn. LingTai does not inject or rotate them.
+
+Official docs: https://github.com/XiaomiMiMo/MiMo-Code
+
 ## Harness boundary
 
 `mimocode` reserves `--format` (daemon progress/result extraction depends on

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/oh-my-pi/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/oh-my-pi/SKILL.md
@@ -58,6 +58,13 @@ The model vocabulary belongs to the installed CLI and its configured providers â
 LingTai does not validate, enumerate, or simulate model ids. Use the CLI's own
 discovery surface (root `--help`) and pass the id through.
 
+## Subscription & auth
+
+Per-provider keys through the CLI's own config; LingTai does not inject or
+rotate credentials.
+
+Official docs: https://github.com/pi-coding-agent/pi-coding-agent
+
 ## Harness boundary: reserved flags
 
 The daemon owns Oh-My-Pi's non-interactive JSON harness

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/opencode/SKILL.md
@@ -57,6 +57,15 @@ for both). Through `backend_options`, plain scalars become `--flag <value>`:
 The model and variant vocabularies belong to the installed CLI and the selected
 provider — LingTai does not validate, enumerate, or simulate them.
 
+## Subscription & auth
+
+Provider-agnostic: `opencode auth login` stores credentials in
+`~/.local/share/opencode/auth.json` (env/.env also load keys). For the curated
+**OpenCode Go** subscription use the `opencode-go` preset with
+`OPENCODE_GO_API_KEY` and `https://opencode.ai/zen/go/v1` (chat wire only).
+
+Official docs: https://opencode.ai/docs/
+
 ## Harness boundary
 
 OpenCode reserves `--format` at the validation layer: the daemon owns

--- a/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/reference/cli-backends/reference/backends/qwen-code/SKILL.md
@@ -59,6 +59,13 @@ Your options land between the harness-owned `--yolo` and the final
 The model vocabulary belongs to the installed CLI and the configured provider —
 LingTai does not validate, enumerate, or simulate model names.
 
+## Subscription & auth
+
+Authenticates via the installed CLI's provider config (Qwen/DashScope keys);
+LingTai does not set or rotate credentials.
+
+Official docs: https://github.com/QwenLM/qwen-code
+
 ## Harness boundary
 
 Qwen Code reserves `--prompt`/`-p`, `--yolo`/`-y`, and `--approval-mode`:


### PR DESCRIPTION
Per Jason's request: systematically update each daemon provider's manual with small progressive-disclosure pages that point to the vendor's official docs and briefly explain what LingTai actually uses.

## Changes
- **8 daemon CLI backend pages** (claude-p, codex, opencode, mimocode, qwen-code, oh-my-pi, kimicode, cursor): added a small "Subscription & auth" section on each — what the vendor subscription/account model is, how LingTai connects (login, API-key env, config file), and the official docs link. Kept within the existing 90-line tiny-page contract (trimmed redundant prose where needed, e.g. claude-p auth bullet dedupe).
- **cli-backends router**: added a routing note so the subscription/auth question is discoverable from the parent.
- **llm-adapters (system-manual)**: added an "External CLI harnesses (daemon backends)" section with a cross-link table (backend → page → subscription model → official docs), clarifying these are a separate axis from LLM provider adapters.

## Tests
- All daemon submanual tests + contract doc + llm-adapters parity: **64 passed**.
- Broader run shows 20 pre-existing failures (wheel/sdist package-state + skill frontmatter on clean main, unrelated to this change — verified by stash comparison).