### PR TITLE
feat(llm): seven-tier thinking levels, Responses default allow, deepseek effort passthrough

### DIFF
--- a/src/lingtai/kernel/config.py
+++ b/src/lingtai/kernel/config.py
@@ -9,9 +9,9 @@ from dataclasses import dataclass
 # Accepted manifest.llm.thinking values, mirroring the upstream Responses
 # ``reasoning.effort`` payload values in ascending effort order. Explicit
 # ``"none"`` is a real payload value (effort none), distinct from an *omitted*
-# field — omitted stays the internal ``"default"`` sentinel and the Codex
-# adapter maps it to ``"xhigh"``.
-THINKING_LEVELS = ("none", "minimal", "low", "medium", "high", "xhigh")
+# field — omitted stays the internal ``"default"`` sentinel and adapters that
+# own a default map it to ``"xhigh"``.
+THINKING_LEVELS = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
 # Codex-family providers that accept manifest.llm.thinking. ``codex-pool``
 # reuses the Codex adapter (both dash/underscore spellings). Custom
@@ -21,13 +21,19 @@ THINKING_PROVIDERS = ("codex", "codex-pool", "codex_pool")
 
 
 def llm_supports_thinking(llm: dict) -> bool:
-    """Return whether a manifest LLM block accepts explicit thinking effort."""
+    """Return whether a manifest LLM block accepts explicit thinking effort.
+
+    Responses-API compatible models are allowed by default: any block whose
+    wire is OpenAI Responses (``api_compat == "openai"`` and
+    ``wire_api == "responses"``) is accepted, regardless of provider. The
+    Codex family remains accepted through ``THINKING_PROVIDERS`` (it owns its
+    own wire/backend), as does any provider explicitly listed there.
+    """
     provider = str(llm.get("provider") or "").lower()
     if provider in THINKING_PROVIDERS:
         return True
     return (
-        provider == "custom"
-        and str(llm.get("api_compat") or "").lower() == "openai"
+        str(llm.get("api_compat") or "").lower() == "openai"
         and str(llm.get("wire_api") or "").lower() == "responses"
     )
 

--- a/src/lingtai/llm/deepseek/adapter.py
+++ b/src/lingtai/llm/deepseek/adapter.py
@@ -206,6 +206,25 @@ class DeepSeekAdapter(OpenAIAdapter):
 
     _session_class = DeepSeekChatSession
 
+    def _chat_reasoning_effort(self, thinking: str) -> str | None:
+        """DeepSeek passes the seven-tier kernel effort through unchanged.
+
+        DeepSeek's OpenAI-compatible Chat Completions wire accepts
+        ``none | minimal | low | medium | high | xhigh | max`` (verified
+        against opencode.ai zen/go). The omitted/``default`` sentinel maps to
+        ``None`` so no field is sent and the upstream default applies.
+        """
+        from lingtai.kernel.config import THINKING_LEVELS
+
+        if thinking == "default":
+            return None
+        if thinking not in THINKING_LEVELS:
+            raise ValueError(
+                "DeepSeek thinking must be one of "
+                f"{', '.join(THINKING_LEVELS)}, or default"
+            )
+        return thinking
+
     def _default_prompt_cache_key(self, model: str) -> str:
         # Fixed provider identity — use a clean ``lingtai-deepseek`` namespace
         # rather than the base_url host. DeepSeek Chat Completions accepts

--- a/src/lingtai/llm/openai/adapter.py
+++ b/src/lingtai/llm/openai/adapter.py
@@ -954,9 +954,15 @@ def _estimate_responses_input_tokens(
 
 
 def _responses_reasoning_kwargs(thinking: str | None) -> dict[str, dict[str, str]]:
-    """Return OpenAI Responses reasoning kwargs for a configured thinking level."""
+    """Return OpenAI Responses reasoning kwargs for a configured thinking level.
+
+    An omitted/``default`` level maps to the explicit ``xhigh`` effort (the
+    kernel's canonical default), matching the Codex adapter's longstanding
+    behavior. Explicit levels pass through; ``none`` is sent as
+    ``reasoning.effort = "none"``.
+    """
     if thinking in (None, "default"):
-        return {}
+        thinking = "xhigh"
     if thinking not in THINKING_LEVELS:
         raise ValueError(
             "OpenAI Responses thinking must be one of "
@@ -2640,9 +2646,14 @@ class OpenAIAdapter(LLMAdapter):
                 },
             }
 
-        # Reasoning effort for o-series models
-        if thinking != "default":
-            extra_kwargs["reasoning_effort"] = "high" if thinking == "high" else "low"
+        # Reasoning effort for o-series models. Subclasses override
+        # ``_chat_reasoning_effort`` to map the kernel thinking levels to
+        # their Chat Completions wire value (e.g. DeepSeek passes the
+        # seven-tier value through unchanged; ``default`` is omitted here and
+        # the upstream default applies).
+        effort = self._chat_reasoning_effort(thinking)
+        if effort is not None:
+            extra_kwargs["reasoning_effort"] = effort
 
         # Subclass-provided extra_body (e.g. OpenRouter's reasoning include).
         # Merge rather than overwrite so callers adding their own extra_body
