### PR TITLE
fix(doctor): probe cloud_mail addon; fix(git): ignore transient lifecycle signals

### DIFF
--- a/src/lingtai/adapters/posix/git_cli.py
+++ b/src/lingtai/adapters/posix/git_cli.py
@@ -15,7 +15,14 @@ _GITIGNORE = (
     ".sleep\n"
     ".suspend\n"
     ".agent.heartbeat\n"
-    ".timemachine.pid\n"
+    ".refresh\n"
+    ".refresh.taken\n"
+    ".prompt\n"
+    ".clear\n"
+    ".inquiry\n"
+    ".inquiry.taken\n"
+    ".rules\n"
+    ".interrupt\n"
 )
 
 

--- a/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/SKILL.md
@@ -58,7 +58,8 @@ Layered so one broken surface is not mistaken for a dead agent:
    `~/.lingtai-tui/runtime/venv/bin/python` replacements.
 7. **First-party MCP server imports** — if a configured stdio command points at a
    usable Python executable, tries importing the configured LingTai curated MCP
-   modules (`lingtai.mcp_servers.` `telegram`/`feishu`/`wechat`/`whatsapp`/`imap`)
+   modules (`lingtai.mcp_servers.`
+   `telegram`/`feishu`/`wechat`/`whatsapp`/`imap`/`cloud_mail`)
    without reading credentials.
 
 ## Reading the result

--- a/src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
+++ b/src/lingtai/intrinsic_skills/lingtai-doctor/scripts/doctor.py
@@ -44,6 +44,7 @@ ADDON_MODULES = {
     "wechat": "lingtai.mcp_servers.wechat",
     "whatsapp": "lingtai.mcp_servers.whatsapp",
     "imap": "lingtai.mcp_servers.imap",
+    "cloud_mail": "lingtai.mcp_servers.cloud_mail",
 }
 
 

--- a/tests/test_git_init.py
+++ b/tests/test_git_init.py
@@ -60,7 +60,14 @@ def test_start_creates_gitignore(tmp_path):
             ".sleep\n"
             ".suspend\n"
             ".agent.heartbeat\n"
-            ".timemachine.pid\n"
+            ".refresh\n"
+            ".refresh.taken\n"
+            ".prompt\n"
+            ".clear\n"
+            ".inquiry\n"
+            ".inquiry.taken\n"
+            ".rules\n"
+            ".interrupt\n"
         )
         assert gitignore.read_text() == expected
     finally:

--- a/tests/test_lingtai_doctor.py
+++ b/tests/test_lingtai_doctor.py
@@ -111,6 +111,50 @@ def test_lingtai_doctor_addon_timeout_becomes_warning(monkeypatch):
     ]
 
 
