### PR TITLE
fix(daemon): expose email tool to daemon tasks

### DIFF
--- a/src/lingtai/tools/daemon/__init__.py
+++ b/src/lingtai/tools/daemon/__init__.py
@@ -438,6 +438,16 @@ EMANATION_BLACKLIST = {
     "knowledge",
 }
 
+# The daemon-eligible subset of the mandatory intrinsic layer — see
+# ``DaemonManager._daemon_intrinsic_surface``. Email is the sole deliberate
+# exception so a parent can grant a running daemon local-network
+# communication; every other intrinsic (identity/lifecycle/recursive-mutation)
+# stays unavailable. Module-level so both the in-process manager and the
+# detached supervisor's tool-surface composition (``execution_host.py``,
+# which cannot construct a full ``Agent``) wire the exact same set instead of
+# risking drift between two hand-maintained copies.
+DAEMON_ALLOWED_INTRINSICS = frozenset({"email"})
+
 
 def _parent_host_tool_floor() -> frozenset[str]:
     """The always-on host tools a preset emanation may borrow from the parent.
@@ -1575,7 +1585,7 @@ class DaemonManager:
         narrow exception so a parent can grant a running daemon local-network
         communication when the task prompt calls for it.
         """
-        allowed = {"email"}
+        allowed = DAEMON_ALLOWED_INTRINSICS
         schemas: dict[str, FunctionSchema] = {}
         handlers: dict = {}
         for name in sorted(allowed):

--- a/src/lingtai/tools/daemon/execution_host.py
+++ b/src/lingtai/tools/daemon/execution_host.py
@@ -72,7 +72,8 @@ class DetachedDaemonExecutionHost:
         *, capsule: dict | None = None, process_port=None,
         interactive_terminal_port=None,
     ) -> None:
-        from lingtai.tools.daemon import DaemonManager
+        from lingtai.tools.daemon import DaemonManager, DAEMON_ALLOWED_INTRINSICS
+        from lingtai.tools.registry import INTRINSICS
 
         self._run_dir = run_dir
         # Keep the owner events available to the Port observation callback even
@@ -91,6 +92,24 @@ class DetachedDaemonExecutionHost:
             model=(manifest.get("llm") or {}).get("model", "unknown"),
         )
         self._agent._mcp_tool_names = set()
+        # The stub deliberately skips BaseAgent._wire_intrinsics (no full Agent
+        # is constructed here — see DaemonSupervisorAgentStub's docstring), so
+        # wire the one daemon-eligible exception it needs directly:
+        # DaemonManager._daemon_intrinsic_surface reads _intrinsics /
+        # _intrinsic_modules, and email's own handler dereferences
+        # agent._email_manager, so its boot() must run too. Every other
+        # intrinsic (identity/lifecycle/recursive mutation) stays unwired —
+        # DAEMON_ALLOWED_INTRINSICS is the single narrow set, shared with the
+        # in-process manager so the two never drift apart.
+        for _name in DAEMON_ALLOWED_INTRINSICS:
+            _module = INTRINSICS[_name]["module"]
+            self._agent._intrinsic_modules[_name] = _module
+            self._agent._intrinsics[_name] = (
+                lambda args, fn=_module.handle: fn(self._agent, args)
+            )
+            _boot_fn = getattr(_module, "boot", None)
+            if _boot_fn is not None:
+                _boot_fn(self._agent)
         self._max_turns = int(manifest["max_turns"])
         self._timeout = float(manifest["timeout_s"])
         self._default_model = self._agent.service.model

--- a/tests/test_daemon_detached_supervisor.py
+++ b/tests/test_daemon_detached_supervisor.py
@@ -1137,6 +1137,114 @@ def test_detached_file_manifest_injects_file_io(tmp_path):
     assert (parent_working_dir / "detached-probe.txt").read_text(encoding="utf-8") == "file works\n"
 
 
