### PR TITLE
feat(telegram): taskcard latency visibility (5s refresh + api delay + ms durations)

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -388,6 +388,14 @@ class TaskCardEventProjection:
             agent_line = f"agent · {lifecycle} · try /refresh"
         elif lifecycle in cls.AGENT_STATES:
             agent_line = f"agent · {lifecycle}"
+        if agent_line and lifecycle == AgentState.ACTIVE.value:
+            active_seconds = metadata.get("agent_active_seconds")
+            if (
+                type(active_seconds) in {int, float}
+                and not isinstance(active_seconds, bool)
+                and active_seconds >= 0
+            ):
+                agent_line = f"{agent_line} ({float(active_seconds):.0f}s)"
 
         session_line = (
             "session · " + " · ".join(session_parts) if session_parts else None

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -607,8 +607,14 @@ class TaskCardEventProjection:
             # useless as ``0s``). The LLM API round-trip gap since the previous
             # progress is rendered on the group divider, not here.
             elapsed = cls.format_elapsed_ms(cls.row_elapsed_ms(row))
-            status_suffix = f", {status}" if status else ""
-            suffix = f" ({elapsed}{status_suffix})"
+            if status == "???":
+                # A tool call with no result yet is genuinely running; showing
+                # ``???`` wasted the slot without saying anything real.
+                status_suffix = ""
+                suffix = f" ({elapsed}, running)" if elapsed else " (running)"
+            else:
+                status_suffix = f", {status}" if status else ""
+                suffix = f" ({elapsed}{status_suffix})"
             tool_prepared.append(
                 (idx, label, redacted, suffix, done, started_at, status)
             )

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -127,33 +127,7 @@ class TaskCardEventProjection:
                 ts = None
             if ts is not None and math.isfinite(ts):
                 row["_ts"] = ts
-        usage = cls._project_current_call_usage(event)
-        if usage:
-            row["_usage"] = usage
         return row
-
-    @staticmethod
-    def _project_current_call_usage(
-        event: dict[str, Any],
-    ) -> dict[str, Any] | None:
-        """Extract per-call LLM usage (output tokens, cache miss, cache rate)."""
-        envelope = event.get("_meta")
-        if not isinstance(envelope, dict):
-            return None
-        agent_meta = envelope.get("agent_meta")
-        if not isinstance(agent_meta, dict):
-            return None
-        state = agent_meta.get("agent_state")
-        if not isinstance(state, dict):
-            return None
-        token_usage = state.get("token_usage")
-        if not isinstance(token_usage, dict):
-            return None
-        current = token_usage.get("current_call")
-        if not isinstance(current, dict):
-            return None
-        supported = ("output", "cache_miss", "cache_rate")
-        return {key: current[key] for key in supported if key in current} or None
 
     @classmethod
     def project_event(
@@ -287,6 +261,55 @@ class TaskCardEventProjection:
         except (json.JSONDecodeError, UnicodeDecodeError):
             return None
         return event if isinstance(event, dict) else None
+
+    @staticmethod
+    def project_current_call_usage(
+        event: dict[str, Any],
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Extract per-call LLM usage from a ``notification_block_injected``
+        carrier. Returns ``(call_id, {output, cache_miss, cache_rate})`` so the
+        tailer can attach it to the matching tool row."""
+        if event.get("type") != "notification_block_injected":
+            return None
+        call_id = event.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            return None
+        envelope = event.get("_meta")
+        if not isinstance(envelope, dict):
+            return None
+        agent_meta = envelope.get("agent_meta")
+        if not isinstance(agent_meta, dict):
+            return None
+        state = agent_meta.get("agent_state")
+        if not isinstance(state, dict):
+            return None
+        token_usage = state.get("token_usage")
+        if not isinstance(token_usage, dict):
+            return None
+        current = token_usage.get("current_call")
+        if not isinstance(current, dict):
+            return None
+        supported = ("output", "cache_miss", "cache_rate")
+        usage = {key: current[key] for key in supported if key in current}
+        return (call_id, usage) if usage else None
+
+    @staticmethod
+    def apply_tool_usages(
+        groups: list[dict[str, Any]],
+        usages: dict[str, dict[str, Any]],
+    ) -> bool:
+        """Attach per-call usage to tool rows by their ``_tool_call_id``."""
+        changed = False
+        for group in groups:
+            for row in group.get("events", []):
+                usage = usages.get(row.get("_tool_call_id"))
+                if usage is None:
+                    continue
+                if row.get("_usage") == usage:
+                    continue
+                row["_usage"] = usage
+                changed = True
+        return changed
 
     @staticmethod
     def apply_tool_results(

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -301,6 +301,16 @@ class TaskCardEventProjection:
         rows: list[dict[str, Any]] = []
         for group in groups[-normal_rows:]:
             rows.append({"kind": "divider", "text": cls.API_CALL_DIVIDER})
+            # The group's API delay is the LLM round-trip gap since the previous
+            # progress; show it just below the divider, not inside tool rows.
+            api_delay_s: float | None = None
+            for row in group.get("events", []):
+                v = row.get("api_delay_s")
+                if type(v) in (int, float) and not isinstance(v, bool) and v >= 0:
+                    api_delay_s = float(v)
+                break
+            if api_delay_s is not None and api_delay_s > 0:
+                rows.append({"kind": "text", "text": f"API {api_delay_s:.1f}s"})
             rows.extend(group.get("events", []))
         text = cls.format_task_card_text(
             "",
@@ -505,21 +515,11 @@ class TaskCardEventProjection:
             status = row.get("status")
             status = status if status in {"success", "error", "???"} else None
             # Duration in whole milliseconds (sub-second tool results were
-            # useless as ``0s``); api_delay_s is the LLM round-trip gap since
-            # the previous progress event, rendered distinctly from the
-            # tool-result elapsed.
+            # useless as ``0s``). The LLM API round-trip gap since the previous
+            # progress is rendered on the group divider, not here.
             elapsed = cls.format_elapsed_ms(cls.row_elapsed_ms(row))
-            api_delay_s = row.get("api_delay_s")
-            if (
-                type(api_delay_s) in (int, float)
-                and not isinstance(api_delay_s, bool)
-                and api_delay_s >= 0
-            ):
-                api_part = f"{float(api_delay_s):.1f}s api, "
-            else:
-                api_part = ""
             status_suffix = f", {status}" if status else ""
-            suffix = f" ({api_part}{elapsed}{status_suffix})"
+            suffix = f" ({elapsed}{status_suffix})"
             tool_prepared.append(
                 (idx, label, redacted, suffix, done, started_at, status)
             )

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -409,7 +409,7 @@ class TaskCardEventProjection:
                 and not isinstance(rate, bool)
                 and 0 <= rate <= 1
             ):
-                parts.append(f"{float(rate):.0%}")
+                parts.append(f"{float(rate):.1%}")
         return " ".join(parts)
 
     @classmethod
@@ -775,12 +775,15 @@ class TaskCardEventProjection:
 
     @classmethod
     def format_elapsed_ms(cls, value: object) -> str:
-        """Render a tool row's elapsed duration as whole milliseconds (``412ms``).
+        """Render a tool row's elapsed duration adaptively.
 
-        The tool row suffix uses milliseconds so sub-second tool results stay
-        useful instead of rounding to ``0s``. Coerces defensively (floored,
-        junk/non-finite/negative degrade to ``0ms``) and caps the display at
-        ``MAX_ELAPSED_MS`` so a runaway timer cannot widen the row unboundedly.
+        Under 0.1s (Jason 2026-08-08): whole milliseconds (``31ms``); at or above
+        0.1s: one decimal second (``2.3s``). Milliseconds for sub-0.1s tools stay
+        useful instead of rounding to ``0s``, and seconds read naturally for
+        longer tools instead of a wide millisecond wall. Coerces defensively
+        (floored, junk/non-finite/negative degrade to ``0ms``) and caps the
+        display at ``MAX_ELAPSED_MS`` so a runaway timer cannot widen the row
+        unboundedly.
         """
         try:
             number = float(value)
@@ -788,4 +791,7 @@ class TaskCardEventProjection:
             return "0ms"
         if not math.isfinite(number) or number < 0:
             return "0ms"
-        return f"{min(int(number), cls.MAX_ELAPSED_MS)}ms"
+        if number < 100:
+            return f"{min(int(number), cls.MAX_ELAPSED_MS)}ms"
+        seconds = min(number, cls.MAX_ELAPSED_MS) / 1000
+        return f"{seconds:.1f}s"

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -31,6 +31,7 @@ class TaskCardEventProjection:
     EVENT_REASONING_CAP = 300
     EVENT_TEXT_CAP = 500
     MAX_EVENTS_PER_CALL = 24
+    MAX_ELAPSED_MS = 9_999_999
     API_CALL_DIVIDER = "──────────"
 
     @classmethod
@@ -118,6 +119,14 @@ class TaskCardEventProjection:
         started_at = cls.format_row_timestamp(event.get("ts"))
         if started_at:
             row["started_at"] = started_at
+        raw_ts = event.get("ts")
+        if type(raw_ts) in (int, float) and not isinstance(raw_ts, bool):
+            try:
+                ts = float(raw_ts)
+            except (OverflowError, ValueError):
+                ts = None
+            if ts is not None and math.isfinite(ts):
+                row["_ts"] = ts
         return row
 
     @classmethod
@@ -159,6 +168,7 @@ class TaskCardEventProjection:
             if max_events_per_call is None
             else max_events_per_call
         )
+        last_tool_ts: float | None = None
         for index, (event, row) in enumerate(projected):
             group_id = cls.event_group_id(event, index)
             group = by_id.get(group_id)
@@ -167,6 +177,19 @@ class TaskCardEventProjection:
                 by_id[group_id] = group
                 groups.append(group)
             events = group["events"]
+            # The LLM API round trip Jason watches as ``active (N sec)`` is the
+            # gap between consecutive progress events: the previous tool_call's
+            # own ``ts`` (stream order, so a group's first row still sees the
+            # previous group's last tool call; only the very first tool row of
+            # the stream has no prior progress and reads 0.0).
+            raw_ts = row.get("_ts")
+            if type(raw_ts) in (int, float) and not isinstance(raw_ts, bool):
+                ts = float(raw_ts)
+                if last_tool_ts is None:
+                    row["api_delay_s"] = 0.0
+                else:
+                    row["api_delay_s"] = max(0.0, round(ts - last_tool_ts, 2))
+                last_tool_ts = ts
             if len(events) < limit:
                 events.append(row)
         count = cls.EVENT_WINDOW if window is None else window
@@ -188,6 +211,7 @@ class TaskCardEventProjection:
                 else:
                     row.pop("group_id", None)
                     row.pop("_tool_call_id", None)
+                    row.pop("_ts", None)
                 if row.get("kind") == "tool":
                     row.pop("kind", None)
                 rows.append(row)
@@ -259,6 +283,9 @@ class TaskCardEventProjection:
                 elapsed_ms = result.get("elapsed_ms")
                 if type(elapsed_ms) in (int, float) and elapsed_ms >= 0:
                     row["elapsed_s"] = elapsed_ms / 1000
+                    # Keep the raw ms so sub-second durations render exactly
+                    # (e.g. ``412ms``) instead of rounding to ``0s``.
+                    row["elapsed_ms"] = elapsed_ms
                 changed = True
         return changed
 
@@ -472,14 +499,29 @@ class TaskCardEventProjection:
             action = str(row.get("tool_action", ""))
             label = f"{tool}.{action}" if action else tool
             redacted = redact_text(str(row.get("reasoning", "")))
-            elapsed = cls.format_elapsed(row.get("elapsed_s", 0))
             done = bool(row.get("done", False))
             started_at = row.get("started_at", "")
             started_at = started_at if isinstance(started_at, str) else ""
             status = row.get("status")
             status = status if status in {"success", "error", "???"} else None
+            # Duration in whole milliseconds (sub-second tool results were
+            # useless as ``0s``); api_delay_s is the LLM round-trip gap since
+            # the previous progress event, rendered distinctly from the
+            # tool-result elapsed.
+            elapsed = cls.format_elapsed_ms(cls.row_elapsed_ms(row))
+            api_delay_s = row.get("api_delay_s")
+            if (
+                type(api_delay_s) in (int, float)
+                and not isinstance(api_delay_s, bool)
+                and api_delay_s >= 0
+            ):
+                api_part = f"{float(api_delay_s):.1f}s api, "
+            else:
+                api_part = ""
+            status_suffix = f", {status}" if status else ""
+            suffix = f" ({api_part}{elapsed}{status_suffix})"
             tool_prepared.append(
-                (idx, label, redacted, elapsed, done, started_at, status)
+                (idx, label, redacted, suffix, done, started_at, status)
             )
 
         metadata_lines = cls.format_metadata(metadata)
@@ -497,7 +539,7 @@ class TaskCardEventProjection:
             _,
             label,
             _redacted,
-            elapsed,
+            suffix,
             done,
             started_at,
             status,
@@ -505,13 +547,7 @@ class TaskCardEventProjection:
             marker = "✓ " if done or status == "success" else "• "
             prefix = f"{marker}{label}: " if label else marker
             stamp_suffix = f" · {started_at}" if started_at else ""
-            status_suffix = f", {status}" if status else ""
-            tool_scaffold += (
-                len(prefix)
-                + len(f" ({elapsed}s{status_suffix})")
-                + len(stamp_suffix)
-                + 2
-            )
+            tool_scaffold += len(prefix) + len(suffix) + len(stamp_suffix) + 2
         fixed = (
             len(cls.HEADER)
             + 1
@@ -529,7 +565,7 @@ class TaskCardEventProjection:
         per_row_cap = max(0, min(cls.REASONING_CAP, budget // divisor))
 
         by_idx: dict[int, str] = {}
-        for idx, label, redacted, elapsed, done, started_at, status in tool_prepared:
+        for idx, label, redacted, suffix, done, started_at, status in tool_prepared:
             excerpt = (
                 redacted[:per_row_cap] + "…"
                 if len(redacted) > per_row_cap
@@ -538,8 +574,7 @@ class TaskCardEventProjection:
             marker = "✓ " if done or status == "success" else "• "
             prefix = f"{marker}{label}: " if label else marker
             stamp_suffix = f" · {started_at}" if started_at else ""
-            status_suffix = f", {status}" if status else ""
-            by_idx[idx] = f"{prefix}{excerpt} ({elapsed}s{status_suffix}){stamp_suffix}"
+            by_idx[idx] = f"{prefix}{excerpt}{suffix}{stamp_suffix}"
         for idx, text in text_prepared:
             excerpt = text[:per_row_cap] + "…" if len(text) > per_row_cap else text
             by_idx[idx] = f"• {excerpt}"
@@ -618,3 +653,44 @@ class TaskCardEventProjection:
             return str(max(0, int(float(value))))
         except (TypeError, ValueError):
             return "0"
+
+    @staticmethod
+    def row_elapsed_ms(row: dict[str, Any]) -> float:
+        """Resolve a tool row's elapsed duration in whole milliseconds.
+
+        Prefers the raw ``elapsed_ms`` captured from the tool result so
+        sub-second durations are preserved exactly; falls back to converting
+        the legacy ``elapsed_s`` field. Missing/malformed values degrade to 0.
+        """
+        raw_ms = row.get("elapsed_ms")
+        if (
+            type(raw_ms) in (int, float)
+            and not isinstance(raw_ms, bool)
+            and raw_ms >= 0
+        ):
+            return float(raw_ms)
+        raw_s = row.get("elapsed_s")
+        if (
+            type(raw_s) in (int, float)
+            and not isinstance(raw_s, bool)
+            and raw_s >= 0
+        ):
+            return float(raw_s) * 1000
+        return 0.0
+
+    @classmethod
+    def format_elapsed_ms(cls, value: object) -> str:
+        """Render a tool row's elapsed duration as whole milliseconds (``412ms``).
+
+        The tool row suffix uses milliseconds so sub-second tool results stay
+        useful instead of rounding to ``0s``. Coerces defensively (floored,
+        junk/non-finite/negative degrade to ``0ms``) and caps the display at
+        ``MAX_ELAPSED_MS`` so a runaway timer cannot widen the row unboundedly.
+        """
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return "0ms"
+        if not math.isfinite(number) or number < 0:
+            return "0ms"
+        return f"{min(int(number), cls.MAX_ELAPSED_MS)}ms"

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -127,7 +127,33 @@ class TaskCardEventProjection:
                 ts = None
             if ts is not None and math.isfinite(ts):
                 row["_ts"] = ts
+        usage = cls._project_current_call_usage(event)
+        if usage:
+            row["_usage"] = usage
         return row
+
+    @staticmethod
+    def _project_current_call_usage(
+        event: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Extract per-call LLM usage (output tokens, cache miss, cache rate)."""
+        envelope = event.get("_meta")
+        if not isinstance(envelope, dict):
+            return None
+        agent_meta = envelope.get("agent_meta")
+        if not isinstance(agent_meta, dict):
+            return None
+        state = agent_meta.get("agent_state")
+        if not isinstance(state, dict):
+            return None
+        token_usage = state.get("token_usage")
+        if not isinstance(token_usage, dict):
+            return None
+        current = token_usage.get("current_call")
+        if not isinstance(current, dict):
+            return None
+        supported = ("output", "cache_miss", "cache_rate")
+        return {key: current[key] for key in supported if key in current} or None
 
     @classmethod
     def project_event(
@@ -212,6 +238,7 @@ class TaskCardEventProjection:
                     row.pop("group_id", None)
                     row.pop("_tool_call_id", None)
                     row.pop("_ts", None)
+                    row.pop("_usage", None)
                 if row.get("kind") == "tool":
                     row.pop("kind", None)
                 rows.append(row)
@@ -302,15 +329,22 @@ class TaskCardEventProjection:
         for group in groups[-normal_rows:]:
             rows.append({"kind": "divider", "text": cls.API_CALL_DIVIDER})
             # The group's API delay is the LLM round-trip gap since the previous
-            # progress; show it just below the divider, not inside tool rows.
+            # progress; the per-call usage rides the same divider line, both kept
+            # out of tool rows.
             api_delay_s: float | None = None
+            usage: dict[str, Any] | None = None
             for row in group.get("events", []):
                 v = row.get("api_delay_s")
-                if type(v) in (int, float) and not isinstance(v, bool) and v >= 0:
+                if api_delay_s is None and type(v) in (int, float) and not isinstance(v, bool) and v >= 0:
                     api_delay_s = float(v)
-                break
-            if api_delay_s is not None and api_delay_s > 0:
-                rows.append({"kind": "text", "text": f"API {api_delay_s:.1f}s"})
+                u = row.get("_usage")
+                if usage is None and isinstance(u, dict) and u:
+                    usage = u
+                if api_delay_s is not None and usage is not None:
+                    break
+            info = cls.format_divider_info(api_delay_s, usage)
+            if info:
+                rows.append({"kind": "text", "text": info})
             rows.extend(group.get("events", []))
         text = cls.format_task_card_text(
             "",
@@ -322,6 +356,38 @@ class TaskCardEventProjection:
             now=now,
         )
         return text[: cls.TEXT_LIMIT] if len(text) > cls.TEXT_LIMIT else text
+
+    @classmethod
+    def format_divider_info(
+        cls,
+        api_delay_s: float | None,
+        usage: dict[str, Any] | None,
+    ) -> str:
+        """Compact divider line: `API x s` plus `↓out ↑miss cache%` per-call usage.
+
+        The down arrow denotes output tokens, the up arrow denotes cache miss
+        (the two token flows that grow with each call); the trailing percentage
+        is that call's cache rate. Any piece missing from the event degrades
+        silently, so old events without usage still render the delay alone.
+        """
+        parts: list[str] = []
+        if api_delay_s is not None and api_delay_s > 0:
+            parts.append(f"API {api_delay_s:.1f}s")
+        if isinstance(usage, dict) and usage:
+            out = usage.get("output")
+            miss = usage.get("cache_miss")
+            rate = usage.get("cache_rate")
+            if type(out) is int and out >= 0:
+                parts.append(f"\u2193{cls.format_count(out)}")
+            if type(miss) is int and miss >= 0:
+                parts.append(f"\u2191{cls.format_count(miss)}")
+            if (
+                type(rate) in {int, float}
+                and not isinstance(rate, bool)
+                and 0 <= rate <= 1
+            ):
+                parts.append(f"{float(rate):.0%}")
+        return " ".join(parts)
 
     @classmethod
     def format_task_card_text(

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -367,7 +367,7 @@ class TaskCardEventProjection:
                     break
             info = cls.format_divider_info(api_delay_s, usage)
             if info:
-                rows.append({"kind": "text", "text": info})
+                rows.append({"kind": "api_info", "text": info})
             rows.extend(group.get("events", []))
         text = cls.format_task_card_text(
             "",
@@ -585,6 +585,11 @@ class TaskCardEventProjection:
             kind = row.get("kind")
             if kind == "divider":
                 api_prepared.append((idx, cls.API_CALL_DIVIDER))
+                continue
+            if kind == "api_info":
+                info = redact_text(str(row.get("text", ""))).strip()
+                if info:
+                    api_prepared.append((idx, info[: cls.EVENT_TEXT_CAP]))
                 continue
             if kind == "text":
                 text = redact_text(str(row.get("text", ""))).strip()

--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -84,7 +84,19 @@ class TaskCardEventProjection:
         cap = cls.EVENT_TEXT_CAP if text_cap is None else text_cap
         if len(text) > cap:
             text = text[: cap - 1] + "…"
-        return {"kind": "text", "text": text}
+        row: dict[str, Any] = {"kind": "text", "text": text}
+        raw_ts = event.get("ts")
+        if type(raw_ts) in (int, float) and not isinstance(raw_ts, bool):
+            try:
+                ts = float(raw_ts)
+            except (OverflowError, ValueError):
+                ts = None
+            if ts is not None and math.isfinite(ts):
+                row["_ts"] = ts
+        api_call_id = event.get("api_call_id")
+        if isinstance(api_call_id, str) and api_call_id:
+            row["_api_call_id"] = api_call_id
+        return row
 
     @classmethod
     def project_tool_call_row(
@@ -213,6 +225,7 @@ class TaskCardEventProjection:
                     row.pop("_tool_call_id", None)
                     row.pop("_ts", None)
                     row.pop("_usage", None)
+                    row.pop("_api_call_id", None)
                 if row.get("kind") == "tool":
                     row.pop("kind", None)
                 rows.append(row)
@@ -294,15 +307,54 @@ class TaskCardEventProjection:
         return (call_id, usage) if usage else None
 
     @staticmethod
+    def project_llm_response_usage(
+        event: dict[str, Any],
+    ) -> tuple[str, dict[str, Any]] | None:
+        """Extract per-call LLM usage from a ``llm_response`` event.
+
+        Pure-text turns (an assistant reply with no tool call) never carry a
+        ``notification_block_injected`` carrier, so their per-call token usage
+        has to come from the ``llm_response`` event itself. Returns
+        ``(api_call_id, {output, cache_miss, cache_rate})``; estimated token
+        counts are still shown (they are the only signal a pure-text turn has)
+        but missing/zero input degrades to ``None``.
+        """
+        if event.get("type") != "llm_response":
+            return None
+        call_id = event.get("api_call_id")
+        if not isinstance(call_id, str) or not call_id:
+            return None
+        output = event.get("output_tokens")
+        cached = event.get("cached_tokens")
+        total = event.get("input_tokens")
+        if (
+            type(output) is not int
+            or type(cached) is not int
+            or type(total) is not int
+            or total <= 0
+        ):
+            return None
+        usage: dict[str, Any] = {"output": output, "cache_miss": max(total - cached, 0)}
+        if cached > 0:
+            usage["cache_rate"] = min(cached / total, 1.0)
+        return (call_id, usage)
+
+    @staticmethod
     def apply_tool_usages(
         groups: list[dict[str, Any]],
         usages: dict[str, dict[str, Any]],
     ) -> bool:
-        """Attach per-call usage to tool rows by their ``_tool_call_id``."""
+        """Attach per-call usage to rows by their ``_tool_call_id``.
+
+        Pure-text rows carry ``_api_call_id`` instead, which the tailer keys
+        from ``llm_response`` events; fall back to it so a text-only turn still
+        gets its divider usage arrows."""
         changed = False
         for group in groups:
             for row in group.get("events", []):
                 usage = usages.get(row.get("_tool_call_id"))
+                if usage is None:
+                    usage = usages.get(row.get("_api_call_id"))
                 if usage is None:
                     continue
                 if row.get("_usage") == usage:

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -616,9 +616,9 @@ class TelegramManager:
         self._task_card_event_metadata: dict | None = None
         self._task_card_event_lock = threading.Lock()
         # Blanket-delivery dedupe: the last automatic frame fingerprint seen per
-        # resident target. A 1s blanket rebuild only edits Telegram when the
+        # resident target. A 5s blanket rebuild only edits Telegram when the
         # frame actually changed (excluding the volatile ``Last Updated`` line),
-        # so bursty event tails coalesce into at most one edit per second
+        # so bursty event tails coalesce into at most one edit every 5s
         # instead of hammering the per-chat edit rate limit.
         self._task_card_automatic_fingerprints: dict[tuple[str, int], str] = {}
         self._task_card_tail_thread: threading.Thread | None = None
@@ -2150,7 +2150,7 @@ class TelegramManager:
     # Latest final-carrier session telemetry is projected separately. There is no
     # durable cursor: startup and log replacement rehydrate from the bounded tail.
     _TASK_CARD_EVENT_WINDOW = TaskCardEventProjection.EVENT_WINDOW
-    _TASK_CARD_EVENT_POLL_INTERVAL = 1.0
+    _TASK_CARD_EVENT_POLL_INTERVAL = 5.0
     _TASK_CARD_EVENT_TAIL_CHUNK = 65536
     _TASK_CARD_EVENT_REASONING_CAP = TaskCardEventProjection.EVENT_REASONING_CAP
     _TASK_CARD_EVENT_TEXT_CAP = TaskCardEventProjection.EVENT_TEXT_CAP
@@ -2844,7 +2844,7 @@ class TelegramManager:
             # Check + deliver + store are atomic per route (RLock is reentrant,
             # so the nested acquisition inside project() is free). This keeps the
             # fingerprint cache consistent with the actually-delivered frame even
-            # when the 1s blanket loop, the re-enable listener, and a rehydrate
+            # when the 5s blanket loop, the re-enable listener, and a rehydrate
             # race on the same route.
             with self._task_card_delivery_lock(account, chat_id):
                 if not force and self._task_card_automatic_fingerprints.get(key) == fingerprint:
@@ -2895,7 +2895,7 @@ class TelegramManager:
                 # Blanket rebuild: every tick re-renders the current window and
                 # the fingerprint dedupe inside the broadcast decides whether a
                 # Telegram edit is actually needed. This coalesces bursty event
-                # tails into at most one edit per second.
+                # tails into at most one edit every 5 seconds.
                 try:
                     self._broadcast_task_card_event_window()
                 except Exception as e:
@@ -2930,7 +2930,7 @@ class TelegramManager:
                     self._broadcast_programmable_task_card_file()
                 except Exception as e:
                     log.debug("Programmable task card poll failed: %s", e)
-                if self._programmable_task_card_stop.wait(1.0):
+                if self._programmable_task_card_stop.wait(self._TASK_CARD_EVENT_POLL_INTERVAL):
                     return
 
         thread = threading.Thread(
@@ -2991,7 +2991,7 @@ class TelegramManager:
         """Ensure the resident target for an established inbound chat.
 
         Renders the full automatic event window (not a sparse placeholder) so
-        the first card a human sees is already complete; the 1s blanket keeps
+        the first card a human sees is already complete; the 5s blanket keeps
         it fresh from there.
         """
         automatic = TaskCardEventProjection.render_event_groups(

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2150,7 +2150,9 @@ class TelegramManager:
     # Latest final-carrier session telemetry is projected separately. There is no
     # durable cursor: startup and log replacement rehydrate from the bounded tail.
     _TASK_CARD_EVENT_WINDOW = TaskCardEventProjection.EVENT_WINDOW
-    _TASK_CARD_EVENT_POLL_INTERVAL = 5.0
+    _TASK_CARD_EVENT_POLL_INTERVAL = float(
+        os.environ.get("LINGTAI_TASKCARD_POLL_INTERVAL", "5.0")
+    )
     _TASK_CARD_EVENT_TAIL_CHUNK = 65536
     _TASK_CARD_EVENT_REASONING_CAP = TaskCardEventProjection.EVENT_REASONING_CAP
     _TASK_CARD_EVENT_TEXT_CAP = TaskCardEventProjection.EVENT_TEXT_CAP

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import re
 import socket
@@ -2184,6 +2185,9 @@ class TelegramManager:
         lifecycle = self._task_card_agent_lifecycle_status()
         if lifecycle is not None:
             snapshot["agent_lifecycle"] = lifecycle
+        active_seconds = self._task_card_active_seconds()
+        if active_seconds is not None:
+            snapshot["agent_active_seconds"] = active_seconds
         model = self._task_card_current_model()
         if model:
             snapshot["model"] = model
@@ -2284,6 +2288,40 @@ class TelegramManager:
         except Exception:
             return state
         return state if alive else "offline"
+
+    def _task_card_active_seconds(self) -> float | None:
+        """Seconds since the agent's last progress while it is active.
+
+        Reads ``.status.json``'s ``runtime.last_progress_at`` (the wall
+        timestamp ``BaseAgent._write_status_snapshot`` refreshes on every
+        turn) and returns its age only when the runtime reports ``active``.
+        This surfaces the live LLM/tool latency: while the model thinks or a
+        tool runs, ``last_progress_at`` stays put and the age grows; when
+        activity resumes it resets. Missing/malformed data, a non-active
+        state, or a future timestamp degrades to ``None``.
+        """
+        try:
+            raw = (self._working_dir / ".status.json").read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        runtime = data.get("runtime")
+        if not isinstance(runtime, dict):
+            return None
+        if runtime.get("state") != AgentState.ACTIVE.value:
+            return None
+        last_progress = runtime.get("last_progress_at")
+        if not isinstance(last_progress, (int, float)) or isinstance(last_progress, bool):
+            return None
+        if not math.isfinite(last_progress):
+            return None
+        age = time.time() - last_progress
+        return age if age >= 0 else None
 
     @staticmethod
     def _project_agent_text_event(event: dict) -> dict | None:

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -3387,7 +3387,8 @@ class TelegramManager:
         When ``rows`` is supplied (the batched multi-row form) each parallel or
         sequential call renders as its own row showing ``tool.action``, its
         redacted reasoning excerpt, its own captured start stamp, its own
-        whole-second elapsed, and a ``✓`` marker once it has completed.  The
+        millisecond elapsed (plus the LLM API round-trip gap since the previous
+        progress event), and a ``✓`` marker once it has completed.  The
         scalar ``tool``/``action``/``reasoning`` path is retained for
         backward-compatible single-tool callers and does not render the footer
         (it is the legacy transient-step form).

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2448,7 +2448,7 @@ class TelegramManager:
                 self._task_card_event_groups = []
                 self._task_card_event_metadata = None
             return
-        rows, offset, metadata = result
+        rows, offset, metadata, usages = result
         with self._task_card_event_lock:
             self._task_card_event_path = path
             self._task_card_event_offset = offset
@@ -2457,6 +2457,9 @@ class TelegramManager:
             self._task_card_event_identity = self._event_file_identity(stat)
             projected = [({"api_call_id": row.get("group_id")}, dict(row)) for row in rows]
             self._task_card_event_groups = self._group_task_card_events(projected)
+            TaskCardEventProjection.apply_tool_usages(
+                self._task_card_event_groups, usages,
+            )
             self._task_card_event_metadata = metadata
 
     def _reverse_tail_latest_rows(
@@ -2483,6 +2486,7 @@ class TelegramManager:
         window = self._TASK_CARD_EVENT_WINDOW
         projected_events: list[tuple[dict, dict]] = []
         latest_metadata: dict | None = None
+        per_call_usages: dict[str, dict] = {}
         tail_offset = size
         try:
             with open(path, "rb") as f:
@@ -2528,6 +2532,10 @@ class TelegramManager:
                         row = self._project_task_card_event(event)
                         if row is not None:
                             round_projected.append((event, row))
+                        carrier = TaskCardEventProjection.project_current_call_usage(event)
+                        if carrier is not None:
+                            carrier_call_id, usage = carrier
+                            per_call_usages[carrier_call_id] = usage
                         candidate = self._project_final_carrier_metadata(event)
                         if candidate is not None:
                             # ``complete`` is oldest-to-newest within this
@@ -2542,9 +2550,10 @@ class TelegramManager:
         # Chunks were prepended above, so projected events are already in
         # journal order before grouping; one API call receives one divider.
         groups = self._group_task_card_events(projected_events)
+        TaskCardEventProjection.apply_tool_usages(groups, per_call_usages)
         return self._flatten_task_card_groups(
             groups, include_group_id=True,
-        ), tail_offset, latest_metadata
+        ), tail_offset, latest_metadata, per_call_usages
 
     @staticmethod
     def _decode_event_line(raw: bytes) -> dict | None:
@@ -2644,6 +2653,7 @@ class TelegramManager:
         projected_events: list[tuple[dict, dict]] = []
         latest_metadata: dict | None = None
         tool_results: dict[str, dict] = {}
+        per_call_usages: dict[str, dict] = {}
         for raw in complete.split(b"\n"):
             event = self._decode_event_line(raw)
             if event is None:
@@ -2651,6 +2661,10 @@ class TelegramManager:
             call_id = event.get("tool_call_id")
             if event.get("type") == "tool_result" and isinstance(call_id, str) and call_id:
                 tool_results[call_id] = event
+            carrier = TaskCardEventProjection.project_current_call_usage(event)
+            if carrier is not None:
+                carrier_call_id, usage = carrier
+                per_call_usages[carrier_call_id] = usage
             row = self._project_task_card_event(event)
             if row is not None:
                 projected_events.append((event, row))
@@ -2682,7 +2696,11 @@ class TelegramManager:
                 self._task_card_event_groups,
                 tool_results,
             )
-        return bool(projected_events) or metadata_changed or result_changed
+            usage_changed = TaskCardEventProjection.apply_tool_usages(
+                self._task_card_event_groups,
+                per_call_usages,
+            )
+        return bool(projected_events) or metadata_changed or result_changed or usage_changed
 
     def _resident_task_card_targets(self) -> list[tuple[str, int]]:
         """Enumerate every ``(account, chat_id)`` with a resident Task Card.

--- a/src/lingtai/mcp_servers/telegram/manager.py
+++ b/src/lingtai/mcp_servers/telegram/manager.py
@@ -2536,6 +2536,10 @@ class TelegramManager:
                         if carrier is not None:
                             carrier_call_id, usage = carrier
                             per_call_usages[carrier_call_id] = usage
+                        llm_usage = TaskCardEventProjection.project_llm_response_usage(event)
+                        if llm_usage is not None:
+                            llm_call_id, usage = llm_usage
+                            per_call_usages[llm_call_id] = usage
                         candidate = self._project_final_carrier_metadata(event)
                         if candidate is not None:
                             # ``complete`` is oldest-to-newest within this
@@ -2665,6 +2669,10 @@ class TelegramManager:
             if carrier is not None:
                 carrier_call_id, usage = carrier
                 per_call_usages[carrier_call_id] = usage
+            llm_usage = TaskCardEventProjection.project_llm_response_usage(event)
+            if llm_usage is not None:
+                llm_call_id, usage = llm_usage
+                per_call_usages[llm_call_id] = usage
             row = self._project_task_card_event(event)
             if row is not None:
                 projected_events.append((event, row))

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -187,14 +187,14 @@ def test_group_events_sets_api_delay_s_delta_from_previous_tool_ts() -> None:
 def test_format_elapsed_ms_renders_milliseconds_defensively() -> None:
     """CHANGE B: sub-second durations render as whole ms (``412ms``), with a
     sane floor/ceiling and no crash on junk payloads."""
-    assert TaskCardEventProjection.format_elapsed_ms(412) == "412ms"
+    assert TaskCardEventProjection.format_elapsed_ms(412) == "0.4s"
     assert TaskCardEventProjection.format_elapsed_ms(0) == "0ms"
-    assert TaskCardEventProjection.format_elapsed_ms(2300) == "2300ms"
+    assert TaskCardEventProjection.format_elapsed_ms(2300) == "2.3s"
     # A legacy elapsed_s value converts to ms through row_elapsed_ms.
     assert TaskCardEventProjection.row_elapsed_ms({"elapsed_s": 0.412}) == 412.0
     assert TaskCardEventProjection.format_elapsed_ms(
         TaskCardEventProjection.row_elapsed_ms({"elapsed_s": 0.412})
-    ) == "412ms"
+    ) == "0.4s"
     # raw elapsed_ms wins over the converted elapsed_s.
     row = {"elapsed_ms": 412, "elapsed_s": 2.3}
     assert TaskCardEventProjection.row_elapsed_ms(row) == 412.0
@@ -203,5 +203,5 @@ def test_format_elapsed_ms_renders_milliseconds_defensively() -> None:
     assert TaskCardEventProjection.format_elapsed_ms(-5) == "0ms"
     assert TaskCardEventProjection.format_elapsed_ms(float("nan")) == "0ms"
     assert TaskCardEventProjection.format_elapsed_ms(10**12) == (
-        f"{TaskCardEventProjection.MAX_ELAPSED_MS}ms"
+        f"{TaskCardEventProjection.MAX_ELAPSED_MS / 1000:.1f}s"
     )

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -128,7 +128,7 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
         "📋 ACTIVITIES\n"
         "──────────\n"
         "• public response\n"
-        "• bash.run: build (0s, ???) · 12:00:00 UTC+00\n"
+        "• bash.run: build (0ms, ???) · 12:00:00 UTC+00\n"
         "\n"
         "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
         "/taskcard N sets normal rows (1-10, current: 1).\n"
@@ -160,3 +160,48 @@ def test_metadata_omits_device_line_when_only_bad_values() -> None:
     lines = TaskCardEventProjection.format_metadata(metadata)
     assert not any("device · " in line for line in lines)
     assert not any("path · " in line for line in lines)
+
+
+def test_group_events_sets_api_delay_s_delta_from_previous_tool_ts() -> None:
+    """CHANGE A: tool rows carry ``api_delay_s`` = ts gap since the previous
+    tool_call (0.0 for the very first), and the private raw ``_ts`` never leaks
+    into the flattened public window."""
+    events = [
+        {"type": "tool_call", "api_call_id": "api-1", "ts": 100.0,
+         "tool_name": "bash", "tool_call_id": "call-1",
+         "tool_args": {"action": "run", "_reasoning": "a"}},
+        {"type": "tool_call", "api_call_id": "api-1", "ts": 103.4,
+         "tool_name": "read", "tool_call_id": "call-2",
+         "tool_args": {"action": "read", "_reasoning": "b"}},
+    ]
+    projected = [
+        (event, TaskCardEventProjection.project_event(event)) for event in events
+    ]
+    groups = TaskCardEventProjection.group_events(projected)
+    rows = TaskCardEventProjection.flatten_groups(groups)
+    assert [row["api_delay_s"] for row in rows] == [0.0, 3.4]
+    assert all("_ts" not in row for row in rows)
+    assert all("api_delay_s" in row for row in rows)
+
+
+def test_format_elapsed_ms_renders_milliseconds_defensively() -> None:
+    """CHANGE B: sub-second durations render as whole ms (``412ms``), with a
+    sane floor/ceiling and no crash on junk payloads."""
+    assert TaskCardEventProjection.format_elapsed_ms(412) == "412ms"
+    assert TaskCardEventProjection.format_elapsed_ms(0) == "0ms"
+    assert TaskCardEventProjection.format_elapsed_ms(2300) == "2300ms"
+    # A legacy elapsed_s value converts to ms through row_elapsed_ms.
+    assert TaskCardEventProjection.row_elapsed_ms({"elapsed_s": 0.412}) == 412.0
+    assert TaskCardEventProjection.format_elapsed_ms(
+        TaskCardEventProjection.row_elapsed_ms({"elapsed_s": 0.412})
+    ) == "412ms"
+    # raw elapsed_ms wins over the converted elapsed_s.
+    row = {"elapsed_ms": 412, "elapsed_s": 2.3}
+    assert TaskCardEventProjection.row_elapsed_ms(row) == 412.0
+    # Defensive: junk, negatives, non-finite, and runaway values degrade safely.
+    assert TaskCardEventProjection.format_elapsed_ms("junk") == "0ms"
+    assert TaskCardEventProjection.format_elapsed_ms(-5) == "0ms"
+    assert TaskCardEventProjection.format_elapsed_ms(float("nan")) == "0ms"
+    assert TaskCardEventProjection.format_elapsed_ms(10**12) == (
+        f"{TaskCardEventProjection.MAX_ELAPSED_MS}ms"
+    )

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -128,7 +128,7 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
         "📋 ACTIVITIES\n"
         "──────────\n"
         "• public response\n"
-        "• bash.run: build (0ms, ???) · 12:00:00 UTC+00\n"
+        "• bash.run: build (0ms, running) · 12:00:00 UTC+00\n"
         "\n"
         "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
         "/taskcard N sets normal rows (1-10, current: 1).\n"

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -467,7 +467,7 @@ def test_tool_result_updates_status_and_elapsed(tmp_path):
     })])
     manager._poll_event_tail()
     rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
-    assert "(2300ms, success)" in rendered
+    assert "(2.3s, success)" in rendered
     assert "RESULT_SECRET" not in rendered
 
     _write_lines(path, [
@@ -478,7 +478,7 @@ def test_tool_result_updates_status_and_elapsed(tmp_path):
         }),
     ])
     manager._poll_event_tail()
