### PR TITLE
feat(telegram): show current context in API status

### DIFF
--- a/src/lingtai/mcp_servers/task_card/event_projection.py
+++ b/src/lingtai/mcp_servers/task_card/event_projection.py
@@ -286,8 +286,11 @@ class TaskCardEventProjection:
         event: dict[str, Any],
     ) -> tuple[str, dict[str, Any]] | None:
         """Extract per-call LLM usage from a ``notification_block_injected``
-        carrier. Returns ``(call_id, {output, cache_miss, cache_rate})`` so the
-        tailer can attach it to the matching tool row."""
+        carrier. Returns ``(call_id, {output, cache_miss, cache_rate,
+        context})`` so the tailer can attach it to the matching tool row.
+        ``context`` is the session's actual ``context_tokens`` count riding the
+        same carrier (never derived from a percentage); absent/invalid values
+        simply omit the key."""
         if event.get("type") != "notification_block_injected":
             return None
         call_id = event.get("call_id")
@@ -310,6 +313,11 @@ class TaskCardEventProjection:
             return None
         supported = ("output", "cache_miss", "cache_rate")
         usage = {key: current[key] for key in supported if key in current}
+        session = token_usage.get("session")
+        if usage and isinstance(session, dict):
+            context = session.get("context_tokens")
+            if type(context) is int and context >= 0:
+                usage["context"] = context
         return (call_id, usage) if usage else None
 
     @staticmethod
@@ -321,9 +329,12 @@ class TaskCardEventProjection:
         Pure-text turns (an assistant reply with no tool call) never carry a
         ``notification_block_injected`` carrier, so their per-call token usage
         has to come from the ``llm_response`` event itself. Returns
-        ``(api_call_id, {output, cache_miss, cache_rate})``; estimated token
-        counts are still shown (they are the only signal a pure-text turn has)
-        but missing/zero input degrades to ``None``.
+        ``(api_call_id, {output, cache_miss, cache_rate, context})``; estimated
+        token counts are still shown (they are the only signal a pure-text turn
+        has) but missing/zero input degrades to ``None``. ``context`` is the
+        event's ``input_tokens`` — the exact value the kernel records as that
+        round's session ``context_tokens`` (``ctx_total_tokens``), an actual
+        count, never reconstructed from the cache percentage.
         """
         if event.get("type") != "llm_response":
             return None
@@ -340,7 +351,11 @@ class TaskCardEventProjection:
             or total <= 0
         ):
             return None
-        usage: dict[str, Any] = {"output": output, "cache_miss": max(total - cached, 0)}
+        usage: dict[str, Any] = {
+            "output": output,
+            "cache_miss": max(total - cached, 0),
+            "context": total,
+        }
         if cached > 0:
             usage["cache_rate"] = min(cached / total, 1.0)
         return (call_id, usage)
@@ -448,12 +463,14 @@ class TaskCardEventProjection:
         api_delay_s: float | None,
         usage: dict[str, Any] | None,
     ) -> str:
-        """Compact divider line: `API x s` plus `↓out ↑miss cache%` per-call usage.
+        """Compact divider line: `API x s` plus `↓out ↑miss ◌ ctx | cache%`.
 
         The down arrow denotes output tokens, the up arrow denotes cache miss