+def test_detached_email_manifest_wires_schema_and_dispatch(tmp_path):
+    """A manifest requesting ``email`` gets a working schema + dispatch.
+
+    ``DetachedDaemonExecutionHost`` composes its tool surface against
+    ``DaemonSupervisorAgentStub``, a bare stand-in that deliberately never runs
+    ``BaseAgent._wire_intrinsics`` (constructing a full ``Agent`` here would
+    fight the parent for its workdir lease). Without wiring the daemon-eligible
+    intrinsic exception onto that stub, every detached run rejected its own
+    manifest-granted ``email`` tool as unknown even though the parent's
+    pre-flight validation — which runs against a real, fully-wired Agent —
+    already accepted it. This exercises the actual detached-process surface,
+    not just the parent-side pre-flight.
+    """
+    from lingtai.tools.daemon.execution_host import DetachedDaemonExecutionHost
+    from threading import Event
+
+    run_dir = _make_run_dir(tmp_path, task="email manifest")
+    parent_working_dir = run_dir.path.parent.parent
+    manifest = build_manifest(
+        run_id=run_dir.run_id, backend="lingtai",
+        parent_working_dir=str(parent_working_dir), run_dir=str(run_dir.path),
+        task="email manifest", tools=["shell", "file", "email"], max_turns=1,
+        timeout_s=30, group_id=None,
+        llm={"provider": "fake", "model": "fake", "api_key": None,
+             "base_url": None, "context_window": None, "provider_defaults": None},
+    )
+
+    host = DetachedDaemonExecutionHost(run_dir, manifest, Event(), Event())
+    schemas, dispatch = host._build_lingtai_surface()
+
+    names = {s.name for s in schemas}
+    assert {"shell", "file", "email"} <= names
+    assert "email" in dispatch
+
+    result = dispatch["email"]({
+        "action": "check",
+        "input": {},
+        "reasoning": "detached email probe",
+    })
+    assert result["status"] == "ok", result
+
+
+def test_detached_preset_manifest_email_requires_explicit_tool(tmp_path):
+    """Preset-path detached runs gate ``email`` the same as the default path.
+
+    Mirrors ``test_build_tool_surface_preset_requires_explicit_email_tool``
+    (test_daemon.py) but through the detached supervisor's own
+    ``_build_lingtai_surface``, which selects the preset branch whenever the
+    manifest carries ``preset_capabilities``.
+    """
+    from lingtai.tools.daemon.execution_host import DetachedDaemonExecutionHost
+    from threading import Event
+
+    run_dir = _make_run_dir(tmp_path, task="preset result only")
+    common_kwargs = dict(
+        parent_working_dir=str(run_dir.path.parent.parent), run_dir=str(run_dir.path),
+        task="preset result only", max_turns=1, timeout_s=30, group_id=None,
+        llm={"provider": "fake", "model": "fake", "api_key": None,
+             "base_url": None, "context_window": None, "provider_defaults": None},
+        preset_llm={"provider": "fake", "model": "fake", "api_key": None,
+                    "base_url": None, "context_window": None, "provider_defaults": None},
+        preset_capabilities={},
+    )
+
+    manifest = build_manifest(run_id=run_dir.run_id, backend="lingtai", tools=[], **common_kwargs)
+    host = DetachedDaemonExecutionHost(run_dir, manifest, Event(), Event())
+    schemas, dispatch = host._build_lingtai_surface()
+    names = {s.name for s in schemas}
+    assert "email" not in names
+    assert "email" not in dispatch
+
+    manifest2 = build_manifest(run_id=run_dir.run_id, backend="lingtai", tools=["email"], **common_kwargs)
+    host2 = DetachedDaemonExecutionHost(run_dir, manifest2, Event(), Event())
+    schemas2, dispatch2 = host2._build_lingtai_surface()
+    names2 = {s.name for s in schemas2}
+    assert "email" in names2
+    assert "email" in dispatch2
+
+
+def test_detached_result_only_manifest_excludes_email(tmp_path):
+    """A result-only manifest (``tools=[]``) must not gain email either.
+
+    Same security posture as the in-process manager's
+    ``test_build_tool_surface_requires_explicit_email_tool``: a daemon that
+    was not explicitly granted ``email`` must stay unable to communicate, on
+    the detached-supervisor path too.
+    """
+    from lingtai.tools.daemon.execution_host import DetachedDaemonExecutionHost
+    from threading import Event
+
+    run_dir = _make_run_dir(tmp_path, task="result only")
+    manifest = build_manifest(
+        run_id=run_dir.run_id, backend="lingtai",
+        parent_working_dir=str(run_dir.path.parent.parent), run_dir=str(run_dir.path),
+        task="result only", tools=[], max_turns=1,
+        timeout_s=30, group_id=None,
+        llm={"provider": "fake", "model": "fake", "api_key": None,
+             "base_url": None, "context_window": None, "provider_defaults": None},
+    )
+
+    host = DetachedDaemonExecutionHost(run_dir, manifest, Event(), Event())
+    schemas, dispatch = host._build_lingtai_surface()
+
+    names = {s.name for s in schemas}
+    assert "email" not in names
+    assert "email" not in dispatch
+
+
 def test_detached_retired_file_tool_names_fail_loudly(tmp_path):
     """A stale manifest naming the retired per-operation tools is rejected.
 


### PR DESCRIPTION
## Summary

- Daemon tasks requesting `tools:['email']` failed at **detached-run time** with `ValueError: Unknown tools for emanation: {'email'}`, even though the parent's own pre-flight validation accepted the request (that check runs against a real, fully-wired `Agent`; the actual run happens in a separate detached supervisor process against a bare `DaemonSupervisorAgentStub` that never wires any intrinsic).
- `DaemonSupervisorAgentStub` deliberately never constructs a full `Agent` (to avoid contending for the parent's workdir lease/heartbeat), so it never ran `BaseAgent._wire_intrinsics()`. It reconstructs `shell`/`file` via `setup_capability`, but nothing wired the one daemon-eligible intrinsic exception (`email`) that `DaemonManager._daemon_intrinsic_surface()` looks for — explaining why `shell`/`file` resolved fine while only `email` was reported "unknown".
- Fix: hoist the existing `allowed = {"email"}` set in `_daemon_intrinsic_surface` into a shared `DAEMON_ALLOWED_INTRINSICS` constant, and wire each entry (module + handler + `boot()`) onto the detached stub the same way `_wire_intrinsics` does for a real agent. No other intrinsic is wired — security posture (identity/lifecycle/recursive-mutation tools stay unavailable; `tools=[]` result-only daemons still get no email) is unchanged.

## Test plan

- [x] New repro confirms the exact reported exception (`ValueError: Unknown tools for emanation: {'email'}`) against `DetachedDaemonExecutionHost._build_lingtai_surface()` on unpatched `origin/main`.
- [x] Added `test_detached_email_manifest_wires_schema_and_dispatch` — schema *and* dispatch both work end-to-end (`email(action='check', ...)` actually returns a result, not just a schema).
- [x] Added `test_detached_preset_manifest_email_requires_explicit_tool` — same contract on the preset branch.
- [x] Added `test_detached_result_only_manifest_excludes_email` — `tools=[]` still excludes email (security-posture regression guard).
- [x] All three fail on unpatched code with the exact reported message; pass after the fix.
- [x] `pytest tests/test_daemon.py tests/test_daemon_detached_supervisor.py tests/test_daemon_preset_capabilities.py tests/test_tool_family_daemon_migration.py tests/ -k "email or daemon"` → 1009 passed, 7 skipped, 3 failed — same 3 failures present on unmodified `origin/main` (unrelated: `task_card` leaking into `_parent_host_tool_floor()`, and two CLI-backend resume/follow-up assertions), no new failures.

Full investigation notes: see the accompanying report generated during this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)