-    assert "(400ms, error)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "(0.4s, error)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
 
 
 def test_second_tool_call_api_delay_is_previous_tool_ts_delta(tmp_path):
@@ -555,7 +555,7 @@ def test_divider_renders_compact_per_call_usage_arrows(tmp_path):
     assert "API 3.4s" in rendered
     assert "\u21931.2k" in rendered    # ↓1.2k output tokens
     assert "\u2191512.3k" in rendered  # ↑512.3k cache miss
-    assert "55%" in rendered           # cache rate
+    assert "55.0%" in rendered         # cache rate (one decimal per Jason)
     # Usage is private per-row state: projected for rendering but never
     # leaked into the public window rows.
     assert all("_usage" not in row for row in manager._task_card_event_window())
@@ -578,8 +578,8 @@ def test_divider_usage_degrades_when_event_lacks_usage(tmp_path):
     assert "\u2193" not in rendered
 
 
-def test_sub_second_tool_elapsed_renders_milliseconds_not_zero_seconds(tmp_path):
-    """CHANGE B: a 412ms tool result renders ``412ms``, never the useless ``0s``."""
+def test_sub_second_tool_elapsed_renders_adaptive_seconds_not_zero_seconds(tmp_path):
+    """CHANGE B: a 412ms tool result renders ``0.4s``, never the useless ``0s``."""
     acct = FakeAccount()
     manager, _ = _manager(tmp_path, acct)
     _pre_resident(acct, 555, manager)
