### PR TITLE
feat(telegram): blanket 1s taskcard rebuild with fingerprint edit dedupe

### DIFF
--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2950,9 +2950,15 @@ class TelegramManager:
             return {"status": "error", "error": str(e)}
 
     def _ensure_task_card_resident(self, account: str, chat_id: int) -> dict:
-        """Ensure the resident target for an established inbound chat."""
-        automatic = self._format_task_card_text(
-            "", "", "", rows=[], metadata=None,
+        """Ensure the resident target for an established inbound chat.
+
+        Renders the full automatic event window (not a sparse placeholder) so
+        the first card a human sees is already complete; the 1s blanket keeps
+        it fresh from there.
+        """
+        automatic = TaskCardEventProjection.render_event_groups(
+            self._task_card_event_groups_snapshot(),
+            metadata=self._task_card_event_metadata_snapshot(),
             normal_rows=self._taskcard_normal_rows(),
         )
         return self._resident.ensure(

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -13,6 +13,7 @@ Mirrors IMAPMailManager patterns with Telegram-specific adaptations.
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import re
 import socket
@@ -613,6 +614,12 @@ class TelegramManager:
         # any older snapshot.
         self._task_card_event_metadata: dict | None = None
         self._task_card_event_lock = threading.Lock()
+        # Blanket-delivery dedupe: the last automatic frame fingerprint seen per
+        # resident target. A 1s blanket rebuild only edits Telegram when the
+        # frame actually changed (excluding the volatile ``Last Updated`` line),
+        # so bursty event tails coalesce into at most one edit per second
+        # instead of hammering the per-chat edit rate limit.
+        self._task_card_automatic_fingerprints: dict[tuple[str, int], str] = {}
         self._task_card_tail_thread: threading.Thread | None = None
         self._task_card_tail_stop = threading.Event()
         self._programmable_task_card_thread: threading.Thread | None = None
@@ -2513,7 +2520,10 @@ class TelegramManager:
 
         Detects truncation/replacement (current size smaller than the tracked
         offset, or a changed inode) and reinitializes from the new tail rather
-        than seeking into now-invalid byte positions.
+        than seeking into now-invalid byte positions. The blanket 1s loop also
+        re-renders every tick; this method only fires when the file itself
+        changed, so bursty appends still coalesce through the fingerprint
+        dedupe in ``_broadcast_task_card_event_window``.
         """
         with self._task_card_event_lock:
             path = self._task_card_event_path
@@ -2555,7 +2565,7 @@ class TelegramManager:
             # rehydrated window — even an empty one — must still be broadcast
             # rather than leaving a stale non-empty render displayed.
             self._init_event_tail()
-            changed = True
+            self._broadcast_task_card_event_window(force=True)
         elif stat.st_size > offset:
             changed = self._append_new_lines(path, offset, stat.st_size)
             with self._task_card_event_lock:
@@ -2565,11 +2575,8 @@ class TelegramManager:
                 # strand an old token and fabricate a replacement later.
                 if current_identity is not None:
                     self._task_card_event_identity = current_identity
-        else:
-            changed = False
-
-        if changed:
-            self._broadcast_task_card_event_window()
+            if changed:
+                self._broadcast_task_card_event_window()
 
     def _append_new_lines(self, path: Path, offset: int, size: int) -> bool:
         """Seek to ``offset`` and consume only complete new lines.
@@ -2759,13 +2766,31 @@ class TelegramManager:
                     e,
                 )
 
-    def _broadcast_task_card_event_window(self) -> None:
-        """Project the current bounded window to every resident Task Card.
+    def _task_card_automatic_fingerprint(self, automatic: str) -> str:
+        """Stable fingerprint of an automatic frame for edit dedupe.
+
+        The volatile ``Last Updated:`` line is excluded — it changes on every
+        render and must not force a Telegram edit when the actual content
+        (events, footer, metadata) is unchanged.
+        """
+        stable = "\n".join(
+            line
+            for line in automatic.splitlines()
+            if not line.startswith(_TASK_CARD_TIME_PREFIX)
+        )
+        return hashlib.sha256(stable.encode("utf-8", "replace")).hexdigest()
+
+    def _broadcast_task_card_event_window(self, *, force: bool = False) -> None:
+        """Blanket-rebuild the current window to every resident Task Card.
 
         Update-first per target (same discipline as ``_task_card_create``):
         edits the tracked resident in place, sending/deleting only as
         fail-open recovery. A delivery failure for one target never blocks
         another target's broadcast.
+
+        ``force`` bypasses the fingerprint dedupe (used when the tail was
+        truncated/replaced — the rehydrated window must be pushed even if it
+        renders to the same text, so stale state cannot survive).
         """
         if not self._taskcard_enabled():
             return
@@ -2775,12 +2800,23 @@ class TelegramManager:
             metadata=self._task_card_event_metadata_snapshot(),
             normal_rows=normal_rows,
         )
+        fingerprint = self._task_card_automatic_fingerprint(automatic)
         for account, chat_id in self._resident_task_card_targets():
+            key = (account, chat_id)
+            if not force and self._task_card_automatic_fingerprints.get(key) == fingerprint:
+                # Skip only when the resident message still exists; if it was
+                # deleted externally, the next tick must re-send even though the
+                # frame fingerprint is unchanged.
+                resident_id = self._get_resident_task_card(account, chat_id)
+                if resident_id is not None:
+                    continue
             try:
-                self._deliver_channel_frame(
+                result = self._deliver_channel_frame(
                     account, chat_id, "automatic", automatic,
                     error="Failed to broadcast task card",
                 )
+                if result.get("status") == "ok":
+                    self._task_card_automatic_fingerprints[key] = fingerprint
             except Exception as e:
                 log.debug(
                     "Automatic task card broadcast failed for %s:%s: %s",
@@ -2805,6 +2841,14 @@ class TelegramManager:
                     self._poll_event_tail()
                 except Exception as e:
                     log.debug("Automatic task card event tail poll failed: %s", e)
+                # Blanket rebuild: every tick re-renders the current window and
+                # the fingerprint dedupe inside the broadcast decides whether a
+                # Telegram edit is actually needed. This coalesces bursty event
+                # tails into at most one edit per second.
+                try:
+                    self._broadcast_task_card_event_window()
+                except Exception as e:
+                    log.debug("Automatic task card blanket broadcast failed: %s", e)
                 if self._task_card_tail_stop.wait(self._TASK_CARD_EVENT_POLL_INTERVAL):
                     return
 

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -12,8 +12,8 @@ Mirrors IMAPMailManager patterns with Telegram-specific adaptations.
 """
 from __future__ import annotations
 
-import json
 import hashlib
+import json
 import os
 import re
 import socket
@@ -2803,25 +2803,38 @@ class TelegramManager:
         fingerprint = self._task_card_automatic_fingerprint(automatic)
         for account, chat_id in self._resident_task_card_targets():
             key = (account, chat_id)
-            if not force and self._task_card_automatic_fingerprints.get(key) == fingerprint:
-                # Skip only when the resident message still exists; if it was
-                # deleted externally, the next tick must re-send even though the
-                # frame fingerprint is unchanged.
-                resident_id = self._get_resident_task_card(account, chat_id)
-                if resident_id is not None:
-                    continue
-            try:
-                result = self._deliver_channel_frame(
-                    account, chat_id, "automatic", automatic,
-                    error="Failed to broadcast task card",
-                )
-                if result.get("status") == "ok":
-                    self._task_card_automatic_fingerprints[key] = fingerprint
-            except Exception as e:
-                log.debug(
-                    "Automatic task card broadcast failed for %s:%s: %s",
-                    account, chat_id, e,
-                )
+            # Check + deliver + store are atomic per route (RLock is reentrant,
+            # so the nested acquisition inside project() is free). This keeps the
+            # fingerprint cache consistent with the actually-delivered frame even
+            # when the 1s blanket loop, the re-enable listener, and a rehydrate
+            # race on the same route.
+            with self._task_card_delivery_lock(account, chat_id):
+                if not force and self._task_card_automatic_fingerprints.get(key) == fingerprint:
+                    # Skip only when the tracked resident still exists. This guard
+                    # catches tracked-map clears (e.g. a peer process rotating the
+                    # resident in state.json); it does NOT probe whether a user
+                    # deleted the message in-chat, so a deleted card heals on the
+                    # next content change (edit fails -> replace_after_probe), not
+                    # on this tick.
+                    resident_id = self._get_resident_task_card(account, chat_id)
+                    if resident_id is not None:
+                        continue
+                try:
+                    result = self._deliver_channel_frame(
+                        account, chat_id, "automatic", automatic,
+                        error="Failed to broadcast task card",
+                    )
+                    # Cache only when a frame was actually delivered. A suppressed
+                    # project (toggle flipped off mid-broadcast) delivers nothing,
+                    # so caching its fingerprint would pin a stale frame once the
+                    # card is re-enabled.
+                    if result.get("status") == "ok" and not result.get("suppressed"):
+                        self._task_card_automatic_fingerprints[key] = fingerprint
+                except Exception as e:
+                    log.debug(
+                        "Automatic task card broadcast failed for %s:%s: %s",
+                        account, chat_id, e,
+                    )
 
     def _start_task_card_tail(self) -> None:
         """Start the one manager-owned tail worker, idempotently.

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -1129,3 +1129,41 @@ def test_blanket_force_bypasses_fingerprint_dedupe(tmp_path):
     # fingerprint is unchanged.
     manager._broadcast_task_card_event_window(force=True)
     assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1
+
+
+def test_blanket_resends_when_resident_lost_on_same_frame(tmp_path, monkeypatch):
+    """Fingerprint match plus a missing tracked resident must still re-send.
+
+    The resident-target enumeration and the tracked-resident lookup are
+    independent: a peer process can rotate the durable state (target survives,
+    resident id gone), so the blanket tick must not suppress the re-send just
+    because the frame fingerprint is unchanged.
+    """
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    events_path = _events_path(tmp_path)
+    _write_lines(events_path, [_tool_call_line()])
+    manager._poll_event_tail()
+    assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1
+    acct.calls.clear()
+
+    # Simulate durable-state rotation: the chat stays a target but the tracked
+    # resident lookup now reports no resident.
+    monkeypatch.setattr(manager, "_get_resident_task_card", lambda account, chat_id: None)
+    manager._broadcast_task_card_event_window()
+    assert [c[0] for c in acct.calls] == ["send_message"]
+
+
+def test_fingerprint_ignores_last_updated_line_only(tmp_path):
+    """The volatile Last Updated line must not change the fingerprint; any
+    other content change must."""
+    manager, _ = _manager(tmp_path, FakeAccount())
+    a = "\u2699 WORKING\n\u2022 row\n\nfooter\nLast Updated: 10:00:00 UTC+08"
+    b = "\u2699 WORKING\n\u2022 row\n\nfooter\nLast Updated: 10:00:01 UTC+08"
+    c = "\u2699 WORKING\n\u2022 other\n\nfooter\nLast Updated: 10:00:00 UTC+08"
+    assert manager._task_card_automatic_fingerprint(a) == \
+        manager._task_card_automatic_fingerprint(b)
+    assert manager._task_card_automatic_fingerprint(a) != \
+        manager._task_card_automatic_fingerprint(c)

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -1081,3 +1081,51 @@ def test_programmable_slot_untouched_by_automatic_broadcast(tmp_path):
     rendered = edits[-1][3]
     assert "automatic-row" in rendered
     assert "programmable content" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Blanket 1s rebuild dedupe: same frame must not re-fire a Telegram edit;
+# content change must; resident loss must force a re-send even on same frame.
+# ---------------------------------------------------------------------------
+
+
+def test_blanket_rebuild_skips_unchanged_frame(tmp_path):
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    events_path = _events_path(tmp_path)
+    _write_lines(events_path, [_tool_call_line()])
+    manager._poll_event_tail()  # first broadcast creates/edits the resident
+
+    assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1
+    acct.calls.clear()
+
+    # Same frame on a later blanket tick: no Telegram edit.
+    manager._broadcast_task_card_event_window()
+    assert acct.calls == []
+
+    # New event changes the frame: edit fires.
+    _write_lines(events_path, [_tool_call_line(tool_name="second", reasoning="more")])
+    manager._poll_event_tail()
+    assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1
+
+
+def test_blanket_force_bypasses_fingerprint_dedupe(tmp_path):
+    """Truncation/replacement uses force=True so identical rehydrated frames
+    still re-edit rather than being suppressed by the unchanged-fingerprint
+    fast path."""
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    events_path = _events_path(tmp_path)
+    _write_lines(events_path, [_tool_call_line()])
+    manager._poll_event_tail()
+    assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1
+    acct.calls.clear()
+
+    # Force broadcast (the truncation path) must edit even though the frame
+    # fingerprint is unchanged.
+    manager._broadcast_task_card_event_window(force=True)
+    assert len([c for c in acct.calls if c[0] == "edit_message"]) == 1

--- a/tests/test_telegram_task_card_toggle.py
+++ b/tests/test_telegram_task_card_toggle.py
@@ -391,7 +391,9 @@ def test_command_reenables_same_resident_once_and_transition_is_atomic(
     assert account.get_task_card(123) == resident_id
     calls.clear()
     manager._broadcast_task_card_event_window()
-    assert [call[0] for call in calls] == ["edit"]
+    # Blanket dedupe: the frame is unchanged since the last deliver, so the
+    # 1s rebuild must NOT fire another Telegram edit.
+    assert [call[0] for call in calls] == []
 
     service.set_taskcard_enabled(False)
     broadcasts: list[bool] = []


### PR DESCRIPTION
## What

The automatic Task Card event tail now re-renders its bounded window **every second** (blanket rebuild), independent of whether the event file grew. The broadcast then skips the actual Telegram edit when the rendered frame is byte-identical to the last delivered one (excluding the volatile "Last Updated" line).

## Why

Current behavior is event-driven: each burst of agent events fires an edit immediately, so a card can first appear with partial content and then be edited repeatedly as more events land — hammering Telegram's per-chat edit rate limit and looking stale/confusing mid-burst.

Blanket rebuild fixes both: content is rebuilt every 1s (never stale), but at most one edit per second is issued (rate-limit safe), and unchanged frames cost zero Telegram calls.

## Details

- `_poll_event_tail` still detects appends/truncation, but truncation/replacement now forces a broadcast (`force=True`) so stale rehydrated content cannot survive even when the frame renders identical.
- `_broadcast_task_card_event_window(force=False)` computes a stable fingerprint (excluding "Last Updated" which changes every render) and skips the edit when unchanged.
- Manual /taskcard commands and the inline menu remain immediate (not throttled by the blanket).

## Tests

- `test_blanket_rebuild_skips_unchanged_frame`: same frame on later tick = no edit; new event = one edit.
- `test_blanket_force_bypasses_fingerprint_dedupe`: force=True (truncation path) edits even on unchanged frame.
- Updated `test_command_reenables_same_resident_once_and_transition_is_atomic` for the dedupe behavior.

All taskcard tests pass (244); 1 pre-existing transport mock failure unrelated (verified failing on main).
