### PR TITLE
feat(telegram): taskcard device footer + interactive settings menu

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -403,16 +403,20 @@ class TaskCardEventProjection:
         if context_line:
             lines.append(context_line)
 
-        # Device identity line: physical path + short host name make the card
-        # self-identifying. Both values pass through the same machine-identifier
-        # allowlist used for API error rows so path/name content stays printable
-        # and bounded. Missing or malformed values simply omit the line.
+        # Device identity line: short host name, shell dialect, and physical
+        # path make the card self-identifying. All values pass through the
+        # same machine-identifier allowlist used for API error rows so
+        # path/name content stays printable and bounded. Missing or malformed
+        # values simply omit the line (partial identity still renders).
         device_parts: list[str] = []
         device = cls.machine_identifier(
             metadata.get("device_short_name"), limit=64
         )
         if device is not None:
             device_parts.append(device)
+        shell_name = cls.machine_identifier(metadata.get("shell_name"), limit=48)
+        if shell_name is not None:
+            device_parts.append(f"shell {shell_name}")
         working_dir = cls.machine_identifier(metadata.get("working_dir"), limit=180)
         if working_dir is not None:
             device_parts.append(working_dir)

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -22,8 +22,8 @@ class TaskCardEventProjection:
         "/taskcard N sets normal rows (1-10"
     )
     DEFAULT_NORMAL_ROWS = 1
-    METADATA_MAX_CHARS = 150
-    METADATA_MAX_LINES = 2
+    METADATA_MAX_CHARS = 260
+    METADATA_MAX_LINES = 3
     TIME_PREFIX = "Last Updated: "
     AGENT_STATES = frozenset(state.value for state in AgentState)
 
@@ -402,6 +402,23 @@ class TaskCardEventProjection:
             lines.append(session_line)
         if context_line:
             lines.append(context_line)
+
+        # Device identity line: physical path + short host name make the card
+        # self-identifying. Both values pass through the same machine-identifier
+        # allowlist used for API error rows so path/name content stays printable
+        # and bounded. Missing or malformed values simply omit the line.
+        device_parts: list[str] = []
+        device = cls.machine_identifier(
+            metadata.get("device_short_name"), limit=64
+        )
+        if device is not None:
+            device_parts.append(device)
+        working_dir = cls.machine_identifier(metadata.get("working_dir"), limit=180)
+        if working_dir is not None:
+            device_parts.append(working_dir)
+        if device_parts:
+            lines.append("device · " + " · ".join(device_parts))
+
         lines = lines[: cls.METADATA_MAX_LINES]
         if not lines:
             return []
@@ -541,7 +558,7 @@ class TaskCardEventProjection:
         value = value.strip()
         if not value or len(value) > limit:
             return None
-        safe_punctuation = frozenset("._:/-")
+        safe_punctuation = frozenset("._:/\\-")
         if not all(
             ch.isascii() and (ch.isalnum() or ch in safe_punctuation) for ch in value
         ):

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -22,8 +22,8 @@ class TaskCardEventProjection:
         "/taskcard N sets normal rows (1-10"
     )
     DEFAULT_NORMAL_ROWS = 1
-    METADATA_MAX_CHARS = 260
-    METADATA_MAX_LINES = 3
+    METADATA_MAX_CHARS = 400
+    METADATA_MAX_LINES = 5
     TIME_PREFIX = "Last Updated: "
     AGENT_STATES = frozenset(state.value for state in AgentState)
 
@@ -395,7 +395,14 @@ class TaskCardEventProjection:
         context_line = "ctx · " + " · ".join(context_parts) if context_parts else None
         lines: list[str] = []
         if agent_line and session_line:
-            lines.append(f"{agent_line} · {session_line}")
+            # One compact line when the session is empty-ish; otherwise keep
+            # the agent status on its own line so long session telemetry does
+            # not push it past the card width.
+            if len(session_line) > 60:
+                lines.append(agent_line)
+                lines.append(session_line)
+            else:
+                lines.append(f"{agent_line} · {session_line}")
         elif agent_line:
             lines.append(agent_line)
         elif session_line:
@@ -403,25 +410,23 @@ class TaskCardEventProjection:
         if context_line:
             lines.append(context_line)
 