@@ -594,7 +594,7 @@ def test_sub_second_tool_elapsed_renders_milliseconds_not_zero_seconds(tmp_path)
     manager._poll_event_tail()
 
     rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
-    assert "(412ms, success)" in rendered
+    assert "(0.4s, success)" in rendered
     assert "RESULT_SECRET" not in rendered
 
 

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -459,7 +459,7 @@ def test_tool_result_updates_status_and_elapsed(tmp_path):
 
     _write_lines(path, [_tool_call_line(tool_name="read", action="read", call_id="c1")])
     manager._poll_event_tail()
-    assert "(0ms, ???)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "(0ms, running)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
 
     _write_lines(path, [json.dumps({
         "type": "tool_result", "tool_call_id": "c1", "status": "ok",

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -438,7 +438,7 @@ def test_only_safe_bounded_fields_are_projected(tmp_path):
     window = manager._task_card_event_window()
     assert len(window) == 1
     row = window[0]
-    assert set(row.keys()) <= {"tool", "tool_action", "reasoning", "started_at", "status"}
+    assert set(row.keys()) <= {"tool", "tool_action", "reasoning", "started_at", "status", "api_delay_s"}
     assert row["tool"] == "bash"
     assert row["tool_action"] == "run"
     assert row["reasoning"] == "safe text"
@@ -459,7 +459,7 @@ def test_tool_result_updates_status_and_elapsed(tmp_path):
 
     _write_lines(path, [_tool_call_line(tool_name="read", action="read", call_id="c1")])
     manager._poll_event_tail()
-    assert "(0s, ???)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "(0.0s api, 0ms, ???)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
 
     _write_lines(path, [json.dumps({
         "type": "tool_result", "tool_call_id": "c1", "status": "ok",
@@ -467,7 +467,7 @@ def test_tool_result_updates_status_and_elapsed(tmp_path):
     })])
     manager._poll_event_tail()
     rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
-    assert "(2s, success)" in rendered
+    assert "(0.0s api, 2300ms, success)" in rendered
     assert "RESULT_SECRET" not in rendered
 
     _write_lines(path, [
@@ -478,7 +478,58 @@ def test_tool_result_updates_status_and_elapsed(tmp_path):
         }),
     ])
     manager._poll_event_tail()
-    assert "(0s, error)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "(0.0s api, 400ms, error)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+
+
+def test_second_tool_call_api_delay_is_previous_tool_ts_delta(tmp_path):
+    """CHANGE A: the second tool call row carries ``api_delay_s`` equal to the
+    ts gap since the previous tool call, and the render shows it distinctly
+    from the tool-result elapsed (``3.4s api``)."""
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    events_path = _events_path(tmp_path)
+    _write_lines(events_path, [
+        _tool_call_line(tool_name="first", call_id="c1", ts=100.0),
+        _tool_call_line(tool_name="second", call_id="c2", ts=103.4),
+    ])
+
+    manager._poll_event_tail()
+
+    window = manager._task_card_event_window()
+    assert [row["tool"] for row in window] == ["first", "second"]
+    # First tool call of the stream has no prior progress: 0.0 baseline.
+    assert window[0]["api_delay_s"] == 0.0
+    # Second tool call: exact ts delta.
+    assert window[1]["api_delay_s"] == 3.4
+    # The raw ts stays private and never leaks into the public window.
+    assert all("_ts" not in row for row in window)
+
+    rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    second_line = next(ln for ln in rendered.splitlines() if "second" in ln)
+    assert "3.4s api" in second_line
+    assert "0.0s api" not in second_line
+
+
+def test_sub_second_tool_elapsed_renders_milliseconds_not_zero_seconds(tmp_path):
+    """CHANGE B: a 412ms tool result renders ``412ms``, never the useless ``0s``."""
+    acct = FakeAccount()
+    manager, _ = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+    path = _events_path(tmp_path)
+
+    _write_lines(path, [_tool_call_line(tool_name="fast", call_id="c1")])
+    manager._poll_event_tail()
+    _write_lines(path, [json.dumps({
+        "type": "tool_result", "tool_call_id": "c1", "status": "ok",
+        "elapsed_ms": 412, "result": "RESULT_SECRET",
+    })])
+    manager._poll_event_tail()
+
+    rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "(0.0s api, 412ms, success)" in rendered
+    assert "RESULT_SECRET" not in rendered
 
 
 def test_tool_call_action_is_rendered_as_tool_action():

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -459,7 +459,7 @@ def test_tool_result_updates_status_and_elapsed(tmp_path):
 
     _write_lines(path, [_tool_call_line(tool_name="read", action="read", call_id="c1")])
     manager._poll_event_tail()
-    assert "(0.0s api, 0ms, ???)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "(0ms, ???)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
 
     _write_lines(path, [json.dumps({
         "type": "tool_result", "tool_call_id": "c1", "status": "ok",
@@ -467,7 +467,7 @@ def test_tool_result_updates_status_and_elapsed(tmp_path):
     })])
     manager._poll_event_tail()
     rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
-    assert "(0.0s api, 2300ms, success)" in rendered
+    assert "(2300ms, success)" in rendered
     assert "RESULT_SECRET" not in rendered
 
     _write_lines(path, [
@@ -478,7 +478,7 @@ def test_tool_result_updates_status_and_elapsed(tmp_path):
         }),
     ])
     manager._poll_event_tail()