+def test_lingtai_doctor_probes_every_curated_addon():
+    """``ADDON_MODULES`` must track ``mcp_catalog.json``.
+
+    An addon missing here is a diagnostic blind spot: a configured entry whose
+    args do not literally carry ``-m lingtai.mcp_servers.<name>`` is never
+    import-probed, so a broken install passes doctor clean.
+    """
+    doctor = load_doctor_module()
+    catalog = json.loads(
+        (ROOT / "src" / "lingtai" / "mcp_catalog.json").read_text(encoding="utf-8")
+    )
+
+    expected = {
+        name: entry["args"][entry["args"].index("-m") + 1]
+        for name, entry in catalog.items()
+        if not name.startswith("_") and "-m" in entry.get("args", [])
+    }
+
+    assert expected, "expected curated stdio addons in mcp_catalog.json"
+    assert doctor.ADDON_MODULES == expected
+
+
+def test_lingtai_doctor_addon_modules_are_importable_packages():
+    doctor = load_doctor_module()
+
+    for name, module in doctor.ADDON_MODULES.items():
+        package = ROOT / "src" / Path(*module.split("."))
+        assert package.is_dir(), f"{name} -> {module} is not a shipped package"
+
+
+def test_lingtai_doctor_skill_doc_lists_every_probed_addon():
+    skill = (
+        ROOT / "src" / "lingtai" / "intrinsic_skills" / "lingtai-doctor" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    doctor = load_doctor_module()
+
+    section = skill.split("**First-party MCP server imports**", 1)
+    assert len(section) == 2, "SKILL.md no longer documents the import probe"
+    probe_text = section[1].split("\n\n", 1)[0]
+
+    for name in doctor.ADDON_MODULES:
+        assert f"`{name}`" in probe_text, f"SKILL.md omits probed addon {name}"
+
+
 def test_lingtai_doctor_type_hints_resolve():
     doctor = load_doctor_module()
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,8 +1,10 @@
 """Observable behavior for Snapshot and SourceRevision Ports."""
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -17,7 +19,8 @@ GITIGNORE_BASELINE = (
     "# Secrets — MCP addon credentials (bot tokens, API keys)\n"
     ".secrets/\n\n"
     "# Transient lifecycle signal files\n"
-    ".sleep\n.suspend\n.agent.heartbeat\n.timemachine.pid\n"
+    ".sleep\n.suspend\n.agent.heartbeat\n"
+    ".refresh\n.refresh.taken\n.prompt\n.clear\n.inquiry\n.inquiry.taken\n.rules\n.interrupt\n"
 )
 SYSTEM_BASELINE = {"covenant.md": "", "principle.md": "", "pad.md": ""}
 
@@ -183,6 +186,59 @@ def test_real_git_snapshot_handles_deletion_and_secret_exclusion(tmp_path):
         text=True,
         check=True,
     ).stdout == ""
