### PR TITLE
docs(skills): add refresh-precheck subskill; apply skills simplification audit

### DIFF
--- a/src/lingtai/intrinsic_skills/context-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/context-manual/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: context-manual
 description: |
-  Router and operational guide for the context tool — molt, tool-result summarize/rebuild, session journaling, and post-wipe recovery. Read this when: you are about to molt; you need to compact or rebuild your provider context; you need to tend the four durable stores; you want guidance on writing a good summary or session journal; you wake up after a system-performed wipe with a system-authored summary; or you need to understand keep_tool_calls and keep_last. Routes consequential molt handoffs to assets/molt-template.md and summarize/rebuild procedure to reference/summarize-manual, keeping routine guidance compact.
-version: 2.0.0
-last_changed_at: 2026-08-07T00:00:00-07:00
+  Router and operational guide for the context tool: molt, summarize/rebuild, session journaling, and post-wipe recovery. Read it when molting, compacting or rebuilding provider context, tending the four durable stores, or waking from a system-performed wipe. Routes consequential handoffs to assets/molt-template.md and the summarize/rebuild procedure to reference/summarize-manual.
+version: 2.1.0
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/tools/context/__init__.py
 - src/lingtai/tools/context/_molt.py
@@ -17,8 +17,6 @@ maintenance: |
 
 This manual is the router for `context` operations — `molt`, `summarize`, and `rebuild`. Keep routine guidance here; load the supporting asset or reference only when you need the full scaffold or the detailed summarize/rebuild procedure.
 
-Your name is not a context operation: use `system(action='name_set')` / `system(action='name_nickname')`.
-
 ## Reference catalog
 
 | Reference | When to load |
@@ -27,9 +25,9 @@ Your name is not a context operation: use `system(action='name_set')` / `system(
 
 ## Full context rebuild
 
-`context(action="rebuild", input={}, reasoning="...")` is the **one active full reconstruction operation**. Every call first re-reads and recomposes all canonical system-prompt sources (configured and durable identity, base prompt, covenant, packaged layers, rules, Pad body and pinned references, the enabled Skills and Knowledge catalogs, brief, comment, tools/runtime guidance), then applies already-pending summaries, then asks the provider to replay the new prompt/history. Bare `{}` is valid and still reconstructs/replays when zero summaries are pending. With `items`, prompt composition still happens first; the new summaries are then recorded/applied before provider replay.
+`context(action="rebuild", ...)` is the **one active full reconstruction operation**: recompose every canonical prompt source → apply pending summaries → provider replay. The tool description and the `rebuild` schema carry the exact contract, including that bare `{}` is valid.
 
-Generic durable mutations do not hot-load: use `file.write` for full-file create/overwrite and `file.edit` for exact replacement, then call `context.rebuild` when changes must apply now. That is the only mutation path for all four durable stores — there is no per-store append, info, or reload action. Passive refresh and molt invoke the same internal reconstruction contract while retaining their distinct lifecycle effects. Do not loop rebuild.
+The fact that is only here: **generic durable mutations do not hot-load.** Write with `file.write`/`file.edit`, then rebuild when the change must apply now — that is the only mutation path for all four durable stores (no per-store append, info, or reload action). Passive refresh and molt invoke the same internal reconstruction contract with their own lifecycle effects. Do not loop rebuild.
 
 ## Asset catalog
 
@@ -42,9 +40,9 @@ Generic durable mutations do not hot-load: use `file.write` for full-file create
 
 Molt is yours to perform. The covenant teaches the philosophy (§V); this is the recipe.
 
-**Molt is an easy, simple task. Do it regularly if you'd like to.** Save anything you need to pad, lingtai, knowledge, and skills beforehand, then molt. No need to wait for the context window to fill up — molting early saves tokens. Keep good notes in the stores so you don't lose your way across molts.
+Save anything you need to pad, lingtai, knowledge, and skills beforehand, then molt — there is no need to wait for the context window to fill up, and molting early saves tokens.
 
-**The four stores are the real persistence. The summary is the briefing on top of them.** If you molt without tending the stores, the next you wakes with only the briefing — no character evolution, no pad state, no new knowledge, no new skills. Tend the stores *first*, every time.
+**Tend the stores first, every time.** The four stores are the real persistence and the summary is only the briefing on top of them: molt without tending them and the next you wakes with the briefing alone — no character evolution, no pad state, no new knowledge, no new skills.
 
 ## 2. Store-Tending Rhythm
 
@@ -52,17 +50,14 @@ For `lingtai` and `knowledge`, tending happens *once* per task, at the end — n
 
 Pad has a different rhythm — update it whenever the index meaningfully changes. See §5 below.
 
-All four durable stores are taught by manuals loaded through the one `psyche` root (pad + lingtai + knowledge + skills = psyche); generic mutation belongs to `file`:
-
-- **`lingtai`** — `psyche(action="lingtai", input={}, reasoning="load identity guidance")` explains identity modes and tending. Mutate `system/lingtai.md` with `file.write`/`file.edit`; no hot load.
-- **`pad`** — `psyche(action="pad", input={}, reasoning="load Pad guidance")` explains the Pad body and the pinned-reference list. Mutate `system/pad.md` and `system/pad_append.json` with `file.write`/`file.edit`; both take effect only after reconstruction.
+All four durable stores are taught by manuals loaded through the one `psyche` root (pad + lingtai + knowledge + skills = psyche); generic mutation belongs to `file`. §3 below is the per-store how-to.
 
 ## 3. Step 1 — Tend the Four Durable Stores and Session Journal
 
 - **lingtai** — carry forward your complete identity in `system/lingtai.md` using `file.write` (full rewrite) or `file.edit` (exact replacement). Read `psyche(action="lingtai", input={}, reasoning="...")` for forced/self-evolve behavior.
 - **pad** — keep the living index in `system/pad.md` via `file.write`/`file.edit`; edit `system/pad_append.json` the same way for the durable pinned-reference list. See `psyche(action="pad", input={}, reasoning="...")`.
 - **knowledge** — write to `knowledge/<name>/KNOWLEDGE.md` for long-term private context using `file.write`/`file.edit`.
-- **skills** — write `.library/custom/<name>/SKILL.md` (with YAML frontmatter: `name`, `description`, `version`) for any reusable procedure the next you (or a peer) might need, then call `context(action="rebuild", input={}, reasoning="rescan skills catalog")` to re-scan the catalog. Share by sending the skill source/artifact so peers install it into their own `.library/custom/<name>/` and refresh; use `../.library_shared/<name>/` only as an explicit opt-in local-network shared root.
+- **skills** — write `.library/custom/<name>/SKILL.md` (with YAML frontmatter: `name`, `description`, `version`) for any reusable procedure the next you (or a peer) might need, then rebuild to refresh the catalog. Share by sending the skill source/artifact so peers install it into their own `.library/custom/<name>/` and refresh; use `../.library_shared/<name>/` only as an explicit opt-in local-network shared root.
 - **session journal** — append a substantial sub-entry under `knowledge/session-journal/` describing what you did this session. See §4 for the full practice.
 
 All five happen *before* the molt call. They are not optional. Without them, the molt sheds everything.
@@ -135,11 +130,8 @@ own strict `input` object, and a root `reasoning`. The four actions are `molt`,
 false: `context` results are small (short-result profile), and summarizing a
 `manual` call would drop the exact procedure you called it for.
 
-Note the two levels that share the word: the **action** `summarize` is the
-domain operation that records compact replacements for bulky tool results, while
-the optional **root** `summarize` boolean is the unrelated result-presentation
-control. They never mean the same thing, and no action takes `summarize` as
-input.
+(The action-`summarize` versus root-`summarize` distinction is stated in the
+resident tool description; no action takes `summarize` as input.)
 
 `context` owns only your context. Your name is `system(action='name_set')` /
 `system(action='name_nickname')`. Your four durable stores share one read-only root: `psyche(action="pad"|"lingtai"|"knowledge"|"skills"|"manual", input={}, reasoning="...")` returns the matching manual and nothing else. Use `file.write`/`file.edit` for their durable files, then rebuild explicitly when needed.
@@ -150,24 +142,18 @@ validates it → only then does the molt proceed. `session_journal_path` is a
 **mandatory** structured argument for agent-initiated molt. If it is missing or
 the journal fails validation, the molt is **refused before any context is shed**
 and your `molt_count`/history are untouched — you get an actionable recovery
-message instead. The validator checks (intentionally simple, a signpost not a
-grader):
-
-- The path is inside your workdir and resolves to
-  `knowledge/session-journal/<entry>/KNOWLEDGE.md` — a per-segment sub-entry,
-  **not** the parent index `knowledge/session-journal/KNOWLEDGE.md`, and not a
-  scratch file like `tmp/...`.
-- The file exists, is non-empty, and is UTF-8 text.
-- It has valid YAML frontmatter with at least `name` and `description`.
-- The frontmatter carries the session-journal marker `type: session-journal`
-  (or `session_journal: true`) — see the template in §4. A generic knowledge
-  file without the marker is rejected.
+message instead. The validator (a signpost, not a grader) checks what the schema
+describes: path inside your workdir resolving to
+`knowledge/session-journal/<entry>/KNOWLEDGE.md` (the per-segment sub-entry, not
+the parent index and not a scratch file), non-empty UTF-8, frontmatter with
+`name` + `description`, and the marker `type: session-journal` or
+`session_journal: true` — see the template in §4.
 
 The accepted path is recorded in the molt result, the persisted summary
 frontmatter (`session_journal_path:`), and the post-molt notification, so later
 recovery and audits can see which journal backed each molt.
 
-The `summary` is the only *conversation-layer* thing the next you will see. Aim for ~10,000 tokens — be thorough when state is complex. The summary is not a recap of conversation. It is your charge to the self that comes after you — anchored in the four stores, which are already waiting in the fresh session.
+The `summary` is the only *conversation-layer* thing the next you will see. Aim for the ~10,000 tokens the schema suggests. The summary is not a recap of conversation. It is your charge to the self that comes after you — anchored in the four stores, which are already waiting in the fresh session.
 
 For a routine molt, include:
 
@@ -187,32 +173,33 @@ Quick routing:
 | Consequential molt / successor handoff — long-running task, multiple collaborators, pending human commitments, open worktrees/artifacts, or any handoff the next you could not reconstruct quickly | Read `assets/molt-template.md` from this skill directory; use its full scaffold and checklist. Fill every section; write `None` rather than omitting one. |
 | Unsure whether the handoff is complex | Use the asset; extra structure is cheaper than a bad handoff. |
 
-Before you call `context(action="molt", ...)`, always verify at minimum:
+Before you call `context(action="molt", ...)`, verify at minimum:
 
-- The session-journal sub-entry for the just-finished segment exists and is
+- The session-journal sub-entry for the just-finished segment exists and was
   written *before* the summary (§4) — it is the narrative the summary points
   back to, and its path is the validated `session_journal_path`.
-- Durable stores and session journal were updated where needed before writing the summary.
-- Every outstanding task has an explicit next action.
-- Collaborators, channels, approvals, and key paths are named where relevant.
-- Active background work is listed or explicitly absent.
+- Durable stores were tended before the summary was written.
 - The first five minutes after wake are obvious.
 
-**`keep_tool_calls`** — optional list of tool-call IDs to preserve across molt. Each named pair (tool_use + tool_result) is replayed into the fresh session right after the summary, in the order you list them. If any ID is not found, the molt is refused. Keep this list short — the durable stores are the primary persistence.
+`assets/molt-template.md` carries the full pre-molt verification checklist
+(outstanding tasks, collaborators, background work, key paths).
 
-**`keep_last`** — optional integer (default: 20). Requested minimum number of recent conversation entries to preserve. The retained suffix may expand backward to include one adjacent assistant tool-call/result batch whole, so it can contain more entries when needed to avoid splitting that batch. These entries are replayed so the post-molt self retains recent context. Pass 0 to explicitly disable (archive everything). Overlapping entries with `keep_tool_calls` are deduplicated.
+**`keep_tool_calls`** — see the schema description for the exact semantics (refusal on an unknown ID, replay order). Keep the list short: the durable stores are the primary persistence.
+
+**`keep_last`** — see the schema description (default 20, backward expansion to keep a tool-call batch whole, `0` to archive everything, dedupe against `keep_tool_calls`).
 
 ## 7. Context Pressure Reminder
 
 Context pressure is agent state, not a dismissible notification. Tool results surface a natural-language reminder under `_meta.agent_meta.agent_state.context.molt` only after context has stayed high for several consecutive fresh provider rounds (the sustained-pressure threshold is 85%). It rides on the current `agent_meta` snapshot (carried on the designated final result of each batch; restamped there while active) so the reminder persists. The field name is historical: the reminder is a context-pressure action, not an early staged molt order or a machine-readable tag block.
 
-When this reminder appears, batch already-digested noisy history into one `context(action='summarize')` pass rather than summarizing a small piece at a time, then run one `context(action='rebuild')` to recompose all canonical prompt sources, apply summaries, and request provider replay — the summarize cadence, rebuild semantics, and recovery target are owned by this manual's own `reference/summarize-manual/SKILL.md`. The molt decision is yours: if a batched summarize/rebuild pass still leaves context above 85%, stop repeating summarize, tend durable stores, and molt deliberately. If context falls below 85% but stays above the recovery target, continue only when the current task still needs the carried context; otherwise molt at a natural task boundary.
+When this reminder appears, follow the urgent cadence in `reference/summarize-manual/SKILL.md` (which owns the summarize cadence, rebuild semantics, and recovery target). The molt decision is yours: if a batched summarize/rebuild pass still leaves context above 85%, stop repeating summarize, tend durable stores, and molt deliberately. If context falls below 85% but stays above the recovery target, continue only when the current task still needs the carried context; otherwise molt at a natural task boundary.
 
 ### Cache-miss budget
 
-A second `agent_meta.agent_state.context.molt` reminder guards a soft **cache-miss token budget** — a since-last-molt cap on total cache-miss (uncached input) tokens. The cache-miss total is `max(input_tokens - cached_tokens, 0)` from the same cumulative/restored totals behind `agent_meta.agent_state.token_usage.session` — it accumulates since your last molt and SURVIVES a refresh/restart (it is not the since-refresh runtime delta), so a refresh does not reset the remaining budget. The budget defaults to **1,000,000** tokens and is set via `manifest.cache_miss_budget` in init.json, or overridden at runtime by the `LINGTAI_CACHE_MISS_BUDGET` env var (positive int; read live at every budget resolution, so your `env_file` + refresh applies it without an init.json edit — an invalid or non-positive value silently falls back to the configured budget).
+The soft **cache-miss token budget** (default 1,000,000 via `manifest.cache_miss_budget`, cumulative since your last molt, surfaced as `cache miss budget {N} reached, molt now`) is owned by the resident `meta_guidance` token-efficiency guidance. Two details only documented here:
 
-Once the since-last-molt cache-miss total reaches or exceeds the budget, tool results restamp `_meta.agent_meta.agent_state.context.molt` with `cache miss budget {N} reached, molt now`, and `_meta.agent_meta.agent_state.context` reports `cache_miss_budget` (the effective budget — the `LINGTAI_CACHE_MISS_BUDGET` env override if set, else the configured one) and `cache_miss_tokens` (the current cache-miss total). If the sustained context-pressure reminder above is also active, both warnings are preserved in `context.molt` (the budget line is appended). This is a soft cap — nothing is blocked — but the recommended action is to **molt now**: a large cache-miss total means the session keeps re-sending uncached context, so shedding it via molt restores cache efficiency.
+- It is **overridable at runtime** by `LINGTAI_CACHE_MISS_BUDGET` (positive int, read live at every budget resolution, so `env_file` + refresh applies it without an init.json edit; an invalid or non-positive value silently falls back to the configured budget). `_meta.agent_meta.agent_state.context` reports the effective `cache_miss_budget` and the current `cache_miss_tokens`.
+- The total **survives a refresh/restart** — it is not the since-refresh runtime delta, so refreshing does not reset the remaining budget. If the sustained context-pressure reminder is also active, both warnings are preserved in `context.molt`.
 
 ## 8. Post-Wipe Recovery
 

--- a/src/lingtai/intrinsic_skills/context-manual/reference/summarize-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/context-manual/reference/summarize-manual/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: summarize-manual
 description: >-
-  Detailed operational guide for tool-result summarization across LingTai's
-  three context-compression / continuation modes: a-priori reasoning-guided
-  (summary=true on bash/read/grep/daemon/glob), a-posteriori agent-guided
-  (context(action="summarize")), and molt. Covers what tool-result summarization
-  is, why it implements progressive disclosure, when to summarize urgently versus
-  during idle cleanup, how to write good summaries, how to recover the original
-  tool result by tool_call_id, and how summarize differs from molt.
-last_changed_at: "2026-07-27T17:02:00-07:00"
+  Operational guide for tool-result summarization: the three compression modes
+  (a-priori `summary=true`, a-posteriori `context(action="summarize")`, molt),
+  the urgent and idle cadences, delayed provider reconstruction and the
+  0.85/1.0 rebuild boundaries, recovery by `tool_call_id`, and summarize
+  versus molt.
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/tools/system/summarize.py
@@ -65,31 +63,19 @@ both with molt.
 - The replacement is clearly marked **generated and non-canonical** and carries
   a retrieval hint pointing back at the preserved raw by `tool_call_id`.
 
-When to set `summary=true`:
+Resident substrate §VII carries the when-to-use rule (prefer it when you can
+state the retention spec before the call and the output is large — rule of thumb
+>10k chars; leave it `false` when you need exact line/file/diff/stderr text you
+will quote, diff, patch, or compare).
 
-- Prefer it over a posteriori summarize whenever you can state before the call
-  what you need to know from the result.
-- The expected output is large (rule of thumb: >10k chars) **and** you do not
-  need the exact raw text — you need a conclusion, a count, a list of anchors,
-  or a yes/no.
-
-When to leave it `false` (the default):
-
-- You need exact line/file/diff/stderr text — anything you will quote, diff,
-  patch, or compare character-by-character. Leave `false` and read the raw.
-
-**A priori is preferred but still lossy.** `summary=true` is an
-assumption-driven compression chosen *before* you inspect the result. Prefer it
-when you can state the narrow facts to retain before the call, because it avoids
-spending context on raw bulk at all. The runtime discards everything outside what
-your `reasoning` named, with no chance for you to notice what mattered, so it is
-**not** a substitute for a-posteriori `context(action="summarize")` when the
-important facts are unknowable before inspection, especially for
-high-information-density results — daemon outputs, code reviews, long reports,
-or anything whose important facts you cannot name in advance.
-Compressing those a priori silently drops the facts you did not know to ask for.
-For them, leave `summary=false`, consume the raw, then summarize a posteriori
-once you know what to keep — or molt when the whole conversation is the pressure.
+**A priori is preferred but still lossy.** The runtime discards everything
+outside what your `reasoning` named, with no chance for you to notice what
+mattered — so it is **not** a substitute for a-posteriori
+`context(action="summarize")` on high-information-density results whose
+important facts you cannot name in advance (daemon outputs, code reviews, long
+reports). For those, leave `summary=false`, consume the raw, then summarize a
+posteriori once you know what to keep — or molt when the whole conversation is
+the pressure.
 
 **Hard cap.** If the raw visible payload exceeds **500,000 characters**, the
 runtime does **not** call the summarizer LLM. Instead you receive a small
@@ -214,20 +200,19 @@ Summarize has two decoupled effects:
    contain the old raw block. A manual `context(action="rebuild")` first re-reads
    and recomposes every canonical system-prompt source, then applies pending/new
    summaries (markers flip to `status: done`), then requests provider replay with
-   the new prompt/history. The 1.0 hard forced path is passive but uses the same
-   full prompt reconstruction contract before fresh replay.
+   the new prompt/history. The automatic 1.0 hard forced path uses the
+   same full prompt reconstruction contract before fresh replay.
 
 The dynamic pending totals in the result comment scan only `status: pending`
 markers — already-applied (`done`) markers and legacy markers without a status
 are not counted as pending.
 
-Provider-side reconstruction is delayed because runtimes usually append turns
-onto a stable cache/continuation prefix. Rebuilding that prefix on every
-summarize would discard cache benefit.
+Reconstruction is delayed because runtimes append turns onto a stable
+cache/continuation prefix, and rebuilding that prefix on every summarize would
+discard the cache benefit.
 
 - **Below 1.0 of the context window:** summarize stays pending at the provider
-  layer and the session keeps appending. This delay is normal, not a failure; do
-  not call `refresh` merely to "apply" the summary.
+  layer and the session keeps appending. This delay is normal, not a failure.
 - **At or above 0.85 of the context window:** `_meta.agent_meta.agent_state.context.rebuild`
   is stamped continuously. It is a decision prompt / permission, not an automatic
   rebuild — recording summaries never triggers a provider-context rebuild on its
@@ -281,8 +266,8 @@ summarize would discard cache benefit.
 Waiting for the 1.0 forced boundary is the emergency path — prefer the proactive
 0.85 rebuild. If no summary is pending, the forced rebuild has nothing to apply
 (the replay-preservation rule above still holds), so summarize more or molt
-instead. `refresh` remains the emergency path for broken/stale context or
-explicit human direction, not the normal way to apply summarize. If summarize or
+instead. `refresh` is the emergency path for broken/stale context or explicit
+human direction — never the way to "apply" a summary. If summarize or
 a rebuild still cannot bring context below `0.75 * context_window` (the recovery
 target), tend durable stores and molt deliberately.
 
@@ -321,16 +306,10 @@ Bad uses:
 
 ## 6 · Summarize is not molt
 
-Neither summary mode is a molt. Both a-priori (`summary=true`) and a-posteriori
-(`context(action="summarize")`) reduce active-context bulk for selected tool
-results. Neither updates pad, character, knowledge, skills, or the
-session-journal, and neither sheds the conversation.
-
-Molt is a context operation. It preserves durable stores, writes the session
-journal and molt briefing, and starts a fresh conversation context. Before
-molting, read `context-manual` and follow its required checklist.
-
-Use them together:
+Neither summary mode updates pad, character, knowledge, skills, or the
+session-journal, and neither sheds the conversation — the mini-molt framing and
+the molt boundary are resident. `context-manual` owns the molt procedure and its
+required checklist. Use them together:
 
 1. Summarize bulky consumed tool results so the active context is navigable.
 2. Tend durable stores for facts, procedures, identity changes, and current plan.

--- a/src/lingtai/intrinsic_skills/file-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/file-manual/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: file-manual
-description: "Operational guide for LingTai's built-in `file` tool and its actions: read, write, edit, glob, and grep. Use when working with local text files, deciding whether to use file tools versus bash, handling large files, avoiding binary/image misuse, or reading non-UTF-8 text via explicit bash/Python/iconv instead of complicating the core read tool. Covers UTF-8 policy, safe write/edit discipline, search workflows, and examples for GBK/Shift-JIS/Latin-1 conversion."
-version: 0.2.0
+description: "Operational guide for LingTai's built-in `file` tool: read, write, edit, glob, manual; the UTF-8 policy and how to handle non-UTF-8 text via explicit bash/Python/iconv; safe write/edit discipline; search workflows. Points to `read-manual` for read pagination and truncation depth."
+version: 0.3.0
 tags: [files, read, write, edit, grep, glob, encoding, utf-8]
-last_changed_at: "2026-07-19T00:00:00Z"
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/tools/file/__init__.py
 - src/lingtai/tools/file/CONTRACT.md
@@ -33,10 +33,6 @@ file(action="read", input={"file_path": "/abs/path/x.py"}, reasoning="why you ar
 optional root boolean (see below). Fields belonging to another action are
 rejected before anything is read or written.
 
-Do **not** use it for binary/image/audio/video content. For images, use the
-`vision` skill/tool. For arbitrary binary inspection or transcoding, use `bash`
-with explicit commands.
-
 ## Choosing the right tool
 
 | Need | Tool |
@@ -53,9 +49,8 @@ with explicit commands.
 
 ## Encoding policy
 
-LingTai's own text assets are UTF-8 — source code, prompts and system notes,
-skills and knowledge entries, and JSON/YAML/TOML/Markdown config and docs. The
-`read`/`write`/`edit` actions pin UTF-8 for exactly this reason.
+LingTai's own text assets are UTF-8, which is why the `read`/`write`/`edit`
+actions pin it.
 
 Do not rely on the host locale. Windows Chinese/Japanese/Korean locales may
 default Python text I/O to GBK/CP936/Shift-JIS-like encodings; internal LingTai
@@ -72,14 +67,9 @@ print(Path('file.txt').read_text(encoding='gbk', errors='replace'))
 PY
 ```
 
-Convert to UTF-8 with Python or `iconv`:
+Convert to UTF-8 with `iconv`:
 
 ```bash
-python - <<'PY'
-from pathlib import Path
-Path('legacy.utf8.txt').write_text(Path('legacy-gbk.txt').read_text(encoding='gbk'), encoding='utf-8')
-PY
-
 iconv -f gbk -t utf-8 legacy-gbk.txt > legacy-gbk.utf8.txt
 iconv -f shift_jis -t utf-8 legacy-sjis.txt > legacy-sjis.utf8.txt
 ```
@@ -87,13 +77,15 @@ iconv -f shift_jis -t utf-8 legacy-sjis.txt > legacy-sjis.utf8.txt
 Rule: if a file will become part of the project, convert it to UTF-8 before
 committing or storing it as a durable LingTai asset.
 
-## Reading safely
+## Search, then read a region
 
 Prefer `action="read"` for known text files; its line numbers make later edits
 and citations easier. If a file may be generated, minified, huge, or noisy,
-search first and read only the relevant region:
+start broad with `glob` (file names), narrow with `grep` (contents), and read
+only the located region:
 
 ```python
+file(action="glob", input={"pattern": "**/*.py", "path": "/abs/path/project"}, reasoning="list candidate modules")
 file(action="grep", input={"pattern": "class Agent|def handle", "path": "/abs/path/src", "glob": "*.py", "max_matches": 50}, reasoning="locate the handler")
 file(action="read", input={"file_path": "/abs/path/src/module.py", "offset": 40, "limit": 80}, reasoning="read the located region")
 ```