-    assert "(0.0s api, 400ms, error)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "(400ms, error)" in [c for c in acct.calls if c[0] == "edit_message"][-1][3]
 
 
 def test_second_tool_call_api_delay_is_previous_tool_ts_delta(tmp_path):
@@ -507,9 +507,10 @@ def test_second_tool_call_api_delay_is_previous_tool_ts_delta(tmp_path):
     assert all("_ts" not in row for row in window)
 
     rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
-    second_line = next(ln for ln in rendered.splitlines() if "second" in ln)
-    assert "3.4s api" in second_line
-    assert "0.0s api" not in second_line
+    # The api delay is rendered on the group divider line, not in tool rows.
+    assert "API 3.4s" in rendered
+    # Tool rows no longer carry the api suffix.
+    assert "3.4s api" not in rendered
 
 
 def test_sub_second_tool_elapsed_renders_milliseconds_not_zero_seconds(tmp_path):
@@ -528,7 +529,7 @@ def test_sub_second_tool_elapsed_renders_milliseconds_not_zero_seconds(tmp_path)
     manager._poll_event_tail()
 
     rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
-    assert "(0.0s api, 412ms, success)" in rendered
+    assert "(412ms, success)" in rendered
     assert "RESULT_SECRET" not in rendered
 
 

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -515,31 +515,37 @@ def test_second_tool_call_api_delay_is_previous_tool_ts_delta(tmp_path):
 
 def test_divider_renders_compact_per_call_usage_arrows(tmp_path):
     """The group divider carries per-call LLM usage: down arrow = output tokens,
-    up arrow = cache miss, trailing percentage = cache rate."""
+    up arrow = cache miss, trailing percentage = cache rate. The usage arrives
+    on the notification_block_injected carrier (real kernel shape), keyed by
+    call_id, and is attached to the matching tool row."""
     acct = FakeAccount()
     manager, service = _manager(tmp_path, acct)
     _pre_resident(acct, 555, manager)
 
-    def line(ts, out, miss, rate):
-        event = json.loads(_tool_call_line(call_id=f"c{int(ts)}", ts=ts))
-        event["_meta"] = {
-            "agent_meta": {
-                "agent_state": {
-                    "token_usage": {
-                        "current_call": {
-                            "output": out,
-                            "cache_miss": miss,
-                            "cache_rate": rate,
+    def carrier(call_id, out, miss, rate):
+        return json.dumps({
+            "type": "notification_block_injected",
+            "call_id": call_id,
+            "_meta": {
+                "agent_meta": {
+                    "agent_state": {
+                        "token_usage": {
+                            "current_call": {
+                                "output": out,
+                                "cache_miss": miss,
+                                "cache_rate": rate,
+                            }
                         }
                     }
                 }
-            }
-        }
-        return json.dumps(event)
+            },
+        })
 
     _write_lines(_events_path(tmp_path), [
-        line(100.0, 412, 31_000, 0.97716),
-        line(103.4, 1_234, 512_345, 0.55),
+        _tool_call_line(call_id="c1", ts=100.0),
+        carrier("c1", 412, 31_000, 0.97716),
+        _tool_call_line(call_id="c2", ts=103.4),
+        carrier("c2", 1_234, 512_345, 0.55),
     ])
 
     manager._poll_event_tail()
@@ -557,7 +563,7 @@ def test_divider_renders_compact_per_call_usage_arrows(tmp_path):
 
 
 def test_divider_usage_degrades_when_event_lacks_usage(tmp_path):
-    """Old tool_call events without usage still render the API delay alone."""
+    """Old tool_call events without a usage carrier still render delay alone."""
     acct = FakeAccount()
     manager, _ = _manager(tmp_path, acct)
     _pre_resident(acct, 555, manager)

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -578,6 +578,68 @@ def test_divider_usage_degrades_when_event_lacks_usage(tmp_path):
     assert "\u2193" not in rendered
 
 
+def test_pure_text_turn_renders_api_usage_from_llm_response(tmp_path):
+    """A pure-text turn (diary reply with no tool call) has no
+    notification_block_injected carrier, so the divider usage arrows come from
+    the llm_response event keyed by api_call_id (Jason 2026-08-08: pure text
+    output turns only showed the API line with no usage)."""
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    def diary(text, ts, api_call_id):
+        return json.dumps({
+            "type": "diary", "ts": ts, "api_call_id": api_call_id,
+            "text": text, "visibility": "public",
+        })
+
+    def llm_response(api_call_id, total, cached, out, ts):
+        return json.dumps({
+            "type": "llm_response", "ts": ts, "api_call_id": api_call_id,
+            "input_tokens": total, "cached_tokens": cached,
+            "output_tokens": out, "estimated": False,
+        })
+
+    _write_lines(_events_path(tmp_path), [
+        diary("first pure text", 100.0, "api_pure_1"),
+        llm_response("api_pure_1", 1_000, 900, 123, 105.0),
+    ])
+
+    manager._poll_event_tail()
+
+    rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "first pure text" in rendered
+    # llm_response usage rides the divider: output, cache miss, cache rate.
+    assert "\u2193123" in rendered
+    assert "\u2191100" in rendered   # 1000 - 900 cache miss
+    assert "90.0%" in rendered      # 900/1000
+
+
+def test_pure_text_turn_api_line_has_no_bullet(tmp_path):
+    """The API divider info line must not carry the bullet prefix (it would
+    look like a tool row). Jason 2026-08-08."""
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    def diary(text, ts, api_call_id):
+        return json.dumps({
+            "type": "diary", "ts": ts, "api_call_id": api_call_id,
+            "text": text, "visibility": "public",
+        })
+
+    _write_lines(_events_path(tmp_path), [
+        diary("only text", 100.0, "api_no_usage"),
+    ])
+    manager._poll_event_tail()
+    rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    lines = rendered.split("\n")
+    # No API info line at all when the turn has no usage (delay 0.0 for a lone
+    # first row is not rendered), and no stray bullet-only line is invented.
+    assert "only text" in rendered
+    assert all("\u2022 API" not in line for line in lines)
+
+
 def test_sub_second_tool_elapsed_renders_adaptive_seconds_not_zero_seconds(tmp_path):
     """CHANGE B: a 412ms tool result renders ``0.4s``, never the useless ``0s``."""
     acct = FakeAccount()

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -513,6 +513,65 @@ def test_second_tool_call_api_delay_is_previous_tool_ts_delta(tmp_path):
     assert "3.4s api" not in rendered
 
 
+def test_divider_renders_compact_per_call_usage_arrows(tmp_path):
+    """The group divider carries per-call LLM usage: down arrow = output tokens,
+    up arrow = cache miss, trailing percentage = cache rate."""
+    acct = FakeAccount()
+    manager, service = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+
+    def line(ts, out, miss, rate):
+        event = json.loads(_tool_call_line(call_id=f"c{int(ts)}", ts=ts))
+        event["_meta"] = {
+            "agent_meta": {
+                "agent_state": {
+                    "token_usage": {
+                        "current_call": {
+                            "output": out,
+                            "cache_miss": miss,
+                            "cache_rate": rate,
+                        }
+                    }
+                }
+            }
+        }
+        return json.dumps(event)
+
+    _write_lines(_events_path(tmp_path), [
+        line(100.0, 412, 31_000, 0.97716),
+        line(103.4, 1_234, 512_345, 0.55),
+    ])
+
+    manager._poll_event_tail()
+
+    rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    # The visible tail (last group) carries its own API delay + arrows + rate.
+    assert "API 3.4s" in rendered
+    assert "\u21931.2k" in rendered    # ↓1.2k output tokens
+    assert "\u2191512.3k" in rendered  # ↑512.3k cache miss
+    assert "55%" in rendered           # cache rate
+    # Usage is private per-row state: projected for rendering but never
+    # leaked into the public window rows.
+    assert all("_usage" not in row for row in manager._task_card_event_window())
+    assert all("_ts" not in row for row in manager._task_card_event_window())
+
+
+def test_divider_usage_degrades_when_event_lacks_usage(tmp_path):
+    """Old tool_call events without usage still render the API delay alone."""
+    acct = FakeAccount()
+    manager, _ = _manager(tmp_path, acct)
+    _pre_resident(acct, 555, manager)
+    _write_lines(_events_path(tmp_path), [
+        _tool_call_line(tool_name="first", call_id="c1", ts=100.0),
+        _tool_call_line(tool_name="second", call_id="c2", ts=103.4),
+    ])
+    manager._poll_event_tail()
+    rendered = [c for c in acct.calls if c[0] == "edit_message"][-1][3]
+    assert "API 3.4s" in rendered
+    assert "\u2191" not in rendered
+    assert "\u2193" not in rendered
+
+
 def test_sub_second_tool_elapsed_renders_milliseconds_not_zero_seconds(tmp_path):
     """CHANGE B: a 412ms tool result renders ``412ms``, never the useless ``0s``."""
     acct = FakeAccount()

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -382,7 +382,29 @@ def test_metadata_renders_compact_normal_lifecycle_states():
     for state in ("active", "idle", "asleep", "suspended"):
         lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": state})
         assert lines == [f"agent · {state}"]
-        assert "/refresh" not in lines[0]
+
+
+def test_metadata_renders_active_seconds_only_when_active():
+    # Active state plus a sane age renders the (N sec) suffix.
+    lines = TelegramManager._format_task_card_metadata({
+        "agent_lifecycle": "active",
+        "agent_active_seconds": 12.0,
+    })
+    assert lines == ["agent · active (12s)"]
+    # Non-active states never render the suffix even if the field is present.
+    lines = TelegramManager._format_task_card_metadata({
+        "agent_lifecycle": "idle",
+        "agent_active_seconds": 12.0,
+    })
+    assert lines == ["agent · idle"]
+    # Missing/invalid age degrades to the plain lifecycle line.
+    lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": "active"})
+    assert lines == ["agent · active"]
+    lines = TelegramManager._format_task_card_metadata({
+        "agent_lifecycle": "active",
+        "agent_active_seconds": "secret",
+    })
+    assert lines == ["agent · active"]
 
 
 def test_metadata_renders_stuck_with_refresh_hint():

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -70,8 +70,8 @@ def test_single_row_shows_tool_action_reasoning_elapsed():
     ])
     assert "bash.run" in text
     assert "compile project" in text
-    # Elapsed renders as whole seconds, no decimal point.
-    assert "3s" in text
+    # Elapsed renders as whole milliseconds, no decimal point.
+    assert "3000ms" in text
     assert "3.0s" not in text
 
 
@@ -84,13 +84,13 @@ def test_parallel_rows_all_represented_with_independent_elapsed():
         {"tool": "grep", "tool_action": "", "reasoning": "scan",
          "elapsed_s": 8, "done": True},
     ])
-    # Each row present with its own tool + whole-second elapsed.
+    # Each row present with its own tool + whole-millisecond elapsed.
     assert "bash.run" in text
     assert "read" in text
     assert "grep" in text
-    assert "5s" in text
-    assert "2s" in text
-    assert "8s" in text
+    assert "5000ms" in text
+    assert "2000ms" in text
+    assert "8000ms" in text
 
 
 # ---------------------------------------------------------------------------
@@ -102,41 +102,41 @@ def test_no_decimal_point_in_render():
         {"tool": "bash", "tool_action": "run", "reasoning": "x",
          "elapsed_s": 12, "done": False},
     ])
-    assert "12s" in text
-    # The elapsed suffix is whole-second, no decimal point in it.
+    assert "12000ms" in text
+    # The elapsed suffix is whole-millisecond, no decimal point in it.
     row_line = next(ln for ln in text.splitlines() if "bash.run" in ln)
-    elapsed_suffix = row_line[row_line.rindex("("):]  # "(12s)"
-    assert elapsed_suffix == "(12s)"
+    elapsed_suffix = row_line[row_line.rindex("("):]  # "(12000ms)"
+    assert elapsed_suffix == "(12000ms)"
     assert "." not in elapsed_suffix
 
 
-def test_float_elapsed_payload_is_floored_to_whole_second():
+def test_float_elapsed_payload_is_floored_to_whole_ms():
     """A float elapsed (e.g. from an in-flight value) is floored, not rounded,
