### PR TITLE
feat(taskcard): proactive task-card nudges for daemon fleets and expired watches

### DIFF
--- a/src/lingtai/prompts/procedures/procedures.md
+++ b/src/lingtai/prompts/procedures/procedures.md
@@ -190,9 +190,12 @@ operations, preset swaps, notification handling, and karma actions.
 
 ### Task Card Lifecycle
 
-Start a `task_card` watch only for meaningful ongoing work a human is
-following; skip it for quick single-step work or ritual updates. Keep the
-rendered body truthful and current while it runs, and optionally `retry` once
+Start a `task_card` watch for meaningful long-running or parallel work a human
+is following: multi-daemon fleets (two or more), multi-PR batches, long
+review→merge flows, anything running past roughly ten minutes. Skip it for
+quick single-step work or ritual updates. When a watch expires mid-task
+(`max_refreshes`), start a new watch rather than letting the card go dark.
+Keep the rendered body truthful and current while it runs, and optionally `retry` once
 more to publish a final state before winding down. Use `stop` to pause a watch
 while preserving its last body; use `remove` once the work is completed,
 cancelled, or abandoned so `/taskcard` and other consumers cannot keep

--- a/src/lingtai/tools/daemon/CONTRACT.md
+++ b/src/lingtai/tools/daemon/CONTRACT.md
@@ -7,8 +7,8 @@ description: >
   daemon_common completion signaling, support-status honesty, run artifacts,
   terminal notifications, and compaction boundaries.
 status: active
-contract_version: 8
-last_changed_at: "2026-07-27"
+contract_version: 9
+last_changed_at: "2026-08-07"
 related_files:
   - src/lingtai/tools/daemon/ANATOMY.md
   - src/lingtai/tools/daemon/__init__.py
@@ -38,6 +38,7 @@ related_files:
   - src/lingtai/llm/openai/ANATOMY.md
   - src/lingtai/llm/mimo/ANATOMY.md
   - tests/test_daemon_contract_doc.py
+  - tests/test_task_card_proactivity.py
   - tests/test_tool_family_daemon_migration.py
   - tests/test_daemon.py
   - tests/test_daemon_empty_parity.py
@@ -264,6 +265,19 @@ conditional: use the Task Card only when Telegram is connected and a Task Card
 is available for the current turn, and read `telegram(action='manual')` for the
 `Programmable Task Card` details. Daemon does not create or require a watcher
 and does not import or call Telegram/Task Card runtime code.
+
+A card-worthy dispatch — two or more tasks in the batch, or an explicitly
+requested `timeout` at or above 900s — additionally appends one nudge sentence
+to `handoff` naming the dispatched count and suggesting
+`task_card(action='start')`. An omitted `timeout` never qualifies on its own:
+the default ceiling describes no actual run length, so a single daemon
+dispatched without an explicit long `timeout` is not card-worthy. The nudge
+also appears only when the agent has the Task Card capability enabled and no
+watch is currently active, so a quick single daemon, an agent with the
+capability disabled, and a fleet dispatched under a live card all receive the
+plain `handoff` unchanged. The active-watch check is a duck-typed read-only
+probe; daemon still imports no Task Card runtime code and never starts a watch
+itself.
 
 ## Capability Invariants
 

--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -412,6 +412,26 @@ _DAEMON_COMPACT_MANUAL_PROCEDURES = (
 )
 
 
+DAEMON_ASYNC_HANDOFF = (
+    "While waiting, go idle or call system(action='sleep'); the terminal result "
+    "will arrive and wake you as a notification; read daemon-manual and "
+    "notification-manual for details. If Telegram is connected and a Task Card "
+    "is available for the current turn, use it to report progress; call "
+    "`telegram(action='manual')` and follow its `Programmable Task Card` "
+    "section for details."
+)
+# A fleet (two or more daemons), or a single one whose caller explicitly asked
+# for a long ceiling, is work a human wants to follow. The default 3600s
+# ceiling does not count: it says nothing about how long the batch will run,
+# and nudging on it would fire for every single quick daemon.
+DAEMON_CARD_NUDGE_MIN_TASKS = 2
+DAEMON_CARD_NUDGE_MIN_TIMEOUT_S = 900.0
+DAEMON_CARD_NUDGE = (
+    " You dispatched {count} daemon(s) with no active task_card watch — consider "
+    "starting one (task_card action='start') so a human can follow progress."
+)
+
+
 _DAEMON_COMMON_MCP_NAME = "daemon_common"
 _DAEMON_EMAIL_MCP_NAME = "email"
 # Tool names satisfied by a LingTai-auto-mounted, task-scoped MCP server