@@ -117,8 +109,8 @@ or ambiguous. That failure is a feature: it prevents accidental broad changes.
 the current system prompt**. The disk change takes effect at the next canonical
 reconstruction. When it must take effect now, finish the file operation first,
 then make one `context(action="rebuild", input={}, reasoning="apply durable prompt changes")`
-call; passive refresh or molt also reconstructs. Do not use rebuild for ordinary
-source-code edits, and do not loop it.
+call (passive refresh or molt also reconstructs) — not for ordinary source-code
+edits, and never in a loop.
 
 1. `read` the relevant lines.
 2. Copy an exact old-string region with enough surrounding context to be unique.
@@ -127,16 +119,6 @@ source-code edits, and do not loop it.
 
 Use `replace_all=true` only when every occurrence is supposed to change and you
 have checked the match set with `grep` first.
-
-## Search workflow
-
-Start broad with `glob` (file names), narrow with `grep` (file contents), then
-inspect with `read`.
-
-```python
-file(action="glob", input={"pattern": "**/*.py", "path": "/abs/path/project"}, reasoning="list candidate modules")
-file(action="grep", input={"pattern": "read_text\\(", "path": "/abs/path/project/src", "glob": "*.py", "max_matches": 100}, reasoning="find the call sites")
-```
 
 ## File paths and privacy
 
@@ -169,16 +151,8 @@ nothing to configure and nothing to read.
 
 ## Manual versus ordinary calls
 
-Normal file work is primary. `action` is always required and always explicit:
-
-- **Ordinary work:** `action="read"`, `"write"`, `"edit"`, `"glob"`, or
-  `"grep"`, with that action's own fields in `input`.
-- **Manual lookup:** `action="manual"` with `input={}` is a one-time entry when
-  you need the installed workflow guide. It returns documentation and performs
-  no file operation. This one manual covers all five operations; for read
-  pagination, truncation, and `line_truncated` depth it points you at
-  `read-manual`, which is a nested reference rather than a separate action.
-
-After a manual result, continue the original task with an ordinary call. Do not
-request the same manual again. Repeating an identical manual call is an error loop,
-not progress.
+`action="manual"` with `input={}` is a one-time entry that returns this guide and
+performs no file operation; `read-manual` is a nested reference reached from it,
+not a separate action. After it returns, continue the original task with an
+ordinary call — repeating an identical manual call is an error loop, not
+progress.

--- a/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: lingtai-doctor
 description: >
-  Read-only health diagnostics for LingTai agents and bots. Use when an agent
-  appears offline or unreachable, when a machine migration may have left stale
-  MCP/addon command paths, when heartbeat/status/process/notification/log
-  surfaces disagree, or before deciding whether to mail, refresh, CPR, or edit
-  persistent configuration. Includes a bundled doctor.py script for layered
-  local checks without exposing secrets.
-version: 0.1.0
+  Read-only health diagnostics for LingTai agents and bots: when one looks dead
+  but the evidence is mixed, when a migration may have left stale MCP/addon
+  command paths, or before deciding whether to mail, refresh, CPR, or edit
+  persistent configuration. Includes a bundled read-only `doctor.py`.
+version: 0.2.0
 tags: [doctor, diagnostics, mcp, addons, heartbeat, migration, recovery]
-last_changed_at: 2026-07-19T00:00:00Z
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
 maintenance: |
@@ -69,7 +67,7 @@ Top-level severity is **OK** (no obvious local mismatch), **WARN** (at least one
 surface looks stale, missing, or inconsistent), or **FAIL** (a critical local
 file/config/path is missing or broken).
 
-The report ends with the same next steps summarized here. Triage in this order,
+Triage in this order,
 then follow the owning manual rather than improvising a repair:
 
 | Doctor evidence | Do | Owner |

--- a/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/SKILL.md
@@ -7,8 +7,8 @@ description: >
   explains how an agent enters and descends that graph, how it pairs with the
   distributed CONTRACT.md interface-definition graph, and what to do when code
   and navigation disagree.
-version: 0.4.0
-last_changed_at: "2026-07-28T00:00:00Z"
+version: 0.5.0
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - ANATOMY.md
 - src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/scripts/check_anatomy_drift.py
@@ -27,13 +27,8 @@ The repository-root [`ANATOMY.md`](../../../../ANATOMY.md) is the normative
 component-grain gate, link/pairing semantics, and maintenance contract. Root
 [`CONTRACT.md`](../../../../CONTRACT.md) owns the governed-component pairing,
 ownership, mutual-progressive-disclosure, and fail-loud mismatch rule. Read
-them there; do not maintain a competing convention in this skill.
-
-- **ANATOMY** describes where code lives and how it composes. Code is the
-  structural source of truth.
-- **CONTRACT** defines each layer's Core, Ports, Adapters, promises, and
-  expected agent behavior. Contract is normative when implementation behavior
-  disagrees.
+them there; do not maintain a competing convention in this skill — including
+the ANATOMY-versus-CONTRACT distinction, which root `ANATOMY.md` states.
 
 When this skill is read from an installed package without a source checkout,
 locate the checkout you intend to modify and read *its* root `ANATOMY.md`
@@ -42,17 +37,13 @@ local checkout follows the same revision.
 
 ## Navigation workflow
 
-1. Open the repository-root `ANATOMY.md`.
-2. Read its `Components` and `Composition` sections.
-3. Choose the relevant child anatomy and descend; repeat until the local
-   anatomy points at an exact code citation.
-4. Open the cited code. Anatomy is navigation; code is evidence.
+Descend the root `ANATOMY.md` through child anatomies until one points at an
+exact `file.py:line` citation, then open the cited code — anatomy is navigation,
+code is evidence. For enumeration questions (every callsite, matching file, or
+import), search once anatomy has identified the territory.
 
-For enumeration questions — every callsite, matching file, or import — use
-search after anatomy identifies the correct territory.
-
-The current source root is `src/lingtai/`; the kernel implementation descends
-through [`src/lingtai/kernel/ANATOMY.md`](../../kernel/ANATOMY.md).
+The kernel implementation descends [`src/lingtai/ANATOMY.md`](../../ANATOMY.md)
+→ [`src/lingtai/kernel/ANATOMY.md`](../../kernel/ANATOMY.md).
 
 ## Maintenance direction
 
@@ -64,19 +55,9 @@ Who repairs drift depends on which agent you are:
 - **LingTai agents** report drift as issues, mail, or PR proposals. Do not
   silently fix.
 
-The repair direction differs by document:
-
-- **Code vs Anatomy:** code is normally the current structural fact. Repair
-  stale paths, citations, connections, composition, or state descriptions. If
-  the code move itself is defective, fix or report the code rather than
-  encoding a false map.
-- **Code vs Contract:** do not rewrite the promise to match accidental
-  behavior. Treat implementation as defective unless an authorized contract
-  change updates the Port, affected Adapters, contract version, and shared
-  tests.
-
-Verify every touched citation, then run the repository's architecture-document
-validator and the drift checker below.
+Root `ANATOMY.md` → "## Maintenance" owns the repair rules for code-vs-anatomy
+and code-vs-contract, and the requirement to verify every touched citation. Run
+the repository's architecture-document validator and the drift checker below.
 
 ## Drift checker
 
@@ -96,32 +77,27 @@ It catches only mechanical citation rot — a `file.py:line` target that is
 missing or past end-of-file. An in-range citation can still point at the wrong
 code, so an agent must open the cited line to confirm the claim.
 
-`scripts/bench_agent_session_rebuild.py` is the companion benchmark cited by
-`src/lingtai/kernel/ANATOMY.md` for the tiered `rebuild_agent_session_from_events()`
-path; it takes `--events`/`--molt-every` against a synthetic temp agent dir, or
-`--agent-dir <path>` to time an existing one.
+`scripts/bench_agent_session_rebuild.py` is the companion benchmark for the
+tiered `rebuild_agent_session_from_events()` path; `src/lingtai/kernel/ANATOMY.md`
+cites it and owns its usage.
 
 ## Reference sidecars
 
 Open one of these only when the question is actually about it; the router above
 is enough for ordinary navigation.
 
-| Reference | Read it when |
-|---|---|
-| `reference/mcp-protocol.md` | You need the supported MCP SDK range and negotiated protocol version, the split between what the official SDK owns and what LingTai owns, the low-level server handler shape, the tool-metadata sidecar, or the stdio config/env-injection boundary. It routes onward for LICC and registry details rather than restating them. |
+- `reference/mcp-protocol.md` — the supported MCP SDK range and negotiated
+  protocol version, the SDK-versus-LingTai ownership split, the low-level server
+  handler shape, the tool-metadata sidecar, and the stdio config/env-injection
+  boundary. It routes onward for LICC and registry details.
 
 ## Fallback essentials
 
-If the root convention cannot yet be opened, keep these minimal safety rules:
-
-- Each anatomy maps one architectural layer beside its code.
-- Components cite verified `repo/relative/file.py:line-line` evidence.
-- Parent/child anatomy links and governed Anatomy/Contract pair links are
-  reciprocal.
-- Pure implementation detail stays out; user manuals, rationale archives, and
-  interface promises belong elsewhere.
-- Missing files, out-of-range citations, or one-way links are defects, but only
-  reading the cited code can confirm semantic correctness.
+If the root convention cannot yet be opened: one anatomy per architectural layer
+beside its code, components citing verified `repo/relative/file.py:line-line`
+evidence, reciprocal parent/child and Anatomy/Contract links, and no pure
+implementation detail. Missing files, out-of-range citations, and one-way links
+are defects — but only reading the cited code confirms semantic correctness.
 
 Return to the root `ANATOMY.md` as soon as the checkout is available; it is the
 source of truth for the complete template and rules.

--- a/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/reference/mcp-protocol.md
+++ b/src/lingtai/intrinsic_skills/lingtai-kernel-anatomy/reference/mcp-protocol.md
@@ -17,15 +17,12 @@ maintenance: |
 # MCP protocol compatibility
 
 What LingTai assumes about the Model Context Protocol, and where those
-assumptions live in the kernel. This is **not** a copy of the standard: the
-protocol is specified externally and the wire is owned by the official SDK.
-This reference records only the compatibility surface LingTai itself owns, so a
-reader can check the code against a fixed anchor instead of guessing.
-
-This file is the maintained target for the `lingtai-kernel-anatomy
-reference/mcp-protocol.md` route referenced by the MCP manual and
-`src/lingtai/init.jsonc`. It ships inside the wheel with the rest of the
-`intrinsic_skills` tree, so the route resolves for an installed agent.
+assumptions live in the kernel. This is **not** a copy of the standard — the
+protocol is specified externally and the wire is owned by the official SDK. It
+records only the compatibility surface LingTai itself owns, so a reader can check
+the code against a fixed anchor instead of guessing. It is the maintained target
+for the `reference/mcp-protocol.md` route used by the MCP manual and
+`src/lingtai/init.jsonc`, and ships inside the wheel.
 
 ## Supported SDK and protocol
 
@@ -43,7 +40,7 @@ must differ.
 
 ## Ownership boundary
 
-Owned by the official SDK — never reimplement locally:
+Owned by the official SDK:
 
 * JSON-RPC framing, request IDs, notifications, cancellation;
 * the `initialize` handshake, `server/discover`, and version negotiation;
@@ -149,30 +146,23 @@ Injection sites: `src/lingtai/agent.py` (initial load and the failed-retry
 respawn) and `src/lingtai/tools/daemon/__init__.py` for task-scoped
 registrations. Caller-supplied `env` wins over both.
 
-This applies to the **stdio path only**. The HTTP path passes headers, not
-environment, so an HTTP-configured server receives neither variable and cannot
-participate in LICC on this route. Treat that as a stated boundary, not an
-oversight.
+The HTTP path passes headers, not environment, so an HTTP-configured server
+receives neither variable and cannot participate in LICC on this route — a stated
+boundary, not an oversight.
 
 Registry validation is owned by `src/lingtai/services/mcp_registry.py`
-(`validate_record`), which accepts only the `stdio` and `http` transports and
-gates which configured servers may load. It is launch-configuration schema, not
-MCP wire schema: a record can be registry-valid and still fail at connect.
-
-**LICC handoff.** The filesystem notification channel these variables enable is
-specified in full by
-`src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md` — including the event
-envelope, the two-lane projection, and the `LICC_VERSION = 1` constant. This
-page deliberately does not restate it; read that contract for any LICC
-question.
+(`validate_record`): launch-configuration schema, not MCP wire schema, so a
+record can be registry-valid and still fail at connect.
 
 ## Outside this contract
 
 The LICC filesystem notification channel
-(`src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md`), the MCP registry and
-identity documents, the `mcp` presentation tool, and the private Telegram Task
-Card route are LingTai-specific. They carry their own versioned contracts and
-have no MCP wire semantics; do not file them as protocol defects.
+(`src/lingtai/services/LICC_NOTIFICATION_CONTRACT.md` — event envelope, two-lane
+projection, `LICC_VERSION = 1`), the MCP registry and identity documents, the
+`mcp` presentation tool, and the private Telegram Task Card route are all
+LingTai-specific. They carry their own versioned contracts and have no MCP wire
+semantics; read them for those questions, and do not file them as protocol
+defects.
 
 ## Related
 

--- a/src/lingtai/intrinsic_skills/lingtai-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-manual/SKILL.md
@@ -33,19 +33,12 @@ and no compatibility alias.
 
 ## Change durable identity with file
 
-- Full rewrite: `file(action="write", input={"file_path":
-  "system/lingtai.md", "content": <your complete identity>}, reasoning="...")`.
-- Exact replacement: `file(action="edit", input={"file_path":
-  "system/lingtai.md", "old_string": <exact>, "new_string": <replacement>,
-  "replace_all": null}, reasoning="...")`.
-
-A full rewrite must carry forward everything you intend to keep. An exact edit
-is appropriate for a bounded, unambiguous change. Neither operation hot-loads
-or otherwise mutates the current prompt.
-
-To apply the durable change now, call one explicit
-`context(action="rebuild", input={}, reasoning="apply durable identity")`.
-Otherwise it takes effect on passive refresh/molt reconstruction.
+Your durable identity is an ordinary file. Rewrite it with
+`file(action="write", input={"file_path": "system/lingtai.md", ...})` — carrying
+forward everything you intend to keep — or make a bounded, unambiguous change
+with `file(action="edit", ...)` on the same path. Neither hot-loads the prompt;
+apply with one `context(action="rebuild", ...)`. The full model is
+`psyche-manual` → "The one mutation model".
 
 ## Identity modes
 
@@ -62,5 +55,4 @@ and mechanical name/manifest `identity`. Names remain
 `system(action="name_set"|"name_nickname")`.
 
 Before molt, tend identity once when the task's lessons genuinely changed who
-you are; use `context-manual` for the journal/summary/molt procedure. LingTai has
-no settings file. Manual results are short; leave root `summarize` false.
+you are; use `context-manual` for the journal/summary/molt procedure.

--- a/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
+++ b/src/lingtai/intrinsic_skills/nokv-workbench/SKILL.md
@@ -4,11 +4,9 @@ name: nokv-workbench
 description: >
   Thin routing manual for NoKV-controlled workbenches. Use when an agent is
   asked to persist task inputs, scripts, outputs, logs, provenance, or run
-  manifests through the `workbench_*` MCP tools instead of ordinary local
-  file writes. Covers MCP registration, directory layout, append and edit
-  discipline, conditional reads, cross-workbench queries, content-identified
-  commits, leased checkpoint snapshots with annotations, renewal, retirement,
-  discovery, point-in-time history reads, and durable restore-to-fork recovery.
+  manifests through the `workbench_*` MCP tools instead of ordinary local file
+  writes. The body covers registration, layout, write/read discipline, commits,
+  leased checkpoints, and restore-to-fork recovery.
 version: 0.5.0
 tags: [nokv, mcp, workbench, artifacts, provenance, snapshots, checkpoints, leases, restore]
 related_files:
@@ -234,12 +232,10 @@ that checkpoint** instead of its current state:
 {"id":"spedas-task-001","section":"outputs","path":"spectrum.csv","at_snapshot":"final-v1"}
 ```
 
-Historical `workbench_read` serves the checkpoint's bytes/text-lines. Reading a
-checkpoint whose lease has expired fails **loudly**. Expiry is terminal:
+Historical `workbench_read` serves the checkpoint's bytes/text-lines. Reading an
+expired checkpoint fails **loudly**, and expiry is terminal:
 expired checkpoints cannot be renewed, even if the background collector has not
-yet removed the pin. Re-mint from the current committed state when that is still
-useful; NoKV never revives a checkpoint whose historical records may already
-have been reclaimed.
+yet removed the pin — see "Expired is not the same as data lost" below.
 
 ## Restore to a new workbench
 
@@ -259,13 +255,11 @@ entry whose `state` is `alive`, and resolve the name to its numeric
 }
 ```
 
-Keep these exact three values for the duration of the workflow. If the MCP
-transport, NoKV server, or Agent connection restarts, resend the same request
-with the same numeric `snapshot_id` and `destination_id`. Do not re-resolve a
-checkpoint name during a retry: an alias can be rebound, while the numeric id
-pins the original request. A retry can return `RestoreInProgress`; use bounded
-backoff and resend the exact request. No separate LingTai restore state or
-multi-step copy protocol is needed.
+Keep these exact three values for the duration of the workflow: on any restart,
+resend the identical request with the same numeric `snapshot_id` and
+`destination_id`. Do not re-resolve a checkpoint name during a retry
+— an alias can be rebound, while the numeric id pins the original request.
+No separate LingTai restore state or multi-step copy protocol is needed.
 
 Success means `state="complete"` and `cleanup_pending=false`. The response
 contains the deterministic `operation_id`, source and destination workbench
@@ -327,9 +321,10 @@ MCP failures preserve top-level `status`, `code`, `message`, `retryable`, and
 | `SyncLogArchiveFailed` | Preserve `details.committed`. Resend the exact request when `retryable=true`; never invent a new destination to work around an ambiguous committed result. |
 | `CapabilityMismatch` | Stop deployment. The connected owner does not support `restore_to_fork_v1`; do not downgrade to a client-side copy. |
 
-Honor `retryable=false` even when a table entry otherwise permits a bounded
-retry. Preserve the original request on every retry; changing any of its three
-fields starts a different operation.
+Unless a row says **Stop**, preserve the exact request and retry with bounded
+backoff only when `retryable=true`; never re-resolve an alias during an exact
+retry. Honor `retryable=false` even when a row otherwise permits a retry —
+changing any of the three request fields starts a different operation.
 
 ### Expired is not the same as data lost
 
@@ -352,11 +347,9 @@ For the MVP, use a parent-created workbench and child-filled files:
 - Multiple writers may `workbench_append` to the same log file — appends are
   serialized by the server with automatic retry. Everything else stays
   disjoint: assign prefixes such as `outputs/agent-a/` and never let two
-  agents `put_file` or `edit` the same path. Same-path `put_file` with
-  `replace=false` intentionally fails with an exists conflict; `replace=true`
-  on a missing target intentionally fails with not-found. Neither mode is
-  upsert. Treat either race as a coordination bug, not a reason to flip the
-  flag and retry blindly.
+  agents `put_file` or `edit` the same path. A same-path collision fails by
+  design (see step 2 — neither `replace` mode is upsert); treat that race as a
+  coordination bug, not a reason to flip the flag and retry blindly.
 
 ## Read and search
 

--- a/src/lingtai/intrinsic_skills/notification-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: notification-manual
 description: >
-  Notification filesystem and standalone notification tool router for LingTai.
-  Read this when using notification(action='manual'|'check'|'dismiss_channel'|
-  'dismiss_event'|'dismiss_ref') with its action+input+reasoning envelope,
-  interpreting `.notification/<channel>.json`,
+  Router for LingTai's notification filesystem protocol and the standalone
+  `notification` tool. Read it when interpreting `.notification/<channel>.json`
   or deciding between producer-specific handling and safe mirror dismissal.
   Routes channel/sync mechanics and dismissal safety into nested references;
-  large-result compaction remains owned by summarize-manual.
-version: 0.5.0
+  large-result compaction is owned by
+  `context-manual` → `reference/summarize-manual/SKILL.md`.
+version: 0.6.0
 tags: [lingtai, notifications, channels, dismiss, manual, force, stale, nudge]
-last_changed_at: "2026-07-27T00:00:00Z"
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/tools/notification/__init__.py
 - src/lingtai/tools/notification/schema.py
@@ -26,46 +25,28 @@ LingTai notifications are a filesystem protocol: producers publish allowlisted
 `.notification/<channel>.json` surfaces, and the kernel exposes their current
 model-visible state. The always-available `notification` tool is the sole
 agent-callable home for reading and clearing those surfaces. `system` has no
-notification or dismiss alias; it still owns `summarize` because context hygiene
-is not a notification operation.
+notification or dismiss alias, and context hygiene is not a notification
+operation either — that is `context(action='summarize')`.
 
 ## Quick start
 
-Every call takes three fields: `action`, the strict `input` object for that
-action, and `reasoning`. Arguments live inside `input` — never at the root.
+The resident tool schema is the source of truth for the five actions, their
+per-action `input` fields, and the `action` + `input` + `reasoning` envelope
+(arguments live inside `input`, never at the root). What it does not say:
 
-| Action | Use |
-|---|---|
-| `notification(action='manual', input={}, reasoning=...)` | Return this installed router body. Strictly read-only: it neither reads nor changes notification state. |
-| `notification(action='check', input={}, reasoning=...)` | Request the live notification payload. The handler returns a placeholder and the kernel stamps `_meta.agent_meta.notifications.attention` plus `_meta.agent_meta.guidance.transient` onto the result. |
-| `notification(action='dismiss_channel', input={'channel': ..., 'force': null, 'reason': null}, reasoning=...)` | Clear one dismissible channel mirror whole. |
-| `notification(action='dismiss_event', input={'event_id': ..., 'channel': null, 'force': null, 'reason': null}, reasoning=...)` | Remove one matching system event; a null `channel` means `system`. |
-| `notification(action='dismiss_ref', input={'ref_id': ..., 'channel': null, 'force': null, 'reason': null}, reasoning=...)` | Remove matching system events by producer reference; a null `channel` means `system`. |
-
-Optional fields are declared as required-but-nullable, which is how a strict
-schema expresses "optional". Pass `null` when you do not want to supply one;
-null is treated exactly like omitting it, so `channel: null` still defaults to
-`system` and `reason: null` does **not** satisfy the post-molt acknowledgement
-requirement.
-
-Each action accepts only its own fields. `event_id` and `ref_id` are not part of
-`dismiss_channel`'s input at all — sending one there is rejected before any
-notification state is read or written, so use `dismiss_event` / `dismiss_ref`
-for a single event.
-
-There is no aggregate `dismiss` action. After handling a notification, use the
-narrowest correct producer-specific or atomic dismiss action and end the turn;
-do not voluntarily call `check` again merely to confirm the clear.
+- `manual` returns **this router body** — it is documentation retrieval, not a
+  notification-state read.
+- Optional fields are declared required-but-nullable, and `null` is treated
+  exactly like omission. The one trap: `reason: null` does **not** satisfy the
+  post-molt acknowledgement requirement.
+- After handling a notification, use the narrowest correct dismiss action and end
+  the turn; do not voluntarily call `check` again merely to confirm the clear.
 
 ## Root `summarize`
 
-`summarize` is a root envelope boolean, not an action argument, and it is
-absent/false by default. Notification is a **short-result** family: `check`
-returns a small placeholder and the dismiss actions return compact receipts, so
-`summarize` is available but normally unnecessary — leave it false. Keep it
-false for `manual` in particular, so exact procedures and constraints are not
-summarized away. Note this is unrelated to `context(action='summarize')`, which
-is the separate action for compacting a large tool result.
+Notification is a **short-result** family, so leave the root `summarize` boolean
+false — especially for `manual`, where summarizing would drop the exact
+procedures and constraints you called it for.
 
 ## Installed manual retrieval
 
@@ -79,8 +60,7 @@ Success returns exactly `status`, `notification_manual`, and `manual_path`. A
 missing installed file returns `status: degraded`, an empty
 `notification_manual`, the same fixed `manual_path`, and an actionable `error`
 naming an initializer or capability-install problem. It never falls back to a
-source checkout and never touches `.notification/`, the Notification Store,
-producer state, delivery fingerprints, or acknowledgement state.
+source checkout, and it touches neither notification nor producer state.
 
 ## Nested reference catalog
 
@@ -113,20 +93,12 @@ producer state, delivery fingerprints, or acknowledgement state.
 
 ## Safety boundaries to keep resident
 