-        # Device identity line: short host name, shell dialect, and physical
-        # path make the card self-identifying. All values pass through the
-        # same machine-identifier allowlist used for API error rows so
-        # path/name content stays printable and bounded. Missing or malformed
-        # values simply omit the line (partial identity still renders).
-        device_parts: list[str] = []
+        # Device identity: short host name + shell dialect + physical path.
+        # Each value passes through the machine-identifier allowlist; the path
+        # is its own line so a long working dir cannot crowd the name/shell.
         device = cls.machine_identifier(
             metadata.get("device_short_name"), limit=64
         )
-        if device is not None:
-            device_parts.append(device)
         shell_name = cls.machine_identifier(metadata.get("shell_name"), limit=48)
-        if shell_name is not None:
-            device_parts.append(f"shell {shell_name}")
-        working_dir = cls.machine_identifier(metadata.get("working_dir"), limit=180)
+        if device is not None or shell_name is not None:
+            parts: list[str] = []
+            if device is not None:
+                parts.append(device)
+            if shell_name is not None:
+                parts.append(f"shell {shell_name}")
+            lines.append("device · " + " · ".join(parts))
+        working_dir = cls.machine_identifier(metadata.get("working_dir"), limit=220)
         if working_dir is not None:
-            device_parts.append(working_dir)
-        if device_parts:
-            lines.append("device · " + " · ".join(device_parts))
+            lines.append(f"path · {working_dir}")
 
         lines = lines[: cls.METADATA_MAX_LINES]
         if not lines:

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -22,8 +22,8 @@ class TaskCardEventProjection:
         "/taskcard N sets normal rows (1-10"
     )
     DEFAULT_NORMAL_ROWS = 1
-    METADATA_MAX_CHARS = 400
-    METADATA_MAX_LINES = 5
+    METADATA_MAX_CHARS = 500
+    METADATA_MAX_LINES = 2
     TIME_PREFIX = "Last Updated: "
     AGENT_STATES = frozenset(state.value for state in AgentState)
 
@@ -393,26 +393,20 @@ class TaskCardEventProjection:
             "session · " + " · ".join(session_parts) if session_parts else None
         )
         context_line = "ctx · " + " · ".join(context_parts) if context_parts else None
-        lines: list[str] = []
+        # One compact footer line: groups separated by "|" so each group stays
+        # readable without forcing line breaks (the card stays narrow on
+        # Telegram). Physical path rides in the last group so a long working
+        # dir cannot crowd the identity.
+        groups: list[str] = []
         if agent_line and session_line:
-            # One compact line when the session is empty-ish; otherwise keep
-            # the agent status on its own line so long session telemetry does
-            # not push it past the card width.
-            if len(session_line) > 60:
-                lines.append(agent_line)
-                lines.append(session_line)
-            else:
-                lines.append(f"{agent_line} · {session_line}")
+            groups.append(f"{agent_line} · {session_line}")
         elif agent_line:
-            lines.append(agent_line)
+            groups.append(agent_line)
         elif session_line:
-            lines.append(session_line)
+            groups.append(session_line)
         if context_line:
-            lines.append(context_line)
+            groups.append(context_line)
 
-        # Device identity: short host name + shell dialect + physical path.
-        # Each value passes through the machine-identifier allowlist; the path
-        # is its own line so a long working dir cannot crowd the name/shell.
         device = cls.machine_identifier(
             metadata.get("device_short_name"), limit=64
         )
@@ -423,13 +417,13 @@ class TaskCardEventProjection:
                 parts.append(device)
             if shell_name is not None:
                 parts.append(f"shell {shell_name}")
-            lines.append("device · " + " · ".join(parts))
+            groups.append("device · " + " · ".join(parts))
         working_dir = cls.machine_identifier(metadata.get("working_dir"), limit=220)
         if working_dir is not None:
-            lines.append(f"path · {working_dir}")
+            groups.append(f"path · {working_dir}")
 
-        lines = lines[: cls.METADATA_MAX_LINES]
-        if not lines:
+        lines = [" | ".join(groups)[: cls.METADATA_MAX_CHARS]]
+        if not lines or not lines[0].strip():
             return []
         joined = "\n".join(lines)
         if len(joined) <= cls.METADATA_MAX_CHARS:

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -393,16 +393,14 @@ class TaskCardEventProjection:
             "session · " + " · ".join(session_parts) if session_parts else None
         )
         context_line = "ctx · " + " · ".join(context_parts) if context_parts else None
