### PR TITLE
feat(telegram): taskcard footer shows agent active (N sec) since last progress

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -388,6 +388,14 @@ class TaskCardEventProjection:
             agent_line = f"agent · {lifecycle} · try /refresh"
         elif lifecycle in cls.AGENT_STATES:
             agent_line = f"agent · {lifecycle}"
+        if agent_line and lifecycle == AgentState.ACTIVE.value:
+            active_seconds = metadata.get("agent_active_seconds")
+            if (
+                type(active_seconds) in {int, float}
+                and not isinstance(active_seconds, bool)
+                and active_seconds >= 0
+            ):
+                agent_line = f"{agent_line} ({float(active_seconds):.0f}s)"
 
         session_line = (
             "session · " + " · ".join(session_parts) if session_parts else None

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import re
 import socket
@@ -2184,6 +2185,9 @@ class TelegramManager:
         lifecycle = self._task_card_agent_lifecycle_status()
         if lifecycle is not None:
             snapshot["agent_lifecycle"] = lifecycle
+        active_seconds = self._task_card_active_seconds()
+        if active_seconds is not None:
+            snapshot["agent_active_seconds"] = active_seconds
         model = self._task_card_current_model()
         if model:
             snapshot["model"] = model
@@ -2284,6 +2288,40 @@ class TelegramManager:
         except Exception:
             return state
         return state if alive else "offline"
+
+    def _task_card_active_seconds(self) -> float | None:
+        """Seconds since the agent's last progress while it is active.
+
+        Reads ``.status.json``'s ``runtime.last_progress_at`` (the wall
+        timestamp ``BaseAgent._write_status_snapshot`` refreshes on every
+        turn) and returns its age only when the runtime reports ``active``.
+        This surfaces the live LLM/tool latency: while the model thinks or a
+        tool runs, ``last_progress_at`` stays put and the age grows; when
+        activity resumes it resets. Missing/malformed data, a non-active
+        state, or a future timestamp degrades to ``None``.
+        """
+        try:
+            raw = (self._working_dir / ".status.json").read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        runtime = data.get("runtime")
+        if not isinstance(runtime, dict):
+            return None
+        if runtime.get("state") != AgentState.ACTIVE.value:
+            return None
+        last_progress = runtime.get("last_progress_at")
+        if not isinstance(last_progress, (int, float)) or isinstance(last_progress, bool):
+            return None
+        if not math.isfinite(last_progress):
+            return None
+        age = time.time() - last_progress
+        return age if age >= 0 else None
 
     @staticmethod
     def _project_agent_text_event(event: dict) -> dict | None:

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -382,7 +382,29 @@ def test_metadata_renders_compact_normal_lifecycle_states():
     for state in ("active", "idle", "asleep", "suspended"):
         lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": state})
         assert lines == [f"agent · {state}"]
-        assert "/refresh" not in lines[0]
+
+
+def test_metadata_renders_active_seconds_only_when_active():
+    # Active state plus a sane age renders the (N sec) suffix.
+    lines = TelegramManager._format_task_card_metadata({
+        "agent_lifecycle": "active",
+        "agent_active_seconds": 12.0,
+    })
+    assert lines == ["agent · active (12s)"]
+    # Non-active states never render the suffix even if the field is present.
+    lines = TelegramManager._format_task_card_metadata({
+        "agent_lifecycle": "idle",
+        "agent_active_seconds": 12.0,
+    })
+    assert lines == ["agent · idle"]
+    # Missing/invalid age degrades to the plain lifecycle line.
+    lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": "active"})
+    assert lines == ["agent · active"]
+    lines = TelegramManager._format_task_card_metadata({
+        "agent_lifecycle": "active",
+        "agent_active_seconds": "secret",
+    })
+    assert lines == ["agent · active"]
 
 
 def test_metadata_renders_stuck_with_refresh_hint():


### PR DESCRIPTION
## What

Task Card footer now renders `agent · active (12s)` while the agent is active, where N is the age of `.status.json` `runtime.last_progress_at` — surfacing live LLM/tool-call latency on the card.

## Why

Jason: the `agent · active` label alone doesn't tell you how long the model has been thinking or a tool has been running. Adding seconds-since-last-progress makes the card a live latency meter: it grows while the LLM/tool works and resets when activity resumes.

## Details

- `_task_card_active_seconds()` (manager.py): reads `.status.json`, returns `now - runtime.last_progress_at` only when `runtime.state == active`; non-active states, missing/malformed/future timestamps degrade to `None`.
- Wired into `_task_card_event_metadata_snapshot()` as `agent_active_seconds`.
- `format_metadata` (event_projection.py): appends `(Ns)` to the agent group only when lifecycle == active and the age is a sane number; other states render the plain lifecycle line.

## Tests

`test_metadata_renders_active_seconds_only_when_active` covers: active + sane age → `agent · active (12s)`; non-active with field present → plain line; missing/invalid age → plain line.

All taskcard tests pass.