-- `check` is the notification-state read; `manual` is documentation retrieval
-  only. Neither writes notification state.
-- Generic dismiss clears a notification mirror, never producer-owned canonical
-  state. Prefer the producer's own verb when one exists.
-- `force=true` is for knowingly clearing a stale or guarded mirror. It does not
-  override protected source-of-truth channels and never mutates producer state.
-- Large tool results are ranked under
-  `_meta.agent_meta.agent_state.current_tool_result_chars`, not emitted as new
-  notifications. Follow `../context-manual/reference/summarize-manual/SKILL.md`;
-  do not invent a second summarization procedure here.
+The producer-verb preference and `force` semantics are resident (meta_guidance
+`notification_handling` and the schema's `_FORCE_DESCRIPTION`). The two facts
+neither of them states:
 
-## Why the boundary is split this way
+- Neither `check` nor `manual` writes notification state.
+- `force=true` does **not** override protected source-of-truth channels.
 
-The filesystem protocol lets in-process and external producers publish one
-current surface without sharing a queue; atomic action names make the clearing
-target explicit; producer guards keep a mirror clear from being mistaken for
-handling source-of-truth state.
+Producer guards exist so that clearing a mirror is never mistaken for handling
+the producer's canonical state.

--- a/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
@@ -33,20 +33,18 @@ The kernel accepts built-in channels including `email`, `system`, `soul`,
 `nudge`, `post-molt`, `tool_loop_guard`, `bash`, `btw`, `cron`, `molt`, and
 `goal`; MCP bridge channels use the `mcp.` prefix. Unknown JSON filenames are
 ignored by collection, and kernel publish/dismiss helpers reject names outside
-the allowlist. This prevents arbitrary workdir files from entering the
-model-visible notification lane.
+the allowlist, so arbitrary workdir files cannot enter the model-visible
+notification lane.
 
-`nudge` is the formal channel for mechanical, throttled checks. Runtime update
-checks publish `data.nudges[]` entries with `kind: kernel_version`; the sole
-normal install/update route is `https://lingtai.ai/install.sh`. Let Shell execute
-its concise `--help`, without reading or pasting the script source, and follow
-whatever it currently instructs rather than assuming a specific child command.
-The installer owns exact-tag migration navigation; real update, mutation,
-configuration writes, and refresh require explicit human/config-owner authority.
-The bundled `runtime-update-checks` reference is limited to local read-only
-diagnosis and refresh mechanics. Source-freshness checks may publish
-`kind: source_drift`, but that handling stays local and never enters
-release-migration routing. This manual owns only the generic channel protocol.
+`nudge` is the formal channel for mechanical, throttled checks: runtime update
+checks publish `data.nudges[]` entries with `kind: kernel_version`, and
+source-freshness checks may publish `kind: source_drift` — which stays local and
+never enters release-migration routing. The sole normal install/update route is
+`https://lingtai.ai/install.sh` (let Shell run its `--help` and follow that), and
+real updates, configuration writes, and refresh require
+explicit human/config-owner authority. Those rules are owned in full by
+`../../../system-manual/reference/runtime-update-checks/SKILL.md`; this manual
+owns only the generic channel protocol.
 
 ## Envelope and producer instructions
 
@@ -75,27 +73,17 @@ replacement so readers never observe a partial JSON file.
 
 ## Voluntary check and model-visible delivery
 
-`notification(action='check', input={}, reasoning=...)` returns a dict
-placeholder. The turn-loop
-post-hook stamps the canonical live payload onto that same result under
-`_meta.agent_meta.notifications.attention` and
-`_meta.agent_meta.guidance.transient`. The handler does not
-assemble a second bare channel representation and does not write notification
-state.
+`check` returns a dict placeholder that the turn-loop post-hook stamps with the
+canonical live payload; the handler assembles no second channel representation
+and writes no notification state.
 
 When notifications arrive while an agent is IDLE or ASLEEP, the kernel can
 synthesize the same `notification(action='check')` tool-call/result shape —
-including the same `action`/`input`/`reasoning` envelope, so it is
-indistinguishable from a read you issued yourself — and wake the agent. During ACTIVE work, the post-hook moves the single live payload
-to a suitable dict-shaped tool result only when required by first appearance,
-material change, or a deliberate check. Delivery fingerprints and the live
-holder belong to kernel synchronization, not to the notification tool's
-`manual` action.
-
-After handling the payload, clear it through the producer-specific action or the
-narrowest safe notification dismiss action and end the turn. Do not call `check`
-again only to confirm dismissal; sparse synchronization will expose a material
-change when needed.
+same `action`/`input`/`reasoning` envelope, indistinguishable from a read you
+issued yourself — and wake the agent. During ACTIVE work the post-hook moves the
+single live payload onto a suitable dict-shaped tool result only on first
+appearance, material change, or a deliberate check. Delivery fingerprints and
+the live holder belong to kernel synchronization, not to the `manual` action.
 
 ## Canonical producer state versus mirror
 
@@ -107,8 +95,7 @@ producer-specific verb in `instructions`.
 
 This separation is deliberate: the filesystem protocol gives the kernel one
 current high-attention surface, while canonical state remains under the
-producer's own schema and lifecycle. Read `../dismissal-safety/SKILL.md` before
-clearing guarded, stale, protected, or event-granular state.
+producer's own schema and lifecycle.
 
 ## Footprint
 

--- a/src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
+++ b/src/lingtai/intrinsic_skills/notification-manual/reference/dismissal-safety/SKILL.md
@@ -23,9 +23,8 @@ maintenance: |
 ## Choose the narrowest owner and target
 
 Use a producer-specific verb first when a notification mirrors producer-owned
-state. For example, handle email unread state with
-`email(action='read', ...)` or `email(action='dismiss', ...)`; generic channel
-dismissal would clear only the high-attention mirror.
+state (e.g. `email(action='read'|'dismiss', ...)`) — a generic channel dismissal
+would clear only the high-attention mirror.
 
 For a dismissible notification-owned surface, choose one atomic target:
 
@@ -33,22 +32,13 @@ For a dismissible notification-owned surface, choose one atomic target:
 notification(action='dismiss_channel',
              input={'channel': 'nudge', 'force': null, 'reason': null},
              reasoning='...')
-notification(action='dismiss_event',
-             input={'event_id': 'evt_...', 'channel': null,
-                    'force': null, 'reason': null},
-             reasoning='...')
-notification(action='dismiss_ref',
-             input={'ref_id': 'goal:current', 'channel': null,
-                    'force': null, 'reason': null},
-             reasoning='...')
 ```
 
-`dismiss_channel` clears one allowlisted `.notification/<channel>.json` whole;
-`event_id` and `ref_id` are not part of its input, so sending one is rejected
-before any notification state is touched. `dismiss_event` and `dismiss_ref` default to
-the `system` channel and remove only matching entries from
-`system.data.events`; removing the final event clears the file. There is no
-kitchen-sink `dismiss`, so the call always states what may disappear.
+`dismiss_event` and `dismiss_ref` take the same envelope with `event_id` /
+`ref_id` instead of `channel`; the schema is the exact-shape source of truth.
+What it does not say: those two **default to the `system` channel** and remove
+only matching entries from `system.data.events`, and **removing the final event
+clears the file**.
 
 All three actions delegate to the canonical notification Core dismissal helper.
 That one policy path enforces allowlists, producer guards, stale-version checks,
@@ -63,10 +53,8 @@ current on-disk version. If a producer updated the channel after delivery, the
 call refuses with `reason='stale_channel_version'` rather than erase unseen
 state. Read the newly delivered state first.
 
-`force=true` may knowingly bypass that stale-version refusal and a
-producer-registered generic-dismiss guard. It still clears only a mirror and
-never mutates producer canonical state. Use it for a confirmed stale mirror, not
-as a routine retry or a substitute for handling the producer.
+`force=true` (semantics in the schema) is for a confirmed stale mirror — not a
+routine retry, and not a substitute for handling the producer.
 
 ## Protected and acknowledgement-sensitive channels
 
@@ -76,49 +64,23 @@ refuses even with `force=true`; use `../../../system-manual/reference/goal-manua
 state correctly.
 
 The kernel-owned `post-molt` continuation channel requires a non-empty reason
-that records the decision, for example:
-
-```text
-notification(
-  action='dismiss_channel',
-  input={
-    'channel': 'post-molt',
-    'force': null,
-    'reason': 'continue: recovered the pending work'
-  },
-  reasoning='acknowledge the post-molt continuation'
-)
-```
-
-A null `reason` counts as omitted, so it does not satisfy this requirement.
+recording the decision in `continue|defer|obsolete` form — e.g.
+`reason='continue: recovered the pending work'` on
+`dismiss_channel(channel='post-molt')`.
 
 ## Large results and legacy reminder escape hatch
 
-New large tool results are not notification events. The kernel ranks formal
-results under `_meta.agent_meta.agent_state.current_tool_result_chars`; read
-`../../../context-manual/reference/summarize-manual/SKILL.md` for the canonical digest,
-`context(action='summarize')`, recovery, and summarize-versus-molt procedure. Do
-not duplicate that workflow here.
+New large tool results are not notification events — they are ranked under
+`_meta.agent_meta.agent_state.current_tool_result_chars`, and
+`../../../context-manual/reference/summarize-manual/SKILL.md` owns the digest,
+`context(action='summarize')`, recovery, and summarize-versus-molt procedure.
 
 A persisted or pre-molt `source='large_tool_result'` system event may still
-exist. If its tool result remains accessible, a successful summarize of the
-matching `tool_call_id` also clears the legacy reminder. If summarization is no
-longer possible, use an atomic notification escape hatch:
-
-```text
-notification(action='dismiss_ref',
-             input={'ref_id': 'large_tool_result:<tool_call_id>',
-                    'channel': null, 'force': null, 'reason': null},
-             reasoning='...')
-notification(action='dismiss_event',
-             input={'event_id': '<event_id>', 'channel': null,
-                    'force': null, 'reason': null},
-             reasoning='...')
-```
-
-Whole-channel system dismissal also covers such an event but may clear unrelated
-system events, so prefer event/ref targeting. Dismissal acknowledges and removes
-the reminder surface only; the original tool result remains unchanged in chat
+exist. A successful summarize of the matching `tool_call_id` clears it. If
+summarization is no longer possible, use
+`dismiss_ref` with `ref_id='large_tool_result:<tool_call_id>'`. Whole-channel
+system dismissal also covers it but may clear unrelated system events, so prefer
+ref/event targeting. Either way the original tool result stays unchanged in chat
 history and `events.jsonl`.
 
 ## On a refusal
@@ -132,6 +94,4 @@ history and `events.jsonl`.
 5. Targeting one system event — use `dismiss_event`/`dismiss_ref`, not a
    whole-channel clear.
 
-These rules keep a mirror operation from silently becoming a producer-state
-decision or erasing concurrent unseen events. No dismissal ever removes producer
-history, mailbox state, or goal semantics.
+No dismissal ever removes producer history, mailbox state, or goal semantics.

--- a/src/lingtai/intrinsic_skills/pad-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/pad-manual/SKILL.md
@@ -33,19 +33,11 @@ alias.
 
 ## Mutate durable Pad content with file
 
-- Full create/overwrite: `file(action="write", input={"file_path":
-  "system/pad.md", "content": <complete body>}, reasoning="...")`.
-- Exact replacement: `file(action="edit", input={"file_path":
-  "system/pad.md", "old_string": <exact>, "new_string": <replacement>,
-  "replace_all": null}, reasoning="...")`.
-
-`file.write` is a full-file operation; include everything you intend to keep.
-`file.edit` replaces exact text and fails if the target is missing/ambiguous.
-
-**Neither file operation reloads or mutates the current prompt.** After durable
-changes, call one explicit `context(action="rebuild", input={}, reasoning="apply
-durable prompt changes")`, or let passive refresh/molt reconstruction apply
-them later.
+Pad's durable sources are ordinary files. Rewrite with
+`file(action="write", input={"file_path": "system/pad.md", ...})`; make an exact
+replacement with `file(action="edit", ...)` on the same path. Neither hot-loads
+the prompt — apply with one `context(action="rebuild", ...)`. The full model is
+`psyche-manual` → "The one mutation model".
 
 ## Pin references
 
@@ -60,10 +52,8 @@ file(action="write", input={"file_path": "system/pad_append.json",
 Write `[]` to clear the list. Reconstruction reads each listed file and appends
 its contents to the Pad section as read-only reference.
 
-**Editing the list never hot-loads the prompt**, exactly like editing
-`system/pad.md`. Run one `context.rebuild` when the new list must become visible.
-Reconstruction re-reads each pinned file every time, so later edits to a pinned
-file also appear only after the next reconstruction.
+Reconstruction re-reads each pinned file every time, so an edit to the list —
+or to a pinned file — appears only after the next rebuild.
 
 Two things to know, because nothing validates this list for you any more: a path
 that does not exist is reported as `append_not_found` at compose time rather than
@@ -76,4 +66,4 @@ knowledge, not in an ever-growing Pad. Before molt, make durable Pad state
 accurate, rebuild only if needed in the current context, then follow
 `context-manual` for the journal/summary/molt procedure.
 
-Pad has no settings file. Results are short; leave root `summarize` false.
+Results are short; leave root `summarize` false.

--- a/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/psyche-manual/SKILL.md
@@ -44,9 +44,8 @@ molt, summarize, and rebuild belong to `context`, and your name belongs to
 | `psyche(action="skills", input={}, reasoning="load skills guidance")` | the skills manual | `.library/{intrinsic,custom}/` plus configured skills paths |
 | `psyche(action="manual", input={}, reasoning="load the routing table")` | this routing table | — |
 
-Every action takes a strict empty `input`, and root `reasoning` is required on
-every call. Any key inside `input` is rejected before the manual is even read, so
-there is nothing to pass and nothing to smuggle.
+Every action takes a strict empty `input`; any key is rejected before the manual
+is read.
 
 ## The one mutation model
 
@@ -58,16 +57,13 @@ durable content is ordinary text, so it is changed by the ordinary text tools.
 2. **Apply** it with one explicit
    `context(action="rebuild", input={}, reasoning="apply durable changes")`.
 
-File mutation never hot-loads the prompt. A durable change you have written but
-not rebuilt is real on disk and simply not yet visible in your context — that
-separation is what makes a batch of edits land atomically instead of one
-half-composed section at a time.
-
-A full rebuild re-reads and recomposes **all** enabled canonical sections once,
-applies pending summaries, and then requests provider replay. Passive
-reconstruction — `system(action="refresh", ...)` and molt — runs that same contract,
-so the four domains are preserved identically whichever path you take. You do
-not need a per-domain reload, and there is no per-domain reload to call.
+File mutation never hot-loads the prompt: a durable change written but not
+rebuilt is real on disk and simply not yet visible in your context — which is what
+makes a batch of edits land atomically instead of one half-composed section at a
+time. A full rebuild recomposes **all** enabled canonical sections once, applies
+pending summaries, then requests provider replay; passive reconstruction
+(`system(action="refresh", ...)` and molt) runs the same contract. There is no
+per-domain reload to call.
 
 Catalog upkeep is not yours to trigger either. Skills and Knowledge catalogs are
 rescanned and recomposed by that same reconstruction path (and at setup/refresh);
@@ -82,18 +78,17 @@ procedure.
   possibly referencing local paths, mail ids, or logs → **knowledge**.
 - A reusable procedure that would help any agent, not just you → **skills**.
 
-When the choice is genuinely unclear, read the two candidate manuals before
-writing; the domain manuals own that distinction in depth and this table does not
-restate it.
+When the choice is genuinely unclear, the domain manuals own that distinction in
+depth.
 
 ## `summarize`
 
-**Short-result.** Every psyche action returns one manual body. `summarize` is
-available at root but normally unnecessary here, and a summarized manual loses
-the exact procedure and constraints you called it for — leave it `false`.
+**Short-result.** Every psyche action returns one manual body, and a summarized
+manual loses the exact procedure you called it for — leave root `summarize`
+`false`. This is the family-wide rule; the domain manuals do not restate it.
 
 ## Settings
 
-`psyche` owns no settings file at either level: there is no
-`settings/psyche.json` and no `settings/psyche.<action>.json`. Nothing to
-configure, and an unrecognized file there is not read by this family.
+No manual in this family owns a settings file at either level — there is no
+`settings/psyche.json`, no `settings/psyche.<action>.json`, and no per-domain
+equivalent. Nothing to configure; an unrecognized file there is not read.

--- a/src/lingtai/intrinsic_skills/read-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/read-manual/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: read-manual
-description: "Complete guide for the `file` tool's read action: continuation workflow, next_offset pagination, line_truncated handling, runtime tool-result spill vs read-level pagination, 100k read default / 200k runtime hard cap, and when to use bash/grep/sed for truncated lines. Use when implementing complete file-read workflows, handling large files, or understanding cap and truncation semantics."
-version: 0.1.0
+description: "Deep dive for the `file` tool's read action: pagination, `next_offset` continuation, `line_truncated`, the 100k default / 200k hard cap, and when to switch to bash/grep/sed."
+version: 0.2.0
 tags: [read, files, continuation, truncation, cap, pagination]
 last_changed_at: "2026-07-19T00:00:00Z"
 related_files:
@@ -20,11 +20,9 @@ results.
 
 This is a nested reference under `file-manual`, not a separate manual action:
 `file(action="manual")` returns `file-manual`, which points here for read depth.
-For basic action choice (read vs write vs edit vs grep vs glob), UTF-8 policy,
-the `summarize` guidance, and the shared manual-versus-ordinary-call rule, see
-`file-manual` — including that repeating an identical manual call is an error
-loop, not progress. After this manual returns, continue the original task with
-an ordinary read call.
+`file-manual` owns basic action choice, the UTF-8 policy, the `summarize`
+guidance, and the manual-versus-ordinary-call rule (including that repeating an
+identical manual call is an error loop, not progress).
 
 ## Two caps
 
@@ -35,8 +33,7 @@ an ordinary read call.
 
 `max_chars` requests a smaller or larger chunk for one call. Values above the
 hard ceiling are clamped to 200 000; the effective value appears as `cap_chars`
-when the result is truncated. Do not assume the old 10 000- or 8 000-character
-limits from earlier versions.
+when the result is truncated.
 
 These two caps act at different layers:
 
@@ -62,33 +59,19 @@ This replaces a dedicated `read(dry_run=true)` mode.
 python - <<'PY'
 from pathlib import Path
 p = Path('/path/to/file')
-count = max_len = max_line = 0
-with p.open('r', encoding='utf-8', errors='replace') as f:
-    for i, line in enumerate(f, 1):
-        count = i
-        if len(line) > max_len:
-            max_len, max_line = len(line), i
-print({'bytes': p.stat().st_size, 'lines': count,
-       'longest_line': max_line, 'longest_chars': max_len})
+lines = p.read_text(encoding='utf-8', errors='replace').splitlines()
+print({'bytes': p.stat().st_size, 'lines': len(lines),
+       'longest_chars': max(map(len, lines), default=0)})
 PY
 ```
 
-Use the result to choose the window:
-
-- `offset` — where to begin or resume (1-based).
-- `limit` — how many lines to request; a tight `limit` (e.g. `50`) narrows the
-  window, and a large `offset` with a small `limit` reads an arbitrary slice.
-- `max_chars` — per-call character budget (default 100k, max 200k).
+Use the result to choose the window: `offset` (1-based start/resume), `limit`
+(lines requested), `max_chars` (per-call budget).
 
 ## Complete-content workflow
 
-For any file that may exceed the cap:
-
-1. Call `read` with the desired `offset` (default 1) and `limit`.
-2. If `truncated` is absent or `false`, the whole requested range was returned —
-   done. If `true`, continue.
-3. Re-call with `offset=next_offset`, keeping the same `limit`, until
-   `truncated` is absent or `false`.
+For any file that may exceed the cap, page with `offset=next_offset` and the
+same `limit` until `truncated` is absent or false:
 
 ```python
 offset = 1
@@ -133,15 +116,6 @@ To inspect a long line fully, use targeted local processing instead of `read`:
 sed -n '42p' /path/to/file                        # print one specific line
 awk '{print NR, length($0)}' /path/to/file | head -20   # characters per line
 grep -n "pattern" /path/to/file                   # search within a long line
-
-# Extract a byte range from a long line
-python - <<'PY'
-with open('/path/to/file') as f:
-    for i, line in enumerate(f, 1):
-        if i == 42:
-            print(line[0:2000], "...", line[-500:], sep="\n")
-            break
-PY
 ```
 
 ## Quick checklist
@@ -150,15 +124,12 @@ Before calling `read`:
 
 - Large file? Probe with `limit=100`–`200`, or run the preflight above.
 - Need the whole file? Use the continuation loop.
-- `line_truncated=true`? Switch to `bash`/`grep`/`sed`/Python.
-- `status=spilled`? Read the `spill_path` artifact or reduce `limit`.
+- Escape hatches: `line_truncated=true` → `bash`/`grep`/`sed`; `status=spilled`
+  → read the `spill_path` artifact or reduce `limit`.
 - Need a specific region? Pass `offset` and a tight `limit`.
 
 ## Manual versus ordinary reads
 
-An ordinary read is `file(action="read", input={...}, reasoning="...")`;
-`action` is always required. Use `file(action="manual", input={})` only as a
-one-time entry — it returns `file-manual`, which points here for the read depth
-above. After the manual returns, continue the original task with an ordinary
-read; do not repeat the same manual call. Repeating it is an error loop, not
-progress.
+`file-manual` owns this rule: `file(action="manual")` is a one-time entry.
+After it returns, continue the original task with an ordinary read; repeating the
+same manual call is an error loop, not progress.

--- a/src/lingtai/intrinsic_skills/read-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/read-manual/SKILL.md
@@ -59,9 +59,14 @@ This replaces a dedicated `read(dry_run=true)` mode.
 python - <<'PY'
 from pathlib import Path
 p = Path('/path/to/file')
-lines = p.read_text(encoding='utf-8', errors='replace').splitlines()
-print({'bytes': p.stat().st_size, 'lines': len(lines),
-       'longest_chars': max(map(len, lines), default=0)})
+count = max_len = max_line = 0
+with p.open('r', encoding='utf-8', errors='replace') as f:
+    for i, line in enumerate(f, 1):
+        count = i
+        if len(line) > max_len:
+            max_len, max_line = len(line), i
+print({'bytes': p.stat().st_size, 'lines': count,
+       'longest_line': max_line, 'longest_chars': max_len})
 PY
 ```
 

--- a/src/lingtai/intrinsic_skills/soul-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/soul-manual/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: soul-manual
 description: |
-  Operational guide for the `soul` tool — your inner voice. Read this when: you need the exact call shape (one `soul` tool, six actions, each with its own strict `input` object); you call `soul(action='flow', input={})` and get a `status: disabled` result; you want to understand why soul flow is off by default and how the operator enables it; you are tuning `delay_seconds`/`consultation_past_count` with `config` and want to know whether fires will actually happen; or you need the difference between the always-available actions (inquiry/config/voice/dismiss/manual) and the opt-in `flow`. Covers the call shape and per-action inputs, the `LINGTAI_SOUL_FLOW_ENABLED` env gate, disabled-flow behavior, delay-vs-off-switch semantics, enabling/disabling, troubleshooting, and the privacy/cost rationale.
-version: 1.1.0
-last_changed_at: "2026-07-27T00:00:00Z"
+  Operational guide for the `soul` tool — your inner voice: the one-tool/six-actions call shape, the `LINGTAI_SOUL_FLOW_ENABLED` opt-in gate, disabled-flow behavior, and the delay-is-cadence-not-an-off-switch semantics. Read it before calling `flow`, tuning `config`, or troubleshooting a `status: disabled` result.
+version: 1.2.0
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/tools/soul/__init__.py
 - src/lingtai/tools/soul/CONTRACT.md
@@ -22,16 +22,12 @@ maintenance: |
 
 ## 0. How to call it
 
-One tool, six actions. Every call is `action` + that action's own `input`
-object + `reasoning`:
+One tool, six actions. Every call is `action` + that action's own strict `input`
+object + `reasoning`; another action's field is rejected before anything runs:
 
 ```json
 {"action": "inquiry", "input": {"inquiry": "What am I avoiding?"}, "reasoning": "check my own blind spot"}
 ```
-
-Each action's `input` is **strict and closed** — it accepts that action's own
-fields and nothing else. Sending another action's field (say `delay_seconds`
-inside an `inquiry` call) is rejected before anything runs:
 
 | Action | `input` |
 |---|---|
@@ -45,11 +41,9 @@ inside an `inquiry` call) is rejected before anything runs:
 Optional fields are declared nullable rather than omittable, so pass `null` for
 the ones you are not setting.
 
-**`summarize`** is a root-level boolean (never inside `input`), absent or false
-by default. Soul's results are all small — a voice, a couple of knob values, a
-status — so leave it false; there is nothing to compress and summarizing only
-risks losing the exact wording of a voice. When calling `manual`, keep it false
-so the exact enable/disable procedure below is not summarized away.
+**`summarize`** is a root-level boolean (never inside `input`). Soul's results
+are all small, and summarizing risks losing a voice's exact wording — leave it
+false, especially for `manual`.
 
 ## 1. The soul-flow gate
 
@@ -77,12 +71,7 @@ caller cannot fire while the gate is off.
 thread:
 
 ```json
-{
-  "status": "disabled",
-  "enabled": false,
-  "env_var": "LINGTAI_SOUL_FLOW_ENABLED",
-  "message": "Soul flow is disabled by default ... set LINGTAI_SOUL_FLOW_ENABLED=1 ... See soul-manual skill."
-}
+{"status": "disabled", "enabled": false, "env_var": "LINGTAI_SOUL_FLOW_ENABLED", "message": "..."}
 ```
 
 **This is expected configuration state, not an error.** Do **not** retry it in
@@ -106,14 +95,9 @@ That is *all* it does:
   disabled the result carries `soul_flow_enabled: false` and a `note` saying the
   knobs are saved but no fires will occur. Enabling is an **operator** action.
 
-Historically flow was "muted" by setting `delay_seconds` to a huge sentinel
-(e.g. `999999999`, ~31.7 years). That was a trust-based non-trigger and it was
-unsafe: the giant delay only muted the **timer**, while the **voluntary** path
-stayed live and could loop against the sleep gate, producing retry storms
-(observed in trajectory audits: repeated
-`voluntary_waiting_idle → voluntary_triggered` and simultaneous
-`soul_fire_gate_check state=asleep` bursts). The sentinel also had to be
-re-applied by hand and was easy to get wrong. The env gate replaces that
+`delay_seconds` is cadence only. A huge sentinel value (e.g. `999999999`) used to
+be the trust-based mute, but it silenced only the **timer** — the voluntary path
+stayed live and could loop against the sleep gate. The env gate replaced that
 fragile convention with an explicit opt-in covering both paths.
 
 ## 4. How to enable / disable
@@ -133,10 +117,8 @@ switch.
 
 ## 5. Checking the current state
 
-- **Is flow enabled right now?** Run `soul(action='flow', input={})` —
-  `status: ok` means enabled, `status: disabled` means the env var is not set.
-  You can also run `soul(action='config', input={...})` and read
-  `soul_flow_enabled` in the result.
+- **Is flow enabled right now?** `soul(action='config', input={...})` reports
+  `soul_flow_enabled` (or see the `flow` status in §2).
 - **Check the env from a shell:**
   `shell({"command": "printenv LINGTAI_SOUL_FLOW_ENABLED"})` — empty output
   means unset (disabled).
@@ -170,15 +152,9 @@ the flow gate lives in the process environment. Nothing here reads a
 
 ## 8. Privacy and cost rationale
 
-Soul flow is **off by default** deliberately:
-
-- **Cost.** Each fire runs `M = 1 + K` parallel LLM calls (one stepped-back
-  read of your current chat, plus `K` past-snapshot voices). Left on with a low
-  delay, this is a recurring, silent token cost on top of your own turns.
-- **Privacy / surprise.** Flow reads your current chat and past-self snapshots
-  and injects involuntary voices into your history. Making it opt-in means an
-  operator consciously decides to spend those tokens and surface that
-  reflection, rather than it happening implicitly.
-
-Enable it when the reflection is worth the cost; otherwise reach for `inquiry`
-when you specifically want a considered pause.
+Soul flow is **off by default** because each fire runs `M = 1 + K` parallel LLM
+calls — a recurring silent token cost — and because it reads your current chat
+and past-self snapshots to inject involuntary voices into your history. Opt-in
+means an operator consciously decides to spend those tokens and surface that
+reflection. Enable it when the reflection is worth the cost; otherwise reach for
+`inquiry` when you specifically want a considered pause.

--- a/src/lingtai/intrinsic_skills/system-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -3,24 +3,14 @@ name: system-manual
 description: >
   Second-layer router for LingTai's progressive-disclosure operating manuals.
   Read this when resident substrate/procedures are too compact and you need the
-  right lower reference. Routes to expanded substrate/runtime, lifecycle and
-  `system` actions, preset runtime, procedures/skills, summarization, SQLite
-  traces, updates/nudges, env vars, goals, name changes, molt/memory, MCP/addon
-  ownership, collaboration, resident prompt design, and the built-in LLM
-  adapters (provider inventory, Codex REST vs WebSocket, adapter env vars).
-version: 1.10.0
-last_changed_at: "2026-08-06T00:00:00Z"
-tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize, nudge, updates, runtime-checks, preset, llm, adapters, codex, websocket]
+  right lower reference; route from the table, then open that node.
+version: 1.11.0
+last_changed_at: "2026-08-07T00:00:00Z"
+tags: [lingtai, agent, runtime, procedures, substrate, system, lifecycle, memory, communication, skills, molt, summarize, nudge, updates, runtime-checks, refresh, preset, llm, adapters, codex, websocket]
 related_files:
 - src/lingtai/prompts/substrate/substrate.md
 - src/lingtai/prompts/procedures/procedures.md