@@ -2672,6 +2683,19 @@ class OpenAIAdapter(LLMAdapter):
         surface reasoning text on reasoning-capable models).
         """
         return {}
+
+    def _chat_reasoning_effort(self, thinking: str) -> str | None:
+        """Map a kernel thinking level to the Chat Completions reasoning_effort value.
+
+        Default maps ``high`` to ``high`` and every other explicit level to
+        ``low`` (OpenAI o-series compatibility), and returns ``None`` for the
+        omitted/``default`` sentinel so the field is not sent. Subclasses with
+        a wider wire vocabulary (e.g. DeepSeek seven-tier passthrough)
+        override this hook.
+        """
+        if thinking == "default":
+            return None
+        return "high" if thinking == "high" else "low"
 
     def generate(
         self,

--- a/tests/test_init_schema.py
+++ b/tests/test_init_schema.py
@@ -277,7 +277,7 @@ def test_known_manifest_llm_pass_through_fields_do_not_warn(key, value):
     assert all(f"unknown field in manifest.llm: {key}" != w for w in warnings)
 
 
-@pytest.mark.parametrize("value", ["none", "minimal", "low", "medium", "high", "xhigh"])
+@pytest.mark.parametrize("value", ["none", "minimal", "low", "medium", "high", "xhigh", "max"])
 def test_llm_thinking_valid_values(value):
     data = _valid_init()
     data["manifest"]["llm"]["provider"] = "codex"
@@ -285,7 +285,7 @@ def test_llm_thinking_valid_values(value):
     validate_init(data)
 
 
-@pytest.mark.parametrize("value", ["none", "minimal", "low", "medium", "high", "xhigh"])
+@pytest.mark.parametrize("value", ["none", "minimal", "low", "medium", "high", "xhigh", "max"])
 def test_llm_thinking_valid_for_custom_openai_responses(value):
     data = _valid_init()
     data["manifest"]["llm"].update(
@@ -299,6 +299,20 @@ def test_llm_thinking_valid_for_custom_openai_responses(value):
 
     validate_init(data)
 
+
+@pytest.mark.parametrize("value", ["none", "minimal", "low", "medium", "high", "xhigh", "max"])
+def test_llm_thinking_valid_for_deepseek_responses(value):
+    # DeepSeek is OpenAI-compatible; Responses wire accepts thinking by default.
+    data = _valid_init()
+    data["manifest"]["llm"].update(
+        {
+            "provider": "deepseek",
+            "api_compat": "openai",
+            "wire_api": "responses",
+            "thinking": value,
+        }
+    )
+    validate_init(data)
 
 @pytest.mark.parametrize("value", ["default", "ultra", 1, None])
 def test_llm_thinking_invalid_for_custom_openai_responses(value):

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -333,7 +333,7 @@ def test_load_preset_rejects_non_integer_context_limit(tmp_path):
         load_preset(str(f))
 
 
-@pytest.mark.parametrize("value", ["none", "minimal", "low", "medium", "high", "xhigh"])
+@pytest.mark.parametrize("value", ["none", "minimal", "low", "medium", "high", "xhigh", "max"])
 def test_load_preset_accepts_thinking_values(tmp_path, value):
     p = {
         "name": "thinking",


### PR DESCRIPTION
## Seven-tier thinking levels + Responses default allow + DeepSeek effort passthrough

Per Jason's direction (Telegram 11313/11315/11319): for Responses-API-supported models we default-allow `manifest.llm.thinking`, the kernel vocab becomes the correct 7 tiers, and the omitted/`default` sentinel maps to explicit `xhigh`.

### Changes
- **`kernel/config.py`**: `THINKING_LEVELS` now `none/minimal/low/medium/high/xhigh/max` (adds `max`, matching upstream Responses/opencode enum). `llm_supports_thinking` accepts any OpenAI-compatible Responses wire by default (`api_compat == "openai"` + `wire_api == "responses"`), no longer restricted to provider `custom`; Codex family still accepted via `THINKING_PROVIDERS`.
- **`llm/openai/adapter.py`**: generic `_responses_reasoning_kwargs` maps omitted/`default` to explicit `reasoning.effort = "xhigh"` (matching Codex's longstanding behavior). New `_chat_reasoning_effort` hook on `OpenAIAdapter` keeps o-series high/low mapping; `default` returns `None` (field not sent).
- **`llm/deepseek/adapter.py`**: `DeepSeekAdapter._chat_reasoning_effort` passes the seven-tier value through unchanged (verified against opencode.ai zen/go which accepts none/minimal/low/medium/high/xhigh/max); `default` returns `None`.
- **Tests**: `max` added to valid-tier parametrization (init_schema + presets); new deepseek Responses thinking acceptance test.

### Validation
- `test_init_schema.py` + `test_presets.py` + `test_deepseek_adapter.py`: 233 passed
- plus `test_preset_materialization.py` + `test_custom_responses_stateless.py` + `test_llm_service.py`: 295 passed
- `git diff --check` clean

Related: #1197. This supersedes the DeepSeek reasoning-effort vertical slice in #1226 (credit to @TZZheng for identifying the provider-aware effort wiring).