-        # One compact footer line: groups separated by "|" so each group stays
+        # One compact footer line: groups separated by "|" so each concept stays
         # readable without forcing line breaks (the card stays narrow on
-        # Telegram). Physical path rides in the last group so a long working
-        # dir cannot crowd the identity.
+        # Telegram). agent/session/ctx/device/path each own a group; a long
+        # working dir rides in the last group so it cannot crowd identity.
         groups: list[str] = []
-        if agent_line and session_line:
-            groups.append(f"{agent_line} · {session_line}")
-        elif agent_line:
+        if agent_line:
             groups.append(agent_line)
-        elif session_line:
+        if session_line:
             groups.append(session_line)
         if context_line:
             groups.append(context_line)

--- a/src/lingtai/mcp_servers/telegram/account.py
+++ b/src/lingtai/mcp_servers/telegram/account.py
@@ -423,6 +423,10 @@ class TelegramAccount:
                 # kb:overview, kb:back, or unknown — back to the overview
                 self._cmd_kanban(chat_id, text="", message_id=message_id)
             return True
+        # Handle tc:* callback data from /taskcard inline buttons
+        if text.startswith("tc:") and chat_id:
+            self._cmd_taskcard_callback(chat_id, message_id, text[3:])
+            return True
         # Handle sys:* callback data from /system inline buttons
         if text.startswith("sys:") and chat_id:
             file_name = text[4:]  # strip "sys:" prefix
@@ -464,8 +468,17 @@ class TelegramAccount:
         return False
 
     def _cmd_taskcard(self, chat_id: int, text: str) -> None:
-        """Report or configure agent-wide Telegram Task Card presentation."""
+        """Report or configure agent-wide Telegram Task Card presentation.
+
+        ``/taskcard`` with no arguments opens the interactive settings menu
+        (inline keyboard, mirroring /kanban's design). ``/taskcard on|off``
+        toggles delivery and ``/taskcard N`` sets the rolling API-call-group
+        window (1-10), both as before.
+        """
         usage = "❌ Usage: /taskcard on | /taskcard off | /taskcard N (1-10)"