-- src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
-- src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
-- src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
-- src/lingtai/intrinsic_skills/notification-manual/reference/channel-model/SKILL.md
 - src/lingtai/kernel/nudge/ANATOMY.md
-- src/lingtai/intrinsic_skills/system-manual/reference/environment-variables/SKILL.md
-- src/lingtai/intrinsic_skills/system-manual/reference/how-to-change-name/SKILL.md
 - src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
 - src/lingtai/llm/_register.py
 - src/lingtai/llm/openai/adapter.py
@@ -37,98 +27,95 @@ that carries the actual detail.
 
 Use this file first when the question is about LingTai's agent runtime, resident
 prompt design, lifecycle, memory, communication, tool routing, system operations,
-runtime trace inspection, runtime/kernel update checks, or nudge handling. Then open the referenced lower node.
+runtime trace inspection, runtime/kernel update checks, or nudge handling, then
+open the lower node the router table names.
 
 
 ## Nested reference catalog
 
-`system-manual` owns the following nested skill-references. Their frontmatter is
-kept here so the router advertises lower nodes without promoting them to
-standalone top-level skills. Open the listed `SKILL.md` when the router table
-selects that topic.
+`system-manual` owns the nested skill-references below, so the router can
+advertise lower nodes without promoting them to standalone top-level skills.
+The router table is the routing authority; this list is the inventory.
 
 ```yaml
 - name: substrate-manual
   location: reference/substrate-manual/SKILL.md
   description: |
-    Nested system-manual reference for the expanded substrate/runtime model:
-    body/extensions, lifecycle states, `system` tool actions, communication and
-    notification discipline, memory layers and the molt model, collaboration
-    topology, MCP/addon ownership, idle/soul, preset tiers, and (§11) the
-    canonical `init.json` composition and preset runtime model.
+    Expanded substrate/runtime model: body/extensions, lifecycle states,
+    `system` actions, memory layers, MCP/addon ownership, preset tiers, and
+    (§11) `init.json` composition and the preset runtime model.
 - name: procedures-manual
   location: reference/procedures-manual/SKILL.md
   description: |
-    Nested system-manual reference for expanded action discipline: progressive
-    disclosure, responsiveness, external side-effect authorization, the daemon
-    workflow methodology, depositing work into pad/knowledge/skills/character,
-    idle/lifecycle procedure, skill routing, HTML deliverables, artifact
-    sharing, and issue reporting.
-- name: summarize-manual
-  location: reference/summarize-manual/SKILL.md
-  description: |
-    Nested system-manual reference and canonical owner of tool-result
-    summarization: the three compression modes (a-priori `summary=true`,
-    a-posteriori `context(action="summarize")`, molt), summarize cadences,
-    delayed provider reconstruction and the 0.85/1.0 rebuild boundaries,
-    original-result recovery by `tool_call_id`, and summarize versus molt.
+    Expanded action discipline: progressive disclosure, responsiveness,
+    external side-effect authorization, the daemon workflow methodology,
+    depositing work, idle/lifecycle, skill routing, deliverables, and issues.
 - name: sqlite-log-query
   location: reference/sqlite-log-query/SKILL.md
   description: |
-    Nested system-manual reference for SQLite/`log.sqlite` runtime trace
-    inspection and trajectory/anomaly mining: `lingtai-agent log doctor`,
-    `lingtai-agent log query`, `lingtai-agent log rebuild`, JSONL
-    source-of-truth rules, read-only SQL safety, offline rebuild/WAL caveats,
-    the events/chat_entries/token_entries schema, query recipes, cheap-model
-    daemon strategy, finding schema, digests, redaction rules, and
-    event_summary.py.
+    SQLite/`log.sqlite` runtime trace inspection: `lingtai-agent log
+    doctor|query|rebuild`, JSONL source-of-truth rules, read-only SQL safety,
+    the events/chat_entries/token_entries schema, SQL recipes, and redaction.
+- name: trajectory-mining
+  location: reference/trajectory-mining/SKILL.md
+  description: |
+    Trajectory/anomaly mining workflow built on sqlite-log-query: manifest
+    policy, cheap-model daemon strategy, prompt templates, the finding schema
+    and validation rubric, digest output, routing, and periodic mode.
+- name: refresh-precheck
+  location: reference/refresh-precheck/SKILL.md
+  description: |
+    Nested system-manual reference: the ordered pre-flight to run BEFORE
+    `system(action="refresh")` (including preset swap/revert), the refresh
+    sequence itself, and the post-refresh verification pass. Covers
+    authorization boundary, allowed-preset catalog, MCP registry/init.json
+    consistency, newly introduced env vars, context-vs-target-context_limit,
+    durable-store and working-tree state, source_drift, and what to check when
+    a refresh fails or comes back with a broken surface.
 - name: runtime-update-checks
   location: reference/runtime-update-checks/SKILL.md
   description: |
-    Nested system-manual reference for the kernel update/nudge lifecycle:
-    runtime and source discovery, `kernel_version` and `source_drift`,
-    heartbeat dispatch, `.notification/nudge.json` envelopes, sync/wake/dismiss,
-    packaged versus editable/source runtimes, installer ownership and human
-    confirmation, refresh boundaries, and read-only diagnosis.
+    Kernel update/nudge lifecycle: runtime and source discovery,
+    `kernel_version` and `source_drift`, heartbeat dispatch,
+    `.notification/nudge.json`, packaged versus editable/source runtimes,
+    installer ownership, refresh boundaries, and read-only diagnosis.
 - name: environment-variables
   location: reference/environment-variables/SKILL.md
   description: |
-    Nested system-manual reference cataloguing every LingTai environment
-    variable: purpose, default, accepted values, scope, read point,
-    reload/restart behavior, invalid-value handling, implementation anchor,
-    and security caution.
+    Router to the repo-root `ENVIRONMENT_VARIABLES.md` registry, which owns
+    every LingTai environment variable's purpose, default, accepted values,
+    scope, read point, reload behavior, and invalid-value handling.
 - name: goal-manual
   location: reference/goal-manual/SKILL.md
   description: |
-    Nested system-manual reference for goal notifications: protected
-    `.notification/goal.json` as the active-goal source of truth, `/goal`
-    guided setup, recommended fields, idle goal reminders, and
+    Goal notifications: protected `.notification/goal.json` as the active-goal
+    source of truth, `/goal` guided setup, idle goal reminders, and
     cancellation/completion semantics.
 - name: how-to-change-name
   location: reference/how-to-change-name/SKILL.md
   description: |
-    Nested system-manual reference for changing a live agent workdir/address on
-    POSIX. Read this after loading system-manual for suspend, an atomic
+    Changing a live agent workdir/address on POSIX: suspend, an atomic
     no-replace rename, and a verified resume.
 - name: llm-adapters
   location: reference/llm-adapters/SKILL.md
   description: |
-    Nested system-manual reference for the built-in LLM adapters: named
-    adapter inventory, per-provider configuration/dispatch, the Codex REST vs
-    WebSocket transport opt-in and its environment variables, and provider
-    special behaviors.
+    Built-in LLM adapters: named adapter inventory, per-provider
+    configuration/dispatch, the Codex REST vs WebSocket transport opt-in and
+    its environment variables, and provider special behaviors.
 ```
 
 ## Router table
 
 | Need / keywords | Read |
 |---|---|
-| Expanded substrate; body/extensions; bash vs daemon vs avatar vs MCP; lifecycle states; ACTIVE/IDLE/ASLEEP/SUSPENDED; same-channel communication; basic notifications; memory layers; molt model; idle/soul; preset tiers; `system` operations | `reference/substrate-manual/SKILL.md` |
+| Expanded substrate; body/extensions; shell vs daemon vs avatar vs MCP; lifecycle states; ACTIVE/IDLE/STUCK/ASLEEP/SUSPENDED; same-channel communication; basic notifications; memory layers; molt model; idle/soul; preset tiers; `system` operations | `reference/substrate-manual/SKILL.md` |
 | `init.json` composition/owner map; preset runtime model; raw vs resolved `system/manifest.resolved.json`; preset identity/path; TUI/library discovery vs `system(action="presets")` allowed-only catalog; main-agent swap/revert/refresh; daemon `tasks[].preset` explicit/omitted path; external CLI backend preset skip | `reference/substrate-manual/SKILL.md` §11 |
 | Expanded procedures; progressive disclosure; writing skills/knowledge; action discipline; responsiveness; skill routing; HTML deliverables; artifact sharing; issue reporting; when to read which manual | `reference/procedures-manual/SKILL.md` |
-| Tool-result summarization; large-result ranking via agent_meta; progressive disclosure of raw outputs; original-result recovery; summarize vs molt | `reference/summarize-manual/SKILL.md` |
-| SQLite; `log.sqlite`; LingTai runtime logs; JSONL traces; `lingtai-agent log doctor`; `lingtai-agent log query`; `lingtai-agent log rebuild`; events/chat_entries schema; daemon/chat-history trace indexing; WAL/live-read caveats; SQL recipes; trajectory/anomaly mining; improvement digests; cheap-model strategy | `reference/sqlite-log-query/SKILL.md` |
-| Notifications; direct `notification(action='manual', input={})`; check/dismiss_channel/dismiss_event/dismiss_ref/manual; `.notification/<channel>.json`; channel allowlist; top-level `instructions`; protected channels; generic vs producer dismiss; stale-version/force; legacy `large_tool_result` dismiss | `notification-manual` |
+| Tool-result summarization; large-result ranking via agent_meta; progressive disclosure of raw outputs; original-result recovery; summarize vs molt | `context-manual` → `reference/summarize-manual/SKILL.md` |
+| SQLite; `log.sqlite`; LingTai runtime logs; JSONL traces; `lingtai-agent log doctor`; `lingtai-agent log query`; `lingtai-agent log rebuild`; events/chat_entries schema; daemon/chat-history trace indexing; WAL/live-read caveats; SQL recipes | `reference/sqlite-log-query/SKILL.md` |
+| Trajectory mining; trajectory/anomaly mining; improvement digests; finding schema and validation; cheap-model daemon strategy; mining prompt templates; periodic mining mode | `reference/trajectory-mining/SKILL.md` |
+| Notifications; direct `notification(action='manual', input={})`; check/dismiss_channel/dismiss_event/dismiss_ref/manual; `.notification/<channel>.json`; channel allowlist; the top-level `instructions` field in the `.notification/<channel>.json` envelope; protected channels; generic vs producer dismiss; stale-version/force; legacy `large_tool_result` dismiss | `notification-manual` |
+| About to call `system(action="refresh")`; preset swap/revert pre-flight; "will this refresh break something?"; refresh returned but MCP/tools/LLM look wrong; refresh failed | `reference/refresh-precheck/SKILL.md` |
 | Kernel update lifecycle; runtime/source discovery; `kernel_version` and `source_drift`; heartbeat nudge dispatch; `.notification/nudge.json`; durable state; sync/wake/dismiss mechanics; packaged vs editable/source installs; refresh vs TUI-managed update; verification/troubleshooting | `reference/runtime-update-checks/SKILL.md` |
 | Environment variables; Nudge controls; accepted values; read/reload behavior; invalid-value fallback; security cautions | `reference/environment-variables/SKILL.md` |
 | Goal notifications; `.notification/goal.json`; active goal source of truth; goal `instructions`; idle goal reminder; cancel/complete goal | `reference/goal-manual/SKILL.md` |
@@ -152,17 +139,13 @@ selects that topic.
 - If this router names a reference, read that reference before improvising.
 - If a reference points to anatomy/code/tests, descend there for ground truth.
 
-## Substrate and procedures are separate on purpose
-
-`substrate` describes what an agent *is* and how the runtime behaves;
-`procedures` describes how an agent *acts*. Keep the resident prompt compact,
-keep this file a router, and put detailed explanations in the nested references
-above rather than collapsing them back into one monolithic body.
-
 ## Maintaining this router
 
-When resident substrate/procedures gain new concepts, add a routing hint here and
-put detail in a nested reference. When a reference grows too large or needs
-companion scripts and assets, split it into another `reference/<name>/SKILL.md` folder and list
-its frontmatter summary in both this nested reference catalog and the router
-table. Keep this file short enough to scan.
+`substrate` describes what an agent *is* and how the runtime behaves;
+`procedures` describes how an agent *acts* — they stay separate on purpose.
+Keep the resident prompt compact and keep this file a router: when resident
+substrate/procedures gain new concepts, add a routing hint here and put the
+detail in a nested reference. When a reference grows too large or needs
+companion scripts and assets, split it into another `reference/<name>/SKILL.md`
+folder and list it in both the nested reference catalog and the router table.
+Keep this file short enough to scan.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/environment-variables/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/environment-variables/SKILL.md
@@ -5,7 +5,7 @@ description: >
   registry. Use the registry for names, defaults, behavior, ownership, and
   security notes.
 version: 1.0.0
-last_changed_at: "2026-07-24"
+last_changed_at: "2026-07-24T00:00:00Z"
 related_files:
 - ENVIRONMENT_VARIABLES.md
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
@@ -18,7 +18,7 @@ maintenance: |
 # Environment-variable registry router
 
 The canonical environment-variable reference is the repository-root
-[`ENVIRONMENT_VARIABLES.md`](../../../../../../ENVIRONMENT_VARIABLES.md).
+repo-root `ENVIRONMENT_VARIABLES.md`.
 
 Use that registry for the complete table, defaults, accepted values, scope,
 read/reload timing, invalid-value behavior, implementation owners, and security

--- a/src/lingtai/intrinsic_skills/system-manual/reference/goal-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/goal-manual/SKILL.md
@@ -145,17 +145,14 @@ the configured delay, the kernel publishes one short event into
 The reminder is intentionally brief. The actual goal and instructions stay in
 `goal.json`. Dismissing the reminder clears only the system event:
 
-```text
-notification(action="dismiss_ref",
-             input={"ref_id": "goal:<id>", "channel": null,
-                    "force": null, "reason": null},
-             reasoning="the goal reminder is handled")
-```
+Same call shape as the goal-request dismiss above, with
+`ref_id="goal:<id>"`.
 
-Dismissing the reminder does not cancel the goal. If the goal remains active, a
-fresh idle interval can generate another reminder. If `goal.json` is deleted or
-marked inactive/done while a reminder is already present, the next IDLE goal
-check clears that stale `goal.reminder` system event.
+Cancellation and completion semantics are above, under "Protected dismiss
+behavior": dismissing a reminder never cancels the goal, so if the goal remains
+active a fresh idle interval can generate another reminder. If `goal.json` is
+deleted or marked inactive/done while a reminder is already present, the next
+IDLE goal check clears that stale `goal.reminder` system event.
 
 ## Cross-reference
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/llm-adapters/SKILL.md
@@ -88,16 +88,15 @@ testing showed REST prompt-prefix caching is sufficient. Resolution priority:
 
 ### Environment variables
 
-| Variable | Purpose | Accepted values | Default |
-|---|---|---|---|
-| `LINGTAI_CODEX_TRANSPORT` | Opt a Codex agent onto the WebSocket wire | `websocket` / `ws` (opt-in); `rest` / `http` / `https` (explicit REST); anything else → REST | unset → REST |
-| `LINGTAI_CODEX_WS` | Legacy boolean opt-in for the WebSocket wire | `1` / `true` / `yes` / `on` → websocket; anything else → REST | unset → REST |
-| `LINGTAI_CODEX_WS_EPOCH_RESET_TURNS` | Explicit WS response-chain epoch reset interval (turns); `0` disables the turn-count reset | non-negative integer | `0` |
+The Codex variables (`LINGTAI_CODEX_TRANSPORT`, `LINGTAI_CODEX_WS`,
+`LINGTAI_CODEX_WS_EPOCH_RESET_TURNS`, and the responses-trace pair) are
+registered with their accepted values and defaults in the repo-root
+`ENVIRONMENT_VARIABLES.md`, routed via `reference/environment-variables/SKILL.md`.
 
-These variables are read at session construction time (per process). The
-selector is deliberately opt-in: an inherited or accidentally-set variable
-never flips a Codex agent onto WebSocket unless the value is explicitly the
-opt-in value.
+Two behaviors worth holding here: they are read at session construction time
+(per process), and the selector is deliberately opt-in — an inherited or
+accidentally-set variable never flips a Codex agent onto WebSocket unless the
+value is explicitly the opt-in value.
 
 ## OpenAI adapter
 
@@ -128,33 +127,18 @@ custom/user-defined presets).
 
 `claude_code` and `kimi_code` are registered LLM providers whose adapters wrap
 local code-workspace CLIs (`ClaudeCodeAdapter`, `KimiCodeAdapter`) rather than
-speaking a wire protocol directly. They are valid main-agent/preset providers
-and are lazy-imported like every other adapter. They are **not** the daemon CLI
-backend axis: the daemon system can dispatch external coding CLIs as task
-subprocesses (`daemon-manual`), independent of these registered providers.
+speaking a wire protocol directly — valid main-agent/preset providers,
+lazy-imported like every other adapter. (Not the daemon backend axis; see above.)
 
 ### External CLI harnesses (daemon backends)
 
 The daemon tool runs external coding CLIs as task subprocesses through the
-`backend` axis (`daemon-manual`). Each CLI backend has its own small
-progressive-disclosure page under
-`daemon-manual` → `reference/cli-backends` — what it is, what LingTai uses it
-for, its subscription/auth model, its official docs, and the reserved
-harness-owned flags it refuses in `backend_options`. These pages are
-entrypoints, not flag catalogs; the installed CLI's live help remains the
-authority.
+`backend` axis. The index of backends, and one page per backend, live under
+`daemon-manual` → `reference/cli-backends/SKILL.md` (each page at
+`reference/cli-backends/reference/backends/<name>/SKILL.md`). Do not maintain a
+second backend list here.
 
-| Daemon backend | Page | Subscription/auth model | Official docs |
-|---|---|---|---|
-| `claude-p` / `claude-code` | `reference/backends/claude-p/SKILL.md` | Claude subscription (Pro/Max), CLI OAuth login | https://docs.anthropic.com/en/docs/claude-code |
-| `codex` | `reference/backends/codex/SKILL.md` | ChatGPT subscription (Plus/Pro), `codex login` or codex-pool | https://developers.openai.com/codex/ |
-| `opencode` | `reference/backends/opencode/SKILL.md` | provider-agnostic auth; OpenCode Go subscription via `OPENCODE_GO_API_KEY` | https://opencode.ai/docs/ |
-| `mimocode` / `mimo` | `reference/backends/mimocode/SKILL.md` | MiMo Code provider keys | https://github.com/XiaomiMiMo/MiMo-Code |
-| `qwen-code` / `qwen` | `reference/backends/qwen-code/SKILL.md` | Qwen provider config | https://github.com/QwenLM/qwen-code |
-| `oh-my-pi` / `omp` | `reference/backends/oh-my-pi/SKILL.md` | Oh-My-Pi provider keys | https://github.com/pi-coding-agent/pi-coding-agent |
-| `kimicode` / `kimi` | `reference/backends/kimicode/SKILL.md` | Moonshot AI keys | https://github.com/MoonshotAI/kimi-code |
-| `cursor` | `reference/backends/cursor/SKILL.md` | Cursor account/subscription login | https://docs.cursor.com/agent |
-
-Each backend page carries the same small `## Subscription & auth` section so
-the question "what do I need to pay for / how does LingTai connect" is
-answered per backend without reading the vendor's full billing docs.
+Each backend page carries the same `## Subscription & auth` section, so "what do
+I need to pay for / how does LingTai connect" is answered per backend without
+reading the vendor's full billing docs. These pages are entrypoints, not flag
+catalogs; the installed CLI's live help remains the authority.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -188,9 +188,14 @@ a third copy here.
 
 ## 8. Web, files, media, and local artifacts
 
-Use existing producer/tool capabilities before inventing workflows — the
-`system-manual` router names the owner for web (`web-manual`), images (`vision`),
-audio/media, and files (`file-manual`).
+Use existing producer/tool capabilities before inventing workflows. Resident
+`procedures` ("Skill Routing — When to Load What") names the owner for web
+fetching/search/scraping (`web-manual`) and image understanding (`vision`); that
+table does not carry the two below, so they live here:
+
+- For shell audio/media work, load the relevant media/listen/minimax skill.
+- For tricky file encodings, large files, binary-like data, or careful edit
+  workflows, read `file-manual`.
 
 When giving humans local artifacts, include a usable path and a short summary.
 Do not expose private internal IDs as if they are user-accessible artifacts.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md
@@ -1,19 +1,14 @@
 ---
 name: procedures-manual
 description: >
-  Nested system-manual reference for expanded LingTai procedure/action guidance.
-  Read via the `system-manual` router when resident procedures are too compact
-  and you need details about progressive disclosure, responsiveness, external
-  side-effect authorization, choosing bash vs daemon vs avatar vs MCP, depositing
-  work into pad/knowledge/skills/character, idle/lifecycle procedure, molt
-  checklist, skill routing, web/file/media/artifact handling, standalone HTML
-  deliverables, sharing artifacts, issue reporting, and resident procedures
-  maintenance. This is a nested skill-reference under `system-manual`, not a
-  standalone catalog skill; its folder may carry scripts/assets as procedure
-  guidance grows.
-version: 1.3.0
+  Nested system-manual reference: the expanded form of the resident procedures
+  prompt — progressive disclosure, responsiveness and side-effect authorization,
+  the daemon workflow methodology, depositing work, idle/lifecycle, skill
+  routing, deliverables, artifact sharing, and issue reporting. Route via
+  `system-manual` when it is unclear whether this is the right node.
+version: 1.4.0
 tags: [lingtai, system-manual, procedures, progressive-disclosure, responsiveness, deliverables, issue-reporting]
-last_changed_at: "2026-07-27T17:02:00-07:00"
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/prompts/procedures/procedures.md
@@ -24,14 +19,10 @@ maintenance: |
 
 # Procedures Manual
 
-The resident `procedures` prompt is the compact action checklist every LingTai
-agent keeps in memory. This reference is its expanded form. Read it when the
-short procedure tells you *what* to do but you need the routing logic, examples,
-edge-case discipline, or deliverable checklist behind it.
-
-This file is a **nested skill-reference owned by `system-manual`**, not a top-level catalog skill.
-Start at `system-manual` when routing is unclear; return here for the expanded
-action discipline.
+This is the expanded form of the resident `procedures` action checklist — a
+nested skill-reference owned by `system-manual`, not a top-level catalog skill.
+Read it when the short procedure tells you *what* to do but you need the routing
+logic, edge-case discipline, or deliverable checklist behind it.
 
 ## 1. Progressive disclosure
 
@@ -54,61 +45,35 @@ not bloat the resident prompt with one-off details.
 
 ### Tool-result digestion
 
-Progressive disclosure applies to tool results as much as to manuals. A raw tool
-result is useful while you inspect it; after you have consumed it and no longer
-need the raw text visible, the better active-context form is an index-style
-summary. Strongly prefer summarizing already-digested completed tool results
-regardless of length unless you still need raw details for inspection, quotation,
-or comparison. This reduces token per API call and helps cache/continuation
-efficiency. Batch already-digested results instead of discharging each
-immediately when batching is practical. If an adapter/provider comment is present,
-follow its adapter-specific summarize rules on top of these general ones.
+Progressive disclosure applies to tool results as much as to manuals. The
+summarize cadence itself is resident (summarize already-digested results, batch
+rather than discharging each one); the addition here: **if an adapter/provider
+comment is present, follow its adapter-specific summarize rules on top of the
+general ones.**
 
 The first economy move is to avoid pulling bulky raw output into main context at
 all. Bulky, mechanical, or repetitive work — full test suites, large log scans,
-large diffs, issue sweeps, batch edits/validation — should usually be delegated to
-a daemon (`claude-p` or an appropriate daemon body): frame the task, give exact
-paths/commands and the expected artifacts, then review the daemon's concise report
-instead of ingesting noisy output you would only have to summarize later. Use
-daemons to keep the raw bulk out of main context; use summarize for the bulk that
-already landed there. See `## 3. Use the right body` for the full daemon workflow
-methodology.
+large diffs, issue sweeps, batch edits/validation — belongs in a daemon: frame the
+task, give exact paths/commands and the expected artifacts, then review the
+concise report. Use daemons to keep raw bulk out of main context; use summarize
+for the bulk that already landed there. §3 owns the daemon workflow methodology.
 
 ### Delayed summarization reconstruction threshold
 