-        (the two token flows that grow with each call); the trailing percentage
-        is that call's cache rate. Any piece missing from the event degrades
-        silently, so old events without usage still render the delay alone.
+        (the two token flows that grow with each call); ``◌`` is the current
+        context length (an actual token count) and the trailing percentage is
+        that call's cache rate, joined as ``◌ <context> | <rate>``. Any piece
+        missing from the event degrades silently — no dangling marker or
+        separator — so old events without usage still render the delay alone.
         """
         parts: list[str] = []
         if api_delay_s is not None and api_delay_s > 0:
@@ -466,12 +483,20 @@ class TaskCardEventProjection:
                 parts.append(f"\u2193{cls.format_count(out)}")
             if type(miss) is int and miss >= 0:
                 parts.append(f"\u2191{cls.format_count(miss)}")
-            if (
-                type(rate) in {int, float}
+            context = cls.format_count(usage.get("context"))
+            rate_text = (
+                f"{float(rate):.1%}"
+                if type(rate) in {int, float}
                 and not isinstance(rate, bool)
                 and 0 <= rate <= 1
-            ):
-                parts.append(f"{float(rate):.1%}")
+                else None
+            )
+            if context is not None and rate_text is not None:
+                parts.append(f"\u25cc {context} | {rate_text}")
+            elif context is not None:
+                parts.append(f"\u25cc {context}")
+            elif rate_text is not None:
+                parts.append(rate_text)
         return " ".join(parts)
 
     @classmethod

--- a/tests/test_telegram_task_card_event_tail.py
+++ b/tests/test_telegram_task_card_event_tail.py
@@ -20,6 +20,7 @@ import threading
 from datetime import datetime
 from pathlib import Path
 
+from lingtai.mcp_servers.task_card.event_projection import TaskCardEventProjection
 from lingtai.mcp_servers.telegram.manager import TelegramManager
 from tests._notification_store_helpers import FakeNotificationStore
 
@@ -522,30 +523,27 @@ def test_divider_renders_compact_per_call_usage_arrows(tmp_path):
     manager, service = _manager(tmp_path, acct)
     _pre_resident(acct, 555, manager)
 
-    def carrier(call_id, out, miss, rate):
+    def carrier(call_id, out, miss, rate, context=None):
+        token_usage = {
+            "current_call": {
+                "output": out,
+                "cache_miss": miss,
+                "cache_rate": rate,
+            }
+        }
+        if context is not None:
+            token_usage["session"] = {"context_tokens": context}
         return json.dumps({
             "type": "notification_block_injected",
             "call_id": call_id,
-            "_meta": {
-                "agent_meta": {
-                    "agent_state": {
-                        "token_usage": {
-                            "current_call": {
-                                "output": out,
-                                "cache_miss": miss,
-                                "cache_rate": rate,
-                            }
-                        }
-                    }
-                }
-            },
+            "_meta": {"agent_meta": {"agent_state": {"token_usage": token_usage}}},
         })
 
     _write_lines(_events_path(tmp_path), [
         _tool_call_line(call_id="c1", ts=100.0),
-        carrier("c1", 412, 31_000, 0.97716),
+        carrier("c1", 412, 31_000, 0.97716, "junk"),
         _tool_call_line(call_id="c2", ts=103.4),
-        carrier("c2", 1_234, 512_345, 0.55),
+        carrier("c2", 1_234, 512_345, 0.55, 259_800),
     ])
 
     manager._poll_event_tail()
@@ -555,7 +553,7 @@ def test_divider_renders_compact_per_call_usage_arrows(tmp_path):
     assert "API 3.4s" in rendered
     assert "\u21931.2k" in rendered    # ↓1.2k output tokens
     assert "\u2191512.3k" in rendered  # ↑512.3k cache miss
-    assert "55.0%" in rendered         # cache rate (one decimal per Jason)
+    assert "API 3.4s ↓1.2k ↑512.3k ◌ 259.8k | 55.0%" in rendered
     # Usage is private per-row state: projected for rendering but never
     # leaked into the public window rows.
     assert all("_usage" not in row for row in manager._task_card_event_window())
@@ -612,8 +610,23 @@ def test_pure_text_turn_renders_api_usage_from_llm_response(tmp_path):
     # llm_response usage rides the divider: output, cache miss, cache rate.
     assert "\u2193123" in rendered
     assert "\u2191100" in rendered   # 1000 - 900 cache miss
-    assert "90.0%" in rendered      # 900/1000
+    assert "◌ 1.0k | 90.0%" in rendered  # context=input_tokens; rate=900/1000
 
+
+
+def test_divider_context_fallbacks():
+    cases = (
+        (
+            {"output": 200, "cache_miss": 2_400, "cache_rate": 0.99, "context": "junk"},
+            "API 8.5s ↓200 ↑2.4k 99.0%",
+        ),
+        (
+            {"output": 200, "cache_miss": 2_400, "context": 259_800},
+            "API 8.5s ↓200 ↑2.4k ◌ 259.8k",
+        ),
+    )
+    for usage, expected in cases:
+        assert TaskCardEventProjection.format_divider_info(8.5, usage) == expected
 
 def test_pure_text_turn_api_line_has_no_bullet(tmp_path):
     """The API divider info line must not carry the bullet prefix (it would


### PR DESCRIPTION
## Summary

- Show the actual per-call context length from `session.context_tokens` / the exact `llm_response.input_tokens` value in the Telegram Task Card API divider.
- Render the approved shape: `API 8.5s ↓200 ↑2.4k ◌ 259.8k | 99.0%`.
- Preserve the existing output when context or cache rate is missing/invalid; no dangling marker or separator.

This is Telegram plumbing only. Feishu output remains byte-compatible, and there is no TUI/shared-formatting refactor.

## Validation

- `python -m pytest -q tests/test_telegram_task_card_event_tail.py` — 47 passed after test-suite minimization (parent rerun).
- Original worker validation before minimization: focused suite 50 passed, task-card union 334 passed, adjacent Telegram 81 passed.
- `ruff check` on both touched files — passed (parent rerun).
- `python -m py_compile` — passed (parent rerun).
- `git diff --check` — passed.

The three architecture/docs governance failures and three MCP/Feishu collection failures are pre-existing and reproduce at the exact base commit; no dependency or shared venv repair was performed.