### PR TITLE
feat(taskcard): compact two-line metadata footer

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -537,20 +537,40 @@ class TaskCardEventProjection:
         session_parts: list[str] = []
         model = metadata.get("model")
         if isinstance(model, str) and model.strip():
-            session_parts.append(f"model {model.strip()}")
+            session_parts.append(model.strip())
         thinking = metadata.get("thinking")
         if isinstance(thinking, str) and thinking.strip():
-            session_parts.append(f"effort {thinking.strip()}")
+            session_parts.append(thinking.strip())
         endpoint = metadata.get("endpoint")
         if isinstance(endpoint, str) and endpoint.strip():
-            session_parts.append(f"endpoint {endpoint.strip()}")
+            session_parts.append(f"@{endpoint.strip()}")
+        context = cls.format_count(metadata.get("context_tokens"))
+        window = cls.format_count(metadata.get("context_window"))
+        usage = metadata.get("context_usage")
+        if (
+            type(usage) in {int, float}
+            and not isinstance(usage, bool)
+            and 0 <= usage <= 1
+        ):
+            if context is not None:
+                session_parts.append(
+                    f"ctx {float(usage):.0%} · {context}/{window}"
+                    if window is not None
+                    else f"ctx {float(usage):.0%}"
+                )
+            else:
+                session_parts.append(f"ctx {float(usage):.0%}")
+        elif context is not None:
+            session_parts.append(
+                f"ctx {context}/{window}" if window is not None else f"ctx {context}"
+            )
         cache_rate = metadata.get("session_cache_rate")
         if (
             type(cache_rate) in {int, float}
             and not isinstance(cache_rate, bool)
             and 0 <= cache_rate <= 1
         ):
-            session_parts.append(f"cache {float(cache_rate):.1%}")
+            session_parts.append(f"cache {float(cache_rate):.0%}")
         miss = cls.format_count(metadata.get("cache_miss_tokens"))
         budget = cls.format_count(metadata.get("cache_miss_budget"))
         if miss is not None:
@@ -561,78 +581,77 @@ class TaskCardEventProjection:
         if calls is not None:
             session_parts.append(f"calls {calls}")
 
-        context_parts: list[str] = []
-        context = cls.format_count(metadata.get("context_tokens"))
-        window = cls.format_count(metadata.get("context_window"))
-        if context is not None:
-            context_parts.append(
-                f"{context}/{window}" if window is not None else context
-            )
-        usage = metadata.get("context_usage")
-        if (
-            type(usage) in {int, float}
-            and not isinstance(usage, bool)
-            and 0 <= usage <= 1
-        ):
-            context_parts.append(f"{float(usage):.0%}")
-
-        agent_line: str | None = None
+        agent_part: str | None = None
         lifecycle = metadata.get("agent_lifecycle")
         if lifecycle in (AgentState.STUCK.value, "offline"):
-            agent_line = f"agent · {lifecycle} · try /refresh"
-        elif lifecycle in cls.AGENT_STATES:
-            agent_line = f"agent · {lifecycle}"
-        if agent_line and lifecycle == AgentState.ACTIVE.value:
+            agent_part = f"agent · {lifecycle} · try /refresh"
+        elif lifecycle == AgentState.ACTIVE.value:
             active_seconds = metadata.get("agent_active_seconds")
             if (
                 type(active_seconds) in {int, float}
                 and not isinstance(active_seconds, bool)
                 and active_seconds >= 0
             ):
-                agent_line = f"{agent_line} ({float(active_seconds):.0f}s)"
+                agent_part = f"active ({float(active_seconds):.0f}s)"
+            else:
+                agent_part = "active"
+        elif lifecycle in cls.AGENT_STATES:
+            agent_part = f"agent · {lifecycle}"
 