-    and shows no decimal — 8.99s displays 8s."""
+    and shows no decimal — 8.99s displays 8990ms."""
     text = _fmt([
         {"tool": "bash", "tool_action": "run", "reasoning": "x",
          "elapsed_s": 8.99, "done": False},
     ])
-    assert "8s" in text
+    assert "8990ms" in text
     assert "8.99" not in text
     assert "9s" not in text
 
 
-def test_zero_elapsed_renders_zero_seconds():
+def test_zero_elapsed_renders_zero_ms():
     text = _fmt([
         {"tool": "bash", "tool_action": "run", "reasoning": "x",
          "elapsed_s": 0, "done": False},
     ])
-    assert "0s" in text
+    assert "0ms" in text
     assert "0.0s" not in text
 
 
-def test_done_row_elapsed_is_whole_second():
+def test_done_row_elapsed_is_whole_ms():
     text = _fmt([
         {"tool": "bash", "tool_action": "run", "reasoning": "x",
          "elapsed_s": 7, "done": True},
     ])
-    assert "7s" in text
+    assert "7000ms" in text
     assert "7.0s" not in text
 
 

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -70,9 +70,9 @@ def test_single_row_shows_tool_action_reasoning_elapsed():
     ])
     assert "bash.run" in text
     assert "compile project" in text