+        if text.strip() in ("/taskcard", f"/taskcard@{self.alias}"):
+            self._cmd_taskcard_menu(chat_id)
+            return
         result = self._local_commands.apply_taskcard(
             text,
             TaskCardSettingsPort(
@@ -505,6 +518,61 @@ class TelegramAccount:
             f"📋 taskcard: {enabled} · normal rows: {normal_rows} — {description}\n"
             "Usage: /taskcard on | /taskcard off | /taskcard N (1-10)",
         )
+
+    def _cmd_taskcard_menu(self, chat_id: int, message_id: int | None = None) -> None:
+        """Show the interactive Task Card settings menu (kanban-style)."""
+        enabled = self._taskcard_enabled()
+        normal_rows = self._taskcard_normal_rows()
+        state_emoji = "🟢" if enabled else "⚪"
+        menu_text = (
+            f"📋 *Task Card — settings*\n\n"
+            f"{state_emoji} Delivery: {'on' if enabled else 'off'}\n"
+            f"👁️ Rows: {normal_rows} (latest API-call groups)\n\n"
+            "Tap to change:"
+        )
+        keyboard = inline_keyboard_options(
+            [
+                {"text": "◀️ Rows −", "data": "tc:rows_dec"},
+                {"text": "Rows ▶️ +", "data": "tc:rows_inc"},
+                {"text": "📶 Delivery on", "data": "tc:on"},
+                {"text": "🚫 Delivery off", "data": "tc:off"},
+                {"text": "✖️ Close", "data": "tc:close"},
+            ],
+            columns=2,
+        )
+        if message_id is not None:
+            self.edit_message(
+                chat_id, message_id, menu_text,
+                reply_markup=keyboard, parse_mode="Markdown",
+            )
+        else:
+            self.send_message(
+                chat_id, menu_text,
+                reply_markup=keyboard, parse_mode="Markdown",
+            )
+
+    def _cmd_taskcard_callback(self, chat_id: int, message_id: int | None, action: str) -> None:
+        """Handle tc:* inline button callbacks from the Task Card menu."""
+        if action == "rows_inc":
+            current = self._taskcard_normal_rows()
+            self._set_taskcard_normal_rows(min(10, current + 1))
+        elif action == "rows_dec":
+            current = self._taskcard_normal_rows()
+            self._set_taskcard_normal_rows(max(1, current - 1))
+        elif action == "on":
+            self._set_taskcard_enabled(True)
+        elif action == "off":
+            self._set_taskcard_enabled(False)
+        elif action in ("close", "back"):
+            if message_id is not None:
+                try:
+                    self.delete_message(chat_id, message_id)
+                except Exception:  # noqa: BLE001 - best-effort cleanup
+                    pass
+            return
+        # Re-render the menu with the updated state (or back to the menu for back).
+        self._cmd_taskcard_menu(chat_id, message_id)
+
 
     def _collect_kanban_data(self) -> dict | None:
         """Read the shared channel-neutral dashboard snapshot."""

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2184,7 +2184,9 @@ class TelegramManager:
         # the reader can tell exactly which agent on which machine produced
         # this card, and where its durable state lives. ``socket.gethostname``
         # returns the short host name (no FQDN suffix); failures degrade to
-        # omitting the key so no line is fabricated.
+        # omitting the key so no line is fabricated. ``shell_kind`` is carried
+        # from the agent's resolved dialect when available so the card also
+        # shows which shell the agent runs on.
         try:
             snapshot["device_short_name"] = socket.gethostname()
         except (OSError, ValueError):
@@ -2195,6 +2197,18 @@ class TelegramManager:
             working_dir = None
         if working_dir:
             snapshot["working_dir"] = working_dir
+        shell_kind = os.environ.get("LINGTAI_SHELL", "").strip()
+        if not shell_kind:
+            try:
+                raw = (self._working_dir / "init.json").read_text(encoding="utf-8")
+                data = json.loads(raw)
+                shell_kind = str(
+                    (data.get("manifest", {}).get("capabilities", {}).get("shell", {}) or {}).get("shell_kind", "")
+                ).strip()
+            except (OSError, ValueError, json.JSONDecodeError, AttributeError):
+                shell_kind = ""
+        if shell_kind:
+            snapshot["shell_name"] = shell_kind
         return snapshot or None
 
     def _task_card_current_model(self) -> str | None:

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import socket
 import tempfile
 import time
 from datetime import datetime, timezone
@@ -2179,6 +2180,21 @@ class TelegramManager:
         model = self._task_card_current_model()
         if model:
             snapshot["model"] = model
+        # Physical path + device short name make the card self-identifying:
+        # the reader can tell exactly which agent on which machine produced
+        # this card, and where its durable state lives. ``socket.gethostname``
+        # returns the short host name (no FQDN suffix); failures degrade to
+        # omitting the key so no line is fabricated.
+        try:
+            snapshot["device_short_name"] = socket.gethostname()
+        except (OSError, ValueError):
+            pass
+        try:
+            working_dir = str(self._working_dir)
+        except Exception:
+            working_dir = None
+        if working_dir:
+            snapshot["working_dir"] = working_dir
         return snapshot or None
 
     def _task_card_current_model(self) -> str | None:

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -135,3 +135,27 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
         "agent · active · session · calls 2\n"
         "Last Updated: 02:30:00 UTC+08"
     )
+
+
+def test_metadata_renders_device_and_working_dir_lines() -> None:
+    """Device identity metadata renders a compact device · name · path line."""
+    metadata = {
+        "agent_lifecycle": "active",
+        "api_calls": 2,
+        "device_short_name": "zesen-desktop",
+        "working_dir": "C:\\Users\\zhuang\\.lingtai\\deepseek-1",
+    }
+    lines = TaskCardEventProjection.format_metadata(metadata)
+    assert "agent · active · session · calls 2" in lines
+    assert any(
+        line.startswith("device · ") and "zesen-desktop" in line
+        and "C:\\Users\\zhuang" in line
+        for line in lines
+    )
+
+
+def test_metadata_omits_device_line_when_only_bad_values() -> None:
+    """Missing or malformed device identity degrades to no device line."""
+    metadata = {"agent_lifecycle": "active", "device_short_name": 42, "working_dir": ""}
+    lines = TaskCardEventProjection.format_metadata(metadata)
+    assert not any(line.startswith("device · ") for line in lines)

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -138,24 +138,24 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
 
 
 def test_metadata_renders_device_and_working_dir_lines() -> None:
-    """Device identity metadata renders a compact device · name · path line."""
+    """Device identity metadata renders compact device + path lines."""
     metadata = {
         "agent_lifecycle": "active",
         "api_calls": 2,
         "device_short_name": "zesen-desktop",
+        "shell_name": "powershell",
         "working_dir": "C:\\Users\\zhuang\\.lingtai\\deepseek-1",
     }
     lines = TaskCardEventProjection.format_metadata(metadata)
-    assert "agent · active · session · calls 2" in lines
     assert any(
-        line.startswith("device · ") and "zesen-desktop" in line
-        and "C:\\Users\\zhuang" in line
-        for line in lines
+        line == "device · zesen-desktop · shell powershell" for line in lines
     )
+    assert any(line.startswith("path · C:\\Users\\zhuang") for line in lines)
 
 
 def test_metadata_omits_device_line_when_only_bad_values() -> None:
-    """Missing or malformed device identity degrades to no device line."""
+    """Missing or malformed device identity degrades to no device/path lines."""
     metadata = {"agent_lifecycle": "active", "device_short_name": 42, "working_dir": ""}
     lines = TaskCardEventProjection.format_metadata(metadata)
     assert not any(line.startswith("device · ") for line in lines)
+    assert not any(line.startswith("path · ") for line in lines)

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -138,7 +138,7 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
 
 
 def test_metadata_renders_device_and_working_dir_lines() -> None:
-    """Device identity metadata renders compact device + path lines."""
+    """Device identity metadata renders a compact ||-separated footer."""
     metadata = {
         "agent_lifecycle": "active",
         "api_calls": 2,
@@ -147,15 +147,16 @@ def test_metadata_renders_device_and_working_dir_lines() -> None:
         "working_dir": "C:\\Users\\zhuang\\.lingtai\\deepseek-1",
     }
     lines = TaskCardEventProjection.format_metadata(metadata)
-    assert any(
-        line == "device · zesen-desktop · shell powershell" for line in lines
-    )
-    assert any(line.startswith("path · C:\\Users\\zhuang") for line in lines)
+    assert len(lines) == 1
+    joined = lines[0]
+    assert "device · zesen-desktop · shell powershell" in joined
+    assert "path · C:\\Users\\zhuang" in joined
+    assert " | " in joined
 
 
 def test_metadata_omits_device_line_when_only_bad_values() -> None:
-    """Missing or malformed device identity degrades to no device/path lines."""
+    """Missing or malformed device identity degrades to no device/path groups."""
     metadata = {"agent_lifecycle": "active", "device_short_name": 42, "working_dir": ""}
     lines = TaskCardEventProjection.format_metadata(metadata)
-    assert not any(line.startswith("device · ") for line in lines)
-    assert not any(line.startswith("path · ") for line in lines)
+    assert not any("device · " in line for line in lines)
+    assert not any("path · " in line for line in lines)

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -132,7 +132,7 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
         "\n"
         "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
         "/taskcard N sets normal rows (1-10, current: 1).\n"
-        "agent · active · session · calls 2\n"
+        "agent · active | session · calls 2\n"
         "Last Updated: 02:30:00 UTC+08"
     )
 

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -422,7 +422,7 @@ def test_metadata_agent_and_session_combine_on_line_one_ctx_preserved():
         "context_usage": 0.62958,
     })
     assert lines == [
-        "agent · active · session · cache 87.8% · miss 170.6k/1.0M · calls 13 | "
+        "agent · active | session · cache 87.8% · miss 170.6k/1.0M · calls 13 | "
         "ctx · 171.2k/272.0k · 63%",
     ]
     assert len(lines) == 1
@@ -443,10 +443,10 @@ def test_metadata_stuck_hint_and_ctx_both_survive_full_metadata():
     # The 2-line cap holds; the hint leads line 1 (safe from end-truncation)
     # and ctx survives as line 2 instead of being dropped by the cap.
     assert lines == [
-        "agent · stuck · try /refresh · session · cache 87.8% · miss 170.6k/1.0M · calls 13 | "
+        "agent · stuck · try /refresh | session · cache 87.8% · miss 170.6k/1.0M · calls 13 | "
         "ctx · 171.2k/272.0k · 63%",
     ]