-Summarize records compact replacements in runtime history immediately, but
-provider-side reconstruction is deliberately delayed. Below the full-context
-boundary, keep working: pending summarized history is not a failure, and
-`refresh` is reserved for emergencies (broken/stale context), never a way to
-force a rebuild.
-
-`reference/summarize-manual/SKILL.md` §3a owns this mechanism in full — the 0.85
-`context.rebuild` stamp and the one proactive `context(action="rebuild")` call
-it permits, the 1.0 once-per-episode forced provider replay, the
-`reconstruction.warning`, the persistent overflow `Molt IMMEDIATELY` line, and
-the task-boundary molt threshold. The public rebuild is the one active full
-reconstruction: canonical prompt sources first, pending/new summaries second,
-provider replay last; bare `{}` remains valid with zero pending. Do not loop
-rebuild/summarize. If summarize or a rebuild still cannot bring context below
+`context-manual` → `reference/summarize-manual/SKILL.md` §3a owns this mechanism
+in full (the 0.85 stamp, the 1.0 forced replay, the reconstruction warning, the
+persistent-overflow line, the task-boundary threshold). The procedural invariants:
+pending summarized history is not a failure, `refresh` is not a way to force a
+rebuild, do not loop rebuild/summarize, and if you still cannot get below
 `0.75 * context_window`, tend durable stores and molt deliberately.
 
 ## 2. Action and responsiveness
 
-When need arises, act. If you can do the task safely, do it; if a tool fails, try
-another; if capability is missing, learn, install, delegate, or spawn. Do not use
-uncertainty as a reason to stall when evidence can be gathered.
+When need arises, act — the acknowledge/progress-message/report-blockers
+discipline is resident. Two things it does not spell out:
 
-For human-facing work:
-
-- Acknowledge human instructions promptly on the same channel.
-- If the next action may take more than a few seconds, send a short progress
-  message first with the communication tool directly. When a notification
-  preview is not enough, read the producer channel first — the conditions are
-  listed in `reference/substrate-manual/SKILL.md` §4.
-- During long work, report meaningful progress, blockers, or completion evidence.
-- Never reply to humans via diary text.
-- Do not infer approval for external side effects when standing rules require
-  explicit confirmation.
+- When a notification preview is not enough, read the producer channel first;
+  the conditions are listed in `reference/substrate-manual/SKILL.md` §4.
 - Before delegating a PR, diff, or implementation for GLM/Claude/daemon
   review, re-check recent human-channel instructions for missed scope,
   boundary, or authorization changes. Use the producer channel, not memory
@@ -136,22 +101,10 @@ that tool's manual.
 
 ### Daemon workflow methodology
 
-Protect the main agent's context and use tokens deliberately. The parent agent
-should stay in the strategic seat: define the objective, negate the first plan
-before acting, design the workflow, choose the bodies, and synthesize the result.
-Daemons should carry the execution: file scans, deterministic transformations,
-read-only reviews, batch conversion, log mining, and other noisy work whose
-details would pollute the main context. Be proactive rather than waiting for an
-explicit delegation request: if the useful output is a conclusion or artifact,
-not the full transcript, isolate the work in a daemon.
-
-Daemon turns do not carry the full resident system prompt, so they are often the
-more token-efficient body for temporary exploration. Choose the daemon/model by
-exercising judgment about the task: match capability, cost, latency, privacy, and
-expected output to the work instead of blindly mirroring the parent. When the
-human gives an explicit instruction about which daemon/model to use, follow it.
-
-Use this methodology for substantial daemon work:
+The resident prompt owns the framing (parent stays strategic, daemons carry
+noisy execution, daemon turns carry no resident prompt so choose the model by
+judgment, follow an explicit human instruction about which daemon/model to use).
+This section owns the *methodology* for substantial daemon work:
 
 1. **Plan in pad first.** Record the objective, assumptions to test, daemon task
    split, expected artifacts, stop criteria, and who/what waits on the result. If
@@ -173,14 +126,9 @@ Use this methodology for substantial daemon work:
    daemon transcript back into the main conversation.
 
 Daemon usage is cultivated from observed practice, not mandated by a daemon-first
-rule. Watch how humans route work to daemons and subagents — which tasks they hand
-off, what they correct, and what they approve or reject — and treat that as the
-training signal for your own routing. After a meaningful daemon workflow, deposit
-the lesson into the layer that fits its lifetime: pad for active workflow state,
-lingtai/character for durable operating style, knowledge for private project facts
-and patterns, skills for reusable procedures. The parent remains responsible for
-framing, review, synthesis, and human-facing decisions; the daemon protects the
-main context by executing bounded work.
+rule: watch how humans route work to daemons and subagents — which tasks they hand
+off, what they correct, what they approve — and treat that as the training signal
+for your own routing. Depositing the lesson afterwards is §4.
 
 Tool results may carry `_advisory.type == "duplicate_tool_call"` when the same
 semantic tool call repeats more than the free-pass threshold. This is
@@ -193,17 +141,14 @@ same call.
 
 ## 4. Write skills and knowledge as you work
 
-After non-trivial work, deposit the grain:
+After non-trivial work, deposit the grain into the layer that fits its lifetime
+— the pad / knowledge / skill / character routing is resident, and `psyche-manual`
+carries the canonical store table. What this section adds:
 
-- Active state and next steps → pad.
-- Private durable facts, local paths, decisions, journals → knowledge.
-- Reusable workflow/checklist/script → skill.
-- Stable changes in identity, relationships, or capabilities → character.
-- Broadly useful skill → consider publishing/shared library, if appropriate and
-  authorized.
-
-Before authoring skills, read `skills-manual`. Before authoring knowledge, read
-`knowledge-manual`. Do not put private project facts into a portable skill.
+- A broadly useful skill is worth publishing to a shared library, if appropriate
+  and authorized.
+- Before authoring skills read `skills-manual`; before authoring knowledge read
+  `knowledge-manual`. Do not put private project facts into a portable skill.
 
 ## 5. Idle, sleep, and lifecycle procedure
 
@@ -230,14 +175,10 @@ lifecycle.
 
 ## 6. Molt and durable stores
 
-**The molt procedure lives in `context-manual`, not here.** It owns durable-store
+**The molt procedure lives in `context-manual`, not here** — durable-store
 tending, the session-journal / molt-history record, the successor summary, and
-the consequential-handoff templates. Read it before molting — while context is
-still cheap, not at the last moment.
-
-The invariant in this procedures reference is routing: do not reconstruct molt
-mechanics here. For the checklist, templates, and summary rules, go to
-`context-manual`.
+the consequential-handoff templates. Read it before molting, while context is
+still cheap. Do not reconstruct molt mechanics in this reference.
 
 ## 7. Skill routing
 
@@ -245,19 +186,11 @@ The situation→manual table is resident in `procedures`, and the `system-manual
 router table owns routing into this manual's sibling references. Do not maintain
 a third copy here.
 
-Read the named manual before using tools whose developer instructions require it
-(e.g. bash, daemon, skills, knowledge, MCP, web browsing).
-
 ## 8. Web, files, media, and local artifacts
 
-Use existing producer/tool capabilities before inventing workflows:
-
-- For web fetching/search/scraping, read `web-manual` before using web search
-  or ad-hoc scraping.
-- For image understanding, use the `vision` skill/tool route.
-- For shell audio/media work, load the relevant media/listen/minimax skill.
-- For tricky file encodings, large files, binary-like data, or careful edit
-  workflows, read `file-manual`.
+Use existing producer/tool capabilities before inventing workflows — the
+`system-manual` router names the owner for web (`web-manual`), images (`vision`),
+audio/media, and files (`file-manual`).
 
 When giving humans local artifacts, include a usable path and a short summary.
 Do not expose private internal IDs as if they are user-accessible artifacts.
@@ -266,7 +199,8 @@ Do not expose private internal IDs as if they are user-accessible artifacts.
 
 For substantial human-facing deliverables—design previews, dashboards, readiness
 matrices, PR/issue triage, research memos, before/after comparisons—prefer
-standalone HTML unless the human asks otherwise.
+standalone HTML unless the human asks otherwise; plain text stays best for quick
+acknowledgements, short status, small diffs, or explicit text requests.
 
 Checklist:
 
@@ -277,9 +211,6 @@ Checklist:
 - clear risks/blockers/next steps;
 - no secrets or private tokens;
 - path and summary in the message to the human.
-
-Plain text is best for quick acknowledgements, short status, small diffs, or
-explicit text requests.
 
 ## 10. Sharing artifacts and reports
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/refresh-precheck/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/refresh-precheck/SKILL.md
@@ -1,0 +1,398 @@
+---
+name: refresh-precheck
+description: |
+  Nested system-manual reference: the ordered pre-flight to run BEFORE
+  `system(action="refresh")` (including preset swap/revert), the refresh
+  sequence itself, and the post-refresh verification pass. Covers
+  authorization boundary, allowed-preset catalog, MCP registry/init.json
+  consistency, newly introduced env vars, context-vs-target-context_limit,
+  durable-store and working-tree state, source_drift, and what to check when
+  a refresh fails or comes back with a broken surface.
+version: 1.0.0
+last_changed_at: "2026-08-07T00:00:00Z"
+tags: [lingtai, system, refresh, preset, precheck, checklist, mcp, env, pth, editable-install, verification, lifecycle]
+related_files:
+- src/lingtai/intrinsic_skills/system-manual/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/environment-variables/SKILL.md
+- src/lingtai/intrinsic_skills/context-manual/SKILL.md
+- src/lingtai/prompts/substrate/substrate.md
+- src/lingtai/prompts/procedures/procedures.md
+- src/lingtai/tools/system/schema.py
+- src/lingtai/kernel/presets.py
+maintenance: |
+  Sequencing-only node: every check here cites the owner that holds the fact
+  (preset runtime model → substrate-manual §11; installer/update authority →
+  runtime-update-checks + resident substrate §I; env var catalogue →
+  environment-variables → root ENVIRONMENT_VARIABLES.md; MCP registry health →
+  mcp-manual; molt/rebuild → context-manual). Do not restate an owned fact
+  here — add or reorder a step and keep the citation. Update when
+  `system(action="refresh")` / `system(action="presets")` semantics, the
+  preset `allowed` gate, or the nudge kinds change.
+---
+
+# Refresh Pre-check — the ordered pre-flight for `system(action="refresh")`
+
+`system(action="refresh")` is the highest-blast-radius routine action an agent
+takes on itself: it rebuilds LLM/config, capabilities, MCP clients, addons,
+prompt sections, and identity projection from `init.json`, optionally swapping
+the active preset.
+
+Every fact needed to run one safely is already owned somewhere — resident
+substrate §I (authorization), `substrate-manual` §3/§11 (refresh and preset
+semantics), `runtime-update-checks` (update/nudge lifecycle and installer
+ownership), `environment-variables` (env var catalogue), `mcp-manual` (registry
+health), `context-manual` (molt/rebuild). What is *not* owned anywhere else is
+the **ordering**: which check runs at the moment before you press the button,
+and what you verify after. That is this node's only job. It adds sequencing,
+not content; each step cites its owner rather than restating it.
+
+## The pre-refresh checklist
+
+Ordered. Steps 0–3 are unconditional; 4–8 are conditional and each names its
+trigger. Every step states **check → command → refuse/proceed**.
+
+### Step 0 — Authorization boundary (unconditional, blocking)
+
+**Check:** does the refresh implement a config/prompt/MCP/preset change that a
+human/config-owner authorized, or is it a self-initiated reload?
+
+- Any refresh that **applies** an update, migration, or configuration write requires
+  explicit human/config-owner authority *before* the write and *before* the refresh
+  (substrate §I; `runtime-update-checks` steps 8–10). A nudge is a fact, not a command,
+  and never grants authority.
+- A refresh that could **interrupt active work** (running daemons, an in-flight
+  collaboration, a peer waiting on a reply) is gated by work safety and the human's
+  intent even when nothing is being written.
+- A pure self-reload with nothing pending and no active work is the only case that does
+  not need a fresh ask.
+
+**If the trigger is a `kernel_version` nudge:** stop. That is the installer's route —
+let Shell run `https://lingtai.ai/install.sh --help` and follow *its* current output.
+Do not read or paste the script source. Refresh is the last step after authorized
+writes are validated, never the first.
+
+### Step 1 — Know what you are actually running (unconditional)
+
+```bash
+PYTHON=${LINGTAI_RUNTIME_PYTHON:-$HOME/.lingtai-tui/runtime/venv/bin/python}
+"$PYTHON" -c 'import sys, lingtai, lingtai.kernel; print(sys.executable); print(lingtai.__file__); print(lingtai.kernel.__file__); print(getattr(lingtai,"__version__","unknown"))'
+```
+
+Refresh reloads the **current on-disk/runtime surface**; it does not fetch code, pull a
+commit, switch an editable checkout, or install a package. If you cannot say which
+interpreter and which module files are authoritative, **stop and ask** — do not refresh
+hoping it resolves the ambiguity.
+
+### Step 2 — `.pth` / editable-install occupancy (unconditional, blocking on mismatch)
+
+Step 1 says *which* files import. This step says *why* — and it is the check that catches a
+refresh-time landmine before it fires.
+
+```bash
+SP=$("$PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+ls -1 "$SP" | grep -Ei '^(__editable__|__editable___)?[._]*lingtai.*\.(pth|dist-info|egg-link)$|^lingtai.*'
+for f in "$SP"/*lingtai*.pth; do echo "== $f"; cat "$f"; done
+cat "$SP"/lingtai-*.dist-info/direct_url.json 2>/dev/null
+```
+
+**Check, in order:**
+
+1. **Exactly one lingtai path marker.** `__editable__.lingtai-*.pth` /
+   `__editable___lingtai*.pth` / `lingtai*.pth` / `lingtai.egg-link`. Two markers, or a
+   `.pth` alongside a real `site-packages/lingtai/` package directory, means pip left both
+   an editable and a non-editable install — imports then resolve by `sys.path` order, not
+   by intent.
+2. **Every path inside each `.pth` exists.** A residual marker from a removed release
+   points at a deleted checkout; the entry is silently skipped, and the *next* candidate on
+   `sys.path` wins. Same for an orphaned `lingtai-*.dist-info` with no matching `.pth`.
+3. **The marker matches the intended install kind.** `~/.lingtai-tui/install.json`
+   declares it (`install_kind`, `kernel_source`, `kernel_source_path`); `direct_url.json`
+   in the dist-info records what pip actually did (`{"dir_info": {"editable": true}}` for
+   an editable). Editable → the `.pth` must point at the source checkout's `src/`.
+   Non-editable → there must be **no** `.pth` and a real package dir instead.
+4. **Cross-check against step 1's `lingtai.__file__`.** If the `.pth` names one source and
+   the import resolves elsewhere, do not refresh — the refresh will load whichever one
+   `sys.path` happens to favour, and you will have no evidence of which. Resolve the
+   provenance first.
+
+Resolve the interpreter through `LINGTAI_RUNTIME_PYTHON` / the runtime venv and read module
+`__file__`, never a PATH `python` — the version/provenance rule is owned by
+`substrate-manual` §I runtime/version checks; this step only sequences it.
+
+**Refuse to refresh if:** more than one lingtai path marker is live; any `.pth` entry does
+not exist on disk; or the marker and `lingtai.__file__` disagree. Repairing an install is a
+pip/installer action, not a refresh — it needs the same authority as step 0.
+
+### Step 3 — Config parses and is internally consistent (unconditional if anything was edited)
+
+```bash
+"$PYTHON" -c 'import json,sys; d=json.load(open("init.json")); print("init.json parses ok"); print("addons:", d.get("addons")); print("mcp:", list((d.get("mcp") or {}).keys()))'
+```
+
+Then cross-check against the registry:
+
+```text
+mcp(action="info", input={}, reasoning="pre-refresh registry health and problems")
+```
+
+**Refuse to refresh if:** `init.json` does not parse (a refresh on unparseable config is
+how you get a broken surface with no easy way back); the `mcp` block names an entry with
+no corresponding registry record (stale/duplicate surface); or `mcp(action="info")`
+reports `problems` you have not explained. Fix the config *first*, then refresh once.
+
+Remember the direction of causation: **a config/prompt/MCP/capability edit needs
+`refresh` to take effect. `context(action="summarize")` never applies config and is not
+a refresh substitute.**
+
+### Step 4 — Preset target validity (trigger: `preset` or `revert_preset` in the call)
+
+```text
+system(action="presets", input={}, reasoning="confirm exact allowed preset paths before swap")
+```
+
+- Use an **exact returned path**. The returned catalog is **allowed-only** — it reads
+  `manifest.preset.allowed` and performs no directory scan. A path from the preset
+  library screen that is not in this list is **not** usable.
+- Never pass both a non-empty `preset` and `revert_preset: true` — that is a conflict
+  error. An empty `preset` string normalizes to absent.
+- `revert_preset: true` reads `manifest.preset.default`; it errors if no default is
+  configured.
+
+### Step 5 — Context fits the target's `context_limit` (trigger: preset swap)
+
+**Check:** current context usage (`agent_meta.agent_state.context`) against the target
+preset's `context_limit` as reported by `system(action="presets")`.
+
+If current context exceeds the target's limit, **the swap is refused before activation
+— molt first.** Do not discover this by attempting the swap; a refused swap after you
+have already told a human "switching now" is a self-inflicted incident. Order is:
+tend durable stores → `context(action="molt", …)` → re-check → swap.
+
+Note also that the cache-miss budget (`manifest.cache_miss_budget`, default 1,000,000)
+accumulates **since last molt and survives a refresh** — refreshing does not reset it.
+
+### Step 6 — Newly introduced environment variables (trigger: the change adds an env read)
+
+**Check three things, in this order:**
+
+1. **Is the variable documented?** New reads belong in
+   `system-manual → reference/environment-variables/SKILL.md` (purpose, default,
+   accepted values, scope, read point, reload behavior, invalid-value handling).
+2. **Will the running agent actually see it?** `env_file`/`venv_path` are resolved at
+   **boot**; refresh/restart *reuse* that resolution. A variable added to a file the
+   process never loaded will not appear just because you refreshed. Confirm the read
+   point, not the file's existence.
+3. **Is the test suite hermetic against it?** If the ambient environment
+   sets the variable, tests that assume the default will pass or fail depending on the
+   shell they run in. The suite needs an autouse fixture clearing it. This check belongs
+   in the *change*, before the refresh, not after a confusing CI result.
+
+### Step 7 — Durable-store and working-tree state (unconditional, cheap)
+
+Refresh preserves identity and conversation. It is **not** a save operation for anything
+else. Before refreshing:
+
+- Deposit anything that should outlive this runtime surface into pad / knowledge /
+  skills / character — durable stores are written with `file.write` / `file.edit`, and a
+  refresh is not a substitute for having written them.
+- Check for uncommitted work in any checkout you are mid-edit on
+  (`git -C <checkout> status --short --branch`). Refresh does not commit, stash, or
+  protect a dirty tree.
+- Check for in-flight daemon work. Ordinary stop/refresh must not terminate active
+  daemon runs, but a refresh mid-batch changes the parent surface those runs report
+  back into — prefer to let a batch finish, or know exactly why you are not.
+- If context is near the limit, tend durable stores **now**, not after (step 5).
+
+### Step 8 — Known breaking-change nudge (unconditional, read-only)
+
+```bash
+ls -l .notification/nudge.json 2>/dev/null && sed -n '1,240p' .notification/nudge.json
+```
+
+- **`source_drift`** (channel `source_integrity`): the running process differs from code
+  on disk. This is exactly the case where refresh *is* the right action — and also the
+  case where you should know what changed before you load it. It stays local to refresh
+  mechanics and never enters release-migration routing.
+- **`init_config_shape`** (channel `configuration_staleness`): configuration-staleness
+  guidance. Read it before refreshing, not after.
+- **`kernel_version`** (channel `release_version`): **not** a refresh trigger by itself —
+  see step 0.
+
+## The refresh sequence
+
+### Before
+
+1. Complete steps 0–8 above. Anything that says *refuse* is a stop, not a warning.
+2. If near the context limit or swapping to a smaller preset: tend durable stores, then
+   molt, then re-check current context against the target's `context_limit`.
+3. Tell the human what you are about to reload and why, if the refresh was their ask or
+   could interrupt their work.
+
+### During
+
+**Exactly one call.** Do not stack refreshes; do not "refresh again to be sure."
+
+```text
+system(action="refresh", input={"reason": "<what config change this applies>"},
+       reasoning="apply the authorized <X> edit")
+```
+
+or, for a swap:
+
+```text
+system(action="refresh", input={"preset": "<exact path from system(action='presets')>"},
+       reasoning="swap to <preset> for <task>")
+```
+
+or, to go home:
+
+```text
+system(action="refresh", input={"revert_preset": true},
+       reasoning="return to default preset after experimenting")
+```
+
+The refresh path checks `allowed` membership → checks target context limit → activates
+atomically (writing raw `init.json`) → persists the new default for a named swap →
+best-effort retries failed MCPs → rebuilds LLM/config/capabilities/MCP/prompts,
+preserving conversation history where a live session exists.
+
+Note: refresh requests a **deferred relaunch** and only when the runtime can build a
+valid launch command and has a configured refresh watcher. Without a launch command it
+returns *without relaunching*; without a refresh watcher it raises. **Neither of those
+is success** — diagnose before believing the refresh happened.
+
+### After (verification — this is not optional)
+
+1. **Confirm you are the new process, from the intended source.** Re-run the step-1
+   interpreter/import probe *and* the step-2 `.pth` listing. Same commands, new process;
+   compare. `lingtai.__file__` must resolve to the intended source, and no stale or
+   duplicate lingtai path marker may have appeared.
+2. **Confirm the MCP surface.** `mcp(action="info", input={}, reasoning="post-refresh
+   verification")` — count, `problems` empty, and the specific tools you expected
+   actually present. A config that looked right is exactly the case where the surface
+   still does not match.
+3. **Confirm the preset.** `system(action="presets", input={}, …)` and/or read the
+   derived `system/manifest.resolved.json` — the fully materialized, validated,
+   path-resolved running configuration. It is derived and read-only; never write it.
+4. **Confirm the tool surface.** The tool list and LLM may have changed. Do not assume
+   the tool you were about to call still exists at the same shape.
+5. **Re-check daemon allowed presets before dispatching.** If you are about
+   to dispatch daemon work with an explicit `tasks[].preset`, re-read
+   `system(action="presets")` *after* the refresh and pass an exact path from that list.
+   An unauthorized path refuses the **whole batch** before load, connectivity probing,
+   capability construction, run-dir creation, scheduling, or dispatch.
+6. **Then, and only then**, dismiss the nudge that motivated the refresh —
+   `notification(action="dismiss_channel", input={"channel": "nudge", …})`. Dismissing
+   before verifying loses the evidence.
+
+## Failure handling
+
+| Symptom | First check | Then |
+|---|---|---|
+| Refresh returned but nothing changed | Re-run the interpreter/import probe in the new process | A refresh only loads code already on disk. It cannot pull a commit or repair an incomplete checkout. Check for a still-held old process or a different environment. |
+| `lingtai` imports from the wrong source, or an edit to the checkout has no effect | Step 2 — list `*lingtai*.pth` + `lingtai-*.dist-info` in the runtime venv's site-packages and compare each `.pth` entry against `lingtai.__file__` | Two markers (editable + non-editable) → `sys.path` order decides, not intent. A `.pth` naming a path that no longer exists → the entry is skipped and the next candidate wins. Orphaned `dist-info` with no `.pth` → stale metadata reporting a version nothing imports. Repair the install via pip/installer with step-0 authority; do **not** refresh against a mismatched marker. |
+| Refresh returned without relaunching | Can the runtime build a valid launch command? Is a refresh watcher configured? | Missing launch command → returns silently; missing watcher → raises. Diagnose the launcher, do not retry blindly. |
+| Refresh raised | The raised error text first | Then `init.json` parse, then `allowed` membership, then target `context_limit` — these are the three gates that reject *before* any runtime change (so the old surface is intact). |
+| Preset swap refused | Was the path in `system(action="presets")` output? Does current context fit the target `context_limit`? | Unauthorized path → ask the config owner to add it to `manifest.preset.allowed`, then refresh, then re-verify with `presets`. Context too large → molt first. |
+| Broken/missing MCP surface after refresh | `mcp(action="info")` `problems` list; `init.json` `mcp` block vs. `mcp_registry.jsonl` records | Fix the registry/config, then refresh **once** more. Do not loop refreshes against an unfixed config. |
+| Active preset file missing or malformed | Which one? | Missing → materialization may fall back to a different loadable default (so the running preset may not be the one you think). Malformed **existing active** preset → materialization fails rather than silently substituting. Read `system/manifest.resolved.json` to see what actually loaded. |
+| Wrong preset is live and you want out | — | `system(action="refresh", input={"revert_preset": true})` — the home button to `manifest.preset.default`. Cannot be combined with `preset`. |
+| Terminal relaunch failure | `logs/refresh_failed_permanent.json` and the high-priority `.notification/system.json` event the kernel writes on permanent relaunch failure | This is a human-escalation condition, not a retry condition. |
+| Mixed/contradictory evidence (offline? stale paths? heartbeat vs. status disagree?) | `lingtai-doctor` — read-only, redacts secrets, never edits | Diagnose before repair; repairs belong to the owning manual. |
+
+**When to ask the human — bright lines.** Ask, do not improvise, when: (a) the
+interpreter/import path is ambiguous; (b) `manifest.preset.allowed` needs a new entry
+(the agent cannot authorize itself, and a daemon call cannot mutate `allowed`); (c) any
+migration or `init.json` write beyond an explicit preset activation is implied; (d) a
+`kernel_version` nudge suggests an install/update; (e) two refreshes have not produced
+the expected surface — the third attempt is not the answer.
+
+## Scope guard — what this node must NOT do
+
+1. **It is not the installer or update route.** It never instructs a download, install,
+   `pip install --upgrade`, package switch, or version migration. The single official
+   route is `https://lingtai.ai/install.sh`, and `runtime-update-checks` owns that
+   routing. This node's `source_drift` handling stays local and never enters
+   release-migration routing.
+2. **It performs no automatic migrations and no config writes.** It is a checklist the
+   agent *reads*; it does not ship a script that edits `init.json`,
+   `mcp_registry.jsonl`, `manifest.preset.allowed`, or any durable store.
+3. **It grants no authorization.** Completing every check does not substitute for the
+   human/config-owner authority required by substrate §I. A checklist is not consent.
+   Explicitly: "the pre-flight passed" is never a reason to skip asking.
+4. **It does not restate owned facts.** Preset runtime model → `substrate-manual` §11.
+   Runtime/version provenance probe (`LINGTAI_RUNTIME_PYTHON` / module `__file__`, never a
+   PATH `python`) → `substrate-manual` §I; step 2 sequences that rule, it does not restate it.
+   Env var catalogue → `environment-variables`. Update/nudge lifecycle →
+   `runtime-update-checks`. MCP registry mechanics → `mcp-manual`. Molt/rebuild →
+   `context-manual`. Notification dismissal safety → `notification-manual`. Each check
+   *cites*; duplication here means four places to update and three that will go stale.
+5. **It does not replace `context(action="rebuild")`.** Rebuild is the active
+   full-context reconstruction operation. Refresh is a lifecycle operation with broader
+   effects. Do not reach for refresh merely to apply a summary — that boundary is
+   already stated in the resident prompts and must be reinforced, not re-litigated, here.
+6. **It is not a gate in code.** Nothing in the kernel enforces it; this is strong
+   guidance an agent is expected to follow, not a runtime refusal.
+
+## Recipes (copy-paste)
+
+### Recipe A — Pre-refresh health check (run before any config-motivated refresh)
+
+```bash
+PYTHON=${LINGTAI_RUNTIME_PYTHON:-$HOME/.lingtai-tui/runtime/venv/bin/python}
+"$PYTHON" -c 'import sys, lingtai, lingtai.kernel; print("py=",sys.executable); print("lingtai=",lingtai.__file__); print("kernel=",lingtai.kernel.__file__)'
+SP=$("$PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+ls -1d "$SP"/*lingtai* 2>/dev/null; for f in "$SP"/*lingtai*.pth; do echo "== $f"; cat "$f"; done
+"$PYTHON" -c 'import json; d=json.load(open("init.json")); print("init.json OK"); print("addons=",d.get("addons")); print("mcp=",list((d.get("mcp") or {}).keys()))'
+ls -l .notification/nudge.json 2>/dev/null && sed -n '1,120p' .notification/nudge.json
+git -C "$(pwd)" status --short --branch 2>/dev/null || true
+```
+
+```text
+mcp(action="info", input={}, reasoning="pre-refresh registry health and problems")
+```
+
+Proceed only if: interpreter unambiguous, exactly one lingtai path marker whose entries
+exist and agree with `lingtai.__file__`, `init.json` parses, `mcp` block matches the
+registry, `problems` empty or explained, and no `kernel_version` nudge is the real
+trigger.
+
+### Recipe B — Daemon-preset preflight (before dispatching daemon work with an explicit preset)
+
+```text
+1. system(action="presets", input={}, reasoning="read the allowed-only catalog")
+2. # If the path you want is absent: it is NOT authorized. Ask the config owner to add
+   #   that exact path to manifest.preset.allowed (preserving every existing entry and
+   #   the existing active/default), then:
+   system(action="refresh", input={"reason": "pick up new allowed preset entry"},
+          reasoning="apply the config owner's allowed-list edit")
+3. system(action="presets", input={}, reasoning="confirm the new path is now listed")
+4. # Pass the EXACT path from step 3 as tasks[].preset — not the pre-authorization
+   #   string, not a library-screen path, not a shorthand.
+```
+
+An unauthorized explicit `tasks[].preset` refuses the **entire batch** before dispatch.
+Omitting `preset` entirely inherits the parent's regular surface and skips this check.
+External CLI backends (`claude-p`, `codex`, `opencode`, …) skip LingTai preset
+resolution entirely — this recipe does not apply to them.
+
+### Recipe C — Post-refresh verification (always, immediately after refresh returns)
+
+```bash
+PYTHON=${LINGTAI_RUNTIME_PYTHON:-$HOME/.lingtai-tui/runtime/venv/bin/python}
+"$PYTHON" -c 'import sys, lingtai, lingtai.kernel; print(sys.executable, lingtai.__file__, lingtai.kernel.__file__)'
+SP=$("$PYTHON" -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'); ls -1d "$SP"/*lingtai*
+sed -n '1,200p' system/manifest.resolved.json 2>/dev/null
+```
+
+```text
+mcp(action="info", input={}, reasoning="post-refresh: confirm MCP tools actually loaded")
+system(action="presets", input={}, reasoning="post-refresh: confirm active preset and allowed set")
+```
+
+Confirm, in order: new process importing from the intended source with no stale/duplicate
+lingtai `.pth` → MCP count/`problems`/expected tools present → active
+preset is what you asked for → the specific tool you are about to use still exists.
+Only then dismiss the motivating nudge.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/refresh-precheck/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/refresh-precheck/SKILL.md
@@ -119,7 +119,7 @@ cat "$SP"/lingtai-*.dist-info/direct_url.json 2>/dev/null
 
 Resolve the interpreter through `LINGTAI_RUNTIME_PYTHON` / the runtime venv and read module
 `__file__`, never a PATH `python` — the version/provenance rule is owned by