-    # Elapsed renders as whole milliseconds, no decimal point.
-    assert "3000ms" in text
-    assert "3.0s" not in text
+    # Elapsed renders adaptively: ms under 0.1s, one-decimal seconds above.
+    assert "3.0s" in text
+    assert "3000ms" not in text
 
 
 def test_parallel_rows_all_represented_with_independent_elapsed():
@@ -88,36 +88,35 @@ def test_parallel_rows_all_represented_with_independent_elapsed():
     assert "bash.run" in text
     assert "read" in text
     assert "grep" in text
-    assert "5000ms" in text
-    assert "2000ms" in text
-    assert "8000ms" in text
+    assert "5.0s" in text
+    assert "2.0s" in text
+    assert "8.0s" in text
 
 
 # ---------------------------------------------------------------------------
-# Whole-second display rule (no decimal point)
+# Adaptive duration display rule (ms under 0.1s, x.x s above)
 # ---------------------------------------------------------------------------
 
-def test_no_decimal_point_in_render():
+def test_adaptive_duration_renders_one_decimal_second():
     text = _fmt([
         {"tool": "bash", "tool_action": "run", "reasoning": "x",
          "elapsed_s": 12, "done": False},
     ])
-    assert "12000ms" in text
-    # The elapsed suffix is whole-millisecond, no decimal point in it.
+    assert "12.0s" in text
+    # The elapsed suffix is one-decimal seconds for >=0.1s durations.
     row_line = next(ln for ln in text.splitlines() if "bash.run" in ln)
     elapsed_suffix = row_line[row_line.rindex("("):]  # "(12000ms)"