-        session_line = (
-            "session · " + " · ".join(session_parts) if session_parts else None
-        )
-        context_line = "ctx · " + " · ".join(context_parts) if context_parts else None
-        # One compact footer line: groups separated by "|" so each concept stays
-        # readable without forcing line breaks (the card stays narrow on
-        # Telegram). agent/session/ctx/device/path each own a group; a long
-        # working dir rides in the last group so it cannot crowd identity.
-        groups: list[str] = []
-        if agent_line:
-            groups.append(agent_line)
-        if session_line:
-            groups.append(session_line)
-        if context_line:
-            groups.append(context_line)
+        # Line 1 = running state: agent lifecycle + session identity/usage,
+        # compact (no per-part prefixes; effort/endpoint/ctx/cache/miss are
+        # self-evident from position). Line 2 = identity: device + short path.
+        line1_parts: list[str] = []
+        if agent_part:
+            line1_parts.append(agent_part)
+        line1_parts.extend(session_parts)
+        line1 = " · ".join(line1_parts) if line1_parts else None
 
         device = cls.machine_identifier(
             metadata.get("device_short_name"), limit=64
         )
         shell_name = cls.machine_identifier(metadata.get("shell_name"), limit=48)
+        line2_parts: list[str] = []
         if device is not None or shell_name is not None:
             parts: list[str] = []
             if device is not None:
                 parts.append(device)
             if shell_name is not None:
                 parts.append(f"shell {shell_name}")
-            groups.append("device · " + " · ".join(parts))
+            line2_parts.append("device · " + " · ".join(parts))
         working_dir = cls.machine_identifier(metadata.get("working_dir"), limit=220)
         if working_dir is not None:
-            groups.append(f"path · {working_dir}")
+            line2_parts.append(f"path · {cls._short_working_dir(working_dir)}")
+        line2 = " | ".join(line2_parts) if line2_parts else None
 
-        lines = [" | ".join(groups)[: cls.METADATA_MAX_CHARS]]
-        if not lines or not lines[0].strip():
+        lines = [ln for ln in (line1, line2) if ln]
+        if not lines:
             return []
         joined = "\n".join(lines)
         if len(joined) <= cls.METADATA_MAX_CHARS:
             return lines
+        # Prefer preserving the session line; truncate from the identity line.
+        budget1 = cls.METADATA_MAX_CHARS
+        if len(lines) > 1:
+            budget1 = min(budget1, len(lines[0]) + 1)
         first = lines[0][: cls.METADATA_MAX_CHARS]
+        if len(lines) == 1:
+            return [first]
         remaining = cls.METADATA_MAX_CHARS - len(first) - 1
-        if remaining <= 0 or len(lines) == 1:
+        if remaining <= 0:
             return [first]
         return [first, lines[1][:remaining]]
+
+    @classmethod
+    def _short_working_dir(cls, working_dir: str) -> str:
+        """Trim an absolute agent path to ``<project>/.lingtai/<agent>``."""
+        idx = working_dir.find("/.lingtai/")
+        if idx > 0:
+            prev = working_dir.rfind("/", 0, idx)
+            if prev >= 0:
+                return working_dir[prev + 1 :]
+            return working_dir
+        return working_dir
 
     @classmethod
     def format_rows_task_card_text(

--- a/tests/test_task_card_event_projection_shared.py
+++ b/tests/test_task_card_event_projection_shared.py
@@ -132,13 +132,13 @@ def test_shared_render_is_byte_identical_to_telegram_golden_surface() -> None:
         "\n"
         "Don't reply to this Task Card. Use /taskcard on|off to toggle; "
         "/taskcard N sets normal rows (1-10, current: 1).\n"
-        "agent · active | session · calls 2\n"
+        "active · calls 2\n"
         "Last Updated: 02:30:00 UTC+08"
     )
 
 
 def test_metadata_renders_device_and_working_dir_lines() -> None:
-    """Device identity metadata renders a compact ||-separated footer."""
+    """Device identity metadata renders a compact ||-separated identity line."""
     metadata = {
         "agent_lifecycle": "active",
         "api_calls": 2,
@@ -147,11 +147,12 @@ def test_metadata_renders_device_and_working_dir_lines() -> None:
         "working_dir": "C:\\Users\\zhuang\\.lingtai\\deepseek-1",
     }
     lines = TaskCardEventProjection.format_metadata(metadata)