-`substrate-manual` §I runtime/version checks; this step only sequences it.
+resident substrate §I runtime/version checks; this step only sequences it.
 
 **Refuse to refresh if:** more than one lingtai path marker is live; any `.pth` entry does
 not exist on disk; or the marker and `lingtai.__file__` disagree. Repairing an install is a
@@ -324,7 +324,7 @@ the expected surface — the third attempt is not the answer.
    Explicitly: "the pre-flight passed" is never a reason to skip asking.
 4. **It does not restate owned facts.** Preset runtime model → `substrate-manual` §11.
    Runtime/version provenance probe (`LINGTAI_RUNTIME_PYTHON` / module `__file__`, never a
-   PATH `python`) → `substrate-manual` §I; step 2 sequences that rule, it does not restate it.
+   PATH `python`) → resident substrate §I; step 2 sequences that rule, it does not restate it.
    Env var catalogue → `environment-variables`. Update/nudge lifecycle →
    `runtime-update-checks`. MCP registry mechanics → `mcp-manual`. Molt/rebuild →
    `context-manual`. Notification dismissal safety → `notification-manual`. Each check

--- a/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/runtime-update-checks/SKILL.md
@@ -4,10 +4,11 @@ description: >
   Nested system-manual reference for tracing LingTai kernel update nudges:
   runtime/version/source identity, packaged versus editable/source behavior,
   heartbeat dispatch, nudge persistence and notification delivery, refresh
-  versus installation, human confirmation, and post-refresh verification.
-version: 0.2.2
+  versus installation, human confirmation, and post-refresh verification. The
+  ordered pre-flight for a refresh is the sibling `refresh-precheck`.
+version: 0.3.0
 tags: [lingtai, runtime, kernel, nudge, updates, refresh, editable, source, diagnostics]
-last_changed_at: 2026-07-27T00:00:00Z
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/intrinsic_skills/system-manual/reference/environment-variables/SKILL.md
@@ -17,10 +18,8 @@ related_files:
 - src/lingtai/kernel/nudge/__init__.py
 - src/lingtai/kernel/nudge/kernel_version.py
 - src/lingtai/kernel/nudge/source_drift.py
+- src/lingtai/intrinsic_skills/system-manual/reference/refresh-precheck/SKILL.md
 - scripts/lib/release_manifest.py
-- RELEASING.md
-- migration/migration.md
-- .github/workflows/wheels.yml
 - src/lingtai/kernel/base_agent/lifecycle.py
 - src/lingtai/kernel/base_agent/__init__.py
 - src/lingtai/kernel/notification_store/__init__.py
@@ -42,18 +41,10 @@ maintenance: |
 
 # Runtime Update Checks
 
-Kernel-local read-only diagnosis and refresh mechanics
-
-For a `kernel_version` nudge, use the release-manifest facts for diagnosis.
-When a newer release exists, let Shell execute the official installer at
-`https://lingtai.ai/install.sh` with `--help`; do not read or paste the large
-script source into agent context. Follow whatever the installer's own concise
-help output currently instructs rather than assuming or hardcoding a specific
-child command or subcommand name — the installer's own help is the current
-source of truth, not this reference. A `source_drift` nudge stays local to
-these mechanics and never enters release-migration routing. This is
-operational guidance, not permission to download, install, change
-configuration, or relaunch a runtime.
+Kernel-local read-only diagnosis and refresh mechanics for update nudges. The
+install/update route itself is owned by the official installer — see step 9 and
+**Boundaries** below for the split. This is operational guidance, not permission
+to download, install, change configuration, or relaunch a runtime.
 
 ## The lifecycle and its owners
 
@@ -173,7 +164,8 @@ The shared Nudge policy records finding identity and dismissal mute expiry in
 `.notification/.nudge_state.json`. The two global controls
 (`LINGTAI_NUDGE_ENABLED`, `LINGTAI_NUDGE_REPEAT_INTERVAL`) suppress publication
 and set the post-dismiss repeat window for an unresolved finding; their defaults,
-accepted values, reload behavior, and invalid-value fallback are owned by
+accepted values, reload behavior, and invalid-value fallback are registered in the
+repo-root `ENVIRONMENT_VARIABLES.md`, routed via
 `reference/environment-variables/SKILL.md`. Producer probe gates are only bounded
 observation costs, not product cadence. A producer removes an entry when its
 real fact resolves; `kernel_version` also removes its own entry when the runtime
@@ -274,9 +266,9 @@ Python as a substitute.
 
 ## Boundaries
 
-The stable `https://lingtai.ai/install.sh` entry owns normal install/update
-execution and version-interval navigation to authoritative release migrations.
-The notification-manual owns channel allowlisting, generic sync concepts, and
-dismissal safety. This bundled reference owns only kernel-local read-only
-diagnosis and refresh mechanics; `source_drift` stays local and does not enter
-release-migration routing.
+`https://lingtai.ai/install.sh` owns install/update execution and release
+migration navigation (step 9). `notification-manual` owns channel allowlisting,
+sync concepts, and dismissal safety. `reference/refresh-precheck/SKILL.md` owns
+the ordered pre-flight and post-refresh verification pass. This reference owns
+only kernel-local read-only diagnosis and refresh mechanics; `source_drift` stays
+local and does not enter release-migration routing.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
@@ -1,22 +1,17 @@
 ---
 name: sqlite-log-query
 description: >
-  Nested system-manual reference for inspecting LingTai runtime traces through
-  the additive SQLite/log.sqlite sidecar. Read via the `system-manual` router
-  when you need `lingtai-agent log doctor|query|rebuild`, JSONL source-of-truth
-  rules, read-only SQL safety, offline rebuild/WAL caveats, events,
-  chat_entries, and token_entries schema, daemon/chat-history/token-ledger
-  indexing, query recipes, runtime problem investigation workflow, trajectory
-  mining workflow, SQL-based event
-  metrics, cheap-model/daemon strategy, finding schema, prompt templates,
-  digest output, or log redaction pitfalls. This is a nested skill-reference
-  under `system-manual`, not a standalone catalog skill; its folder may carry
-  companion scripts and assets as SQLite trace tooling grows.
-version: 1.2.1
-tags: [lingtai, system-manual, sqlite, log.sqlite, runtime-logs, trace, jsonl, daemon, trajectory, mining, event-log, improvement, pitfalls, observability, cheap-model]
-last_changed_at: 2026-07-19T00:00:00Z
+  Nested system-manual reference for the additive SQLite/`log.sqlite` sidecar
+  over LingTai's JSONL runtime traces. Read it when you need
+  `lingtai-agent log doctor|query|rebuild`, read-only SQL safety and WAL/rebuild
+  caveats, the events/chat_entries/token_entries schema, SQL recipes, or the
+  redaction rules. Trajectory mining is the sibling `trajectory-mining`.
+version: 1.3.0
+tags: [lingtai, system-manual, sqlite, log.sqlite, runtime-logs, trace, jsonl, daemon, event-log, pitfalls, observability]
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/trajectory-mining/SKILL.md
 - src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/scripts/event_summary.py
 maintenance: |
   Tracks the sqlite-log-query topic it documents; update when that integration changes.
@@ -31,11 +26,6 @@ event types are hottest, what happened inside daemon runs, what chat-history
 turn surrounded a failure, whether notification/daemon/context events are
 storming, or how token usage is distributed across main/soul/daemon sources.
 
-This reference also covers **trajectory mining** — the systematic process of
-turning LingTai runtime event streams into actionable lessons for improving
-LingTai itself. Trajectory mining starts from the SQLite log sidecar and uses
-SQL queries as the primary data access layer.
-
 ## Safety contract
 
 - **JSONL is authoritative.** `logs/log.sqlite` is derived; deleting it should not
@@ -44,9 +34,9 @@ SQL queries as the primary data access layer.
   writes yourself.
 - **Queries are read-only with respect to SQLite database contents.** `log query` accepts read-only
   `SELECT`, CTE (`WITH ... SELECT`), and `EXPLAIN` statements and opens the sidecar through the
-  kernel read-only inspection path. `query` and `doctor` preserve the main database mtime; ordinary
-  live-safe SQLite `mode=ro` may create or update SQLite read-support `-wal`/`-shm` sidecar files as
-  needed.
+  kernel read-only inspection path: they never write the main database file (opened `mode=ro` with
+  `PRAGMA query_only=ON`), though SQLite read-support `-wal`/`-shm` sidecar files may still be
+  created or updated.
 - **Rebuild is offline.** `log rebuild` requires the agent working-directory lock;
   if the agent is running, stop/sleep/lull/suspend it first as appropriate.
 - **Runtime SQLite is best effort.** New top-level `logs/events.jsonl` and
@@ -57,7 +47,8 @@ SQL queries as the primary data access layer.
 - **Live queries are snapshots.** Runtime writes use SQLite WAL mode. For a complete historical
   snapshot, stop the agent and run `log rebuild` before querying.
 - **Never paste secrets.** Logs and chat history can contain URLs, tokens,
-  prompts, and user data. Redact before sharing.
+  prompts, and user data — including raw `fields_json`/`entry_json`. Apply the
+  redaction rules below before sharing anything.
 
 ## Commands
 
@@ -73,8 +64,10 @@ Check whether the sidecar exists and is readable:
 lingtai-agent log doctor "$AGENT_DIR"
 ```
 
-If `doctor` reports `{"status":"missing"...}` or the sidecar is stale/corrupt,
-rebuild **only while the target agent is stopped/offline**:
+If `doctor` reports `{"status":"missing"...}` or a failing `integrity_check`,
+rebuild **only while the target agent is stopped/offline**. `doctor` does not
+detect staleness — a stale but intact sidecar still reports `status: ok`;
+compare `import_cursors` against source-file mtimes, or just rebuild:
 
 ```bash
 lingtai-agent log rebuild "$AGENT_DIR"
@@ -90,22 +83,15 @@ lingtai-agent log rebuild "$AGENT_DIR"
 - `daemons/*/logs/token_ledger.jsonl` → `token_entries` (`source_kind='daemon_token_ledger'`, `run_id=<daemon folder>`)
 - `daemons/*/history/chat_history.jsonl` → `chat_entries` (`source_kind='daemon_chat'`, `run_id=<daemon folder>`)
 
-Run a read-only query:
+Run a read-only query. The CLI always prints JSON; pipe to `jq .` to
+pretty-print when it is available:
 
 ```bash
 lingtai-agent log query "$AGENT_DIR" \
   'SELECT id, ts, type, agent_address, substr(fields_json, 1, 240) AS fields
    FROM events
    ORDER BY ts DESC
-   LIMIT 20'
-```
-
-The CLI prints JSON. Pipe to `jq` when available:
-
-```bash
-lingtai-agent log query "$AGENT_DIR" \
-  'SELECT type, COUNT(*) AS n FROM events GROUP BY type ORDER BY n DESC LIMIT 20' \
-  | jq .
+   LIMIT 20' | jq .
 ```
 
 ## Schema quick reference
@@ -296,7 +282,7 @@ SELECT
   json_extract(fields_json, '$.tool') AS tool,
   json_extract(fields_json, '$.error') AS error
 FROM events
-WHERE fields_json LIKE '%error%'
+WHERE type LIKE 'tool_%'
 ORDER BY ts DESC
 LIMIT 50;
 ```
@@ -310,14 +296,6 @@ Before trajectory mining, discover what data exists in the sidecar. The
 sidecar replaces the old `find`-based JSONL scanning with SQL:
 
 ```sql
--- What sources were imported?
-SELECT source_kind, source_file, COUNT(*) AS n
-FROM events
-GROUP BY source_kind, source_file
-ORDER BY n DESC;
-```
-
-```sql
 -- Schema discovery: what keys appear in fields_json?
 SELECT json_each.key, COUNT(*) AS n
 FROM events, json_each(events.fields_json)
@@ -327,22 +305,16 @@ LIMIT 30;
 ```
 
 ```sql
--- What source families are present?
-SELECT scope, source_kind, COUNT(*) AS n,
+-- What source families are present, and over what span?
+SELECT scope, source_kind, source_file, COUNT(*) AS n,
        MIN(ts) AS earliest, MAX(ts) AS latest
 FROM events
-GROUP BY scope, source_kind
+GROUP BY scope, source_kind, source_file
 ORDER BY n DESC;
 ```
 
-### Key source families
-
-| Family | Typical source_kind | Primary signal |
-|--------|---------------------|----------------|
-| Agent event log | `agent_events` | tool calls, tool results, errors, context pressure |
-| Daemon event log | `daemon_events` | task lifecycle, timeouts, exits |
-| Agent chat | `agent_chat` / `agent_chat_archive` | turn-level conversation |
-| Daemon chat | `daemon_chat` | daemon task interactions |
+The `source_kind` values and their JSONL origins are listed under `log rebuild`
+above and in the three schema tables.
 
 ## Workflow: investigate a suspected runtime problem
 
@@ -357,48 +329,20 @@ ORDER BY n DESC;
 5. Cross-check surprising findings against source JSONL (`logs/events.jsonl`,
    `history/chat_history*.jsonl`, daemon subdirectories) before filing bugs or
    making claims.
-6. When reporting, quote minimal evidence and redact secrets.
+6. When reporting, quote minimal evidence and apply the redaction rules below.
 
 ---
 
-## Trajectory Mining
+## Trajectory mining
 
-### When to Use / When Not to Use
+Systematic mining of these traces into validated improvement candidates —
+manifest policy, cheap-model/daemon strategy, prompt templates, the finding
+schema and confidence rubric, the digest template, output routing, periodic
+mode, and the 10-step on-demand procedure — is owned by the sibling reference
+`../trajectory-mining/SKILL.md`. The queries below are its mechanical first
+pass; the redaction rules further down apply to every excerpt it feeds an LLM.
 
-**Use trajectory mining when:**
-- The human asks to mine, analyze, or audit LingTai event logs.
-- The human says something like "最近轨迹", "look at my agent logs", "what went
-  wrong last session", "scan for patterns", or "generate improvement candidates".
-- You need to systematically extract operational pitfalls from large structured
-  traces before writing a knowledge entry, skill, or issue draft.
-- You want to build a cheap pre-pass before involving expensive models.
-
-**Do not use trajectory mining when:**
-- The human just wants a quick summary of chat history without event-log grounding.
-- The request is about code review, architecture analysis, or feature planning
-  unrelated to runtime traces.
-- You already have a specific, pre-identified bug and just need to fix it — skip
-  the mining phase and go directly to debugging.
-
-### Manifest building
-
-After discovery, build a manifest before any LLM review. The manifest is your
-contract for what you will and will not read:
-
-```text
-source_kind | source_file | n | time_range | top_types | why_included
-```
-
-Keep the manifest in memory (or a temp file) — do not persist private log paths
-to shared storage.
-
-**Limits:**
-- Default window: last 24 hours or current workstream. Never scan everything
-  unless explicitly asked.
-- Maximum lines to feed any single LLM call: 300 lines of redacted excerpts.
-- If a result set exceeds 5000 rows, use time-window or event-family slicing.
-
-### Mechanical first-pass metrics (SQL queries)
+## Metrics and slicing recipes
 
 Run cheap aggregations before any LLM call. These are free signal. Start with the
 event-type and source-kind counts from **Query recipes** above, then add:
@@ -490,7 +434,7 @@ ORDER BY ts DESC
 LIMIT 30;
 ```
 
-### Chunking / slicing (SQL queries)
+## Chunking and slicing
 
 Never dump large private event logs into an LLM. Use these SQL slicing
 strategies:
@@ -540,359 +484,6 @@ ORDER BY n DESC
 LIMIT 30;
 ```
 
-### Cheap model / daemon strategy
-
-#### Model selection priority
-
-| Model / Preset | When to Use |
-|----------------|-------------|
-| DeepSeek Flash / DeepSeek-V3 cheap variant | Large-volume classification, error clustering, first-pass anomaly detection |
-| MiniMax | Structured YAML extraction from moderate excerpts |
-| Codex gpt5.3-like / tier:1 preset | Pattern matching over aggregated metrics |
-| tier:2 preset | Moderate-complexity finding synthesis |
-| Primary agent model (this session) | Shortlist triage, finding merging, confidence adjudication |
-| Expensive model (Opus-class) | Only for ambiguous high-impact architecture/design findings |
-
-**Default: never reach tier:3+ unless the human explicitly approves the budget.**
-
-#### Daemon task structure
-
-Spawn one daemon task per (source family × time window). Keep each task small:
-
-- Input: redacted aggregate metrics + bounded excerpts (≤300 lines)
-- Output: structured YAML only, using the finding schema below
-- No side effects inside the daemon
-
-Example daemon task description:
-
-```text
-Analyze these LingTai event-log excerpts (source: <family>, window: <time range>).
-Extract durable runtime improvement candidates visible in the event data.
-Focus on: tool failures, latency gaps, context pressure, daemon lifecycle, auth/env issues, observability gaps.
-Do NOT quote secrets, tokens, or full message bodies. Redact paths if they contain usernames or private data.
-Output ONLY a YAML list using this schema: [id, category, severity, confidence, event_evidence, pattern, impact, suggested_destination, suggested_next_step, side_effect_required].
-Prefer 3-5 high-signal findings over a long list of weak ones.
-```
-
-#### Parallel dispatch strategy
-
-When multiple source families or time windows exist, dispatch them in parallel:
-
-```
-daemon-1: agent_events — tool_call/tool_result family — last 24h
-daemon-2: daemon_events — lifecycle family — last 7d
-daemon-3: agent_chat — turn timing family — last 24h
-daemon-4: context/spill events — pressure family — last 7d
-```
-
-Collect all results before primary-agent triage.
-
-### Prompt templates
-
-#### Classifier prompt
-
-```
-You are a runtime event log classifier for a multi-agent system called LingTai.
-Below is a redacted aggregate summary of event-log metrics from a single source family and time window.
-Classify the top patterns you see into the following categories:
-  tool-failure, latency, context-pressure, daemon-lifecycle, auth-env, observability-gap, doc-gap, missing-skill, bug-candidate, process-improvement
-
-For each category you identify, output one YAML block:
-  category: <category>
-  evidence_summary: <1-2 sentences citing event types, counts, or timing — no secrets>
-  confidence: low | medium | high
-
-METRICS:
-{metrics_block}
-
-Output ONLY valid YAML. No prose before or after.
-```
-
-#### Anomaly summarizer prompt
-
-```
-You are analyzing a bounded excerpt from a LingTai agent event log.
-The excerpt is centered on a suspicious event. Surrounding lines are provided for context.
-Your task: summarize the anomaly in terms of what failed, why it likely failed (based on event data only), and what the downstream impact was.
-
-Rules:
-- Do not quote tokens, credentials, or full message bodies.
-- Reference events by their type, timestamp offset, and redacted field names.
-- Output YAML only:
-  anomaly_type: <one of: tool-failure | latency-spike | context-overflow | daemon-exit | auth-failure | unknown>
-  timeline: <ordered list of key events in the excerpt>
-  root_cause_hypothesis: <1 sentence, hedged>
-  downstream_impact: <1 sentence>
-  confidence: low | medium | high
-
-EXCERPT (redacted):
-{excerpt_block}
-```
-
-#### Observability-gap prompt
-
-```
-You are reviewing LingTai event-log summaries to identify what information is MISSING that would be needed to diagnose operational problems.
-You have seen: {event_types_present}.
-You did NOT see (or saw too rarely): {event_types_sparse}.
-
-For each significant gap, output YAML:
-  gap: <what is missing>
-  why_needed: <what class of problem it would help diagnose>
-  suggested_event: <what event type or field would close the gap>
-  priority: low | medium | high
-
-Output ONLY valid YAML. No prose.
-```
-
-#### Cross-run pattern prompt
-
-```
-You are comparing event-log aggregate summaries from multiple LingTai sessions or agents.
-Each summary is labeled with its source (agent name or daemon ID) and time window.
-Identify patterns that repeat ACROSS multiple sources/sessions, not just within one.
-
-For each cross-run pattern, output YAML:
-  pattern_id: <short slug>
-  description: <what repeats and where>
-  sources_affected: [list of source labels]
-  recurrence_count: <approximate>
-  severity: low | medium | high
-  confidence: low | medium | high
-
-SUMMARIES:
-{summaries_block}
-
-Output ONLY valid YAML. No prose.
-```
-
-### Finding schema
-
-Every finding, from any daemon or primary-agent review, must fit this schema:
-
-```yaml
-- id: short-stable-slug              # kebab-case, unique within the digest
-  category: tool-failure | latency | context-pressure | daemon-lifecycle | auth-env | observability-gap | doc-gap | missing-skill | bug-candidate | process-improvement
-  severity: low | medium | high
-  confidence: low | medium | high
-  event_evidence:
-    - source: local path or source_file value
-      line_or_time: line number, Unix timestamp, ISO timestamp, or event id
-      event_type: tool_call | tool_result | notification | daemon_state | context_pressure | other
-      redacted: true | false
-      note: short redacted quote or paraphrase of the event content
-  optional_context:
-    - source: path, URL, or issue reference
-      note: why this corroborates the event-log signal
-  pattern: what repeated or what caused harm — describe in event terms
-  impact: why it matters to LingTai, users, or agents
-  suggested_destination: knowledge | skill | issue-draft | code-investigation | observability-improvement | no-action
-  suggested_next_step: smallest concrete next action
-  side_effect_required: none | human-approval-required
-```
-
-**Validation requirements before including a finding:**
-- At least one `event_evidence` entry with a verifiable source and line/time.
-- `pattern` must describe something visible in event data, not inferred from chat history alone.
-- Singleton events (happened once, low impact) → `severity: low`, or exclude entirely.
-- `confidence: high` only if the same pattern appears in ≥3 distinct event occurrences or is
-  corroborated by optional_context.
-
-### Validation and confidence rubric
-
-Before finalizing any finding:
-
-1. **Re-read the source data**: confirm the source_file, source_line, or time
-   range are accurate.
-2. **Reconcile timestamps**: if multiple events are involved, verify they form
-   a plausible causal sequence.
-3. **Check recurrence**: re-query for similar events across the full time window;
-   note count.
-4. **Singleton rule**: a single occurrence of an error with no pattern context →
-   downgrade to `severity: low` and `confidence: low` unless the single event
-   had confirmed high impact (e.g., agent stopped functioning).
-5. **Reject hallucinated fields**: if a daemon output references event fields
-   that do not exist in the actual schema discovered in source discovery, discard
-   or flag that finding.
-
-| Evidence | Confidence |
-|----------|-----------|
-| ≥3 occurrences of the same event pattern, confirmed in source file | high |
-| 2 occurrences OR 1 occurrence + corroborating optional_context | medium |
-| 1 occurrence, no corroboration, no impact confirmed | low |
-| Inferred from absence of events only | low |
-| Daemon output references field not found in actual schema | reject |
-
-### Output digest template
-
-Produce the digest in the agent's working language. Fields in brackets are
-placeholders.
-
-```
-# 轨迹挖掘摘要 / Trajectory Mining Digest
-Generated: [ISO timestamp]
-Sources scanned: [source_kinds, total ~N events, time window]
-Models used: [list of cheap models + primary agent]
-
----
-
-## High-Signal Findings ([N])
-
-[YAML block of top findings, severity: high or medium + high confidence]
-
----
-
-## Quick Wins ([N])
-Findings where suggested_destination is knowledge, skill, or observability-improvement
-and side_effect_required is none.
-
-[YAML block]
-
----
-
-## Issue Candidates ([N])
-Findings requiring human approval before action.
-
-[YAML block with side_effect_required: human-approval-required]
-
----
-
-## Observability Gaps ([N])
-What was missing from the event logs that would help future diagnosis.
-
-[YAML block, category: observability-gap]
-
----
-
-## No-Action Observations ([N])
-Low-confidence or low-impact findings, retained for reference.
-
-[YAML block, severity: low or confidence: low]
-
----
-
-## Evidence Appendix
-[Table: finding_id | source_file | line_or_time | event_type | redacted_note]
-
----
-
-## Recommended Next Steps
-Choose one or more:
-- [ ] Write/update skill: [skill name]
-- [ ] Write knowledge entry: [topic]
-- [ ] Draft issue for human review: [title]
-- [ ] Code investigation: [component]
-- [ ] Add observability: [event type / field]
-- [ ] No action needed
-```
-
-### Routing next actions
-
-After producing the digest, route durable outputs as follows:
-
-| Finding type | Destination | Action |
-|---|---|---|
-| Reusable operational pattern | `skill` | Propose skill update; wait for human approval |
-| Private operational fact about this deployment | `knowledge` | Write knowledge entry (no secrets) |
-| Active task / in-progress investigation | `pad` | Update pad with bounded note |
-| LingTai bug or design issue | Issue draft | Use `lingtai-issue-report` skill if available; **ask human approval before filing** |
-| Code change needed | Local worktree/patch | Propose; do not apply without approval |
-| Configuration change | Propose in digest | **Do not apply without approval** |
-| No clear action | `no-action` | Note in digest; move on |
-
-### Periodic mode
-
-If the human wants recurring event-log mining:
-
-- **Do not set any scheduler without explicit approval.** Ask the human to
-  confirm the cadence and scope first.
-- Default cadence when approved: daily digest, not continuous monitoring.
-- The scheduled job should only wake the agent with a bounded prompt; the agent
-  performs the review.
-- The digest should be silent (written to `pad.md` or a report file) unless
-  `standing-rules.md` allows periodic check-in messages.
-
-Suggested scheduled prompt body (for human approval before use):
-
-```text
-Run trajectory mining on recent SQLite event traces for the last 24h.
-Produce a concise digest of high-signal runtime pitfalls and improvement candidates.
-Do not create issues, commits, PRs, config changes, or scheduled jobs without explicit human approval.
-Write the digest to: reports/trajectory-digest-YYYYMMDD.md
-```
-
-### Concrete example findings
-
-#### Example A: Stale Claude Code OAuth Token
-
-```yaml
-- id: stale-claude-code-oauth-token
-  category: auth-env
-  severity: high
-  confidence: high
-  event_evidence:
-    - source: daemons/em-<id>/logs/events.jsonl
-      line_or_time: "~line 847, ts 1716XXXXXX"
-      event_type: tool_result
-      redacted: true
-      note: "claude CLI returned 'weekly limit reached'; subsequent tool_result showed success after env patch"
-  optional_context:
-    - source: "GitHub: Lingtai-AI/lingtai#189"
-      note: confirmed stale inherited env token failure mode
-  pattern: >
-    Long-lived daemon inherits stale CLAUDE_CODE_OAUTH_TOKEN from parent env.
-    After credential refresh, the env override prevents the new token from taking effect.
-    Agents see 'weekly limit' errors and stop delegating heavy work.
-  impact: Agents misdiagnose quota exhaustion; heavy work is not delegated.
-  suggested_destination: code-investigation
-  suggested_next_step: Strip stale env tokens in daemon backend env; add smoke test.
-  side_effect_required: human-approval-required
-```
-
-#### Example B: Tool-Result Spill / Context Pressure
-
-```yaml
-- id: tool-result-spill-context-pressure
-  category: context-pressure
-  severity: medium
-  confidence: medium
-  event_evidence:
-    - source: logs/events.jsonl
-      line_or_time: "lines ~1200–1250"
-      event_type: tool_result
-      redacted: true
-      note: "tool_result event has result_size > threshold; subsequent context_pressure event shows usage >85%"
-  pattern: >
-    Large tool results push context usage past 85%. The spill event appears but
-    the agent continues without triggering molt early enough.
-  impact: Tasks are interrupted or produce incomplete output; user must re-prompt.
-  suggested_destination: observability-improvement
-  suggested_next_step: Verify that spill events are routed to the molt trigger.
-  side_effect_required: none
-```
-
-### On-demand procedure (step-by-step)
-
-Run the sections above in this order:
-
-1. **Clarify window and scope.** Default: recent event logs for the current
-   agent/project plus daemon events from the active workstream. "最近轨迹" →
-   last 24h or current active workstream. Named subsystem → filter to it.
-2. **Discover sources** and build the manifest.
-3. **Schema discovery** — sample keys via `json_each()` before writing any
-   extraction code.
-4. **Mechanical first-pass** — run the aggregation queries; do not pass raw logs
-   to any LLM.
-5. **Chunk and redact** — apply a slicing strategy, then the redaction rules.
-6. **Dispatch cheap daemon batch** — one daemon per source family / time window.
-7. **Primary-agent triage** — merge findings, validate against the confidence
-   rubric.
-8. **Produce digest** — render the template, include the evidence appendix.
-9. **Route outputs** — propose routing; wait for human approval before any side
-   effect.
-10. **Stop.** A good digest gives the human enough to choose: update skill, file
-    issue, make patch, ignore, or schedule.
-
 ---
 
 ## Redaction and privacy rules
@@ -922,12 +513,10 @@ Beyond the safety contract above:
   index, not agent state.
 - Do not rebuild a live agent by bypassing the CLI lock; that risks racing the
   runtime logger.
-- Do not share raw `fields_json` or `entry_json` blindly; they may contain private
-  content.
 - Do not assume `id` survives rebuilds. Use `source_file/source_offset`, time,
   `run_id`, and surrounding context for durable references.
-- If a query returns fewer rows than expected on a live agent, remember the WAL
-  snapshot and explicit-rebuild caveats; stop/rebuild or inspect JSONL.
+- If a query returns fewer rows than expected on a live agent, that is the WAL
+  snapshot caveat in the safety contract — stop/rebuild or inspect JSONL.
 
 ## Scripts
 
@@ -938,19 +527,11 @@ database contents without modifying them, makes no network requests, and require
 no secrets. SQLite may create or update read-support `-wal`/`-shm` sidecars.
 
 ```bash
-# Summarize all events in the sidecar
 python3 scripts/event_summary.py "$AGENT_DIR/logs/log.sqlite"