-    assert lines[0].startswith("agent · stuck · try /refresh")
+    assert lines[0].startswith("agent · stuck · try /refresh |")
     assert len(lines) == 1
     assert len(lines[0]) <= 500
 

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -340,11 +340,10 @@ def test_metadata_is_two_lines_bounded_and_between_footer_and_timestamp():
     time_idx = next(i for i, line in enumerate(lines) if line.startswith("Last Updated: "))
     metadata_lines = lines[footer_idx + 1:time_idx]
     assert metadata_lines == [
-        "session · cache 87.8% · miss 170.6k/1.0M · calls 13",
-        "ctx · 171.2k/272.0k · 63%",
+        "session · cache 87.8% · miss 170.6k/1.0M · calls 13 | ctx · 171.2k/272.0k · 63%",
     ]
-    assert len(metadata_lines) <= 2
-    assert len("\n".join(metadata_lines)) <= 150
+    assert len(metadata_lines) == 1
+    assert len(metadata_lines[0]) <= 500
 
 
 def test_metadata_omits_untrusted_or_invalid_values():
@@ -370,9 +369,9 @@ def test_metadata_pathological_counts_never_overflow_or_break_budget():
         "context_window": 10**1000,
         "context_usage": 1.0,
     })
-    assert len(lines) == 2
-    assert len("\n".join(lines)) <= 150
-    assert "inf" not in "\n".join(lines).lower()
+    assert len(lines) == 1
+    assert len(lines[0]) <= 500
+    assert "inf" not in lines[0].lower()
 
 
 # ---------------------------------------------------------------------------
@@ -423,11 +422,11 @@ def test_metadata_agent_and_session_combine_on_line_one_ctx_preserved():
         "context_usage": 0.62958,
     })
     assert lines == [
-        "agent · active · session · cache 87.8% · miss 170.6k/1.0M · calls 13",
+        "agent · active · session · cache 87.8% · miss 170.6k/1.0M · calls 13 | "
         "ctx · 171.2k/272.0k · 63%",
     ]
-    assert len(lines) <= 2
-    assert len("\n".join(lines)) <= 150
+    assert len(lines) == 1
+    assert len(lines[0]) <= 500
 
 
 def test_metadata_stuck_hint_and_ctx_both_survive_full_metadata():
@@ -444,12 +443,12 @@ def test_metadata_stuck_hint_and_ctx_both_survive_full_metadata():
     # The 2-line cap holds; the hint leads line 1 (safe from end-truncation)
     # and ctx survives as line 2 instead of being dropped by the cap.
     assert lines == [
-        "agent · stuck · try /refresh · session · cache 87.8% · miss 170.6k/1.0M · calls 13",
+        "agent · stuck · try /refresh · session · cache 87.8% · miss 170.6k/1.0M · calls 13 | "
         "ctx · 171.2k/272.0k · 63%",
     ]
     assert lines[0].startswith("agent · stuck · try /refresh")
-    assert len(lines) <= 2
-    assert len("\n".join(lines)) <= 150
+    assert len(lines) == 1
+    assert len(lines[0]) <= 500
 
 
 def test_metadata_unchanged_when_no_agent_lifecycle_present():