-    assert elapsed_suffix == "(12000ms)"
-    assert "." not in elapsed_suffix
+    assert elapsed_suffix == "(12.0s)"
+    assert "." in elapsed_suffix
 
 
-def test_float_elapsed_payload_is_floored_to_whole_ms():
-    """A float elapsed (e.g. from an in-flight value) is floored, not rounded,
-    and shows no decimal — 8.99s displays 8990ms."""
+def test_float_elapsed_payload_floors_to_one_decimal_second():
+    """A float elapsed (e.g. from an in-flight value) floors to one decimal — 8.99s displays 9.0s."""
     text = _fmt([
         {"tool": "bash", "tool_action": "run", "reasoning": "x",
          "elapsed_s": 8.99, "done": False},
     ])
-    assert "8990ms" in text
+    assert "9.0s" in text
     assert "8.99" not in text
     assert "9s" not in text
 
@@ -136,8 +135,8 @@ def test_done_row_elapsed_is_whole_ms():
         {"tool": "bash", "tool_action": "run", "reasoning": "x",
          "elapsed_s": 7, "done": True},
     ])
-    assert "7000ms" in text
-    assert "7.0s" not in text
+    assert "7.0s" in text
+    assert "7000ms" not in text
 
 
 def test_done_row_has_marker_and_active_row_does_not():