@@ -4213,6 +4233,10 @@ class DaemonManager:
         else:
             effective_max_turns = self._max_turns
 
+        # The caller's own timeout, kept separate from the effective one: the
+        # default ceiling says nothing about how long this batch will run, but
+        # an explicitly requested long ceiling does.
+        requested_timeout: float | None = None
         if timeout is not None:
             try:
                 to = float(timeout)
@@ -4227,6 +4251,7 @@ class DaemonManager:
                 return {"status": "error",
                         "message": f"timeout must be ≥ 5 seconds (got {to})"}
             effective_timeout = min(to, self._timeout)
+            requested_timeout = effective_timeout
         else:
             effective_timeout = self._timeout
 
@@ -4254,6 +4279,7 @@ class DaemonManager:
                 tasks, backend=backend,
                 effective_max_turns=effective_max_turns,
                 effective_timeout=effective_timeout,
+                requested_timeout=requested_timeout,
             )
 
         # Pre-flight: validate per-task ``context_token_limit`` (LingTai backend
@@ -4519,7 +4545,42 @@ class DaemonManager:
 
         return {"status": "dispatched", "count": len(tasks), "ids": ids,
                 "group_id": group_id,
-                "handoff": "While waiting, go idle or call system(action='sleep'); the terminal result will arrive and wake you as a notification; read daemon-manual and notification-manual for details. If Telegram is connected and a Task Card is available for the current turn, use it to report progress; call `telegram(action='manual')` and follow its `Programmable Task Card` section for details."}
+                "handoff": self._emanate_handoff(len(tasks), requested_timeout)}
+
+    def _emanate_handoff(self, count: int, requested_timeout_s: float | None) -> str:
+        """Async handoff line, plus a Task Card nudge for fleet-scale dispatch.
+
+        The nudge is conditional twice over: only for a fleet or a deliberately
+        long single run, and only when no watch is already running — a quick
+        daemon, or one dispatched under a live card, gets the plain handoff.
+        """
+        if not self._should_nudge_task_card(count, requested_timeout_s):
+            return DAEMON_ASYNC_HANDOFF
+        return DAEMON_ASYNC_HANDOFF + DAEMON_CARD_NUDGE.format(count=count)
+
+    def _should_nudge_task_card(
+        self, count: int, requested_timeout_s: float | None
+    ) -> bool:
+        """True when this dispatch is card-worthy and no watch is active.
+
+        Duck-typed on purpose: daemon still neither imports nor requires Task
+        Card runtime code, so an agent whose capability is disabled simply
+        never gets nudged.
+        """
+        if count < DAEMON_CARD_NUDGE_MIN_TASKS and (
+            requested_timeout_s is None
+            or requested_timeout_s < DAEMON_CARD_NUDGE_MIN_TIMEOUT_S
+        ):
+            return False
+        has_active = getattr(
+            getattr(self._agent, "_task_card_manager", None), "has_active_watch", None
+        )
+        if not callable(has_active):
+            return False
+        try:
+            return not has_active()
+        except Exception:
+            return False
 
     def _handle_emanate_cli(
         self,
@@ -4527,6 +4588,7 @@ class DaemonManager:
         backend: str,
         effective_max_turns: int,
         effective_timeout: float,
+        requested_timeout: float | None = None,
     ) -> dict:
         """Dispatch emanations via an external CLI backend.
 
@@ -4779,7 +4841,7 @@ class DaemonManager:
                   tasks=[{"task": s["task"][:80], "tools": s.get("tools", [])} for s in tasks])
         return {"status": "dispatched", "count": len(tasks), "ids": ids,
                 "group_id": group_id, "backend": backend,
-                "handoff": "While waiting, go idle or call system(action='sleep'); the terminal result will arrive and wake you as a notification; read daemon-manual and notification-manual for details. If Telegram is connected and a Task Card is available for the current turn, use it to report progress; call `telegram(action='manual')` and follow its `Programmable Task Card` section for details."}
+                "handoff": self._emanate_handoff(len(tasks), requested_timeout)}
 
     @staticmethod
     def _truncate_list_string(value: object, limit: int = 500) -> object:

--- a/src/lingtai/tools/daemon/manual/SKILL.md
+++ b/src/lingtai/tools/daemon/manual/SKILL.md
@@ -6,8 +6,8 @@ description: >
   hunch, understand `daemon(action="list", input={})`, use CLI backends and `backend_options`,
   and clean up daemon footprint. Read this after dispatching daemon work that is
   slow, failed, timed out, exited 143 / SIGTERM, or needs backend-specific reasoning.
-version: 0.10.0
-last_changed_at: 2026-07-27T00:00:00Z
+version: 0.11.0
+last_changed_at: 2026-08-07T00:00:00Z
 related_files:
 - src/lingtai/tools/daemon/CONTRACT.md
 - src/lingtai/tools/daemon/ANATOMY.md
@@ -273,6 +273,11 @@ are the three that change state.
   `telegram(action='manual')` and follow its `Programmable Task Card` section.
   The daemon tool does not create a Task Card automatically or require a
   watcher; daemon lifecycle and terminal-notification behavior are unchanged.
+  A card-worthy dispatch — two or more tasks, or an explicitly requested
+  `timeout` of 900s or more — appends one extra nudge sentence to `handoff`
+  when you have no active watch: start one with `task_card(action='start')` so
+  a human can follow the fleet instead of watching it run dark. The nudge
+  disappears once a watch is running.
 - **`check` still resolves a daemon after refresh/molt.** A refresh/molt gives
   you a fresh daemon registry with no in-memory entries, but the run folders
   and their notifications survive on disk. New daemon ids are compact run ids

--- a/src/lingtai/tools/task_card/CONTRACT.md
+++ b/src/lingtai/tools/task_card/CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: intrinsic-task-card
-contract_version: 3
+contract_version: 4
 root_contract: CONTRACT.md
 related_files:
   - src/lingtai/tools/task_card/ANATOMY.md
@@ -14,6 +14,7 @@ related_files:
   - src/lingtai/mcp_servers/feishu/task_card.py
   - src/lingtai/mcp_servers/feishu/manager.py
   - tests/test_task_card_controller.py
+  - tests/test_task_card_proactivity.py
   - tests/test_telegram_toolfamily_ltpv2.py
   - tests/test_telegram_task_card_programmable.py
   - tests/test_feishu_programmable_task_cards.py
@@ -59,7 +60,12 @@ declarative artifact and one active watch per agent.
    recovery policy.
 7. Renderer execution failures after a watch exists preserve the last valid body
    and emit deduped `task_card.error` and `recovered` notifications. Refresh
-   exhaustion emits one `task_card.limit` notification keyed by watch and limit.
+   exhaustion emits one `task_card.limit` notification keyed by watch and limit;
+   its body tells the agent to start a new watch when the underlying work is
+   still ongoing, so an expired watch does not silently leave the card dark.
+   The capability also exposes a read-only `has_active_watch()` probe so another
+   capability (the daemon fleet nudge) can ask whether a card is already running
+   without creating, mutating, or importing watch state.
 8. Missing, invalid, or inactive producer state is outside this contract.
    Consumers decide what those states mean.
 9. `taskcard/taskcard.json` holds optional `interval_s`, `timeout_s`, and

--- a/src/lingtai/tools/task_card/__init__.py
+++ b/src/lingtai/tools/task_card/__init__.py
@@ -164,7 +164,8 @@ def get_description() -> str:
         "channel-specific readers. Use it proactively for meaningful long-running, "
         "multi-step, or parallel work so a human can follow progress; skip it for "
         "quick single-step work, ritual updates, or a body you cannot keep truthful "
-        "and current. Use stop to pause a watch while preserving its last body, and "
+        "and current. Restart a new watch when one expires mid-task. Use stop to "
+        "pause a watch while preserving its last body, and "
         "remove once the work is completed, cancelled, or abandoned so the artifact "
         "cannot mislead a consumer as stale. Actions: start, inspect, retry, stop, "
         "remove, manual."
@@ -790,7 +791,9 @@ class TaskCardManager:
                 body=(
                     f"Task Card watch {watch.watch_id} reached its refresh limit. "
                     "Refresh or reinspect the underlying task state, and start a new "
-                    "watch only if useful."
+                    "watch only if useful. If this work is still ongoing, start a new "
+                    "watch (task_card action='start') — do not let the card go dark "
+                    "mid-task."
                 ),
                 idempotency_key=f"task_card.limit:{watch.watch_id}:{maximum}",
                 skip_if_idempotency_key_exists=True,
@@ -799,6 +802,20 @@ class TaskCardManager:
             )
         except Exception:
             pass
+
+    def has_active_watch(self) -> bool:
+        """True while exactly one watch is running and not yet retiring.
+
+        Read-only cross-capability probe: the daemon fleet nudge asks this
+        before suggesting a card, so an agent that already keeps one is never
+        told to start another.
+        """
+        with self._lock:
+            watch = self._watch
+        if watch is None:
+            return False
+        with watch.lock:
+            return not (watch.stopping or watch.terminated)
 
     def _require_watch(self, watch_id: Any) -> _Watch:
         if not isinstance(watch_id, str):

--- a/src/lingtai/tools/task_card/manual/SKILL.md
+++ b/src/lingtai/tools/task_card/manual/SKILL.md
@@ -129,6 +129,9 @@ Guidelines:
 
 - Keep one active watch per agent. A second `start` is refused until the first
   watch is stopped.
+- Restart a watch that expires mid-task. Exhausting `max_refreshes` retires the
+  watch and sends one `task_card.limit` notification; if the underlying work is
+  still ongoing, `start` a new watch rather than letting the card go dark.
 - Write the body you want projected. The producer is channel-neutral and does
   not own Telegram/Feishu/portal layout details.
 - Keep renderer output truthful and complete. Projection channels may compare

--- a/tests/ANATOMY.md
+++ b/tests/ANATOMY.md
@@ -312,6 +312,7 @@ related_files:
   - tests/test_task_card_controller.py
   - tests/test_task_card_event_projection_shared.py
   - tests/test_task_card_handoff_guidance.py
+  - tests/test_task_card_proactivity.py
   - tests/test_task_card_resident_shared.py
   - tests/test_taskcard_resident_meta.py
   - tests/test_tc_inbox.py

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1989,6 +1989,8 @@ def test_handle_emanate_dispatches_and_returns_ids(tmp_path, monkeypatch):
         {"task": "task B", "tools": ["file"]},
     ]})
     assert result["status"] == "dispatched"
+    # Two tasks is a fleet, and this agent keeps no watch, so the handoff also
+    # carries the Task Card nudge (see tests/test_task_card_proactivity.py).
     assert result["handoff"] == (
         "While waiting, go idle or call system(action='sleep'); the terminal result "
         "will arrive and wake you as a notification; read daemon-manual and "
@@ -1996,6 +1998,8 @@ def test_handle_emanate_dispatches_and_returns_ids(tmp_path, monkeypatch):
         "is available for the current turn, use it to report progress; call "
         "`telegram(action='manual')` and follow its `Programmable Task Card` "
         "section for details."
+        " You dispatched 2 daemon(s) with no active task_card watch — consider "
+        "starting one (task_card action='start') so a human can follow progress."
     )
     assert result["count"] == 2
     ids = result["ids"]

--- a/tests/test_daemon_contract_doc.py
+++ b/tests/test_daemon_contract_doc.py
@@ -45,8 +45,8 @@ def test_daemon_contract_frontmatter_lists_related_files_and_triggers():
     meta = _frontmatter(DOC)
     assert meta["name"] == "daemon-contract"
     assert meta["status"] == "active"
-    # Bumped to 8 by the ToolFamily migration (LTP v2 envelope tool surface).
-    assert meta["contract_version"] == 8
+    # Bumped to 9 by the conditional Task Card nudge on the emanate handoff.
+    assert meta["contract_version"] == 9
     related = set(meta["related_files"])
     triggers = set(meta["review_triggers"])
     for rel in REQUIRED_RELATED:

--- a/tests/test_task_card_proactivity.py
+++ b/tests/test_task_card_proactivity.py
@@ -1,0 +1,190 @@
+"""Proactivity mechanisms that keep a Task Card open when the work warrants one.
+
+Three independent nudges are covered here: the daemon fleet nudge appended to
+an `emanate` handoff, the continuation hint carried by the expired-watch
+`task_card.limit` event, and the resident/tool wording that names which work is
+card-worthy.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lingtai.tools.daemon import (
+    DAEMON_ASYNC_HANDOFF,
+    DAEMON_CARD_NUDGE_MIN_TASKS,
+    DAEMON_CARD_NUDGE_MIN_TIMEOUT_S,
+)
+from lingtai.tools.task_card import TaskCardManager, get_description
+
+from tests._daemon_helpers import make_daemon_agent
+from tests.test_task_card_controller import _FakeAgent, _OK_BODY, _write_renderer
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROCEDURES = ROOT / "src/lingtai/prompts/procedures/procedures.md"
+
+
+class _StubCard:
+    """Minimal duck type for the daemon's read-only active-watch probe."""
+
+    def __init__(self, active: bool) -> None:
+        self._active = active
+
+    def has_active_watch(self) -> bool:
+        return self._active
+
+
+class _RaisingCard:
+    def has_active_watch(self) -> bool:
+        raise RuntimeError("probe exploded")
+
+
+@pytest.fixture
+def daemon(tmp_path):
+    return make_daemon_agent(tmp_path).get_capability("daemon")
+
+
+def _start_watch(manager: TaskCardManager, workdir: Path, *, max_refreshes: int) -> dict:
+    workdir.mkdir(parents=True, exist_ok=True)
+    return manager.handle(
+        {
+            "action": "start",
+            "input": {
+                "renderer_path": _write_renderer(workdir, _OK_BODY),
+                "interval_s": 3600,
+                "max_refreshes": max_refreshes,
+            },
+            "reasoning": "start a task card",
+        }
+    )
+
+
+# --- Mechanism 1: daemon fleet nudge ---
+
+
+def test_fleet_dispatch_without_a_watch_is_nudged(daemon):
+    daemon._agent._task_card_manager = _StubCard(False)
+    handoff = daemon._emanate_handoff(4, None)
+    assert handoff.startswith(DAEMON_ASYNC_HANDOFF)
+    assert "You dispatched 4 daemon(s) with no active task_card watch" in handoff
+    assert "task_card action='start'" in handoff
+
+
+def test_single_quick_dispatch_is_not_nudged(daemon):
+    daemon._agent._task_card_manager = _StubCard(False)
+    assert daemon._emanate_handoff(1, 300.0) == DAEMON_ASYNC_HANDOFF
+
+
+def test_single_dispatch_on_the_default_ceiling_is_not_nudged(daemon):
+    """An omitted timeout must not qualify: the default ceiling is 3600s, so
+    keying on it would nudge on every single quick daemon."""
+    daemon._agent._task_card_manager = _StubCard(False)
+    assert daemon._emanate_handoff(1, None) == DAEMON_ASYNC_HANDOFF
+
+
+def test_single_explicitly_long_dispatch_is_nudged(daemon):
+    daemon._agent._task_card_manager = _StubCard(False)
+    handoff = daemon._emanate_handoff(1, DAEMON_CARD_NUDGE_MIN_TIMEOUT_S)
+    assert "You dispatched 1 daemon(s) with no active task_card watch" in handoff
+
+
+def test_active_watch_suppresses_the_nudge(daemon):
+    daemon._agent._task_card_manager = _StubCard(True)
+    assert daemon._emanate_handoff(4, 3600.0) == DAEMON_ASYNC_HANDOFF
+
+
+def test_agent_without_the_task_card_capability_is_never_nudged(tmp_path):
+    """`task_card` is a core default, but a host may disable it; a daemon
+    dispatch on such an agent must fall back to the plain handoff."""
+    agent = make_daemon_agent(tmp_path)
+    del agent._task_card_manager
+    assert agent.get_capability("daemon")._emanate_handoff(4, None) == DAEMON_ASYNC_HANDOFF
+
+
+def test_probe_failure_falls_back_to_the_plain_handoff(daemon):
+    daemon._agent._task_card_manager = _RaisingCard()
+    assert daemon._emanate_handoff(4, 3600.0) == DAEMON_ASYNC_HANDOFF
+
+
+def test_nudge_thresholds_are_fleet_scale():
+    assert DAEMON_CARD_NUDGE_MIN_TASKS == 2
+    assert DAEMON_CARD_NUDGE_MIN_TIMEOUT_S == 900.0
+
+
+def test_real_task_card_capability_toggles_the_nudge(tmp_path):
+    """End-to-end across the two capabilities: a live watch silences the nudge
+    and retiring it brings the nudge back."""
+    agent = make_daemon_agent(tmp_path, ["daemon", "task_card"])
+    daemon = agent.get_capability("daemon")
+    card = agent.get_capability("task_card")
+    assert card is agent._task_card_manager
+    assert not card.has_active_watch()
+    assert "no active task_card watch" in daemon._emanate_handoff(2, None)
+
+    started = _start_watch(card, Path(agent._working_dir), max_refreshes=10)
+    assert started["status"] == "ok"
+    assert card.has_active_watch()
+    assert daemon._emanate_handoff(2, None) == DAEMON_ASYNC_HANDOFF
+
+    card.handle(
+        {
+            "action": "stop",
+            "input": {"watch_id": started["watch_id"]},
+            "reasoning": "cleanup",
+        }
+    )
+    assert not card.has_active_watch()
+    assert "no active task_card watch" in daemon._emanate_handoff(2, None)
+
+
+# --- Mechanism 2: expired-watch continuation hint ---
+
+
+def test_expired_watch_event_asks_for_a_new_watch(tmp_path):
+    agent = _FakeAgent(tmp_path)
+    manager = TaskCardManager(agent)
+    assert _start_watch(manager, tmp_path, max_refreshes=1)["status"] == "ok"
+    watch = manager._watch
+    assert watch is not None
+
+    manager._tick(watch)
+
+    limit_wakes = [wake for wake in agent.wakes if wake["source"] == "task_card.limit"]
+    assert len(limit_wakes) == 1
+    body = limit_wakes[0]["body"]
+    assert "reached its refresh limit" in body
+    assert "If this work is still ongoing, start a new watch (task_card action='start')" in body
+    assert "do not let the card go dark mid-task" in body
+
+
+def test_exhausted_watch_reports_itself_inactive(tmp_path):
+    """The nudge is only useful if an exhausted watch stops counting as active."""
+    agent = _FakeAgent(tmp_path)
+    manager = TaskCardManager(agent)
+    assert _start_watch(manager, tmp_path, max_refreshes=1)["status"] == "ok"
+    assert manager.has_active_watch()
+    manager._tick(manager._watch)
+    assert not manager.has_active_watch()
+
+
+# --- Mechanism 3: resident + tool trigger wording ---
+
+
+def test_tool_description_asks_for_a_restart_after_expiry():
+    assert "Restart a new watch when one expires mid-task." in get_description()
+
+
+def test_resident_procedures_name_the_card_worthy_triggers():
+    text = PROCEDURES.read_text(encoding="utf-8")
+    section = text.split("### Task Card Lifecycle", 1)[1].split("\n### ", 1)[0]
+    for fragment in (
+        "multi-daemon fleets",
+        "multi-PR batches",
+        "review→merge",
+        "ten minutes",
+        "`max_refreshes`",
+        "go dark",
+    ):
+        assert fragment in section, f"{fragment!r} missing from Task Card Lifecycle"


