### PR TITLE
feat(prompt): resident plugins + mcp fields parallel to skills; default plugin/ root

### DIFF
--- a/src/lingtai/kernel/prompt.py
+++ b/src/lingtai/kernel/prompt.py
@@ -68,6 +68,12 @@ class SystemPromptManager:
         "rules",
         "brief",
         "skills",
+        # Registered plugin packages and standalone MCP servers sit parallel to
+        # vanilla skills: each is a resident catalog field (written by the
+        # plugin/mcp capabilities, kept adjacent to skills so the agent sees the
+        # three capability namespaces side by side).
+        "plugin",
+        "mcp",
         "knowledge",
         "identity",
         "character",
@@ -118,8 +124,8 @@ class SystemPromptManager:
             "meta_guidance", "comment",
         ),
         (
-            "rules", "brief", "skills", "knowledge", "identity", "character",
-            "pad",
+            "rules", "brief", "skills", "plugin", "mcp", "knowledge",
+            "identity", "character", "pad",
         ),
     )
 

--- a/src/lingtai/services/mcp_registry.py
+++ b/src/lingtai/services/mcp_registry.py
@@ -418,8 +418,18 @@ def _build_identity_xml(identity: dict | None, indent: str = "    ") -> list[str
 def _build_registry_xml(
     records: list[dict], identities: dict[str, dict] | None = None
 ) -> str:
-    if not records:
-        return ""
+    # Plugin-sourced MCP servers are presented in the ``plugins`` field (as the
+    # plugin's own <mcp_names>), not in the vanilla <registered_mcp> catalog.
+    visible = [r for r in records if not str(r.get("source", "")).startswith("plugin:")]
+    if not visible:
+        return (
+            "No standalone MCP servers are registered for this agent. Register "
+            "one by adding an entry under `mcp` in your init.json (or a record "
+            "in mcp_registry.jsonl) and run system(action=\"refresh\"). MCPs "
+            "bundled inside Agent Plugins are listed in the `plugins` field. "
+            "See the mcp-manual skill in .library/intrinsic/capabilities/mcp/ "
+            "for the full registration contract."
+        )
     identities = identities or {}
     lines = [
         "The following MCP servers are registered for this agent. To activate "
@@ -432,7 +442,7 @@ def _build_registry_xml(
         "",
         "<registered_mcp>",
     ]
-    for r in records:
+    for r in visible:
         lines.append("  <mcp>")
         lines.append(f"    <name>{_escape_xml(r['name'])}</name>")
         lines.append(f"    <summary>{_escape_xml(r['summary'])}</summary>")

--- a/src/lingtai/services/plugin_registry.py
+++ b/src/lingtai/services/plugin_registry.py
@@ -808,6 +808,12 @@ def register_plugins(working_dir: Path, declared: list[str]) -> dict:
 
     working_dir = Path(working_dir)
     declared = list(declared or [])
+    # Default plugin root: <workdir>/plugin/ is scanned automatically when it
+    # exists, so dropping a plugin directory there needs no init.json entry.
+    # Explicit declarations still come first and win duplicate names.
+    default_plugin_dir = working_dir / "plugin"
+    if default_plugin_dir.is_dir() and str(default_plugin_dir) not in declared:
+        declared = [str(default_plugin_dir)] + declared
     records, problems, paths_report = read_plugins(working_dir, declared)
 
     # Pass 1 — decide what the registry should hold, and why anything is skipped.
@@ -942,7 +948,17 @@ def _plugin_xml(record: dict, mount: str, indent: str = "  ") -> list[str]:
     if record.get("summary"):
         lines.append(f"{indent}  <summary>{_escape_xml(record['summary'])}</summary>")
     lines.append(f"{indent}  <skills>{record['skill_count']}</skills>")
+    skill_names = record.get("skills") or []
+    if skill_names:
+        lines.append(
+            f"{indent}  <skill_names>{_escape_xml(', '.join(skill_names))}</skill_names>"
+        )
     lines.append(f"{indent}  <mcp_servers>{record['mcp_server_count']}</mcp_servers>")
+    mcp_names = record.get("mcp_servers") or []
+    if mcp_names:
+        lines.append(
+            f"{indent}  <mcp_names>{_escape_xml(', '.join(mcp_names))}</mcp_names>"
+        )
     if mount == "registered":
         registered = record.get("mcp_registered") or []
         lines.append(
@@ -975,16 +991,23 @@ def _build_registry_xml(
     """
     discovered = discovered or []
     if not registered and not discovered:
-        return ""
+        return (
+            "No Agent Plugins (agent-plugins.org, v1.0.0) are registered or "
+            "discovered for this agent. Drop a plugin directory under "
+            "<workdir>/plugin/<name>/plugin.json (or declare it in init.json "
+            "manifest.plugins) and refresh to mount it. See "
+            "plugin(action=\"manual\") for the plugin-manual."
+        )
 
     preamble = (
         "The following Agent Plugins (agent-plugins.org, v1.0.0) are visible to "
         "this agent. <mount>registered</mount> means the plugin was declared in "
-        "init.json manifest.plugins and mounted at boot: its skills are in your "
-        "skills catalog (located inside the plugin, not copied into .library/) "
-        "and each name in <mcp_registered> holds an mcp_registry.jsonl record "
-        "with source=\"plugin:<name>\" — registered, but NOT running, so "
-        "activation still needs an init.json top-level mcp entry. "
+        "init.json manifest.plugins and mounted at boot: its skills stay inside "
+        "the plugin (readable via file/read from <source>, not composed into the "
+        "vanilla skills catalog) and each name in <mcp_registered> holds an "
+        "mcp_registry.jsonl record with source=\"plugin:<name>\" — registered, "
+        "but NOT running, so activation still needs an init.json top-level mcp "
+        "entry. "
         "<mount>discovered</mount> means the plugin was only found on an "
         "inherited skills path: nothing is mounted, its skills are NOT in your "
         "catalog and its MCP servers are NOT registered. Call "

--- a/src/lingtai/tools/plugin/__init__.py
+++ b/src/lingtai/tools/plugin/__init__.py
@@ -128,13 +128,19 @@ def _registered_entries(agent: "BaseAgent", snapshot: dict) -> list[dict]:
         entry = dict(plugin)
         entry.pop("skill_paths", None)
         entry["skipped"] = list(plugin.get("skipped") or [])
+        # Closed namespace: a plugin's skills live inside the plugin (readable
+        # via file/read from <source>) and are listed in the plugins field as
+        # <skill_names>; they are never composed into the vanilla skills
+        # catalog. skills_mounted therefore means "visible as the plugin's own
+        # skills", not "composed into the skills catalog".
         entry["skills_mounted"] = bool(plugin.get("skills")) and skills_on
         if plugin.get("skills") and not skills_on:
             entry["skipped"].append({
                 "component": "skills/",
                 "reason": (
                     "skills capability is not enabled on this agent, so the "
-                    "plugin's skills were not composed into any catalog"
+                    "plugin's skills are listed in the plugins field without a "
+                    "skills-catalog composition"
                 ),
             })
         entries.append(entry)

--- a/src/lingtai/tools/skills/__init__.py
+++ b/src/lingtai/tools/skills/__init__.py
@@ -103,31 +103,20 @@ def _scan_one_skill(directory: Path) -> tuple[list[dict], list[dict]]:
 
 
 def _compose_paths(agent: "BaseAgent", paths: list[str]) -> list[str]:
-    """Union the declared Tier-1 paths with the registered plugins' skills.
+    """Union the declared Tier-1 paths (vanilla skills only).
 
-    An Agent Plugin declared in ``init.json`` ``manifest.plugins`` is registered
-    before capability setup (see ``services.plugin_registry.register_plugins``),
-    and one thing registration produces is the absolute path of every *validated*
-    skill directory inside each declared plugin. Composing those here — rather
-    than copying the skill files anywhere — is what makes a plugin's skills
-    appear in this catalog as ordinary skills, with their ``location`` pointing
-    inside the plugin, so the plugin remains their visible source and
-    uninstalling it removes them by simply not being declared any more.
+    Plugin skills deliberately stay out of the vanilla skills catalog: a
+    declared plugin's skills are listed in the ``plugins`` system-prompt field
+    (inside the plugin, readable via file/read from ``<source>``) rather than
+    composed into this catalog. This keeps the two namespaces parallel and
+    closed, per the Agent Plugins presentation contract: ``skills`` shows only
+    vanilla skills, ``plugins`` shows plugin packages as a whole.
 
-    They are per-skill paths and not the plugin's ``skills/`` parent on purpose:
-    a skill directory whose resolved path escapes the plugin root is rejected at
-    registration, and handing this scan the parent would mount it anyway.
-
-    Declared paths come first, plugin paths after, duplicates dropped: an
-    operator who also lists a plugin's skill directory explicitly gets one scan,
-    not two entries per skill.
+    Declared paths come first, duplicates dropped: an operator who lists a
+    directory twice gets one scan, not two entries per skill.
     """
-    ordered = list(paths)
-    ordered.extend(
-        p for p in getattr(agent, "_plugin_skill_paths", []) or [] if isinstance(p, str)
-    )
     seen: set[str] = set()
-    return [p for p in ordered if not (p in seen or seen.add(p))]
+    return [p for p in paths if not (p in seen or seen.add(p))]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plugin_tool.py
+++ b/tests/test_plugin_tool.py
@@ -304,21 +304,23 @@ def test_escaping_skill_is_absent_from_the_composed_skills_catalog(tmp_path):
     assert entry["skills"] == ["good"]
     assert any("escapes plugin root" in s["reason"] for s in entry["skipped"])
 
-    # Drive the real reconcile — the composed catalog, not just the snapshot.
-    before = skillsmod._reconcile(agent, [])["catalog_size"]
-    body = _prompt_section_named(agent, "skills")
-    assert "name: good" in body
-    assert "name: leaked" not in body, "a skipped skill must not reach the prompt"
-    assert str(outside) not in body
+    # Drive the real reconcile — the plugin field (closed namespace), not the
+    # vanilla skills catalog. Plugin skills stay inside the plugin; only the
+    # plugin prompt section lists them (as <skill_names>), the skills catalog
+    # never composes them in.
+    skillsmod._reconcile(agent, [])
+    plugin_body = _prompt_section_named(agent, "plugin")
+    assert "<name>mixed</name>" in plugin_body
+    assert "<skill_names>good</skill_names>" in plugin_body
+    assert "leaked" not in plugin_body, "a skipped skill must not reach the prompt"
+    assert str(outside) not in plugin_body
 
-    # And it is the containment gate doing it, not an empty mount: undeclaring
-    # the plugin drops exactly the one skill that was allowed through.
-    _refresh_plugins(agent, [])
-    assert skillsmod._reconcile(agent, [])["catalog_size"] == before - 1
+    skills_body = _prompt_section_named(agent, "skills")
+    assert "name: good" not in skills_body, "plugin skills stay out of the vanilla catalog"
 
 
 def test_nested_skills_are_reported_exactly_as_they_mount(tmp_path):
-    """F2: `skills/group/nested/SKILL.md` mounts, so it must also be reported."""
+    """F2: `skills/group/nested/SKILL.md` is reported in the plugin field."""
     plugin_dir = _write_plugin(tmp_path / "plugins", "deep")
     nested = plugin_dir / "skills" / "group" / "nested"
     nested.mkdir(parents=True)
@@ -338,8 +340,9 @@ def test_nested_skills_are_reported_exactly_as_they_mount(tmp_path):
     assert problems == []
 
     agent, _workdir = _mk_agent(tmp_path, plugins=[str(plugin_dir)], skills_paths=[])
-    body = _prompt_section_named(agent, "skills")
-    assert "name: nested" in body and "name: top" in body
+    body = _prompt_section_named(agent, "plugin")
+    assert "<skill_names>group/nested, top</skill_names>" in body
+    assert "<skills>2</skills>" in body
     entry = _info(agent)["registered"][0]
     assert entry["skill_count"] == 2
 
@@ -460,12 +463,14 @@ def test_prompt_marks_an_inherited_plugin_as_discovered_only(tmp_path):
     assert "<mcp_registered>" not in catalog
 
 
-def test_empty_catalog_renders_an_empty_section(tmp_path):
+def test_empty_catalog_renders_a_resident_section(tmp_path):
+    """The plugins field is resident: with nothing declared it still explains itself."""
     agent, _workdir = _mk_agent(tmp_path, [str(tmp_path / "nothing-here")])
     section = agent._prompt_manager._sections.get("plugin")
     assert section is not None
     body = section["content"] if isinstance(section, dict) else str(section)
-    assert body == ""
+    assert "No Agent Plugins" in body
+    assert "plugin/<name>/plugin.json" in body
 
 
 def test_plugin_inherits_skills_capability_paths_for_discovery_only(tmp_path):
@@ -677,16 +682,18 @@ def _prompt_section_named(agent, name: str) -> str:
     return section["content"] if isinstance(section, dict) else str(section)
 
 
-def test_declared_plugin_skill_appears_in_the_skills_catalog(tmp_path):
-    """The mount that matters: the skill shows up as an ordinary skill."""
+def test_declared_plugin_skill_appears_in_the_plugin_field(tmp_path):
+    """The mount that matters: the skill shows up in the plugins field."""
     plugin_dir = _write_plugin(tmp_path / "plugins", "alpha", skills=["greeter"])
     agent, _workdir = _mk_agent(tmp_path, plugins=[str(plugin_dir)], skills_paths=[])
 
-    body = _prompt_section_named(agent, "skills")
-    assert "name: greeter" in body
-    # Composed, not copied: the catalog location still points inside the plugin,
-    # so the plugin stays the visible source of its own skill.
-    assert f"location: {plugin_dir / 'skills' / 'greeter' / 'SKILL.md'}" in body
+    body = _prompt_section_named(agent, "plugin")
+    assert "<name>alpha</name>" in body
+    assert "<skill_names>greeter</skill_names>" in body
+    # Closed namespace: the vanilla skills catalog does not compose it in.
+    assert "name: greeter" not in _prompt_section_named(agent, "skills")
+    # The plugin stays the visible source; <source> points inside the plugin.
+    assert str(plugin_dir) in body
 
 
 def test_an_inherited_plugins_skill_stays_out_of_the_catalog(tmp_path):
@@ -1037,16 +1044,16 @@ def test_undeclaring_a_plugin_prunes_its_registry_records(tmp_path):
     assert agent._plugin_registration["mcp_pruned"] == ["greeter"]
 
 
-def test_uninstalling_removes_the_skill_from_the_catalog(tmp_path):
+def test_uninstalling_removes_the_skill_from_the_plugin_field(tmp_path):
     plugin_dir = _write_plugin(tmp_path / "plugins", "alpha", skills=["greeter"])
     agent, _workdir = _mk_agent(tmp_path, plugins=[str(plugin_dir)], skills_paths=[])
-    assert "name: greeter" in _prompt_section_named(agent, "skills")
+    assert "<skill_names>greeter</skill_names>" in _prompt_section_named(agent, "plugin")
 
-    from lingtai.tools import skills as skillsmod
+    from lingtai.tools import plugin as pluginmod
 
     _refresh_plugins(agent, [])
-    skillsmod._reconcile(agent, [])
-    assert "name: greeter" not in _prompt_section_named(agent, "skills")
+    pluginmod._reconcile(agent, [])
+    assert "greeter" not in _prompt_section_named(agent, "plugin")
 
 
 def test_pruning_leaves_records_the_plugin_system_does_not_own(tmp_path):
@@ -1215,7 +1222,7 @@ def test_cli_shaped_boot_registers_once_and_is_idempotent(tmp_path):
     assert agent._plugin_registration["mcp_pruned"] == []
     assert [r["name"] for r in _registry_lines(workdir)] == ["greeter"]
     assert len(_events(workdir, "plugin_register")) == 2
-    assert "name: greeter" in _prompt_section_named(agent, "skills")
+    assert "<skill_names>greeter</skill_names>" in _prompt_section_named(agent, "plugin")
 
 
 # ---------------------------------------------------------------------------
@@ -1283,9 +1290,10 @@ def test_the_shipped_example_plugin_registers_end_to_end(tmp_path):
     assert entry["mcp_registered"] == ["hello-lingtai"]
     assert entry["skipped"] == []
 
-    # Its skill is a real catalog entry, located inside the plugin.
-    body = _prompt_section_named(agent, "skills")
-    assert "name: hello-lingtai" in body
+    # Its skill is a plugin-field entry, located inside the plugin.
+    body = _prompt_section_named(agent, "plugin")
+    assert "<skill_names>hello-lingtai</skill_names>" in body
+    assert str(EXAMPLE_PLUGIN) in body
 
     # Its server holds a registry record whose ${PLUGIN_ROOT} arg resolved to
     # the real on-disk script, so the record is runnable as written.
@@ -1332,3 +1340,39 @@ def test_manual_ships_with_the_package():
     assert "### Uninstalling" in body
     assert "### Canonical config key" in body
     assert "`manifest.plugins` is the **canonical** declaration key" in body
+
+
+def test_default_plugin_root_is_scanned_without_declaration(tmp_path):
+    """<workdir>/plugin/<name>/plugin.json registers with no init.json entry."""
+    agent, workdir = _mk_agent(tmp_path, plugins=[])
+    root = workdir / "plugin"
+    _write_plugin(root, "auto", skills=["hi"], mcp_servers={"s": {"type": "stdio", "command": "node"}})
+    _refresh_plugins(agent, [])
+    from lingtai.tools import plugin as pluginmod
+    pluginmod._reconcile(agent, [])
+
+    assert "<name>auto</name>" in _prompt_section_named(agent, "plugin")
+    assert "<skill_names>hi</skill_names>" in _prompt_section_named(agent, "plugin")
+    assert "<mcp_names>s</mcp_names>" in _prompt_section_named(agent, "plugin")
+    # The MCP is registered (runnable) but hidden from the vanilla mcp field.
+    assert [r["name"] for r in _registry_lines(workdir)] == ["s"]
+    assert "<name>s</name>" not in _prompt_section_named(agent, "mcp")
+
+
+def test_plugin_sourced_mcp_is_hidden_from_the_vanilla_mcp_field(tmp_path):
+    """Registered plugin MCPs appear only under plugins, not <registered_mcp>."""
+    agent, workdir = _mk_agent(tmp_path, plugins=[])
+    root = workdir / "plugin"
+    _write_plugin(root, "auto", mcp_servers={"s": {"type": "stdio", "command": "node"}})
+    _refresh_plugins(agent, [])
+    from lingtai.tools import plugin as pluginmod
+    pluginmod._reconcile(agent, [])
+    assert "<mcp_names>s</mcp_names>" in _prompt_section_named(agent, "plugin")
+    assert "<name>s</name>" not in _prompt_section_named(agent, "mcp")
+
+
+def test_mcp_field_is_resident_when_no_standalone_servers(tmp_path):
+    """The mcp field explains itself even with an empty registry."""
+    agent, _workdir = _mk_agent(tmp_path, plugins=[])
+    body = _prompt_section_named(agent, "mcp")
+    assert "No standalone MCP servers" in body


### PR DESCRIPTION
## Resident `plugins` + `mcp` prompt fields, parallel to `skills`

Per Jason's direction: plugins should not be silently split into separate mcp and skills registrations; they should appear as a whole in their own system-prompt field, with registered MCPs getting their own parallel field too.

### Prompt shape (three parallel catalog fields)
- `## skills` — vanilla skills only (plugin skills are NOT composed in)
- `## plugins` — each registered plugin as a whole: `name · summary · <skill_names> · <mcp_names>`; resident (self-explaining placeholder when empty)
- `## mcp` — each standalone registered server `name · summary · transport · source`; resident when empty

### Physical convention
- Default plugin root: `<workdir>/plugin/<name>/plugin.json` — dropping a plugin directory there needs no `init.json` entry; explicit `manifest.plugins` declarations still win and come first.

### Closed namespace, function preserved
- Plugin skills stay inside the plugin: listed in `plugins` (readable via `file/read` from `<source>`), never composed into the vanilla skills catalog.
- Plugin `mcp.json` servers are still registered into `mcp_registry.jsonl` (`source="plugin:<name>"`, runnable) but hidden from the vanilla `<registered_mcp>` catalog — they appear under the owning plugin.

### Files
- `src/lingtai/kernel/prompt.py` — add `plugin`/`mcp` to order + batches (adjacent to skills)
- `src/lingtai/services/plugin_registry.py` — default `plugin/` scan; resident XML; `<skill_names>`/`<mcp_names>`; preamble
- `src/lingtai/services/mcp_registry.py` — resident XML; hide `plugin:*` sourced servers from `<registered_mcp>`
- `src/lingtai/tools/skills/__init__.py` — stop composing plugin skill paths into vanilla catalog
- `src/lingtai/tools/plugin/__init__.py` — `skills_mounted` semantics + skipped reason
- `tests/test_plugin_tool.py` — update closed-namespace assertions; 3 new tests

### Validation
- 182 plugin/mcp/prompt tests pass (plugin suite 177, mcp 3+prompt).
- 3 new tests: default root scan, plugin-sourced MCP hidden from vanilla mcp field, resident mcp field.
- `git diff --check` clean.
- Two `test_skills.py` failures are pre-existing environment issues (a `task_card` intrinsic SKILL.md lacking `name` frontmatter in this checkout), present on base too and unrelated to this change.