-
-# Limit to last 24 hours
-python3 scripts/event_summary.py "$AGENT_DIR/logs/log.sqlite" --hours 24
-
-# Output as compact JSON
-python3 scripts/event_summary.py "$AGENT_DIR/logs/log.sqlite" --format json
-
-# Filter to a specific source kind
 python3 scripts/event_summary.py "$AGENT_DIR/logs/log.sqlite" --source-kind daemon_events
 ```
 
-The script outputs: event type counts, tool call summaries, error clusters,
-latency gap analysis, source kind breakdown, time range, and schema key
-discovery — all via read-only SQL queries.
+Also accepts `--hours N` and `--format json`. It runs the mechanical first-pass
+queries above — event type counts, tool call summaries, error clusters, latency
+gap analysis, source kind breakdown, time range, and schema key discovery — all
+via read-only SQL.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md
@@ -1,21 +1,14 @@
 ---
 name: substrate-manual
 description: >
-  Nested system-manual reference for the expanded LingTai substrate/runtime model.
-  Read via the `system-manual` router when resident substrate is too compact and
-  you need details about body/extensions, bash vs daemon vs avatar vs MCP,
-  lifecycle states (ACTIVE/IDLE/STUCK/ASLEEP/SUSPENDED), the `system` tool,
-  notification/read/dismiss discipline, communication channels, memory layers,
-  molt model, runtime log routing, collaboration topology, MCP/addon ownership,
-  idle/soul behavior, preset tiers, the detailed preset runtime model (raw vs
-  resolved init.json, preset identity, TUI/library vs main-agent allowed-only
-  catalogs, swap/revert/refresh, daemon task explicit/omitted/CLI-skip paths),
-  and resident substrate maintenance. This is
-  a nested skill-reference under `system-manual`, not a standalone catalog skill;
-  its folder may carry scripts/assets as the substrate reference grows.
-version: 1.3.0
+  Nested system-manual reference: the expanded form of the resident substrate
+  prompt — body/extensions, lifecycle states, the `system` tool in practice,
+  communication and memory layers, collaboration topology, MCP/addon ownership,
+  and (§11) the canonical `init.json` composition and preset runtime model.
+  Route via `system-manual` when it is unclear whether this is the right node.
+version: 1.4.0
 tags: [lingtai, system-manual, substrate, runtime, lifecycle, communication, memory, notifications, mcp, preset]
-last_changed_at: "2026-07-27T17:02:00-07:00"
+last_changed_at: "2026-08-07T00:00:00Z"
 related_files:
 - src/lingtai/intrinsic_skills/system-manual/SKILL.md
 - src/lingtai/prompts/substrate/substrate.md
@@ -26,24 +19,18 @@ maintenance: |
 
 # Substrate Manual
 
-The resident `substrate` prompt is the compact operating model every LingTai
-agent keeps in memory. This reference is its expanded form. Read it when the
-short substrate rule is not enough to decide what an agent is, which body to use,
-how lifecycle states differ, how communication/notifications work, where memory
-belongs, or what the `system` tool controls.
-
-This file is a **nested skill-reference owned by `system-manual`**, not a top-level catalog skill.
-Start at `system-manual` when routing is unclear; return here for the expanded
-runtime model.
+This is the expanded form of the resident `substrate` prompt — a nested
+skill-reference owned by `system-manual`, not a top-level catalog skill. Read it
+when the short resident rule is not enough; route via `system-manual` when it is
+unclear whether this is the right node.
 
 ## 1. Body and extensions
 
-An agent has one active mind—the LLM turn loop—and several extensions. Choose the
-smallest durable form that fits the need:
+An agent has one active mind—the LLM turn loop—and several extensions:
 
 | Extension | Persistence | Use it for | Do not use it for |
 |---|---:|---|---|
-| **Bash** | One command / job | Deterministic host work: git, tests, scripts, curl, builds, file transforms | Long-lived specialization or social coordination |
+| **Shell (bash)** | One command / job | Deterministic host work: git, tests, scripts, curl, builds, file transforms | Long-lived specialization or social coordination |
 | **Daemon** | Ephemeral | Context-isolated exploration where you only need the conclusion or artifact | Work that must remember, own a relationship, or persist learning |
 | **Avatar** | Persistent peer | A durable specialist, collaborator, or capability that should grow over time | Tiny mechanical tasks better done by bash/daemon |
 | **MCP server** | Persistent external tool | Real services and integrations: IMAP, Telegram, Feishu, WeChat, third-party APIs | One-off shell operations or agent memory |
@@ -59,11 +46,6 @@ Decision tree:
 4. Is it a durable external service? Use or configure an MCP.
 5. Is it a private fact or decision? Put it in knowledge.
 6. Is it reusable procedure? Write or update a skill.
-
-Prefer bash over daemon for deterministic commands, daemon over avatar for
-throwaway parallel exploration, avatar over daemon for ongoing specialization,
-knowledge over pad for durable private facts, and skills over knowledge for
-reusable procedures others may need.
 
 ## 2. Lifecycle states
 
@@ -89,14 +71,12 @@ General guidance:
 
 Use after changing `init.json`, MCP registry, presets, prompt sections, or
 installed capabilities. Refresh preserves identity and conversation while
-rebuilding the runtime surface. For runtime/version checks, inspect the live
-agent interpreter and imports — prefer `LINGTAI_RUNTIME_PYTHON` when available,
-then confirm `lingtai.__file__` and `lingtai.kernel.__file__` — rather than a
-convenient shell `python`, conda env, or unrelated checkout. TUI-managed runs
-normally expose that interpreter from their runtime venv (for example
-`~/.lingtai-tui/runtime/venv` on macOS/Linux; Windows uses the corresponding
-`Scripts\python.exe` inside the venv). If a new MCP/tool still does not appear
-after refresh, inspect registry/config health before retrying.
+rebuilding the runtime surface. Resident substrate §I owns the runtime/version
+probe rule; TUI-managed runs normally expose that interpreter from their runtime
+venv (for example `~/.lingtai-tui/runtime/venv` on macOS/Linux; Windows uses the
+corresponding `Scripts\python.exe` inside the venv). The ordered pre-flight to
+run before pressing the button, and the post-refresh verification pass, are owned
+by `reference/refresh-precheck/SKILL.md`.
 
 **Peer readiness during relaunch.** A same-workdir `lingtai run` process can exist
 before it has published a fresh heartbeat. During that gap, peer internal email
@@ -106,94 +86,58 @@ email instead of stacking CPR attempts. Internal email does not queue recipient
 delivery across this gap; `email-manual` owns the detailed delivery and bounce
 contract.
 
-Refresh is also a passive full-context reconstruction path with its own broader
+Refresh is also a passive full-context reconstruction path with broader
 lifecycle effects: reach for it when runtime context/configuration is broken or
-stale, not merely to apply a summary. Normal active reconstruction belongs only
-to `context(action="rebuild")`: it recomposes every canonical prompt source,
-then applies pending/new summaries, then requests provider replay; bare `{}` is
-valid with zero pending. At the 1.0 hard boundary the runtime still forces its
-once-per-episode provider replay (see `summarize` below).
+stale, never merely to apply a summary. Active reconstruction belongs to
+`context(action="rebuild")` — see `context-manual` →
+`reference/summarize-manual/SKILL.md` for the rebuild contract and the 0.85/1.0
+boundaries.
 
 ### `presets`
 
-Use to list preset bundles and their tier/connectivity/capability tags. Tier tags
-are cost/quality hints, not moral rankings:
-
-- tier 5: irreplaceable reasoning.
-- tier 4: premium/high-stakes work.
-- tier 3: strong everyday work.
-- tier 2: cheap throughput.
-- tier 1: opportunistic/free use.
-
-Prefer the cheapest preset that can reliably perform the task; switch back when
-experimentation is done. For the detailed preset runtime model — raw versus
-resolved `init.json`, path identity, the two catalogs, main-agent swap/revert,
-and the daemon task/CLI distinction — see §11 below.
+Use to list preset bundles and their tier/connectivity/capability tags. The
+tier-5-to-tier-1 ladder is cost/quality hints, not moral rankings, and is listed
+in resident substrate §VII; prefer the cheapest preset that can reliably perform
+the task and switch back when experimentation is done. The detailed preset
+runtime model — raw versus resolved `init.json`, path identity, the two catalogs,
+main-agent swap/revert, and the daemon task/CLI distinction — is §11 below; the
+pre-swap checklist is `reference/refresh-precheck/SKILL.md`.
 
 ### Notifications and dismiss → the `notification` tool
 
-Reading and clearing notification channels is **not** a `system` operation. The
-`system` tool exposes no notification or dismiss verb. Use the standalone
-`notification` tool: `check` to read the live payload, and the atomic dismiss
-verbs `dismiss_channel` / `dismiss_event` / `dismiss_ref` to clear a channel or a
-single `system` event. Prefer producer-specific verbs first for guarded
+Reading and clearing notification channels is **not** a `system` operation (the
+verbs are on the `notification` tool; resident substrate lists them). The rule
+worth holding here: **prefer producer-specific verbs first** for guarded
 producers (`email.read`, `email.dismiss`, Telegram `read`, other MCP read
 actions); a generic channel dismiss is for channels that do not own their own
 read state, or for stale mirrors when the producer-owned state is already
 handled. Never treat a notification preview as the full source of truth — §4
 lists when to read the producer channel instead.
 
-For channel allowlist, envelope shape, protected channels, stale-version/force
-semantics, and how large results are ranked via agent_meta and summarized (plus
-legacy `large_tool_result` dismiss), read
-the first-level `notification-manual` skill.
+Everything else — allowlist, envelope shape, protected channels,
+stale-version/force, large-result ranking and the legacy `large_tool_result`
+dismiss — is owned by the first-level `notification-manual` skill.
 
-### Three context-compression / continuation modes
+### Context compression, and where `summarize` lives
 
-LingTai has three deliberate ways to keep context lean, from local to
-whole-conversation. All three preserve the raw original in durable logs; none is
-canonical.
+`system` exposes **no** `summarize` action. The three deliberate compression
+modes — a-priori `summary=true`, a-posteriori `context(action="summarize")`, and
+molt — are listed in resident substrate §VII and owned in full by `context-manual`
+→ `reference/summarize-manual/SKILL.md` §0. Read that reference for the 0.85
+proactive-rebuild stamp, the 1.0 forced-rebuild boundary and its overflow
+warning, urgent versus idle-cleanup cadence, summary quality, original-result
+recovery by `tool_call_id`, and the summarize-versus-molt distinction.
 
-1. **A priori — reasoning-guided** (`summary=true` on
-   `bash`/`read`/`grep`/`daemon`/`glob`): the raw is replaced by a
-   `reasoning`-driven generated summary *before* it enters your context.
-2. **A posteriori — agent-guided** (`context(action="summarize")`): replace a
-   result you have *already seen* and digested with your own summary.
-3. **Molt — context-pressure-triggered** (§5): the whole-conversation
-   continuation / reset.
+Two boundaries are worth restating only as boundaries: summarize records history
+now while provider-side reconstruction is delayed, so a pending summary is
+normal and `refresh` is not the way to apply one; and `refresh` stays reserved
+for emergency context reconstruction, never as a summarize substitute.
 
-Pick a priori when you can predict bulk, do not need the raw, and already know
-what the call must retain; a posteriori when you have already consumed a result
-or could not name the important facts before inspection; molt when the
-conversation as a whole is the problem.
-
-### `summarize`
-
-`summarize` is the a-posteriori system action for tool-result context hygiene:
-after you have consumed a completed prior tool result and no longer need the raw
-text visible, record a compact summary replacement for its raw payload regardless
-of length. The summary preserves the conclusion, evidence, anchors, validation,
-risks, and next steps while lowering active context.
-
-Runtime high-attention guidance for this behavior is carried in
-`_meta.agent_meta.guidance`. Treat guidance as a system-prompt-like appendix
-placed at the end of context: it is an ordered `sections[]` structure, not a
-loose metadata bag. The kernel's `meta_readme` explanation of the `_meta`
-envelope is therefore one guidance section inside `sections[]`, alongside the
-packaged sections assembled from the skill-style Markdown guidance catalog under
-`src/lingtai/prompts/meta_guidance/catalog/` (`INDEX.md` + one `<id>.md` per
-section); follow that latest guidance first when it appears.
-
-Two boundaries matter here and are **owned in full by
-`reference/summarize-manual/SKILL.md`**: summarize records history now but
-provider-side reconstruction is delayed, so a pending summary is normal and
-`refresh` is not the way to apply one; and `refresh` stays reserved for emergency
-context reconstruction (see above), never as a summarize substitute. Read that
-reference for the 0.85 proactive-rebuild stamp, the 1.0 forced-rebuild boundary
-and its overflow warning, urgent versus idle-cleanup cadence, summary quality,
-original-result recovery by `tool_call_id`, and the summarize-versus-molt
-distinction — including when a completed task is worth a proactive
-task-boundary molt.
+Runtime high-attention guidance for this behavior arrives in
+`_meta.agent_meta.guidance` — an ordered `sections[]` structure assembled from
+the guidance catalog under `src/lingtai/prompts/meta_guidance/catalog/`
+(`INDEX.md` + one `<id>.md` per section), which owns its own semantics. Follow
+that latest guidance first when it appears.
 
 ### Sleep, lull, interrupt, suspend, CPR, clear, nirvana
 
@@ -214,18 +158,11 @@ administrative tools, not shortcuts around collaboration.
 
 ## 4. Communication and notifications
 
-Humans do not communicate through diary text. Reply on the channel where the
-message arrived, using the channel's reply/send tools. Text output is private
-journal/diary.
-
-Notification previews are hints. Read the producer channel when:
-
-- the preview is truncated or summarized;
-- the message has media, attachments, callbacks, or voice transcription;
-- the preview contains multiple messages and the newest unresponded message is
-  not obvious;
-- exact wording matters for authorization;
-- the channel has producer-owned read/dismiss state.
+Resident §III owns the rule (reply on the channel the message arrived on; text
+output is private diary) and lists the usual reasons a preview is not enough.
+Two conditions are easy to miss and are worth naming here: read the producer
+channel when **exact wording matters for authorization**, and whenever the
+channel has **producer-owned read/dismiss state**.
 
 The responsiveness discipline built on this surface — acknowledging promptly,
 sending a progress message before long work, and reporting blockers — belongs to
@@ -242,28 +179,17 @@ Conversation is temporary. Durable layers are:
 | **Knowledge** | Private durable memory | Project facts, decisions, local paths, journals, raw observations, collaborator context |
 | **Skills** | Portable know-how | Reusable workflows, command recipes, checklists, scripts, templates |
 
-Flow knowledge outward:
-
-1. Work happens in conversation.
-2. Active state and pointers go to pad.
-3. Private durable facts go to knowledge.
-4. Reusable procedures become skills.
-5. Identity/relationship changes update character.
-
+Knowledge flows outward from conversation into those four layers; the routing
+rule is resident §IV and the store-tending procedure is `context-manual` §2.
 When context pressure rises, tend durable stores before molting. The detailed
 molt procedure, session-journal / molt-history record, and successor briefing
-rules live in `context-manual`; this substrate reference only describes the
-memory model.
+rules live in `context-manual`; this reference only describes the memory model.
 
 ## 6. Runtime logs and trace inspection
 
-Runtime trace inspection is routed through `system-manual` to the SQLite subguide:
-`reference/sqlite-log-query/SKILL.md`. Use that reference for `logs/log.sqlite`,
-`lingtai-agent log doctor|query|rebuild`, JSONL source-of-truth rules, WAL/live
-read caveats, and the `events` / `chat_entries` schema.
-
-Do not invent SQL schema from memory. Load the reference before writing trace
-queries.
+Runtime trace inspection is owned by `reference/sqlite-log-query/SKILL.md`, and
+mining those traces for improvement candidates by `reference/trajectory-mining/SKILL.md`.
+Do not invent SQL schema from memory — load the reference before writing trace queries.
 
 ## 7. Collaboration and network topology
 
@@ -275,9 +201,8 @@ places:
 - pad: active delegations and who is waiting on whom;
 - mail/chat history: evidence of actual interactions.
 
-Ask peers for help when their capability fits. Help peers when you can, or route
-them to someone better. Report outcomes to the people who need them; avoid broad
-noise.
+Ask peers whose capability fits, help or route those who ask you, and report
+outcomes to the people who need them without broadcasting noise.
 
 ## 8. MCP and addon ownership
 
@@ -287,32 +212,24 @@ MCP servers are durable integrations. The operating model has three layers:
 2. **Activation/config**: what is enabled for this agent.
 3. **Runtime tools**: what appears after refresh.
 
-For configuration, onboarding, or troubleshooting, read `mcp-manual` and the
-specific addon's README. Curated LingTai addon MCPs (IMAP, Telegram, Feishu,
-WeChat, WhatsApp) own their own setup details; do not guess field names from
-memory. If you are an avatar without admin ownership of an MCP, do not
-reconfigure the orchestrator-owned integration; escalate or ask the orchestrator.
+`mcp-manual` owns configuration, onboarding, and troubleshooting for every
+layer — read it rather than guessing field names. If you are an avatar without
+admin ownership of an MCP, do not reconfigure the orchestrator-owned
+integration; escalate or ask the orchestrator.
 
 ## 9. Idle and soul
 
-When there is no concrete task, go idle/asleep rather than spinning, polling, or
-using timed sleeps. Idle keeps listeners available.
-
-Soul flow is advice, not command — and it is **opt-in, disabled by default**
-(gated by the `LINGTAI_SOUL_FLOW_ENABLED` env var). Verify external-event claims
-through the relevant channel before acting on any voice. Use self-inquiry when
-you need a deliberate pause for judgment; use durable stores for conclusions that
-should survive molt. `soul-manual` owns the full soul-flow mechanics: the env
-gate, disabled-flow behavior, `delay_seconds` as cadence-not-off-switch,
-enabling/disabling, and the privacy/cost rationale.
+With no concrete task, go idle/asleep rather than spinning, polling, or using
+timed sleeps — idle keeps listeners available (resident §V). `soul-manual` owns
+soul-flow mechanics in full: the `LINGTAI_SOUL_FLOW_ENABLED` gate, disabled-flow
+behavior, `delay_seconds` as cadence-not-off-switch, and the privacy/cost
+rationale.
 
 ## 10. Resident substrate maintenance
 
-Keep resident substrate compact. It should hold invariant rules and routing cues,
-not examples or long rationale. When a substrate section grows into recipes,
-troubleshooting trees, or extended explanation, move the detail here or into a
-more specific `system-manual/reference/*.md` node and leave a short resident
-route behind.
+Maintainer-facing: keep resident substrate to invariant rules and routing cues.
+The split rule ("detail goes into a nested reference, the router keeps a hint")
+is stated once, in `system-manual` → "Maintaining this router".
 
 ## 11. Preset runtime model — `init.json` composition and the preset lifecycle
 

--- a/src/lingtai/intrinsic_skills/system-manual/reference/trajectory-mining/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/trajectory-mining/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: trajectory-mining
+description: >
+  Nested system-manual reference for trajectory mining — turning LingTai runtime
+  event streams into validated, actionable improvement candidates. Read this
+  after `reference/sqlite-log-query/SKILL.md` has given you the data access
+  layer: manifest policy, cheap-model/daemon strategy, prompt templates, the
+  finding schema and confidence rubric, the digest template, output routing, and
+  periodic mode.
+version: 1.0.0
+last_changed_at: "2026-08-07T00:00:00Z"
+tags: [lingtai, system-manual, trajectory, mining, improvement, digest, findings, observability, cheap-model, daemon, audit]
+related_files:
+- src/lingtai/intrinsic_skills/system-manual/SKILL.md
+- src/lingtai/intrinsic_skills/system-manual/reference/sqlite-log-query/SKILL.md
+maintenance: |
+  Workflow/process node. The SQLite sidecar schema, the CLI commands, the SQL
+  recipes, and the redaction rules are owned by
+  `reference/sqlite-log-query/SKILL.md` — cite them, do not restate them here.
+  Update when the finding schema, the confidence rubric, the digest template, or
+  the routing destinations change.
+---
+
+# Trajectory Mining
+
+Trajectory mining is the systematic process of turning LingTai runtime event
+streams into actionable lessons for improving LingTai itself. It starts from the
+SQLite log sidecar and uses SQL as the primary data access layer.
+
+**Prerequisite reading:** `reference/sqlite-log-query/SKILL.md` owns the data
+layer — `lingtai-agent log doctor|query|rebuild`, the
+`events`/`chat_entries`/`token_entries` schema, source discovery, the mechanical
+first-pass metric and slicing queries, and the canonical redaction rules. This
+node owns only the workflow built on top of it.
+
+## When to use / when not to use
+
+**Use trajectory mining when:**
+- The human asks to mine, analyze, or audit LingTai event logs.
+- The human says something like "最近轨迹", "look at my agent logs", "what went
+  wrong last session", "scan for patterns", or "generate improvement candidates".
+- You need to systematically extract operational pitfalls from large structured
+  traces before writing a knowledge entry, skill, or issue draft.
+- You want to build a cheap pre-pass before involving expensive models.
+
+**Do not use trajectory mining when:**
+- The human just wants a quick summary of chat history without event-log grounding.
+- The request is about code review, architecture analysis, or feature planning
+  unrelated to runtime traces.
+- You already have a specific, pre-identified bug and just need to fix it — skip
+  the mining phase and go directly to debugging.
+
+## Manifest building
+
+After source discovery, build a manifest before any LLM review. The manifest is
+your contract for what you will and will not read:
+
+```text
+source_kind | source_file | n | time_range | top_types | why_included
+```
+
+Keep the manifest in memory (or a temp file) — do not persist private log paths
+to shared storage.
+
+**Limits:**
+- Default window: last 24 hours or current workstream. Never scan everything
+  unless explicitly asked.
+- Maximum lines to feed any single LLM call: 300 lines of redacted excerpts.
+- If a result set exceeds 5000 rows, use time-window or event-family slicing
+  (queries in sqlite-log-query → "Metrics and slicing recipes").
+
+## Cheap model / daemon strategy
+
+### Model selection priority
+
+Work up from the cheapest surface that can do the job; the concrete adapter and
+preset names available to you are owned by
+`reference/llm-adapters/SKILL.md` and `system(action="presets")`.
+
+| Tier | When to use |
+|---|---|
+| Cheapest available model | Large-volume classification, error clustering, first-pass anomaly detection |
+| Cheap structured-output model | Structured YAML extraction from moderate excerpts |
+| Mid-tier model | Pattern matching over aggregated metrics; moderate-complexity finding synthesis |
+| Primary agent model (this session) | Shortlist triage, finding merging, confidence adjudication |
+| Frontier model | Only for ambiguous high-impact architecture/design findings |
+
+**Default: never reach the frontier tier unless the human explicitly approves the
+budget.**
+
+### Daemon task structure
+
+Spawn one daemon task per (source family × time window). Keep each task small:
+
+- Input: redacted aggregate metrics + bounded excerpts (≤300 lines)
+- Output: structured YAML only, using the finding schema below
+- No side effects inside the daemon
+
+Example daemon task description:
+
+```text
+Analyze these LingTai event-log excerpts (source: <family>, window: <time range>).
+Extract durable runtime improvement candidates visible in the event data.
+Focus on: tool failures, latency gaps, context pressure, daemon lifecycle, auth/env issues, observability gaps.
+Do NOT quote secrets, tokens, or full message bodies. Redact paths if they contain usernames or private data.
+Output ONLY a YAML list using this schema: [id, category, severity, confidence, event_evidence, pattern, impact, suggested_destination, suggested_next_step, side_effect_required].
+Prefer 3-5 high-signal findings over a long list of weak ones.
+```
+
+### Parallel dispatch strategy
+
+When multiple source families or time windows exist, dispatch them in parallel:
+
+```
+daemon-1: agent_events — tool_call/tool_result family — last 24h
+daemon-2: daemon_events — lifecycle family — last 7d
+daemon-3: agent_chat — turn timing family — last 24h
+daemon-4: context/spill events — pressure family — last 7d
+```
+
+Collect all results before primary-agent triage.
+
+## Prompt templates
+
+Each template below expects redacted input and returns YAML only — no prose
+before or after the YAML block.
+
+### Classifier prompt
+
+```
+You are a runtime event log classifier for a multi-agent system called LingTai.
+Below is a redacted aggregate summary of event-log metrics from a single source family and time window.
+Classify the top patterns you see into the following categories:
+  tool-failure, latency, context-pressure, daemon-lifecycle, auth-env, observability-gap, doc-gap, missing-skill, bug-candidate, process-improvement
+
+For each category you identify, output one YAML block:
+  category: <category>
+  evidence_summary: <1-2 sentences citing event types, counts, or timing — no secrets>
+  confidence: low | medium | high
+
+METRICS:
+{metrics_block}
+```
+
+### Anomaly summarizer prompt
+
+```
+You are analyzing a bounded excerpt from a LingTai agent event log.
+The excerpt is centered on a suspicious event. Surrounding lines are provided for context.
+Your task: summarize the anomaly in terms of what failed, why it likely failed (based on event data only), and what the downstream impact was.
+
+Rules:
+- Do not quote tokens, credentials, or full message bodies.
+- Reference events by their type, timestamp offset, and redacted field names.
+- Output YAML only:
+  anomaly_type: <one of: tool-failure | latency-spike | context-overflow | daemon-exit | auth-failure | unknown>
+  timeline: <ordered list of key events in the excerpt>
+  root_cause_hypothesis: <1 sentence, hedged>
+  downstream_impact: <1 sentence>
+  confidence: low | medium | high
+
+EXCERPT (redacted):
+{excerpt_block}
+```
+
+### Observability-gap prompt
+
+```
+You are reviewing LingTai event-log summaries to identify what information is MISSING that would be needed to diagnose operational problems.
+You have seen: {event_types_present}.
+You did NOT see (or saw too rarely): {event_types_sparse}.
+
+For each significant gap, output YAML:
+  gap: <what is missing>
+  why_needed: <what class of problem it would help diagnose>
+  suggested_event: <what event type or field would close the gap>
+  priority: low | medium | high
+```
+
+### Cross-run pattern prompt
+
+```
+You are comparing event-log aggregate summaries from multiple LingTai sessions or agents.
+Each summary is labeled with its source (agent name or daemon ID) and time window.
+Identify patterns that repeat ACROSS multiple sources/sessions, not just within one.
+
+For each cross-run pattern, output YAML:
+  pattern_id: <short slug>
+  description: <what repeats and where>
+  sources_affected: [list of source labels]
+  recurrence_count: <approximate>
+  severity: low | medium | high
+  confidence: low | medium | high
+
+SUMMARIES:
+{summaries_block}
+```
+
+## Finding schema
+
+Every finding, from any daemon or primary-agent review, must fit this schema:
+
+```yaml
+- id: short-stable-slug              # kebab-case, unique within the digest
+  category: tool-failure | latency | context-pressure | daemon-lifecycle | auth-env | observability-gap | doc-gap | missing-skill | bug-candidate | process-improvement
+  severity: low | medium | high
+  confidence: low | medium | high
+  event_evidence:
+    - source: local path or source_file value
+      line_or_time: line number, Unix timestamp, ISO timestamp, or event id
+      event_type: tool_call | tool_result | notification | daemon_state | context_pressure | other
+      redacted: true | false
+      note: short redacted quote or paraphrase of the event content
+  optional_context:
+    - source: path, URL, or issue reference
+      note: why this corroborates the event-log signal
+  pattern: what repeated or what caused harm — describe in event terms
+  impact: why it matters to LingTai, users, or agents
+  suggested_destination: knowledge | skill | issue-draft | code-investigation | observability-improvement | no-action
+  suggested_next_step: smallest concrete next action
+  side_effect_required: none | human-approval-required
+```
+
+A finding needs at least one `event_evidence` entry with a verifiable source and
+line/time, and its `pattern` must describe something visible in event data, not
+inferred from chat history alone.
+
+## Validation and confidence rubric
+
+Before finalizing any finding:
+
+1. **Re-read the source data**: confirm the source_file, source_line, or time
+   range are accurate, and that timestamps form a plausible causal sequence.
+2. **Check recurrence**: re-query for similar events across the full time window
+   and note the count.
+3. **Reject hallucinated fields**: if a daemon output references event fields
+   that do not exist in the actual schema discovered in source discovery, discard
+   or flag that finding.
+
+| Evidence | Confidence |
+|----------|-----------|
+| ≥3 occurrences of the same event pattern, confirmed in source file | high |
+| 2 occurrences OR 1 occurrence + corroborating optional_context | medium |
+| 1 occurrence, no corroboration, no impact confirmed | low |
+| Inferred from absence of events only | low |
+| Daemon output references field not found in actual schema | reject |
+
+A single occurrence of an error with no pattern context is `severity: low` and
+`confidence: low` unless that single event had confirmed high impact (e.g. the
+agent stopped functioning) — otherwise exclude it.
+
+## Output digest template
+
+Produce the digest in the agent's working language. Fields in brackets are
+placeholders.
+
+```
+# 轨迹挖掘摘要 / Trajectory Mining Digest
+Generated: [ISO timestamp]
+Sources scanned: [source_kinds, total ~N events, time window]
+Models used: [list of cheap models + primary agent]
+
+---
+
+## High-Signal Findings ([N])
+severity high or medium, with high confidence.
+
+[YAML block]
+
+---
+
+## Quick Wins ([N])
+suggested_destination is knowledge, skill, or observability-improvement, and
+side_effect_required is none.
+
+[YAML block]
+
+---
+
+## Issue Candidates ([N])
+side_effect_required: human-approval-required.
+
+[YAML block]
+
+---
+
+## Observability Gaps ([N])
+category: observability-gap — what was missing that would help future diagnosis.
+
+[YAML block]
+
+---
+
+## No-Action Observations ([N])
+severity low or confidence low, retained for reference.
+
+[YAML block]
+
+---
+
+## Evidence Appendix
+[Table: finding_id | source_file | line_or_time | event_type | redacted_note]
+
+---
+
+## Recommended Next Steps
+Choose one or more:
+- [ ] Write/update skill: [skill name]
+- [ ] Write knowledge entry: [topic]
+- [ ] Draft issue for human review: [title]
+- [ ] Code investigation: [component]
+- [ ] Add observability: [event type / field]
+- [ ] No action needed
+```
+
+## Routing next actions
+
+After producing the digest, route durable outputs as follows:
+
+| Finding type | Destination | Action |
+|---|---|---|
+| Reusable operational pattern | `skill` | Propose skill update; wait for human approval |
+| Private operational fact about this deployment | `knowledge` | Write knowledge entry (no secrets) |
+| Active task / in-progress investigation | `pad` | Update pad with bounded note |
+| LingTai bug or design issue | Issue draft | Use `lingtai-issue-report` skill if available; **ask human approval before filing** |
+| Code change needed | Local worktree/patch | Propose; do not apply without approval |
+| Configuration change | Propose in digest | **Do not apply without approval** |
+| No clear action | `no-action` | Note in digest; move on |
+
+## Periodic mode
+
+If the human wants recurring event-log mining:
+
+- **Do not set any scheduler without explicit approval.** Ask the human to
+  confirm the cadence and scope first.
+- Default cadence when approved: daily digest, not continuous monitoring.
+- The scheduled job should only wake the agent with a bounded prompt; the agent
+  performs the review.
+- The digest should be silent (written to `pad.md` or a report file) unless
+  `standing-rules.md` allows periodic check-in messages.
+
+Suggested scheduled prompt body (for human approval before use):
+
+```text
+Run trajectory mining on recent SQLite event traces for the last 24h.
+Produce a concise digest of high-signal runtime pitfalls and improvement candidates.
+Do not create issues, commits, PRs, config changes, or scheduled jobs without explicit human approval.
+Write the digest to: reports/trajectory-digest-YYYYMMDD.md
+```
+
+## Concrete example findings
+
+### Example A: stale Claude Code OAuth token
+
+```yaml
+- id: stale-claude-code-oauth-token
+  category: auth-env
+  severity: high
+  confidence: high
+  event_evidence:
+    - source: daemons/em-<id>/logs/events.jsonl
+      line_or_time: "~line 847, ts 1716XXXXXX"
+      event_type: tool_result
+      redacted: true
+      note: "claude CLI returned 'weekly limit reached'; subsequent tool_result showed success after env patch"
+  optional_context:
+    - source: "GitHub: Lingtai-AI/lingtai#189"
+      note: confirmed stale inherited env token failure mode
+  pattern: >
+    Long-lived daemon inherits stale CLAUDE_CODE_OAUTH_TOKEN from parent env.
+    After credential refresh, the env override prevents the new token from taking effect.
+    Agents see 'weekly limit' errors and stop delegating heavy work.
+  impact: Agents misdiagnose quota exhaustion; heavy work is not delegated.
+  suggested_destination: code-investigation
+  suggested_next_step: Strip stale env tokens in daemon backend env; add smoke test.
+  side_effect_required: human-approval-required
+```
+
+### Example B: tool-result spill / context pressure
+
+```yaml
+- id: tool-result-spill-context-pressure
+  category: context-pressure
+  severity: medium
+  confidence: medium
+  event_evidence:
+    - source: logs/events.jsonl
+      line_or_time: "lines ~1200–1250"
+      event_type: tool_result
+      redacted: true
+      note: "tool_result event has result_size > threshold; subsequent context_pressure event shows usage >85%"
+  pattern: >
+    Large tool results push context usage past 85%. The spill event appears but
+    the agent continues without triggering molt early enough.
+  impact: Tasks are interrupted or produce incomplete output; user must re-prompt.
+  suggested_destination: observability-improvement
+  suggested_next_step: Verify that spill events are routed to the molt trigger.
+  side_effect_required: none
+```
+
+## On-demand procedure (step-by-step)
+
+1. **Clarify window and scope.** Default: recent event logs for the current
+   agent/project plus daemon events from the active workstream. "最近轨迹" →
+   last 24h or current active workstream. Named subsystem → filter to it.
+2. **Discover sources** (sqlite-log-query → "Source discovery") and build the
+   manifest.
+3. **Schema discovery** — sample keys via `json_each()` before writing any
+   extraction code.
+4. **Mechanical first-pass** — run the aggregation queries; do not pass raw logs
+   to any LLM.
+5. **Chunk and redact** — apply a slicing strategy, then sqlite-log-query's
+   redaction rules.
+6. **Dispatch cheap daemon batch** — one daemon per source family / time window.
+7. **Primary-agent triage** — merge findings, validate against the confidence
+   rubric.
+8. **Produce digest** — render the template, include the evidence appendix.
+9. **Route outputs** — propose routing; wait for human approval before any side
+   effect.
+10. **Stop.** A good digest gives the human enough to choose: update skill, file
+    issue, make patch, ignore, or schedule.

--- a/src/lingtai/intrinsic_skills/system-manual/reference/trajectory-mining/SKILL.md
+++ b/src/lingtai/intrinsic_skills/system-manual/reference/trajectory-mining/SKILL.md
@@ -122,9 +122,6 @@ Collect all results before primary-agent triage.
 
 ## Prompt templates
 
-Each template below expects redacted input and returns YAML only — no prose
-before or after the YAML block.
-
 ### Classifier prompt
 
 ```
@@ -140,6 +137,8 @@ For each category you identify, output one YAML block:
 
 METRICS:
 {metrics_block}
+
+Output ONLY valid YAML. No prose before or after.
 ```
 
 ### Anomaly summarizer prompt
@@ -161,6 +160,8 @@ Rules:
 
 EXCERPT (redacted):
 {excerpt_block}
+
+Output ONLY valid YAML. No prose before or after.
 ```
 
 ### Observability-gap prompt
@@ -175,6 +176,8 @@ For each significant gap, output YAML:
   why_needed: <what class of problem it would help diagnose>
   suggested_event: <what event type or field would close the gap>
   priority: low | medium | high
+
+Output ONLY valid YAML. No prose before or after.
 ```
 
 ### Cross-run pattern prompt
@@ -194,6 +197,8 @@ For each cross-run pattern, output YAML:
 
 SUMMARIES:
 {summaries_block}
+
+Output ONLY valid YAML. No prose before or after.
 ```
 
 ## Finding schema

--- a/src/lingtai/prompts/meta_guidance/catalog/summarize_reconstruction_threshold.md
+++ b/src/lingtai/prompts/meta_guidance/catalog/summarize_reconstruction_threshold.md
@@ -11,7 +11,7 @@ why: >
 related_files:
   - "src/lingtai/prompts/principle/principle.md"
   - "src/lingtai/prompts/meta_guidance/catalog/INDEX.md"
-  - "reference/summarize-manual/SKILL.md"
+  - "src/lingtai/intrinsic_skills/context-manual/reference/summarize-manual/SKILL.md"
 maintenance: >
   When editing this file, treat related_files as maintained inner links for the prompt/guidance
   source graph. Before changing behavior or prose, crawl the listed files, update any affected

--- a/src/lingtai/prompts/meta_guidance/meta_guidance.yaml
+++ b/src/lingtai/prompts/meta_guidance/meta_guidance.yaml
@@ -52,7 +52,7 @@ related_files:
       Owns how the meta_guidance section body is built and spliced: build_meta_guidance()
       renders the loaded catalog alongside the `_meta` readme and adapter static rules.
       Crawl here for the concrete render/splice rules, not this contract.
-  - path: src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual/SKILL.md
+  - path: src/lingtai/intrinsic_skills/context-manual/reference/summarize-manual/SKILL.md
     why: >
       Owns the expanded token/context-economy semantics the resident guidance only
       summarizes: the summarize/molt compression modes, when to summarize vs molt, and

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -212,7 +212,7 @@ def test_task_boundary_molt_guidance_is_cost_thresholded():
         Path("src/lingtai/prompts/substrate/substrate.md"),
         Path("src/lingtai/intrinsic_skills/system-manual/reference/procedures-manual/SKILL.md"),
         Path("src/lingtai/intrinsic_skills/system-manual/reference/substrate-manual/SKILL.md"),
-        Path("src/lingtai/intrinsic_skills/system-manual/reference/summarize-manual/SKILL.md"),
+        Path("src/lingtai/intrinsic_skills/context-manual/reference/summarize-manual/SKILL.md"),
     ]
     parts = [strip_frontmatter(path.read_text()) for path in md_paths]
     # Guidance is now a skill-style Markdown catalog; fold each section body in.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -363,6 +363,8 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "reference/procedures-manual/SKILL.md" in system_manual_body
         assert "reference/sqlite-log-query/SKILL.md" in system_manual_body
         assert "reference/runtime-update-checks/SKILL.md" in system_manual_body
+        assert "reference/refresh-precheck/SKILL.md" in system_manual_body
+        assert "reference/trajectory-mining/SKILL.md" in system_manual_body
         assert "lingtai-agent log doctor" in system_manual_body
         assert "lingtai-agent log query" in system_manual_body
         assert "lingtai-agent log rebuild" in system_manual_body
@@ -370,6 +372,8 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "name: procedures-manual" in system_manual_body
         assert "name: sqlite-log-query" in system_manual_body
         assert "name: runtime-update-checks" in system_manual_body
+        assert "name: refresh-precheck" in system_manual_body
+        assert "name: trajectory-mining" in system_manual_body
         assert "Nested reference catalog" in system_manual_body
         assert "location: reference/notification-manual/SKILL.md" not in system_manual_body
 
@@ -477,12 +481,31 @@ def test_skills_setup_hard_copies_standalone_intrinsic_skills(tmp_path):
         assert "Nested system-manual reference" in sqlite_log_query_body
         assert "# SQLite Log Query" in sqlite_log_query_body
         assert "lingtai-agent log query" in sqlite_log_query_body
-        # Trajectory mining content is now in the sqlite-log-query reference
-        assert "Trajectory Mining" in sqlite_log_query_body
-        assert "trajectory mining" in sqlite_log_query_body.lower()
-        assert "Finding schema" in sqlite_log_query_body or "finding schema" in sqlite_log_query_body.lower()
-        assert "cheap model" in sqlite_log_query_body.lower() or "cheap-model" in sqlite_log_query_body.lower()
         assert "scripts/event_summary.py" in sqlite_log_query_body
+        # Trajectory mining is its own sibling reference; sqlite-log-query keeps
+        # the data layer (schema, SQL recipes, redaction) and routes to it.
+        assert "trajectory mining" in sqlite_log_query_body.lower()
+        assert "../trajectory-mining/SKILL.md" in sqlite_log_query_body
+
+        trajectory_ref = system_manual_md.parent / "reference" / "trajectory-mining" / "SKILL.md"
+        assert trajectory_ref.is_file()
+        trajectory_body = trajectory_ref.read_text(encoding="utf-8")
+        assert "name: trajectory-mining" in trajectory_body
+        assert "# Trajectory Mining" in trajectory_body
+        assert "finding schema" in trajectory_body.lower()
+        assert "cheap model" in trajectory_body.lower() or "cheap-model" in trajectory_body.lower()
+        assert "reference/sqlite-log-query/SKILL.md" in trajectory_body
+
+        refresh_precheck_ref = (
+            system_manual_md.parent / "reference" / "refresh-precheck" / "SKILL.md"
+        )
+        assert refresh_precheck_ref.is_file()
+        refresh_precheck_body = refresh_precheck_ref.read_text(encoding="utf-8")
+        assert "name: refresh-precheck" in refresh_precheck_body
+        assert "Nested system-manual reference" in refresh_precheck_body
+        assert 'system(action="refresh")' in refresh_precheck_body
+        assert 'system(action="presets")' in refresh_precheck_body
+        assert ".pth" in refresh_precheck_body
 
         # event_summary.py script exists, is referenced, and can summarize
         # a minimal SQLite sidecar using the actual events schema columns.


### PR DESCRIPTION
Two parts, both docs/manuals only.

Part 1 — new `system-manual/reference/refresh-precheck/SKILL.md`: the ordered
pre-flight to run BEFORE `system(action="refresh")` (including preset
swap/revert), the refresh sequence, and the post-refresh verification pass.
Every step cites its owner (preset model -> substrate-manual §11; installer
authority -> runtime-update-checks + substrate §I; env vars ->
environment-variables; MCP -> mcp-manual; molt -> context-manual) so the node
adds sequencing, not a fourth copy of the same facts. Step 2 covers `.pth` /
editable-install occupancy. Wired into the system-manual nested catalog and
router table.

Part 2 — 8-group simplification audit.

P0 correctness: `summarize-manual` was advertised at
`system-manual/reference/summarize-manual/` which does not exist; the file
lives under `context-manual/`. Fixed all 5 stale references (system-manual
catalog + router row, procedures-manual, substrate-manual,
meta_guidance.yaml, meta_guidance catalog entry, tests/test_prompt.py). This
repairs two test failures that were already red on main. Also fixed:
substrate-manual described `summarize` as a `system` action (the system tool
exposes none), notification-manual claimed `system` "owns summarize",
runtime-update-checks pointed env-var ownership at a pure router instead of
the root registry, llm-adapters cited stale backend page paths, sqlite-log-query
overclaimed `doctor` staleness detection and mtime preservation.

P1 simplification: extracted the 532-line Trajectory Mining section out of
sqlite-log-query (956 -> 537 lines) into a new sibling
`reference/trajectory-mining/SKILL.md`; removed passages across 20 manuals
that restated resident prompt text, tool-schema text, or another manual that
already owns the fact. No agent-reachable fact was dropped — every cut is a
restatement, and each one now points at its single owner.

Verification: full suite is 35 failed / 7800 passed vs 38 / 7797 on
origin/main; the delta is the two stale-path failures fixed here plus one
flaky mail-listener test that varies run to run on both.