### PR DESCRIPTION
## Why

Jason observed that the agent under-uses the Task Card: it opened cards for some
tasks but let them go dark when a watch hit `max_refreshes`, and it ran a
4-daemon parallel fleet (~1h) and a long review→merge flow with no active card
at all. Nothing in the kernel asked for one. This PR makes the kernel prompt for
a card when it clearly matters, and stay quiet otherwise.

Three small, independent mechanisms.

## 1. Daemon fleet nudge (`src/lingtai/tools/daemon/__init__.py`)

The `emanate` success `handoff` — previously one duplicated literal at both the
LingTai and CLI dispatch sites — is now built by `DaemonManager._emanate_handoff`
from a `DAEMON_ASYNC_HANDOFF` constant. For a **card-worthy** dispatch it appends
one sentence:

> You dispatched 4 daemon(s) with no active task_card watch — consider starting
> one (task_card action='start') so a human can follow progress.

Card-worthy = two or more tasks in the batch, **or** an explicitly requested
`timeout` of 900s or more. The nudge is suppressed when a watch is already
running, and when the Task Card capability is disabled.

**Note on the timeout threshold.** The brief said "timeout >= 900s", but the
`emanate` default timeout is 3600s, so keying on the *effective* timeout would
nudge on every single quick daemon — exactly the spam the brief rules out. The
implementation therefore keys on the caller's *explicitly requested* timeout
(threaded through as `requested_timeout`); an omitted timeout never qualifies on
its own. This is documented in the contract and covered by a test.