@@ -464,7 +463,7 @@ def test_metadata_unchanged_when_no_agent_lifecycle_present():
         "context_usage": 0.62958,
     })
     assert lines == [
-        "session · cache 87.8% · miss 170.6k/1.0M · calls 13",
+        "session · cache 87.8% · miss 170.6k/1.0M · calls 13 | "
         "ctx · 171.2k/272.0k · 63%",
     ]
 

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -588,7 +588,14 @@ def test_lifecycle_status_presence_error_falls_back_to_raw_state(tmp_path, monke
 
 def test_event_metadata_snapshot_none_when_nothing_available(tmp_path):
     mgr, _ = _integration_manager(tmp_path)
-    assert mgr._task_card_event_metadata_snapshot() is None
+    snapshot = mgr._task_card_event_metadata_snapshot()
+    # The snapshot always carries the self-identifying device/path fields, so
+    # it is never None; lifecycle/model remain absent when nothing is available.
+    assert snapshot is not None
+    assert "agent_lifecycle" not in snapshot
+    assert "model" not in snapshot
+    assert "device_short_name" in snapshot
+    assert "working_dir" in snapshot
 
 
 def test_event_metadata_snapshot_adds_lifecycle_alone(tmp_path, monkeypatch):
@@ -597,7 +604,10 @@ def test_event_metadata_snapshot_adds_lifecycle_alone(tmp_path, monkeypatch):
     monkeypatch.setattr(manager_mod, "observe_alive", lambda *a, **kw: True)
     mgr, _ = _integration_manager(tmp_path)
     _write_status(tmp_path, {"runtime": {"state": "active"}})
-    assert mgr._task_card_event_metadata_snapshot() == {"agent_lifecycle": "active"}
+    snapshot = mgr._task_card_event_metadata_snapshot()
+    assert snapshot["agent_lifecycle"] == "active"
+    assert "device_short_name" in snapshot
+    assert "working_dir" in snapshot
 
 
 def test_event_metadata_snapshot_merges_with_existing_session_metadata(tmp_path):
@@ -605,7 +615,10 @@ def test_event_metadata_snapshot_merges_with_existing_session_metadata(tmp_path)
     _write_status(tmp_path, {"runtime": {"state": "suspended"}})
     mgr._task_card_event_metadata = {"api_calls": 4}
     snapshot = mgr._task_card_event_metadata_snapshot()
-    assert snapshot == {"api_calls": 4, "agent_lifecycle": "suspended"}
+    assert snapshot["api_calls"] == 4
+    assert snapshot["agent_lifecycle"] == "suspended"
+    assert "device_short_name" in snapshot
+    assert "working_dir" in snapshot
     # The manager's own stored metadata must not be mutated by the merge.
     assert mgr._task_card_event_metadata == {"api_calls": 4}
 
@@ -627,4 +640,7 @@ def test_event_metadata_snapshot_adds_current_model(tmp_path):
     mgr, _ = _integration_manager(tmp_path)
     _write_status(tmp_path, {"runtime": {"state": "active"}})
     snapshot = mgr._task_card_event_metadata_snapshot()
-    assert snapshot == {"agent_lifecycle": "active", "model": "deepseek-v4-flash"}
+    assert snapshot["agent_lifecycle"] == "active"
+    assert snapshot["model"] == "deepseek-v4-flash"
+    assert "device_short_name" in snapshot
+    assert "working_dir" in snapshot

--- a/tests/test_telegram_task_card_toggle.py
+++ b/tests/test_telegram_task_card_toggle.py
@@ -206,8 +206,11 @@ def test_taskcard_commands_are_local_agent_wide_and_mentions_work(
         "update_id": 1,
         "message": {"from": {"id": 7}, "chat": {"id": 10}, "text": "/taskcard"},
     })
-    assert "taskcard: True" in replies[-1]
-    assert "Usage: /taskcard on | /taskcard off" in replies[-1]
+    # Bare /taskcard now opens the interactive settings menu instead of a
+    # text status reply (kanban-style).
+    assert "Task Card — settings" in replies[-1]
+    assert "Delivery" in replies[-1]
+    assert "Rows:" in replies[-1]
 
     one._process_update({
         "update_id": 2,


### PR DESCRIPTION
## Summary

Two Task Card improvements for Telegram, requested by Jason:

### 1. Device identity in the automatic footer
- The automatic taskcard footer now renders a compact **device** line: short host name + working-dir physical path (e.g. \device · zesen-desktop · C:\\Users\\zhuang\\.lingtai\\deepseek-1\).
- The card is now self-identifying: the reader can tell which agent on which machine produced it.
- Missing/malformed values degrade to no device line (no fabrication). Windows backslash allowed in the machine-identifier allowlist so paths render.

### 2. Interactive /taskcard settings menu
- Bare \/taskcard\ now opens an interactive inline-keyboard settings menu (kanban-style) with delivery on/off and rows +/- controls, instead of a plain text status reply.
- \/taskcard on|off\ and \/taskcard N\ keep their exact prior behavior.

## Files changed
- \src/lingtai/mcp_servers/task_card/event_projection.py\ — device line rendering, allowlist backslash, metadata budget 150→260 / lines 2→3
- \src/lingtai/mcp_servers/telegram/manager.py\ — snapshot carries device_short_name + working_dir (socket.gethostname)
- \src/lingtai/mcp_servers/telegram/account.py\ — tc: callback routing, \_cmd_taskcard_menu\, \_cmd_taskcard_callback\
- tests: device-line render, omit-on-bad-values, snapshot subsets, menu reply shape

## Tests
\	est_task_card_event_projection_shared.py\, \	est_local_command_core.py\, \	est_telegram_task_card_{toggle,state,rows,timestamp}.py\ — 344 passed (1 pre-existing transport mock failure unrelated: _FakeService.list_accounts)