### PR TITLE
chore(kernel): version examples, CI docs, dead i18n (staleness audit)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -76,7 +76,7 @@ jobs:
             exit 0
           fi
           if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::release_tag must be a simple semantic-version tag such as v0.17.1."
+            echo "::error::release_tag must be a simple semantic-version tag such as v0.19.5."
             exit 1
           fi
           tag_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
@@ -207,7 +207,7 @@ jobs:
             exit 0
           fi
           if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::release_tag must be a simple semantic-version tag such as v0.17.1."
+            echo "::error::release_tag must be a simple semantic-version tag such as v0.19.5."
             exit 1
           fi
           tag_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
@@ -270,7 +270,7 @@ jobs:
             exit 0
           fi
           if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::release_tag must be a simple semantic-version tag such as v0.17.1."
+            echo "::error::release_tag must be a simple semantic-version tag such as v0.19.5."
             exit 1
           fi
           tag_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ maintenance: |
 
 **The Python runtime and SDK that powers LingTai agents.**
 
-[![PyPI](https://img.shields.io/pypi/v/lingtai?color=%237dab8f)](https://pypi.org/project/lingtai/)
+[![Release](https://img.shields.io/github/v/release/Lingtai-AI/lingtai-kernel?color=%237dab8f)](https://github.com/Lingtai-AI/lingtai-kernel/releases)
 [![License](https://img.shields.io/github/license/Lingtai-AI/lingtai-kernel?color=%237dab8f)](LICENSE)
 [![Blog](https://img.shields.io/badge/blog-lingtai.ai-%23d4a853)](https://lingtai.ai)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,13 +53,13 @@ which:
    ```json
    {
      "schema": "lingtai.kernel.release/v1",
-     "kernel_version": "0.16.4",
-     "kernel_tag": "v0.16.4",
+     "kernel_version": "0.19.5",
+     "kernel_tag": "v0.19.5",
      "commit": "<full 40-char sha>",
-     "generated_at": "2026-07-15T00:00:00Z",
+     "generated_at": "2026-08-07T00:00:00Z",
      "artifacts": [
        {
-         "filename": "lingtai-0.16.4-cp312-cp312-macosx_11_0_arm64.whl",
+         "filename": "lingtai-0.19.5-cp312-cp312-macosx_11_0_arm64.whl",
          "sha256": "<64-char hex>",
          "kind": "wheel",
          "python_tag": "cp312",
@@ -67,7 +67,7 @@ which:
          "platform_tag": "macosx_11_0_arm64"
        },
        {
-         "filename": "lingtai-0.16.4.tar.gz",
+         "filename": "lingtai-0.19.5.tar.gz",
          "sha256": "<64-char hex>",
          "kind": "sdist",
          "python_tag": null,
@@ -75,7 +75,7 @@ which:
          "platform_tag": null
        }
      ],
-     "sdist_fallback": "lingtai-0.16.4.tar.gz"
+     "sdist_fallback": "lingtai-0.19.5.tar.gz"
    }
    ```
 
@@ -133,7 +133,7 @@ always triggers a fail-loud error before upload planning completes.
 # ./release-assets, then:
 python scripts/generate_release_manifest.py \
   --assets-dir release-assets \
-  --kernel-version 0.16.4 --kernel-tag v0.16.4 \
+  --kernel-version 0.19.5 --kernel-tag v0.19.5 \
   --commit "$(git rev-parse HEAD)" \
   --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   --out-manifest release-assets/lingtai-kernel-release-manifest.json \

--- a/docs.yaml
+++ b/docs.yaml
@@ -61,7 +61,7 @@ related_files:
 maintenance: |
   This file is the canonical, machine-readable authoring template and
   validation contract for every Markdown document in the repository — all
-  244 candidates, with zero path-level content exemptions. A change to
+  304 candidates, with zero path-level content exemptions. A change to
   required_fields, field_constraints, metadata_modes,
   metadata_mode_overrides, placeholder_patterns, or lifecycle_contract requires
   updating scripts/check_docs_governance.py and tests/test_docs_governance.py

--- a/docs/plans/2026-06-25-fsutil-migration.md
+++ b/docs/plans/2026-06-25-fsutil-migration.md
@@ -61,19 +61,19 @@ These are migration *candidates*, not a commitment to change every one.
 - [x] `workdir.py::WorkingDir.write_manifest` (`.agent.json`) — **migrated here**
 - [x] `base_agent/__init__.py::_write_status_snapshot` (`.status.json`) — migrated with byte-parity coverage and opt-in existing-mode retention
 - [ ] `workdir.py::write_resolved_manifest` (`manifest.resolved.json`, trailing newline → pass explicit newline or keep inline)
-- [ ] notification files (`.notification/*.json`)
-- [ ] `intrinsics/email/primitives.py` message/`message.json` writes (currently direct `write_text`; some non-contact paths can escape non-ASCII)
-- [ ] `intrinsics/email/manager.py` contact persistence (already atomic via `mkstemp`+`os.replace`; migrate for consistency)
+- [x] notification files (`.notification/*.json`) — migrated to `atomic_write_json` (`adapters/posix/notification_store.py`)
+- [ ] `tools/email/primitives.py` message/`message.json` writes (currently direct `write_text`; some non-contact paths can escape non-ASCII)
+- [ ] `tools/email/manager.py` contact persistence (already atomic via `mkstemp`+`os.replace`; migrate for consistency)
 
 ### Stage 2 — ledgers / append-only logs
-- [ ] `token_ledger.py` append (also mirrors to sqlite via returned offset — keep offset contract)
+- [x] `token_ledger.py` append — migrated to `append_jsonl`/`iter_jsonl_records` (also mirrors to sqlite via returned offset — offset contract kept)
 - [ ] soul-flow / event JSONL writers
 - [ ] `tool_result_recovery.py` JSONL read/reverse-tail
 - [ ] runtime log JSONL recovery paths
 
 ### Stage 3 — broader writes + retire local helpers
 - [ ] `migrate/*.py` write/replace sites
-- [ ] `intrinsics/soul/config.py`, psyche snapshot/molt/archive writers
+- [ ] `tools/soul/config.py`, psyche snapshot/molt/archive writers
 - [ ] remaining `read_json(default=...)`-style local readers → `_fsutil.read_json`
 
 Each checkbox above should land as (or within) its own PR with format-parity

--- a/docs/plans/2026-07-14-powershell-adapter-readiness.md
+++ b/docs/plans/2026-07-14-powershell-adapter-readiness.md
@@ -82,7 +82,7 @@ base; the preserved old-base worktree is snapshot evidence only.
 | External daemon CLI backends | **CORE MECHANISM LEAK** | Backend argv/parsing and process supervision are still directly coupled to `Popen` and POSIX process-group termination. Migrate one headless backend family at a time. The in-process LingTai backend is a separate portable sub-surface. |
 | Avatar launcher | **CORE MECHANISM LEAK** | Validation, boot handshake, and ledger policy are independent, but launch still directly owns POSIX detached-process mechanics. |
 | Interactive daemon / PTY | **DEFERRED** | ConPTY and interactive Claude are a third axis. They do not block the headless support tier. |
-| Windows composition profile | **WIRING GAP** | Create the profile only after capability-native boundaries exist. Reuse portable filesystem adapters and register genuine Windows lease/shell/process implementations. |
+| Windows composition profile | **SELECTOR-WIRED / native acceptance pending** | Reuse portable filesystem adapters and register genuine Windows lease/shell/process implementations. `select_workdir_lease`, `select_refresh_watcher`, `select_avatar_launcher`, `select_shell_dialect`, `select_shell_async_process`, and `select_shell_state_lock` all register their Windows adapters (`WindowsWorkdirLeaseAdapter`, `WindowsRefreshWatcherAdapter`, `WindowsAvatarLauncherAdapter`, `PowerShellDialect`, `WindowsShellAsyncProcessAdapter`, `WindowsShellStateLockAdapter`) as of 2026-08-04–2026-08-07, and the Windows sync run path in `tools/bash/__init__.py` uses `adapters/windows/win32_job.py` for Job-Object process containment. The remaining gap is native acceptance/certification testing, not selector wiring. |
 
 ## Dependency-ordered stages
 
@@ -136,9 +136,13 @@ ranges and one current-main baseline citation were repaired and revalidated.
 **Stage 2 candidate evidence (2026-07-14):** an exact-worktree parent run with
 the repository venv recorded **140 passed in 18.42s** across the new shell
 contract plus the existing synchronous and asynchronous Bash suites.
-`git diff --check` and targeted compile checks were clean. The actual PowerShell
-adapter is deferred to Stage 6, after Stage 3 process supervision exists. Every
-dialect must provide its own policy parser and may not silently bypass policy.
+`git diff --check` and targeted compile checks were clean. At the time of this
+stage the actual PowerShell adapter was deferred to Stage 6, after Stage 3
+process supervision exists; it has since landed at
+`src/lingtai/adapters/windows/powershell.py` and
+`src/lingtai/adapters/windows/powershell_process.py` (see Stage 6 wiring
+status below). Every dialect must provide its own policy parser and may not
+silently bypass policy.
 
 ### Stage 3 — separate Bash asynchronous process supervision
 
@@ -147,9 +151,13 @@ dialect must provide its own policy parser and may not silently bypass policy.
 - [x] Keep durable leases, reminders, poll/cancel state, and terminal-result
   fidelity in the existing policy layer.
 - [x] Wire POSIX process groups and the Bash-local state lock as production
-  adapters. Windows Job Object and Windows state-lock implementations are
-  intentionally deferred to Stage 6, where Windows composition and native
-  acceptance register and certify them behind these fixed contracts.
+  adapters. At the time of this stage, Windows Job Object and Windows
+  state-lock implementations were intentionally deferred to Stage 6, where
+  Windows composition and native acceptance register and certify them behind
+  these fixed contracts; they have since landed at
+  `src/lingtai/adapters/windows/win32_job.py` and
+  `src/lingtai/adapters/windows/powershell_state_lock.py` (see Stage 6 wiring
+  status below).
 
 Stage 3 does not claim Windows process or locking support; its dependency
 correction is to cut and certify the Bash-local contracts and POSIX production
@@ -219,9 +227,10 @@ support remain pending.
   boot policy.
 - [x] Move only interpreter launch, detachment, liveness, and termination behind
   an avatar-local launcher Port.
-- [ ] Add a Windows launcher adapter. This re-cut intentionally keeps only the
-  POSIX reference adapter and the fail-loud selector; no controlled-double or
-  native Windows acceptance is evidence of Windows support.
+- [x] Add a Windows launcher adapter. This re-cut intentionally kept only the
+  POSIX reference adapter and the fail-loud selector at the time; a Windows
+  adapter (`adapters/windows/avatar_launcher.py`) has since landed and
+  `select_avatar_launcher` now registers it (2026-08-07).
 
 Stage 5 parent-validated candidate evidence (2026-07-15): the shared launcher
 Contract covered the POSIX reference adapter; focused avatar/rules/preset/timezone
@@ -235,8 +244,14 @@ wiring, and acceptance test; native Windows support remains pending Stage 6.
 
 - [ ] Reuse the portable LifecycleClock, AgentPresence, MailTransport,
   MigrationWorkspace, NotificationStore, and other proven portable adapters.
-- [ ] Register genuine Windows implementations for WorkdirLease, ShellDialect,
-  process supervision, RefreshWatcher, and avatar launch.
+- [x] Register genuine Windows implementations for WorkdirLease, ShellDialect,
+  process supervision, RefreshWatcher, and avatar launch. All five are now
+  registered via their composition-root selectors (`select_workdir_lease`,
+  `select_shell_dialect`, `select_shell_async_process`,
+  `select_shell_state_lock`, `select_refresh_watcher`,
+  `select_avatar_launcher`, landed 2026-08-04 through 2026-08-07); the
+  remaining Stage 6 work is native acceptance/certification, not selector
+  wiring.
 - [ ] Keep compatibility-preserving neutral adapter renames/re-homing inside this
   production composition slice, not in standalone rename PRs.
 - [ ] Run native acceptance in tiers:

--- a/docs/readmes/README.wen.md
+++ b/docs/readmes/README.wen.md
@@ -53,9 +53,13 @@ uv pip install -e . pytest
 
 ## 架构与开发者门径
 
+凡欲改此仓者，编码代理宜先寻而读本仓本地之开发指南技艺；此技艺统其工作之流，导诸事至下列门径，而不重复 Anatomy 或 Contract 之体系。
+
 | 门径 | 所涵 |
 |---|---|
-| [`ANATOMY.md`](../../ANATOMY.md) | 仓之舆图——顶层之布局，暨各子系统解剖所始之处。 |
+| [`dev-guide-skill/SKILL.md`](../../dev-guide-skill/SKILL.md) | 必行之仓本地开发指南技艺：编码代理改动之前所必循之开发流程。 |
+| [`ANATOMY.md`](../../ANATOMY.md) | 仓之舆图——顶层之布局，暨各子系统解剖所始之处，及其如何联至行为之 Contract。 |
+| [`CONTRACT.md`](../../CONTRACT.md) | 规范之接口与行为之诺，暨受治组件配对归属之则，与 Anatomy 之构相联。 |
 | [`src/lingtai/kernel/ANATOMY.md`](../../src/lingtai/kernel/ANATOMY.md) | 核心之运行时：`BaseAgent`、轮次与生灭、工具之机、书信、LLM 之约。 |
 | [`src/lingtai/ANATOMY.md`](../../src/lingtai/ANATOMY.md) | `lingtai` 之包：`Agent(BaseAgent)`、诸能、预设、CLI、公开之重导。 |
 | [`src/lingtai/tools/ANATOMY.md`](../../src/lingtai/tools/ANATOMY.md) | 具体之内置工具，暨组合诸工具之注册表。 |

--- a/docs/readmes/README.zh.md
+++ b/docs/readmes/README.zh.md
@@ -53,9 +53,13 @@ uv pip install -e . pytest
 
 ## 架构 / 开发者入口
 
+在修改任何内容之前，编码代理应首先查找并阅读本仓库本地的开发指南技能；它统领工作流程，并将各项任务导向下方链接的入口点，而不重复 Anatomy 或 Contract 体系。
+
 | 入口 | 涵盖内容 |
 |---|---|
-| [`ANATOMY.md`](../../ANATOMY.md) | 仓库地图——顶层布局，以及各子系统的解剖从何处开始。 |
+| [`dev-guide-skill/SKILL.md`](../../dev-guide-skill/SKILL.md) | 强制性的仓库本地开发指南技能：编码代理在修改前必须遵循的开发工作流程。 |
+| [`ANATOMY.md`](../../ANATOMY.md) | 仓库地图——顶层布局，以及各子系统的解剖从何处开始，并如何联结到其行为 Contract。 |
+| [`CONTRACT.md`](../../CONTRACT.md) | 规范性的接口/行为承诺，以及受治理组件配对/归属规则，与 Anatomy 结构相链接。 |
 | [`src/lingtai/kernel/ANATOMY.md`](../../src/lingtai/kernel/ANATOMY.md) | 核心运行时：`BaseAgent`、轮次/生命周期、工具机制、信件、LLM 协议。 |
 | [`src/lingtai/ANATOMY.md`](../../src/lingtai/ANATOMY.md) | `lingtai` 包：`Agent(BaseAgent)`、能力、预设、CLI、公开重导出。 |
 | [`src/lingtai/tools/ANATOMY.md`](../../src/lingtai/tools/ANATOMY.md) | 具体的内置工具，以及组合它们的注册表。 |

--- a/reports/kernel-release-v0.15.2-20260627/release-report.md
+++ b/reports/kernel-release-v0.15.2-20260627/release-report.md
@@ -37,8 +37,10 @@ A first full run without `PYTHONPATH=src` produced three subprocess import failu
 ```
 
 ## Publish checklist
-- [ ] Version/report/cap PR merged
-- [ ] GitHub release `v0.15.2` published
-- [ ] PyPI `lingtai 0.15.2` uploaded and verified
-- [ ] Release URLs verified
+This checklist reflects a pre-publish snapshot; the release has since completed
+(release commits `95bb06ef`, `603e5d85`; tag `v0.15.2`).
+- [x] Version/report/cap PR merged
+- [x] GitHub release `v0.15.2` published — https://github.com/Lingtai-AI/lingtai-kernel/releases/tag/v0.15.2
+- [x] ~~PyPI `lingtai 0.15.2` uploaded and verified~~ — not applicable; RELEASING.md's non-goals establish no PyPI publication for this package
+- [x] Release URLs verified
 - [x] Local validation caveat recorded

--- a/scripts/check_docs_governance.py
+++ b/scripts/check_docs_governance.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Standalone docs-governance validator (not a hosted CI workflow — this
-repository has no PR-triggered pytest workflow today; only wheels.yml
-exists, release-triggered, no test step). Runnable locally/anywhere and
-imported by tests/test_docs_governance.py so pytest exercises identical
-logic.
+"""Standalone docs-governance validator (not itself a hosted CI workflow —
+kernel-windows-pr.yml and shell-windows-pr.yml already run pytest on every
+pull request; this script is runnable locally/anywhere and imported by
+tests/test_docs_governance.py so pytest exercises identical logic.
 
 docs.yaml is mechanically authoritative. related_files.target_policy is
 owner_validated_relative_link: this checker validates syntax (non-empty,

--- a/scripts/generate_release_manifest.py
+++ b/scripts/generate_release_manifest.py
@@ -6,8 +6,8 @@ one flat directory):
 
     python scripts/generate_release_manifest.py \\
         --assets-dir ./release-assets \\
-        --kernel-version 0.16.4 \\
-        --kernel-tag v0.16.4 \\
+        --kernel-version 0.19.5 \\
+        --kernel-tag v0.19.5 \\
         --commit "$GITHUB_SHA" \\
         --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \\
         --out-manifest ./release-assets/lingtai-kernel-release-manifest.json \\
@@ -144,8 +144,8 @@ def write_sha256sums(manifest: ReleaseManifest, out_path: Path) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--assets-dir", type=Path, required=True, help="directory containing built .whl/.tar.gz files")
-    parser.add_argument("--kernel-version", required=True, help="PEP 440 version, e.g. 0.16.4")
-    parser.add_argument("--kernel-tag", required=True, help="release tag, e.g. v0.16.4")
+    parser.add_argument("--kernel-version", required=True, help="PEP 440 version, e.g. 0.19.5")
+    parser.add_argument("--kernel-tag", required=True, help="release tag, e.g. v0.19.5")
     parser.add_argument("--commit", required=True, help="full git commit SHA the release was built from")
     parser.add_argument("--generated-at", required=True, help="UTC ISO8601 timestamp, injected by the caller")
     parser.add_argument("--out-manifest", type=Path, required=True)

--- a/scripts/sync_gitee_mirror.py
+++ b/scripts/sync_gitee_mirror.py
@@ -26,7 +26,7 @@ Usage:
     export GITEE_ACCESS_TOKEN=...  # never echo or log this
     python scripts/sync_gitee_mirror.py \\
         --owner huangzesen1997 --repo lingtai-kernel \\
-        --commit <full-sha> --tag v0.16.4 --branch main \\
+        --commit <full-sha> --tag v0.19.5 --branch main \\
         --execute
 """
 from __future__ import annotations
@@ -131,7 +131,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--owner", default="huangzesen1997")
     parser.add_argument("--repo", default="lingtai-kernel")
     parser.add_argument("--commit", required=True, help="full commit SHA to synchronize")
-    parser.add_argument("--tag", required=True, help="release tag to synchronize, e.g. v0.16.4")
+    parser.add_argument("--tag", required=True, help="release tag to synchronize, e.g. v0.19.5")
     parser.add_argument("--branch", default="main")
     parser.add_argument("--username", help="Gitee HTTPS username; defaults to --owner")
     parser.add_argument("--token-env", default="GITEE_ACCESS_TOKEN", help="env var holding the Gitee token; never printed")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ two extra steps into the standard ``setuptools.build_meta`` flow:
    distribution reports ``has_ext_modules()`` *before* superclass layout
    finalization. That single predicate drives the platform tag
    (``root_is_pure=False`` → e.g.
-   ``lingtai-0.10.10-cp311-cp311-macosx_14_0_arm64.whl``) *and* the install
+   ``lingtai-0.19.5-cp311-cp311-macosx_14_0_arm64.whl``) *and* the install
    scheme, so every package — including the bundled binary under
    ``lingtai/bin/`` — lands at the archive root (platlib) instead of under
    ``<name>-<ver>.data/purelib/``. The latter placement is what auditwheel

--- a/src/lingtai/kernel/i18n/ANATOMY.md
+++ b/src/lingtai/kernel/i18n/ANATOMY.md
@@ -26,7 +26,7 @@ The kernel's message catalog — a flat key-value string table covering system n
   - `_load(lang)` (`i18n/__init__.py:22-30`) — loads and caches a locale file; returns `{}` if the JSON file is missing.
   - `register_strings(lang, strings)` (`i18n/__init__.py:33-41`) — additive merge of external strings into `_CACHE`; its docstring names the wrapper as the caller.
   - `t(lang, key, **kwargs)` (`i18n/__init__.py:44-60`) — loads the locale, looks up the key, falls back to English, then to the raw key string, and formats with `defaultdict(str, kwargs)`.
-- `en.json` — English (baseline). ~80 keys across 7 prefixes: `system.`, `soul.`, `insight.`, `psyche.`, `system_tool.`, `tool.`, `email.`.
+- `en.json` — English (baseline). **7 keys across 2 prefixes**: `system.`, `insight.`. Other prefixes referenced by callers below (`soul.`, `context.`, `system_tool.`, `email.`) are not in this file — they are registered into the shared `_CACHE` at runtime by the tools bridge (see "Inbound — tools bridge" below), not shipped as kernel-owned disk defaults.
 - `zh.json` — 中文. Mirror of en.json; same key set.
 - `wen.json` — 文言. Mirror of en.json in Classical Chinese register; same key set.
 

--- a/src/lingtai/kernel/i18n/en.json
+++ b/src/lingtai/kernel/i18n/en.json
@@ -2,10 +2,8 @@
   "system.current_time": "[Current time: {time} | context: {ctx}]",
   "system.context_breakdown": "{pct} (sys {sys} + ctx {ctx})",
   "system.context_unknown": "unavailable",
-  "system.new_mail.no_subject": "(no subject)",
   "system.mail_bounce": "[system] Mail delivery failed: {error}\n  To: {address}\n  Subject: {subject}",
   "system.stuck_revive": "[system] LLM call failed at {ts}. Last error: {err_desc}. Retrying.",
-  "system.molt_wiped": "[system] Molt complete. Working memory is empty. If you want to retrieve some prior context, check logs/events.jsonl — the file is large, so grep/tail/filter rather than dumping it whole.",
   "insight.auto_question": "You are producing insights for the human operator. Based on everything in this conversation — the task, the context, domain knowledge, risks, and opportunities — produce exactly 2-3 bullet points of things the human would benefit from knowing. Each bullet should be a concrete, specific insight: a pattern you've noticed, relevant background knowledge, a risk they may not see, or an opportunity to explore. Format: start each bullet with '- ' on its own line. No preamble, no summary — just the bullets.",
   "system.refresh_successful": "[system] Refresh successful. Tools and configuration reloaded. You may continue."
 }

--- a/src/lingtai/kernel/i18n/wen.json
+++ b/src/lingtai/kernel/i18n/wen.json
@@ -2,10 +2,8 @@
   "system.current_time": "[此时：{time} | 上下文：{ctx}]",
   "system.context_breakdown": "{pct} (系统 {sys} + 对话 {ctx})",
   "system.context_unknown": "未知",
-  "system.new_mail.no_subject": "（无题）",
   "system.mail_bounce": "[系统] 书信未达：{error}\n  收者：{address}\n  题：{subject}",
   "system.stuck_revive": "[系统] 灵识于 {ts} 失联。汝所调之器：{err_desc}。正在重连。",
-  "system.molt_wiped": "[系统] 凝蜕毕。工作记忆已空。欲寻前事，查 logs/events.jsonl——其文浩繁，宜 grep、tail、按类筛之，勿整取。",
   "insight.auto_question": "为人主生洞见。据此对话之一切——任务、背景、识见、险机——列二三要点，皆人主所宜知者。每条须具体：所察之理、相关之识、未见之险、可乘之机。格式：每条以'- '起，独占一行。勿加前言，勿加总结——唯列要点。",
   "system.refresh_successful": "[system] 更衣已成。器用与配置俱已重载。可续前事。"
 }

--- a/src/lingtai/kernel/i18n/zh.json
+++ b/src/lingtai/kernel/i18n/zh.json
@@ -2,10 +2,8 @@
   "system.current_time": "[此时：{time} | 上下文：{ctx}]",
   "system.context_breakdown": "{pct} (系统 {sys} + 对话 {ctx})",
   "system.context_unknown": "未知",
-  "system.new_mail.no_subject": "（无主题）",
   "system.mail_bounce": "[系统] 消息投递失败：{error}\n  收件人：{address}\n  主题：{subject}",
   "system.stuck_revive": "[系统] LLM 调用于 {ts} 失败。最近错误：{err_desc}。正在重试。",
-  "system.molt_wiped": "[系统] 凝蜕毕。工作记忆已空。若欲寻前事，查 logs/events.jsonl——其文甚巨，宜 grep / tail / 按类筛，切勿整取。",
   "insight.auto_question": "你正在为人类操作者生成洞察。基于本次对话中的一切——任务、背景、领域知识、风险和机会——给出恰好2-3条对人类有益的要点。每条应是具体的洞察：你注意到的规律、相关的背景知识、他们可能未察觉的风险、或值得探索的机会。格式：每条以'- '开头，独占一行。不要前言，不要总结——只给要点。",
   "system.refresh_successful": "[system] 沐浴成功。工具与配置已重新加载。可以继续。"
 }


### PR DESCRIPTION
## Summary

Part of the K-4 slice of the kernel-side staleness audit (`~21 findings`, P2).

- Bump stale version examples (`v0.16.4` / `v0.10.10` / `v0.17.1` → current `0.19.5` series) in `wheels.yml`, `RELEASING.md`, `README.md`, `setup.py`, `sync_gitee_mirror.py`, and `generate_release_manifest.py`.
- Swap `README.md`'s PyPI badge for a GitHub Releases badge — it contradicted `RELEASING.md`'s explicit "No PyPI publication" policy, and no PyPI publish step exists anywhere in CI.
- Correct `check_docs_governance.py`'s docstring claim that no PR-triggered pytest workflow exists — `kernel-windows-pr.yml` and `shell-windows-pr.yml` both already run pytest on `pull_request`.
- Refresh `docs.yaml`'s stale "244 candidates" tracked-markdown-file count to the current `304` (verified via `git ls-files | grep -c '\.md$'`, which matches the checker's own discovery logic).
- Check off `docs/plans/2026-06-25-fsutil-migration.md` and `docs/plans/2026-07-14-powershell-adapter-readiness.md` items that have since landed in production code (notification-store atomic writes, token-ledger JSONL helpers, Windows workdir-lease/refresh-watcher/avatar-launcher selector wiring), and correct stale `intrinsics/email`/`intrinsics/soul` paths to their current `tools/email`/`tools/soul` locations.
- Mark the `v0.15.2` release report's publish checklist as the completed release it now documents (release commits `95bb06ef`/`603e5d85`, tag `v0.15.2`, verified via `gh release view`).
- Sync `README.zh.md` and `README.wen.md`'s architecture entry-point tables with `README.md` — both were missing the `dev-guide-skill/SKILL.md` and `CONTRACT.md` rows plus the intro paragraph.
- Drop the dead i18n keys `system.molt_wiped` and `system.new_mail.no_subject` from `src/lingtai/kernel/i18n/{en,zh,wen}.json` — zero code references, superseded by the `tools/i18n` catalog. **Split into its own commit** so it can be reverted independently if a downstream consumer surfaces.

## Test plan

- [x] `python3 -m json.load` sanity check on all three edited i18n files
- [x] `python3 -m pytest tests/test_i18n.py` — 3 pre-existing failures unrelated to this change (unrelated `knowledge.preamble`/`skills.preamble` keys), reproduced identically on `origin/main` before this branch
- [x] `python3 scripts/check_docs_governance.py --check` — 3 pre-existing unrelated failures (feishu reference docs missing frontmatter), reproduced identically on `origin/main`
- [x] `python3 -m pytest tests/test_docs_governance.py tests/test_architecture_documents.py` — same 3 pre-existing unrelated failures reproduced on `origin/main`, no new failures introduced by this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)