The active-watch check is a duck-typed read-only probe
(`getattr(agent, "_task_card_manager", None).has_active_watch()`), so daemon
still imports no Task Card runtime code and never starts a watch itself — the
existing contract invariant is preserved. A probe that raises falls back to the
plain handoff.

`TaskCardManager.has_active_watch()` is the new read-only accessor: true only
while one watch is running and not yet stopping/terminated, so an exhausted or
stopped watch correctly reads as inactive.

## 2. Expired-watch continuation hint (`src/lingtai/tools/task_card/__init__.py`)

The `task_card.limit` event body gains a stronger closing line:

> If this work is still ongoing, start a new watch (task_card action='start') —
> do not let the card go dark mid-task.

Only the canonical intrinsic capability was changed. The identical string in
`src/lingtai/mcp_servers/telegram/task_card/controller.py` was deliberately left
alone: its module docstring states it is retained historical compatibility code
from the retired Telegram-owned design, not the current ownership path.

## 3. Resident + tool trigger wording

`src/lingtai/prompts/procedures/procedures.md` — the `Task Card Lifecycle`
section now names concrete triggers (multi-daemon fleets of two or more,
multi-PR batches, long review→merge flows, anything past roughly ten minutes)
and the restart-on-expiry rule, in the existing resident voice.