-    assert len(lines) == 1
-    joined = lines[0]
-    assert "device · zesen-desktop · shell powershell" in joined
-    assert "path · C:\\Users\\zhuang" in joined
-    assert " | " in joined
+    assert len(lines) == 2
+    assert lines[0] == "active · calls 2"
+    identity = lines[1]
+    assert "device · zesen-desktop · shell powershell" in identity
+    assert "path · C:\\Users\\zhuang" in identity
+    assert " | " in identity
 
 
 def test_metadata_omits_device_line_when_only_bad_values() -> None:

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -784,8 +784,8 @@ def test_event_log_final_carrier_projects_session_telemetry_into_final_render(tm
     rendered = edits[-1][3]
     assert "• bash.run: event-log row" in rendered
     assert f" · {expected_stamp}" in rendered
-    assert "session · cache 87.8% · miss 170.6k/1.0M · calls 13" in rendered
-    assert "ctx · 171.2k/272.0k · 63%" in rendered
+    assert "cache 88% · miss 170.6k/1.0M · calls 13" in rendered
+    assert "ctx 63% · 171.2k/272.0k" in rendered
     assert "calls 888" not in rendered
     assert "calls 999" not in rendered
     assert "calls 777" not in rendered
@@ -1033,7 +1033,10 @@ def test_normal_rows_limits_rendered_event_tail_without_shrinking_buffer(tmp_pat
     assert len(edits) == 1
     rendered = edits[0][3]
     assert "newest" in rendered
-    assert "older" not in rendered
+    # The older event must not be rendered as a tool row (checked via the
+    # exact tool-row prefix, not a bare substring, because the metadata path
+    # line may legitimately contain "older" inside words like "folders").
+    assert "\u2022 older." not in rendered
     assert "current: 1" in rendered
 
 

--- a/tests/test_telegram_task_card_rows.py
+++ b/tests/test_telegram_task_card_rows.py
@@ -339,7 +339,7 @@ def test_metadata_is_two_lines_bounded_and_between_footer_and_timestamp():
     time_idx = next(i for i, line in enumerate(lines) if line.startswith("Last Updated: "))
     metadata_lines = lines[footer_idx + 1:time_idx]
     assert metadata_lines == [
-        "session · cache 87.8% · miss 170.6k/1.0M · calls 13 | ctx · 171.2k/272.0k · 63%",
+        "ctx 63% · 171.2k/272.0k · cache 88% · miss 170.6k/1.0M · calls 13",
     ]
     assert len(metadata_lines) == 1
     assert len(metadata_lines[0]) <= 500
@@ -380,7 +380,10 @@ def test_metadata_pathological_counts_never_overflow_or_break_budget():
 def test_metadata_renders_compact_normal_lifecycle_states():
     for state in ("active", "idle", "asleep", "suspended"):
         lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": state})
-        assert lines == [f"agent · {state}"]
+        if state == "active":
+            assert lines == ["active"]
+        else:
+            assert lines == [f"agent · {state}"]
 
 
 def test_metadata_renders_active_seconds_only_when_active():
@@ -389,7 +392,7 @@ def test_metadata_renders_active_seconds_only_when_active():
         "agent_lifecycle": "active",
         "agent_active_seconds": 12.0,
     })
-    assert lines == ["agent · active (12s)"]
+    assert lines == ["active (12s)"]
     # Non-active states never render the suffix even if the field is present.
     lines = TelegramManager._format_task_card_metadata({
         "agent_lifecycle": "idle",
@@ -398,12 +401,12 @@ def test_metadata_renders_active_seconds_only_when_active():
     assert lines == ["agent · idle"]
     # Missing/invalid age degrades to the plain lifecycle line.
     lines = TelegramManager._format_task_card_metadata({"agent_lifecycle": "active"})
-    assert lines == ["agent · active"]
+    assert lines == ["active"]
     lines = TelegramManager._format_task_card_metadata({
         "agent_lifecycle": "active",
         "agent_active_seconds": "secret",
     })
-    assert lines == ["agent · active"]
+    assert lines == ["active"]
 
 
 def test_metadata_renders_stuck_with_refresh_hint():
@@ -427,7 +430,7 @@ def test_metadata_ignores_unrecognized_lifecycle_value():
         "agent_lifecycle": "haunted",
         "session_cache_rate": 0.5,
     })