+
+
+LIFECYCLE_SIGNAL_FILES = (
+    ".sleep",
+    ".suspend",
+    ".agent.heartbeat",
+    ".refresh",
+    ".refresh.taken",
+    ".prompt",
+    ".clear",
+    ".inquiry",
+    ".inquiry.taken",
+    ".rules",
+    ".interrupt",
+)
+
+
+def test_real_git_snapshot_never_commits_lifecycle_signal_files(tmp_path):
+    """Signal files are transient control state, not agent history.
+
+    ``lifecycle.py`` writes each of these into the same working directory this
+    adapter snapshots with ``git add -A``; a periodic snapshot firing while one
+    is present must not sweep it into the commit.
+    """
+    if shutil.which("git") is None:
+        pytest.skip("real Git behavior lock requires the git executable")
+    adapter = PosixGitCliAdapter(tmp_path)
+    adapter.initialize()
+
+    for name in LIFECYCLE_SIGNAL_FILES:
+        (tmp_path / name).write_text("signal")
+    assert adapter.snapshot() is None
+
+    tracked = subprocess.run(
+        ["git", "ls-files"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    assert [name for name in LIFECYCLE_SIGNAL_FILES if name in tracked] == []
+
+
+def test_lifecycle_signal_file_literals_are_all_ignored():
+    """Guard against a new signal file landing in ``lifecycle.py`` unignored."""
+    source = Path(lifecycle.__file__).read_text(encoding="utf-8")
+    written = {
+        match.group(1)
+        for match in re.finditer(r"_working_dir / \"(\.[A-Za-z.]+)\"", source)
+    }
+    assert written, "expected to find signal-file literals in lifecycle.py"
+    ignored = {line for line in GITIGNORE_BASELINE.splitlines() if line.startswith(".")}
+    assert written <= ignored, f"unignored lifecycle signal files: {written - ignored}"
 
 
 def test_snapshot_swallows_git_absence_and_failure(tmp_path):


### PR DESCRIPTION
## Context

PR **K-1** of the 2026-08-07 kernel/product **staleness audit** (`/tmp/stale-audit/verdict-opus.md`, §3 PR grouping and §5 must-fix P0 shortlist items **3** and **4**). This is the only kernel PR in that audit with a behavioral change; the remaining kernel PRs (K-2…K-4) are documentation-only and land separately.

Both findings were independently re-verified against `c46fad8e` before this change (`verified-1.md`, `verified-2.md`).

## 1. `doctor` never probed `cloud_mail` — P0 diagnostic blind spot

`lingtai-doctor/scripts/doctor.py`'s `ADDON_MODULES` mapped only `telegram`/`feishu`/`wechat`/`whatsapp`/`imap`. `cloud_mail` is the **sixth curated addon** in `src/lingtai/mcp_catalog.json` and ships its own `lingtai-cloud-mail` console entry point.

`collect_mcp()` falls back to `ADDON_MODULES[name]` whenever a configured entry's args don't literally carry `-m lingtai.mcp_servers.<name>` — so a `cloud_mail` entry configured via its entry point was **silently skipped**, and a broken install passed doctor clean.

- `doctor.py` — add `"cloud_mail": "lingtai.mcp_servers.cloud_mail"`.
- `lingtai-doctor/SKILL.md` — "What it checks" item 7 enumerated the same stale five; now lists six.

## 2. Lifecycle signal files leaked into agent git history — P0 data pollution

`PosixGitCliAdapter._GITIGNORE`'s `# Transient lifecycle signal files` block covered only `.sleep`, `.suspend`, `.agent.heartbeat`. `kernel/base_agent/lifecycle.py` writes seven more into **the exact working directory this adapter snapshots with `git add -A`**:

| file | producer |
|---|---|
| `.interrupt` | `lifecycle.py:397` |
| `.refresh` | `lifecycle.py:407`, `refresh_watcher/watcher_program.py` |
| `.refresh.taken` | `lifecycle.py:409`, `lifecycle.py:763` (`touch()`) |
| `.prompt` | `lifecycle.py:448` |
| `.clear` | `lifecycle.py:463` |
| `.inquiry` / `.inquiry.taken` | `lifecycle.py:485-486` |
| `.rules` | `lifecycle.py:873` |

These are unlinked after processing, but a periodic snapshot (Time Machine) firing while one is present sweeps it into the commit — exactly the failure the existing `.sleep`/`.suspend` entries were added to prevent (`548d80bc`).

**Note — one addition beyond the audit list:** the audit enumerated seven files; `.refresh.taken` is included here as an eighth. It is unambiguously created in the working dir (`taken_path_obj.touch()` at `lifecycle.py:763`, plus the `.refresh` → `.refresh.taken` rename), and is the exact twin of the already-listed `.inquiry.taken`. Omitting it would have left the same hole open.

**Also dropped:** `.timemachine.pid`, dead config — a full-repo grep finds no producer, only `git_cli.py` itself and the two tests asserting the literal ignore text.

## Tests

Updated the two existing exact-text baselines (`tests/test_git_init.py`, `tests/test_snapshot.py`) and added four regression locks so neither finding can recur silently:

- `test_lingtai_doctor_probes_every_curated_addon` — pins `ADDON_MODULES` to `mcp_catalog.json`, so a new curated addon that isn't probed fails CI.
- `test_lingtai_doctor_addon_modules_are_importable_packages` — every mapped module is a shipped package.
- `test_lingtai_doctor_skill_doc_lists_every_probed_addon` — pins SKILL.md's probe list to `ADDON_MODULES`.
- `test_real_git_snapshot_never_commits_lifecycle_signal_files` — real-git behavior lock: writes all eleven signal files, snapshots, asserts none become tracked.
- `test_lifecycle_signal_file_literals_are_all_ignored` — scans `lifecycle.py` for `_working_dir / ".<name>"` literals and asserts each is covered by the ignore block, so a *new* signal file cannot land unignored.

Both new locks were verified to fail against the pre-fix code.

```
PYTHONPATH=src python -m pytest tests/ -k 'doctor or git_cli or gitignore or snapshot or git_init or lifecycle or refresh' -q
376 passed, 2 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)