The `task_card` tool description gains "Restart a new watch when one expires
mid-task."; the task_card manual gains a matching guideline bullet, and the
daemon manual documents the new conditional nudge.

## Docs / governance

- `src/lingtai/tools/daemon/CONTRACT.md` — nudge conditions and the preserved
  no-import invariant; `contract_version` 8 → 9.
- `src/lingtai/tools/task_card/CONTRACT.md` — the limit-event continuation hint
  and the `has_active_watch()` probe; `contract_version` 3 → 4.
- `daemon/manual/SKILL.md` version 0.10.0 → 0.11.0.
- `tests/ANATOMY.md` and both component contracts list the new test file, so the
  no-orphan anatomy rule stays satisfied.

## Tests

New `tests/test_task_card_proactivity.py` (13 tests): fleet nudged; single quick
dispatch silent; default-ceiling single dispatch silent; explicitly-long single
dispatch nudged; active watch suppresses; capability disabled never nudges;
probe failure falls back; thresholds are fleet-scale; end-to-end across both
real capabilities (start a real watch → nudge disappears, stop it → nudge
returns); limit-event body carries the continuation hint; an exhausted watch
reports itself inactive; tool description and resident trigger wording.

`tests/test_daemon.py::test_handle_emanate_dispatches_and_returns_ids` now
asserts the nudged handoff — that 2-task dispatch is a fleet with no watch, and
it is the end-to-end proof the nudge reaches the real dispatch result.

Command: `PYTHONPATH=<worktree>/src python -m pytest <affected> -q -p no:randomly`

- Affected suite (daemon, task_card, telegram/feishu task card, prompt, anatomy,
  source drift, bash async, meta block): **838 passed, 1 failed**.
- The single failure is `test_architecture_documents.py::test_every_tracked_file_climbs_the_anatomy_graph`,
  which **fails identically on main at e9005a7d** for two unrelated files
  (`system-manual/reference/refresh-precheck/SKILL.md`,
  `system-manual/reference/trajectory-mining/SKILL.md`). No new orphans: the new
  test file is reachable.
- Also pre-existing on main and unchanged here: two `tests/test_skills.py`
  failures (`psyche-manual/SKILL.md` missing `last_changed_at`).