-    assert lines == ["session · cache 50.0%"]
+    assert lines == ["cache 50%"]
 
 
 def test_metadata_agent_and_session_combine_on_line_one_ctx_preserved():
@@ -443,8 +446,7 @@ def test_metadata_agent_and_session_combine_on_line_one_ctx_preserved():
         "context_usage": 0.62958,
     })
     assert lines == [
-        "agent · active | session · cache 87.8% · miss 170.6k/1.0M · calls 13 | "
-        "ctx · 171.2k/272.0k · 63%",
+        "active · ctx 63% · 171.2k/272.0k · cache 88% · miss 170.6k/1.0M · calls 13",
     ]
     assert len(lines) == 1
     assert len(lines[0]) <= 500
@@ -464,10 +466,9 @@ def test_metadata_stuck_hint_and_ctx_both_survive_full_metadata():
     # The 2-line cap holds; the hint leads line 1 (safe from end-truncation)
     # and ctx survives as line 2 instead of being dropped by the cap.
     assert lines == [
-        "agent · stuck · try /refresh | session · cache 87.8% · miss 170.6k/1.0M · calls 13 | "
-        "ctx · 171.2k/272.0k · 63%",
+        "agent · stuck · try /refresh · ctx 63% · 171.2k/272.0k · cache 88% · miss 170.6k/1.0M · calls 13",
     ]
-    assert lines[0].startswith("agent · stuck · try /refresh |")
+    assert lines[0].startswith("agent · stuck · try /refresh ·")
     assert len(lines) == 1
     assert len(lines[0]) <= 500
 
@@ -484,8 +485,7 @@ def test_metadata_unchanged_when_no_agent_lifecycle_present():
         "context_usage": 0.62958,
     })
     assert lines == [
-        "session · cache 87.8% · miss 170.6k/1.0M · calls 13 | "
-        "ctx · 171.2k/272.0k · 63%",
+        "ctx 63% · 171.2k/272.0k · cache 88% · miss 170.6k/1.0M · calls 13",
     ]
 
 
@@ -648,7 +648,7 @@ def test_metadata_renders_current_model_first():
         "model": "deepseek-v4-flash",
         "session_cache_rate": 0.5,
     })
-    assert lines == ["session · model deepseek-v4-flash · cache 50.0%"]
+    assert lines == ["deepseek-v4-flash · cache 50%"]
 
 
 def test_event_metadata_snapshot_adds_current_model(tmp_path):


### PR DESCRIPTION
## Task Card metadata footer — compact two-line layout

Per Jason's direction: the footer was too crowded (agent/session/ctx/device/path all on one line with verbose prefixes).

### Before
`agent · active (1s) | session · model deepseek-v4-flash · endpoint opencode.ai · cache 93.9% · miss 437.2k/1.0M · calls 29 | ctx · 375.3k/1.0M · 38% | device · … | path · /Users/…/dev-2/.lingtai/mimo-1`

### After
```
active (1s) · deepseek-v4-flash · xhigh · @opencode.ai · ctx 38% · 375.3k/1.0M · cache 94% · miss 437.2k/1.0M
device · Velli-Group-Mac-Studio.local | path · dev-2/.lingtai/mimo-1
```

- Line 1 = running state: prefix words dropped (position implies meaning); effort shown bare; endpoint as `@host`; ctx/cache as percentages; `miss` and `calls` keep labels (per feedback); api_calls preserved (crucial).
- Line 2 = identity: `device` and `path` retained; path trimmed to `<project>/.lingtai/<agent>`.
- Stuck/offline keep the `try /refresh` hint; other lifecycle states render compactly (`active` bare, `agent · idle/asleep/suspended`).

### Validation
- 182 task-card tests pass (golden shared/rows/event-tail updated to the two-line layout).
- `git diff --check` clean.