--- a/tests/test_telegram_task_card_timestamp.py
+++ b/tests/test_telegram_task_card_timestamp.py
@@ -137,7 +137,7 @@ def test_render_tool_row_without_started_at_is_safe():
          "elapsed_s": 1, "done": False},
     ], now=_NOW)
     assert "bash" in text
-    assert "(1s)" in text
+    assert "(1000ms)" in text
     row_line = next(ln for ln in text.splitlines() if ln.startswith(("•", "✓")))
     assert "UTC" not in row_line
     assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"

--- a/tests/test_telegram_task_card_timestamp.py
+++ b/tests/test_telegram_task_card_timestamp.py
@@ -137,7 +137,7 @@ def test_render_tool_row_without_started_at_is_safe():
          "elapsed_s": 1, "done": False},
     ], now=_NOW)
     assert "bash" in text
-    assert "(1000ms)" in text
+    assert "(1.0s)" in text
     row_line = next(ln for ln in text.splitlines() if ln.startswith(("•", "✓")))
     assert "UTC" not in row_line
     assert text.splitlines()[-1] == "Last Updated: 17:18:36 UTC-07"


### PR DESCRIPTION
## What

Three taskcard improvements around live latency visibility + Telegram 429 mitigation:

1. **Blanket refresh 1s → 5s** — `agent · active (N sec)` changes every second, defeating fingerprint dedupe and editing Telegram every tick (hit a real 429, retry 175s; all Bot API requests share ~30 req/s quota per tdlib#3034).
2. **Poll interval configurable** — `LINGTAI_TASKCARD_POLL_INTERVAL` env var (default 5s) so networks that want 1s cadence can opt in.
3. **Tool row latency detail** — each tool call row now shows `(3.4s api, 2300ms, success)`: `api` = seconds since the previous tool call (the LLM API round-trip that the active (N sec) footer accumulates), and the tool-result duration renders in milliseconds instead of whole seconds (previously sub-second calls showed useless `0s`).

## Details

- `_TASK_CARD_EVENT_POLL_INTERVAL`: 1.0 → env-configurable, default 5.0; event tail + programmable poller both use it. First-frame render and manual commands stay immediate.
- event_projection: raw `_ts` carried privately; `group_events` computes `api_delay_s` (stream-order delta, first = 0.0, clamped ≥ 0); render builds one suffix used in both scaffold budget and output; `format_elapsed_ms` (floored, defensive, capped at 9_999_999).

## Tests

170 taskcard-related tests pass (116 + 54 across event tail, projection shared, rows, timestamp, blockers, feishu, singleton, in_place, last_message). New tests cover api_delay_s delta and ms rendering.
